### PR TITLE
Add token management modal to mint dropdown

### DIFF
--- a/frontend/src/abis/ExtendedERC20.js
+++ b/frontend/src/abis/ExtendedERC20.js
@@ -1,0 +1,192 @@
+/**
+ * Extended ERC20 ABI with mint, burn, pause, and ownership functionality
+ * Compatible with OpenZeppelin's ERC20Burnable, ERC20Pausable, and Ownable extensions
+ */
+export const EXTENDED_ERC20_ABI = [
+  // Standard ERC20
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [{"name": "", "type": "string"}],
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{"name": "", "type": "string"}],
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{"name": "", "type": "uint8"}],
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{"name": "", "type": "uint256"}],
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{"name": "account", "type": "address"}],
+    "name": "balanceOf",
+    "outputs": [{"name": "", "type": "uint256"}],
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {"name": "recipient", "type": "address"},
+      {"name": "amount", "type": "uint256"}
+    ],
+    "name": "transfer",
+    "outputs": [{"name": "", "type": "bool"}],
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {"name": "spender", "type": "address"},
+      {"name": "amount", "type": "uint256"}
+    ],
+    "name": "approve",
+    "outputs": [{"name": "", "type": "bool"}],
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {"name": "owner", "type": "address"},
+      {"name": "spender", "type": "address"}
+    ],
+    "name": "allowance",
+    "outputs": [{"name": "", "type": "uint256"}],
+    "type": "function"
+  },
+  
+  // Mintable
+  {
+    "constant": false,
+    "inputs": [
+      {"name": "to", "type": "address"},
+      {"name": "amount", "type": "uint256"}
+    ],
+    "name": "mint",
+    "outputs": [{"name": "", "type": "bool"}],
+    "type": "function"
+  },
+  
+  // Burnable
+  {
+    "constant": false,
+    "inputs": [{"name": "amount", "type": "uint256"}],
+    "name": "burn",
+    "outputs": [],
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {"name": "account", "type": "address"},
+      {"name": "amount", "type": "uint256"}
+    ],
+    "name": "burnFrom",
+    "outputs": [],
+    "type": "function"
+  },
+  
+  // Pausable
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "paused",
+    "outputs": [{"name": "", "type": "bool"}],
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "type": "function"
+  },
+  
+  // Ownable
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{"name": "", "type": "address"}],
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{"name": "newOwner", "type": "address"}],
+    "name": "transferOwnership",
+    "outputs": [],
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "type": "function"
+  },
+  
+  // Events
+  {
+    "anonymous": false,
+    "inputs": [
+      {"indexed": true, "name": "from", "type": "address"},
+      {"indexed": true, "name": "to", "type": "address"},
+      {"indexed": false, "name": "value", "type": "uint256"}
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {"indexed": true, "name": "owner", "type": "address"},
+      {"indexed": true, "name": "spender", "type": "address"},
+      {"indexed": false, "name": "value", "type": "uint256"}
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{"indexed": false, "name": "account", "type": "address"}],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{"indexed": false, "name": "account", "type": "address"}],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {"indexed": true, "name": "previousOwner", "type": "address"},
+      {"indexed": true, "name": "newOwner", "type": "address"}
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  }
+]

--- a/frontend/src/abis/ExtendedERC721.js
+++ b/frontend/src/abis/ExtendedERC721.js
@@ -1,0 +1,217 @@
+/**
+ * Extended ERC721 ABI with mint, burn, pause, and ownership functionality
+ * Compatible with OpenZeppelin's ERC721Burnable, ERC721Pausable, and Ownable extensions
+ */
+export const EXTENDED_ERC721_ABI = [
+  // Standard ERC721
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [{"name": "", "type": "string"}],
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{"name": "", "type": "string"}],
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{"name": "", "type": "uint256"}],
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{"name": "owner", "type": "address"}],
+    "name": "balanceOf",
+    "outputs": [{"name": "", "type": "uint256"}],
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{"name": "tokenId", "type": "uint256"}],
+    "name": "ownerOf",
+    "outputs": [{"name": "", "type": "address"}],
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {"name": "from", "type": "address"},
+      {"name": "to", "type": "address"},
+      {"name": "tokenId", "type": "uint256"}
+    ],
+    "name": "transferFrom",
+    "outputs": [],
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {"name": "to", "type": "address"},
+      {"name": "tokenId", "type": "uint256"}
+    ],
+    "name": "approve",
+    "outputs": [],
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {"name": "operator", "type": "address"},
+      {"name": "approved", "type": "bool"}
+    ],
+    "name": "setApprovalForAll",
+    "outputs": [],
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{"name": "tokenId", "type": "uint256"}],
+    "name": "getApproved",
+    "outputs": [{"name": "", "type": "address"}],
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {"name": "owner", "type": "address"},
+      {"name": "operator", "type": "address"}
+    ],
+    "name": "isApprovedForAll",
+    "outputs": [{"name": "", "type": "bool"}],
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{"name": "tokenId", "type": "uint256"}],
+    "name": "tokenURI",
+    "outputs": [{"name": "", "type": "string"}],
+    "type": "function"
+  },
+  
+  // Mintable
+  {
+    "constant": false,
+    "inputs": [
+      {"name": "to", "type": "address"},
+      {"name": "tokenURI", "type": "string"}
+    ],
+    "name": "safeMint",
+    "outputs": [],
+    "type": "function"
+  },
+  
+  // Burnable
+  {
+    "constant": false,
+    "inputs": [{"name": "tokenId", "type": "uint256"}],
+    "name": "burn",
+    "outputs": [],
+    "type": "function"
+  },
+  
+  // Pausable
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "paused",
+    "outputs": [{"name": "", "type": "bool"}],
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "type": "function"
+  },
+  
+  // Ownable
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{"name": "", "type": "address"}],
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{"name": "newOwner", "type": "address"}],
+    "name": "transferOwnership",
+    "outputs": [],
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "type": "function"
+  },
+  
+  // Events
+  {
+    "anonymous": false,
+    "inputs": [
+      {"indexed": true, "name": "from", "type": "address"},
+      {"indexed": true, "name": "to", "type": "address"},
+      {"indexed": true, "name": "tokenId", "type": "uint256"}
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {"indexed": true, "name": "owner", "type": "address"},
+      {"indexed": true, "name": "approved", "type": "address"},
+      {"indexed": true, "name": "tokenId", "type": "uint256"}
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {"indexed": true, "name": "owner", "type": "address"},
+      {"indexed": true, "name": "operator", "type": "address"},
+      {"indexed": false, "name": "approved", "type": "bool"}
+    ],
+    "name": "ApprovalForAll",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{"indexed": false, "name": "account", "type": "address"}],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{"indexed": false, "name": "account", "type": "address"}],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {"indexed": true, "name": "previousOwner", "type": "address"},
+      {"indexed": true, "name": "newOwner", "type": "address"}
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  }
+]

