### PR TITLE
Add Blockscout links for transactions and contracts

### DIFF
--- a/frontend/src/components/fairwins/TokenManagementModal.css
+++ b/frontend/src/components/fairwins/TokenManagementModal.css
@@ -382,6 +382,27 @@
   cursor: not-allowed;
 }
 
+/* Explorer Link */
+.tm-explorer-link {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: #9ca3af;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  text-decoration: none;
+}
+
+.tm-explorer-link:hover {
+  background: rgba(59, 130, 246, 0.1);
+  color: #3b82f6;
+}
+
 /* Date */
 .td-date {
   color: #6b7280;

--- a/frontend/src/components/fairwins/TokenManagementModal.jsx
+++ b/frontend/src/components/fairwins/TokenManagementModal.jsx
@@ -3,6 +3,7 @@ import { ethers } from 'ethers'
 import { useWallet, useWeb3 } from '../../hooks'
 import { EXTENDED_ERC20_ABI } from '../../abis/ExtendedERC20'
 import { EXTENDED_ERC721_ABI } from '../../abis/ExtendedERC721'
+import { getAddressUrl, getTransactionUrl } from '../../config/blockExplorer'
 import './TokenManagementModal.css'
 
 /**
@@ -34,7 +35,7 @@ function TokenManagementModal({ isOpen, onClose }) {
   const [chainInfo, setChainInfo] = useState(null)
 
   const { address, isConnected } = useWallet()
-  const { signer, isCorrectNetwork } = useWeb3()
+  const { signer, isCorrectNetwork, chainId } = useWeb3()
 
   const ITEMS_PER_PAGE = 10
 
@@ -788,6 +789,19 @@ function TokenManagementModal({ isOpen, onClose }) {
                           <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
                         </svg>
                       </button>
+                      <a
+                        href={getAddressUrl(chainId || 63, chainInfo.contractAddress, 'contract')}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="tm-explorer-link"
+                        title="View on Blockscout"
+                      >
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                          <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" />
+                          <polyline points="15,3 21,3 21,9" />
+                          <line x1="10" y1="14" x2="21" y2="3" />
+                        </svg>
+                      </a>
                     </div>
                   </div>
                   <div className="tm-info-item full-width">
@@ -883,6 +897,21 @@ function TokenManagementModal({ isOpen, onClose }) {
                                 <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
                               </svg>
                             </button>
+                            {isValidHash && (
+                              <a
+                                href={getTransactionUrl(chainId || 63, chainInfo.transactionHash)}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="tm-explorer-link"
+                                title="View on Blockscout"
+                              >
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                  <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" />
+                                  <polyline points="15,3 21,3 21,9" />
+                                  <line x1="10" y1="14" x2="21" y2="3" />
+                                </svg>
+                              </a>
+                            )}
                           </>
                         )
                       })()}

--- a/frontend/src/components/ui/PremiumPurchaseModal.jsx
+++ b/frontend/src/components/ui/PremiumPurchaseModal.jsx
@@ -5,6 +5,7 @@ import { useWalletTransactions } from '../../hooks/useWalletManagement'
 import { useNotification } from '../../hooks/useUI'
 import { recordRolePurchase } from '../../utils/roleStorage'
 import { purchaseRoleWithUSC, registerZKKey } from '../../utils/blockchainService'
+import { getTransactionUrl } from '../../config/blockExplorer'
 import './PremiumPurchaseModal.css'
 
 /**
@@ -94,7 +95,7 @@ const ROLE_PRICES = {
 
 function PremiumPurchaseModal({ isOpen = true, onClose }) {
   const { ROLE_INFO, grantRole, hasRole } = useRoles()
-  const { account, isConnected, isCorrectNetwork, switchNetwork } = useWeb3()
+  const { account, isConnected, isCorrectNetwork, switchNetwork, chainId } = useWeb3()
   const { signer } = useWalletTransactions()
   const { showNotification } = useNotification()
 
@@ -626,7 +627,7 @@ function PremiumPurchaseModal({ isOpen = true, onClose }) {
                       </div>
                       {result.txHash && (
                         <a
-                          href={`https://blockscout.com/etc/mainnet/tx/${result.txHash}`}
+                          href={getTransactionUrl(chainId || 63, result.txHash)}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="ppm-tx-link"

--- a/frontend/src/config/blockExplorer.js
+++ b/frontend/src/config/blockExplorer.js
@@ -1,0 +1,90 @@
+/**
+ * Blockscout Block Explorer Configuration
+ *
+ * Centralized configuration for Blockscout URLs across the application.
+ * All explorer links should use these utilities to ensure consistency.
+ */
+
+// Blockscout base URLs by chain ID
+export const BLOCKSCOUT_URLS = {
+  61: 'https://etc.blockscout.com',      // ETC Mainnet
+  63: 'https://etc-mordor.blockscout.com', // Mordor Testnet
+}
+
+/**
+ * Get the Blockscout base URL for a given chain ID
+ * @param {number} chainId - The chain ID (61 for mainnet, 63 for Mordor)
+ * @returns {string} The Blockscout base URL
+ */
+export const getBlockscoutBaseUrl = (chainId) => {
+  return BLOCKSCOUT_URLS[chainId] || BLOCKSCOUT_URLS[63] // Default to Mordor
+}
+
+/**
+ * Get the full Blockscout URL for an address, transaction, or block
+ * @param {number} chainId - The chain ID
+ * @param {string} hash - The address, transaction hash, or block number
+ * @param {'address' | 'tx' | 'block' | 'token'} type - The type of resource
+ * @returns {string} The full Blockscout URL
+ */
+export const getBlockscoutUrl = (chainId, hash, type = 'address') => {
+  const baseUrl = getBlockscoutBaseUrl(chainId)
+  return `${baseUrl}/${type}/${hash}`
+}
+
+/**
+ * Get Blockscout URL for an address with optional tab
+ * @param {number} chainId - The chain ID
+ * @param {string} address - The contract or wallet address
+ * @param {'contract' | 'transactions' | 'token_transfers' | 'internal_txns'} tab - Optional tab to open
+ * @returns {string} The full Blockscout URL with optional tab
+ */
+export const getAddressUrl = (chainId, address, tab = null) => {
+  const baseUrl = getBlockscoutBaseUrl(chainId)
+  const url = `${baseUrl}/address/${address}`
+  return tab ? `${url}?tab=${tab}` : url
+}
+
+/**
+ * Get Blockscout URL for a transaction
+ * @param {number} chainId - The chain ID
+ * @param {string} txHash - The transaction hash
+ * @returns {string} The full Blockscout URL for the transaction
+ */
+export const getTransactionUrl = (chainId, txHash) => {
+  const baseUrl = getBlockscoutBaseUrl(chainId)
+  return `${baseUrl}/tx/${txHash}`
+}
+
+/**
+ * Get Blockscout URL for a block
+ * @param {number} chainId - The chain ID
+ * @param {string | number} blockNumber - The block number
+ * @returns {string} The full Blockscout URL for the block
+ */
+export const getBlockUrl = (chainId, blockNumber) => {
+  const baseUrl = getBlockscoutBaseUrl(chainId)
+  return `${baseUrl}/block/${blockNumber}`
+}
+
+/**
+ * Get Blockscout URL for a token page
+ * @param {number} chainId - The chain ID
+ * @param {string} tokenAddress - The token contract address
+ * @returns {string} The full Blockscout URL for the token
+ */
+export const getTokenUrl = (chainId, tokenAddress) => {
+  const baseUrl = getBlockscoutBaseUrl(chainId)
+  return `${baseUrl}/token/${tokenAddress}`
+}
+
+// Default export for convenience
+export default {
+  BLOCKSCOUT_URLS,
+  getBlockscoutBaseUrl,
+  getBlockscoutUrl,
+  getAddressUrl,
+  getTransactionUrl,
+  getBlockUrl,
+  getTokenUrl,
+}

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -44,5 +44,5 @@ export const NETWORK_CONFIG = {
   chainId: parseInt(import.meta.env.VITE_NETWORK_ID || '63', 10),
   name: 'Mordor Testnet',
   rpcUrl: import.meta.env.VITE_RPC_URL || 'https://rpc.mordor.etccooperative.org',
-  blockExplorer: 'https://blockscout.com/etc/mordor'
+  blockExplorer: 'https://etc-mordor.blockscout.com'
 }

--- a/frontend/src/thirdweb.js
+++ b/frontend/src/thirdweb.js
@@ -46,8 +46,8 @@ export const ethereumClassic = defineChain({
   rpc: networkId === 61 ? rpcUrl : 'https://etc.rivet.link',
   blockExplorers: [
     {
-      name: 'BlockScout',
-      url: 'https://blockscout.com/etc/mainnet',
+      name: 'Blockscout',
+      url: 'https://etc.blockscout.com',
     },
   ],
   testnet: false,
@@ -65,8 +65,8 @@ export const mordor = defineChain({
   rpc: rpcUrl,
   blockExplorers: [
     {
-      name: 'BlockScout',
-      url: 'https://blockscout.com/etc/mordor',
+      name: 'Blockscout',
+      url: 'https://etc-mordor.blockscout.com',
     },
   ],
   testnet: true,

--- a/frontend/src/wagmi.js
+++ b/frontend/src/wagmi.js
@@ -15,7 +15,7 @@ const ethereumClassic = {
     public: { http: ['https://etc.rivet.link'] },
   },
   blockExplorers: {
-    default: { name: 'BlockScout', url: 'https://blockscout.com/etc/mainnet' },
+    default: { name: 'Blockscout', url: 'https://etc.blockscout.com' },
   },
   testnet: false,
 }
@@ -34,7 +34,7 @@ const mordor = {
     public: { http: ['https://rpc.mordor.etccooperative.org'] },
   },
   blockExplorers: {
-    default: { name: 'BlockScout', url: 'https://blockscout.com/etc/mordor' },
+    default: { name: 'Blockscout', url: 'https://etc-mordor.blockscout.com' },
   },
   testnet: true,
 }


### PR DESCRIPTION
- Create centralized blockExplorer.js utility with URL generation functions
- Update wagmi.js and thirdweb.js to use etc.blockscout.com/etc-mordor.blockscout.com URLs
- Fix PremiumPurchaseModal to use dynamic chain-aware explorer links
- Add Blockscout links to TokenManagementModal for contract addresses and tx hashes
- Update contracts.js NETWORK_CONFIG with correct Blockscout URL format