### PR TITLE
Debug failing Manticore test logs

### DIFF
--- a/scripts/utils/run-manticore.py
+++ b/scripts/utils/run-manticore.py
@@ -56,7 +56,12 @@ def main():
     # Add remappings as solc arguments
     for remap in remappings:
         cmd.extend(['--solc-remaps', remap])
-    
+
+    # Pass --via-ir to solc to enable IR-based compilation
+    # This is required for complex contracts that would otherwise fail with "Stack too deep" errors
+    # The Hardhat config uses viaIR: true, so we need to match that for Manticore
+    cmd.extend(['--solc-args', '--via-ir'])
+
     # Set verbosity
     cmd.extend(['-v'])
     


### PR DESCRIPTION
Pass --via-ir to solc when running Manticore symbolic execution to match the Hardhat config's viaIR: true setting. This fixes "Stack too deep" compilation errors for complex contracts like ProposalRegistry, ConditionalMarketFactory, DAOFactory, ETCSwapV3Integration, and FutarchyGovernor.

Without this flag, solc would fail with stack depth issues, causing Manticore to throw 'NoneType' object has no attribute 'result' errors when trying to access transaction results from failed compilations.