--- a/frontend/src/components/TokenMintButton.jsx
+++ b/frontend/src/components/TokenMintButton.jsx
@@ -5,6 +5,7 @@ import { useUserPreferences } from '../hooks/useUserPreferences'
 import { useWallet, useWeb3 } from '../hooks'
 import TokenMintBuilderModal from './fairwins/TokenMintBuilderModal'
 import MarketCreationModal from './fairwins/MarketCreationModal'
+import TokenManagementModal from './fairwins/TokenManagementModal'
 import RolePurchaseModal from './ui/RolePurchaseModal'
 import './TokenMintButton.css'
 
@@ -24,6 +25,7 @@ function TokenMintButton() {
   const [isOpen, setIsOpen] = useState(false)
   const [showTokenBuilder, setShowTokenBuilder] = useState(false)
   const [showMarketCreation, setShowMarketCreation] = useState(false)
+  const [showTokenManagement, setShowTokenManagement] = useState(false)
   const dropdownRef = useRef(null)
   const buttonRef = useRef(null)
 
@@ -79,6 +81,11 @@ function TokenMintButton() {
   const handleCreateMarket = () => {
     setIsOpen(false)
     setShowMarketCreation(true)
+  }
+
+  const handleManageTokens = () => {
+    setIsOpen(false)
+    setShowTokenManagement(true)
   }
 
   const handlePurchaseMembership = () => {
@@ -316,10 +323,22 @@ function TokenMintButton() {
       id: 'create-token',
       label: 'Create New Token',
       icon: '🪙',
-      description: hasTokenMintRole 
-        ? 'Mint ERC20 or ERC721 tokens' 
+      description: hasTokenMintRole
+        ? 'Mint ERC20 or ERC721 tokens'
         : 'Requires TokenMint role',
       action: handleOpenTokenBuilder,
+      disabled: !hasTokenMintRole
+    })
+
+    // Token management option - requires TOKENMINT role
+    options.push({
+      id: 'manage-tokens',
+      label: 'Manage Tokens',
+      icon: '⚙️',
+      description: hasTokenMintRole
+        ? 'Manage deployed tokens, NFTs & markets'
+        : 'Requires TokenMint role',
+      action: handleManageTokens,
       disabled: !hasTokenMintRole
     })
 
@@ -417,6 +436,12 @@ function TokenMintButton() {
         isOpen={showMarketCreation}
         onClose={() => setShowMarketCreation(false)}
         onCreate={handleMarketCreation}
+      />
+
+      {/* Token Management Modal */}
+      <TokenManagementModal
+        isOpen={showTokenManagement}
+        onClose={() => setShowTokenManagement(false)}
       />
     </>
   )

--- a/frontend/src/components/fairwins/TokenManagementModal.css
+++ b/frontend/src/components/fairwins/TokenManagementModal.css
@@ -372,6 +372,16 @@
   color: #4b5563;
 }
 
+.tm-copy-btn.success {
+  background: rgba(34, 197, 94, 0.1);
+  color: #22c55e;
+}
+
+.tm-copy-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 /* Date */
 .td-date {
   color: #6b7280;
@@ -740,7 +750,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 100;
+  z-index: 200;
   animation: tm-fadeIn 0.15s ease-out;
 }
 

--- a/frontend/src/components/fairwins/TokenManagementModal.css
+++ b/frontend/src/components/fairwins/TokenManagementModal.css
@@ -1,0 +1,1051 @@
+/* Token Management Modal - Minimalist Modern Design */
+
+/* Overlay */
+.tm-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1200;
+  animation: tm-fadeIn 0.2s ease-out;
+}
+
+@keyframes tm-fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* Modal Container */
+.tm-modal {
+  position: relative;
+  width: 95%;
+  max-width: 1100px;
+  max-height: 90vh;
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  animation: tm-slideUp 0.3s ease-out;
+  overflow: hidden;
+}
+
+@keyframes tm-slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Header */
+.tm-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 24px 28px;
+  border-bottom: 1px solid #f0f0f0;
+  background: linear-gradient(135deg, #fafafa 0%, #ffffff 100%);
+}
+
+.tm-header-content h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #1a1a1a;
+  letter-spacing: -0.02em;
+}
+
+.tm-header-content p {
+  margin: 4px 0 0;
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+.tm-close-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: #6b7280;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.tm-close-btn:hover {
+  background: #f3f4f6;
+  color: #1a1a1a;
+}
+
+/* Tabs */
+.tm-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 0 28px;
+  background: #fafafa;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.tm-tab {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 20px;
+  background: transparent;
+  border: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #6b7280;
+  cursor: pointer;
+  position: relative;
+  transition: color 0.15s ease;
+}
+
+.tm-tab:hover {
+  color: #1a1a1a;
+}
+
+.tm-tab.active {
+  color: #1a1a1a;
+}
+
+.tm-tab.active::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: #2D7A4F;
+  border-radius: 2px 2px 0 0;
+}
+
+.tm-tab-icon {
+  font-size: 1rem;
+  opacity: 0.7;
+}
+
+.tm-tab.active .tm-tab-icon {
+  opacity: 1;
+}
+
+.tm-tab-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  background: #e5e7eb;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #6b7280;
+}
+
+.tm-tab.active .tm-tab-count {
+  background: rgba(45, 122, 79, 0.1);
+  color: #2D7A4F;
+}
+
+/* Content */
+.tm-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 28px;
+  min-height: 400px;
+}
+
+/* Loading State */
+.tm-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 20px;
+  color: #6b7280;
+  gap: 12px;
+}
+
+.tm-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid #e5e7eb;
+  border-top-color: #2D7A4F;
+  border-radius: 50%;
+  animation: tm-spin 0.8s linear infinite;
+}
+
+@keyframes tm-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Empty State */
+.tm-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 20px;
+  text-align: center;
+}
+
+.tm-empty-icon {
+  font-size: 3rem;
+  opacity: 0.3;
+  margin-bottom: 16px;
+}
+
+.tm-empty h3 {
+  margin: 0 0 8px;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.tm-empty p {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+/* Table */
+.tm-table-container {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.tm-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.tm-table thead {
+  background: #fafafa;
+}
+
+.tm-table th {
+  padding: 12px 16px;
+  text-align: left;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.tm-table th.th-actions {
+  text-align: right;
+  width: 100px;
+}
+
+.tm-table tbody tr {
+  border-bottom: 1px solid #f3f4f6;
+  transition: background 0.15s ease;
+}
+
+.tm-table tbody tr:last-child {
+  border-bottom: none;
+}
+
+.tm-table tbody tr:hover {
+  background: #fafafa;
+}
+
+.tm-table td {
+  padding: 14px 16px;
+  color: #1a1a1a;
+  vertical-align: middle;
+}
+
+/* Type Badge */
+.tm-type-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.tm-type-badge.erc20 {
+  background: rgba(99, 102, 241, 0.1);
+  color: #6366f1;
+}
+
+.tm-type-badge.erc721 {
+  background: rgba(236, 72, 153, 0.1);
+  color: #ec4899;
+}
+
+/* Name Cell */
+.td-name {
+  max-width: 250px;
+}
+
+.tm-name {
+  font-weight: 500;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tm-status-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  margin-left: 8px;
+}
+
+.tm-status-badge.paused {
+  background: rgba(245, 158, 11, 0.1);
+  color: #f59e0b;
+}
+
+.tm-status-badge.active {
+  background: rgba(34, 197, 94, 0.1);
+  color: #22c55e;
+}
+
+.tm-status-badge.resolved {
+  background: rgba(99, 102, 241, 0.1);
+  color: #6366f1;
+}
+
+/* Symbol */
+.td-symbol {
+  font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+  font-weight: 600;
+  color: #2D7A4F;
+}
+
+/* Address */
+.td-address {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.td-address code {
+  font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.8rem;
+  background: #f3f4f6;
+  padding: 4px 8px;
+  border-radius: 4px;
+  color: #4b5563;
+}
+
+.tm-copy-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: #9ca3af;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.tm-copy-btn:hover {
+  background: #f3f4f6;
+  color: #4b5563;
+}
+
+/* Date */
+.td-date {
+  color: #6b7280;
+  white-space: nowrap;
+}
+
+/* Actions */
+.td-actions {
+  text-align: right;
+}
+
+.tm-action-group {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+}
+
+.tm-info-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  color: #6b7280;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.tm-info-btn:hover {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+  color: #1a1a1a;
+}
+
+/* Action Dropdown */
+.tm-action-dropdown {
+  position: relative;
+}
+
+.tm-action-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  color: #6b7280;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.tm-action-trigger:hover {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+  color: #1a1a1a;
+}
+
+.tm-dropdown-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  min-width: 180px;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
+  padding: 6px;
+  z-index: 100;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-8px);
+  transition: all 0.15s ease;
+}
+
+.tm-action-dropdown:hover .tm-dropdown-menu,
+.tm-action-dropdown:focus-within .tm-dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.tm-dropdown-menu button {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 12px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  color: #374151;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s ease;
+}
+
+.tm-dropdown-menu button:hover {
+  background: #f3f4f6;
+}
+
+.tm-dropdown-menu button.danger {
+  color: #dc2626;
+}
+
+.tm-dropdown-menu button.danger:hover {
+  background: rgba(220, 38, 38, 0.05);
+}
+
+.tm-dropdown-menu hr {
+  border: none;
+  border-top: 1px solid #e5e7eb;
+  margin: 6px 0;
+}
+
+.tm-dropdown-menu .action-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  font-size: 0.9rem;
+}
+
+/* Pagination */
+.tm-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid #f3f4f6;
+}
+
+.tm-page-info {
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.tm-page-controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.tm-page-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  color: #6b7280;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.tm-page-btn:hover:not(:disabled) {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+  color: #1a1a1a;
+}
+
+.tm-page-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.tm-page-current {
+  padding: 0 12px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+/* Info Panel */
+.tm-info-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 380px;
+  background: #ffffff;
+  border-left: 1px solid #e5e7eb;
+  box-shadow: -10px 0 30px rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: column;
+  animation: tm-slideIn 0.25s ease-out;
+  z-index: 50;
+}
+
+@keyframes tm-slideIn {
+  from {
+    opacity: 0;
+    transform: translateX(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.tm-info-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.tm-info-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.tm-info-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: #6b7280;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.tm-info-close:hover {
+  background: #f3f4f6;
+  color: #1a1a1a;
+}
+
+.tm-info-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 24px;
+}
+
+.tm-info-section {
+  margin-bottom: 24px;
+}
+
+.tm-info-section:last-child {
+  margin-bottom: 0;
+}
+
+.tm-info-section h4 {
+  margin: 0 0 12px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #9ca3af;
+}
+
+.tm-info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.tm-info-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tm-info-item.full-width {
+  grid-column: 1 / -1;
+}
+
+.tm-info-item label {
+  font-size: 0.75rem;
+  color: #6b7280;
+}
+
+.tm-info-item span {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #1a1a1a;
+}
+
+.tm-info-item code {
+  font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.75rem;
+  word-break: break-all;
+  background: #f3f4f6;
+  padding: 6px 8px;
+  border-radius: 4px;
+  color: #4b5563;
+}
+
+.tm-address-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tm-address-row code {
+  flex: 1;
+}
+
+.tm-uri {
+  word-break: break-all;
+  font-family: 'SF Mono', SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.75rem;
+  color: #6366f1;
+}
+
+/* Features List */
+.tm-features-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tm-feature {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  background: #f3f4f6;
+  color: #6b7280;
+}
+
+.tm-feature.enabled {
+  background: rgba(34, 197, 94, 0.1);
+  color: #16a34a;
+}
+
+.tm-feature.disabled {
+  background: #f3f4f6;
+  color: #9ca3af;
+}
+
+.tm-feature.active {
+  background: rgba(245, 158, 11, 0.1);
+  color: #d97706;
+}
+
+.tm-feature .feature-icon {
+  font-size: 0.9rem;
+}
+
+/* Action Modal */
+.tm-action-modal-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  animation: tm-fadeIn 0.15s ease-out;
+}
+
+.tm-action-modal {
+  width: 90%;
+  max-width: 420px;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+  animation: tm-slideUp 0.2s ease-out;
+}
+
+.tm-action-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.tm-action-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.tm-action-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: #6b7280;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.tm-action-close:hover {
+  background: #f3f4f6;
+  color: #1a1a1a;
+}
+
+.tm-action-body {
+  padding: 24px;
+}
+
+.tm-form-group {
+  margin-bottom: 18px;
+}
+
+.tm-form-group:last-child {
+  margin-bottom: 0;
+}
+
+.tm-form-group label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #374151;
+}
+
+.tm-form-group input[type="text"],
+.tm-form-group input[type="number"] {
+  width: 100%;
+  padding: 12px 14px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  color: #1a1a1a;
+  transition: all 0.15s ease;
+  box-sizing: border-box;
+}
+
+.tm-form-group input:focus {
+  outline: none;
+  border-color: #2D7A4F;
+  box-shadow: 0 0 0 3px rgba(45, 122, 79, 0.1);
+}
+
+.tm-form-group input::placeholder {
+  color: #9ca3af;
+}
+
+.tm-form-group.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.tm-form-group.checkbox input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: #2D7A4F;
+  cursor: pointer;
+}
+
+.tm-form-group.checkbox label {
+  margin: 0;
+  cursor: pointer;
+}
+
+.tm-field-hint {
+  display: block;
+  margin-top: 6px;
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.tm-action-confirm {
+  text-align: center;
+  padding: 12px 0;
+}
+
+.tm-action-confirm p {
+  margin: 0 0 8px;
+  color: #374151;
+}
+
+.tm-action-confirm.danger {
+  background: rgba(220, 38, 38, 0.05);
+  padding: 20px;
+  border-radius: 8px;
+  border: 1px solid rgba(220, 38, 38, 0.1);
+}
+
+.tm-danger-icon {
+  font-size: 2rem;
+  margin-bottom: 12px;
+}
+
+.tm-warning {
+  color: #dc2626;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.tm-action-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 16px 24px;
+  border-top: 1px solid #f0f0f0;
+  background: #fafafa;
+  border-radius: 0 0 12px 12px;
+}
+
+.tm-btn-secondary {
+  padding: 10px 20px;
+  background: transparent;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #6b7280;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.tm-btn-secondary:hover {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+  color: #374151;
+}
+
+.tm-btn-primary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  background: #2D7A4F;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #ffffff;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.tm-btn-primary:hover:not(:disabled) {
+  background: #246340;
+}
+
+.tm-btn-primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.tm-btn-primary.danger {
+  background: #dc2626;
+}
+
+.tm-btn-primary.danger:hover:not(:disabled) {
+  background: #b91c1c;
+}
+
+.tm-btn-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  animation: tm-spin 0.6s linear infinite;
+}
+
+/* Responsive Design */
+@media (max-width: 900px) {
+  .tm-modal {
+    max-width: 100%;
+    max-height: 100%;
+    height: 100%;
+    border-radius: 0;
+  }
+
+  .tm-info-panel {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    border-left: none;
+    border-radius: 0;
+  }
+
+  .tm-table-container {
+    overflow-x: auto;
+  }
+
+  .tm-table {
+    min-width: 700px;
+  }
+}
+
+@media (max-width: 600px) {
+  .tm-header {
+    padding: 16px 20px;
+  }
+
+  .tm-header-content h2 {
+    font-size: 1.25rem;
+  }
+
+  .tm-tabs {
+    padding: 0 12px;
+    overflow-x: auto;
+  }
+
+  .tm-tab {
+    padding: 12px 14px;
+    font-size: 0.85rem;
+  }
+
+  .tm-content {
+    padding: 16px 20px;
+  }
+
+  .tm-pagination {
+    flex-direction: column;
+    gap: 12px;
+    text-align: center;
+  }
+
+  .tm-action-modal {
+    width: 100%;
+    max-height: 100%;
+    height: 100%;
+    border-radius: 0;
+  }
+}
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+  .tm-modal-overlay,
+  .tm-modal,
+  .tm-info-panel,
+  .tm-action-modal,
+  .tm-dropdown-menu,
+  .tm-spinner {
+    animation: none;
+  }
+
+  .tm-dropdown-menu {
+    transition: opacity 0.1s ease;
+    transform: none;
+  }
+}
+
+/* High Contrast Mode */
+@media (prefers-contrast: high) {
+  .tm-table-container,
+  .tm-action-modal,
+  .tm-info-panel {
+    border-width: 2px;
+  }
+
+  .tm-tab.active::after {
+    height: 3px;
+  }
+
+  .tm-btn-primary:focus-visible,
+  .tm-btn-secondary:focus-visible {
+    outline: 3px solid #000000;
+    outline-offset: 2px;
+  }
+}

