### PR TITLE
fix: address Slither static analysis findings

### DIFF
--- a/contracts/access/MembershipPaymentManager.sol
+++ b/contracts/access/MembershipPaymentManager.sol
@@ -309,6 +309,8 @@ contract MembershipPaymentManager is AccessControl, ReentrancyGuard, Pausable {
     ) external nonReentrant whenNotPaused returns (bytes32) {
         require(payer != address(0), "Invalid payer");
         require(buyer != address(0), "Invalid buyer");
+        // Security: Only allow msg.sender to pay, preventing arbitrary from in transferFrom
+        require(payer == msg.sender, "Payer must be msg.sender");
         require(amount > 0, "Amount must be greater than 0");
         require(paymentTokens[paymentToken].isActive, "Payment token not active");
         require(rolePricing[role].isActive, "Role pricing not configured");

--- a/contracts/core/WelfareMetricRegistry.sol
+++ b/contracts/core/WelfareMetricRegistry.sol
@@ -152,10 +152,11 @@ contract WelfareMetricRegistry is Ownable, ReentrancyGuard {
 
         metrics[metricId].active = false;
 
-        // Remove from active array
-        for (uint256 i = 0; i < activeMetricIds.length; i++) {
+        // Remove from active array - cache length for gas optimization
+        uint256 length = activeMetricIds.length;
+        for (uint256 i = 0; i < length; i++) {
             if (activeMetricIds[i] == metricId) {
-                activeMetricIds[i] = activeMetricIds[activeMetricIds.length - 1];
+                activeMetricIds[i] = activeMetricIds[length - 1];
                 activeMetricIds.pop();
                 break;
             }

--- a/contracts/markets/ConditionalMarketFactory.sol
+++ b/contracts/markets/ConditionalMarketFactory.sol
@@ -725,8 +725,8 @@ contract ConditionalMarketFactory is Ownable, ReentrancyGuard, IERC1155Receiver 
             // Transfer collateral from buyer to this contract
             IERC20(market.collateralToken).safeTransferFrom(msg.sender, address(this), amount);
             
-            // Approve ETCSwap integration to spend collateral
-            IERC20(market.collateralToken).approve(address(etcSwapIntegration), amount);
+            // Approve ETCSwap integration to spend collateral (using forceApprove for safety)
+            IERC20(market.collateralToken).forceApprove(address(etcSwapIntegration), amount);
             
             // Calculate minimum output with slippage protection
             // Use quoter to estimate output and apply default slippage tolerance
@@ -776,8 +776,8 @@ contract ConditionalMarketFactory is Ownable, ReentrancyGuard, IERC1155Receiver 
             // Transfer collateral from buyer to this contract
             IERC20(market.collateralToken).safeTransferFrom(msg.sender, address(this), amount);
             
-            // Approve CTF1155 to spend collateral
-            IERC20(market.collateralToken).approve(address(ctf1155), amount);
+            // Approve CTF1155 to spend collateral (using forceApprove for safety)
+            IERC20(market.collateralToken).forceApprove(address(ctf1155), amount);
             
             // Split collateral into BOTH position tokens (binary market)
             // CTF1155 requires partition with at least 2 elements
@@ -851,8 +851,8 @@ contract ConditionalMarketFactory is Ownable, ReentrancyGuard, IERC1155Receiver 
             // Transfer tokens from seller to this contract
             IERC20(outcomeToken).safeTransferFrom(msg.sender, address(this), tokenAmount);
             
-            // Approve ETCSwap integration to spend outcome tokens
-            IERC20(outcomeToken).approve(address(etcSwapIntegration), tokenAmount);
+            // Approve ETCSwap integration to spend outcome tokens (using forceApprove for safety)
+            IERC20(outcomeToken).forceApprove(address(etcSwapIntegration), tokenAmount);
             
             // Calculate minimum output with slippage protection
             // Use quoter to estimate output and apply default slippage tolerance

--- a/contracts/privacy/ZKVerifier.sol
+++ b/contracts/privacy/ZKVerifier.sol
@@ -226,24 +226,22 @@ contract ZKVerifier is AccessControl {
      */
     function _decodeProof(bytes calldata proofBytes) internal pure returns (Proof memory) {
         require(proofBytes.length >= 256, "Proof too short");
-        
-        Proof memory proof;
-        
-        // Decode A (64 bytes = 2 * 32 bytes)
-        proof.a[0] = uint256(bytes32(proofBytes[0:32]));
-        proof.a[1] = uint256(bytes32(proofBytes[32:64]));
-        
-        // Decode B (128 bytes = 2 * 2 * 32 bytes)
-        proof.b[0][0] = uint256(bytes32(proofBytes[64:96]));
-        proof.b[0][1] = uint256(bytes32(proofBytes[96:128]));
-        proof.b[1][0] = uint256(bytes32(proofBytes[128:160]));
-        proof.b[1][1] = uint256(bytes32(proofBytes[160:192]));
-        
-        // Decode C (64 bytes = 2 * 32 bytes)
-        proof.c[0] = uint256(bytes32(proofBytes[192:224]));
-        proof.c[1] = uint256(bytes32(proofBytes[224:256]));
-        
-        return proof;
+
+        // Decode proof components directly into struct literal to avoid uninitialized variable
+        return Proof({
+            a: [
+                uint256(bytes32(proofBytes[0:32])),
+                uint256(bytes32(proofBytes[32:64]))
+            ],
+            b: [
+                [uint256(bytes32(proofBytes[64:96])), uint256(bytes32(proofBytes[96:128]))],
+                [uint256(bytes32(proofBytes[128:160])), uint256(bytes32(proofBytes[160:192]))]
+            ],
+            c: [
+                uint256(bytes32(proofBytes[192:224])),
+                uint256(bytes32(proofBytes[224:256]))
+            ]
+        });
     }
     
     /**

--- a/test/MembershipPaymentManager.test.js
+++ b/test/MembershipPaymentManager.test.js
@@ -353,8 +353,8 @@ describe("MembershipPaymentManager - Unit Tests", function () {
 
     it("Should process payment successfully", async function () {
       const amount = ethers.parseUnits("100", 6);
-      
-      const tx = await paymentManager.processPayment(buyer1.address, buyer1.address, MARKET_MAKER_ROLE,
+
+      const tx = await paymentManager.connect(buyer1).processPayment(buyer1.address, buyer1.address, MARKET_MAKER_ROLE,
         await mockToken1.getAddress(),
         amount,
         0 // tier 0
@@ -390,7 +390,7 @@ describe("MembershipPaymentManager - Unit Tests", function () {
       );
       
       await expect(
-        paymentManager.processPayment(buyer1.address, buyer1.address, MARKET_MAKER_ROLE,
+        paymentManager.connect(buyer1).processPayment(buyer1.address, buyer1.address, MARKET_MAKER_ROLE,
           await mockToken1.getAddress(),
           ethers.parseUnits("100", 6),
           0
@@ -400,7 +400,7 @@ describe("MembershipPaymentManager - Unit Tests", function () {
 
     it("Should reject payment with insufficient amount", async function () {
       await expect(
-        paymentManager.processPayment(buyer1.address, buyer1.address, MARKET_MAKER_ROLE,
+        paymentManager.connect(buyer1).processPayment(buyer1.address, buyer1.address, MARKET_MAKER_ROLE,
           await mockToken1.getAddress(),
           ethers.parseUnits("50", 6), // Less than required 100
           0
@@ -410,7 +410,7 @@ describe("MembershipPaymentManager - Unit Tests", function () {
 
     it("Should reject payment for role with no price set", async function () {
       await expect(
-        paymentManager.processPayment(buyer1.address, buyer1.address, CLEARPATH_USER_ROLE, // No price set
+        paymentManager.connect(buyer1).processPayment(buyer1.address, buyer1.address, CLEARPATH_USER_ROLE, // No price set
           await mockToken1.getAddress(),
           ethers.parseUnits("100", 6),
           0
@@ -422,10 +422,10 @@ describe("MembershipPaymentManager - Unit Tests", function () {
       const recipients = [recipient1.address, recipient2.address];
       const basisPoints = [7000, 3000]; // 70% and 30%
       await paymentManager.connect(treasuryAdmin).setPaymentRouting(recipients, basisPoints);
-      
+
       const amount = ethers.parseUnits("100", 6);
-      
-      await paymentManager.processPayment(buyer1.address, buyer1.address, MARKET_MAKER_ROLE,
+
+      await paymentManager.connect(buyer1).processPayment(buyer1.address, buyer1.address, MARKET_MAKER_ROLE,
         await mockToken1.getAddress(),
         amount,
         0
@@ -438,39 +438,39 @@ describe("MembershipPaymentManager - Unit Tests", function () {
 
     it("Should track user payment history", async function () {
       const amount = ethers.parseUnits("100", 6);
-      
-      await paymentManager.processPayment(buyer1.address, buyer1.address, MARKET_MAKER_ROLE,
+
+      await paymentManager.connect(buyer1).processPayment(buyer1.address, buyer1.address, MARKET_MAKER_ROLE,
         await mockToken1.getAddress(),
         amount,
         0
       );
-      
+
       const userPayments = await paymentManager.getUserPayments(buyer1.address);
       expect(userPayments.length).to.equal(1);
     });
 
     it("Should handle multiple payments from same user", async function () {
       const amount = ethers.parseUnits("100", 6);
-      
-      await paymentManager.processPayment(buyer1.address, buyer1.address, MARKET_MAKER_ROLE,
+
+      await paymentManager.connect(buyer1).processPayment(buyer1.address, buyer1.address, MARKET_MAKER_ROLE,
         await mockToken1.getAddress(),
         amount,
         0
       );
-      
+
       // Set price for another role
       await paymentManager.connect(pricingAdmin).setRolePrice(
         CLEARPATH_USER_ROLE,
         await mockToken1.getAddress(),
         ethers.parseUnits("250", 6)
       );
-      
-      await paymentManager.processPayment(buyer1.address, buyer1.address, CLEARPATH_USER_ROLE,
+
+      await paymentManager.connect(buyer1).processPayment(buyer1.address, buyer1.address, CLEARPATH_USER_ROLE,
         await mockToken1.getAddress(),
         ethers.parseUnits("250", 6),
         1 // tier 1
       );
-      
+
       const userPayments = await paymentManager.getUserPayments(buyer1.address);
       expect(userPayments.length).to.equal(2);
       expect(await paymentManager.totalPaymentsCount()).to.equal(2);
@@ -501,7 +501,7 @@ describe("MembershipPaymentManager - Unit Tests", function () {
       );
       
       // Process payment and get ID from event
-      const tx = await paymentManager.processPayment(buyer1.address, buyer1.address, MARKET_MAKER_ROLE,
+      const tx = await paymentManager.connect(buyer1).processPayment(buyer1.address, buyer1.address, MARKET_MAKER_ROLE,
         await mockToken1.getAddress(),
         price,
         0
@@ -701,9 +701,9 @@ describe("MembershipPaymentManager - Unit Tests", function () {
       );
       
       await paymentManager.connect(paymentAdmin).pause();
-      
+
       await expect(
-        paymentManager.processPayment(buyer1.address, buyer1.address, MARKET_MAKER_ROLE,
+        paymentManager.connect(buyer1).processPayment(buyer1.address, buyer1.address, MARKET_MAKER_ROLE,
           await mockToken1.getAddress(),
           price,
           0


### PR DESCRIPTION
Security fixes:
- MembershipPaymentManager: Require payer == msg.sender to prevent arbitrary from address in transferFrom vulnerability
- ZKVerifier: Initialize proof struct with literal to fix uninitialized local variable warning

Code quality improvements:
- ConditionalMarketFactory: Use forceApprove instead of approve to properly handle return values and non-standard tokens
- WelfareMetricRegistry: Cache activeMetricIds.length in deactivateMetric loop for gas optimization

These changes address high and medium severity findings from Slither static analysis.