--- a/frontend/src/components/fairwins/TokenManagementModal.jsx
+++ b/frontend/src/components/fairwins/TokenManagementModal.jsx
@@ -354,24 +354,39 @@ function TokenManagementModal({ isOpen, onClose }) {
             actionDescription = `Burning ${actionData.amount} ${selectedItem.symbol}`
           } else {
             // ERC721: burn(uint256 tokenId) - amount field is used for tokenId
-            const tokenId = parseInt(actionData.amount)
+            const tokenId = BigInt(actionData.amount)
             tx = await contract.burn(tokenId)
-            actionDescription = `Burning NFT #${tokenId}`
+            actionDescription = `Burning NFT #${actionData.amount}`
           }
           break
 
         case 'transfer':
-          // ERC20: transfer(address to, uint256 amount)
-          const transferAmount = ethers.parseUnits(actionData.amount, selectedItem.decimals || 18)
-          tx = await contract.transfer(actionData.address, transferAmount)
-          actionDescription = `Transferring ${actionData.amount} ${selectedItem.symbol} to ${formatAddress(actionData.address)}`
+          if (selectedItem.type === 'ERC20') {
+            // ERC20: transfer(address to, uint256 amount)
+            const transferAmount = ethers.parseUnits(actionData.amount, selectedItem.decimals || 18)
+            tx = await contract.transfer(actionData.address, transferAmount)
+            actionDescription = `Transferring ${actionData.amount} ${selectedItem.symbol} to ${formatAddress(actionData.address)}`
+          } else {
+            // ERC721: transferFrom(address from, address to, uint256 tokenId)
+            const tokenId = BigInt(actionData.amount)
+            const ownerAddress = await contract.ownerOf(tokenId)
+            tx = await contract.transferFrom(ownerAddress, actionData.address, tokenId)
+            actionDescription = `Transferring NFT #${actionData.amount} to ${formatAddress(actionData.address)}`
+          }
           break
 
         case 'approve':
-          // ERC20: approve(address spender, uint256 amount)
-          const approveAmount = ethers.parseUnits(actionData.amount, selectedItem.decimals || 18)
-          tx = await contract.approve(actionData.spender, approveAmount)
-          actionDescription = `Approving ${actionData.amount} ${selectedItem.symbol} for ${formatAddress(actionData.spender)}`
+          if (selectedItem.type === 'ERC20') {
+            // ERC20: approve(address spender, uint256 amount)
+            const approveAmount = ethers.parseUnits(actionData.amount, selectedItem.decimals || 18)
+            tx = await contract.approve(actionData.spender, approveAmount)
+            actionDescription = `Approving ${actionData.amount} ${selectedItem.symbol} for ${formatAddress(actionData.spender)}`
+          } else {
+            // ERC721: approve(address to, uint256 tokenId)
+            const tokenId = BigInt(actionData.amount)
+            tx = await contract.approve(actionData.spender, tokenId)
+            actionDescription = `Approving NFT #${actionData.amount} for ${formatAddress(actionData.spender)}`
+          }
           break
 
         case 'setApprovalForAll':

--- a/frontend/src/components/fairwins/TokenManagementModal.jsx
+++ b/frontend/src/components/fairwins/TokenManagementModal.jsx
@@ -733,25 +733,26 @@ function TokenManagementModal({ isOpen, onClose }) {
                   <div className="tm-info-item full-width">
                     <label>Transaction Hash</label>
                     <div className="tm-address-row">
-                      <code>
-                        {typeof chainInfo.transactionHash === 'string' && chainInfo.transactionHash.length > 0
-                          ? formatAddress(chainInfo.transactionHash)
-                          : 'N/A'}
-                      </code>
-                      <button
-                        className={`tm-copy-btn ${copySuccess === chainInfo.transactionHash ? 'success' : ''}`}
-                        disabled={!(typeof chainInfo.transactionHash === 'string' && chainInfo.transactionHash.length > 0)}
-                        onClick={() => {
-                          if (typeof chainInfo.transactionHash === 'string' && chainInfo.transactionHash.length > 0) {
-                            copyToClipboard(chainInfo.transactionHash)
-                          }
-                        }}
-                      >
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                          <rect x="9" y="9" width="13" height="13" rx="2" />
-                          <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
-                        </svg>
-                      </button>
+                      {(() => {
+                        const isValidHash = typeof chainInfo.transactionHash === 'string' && chainInfo.transactionHash.length > 0
+                        return (
+                          <>
+                            <code>
+                              {isValidHash ? formatAddress(chainInfo.transactionHash) : 'N/A'}
+                            </code>
+                            <button
+                              className={`tm-copy-btn ${copySuccess === chainInfo.transactionHash ? 'success' : ''}`}
+                              disabled={!isValidHash}
+                              onClick={() => isValidHash && copyToClipboard(chainInfo.transactionHash)}
+                            >
+                              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                <rect x="9" y="9" width="13" height="13" rx="2" />
+                                <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+                              </svg>
+                            </button>
+                          </>
+                        )
+                      })()}
                     </div>
                   </div>
                 </div>

--- a/frontend/src/components/fairwins/TokenManagementModal.jsx
+++ b/frontend/src/components/fairwins/TokenManagementModal.jsx
@@ -1,0 +1,847 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useWallet, useWeb3 } from '../../hooks'
+import './TokenManagementModal.css'
+
+/**
+ * TokenManagementModal Component
+ *
+ * A minimalist modern modal for managing deployed tokens, NFTs, and markets.
+ * Features:
+ * - Tabbed interface for Tokens, NFTs, and Markets
+ * - Clean paginated table (10 items per page)
+ * - Info button for viewing on-chain token details
+ * - Token management controls (mint, burn, pause, freeze, etc.)
+ */
+function TokenManagementModal({ isOpen, onClose }) {
+  const [activeTab, setActiveTab] = useState('tokens')
+  const [currentPage, setCurrentPage] = useState(1)
+  const [loading, setLoading] = useState(false)
+  const [selectedItem, setSelectedItem] = useState(null)
+  const [showInfoPanel, setShowInfoPanel] = useState(false)
+  const [actionModal, setActionModal] = useState(null)
+  const [actionData, setActionData] = useState({})
+  const [actionLoading, setActionLoading] = useState(false)
+
+  // Data states
+  const [tokens, setTokens] = useState([])
+  const [nfts, setNfts] = useState([])
+  const [markets, setMarkets] = useState([])
+  const [chainInfo, setChainInfo] = useState(null)
+
+  const { address, isConnected } = useWallet()
+  const { provider, signer } = useWeb3()
+
+  const ITEMS_PER_PAGE = 10
+
+  // Mock data for demonstration - in production, these would be fetched from chain
+  useEffect(() => {
+    if (isOpen && isConnected) {
+      loadData()
+    }
+  }, [isOpen, isConnected, address])
+
+  const loadData = async () => {
+    setLoading(true)
+    try {
+      // Simulate loading time
+      await new Promise(resolve => setTimeout(resolve, 500))
+
+      // Mock token data - in production, fetch from TokenMintFactory events
+      setTokens([
+        {
+          id: 1,
+          address: '0x1234567890abcdef1234567890abcdef12345678',
+          name: 'Demo Token',
+          symbol: 'DEMO',
+          type: 'ERC20',
+          totalSupply: '1000000',
+          decimals: 18,
+          isPausable: true,
+          isBurnable: true,
+          isPaused: false,
+          owner: address,
+          createdAt: Date.now() - 86400000 * 30
+        },
+        {
+          id: 2,
+          address: '0xabcdef1234567890abcdef1234567890abcdef12',
+          name: 'Reward Points',
+          symbol: 'RWD',
+          type: 'ERC20',
+          totalSupply: '5000000',
+          decimals: 18,
+          isPausable: true,
+          isBurnable: false,
+          isPaused: false,
+          owner: address,
+          createdAt: Date.now() - 86400000 * 15
+        }
+      ])
+
+      setNfts([
+        {
+          id: 1,
+          address: '0x9876543210fedcba9876543210fedcba98765432',
+          name: 'Art Collection',
+          symbol: 'ART',
+          type: 'ERC721',
+          totalSupply: '100',
+          baseURI: 'ipfs://QmXyz...',
+          isPausable: true,
+          isBurnable: true,
+          isPaused: false,
+          owner: address,
+          createdAt: Date.now() - 86400000 * 7
+        }
+      ])
+
+      setMarkets([
+        {
+          id: 1,
+          address: '0xfedcba9876543210fedcba9876543210fedcba98',
+          question: 'Will ETH reach $5000 by March 2025?',
+          type: 'Prediction',
+          status: 'Active',
+          totalLiquidity: '2.5',
+          tradingEnds: Date.now() + 86400000 * 30,
+          createdAt: Date.now() - 86400000 * 10
+        }
+      ])
+    } catch (error) {
+      console.error('Error loading data:', error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const getCurrentData = () => {
+    switch (activeTab) {
+      case 'tokens': return tokens
+      case 'nfts': return nfts
+      case 'markets': return markets
+      default: return []
+    }
+  }
+
+  const data = getCurrentData()
+  const totalPages = Math.ceil(data.length / ITEMS_PER_PAGE)
+  const paginatedData = data.slice(
+    (currentPage - 1) * ITEMS_PER_PAGE,
+    currentPage * ITEMS_PER_PAGE
+  )
+
+  // Reset page when switching tabs
+  useEffect(() => {
+    setCurrentPage(1)
+    setSelectedItem(null)
+    setShowInfoPanel(false)
+  }, [activeTab])
+
+  const fetchChainInfo = async (item) => {
+    setLoading(true)
+    try {
+      // In production, fetch real on-chain data
+      await new Promise(resolve => setTimeout(resolve, 300))
+
+      const info = {
+        contractAddress: item.address,
+        name: item.name,
+        symbol: item.symbol,
+        type: item.type,
+        owner: item.owner || address,
+        ...(item.type === 'ERC20' && {
+          totalSupply: item.totalSupply,
+          decimals: item.decimals || 18,
+          balanceOfOwner: '500000'
+        }),
+        ...(item.type === 'ERC721' && {
+          totalSupply: item.totalSupply,
+          baseURI: item.baseURI
+        }),
+        isPaused: item.isPaused || false,
+        isPausable: item.isPausable || false,
+        isBurnable: item.isBurnable || false,
+        blockNumber: 12345678,
+        transactionHash: '0x' + 'a'.repeat(64)
+      }
+
+      setChainInfo(info)
+      setShowInfoPanel(true)
+    } catch (error) {
+      console.error('Error fetching chain info:', error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleAction = async (action, item) => {
+    setSelectedItem(item)
+    setActionModal(action)
+    setActionData({})
+  }
+
+  const executeAction = async () => {
+    if (!selectedItem || !actionModal) return
+
+    setActionLoading(true)
+    try {
+      // In production, these would call actual contract methods
+      await new Promise(resolve => setTimeout(resolve, 1000))
+
+      console.log(`Executing ${actionModal} on ${selectedItem.name}:`, actionData)
+
+      // Update local state based on action
+      if (actionModal === 'pause') {
+        updateItemState(selectedItem.id, { isPaused: true })
+      } else if (actionModal === 'unpause') {
+        updateItemState(selectedItem.id, { isPaused: false })
+      }
+
+      setActionModal(null)
+      setActionData({})
+      setSelectedItem(null)
+    } catch (error) {
+      console.error(`Error executing ${actionModal}:`, error)
+    } finally {
+      setActionLoading(false)
+    }
+  }
+
+  const updateItemState = (id, updates) => {
+    if (activeTab === 'tokens') {
+      setTokens(prev => prev.map(t => t.id === id ? { ...t, ...updates } : t))
+    } else if (activeTab === 'nfts') {
+      setNfts(prev => prev.map(n => n.id === id ? { ...n, ...updates } : n))
+    }
+  }
+
+  const formatAddress = (addr) => {
+    if (!addr) return '—'
+    return `${addr.slice(0, 6)}...${addr.slice(-4)}`
+  }
+
+  const formatDate = (timestamp) => {
+    return new Date(timestamp).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    })
+  }
+
+  const copyToClipboard = async (text) => {
+    try {
+      await navigator.clipboard.writeText(text)
+    } catch (err) {
+      console.error('Failed to copy:', err)
+    }
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div className="tm-modal-overlay" onClick={onClose}>
+      <div className="tm-modal" onClick={e => e.stopPropagation()}>
+        {/* Header */}
+        <div className="tm-header">
+          <div className="tm-header-content">
+            <h2>Token Management</h2>
+            <p>Manage your deployed tokens, NFTs, and markets</p>
+          </div>
+          <button className="tm-close-btn" onClick={onClose} aria-label="Close modal">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="tm-tabs">
+          <button
+            className={`tm-tab ${activeTab === 'tokens' ? 'active' : ''}`}
+            onClick={() => setActiveTab('tokens')}
+          >
+            <span className="tm-tab-icon">⬡</span>
+            Tokens
+            <span className="tm-tab-count">{tokens.length}</span>
+          </button>
+          <button
+            className={`tm-tab ${activeTab === 'nfts' ? 'active' : ''}`}
+            onClick={() => setActiveTab('nfts')}
+          >
+            <span className="tm-tab-icon">◈</span>
+            NFTs
+            <span className="tm-tab-count">{nfts.length}</span>
+          </button>
+          <button
+            className={`tm-tab ${activeTab === 'markets' ? 'active' : ''}`}
+            onClick={() => setActiveTab('markets')}
+          >
+            <span className="tm-tab-icon">◐</span>
+            Markets
+            <span className="tm-tab-count">{markets.length}</span>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="tm-content">
+          {loading && !paginatedData.length ? (
+            <div className="tm-loading">
+              <div className="tm-spinner" />
+              <span>Loading...</span>
+            </div>
+          ) : paginatedData.length === 0 ? (
+            <div className="tm-empty">
+              <div className="tm-empty-icon">
+                {activeTab === 'tokens' && '⬡'}
+                {activeTab === 'nfts' && '◈'}
+                {activeTab === 'markets' && '◐'}
+              </div>
+              <h3>No {activeTab} found</h3>
+              <p>Create your first {activeTab.slice(0, -1)} to get started</p>
+            </div>
+          ) : (
+            <>
+              <div className="tm-table-container">
+                <table className="tm-table">
+                  <thead>
+                    <tr>
+                      {activeTab !== 'markets' && <th>Type</th>}
+                      <th>{activeTab === 'markets' ? 'Question' : 'Name'}</th>
+                      {activeTab !== 'markets' && <th>Symbol</th>}
+                      <th>Address</th>
+                      {activeTab === 'markets' && <th>Status</th>}
+                      <th>Created</th>
+                      <th className="th-actions">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {paginatedData.map((item) => (
+                      <tr key={item.id}>
+                        {activeTab !== 'markets' && (
+                          <td>
+                            <span className={`tm-type-badge ${item.type.toLowerCase()}`}>
+                              {item.type}
+                            </span>
+                          </td>
+                        )}
+                        <td className="td-name">
+                          <span className="tm-name">{activeTab === 'markets' ? item.question : item.name}</span>
+                          {item.isPaused && (
+                            <span className="tm-status-badge paused">Paused</span>
+                          )}
+                        </td>
+                        {activeTab !== 'markets' && (
+                          <td className="td-symbol">{item.symbol}</td>
+                        )}
+                        <td className="td-address">
+                          <code>{formatAddress(item.address)}</code>
+                          <button
+                            className="tm-copy-btn"
+                            onClick={() => copyToClipboard(item.address)}
+                            aria-label="Copy address"
+                          >
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                              <rect x="9" y="9" width="13" height="13" rx="2" />
+                              <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+                            </svg>
+                          </button>
+                        </td>
+                        {activeTab === 'markets' && (
+                          <td>
+                            <span className={`tm-status-badge ${item.status.toLowerCase()}`}>
+                              {item.status}
+                            </span>
+                          </td>
+                        )}
+                        <td className="td-date">{formatDate(item.createdAt)}</td>
+                        <td className="td-actions">
+                          <div className="tm-action-group">
+                            <button
+                              className="tm-info-btn"
+                              onClick={() => {
+                                setSelectedItem(item)
+                                fetchChainInfo(item)
+                              }}
+                              aria-label="View details"
+                              title="View on-chain details"
+                            >
+                              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                <circle cx="12" cy="12" r="10" />
+                                <path d="M12 16v-4M12 8h.01" />
+                              </svg>
+                            </button>
+                            {activeTab !== 'markets' && (
+                              <div className="tm-action-dropdown">
+                                <button className="tm-action-trigger">
+                                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                    <circle cx="12" cy="12" r="1" />
+                                    <circle cx="19" cy="12" r="1" />
+                                    <circle cx="5" cy="12" r="1" />
+                                  </svg>
+                                </button>
+                                <div className="tm-dropdown-menu">
+                                  <button onClick={() => handleAction('mint', item)}>
+                                    <span className="action-icon">+</span> Mint
+                                  </button>
+                                  {item.isBurnable && (
+                                    <button onClick={() => handleAction('burn', item)}>
+                                      <span className="action-icon">🔥</span> Burn
+                                    </button>
+                                  )}
+                                  {item.isPausable && !item.isPaused && (
+                                    <button onClick={() => handleAction('pause', item)}>
+                                      <span className="action-icon">⏸</span> Pause
+                                    </button>
+                                  )}
+                                  {item.isPausable && item.isPaused && (
+                                    <button onClick={() => handleAction('unpause', item)}>
+                                      <span className="action-icon">▶</span> Unpause
+                                    </button>
+                                  )}
+                                  <button onClick={() => handleAction('transfer', item)}>
+                                    <span className="action-icon">↗</span> Transfer
+                                  </button>
+                                  {item.type === 'ERC20' && (
+                                    <button onClick={() => handleAction('approve', item)}>
+                                      <span className="action-icon">✓</span> Approve
+                                    </button>
+                                  )}
+                                  {item.type === 'ERC721' && (
+                                    <button onClick={() => handleAction('setApprovalForAll', item)}>
+                                      <span className="action-icon">✓</span> Set Approval
+                                    </button>
+                                  )}
+                                  <hr />
+                                  <button onClick={() => handleAction('transferOwnership', item)}>
+                                    <span className="action-icon">👤</span> Transfer Ownership
+                                  </button>
+                                  <button onClick={() => handleAction('renounceOwnership', item)} className="danger">
+                                    <span className="action-icon">⚠</span> Renounce Ownership
+                                  </button>
+                                </div>
+                              </div>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {/* Pagination */}
+              {totalPages > 1 && (
+                <div className="tm-pagination">
+                  <span className="tm-page-info">
+                    Page {currentPage} of {totalPages}
+                  </span>
+                  <div className="tm-page-controls">
+                    <button
+                      className="tm-page-btn"
+                      onClick={() => setCurrentPage(1)}
+                      disabled={currentPage === 1}
+                      aria-label="First page"
+                    >
+                      ««
+                    </button>
+                    <button
+                      className="tm-page-btn"
+                      onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+                      disabled={currentPage === 1}
+                      aria-label="Previous page"
+                    >
+                      ‹
+                    </button>
+                    <span className="tm-page-current">{currentPage}</span>
+                    <button
+                      className="tm-page-btn"
+                      onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+                      disabled={currentPage === totalPages}
+                      aria-label="Next page"
+                    >
+                      ›
+                    </button>
+                    <button
+                      className="tm-page-btn"
+                      onClick={() => setCurrentPage(totalPages)}
+                      disabled={currentPage === totalPages}
+                      aria-label="Last page"
+                    >
+                      »»
+                    </button>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Info Panel Slide-out */}
+        {showInfoPanel && chainInfo && (
+          <div className="tm-info-panel">
+            <div className="tm-info-header">
+              <h3>On-Chain Details</h3>
+              <button
+                className="tm-info-close"
+                onClick={() => setShowInfoPanel(false)}
+                aria-label="Close info panel"
+              >
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M18 6L6 18M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <div className="tm-info-content">
+              <div className="tm-info-section">
+                <h4>Contract Information</h4>
+                <div className="tm-info-grid">
+                  <div className="tm-info-item">
+                    <label>Name</label>
+                    <span>{chainInfo.name}</span>
+                  </div>
+                  <div className="tm-info-item">
+                    <label>Symbol</label>
+                    <span>{chainInfo.symbol}</span>
+                  </div>
+                  <div className="tm-info-item">
+                    <label>Type</label>
+                    <span className={`tm-type-badge ${chainInfo.type.toLowerCase()}`}>
+                      {chainInfo.type}
+                    </span>
+                  </div>
+                  <div className="tm-info-item full-width">
+                    <label>Contract Address</label>
+                    <div className="tm-address-row">
+                      <code>{chainInfo.contractAddress}</code>
+                      <button
+                        className="tm-copy-btn"
+                        onClick={() => copyToClipboard(chainInfo.contractAddress)}
+                      >
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                          <rect x="9" y="9" width="13" height="13" rx="2" />
+                          <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                  <div className="tm-info-item full-width">
+                    <label>Owner</label>
+                    <div className="tm-address-row">
+                      <code>{chainInfo.owner}</code>
+                      <button
+                        className="tm-copy-btn"
+                        onClick={() => copyToClipboard(chainInfo.owner)}
+                      >
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                          <rect x="9" y="9" width="13" height="13" rx="2" />
+                          <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="tm-info-section">
+                <h4>Token Details</h4>
+                <div className="tm-info-grid">
+                  {chainInfo.totalSupply && (
+                    <div className="tm-info-item">
+                      <label>Total Supply</label>
+                      <span>{Number(chainInfo.totalSupply).toLocaleString()}</span>
+                    </div>
+                  )}
+                  {chainInfo.decimals && (
+                    <div className="tm-info-item">
+                      <label>Decimals</label>
+                      <span>{chainInfo.decimals}</span>
+                    </div>
+                  )}
+                  {chainInfo.balanceOfOwner && (
+                    <div className="tm-info-item">
+                      <label>Your Balance</label>
+                      <span>{Number(chainInfo.balanceOfOwner).toLocaleString()}</span>
+                    </div>
+                  )}
+                  {chainInfo.baseURI && (
+                    <div className="tm-info-item full-width">
+                      <label>Base URI</label>
+                      <span className="tm-uri">{chainInfo.baseURI}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              <div className="tm-info-section">
+                <h4>Features</h4>
+                <div className="tm-features-list">
+                  <div className={`tm-feature ${chainInfo.isPausable ? 'enabled' : 'disabled'}`}>
+                    <span className="feature-icon">{chainInfo.isPausable ? '✓' : '✗'}</span>
+                    Pausable
+                  </div>
+                  <div className={`tm-feature ${chainInfo.isBurnable ? 'enabled' : 'disabled'}`}>
+                    <span className="feature-icon">{chainInfo.isBurnable ? '✓' : '✗'}</span>
+                    Burnable
+                  </div>
+                  <div className={`tm-feature ${chainInfo.isPaused ? 'active' : ''}`}>
+                    <span className="feature-icon">{chainInfo.isPaused ? '⏸' : '▶'}</span>
+                    {chainInfo.isPaused ? 'Paused' : 'Active'}
+                  </div>
+                </div>
+              </div>
+
+              <div className="tm-info-section">
+                <h4>Deployment</h4>
+                <div className="tm-info-grid">
+                  <div className="tm-info-item">
+                    <label>Block Number</label>
+                    <span>{chainInfo.blockNumber.toLocaleString()}</span>
+                  </div>
+                  <div className="tm-info-item full-width">
+                    <label>Transaction Hash</label>
+                    <div className="tm-address-row">
+                      <code>{formatAddress(chainInfo.transactionHash)}</code>
+                      <button
+                        className="tm-copy-btn"
+                        onClick={() => copyToClipboard(chainInfo.transactionHash)}
+                      >
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                          <rect x="9" y="9" width="13" height="13" rx="2" />
+                          <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Action Modal */}
+        {actionModal && selectedItem && (
+          <div className="tm-action-modal-overlay" onClick={() => setActionModal(null)}>
+            <div className="tm-action-modal" onClick={e => e.stopPropagation()}>
+              <div className="tm-action-header">
+                <h3>{actionModal.charAt(0).toUpperCase() + actionModal.slice(1)} {selectedItem.name}</h3>
+                <button
+                  className="tm-action-close"
+                  onClick={() => setActionModal(null)}
+                  aria-label="Close"
+                >
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M18 6L6 18M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+              <div className="tm-action-body">
+                {actionModal === 'mint' && (
+                  <>
+                    <div className="tm-form-group">
+                      <label htmlFor="mint-address">Recipient Address</label>
+                      <input
+                        id="mint-address"
+                        type="text"
+                        placeholder="0x..."
+                        value={actionData.address || ''}
+                        onChange={(e) => setActionData({...actionData, address: e.target.value})}
+                      />
+                    </div>
+                    {selectedItem.type === 'ERC20' ? (
+                      <div className="tm-form-group">
+                        <label htmlFor="mint-amount">Amount</label>
+                        <input
+                          id="mint-amount"
+                          type="number"
+                          placeholder="1000"
+                          value={actionData.amount || ''}
+                          onChange={(e) => setActionData({...actionData, amount: e.target.value})}
+                        />
+                      </div>
+                    ) : (
+                      <div className="tm-form-group">
+                        <label htmlFor="mint-uri">Token URI</label>
+                        <input
+                          id="mint-uri"
+                          type="text"
+                          placeholder="ipfs://..."
+                          value={actionData.tokenURI || ''}
+                          onChange={(e) => setActionData({...actionData, tokenURI: e.target.value})}
+                        />
+                      </div>
+                    )}
+                  </>
+                )}
+
+                {actionModal === 'burn' && (
+                  <div className="tm-form-group">
+                    <label htmlFor="burn-amount">
+                      {selectedItem.type === 'ERC20' ? 'Amount to Burn' : 'Token ID to Burn'}
+                    </label>
+                    <input
+                      id="burn-amount"
+                      type="number"
+                      placeholder={selectedItem.type === 'ERC20' ? '1000' : '1'}
+                      value={actionData.amount || ''}
+                      onChange={(e) => setActionData({...actionData, amount: e.target.value})}
+                    />
+                  </div>
+                )}
+
+                {actionModal === 'transfer' && (
+                  <>
+                    <div className="tm-form-group">
+                      <label htmlFor="transfer-address">Recipient Address</label>
+                      <input
+                        id="transfer-address"
+                        type="text"
+                        placeholder="0x..."
+                        value={actionData.address || ''}
+                        onChange={(e) => setActionData({...actionData, address: e.target.value})}
+                      />
+                    </div>
+                    <div className="tm-form-group">
+                      <label htmlFor="transfer-amount">
+                        {selectedItem.type === 'ERC20' ? 'Amount' : 'Token ID'}
+                      </label>
+                      <input
+                        id="transfer-amount"
+                        type="number"
+                        placeholder={selectedItem.type === 'ERC20' ? '1000' : '1'}
+                        value={actionData.amount || ''}
+                        onChange={(e) => setActionData({...actionData, amount: e.target.value})}
+                      />
+                    </div>
+                  </>
+                )}
+
+                {actionModal === 'approve' && (
+                  <>
+                    <div className="tm-form-group">
+                      <label htmlFor="approve-spender">Spender Address</label>
+                      <input
+                        id="approve-spender"
+                        type="text"
+                        placeholder="0x..."
+                        value={actionData.spender || ''}
+                        onChange={(e) => setActionData({...actionData, spender: e.target.value})}
+                      />
+                    </div>
+                    <div className="tm-form-group">
+                      <label htmlFor="approve-amount">Amount</label>
+                      <input
+                        id="approve-amount"
+                        type="number"
+                        placeholder="Unlimited or specific amount"
+                        value={actionData.amount || ''}
+                        onChange={(e) => setActionData({...actionData, amount: e.target.value})}
+                      />
+                    </div>
+                  </>
+                )}
+
+                {actionModal === 'setApprovalForAll' && (
+                  <>
+                    <div className="tm-form-group">
+                      <label htmlFor="approval-operator">Operator Address</label>
+                      <input
+                        id="approval-operator"
+                        type="text"
+                        placeholder="0x..."
+                        value={actionData.operator || ''}
+                        onChange={(e) => setActionData({...actionData, operator: e.target.value})}
+                      />
+                    </div>
+                    <div className="tm-form-group checkbox">
+                      <input
+                        id="approval-approved"
+                        type="checkbox"
+                        checked={actionData.approved || false}
+                        onChange={(e) => setActionData({...actionData, approved: e.target.checked})}
+                      />
+                      <label htmlFor="approval-approved">Approve for all tokens</label>
+                    </div>
+                  </>
+                )}
+
+                {(actionModal === 'pause' || actionModal === 'unpause') && (
+                  <div className="tm-action-confirm">
+                    <p>
+                      Are you sure you want to {actionModal} <strong>{selectedItem.name}</strong>?
+                    </p>
+                    {actionModal === 'pause' && (
+                      <p className="tm-warning">
+                        This will prevent all token transfers until unpaused.
+                      </p>
+                    )}
+                  </div>
+                )}
+
+                {actionModal === 'transferOwnership' && (
+                  <div className="tm-form-group">
+                    <label htmlFor="new-owner">New Owner Address</label>
+                    <input
+                      id="new-owner"
+                      type="text"
+                      placeholder="0x..."
+                      value={actionData.newOwner || ''}
+                      onChange={(e) => setActionData({...actionData, newOwner: e.target.value})}
+                    />
+                    <span className="tm-field-hint">
+                      This action cannot be undone. Make sure the address is correct.
+                    </span>
+                  </div>
+                )}
+
+                {actionModal === 'renounceOwnership' && (
+                  <div className="tm-action-confirm danger">
+                    <p className="tm-danger-icon">⚠️</p>
+                    <p>
+                      Are you sure you want to renounce ownership of <strong>{selectedItem.name}</strong>?
+                    </p>
+                    <p className="tm-warning">
+                      This action is IRREVERSIBLE. No one will be able to manage this token after renouncing.
+                    </p>
+                    <div className="tm-form-group checkbox">
+                      <input
+                        id="confirm-renounce"
+                        type="checkbox"
+                        checked={actionData.confirmed || false}
+                        onChange={(e) => setActionData({...actionData, confirmed: e.target.checked})}
+                      />
+                      <label htmlFor="confirm-renounce">I understand this cannot be undone</label>
+                    </div>
+                  </div>
+                )}
+              </div>
+              <div className="tm-action-footer">
+                <button
+                  className="tm-btn-secondary"
+                  onClick={() => setActionModal(null)}
+                >
+                  Cancel
+                </button>
+                <button
+                  className={`tm-btn-primary ${actionModal === 'renounceOwnership' ? 'danger' : ''}`}
+                  onClick={executeAction}
+                  disabled={actionLoading || (actionModal === 'renounceOwnership' && !actionData.confirmed)}
+                >
+                  {actionLoading ? (
+                    <>
+                      <span className="tm-btn-spinner" />
+                      Processing...
+                    </>
+                  ) : (
+                    `Confirm ${actionModal.charAt(0).toUpperCase() + actionModal.slice(1)}`
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default TokenManagementModal


### PR DESCRIPTION
- Create TokenManagementModal component with tabbed interface for tokens, NFTs, and markets
- Implement clean paginated table with 10 items per page
- Add info panel for viewing on-chain token details (address, supply, features, deployment info)
- Include token management controls: mint, burn, pause/unpause, transfer, approve, transfer/renounce ownership
- Apply minimalist modern design with smooth animations
- Add responsive design for mobile devices
- Integrate modal into TokenMintButton dropdown menu