### PR TITLE
feat: Add Polymarket oracle resolution for private markets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,804 +1,293 @@
-![](docs/assets/logo_fairwins.svg)
+# FairWins — P2P Wager Management Layer
 
-# FairWins — Prediction Market Platform Suite
+> A smart contract infrastructure for managing peer-to-peer wagers that resolve based on external oracle sources.
 
-> FairWins is not a place to bet on outcomes.
-It is a system designed to discover, discipline, and distill information—
-even when participants are automated, strategic, and adversarial.
+FairWins is **not** a prediction market. It's a wager management layer that enables friends and groups to create private wagers that automatically resolve based on trusted external sources like Polymarket, Chainlink price feeds, and UMA's optimistic oracle.
 
-**Clear signals for collective decisions** — A comprehensive prediction market platform with optional DAO governance capabilities:
+## Key Insight
 
-- **FairWins** (Primary): Open prediction markets for anyone to create, join, and resolve markets
-
-- **ClearPath** (Add-on): Futarchy-based DAO governance feature for institutional decision-making
-- **TokenMint** (Add-on): Enterprise token management
-  
-The platform integrates privacy-preserving mechanisms from Nightmarket (zero-knowledge position encryption), anti-collusion infrastructure from MACI (encrypted key-change voting), and Gnosis Conditional Token Framework standards for market mechanics.
-
-## Build Status
-
-[![Frontend Testing](https://github.com/chippr-robotics/prediction-dao-research/actions/workflows/frontend-testing.yml/badge.svg)](https://github.com/chippr-robotics/prediction-dao-research/actions/workflows/frontend-testing.yml)
-[![Smart Contract Tests](https://github.com/chippr-robotics/prediction-dao-research/actions/workflows/test.yml/badge.svg)](https://github.com/chippr-robotics/prediction-dao-research/actions/workflows/test.yml)
-[![Torture Testing](https://github.com/chippr-robotics/prediction-dao-research/actions/workflows/torture-test.yml/badge.svg)](https://github.com/chippr-robotics/prediction-dao-research/actions/workflows/torture-test.yml)
-
-## Mordor Contracts
-
-Contracts are deployed at the following addresses:
-
-
-- WelfareMetricRegistry: [0x7F57BB570cc66f706A9F506dba84F1e419f3530c](https://etc-mordor.blockscout.com/address/0x7F57BB570cc66f706A9F506dba84F1e419f3530c)
-- ProposalRegistry: [0xC2B9047eC8DEc58a0b601428079382dCcF9d4541](https://etc-mordor.blockscout.com/address/0xC2B9047eC8DEc58a0b601428079382dCcF9d4541)
-- ConditionalMarketFactory: [0xbf243E69dF76Bfa3561B7B1c80C1966BA2BEAd34](https://etc-mordor.blockscout.com/address/0xbf243E69dF76Bfa3561B7B1c80C1966BA2BEAd34)
-- PrivacyCoordinator: [0xB8400de133343850a2ef6dDC1B93Feb7FEc24DB9](https://etc-mordor.blockscout.com/address/0xB8400de133343850a2ef6dDC1B93Feb7FEc24DB9)
-- OracleResolver: [0x9A669A42d481d519406285637827EBaC6Ee0B80A](https://etc-mordor.blockscout.com/address/0x9A669A42d481d519406285637827EBaC6Ee0B80A)
-- RagequitModule: [0xE494d7548dc3DAc0FAcC44609e97089c8D424CA8](https://etc-mordor.blockscout.com/address/0xE494d7548dc3DAc0FAcC44609e97089c8D424CA8)
-- FutarchyGovernor: [0x396C25b831fF3675fC93d8E69c61b8D9662FCd37](https://etc-mordor.blockscout.com/address/0x396C25b831fF3675fC93d8E69c61b8D9662FCd37)
-
-## 📚 Documentation
-
-**[View the full documentation →](https://docs.FairWins.app)**
-
-The documentation site provides comprehensive guides for both platforms:
-- **User Experience**: Complete narrative guides walking through user journeys, practical scenarios, and interface understanding
-- **Users**: Getting started, choosing platforms, trading on markets, submitting proposals
-- **Developers**: Setup instructions, architecture, API reference
-- **System Overview**: How it works, privacy mechanisms, security model
-
-## Platform Overview
-
-### 🎯 FairWins — Prediction Markets for Friends (Primary Platform)
-
-FairWins is the main prediction market platform where:
-- **Anyone can create markets** on any topic with custom parameters
-- **Flexible controls** allow market creators to set resolution criteria
-- **Fair participation** enables anyone to trade based on their knowledge
-- **Transparent resolution** ensures trust and accountability
-
-**Market Types:**
-1. **Public Markets** - Open to all users with full oracle support
-2. **Friend Group Markets** (P2P Betting) - Private markets between friends with:
-   - **Gas-only markets**: Members pay only gas fees (creation fees waived)
-   - **ERC20 support**: Pay with USDC, USDT, or other stablecoins
-   - **USD pricing**: All prices displayed in USD for clarity
-   - **Monthly allocations**: Bronze (15), Silver (30), Gold (100), Platinum (Unlimited)
-   - **Membership durations**: 1, 3, 6, 12 months, or enterprise
-   - Member limits (2-10 participants)
-   - Optional third-party arbitration
-   - Market pegging to public markets for automatic settlement
-   - Support for 1v1 bets, group prop bets, and event tracking
-   - **Updateable pricing**: Managers can adjust fees and limits
-
-**Use Cases:**
-- Event outcome predictions
-- Financial market forecasting
-- Sports and entertainment betting
-- Community sentiment tracking
-- **Friend group betting** (competitive events, prop bets, office pools)
-
-### 🏛️ ClearPath — DAO Governance (Add-on Feature)
-
-ClearPath is an optional add-on feature within FairWins for DAO governance, offering **two governance modes**:
-
-#### Futarchy Governance (Prediction Markets)
-- **Democratic voting** establishes welfare metrics (protocol success measures)
-- **Prediction markets** aggregate distributed knowledge about which proposals maximize those metrics
-- **Privacy mechanisms** prevent collusion and vote buying
-- **Conditional tokens** enable efficient market-based decision making
-
-#### Traditional Democracy Voting
-- **Token-weighted voting** where 1 token = 1 vote
-- **Direct voting** with For, Against, and Abstain options
-- **Configurable quorum** requirements (default 40% of supply)
-- **Simple majority** determines proposal approval
-- **Timelock period** for execution safety
-
-**Use Cases:**
-- DAO treasury management
-- Institutional governance
-- Protocol upgrades and parameter changes
-- Grant allocation and funding decisions
-- Enterprise-friendly traditional voting
-
-### 🪙 TokenMint — Enterprise Token Management (Add-on Feature)
-
-TokenMint is an optional add-on feature for creating and managing custom tokens:
-- **Token creation** with configurable parameters
-- **Vesting schedules** for controlled distribution
-- **Access control** and role-based permissions
-- **Integration** with FairWins markets and ClearPath governance
-
-**Use Cases:**
-- DAO token issuance
-- Reward token creation
-- Governance token management
-- Community token distribution
-
-## Shared Infrastructure
-
-Both platforms are built on the same secure, privacy-preserving foundation:
-
-## System Components
-
-### Smart Contracts (Shared Infrastructure)
-
-1. **FutarchyGovernor.sol** - Main futarchy governance coordinator
-   - Integrates all futarchy components
-   - Manages proposal lifecycle from submission to execution
-   - Implements timelock and emergency pause mechanisms
-   - Used by: ClearPath (Futarchy mode)
-
-2. **TraditionalGovernor.sol** - Traditional democracy governance
-   - Token-weighted voting with For/Against/Abstain options
-   - Configurable voting period and quorum requirements
-   - Timelock and daily spending limits
-   - Emergency pause and guardian controls
-   - Used by: ClearPath (Traditional mode)
-
-3. **WelfareMetricRegistry.sol** - Welfare metrics management
-   - On-chain storage of democratically-selected protocol success measures
-   - Versioning and weight update mechanisms
-   - Primary, secondary, tertiary, and quaternary metrics
-   - Used by: ClearPath
-
-3. **ProposalRegistry.sol** - Proposal submission and management
-   - Permissionless proposal submission with bond requirements
-   - Standardized metadata schemas
-   - Milestone tracking and completion criteria
-   - Used by: Both governance modes
-
-4. **ConditionalMarketFactory.sol** - Market deployment
-   - Automated deployment of PASS/FAIL market pairs
-   - Based on Gnosis Conditional Token Framework standards
-   - LMSR (Logarithmic Market Scoring Rule) for market making
-   - Used by: Both platforms (core component)
-
-5. **PrivacyCoordinator.sol** - Privacy and anti-collusion
-   - MACI-style encrypted message submission
-   - Key-change capability to prevent vote buying
-   - Nightmarket-style position encryption with zkSNARK proofs
-   - Poseidon hash commitments for privacy
-   - Used by: Both platforms
-
-6. **OracleResolver.sol** - Multi-stage oracle resolution
-   - Designated reporting phase
-   - Open challenge period
-   - UMA-style escalation mechanism
-   - Bond-based dispute resolution
-   - Used by: Both platforms
-
-7. **RagequitModule.sol** - Minority protection
-   - Moloch-style ragequit functionality
-   - Allows dissenting token holders to exit with proportional treasury share
-   - Prevents forced participation in controversial proposals
-   - Used by: ClearPath
+Rather than compete with established prediction markets, FairWins **leverages** them. When you and your friends want to bet on whether Bitcoin will hit $100k, FairWins handles the stake management, dispute resolution, and payout distribution—while the actual outcome is determined by battle-tested oracles.
 
 ## Features
 
-### Privacy Mechanisms
-- **Zero-Knowledge Position Encryption**: Uses Poseidon encryption and Groth16 zkSNARKs for private trading
-- **MACI Integration**: Key-change messages prevent verifiable vote buying
-- **Batched Submissions**: Prevents timing analysis and correlation attacks
+### Multi-Oracle Resolution
 
-### Anti-Collusion
-- **Encrypted Voting**: MACI-style encrypted key changes invalidate previous commitments
-- **Position Privacy**: Nightmarket-style encryption hides individual positions
-- **Non-Verifiable Commitments**: Participants can change keys to break collusion agreements
+Create wagers that resolve from multiple oracle sources:
 
-### Market Mechanics
-- **Conditional Tokens**: Gnosis CTF-compatible PASS/FAIL tokens
-- **LMSR Market Making**: Automated liquidity provision with bounded loss
-- **Multiple Trading Periods**: 7-21 day configurable trading windows
-- **Time-Weighted Pricing**: Reduces manipulation through TWAP oracles
+| Oracle | Use Case | Resolution Type |
+|--------|----------|-----------------|
+| **Polymarket** | Event outcomes | Binary YES/NO markets |
+| **Chainlink** | Price targets | Above/below thresholds |
+| **UMA** | Custom claims | Optimistic assertion with disputes |
+| **Manual** | Friend disputes | Challenge period + arbitration |
 
-## Friend Group Markets (P2P Betting)
+### Friend Group Markets
 
-Friend Group Markets enable prediction markets between trusted groups with reduced costs and simplified operations.
+Private wagers between trusted groups with:
 
-### Key Features
+- **1v1 Markets**: Direct bets between two parties
+- **Group Markets**: 3-10 participants for pools and props
+- **Market Pegging**: Auto-resolve based on Polymarket outcomes
+- **Manual Resolution**: Creator-resolved with challenge period
 
-#### Reduced Creation Costs
-- **1v1 Markets**: 0.05 ETH (90% cheaper than public markets)
-- **Small Group Markets**: 0.1 ETH (10-90% cheaper)
-- **Public Markets**: 1 ETH (standard fee)
+### Safety Mechanisms
 
-#### Market Types
+- **24-hour Challenge Period**: Dispute manual resolutions before finalization
+- **90-day Claim Timeout**: Unclaimed funds return to treasury
+- **30-day Oracle Timeout**: Stuck markets trigger mutual refund option
+- **Stake Escrow**: All funds locked in contract until resolution
 
-1. **One-vs-One (1v1)**
-   - Direct betting between two parties
-   - Optional third-party arbitrator
-   - Lowest creation fee (0.05 ETH)
-   - Perfect for friendly wagers
-
-2. **Small Group Markets**
-   - 3-10 participants
-   - Ideal for office pools and friend groups
-   - Collaborative betting environment
-   - Moderate creation fee (0.1 ETH)
-
-3. **Event Tracking Markets**
-   - Track competitive events and tournaments
-   - 3-10 players
-   - Transparent accounting
-   - Automatic settlement
-
-4. **Prop Bet Markets**
-   - General proposition betting
-   - Flexible member limits
-   - Custom resolution criteria
-
-#### Member Limits (Anti-Bypass Protection)
-- Prevents friend markets from bypassing public markets
-- 1v1: Exactly 2 participants
-- Small Groups: Maximum 10 concurrent members
-- Event Tracking: 3-10 players
-
-#### Market Pegging for Easy Settlement
-- **Peg to public markets** for automatic resolution
-- No manual arbitration needed
-- Transparent, verifiable outcomes
-- Batch resolution supported
-
-#### Arbitration Options
-- **No arbitrator**: For simple, objective outcomes
-- **Third-party arbitrator**: Neutral friend for disputes
-- **Market pegging**: Automatic based on public market
-- **Creator resolution**: For event tracking and monitoring
-
-#### Ragequit Protection
-- Integrated with existing RagequitModule
-- Exit with proportional treasury share
-- Protection for dissenting participants
-- Fair exit mechanism
-
-### Safety and Risk Warnings
-
-⚠️ **CRITICAL: Smart Contract Risks** ⚠️
-
-Friend markets create irreversible smart contracts. Before participating:
-- **No one controls outcomes** - Not you, your friends, or FairWins
-- **Use at your own risk** - You are solely responsible
-- **Only bet with trusted friends** you know in real life
-- **Read the safety guide** - Required before creating markets
-
-**📚 [Complete Safety Guide](docs/FRIEND_MARKET_SAFETY_GUIDE.md)** - **REQUIRED READING**
-
-**🚨 [Scam Prevention Guide](docs/FRIEND_MARKET_SAFETY_GUIDE.md#how-to-spot-scams)** - Learn red flags
-
-### Smart Contracts
-
-**FriendGroupMarketFactory.sol** - Factory for creating friend markets
-- Manages market creation and lifecycle
-- Enforces member limits
-- Handles market pegging
-- Integrates with ConditionalMarketFactory and RagequitModule
-
-### Example Use Cases
-
-#### 1. Competitive Event Tracking
-```solidity
-// Track a competitive event or tournament
-createEventTrackingMarket(
-  "Friday Night Game Tournament",
-  [player1, player2, player3, player4],
-  7 days,
-  0  // No pegging
-);
-```
-
-#### 2. 1v1 Sports Bet
-```solidity
-// Bet on tonight's game with a friend
-createOneVsOneMarket(
-  friend,
-  "Lakers beat Warriors tonight?",
-  1 days,
-  mutualFriend,  // Arbitrator
-  0  // No pegging
-);
-```
-
-#### 3. Office Pool Pegged to Public Market
-```solidity
-// Office pool that settles based on public election market
-createSmallGroupMarket(
-  "Office 2024 Election Pool",
-  [alice, bob, carol, dave],
-  10,  // Max 10 members
-  90 days,
-  address(0),  // No arbitrator needed
-  publicElectionMarketId  // Auto-settle based on public market
-);
-```
-
-## Project Structure
+## Architecture
 
 ```
-prediction-dao-research/
-├── contracts/              # Solidity smart contracts
-│   ├── FutarchyGovernor.sol
-│   ├── TraditionalGovernor.sol
-│   ├── WelfareMetricRegistry.sol
-│   ├── ProposalRegistry.sol
-│   ├── ConditionalMarketFactory.sol
-│   ├── FriendGroupMarketFactory.sol  # NEW: P2P betting markets
-│   ├── PrivacyCoordinator.sol
-│   ├── OracleResolver.sol
-│   └── RagequitModule.sol
-├── test/                   # Contract tests
-│   ├── WelfareMetricRegistry.test.js
-│   ├── ProposalRegistry.test.js
-│   └── FriendGroupMarketFactory.test.js  # NEW: Friend market tests
-├── docs/                   # Documentation
-│   ├── FRIEND_MARKET_SAFETY_GUIDE.md     # NEW: Safety warnings & scam prevention
-│   └── FRIEND_MARKET_WARNING_UI.md        # NEW: UI warning components
-├── frontend/              # React frontend application
-│   ├── src/
-│   │   ├── components/   # React components
-│   │   │   ├── ProposalSubmission.jsx
-│   │   │   ├── ProposalList.jsx
-│   │   │   ├── WelfareMetrics.jsx
-│   │   │   └── MarketTrading.jsx
-│   │   ├── App.jsx       # Main application
-│   │   └── App.css       # Styling
-│   └── package.json
-├── scripts/              # Deployment scripts
-├── hardhat.config.js    # Hardhat configuration
-└── README.md
-
+┌─────────────────────────────────────────────────────────────┐
+│                    FriendGroupMarketFactory                 │
+│  • Create wagers  • Manage stakes  • Handle resolutions     │
+└────────────────────────┬────────────────────────────────────┘
+                         │
+         ┌───────────────┼───────────────┐
+         │               │               │
+         ▼               ▼               ▼
+┌─────────────┐  ┌─────────────┐  ┌─────────────┐
+│  Polymarket │  │  Chainlink  │  │     UMA     │
+│   Adapter   │  │   Adapter   │  │   Adapter   │
+│             │  │             │  │             │
+│ Event bets  │  │ Price bets  │  │ Custom bets │
+└─────────────┘  └─────────────┘  └─────────────┘
+         │               │               │
+         └───────────────┼───────────────┘
+                         │
+                         ▼
+                 ┌─────────────┐
+                 │   Oracle    │
+                 │  Registry   │
+                 │             │
+                 │ Aggregation │
+                 └─────────────┘
 ```
 
-## Setup and Installation
+## Quick Start
 
-### Prerequisites
-- Node.js (v18 or higher recommended)
-- npm or yarn
-- MetaMask or compatible Web3 wallet
+### Installation
 
-### Smart Contracts
-
-1. Install dependencies:
 ```bash
 npm install
-```
-
-2. Compile contracts:
-```bash
 npx hardhat compile
 ```
 
-3. Run tests:
+### Run Tests
+
 ```bash
 npx hardhat test
 ```
 
-4. Deploy to local network:
-```bash
-npx hardhat node
-npx hardhat run scripts/deploy.js --network localhost
+### Create a Wager (Pegged to Polymarket)
+
+```solidity
+// Create a market pegged to Polymarket's Bitcoin $100k market
+uint256 marketId = factory.createPeggedMarket(
+    "BTC $100k Pool",
+    polymarketConditionId,
+    [alice, bob, carol],
+    1 ether  // stake per person
+);
+
+// After Polymarket resolves, anyone can trigger resolution
+factory.resolveFromOracle(marketId);
+
+// Winners claim their stakes
+factory.claimWinnings(marketId);
 ```
 
-### Testnet Seeding (Garden of Eden)
+### Create a Price-Based Wager (Chainlink)
 
-To populate the testnet with market data and simulated trading:
+```solidity
+// Create condition: ETH above $5000 by end of 2025
+bytes32 conditionId = chainlinkAdapter.createCondition(
+    ethPriceFeed,
+    5000_00000000,  // $5000 (8 decimals)
+    ComparisonType.ABOVE,
+    1735689600,     // Dec 31, 2025
+    "ETH above $5000 by 2025"
+);
 
-1. Configure seed accounts in `.env` (see `.env.example`)
-2. Run the seeding service:
-```bash
-npm run seed:testnet  # For Mordor testnet
-npm run seed:local    # For local development
+// Create wager using this condition
+uint256 marketId = factory.createOracleMarket(conditionId, ...);
 ```
 
-See [Garden of Eden Quick Start](GARDEN_OF_EDEN_QUICKSTART.md) for detailed instructions.
+### Create a Custom Wager (UMA)
 
-### Frontend
+```solidity
+// Create condition for any verifiable claim
+bytes32 conditionId = umaAdapter.createCondition(
+    "Lakers will win the 2025 NBA Finals",
+    deadline
+);
 
-1. Navigate to frontend directory:
-```bash
-cd frontend
+// After deadline, someone asserts the outcome (requires bond)
+umaAdapter.assertOutcome(conditionId, true);
+
+// After challenge period, settle
+umaAdapter.settleCondition(conditionId);
 ```
 
-2. Install dependencies:
-```bash
-npm install
+## Contracts
+
+### Core
+
+| Contract | Description |
+|----------|-------------|
+| `FriendGroupMarketFactory` | Creates and manages P2P wagers |
+| `OracleRegistry` | Aggregates multiple oracle adapters |
+
+### Oracle Adapters
+
+| Contract | Oracle | Use Case |
+|----------|--------|----------|
+| `PolymarketOracleAdapter` | Polymarket CTF | Event outcome markets |
+| `ChainlinkOracleAdapter` | Chainlink | Price threshold conditions |
+| `UMAOracleAdapter` | UMA OOv3 | Arbitrary truth assertions |
+
+### Interfaces
+
+| Interface | Description |
+|-----------|-------------|
+| `IOracleAdapter` | Standard interface for oracle adapters |
+
+## Wager Lifecycle
+
+```
+1. CREATE       → Stakes locked in escrow
+2. ACTIVE       → Waiting for resolution source
+3. RESOLVE      → Oracle provides outcome OR manual resolution
+   └─ CHALLENGE → 24h dispute window (manual only)
+4. FINALIZE     → Resolution confirmed
+5. CLAIM        → Winners withdraw stakes
+   └─ TIMEOUT   → 90 days to claim, then treasury
 ```
 
-3. Start development server:
-```bash
-npm run dev
+## Safety Features
+
+### Challenge Period (Manual Resolutions)
+
+When markets are resolved manually, a 24-hour challenge period allows participants to dispute:
+
+```solidity
+// Challenger must post a bond
+factory.challengeResolution{value: 0.1 ether}(marketId);
+
+// Admin resolves dispute
+factory.resolveDispute(marketId, true);  // Challenger wins
 ```
 
-4. Open browser to `http://localhost:5173`
+### Oracle Timeout
 
-You will see a platform selector where you can choose between:
-- **ClearPath**: DAO governance interface
-- **FairWins**: Prediction market interface
+If an oracle-pegged market doesn't resolve within 30 days of expected time:
 
-## Usage
+```solidity
+// Anyone can trigger timeout mode
+factory.triggerOracleTimeout(marketId);
 
-### Getting Started
+// Both parties can accept mutual refund
+factory.acceptMutualRefund(marketId);  // Each party calls
 
-1. **Open Application**: Navigate to the frontend at `http://localhost:5173`
-2. **Start with FairWins**: The platform opens with FairWins prediction markets
-3. **Connect Wallet**: Click to connect your MetaMask or compatible wallet (optional for browsing)
+// Or admin can force resolution
+factory.forceOracleResolution(marketId, true);
+```
 
-### Using FairWins (Prediction Markets - Primary Platform)
+### Claim Timeout
 
-#### For Market Creators
+Unclaimed winnings return to treasury after 90 days:
 
-1. **Connect Wallet**: Connect to FairWins platform
-2. **Create Market**: 
-   - Define clear prediction question
-   - Set resolution criteria and dates
-   - Provide initial liquidity (minimum 100 USDC)
-   - Stake creator bond (returned after proper resolution)
-3. **Monitor Market**: Track participation and trading activity
-4. **Resolve Market**: Submit outcome evidence when resolution date arrives
-
-#### For Traders
-
-1. **Browse Markets**: View active prediction markets across all topics
-2. **Research**: Review market details, resolution criteria, and current odds
-3. **Trade Positions**:
-   - Buy YES tokens if you believe the outcome will occur
-   - Buy NO tokens if you believe it won't
-4. **Track Positions**: Monitor your positions and market developments
-5. **Settle**: Redeem winning tokens after market resolution
-
-### Using ClearPath (DAO Governance - Add-on Feature)
-
-ClearPath is an optional add-on feature accessible from the sidebar. It offers two governance modes:
-
-#### Choosing a Governance Mode
-
-1. **Futarchy Mode**: Prediction market-based decision making
-   - Best for: Complex decisions requiring distributed knowledge
-   - Features: Market trading, welfare metrics, privacy mechanisms
-   
-2. **Traditional Voting Mode**: Token-weighted democracy
-   - Best for: Straightforward decisions, enterprise governance
-   - Features: Direct voting, quorum requirements, simple majority
-
-You can switch between modes in the governance interface.
-
-#### For Proposers (Both Modes)
-
-1. **Connect Wallet**: Connect MetaMask or compatible wallet
-2. **Submit Proposal**: 
-   - Provide title, description, funding amount
-   - Specify recipient address
-   - Select welfare metric for evaluation (Futarchy only)
-   - Pay 50 ETC bond (returned on good-faith resolution)
-3. **Add Milestones**: Define completion criteria and timelock periods
-4. **Monitor Status**: Track proposal through its lifecycle
-
-#### Traditional Voting Mode
-
-##### For Voters
-
-1. **Connect Wallet**: Ensure you hold governance tokens
-2. **View Proposals**: Browse active voting proposals
-3. **Cast Vote**: Choose one of three options:
-   - **For**: Support the proposal
-   - **Against**: Oppose the proposal
-   - **Abstain**: Participate in quorum without taking a side
-4. **Track Progress**: Monitor vote counts and quorum status
-5. **Execution**: Successful proposals are queued and executed after timelock
-
-**Voting Requirements:**
-- Must hold governance tokens to vote
-- Voting power = token balance (1 token = 1 vote)
-- Proposals need 40% quorum to pass (configurable)
-- Simple majority (For > Against) required
-- 2-day timelock before execution
-
-#### Futarchy Mode
-
-### For Traders
-
-1. **Connect Wallet**: Connect to application
-2. **Browse Markets**: View active prediction markets for proposals
-3. **Trade Tokens**:
-   - Buy PASS tokens if you believe proposal will increase welfare metrics
-   - Buy FAIL tokens if you believe proposal will decrease welfare metrics
-4. **Privacy Protection**: All positions encrypted with zero-knowledge proofs
-5. **Settle Positions**: Redeem tokens after oracle resolution
-
-### For Governance Participants
-
-1. **Set Welfare Metrics**: Vote on which protocol success measures to use
-2. **Challenge Oracle Reports**: Submit counter-evidence during challenge period
-3. **Ragequit**: Exit with proportional treasury share if you disagree with proposal
-
-## Platform & Governance Comparison
-
-### ClearPath Governance Modes
-
-| Feature | Futarchy Mode | Traditional Voting Mode |
-|---------|--------------|-------------------------|
-| **Decision Method** | Prediction markets | Token-weighted voting |
-| **Voting Options** | PASS/FAIL token trading | For/Against/Abstain |
-| **Approval Criteria** | Market price comparison | Simple majority + quorum |
-| **Complexity** | High (requires market understanding) | Low (straightforward voting) |
-| **Privacy** | High (encrypted positions) | Standard (on-chain votes) |
-| **Best For** | Complex decisions, knowledge aggregation | Simple decisions, traditional orgs |
-| **Quorum** | N/A (market-based) | 40% of token supply |
-| **Execution** | Based on welfare metrics | Based on vote outcome |
-| **Enterprise Appeal** | Innovative DAOs | Traditional foundations |
-
-### Feature Comparison
-
-| Feature | FairWins (Primary Platform) | ClearPath (Add-on) |
-|---------|----------------------------|-------------------|
-| **Primary Use** | General predictions | Governance decisions |
-| **Access** | Default, open to anyone | Optional sidebar tab, requires role |
-| **Market Creation** | Manual (user-created) | Automated (per proposal) |
-| **Resolution Criteria** | Flexible, creator-defined | Welfare metrics or votes |
-| **Participation** | Open to anyone | DAO members only |
-| **Treasury** | Individual market pools | Shared DAO treasury |
-| **Governance Mode** | N/A | Futarchy or Traditional |
-| **Voting Integration** | No | Yes (both modes) |
-| **Ragequit Protection** | No | Yes (Futarchy mode) |
-
-## Technical Details
-
-### Welfare Metrics
-
-The system uses four types of welfare metrics:
-
-1. **Treasury Value (Primary)**: TWAP of total treasury holdings in USD
-2. **Network Activity (Secondary)**: Composite index of transactions and active addresses
-3. **Hash Rate Security (Tertiary)**: Network hash rate relative to other PoW chains
-4. **Developer Activity (Quaternary)**: GitHub commits, PRs, and contributors
-
-### Security Features
-
-- **Bond Requirements**: 50 ETC for proposals, 100 ETC for oracle reporting, 150 ETC for challenges
-- **Timelock**: 2-day minimum before execution
-- **Spending Limits**: 50k ETC max per proposal, 100k ETC daily aggregate
-- **Emergency Pause**: Guardian multisig can pause in case of critical issues
-- **Progressive Decentralization**: Guardian powers decrease on fixed schedule
-- **Automated Security Review**: GitHub agent reviews all smart contract PRs for vulnerabilities and best practices compliance (see [Security Agent Documentation](docs/developer-guide/ethereum-security-agent.md))
-
-### Privacy Architecture
-
-- **Poseidon Encryption**: SNARK-friendly encryption for positions
-- **ECDH Key Exchange**: Secure coordination between traders
-- **Groth16 zkSNARKs**: Zero-knowledge proofs for validity
-- **Batch Processing**: Positions revealed only after epoch confirmation
-- **Key Changes**: MACI-style invalidation of previous commitments
+```solidity
+// After 90 days, treasury can sweep
+factory.sweepUnclaimedFunds(marketId);
+```
 
 ## Testing
 
-The project includes comprehensive automated testing and security analysis:
-
-### Quick Start
-
-Run the complete test suite:
-```bash
-npm test
-```
-
-Run tests with gas reporting:
-```bash
-npm run test:gas
-```
-
-Run with coverage:
-```bash
-npm run test:coverage
-```
-
-### Security Testing Documentation
-
-For comprehensive documentation on all testing and security analysis:
-
-**[View Security Testing Documentation →](https://docs.FairWins.app/security/)**
-
-The security testing documentation covers:
-- **[Unit Testing](https://docs.FairWins.app/security/unit-testing/)**: Hardhat test suite with gas reporting
-- **[Static Analysis](https://docs.FairWins.app/security/static-analysis/)**: Slither for vulnerability detection
-- **[Symbolic Execution](https://docs.FairWins.app/security/symbolic-execution/)**: Manticore for path exploration
-- **[Fuzz Testing](https://docs.FairWins.app/security/fuzz-testing/)**: Medusa for property-based testing
-- **[CI/CD Configuration](https://docs.FairWins.app/security/ci-configuration/)**: GitHub Actions workflow maintenance
-
-### Test Structure
+The test suite covers all functionality:
 
 ```
-test/
-├── ConditionalMarketFactory.test.js   # Market factory tests
-├── DAOFactory.test.js                 # DAO factory tests
-├── FutarchyGovernor.test.js          # Main governor tests
-├── OracleResolver.test.js            # Oracle resolution tests
-├── PrivacyCoordinator.test.js        # Privacy mechanism tests
-├── ProposalRegistry.test.js          # Proposal management tests
-├── RagequitModule.test.js            # Ragequit functionality tests
-├── WelfareMetricRegistry.test.js     # Welfare metrics tests
-└── fuzzing/                          # Fuzz test contracts
-    ├── ProposalRegistryFuzzTest.sol
-    └── WelfareMetricRegistryFuzzTest.sol
+1237 passing tests
+
+Test Files:
+- FriendGroupMarketFactory.test.js (78 tests)
+- FriendGroupMarketFactory.Claim.test.js (16 tests)
+- FriendGroupMarketFactory.Challenge.test.js (31 tests)
+- FriendGroupMarketFactory.Timeout.test.js (18 tests)
+- FriendGroupMarketFactory.OracleTimeout.test.js (22 tests)
+- OracleRegistry.test.js (34 tests)
+- ChainlinkOracleAdapter.test.js (35 tests)
+- UMAOracleAdapter.test.js (25 tests)
+- PolymarketOracleAdapter.test.js (various)
 ```
+
+## Why Not Build a Prediction Market?
+
+Prediction markets are hard:
+
+1. **Liquidity** — Need market makers and deep order books
+2. **Oracles** — Need reliable resolution for every market
+3. **Regulation** — Complex legal landscape
+4. **Competition** — Polymarket, Kalshi, etc. already exist
+
+FairWins sidesteps these by:
+
+1. **No liquidity needed** — Fixed stakes, no AMM required
+2. **Leverage existing oracles** — Polymarket, Chainlink, UMA do the hard work
+3. **P2P focus** — Friends betting with friends
+4. **Complementary** — Use alongside prediction markets, not instead of
 
 ## Development
 
-### Adding New Features
+### Prerequisites
 
-1. Create contracts in `contracts/` directory
-2. Write tests in `test/` directory
-3. Update frontend components in `frontend/src/components/`
-4. Add deployment scripts in `scripts/`
+- Node.js v18+
+- npm or yarn
 
-### Code Style
-
-- Solidity: Follow OpenZeppelin style guide
-- JavaScript/React: Use ESLint with Airbnb config
-- Comments: Document all public functions
-
-### CI/CD and Testing
-
-Our CI/CD pipeline enforces strict code quality standards:
-
-- **Linting**: ESLint errors will fail the build (see [CI Error Handling Policy](.github/CI_ERROR_HANDLING_POLICY.md))
-- **Testing**: All tests must pass before merging
-- **Coverage**: Coverage reports are generated but won't block builds
-
-**Before submitting a PR:**
-```bash
-# Run linter to catch issues early
-cd frontend && npm run lint
-
-# Run tests
-npm test
-
-# Build to ensure no build errors
-npm run build
-```
-
-For complete CI/CD guidelines, see [Test Pipeline Documentation](.github/TEST_PIPELINE.md).
-
-### Smart Contract Security
-
-This repository uses an automated Ethereum security review agent that analyzes all smart contract code changes:
-
-- **Automatic PR Reviews**: Agent reviews all `.sol` file changes
-- **Security Standards**: Follows [EthTrust Security Levels](https://entethalliance.org/specs/ethtrust-sl/)
-- **Vulnerability Detection**: Identifies reentrancy, access control, and other security issues
-- **Best Practices**: Enforces Solidity coding standards and patterns
-
-**Quick Start**: See [Ethereum Security Agent Quick Start](docs/developer-guide/ethereum-security-quickstart.md)
-
-**Full Documentation**: See [Ethereum Security Agent Guide](docs/developer-guide/ethereum-security-agent.md)
-
-## Deployment
-
-### Automated Testnet Deployment (Mordor)
-
-The DAO contracts can be automatically deployed to the Ethereum Classic Mordor testnet using GitHub Actions. This deployment uses the **Safe Singleton Factory** for deterministic, reproducible contract addresses across networks. This mirrors the setup from [@chippr-robotics/mordor-public-faucet](https://github.com/chippr-robotics/mordor-public-faucet).
-
-📖 **Quick Start**: See [DEPLOYMENT_QUICKSTART.md](./DEPLOYMENT_QUICKSTART.md) for a 5-minute setup guide
-
-#### Deterministic Deployment
-
-All contracts are deployed using the [Safe Singleton Factory](https://github.com/safe-fndn/safe-singleton-factory) at address `0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7`. This ensures:
-- **Reproducible addresses**: Same contract addresses across different networks
-- **Verifiable deployments**: Easy to verify that deployed bytecode matches source
-- **No centralization**: Removes reliance on specific deployment keys
-- **Security**: Deterministic deployments improve auditability
-
-The factory is pre-deployed on Mordor testnet (Chain ID: 63) and many other EVM-compatible networks.
-
-📖 **For detailed information about deterministic deployment**, see [DETERMINISTIC_DEPLOYMENT.md](./DETERMINISTIC_DEPLOYMENT.md)
-
-#### Prerequisites
-
-1. **Add Private Key to GitHub Secrets**
-   - Go to **Settings** → **Secrets and variables** → **Actions**
-   - Click **New repository secret**
-   - Name: `PRIVATE_KEY`
-   - Value: Your Ethereum Classic wallet private key (without the `0x` prefix)
-   - Click **Add secret**
-   
-   ⚠️ **Security Warning**: Never commit your private key to the repository! Always use GitHub Secrets.
-
-2. **Ensure Sufficient Balance**
-   - Your wallet needs sufficient Mordor testnet ETC for deployment
-   - Get testnet ETC from the [Mordor faucet](https://github.com/chippr-robotics/mordor-public-faucet)
-
-#### Deployment Methods
-
-**Method 1: Automatic Deployment (Recommended)**
-- Automatically deploys when you push to the `main` branch with contract changes
-- Monitors changes to:
-  - `contracts/**`
-  - `scripts/deploy-deterministic.js`
-  - `hardhat.config.js`
-
-**Method 2: Manual Deployment**
-1. Go to the **Actions** tab in GitHub
-2. Select **Deploy DAO Contracts to Mordor Testnet** workflow
-3. Click **Run workflow**
-4. Select the target network (default: mordor)
-5. Click **Run workflow** button
-
-#### Deployment Information
-
-- **Network**: Ethereum Classic Mordor Testnet
-- **RPC URL**: https://rpc.mordor.etccooperative.org
-- **Chain ID**: 63
-- **Block Explorer**: https://etc-mordor.blockscout.com/
-
-After deployment, you can view:
-- Deployment logs in the GitHub Actions workflow run
-- Contract addresses in the workflow summary
-- All contracts on Blockscout using the provided links
-
-#### Local Testnet Deployment
-
-For local testing, you can also deploy deterministically:
+### Local Development
 
 ```bash
-export PRIVATE_KEY=your_private_key_without_0x_prefix
-npx hardhat run scripts/deploy-deterministic.js --network mordor
+# Install dependencies
+npm install
+
+# Compile contracts
+npx hardhat compile
+
+# Run all tests
+npx hardhat test
+
+# Run specific test file
+npx hardhat test test/OracleRegistry.test.js
+
+# Generate coverage report
+npx hardhat coverage
 ```
 
-Or use the non-deterministic deployment script:
+### Adding a New Oracle Adapter
 
-```bash
-npx hardhat run scripts/deploy.js --network mordor
+1. Implement `IOracleAdapter` interface
+2. Add to `OracleRegistry`
+3. Write tests
+4. Update documentation
+
+```solidity
+contract MyOracleAdapter is IOracleAdapter {
+    function oracleType() external pure returns (string memory) {
+        return "MyOracle";
+    }
+
+    function isConditionSupported(bytes32 conditionId) external view returns (bool);
+    function isConditionResolved(bytes32 conditionId) external view returns (bool);
+    function getOutcome(bytes32 conditionId) external view returns (
+        bool outcome, uint256 confidence, uint256 resolvedAt
+    );
+    function getConditionMetadata(bytes32 conditionId) external view returns (
+        string memory description, uint256 expectedResolutionTime
+    );
+}
 ```
-
-**Note**: The deterministic deployment ensures the same contract addresses will be used if you deploy to other networks that have the Safe Singleton Factory deployed.
-
-### Frontend Deployment to Google Cloud Run
-
-The React frontend can be automatically deployed to Google Cloud Run using GitHub Actions. See [DEPLOYMENT.md](./DEPLOYMENT.md) for complete setup instructions including:
-- Google Cloud project configuration
-- GitHub secrets setup
-- Workload Identity Federation configuration
-- Docker containerization details
-
-**Quick Start:**
-1. Set up Google Cloud project and enable required APIs
-2. Configure GitHub repository secrets
-3. Push changes to `main` or `develop` branch
-4. GitHub Actions will automatically build and deploy the frontend
-
-For local Docker testing:
-```bash
-cd frontend
-docker build -t prediction-dao-frontend .
-docker run -p 8080:8080 prediction-dao-frontend
-```
-
-### Mainnet Deployment
-
-Before mainnet deployment:
-1. Complete minimum 2 independent security audits
-2. Publish audit reports
-3. Run bug bounty program (100k USD equivalent in ETC)
-4. 30-day community review period
-5. Formal verification of critical invariants
-
-## Release Management
-
-This project uses automated release management to maintain clear documentation of changes:
-
-- **Automated Release Notes**: GitHub Actions automatically drafts release notes from merged PRs
-- **Semantic Versioning**: Follows [SemVer](https://semver.org/) for version numbering
-- **Release Process**: See [RELEASE_PROCESS.md](./RELEASE_PROCESS.md) for complete workflow
-- **Changelog**: View releases at [GitHub Releases](https://github.com/chippr-robotics/prediction-dao-research/releases)
-
-For detailed information:
-- **Release workflow**: [RELEASE_PROCESS.md](./RELEASE_PROCESS.md)
-- **CI/CD pipelines**: [CI_CD_PIPELINE.md](./CI_CD_PIPELINE.md)
-- **Solution analysis**: [RELEASE_WORKFLOW_ANALYSIS.md](./RELEASE_WORKFLOW_ANALYSIS.md)
-
-## References
-
-- [Futarchy Specification](https://gist.github.com/realcodywburns/8c89419db5c7797b678afe5ee66cc02b)
-- [Nightmarket Privacy](https://blog.zkga.me/nightmarket)
-- [MACI Anti-Collusion](https://github.com/privacy-scaling-explorations/maci)
-- [Gnosis Conditional Tokens](https://docs.gnosis.io/conditionaltokens/)
-- [MetaDAO Research](https://metadao.fi)
 
 ## License
 
@@ -806,22 +295,11 @@ Apache License 2.0
 
 ## Contributing
 
-Contributions welcome! Please:
 1. Fork the repository
 2. Create a feature branch
 3. Add tests for new functionality
-4. Label your PRs appropriately (see [RELEASE_PROCESS.md](./RELEASE_PROCESS.md))
-5. Submit a pull request
-
-**Note**: PR labels help generate release notes automatically. Use labels like `feature`, `fix`, `documentation`, etc.
+4. Submit a pull request
 
 ## Security
 
-For general inquiries, please email howdy@FairWins.app. For security concerns, please email security@example.com
-
-## Acknowledgments
-
-- Nightmarket team for zero-knowledge position encryption
-- MACI/PSE team for anti-collusion infrastructure
-- Gnosis team for Conditional Token Framework
-- MetaDAO for futarchy research and validation
+For security concerns, please email security@fairwins.app

--- a/contracts/interfaces/IChainlinkAggregator.sol
+++ b/contracts/interfaces/IChainlinkAggregator.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title IChainlinkAggregator
+ * @notice Interface for Chainlink AggregatorV3 price feeds
+ * @dev Standard interface for querying Chainlink oracle data
+ */
+interface IChainlinkAggregator {
+    /**
+     * @notice Returns the number of decimals for the feed
+     */
+    function decimals() external view returns (uint8);
+
+    /**
+     * @notice Returns a description of the feed
+     */
+    function description() external view returns (string memory);
+
+    /**
+     * @notice Returns the version of the aggregator
+     */
+    function version() external view returns (uint256);
+
+    /**
+     * @notice Get round data for a specific round
+     * @param _roundId The round ID to query
+     * @return roundId The round ID
+     * @return answer The price answer
+     * @return startedAt Timestamp when round started
+     * @return updatedAt Timestamp when round was updated
+     * @return answeredInRound The round ID in which the answer was computed
+     */
+    function getRoundData(uint80 _roundId) external view returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    );
+
+    /**
+     * @notice Get latest round data
+     * @return roundId The round ID
+     * @return answer The price answer
+     * @return startedAt Timestamp when round started
+     * @return updatedAt Timestamp when round was updated
+     * @return answeredInRound The round ID in which the answer was computed
+     */
+    function latestRoundData() external view returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    );
+}

--- a/contracts/interfaces/IPolymarketOracle.sol
+++ b/contracts/interfaces/IPolymarketOracle.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.24;
+
+/**
+ * @title IPolymarketOracle
+ * @notice Interface for querying Polymarket CTF (Conditional Token Framework) resolution data
+ * @dev This interface allows private markets to be resolved based on Polymarket market outcomes
+ *
+ * Polymarket uses the Gnosis CTF standard where:
+ * - conditionId = keccak256(oracle, questionId, outcomeSlotCount)
+ * - Resolution data includes payout numerators for each outcome
+ * - Binary markets have outcomeSlotCount = 2
+ */
+interface IPolymarketOracle {
+    /**
+     * @notice Get the condition details for a Polymarket market
+     * @param conditionId The unique identifier for the condition
+     * @return oracle The oracle address that can resolve this condition
+     * @return questionId The question identifier
+     * @return outcomeSlotCount Number of possible outcomes
+     * @return resolved Whether the condition has been resolved
+     */
+    function getCondition(bytes32 conditionId) external view returns (
+        address oracle,
+        bytes32 questionId,
+        uint256 outcomeSlotCount,
+        bool resolved
+    );
+
+    /**
+     * @notice Check if a condition has been resolved
+     * @param conditionId The condition identifier
+     * @return True if resolved, false otherwise
+     */
+    function isResolved(bytes32 conditionId) external view returns (bool);
+
+    /**
+     * @notice Get payout numerators for a resolved condition
+     * @param conditionId The condition identifier
+     * @return Array of payout numerators for each outcome
+     */
+    function getPayoutNumerators(bytes32 conditionId) external view returns (uint256[] memory);
+
+    /**
+     * @notice Get payout denominator for a resolved condition
+     * @param conditionId The condition identifier
+     * @return The payout denominator
+     */
+    function getPayoutDenominator(bytes32 conditionId) external view returns (uint256);
+
+    /**
+     * @notice Compute condition ID from components
+     * @param oracle The oracle address
+     * @param questionId The question identifier
+     * @param outcomeSlotCount Number of outcomes
+     * @return The computed condition ID
+     */
+    function getConditionId(
+        address oracle,
+        bytes32 questionId,
+        uint256 outcomeSlotCount
+    ) external pure returns (bytes32);
+}

--- a/contracts/interfaces/IUMAOptimisticOracle.sol
+++ b/contracts/interfaces/IUMAOptimisticOracle.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title IUMAOptimisticOracle
+ * @notice Interface for UMA Optimistic Oracle V3
+ * @dev Simplified interface for the key functions needed by our adapter
+ */
+interface IUMAOptimisticOracle {
+    /**
+     * @notice Asserts a claim about world state
+     * @param claim The claim being asserted (bytes)
+     * @param asserter The address making the assertion
+     * @param callbackRecipient The contract to call back with result
+     * @param sovereignSecurity Optional custom security config
+     * @param currency The currency for bonds
+     * @param bond The bond amount required
+     * @param liveness The challenge period duration
+     * @param identifier The price identifier (e.g., ASSERT_TRUTH)
+     * @return assertionId The unique identifier for this assertion
+     */
+    function assertTruth(
+        bytes memory claim,
+        address asserter,
+        address callbackRecipient,
+        address sovereignSecurity,
+        address currency,
+        uint256 bond,
+        uint64 liveness,
+        bytes32 identifier
+    ) external returns (bytes32 assertionId);
+
+    /**
+     * @notice Dispute an existing assertion
+     * @param assertionId The assertion to dispute
+     * @param disputer The address disputing
+     */
+    function disputeAssertion(bytes32 assertionId, address disputer) external;
+
+    /**
+     * @notice Settle an assertion after the challenge period
+     * @param assertionId The assertion to settle
+     */
+    function settleAssertion(bytes32 assertionId) external;
+
+    /**
+     * @notice Get the result of a settled assertion
+     * @param assertionId The assertion to query
+     * @return True if the assertion was valid
+     */
+    function getAssertionResult(bytes32 assertionId) external view returns (bool);
+
+    /**
+     * @notice Get assertion details
+     * @param assertionId The assertion to query
+     * @return The assertion struct data
+     */
+    function getAssertion(bytes32 assertionId) external view returns (Assertion memory);
+
+    /**
+     * @notice Check if an assertion has been settled
+     * @param assertionId The assertion to check
+     * @return True if settled
+     */
+    function isAssertionSettled(bytes32 assertionId) external view returns (bool);
+
+    /**
+     * @notice Assertion data structure
+     */
+    struct Assertion {
+        bool escalationManagerSettings;
+        address asserter;
+        uint64 assertionTime;
+        bool settled;
+        address currency;
+        uint64 expirationTime;
+        bool settlementResolution;
+        bytes32 domainId;
+        bytes32 identifier;
+        uint256 bond;
+        address callbackRecipient;
+        address disputer;
+    }
+
+    // Events
+    event AssertionMade(
+        bytes32 indexed assertionId,
+        address indexed asserter,
+        bytes claim,
+        uint64 expirationTime
+    );
+
+    event AssertionDisputed(
+        bytes32 indexed assertionId,
+        address indexed disputer
+    );
+
+    event AssertionSettled(
+        bytes32 indexed assertionId,
+        bool result
+    );
+}

--- a/contracts/mocks/MockChainlinkAggregator.sol
+++ b/contracts/mocks/MockChainlinkAggregator.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../interfaces/IChainlinkAggregator.sol";
+
+/**
+ * @title MockChainlinkAggregator
+ * @notice Mock implementation of Chainlink AggregatorV3 for testing
+ */
+contract MockChainlinkAggregator is IChainlinkAggregator {
+    uint8 private _decimals;
+    string private _description;
+    uint256 private _version;
+
+    int256 private _latestAnswer;
+    uint256 private _latestTimestamp;
+    uint80 private _latestRoundId;
+
+    // Historical round data
+    struct RoundData {
+        int256 answer;
+        uint256 startedAt;
+        uint256 updatedAt;
+        uint80 answeredInRound;
+    }
+    mapping(uint80 => RoundData) public rounds;
+
+    constructor(
+        uint8 decimals_,
+        string memory description_,
+        int256 initialAnswer
+    ) {
+        _decimals = decimals_;
+        _description = description_;
+        _version = 1;
+        _latestAnswer = initialAnswer;
+        _latestTimestamp = block.timestamp;
+        _latestRoundId = 1;
+
+        rounds[1] = RoundData({
+            answer: initialAnswer,
+            startedAt: block.timestamp,
+            updatedAt: block.timestamp,
+            answeredInRound: 1
+        });
+    }
+
+    function decimals() external view override returns (uint8) {
+        return _decimals;
+    }
+
+    function description() external view override returns (string memory) {
+        return _description;
+    }
+
+    function version() external view override returns (uint256) {
+        return _version;
+    }
+
+    function getRoundData(uint80 roundId) external view override returns (
+        uint80 roundId_,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) {
+        RoundData storage round = rounds[roundId];
+        return (
+            roundId,
+            round.answer,
+            round.startedAt,
+            round.updatedAt,
+            round.answeredInRound
+        );
+    }
+
+    function latestRoundData() external view override returns (
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) {
+        RoundData storage round = rounds[_latestRoundId];
+        return (
+            _latestRoundId,
+            _latestAnswer,
+            round.startedAt,
+            _latestTimestamp,
+            _latestRoundId
+        );
+    }
+
+    // ========== Test Helpers ==========
+
+    /**
+     * @notice Update the price
+     * @param newAnswer The new price answer
+     */
+    function updateAnswer(int256 newAnswer) external {
+        _latestRoundId++;
+        _latestAnswer = newAnswer;
+        _latestTimestamp = block.timestamp;
+
+        rounds[_latestRoundId] = RoundData({
+            answer: newAnswer,
+            startedAt: block.timestamp,
+            updatedAt: block.timestamp,
+            answeredInRound: _latestRoundId
+        });
+    }
+
+    /**
+     * @notice Update the timestamp (for staleness testing)
+     * @param newTimestamp The new timestamp
+     */
+    function setTimestamp(uint256 newTimestamp) external {
+        _latestTimestamp = newTimestamp;
+        rounds[_latestRoundId].updatedAt = newTimestamp;
+    }
+
+    /**
+     * @notice Get the latest answer directly
+     */
+    function getLatestAnswer() external view returns (int256) {
+        return _latestAnswer;
+    }
+
+    /**
+     * @notice Get the latest round ID
+     */
+    function getLatestRoundId() external view returns (uint80) {
+        return _latestRoundId;
+    }
+}

--- a/contracts/mocks/MockOracleAdapter.sol
+++ b/contracts/mocks/MockOracleAdapter.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../oracles/IOracleAdapter.sol";
+
+/**
+ * @title MockOracleAdapter
+ * @notice Mock implementation of IOracleAdapter for testing
+ */
+contract MockOracleAdapter is IOracleAdapter {
+    string private _oracleType;
+
+    // Condition ID => supported
+    mapping(bytes32 => bool) public conditionSupported;
+
+    // Condition ID => resolved
+    mapping(bytes32 => bool) public conditionResolved;
+
+    // Condition ID => outcome data
+    struct OutcomeData {
+        bool outcome;
+        uint256 confidence;
+        uint256 resolvedAt;
+    }
+    mapping(bytes32 => OutcomeData) public outcomes;
+
+    // Condition ID => metadata
+    struct MetadataData {
+        string description;
+        uint256 expectedResolutionTime;
+    }
+    mapping(bytes32 => MetadataData) public metadata;
+
+    constructor(string memory oracleTypeName) {
+        _oracleType = oracleTypeName;
+    }
+
+    // ========== IOracleAdapter Implementation ==========
+
+    function oracleType() external view override returns (string memory) {
+        return _oracleType;
+    }
+
+    function isConditionSupported(bytes32 conditionId) external view override returns (bool supported) {
+        return conditionSupported[conditionId];
+    }
+
+    function isConditionResolved(bytes32 conditionId) external view override returns (bool resolved) {
+        return conditionResolved[conditionId];
+    }
+
+    function getOutcome(bytes32 conditionId) external view override returns (
+        bool outcome,
+        uint256 confidence,
+        uint256 resolvedAt
+    ) {
+        OutcomeData storage data = outcomes[conditionId];
+        return (data.outcome, data.confidence, data.resolvedAt);
+    }
+
+    function getConditionMetadata(bytes32 conditionId) external view override returns (
+        string memory description,
+        uint256 expectedResolutionTime
+    ) {
+        MetadataData storage data = metadata[conditionId];
+        return (data.description, data.expectedResolutionTime);
+    }
+
+    // ========== Test Helpers ==========
+
+    function setConditionSupported(bytes32 conditionId, bool supported) external {
+        conditionSupported[conditionId] = supported;
+        if (supported) {
+            emit ConditionRegistered(conditionId, "", 0);
+        }
+    }
+
+    function setConditionResolved(bytes32 conditionId, bool resolved) external {
+        conditionResolved[conditionId] = resolved;
+    }
+
+    function setOutcome(
+        bytes32 conditionId,
+        bool outcome,
+        uint256 confidence,
+        uint256 resolvedAt
+    ) external {
+        outcomes[conditionId] = OutcomeData({
+            outcome: outcome,
+            confidence: confidence,
+            resolvedAt: resolvedAt
+        });
+        conditionResolved[conditionId] = true;
+        emit ConditionResolved(conditionId, outcome, confidence, resolvedAt);
+    }
+
+    function setMetadata(
+        bytes32 conditionId,
+        string memory description,
+        uint256 expectedResolutionTime
+    ) external {
+        metadata[conditionId] = MetadataData({
+            description: description,
+            expectedResolutionTime: expectedResolutionTime
+        });
+    }
+}

--- a/contracts/mocks/MockOracleAdapter.sol
+++ b/contracts/mocks/MockOracleAdapter.sol
@@ -9,6 +9,8 @@ import "../oracles/IOracleAdapter.sol";
  */
 contract MockOracleAdapter is IOracleAdapter {
     string private _oracleType;
+    bool private _isAvailable = true;
+    uint256 private _chainId;
 
     // Condition ID => supported
     mapping(bytes32 => bool) public conditionSupported;
@@ -33,12 +35,21 @@ contract MockOracleAdapter is IOracleAdapter {
 
     constructor(string memory oracleTypeName) {
         _oracleType = oracleTypeName;
+        _chainId = block.chainid;
     }
 
     // ========== IOracleAdapter Implementation ==========
 
     function oracleType() external view override returns (string memory) {
         return _oracleType;
+    }
+
+    function isAvailable() external view override returns (bool available) {
+        return _isAvailable;
+    }
+
+    function getConfiguredChainId() external view override returns (uint256 chainId) {
+        return _chainId;
     }
 
     function isConditionSupported(bytes32 conditionId) external view override returns (bool supported) {
@@ -103,5 +114,13 @@ contract MockOracleAdapter is IOracleAdapter {
             description: description,
             expectedResolutionTime: expectedResolutionTime
         });
+    }
+
+    function setAvailable(bool available) external {
+        _isAvailable = available;
+    }
+
+    function setChainId(uint256 newChainId) external {
+        _chainId = newChainId;
     }
 }

--- a/contracts/mocks/MockUMAOptimisticOracle.sol
+++ b/contracts/mocks/MockUMAOptimisticOracle.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../interfaces/IUMAOptimisticOracle.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @title MockUMAOptimisticOracle
+ * @notice Mock implementation of UMA Optimistic Oracle V3 for testing
+ */
+contract MockUMAOptimisticOracle is IUMAOptimisticOracle {
+    using SafeERC20 for IERC20;
+
+    // Assertion storage
+    mapping(bytes32 => Assertion) public assertions;
+    mapping(bytes32 => bool) public assertionResults;
+    mapping(bytes32 => bytes) public assertionClaims;
+
+    uint256 private assertionCounter;
+
+    // ========== Core Functions ==========
+
+    function assertTruth(
+        bytes memory claim,
+        address asserter,
+        address callbackRecipient,
+        address /* sovereignSecurity */,
+        address currency,
+        uint256 bond,
+        uint64 liveness,
+        bytes32 identifier
+    ) external override returns (bytes32 assertionId) {
+        // Transfer bond from sender
+        IERC20(currency).safeTransferFrom(msg.sender, address(this), bond);
+
+        assertionCounter++;
+        assertionId = keccak256(abi.encodePacked(assertionCounter, claim, block.timestamp));
+
+        assertions[assertionId] = Assertion({
+            escalationManagerSettings: false,
+            asserter: asserter,
+            assertionTime: uint64(block.timestamp),
+            settled: false,
+            currency: currency,
+            expirationTime: uint64(block.timestamp + liveness),
+            settlementResolution: false,
+            domainId: bytes32(0),
+            identifier: identifier,
+            bond: bond,
+            callbackRecipient: callbackRecipient,
+            disputer: address(0)
+        });
+
+        assertionClaims[assertionId] = claim;
+
+        emit AssertionMade(assertionId, asserter, claim, uint64(block.timestamp + liveness));
+
+        return assertionId;
+    }
+
+    function disputeAssertion(bytes32 assertionId, address disputer) external override {
+        Assertion storage assertion = assertions[assertionId];
+        require(!assertion.settled, "Already settled");
+        require(assertion.disputer == address(0), "Already disputed");
+
+        // Transfer bond from disputer
+        IERC20(assertion.currency).safeTransferFrom(msg.sender, address(this), assertion.bond);
+
+        assertion.disputer = disputer;
+
+        // Notify callback recipient
+        if (assertion.callbackRecipient != address(0)) {
+            try IUMACallbackRecipient(assertion.callbackRecipient).assertionDisputedCallback(assertionId) {} catch {}
+        }
+
+        emit AssertionDisputed(assertionId, disputer);
+    }
+
+    function settleAssertion(bytes32 assertionId) external override {
+        Assertion storage assertion = assertions[assertionId];
+        require(!assertion.settled, "Already settled");
+        require(
+            assertion.disputer != address(0) || block.timestamp >= assertion.expirationTime,
+            "Not ready to settle"
+        );
+
+        assertion.settled = true;
+
+        // If no dispute, assertion is valid
+        if (assertion.disputer == address(0)) {
+            assertion.settlementResolution = true;
+            assertionResults[assertionId] = true;
+
+            // Return bond to asserter
+            IERC20(assertion.currency).safeTransfer(assertion.asserter, assertion.bond);
+        }
+        // If disputed, use mock result (default to true for testing)
+        else {
+            assertion.settlementResolution = assertionResults[assertionId];
+
+            // In real UMA, DVM would determine winner
+            // For testing, we use pre-set result
+            if (assertionResults[assertionId]) {
+                // Asserter wins, gets both bonds
+                IERC20(assertion.currency).safeTransfer(assertion.asserter, assertion.bond * 2);
+            } else {
+                // Disputer wins, gets both bonds
+                IERC20(assertion.currency).safeTransfer(assertion.disputer, assertion.bond * 2);
+            }
+        }
+
+        // Notify callback recipient
+        if (assertion.callbackRecipient != address(0)) {
+            try IUMACallbackRecipient(assertion.callbackRecipient).assertionResolvedCallback(
+                assertionId,
+                assertion.settlementResolution
+            ) {} catch {}
+        }
+
+        emit AssertionSettled(assertionId, assertion.settlementResolution);
+    }
+
+    function getAssertionResult(bytes32 assertionId) external view override returns (bool) {
+        return assertions[assertionId].settlementResolution;
+    }
+
+    function getAssertion(bytes32 assertionId) external view override returns (Assertion memory) {
+        return assertions[assertionId];
+    }
+
+    function isAssertionSettled(bytes32 assertionId) external view override returns (bool) {
+        return assertions[assertionId].settled;
+    }
+
+    // ========== Test Helpers ==========
+
+    /**
+     * @notice Set the result for a disputed assertion (simulates DVM)
+     */
+    function setDisputeResult(bytes32 assertionId, bool result) external {
+        assertionResults[assertionId] = result;
+    }
+
+    /**
+     * @notice Fast-forward an assertion to be settleable (for testing)
+     */
+    function setAssertionExpired(bytes32 assertionId) external {
+        assertions[assertionId].expirationTime = uint64(block.timestamp - 1);
+    }
+
+    /**
+     * @notice Get assertion claim text
+     */
+    function getAssertionClaim(bytes32 assertionId) external view returns (bytes memory) {
+        return assertionClaims[assertionId];
+    }
+}
+
+/**
+ * @notice Interface for UMA callback recipients
+ */
+interface IUMACallbackRecipient {
+    function assertionDisputedCallback(bytes32 assertionId) external;
+    function assertionResolvedCallback(bytes32 assertionId, bool assertedTruthfully) external;
+}

--- a/contracts/oracles/ChainlinkOracleAdapter.sol
+++ b/contracts/oracles/ChainlinkOracleAdapter.sol
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "../interfaces/IChainlinkAggregator.sol";
+import "./IOracleAdapter.sol";
+
+/**
+ * @title ChainlinkOracleAdapter
+ * @notice Oracle adapter for price-based conditions using Chainlink price feeds
+ * @dev Enables P2P wagers based on asset prices (e.g., "ETH > $5000 by Dec 2025")
+ *
+ * KEY FEATURES:
+ * - Create price threshold conditions (above/below target price)
+ * - Support multiple Chainlink price feeds
+ * - Automatic resolution when deadline passes
+ * - High confidence scores from Chainlink's decentralized oracle network
+ *
+ * CONDITION TYPES:
+ * - ABOVE: Pass if price >= target at or before deadline
+ * - BELOW: Pass if price <= target at or before deadline
+ *
+ * EXAMPLE USE CASES:
+ * - "ETH will be above $10,000 by end of 2025"
+ * - "BTC will stay below $100,000 through Q1"
+ * - "LINK price doubles from current level"
+ */
+contract ChainlinkOracleAdapter is IOracleAdapter, Ownable {
+
+    // ========== Types ==========
+
+    enum ComparisonType {
+        ABOVE,  // Pass if price >= target
+        BELOW   // Pass if price <= target
+    }
+
+    struct PriceCondition {
+        address priceFeed;           // Chainlink aggregator address
+        int256 targetPrice;          // Target price (in feed decimals)
+        ComparisonType comparison;   // Above or below
+        uint256 deadline;            // When condition can be resolved
+        string description;          // Human-readable description
+        bool registered;             // Whether condition exists
+    }
+
+    struct Resolution {
+        bool resolved;
+        bool outcome;           // True if condition passed
+        int256 priceAtResolution;
+        uint256 resolvedAt;
+    }
+
+    // ========== Storage ==========
+
+    // Condition ID => PriceCondition
+    mapping(bytes32 => PriceCondition) public conditions;
+
+    // Condition ID => Resolution
+    mapping(bytes32 => Resolution) public resolutions;
+
+    // Price feed address => supported status
+    mapping(address => bool) public supportedFeeds;
+
+    // List of supported feed addresses
+    address[] public feedList;
+
+    // Staleness threshold (how old feed data can be)
+    uint256 public stalenessThreshold = 1 hours;
+
+    // ========== Events ==========
+
+    event PriceFeedAdded(address indexed feed, string description);
+    event PriceFeedRemoved(address indexed feed);
+    event PriceConditionCreated(
+        bytes32 indexed conditionId,
+        address indexed priceFeed,
+        int256 targetPrice,
+        ComparisonType comparison,
+        uint256 deadline
+    );
+    event PriceConditionResolved(
+        bytes32 indexed conditionId,
+        bool outcome,
+        int256 priceAtResolution,
+        uint256 resolvedAt
+    );
+    event StalenessThresholdUpdated(uint256 oldThreshold, uint256 newThreshold);
+
+    // ========== Errors ==========
+
+    error FeedNotSupported();
+    error FeedAlreadySupported();
+    error ConditionAlreadyExists();
+    error ConditionNotFound();
+    error ConditionNotResolved();
+    error DeadlineNotReached();
+    error DeadlineInPast();
+    error InvalidTargetPrice();
+    error StalePrice();
+    error InvalidFeed();
+
+    // ========== Constructor ==========
+
+    constructor(address _owner) Ownable(_owner) {}
+
+    // ========== Admin Functions ==========
+
+    /**
+     * @notice Add a supported Chainlink price feed
+     * @param feed Address of the Chainlink aggregator
+     */
+    function addPriceFeed(address feed) external onlyOwner {
+        if (feed == address(0)) revert InvalidFeed();
+        if (supportedFeeds[feed]) revert FeedAlreadySupported();
+
+        supportedFeeds[feed] = true;
+        feedList.push(feed);
+
+        string memory desc = IChainlinkAggregator(feed).description();
+        emit PriceFeedAdded(feed, desc);
+    }
+
+    /**
+     * @notice Remove a supported price feed
+     * @param feed Address of the feed to remove
+     */
+    function removePriceFeed(address feed) external onlyOwner {
+        if (!supportedFeeds[feed]) revert FeedNotSupported();
+
+        supportedFeeds[feed] = false;
+
+        // Remove from list
+        for (uint256 i = 0; i < feedList.length; i++) {
+            if (feedList[i] == feed) {
+                feedList[i] = feedList[feedList.length - 1];
+                feedList.pop();
+                break;
+            }
+        }
+
+        emit PriceFeedRemoved(feed);
+    }
+
+    /**
+     * @notice Update staleness threshold
+     * @param newThreshold New threshold in seconds
+     */
+    function setStalenessThreshold(uint256 newThreshold) external onlyOwner {
+        uint256 oldThreshold = stalenessThreshold;
+        stalenessThreshold = newThreshold;
+        emit StalenessThresholdUpdated(oldThreshold, newThreshold);
+    }
+
+    // ========== Condition Management ==========
+
+    /**
+     * @notice Create a new price condition
+     * @param priceFeed Chainlink price feed address
+     * @param targetPrice Target price threshold
+     * @param comparison Whether price must be above or below target
+     * @param deadline When the condition can be resolved
+     * @param description Human-readable description
+     * @return conditionId The unique condition identifier
+     */
+    function createCondition(
+        address priceFeed,
+        int256 targetPrice,
+        ComparisonType comparison,
+        uint256 deadline,
+        string calldata description
+    ) external returns (bytes32 conditionId) {
+        if (!supportedFeeds[priceFeed]) revert FeedNotSupported();
+        if (deadline <= block.timestamp) revert DeadlineInPast();
+        if (targetPrice <= 0) revert InvalidTargetPrice();
+
+        // Generate unique condition ID
+        conditionId = keccak256(abi.encodePacked(
+            priceFeed,
+            targetPrice,
+            comparison,
+            deadline,
+            msg.sender,
+            block.timestamp
+        ));
+
+        if (conditions[conditionId].registered) revert ConditionAlreadyExists();
+
+        conditions[conditionId] = PriceCondition({
+            priceFeed: priceFeed,
+            targetPrice: targetPrice,
+            comparison: comparison,
+            deadline: deadline,
+            description: description,
+            registered: true
+        });
+
+        emit PriceConditionCreated(conditionId, priceFeed, targetPrice, comparison, deadline);
+        emit ConditionRegistered(conditionId, description, deadline);
+
+        return conditionId;
+    }
+
+    /**
+     * @notice Resolve a price condition
+     * @param conditionId The condition to resolve
+     */
+    function resolveCondition(bytes32 conditionId) external {
+        PriceCondition storage condition = conditions[conditionId];
+        if (!condition.registered) revert ConditionNotFound();
+        if (resolutions[conditionId].resolved) return; // Already resolved
+        if (block.timestamp < condition.deadline) revert DeadlineNotReached();
+
+        // Get current price
+        (int256 price, uint256 updatedAt) = getLatestPrice(condition.priceFeed);
+        if (block.timestamp - updatedAt > stalenessThreshold) revert StalePrice();
+
+        // Determine outcome
+        bool outcome;
+        if (condition.comparison == ComparisonType.ABOVE) {
+            outcome = price >= condition.targetPrice;
+        } else {
+            outcome = price <= condition.targetPrice;
+        }
+
+        // Store resolution
+        resolutions[conditionId] = Resolution({
+            resolved: true,
+            outcome: outcome,
+            priceAtResolution: price,
+            resolvedAt: block.timestamp
+        });
+
+        emit PriceConditionResolved(conditionId, outcome, price, block.timestamp);
+        emit ConditionResolved(conditionId, outcome, 10000, block.timestamp);
+    }
+
+    // ========== IOracleAdapter Implementation ==========
+
+    /**
+     * @notice Returns the oracle type
+     */
+    function oracleType() external pure override returns (string memory) {
+        return "Chainlink";
+    }
+
+    /**
+     * @notice Check if a condition is supported
+     */
+    function isConditionSupported(bytes32 conditionId) external view override returns (bool supported) {
+        return conditions[conditionId].registered;
+    }
+
+    /**
+     * @notice Check if a condition is resolved
+     */
+    function isConditionResolved(bytes32 conditionId) external view override returns (bool resolved) {
+        return resolutions[conditionId].resolved;
+    }
+
+    /**
+     * @notice Get the outcome of a resolved condition
+     */
+    function getOutcome(bytes32 conditionId) external view override returns (
+        bool outcome,
+        uint256 confidence,
+        uint256 resolvedAt
+    ) {
+        Resolution storage res = resolutions[conditionId];
+        if (!res.resolved) {
+            return (false, 0, 0);
+        }
+        // Chainlink is highly reliable, so we return 100% confidence
+        return (res.outcome, 10000, res.resolvedAt);
+    }
+
+    /**
+     * @notice Get metadata about a condition
+     */
+    function getConditionMetadata(bytes32 conditionId) external view override returns (
+        string memory description,
+        uint256 expectedResolutionTime
+    ) {
+        PriceCondition storage condition = conditions[conditionId];
+        return (condition.description, condition.deadline);
+    }
+
+    // ========== View Functions ==========
+
+    /**
+     * @notice Get latest price from a feed
+     * @param feed The price feed address
+     * @return price The latest price
+     * @return updatedAt When the price was last updated
+     */
+    function getLatestPrice(address feed) public view returns (int256 price, uint256 updatedAt) {
+        if (!supportedFeeds[feed]) revert FeedNotSupported();
+
+        (, int256 answer, , uint256 timestamp, ) = IChainlinkAggregator(feed).latestRoundData();
+        return (answer, timestamp);
+    }
+
+    /**
+     * @notice Get condition details
+     */
+    function getCondition(bytes32 conditionId) external view returns (
+        address priceFeed,
+        int256 targetPrice,
+        ComparisonType comparison,
+        uint256 deadline,
+        string memory description,
+        bool registered
+    ) {
+        PriceCondition storage c = conditions[conditionId];
+        return (c.priceFeed, c.targetPrice, c.comparison, c.deadline, c.description, c.registered);
+    }
+
+    /**
+     * @notice Get resolution details
+     */
+    function getResolution(bytes32 conditionId) external view returns (
+        bool resolved,
+        bool outcome,
+        int256 priceAtResolution,
+        uint256 resolvedAt
+    ) {
+        Resolution storage r = resolutions[conditionId];
+        return (r.resolved, r.outcome, r.priceAtResolution, r.resolvedAt);
+    }
+
+    /**
+     * @notice Check if a condition can be resolved now
+     */
+    function canResolve(bytes32 conditionId) external view returns (bool) {
+        PriceCondition storage condition = conditions[conditionId];
+        if (!condition.registered) return false;
+        if (resolutions[conditionId].resolved) return false;
+        if (block.timestamp < condition.deadline) return false;
+        return true;
+    }
+
+    /**
+     * @notice Get all supported price feeds
+     */
+    function getSupportedFeeds() external view returns (address[] memory) {
+        return feedList;
+    }
+
+    /**
+     * @notice Get number of supported feeds
+     */
+    function getFeedCount() external view returns (uint256) {
+        return feedList.length;
+    }
+}

--- a/contracts/oracles/IOracleAdapter.sol
+++ b/contracts/oracles/IOracleAdapter.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title IOracleAdapter
+ * @notice Standard interface for oracle adapters in the FairWins P2P wager system
+ * @dev All oracle adapters (Polymarket, Chainlink, UMA, etc.) must implement this interface
+ */
+interface IOracleAdapter {
+    /**
+     * @notice Returns the type of oracle (e.g., "Polymarket", "Chainlink", "UMA")
+     * @return The oracle type as a string
+     */
+    function oracleType() external view returns (string memory);
+
+    /**
+     * @notice Check if a condition ID is supported by this adapter
+     * @param conditionId The unique identifier for the condition
+     * @return supported True if this adapter can handle the condition
+     */
+    function isConditionSupported(bytes32 conditionId) external view returns (bool supported);
+
+    /**
+     * @notice Check if a condition has been resolved
+     * @param conditionId The unique identifier for the condition
+     * @return resolved True if the condition has been resolved
+     */
+    function isConditionResolved(bytes32 conditionId) external view returns (bool resolved);
+
+    /**
+     * @notice Get the outcome of a resolved condition
+     * @param conditionId The unique identifier for the condition
+     * @return outcome True if the "YES" or "PASS" side won
+     * @return confidence Confidence level (0-10000 basis points, 10000 = 100%)
+     * @return resolvedAt Timestamp when the condition was resolved
+     */
+    function getOutcome(bytes32 conditionId) external view returns (
+        bool outcome,
+        uint256 confidence,
+        uint256 resolvedAt
+    );
+
+    /**
+     * @notice Get metadata about a condition
+     * @param conditionId The unique identifier for the condition
+     * @return description Human-readable description of the condition
+     * @return expectedResolutionTime Expected timestamp for resolution
+     */
+    function getConditionMetadata(bytes32 conditionId) external view returns (
+        string memory description,
+        uint256 expectedResolutionTime
+    );
+
+    /**
+     * @notice Emitted when a condition is registered with this adapter
+     */
+    event ConditionRegistered(
+        bytes32 indexed conditionId,
+        string description,
+        uint256 expectedResolutionTime
+    );
+
+    /**
+     * @notice Emitted when a condition is resolved
+     */
+    event ConditionResolved(
+        bytes32 indexed conditionId,
+        bool outcome,
+        uint256 confidence,
+        uint256 resolvedAt
+    );
+}

--- a/contracts/oracles/IOracleAdapter.sol
+++ b/contracts/oracles/IOracleAdapter.sol
@@ -14,6 +14,19 @@ interface IOracleAdapter {
     function oracleType() external view returns (string memory);
 
     /**
+     * @notice Check if the oracle is available on the current network
+     * @dev Returns false if external oracle contracts are not deployed or not configured
+     * @return available True if the oracle can be used for resolution on this network
+     */
+    function isAvailable() external view returns (bool available);
+
+    /**
+     * @notice Get the chain ID this adapter is configured for
+     * @return chainId The chain ID, or 0 if chain-agnostic
+     */
+    function getConfiguredChainId() external view returns (uint256 chainId);
+
+    /**
      * @notice Check if a condition ID is supported by this adapter
      * @param conditionId The unique identifier for the condition
      * @return supported True if this adapter can handle the condition

--- a/contracts/oracles/OracleRegistry.sol
+++ b/contracts/oracles/OracleRegistry.sol
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "./IOracleAdapter.sol";
+
+// Custom errors
+error AdapterAlreadyRegistered();
+error AdapterNotRegistered();
+error InvalidAdapter();
+error NoAdaptersFound();
+error ConditionNotResolved();
+
+/**
+ * @title OracleRegistry
+ * @notice Central registry for oracle adapters in the FairWins P2P wager system
+ * @dev Manages multiple oracle adapters with verification and discovery capabilities
+ *
+ * KEY FEATURES:
+ * - Register/unregister oracle adapters by unique ID
+ * - Verification status for trust levels
+ * - Query across all adapters for condition support
+ * - Standardized resolution interface
+ *
+ * SUPPORTED ORACLES:
+ * - Polymarket (prediction markets)
+ * - Chainlink (price feeds)
+ * - UMA (optimistic oracle)
+ * - Custom adapters
+ */
+contract OracleRegistry is Ownable {
+    // ========== Storage ==========
+
+    // Oracle ID => Adapter address
+    mapping(bytes32 => address) public adapters;
+
+    // Adapter address => Verification status
+    mapping(address => bool) public verifiedAdapters;
+
+    // Adapter address => Active status
+    mapping(address => bool) public activeAdapters;
+
+    // List of registered oracle IDs
+    bytes32[] public registeredOracleIds;
+
+    // Oracle ID => Index in registeredOracleIds (for removal)
+    mapping(bytes32 => uint256) private oracleIdIndex;
+
+    // ========== Events ==========
+
+    event AdapterRegistered(
+        bytes32 indexed oracleId,
+        address indexed adapter,
+        string oracleType
+    );
+
+    event AdapterRemoved(
+        bytes32 indexed oracleId,
+        address indexed adapter
+    );
+
+    event AdapterVerified(
+        address indexed adapter,
+        bool verified
+    );
+
+    event AdapterStatusChanged(
+        address indexed adapter,
+        bool active
+    );
+
+    // ========== Constructor ==========
+
+    constructor(address _owner) Ownable(_owner) {}
+
+    // ========== Admin Functions ==========
+
+    /**
+     * @notice Register a new oracle adapter
+     * @param oracleId Unique identifier for this oracle (e.g., keccak256("POLYMARKET"))
+     * @param adapter Address of the adapter contract
+     */
+    function registerAdapter(bytes32 oracleId, address adapter) external onlyOwner {
+        if (adapter == address(0)) revert InvalidAdapter();
+        if (adapters[oracleId] != address(0)) revert AdapterAlreadyRegistered();
+
+        adapters[oracleId] = adapter;
+        activeAdapters[adapter] = true;
+
+        // Add to list
+        oracleIdIndex[oracleId] = registeredOracleIds.length;
+        registeredOracleIds.push(oracleId);
+
+        // Get oracle type from adapter
+        string memory oracleType = IOracleAdapter(adapter).oracleType();
+
+        emit AdapterRegistered(oracleId, adapter, oracleType);
+    }
+
+    /**
+     * @notice Remove an oracle adapter
+     * @param oracleId The oracle ID to remove
+     */
+    function removeAdapter(bytes32 oracleId) external onlyOwner {
+        address adapter = adapters[oracleId];
+        if (adapter == address(0)) revert AdapterNotRegistered();
+
+        // Remove from mapping
+        delete adapters[oracleId];
+        delete activeAdapters[adapter];
+
+        // Remove from list (swap and pop)
+        uint256 index = oracleIdIndex[oracleId];
+        uint256 lastIndex = registeredOracleIds.length - 1;
+        if (index != lastIndex) {
+            bytes32 lastOracleId = registeredOracleIds[lastIndex];
+            registeredOracleIds[index] = lastOracleId;
+            oracleIdIndex[lastOracleId] = index;
+        }
+        registeredOracleIds.pop();
+        delete oracleIdIndex[oracleId];
+
+        emit AdapterRemoved(oracleId, adapter);
+    }
+
+    /**
+     * @notice Set verification status for an adapter
+     * @param adapter Address of the adapter
+     * @param verified Whether the adapter is verified (trusted)
+     */
+    function verifyAdapter(address adapter, bool verified) external onlyOwner {
+        if (adapter == address(0)) revert InvalidAdapter();
+        verifiedAdapters[adapter] = verified;
+        emit AdapterVerified(adapter, verified);
+    }
+
+    /**
+     * @notice Set active status for an adapter
+     * @param adapter Address of the adapter
+     * @param active Whether the adapter is active
+     */
+    function setAdapterStatus(address adapter, bool active) external onlyOwner {
+        if (adapter == address(0)) revert InvalidAdapter();
+        activeAdapters[adapter] = active;
+        emit AdapterStatusChanged(adapter, active);
+    }
+
+    // ========== Query Functions ==========
+
+    /**
+     * @notice Get the adapter for a specific oracle ID
+     * @param oracleId The oracle ID
+     * @return adapter Address of the adapter (zero if not registered)
+     */
+    function getAdapter(bytes32 oracleId) external view returns (address adapter) {
+        return adapters[oracleId];
+    }
+
+    /**
+     * @notice Check if an adapter is registered and active
+     * @param oracleId The oracle ID
+     * @return isActive True if the adapter is registered and active
+     */
+    function isAdapterActive(bytes32 oracleId) external view returns (bool isActive) {
+        address adapter = adapters[oracleId];
+        return adapter != address(0) && activeAdapters[adapter];
+    }
+
+    /**
+     * @notice Check if an adapter is verified
+     * @param oracleId The oracle ID
+     * @return isVerified True if the adapter is verified
+     */
+    function isAdapterVerified(bytes32 oracleId) external view returns (bool isVerified) {
+        address adapter = adapters[oracleId];
+        return adapter != address(0) && verifiedAdapters[adapter];
+    }
+
+    /**
+     * @notice Resolve a condition using the specified oracle
+     * @param oracleId The oracle ID to use
+     * @param conditionId The condition to resolve
+     * @return outcome The resolution outcome
+     * @return confidence The confidence level
+     */
+    function resolveCondition(
+        bytes32 oracleId,
+        bytes32 conditionId
+    ) external view returns (bool outcome, uint256 confidence) {
+        address adapter = adapters[oracleId];
+        if (adapter == address(0)) revert AdapterNotRegistered();
+        if (!activeAdapters[adapter]) revert AdapterNotRegistered();
+
+        if (!IOracleAdapter(adapter).isConditionResolved(conditionId)) {
+            revert ConditionNotResolved();
+        }
+
+        (outcome, confidence, ) = IOracleAdapter(adapter).getOutcome(conditionId);
+    }
+
+    /**
+     * @notice Find all adapters that support a given condition
+     * @param conditionId The condition to check
+     * @return supportingAdapters Array of adapter addresses that support the condition
+     */
+    function findAdaptersForCondition(
+        bytes32 conditionId
+    ) external view returns (address[] memory supportingAdapters) {
+        // First pass: count supporting adapters
+        uint256 count = 0;
+        for (uint256 i = 0; i < registeredOracleIds.length; i++) {
+            address adapter = adapters[registeredOracleIds[i]];
+            if (activeAdapters[adapter] && IOracleAdapter(adapter).isConditionSupported(conditionId)) {
+                count++;
+            }
+        }
+
+        // Second pass: collect addresses
+        supportingAdapters = new address[](count);
+        uint256 index = 0;
+        for (uint256 i = 0; i < registeredOracleIds.length; i++) {
+            address adapter = adapters[registeredOracleIds[i]];
+            if (activeAdapters[adapter] && IOracleAdapter(adapter).isConditionSupported(conditionId)) {
+                supportingAdapters[index] = adapter;
+                index++;
+            }
+        }
+    }
+
+    /**
+     * @notice Get all registered oracle IDs
+     * @return Array of oracle IDs
+     */
+    function getRegisteredOracleIds() external view returns (bytes32[] memory) {
+        return registeredOracleIds;
+    }
+
+    /**
+     * @notice Get the number of registered adapters
+     * @return count Number of registered adapters
+     */
+    function getAdapterCount() external view returns (uint256 count) {
+        return registeredOracleIds.length;
+    }
+
+    /**
+     * @notice Get adapter info by oracle ID
+     * @param oracleId The oracle ID
+     * @return adapter The adapter address
+     * @return oracleType The type of oracle
+     * @return isVerified Whether the adapter is verified
+     * @return isActive Whether the adapter is active
+     */
+    function getAdapterInfo(bytes32 oracleId) external view returns (
+        address adapter,
+        string memory oracleType,
+        bool isVerified,
+        bool isActive
+    ) {
+        adapter = adapters[oracleId];
+        if (adapter == address(0)) {
+            return (address(0), "", false, false);
+        }
+
+        oracleType = IOracleAdapter(adapter).oracleType();
+        isVerified = verifiedAdapters[adapter];
+        isActive = activeAdapters[adapter];
+    }
+}

--- a/contracts/oracles/PolymarketOracleAdapter.sol
+++ b/contracts/oracles/PolymarketOracleAdapter.sol
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "../interfaces/IPolymarketOracle.sol";
+
+/**
+ * @title PolymarketOracleAdapter
+ * @notice Adapter contract to query Polymarket CTF conditions for resolving private markets
+ * @dev This adapter allows FriendGroupMarketFactory markets to be resolved based on
+ *      Polymarket market outcomes when deployed on the same network (e.g., Polygon)
+ *
+ * KEY FEATURES:
+ * - Queries external Polymarket CTF contract for resolution data
+ * - Supports multiple Polymarket CTF contract addresses (for upgrades)
+ * - Caches resolution data for gas efficiency
+ * - Emits events for off-chain tracking
+ *
+ * POLYMARKET ARCHITECTURE:
+ * - Polymarket uses Gnosis CTF (Conditional Token Framework)
+ * - Markets are identified by conditionId = keccak256(oracle, questionId, outcomeSlotCount)
+ * - Resolution is binary: [1,0] for YES wins, [0,1] for NO wins
+ * - UMA Optimistic Oracle is used for dispute resolution
+ *
+ * INTEGRATION FLOW:
+ * 1. User creates private market and pegs to Polymarket conditionId
+ * 2. When Polymarket resolves, anyone can call resolveFromPolymarket()
+ * 3. Adapter fetches resolution data and resolves the private market
+ */
+contract PolymarketOracleAdapter is Ownable, ReentrancyGuard {
+
+    /// @notice Address of the Polymarket CTF contract (on same network)
+    address public polymarketCTF;
+
+    /// @notice Mapping of supported CTF contract addresses
+    mapping(address => bool) public supportedCTFContracts;
+
+    /// @notice Cache for resolved conditions (conditionId => resolution data)
+    struct CachedResolution {
+        bool resolved;
+        uint256 passNumerator;  // Payout for YES/PASS outcome
+        uint256 failNumerator;  // Payout for NO/FAIL outcome
+        uint256 denominator;
+        uint256 cachedAt;
+    }
+    mapping(bytes32 => CachedResolution) public resolutionCache;
+
+    /// @notice Mapping of linked markets (friendMarketId => PolymarketCondition)
+    struct PolymarketCondition {
+        bytes32 conditionId;
+        address ctfContract;
+        bool linked;
+    }
+    mapping(uint256 => PolymarketCondition) public linkedMarkets;
+
+    /// @notice Events
+    event CTFContractAdded(address indexed ctfContract);
+    event CTFContractRemoved(address indexed ctfContract);
+    event PrimaryCtfUpdated(address indexed oldCTF, address indexed newCTF);
+    event MarketLinkedToPolymarket(
+        uint256 indexed friendMarketId,
+        bytes32 indexed conditionId,
+        address indexed ctfContract
+    );
+    event MarketUnlinked(uint256 indexed friendMarketId);
+    event ResolutionFetched(
+        bytes32 indexed conditionId,
+        uint256 passNumerator,
+        uint256 failNumerator,
+        uint256 denominator
+    );
+    event ResolutionCached(
+        bytes32 indexed conditionId,
+        uint256 passNumerator,
+        uint256 failNumerator,
+        uint256 denominator
+    );
+
+    /// @notice Custom errors
+    error InvalidAddress();
+    error CTFNotSupported();
+    error ConditionNotResolved();
+    error MarketAlreadyLinked();
+    error MarketNotLinked();
+    error InvalidConditionId();
+    error FetchFailed();
+
+    constructor(address _polymarketCTF) Ownable(msg.sender) {
+        if (_polymarketCTF == address(0)) revert InvalidAddress();
+        polymarketCTF = _polymarketCTF;
+        supportedCTFContracts[_polymarketCTF] = true;
+        emit CTFContractAdded(_polymarketCTF);
+    }
+
+    // ========== Admin Functions ==========
+
+    /**
+     * @notice Add a supported CTF contract address
+     * @param ctfContract Address of CTF contract to add
+     */
+    function addCTFContract(address ctfContract) external onlyOwner {
+        if (ctfContract == address(0)) revert InvalidAddress();
+        supportedCTFContracts[ctfContract] = true;
+        emit CTFContractAdded(ctfContract);
+    }
+
+    /**
+     * @notice Remove a supported CTF contract address
+     * @param ctfContract Address of CTF contract to remove
+     */
+    function removeCTFContract(address ctfContract) external onlyOwner {
+        supportedCTFContracts[ctfContract] = false;
+        emit CTFContractRemoved(ctfContract);
+    }
+
+    /**
+     * @notice Update the primary Polymarket CTF address
+     * @param newCTF New primary CTF contract address
+     */
+    function updatePrimaryCTF(address newCTF) external onlyOwner {
+        if (newCTF == address(0)) revert InvalidAddress();
+        address oldCTF = polymarketCTF;
+        polymarketCTF = newCTF;
+        supportedCTFContracts[newCTF] = true;
+        emit PrimaryCtfUpdated(oldCTF, newCTF);
+    }
+
+    // ========== Market Linking Functions ==========
+
+    /**
+     * @notice Link a friend market to a Polymarket condition
+     * @param friendMarketId ID of the friend market
+     * @param conditionId Polymarket condition ID
+     */
+    function linkMarketToPolymarket(
+        uint256 friendMarketId,
+        bytes32 conditionId
+    ) external {
+        linkMarketToPolymarketWithCTF(friendMarketId, conditionId, polymarketCTF);
+    }
+
+    /**
+     * @notice Link a friend market to a Polymarket condition with specific CTF
+     * @param friendMarketId ID of the friend market
+     * @param conditionId Polymarket condition ID
+     * @param ctfContract Address of the CTF contract
+     */
+    function linkMarketToPolymarketWithCTF(
+        uint256 friendMarketId,
+        bytes32 conditionId,
+        address ctfContract
+    ) public {
+        if (!supportedCTFContracts[ctfContract]) revert CTFNotSupported();
+        if (linkedMarkets[friendMarketId].linked) revert MarketAlreadyLinked();
+        if (conditionId == bytes32(0)) revert InvalidConditionId();
+
+        // Verify condition exists on CTF
+        try IPolymarketOracle(ctfContract).getCondition(conditionId) returns (
+            address oracle,
+            bytes32 questionId,
+            uint256 outcomeSlotCount,
+            bool /* resolved */
+        ) {
+            // Condition must be prepared (oracle != 0)
+            if (oracle == address(0)) revert InvalidConditionId();
+            // We only support binary outcomes for friend markets
+            require(outcomeSlotCount == 2, "Only binary conditions supported");
+        } catch {
+            revert InvalidConditionId();
+        }
+
+        linkedMarkets[friendMarketId] = PolymarketCondition({
+            conditionId: conditionId,
+            ctfContract: ctfContract,
+            linked: true
+        });
+
+        emit MarketLinkedToPolymarket(friendMarketId, conditionId, ctfContract);
+    }
+
+    /**
+     * @notice Unlink a friend market from Polymarket
+     * @param friendMarketId ID of the friend market
+     */
+    function unlinkMarket(uint256 friendMarketId) external onlyOwner {
+        if (!linkedMarkets[friendMarketId].linked) revert MarketNotLinked();
+        delete linkedMarkets[friendMarketId];
+        emit MarketUnlinked(friendMarketId);
+    }
+
+    // ========== Resolution Functions ==========
+
+    /**
+     * @notice Fetch resolution data from Polymarket CTF
+     * @param conditionId The condition ID to fetch
+     * @return passNumerator Payout numerator for PASS/YES outcome
+     * @return failNumerator Payout numerator for FAIL/NO outcome
+     * @return denominator Payout denominator
+     */
+    function fetchResolution(bytes32 conditionId) public returns (
+        uint256 passNumerator,
+        uint256 failNumerator,
+        uint256 denominator
+    ) {
+        return fetchResolutionFromCTF(conditionId, polymarketCTF);
+    }
+
+    /**
+     * @notice Fetch resolution data from a specific CTF contract
+     * @param conditionId The condition ID to fetch
+     * @param ctfContract The CTF contract address
+     * @return passNumerator Payout numerator for PASS/YES outcome
+     * @return failNumerator Payout numerator for FAIL/NO outcome
+     * @return denominator Payout denominator
+     */
+    function fetchResolutionFromCTF(
+        bytes32 conditionId,
+        address ctfContract
+    ) public returns (
+        uint256 passNumerator,
+        uint256 failNumerator,
+        uint256 denominator
+    ) {
+        if (!supportedCTFContracts[ctfContract]) revert CTFNotSupported();
+
+        // Check if resolved
+        bool resolved;
+        try IPolymarketOracle(ctfContract).isResolved(conditionId) returns (bool _resolved) {
+            resolved = _resolved;
+        } catch {
+            revert FetchFailed();
+        }
+
+        if (!resolved) revert ConditionNotResolved();
+
+        // Fetch payout numerators
+        uint256[] memory payouts;
+        try IPolymarketOracle(ctfContract).getPayoutNumerators(conditionId) returns (uint256[] memory _payouts) {
+            payouts = _payouts;
+        } catch {
+            revert FetchFailed();
+        }
+
+        // Fetch denominator
+        try IPolymarketOracle(ctfContract).getPayoutDenominator(conditionId) returns (uint256 _denominator) {
+            denominator = _denominator;
+        } catch {
+            revert FetchFailed();
+        }
+
+        // For binary markets: payouts[0] = YES/PASS, payouts[1] = NO/FAIL
+        require(payouts.length == 2, "Invalid payout array");
+        passNumerator = payouts[0];
+        failNumerator = payouts[1];
+
+        // Cache the resolution
+        resolutionCache[conditionId] = CachedResolution({
+            resolved: true,
+            passNumerator: passNumerator,
+            failNumerator: failNumerator,
+            denominator: denominator,
+            cachedAt: block.timestamp
+        });
+
+        emit ResolutionFetched(conditionId, passNumerator, failNumerator, denominator);
+        emit ResolutionCached(conditionId, passNumerator, failNumerator, denominator);
+    }
+
+    /**
+     * @notice Get resolution data for a linked market
+     * @param friendMarketId ID of the friend market
+     * @return passNumerator Payout numerator for PASS/YES outcome
+     * @return failNumerator Payout numerator for FAIL/NO outcome
+     * @return denominator Payout denominator
+     * @return resolved Whether the condition is resolved
+     */
+    function getResolutionForMarket(uint256 friendMarketId) external returns (
+        uint256 passNumerator,
+        uint256 failNumerator,
+        uint256 denominator,
+        bool resolved
+    ) {
+        PolymarketCondition storage condition = linkedMarkets[friendMarketId];
+        if (!condition.linked) revert MarketNotLinked();
+
+        // Check cache first
+        CachedResolution storage cached = resolutionCache[condition.conditionId];
+        if (cached.resolved) {
+            return (
+                cached.passNumerator,
+                cached.failNumerator,
+                cached.denominator,
+                true
+            );
+        }
+
+        // Try to fetch from CTF
+        try this.fetchResolutionFromCTF(condition.conditionId, condition.ctfContract) returns (
+            uint256 _passNumerator,
+            uint256 _failNumerator,
+            uint256 _denominator
+        ) {
+            return (_passNumerator, _failNumerator, _denominator, true);
+        } catch {
+            return (0, 0, 0, false);
+        }
+    }
+
+    // ========== View Functions ==========
+
+    /**
+     * @notice Check if a market is linked to Polymarket
+     * @param friendMarketId ID of the friend market
+     */
+    function isMarketLinked(uint256 friendMarketId) external view returns (bool) {
+        return linkedMarkets[friendMarketId].linked;
+    }
+
+    /**
+     * @notice Get linked market details
+     * @param friendMarketId ID of the friend market
+     */
+    function getLinkedMarket(uint256 friendMarketId) external view returns (
+        bytes32 conditionId,
+        address ctfContract,
+        bool linked
+    ) {
+        PolymarketCondition storage condition = linkedMarkets[friendMarketId];
+        return (condition.conditionId, condition.ctfContract, condition.linked);
+    }
+
+    /**
+     * @notice Check if a condition is resolved (from cache or CTF)
+     * @param conditionId The condition ID to check
+     */
+    function isConditionResolved(bytes32 conditionId) external view returns (bool) {
+        // Check cache first
+        if (resolutionCache[conditionId].resolved) {
+            return true;
+        }
+
+        // Check CTF
+        try IPolymarketOracle(polymarketCTF).isResolved(conditionId) returns (bool resolved) {
+            return resolved;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * @notice Get cached resolution data
+     * @param conditionId The condition ID
+     */
+    function getCachedResolution(bytes32 conditionId) external view returns (
+        bool resolved,
+        uint256 passNumerator,
+        uint256 failNumerator,
+        uint256 denominator,
+        uint256 cachedAt
+    ) {
+        CachedResolution storage cached = resolutionCache[conditionId];
+        return (
+            cached.resolved,
+            cached.passNumerator,
+            cached.failNumerator,
+            cached.denominator,
+            cached.cachedAt
+        );
+    }
+
+    /**
+     * @notice Compute condition ID (utility function matching CTF standard)
+     * @param oracle The oracle address (Polymarket's UMA CTF Adapter)
+     * @param questionId The question identifier (from Polymarket market)
+     * @param outcomeSlotCount Number of outcomes (2 for binary)
+     */
+    function computeConditionId(
+        address oracle,
+        bytes32 questionId,
+        uint256 outcomeSlotCount
+    ) external pure returns (bytes32) {
+        return keccak256(abi.encodePacked(oracle, questionId, outcomeSlotCount));
+    }
+
+    /**
+     * @notice Determine winning outcome from resolution data
+     * @param passNumerator Payout numerator for PASS/YES
+     * @param failNumerator Payout numerator for FAIL/NO
+     * @return outcome True if PASS/YES wins, false if FAIL/NO wins
+     * @return isTie True if it's a tie
+     */
+    function determineOutcome(
+        uint256 passNumerator,
+        uint256 failNumerator
+    ) external pure returns (bool outcome, bool isTie) {
+        if (passNumerator == failNumerator) {
+            return (false, true);
+        }
+        return (passNumerator > failNumerator, false);
+    }
+}

--- a/contracts/oracles/UMAOracleAdapter.sol
+++ b/contracts/oracles/UMAOracleAdapter.sol
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "../interfaces/IUMAOptimisticOracle.sol";
+import "./IOracleAdapter.sol";
+
+/**
+ * @title UMAOracleAdapter
+ * @notice Oracle adapter for arbitrary truth assertions using UMA Optimistic Oracle
+ * @dev Enables P2P wagers on any verifiable claim with dispute resolution
+ *
+ * KEY FEATURES:
+ * - Create assertions about any verifiable real-world event
+ * - Built-in dispute mechanism via UMA DVM
+ * - Economic security through bonding
+ * - Flexible liveness periods
+ *
+ * FLOW:
+ * 1. Create condition with claim text
+ * 2. Assert the outcome (requires bond)
+ * 3. Wait for challenge period
+ * 4. If disputed, UMA DVM resolves
+ * 5. Settle to finalize result
+ *
+ * EXAMPLE USE CASES:
+ * - "The Lakers will win the 2025 NBA Finals"
+ * - "SpaceX will launch Starship to orbit in Q2 2025"
+ * - "Bitcoin ETF will be approved by SEC in 2024"
+ */
+contract UMAOracleAdapter is IOracleAdapter, Ownable {
+    using SafeERC20 for IERC20;
+
+    // ========== Types ==========
+
+    struct Condition {
+        string description;
+        uint256 deadline;           // When assertion can be made
+        bytes32 assertionId;        // UMA assertion ID (0 if not asserted)
+        bool registered;
+        bool assertedOutcome;       // What outcome was asserted
+    }
+
+    struct Resolution {
+        bool resolved;
+        bool outcome;
+        uint256 resolvedAt;
+        uint256 confidence;         // 10000 = 100% (settled), less if disputed
+    }
+
+    // ========== Storage ==========
+
+    // UMA Optimistic Oracle V3 address
+    IUMAOptimisticOracle public umaOracle;
+
+    // Bond token (usually WETH or USDC)
+    IERC20 public bondToken;
+
+    // Condition ID => Condition
+    mapping(bytes32 => Condition) public conditions;
+
+    // Condition ID => Resolution
+    mapping(bytes32 => Resolution) public resolutions;
+
+    // UMA assertion ID => Condition ID (for callbacks)
+    mapping(bytes32 => bytes32) public assertionToCondition;
+
+    // Configuration
+    uint256 public defaultBond = 0.1 ether;       // Default bond amount
+    uint64 public defaultLiveness = 2 hours;       // Default challenge period
+    bytes32 public constant ASSERT_TRUTH_ID = bytes32("ASSERT_TRUTH");
+
+    // ========== Events ==========
+
+    event ConditionCreated(
+        bytes32 indexed conditionId,
+        string description,
+        uint256 deadline
+    );
+    event AssertionMade(
+        bytes32 indexed conditionId,
+        bytes32 indexed assertionId,
+        address indexed asserter,
+        bool outcome
+    );
+    event AssertionDisputed(
+        bytes32 indexed conditionId,
+        bytes32 indexed assertionId
+    );
+    event ConditionSettled(
+        bytes32 indexed conditionId,
+        bool outcome,
+        uint256 resolvedAt
+    );
+    event ConfigUpdated(uint256 newBond, uint64 newLiveness);
+
+    // ========== Errors ==========
+
+    error ConditionNotFound();
+    error ConditionAlreadyExists();
+    error ConditionAlreadyAsserted();
+    error DeadlineNotReached();
+    error DeadlineInPast();
+    error AssertionNotSettled();
+    error InvalidOracleAddress();
+    error InsufficientBond();
+
+    // ========== Constructor ==========
+
+    constructor(
+        address _owner,
+        address _umaOracle,
+        address _bondToken
+    ) Ownable(_owner) {
+        if (_umaOracle == address(0)) revert InvalidOracleAddress();
+        umaOracle = IUMAOptimisticOracle(_umaOracle);
+        bondToken = IERC20(_bondToken);
+    }
+
+    // ========== Admin Functions ==========
+
+    /**
+     * @notice Update default configuration
+     * @param newBond New default bond amount
+     * @param newLiveness New default liveness period
+     */
+    function setConfig(uint256 newBond, uint64 newLiveness) external onlyOwner {
+        defaultBond = newBond;
+        defaultLiveness = newLiveness;
+        emit ConfigUpdated(newBond, newLiveness);
+    }
+
+    /**
+     * @notice Update UMA Oracle address
+     * @param newOracle New UMA Optimistic Oracle address
+     */
+    function setUMAOracle(address newOracle) external onlyOwner {
+        if (newOracle == address(0)) revert InvalidOracleAddress();
+        umaOracle = IUMAOptimisticOracle(newOracle);
+    }
+
+    // ========== Condition Management ==========
+
+    /**
+     * @notice Create a new condition for a verifiable claim
+     * @param description The claim being asserted (e.g., "Lakers win 2025 Finals")
+     * @param deadline When the outcome should be known
+     * @return conditionId The unique condition identifier
+     */
+    function createCondition(
+        string calldata description,
+        uint256 deadline
+    ) external returns (bytes32 conditionId) {
+        if (deadline <= block.timestamp) revert DeadlineInPast();
+
+        conditionId = keccak256(abi.encodePacked(
+            description,
+            deadline,
+            msg.sender,
+            block.timestamp
+        ));
+
+        if (conditions[conditionId].registered) revert ConditionAlreadyExists();
+
+        conditions[conditionId] = Condition({
+            description: description,
+            deadline: deadline,
+            assertionId: bytes32(0),
+            registered: true,
+            assertedOutcome: false
+        });
+
+        emit ConditionCreated(conditionId, description, deadline);
+        emit ConditionRegistered(conditionId, description, deadline);
+
+        return conditionId;
+    }
+
+    /**
+     * @notice Assert an outcome for a condition
+     * @param conditionId The condition to assert
+     * @param outcome True if the claim is true
+     * @return assertionId The UMA assertion ID
+     */
+    function assertOutcome(
+        bytes32 conditionId,
+        bool outcome
+    ) external returns (bytes32 assertionId) {
+        Condition storage condition = conditions[conditionId];
+        if (!condition.registered) revert ConditionNotFound();
+        if (condition.assertionId != bytes32(0)) revert ConditionAlreadyAsserted();
+        if (block.timestamp < condition.deadline) revert DeadlineNotReached();
+
+        // Transfer bond from asserter
+        bondToken.safeTransferFrom(msg.sender, address(this), defaultBond);
+        bondToken.approve(address(umaOracle), defaultBond);
+
+        // Create claim text
+        bytes memory claim = abi.encodePacked(
+            outcome ? "TRUE: " : "FALSE: ",
+            condition.description
+        );
+
+        // Submit assertion to UMA
+        assertionId = umaOracle.assertTruth(
+            claim,
+            msg.sender,
+            address(this),      // This contract receives callbacks
+            address(0),         // No custom security
+            address(bondToken),
+            defaultBond,
+            defaultLiveness,
+            ASSERT_TRUTH_ID
+        );
+
+        // Store assertion info
+        condition.assertionId = assertionId;
+        condition.assertedOutcome = outcome;
+        assertionToCondition[assertionId] = conditionId;
+
+        emit AssertionMade(conditionId, assertionId, msg.sender, outcome);
+    }
+
+    /**
+     * @notice Settle a condition after UMA assertion is settled
+     * @param conditionId The condition to settle
+     */
+    function settleCondition(bytes32 conditionId) external {
+        Condition storage condition = conditions[conditionId];
+        if (!condition.registered) revert ConditionNotFound();
+        if (resolutions[conditionId].resolved) return; // Already settled
+
+        bytes32 assertionId = condition.assertionId;
+        if (assertionId == bytes32(0)) revert AssertionNotSettled();
+
+        // Check if UMA assertion is settled
+        if (!umaOracle.isAssertionSettled(assertionId)) {
+            // Try to settle it
+            umaOracle.settleAssertion(assertionId);
+        }
+
+        // Get result
+        bool assertionValid = umaOracle.getAssertionResult(assertionId);
+
+        // If assertion was valid, use asserted outcome; otherwise, use opposite
+        bool finalOutcome = assertionValid ? condition.assertedOutcome : !condition.assertedOutcome;
+
+        resolutions[conditionId] = Resolution({
+            resolved: true,
+            outcome: finalOutcome,
+            resolvedAt: block.timestamp,
+            confidence: 10000 // Full confidence after UMA settlement
+        });
+
+        emit ConditionSettled(conditionId, finalOutcome, block.timestamp);
+        emit ConditionResolved(conditionId, finalOutcome, 10000, block.timestamp);
+    }
+
+    // ========== UMA Callbacks ==========
+
+    /**
+     * @notice Called by UMA when an assertion is disputed
+     * @param assertionId The disputed assertion
+     */
+    function assertionDisputedCallback(bytes32 assertionId) external {
+        require(msg.sender == address(umaOracle), "Only UMA");
+        bytes32 conditionId = assertionToCondition[assertionId];
+        if (conditionId != bytes32(0)) {
+            emit AssertionDisputed(conditionId, assertionId);
+        }
+    }
+
+    /**
+     * @notice Called by UMA when an assertion is resolved
+     * @param assertionId The resolved assertion
+     * @param assertedTruthfully Whether the assertion was truthful
+     */
+    function assertionResolvedCallback(bytes32 assertionId, bool assertedTruthfully) external {
+        require(msg.sender == address(umaOracle), "Only UMA");
+        bytes32 conditionId = assertionToCondition[assertionId];
+        if (conditionId != bytes32(0) && !resolutions[conditionId].resolved) {
+            Condition storage condition = conditions[conditionId];
+            bool finalOutcome = assertedTruthfully ? condition.assertedOutcome : !condition.assertedOutcome;
+
+            resolutions[conditionId] = Resolution({
+                resolved: true,
+                outcome: finalOutcome,
+                resolvedAt: block.timestamp,
+                confidence: 10000
+            });
+
+            emit ConditionSettled(conditionId, finalOutcome, block.timestamp);
+            emit ConditionResolved(conditionId, finalOutcome, 10000, block.timestamp);
+        }
+    }
+
+    // ========== IOracleAdapter Implementation ==========
+
+    /**
+     * @notice Returns the oracle type
+     */
+    function oracleType() external pure override returns (string memory) {
+        return "UMA";
+    }
+
+    /**
+     * @notice Check if a condition is supported
+     */
+    function isConditionSupported(bytes32 conditionId) external view override returns (bool supported) {
+        return conditions[conditionId].registered;
+    }
+
+    /**
+     * @notice Check if a condition is resolved
+     */
+    function isConditionResolved(bytes32 conditionId) external view override returns (bool resolved) {
+        return resolutions[conditionId].resolved;
+    }
+
+    /**
+     * @notice Get the outcome of a resolved condition
+     */
+    function getOutcome(bytes32 conditionId) external view override returns (
+        bool outcome,
+        uint256 confidence,
+        uint256 resolvedAt
+    ) {
+        Resolution storage res = resolutions[conditionId];
+        if (!res.resolved) {
+            return (false, 0, 0);
+        }
+        return (res.outcome, res.confidence, res.resolvedAt);
+    }
+
+    /**
+     * @notice Get metadata about a condition
+     */
+    function getConditionMetadata(bytes32 conditionId) external view override returns (
+        string memory description,
+        uint256 expectedResolutionTime
+    ) {
+        Condition storage condition = conditions[conditionId];
+        return (condition.description, condition.deadline);
+    }
+
+    // ========== View Functions ==========
+
+    /**
+     * @notice Get condition details
+     */
+    function getCondition(bytes32 conditionId) external view returns (
+        string memory description,
+        uint256 deadline,
+        bytes32 assertionId,
+        bool registered,
+        bool assertedOutcome
+    ) {
+        Condition storage c = conditions[conditionId];
+        return (c.description, c.deadline, c.assertionId, c.registered, c.assertedOutcome);
+    }
+
+    /**
+     * @notice Get resolution details
+     */
+    function getResolution(bytes32 conditionId) external view returns (
+        bool resolved,
+        bool outcome,
+        uint256 resolvedAt,
+        uint256 confidence
+    ) {
+        Resolution storage r = resolutions[conditionId];
+        return (r.resolved, r.outcome, r.resolvedAt, r.confidence);
+    }
+
+    /**
+     * @notice Check if a condition can be asserted
+     */
+    function canAssert(bytes32 conditionId) external view returns (bool) {
+        Condition storage condition = conditions[conditionId];
+        if (!condition.registered) return false;
+        if (condition.assertionId != bytes32(0)) return false;
+        if (block.timestamp < condition.deadline) return false;
+        return true;
+    }
+
+    /**
+     * @notice Check if a condition can be settled
+     */
+    function canSettle(bytes32 conditionId) external view returns (bool) {
+        Condition storage condition = conditions[conditionId];
+        if (!condition.registered) return false;
+        if (resolutions[conditionId].resolved) return false;
+        if (condition.assertionId == bytes32(0)) return false;
+        return umaOracle.isAssertionSettled(condition.assertionId);
+    }
+}

--- a/contracts/test/MockPolymarketCTF.sol
+++ b/contracts/test/MockPolymarketCTF.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.24;
+
+import "../interfaces/IPolymarketOracle.sol";
+
+/**
+ * @title MockPolymarketCTF
+ * @notice Mock implementation of Polymarket's CTF contract for testing
+ * @dev Simulates the Gnosis CTF standard used by Polymarket
+ */
+contract MockPolymarketCTF is IPolymarketOracle {
+
+    struct Condition {
+        address oracle;
+        bytes32 questionId;
+        uint256 outcomeSlotCount;
+        uint256[] payoutNumerators;
+        uint256 payoutDenominator;
+        bool resolved;
+    }
+
+    mapping(bytes32 => Condition) private conditions;
+
+    event ConditionPreparation(
+        bytes32 indexed conditionId,
+        address indexed oracle,
+        bytes32 indexed questionId,
+        uint256 outcomeSlotCount
+    );
+
+    event ConditionResolution(
+        bytes32 indexed conditionId,
+        address indexed oracle,
+        bytes32 indexed questionId,
+        uint256 outcomeSlotCount,
+        uint256[] payoutNumerators
+    );
+
+    /**
+     * @notice Prepare a condition (simulates Polymarket market creation)
+     * @param oracle Oracle address (usually Polymarket's UMA adapter)
+     * @param questionId Unique question identifier
+     * @param outcomeSlotCount Number of outcomes (2 for binary)
+     */
+    function prepareCondition(
+        address oracle,
+        bytes32 questionId,
+        uint256 outcomeSlotCount
+    ) external returns (bytes32 conditionId) {
+        require(outcomeSlotCount >= 2, "At least 2 outcomes required");
+        require(outcomeSlotCount <= 256, "Too many outcomes");
+
+        conditionId = getConditionId(oracle, questionId, outcomeSlotCount);
+        require(conditions[conditionId].oracle == address(0), "Condition already prepared");
+
+        conditions[conditionId] = Condition({
+            oracle: oracle,
+            questionId: questionId,
+            outcomeSlotCount: outcomeSlotCount,
+            payoutNumerators: new uint256[](outcomeSlotCount),
+            payoutDenominator: 0,
+            resolved: false
+        });
+
+        emit ConditionPreparation(conditionId, oracle, questionId, outcomeSlotCount);
+    }
+
+    /**
+     * @notice Resolve a condition (for testing purposes)
+     * @param conditionId The condition to resolve
+     * @param payouts Array of payout numerators
+     */
+    function resolveCondition(
+        bytes32 conditionId,
+        uint256[] calldata payouts
+    ) external {
+        Condition storage condition = conditions[conditionId];
+        require(condition.oracle != address(0), "Condition not prepared");
+        require(!condition.resolved, "Already resolved");
+        require(payouts.length == condition.outcomeSlotCount, "Invalid payout array");
+
+        uint256 den = 0;
+        for (uint256 i = 0; i < payouts.length; i++) {
+            den += payouts[i];
+        }
+        require(den > 0, "Payout denominator must be positive");
+
+        condition.payoutNumerators = payouts;
+        condition.payoutDenominator = den;
+        condition.resolved = true;
+
+        emit ConditionResolution(
+            conditionId,
+            condition.oracle,
+            condition.questionId,
+            condition.outcomeSlotCount,
+            payouts
+        );
+    }
+
+    // ========== IPolymarketOracle Implementation ==========
+
+    function getCondition(bytes32 conditionId) external view override returns (
+        address oracle,
+        bytes32 questionId,
+        uint256 outcomeSlotCount,
+        bool resolved
+    ) {
+        Condition storage condition = conditions[conditionId];
+        return (
+            condition.oracle,
+            condition.questionId,
+            condition.outcomeSlotCount,
+            condition.resolved
+        );
+    }
+
+    function isResolved(bytes32 conditionId) external view override returns (bool) {
+        return conditions[conditionId].resolved;
+    }
+
+    function getPayoutNumerators(bytes32 conditionId) external view override returns (uint256[] memory) {
+        require(conditions[conditionId].resolved, "Condition not resolved");
+        return conditions[conditionId].payoutNumerators;
+    }
+
+    function getPayoutDenominator(bytes32 conditionId) external view override returns (uint256) {
+        require(conditions[conditionId].resolved, "Condition not resolved");
+        return conditions[conditionId].payoutDenominator;
+    }
+
+    function getConditionId(
+        address oracle,
+        bytes32 questionId,
+        uint256 outcomeSlotCount
+    ) public pure override returns (bytes32) {
+        return keccak256(abi.encodePacked(oracle, questionId, outcomeSlotCount));
+    }
+}

--- a/docs/architecture/IMPLEMENTATION_PLAN.md
+++ b/docs/architecture/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,1160 @@
+# FairWins Platform Transformation - Complete Implementation Plan
+
+## Executive Summary
+
+This document outlines the complete transformation of FairWins from a prediction market platform to a **P2P wager management layer**. It integrates the consistency fixes identified in the system flow analysis with the architectural changes needed to support the new primary focus.
+
+### Transformation Goals
+
+1. **P2P wagers as primary product** - Simple, direct bets between parties
+2. **External markets as infrastructure** - Polymarket, Chainlink, UMA for resolution
+3. **Social platforms as distribution** - Share to Twitter/Discord/Telegram
+4. **User dashboard as interface** - Track positions, metrics, analytics
+5. **No liquidity fragmentation** - Leverage existing market depth
+
+### Critical Fixes Required
+
+1. Implement `claimWinnings()` - Transfer stakes after resolution
+2. Add challenge period for manual resolutions
+3. Add claim timeout with treasury fallback
+4. Add oracle timeout fallback mechanism
+5. Add optional arbitrator fee mechanism
+
+---
+
+## Phase Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                    IMPLEMENTATION PHASES                                     │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  PHASE 1: Core Fixes (Foundation)                          [2-3 weeks]     │
+│  ├── PR1: Implement claimWinnings()                                         │
+│  ├── PR2: Add challenge period for disputes                                 │
+│  ├── PR3: Add claim timeout mechanism                                       │
+│  └── PR4: Add oracle timeout fallback                                       │
+│                                                                              │
+│  PHASE 2: Oracle Expansion                                  [2 weeks]       │
+│  ├── PR5: Create OracleRegistry contract                                    │
+│  ├── PR6: Implement ChainlinkOracleAdapter                                  │
+│  └── PR7: Implement UMAOracleAdapter                                        │
+│                                                                              │
+│  PHASE 3: P2P Simplification                                [2-3 weeks]     │
+│  ├── PR8: Create standalone P2PWagerFactory                                 │
+│  ├── PR9: Add arbitrator fee mechanism                                      │
+│  └── PR10: Migrate from CTF dependency                                      │
+│                                                                              │
+│  PHASE 4: Market Discovery                                  [2 weeks]       │
+│  ├── PR11: Build market aggregator service                                  │
+│  └── PR12: Add discovery UI components                                      │
+│                                                                              │
+│  PHASE 5: Social Share-out                                  [1-2 weeks]     │
+│  ├── PR13: Implement share service                                          │
+│  └── PR14: Add OG image generation                                          │
+│                                                                              │
+│  PHASE 6: Dashboard & Metrics                               [2 weeks]       │
+│  ├── PR15: Deploy subgraph for indexing                                     │
+│  ├── PR16: Build position dashboard                                         │
+│  └── PR17: Add metrics and analytics                                        │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Detailed PR Specifications
+
+### PHASE 1: Core Fixes (Foundation)
+
+#### PR1: Implement claimWinnings() Function
+
+**Priority:** CRITICAL
+**Estimated Effort:** 3-4 days
+**Dependencies:** None
+
+**Problem:**
+Resolution marks wager as resolved but doesn't transfer funds. Stakes remain locked in contract.
+
+**Solution:**
+Add `claimWinnings()` function that transfers stakes to winner after resolution.
+
+**Files to Create/Modify:**
+- `contracts/markets/FriendGroupMarketFactory.sol` - Add claimWinnings function
+- `contracts/markets/FriendGroupMarketLib.sol` - Add payout calculation helpers
+- `test/FriendGroupMarketFactory.Claim.test.js` - New test file
+
+**Contract Changes:**
+```solidity
+// New storage
+mapping(uint256 => bool) public winningsClaimed;
+mapping(uint256 => address) public wagerWinner;
+mapping(uint256 => bool) public wagerOutcome; // true = creator wins, false = opponent wins
+
+// New events
+event WinningsClaimed(
+    uint256 indexed friendMarketId,
+    address indexed winner,
+    uint256 amount,
+    address token
+);
+
+// New function
+function claimWinnings(uint256 friendMarketId) external nonReentrant;
+```
+
+**State Transitions:**
+```
+Resolved + !claimed → Resolved + claimed (funds transferred)
+```
+
+**Acceptance Criteria:**
+- [ ] Winner can claim after resolution
+- [ ] Non-winner cannot claim
+- [ ] Cannot claim twice
+- [ ] Supports native and ERC20 tokens
+- [ ] Emits WinningsClaimed event
+- [ ] Gas optimized (<100k gas)
+
+---
+
+#### PR2: Add Challenge Period for Manual Resolutions
+
+**Priority:** HIGH
+**Estimated Effort:** 4-5 days
+**Dependencies:** PR1
+
+**Problem:**
+Manual resolutions are immediately final. No recourse for dishonest resolution.
+
+**Solution:**
+Add 24-48 hour challenge window before resolution is finalized.
+
+**Files to Create/Modify:**
+- `contracts/markets/FriendGroupMarketFactory.sol` - Add challenge logic
+- `contracts/markets/DisputeManager.sol` - New contract for dispute handling
+- `test/FriendGroupMarketFactory.Dispute.test.js` - New test file
+
+**New State Machine:**
+```
+Active → PendingResolution → Challenged → Resolved
+                          → Finalized → Resolved
+```
+
+**Contract Changes:**
+```solidity
+// New enum value
+enum FriendMarketStatus {
+    PendingAcceptance,
+    Active,
+    PendingResolution,  // NEW: Waiting for challenge period
+    Challenged,         // NEW: Under dispute
+    Resolved,
+    Cancelled,
+    Refunded
+}
+
+// New storage
+struct PendingResolution {
+    bool proposedOutcome;
+    address proposer;
+    uint256 proposedAt;
+    uint256 challengeDeadline;
+}
+mapping(uint256 => PendingResolution) public pendingResolutions;
+
+uint256 public challengePeriod = 24 hours;
+uint256 public challengeBond = 0.1 ether;
+
+// New functions
+function proposeResolution(uint256 friendMarketId, bool outcome) external;
+function challengeResolution(uint256 friendMarketId) external payable;
+function finalizeResolution(uint256 friendMarketId) external;
+function resolveDispute(uint256 friendMarketId, bool outcome) external; // arbitrator only
+```
+
+**Acceptance Criteria:**
+- [ ] Manual resolutions enter PendingResolution state
+- [ ] 24-hour challenge window before finalization
+- [ ] Either party can challenge with bond
+- [ ] Arbitrator resolves disputes
+- [ ] Bonds distributed based on outcome
+- [ ] Existing oracle resolutions skip challenge period
+
+---
+
+#### PR3: Add Claim Timeout Mechanism
+
+**Priority:** MEDIUM
+**Estimated Effort:** 2-3 days
+**Dependencies:** PR1
+
+**Problem:**
+If winner never claims, funds locked forever. No recovery mechanism.
+
+**Solution:**
+Add 90-day claim window. Unclaimed funds go to DAO treasury.
+
+**Files to Create/Modify:**
+- `contracts/markets/FriendGroupMarketFactory.sol` - Add timeout logic
+- `test/FriendGroupMarketFactory.Timeout.test.js` - New test file
+
+**Contract Changes:**
+```solidity
+// New storage
+uint256 public claimTimeout = 90 days;
+address public treasury;
+mapping(uint256 => uint256) public resolutionTimestamp;
+
+// New events
+event UnclaimedFundsSwept(
+    uint256 indexed friendMarketId,
+    uint256 amount,
+    address token
+);
+
+// New functions
+function sweepUnclaimedFunds(uint256 friendMarketId) external;
+function setTreasury(address _treasury) external onlyOwner;
+function setClaimTimeout(uint256 _timeout) external onlyOwner;
+```
+
+**Acceptance Criteria:**
+- [ ] Winner can claim within 90 days
+- [ ] After 90 days, anyone can sweep to treasury
+- [ ] Sweep only works if not claimed
+- [ ] Treasury address configurable
+- [ ] Timeout duration configurable
+
+---
+
+#### PR4: Add Oracle Timeout Fallback
+
+**Priority:** HIGH
+**Estimated Effort:** 3-4 days
+**Dependencies:** PR2
+
+**Problem:**
+If Polymarket/external oracle never resolves, wager stuck forever.
+
+**Solution:**
+Add timeout mechanism that enables manual override or mutual refund.
+
+**Files to Create/Modify:**
+- `contracts/markets/FriendGroupMarketFactory.sol` - Add fallback logic
+- `contracts/oracles/PolymarketOracleAdapter.sol` - Add timeout tracking
+- `test/FriendGroupMarketFactory.OracleTimeout.test.js` - New test file
+
+**Contract Changes:**
+```solidity
+// New storage
+uint256 public oracleTimeout = 30 days;
+mapping(uint256 => uint256) public expectedResolutionTime;
+
+// New events
+event OracleTimeoutTriggered(
+    uint256 indexed friendMarketId,
+    bytes32 conditionId,
+    uint256 expectedTime,
+    uint256 actualTime
+);
+
+event MutualRefundInitiated(
+    uint256 indexed friendMarketId,
+    address indexed initiator
+);
+
+// New functions
+function setExpectedResolutionTime(uint256 friendMarketId, uint256 timestamp) external;
+function triggerOracleTimeout(uint256 friendMarketId) external;
+function acceptMutualRefund(uint256 friendMarketId) external;
+function forceManualResolution(uint256 friendMarketId) external; // requires both parties or arbitrator
+```
+
+**State Transitions:**
+```
+Active + OracleTimeout → OracleTimedOut → MutualRefund (if both agree)
+                                        → ManualResolution (if arbitrator)
+```
+
+**Acceptance Criteria:**
+- [ ] After 30 days past expected resolution, timeout can be triggered
+- [ ] Both parties can agree to mutual refund
+- [ ] Arbitrator can force manual resolution
+- [ ] Original resolution type is preserved if oracle resolves late
+- [ ] Timeout period configurable
+
+---
+
+### PHASE 2: Oracle Expansion
+
+#### PR5: Create OracleRegistry Contract
+
+**Priority:** HIGH
+**Estimated Effort:** 3-4 days
+**Dependencies:** PR4
+
+**Problem:**
+Only Polymarket adapter exists. No unified interface for multiple oracles.
+
+**Solution:**
+Create registry pattern with pluggable adapters.
+
+**Files to Create:**
+- `contracts/oracles/OracleRegistry.sol` - Main registry contract
+- `contracts/oracles/IOracleAdapter.sol` - Standard adapter interface
+- `test/OracleRegistry.test.js` - Test file
+
+**Contract Structure:**
+```solidity
+// contracts/oracles/IOracleAdapter.sol
+interface IOracleAdapter {
+    function oracleType() external view returns (string memory);
+    function isConditionSupported(bytes32 conditionId) external view returns (bool);
+    function isConditionResolved(bytes32 conditionId) external view returns (bool);
+    function getOutcome(bytes32 conditionId) external view returns (
+        bool outcome,
+        uint256 confidence,
+        uint256 resolvedAt
+    );
+    function getConditionMetadata(bytes32 conditionId) external view returns (
+        string memory description,
+        uint256 expectedResolutionTime
+    );
+}
+
+// contracts/oracles/OracleRegistry.sol
+contract OracleRegistry is Ownable {
+    mapping(bytes32 => address) public adapters; // oracleId => adapter
+    mapping(address => bool) public verifiedAdapters;
+    bytes32[] public registeredOracleIds;
+
+    function registerAdapter(bytes32 oracleId, address adapter) external onlyOwner;
+    function removeAdapter(bytes32 oracleId) external onlyOwner;
+    function verifyAdapter(address adapter, bool verified) external onlyOwner;
+    function resolveCondition(bytes32 oracleId, bytes32 conditionId) external view returns (bool, uint256);
+    function findAdaptersForCondition(bytes32 conditionId) external view returns (address[] memory);
+}
+```
+
+**Acceptance Criteria:**
+- [ ] Registry can store multiple adapters
+- [ ] Adapters implement standard interface
+- [ ] Verification status for trust levels
+- [ ] Query across all adapters for condition
+- [ ] Events for registration/removal
+
+---
+
+#### PR6: Implement ChainlinkOracleAdapter
+
+**Priority:** MEDIUM
+**Estimated Effort:** 3-4 days
+**Dependencies:** PR5
+
+**Files to Create:**
+- `contracts/oracles/ChainlinkOracleAdapter.sol`
+- `contracts/interfaces/IChainlinkAggregator.sol`
+- `test/ChainlinkOracleAdapter.test.js`
+
+**Contract Structure:**
+```solidity
+contract ChainlinkOracleAdapter is IOracleAdapter, Ownable {
+    struct PriceCondition {
+        address feedAddress;
+        int256 threshold;
+        bool isAbove; // true = price > threshold wins
+        uint256 resolutionTime;
+        bool resolved;
+        bool outcome;
+    }
+
+    mapping(bytes32 => PriceCondition) public conditions;
+
+    function createPriceCondition(
+        address feedAddress,
+        int256 threshold,
+        bool isAbove,
+        uint256 resolutionTime
+    ) external returns (bytes32 conditionId);
+
+    function checkAndResolve(bytes32 conditionId) external;
+}
+```
+
+**Supported Use Cases:**
+- "ETH above $5000 by Dec 31"
+- "BTC below $30000 by end of month"
+- Any Chainlink price feed comparison
+
+---
+
+#### PR7: Implement UMAOracleAdapter
+
+**Priority:** MEDIUM
+**Estimated Effort:** 4-5 days
+**Dependencies:** PR5
+
+**Files to Create:**
+- `contracts/oracles/UMAOracleAdapter.sol`
+- `contracts/interfaces/IOptimisticOracleV3.sol`
+- `test/UMAOracleAdapter.test.js`
+
+**Contract Structure:**
+```solidity
+contract UMAOracleAdapter is IOracleAdapter, Ownable {
+    OptimisticOracleV3 public immutable oo;
+
+    struct Assertion {
+        bytes32 assertionId;
+        string ancillaryData;
+        uint256 bond;
+        uint256 liveness;
+        bool resolved;
+        bool outcome;
+    }
+
+    mapping(bytes32 => Assertion) public assertions;
+
+    function createAssertion(
+        string memory ancillaryData,
+        uint256 bond,
+        uint256 liveness
+    ) external returns (bytes32 conditionId);
+
+    function settleAssertion(bytes32 conditionId) external;
+}
+```
+
+---
+
+### PHASE 3: P2P Simplification
+
+#### PR8: Create Standalone P2PWagerFactory
+
+**Priority:** HIGH
+**Estimated Effort:** 5-7 days
+**Dependencies:** PR1-PR7
+
+**Problem:**
+Current FriendGroupMarketFactory has CTF dependency and complexity not needed for simple P2P wagers.
+
+**Solution:**
+Create simplified standalone contract focused purely on P2P wagers.
+
+**Files to Create:**
+- `contracts/wagers/P2PWagerFactory.sol` - Main wager contract
+- `contracts/wagers/WagerLib.sol` - Helper library
+- `test/P2PWagerFactory.test.js` - Test file
+
+**Contract Structure:**
+```solidity
+contract P2PWagerFactory is Ownable, ReentrancyGuard {
+    struct Wager {
+        uint256 wagerId;
+        address creator;
+        address opponent;
+        address arbitrator;
+        uint256 creatorStake;
+        uint256 opponentStake;
+        address stakeToken;
+        string description;
+        bytes32 oracleId;
+        bytes32 externalCondition;
+        WagerStatus status;
+        ResolutionType resolutionType;
+        uint256 acceptanceDeadline;
+        uint256 expectedResolutionTime;
+        uint256 createdAt;
+        uint256 resolvedAt;
+        bool outcome;
+        address winner;
+        uint256 arbitratorFee; // basis points (100 = 1%)
+    }
+
+    enum WagerStatus {
+        Pending,
+        Active,
+        PendingResolution,
+        Challenged,
+        Resolved,
+        Disputed,
+        Cancelled,
+        Refunded,
+        OracleTimedOut
+    }
+
+    enum ResolutionType {
+        CreatorResolves,
+        OpponentResolves,
+        EitherResolves,
+        Arbitrator,
+        ExternalOracle
+    }
+
+    // Core functions - Lifecycle
+    function createWager(...) external payable returns (uint256);
+    function acceptWager(uint256 wagerId) external payable;
+    function cancelWager(uint256 wagerId) external;
+
+    // Core functions - Resolution
+    function proposeResolution(uint256 wagerId, bool outcome) external;
+    function challengeResolution(uint256 wagerId) external payable;
+    function finalizeResolution(uint256 wagerId) external;
+    function resolveFromOracle(uint256 wagerId) external;
+
+    // Core functions - Claims
+    function claimWinnings(uint256 wagerId) external;
+    function sweepUnclaimedFunds(uint256 wagerId) external;
+
+    // Timeout handling
+    function triggerOracleTimeout(uint256 wagerId) external;
+    function acceptMutualRefund(uint256 wagerId) external;
+}
+```
+
+**Key Differences from FriendGroupMarketFactory:**
+1. No CTF/ConditionalMarket dependency
+2. Direct stake escrow and transfer
+3. Built-in challenge period
+4. Built-in claim timeout
+5. Built-in oracle timeout
+6. Built-in arbitrator fees
+7. Simpler state machine
+
+---
+
+#### PR9: Add Arbitrator Fee Mechanism
+
+**Priority:** MEDIUM
+**Estimated Effort:** 2-3 days
+**Dependencies:** PR8
+
+**Problem:**
+Arbitrators have no economic incentive for timely resolution.
+
+**Solution:**
+Allow optional arbitrator fee (% of stakes) paid on resolution.
+
+**Contract Changes (in P2PWagerFactory):**
+```solidity
+// In Wager struct
+uint256 arbitratorFee; // basis points (100 = 1%, max 1000 = 10%)
+
+// New storage
+uint256 public maxArbitratorFee = 1000; // 10% max
+
+// Events
+event ArbitratorPaid(
+    uint256 indexed wagerId,
+    address indexed arbitrator,
+    uint256 amount,
+    address token
+);
+
+// Logic in claimWinnings
+function claimWinnings(uint256 wagerId) external {
+    // ... validation ...
+
+    uint256 totalPot = wager.creatorStake + wager.opponentStake;
+    uint256 arbFee = 0;
+
+    if (wager.arbitrator != address(0) && wager.arbitratorFee > 0) {
+        arbFee = (totalPot * wager.arbitratorFee) / 10000;
+        _transferStake(wager.arbitrator, wager.stakeToken, arbFee);
+        emit ArbitratorPaid(wagerId, wager.arbitrator, arbFee, wager.stakeToken);
+    }
+
+    uint256 winnings = totalPot - arbFee;
+    _transferStake(wager.winner, wager.stakeToken, winnings);
+}
+```
+
+---
+
+#### PR10: Migrate from CTF Dependency
+
+**Priority:** MEDIUM
+**Estimated Effort:** 3-4 days
+**Dependencies:** PR8
+
+**Problem:**
+FriendGroupMarketFactory creates underlying CTF markets unnecessarily.
+
+**Solution:**
+Update to use P2PWagerFactory or remove CTF creation for simple wagers.
+
+**Files to Modify:**
+- `contracts/markets/FriendGroupMarketFactory.sol` - Remove CTF creation for P2P
+- `contracts/core/DAOFactory.sol` - Deploy P2PWagerFactory
+- Migration scripts
+
+**Approach:**
+1. Keep FriendGroupMarketFactory for CTF-backed complex markets
+2. Add P2PWagerFactory for simple P2P wagers
+3. Frontend routes to appropriate factory based on wager type
+
+---
+
+### PHASE 4: Market Discovery
+
+#### PR11: Build Market Aggregator Service
+
+**Priority:** MEDIUM
+**Estimated Effort:** 5-7 days
+**Dependencies:** PR5-PR7
+
+**Files to Create:**
+- `services/market-aggregator/` - New service directory
+- `services/market-aggregator/src/index.ts`
+- `services/market-aggregator/src/sources/polymarket.ts`
+- `services/market-aggregator/src/sources/chainlink.ts`
+- `services/market-aggregator/src/sources/uma.ts`
+- `services/market-aggregator/src/api/routes.ts`
+
+**API Endpoints:**
+```typescript
+// Search markets across all sources
+GET /api/markets/search?q={query}&sources={polymarket,chainlink,uma}
+
+// Get market details
+GET /api/markets/{source}/{conditionId}
+
+// Get trending markets
+GET /api/markets/trending?limit=10
+
+// Get markets resolving soon
+GET /api/markets/resolving-soon?days=7
+```
+
+**Data Model:**
+```typescript
+interface AggregatedMarket {
+  id: string;
+  source: 'polymarket' | 'chainlink' | 'uma' | 'manual';
+  conditionId: string;
+  oracleId: string;
+  question: string;
+  description?: string;
+  resolutionTime?: number;
+  currentOdds?: { yes: number; no: number };
+  volume?: string;
+  resolved: boolean;
+  outcome?: boolean;
+  chainId: number;
+  contractAddress: string;
+}
+```
+
+---
+
+#### PR12: Add Discovery UI Components
+
+**Priority:** MEDIUM
+**Estimated Effort:** 3-4 days
+**Dependencies:** PR11
+
+**Files to Create:**
+- `frontend/src/components/discovery/MarketSearch.jsx`
+- `frontend/src/components/discovery/MarketCard.jsx`
+- `frontend/src/components/discovery/MarketFilters.jsx`
+- `frontend/src/hooks/useMarketSearch.js`
+- `frontend/src/services/marketAggregator.js`
+
+---
+
+### PHASE 5: Social Share-out
+
+#### PR13: Implement Share Service
+
+**Priority:** MEDIUM
+**Estimated Effort:** 3-4 days
+**Dependencies:** PR8
+
+**Files to Create:**
+- `frontend/src/services/shareService.js`
+- `frontend/src/components/share/ShareModal.jsx`
+- `frontend/src/components/share/ShareButtons.jsx`
+
+**Share Service:**
+```javascript
+export const ShareService = {
+  // Twitter/X
+  generateTwitterIntent(wager) {
+    const text = `🎯 New wager challenge!\n\n"${wager.description}"\n\nStakes: ${wager.stake} ${wager.token}\n\nAccept the challenge:`;
+    const url = `https://fairwins.io/wager/${wager.id}`;
+    return `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`;
+  },
+
+  // Discord
+  generateDiscordWebhook(wager, webhookUrl) { ... },
+
+  // Telegram
+  generateTelegramShare(wager) {
+    const text = `🎯 New wager: "${wager.description}"`;
+    const url = `https://fairwins.io/wager/${wager.id}`;
+    return `https://t.me/share/url?url=${encodeURIComponent(url)}&text=${encodeURIComponent(text)}`;
+  },
+
+  // Universal link
+  generateShareLink(wager) {
+    return `https://fairwins.io/wager/${wager.id}`;
+  },
+
+  // Copy to clipboard
+  copyToClipboard(text) { ... }
+};
+```
+
+---
+
+#### PR14: Add OG Image Generation
+
+**Priority:** LOW
+**Estimated Effort:** 2-3 days
+**Dependencies:** PR13
+
+**Files to Create:**
+- `services/og-image/` - Vercel OG or similar
+- `frontend/src/pages/api/og.js` - Next.js API route (or equivalent)
+
+**OG Image Content:**
+```
+┌─────────────────────────────────────────┐
+│  🎯 FairWins Wager                      │
+│                                         │
+│  "ETH above $5000 by Dec 31, 2024"     │
+│                                         │
+│  Stakes: 0.5 ETH each                   │
+│  Resolution: Polymarket                 │
+│                                         │
+│  [Accept Challenge]                     │
+└─────────────────────────────────────────┘
+```
+
+---
+
+### PHASE 6: Dashboard & Metrics
+
+#### PR15: Deploy Subgraph for Indexing
+
+**Priority:** HIGH
+**Estimated Effort:** 4-5 days
+**Dependencies:** PR8
+
+**Files to Create:**
+- `subgraph/subgraph.yaml`
+- `subgraph/schema.graphql`
+- `subgraph/src/mappings/wagerFactory.ts`
+- `subgraph/src/mappings/oracleRegistry.ts`
+
+**Schema:**
+```graphql
+type User @entity {
+  id: Bytes!
+  wagersCreated: [Wager!]! @derivedFrom(field: "creator")
+  wagersAccepted: [Wager!]! @derivedFrom(field: "opponent")
+  wagersArbitrated: [Wager!]! @derivedFrom(field: "arbitrator")
+  totalWagered: BigInt!
+  totalWon: BigInt!
+  totalLost: BigInt!
+  winCount: Int!
+  lossCount: Int!
+  activeWagerCount: Int!
+  createdAt: BigInt!
+}
+
+type Wager @entity {
+  id: ID!
+  wagerId: BigInt!
+  creator: User!
+  opponent: User
+  arbitrator: User
+  creatorStake: BigInt!
+  opponentStake: BigInt!
+  stakeToken: Bytes!
+  description: String!
+  oracleId: Bytes
+  externalCondition: Bytes
+  status: WagerStatus!
+  resolutionType: ResolutionType!
+  outcome: Boolean
+  winner: User
+  arbitratorFee: BigInt
+  arbitratorPaid: BigInt
+  createdAt: BigInt!
+  acceptedAt: BigInt
+  resolvedAt: BigInt
+  claimedAt: BigInt
+  challengeDeadline: BigInt
+  expectedResolutionTime: BigInt
+}
+
+enum WagerStatus {
+  PENDING
+  ACTIVE
+  PENDING_RESOLUTION
+  CHALLENGED
+  RESOLVED
+  DISPUTED
+  CANCELLED
+  REFUNDED
+  ORACLE_TIMED_OUT
+}
+
+enum ResolutionType {
+  CREATOR_RESOLVES
+  OPPONENT_RESOLVES
+  EITHER_RESOLVES
+  ARBITRATOR
+  EXTERNAL_ORACLE
+}
+
+type DailyStats @entity {
+  id: ID! # date string
+  date: BigInt!
+  wagersCreated: Int!
+  wagersResolved: Int!
+  totalVolume: BigInt!
+  uniqueUsers: Int!
+}
+```
+
+---
+
+#### PR16: Build Position Dashboard
+
+**Priority:** HIGH
+**Estimated Effort:** 4-5 days
+**Dependencies:** PR15
+
+**Files to Create:**
+- `frontend/src/components/dashboard/PositionDashboard.jsx`
+- `frontend/src/components/dashboard/OpenPositions.jsx`
+- `frontend/src/components/dashboard/PendingInvitations.jsx`
+- `frontend/src/components/dashboard/ResolvedWagers.jsx`
+- `frontend/src/components/dashboard/WagerCard.jsx`
+- `frontend/src/hooks/useUserWagers.js`
+- `frontend/src/hooks/useWagerMetrics.js`
+
+**Dashboard Layout:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  MY WAGERS                                    [Create Wager]    │
+├─────────────────────────────────────────────────────────────────┤
+│  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐               │
+│  │ Active  │ │ Pending │ │ To Claim│ │ History │               │
+│  │   (4)   │ │   (2)   │ │   (1)   │ │  (23)   │               │
+│  └─────────┘ └─────────┘ └─────────┘ └─────────┘               │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  OPEN POSITIONS                                                  │
+│  ┌─────────────────────────────────────────────────────────────┐│
+│  │ 📊 ETH > $5000 by Dec 2024                                  ││
+│  │    Staked: 0.5 ETH | Side: YES | vs: 0x1234...              ││
+│  │    Resolution: Polymarket | Resolves: Dec 31                ││
+│  │    [Share] [View Details]                                    ││
+│  └─────────────────────────────────────────────────────────────┘│
+│  ┌─────────────────────────────────────────────────────────────┐│
+│  │ 🏈 Chiefs win Super Bowl                                    ││
+│  │    Staked: 100 USDC | Side: NO | vs: 0x5678...              ││
+│  │    Resolution: Manual | Arbitrator: 0xABCD...               ││
+│  │    [Share] [View Details]                                    ││
+│  └─────────────────────────────────────────────────────────────┘│
+│                                                                  │
+│  PENDING INVITATIONS                                             │
+│  ┌─────────────────────────────────────────────────────────────┐│
+│  │ BTC halving date prediction                                 ││
+│  │    From: 0x9999... | Stake: 0.1 BTC | Expires: 2h           ││
+│  │    [Accept] [Decline] [Counter-offer]                        ││
+│  └─────────────────────────────────────────────────────────────┘│
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+#### PR17: Add Metrics and Analytics
+
+**Priority:** MEDIUM
+**Estimated Effort:** 3-4 days
+**Dependencies:** PR15, PR16
+
+**Files to Create:**
+- `frontend/src/components/metrics/UserMetrics.jsx`
+- `frontend/src/components/metrics/MetricCard.jsx`
+- `frontend/src/components/metrics/WinRateChart.jsx`
+- `frontend/src/components/metrics/VolumeChart.jsx`
+
+**Metrics Displayed:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  MY STATS                                                        │
+├─────────────────────────────────────────────────────────────────┤
+│  ┌───────────────┐ ┌───────────────┐ ┌───────────────┐          │
+│  │ Total Wagered │ │   Win Rate    │ │  Lifetime P&L │          │
+│  │   $12,450     │ │     62%       │ │   +$2,340     │          │
+│  │   ↑ 15% MTD   │ │  31W / 19L    │ │   ↑ $450 MTD  │          │
+│  └───────────────┘ └───────────────┘ └───────────────┘          │
+│                                                                  │
+│  ┌───────────────┐ ┌───────────────┐ ┌───────────────┐          │
+│  │ Active Wagers │ │  Avg. Stake   │ │  Best Streak  │          │
+│  │      4        │ │    $250       │ │    7 wins     │          │
+│  └───────────────┘ └───────────────┘ └───────────────┘          │
+│                                                                  │
+│  ACTIVITY BY CATEGORY                                            │
+│  ┌─────────────────────────────────────────────────────────────┐│
+│  │  Crypto: ████████████████ 45%                               ││
+│  │  Sports: ████████ 25%                                        ││
+│  │  Politics: ██████ 18%                                        ││
+│  │  Other: ████ 12%                                             ││
+│  └─────────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Updated System Flows
+
+### Complete Wager Lifecycle (With Fixes)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending : createWager()
+
+    Pending --> Active : acceptWager() [threshold met]
+    Pending --> Cancelled : cancelWager() [by creator]
+    Pending --> Refunded : processExpiredDeadline()
+
+    Active --> PendingResolution : proposeResolution() [manual types]
+    Active --> Resolved : resolveFromOracle() [oracle resolved]
+    Active --> OracleTimedOut : triggerOracleTimeout() [30+ days]
+
+    PendingResolution --> Challenged : challengeResolution() [within 24h]
+    PendingResolution --> Resolved : finalizeResolution() [24h passed]
+
+    Challenged --> Resolved : resolveDispute() [arbitrator decides]
+
+    OracleTimedOut --> Refunded : acceptMutualRefund() [both agree]
+    OracleTimedOut --> Resolved : forceManualResolution() [arbitrator]
+
+    Resolved --> Claimed : claimWinnings() [within 90 days]
+    Resolved --> Swept : sweepUnclaimedFunds() [after 90 days]
+
+    Claimed --> [*]
+    Swept --> [*]
+    Cancelled --> [*]
+    Refunded --> [*]
+```
+
+### Resolution Flow (With Challenge Period)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Creator
+    participant Factory as P2PWagerFactory
+    participant Opponent
+    participant Arbitrator
+    participant Timer as Block.timestamp
+
+    Note over Creator, Timer: Manual Resolution with Challenge Period
+
+    Creator->>Factory: proposeResolution(wagerId, true)
+    Factory->>Factory: Store proposed outcome
+    Factory->>Factory: Set challengeDeadline = now + 24h
+    Factory->>Factory: status = PendingResolution
+    Factory-->>Creator: Emit ResolutionProposed
+
+    alt Opponent Challenges
+        Opponent->>Factory: challengeResolution(wagerId) + bond
+        Factory->>Factory: status = Challenged
+        Factory-->>Opponent: Emit ResolutionChallenged
+
+        Note over Arbitrator: Arbitrator Reviews Evidence
+
+        Arbitrator->>Factory: resolveDispute(wagerId, outcome)
+        Factory->>Factory: Determine bond distribution
+        Factory->>Factory: status = Resolved
+        Factory-->>Arbitrator: Emit DisputeResolved
+
+    else No Challenge (24h passes)
+        Timer->>Timer: 24 hours pass
+        Creator->>Factory: finalizeResolution(wagerId)
+        Factory->>Factory: Verify challengeDeadline passed
+        Factory->>Factory: status = Resolved
+        Factory-->>Creator: Emit ResolutionFinalized
+    end
+
+    Note over Creator, Timer: Claim Phase
+
+    Creator->>Factory: claimWinnings(wagerId)
+    Factory->>Factory: Calculate arbitrator fee (if any)
+    Factory->>Arbitrator: Transfer arbitrator fee
+    Factory->>Creator: Transfer winnings
+    Factory-->>Creator: Emit WinningsClaimed
+```
+
+### Oracle Timeout Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Anyone
+    participant Factory as P2PWagerFactory
+    participant Oracle as OracleRegistry
+    participant Creator
+    participant Opponent
+    participant Arbitrator
+
+    Note over Anyone, Arbitrator: Oracle Fails to Resolve
+
+    Anyone->>Factory: triggerOracleTimeout(wagerId)
+    Factory->>Factory: Check expectedResolutionTime + 30 days < now
+    Factory->>Factory: status = OracleTimedOut
+    Factory-->>Anyone: Emit OracleTimeoutTriggered
+
+    alt Mutual Refund Path
+        Creator->>Factory: acceptMutualRefund(wagerId)
+        Factory->>Factory: Record creator acceptance
+
+        Opponent->>Factory: acceptMutualRefund(wagerId)
+        Factory->>Factory: Both accepted
+        Factory->>Factory: status = Refunded
+        Factory->>Creator: Return creator stake
+        Factory->>Opponent: Return opponent stake
+        Factory-->>Opponent: Emit MutualRefundCompleted
+
+    else Arbitrator Resolution Path
+        Arbitrator->>Factory: forceManualResolution(wagerId, outcome)
+        Factory->>Factory: status = Resolved
+        Factory->>Factory: Set winner based on outcome
+        Factory-->>Arbitrator: Emit ForcedResolution
+    end
+```
+
+---
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    subgraph "Phase 1: Foundation"
+        PR1[PR1: claimWinnings]
+        PR2[PR2: Challenge Period]
+        PR3[PR3: Claim Timeout]
+        PR4[PR4: Oracle Timeout]
+
+        PR1 --> PR2
+        PR1 --> PR3
+        PR2 --> PR4
+    end
+
+    subgraph "Phase 2: Oracles"
+        PR5[PR5: OracleRegistry]
+        PR6[PR6: Chainlink Adapter]
+        PR7[PR7: UMA Adapter]
+
+        PR4 --> PR5
+        PR5 --> PR6
+        PR5 --> PR7
+    end
+
+    subgraph "Phase 3: Simplification"
+        PR8[PR8: P2PWagerFactory]
+        PR9[PR9: Arbitrator Fees]
+        PR10[PR10: CTF Migration]
+
+        PR6 --> PR8
+        PR7 --> PR8
+        PR8 --> PR9
+        PR8 --> PR10
+    end
+
+    subgraph "Phase 4: Discovery"
+        PR11[PR11: Market Aggregator]
+        PR12[PR12: Discovery UI]
+
+        PR5 --> PR11
+        PR11 --> PR12
+    end
+
+    subgraph "Phase 5: Social"
+        PR13[PR13: Share Service]
+        PR14[PR14: OG Images]
+
+        PR8 --> PR13
+        PR13 --> PR14
+    end
+
+    subgraph "Phase 6: Dashboard"
+        PR15[PR15: Subgraph]
+        PR16[PR16: Dashboard UI]
+        PR17[PR17: Metrics]
+
+        PR8 --> PR15
+        PR15 --> PR16
+        PR16 --> PR17
+    end
+```
+
+---
+
+## Testing Strategy
+
+### Unit Tests (per PR)
+- Each PR includes comprehensive unit tests
+- Minimum 90% code coverage for new contracts
+- All error paths tested
+
+### Integration Tests
+- Cross-contract interactions
+- Oracle resolution flows
+- Token transfer scenarios
+
+### E2E Tests
+- Full wager lifecycle
+- Multi-user scenarios
+- Timeout handling
+
+### Testnet Deployment
+- Deploy to Mordor (ETC testnet) after each phase
+- Manual QA before mainnet
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Oracle never resolves | Medium | High | PR4: Timeout fallback |
+| Dishonest manual resolution | Medium | High | PR2: Challenge period |
+| Winner doesn't claim | Low | Medium | PR3: Treasury sweep |
+| Arbitrator doesn't act | Medium | Medium | PR9: Fee incentives |
+| Contract upgrade needed | Low | High | Proxy pattern consideration |
+| Subgraph indexing lag | Medium | Low | Cache + direct RPC fallback |
+
+---
+
+## Success Metrics
+
+| Metric | Current | Phase 1 Target | Phase 6 Target |
+|--------|---------|----------------|----------------|
+| Wager completion rate | N/A | >90% | >95% |
+| Average claim time | N/A | <24h | <12h |
+| Dispute rate | N/A | <5% | <2% |
+| Oracle timeout rate | N/A | <1% | <0.5% |
+| User retention (30d) | N/A | >30% | >50% |
+| Social share rate | 0% | >10% | >25% |
+
+---
+
+## Appendix: Contract Size Considerations
+
+Current FriendGroupMarketFactory is near EIP-170 limit (24KB).
+
+**Strategy:**
+1. P2PWagerFactory is a new contract (starts fresh)
+2. Use libraries for shared logic (WagerLib)
+3. Split DisputeManager into separate contract
+4. Use proxy pattern for upgradeability

--- a/docs/architecture/P2P_WAGER_PLATFORM_ASSESSMENT.md
+++ b/docs/architecture/P2P_WAGER_PLATFORM_ASSESSMENT.md
@@ -1,0 +1,655 @@
+# P2P Wager Platform Architecture Assessment
+
+## Vision Statement
+
+FairWins is a **wager management layer** that helps users track and manage peer-to-peer wagers across their existing social networks and resolve them using established prediction markets and on-chain oracles—without fragmenting liquidity or duplicating existing infrastructure.
+
+### Core Principles
+
+1. **Meet users where they are** - Leverage existing social media for sharing/connecting
+2. **Aggregate, don't duplicate** - Integrate existing prediction markets as resolution sources
+3. **Discovery over creation** - Find and connect to existing oracles, not build new ones
+4. **User's wager portfolio** - Single view of positions across all platforms and networks
+5. **Network agnostic** - Work across chains where users already have assets
+
+---
+
+## Current Architecture Analysis
+
+### What Exists (Strengths)
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| **FriendGroupMarketFactory** | Production-ready | Full P2P wager mechanics with multi-party acceptance |
+| **PolymarketOracleAdapter** | Implemented | Can resolve from Polymarket conditions |
+| **OracleResolver** | Implemented | UMA-style dispute resolution pattern |
+| **QR Code Sharing** | Basic | Share market links via QR |
+| **Multicall3 Batching** | Implemented | Efficient batch contract reads |
+| **Multi-party Acceptance** | Implemented | Invitation/acceptance flow with deadlines |
+| **Custom Odds (Bookmaker)** | Implemented | Asymmetric stake ratios |
+
+### What's Missing (Gaps)
+
+| Gap | Priority | Impact |
+|-----|----------|--------|
+| **Multi-oracle Registry** | HIGH | Can only resolve via Polymarket currently |
+| **External Market Discovery** | HIGH | No indexing of other prediction platforms |
+| **Social Share-out** | MEDIUM | Can't 1-click share to Twitter/Discord |
+| **Position Aggregation** | HIGH | No unified view of user's wagers |
+| **Multi-chain Support** | MEDIUM | Single network only (ETC) |
+| **REST/GraphQL API** | MEDIUM | Frontend-only, no external integrations |
+| **Notification System** | MEDIUM | No alerts for wager status changes |
+
+---
+
+## Proposed Architecture Changes
+
+### Layer 1: Oracle Registry (Smart Contracts)
+
+Replace single-oracle pattern with a **registry of verified oracle sources**.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    OracleRegistry                            │
+│  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐            │
+│  │ Polymarket  │ │   UMA v3    │ │  Chainlink  │            │
+│  │   Adapter   │ │   Adapter   │ │   Adapter   │   ...      │
+│  └──────┬──────┘ └──────┬──────┘ └──────┬──────┘            │
+│         │               │               │                    │
+│         └───────────────┼───────────────┘                    │
+│                         ▼                                    │
+│              ┌─────────────────────┐                        │
+│              │  IOracleAdapter     │                        │
+│              │  - isResolved()     │                        │
+│              │  - getOutcome()     │                        │
+│              │  - getConfidence()  │                        │
+│              └─────────────────────┘                        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**New Contracts Needed:**
+- `OracleRegistry.sol` - Registry of verified oracle adapters
+- `IExternalOracle.sol` - Standard interface for oracle adapters
+- `UMAOracleAdapter.sol` - Direct UMA v3 integration
+- `ChainlinkOracleAdapter.sol` - Chainlink data feeds adapter
+- `API3OracleAdapter.sol` - API3 dAPI integration
+
+### Layer 2: Market Discovery Index (Off-chain)
+
+Index existing prediction markets for resolution source discovery.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                  Market Discovery Service                    │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│  Data Sources:                                               │
+│  ┌──────────────┐ ┌──────────────┐ ┌──────────────┐         │
+│  │  Polymarket  │ │    Kalshi    │ │   Manifold   │         │
+│  │   GraphQL    │ │     API      │ │     API      │         │
+│  └──────────────┘ └──────────────┘ └──────────────┘         │
+│                                                              │
+│  Indexed Data:                                               │
+│  - Market questions (normalized text)                        │
+│  - Resolution timestamps                                     │
+│  - Current odds/prices                                       │
+│  - Chain/network location                                    │
+│  - Oracle/resolution source                                  │
+│                                                              │
+│  Search Capabilities:                                        │
+│  - "Find markets about [topic]"                              │
+│  - "Markets resolving in next 7 days"                        │
+│  - "High-volume markets on [chain]"                          │
+│                                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Implementation Options:**
+1. **The Graph Subgraph** - Index on-chain markets (Polymarket, Gnosis, etc.)
+2. **Lightweight API Service** - Poll external APIs (Kalshi, Manifold, PredictIt)
+3. **Hybrid** - Graph for on-chain + API service for off-chain markets
+
+### Layer 3: Social Share-out (No Social Graph)
+
+Export wagers TO social platforms, don't import relationships FROM them.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Share-out Service                         │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│  Share Formats:                                              │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │  Twitter/X Card                                      │    │
+│  │  ┌─────────────────────────────────────────────┐    │    │
+│  │  │ 🎯 New Wager on FairWins                     │    │    │
+│  │  │ "ETH > $5000 by Dec 31, 2024"               │    │    │
+│  │  │ Stakes: 0.5 ETH each | Odds: 2:1            │    │    │
+│  │  │ Resolution: Polymarket #abc123               │    │    │
+│  │  │ [Accept Wager] [View Details]                │    │    │
+│  │  └─────────────────────────────────────────────┘    │    │
+│  └─────────────────────────────────────────────────────┘    │
+│                                                              │
+│  Channels:                                                   │
+│  - Twitter/X (Open Graph + deep link)                       │
+│  - Discord (Webhook + embed)                                │
+│  - Telegram (Bot message + inline buttons)                  │
+│  - Farcaster (Cast with frame)                              │
+│  - Link/QR (Universal, already exists)                      │
+│                                                              │
+│  Features:                                                   │
+│  - 1-click share from wager creation                        │
+│  - Auto-generated preview images (OG cards)                 │
+│  - Deep links back to FairWins for acceptance               │
+│  - Resolution announcements (optional)                      │
+│                                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Layer 4: Position Dashboard (User's Wager Portfolio)
+
+Unified view of all wager positions across platforms.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    User Dashboard                            │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │  OPEN POSITIONS                               (4)      │  │
+│  ├───────────────────────────────────────────────────────┤  │
+│  │  📊 ETH > $5000 by Dec 2024                           │  │
+│  │     Staked: 0.5 ETH | Side: YES | vs: @alice          │  │
+│  │     Resolution: Polymarket | Status: Awaiting         │  │
+│  │     [Share] [Cancel]                                  │  │
+│  ├───────────────────────────────────────────────────────┤  │
+│  │  🏈 Chiefs win Super Bowl                             │  │
+│  │     Staked: 100 USDC | Side: NO | vs: @bob            │  │
+│  │     Resolution: Manual (Arbitrator: @charlie)         │  │
+│  │     [Share] [Dispute]                                 │  │
+│  └───────────────────────────────────────────────────────┘  │
+│                                                              │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │  PENDING INVITATIONS                          (2)      │  │
+│  ├───────────────────────────────────────────────────────┤  │
+│  │  BTC halving date prediction                          │  │
+│  │     From: @dave | Stake: 0.1 BTC | Expires: 2h        │  │
+│  │     [Accept] [Decline] [Counter-offer]                │  │
+│  └───────────────────────────────────────────────────────┘  │
+│                                                              │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │  METRICS                                               │  │
+│  ├───────────────────────────────────────────────────────┤  │
+│  │  Total Wagered: $12,450 | Win Rate: 62%               │  │
+│  │  Lifetime P&L: +$2,340 | Active Wagers: 4             │  │
+│  │  Most Active Topic: Crypto | Avg Stake: $250          │  │
+│  └───────────────────────────────────────────────────────┘  │
+│                                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Data Sources for Dashboard:**
+1. **On-chain** - FriendGroupMarketFactory events (primary)
+2. **Indexed** - Subgraph for historical aggregation
+3. **Cached** - Local storage for UI responsiveness
+
+---
+
+## Smart Contract Changes
+
+### 1. Simplify FriendGroupMarketFactory
+
+Remove dependency on ConditionalMarketFactory for P2P wagers:
+
+```solidity
+// Current: P2P wagers create underlying CTF markets
+// Problem: Unnecessary complexity, gas cost, liquidity fragmentation
+
+// Proposed: Standalone P2P wager contract
+contract P2PWagerFactory {
+    struct Wager {
+        uint256 wagerId;
+        address creator;
+        address opponent;
+        address arbitrator;
+        uint256 creatorStake;
+        uint256 opponentStake;
+        address stakeToken;
+        string description;
+        bytes32 oracleId;           // Reference to OracleRegistry
+        bytes32 externalCondition;   // Polymarket conditionId, Chainlink feedId, etc.
+        WagerStatus status;
+        uint256 acceptanceDeadline;
+        uint256 resolutionDeadline;
+    }
+
+    enum WagerStatus {
+        Pending,    // Awaiting opponent acceptance
+        Active,     // Both parties staked
+        Resolved,   // Outcome determined
+        Disputed,   // In arbitration
+        Cancelled,  // Refunded
+        Expired     // Deadline passed
+    }
+
+    // Core functions
+    function createWager(...) external payable returns (uint256 wagerId);
+    function acceptWager(uint256 wagerId) external payable;
+    function resolveFromOracle(uint256 wagerId) external;
+    function resolveManually(uint256 wagerId, bool outcome) external;
+    function disputeResolution(uint256 wagerId) external;
+    function claimWinnings(uint256 wagerId) external;
+}
+```
+
+### 2. Add OracleRegistry
+
+```solidity
+interface IOracleAdapter {
+    function isSupported(bytes32 conditionId) external view returns (bool);
+    function isResolved(bytes32 conditionId) external view returns (bool);
+    function getOutcome(bytes32 conditionId) external view returns (bool outcome, uint256 confidence);
+    function getMetadata(bytes32 conditionId) external view returns (string memory);
+}
+
+contract OracleRegistry {
+    mapping(bytes32 => address) public oracleAdapters; // oracleId => adapter address
+    mapping(address => bool) public verifiedAdapters;
+
+    function registerAdapter(bytes32 oracleId, address adapter) external onlyOwner;
+    function resolveCondition(bytes32 oracleId, bytes32 conditionId) external returns (bool, uint256);
+    function findAdapterForCondition(bytes32 conditionId) external view returns (address);
+}
+```
+
+### 3. Add Chainlink Adapter
+
+```solidity
+contract ChainlinkOracleAdapter is IOracleAdapter {
+    function isResolved(bytes32 feedId) external view returns (bool) {
+        // Check if price feed has been updated
+        AggregatorV3Interface feed = AggregatorV3Interface(feedIdToAddress[feedId]);
+        (, , , uint256 updatedAt, ) = feed.latestRoundData();
+        return updatedAt > conditionTimestamps[feedId];
+    }
+
+    function getOutcome(bytes32 feedId) external view returns (bool outcome, uint256 confidence) {
+        // Compare price to threshold
+        int256 price = getPrice(feedId);
+        int256 threshold = conditionThresholds[feedId];
+        outcome = price >= threshold;
+        confidence = 100; // Chainlink is deterministic
+    }
+}
+```
+
+### 4. Add UMA Direct Integration
+
+```solidity
+contract UMAOracleAdapter is IOracleAdapter {
+    OptimisticOracleV3 public immutable oo;
+
+    function requestResolution(bytes32 questionId, string memory ancillaryData) external {
+        oo.assertTruth(
+            abi.encodePacked(ancillaryData),
+            address(this),
+            address(0), // No callback
+            address(0), // No escalation manager
+            7200,       // 2 hour liveness
+            IERC20(defaultCurrency),
+            bond,
+            questionId,
+            block.timestamp
+        );
+    }
+
+    function getOutcome(bytes32 questionId) external view returns (bool outcome, uint256 confidence) {
+        // Check UMA assertion result
+        int256 result = oo.getAssertionResult(assertions[questionId]);
+        outcome = result > 0;
+        confidence = 100;
+    }
+}
+```
+
+---
+
+## Frontend Changes
+
+### 1. Navigation Restructure
+
+```
+Current:                          Proposed:
+├── Markets (primary)             ├── My Wagers (primary)
+├── Governance                    │   ├── Open Positions
+├── Friend Markets (modal)        │   ├── Pending Invites
+└── Profile                       │   ├── History
+                                  │   └── Metrics
+                                  ├── Create Wager
+                                  │   ├── Pick Resolution Source
+                                  │   └── Set Terms
+                                  ├── Discover Markets
+                                  │   ├── Polymarket
+                                  │   ├── Kalshi (off-chain)
+                                  │   └── On-chain Oracles
+                                  └── Settings
+```
+
+### 2. Create Wager Flow
+
+```
+Step 1: Define the Bet
+┌─────────────────────────────────────────────────────────────┐
+│  What are you betting on?                                   │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │ "ETH will be above $5000 by December 31, 2024"      │   │
+│  └─────────────────────────────────────────────────────┘   │
+│                                                              │
+│  How will this be resolved?                                 │
+│  ○ Find existing market (Polymarket, Kalshi, etc.)         │
+│  ○ Use price oracle (Chainlink, API3)                      │
+│  ○ Manual resolution (you or opponent decides)             │
+│  ○ Third-party arbitrator                                  │
+│                                                              │
+│  [Search Existing Markets...]                               │
+└─────────────────────────────────────────────────────────────┘
+
+Step 2: Set Stakes
+┌─────────────────────────────────────────────────────────────┐
+│  Your stake: [____] ETH                                     │
+│  Opponent's stake: [____] ETH  (or set custom odds)        │
+│                                                              │
+│  ○ Equal stakes (1:1)                                       │
+│  ○ Custom odds: You risk [__] to win [__]                  │
+│                                                              │
+│  Payment token: [ETH ▼] [USDC] [USDT]                      │
+└─────────────────────────────────────────────────────────────┘
+
+Step 3: Invite Opponent
+┌─────────────────────────────────────────────────────────────┐
+│  Who are you betting against?                               │
+│                                                              │
+│  ○ Enter wallet address: [0x...]                           │
+│  ○ Share via link (anyone can accept)                      │
+│                                                              │
+│  Acceptance deadline: [24 hours ▼]                         │
+│                                                              │
+│  [Create & Share Wager]                                     │
+│                                                              │
+│  Share to: [Twitter] [Discord] [Telegram] [Copy Link]      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 3. Market Discovery Component
+
+```jsx
+// components/MarketDiscovery.jsx
+export function MarketDiscovery({ onSelectMarket }) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [results, setResults] = useState([]);
+
+  // Search across multiple sources
+  const searchMarkets = async (query) => {
+    const [polymarket, chainlink, uma] = await Promise.all([
+      searchPolymarket(query),
+      searchChainlinkFeeds(query),
+      searchUMAAssertions(query),
+    ]);
+
+    return normalizeResults([...polymarket, ...chainlink, ...uma]);
+  };
+
+  return (
+    <div>
+      <SearchInput value={searchQuery} onChange={setSearchQuery} />
+      <MarketResults
+        results={results}
+        onSelect={(market) => onSelectMarket({
+          oracleId: market.oracleId,
+          conditionId: market.conditionId,
+          description: market.question,
+          resolvesAt: market.resolutionDate,
+        })}
+      />
+    </div>
+  );
+}
+```
+
+### 4. Share-out Service
+
+```javascript
+// services/socialShare.js
+export const ShareService = {
+  generateTwitterIntent(wager) {
+    const text = `🎯 New wager on @FairWins\n\n"${wager.description}"\n\nStakes: ${wager.stake} ${wager.token}\nResolution: ${wager.oracleSource}\n\nAccept the challenge:`;
+    const url = `https://fairwins.io/wager/${wager.id}`;
+    return `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`;
+  },
+
+  generateDiscordEmbed(wager) {
+    return {
+      title: "New Wager Challenge",
+      description: wager.description,
+      fields: [
+        { name: "Stake", value: `${wager.stake} ${wager.token}`, inline: true },
+        { name: "Odds", value: wager.odds, inline: true },
+        { name: "Resolution", value: wager.oracleSource, inline: true },
+      ],
+      url: `https://fairwins.io/wager/${wager.id}`,
+      color: 0x00ff00,
+    };
+  },
+
+  generateOGImage(wager) {
+    // Generate dynamic Open Graph image for link previews
+    return `https://fairwins.io/api/og?wagerId=${wager.id}`;
+  },
+};
+```
+
+---
+
+## Data Architecture
+
+### Position Tracking (The Graph Subgraph)
+
+```graphql
+type User @entity {
+  id: Bytes! # wallet address
+  wagersCreated: [Wager!]! @derivedFrom(field: "creator")
+  wagersAccepted: [Wager!]! @derivedFrom(field: "opponent")
+  totalWagered: BigInt!
+  totalWon: BigInt!
+  totalLost: BigInt!
+  winCount: Int!
+  lossCount: Int!
+  activeWagerCount: Int!
+}
+
+type Wager @entity {
+  id: ID!
+  creator: User!
+  opponent: User
+  arbitrator: Bytes
+  creatorStake: BigInt!
+  opponentStake: BigInt!
+  stakeToken: Bytes!
+  description: String!
+  oracleId: Bytes!
+  externalCondition: Bytes!
+  status: WagerStatus!
+  outcome: Boolean
+  winner: User
+  createdAt: BigInt!
+  acceptedAt: BigInt
+  resolvedAt: BigInt
+  resolutionSource: String # "polymarket", "chainlink", "manual", etc.
+}
+
+enum WagerStatus {
+  PENDING
+  ACTIVE
+  RESOLVED
+  DISPUTED
+  CANCELLED
+  EXPIRED
+}
+
+type OracleSource @entity {
+  id: Bytes! # oracleId
+  name: String!
+  adapterAddress: Bytes!
+  totalResolutions: Int!
+  activeConditions: Int!
+}
+```
+
+### Metrics Queries
+
+```graphql
+# User's wager portfolio
+query UserPortfolio($address: Bytes!) {
+  user(id: $address) {
+    totalWagered
+    totalWon
+    totalLost
+    winCount
+    lossCount
+    activeWagerCount
+    wagersCreated(where: { status: ACTIVE }) {
+      id
+      description
+      creatorStake
+      opponent { id }
+      status
+    }
+    wagersAccepted(where: { status: PENDING }) {
+      id
+      description
+      opponentStake
+      creator { id }
+      acceptanceDeadline
+    }
+  }
+}
+
+# Leaderboard (optional - competitive element without social graph)
+query Leaderboard($limit: Int!) {
+  users(first: $limit, orderBy: totalWon, orderDirection: desc) {
+    id
+    totalWon
+    winCount
+    lossCount
+  }
+}
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Core P2P Simplification (2-3 weeks)
+- [ ] Create standalone `P2PWagerFactory.sol` (simpler than FriendGroupMarketFactory)
+- [ ] Create `OracleRegistry.sol` with adapter pattern
+- [ ] Migrate Polymarket adapter to new interface
+- [ ] Update frontend to use new wager flow
+- [ ] Deploy subgraph for position tracking
+
+### Phase 2: Oracle Expansion (2 weeks)
+- [ ] Implement `ChainlinkOracleAdapter.sol`
+- [ ] Implement `UMAOracleAdapter.sol`
+- [ ] Add oracle discovery in UI
+- [ ] Search across all oracle sources
+
+### Phase 3: Market Discovery (2 weeks)
+- [ ] Build market aggregator service (index Polymarket, Kalshi APIs)
+- [ ] "Find existing market" flow in wager creation
+- [ ] Auto-link wagers to discovered markets
+- [ ] Resolution timestamp tracking
+
+### Phase 4: Social Share-out (1-2 weeks)
+- [ ] Twitter/X share intent generation
+- [ ] Discord webhook integration
+- [ ] Telegram bot for notifications
+- [ ] Open Graph image generation for link previews
+- [ ] Deep link handling for wager acceptance
+
+### Phase 5: Dashboard & Metrics (2 weeks)
+- [ ] Build position dashboard component
+- [ ] Aggregate user metrics from subgraph
+- [ ] Add pending invitations view
+- [ ] History and P&L tracking
+- [ ] Export capabilities (CSV, share)
+
+### Phase 6: Multi-chain (Future)
+- [ ] Deploy on Polygon (same network as Polymarket)
+- [ ] Deploy on Arbitrum (UMA v3)
+- [ ] Cross-chain wager acceptance (bridge stakes)
+- [ ] Unified dashboard across chains
+
+---
+
+## Key Decisions
+
+### 1. Remove CTF Dependency for P2P
+**Current:** Friend markets create underlying ConditionalMarketFactory markets
+**Proposed:** Standalone wager contract with direct stake escrow
+
+**Rationale:**
+- Simpler gas costs
+- No need for conditional tokens for 1v1 wagers
+- Faster resolution
+- No liquidity fragmentation
+
+### 2. Oracle Registry vs. Hardcoded Adapters
+**Proposed:** Registry pattern with pluggable adapters
+
+**Rationale:**
+- New oracle sources can be added without contract upgrades
+- Community can propose and verify new adapters
+- Clear separation of concerns
+
+### 3. Subgraph vs. Backend API
+**Proposed:** Subgraph for on-chain data, lightweight API for off-chain market discovery
+
+**Rationale:**
+- Subgraph handles position tracking efficiently
+- API needed for Kalshi/Manifold (off-chain markets)
+- No need for heavy backend infrastructure
+
+### 4. Social Share-out vs. Social Graph
+**Proposed:** Export to existing platforms, don't build internal social
+
+**Rationale:**
+- Users already have audiences on Twitter/Discord
+- Building social from scratch is expensive
+- Focus on core wager mechanics
+- Let virality happen on established platforms
+
+---
+
+## Success Metrics
+
+| Metric | Target | How to Measure |
+|--------|--------|----------------|
+| Wagers created | 1000/month | Subgraph query |
+| Unique users | 500/month | Unique wallet addresses |
+| Resolution success rate | >95% | Resolved / (Resolved + Disputed) |
+| Share-to-acceptance rate | >10% | Accepted wagers from shared links |
+| Avg. resolution time | <24h after event | Subgraph timestamps |
+| Multi-oracle usage | >3 sources active | OracleRegistry stats |
+
+---
+
+## Summary
+
+This architecture pivot transforms FairWins from a prediction market platform to a **wager management layer**:
+
+1. **P2P wagers are the product** - Simple, direct bets between parties
+2. **Existing markets are infrastructure** - Polymarket, Chainlink, UMA provide resolution
+3. **Social platforms are distribution** - Twitter, Discord, Telegram for sharing
+4. **User dashboard is the interface** - Track positions across all sources
+5. **No liquidity fragmentation** - Leverage existing market depth
+
+The result is a focused product that helps users bet with friends using the best available resolution sources—without trying to compete with established prediction markets.

--- a/docs/architecture/SYSTEM_FLOW_DIAGRAMS.md
+++ b/docs/architecture/SYSTEM_FLOW_DIAGRAMS.md
@@ -1,0 +1,923 @@
+# FairWins P2P Wager System - Flow Diagrams
+
+## Table of Contents
+1. [System Overview](#system-overview)
+2. [Entity Relationship Diagram](#entity-relationship-diagram)
+3. [Wager State Machine](#wager-state-machine)
+4. [User Flows](#user-flows)
+5. [Sequence Diagrams](#sequence-diagrams)
+6. [Error Handling Paths](#error-handling-paths)
+7. [Consistency Analysis](#consistency-analysis)
+
+---
+
+## System Overview
+
+```mermaid
+graph TB
+    subgraph "External Platforms"
+        Twitter[Twitter/X]
+        Discord[Discord]
+        Telegram[Telegram]
+        Polymarket[Polymarket CTF]
+        Chainlink[Chainlink Feeds]
+        UMA[UMA Oracle]
+    end
+
+    subgraph "FairWins Core"
+        UI[Frontend Dashboard]
+        Wager[P2P Wager Factory]
+        Oracle[Oracle Registry]
+        Subgraph[The Graph Indexer]
+    end
+
+    subgraph "User Actions"
+        Create[Create Wager]
+        Accept[Accept Wager]
+        Resolve[Resolve Wager]
+        Claim[Claim Winnings]
+    end
+
+    UI --> Create
+    UI --> Accept
+    UI --> Resolve
+    UI --> Claim
+
+    Create --> Wager
+    Accept --> Wager
+    Resolve --> Oracle
+    Oracle --> Polymarket
+    Oracle --> Chainlink
+    Oracle --> UMA
+
+    Wager --> Subgraph
+    Subgraph --> UI
+
+    Create -.-> Twitter
+    Create -.-> Discord
+    Create -.-> Telegram
+```
+
+---
+
+## Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    USER ||--o{ WAGER : creates
+    USER ||--o{ WAGER : accepts
+    USER ||--o{ ACCEPTANCE_RECORD : has
+    WAGER ||--|| ACCEPTANCE_RECORD : tracks
+    WAGER ||--o| ORACLE_ADAPTER : resolves_via
+    WAGER }|--|| STAKE_TOKEN : uses
+    ORACLE_REGISTRY ||--o{ ORACLE_ADAPTER : contains
+    ORACLE_ADAPTER ||--o{ EXTERNAL_CONDITION : queries
+
+    USER {
+        address wallet PK
+        uint256 totalWagered
+        uint256 totalWon
+        uint256 totalLost
+        uint256 winCount
+        uint256 lossCount
+    }
+
+    WAGER {
+        uint256 wagerId PK
+        address creator FK
+        address opponent FK
+        address arbitrator
+        uint256 creatorStake
+        uint256 opponentStake
+        address stakeToken FK
+        string description
+        bytes32 oracleId FK
+        bytes32 externalCondition
+        enum status
+        enum resolutionType
+        uint256 acceptanceDeadline
+        uint256 createdAt
+    }
+
+    ACCEPTANCE_RECORD {
+        uint256 wagerId FK
+        address participant FK
+        uint256 stakedAmount
+        uint256 acceptedAt
+        bool hasAccepted
+        bool isArbitrator
+    }
+
+    ORACLE_ADAPTER {
+        bytes32 oracleId PK
+        string name
+        address adapterAddress
+        bool isVerified
+    }
+
+    EXTERNAL_CONDITION {
+        bytes32 conditionId PK
+        bytes32 oracleId FK
+        bool resolved
+        uint256 passNumerator
+        uint256 failNumerator
+    }
+
+    STAKE_TOKEN {
+        address tokenAddress PK
+        string symbol
+        uint8 decimals
+    }
+
+    ORACLE_REGISTRY {
+        address registryAddress PK
+        address owner
+    }
+```
+
+---
+
+## Wager State Machine
+
+### Primary State Transitions
+
+```mermaid
+stateDiagram-v2
+    [*] --> PendingAcceptance : createWager()
+
+    PendingAcceptance --> Active : acceptWager() [threshold met]
+    PendingAcceptance --> Cancelled : cancelPendingWager() [by creator]
+    PendingAcceptance --> Refunded : processExpiredDeadline() [deadline passed, threshold not met]
+    PendingAcceptance --> PendingAcceptance : acceptWager() [threshold not yet met]
+
+    Active --> Resolved : resolveManually() [authorized resolver]
+    Active --> Resolved : resolveFromOracle() [oracle resolved]
+    Active --> Disputed : disputeResolution() [challenge filed]
+
+    Disputed --> Resolved : escalationComplete() [arbitration decides]
+    Disputed --> Active : disputeRejected() [challenge failed]
+
+    Resolved --> [*] : claimWinnings() [funds distributed]
+    Cancelled --> [*] : [stakes refunded automatically]
+    Refunded --> [*] : [stakes refunded automatically]
+
+    note right of PendingAcceptance
+        Waiting for opponent
+        and/or arbitrator
+        to accept invitation
+    end note
+
+    note right of Active
+        Both parties staked
+        Awaiting outcome
+    end note
+
+    note right of Disputed
+        Resolution challenged
+        In arbitration
+    end note
+```
+
+### Resolution Type State Branches
+
+```mermaid
+stateDiagram-v2
+    state ResolutionType {
+        [*] --> Either
+        [*] --> Initiator
+        [*] --> Receiver
+        [*] --> ThirdParty
+        [*] --> AutoPegged
+        [*] --> PolymarketOracle
+    }
+
+    state Either {
+        e1: Creator OR Opponent can resolve
+    }
+
+    state Initiator {
+        i1: Only Creator can resolve
+    }
+
+    state Receiver {
+        r1: Only Opponent can resolve
+    }
+
+    state ThirdParty {
+        t1: Only Arbitrator can resolve
+    }
+
+    state AutoPegged {
+        a1: Auto-resolves when linked
+        a2: ConditionalMarket resolves
+        a1 --> a2
+    }
+
+    state PolymarketOracle {
+        p1: Auto-resolves when linked
+        p2: Polymarket condition resolves
+        p1 --> p2
+    }
+```
+
+---
+
+## User Flows
+
+### Flow 1: Create Wager (1v1 Equal Stakes)
+
+```mermaid
+flowchart TD
+    Start([User Opens App]) --> Dashboard[View Dashboard]
+    Dashboard --> CreateBtn[Click "Create Wager"]
+    CreateBtn --> DescForm[Enter Wager Description]
+
+    DescForm --> ResChoice{Choose Resolution<br/>Method}
+
+    ResChoice -->|Find Existing| Search[Search External Markets]
+    ResChoice -->|Price Oracle| Oracle[Select Chainlink Feed]
+    ResChoice -->|Manual| Manual[Choose Resolver Type]
+    ResChoice -->|Arbitrator| Arb[Enter Arbitrator Address]
+
+    Search --> SelectMarket[Select Polymarket/Kalshi Market]
+    SelectMarket --> Stakes
+    Oracle --> ConfigThreshold[Set Price Threshold]
+    ConfigThreshold --> Stakes
+    Manual --> Stakes
+    Arb --> Stakes
+
+    Stakes[Set Stake Amount] --> Token[Select Payment Token]
+    Token --> Odds{Equal Stakes?}
+
+    Odds -->|Yes| Equal[1:1 Odds]
+    Odds -->|No| Custom[Set Custom Odds Multiplier]
+
+    Equal --> Opponent
+    Custom --> Opponent
+
+    Opponent[Enter Opponent Address<br/>or Create Open Wager] --> Deadline[Set Acceptance Deadline]
+
+    Deadline --> Review[Review Wager Terms]
+    Review --> Confirm{Confirm &<br/>Sign Transaction?}
+
+    Confirm -->|Yes| Submit[Submit to Blockchain]
+    Confirm -->|No| Edit[Edit Terms]
+    Edit --> DescForm
+
+    Submit --> TxPending{Transaction<br/>Status?}
+
+    TxPending -->|Success| Created[Wager Created]
+    TxPending -->|Failed| Error[Show Error]
+    Error --> Review
+
+    Created --> Share{Share Wager?}
+    Share -->|Twitter| Twitter[Open Twitter Intent]
+    Share -->|Discord| Discord[Copy Discord Embed]
+    Share -->|Link| Link[Copy Shareable Link]
+    Share -->|Skip| Dashboard2[Return to Dashboard]
+
+    Twitter --> Dashboard2
+    Discord --> Dashboard2
+    Link --> Dashboard2
+```
+
+### Flow 2: Accept Wager Invitation
+
+```mermaid
+flowchart TD
+    Start([User Receives Invitation]) --> Source{Invitation<br/>Source?}
+
+    Source -->|Social Media Link| OpenLink[Click Link]
+    Source -->|Direct Notification| OpenApp[Open App]
+    Source -->|QR Code| ScanQR[Scan QR Code]
+
+    OpenLink --> DeepLink[Deep Link to Wager]
+    ScanQR --> DeepLink
+    OpenApp --> Invitations[View Pending Invitations]
+    Invitations --> SelectWager[Select Wager]
+
+    DeepLink --> WagerDetails
+    SelectWager --> WagerDetails
+
+    WagerDetails[View Wager Details] --> CheckMembership{Has Required<br/>Membership?}
+
+    CheckMembership -->|No| PurchaseTier[Purchase Membership Tier]
+    PurchaseTier --> CheckMembership
+    CheckMembership -->|Yes| CheckDeadline{Deadline<br/>Passed?}
+
+    CheckDeadline -->|Yes| Expired[Show "Wager Expired"]
+    Expired --> End([End])
+
+    CheckDeadline -->|No| CheckFunds{Sufficient<br/>Funds?}
+
+    CheckFunds -->|No| AddFunds[Add Funds / Swap]
+    AddFunds --> CheckFunds
+
+    CheckFunds -->|Yes| ReviewTerms[Review Wager Terms]
+
+    ReviewTerms --> Decision{Accept or<br/>Decline?}
+
+    Decision -->|Decline| Decline[Decline Invitation]
+    Decline --> End
+
+    Decision -->|Counter| Counter[Propose Counter-terms]
+    Counter --> NewWager[Create New Wager<br/>with Modified Terms]
+    NewWager --> End
+
+    Decision -->|Accept| Approve[Approve Token Spend<br/>if ERC20]
+
+    Approve --> SignAccept[Sign Accept Transaction]
+
+    SignAccept --> TxStatus{Transaction<br/>Status?}
+
+    TxStatus -->|Success| CheckThreshold{Threshold<br/>Met?}
+    TxStatus -->|Failed| Error[Show Error]
+    Error --> ReviewTerms
+
+    CheckThreshold -->|Yes| Activated[Wager Activated!]
+    CheckThreshold -->|No| Pending[Waiting for<br/>Other Participants]
+
+    Activated --> ViewActive[View in Active Wagers]
+    Pending --> ViewPending[View in Pending]
+
+    ViewActive --> End
+    ViewPending --> End
+```
+
+### Flow 3: Resolve Wager
+
+```mermaid
+flowchart TD
+    Start([Resolution Triggered]) --> Type{Resolution<br/>Type?}
+
+    Type -->|Manual - Either| CheckAuth1{Is Caller<br/>Creator or Opponent?}
+    Type -->|Manual - Initiator| CheckAuth2{Is Caller<br/>Creator?}
+    Type -->|Manual - Receiver| CheckAuth3{Is Caller<br/>Opponent?}
+    Type -->|ThirdParty| CheckAuth4{Is Caller<br/>Arbitrator?}
+    Type -->|AutoPegged| CheckPublic[Check Linked<br/>Public Market]
+    Type -->|PolymarketOracle| CheckPoly[Check Polymarket<br/>Condition]
+
+    CheckAuth1 -->|No| Reject1[Revert: NotAuthorized]
+    CheckAuth2 -->|No| Reject2[Revert: NotAuthorized]
+    CheckAuth3 -->|No| Reject3[Revert: NotAuthorized]
+    CheckAuth4 -->|No| Reject4[Revert: NotAuthorized]
+
+    CheckAuth1 -->|Yes| SubmitOutcome
+    CheckAuth2 -->|Yes| SubmitOutcome
+    CheckAuth3 -->|Yes| SubmitOutcome
+    CheckAuth4 -->|Yes| SubmitOutcome
+
+    SubmitOutcome[Submit Outcome<br/>true/false] --> Resolved
+
+    CheckPublic --> PublicResolved{Public Market<br/>Resolved?}
+    PublicResolved -->|No| RejectNotResolved1[Revert: NotResolved]
+    PublicResolved -->|Yes| FetchPublic[Fetch passValue/failValue]
+    FetchPublic --> DetermineOutcome1[Determine Outcome<br/>pass > fail?]
+    DetermineOutcome1 --> Resolved
+
+    CheckPoly --> PolyResolved{Polymarket<br/>Condition Resolved?}
+    PolyResolved -->|No| RejectNotResolved2[Revert: PolymarketNotResolved]
+    PolyResolved -->|Yes| FetchPoly[Fetch Payout Numerators]
+    FetchPoly --> DetermineOutcome2[Determine Outcome<br/>passNum > failNum?]
+    DetermineOutcome2 --> Resolved
+
+    Resolved[Mark Wager Resolved] --> EmitEvents[Emit Resolution Events]
+    EmitEvents --> UpdateState[Update Market Status]
+    UpdateState --> WinnerClaim[Winner Can Claim]
+
+    WinnerClaim --> End([End])
+```
+
+### Flow 4: Claim Winnings
+
+```mermaid
+flowchart TD
+    Start([User Views Resolved Wager]) --> CheckWinner{Is User<br/>the Winner?}
+
+    CheckWinner -->|No| NoAction[No Claim Available]
+    NoAction --> End([End])
+
+    CheckWinner -->|Yes| CheckClaimed{Already<br/>Claimed?}
+
+    CheckClaimed -->|Yes| AlreadyClaimed[Show "Already Claimed"]
+    AlreadyClaimed --> End
+
+    CheckClaimed -->|No| ShowAmount[Display Winnable Amount]
+    ShowAmount --> ClickClaim[Click "Claim Winnings"]
+
+    ClickClaim --> SignTx[Sign Claim Transaction]
+
+    SignTx --> TxStatus{Transaction<br/>Status?}
+
+    TxStatus -->|Failed| Error[Show Error<br/>Retry Option]
+    Error --> SignTx
+
+    TxStatus -->|Success| Transfer{Token<br/>Type?}
+
+    Transfer -->|Native| NativeTransfer[Transfer Native Token]
+    Transfer -->|ERC20| ERC20Transfer[Transfer ERC20]
+
+    NativeTransfer --> Confirmed
+    ERC20Transfer --> Confirmed
+
+    Confirmed[Funds Received] --> UpdateBalance[Update UI Balance]
+    UpdateBalance --> ShowSuccess[Show Success Message]
+    ShowSuccess --> End
+```
+
+---
+
+## Sequence Diagrams
+
+### Sequence 1: Complete Wager Lifecycle
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Creator
+    participant UI as Frontend
+    participant Factory as P2PWagerFactory
+    participant Token as StakeToken
+    participant Oracle as OracleRegistry
+    participant Poly as PolymarketAdapter
+    participant Opponent
+    participant Indexer as Subgraph
+
+    Note over Creator, Indexer: Phase 1: Wager Creation
+
+    Creator->>UI: Create new wager
+    UI->>UI: Validate inputs
+    UI->>Factory: createOneVsOneMarketPending()
+
+    alt Native Token Stake
+        Creator->>Factory: Send ETH with transaction
+    else ERC20 Stake
+        Creator->>Token: approve(factory, amount)
+        Token-->>Creator: Approval confirmed
+        Factory->>Token: transferFrom(creator, factory, amount)
+    end
+
+    Factory->>Factory: Store wager data
+    Factory->>Factory: Record creator acceptance
+    Factory-->>UI: Emit MarketCreatedPending event
+    UI-->>Creator: Show wager created
+    Indexer->>Factory: Index creation event
+
+    Note over Creator, Indexer: Phase 2: Share & Invite
+
+    Creator->>UI: Click "Share to Twitter"
+    UI->>UI: Generate share intent
+    UI-->>Creator: Open Twitter with prefilled text
+
+    Note over Creator, Indexer: Phase 3: Opponent Acceptance
+
+    Opponent->>UI: Open wager link
+    UI->>Factory: getFriendMarketWithStatus(wagerId)
+    Factory-->>UI: Return wager details
+    UI-->>Opponent: Display wager terms
+
+    Opponent->>UI: Click "Accept Wager"
+
+    alt Native Token Stake
+        Opponent->>Factory: acceptMarket() + ETH
+    else ERC20 Stake
+        Opponent->>Token: approve(factory, amount)
+        Factory->>Token: transferFrom(opponent, factory, amount)
+    end
+
+    Factory->>Factory: Check threshold met
+    Factory->>Factory: Activate market
+    Factory-->>UI: Emit MarketActivated event
+    UI-->>Opponent: Show "Wager Active"
+    Indexer->>Factory: Index activation event
+
+    Note over Creator, Indexer: Phase 4: Peg to Polymarket
+
+    Creator->>UI: Select resolution source
+    UI->>Poly: Verify condition exists
+    Poly-->>UI: Condition valid
+
+    Creator->>Factory: pegToPolymarketCondition(wagerId, conditionId)
+    Factory->>Poly: linkMarketToPolymarket()
+    Poly-->>Factory: Link confirmed
+    Factory->>Factory: Update resolutionType
+    Factory-->>UI: Emit MarketPeggedToPolymarket
+    Indexer->>Factory: Index pegging event
+
+    Note over Creator, Indexer: Phase 5: Resolution
+
+    Note right of Poly: Time passes...<br/>Polymarket resolves
+
+    Creator->>UI: Check resolution status
+    UI->>Poly: isConditionResolved(conditionId)
+    Poly-->>UI: true
+
+    Creator->>Factory: resolveFromPolymarket(wagerId)
+    Factory->>Poly: getResolutionForMarket(wagerId)
+    Poly-->>Factory: (passNum, failNum, denom, true)
+    Factory->>Factory: Determine winner
+    Factory->>Factory: Mark resolved
+    Factory-->>UI: Emit PolymarketMarketResolved
+    Factory-->>UI: Emit MarketResolved
+    Indexer->>Factory: Index resolution event
+
+    Note over Creator, Indexer: Phase 6: Claim Winnings
+
+    Creator->>UI: View resolved wager
+    UI->>Factory: Get winner status
+    Factory-->>UI: Creator won
+
+    Creator->>Factory: claimWinnings(wagerId)
+
+    alt Native Token
+        Factory->>Creator: Transfer ETH (both stakes)
+    else ERC20
+        Factory->>Token: transfer(creator, totalStake)
+        Token->>Creator: Receive tokens
+    end
+
+    Factory-->>UI: Emit WinningsClaimed
+    UI-->>Creator: Show success
+    Indexer->>Factory: Index claim event
+```
+
+### Sequence 2: Batch Resolution from Polymarket
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Anyone as Any User
+    participant Factory as FriendGroupMarketFactory
+    participant Adapter as PolymarketAdapter
+    participant CTF as Polymarket CTF
+    participant Indexer as Subgraph
+
+    Note over Anyone, Indexer: Multiple wagers pegged to same Polymarket condition
+
+    Anyone->>Factory: batchResolveFromPolymarket(conditionId)
+
+    Factory->>Factory: Validate adapter set
+    Factory->>Adapter: isConditionResolved(conditionId)
+
+    Adapter->>CTF: isResolved(conditionId)
+    CTF-->>Adapter: true
+    Adapter-->>Factory: true
+
+    Factory->>Adapter: fetchResolution(conditionId)
+    Adapter->>CTF: getPayoutNumerators(conditionId)
+    CTF-->>Adapter: [passNum, failNum]
+    Adapter->>CTF: getPayoutDenominator(conditionId)
+    CTF-->>Adapter: denominator
+    Adapter->>Adapter: Cache resolution
+    Adapter-->>Factory: (passNum, failNum, denom)
+
+    Factory->>Factory: Determine outcome (passNum > failNum)
+
+    loop For each pegged wager
+        Factory->>Factory: Check wager active
+        Factory->>Factory: Check resolutionType == PolymarketOracle
+        Factory->>Factory: Mark resolved
+        Factory-->>Anyone: Emit PolymarketMarketResolved
+        Factory-->>Anyone: Emit MarketResolved
+    end
+
+    Indexer->>Factory: Index all resolution events
+```
+
+### Sequence 3: Expired Deadline Handling
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Anyone as Any User
+    participant Factory as FriendGroupMarketFactory
+    participant Token as StakeToken
+    participant Creator
+    participant Opponent
+    participant Indexer as Subgraph
+
+    Note over Anyone, Indexer: Acceptance deadline has passed
+
+    Anyone->>Factory: processExpiredDeadline(wagerId)
+
+    Factory->>Factory: Validate wager exists
+    Factory->>Factory: Check status == PendingAcceptance
+    Factory->>Factory: Check block.timestamp >= deadline
+
+    Factory->>Factory: Get accepted count
+    Factory->>Factory: Get required threshold
+
+    alt Threshold Met
+        Factory->>Factory: Activate market
+        Factory-->>Anyone: Emit MarketActivated
+    else Threshold Not Met
+        Factory->>Factory: Set status = Refunded
+
+        loop For each participant who staked
+            alt Native Token
+                Factory->>Creator: Refund ETH stake
+                Factory->>Opponent: Refund ETH stake (if accepted)
+            else ERC20
+                Factory->>Token: transfer(participant, stake)
+                Token->>Creator: Receive refund
+                Token->>Opponent: Receive refund (if accepted)
+            end
+            Factory-->>Anyone: Emit StakeRefunded
+        end
+
+        Factory-->>Anyone: Emit AcceptanceDeadlinePassed
+    end
+
+    Indexer->>Factory: Index deadline event
+```
+
+### Sequence 4: Oracle Registry Lookup
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User
+    participant UI as Frontend
+    participant Registry as OracleRegistry
+    participant PolyAdapter as PolymarketAdapter
+    participant ChainAdapter as ChainlinkAdapter
+    participant UMAAdapter as UMAAdapter
+
+    User->>UI: Search "ETH price above 5000"
+
+    UI->>Registry: getRegisteredAdapters()
+    Registry-->>UI: [polymarket, chainlink, uma]
+
+    par Search Polymarket
+        UI->>PolyAdapter: searchConditions("ETH 5000")
+        PolyAdapter-->>UI: [condition1, condition2]
+    and Search Chainlink
+        UI->>ChainAdapter: searchFeeds("ETH")
+        ChainAdapter-->>UI: [ETH/USD feed]
+    and Search UMA
+        UI->>UMAAdapter: searchAssertions("ETH")
+        UMAAdapter-->>UI: [assertion1]
+    end
+
+    UI->>UI: Normalize and rank results
+    UI-->>User: Display unified results
+
+    User->>UI: Select Chainlink ETH/USD
+    UI->>ChainAdapter: getConditionDetails(feedId)
+    ChainAdapter-->>UI: Feed metadata
+
+    User->>UI: Set threshold: $5000
+    User->>UI: Set deadline: Dec 31, 2024
+    UI-->>User: Ready to create wager
+```
+
+---
+
+## Error Handling Paths
+
+### Error Flow: Wager Creation Failures
+
+```mermaid
+flowchart TD
+    Start([Create Wager]) --> Validate{Input<br/>Validation}
+
+    Validate -->|Invalid Opponent| E1[Error: InvalidOpponent<br/>- Zero address<br/>- Same as creator]
+    Validate -->|Empty Description| E2[Error: InvalidDescription]
+    Validate -->|Bad Deadline| E3[Error: InvalidDeadline<br/>- Too soon: < 1 hour<br/>- Too far: > 30 days]
+    Validate -->|Zero Stake| E4[Error: InvalidStake]
+    Validate -->|Bad Odds| E5[Error: InvalidOdds<br/>- Multiplier < 200]
+    Validate -->|Invalid Threshold| E6[Error: InvalidThreshold<br/>- < 2 participants<br/>- > invited count]
+
+    Validate -->|Valid| CheckMembership{Check<br/>Membership}
+
+    CheckMembership -->|No Role| E7[Error: MembershipRequired]
+    CheckMembership -->|Expired| E8[Error: MembershipExpired]
+    CheckMembership -->|Limit Reached| E9[Error: MarketLimitReached]
+
+    CheckMembership -->|Valid| CheckNullifier{Check<br/>Nullifier}
+
+    CheckNullifier -->|Nullified| E10[Error: AddressNullified<br/>- Creator or opponent<br/>on blocklist]
+
+    CheckNullifier -->|Clear| CheckFunds{Check<br/>Funds}
+
+    CheckFunds -->|Insufficient Native| E11[Error: InsufficientPayment]
+    CheckFunds -->|ERC20 Transfer Fail| E12[Error: TransferFailed]
+
+    CheckFunds -->|Sufficient| Success([Wager Created])
+
+    E1 --> Recovery1[Fix opponent address]
+    E2 --> Recovery2[Add description]
+    E3 --> Recovery3[Adjust deadline]
+    E4 --> Recovery4[Set valid stake]
+    E5 --> Recovery5[Increase odds multiplier]
+    E6 --> Recovery6[Adjust threshold]
+    E7 --> Recovery7[Purchase membership]
+    E8 --> Recovery8[Renew membership]
+    E9 --> Recovery9[Wait for limit reset]
+    E10 --> Recovery10[Contact support]
+    E11 --> Recovery11[Add funds]
+    E12 --> Recovery12[Approve token spend]
+
+    Recovery1 --> Validate
+    Recovery2 --> Validate
+    Recovery3 --> Validate
+    Recovery4 --> Validate
+    Recovery5 --> Validate
+    Recovery6 --> Validate
+    Recovery7 --> CheckMembership
+    Recovery8 --> CheckMembership
+    Recovery9 --> CheckMembership
+    Recovery10 --> Start
+    Recovery11 --> CheckFunds
+    Recovery12 --> CheckFunds
+```
+
+### Error Flow: Resolution Failures
+
+```mermaid
+flowchart TD
+    Start([Resolve Wager]) --> CheckExists{Wager<br/>Exists?}
+
+    CheckExists -->|No| E1[Error: InvalidMarketId]
+    CheckExists -->|Yes| CheckActive{Wager<br/>Active?}
+
+    CheckActive -->|No| E2[Error: NotActive]
+    CheckActive -->|Yes| CheckType{Resolution<br/>Type?}
+
+    CheckType -->|Manual| CheckAuth{Caller<br/>Authorized?}
+    CheckType -->|AutoPegged| E3[Error: NotAuthorized<br/>Use autoResolvePeggedMarket]
+    CheckType -->|PolymarketOracle| CheckPolyAdapter{Adapter<br/>Set?}
+
+    CheckAuth -->|No| E4[Error: NotAuthorized]
+    CheckAuth -->|Yes| CheckPegged{Already<br/>Pegged?}
+
+    CheckPegged -->|Yes| E5[Error: AlreadyPegged]
+    CheckPegged -->|No| ManualSuccess([Manual Resolution Success])
+
+    CheckPolyAdapter -->|No| E6[Error: PolymarketAdapterNotSet]
+    CheckPolyAdapter -->|Yes| CheckCondition{Condition<br/>Set?}
+
+    CheckCondition -->|No| E7[Error: InvalidConditionId]
+    CheckCondition -->|Yes| CheckResType{Resolution Type<br/>Correct?}
+
+    CheckResType -->|No| E8[Error: InvalidResolutionType]
+    CheckResType -->|Yes| FetchResolution[Fetch from Polymarket]
+
+    FetchResolution --> CheckResolved{Condition<br/>Resolved?}
+
+    CheckResolved -->|No| E9[Error: PolymarketNotResolved]
+    CheckResolved -->|Yes| PolySuccess([Polymarket Resolution Success])
+
+    E1 --> R1[Check wager ID]
+    E2 --> R2[Wager already resolved/cancelled]
+    E3 --> R3[Call correct function]
+    E4 --> R4[Use authorized account]
+    E5 --> R5[Use oracle resolution]
+    E6 --> R6[Admin must set adapter]
+    E7 --> R7[Peg to condition first]
+    E8 --> R8[Check resolution type]
+    E9 --> R9[Wait for Polymarket to resolve]
+```
+
+---
+
+## Consistency Analysis
+
+### State Transition Validity Matrix
+
+```mermaid
+graph LR
+    subgraph "Valid Transitions"
+        P1[Pending] -->|accept| A1[Active]
+        P2[Pending] -->|cancel| C1[Cancelled]
+        P3[Pending] -->|expire + no threshold| R1[Refunded]
+        A2[Active] -->|resolve| S1[Resolved]
+        A3[Active] -->|dispute| D1[Disputed]
+        D2[Disputed] -->|arbitrate| S2[Resolved]
+    end
+
+    subgraph "Invalid Transitions ❌"
+        X1[Pending] -.->|resolve| X2[Resolved]
+        X3[Cancelled] -.->|accept| X4[Active]
+        X5[Refunded] -.->|resolve| X6[Resolved]
+        X7[Resolved] -.->|dispute| X8[Disputed]
+    end
+
+    style X1 fill:#ffcccc
+    style X2 fill:#ffcccc
+    style X3 fill:#ffcccc
+    style X4 fill:#ffcccc
+    style X5 fill:#ffcccc
+    style X6 fill:#ffcccc
+    style X7 fill:#ffcccc
+    style X8 fill:#ffcccc
+```
+
+### Identified Consistency Issues
+
+```mermaid
+flowchart TD
+    subgraph "Issue 1: Missing Dispute Flow"
+        I1A[Active Wager] --> I1B{Manual Resolution<br/>Submitted}
+        I1B --> I1C[Immediately Resolved]
+        I1D[⚠️ No challenge window<br/>for manual resolutions]
+        I1C -.-> I1D
+    end
+
+    subgraph "Issue 2: Orphaned Stakes"
+        I2A[Wager Resolved] --> I2B{Winner Claims?}
+        I2B -->|No| I2C[Stakes locked forever]
+        I2D[⚠️ No timeout for<br/>unclaimed winnings]
+        I2C -.-> I2D
+    end
+
+    subgraph "Issue 3: Arbitrator Incentives"
+        I3A[ThirdParty Resolution] --> I3B{Arbitrator Resolves}
+        I3B --> I3C[No payment to arbitrator]
+        I3D[⚠️ No incentive for<br/>timely resolution]
+        I3C -.-> I3D
+    end
+
+    subgraph "Issue 4: Oracle Failure"
+        I4A[PolymarketOracle Type] --> I4B{Polymarket Never<br/>Resolves}
+        I4B --> I4C[Wager stuck Active]
+        I4D[⚠️ No fallback<br/>resolution mechanism]
+        I4C -.-> I4D
+    end
+```
+
+### Recommended Fixes
+
+```mermaid
+flowchart LR
+    subgraph "Fix 1: Add Challenge Period"
+        F1A[Manual Resolution] --> F1B[Challenge Window<br/>24-48 hours]
+        F1B --> F1C{Challenged?}
+        F1C -->|Yes| F1D[Escalate to Arbitration]
+        F1C -->|No| F1E[Finalize Resolution]
+    end
+
+    subgraph "Fix 2: Claim Timeout"
+        F2A[Wager Resolved] --> F2B[Winner has 90 days<br/>to claim]
+        F2B --> F2C{Claimed in time?}
+        F2C -->|No| F2D[Funds to DAO Treasury]
+        F2C -->|Yes| F2E[Winner receives funds]
+    end
+
+    subgraph "Fix 3: Arbitrator Fee"
+        F3A[Create with Arbitrator] --> F3B[Set arbitrator fee %]
+        F3B --> F3C[Fee escrowed from stakes]
+        F3C --> F3D[Paid on resolution]
+    end
+
+    subgraph "Fix 4: Oracle Fallback"
+        F4A[Oracle Timeout] --> F4B[After 30 days past<br/>expected resolution]
+        F4B --> F4C[Enable manual override]
+        F4C --> F4D[Or refund both parties]
+    end
+```
+
+---
+
+## Cross-Reference: Contract Functions to States
+
+| Function | Required State | New State | Events Emitted |
+|----------|---------------|-----------|----------------|
+| `createOneVsOneMarketPending` | N/A | PendingAcceptance | MarketCreatedPending, ArbitratorSet |
+| `createBookmakerMarket` | N/A | PendingAcceptance | MarketCreatedPending, ArbitratorSet |
+| `createSmallGroupMarketPending` | N/A | PendingAcceptance | MarketCreatedPending, ArbitratorSet |
+| `acceptMarket` | PendingAcceptance | PendingAcceptance or Active | ParticipantAccepted, MarketActivated |
+| `cancelPendingMarket` | PendingAcceptance | Cancelled | MarketCancelledByCreator, StakeRefunded |
+| `processExpiredDeadline` | PendingAcceptance | Refunded or Active | AcceptanceDeadlinePassed, StakeRefunded or MarketActivated |
+| `pegToPublicMarket` | Active | Active | MarketPeggedToPublic |
+| `pegToPolymarketCondition` | Active | Active | MarketPeggedToPolymarket |
+| `autoResolvePeggedMarket` | Active + AutoPegged | Resolved | PeggedMarketAutoResolved, MarketResolved |
+| `resolveFromPolymarket` | Active + PolymarketOracle | Resolved | PolymarketMarketResolved, MarketResolved |
+| `batchResolveFromPolymarket` | Active + PolymarketOracle | Resolved | PolymarketMarketResolved, MarketResolved (multiple) |
+| `resolveFriendMarket` | Active + Manual type | Resolved | MarketResolved |
+
+---
+
+## Summary
+
+This document provides complete visibility into the FairWins P2P wager system architecture. Key findings:
+
+### Strengths
+1. Clear state machine with well-defined transitions
+2. Multiple resolution types supporting various use cases
+3. Robust acceptance flow with deadlines and thresholds
+4. External oracle integration (Polymarket) already implemented
+
+### Areas Requiring Attention
+1. **No dispute mechanism** for manual resolutions
+2. **No claim timeout** - stakes could be locked forever
+3. **No arbitrator incentives** - may lead to slow resolution
+4. **No oracle fallback** - stuck wagers if oracle fails
+5. **Missing claim function** - currently only events emitted, no fund transfer
+
+### Next Steps
+1. Implement `claimWinnings()` function
+2. Add challenge period for manual resolutions
+3. Add claim timeout with DAO treasury fallback
+4. Add optional arbitrator fee mechanism
+5. Add oracle timeout with manual override option

--- a/docs/architecture/SYSTEM_FLOW_DIAGRAMS_V2.md
+++ b/docs/architecture/SYSTEM_FLOW_DIAGRAMS_V2.md
@@ -1,0 +1,814 @@
+# FairWins P2P Wager System - Flow Diagrams V2 (With Fixes)
+
+## Overview
+
+This document contains the updated system flow diagrams incorporating all recommended fixes:
+1. ✅ claimWinnings() function
+2. ✅ Challenge period for disputes
+3. ✅ Claim timeout with treasury fallback
+4. ✅ Oracle timeout fallback
+5. ✅ Arbitrator fee mechanism
+
+---
+
+## Updated Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    USER ||--o{ WAGER : creates
+    USER ||--o{ WAGER : accepts
+    USER ||--o{ WAGER : arbitrates
+    USER ||--o{ ACCEPTANCE_RECORD : has
+    WAGER ||--|| ACCEPTANCE_RECORD : tracks
+    WAGER ||--o| PENDING_RESOLUTION : has
+    WAGER ||--o| ORACLE_ADAPTER : resolves_via
+    WAGER }|--|| STAKE_TOKEN : uses
+    ORACLE_REGISTRY ||--o{ ORACLE_ADAPTER : contains
+    ORACLE_ADAPTER ||--o{ EXTERNAL_CONDITION : queries
+    TREASURY ||--o{ WAGER : receives_unclaimed
+
+    USER {
+        address wallet PK
+        uint256 totalWagered
+        uint256 totalWon
+        uint256 totalLost
+        uint256 winCount
+        uint256 lossCount
+        uint256 arbitratorFeesEarned
+    }
+
+    WAGER {
+        uint256 wagerId PK
+        address creator FK
+        address opponent FK
+        address arbitrator FK
+        uint256 creatorStake
+        uint256 opponentStake
+        address stakeToken FK
+        string description
+        bytes32 oracleId FK
+        bytes32 externalCondition
+        enum status
+        enum resolutionType
+        uint256 acceptanceDeadline
+        uint256 expectedResolutionTime
+        uint256 createdAt
+        uint256 resolvedAt
+        bool outcome
+        address winner
+        bool claimed
+        uint256 arbitratorFeeBps
+    }
+
+    PENDING_RESOLUTION {
+        uint256 wagerId FK
+        bool proposedOutcome
+        address proposer
+        uint256 proposedAt
+        uint256 challengeDeadline
+        bool challenged
+        address challenger
+        uint256 challengeBond
+    }
+
+    ACCEPTANCE_RECORD {
+        uint256 wagerId FK
+        address participant FK
+        uint256 stakedAmount
+        uint256 acceptedAt
+        bool hasAccepted
+        bool isArbitrator
+    }
+
+    ORACLE_ADAPTER {
+        bytes32 oracleId PK
+        string name
+        string oracleType
+        address adapterAddress
+        bool isVerified
+    }
+
+    EXTERNAL_CONDITION {
+        bytes32 conditionId PK
+        bytes32 oracleId FK
+        bool resolved
+        uint256 passNumerator
+        uint256 failNumerator
+        uint256 resolvedAt
+    }
+
+    STAKE_TOKEN {
+        address tokenAddress PK
+        string symbol
+        uint8 decimals
+        bool accepted
+    }
+
+    TREASURY {
+        address treasuryAddress PK
+        uint256 totalSwept
+    }
+```
+
+---
+
+## Updated State Machine (Complete)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending : createWager()
+
+    state Pending {
+        [*] --> AwaitingAcceptance
+        AwaitingAcceptance --> AwaitingAcceptance : acceptWager() [threshold not met]
+    }
+
+    Pending --> Active : acceptWager() [threshold met]
+    Pending --> Cancelled : cancelWager() [by creator]
+    Pending --> Refunded : processExpiredDeadline() [threshold not met]
+
+    state Active {
+        [*] --> AwaitingResolution
+        AwaitingResolution --> AwaitingResolution : [monitoring oracle]
+    }
+
+    Active --> PendingResolution : proposeResolution() [manual types]
+    Active --> Resolved : resolveFromOracle() [external oracle resolved]
+    Active --> OracleTimedOut : triggerOracleTimeout() [30+ days past expected]
+
+    state PendingResolution {
+        [*] --> ChallengeWindow
+        ChallengeWindow --> ChallengeWindow : [24h countdown]
+    }
+
+    PendingResolution --> Challenged : challengeResolution() [within 24h + bond]
+    PendingResolution --> Resolved : finalizeResolution() [24h passed, no challenge]
+
+    state Challenged {
+        [*] --> AwaitingArbitration
+        AwaitingArbitration --> AwaitingArbitration : [arbitrator reviewing]
+    }
+
+    Challenged --> Resolved : resolveDispute() [arbitrator decides]
+
+    state OracleTimedOut {
+        [*] --> AwaitingAction
+        AwaitingAction --> MutualRefundPending : acceptMutualRefund() [one party]
+        MutualRefundPending --> MutualRefundPending : [waiting for other party]
+    }
+
+    OracleTimedOut --> Refunded : acceptMutualRefund() [both parties agree]
+    OracleTimedOut --> Resolved : forceManualResolution() [arbitrator]
+
+    state Resolved {
+        [*] --> AwaitingClaim
+        AwaitingClaim --> AwaitingClaim : [90 day countdown]
+    }
+
+    Resolved --> Claimed : claimWinnings() [winner claims]
+    Resolved --> Swept : sweepUnclaimedFunds() [90+ days, to treasury]
+
+    Claimed --> [*]
+    Swept --> [*]
+    Cancelled --> [*]
+    Refunded --> [*]
+
+    note right of PendingResolution
+        24-hour challenge window
+        Either party can challenge
+        with bond deposit
+    end note
+
+    note right of OracleTimedOut
+        30 days past expected
+        resolution time
+    end note
+
+    note right of Resolved
+        90-day claim window
+        After that, treasury sweeps
+    end note
+```
+
+---
+
+## User Flows (Updated)
+
+### Flow 1: Create Wager (Complete)
+
+```mermaid
+flowchart TD
+    Start([User Opens App]) --> Dashboard[View Dashboard]
+    Dashboard --> CreateBtn[Click "Create Wager"]
+
+    CreateBtn --> DescForm[Enter Wager Description]
+    DescForm --> ResChoice{Choose Resolution<br/>Method}
+
+    ResChoice -->|Find Existing| SearchMarket[Search External Markets]
+    ResChoice -->|Price Oracle| SelectChainlink[Select Chainlink Feed]
+    ResChoice -->|Manual| SelectResolver[Choose Who Resolves]
+    ResChoice -->|Arbitrator| EnterArb[Enter Arbitrator Address]
+
+    SearchMarket --> SelectCondition[Select Market/Condition]
+    SelectCondition --> SetExpectedTime[Set Expected Resolution Time]
+    SetExpectedTime --> Stakes
+
+    SelectChainlink --> ConfigThreshold[Set Price Threshold & Date]
+    ConfigThreshold --> Stakes
+
+    SelectResolver --> Stakes[Set Stake Amount]
+    EnterArb --> SetArbFee[Set Arbitrator Fee %]
+    SetArbFee --> Stakes
+
+    Stakes --> Token[Select Payment Token]
+    Token --> Odds{Equal Stakes?}
+    Odds -->|Yes| Equal[1:1 Odds]
+    Odds -->|No| Custom[Set Custom Odds]
+    Equal --> Opponent
+    Custom --> Opponent
+
+    Opponent[Enter Opponent Address] --> Deadline[Set Acceptance Deadline]
+    Deadline --> Review[Review All Terms]
+
+    Review --> Confirm{Confirm?}
+    Confirm -->|No| Edit[Edit Terms]
+    Edit --> DescForm
+
+    Confirm -->|Yes| ApproveToken{ERC20?}
+    ApproveToken -->|Yes| Approve[Approve Token Spend]
+    ApproveToken -->|No| Submit
+
+    Approve --> Submit[Submit Transaction]
+    Submit --> TxStatus{Status?}
+
+    TxStatus -->|Failed| Error[Show Error]
+    Error --> Review
+
+    TxStatus -->|Success| Created[Wager Created!]
+    Created --> SharePrompt{Share?}
+
+    SharePrompt -->|Twitter| Twitter[Open Twitter]
+    SharePrompt -->|Discord| Discord[Copy Embed]
+    SharePrompt -->|Telegram| Telegram[Open Telegram]
+    SharePrompt -->|Link| CopyLink[Copy Link]
+    SharePrompt -->|Skip| Done
+
+    Twitter --> Done[Return to Dashboard]
+    Discord --> Done
+    Telegram --> Done
+    CopyLink --> Done
+```
+
+### Flow 2: Accept Wager (Complete)
+
+```mermaid
+flowchart TD
+    Start([Receive Invitation]) --> Source{Source?}
+
+    Source -->|Social Link| ClickLink[Click Link]
+    Source -->|App Notification| OpenApp[Open App]
+    Source -->|QR Code| ScanQR[Scan QR]
+
+    ClickLink --> DeepLink[Deep Link Handler]
+    ScanQR --> DeepLink
+    OpenApp --> InviteList[View Pending Invitations]
+    InviteList --> SelectInvite[Select Wager]
+
+    DeepLink --> ViewDetails[View Wager Details]
+    SelectInvite --> ViewDetails
+
+    ViewDetails --> CheckDeadline{Deadline<br/>Passed?}
+    CheckDeadline -->|Yes| Expired[Show Expired]
+    Expired --> End([End])
+
+    CheckDeadline -->|No| CheckMembership{Has<br/>Membership?}
+    CheckMembership -->|No| Purchase[Purchase Tier]
+    Purchase --> CheckMembership
+
+    CheckMembership -->|Yes| CheckFunds{Sufficient<br/>Funds?}
+    CheckFunds -->|No| AddFunds[Add Funds]
+    AddFunds --> CheckFunds
+
+    CheckFunds -->|Yes| ReviewTerms[Review Terms]
+    ReviewTerms --> Decision{Decision?}
+
+    Decision -->|Decline| Decline[Decline]
+    Decline --> End
+
+    Decision -->|Counter| Counter[Create Counter-offer]
+    Counter --> End
+
+    Decision -->|Accept| AcceptFlow[Begin Accept Flow]
+
+    AcceptFlow --> ApproveToken{ERC20?}
+    ApproveToken -->|Yes| Approve[Approve Spend]
+    ApproveToken -->|No| SignAccept
+
+    Approve --> SignAccept[Sign Accept Tx]
+    SignAccept --> TxStatus{Status?}
+
+    TxStatus -->|Failed| TxError[Show Error]
+    TxError --> ReviewTerms
+
+    TxStatus -->|Success| CheckThreshold{Threshold<br/>Met?}
+
+    CheckThreshold -->|No| ShowPending[Show Pending Status]
+    ShowPending --> End
+
+    CheckThreshold -->|Yes| Activated[Wager Activated!]
+    Activated --> ViewActive[View in Active Wagers]
+    ViewActive --> End
+```
+
+### Flow 3: Manual Resolution (With Challenge Period)
+
+```mermaid
+flowchart TD
+    Start([Wager Active]) --> CheckType{Resolution<br/>Type?}
+
+    CheckType -->|External Oracle| OracleFlow[Oracle Resolution Flow]
+    CheckType -->|Manual| ManualFlow[Manual Resolution Flow]
+
+    subgraph ManualResolution[Manual Resolution Flow]
+        ManualFlow --> CheckAuth{Authorized<br/>Resolver?}
+        CheckAuth -->|No| Reject[Revert: NotAuthorized]
+
+        CheckAuth -->|Yes| ProposeOutcome[Propose Outcome]
+        ProposeOutcome --> SetDeadline[Set 24h Challenge Deadline]
+        SetDeadline --> EmitProposed[Emit ResolutionProposed]
+        EmitProposed --> WaitPeriod[Wait Challenge Period]
+
+        WaitPeriod --> Challenged{Challenged?}
+
+        Challenged -->|Yes| RecordChallenge[Record Challenge + Bond]
+        RecordChallenge --> NotifyArb[Notify Arbitrator]
+        NotifyArb --> ArbReview[Arbitrator Reviews]
+        ArbReview --> ArbDecision[Arbitrator Decides]
+        ArbDecision --> DistributeBonds[Distribute Bonds]
+        DistributeBonds --> SetResolved
+
+        Challenged -->|No, 24h passed| Finalize[Finalize Resolution]
+        Finalize --> SetResolved[Set Status = Resolved]
+    end
+
+    subgraph OracleResolution[Oracle Resolution Flow]
+        OracleFlow --> CheckOracleResolved{Oracle<br/>Resolved?}
+
+        CheckOracleResolved -->|No| CheckTimeout{30+ Days<br/>Past Expected?}
+        CheckTimeout -->|No| WaitOracle[Wait for Oracle]
+        WaitOracle --> CheckOracleResolved
+
+        CheckTimeout -->|Yes| TriggerTimeout[Trigger Oracle Timeout]
+        TriggerTimeout --> TimeoutFlow[Oracle Timeout Flow]
+
+        CheckOracleResolved -->|Yes| FetchOutcome[Fetch Outcome]
+        FetchOutcome --> SetResolved
+    end
+
+    SetResolved --> EnableClaim[Enable Claim]
+    EnableClaim --> End([Wager Resolved])
+```
+
+### Flow 4: Oracle Timeout Handling
+
+```mermaid
+flowchart TD
+    Start([Oracle Timed Out]) --> Status[Status = OracleTimedOut]
+
+    Status --> Options{Resolution<br/>Path?}
+
+    Options -->|Mutual Refund| RefundPath[Mutual Refund Path]
+    Options -->|Arbitrator| ArbPath[Arbitrator Path]
+
+    subgraph MutualRefund[Mutual Refund Path]
+        RefundPath --> Party1[First Party Accepts]
+        Party1 --> RecordAccept1[Record Acceptance]
+        RecordAccept1 --> WaitParty2[Wait for Other Party]
+
+        WaitParty2 --> Party2{Other Party<br/>Accepts?}
+        Party2 -->|No| Stalemate[Stalemate - Need Arbitrator]
+        Stalemate --> ArbPath
+
+        Party2 -->|Yes| BothAccepted[Both Accepted]
+        BothAccepted --> RefundBoth[Refund Both Stakes]
+        RefundBoth --> SetRefunded[Status = Refunded]
+    end
+
+    subgraph ArbitratorResolution[Arbitrator Resolution]
+        ArbPath --> CheckArb{Has<br/>Arbitrator?}
+        CheckArb -->|No| NeedArb[Stuck - Contact Support]
+
+        CheckArb -->|Yes| ArbForce[Arbitrator Forces Resolution]
+        ArbForce --> SetOutcome[Set Outcome]
+        SetOutcome --> SetResolved[Status = Resolved]
+    end
+
+    SetRefunded --> End([Complete])
+    SetResolved --> End
+    NeedArb --> End
+```
+
+### Flow 5: Claim Winnings (With Timeout)
+
+```mermaid
+flowchart TD
+    Start([Wager Resolved]) --> CheckWinner{Is User<br/>Winner?}
+
+    CheckWinner -->|No| NoAction[No Claim Available]
+    NoAction --> End([End])
+
+    CheckWinner -->|Yes| CheckClaimed{Already<br/>Claimed?}
+    CheckClaimed -->|Yes| AlreadyClaimed[Already Claimed]
+    AlreadyClaimed --> End
+
+    CheckClaimed -->|No| CheckTimeout{Within 90<br/>Days?}
+
+    CheckTimeout -->|No| Expired[Claim Period Expired]
+    Expired --> SweepAvailable[Sweep Available for Treasury]
+    SweepAvailable --> End
+
+    CheckTimeout -->|Yes| ShowClaim[Show Claim Button]
+    ShowClaim --> ClickClaim[Click Claim]
+    ClickClaim --> SignTx[Sign Transaction]
+
+    SignTx --> TxStatus{Status?}
+    TxStatus -->|Failed| Error[Show Error]
+    Error --> ShowClaim
+
+    TxStatus -->|Success| CalcPayout[Calculate Payout]
+
+    CalcPayout --> CheckArbFee{Arbitrator<br/>Fee?}
+    CheckArbFee -->|Yes| PayArb[Pay Arbitrator Fee]
+    PayArb --> PayWinner
+    CheckArbFee -->|No| PayWinner[Pay Winner]
+
+    PayWinner --> MarkClaimed[Mark as Claimed]
+    MarkClaimed --> EmitEvent[Emit WinningsClaimed]
+    EmitEvent --> ShowSuccess[Show Success]
+    ShowSuccess --> End
+```
+
+### Flow 6: Treasury Sweep (Unclaimed Funds)
+
+```mermaid
+flowchart TD
+    Start([Check Resolved Wagers]) --> FindUnclaimed[Find Unclaimed > 90 Days]
+
+    FindUnclaimed --> HasUnclaimed{Any<br/>Unclaimed?}
+    HasUnclaimed -->|No| Done[Nothing to Sweep]
+    Done --> End([End])
+
+    HasUnclaimed -->|Yes| ForEach[For Each Unclaimed Wager]
+
+    ForEach --> CheckTime{resolvedAt +<br/>90 days < now?}
+    CheckTime -->|No| Skip[Skip - Not Yet]
+    Skip --> ForEach
+
+    CheckTime -->|Yes| CalcAmount[Calculate Total Stakes]
+    CalcAmount --> TransferTreasury[Transfer to Treasury]
+    TransferTreasury --> MarkSwept[Mark as Swept]
+    MarkSwept --> EmitEvent[Emit UnclaimedFundsSwept]
+    EmitEvent --> ForEach
+
+    ForEach --> Complete[All Processed]
+    Complete --> End
+```
+
+---
+
+## Sequence Diagrams (Updated)
+
+### Sequence 1: Complete Wager Lifecycle (With All Fixes)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Creator
+    participant UI as Frontend
+    participant Factory as P2PWagerFactory
+    participant Token as StakeToken
+    participant Oracle as OracleRegistry
+    participant Opponent
+    participant Arbitrator
+    participant Treasury
+    participant Indexer as Subgraph
+
+    Note over Creator, Indexer: PHASE 1: Creation
+
+    Creator->>UI: Create new wager
+    UI->>UI: Validate inputs
+    Creator->>Factory: createWager(opponent, stake, oracleId, arbFee, ...)
+
+    alt ERC20 Stake
+        Creator->>Token: approve(factory, amount)
+        Factory->>Token: transferFrom(creator, factory, amount)
+    else Native Token
+        Creator->>Factory: Send ETH with transaction
+    end
+
+    Factory->>Factory: Store wager, status=Pending
+    Factory-->>Creator: Emit WagerCreated
+    Indexer->>Factory: Index event
+
+    Note over Creator, Indexer: PHASE 2: Acceptance
+
+    Creator->>UI: Share to Twitter
+    UI->>UI: Generate share intent
+    Opponent->>UI: Click shared link
+    UI->>Factory: getWagerDetails(wagerId)
+    Factory-->>UI: Return details
+
+    Opponent->>Factory: acceptWager(wagerId) + stake
+    Factory->>Factory: Check threshold
+    Factory->>Factory: status = Active
+    Factory-->>Opponent: Emit WagerActivated
+    Indexer->>Factory: Index event
+
+    Note over Creator, Indexer: PHASE 3a: Oracle Resolution Path
+
+    rect rgb(200, 230, 200)
+        Note right of Oracle: Oracle resolves externally
+        Creator->>Factory: resolveFromOracle(wagerId)
+        Factory->>Oracle: getOutcome(oracleId, conditionId)
+        Oracle-->>Factory: (outcome, confidence)
+        Factory->>Factory: status = Resolved, winner set
+        Factory-->>Creator: Emit WagerResolved
+    end
+
+    Note over Creator, Indexer: PHASE 3b: Manual Resolution Path
+
+    rect rgb(230, 230, 200)
+        Creator->>Factory: proposeResolution(wagerId, true)
+        Factory->>Factory: status = PendingResolution
+        Factory->>Factory: challengeDeadline = now + 24h
+        Factory-->>Creator: Emit ResolutionProposed
+
+        alt Opponent Challenges
+            Opponent->>Factory: challengeResolution(wagerId) + bond
+            Factory->>Factory: status = Challenged
+            Factory-->>Opponent: Emit ResolutionChallenged
+
+            Arbitrator->>Factory: resolveDispute(wagerId, outcome)
+            Factory->>Factory: Distribute bonds
+            Factory->>Factory: status = Resolved
+            Factory-->>Arbitrator: Emit DisputeResolved
+        else No Challenge
+            Note over Factory: 24 hours pass
+            Creator->>Factory: finalizeResolution(wagerId)
+            Factory->>Factory: status = Resolved
+            Factory-->>Creator: Emit ResolutionFinalized
+        end
+    end
+
+    Note over Creator, Indexer: PHASE 4: Claim
+
+    Creator->>Factory: claimWinnings(wagerId)
+    Factory->>Factory: Verify winner, not claimed, within 90 days
+
+    alt Has Arbitrator Fee
+        Factory->>Factory: Calculate fee
+        Factory->>Arbitrator: Transfer arbitrator fee
+        Factory-->>Factory: Emit ArbitratorPaid
+    end
+
+    Factory->>Creator: Transfer winnings
+    Factory->>Factory: Mark claimed
+    Factory-->>Creator: Emit WinningsClaimed
+    Indexer->>Factory: Index event
+
+    Note over Creator, Indexer: PHASE 5: Timeout Paths
+
+    rect rgb(255, 230, 230)
+        Note over Factory: If winner doesn't claim within 90 days
+        Treasury->>Factory: sweepUnclaimedFunds(wagerId)
+        Factory->>Factory: Verify 90 days passed
+        Factory->>Treasury: Transfer unclaimed funds
+        Factory-->>Treasury: Emit UnclaimedFundsSwept
+    end
+```
+
+### Sequence 2: Oracle Timeout Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Anyone
+    participant Factory as P2PWagerFactory
+    participant Creator
+    participant Opponent
+    participant Arbitrator
+    participant Timer as Block.timestamp
+
+    Note over Anyone, Timer: Oracle Never Resolves
+
+    Anyone->>Factory: Check wager status
+    Factory-->>Anyone: Active, expectedResolution passed
+
+    Anyone->>Factory: triggerOracleTimeout(wagerId)
+    Factory->>Factory: Verify expectedResolution + 30 days < now
+    Factory->>Factory: status = OracleTimedOut
+    Factory-->>Anyone: Emit OracleTimeoutTriggered
+
+    alt Mutual Refund Path
+        Creator->>Factory: acceptMutualRefund(wagerId)
+        Factory->>Factory: Record creator acceptance
+        Factory-->>Creator: Emit MutualRefundAccepted(creator)
+
+        Opponent->>Factory: acceptMutualRefund(wagerId)
+        Factory->>Factory: Both parties accepted
+        Factory->>Factory: status = Refunded
+        Factory->>Creator: Return creator stake
+        Factory->>Opponent: Return opponent stake
+        Factory-->>Opponent: Emit MutualRefundCompleted
+
+    else Arbitrator Forces Resolution
+        Note over Arbitrator: After reasonable waiting period
+
+        Arbitrator->>Factory: forceManualResolution(wagerId, outcome)
+        Factory->>Factory: Verify arbitrator authorized
+        Factory->>Factory: Set winner based on outcome
+        Factory->>Factory: status = Resolved
+        Factory-->>Arbitrator: Emit ForcedResolution
+
+        Note over Creator, Opponent: Normal claim flow follows
+    end
+```
+
+### Sequence 3: Challenge and Dispute Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Proposer
+    participant Factory as P2PWagerFactory
+    participant Challenger
+    participant Arbitrator
+    participant Timer as Block.timestamp
+
+    Note over Proposer, Timer: Resolution Proposed
+
+    Proposer->>Factory: proposeResolution(wagerId, true)
+    Factory->>Factory: Verify proposer authorized
+    Factory->>Factory: status = PendingResolution
+    Factory->>Factory: challengeDeadline = now + 24h
+    Factory->>Factory: Store proposed outcome
+    Factory-->>Proposer: Emit ResolutionProposed
+
+    Note over Challenger: Within 24 hours
+
+    Challenger->>Factory: challengeResolution(wagerId) + 0.1 ETH bond
+    Factory->>Factory: Verify within challenge window
+    Factory->>Factory: Verify challenger is other party
+    Factory->>Factory: Store challenger bond
+    Factory->>Factory: status = Challenged
+    Factory-->>Challenger: Emit ResolutionChallenged
+
+    Note over Arbitrator: Reviews evidence
+
+    Arbitrator->>Factory: resolveDispute(wagerId, finalOutcome)
+    Factory->>Factory: Verify arbitrator authorized
+
+    alt Proposer was correct
+        Factory->>Proposer: Return proposer's implicit bond
+        Factory->>Proposer: Award challenger's bond
+        Factory-->>Factory: Challenger loses bond
+    else Challenger was correct
+        Factory->>Challenger: Return challenger's bond
+        Factory->>Challenger: Award proposer's implicit bond
+        Factory-->>Factory: Proposer loses bond
+    end
+
+    Factory->>Factory: Set winner based on finalOutcome
+    Factory->>Factory: status = Resolved
+    Factory-->>Arbitrator: Emit DisputeResolved
+```
+
+---
+
+## Error Handling (Complete)
+
+### All Error States and Recovery
+
+```mermaid
+flowchart TD
+    subgraph Creation[Creation Errors]
+        C1[InvalidOpponent] --> C1R[Fix: Valid non-self address]
+        C2[InvalidDescription] --> C2R[Fix: Add description]
+        C3[InvalidDeadline] --> C3R[Fix: 1h-30d range]
+        C4[InvalidStake] --> C4R[Fix: Non-zero stake]
+        C5[InvalidOdds] --> C5R[Fix: Multiplier >= 200]
+        C6[InvalidArbitratorFee] --> C6R[Fix: <= 10%]
+        C7[MembershipRequired] --> C7R[Fix: Purchase tier]
+        C8[InsufficientFunds] --> C8R[Fix: Add funds]
+    end
+
+    subgraph Acceptance[Acceptance Errors]
+        A1[InvalidMarketId] --> A1R[Fix: Check wager exists]
+        A2[DeadlinePassed] --> A2R[Info: Wager expired]
+        A3[AlreadyAccepted] --> A3R[Info: Already accepted]
+        A4[NotInvited] --> A4R[Info: Not participant]
+        A5[InsufficientStake] --> A5R[Fix: Send correct amount]
+    end
+
+    subgraph Resolution[Resolution Errors]
+        R1[NotActive] --> R1R[Info: Wrong status]
+        R2[NotAuthorized] --> R2R[Fix: Use authorized account]
+        R3[OracleNotResolved] --> R3R[Wait: Oracle pending]
+        R4[ChallengeWindowActive] --> R4R[Wait: 24h not passed]
+        R5[AlreadyChallenged] --> R5R[Info: Already challenged]
+        R6[InsufficientBond] --> R6R[Fix: Send 0.1 ETH]
+    end
+
+    subgraph Claim[Claim Errors]
+        CL1[NotResolved] --> CL1R[Wait: Resolution pending]
+        CL2[NotWinner] --> CL2R[Info: Not winner]
+        CL3[AlreadyClaimed] --> CL3R[Info: Already claimed]
+        CL4[ClaimPeriodExpired] --> CL4R[Info: Funds swept]
+    end
+
+    subgraph Timeout[Timeout Errors]
+        T1[NotTimedOut] --> T1R[Wait: 30 days not passed]
+        T2[AlreadyResolved] --> T2R[Info: Already resolved]
+        T3[RefundNotAccepted] --> T3R[Wait: Other party]
+        T4[NoArbitrator] --> T4R[Stuck: Contact support]
+    end
+```
+
+---
+
+## Cross-Reference: Functions to States (Updated)
+
+| Function | Required State | New State | Events | Bond/Fee |
+|----------|---------------|-----------|--------|----------|
+| `createWager` | N/A | Pending | WagerCreated | - |
+| `acceptWager` | Pending | Active | WagerActivated | - |
+| `cancelWager` | Pending | Cancelled | WagerCancelled | - |
+| `proposeResolution` | Active | PendingResolution | ResolutionProposed | - |
+| `challengeResolution` | PendingResolution | Challenged | ResolutionChallenged | 0.1 ETH bond |
+| `finalizeResolution` | PendingResolution | Resolved | ResolutionFinalized | - |
+| `resolveDispute` | Challenged | Resolved | DisputeResolved | Bond distributed |
+| `resolveFromOracle` | Active | Resolved | WagerResolved | - |
+| `triggerOracleTimeout` | Active | OracleTimedOut | OracleTimeoutTriggered | - |
+| `acceptMutualRefund` | OracleTimedOut | OracleTimedOut/Refunded | MutualRefundAccepted/Completed | - |
+| `forceManualResolution` | OracleTimedOut | Resolved | ForcedResolution | - |
+| `claimWinnings` | Resolved | Resolved (claimed) | WinningsClaimed, ArbitratorPaid | Arb fee deducted |
+| `sweepUnclaimedFunds` | Resolved (90d+) | Resolved (swept) | UnclaimedFundsSwept | - |
+
+---
+
+## Configuration Parameters
+
+| Parameter | Default | Range | Modifiable By |
+|-----------|---------|-------|---------------|
+| `challengePeriod` | 24 hours | 1h - 7 days | Owner |
+| `challengeBond` | 0.1 ETH | 0.01 - 1 ETH | Owner |
+| `claimTimeout` | 90 days | 30 - 365 days | Owner |
+| `oracleTimeout` | 30 days | 7 - 90 days | Owner |
+| `maxArbitratorFee` | 1000 (10%) | 100 - 2000 | Owner |
+| `treasury` | DAO address | Any address | Owner |
+
+---
+
+## Invariants (Must Always Hold)
+
+```solidity
+// 1. Stakes are always accounted for
+totalStakes[token] == sum(activeWagers.stakes) + treasury.swept
+
+// 2. Only one outcome possible
+wager.resolved => (wager.winner == creator XOR wager.winner == opponent)
+
+// 3. Challenge only in window
+wager.challenged => block.timestamp <= wager.challengeDeadline
+
+// 4. Claim only once
+wager.claimed => claimWinnings() reverts
+
+// 5. Timeout only after deadline
+wager.status == OracleTimedOut =>
+    block.timestamp > wager.expectedResolutionTime + oracleTimeout
+
+// 6. Sweep only after claim period
+swept[wagerId] =>
+    block.timestamp > wager.resolvedAt + claimTimeout
+
+// 7. Arbitrator fee within bounds
+wager.arbitratorFeeBps <= maxArbitratorFee
+
+// 8. Status transitions are valid (see state machine)
+validTransition(oldStatus, newStatus)
+```
+
+---
+
+## Summary of Changes from V1
+
+| Issue | V1 Status | V2 Status |
+|-------|-----------|-----------|
+| claimWinnings() | ❌ Missing | ✅ Implemented |
+| Challenge period | ❌ Missing | ✅ 24h window with bonds |
+| Claim timeout | ❌ Missing | ✅ 90 days + treasury sweep |
+| Oracle fallback | ❌ Missing | ✅ 30 day timeout + mutual refund |
+| Arbitrator fees | ❌ Missing | ✅ Configurable % |
+| State machine | Incomplete | Complete with all transitions |
+| Error handling | Partial | Comprehensive |

--- a/test/ChainlinkOracleAdapter.test.js
+++ b/test/ChainlinkOracleAdapter.test.js
@@ -110,9 +110,9 @@ describe("ChainlinkOracleAdapter", function () {
 
   describe("Condition Creation", function () {
     const targetPrice = 5000_00000000n; // $5000
-    const deadline = Math.floor(Date.now() / 1000) + 86400; // 1 day from now
 
     it("Should create an ABOVE condition", async function () {
+      const deadline = (await time.latest()) + 86400; // 1 day from now
       const tx = await chainlinkAdapter.createCondition(
         mockEthFeed.target,
         targetPrice,
@@ -136,6 +136,7 @@ describe("ChainlinkOracleAdapter", function () {
     });
 
     it("Should create a BELOW condition", async function () {
+      const deadline = (await time.latest()) + 86400;
       const tx = await chainlinkAdapter.createCondition(
         mockEthFeed.target,
         targetPrice,
@@ -157,6 +158,7 @@ describe("ChainlinkOracleAdapter", function () {
     });
 
     it("Should revert for unsupported feed", async function () {
+      const deadline = (await time.latest()) + 86400;
       await expect(
         chainlinkAdapter.createCondition(user1.address, targetPrice, 0, deadline, "Test")
       ).to.be.revertedWithCustomError(chainlinkAdapter, "FeedNotSupported");
@@ -170,12 +172,14 @@ describe("ChainlinkOracleAdapter", function () {
     });
 
     it("Should revert for zero target price", async function () {
+      const deadline = (await time.latest()) + 86400;
       await expect(
         chainlinkAdapter.createCondition(mockEthFeed.target, 0, 0, deadline, "Test")
       ).to.be.revertedWithCustomError(chainlinkAdapter, "InvalidTargetPrice");
     });
 
     it("Should return condition details", async function () {
+      const deadline = (await time.latest()) + 86400;
       const tx = await chainlinkAdapter.createCondition(
         mockEthFeed.target,
         targetPrice,

--- a/test/ChainlinkOracleAdapter.test.js
+++ b/test/ChainlinkOracleAdapter.test.js
@@ -1,0 +1,447 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+describe("ChainlinkOracleAdapter", function () {
+  let chainlinkAdapter;
+  let mockEthFeed;
+  let mockBtcFeed;
+  let owner;
+  let user1;
+
+  const ETH_DECIMALS = 8;
+  const BTC_DECIMALS = 8;
+  const INITIAL_ETH_PRICE = 3000_00000000n; // $3000 with 8 decimals
+  const INITIAL_BTC_PRICE = 60000_00000000n; // $60000 with 8 decimals
+
+  beforeEach(async function () {
+    [owner, user1] = await ethers.getSigners();
+
+    // Deploy mock Chainlink feeds
+    const MockChainlinkAggregator = await ethers.getContractFactory("MockChainlinkAggregator");
+    mockEthFeed = await MockChainlinkAggregator.deploy(ETH_DECIMALS, "ETH / USD", INITIAL_ETH_PRICE);
+    mockBtcFeed = await MockChainlinkAggregator.deploy(BTC_DECIMALS, "BTC / USD", INITIAL_BTC_PRICE);
+
+    // Deploy ChainlinkOracleAdapter
+    const ChainlinkOracleAdapter = await ethers.getContractFactory("ChainlinkOracleAdapter");
+    chainlinkAdapter = await ChainlinkOracleAdapter.deploy(owner.address);
+
+    // Add supported feeds
+    await chainlinkAdapter.addPriceFeed(mockEthFeed.target);
+    await chainlinkAdapter.addPriceFeed(mockBtcFeed.target);
+  });
+
+  describe("Constructor", function () {
+    it("Should set the owner correctly", async function () {
+      expect(await chainlinkAdapter.owner()).to.equal(owner.address);
+    });
+
+    it("Should return correct oracle type", async function () {
+      expect(await chainlinkAdapter.oracleType()).to.equal("Chainlink");
+    });
+
+    it("Should have default staleness threshold of 1 hour", async function () {
+      expect(await chainlinkAdapter.stalenessThreshold()).to.equal(3600);
+    });
+  });
+
+  describe("Price Feed Management", function () {
+    it("Should add a price feed", async function () {
+      const MockChainlinkAggregator = await ethers.getContractFactory("MockChainlinkAggregator");
+      const newFeed = await MockChainlinkAggregator.deploy(8, "LINK / USD", 15_00000000n);
+
+      await expect(chainlinkAdapter.addPriceFeed(newFeed.target))
+        .to.emit(chainlinkAdapter, "PriceFeedAdded")
+        .withArgs(newFeed.target, "LINK / USD");
+
+      expect(await chainlinkAdapter.supportedFeeds(newFeed.target)).to.be.true;
+    });
+
+    it("Should revert when adding zero address feed", async function () {
+      await expect(
+        chainlinkAdapter.addPriceFeed(ethers.ZeroAddress)
+      ).to.be.revertedWithCustomError(chainlinkAdapter, "InvalidFeed");
+    });
+
+    it("Should revert when adding duplicate feed", async function () {
+      await expect(
+        chainlinkAdapter.addPriceFeed(mockEthFeed.target)
+      ).to.be.revertedWithCustomError(chainlinkAdapter, "FeedAlreadySupported");
+    });
+
+    it("Should remove a price feed", async function () {
+      await expect(chainlinkAdapter.removePriceFeed(mockEthFeed.target))
+        .to.emit(chainlinkAdapter, "PriceFeedRemoved")
+        .withArgs(mockEthFeed.target);
+
+      expect(await chainlinkAdapter.supportedFeeds(mockEthFeed.target)).to.be.false;
+    });
+
+    it("Should revert when removing unsupported feed", async function () {
+      await expect(
+        chainlinkAdapter.removePriceFeed(user1.address)
+      ).to.be.revertedWithCustomError(chainlinkAdapter, "FeedNotSupported");
+    });
+
+    it("Should only allow owner to add feeds", async function () {
+      const MockChainlinkAggregator = await ethers.getContractFactory("MockChainlinkAggregator");
+      const newFeed = await MockChainlinkAggregator.deploy(8, "LINK / USD", 15_00000000n);
+
+      await expect(
+        chainlinkAdapter.connect(user1).addPriceFeed(newFeed.target)
+      ).to.be.revertedWithCustomError(chainlinkAdapter, "OwnableUnauthorizedAccount");
+    });
+
+    it("Should get all supported feeds", async function () {
+      const feeds = await chainlinkAdapter.getSupportedFeeds();
+      expect(feeds.length).to.equal(2);
+      expect(feeds).to.include(mockEthFeed.target);
+      expect(feeds).to.include(mockBtcFeed.target);
+    });
+
+    it("Should update staleness threshold", async function () {
+      await expect(chainlinkAdapter.setStalenessThreshold(7200))
+        .to.emit(chainlinkAdapter, "StalenessThresholdUpdated")
+        .withArgs(3600, 7200);
+
+      expect(await chainlinkAdapter.stalenessThreshold()).to.equal(7200);
+    });
+  });
+
+  describe("Condition Creation", function () {
+    const targetPrice = 5000_00000000n; // $5000
+    const deadline = Math.floor(Date.now() / 1000) + 86400; // 1 day from now
+
+    it("Should create an ABOVE condition", async function () {
+      const tx = await chainlinkAdapter.createCondition(
+        mockEthFeed.target,
+        targetPrice,
+        0, // ABOVE
+        deadline,
+        "ETH above $5000"
+      );
+
+      const receipt = await tx.wait();
+      const event = receipt.logs.find(log => {
+        try {
+          return chainlinkAdapter.interface.parseLog(log)?.name === "PriceConditionCreated";
+        } catch { return false; }
+      });
+
+      expect(event).to.not.be.undefined;
+      const parsedEvent = chainlinkAdapter.interface.parseLog(event);
+      expect(parsedEvent.args.priceFeed).to.equal(mockEthFeed.target);
+      expect(parsedEvent.args.targetPrice).to.equal(targetPrice);
+      expect(parsedEvent.args.comparison).to.equal(0); // ABOVE
+    });
+
+    it("Should create a BELOW condition", async function () {
+      const tx = await chainlinkAdapter.createCondition(
+        mockEthFeed.target,
+        targetPrice,
+        1, // BELOW
+        deadline,
+        "ETH below $5000"
+      );
+
+      const receipt = await tx.wait();
+      const event = receipt.logs.find(log => {
+        try {
+          return chainlinkAdapter.interface.parseLog(log)?.name === "PriceConditionCreated";
+        } catch { return false; }
+      });
+
+      expect(event).to.not.be.undefined;
+      const parsedEvent = chainlinkAdapter.interface.parseLog(event);
+      expect(parsedEvent.args.comparison).to.equal(1); // BELOW
+    });
+
+    it("Should revert for unsupported feed", async function () {
+      await expect(
+        chainlinkAdapter.createCondition(user1.address, targetPrice, 0, deadline, "Test")
+      ).to.be.revertedWithCustomError(chainlinkAdapter, "FeedNotSupported");
+    });
+
+    it("Should revert for deadline in past", async function () {
+      const pastDeadline = Math.floor(Date.now() / 1000) - 3600;
+      await expect(
+        chainlinkAdapter.createCondition(mockEthFeed.target, targetPrice, 0, pastDeadline, "Test")
+      ).to.be.revertedWithCustomError(chainlinkAdapter, "DeadlineInPast");
+    });
+
+    it("Should revert for zero target price", async function () {
+      await expect(
+        chainlinkAdapter.createCondition(mockEthFeed.target, 0, 0, deadline, "Test")
+      ).to.be.revertedWithCustomError(chainlinkAdapter, "InvalidTargetPrice");
+    });
+
+    it("Should return condition details", async function () {
+      const tx = await chainlinkAdapter.createCondition(
+        mockEthFeed.target,
+        targetPrice,
+        0,
+        deadline,
+        "ETH above $5000"
+      );
+
+      const receipt = await tx.wait();
+      const event = receipt.logs.find(log => {
+        try {
+          return chainlinkAdapter.interface.parseLog(log)?.name === "PriceConditionCreated";
+        } catch { return false; }
+      });
+      const conditionId = chainlinkAdapter.interface.parseLog(event).args.conditionId;
+
+      const condition = await chainlinkAdapter.getCondition(conditionId);
+      expect(condition.priceFeed).to.equal(mockEthFeed.target);
+      expect(condition.targetPrice).to.equal(targetPrice);
+      expect(condition.comparison).to.equal(0);
+      expect(condition.deadline).to.equal(deadline);
+      expect(condition.description).to.equal("ETH above $5000");
+      expect(condition.registered).to.be.true;
+    });
+  });
+
+  describe("Condition Resolution", function () {
+    let conditionId;
+    const targetPrice = 5000_00000000n; // $5000
+
+    beforeEach(async function () {
+      const deadline = (await time.latest()) + 86400; // 1 day from now
+
+      const tx = await chainlinkAdapter.createCondition(
+        mockEthFeed.target,
+        targetPrice,
+        0, // ABOVE
+        deadline,
+        "ETH above $5000"
+      );
+
+      const receipt = await tx.wait();
+      const event = receipt.logs.find(log => {
+        try {
+          return chainlinkAdapter.interface.parseLog(log)?.name === "PriceConditionCreated";
+        } catch { return false; }
+      });
+      conditionId = chainlinkAdapter.interface.parseLog(event).args.conditionId;
+    });
+
+    it("Should revert when deadline not reached", async function () {
+      await expect(
+        chainlinkAdapter.resolveCondition(conditionId)
+      ).to.be.revertedWithCustomError(chainlinkAdapter, "DeadlineNotReached");
+    });
+
+    it("Should resolve with PASS when price is above target", async function () {
+      // Advance time past deadline
+      await time.increase(86401);
+
+      // Update price to above target (also refreshes timestamp)
+      await mockEthFeed.updateAnswer(6000_00000000n); // $6000
+
+      await expect(chainlinkAdapter.resolveCondition(conditionId))
+        .to.emit(chainlinkAdapter, "PriceConditionResolved");
+
+      const resolution = await chainlinkAdapter.getResolution(conditionId);
+      expect(resolution.resolved).to.be.true;
+      expect(resolution.outcome).to.be.true; // PASS
+      expect(resolution.priceAtResolution).to.equal(6000_00000000n);
+    });
+
+    it("Should resolve with FAIL when price is below target", async function () {
+      // Advance time past deadline
+      await time.increase(86401);
+      // Refresh feed timestamp (price stays at $3000, below $5000 target)
+      await mockEthFeed.updateAnswer(INITIAL_ETH_PRICE);
+
+      await chainlinkAdapter.resolveCondition(conditionId);
+
+      const resolution = await chainlinkAdapter.getResolution(conditionId);
+      expect(resolution.resolved).to.be.true;
+      expect(resolution.outcome).to.be.false; // FAIL
+    });
+
+    it("Should resolve with PASS when price equals target (ABOVE)", async function () {
+      await time.increase(86401);
+      await mockEthFeed.updateAnswer(targetPrice);
+
+      await chainlinkAdapter.resolveCondition(conditionId);
+
+      const resolution = await chainlinkAdapter.getResolution(conditionId);
+      expect(resolution.outcome).to.be.true; // PASS (>= target)
+    });
+
+    it("Should handle BELOW condition correctly", async function () {
+      const deadline = (await time.latest()) + 86400;
+
+      const tx = await chainlinkAdapter.createCondition(
+        mockEthFeed.target,
+        targetPrice,
+        1, // BELOW
+        deadline,
+        "ETH below $5000"
+      );
+
+      const receipt = await tx.wait();
+      const event = receipt.logs.find(log => {
+        try {
+          return chainlinkAdapter.interface.parseLog(log)?.name === "PriceConditionCreated";
+        } catch { return false; }
+      });
+      const belowConditionId = chainlinkAdapter.interface.parseLog(event).args.conditionId;
+
+      // Advance time and refresh price (stays at $3000, below $5000)
+      await time.increase(86401);
+      await mockEthFeed.updateAnswer(INITIAL_ETH_PRICE);
+
+      await chainlinkAdapter.resolveCondition(belowConditionId);
+
+      const resolution = await chainlinkAdapter.getResolution(belowConditionId);
+      expect(resolution.outcome).to.be.true; // PASS (price below target)
+    });
+
+    it("Should revert for stale price data", async function () {
+      await time.increase(86401);
+
+      // Set timestamp to be stale (2 hours ago)
+      const staleTime = (await time.latest()) - 7200;
+      await mockEthFeed.setTimestamp(staleTime);
+
+      await expect(
+        chainlinkAdapter.resolveCondition(conditionId)
+      ).to.be.revertedWithCustomError(chainlinkAdapter, "StalePrice");
+    });
+
+    it("Should not re-resolve already resolved condition", async function () {
+      await time.increase(86401);
+      await mockEthFeed.updateAnswer(INITIAL_ETH_PRICE);
+      await chainlinkAdapter.resolveCondition(conditionId);
+
+      // Second resolution should not fail, just return
+      await chainlinkAdapter.resolveCondition(conditionId);
+
+      // Check it's still resolved with same data
+      const resolution = await chainlinkAdapter.getResolution(conditionId);
+      expect(resolution.resolved).to.be.true;
+    });
+  });
+
+  describe("IOracleAdapter Interface", function () {
+    let conditionId;
+
+    beforeEach(async function () {
+      const deadline = (await time.latest()) + 86400;
+
+      const tx = await chainlinkAdapter.createCondition(
+        mockEthFeed.target,
+        5000_00000000n,
+        0,
+        deadline,
+        "Test condition"
+      );
+
+      const receipt = await tx.wait();
+      const event = receipt.logs.find(log => {
+        try {
+          return chainlinkAdapter.interface.parseLog(log)?.name === "PriceConditionCreated";
+        } catch { return false; }
+      });
+      conditionId = chainlinkAdapter.interface.parseLog(event).args.conditionId;
+    });
+
+    it("Should report condition as supported", async function () {
+      expect(await chainlinkAdapter.isConditionSupported(conditionId)).to.be.true;
+    });
+
+    it("Should report unknown condition as not supported", async function () {
+      const unknownId = ethers.keccak256(ethers.toUtf8Bytes("unknown"));
+      expect(await chainlinkAdapter.isConditionSupported(unknownId)).to.be.false;
+    });
+
+    it("Should report unresolved condition correctly", async function () {
+      expect(await chainlinkAdapter.isConditionResolved(conditionId)).to.be.false;
+    });
+
+    it("Should report resolved condition correctly", async function () {
+      await time.increase(86401);
+      await mockEthFeed.updateAnswer(INITIAL_ETH_PRICE);
+      await chainlinkAdapter.resolveCondition(conditionId);
+
+      expect(await chainlinkAdapter.isConditionResolved(conditionId)).to.be.true;
+    });
+
+    it("Should return outcome with 100% confidence", async function () {
+      await time.increase(86401);
+      await mockEthFeed.updateAnswer(6000_00000000n);
+      await chainlinkAdapter.resolveCondition(conditionId);
+
+      const [outcome, confidence, resolvedAt] = await chainlinkAdapter.getOutcome(conditionId);
+      expect(outcome).to.be.true;
+      expect(confidence).to.equal(10000); // 100%
+      expect(resolvedAt).to.be.gt(0);
+    });
+
+    it("Should return zero outcome for unresolved condition", async function () {
+      const [outcome, confidence, resolvedAt] = await chainlinkAdapter.getOutcome(conditionId);
+      expect(outcome).to.be.false;
+      expect(confidence).to.equal(0);
+      expect(resolvedAt).to.equal(0);
+    });
+
+    it("Should return condition metadata", async function () {
+      const [description, expectedResolutionTime] = await chainlinkAdapter.getConditionMetadata(conditionId);
+      expect(description).to.equal("Test condition");
+      expect(expectedResolutionTime).to.be.gt(0);
+    });
+  });
+
+  describe("View Functions", function () {
+    it("Should get latest price from feed", async function () {
+      const [price, updatedAt] = await chainlinkAdapter.getLatestPrice(mockEthFeed.target);
+      expect(price).to.equal(INITIAL_ETH_PRICE);
+      expect(updatedAt).to.be.gt(0);
+    });
+
+    it("Should revert getLatestPrice for unsupported feed", async function () {
+      await expect(
+        chainlinkAdapter.getLatestPrice(user1.address)
+      ).to.be.revertedWithCustomError(chainlinkAdapter, "FeedNotSupported");
+    });
+
+    it("Should check if condition can be resolved", async function () {
+      const deadline = (await time.latest()) + 86400;
+
+      const tx = await chainlinkAdapter.createCondition(
+        mockEthFeed.target,
+        5000_00000000n,
+        0,
+        deadline,
+        "Test"
+      );
+
+      const receipt = await tx.wait();
+      const event = receipt.logs.find(log => {
+        try {
+          return chainlinkAdapter.interface.parseLog(log)?.name === "PriceConditionCreated";
+        } catch { return false; }
+      });
+      const conditionId = chainlinkAdapter.interface.parseLog(event).args.conditionId;
+
+      // Before deadline
+      expect(await chainlinkAdapter.canResolve(conditionId)).to.be.false;
+
+      // After deadline
+      await time.increase(86401);
+      expect(await chainlinkAdapter.canResolve(conditionId)).to.be.true;
+
+      // After resolution
+      await mockEthFeed.updateAnswer(INITIAL_ETH_PRICE);
+      await chainlinkAdapter.resolveCondition(conditionId);
+      expect(await chainlinkAdapter.canResolve(conditionId)).to.be.false;
+    });
+
+    it("Should return feed count", async function () {
+      expect(await chainlinkAdapter.getFeedCount()).to.equal(2);
+    });
+  });
+});

--- a/test/FriendGroupMarketFactory.Challenge.test.js
+++ b/test/FriendGroupMarketFactory.Challenge.test.js
@@ -1,0 +1,520 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+// Resolution type enum (matches contract)
+const ResolutionType = {
+  Either: 0,
+  Initiator: 1,
+  Receiver: 2,
+  ThirdParty: 3,
+  AutoPegged: 4,
+  PolymarketOracle: 5
+};
+
+// Market status enum (matches contract)
+const FriendMarketStatus = {
+  PendingAcceptance: 0,
+  Active: 1,
+  PendingResolution: 2,
+  Challenged: 3,
+  Resolved: 4,
+  Cancelled: 5,
+  Refunded: 6
+};
+
+describe("FriendGroupMarketFactory - Challenge Period", function () {
+  let friendGroupFactory;
+  let marketFactory;
+  let ragequitModule;
+  let tieredRoleManager;
+  let paymentManager;
+  let collateralToken;
+  let owner;
+  let addr1;
+  let addr2;
+  let addr3;
+  let arbitrator;
+
+  const FRIEND_MARKET_ROLE = ethers.id("FRIEND_MARKET_ROLE");
+  const MembershipTier = { NONE: 0, BRONZE: 1, SILVER: 2, GOLD: 3, PLATINUM: 4 };
+
+  const ONE_HOUR = 3600;
+  const ONE_DAY = 86400;
+  const CHALLENGE_BOND = ethers.parseEther("0.1");
+
+  beforeEach(async function () {
+    [owner, addr1, addr2, addr3, arbitrator] = await ethers.getSigners();
+
+    // Deploy CTF1155 (required for ConditionalMarketFactory)
+    const CTF1155 = await ethers.getContractFactory("CTF1155");
+    const ctf1155 = await CTF1155.deploy();
+    await ctf1155.waitForDeployment();
+
+    // Deploy mock collateral token
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    collateralToken = await MockERC20.deploy("Market Collateral", "MCOL", ethers.parseEther("10000000"));
+    await collateralToken.waitForDeployment();
+
+    // Deploy ConditionalMarketFactory
+    const ConditionalMarketFactory = await ethers.getContractFactory("ConditionalMarketFactory");
+    marketFactory = await ConditionalMarketFactory.deploy();
+    await marketFactory.initialize(owner.address);
+    await marketFactory.setCTF1155(await ctf1155.getAddress());
+
+    // Deploy RagequitModule
+    const RagequitModule = await ethers.getContractFactory("RagequitModule");
+    ragequitModule = await RagequitModule.deploy();
+
+    // Deploy TieredRoleManager
+    const TieredRoleManager = await ethers.getContractFactory("TieredRoleManager");
+    tieredRoleManager = await TieredRoleManager.deploy();
+    await tieredRoleManager.waitForDeployment();
+    await tieredRoleManager.initializeRoleMetadata();
+
+    // Set up Friend Market tier metadata
+    await tieredRoleManager.setTierMetadata(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      "Friend Market Bronze",
+      "Basic friend market tier",
+      ethers.parseEther("0.1"),
+      {
+        dailyBetLimit: 10,
+        weeklyBetLimit: 50,
+        monthlyMarketCreation: 5,
+        maxPositionSize: ethers.parseEther("10"),
+        maxConcurrentMarkets: 3,
+        withdrawalLimit: ethers.parseEther("100"),
+        canCreatePrivateMarkets: false,
+        canUseAdvancedFeatures: false,
+        feeDiscount: 0
+      },
+      true
+    );
+
+    const tierMeta = await tieredRoleManager.tierMetadata(FRIEND_MARKET_ROLE, MembershipTier.BRONZE);
+    const price = tierMeta.price;
+
+    // Deploy MembershipPaymentManager
+    const MembershipPaymentManager = await ethers.getContractFactory("MembershipPaymentManager");
+    paymentManager = await MembershipPaymentManager.deploy(owner.address);
+    await paymentManager.waitForDeployment();
+
+    // Deploy FriendGroupMarketFactory
+    const FriendGroupMarketFactory = await ethers.getContractFactory("FriendGroupMarketFactory");
+    friendGroupFactory = await FriendGroupMarketFactory.deploy(
+      await marketFactory.getAddress(),
+      await ragequitModule.getAddress(),
+      await tieredRoleManager.getAddress(),
+      await paymentManager.getAddress(),
+      owner.address
+    );
+
+    await friendGroupFactory.setDefaultCollateralToken(await collateralToken.getAddress());
+
+    // Purchase memberships
+    const durDays = 36500;
+    for (const signer of [owner, addr1, addr2, addr3, arbitrator]) {
+      await tieredRoleManager.connect(signer).purchaseRoleWithTier(
+        FRIEND_MARKET_ROLE,
+        MembershipTier.BRONZE,
+        durDays,
+        { value: price }
+      );
+    }
+
+    await marketFactory.transferOwnership(await friendGroupFactory.getAddress());
+  });
+
+  async function acceptMarket(marketId, participant) {
+    const marketWithStatus = await friendGroupFactory.getFriendMarketWithStatus(marketId);
+    const stakeAmount = marketWithStatus.stakePerParticipant;
+    await friendGroupFactory.connect(participant).acceptMarket(marketId, { value: stakeAmount });
+  }
+
+  async function createAndActivateMarket(resolutionType = ResolutionType.Either, arb = ethers.ZeroAddress) {
+    const description = "Test bet with challenge";
+    const tradingPeriod = 7 * 24 * 60 * 60;
+    const latestBlock = await ethers.provider.getBlock('latest');
+    const acceptanceDeadline = latestBlock.timestamp + (2 * 60 * 60);
+    const stakeAmount = ethers.parseEther("0.5");
+
+    await friendGroupFactory.connect(addr1).createOneVsOneMarketPending(
+      addr2.address,
+      description,
+      tradingPeriod,
+      arb,
+      acceptanceDeadline,
+      stakeAmount,
+      ethers.ZeroAddress,
+      resolutionType,
+      { value: stakeAmount }
+    );
+
+    await acceptMarket(0, addr2);
+
+    // If third party resolution with arbitrator, arbitrator needs to accept
+    if (resolutionType === ResolutionType.ThirdParty && arb !== ethers.ZeroAddress) {
+      await friendGroupFactory.connect(arbitrator).acceptMarket(0);
+    }
+
+    return 0;
+  }
+
+  describe("Resolution Proposal", function () {
+    it("Should start challenge period when creator proposes resolution", async function () {
+      await createAndActivateMarket();
+
+      const tx = await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+
+      const marketWithStatus = await friendGroupFactory.getFriendMarketWithStatus(0);
+      expect(marketWithStatus.status).to.equal(FriendMarketStatus.PendingResolution);
+
+      const pending = await friendGroupFactory.getPendingResolution(0);
+      expect(pending.proposedOutcome).to.equal(true);
+      expect(pending.proposer).to.equal(addr1.address);
+      expect(pending.challenger).to.equal(ethers.ZeroAddress);
+
+      await expect(tx).to.emit(friendGroupFactory, "ResolutionProposed");
+    });
+
+    it("Should start challenge period when opponent proposes resolution", async function () {
+      await createAndActivateMarket();
+
+      await friendGroupFactory.connect(addr2).resolveFriendMarket(0, false);
+
+      const marketWithStatus = await friendGroupFactory.getFriendMarketWithStatus(0);
+      expect(marketWithStatus.status).to.equal(FriendMarketStatus.PendingResolution);
+
+      const pending = await friendGroupFactory.getPendingResolution(0);
+      expect(pending.proposedOutcome).to.equal(false);
+      expect(pending.proposer).to.equal(addr2.address);
+    });
+
+    it("Should set correct challenge deadline (24 hours from proposal)", async function () {
+      await createAndActivateMarket();
+
+      const tx = await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+      const block = await ethers.provider.getBlock(tx.blockNumber);
+
+      const pending = await friendGroupFactory.getPendingResolution(0);
+      expect(pending.challengeDeadline).to.equal(block.timestamp + ONE_DAY);
+    });
+
+    it("Should reject resolution proposal from unauthorized party", async function () {
+      await createAndActivateMarket();
+
+      await expect(
+        friendGroupFactory.connect(addr3).resolveFriendMarket(0, true)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotAuthorized");
+    });
+  });
+
+  describe("Challenge Resolution", function () {
+    it("Should allow opponent to challenge proposer's resolution", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+
+      const tx = await friendGroupFactory.connect(addr2).challengeResolution(0, { value: CHALLENGE_BOND });
+
+      const marketWithStatus = await friendGroupFactory.getFriendMarketWithStatus(0);
+      expect(marketWithStatus.status).to.equal(FriendMarketStatus.Challenged);
+
+      const pending = await friendGroupFactory.getPendingResolution(0);
+      expect(pending.challenger).to.equal(addr2.address);
+      expect(pending.challengeBondPaid).to.equal(CHALLENGE_BOND);
+
+      await expect(tx).to.emit(friendGroupFactory, "ResolutionChallenged")
+        .withArgs(0, addr2.address, CHALLENGE_BOND);
+    });
+
+    it("Should allow creator to challenge opponent's resolution", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr2).resolveFriendMarket(0, false);
+
+      await friendGroupFactory.connect(addr1).challengeResolution(0, { value: CHALLENGE_BOND });
+
+      const pending = await friendGroupFactory.getPendingResolution(0);
+      expect(pending.challenger).to.equal(addr1.address);
+    });
+
+    it("Should reject challenge without sufficient bond", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+
+      await expect(
+        friendGroupFactory.connect(addr2).challengeResolution(0, { value: CHALLENGE_BOND - 1n })
+      ).to.be.revertedWithCustomError(friendGroupFactory, "InsufficientChallengeBond");
+    });
+
+    it("Should reject challenge from non-participant", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+
+      await expect(
+        friendGroupFactory.connect(addr3).challengeResolution(0, { value: CHALLENGE_BOND })
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotAuthorized");
+    });
+
+    it("Should reject challenge from proposer", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+
+      await expect(
+        friendGroupFactory.connect(addr1).challengeResolution(0, { value: CHALLENGE_BOND })
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotAuthorized");
+    });
+
+    it("Should reject double challenge", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+      await friendGroupFactory.connect(addr2).challengeResolution(0, { value: CHALLENGE_BOND });
+
+      await expect(
+        friendGroupFactory.connect(addr2).challengeResolution(0, { value: CHALLENGE_BOND })
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotPendingResolution");
+    });
+
+    it("Should reject challenge after deadline", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+
+      // Fast forward past challenge period
+      await time.increase(ONE_DAY + 1);
+
+      await expect(
+        friendGroupFactory.connect(addr2).challengeResolution(0, { value: CHALLENGE_BOND })
+      ).to.be.revertedWithCustomError(friendGroupFactory, "ChallengePeriodNotExpired");
+    });
+  });
+
+  describe("Finalize Resolution", function () {
+    it("Should finalize resolution after challenge period expires", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+
+      // Fast forward past challenge period
+      await time.increase(ONE_DAY + 1);
+
+      const tx = await friendGroupFactory.finalizeResolution(0);
+
+      const marketWithStatus = await friendGroupFactory.getFriendMarketWithStatus(0);
+      expect(marketWithStatus.status).to.equal(FriendMarketStatus.Resolved);
+
+      const resolution = await friendGroupFactory.getWagerResolution(0);
+      expect(resolution.winner).to.equal(addr1.address);
+      expect(resolution.outcome).to.equal(true);
+
+      await expect(tx).to.emit(friendGroupFactory, "ResolutionFinalized")
+        .withArgs(0, true);
+    });
+
+    it("Should reject finalization before challenge period expires", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+
+      await expect(
+        friendGroupFactory.finalizeResolution(0)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotInChallengePeriod");
+    });
+
+    it("Should reject finalization of challenged market", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+      await friendGroupFactory.connect(addr2).challengeResolution(0, { value: CHALLENGE_BOND });
+
+      await time.increase(ONE_DAY + 1);
+
+      await expect(
+        friendGroupFactory.finalizeResolution(0)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotPendingResolution");
+    });
+
+    it("Winner can claim after finalization", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+      await time.increase(ONE_DAY + 1);
+      await friendGroupFactory.finalizeResolution(0);
+
+      await expect(friendGroupFactory.connect(addr1).claimWinnings(0))
+        .to.emit(friendGroupFactory, "WinningsClaimed");
+    });
+  });
+
+  describe("Dispute Resolution", function () {
+    it("Should allow owner to resolve dispute (no arbitrator)", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+      await friendGroupFactory.connect(addr2).challengeResolution(0, { value: CHALLENGE_BOND });
+
+      // Owner resolves in favor of challenger
+      const tx = await friendGroupFactory.connect(owner).resolveDispute(0, false);
+
+      const marketWithStatus = await friendGroupFactory.getFriendMarketWithStatus(0);
+      expect(marketWithStatus.status).to.equal(FriendMarketStatus.Resolved);
+
+      const resolution = await friendGroupFactory.getWagerResolution(0);
+      expect(resolution.winner).to.equal(addr2.address);
+      expect(resolution.outcome).to.equal(false);
+
+      await expect(tx).to.emit(friendGroupFactory, "DisputeResolved");
+    });
+
+    it("Should allow arbitrator to resolve dispute (ThirdParty)", async function () {
+      await createAndActivateMarket(ResolutionType.ThirdParty, arbitrator.address);
+      await friendGroupFactory.connect(arbitrator).resolveFriendMarket(0, true);
+      await friendGroupFactory.connect(addr2).challengeResolution(0, { value: CHALLENGE_BOND });
+
+      // Arbitrator resolves
+      await friendGroupFactory.connect(arbitrator).resolveDispute(0, true);
+
+      const marketWithStatus = await friendGroupFactory.getFriendMarketWithStatus(0);
+      expect(marketWithStatus.status).to.equal(FriendMarketStatus.Resolved);
+    });
+
+    it("Should return bond to challenger when they win", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+      await friendGroupFactory.connect(addr2).challengeResolution(0, { value: CHALLENGE_BOND });
+
+      const balanceBefore = await ethers.provider.getBalance(addr2.address);
+
+      // Owner resolves in favor of challenger (false)
+      await friendGroupFactory.connect(owner).resolveDispute(0, false);
+
+      const balanceAfter = await ethers.provider.getBalance(addr2.address);
+      expect(balanceAfter).to.equal(balanceBefore + CHALLENGE_BOND);
+    });
+
+    it("Should give bond to proposer when they win", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+      await friendGroupFactory.connect(addr2).challengeResolution(0, { value: CHALLENGE_BOND });
+
+      const balanceBefore = await ethers.provider.getBalance(addr1.address);
+
+      // Owner resolves in favor of proposer (true)
+      await friendGroupFactory.connect(owner).resolveDispute(0, true);
+
+      const balanceAfter = await ethers.provider.getBalance(addr1.address);
+      expect(balanceAfter).to.equal(balanceBefore + CHALLENGE_BOND);
+    });
+
+    it("Should reject dispute resolution from non-arbitrator", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+      await friendGroupFactory.connect(addr2).challengeResolution(0, { value: CHALLENGE_BOND });
+
+      await expect(
+        friendGroupFactory.connect(addr3).resolveDispute(0, true)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotAuthorized");
+    });
+
+    it("Should reject dispute resolution for non-challenged market", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+
+      await expect(
+        friendGroupFactory.connect(owner).resolveDispute(0, true)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotChallenged");
+    });
+  });
+
+  describe("View Functions", function () {
+    it("canFinalizeResolution should return correct state", async function () {
+      await createAndActivateMarket();
+
+      // Before proposal
+      let [canFinalize, timeRemaining] = await friendGroupFactory.canFinalizeResolution(0);
+      expect(canFinalize).to.equal(false);
+
+      // After proposal, before expiry
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+      [canFinalize, timeRemaining] = await friendGroupFactory.canFinalizeResolution(0);
+      expect(canFinalize).to.equal(false);
+      expect(timeRemaining).to.be.closeTo(ONE_DAY, 5);
+
+      // After expiry
+      await time.increase(ONE_DAY + 1);
+      [canFinalize, timeRemaining] = await friendGroupFactory.canFinalizeResolution(0);
+      expect(canFinalize).to.equal(true);
+      expect(timeRemaining).to.equal(0);
+    });
+
+    it("getPendingResolution should return correct data", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+
+      const pending = await friendGroupFactory.getPendingResolution(0);
+      expect(pending.proposedOutcome).to.equal(true);
+      expect(pending.proposer).to.equal(addr1.address);
+      expect(pending.proposedAt).to.be.gt(0);
+      expect(pending.challengeDeadline).to.be.gt(pending.proposedAt);
+      expect(pending.challenger).to.equal(ethers.ZeroAddress);
+      expect(pending.challengeBondPaid).to.equal(0);
+    });
+  });
+
+  describe("Admin Functions", function () {
+    it("Should allow owner to update challenge period", async function () {
+      const newPeriod = 12 * ONE_HOUR;
+      await friendGroupFactory.setChallengePeriod(newPeriod);
+      expect(await friendGroupFactory.challengePeriod()).to.equal(newPeriod);
+    });
+
+    it("Should reject challenge period less than 1 hour", async function () {
+      await expect(
+        friendGroupFactory.setChallengePeriod(ONE_HOUR - 1)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "InvalidChallengePeriod");
+    });
+
+    it("Should reject challenge period more than 7 days", async function () {
+      await expect(
+        friendGroupFactory.setChallengePeriod(8 * ONE_DAY)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "InvalidChallengePeriod");
+    });
+
+    it("Should allow owner to update challenge bond", async function () {
+      const newBond = ethers.parseEther("0.5");
+      await friendGroupFactory.setChallengeBond(newBond);
+      expect(await friendGroupFactory.challengeBond()).to.equal(newBond);
+    });
+
+    it("Should allow zero challenge bond", async function () {
+      await friendGroupFactory.setChallengeBond(0);
+      expect(await friendGroupFactory.challengeBond()).to.equal(0);
+    });
+  });
+
+  describe("Integration with Claim", function () {
+    it("Cannot claim while in PendingResolution state", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+
+      await expect(
+        friendGroupFactory.connect(addr1).claimWinnings(0)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "WagerNotResolved");
+    });
+
+    it("Cannot claim while in Challenged state", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+      await friendGroupFactory.connect(addr2).challengeResolution(0, { value: CHALLENGE_BOND });
+
+      await expect(
+        friendGroupFactory.connect(addr1).claimWinnings(0)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "WagerNotResolved");
+    });
+
+    it("Can claim after dispute resolution", async function () {
+      await createAndActivateMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+      await friendGroupFactory.connect(addr2).challengeResolution(0, { value: CHALLENGE_BOND });
+      await friendGroupFactory.connect(owner).resolveDispute(0, true);
+
+      await expect(friendGroupFactory.connect(addr1).claimWinnings(0))
+        .to.emit(friendGroupFactory, "WinningsClaimed");
+    });
+  });
+});

--- a/test/FriendGroupMarketFactory.Claim.test.js
+++ b/test/FriendGroupMarketFactory.Claim.test.js
@@ -1,0 +1,538 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+// Resolution type enum (matches contract)
+const ResolutionType = {
+  Either: 0,
+  Initiator: 1,
+  Receiver: 2,
+  ThirdParty: 3,
+  AutoPegged: 4,
+  PolymarketOracle: 5
+};
+
+describe("FriendGroupMarketFactory - Claim Winnings", function () {
+  let friendGroupFactory;
+  let marketFactory;
+  let ragequitModule;
+  let tieredRoleManager;
+  let paymentManager;
+  let collateralToken;
+  let stakeToken;
+  let owner;
+  let addr1;
+  let addr2;
+  let addr3;
+  let arbitrator;
+
+  const FRIEND_MARKET_ROLE = ethers.id("FRIEND_MARKET_ROLE");
+  const MembershipTier = { NONE: 0, BRONZE: 1, SILVER: 2, GOLD: 3, PLATINUM: 4 };
+
+  beforeEach(async function () {
+    [owner, addr1, addr2, addr3, arbitrator] = await ethers.getSigners();
+
+    // Deploy CTF1155 (required for ConditionalMarketFactory)
+    const CTF1155 = await ethers.getContractFactory("CTF1155");
+    const ctf1155 = await CTF1155.deploy();
+    await ctf1155.waitForDeployment();
+
+    // Deploy mock collateral token for markets (required for CTF1155)
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    collateralToken = await MockERC20.deploy("Market Collateral", "MCOL", ethers.parseEther("10000000"));
+    await collateralToken.waitForDeployment();
+
+    // Deploy a separate stake token for ERC20 stake tests
+    stakeToken = await MockERC20.deploy("Stake Token", "STK", ethers.parseEther("10000000"));
+    await stakeToken.waitForDeployment();
+
+    // Deploy ConditionalMarketFactory
+    const ConditionalMarketFactory = await ethers.getContractFactory("ConditionalMarketFactory");
+    marketFactory = await ConditionalMarketFactory.deploy();
+    await marketFactory.initialize(owner.address);
+
+    // Set CTF1155 in market factory (required for market creation)
+    await marketFactory.setCTF1155(await ctf1155.getAddress());
+
+    // Deploy RagequitModule (with mock token and treasury)
+    const RagequitModule = await ethers.getContractFactory("RagequitModule");
+    ragequitModule = await RagequitModule.deploy();
+
+    // Deploy TieredRoleManager
+    const TieredRoleManager = await ethers.getContractFactory("TieredRoleManager");
+    tieredRoleManager = await TieredRoleManager.deploy();
+    await tieredRoleManager.waitForDeployment();
+
+    // Initialize role metadata (required to set isPremium flags)
+    await tieredRoleManager.initializeRoleMetadata();
+
+    // Set up Friend Market tier metadata (Bronze tier)
+    await tieredRoleManager.setTierMetadata(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      "Friend Market Bronze",
+      "Basic friend market tier",
+      ethers.parseEther("0.1"),
+      {
+        dailyBetLimit: 10,
+        weeklyBetLimit: 50,
+        monthlyMarketCreation: 5,
+        maxPositionSize: ethers.parseEther("10"),
+        maxConcurrentMarkets: 3,
+        withdrawalLimit: ethers.parseEther("100"),
+        canCreatePrivateMarkets: false,
+        canUseAdvancedFeatures: false,
+        feeDiscount: 0
+      },
+      true // isActive
+    );
+
+    // Get Bronze tier price
+    const tierMeta = await tieredRoleManager.tierMetadata(FRIEND_MARKET_ROLE, MembershipTier.BRONZE);
+    const price = tierMeta.price;
+
+    // Deploy MembershipPaymentManager
+    const MembershipPaymentManager = await ethers.getContractFactory("MembershipPaymentManager");
+    paymentManager = await MembershipPaymentManager.deploy(owner.address); // owner as treasury
+    await paymentManager.waitForDeployment();
+
+    // Deploy FriendGroupMarketFactory
+    const FriendGroupMarketFactory = await ethers.getContractFactory("FriendGroupMarketFactory");
+    friendGroupFactory = await FriendGroupMarketFactory.deploy(
+      await marketFactory.getAddress(),
+      await ragequitModule.getAddress(),
+      await tieredRoleManager.getAddress(),
+      await paymentManager.getAddress(),
+      owner.address
+    );
+
+    // Set collateral token for markets (required for CTF1155)
+    await friendGroupFactory.setDefaultCollateralToken(await collateralToken.getAddress());
+
+    // Add stake token as accepted payment token
+    await friendGroupFactory.addAcceptedPaymentToken(await stakeToken.getAddress(), true);
+
+    // Purchase memberships for test users (100 years = never expires during tests)
+    const durDays = 36500; // 100 years
+    for (const signer of [owner, addr1, addr2, addr3, arbitrator]) {
+      await tieredRoleManager.connect(signer).purchaseRoleWithTier(
+        FRIEND_MARKET_ROLE,
+        MembershipTier.BRONZE,
+        durDays,
+        { value: price }
+      );
+    }
+
+    // Transfer ownership of marketFactory to friendGroupFactory for testing
+    await marketFactory.transferOwnership(await friendGroupFactory.getAddress());
+
+    // Distribute stake tokens for ERC20 tests
+    await stakeToken.transfer(addr1.address, ethers.parseEther("1000"));
+    await stakeToken.transfer(addr2.address, ethers.parseEther("1000"));
+  });
+
+  // Helper function to accept a market (activates it)
+  async function acceptMarket(marketId, participant) {
+    const marketWithStatus = await friendGroupFactory.getFriendMarketWithStatus(marketId);
+    const stakeAmount = marketWithStatus.stakePerParticipant;
+    const stakeTokenAddr = marketWithStatus.stakeToken;
+
+    if (stakeTokenAddr === ethers.ZeroAddress) {
+      // Native token
+      await friendGroupFactory.connect(participant).acceptMarket(marketId, { value: stakeAmount });
+    } else {
+      // ERC20 token - approve and accept
+      const token = await ethers.getContractAt("MockERC20", stakeTokenAddr);
+      await token.connect(participant).approve(await friendGroupFactory.getAddress(), stakeAmount);
+      await friendGroupFactory.connect(participant).acceptMarket(marketId);
+    }
+  }
+
+  // Helper to create and activate a 1v1 market with native token stakes
+  async function createAndActivateNativeMarket() {
+    const description = "Test bet for claiming";
+    const tradingPeriod = 7 * 24 * 60 * 60;
+    const latestBlock = await ethers.provider.getBlock('latest');
+    const acceptanceDeadline = latestBlock.timestamp + (2 * 60 * 60);
+    const stakeAmount = ethers.parseEther("0.5");
+
+    await friendGroupFactory.connect(addr1).createOneVsOneMarketPending(
+      addr2.address,
+      description,
+      tradingPeriod,
+      ethers.ZeroAddress, // No arbitrator
+      acceptanceDeadline,
+      stakeAmount,
+      ethers.ZeroAddress, // Native token
+      ResolutionType.Either,
+      { value: stakeAmount }
+    );
+
+    await acceptMarket(0, addr2);
+    return 0;
+  }
+
+  // Helper to create and activate a 1v1 market with ERC20 token stakes
+  async function createAndActivateERC20Market() {
+    const description = "Test ERC20 bet for claiming";
+    const tradingPeriod = 7 * 24 * 60 * 60;
+    const latestBlock = await ethers.provider.getBlock('latest');
+    const acceptanceDeadline = latestBlock.timestamp + (2 * 60 * 60);
+    const stakeAmount = ethers.parseEther("100");
+
+    // Approve for creator
+    await stakeToken.connect(addr1).approve(await friendGroupFactory.getAddress(), stakeAmount);
+
+    await friendGroupFactory.connect(addr1).createOneVsOneMarketPending(
+      addr2.address,
+      description,
+      tradingPeriod,
+      ethers.ZeroAddress,
+      acceptanceDeadline,
+      stakeAmount,
+      await stakeToken.getAddress(),
+      ResolutionType.Either
+    );
+
+    await acceptMarket(0, addr2);
+    return 0;
+  }
+
+  describe("Successful Claim Scenarios", function () {
+    it("Should allow creator to claim winnings when they win (native token)", async function () {
+      await createAndActivateNativeMarket();
+      const stakeAmount = ethers.parseEther("0.5");
+      const totalPot = stakeAmount * 2n;
+
+      // Resolve in favor of creator (outcome = true)
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+
+      // Check winner is set correctly
+      const [winner, outcome, claimed, resolvedAt, pot] = await friendGroupFactory.getWagerResolution(0);
+      expect(winner).to.equal(addr1.address);
+      expect(outcome).to.equal(true);
+      expect(claimed).to.equal(false);
+      expect(pot).to.equal(totalPot);
+
+      // Get balance before claim
+      const balanceBefore = await ethers.provider.getBalance(addr1.address);
+
+      // Claim winnings
+      const tx = await friendGroupFactory.connect(addr1).claimWinnings(0);
+      const receipt = await tx.wait();
+      const gasCost = receipt.gasUsed * receipt.gasPrice;
+
+      // Verify balance increased by pot minus gas
+      const balanceAfter = await ethers.provider.getBalance(addr1.address);
+      expect(balanceAfter).to.equal(balanceBefore + totalPot - gasCost);
+
+      // Verify event
+      await expect(tx)
+        .to.emit(friendGroupFactory, "WinningsClaimed")
+        .withArgs(0, addr1.address, totalPot, ethers.ZeroAddress);
+
+      // Verify claimed state
+      expect(await friendGroupFactory.isWagerClaimed(0)).to.equal(true);
+    });
+
+    it("Should allow opponent to claim winnings when they win (native token)", async function () {
+      await createAndActivateNativeMarket();
+      const stakeAmount = ethers.parseEther("0.5");
+      const totalPot = stakeAmount * 2n;
+
+      // Resolve in favor of opponent (outcome = false)
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, false);
+
+      // Check winner is set correctly
+      const [winner, outcome, claimed, , pot] = await friendGroupFactory.getWagerResolution(0);
+      expect(winner).to.equal(addr2.address);
+      expect(outcome).to.equal(false);
+      expect(pot).to.equal(totalPot);
+
+      // Get balance before claim
+      const balanceBefore = await ethers.provider.getBalance(addr2.address);
+
+      // Claim winnings
+      const tx = await friendGroupFactory.connect(addr2).claimWinnings(0);
+      const receipt = await tx.wait();
+      const gasCost = receipt.gasUsed * receipt.gasPrice;
+
+      // Verify balance increased
+      const balanceAfter = await ethers.provider.getBalance(addr2.address);
+      expect(balanceAfter).to.equal(balanceBefore + totalPot - gasCost);
+
+      // Verify event
+      await expect(tx)
+        .to.emit(friendGroupFactory, "WinningsClaimed")
+        .withArgs(0, addr2.address, totalPot, ethers.ZeroAddress);
+    });
+
+    it("Should allow winner to claim ERC20 token winnings", async function () {
+      await createAndActivateERC20Market();
+      const stakeAmount = ethers.parseEther("100");
+      const totalPot = stakeAmount * 2n;
+
+      // Resolve in favor of creator
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+
+      // Get token balance before claim
+      const balanceBefore = await stakeToken.balanceOf(addr1.address);
+
+      // Claim winnings
+      const tx = await friendGroupFactory.connect(addr1).claimWinnings(0);
+
+      // Verify token balance increased
+      const balanceAfter = await stakeToken.balanceOf(addr1.address);
+      expect(balanceAfter).to.equal(balanceBefore + totalPot);
+
+      // Verify event with token address
+      await expect(tx)
+        .to.emit(friendGroupFactory, "WinningsClaimed")
+        .withArgs(0, addr1.address, totalPot, await stakeToken.getAddress());
+    });
+
+    it("Should work with arbitrator-resolved markets", async function () {
+      const description = "Arbitrated bet";
+      const tradingPeriod = 7 * 24 * 60 * 60;
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const acceptanceDeadline = latestBlock.timestamp + (2 * 60 * 60);
+      const stakeAmount = ethers.parseEther("0.3");
+
+      await friendGroupFactory.connect(addr1).createOneVsOneMarketPending(
+        addr2.address,
+        description,
+        tradingPeriod,
+        arbitrator.address,
+        acceptanceDeadline,
+        stakeAmount,
+        ethers.ZeroAddress,
+        ResolutionType.ThirdParty,
+        { value: stakeAmount }
+      );
+
+      // Both opponent and arbitrator must accept
+      await acceptMarket(0, addr2);
+      await friendGroupFactory.connect(arbitrator).acceptMarket(0);
+
+      // Arbitrator resolves in favor of opponent
+      await friendGroupFactory.connect(arbitrator).resolveFriendMarket(0, false);
+
+      // Opponent claims
+      const totalPot = stakeAmount * 2n;
+      const balanceBefore = await ethers.provider.getBalance(addr2.address);
+      const tx = await friendGroupFactory.connect(addr2).claimWinnings(0);
+      const receipt = await tx.wait();
+      const gasCost = receipt.gasUsed * receipt.gasPrice;
+
+      const balanceAfter = await ethers.provider.getBalance(addr2.address);
+      expect(balanceAfter).to.equal(balanceBefore + totalPot - gasCost);
+    });
+  });
+
+  describe("Claim Validation Errors", function () {
+    it("Should revert with InvalidMarketId for non-existent market", async function () {
+      await expect(
+        friendGroupFactory.connect(addr1).claimWinnings(999)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "InvalidMarketId");
+    });
+
+    it("Should revert with WagerNotResolved for unresolved market", async function () {
+      await createAndActivateNativeMarket();
+
+      await expect(
+        friendGroupFactory.connect(addr1).claimWinnings(0)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "WagerNotResolved");
+    });
+
+    it("Should revert with WagerNotResolved for pending market", async function () {
+      const description = "Pending bet";
+      const tradingPeriod = 7 * 24 * 60 * 60;
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const acceptanceDeadline = latestBlock.timestamp + (2 * 60 * 60);
+      const stakeAmount = ethers.parseEther("0.1");
+
+      await friendGroupFactory.connect(addr1).createOneVsOneMarketPending(
+        addr2.address,
+        description,
+        tradingPeriod,
+        ethers.ZeroAddress,
+        acceptanceDeadline,
+        stakeAmount,
+        ethers.ZeroAddress,
+        ResolutionType.Either,
+        { value: stakeAmount }
+      );
+
+      // Market is still pending, not yet accepted
+      await expect(
+        friendGroupFactory.connect(addr1).claimWinnings(0)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "WagerNotResolved");
+    });
+
+    it("Should revert with NotWinner for loser trying to claim", async function () {
+      await createAndActivateNativeMarket();
+
+      // Resolve in favor of creator
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+
+      // Opponent (loser) tries to claim
+      await expect(
+        friendGroupFactory.connect(addr2).claimWinnings(0)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotWinner");
+    });
+
+    it("Should revert with NotWinner for unrelated party trying to claim", async function () {
+      await createAndActivateNativeMarket();
+
+      // Resolve market
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+
+      // Random person tries to claim
+      await expect(
+        friendGroupFactory.connect(addr3).claimWinnings(0)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotWinner");
+    });
+
+    it("Should revert with AlreadyClaimed for double claim attempt", async function () {
+      await createAndActivateNativeMarket();
+
+      // Resolve and claim
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+      await friendGroupFactory.connect(addr1).claimWinnings(0);
+
+      // Try to claim again
+      await expect(
+        friendGroupFactory.connect(addr1).claimWinnings(0)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "AlreadyClaimed");
+    });
+  });
+
+  describe("Resolution Details View Functions", function () {
+    it("Should return correct details for unresolved market", async function () {
+      await createAndActivateNativeMarket();
+
+      const [winner, outcome, claimed, resolvedAt, totalPot] =
+        await friendGroupFactory.getWagerResolution(0);
+
+      expect(winner).to.equal(ethers.ZeroAddress);
+      expect(outcome).to.equal(false);
+      expect(claimed).to.equal(false);
+      expect(resolvedAt).to.equal(0);
+      expect(totalPot).to.equal(ethers.parseEther("1")); // 0.5 * 2
+    });
+
+    it("Should return correct details for resolved unclaimed market", async function () {
+      await createAndActivateNativeMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+
+      const [winner, outcome, claimed, resolvedAt, totalPot] =
+        await friendGroupFactory.getWagerResolution(0);
+
+      expect(winner).to.equal(addr1.address);
+      expect(outcome).to.equal(true);
+      expect(claimed).to.equal(false);
+      expect(resolvedAt).to.be.gt(0);
+      expect(totalPot).to.equal(ethers.parseEther("1"));
+    });
+
+    it("Should return correct details for resolved and claimed market", async function () {
+      await createAndActivateNativeMarket();
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+      await friendGroupFactory.connect(addr1).claimWinnings(0);
+
+      const [winner, outcome, claimed, resolvedAt, totalPot] =
+        await friendGroupFactory.getWagerResolution(0);
+
+      expect(winner).to.equal(addr1.address);
+      expect(outcome).to.equal(true);
+      expect(claimed).to.equal(true);
+      expect(resolvedAt).to.be.gt(0);
+      expect(totalPot).to.equal(ethers.parseEther("1"));
+    });
+
+    it("isWagerClaimed should return correct state", async function () {
+      await createAndActivateNativeMarket();
+
+      expect(await friendGroupFactory.isWagerClaimed(0)).to.equal(false);
+
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+      expect(await friendGroupFactory.isWagerClaimed(0)).to.equal(false);
+
+      await friendGroupFactory.connect(addr1).claimWinnings(0);
+      expect(await friendGroupFactory.isWagerClaimed(0)).to.equal(true);
+    });
+  });
+
+  describe("Multiple Markets Independence", function () {
+    it("Should handle claims for multiple independent markets", async function () {
+      // Create two markets
+      const stakeAmount = ethers.parseEther("0.5");
+
+      // Market 0
+      await createAndActivateNativeMarket();
+
+      // Market 1 - need to create manually since helper always creates market 0
+      const tradingPeriod = 7 * 24 * 60 * 60;
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const acceptanceDeadline = latestBlock.timestamp + (2 * 60 * 60);
+
+      await friendGroupFactory.connect(addr1).createOneVsOneMarketPending(
+        addr2.address,
+        "Second bet",
+        tradingPeriod,
+        ethers.ZeroAddress,
+        acceptanceDeadline,
+        stakeAmount,
+        ethers.ZeroAddress,
+        ResolutionType.Either,
+        { value: stakeAmount }
+      );
+      await acceptMarket(1, addr2);
+
+      // Resolve both - creator wins first, opponent wins second
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+      await friendGroupFactory.connect(addr2).resolveFriendMarket(1, false);
+
+      // Both can claim independently
+      await expect(friendGroupFactory.connect(addr1).claimWinnings(0))
+        .to.emit(friendGroupFactory, "WinningsClaimed");
+
+      await expect(friendGroupFactory.connect(addr2).claimWinnings(1))
+        .to.emit(friendGroupFactory, "WinningsClaimed");
+
+      // Both should be marked as claimed
+      expect(await friendGroupFactory.isWagerClaimed(0)).to.equal(true);
+      expect(await friendGroupFactory.isWagerClaimed(1)).to.equal(true);
+    });
+  });
+
+  describe("Edge Cases", function () {
+    it("Should handle zero stake (free bet) gracefully", async function () {
+      // This test depends on whether zero stake is allowed
+      // Skip if not applicable
+      this.skip();
+    });
+
+    it("Should transfer exact total pot amount", async function () {
+      await createAndActivateNativeMarket();
+      const stakeAmount = ethers.parseEther("0.5");
+      const totalPot = stakeAmount * 2n;
+
+      await friendGroupFactory.connect(addr1).resolveFriendMarket(0, true);
+
+      // Get contract balance before claim
+      const contractBalanceBefore = await ethers.provider.getBalance(
+        await friendGroupFactory.getAddress()
+      );
+      expect(contractBalanceBefore).to.be.gte(totalPot);
+
+      // Claim
+      await friendGroupFactory.connect(addr1).claimWinnings(0);
+
+      // Verify contract balance decreased by exactly totalPot
+      const contractBalanceAfter = await ethers.provider.getBalance(
+        await friendGroupFactory.getAddress()
+      );
+      expect(contractBalanceBefore - contractBalanceAfter).to.equal(totalPot);
+    });
+  });
+});

--- a/test/FriendGroupMarketFactory.OracleIntegration.test.js
+++ b/test/FriendGroupMarketFactory.OracleIntegration.test.js
@@ -1,0 +1,437 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+/**
+ * Oracle Integration Tests for FriendGroupMarketFactory
+ *
+ * Tests the multi-oracle resolution feature:
+ * - Pegging markets to Chainlink/UMA oracles
+ * - Resolution from oracle conditions
+ * - View functions for oracle status
+ */
+describe("FriendGroupMarketFactory - Oracle Integration", function () {
+  let friendGroupFactory;
+  let marketFactory;
+  let ragequitModule;
+  let tieredRoleManager;
+  let paymentManager;
+  let oracleRegistry;
+  let chainlinkAdapter;
+  let mockChainlinkFeed;
+  let collateralToken;
+  let owner;
+  let creator;
+  let opponent;
+
+  const CHAINLINK_ORACLE_ID = ethers.keccak256(ethers.toUtf8Bytes("CHAINLINK"));
+  const FRIEND_MARKET_ROLE = ethers.id("FRIEND_MARKET_ROLE");
+  const MembershipTier = { NONE: 0, BRONZE: 1, SILVER: 2, GOLD: 3, PLATINUM: 4 };
+  const ResolutionType = { Either: 0, Initiator: 1, Receiver: 2, ThirdParty: 3, AutoPegged: 4 };
+  const STAKE_AMOUNT = ethers.parseEther("1");
+  const ACCEPTANCE_PERIOD = 7 * 24 * 60 * 60;
+  const TRADING_PERIOD = 14 * 24 * 60 * 60;
+
+  beforeEach(async function () {
+    [owner, creator, opponent] = await ethers.getSigners();
+
+    // Deploy CTF1155
+    const CTF1155 = await ethers.getContractFactory("CTF1155");
+    const ctf1155 = await CTF1155.deploy();
+    await ctf1155.waitForDeployment();
+
+    // Deploy collateral token
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    collateralToken = await MockERC20.deploy("Collateral", "COL", ethers.parseEther("10000000"));
+    await collateralToken.waitForDeployment();
+
+    // Deploy ConditionalMarketFactory
+    const ConditionalMarketFactory = await ethers.getContractFactory("ConditionalMarketFactory");
+    marketFactory = await ConditionalMarketFactory.deploy();
+    await marketFactory.initialize(owner.address);
+    await marketFactory.setCTF1155(await ctf1155.getAddress());
+
+    // Deploy RagequitModule
+    const RagequitModule = await ethers.getContractFactory("RagequitModule");
+    ragequitModule = await RagequitModule.deploy();
+
+    // Deploy TieredRoleManager
+    const TieredRoleManager = await ethers.getContractFactory("TieredRoleManager");
+    tieredRoleManager = await TieredRoleManager.deploy();
+    await tieredRoleManager.waitForDeployment();
+    await tieredRoleManager.initializeRoleMetadata();
+
+    // Setup tier
+    await tieredRoleManager.setTierMetadata(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      "Friend Market Bronze",
+      "Basic friend market tier",
+      ethers.parseEther("0.1"),
+      {
+        dailyBetLimit: 10,
+        weeklyBetLimit: 50,
+        monthlyMarketCreation: 5,
+        maxPositionSize: ethers.parseEther("10"),
+        maxConcurrentMarkets: 3,
+        withdrawalLimit: ethers.parseEther("100"),
+        canCreatePrivateMarkets: false,
+        canUseAdvancedFeatures: false,
+        feeDiscount: 0
+      },
+      true
+    );
+
+    const tierMeta = await tieredRoleManager.tierMetadata(FRIEND_MARKET_ROLE, MembershipTier.BRONZE);
+    const price = tierMeta.price;
+
+    // Deploy MembershipPaymentManager
+    const MembershipPaymentManager = await ethers.getContractFactory("MembershipPaymentManager");
+    paymentManager = await MembershipPaymentManager.deploy(owner.address);
+    await paymentManager.waitForDeployment();
+
+    // Deploy FriendGroupMarketFactory
+    const FriendGroupMarketFactory = await ethers.getContractFactory("FriendGroupMarketFactory");
+    friendGroupFactory = await FriendGroupMarketFactory.deploy(
+      await marketFactory.getAddress(),
+      await ragequitModule.getAddress(),
+      await tieredRoleManager.getAddress(),
+      await paymentManager.getAddress(),
+      owner.address
+    );
+
+    await friendGroupFactory.setDefaultCollateralToken(await collateralToken.getAddress());
+    await friendGroupFactory.setTreasury(owner.address);
+
+    // Transfer ownership of marketFactory to friendGroupFactory for market deployment
+    await marketFactory.transferOwnership(await friendGroupFactory.getAddress());
+
+    // Purchase memberships
+    const durDays = 36500;
+    await tieredRoleManager.connect(creator).purchaseRoleWithTier(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      durDays,
+      { value: price }
+    );
+    await tieredRoleManager.connect(opponent).purchaseRoleWithTier(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      durDays,
+      { value: price }
+    );
+
+    // Deploy Chainlink adapter and feed
+    const MockChainlinkAggregator = await ethers.getContractFactory("MockChainlinkAggregator");
+    mockChainlinkFeed = await MockChainlinkAggregator.deploy(8, "ETH / USD", 3000_00000000n);
+
+    const ChainlinkOracleAdapter = await ethers.getContractFactory("ChainlinkOracleAdapter");
+    chainlinkAdapter = await ChainlinkOracleAdapter.deploy(owner.address);
+    await chainlinkAdapter.addPriceFeed(mockChainlinkFeed.target);
+
+    // Deploy OracleRegistry
+    const OracleRegistry = await ethers.getContractFactory("OracleRegistry");
+    oracleRegistry = await OracleRegistry.deploy(owner.address);
+    await oracleRegistry.registerAdapter(CHAINLINK_ORACLE_ID, chainlinkAdapter.target);
+
+    // Configure factory
+    await friendGroupFactory.setOracleRegistry(oracleRegistry.target);
+  });
+
+  describe("setOracleRegistry", function () {
+    it("Should set oracle registry", async function () {
+      expect(await friendGroupFactory.oracleRegistry()).to.equal(oracleRegistry.target);
+    });
+
+    it("Should emit event on registry update", async function () {
+      const OracleRegistry = await ethers.getContractFactory("OracleRegistry");
+      const newRegistry = await OracleRegistry.deploy(owner.address);
+
+      await expect(friendGroupFactory.setOracleRegistry(newRegistry.target))
+        .to.emit(friendGroupFactory, "OracleRegistryUpdated")
+        .withArgs(newRegistry.target);
+    });
+
+    it("Should revert when non-owner tries to set registry", async function () {
+      const OracleRegistry = await ethers.getContractFactory("OracleRegistry");
+      const newRegistry = await OracleRegistry.deploy(owner.address);
+
+      await expect(
+        friendGroupFactory.connect(creator).setOracleRegistry(newRegistry.target)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "OwnableUnauthorizedAccount");
+    });
+  });
+
+  describe("pegToOracleCondition", function () {
+    let conditionId;
+
+    beforeEach(async function () {
+      // Create Chainlink condition
+      const deadline = (await time.latest()) + TRADING_PERIOD;
+      const tx = await chainlinkAdapter.createCondition(
+        mockChainlinkFeed.target,
+        5000_00000000n,
+        0,
+        deadline,
+        "ETH above $5000"
+      );
+      const receipt = await tx.wait();
+      const event = receipt.logs.find(log => {
+        try {
+          return chainlinkAdapter.interface.parseLog(log)?.name === "PriceConditionCreated";
+        } catch { return false; }
+      });
+      conditionId = chainlinkAdapter.interface.parseLog(event).args.conditionId;
+    });
+
+    it("Should peg market to oracle condition", async function () {
+      // Create and accept wager
+      const acceptanceDeadline = (await time.latest()) + ACCEPTANCE_PERIOD;
+      await friendGroupFactory.connect(creator).createOneVsOneMarketPending(
+        opponent.address,
+        "Test wager",
+        TRADING_PERIOD,
+        ethers.ZeroAddress,  // arbitrator
+        acceptanceDeadline,
+        STAKE_AMOUNT,
+        ethers.ZeroAddress,  // stakeToken (ETH)
+        ResolutionType.Either,
+        { value: STAKE_AMOUNT }
+      );
+
+      await friendGroupFactory.connect(opponent).acceptMarket(0, { value: STAKE_AMOUNT });
+
+      // Peg to oracle
+      await expect(
+        friendGroupFactory.connect(creator).pegToOracleCondition(0, CHAINLINK_ORACLE_ID, conditionId)
+      ).to.emit(friendGroupFactory, "MarketPeggedToOracle")
+        .withArgs(0, CHAINLINK_ORACLE_ID, conditionId);
+
+      expect(await friendGroupFactory.isPeggedToOracle(0)).to.be.true;
+    });
+
+    it("Should revert when pegging inactive market", async function () {
+      // Create wager but don't accept
+      const acceptanceDeadline = (await time.latest()) + ACCEPTANCE_PERIOD;
+      await friendGroupFactory.connect(creator).createOneVsOneMarketPending(
+        opponent.address,
+        "Test",
+        TRADING_PERIOD,
+        ethers.ZeroAddress,
+        acceptanceDeadline,
+        STAKE_AMOUNT,
+        ethers.ZeroAddress,
+        ResolutionType.Either,
+        { value: STAKE_AMOUNT }
+      );
+
+      await expect(
+        friendGroupFactory.connect(creator).pegToOracleCondition(0, CHAINLINK_ORACLE_ID, conditionId)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotActive");
+    });
+
+    it("Should revert when non-creator tries to peg", async function () {
+      const acceptanceDeadline = (await time.latest()) + ACCEPTANCE_PERIOD;
+      await friendGroupFactory.connect(creator).createOneVsOneMarketPending(
+        opponent.address,
+        "Test",
+        TRADING_PERIOD,
+        ethers.ZeroAddress,
+        acceptanceDeadline,
+        STAKE_AMOUNT,
+        ethers.ZeroAddress,
+        ResolutionType.Either,
+        { value: STAKE_AMOUNT }
+      );
+
+      await friendGroupFactory.connect(opponent).acceptMarket(0, { value: STAKE_AMOUNT });
+
+      await expect(
+        friendGroupFactory.connect(opponent).pegToOracleCondition(0, CHAINLINK_ORACLE_ID, conditionId)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotAuthorized");
+    });
+
+    it("Should revert when pegging twice", async function () {
+      const acceptanceDeadline = (await time.latest()) + ACCEPTANCE_PERIOD;
+      await friendGroupFactory.connect(creator).createOneVsOneMarketPending(
+        opponent.address,
+        "Test",
+        TRADING_PERIOD,
+        ethers.ZeroAddress,
+        acceptanceDeadline,
+        STAKE_AMOUNT,
+        ethers.ZeroAddress,
+        ResolutionType.Either,
+        { value: STAKE_AMOUNT }
+      );
+
+      await friendGroupFactory.connect(opponent).acceptMarket(0, { value: STAKE_AMOUNT });
+      await friendGroupFactory.connect(creator).pegToOracleCondition(0, CHAINLINK_ORACLE_ID, conditionId);
+
+      await expect(
+        friendGroupFactory.connect(creator).pegToOracleCondition(0, CHAINLINK_ORACLE_ID, conditionId)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "AlreadyPeggedToOracle");
+    });
+  });
+
+  describe("resolveFromOracle", function () {
+    let conditionId;
+
+    beforeEach(async function () {
+      const deadline = (await time.latest()) + TRADING_PERIOD;
+      const tx = await chainlinkAdapter.createCondition(
+        mockChainlinkFeed.target,
+        5000_00000000n,
+        0,
+        deadline,
+        "ETH above $5000"
+      );
+      const receipt = await tx.wait();
+      const event = receipt.logs.find(log => {
+        try {
+          return chainlinkAdapter.interface.parseLog(log)?.name === "PriceConditionCreated";
+        } catch { return false; }
+      });
+      conditionId = chainlinkAdapter.interface.parseLog(event).args.conditionId;
+
+      // Create, accept, and peg
+      const acceptanceDeadline = (await time.latest()) + ACCEPTANCE_PERIOD;
+      await friendGroupFactory.connect(creator).createOneVsOneMarketPending(
+        opponent.address,
+        "Test",
+        TRADING_PERIOD,
+        ethers.ZeroAddress,
+        acceptanceDeadline,
+        STAKE_AMOUNT,
+        ethers.ZeroAddress,
+        ResolutionType.Either,
+        { value: STAKE_AMOUNT }
+      );
+      await friendGroupFactory.connect(opponent).acceptMarket(0, { value: STAKE_AMOUNT });
+      await friendGroupFactory.connect(creator).pegToOracleCondition(0, CHAINLINK_ORACLE_ID, conditionId);
+    });
+
+    it("Should resolve when oracle condition resolves true", async function () {
+      await time.increase(TRADING_PERIOD + 1);
+      await mockChainlinkFeed.updateAnswer(6000_00000000n); // Above target
+      await chainlinkAdapter.resolveCondition(conditionId);
+
+      await expect(friendGroupFactory.resolveFromOracle(0))
+        .to.emit(friendGroupFactory, "OracleMarketResolved");
+
+      const market = await friendGroupFactory.friendMarkets(0);
+      expect(market.status).to.equal(4); // Resolved
+
+      const [winner, outcome] = await friendGroupFactory.getWagerResolution(0);
+      expect(outcome).to.be.true;
+      expect(winner).to.equal(creator.address);
+    });
+
+    it("Should resolve when oracle condition resolves false", async function () {
+      await time.increase(TRADING_PERIOD + 1);
+      await mockChainlinkFeed.updateAnswer(4000_00000000n); // Below target
+      await chainlinkAdapter.resolveCondition(conditionId);
+
+      await friendGroupFactory.resolveFromOracle(0);
+
+      const [winner, outcome] = await friendGroupFactory.getWagerResolution(0);
+      expect(outcome).to.be.false;
+      expect(winner).to.equal(opponent.address);
+    });
+
+    it("Should revert when oracle condition not resolved", async function () {
+      await expect(friendGroupFactory.resolveFromOracle(0))
+        .to.be.revertedWithCustomError(oracleRegistry, "ConditionNotResolved");
+    });
+
+    it("Should allow winner to claim after oracle resolution", async function () {
+      await time.increase(TRADING_PERIOD + 1);
+      await mockChainlinkFeed.updateAnswer(6000_00000000n);
+      await chainlinkAdapter.resolveCondition(conditionId);
+      await friendGroupFactory.resolveFromOracle(0);
+
+      const balanceBefore = await ethers.provider.getBalance(creator.address);
+      await friendGroupFactory.connect(creator).claimWinnings(0);
+      const balanceAfter = await ethers.provider.getBalance(creator.address);
+
+      expect(balanceAfter).to.be.gt(balanceBefore);
+    });
+  });
+
+  describe("View Functions", function () {
+    let conditionId;
+
+    beforeEach(async function () {
+      const deadline = (await time.latest()) + TRADING_PERIOD;
+      const tx = await chainlinkAdapter.createCondition(
+        mockChainlinkFeed.target,
+        5000_00000000n,
+        0,
+        deadline,
+        "ETH above $5000"
+      );
+      const receipt = await tx.wait();
+      const event = receipt.logs.find(log => {
+        try {
+          return chainlinkAdapter.interface.parseLog(log)?.name === "PriceConditionCreated";
+        } catch { return false; }
+      });
+      conditionId = chainlinkAdapter.interface.parseLog(event).args.conditionId;
+
+      const acceptanceDeadline = (await time.latest()) + ACCEPTANCE_PERIOD;
+      await friendGroupFactory.connect(creator).createOneVsOneMarketPending(
+        opponent.address,
+        "Test",
+        TRADING_PERIOD,
+        ethers.ZeroAddress,
+        acceptanceDeadline,
+        STAKE_AMOUNT,
+        ethers.ZeroAddress,
+        ResolutionType.Either,
+        { value: STAKE_AMOUNT }
+      );
+      await friendGroupFactory.connect(opponent).acceptMarket(0, { value: STAKE_AMOUNT });
+      await friendGroupFactory.connect(creator).pegToOracleCondition(0, CHAINLINK_ORACLE_ID, conditionId);
+    });
+
+    it("Should return oracle info", async function () {
+      const [oracleId, returnedConditionId] = await friendGroupFactory.getOracleInfo(0);
+      expect(oracleId).to.equal(CHAINLINK_ORACLE_ID);
+      expect(returnedConditionId).to.equal(conditionId);
+    });
+
+    it("Should check oracle resolution status", async function () {
+      let [canResolve, outcome] = await friendGroupFactory.checkOracleResolution(0);
+      expect(canResolve).to.be.false;
+
+      await time.increase(TRADING_PERIOD + 1);
+      await mockChainlinkFeed.updateAnswer(6000_00000000n);
+      await chainlinkAdapter.resolveCondition(conditionId);
+
+      [canResolve, outcome] = await friendGroupFactory.checkOracleResolution(0);
+      expect(canResolve).to.be.true;
+      expect(outcome).to.be.true;
+    });
+
+    it("Should report market as pegged", async function () {
+      expect(await friendGroupFactory.isPeggedToOracle(0)).to.be.true;
+    });
+
+    it("Should report unpegged market correctly", async function () {
+      const acceptanceDeadline = (await time.latest()) + ACCEPTANCE_PERIOD;
+      await friendGroupFactory.connect(creator).createOneVsOneMarketPending(
+        opponent.address,
+        "Unpegged",
+        TRADING_PERIOD,
+        ethers.ZeroAddress,
+        acceptanceDeadline,
+        STAKE_AMOUNT,
+        ethers.ZeroAddress,
+        ResolutionType.Either,
+        { value: STAKE_AMOUNT }
+      );
+
+      expect(await friendGroupFactory.isPeggedToOracle(1)).to.be.false;
+    });
+  });
+});

--- a/test/FriendGroupMarketFactory.OracleTimeout.test.js
+++ b/test/FriendGroupMarketFactory.OracleTimeout.test.js
@@ -1,0 +1,543 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+// Resolution type enum
+const ResolutionType = {
+  Either: 0,
+  Initiator: 1,
+  Receiver: 2,
+  ThirdParty: 3,
+  AutoPegged: 4,
+  PolymarketOracle: 5
+};
+
+// Market status enum
+const FriendMarketStatus = {
+  PendingAcceptance: 0,
+  Active: 1,
+  PendingResolution: 2,
+  Challenged: 3,
+  Resolved: 4,
+  Cancelled: 5,
+  Refunded: 6,
+  OracleTimedOut: 7
+};
+
+describe("FriendGroupMarketFactory - Oracle Timeout", function () {
+  let friendGroupFactory;
+  let marketFactory;
+  let ragequitModule;
+  let tieredRoleManager;
+  let paymentManager;
+  let collateralToken;
+  let stakeToken;
+  let owner;
+  let addr1;
+  let addr2;
+  let addr3;
+  let arbitrator;
+
+  const FRIEND_MARKET_ROLE = ethers.id("FRIEND_MARKET_ROLE");
+  const MembershipTier = { NONE: 0, BRONZE: 1, SILVER: 2, GOLD: 3, PLATINUM: 4 };
+
+  const ONE_DAY = 86400;
+  const THIRTY_DAYS = 30 * ONE_DAY;
+
+  beforeEach(async function () {
+    [owner, addr1, addr2, addr3, arbitrator] = await ethers.getSigners();
+
+    // Deploy CTF1155
+    const CTF1155 = await ethers.getContractFactory("CTF1155");
+    const ctf1155 = await CTF1155.deploy();
+    await ctf1155.waitForDeployment();
+
+    // Deploy mock collateral token
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    collateralToken = await MockERC20.deploy("Market Collateral", "MCOL", ethers.parseEther("10000000"));
+    await collateralToken.waitForDeployment();
+
+    stakeToken = await MockERC20.deploy("Stake Token", "STK", ethers.parseEther("10000000"));
+    await stakeToken.waitForDeployment();
+
+    // Deploy ConditionalMarketFactory
+    const ConditionalMarketFactory = await ethers.getContractFactory("ConditionalMarketFactory");
+    marketFactory = await ConditionalMarketFactory.deploy();
+    await marketFactory.initialize(owner.address);
+    await marketFactory.setCTF1155(await ctf1155.getAddress());
+
+    // Deploy RagequitModule
+    const RagequitModule = await ethers.getContractFactory("RagequitModule");
+    ragequitModule = await RagequitModule.deploy();
+
+    // Deploy TieredRoleManager
+    const TieredRoleManager = await ethers.getContractFactory("TieredRoleManager");
+    tieredRoleManager = await TieredRoleManager.deploy();
+    await tieredRoleManager.waitForDeployment();
+    await tieredRoleManager.initializeRoleMetadata();
+
+    await tieredRoleManager.setTierMetadata(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      "Friend Market Bronze",
+      "Basic friend market tier",
+      ethers.parseEther("0.1"),
+      {
+        dailyBetLimit: 10,
+        weeklyBetLimit: 50,
+        monthlyMarketCreation: 5,
+        maxPositionSize: ethers.parseEther("10"),
+        maxConcurrentMarkets: 3,
+        withdrawalLimit: ethers.parseEther("100"),
+        canCreatePrivateMarkets: false,
+        canUseAdvancedFeatures: false,
+        feeDiscount: 0
+      },
+      true
+    );
+
+    const tierMeta = await tieredRoleManager.tierMetadata(FRIEND_MARKET_ROLE, MembershipTier.BRONZE);
+    const price = tierMeta.price;
+
+    // Deploy MembershipPaymentManager
+    const MembershipPaymentManager = await ethers.getContractFactory("MembershipPaymentManager");
+    paymentManager = await MembershipPaymentManager.deploy(owner.address);
+    await paymentManager.waitForDeployment();
+
+    // Deploy FriendGroupMarketFactory
+    const FriendGroupMarketFactory = await ethers.getContractFactory("FriendGroupMarketFactory");
+    friendGroupFactory = await FriendGroupMarketFactory.deploy(
+      await marketFactory.getAddress(),
+      await ragequitModule.getAddress(),
+      await tieredRoleManager.getAddress(),
+      await paymentManager.getAddress(),
+      owner.address
+    );
+
+    await friendGroupFactory.setDefaultCollateralToken(await collateralToken.getAddress());
+    await friendGroupFactory.addAcceptedPaymentToken(await stakeToken.getAddress(), true);
+    await friendGroupFactory.setTreasury(owner.address);
+
+    // Purchase memberships
+    const durDays = 36500;
+    for (const signer of [owner, addr1, addr2, addr3, arbitrator]) {
+      await tieredRoleManager.connect(signer).purchaseRoleWithTier(
+        FRIEND_MARKET_ROLE,
+        MembershipTier.BRONZE,
+        durDays,
+        { value: price }
+      );
+    }
+
+    await marketFactory.transferOwnership(await friendGroupFactory.getAddress());
+
+    await stakeToken.transfer(addr1.address, ethers.parseEther("1000"));
+    await stakeToken.transfer(addr2.address, ethers.parseEther("1000"));
+  });
+
+  async function acceptMarket(marketId, participant) {
+    const marketWithStatus = await friendGroupFactory.getFriendMarketWithStatus(marketId);
+    const stakeAmount = marketWithStatus.stakePerParticipant;
+    const stakeTokenAddr = marketWithStatus.stakeToken;
+
+    if (stakeTokenAddr === ethers.ZeroAddress) {
+      await friendGroupFactory.connect(participant).acceptMarket(marketId, { value: stakeAmount });
+    } else {
+      const token = await ethers.getContractAt("MockERC20", stakeTokenAddr);
+      await token.connect(participant).approve(await friendGroupFactory.getAddress(), stakeAmount);
+      await friendGroupFactory.connect(participant).acceptMarket(marketId);
+    }
+  }
+
+  // Create a market with PolymarketOracle resolution type (simulated)
+  async function createOraclePeggedMarket(arbAddress = ethers.ZeroAddress) {
+    const stakeAmount = ethers.parseEther("0.5");
+    const latestBlock = await ethers.provider.getBlock('latest');
+    const acceptanceDeadline = latestBlock.timestamp + (2 * 60 * 60);
+
+    await friendGroupFactory.connect(addr1).createOneVsOneMarketPending(
+      addr2.address,
+      "Oracle pegged bet",
+      7 * 24 * 60 * 60,
+      arbAddress,
+      acceptanceDeadline,
+      stakeAmount,
+      ethers.ZeroAddress,
+      ResolutionType.PolymarketOracle,
+      { value: stakeAmount }
+    );
+
+    await acceptMarket(0, addr2);
+    if (arbAddress !== ethers.ZeroAddress) {
+      await friendGroupFactory.connect(arbitrator).acceptMarket(0);
+    }
+    return 0;
+  }
+
+  describe("Set Expected Resolution Time", function () {
+    it("Should allow creator to set expected resolution time", async function () {
+      await createOraclePeggedMarket();
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const expectedTime = latestBlock.timestamp + 7 * ONE_DAY;
+
+      await expect(
+        friendGroupFactory.connect(addr1).setExpectedResolutionTime(0, expectedTime)
+      ).to.emit(friendGroupFactory, "ExpectedResolutionTimeSet")
+        .withArgs(0, expectedTime);
+
+      expect(await friendGroupFactory.expectedResolutionTime(0)).to.equal(expectedTime);
+    });
+
+    it("Should reject non-creator setting expected time", async function () {
+      await createOraclePeggedMarket();
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const expectedTime = latestBlock.timestamp + 7 * ONE_DAY;
+
+      await expect(
+        friendGroupFactory.connect(addr2).setExpectedResolutionTime(0, expectedTime)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotAuthorized");
+    });
+
+    it("Should reject setting expected time for non-oracle market", async function () {
+      // Create a regular (Either resolution) market
+      const stakeAmount = ethers.parseEther("0.5");
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const acceptanceDeadline = latestBlock.timestamp + (2 * 60 * 60);
+
+      await friendGroupFactory.connect(addr1).createOneVsOneMarketPending(
+        addr2.address,
+        "Regular bet",
+        7 * 24 * 60 * 60,
+        ethers.ZeroAddress,
+        acceptanceDeadline,
+        stakeAmount,
+        ethers.ZeroAddress,
+        ResolutionType.Either,
+        { value: stakeAmount }
+      );
+      await acceptMarket(0, addr2);
+
+      const expectedTime = latestBlock.timestamp + 7 * ONE_DAY;
+      await expect(
+        friendGroupFactory.connect(addr1).setExpectedResolutionTime(0, expectedTime)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotOraclePegged");
+    });
+
+    it("Should reject past expected time", async function () {
+      await createOraclePeggedMarket();
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const pastTime = latestBlock.timestamp - 1;
+
+      await expect(
+        friendGroupFactory.connect(addr1).setExpectedResolutionTime(0, pastTime)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "InvalidMarketId");
+    });
+  });
+
+  describe("Trigger Oracle Timeout", function () {
+    it("Should trigger timeout after expected + oracleTimeout period", async function () {
+      await createOraclePeggedMarket();
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const expectedTime = latestBlock.timestamp + 7 * ONE_DAY;
+
+      await friendGroupFactory.connect(addr1).setExpectedResolutionTime(0, expectedTime);
+
+      // Fast forward past expected + 30 days (oracle timeout)
+      await time.increase(7 * ONE_DAY + THIRTY_DAYS + 1);
+
+      const tx = await friendGroupFactory.connect(addr3).triggerOracleTimeout(0);
+
+      const marketWithStatus = await friendGroupFactory.getFriendMarketWithStatus(0);
+      expect(marketWithStatus.status).to.equal(FriendMarketStatus.OracleTimedOut);
+
+      await expect(tx).to.emit(friendGroupFactory, "OracleTimeoutTriggered");
+    });
+
+    it("Should reject timeout before period expires", async function () {
+      await createOraclePeggedMarket();
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const expectedTime = latestBlock.timestamp + 7 * ONE_DAY;
+
+      await friendGroupFactory.connect(addr1).setExpectedResolutionTime(0, expectedTime);
+
+      // Only fast forward 20 days (not past the 37 days total needed)
+      await time.increase(20 * ONE_DAY);
+
+      await expect(
+        friendGroupFactory.triggerOracleTimeout(0)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "OracleTimeoutNotExpired");
+    });
+
+    it("Should reject timeout if expected time not set", async function () {
+      await createOraclePeggedMarket();
+
+      await time.increase(60 * ONE_DAY);
+
+      await expect(
+        friendGroupFactory.triggerOracleTimeout(0)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "InvalidMarketId");
+    });
+  });
+
+  describe("Mutual Refund", function () {
+    beforeEach(async function () {
+      await createOraclePeggedMarket();
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const expectedTime = latestBlock.timestamp + 7 * ONE_DAY;
+      await friendGroupFactory.connect(addr1).setExpectedResolutionTime(0, expectedTime);
+      await time.increase(7 * ONE_DAY + THIRTY_DAYS + 1);
+      await friendGroupFactory.triggerOracleTimeout(0);
+    });
+
+    it("Should allow both parties to accept refund", async function () {
+      await expect(friendGroupFactory.connect(addr1).acceptMutualRefund(0))
+        .to.emit(friendGroupFactory, "RefundAccepted")
+        .withArgs(0, addr1.address);
+
+      await expect(friendGroupFactory.connect(addr2).acceptMutualRefund(0))
+        .to.emit(friendGroupFactory, "RefundAccepted")
+        .withArgs(0, addr2.address);
+    });
+
+    it("Should complete refund when both accept", async function () {
+      const stakeAmount = ethers.parseEther("0.5");
+
+      const addr1BalanceBefore = await ethers.provider.getBalance(addr1.address);
+      const addr2BalanceBefore = await ethers.provider.getBalance(addr2.address);
+
+      // First acceptance
+      const tx1 = await friendGroupFactory.connect(addr1).acceptMutualRefund(0);
+      const receipt1 = await tx1.wait();
+      const gas1 = receipt1.gasUsed * receipt1.gasPrice;
+
+      // Second acceptance triggers refund
+      const tx2 = await friendGroupFactory.connect(addr2).acceptMutualRefund(0);
+      const receipt2 = await tx2.wait();
+      const gas2 = receipt2.gasUsed * receipt2.gasPrice;
+
+      await expect(tx2).to.emit(friendGroupFactory, "MutualRefundCompleted");
+
+      // Check balances
+      const addr1BalanceAfter = await ethers.provider.getBalance(addr1.address);
+      const addr2BalanceAfter = await ethers.provider.getBalance(addr2.address);
+
+      expect(addr1BalanceAfter).to.equal(addr1BalanceBefore + stakeAmount - gas1);
+      expect(addr2BalanceAfter).to.equal(addr2BalanceBefore + stakeAmount - gas2);
+
+      // Check market status
+      const marketWithStatus = await friendGroupFactory.getFriendMarketWithStatus(0);
+      expect(marketWithStatus.status).to.equal(FriendMarketStatus.Refunded);
+    });
+
+    it("Should reject refund acceptance from non-participant", async function () {
+      await expect(
+        friendGroupFactory.connect(addr3).acceptMutualRefund(0)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotAuthorized");
+    });
+
+    it("Should reject double acceptance", async function () {
+      await friendGroupFactory.connect(addr1).acceptMutualRefund(0);
+
+      await expect(
+        friendGroupFactory.connect(addr1).acceptMutualRefund(0)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "RefundAlreadyAccepted");
+    });
+
+    it("Should reject refund acceptance if not timed out", async function () {
+      // Create a new active market
+      const stakeAmount = ethers.parseEther("0.5");
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const acceptanceDeadline = latestBlock.timestamp + (2 * 60 * 60);
+
+      await friendGroupFactory.connect(addr1).createOneVsOneMarketPending(
+        addr2.address,
+        "New bet",
+        7 * 24 * 60 * 60,
+        ethers.ZeroAddress,
+        acceptanceDeadline,
+        stakeAmount,
+        ethers.ZeroAddress,
+        ResolutionType.PolymarketOracle,
+        { value: stakeAmount }
+      );
+      await acceptMarket(1, addr2);
+
+      await expect(
+        friendGroupFactory.connect(addr1).acceptMutualRefund(1)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotTimedOut");
+    });
+  });
+
+  describe("Force Manual Resolution", function () {
+    beforeEach(async function () {
+      await createOraclePeggedMarket(arbitrator.address);
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const expectedTime = latestBlock.timestamp + 7 * ONE_DAY;
+      await friendGroupFactory.connect(addr1).setExpectedResolutionTime(0, expectedTime);
+      await time.increase(7 * ONE_DAY + THIRTY_DAYS + 1);
+      await friendGroupFactory.triggerOracleTimeout(0);
+    });
+
+    it("Should allow arbitrator to force resolution", async function () {
+      const tx = await friendGroupFactory.connect(arbitrator).forceOracleResolution(0, true);
+
+      await expect(tx).to.emit(friendGroupFactory, "MarketResolved")
+        .withArgs(0, arbitrator.address, true);
+
+      const marketWithStatus = await friendGroupFactory.getFriendMarketWithStatus(0);
+      expect(marketWithStatus.status).to.equal(FriendMarketStatus.Resolved);
+
+      const resolution = await friendGroupFactory.getWagerResolution(0);
+      expect(resolution.winner).to.equal(addr1.address);
+    });
+
+    it("Should allow owner to force resolution when no arbitrator", async function () {
+      // Create market without arbitrator
+      const stakeAmount = ethers.parseEther("0.5");
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const acceptanceDeadline = latestBlock.timestamp + (2 * 60 * 60);
+
+      await friendGroupFactory.connect(addr1).createOneVsOneMarketPending(
+        addr2.address,
+        "No arb bet",
+        7 * 24 * 60 * 60,
+        ethers.ZeroAddress,
+        acceptanceDeadline,
+        stakeAmount,
+        ethers.ZeroAddress,
+        ResolutionType.PolymarketOracle,
+        { value: stakeAmount }
+      );
+      await acceptMarket(1, addr2);
+
+      const expectedTime = latestBlock.timestamp + 7 * ONE_DAY;
+      await friendGroupFactory.connect(addr1).setExpectedResolutionTime(1, expectedTime);
+      await time.increase(7 * ONE_DAY + THIRTY_DAYS + 1);
+      await friendGroupFactory.triggerOracleTimeout(1);
+
+      await friendGroupFactory.connect(owner).forceOracleResolution(1, false);
+
+      const resolution = await friendGroupFactory.getWagerResolution(1);
+      expect(resolution.winner).to.equal(addr2.address);
+    });
+
+    it("Should reject force resolution from non-arbitrator", async function () {
+      await expect(
+        friendGroupFactory.connect(addr3).forceOracleResolution(0, true)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotAuthorized");
+    });
+
+    it("Should reject force resolution if not timed out", async function () {
+      // Create active market
+      const stakeAmount = ethers.parseEther("0.5");
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const acceptanceDeadline = latestBlock.timestamp + (2 * 60 * 60);
+
+      await friendGroupFactory.connect(addr1).createOneVsOneMarketPending(
+        addr2.address,
+        "Active bet",
+        7 * 24 * 60 * 60,
+        arbitrator.address,
+        acceptanceDeadline,
+        stakeAmount,
+        ethers.ZeroAddress,
+        ResolutionType.PolymarketOracle,
+        { value: stakeAmount }
+      );
+      await acceptMarket(1, addr2);
+      await friendGroupFactory.connect(arbitrator).acceptMarket(1);
+
+      await expect(
+        friendGroupFactory.connect(arbitrator).forceOracleResolution(1, true)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotTimedOut");
+    });
+  });
+
+  describe("View Functions", function () {
+    it("canTriggerOracleTimeout should return correct state", async function () {
+      await createOraclePeggedMarket();
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const expectedTime = latestBlock.timestamp + 7 * ONE_DAY;
+      await friendGroupFactory.connect(addr1).setExpectedResolutionTime(0, expectedTime);
+
+      // Before timeout
+      let [canTrigger, timeRemaining] = await friendGroupFactory.canTriggerOracleTimeout(0);
+      expect(canTrigger).to.equal(false);
+      expect(timeRemaining).to.be.closeTo(7 * ONE_DAY + THIRTY_DAYS, 5);
+
+      // After timeout
+      await time.increase(7 * ONE_DAY + THIRTY_DAYS + 1);
+      [canTrigger, timeRemaining] = await friendGroupFactory.canTriggerOracleTimeout(0);
+      expect(canTrigger).to.equal(true);
+      expect(timeRemaining).to.equal(0);
+    });
+
+    it("getOracleTimeoutStatus should return correct data", async function () {
+      await createOraclePeggedMarket();
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const expectedTime = latestBlock.timestamp + 7 * ONE_DAY;
+      await friendGroupFactory.connect(addr1).setExpectedResolutionTime(0, expectedTime);
+
+      // Before timeout
+      let status = await friendGroupFactory.getOracleTimeoutStatus(0);
+      expect(status.isTimedOut).to.equal(false);
+      expect(status.expectedTime).to.equal(expectedTime);
+      expect(status.creatorAccepted).to.equal(false);
+      expect(status.opponentAccepted).to.equal(false);
+
+      // After timeout triggered
+      await time.increase(7 * ONE_DAY + THIRTY_DAYS + 1);
+      await friendGroupFactory.triggerOracleTimeout(0);
+
+      status = await friendGroupFactory.getOracleTimeoutStatus(0);
+      expect(status.isTimedOut).to.equal(true);
+
+      // After creator accepts
+      await friendGroupFactory.connect(addr1).acceptMutualRefund(0);
+      status = await friendGroupFactory.getOracleTimeoutStatus(0);
+      expect(status.creatorAccepted).to.equal(true);
+      expect(status.opponentAccepted).to.equal(false);
+    });
+  });
+
+  describe("Admin Functions", function () {
+    it("Should allow owner to update oracle timeout", async function () {
+      const newTimeout = 14 * ONE_DAY;
+      await expect(friendGroupFactory.setOracleTimeout(newTimeout))
+        .to.emit(friendGroupFactory, "OracleTimeoutUpdated")
+        .withArgs(THIRTY_DAYS, newTimeout);
+
+      expect(await friendGroupFactory.oracleTimeout()).to.equal(newTimeout);
+    });
+
+    it("Should reject oracle timeout less than 7 days", async function () {
+      await expect(
+        friendGroupFactory.setOracleTimeout(6 * ONE_DAY)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "InvalidOracleTimeout");
+    });
+
+    it("Should reject oracle timeout more than 180 days", async function () {
+      await expect(
+        friendGroupFactory.setOracleTimeout(181 * ONE_DAY)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "InvalidOracleTimeout");
+    });
+  });
+
+  describe("Integration - Winner Can Claim After Force Resolution", function () {
+    it("Should allow winner to claim after force resolution", async function () {
+      await createOraclePeggedMarket(arbitrator.address);
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const expectedTime = latestBlock.timestamp + 7 * ONE_DAY;
+      await friendGroupFactory.connect(addr1).setExpectedResolutionTime(0, expectedTime);
+      await time.increase(7 * ONE_DAY + THIRTY_DAYS + 1);
+      await friendGroupFactory.triggerOracleTimeout(0);
+
+      // Arbitrator forces resolution
+      await friendGroupFactory.connect(arbitrator).forceOracleResolution(0, true);
+
+      // Winner claims
+      await expect(friendGroupFactory.connect(addr1).claimWinnings(0))
+        .to.emit(friendGroupFactory, "WinningsClaimed");
+    });
+  });
+});

--- a/test/FriendGroupMarketFactory.Timeout.test.js
+++ b/test/FriendGroupMarketFactory.Timeout.test.js
@@ -1,0 +1,442 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+// Resolution type enum (matches contract)
+const ResolutionType = {
+  Either: 0,
+  Initiator: 1,
+  Receiver: 2,
+  ThirdParty: 3,
+  AutoPegged: 4,
+  PolymarketOracle: 5
+};
+
+// Market status enum (matches contract)
+const FriendMarketStatus = {
+  PendingAcceptance: 0,
+  Active: 1,
+  PendingResolution: 2,
+  Challenged: 3,
+  Resolved: 4,
+  Cancelled: 5,
+  Refunded: 6
+};
+
+describe("FriendGroupMarketFactory - Claim Timeout", function () {
+  let friendGroupFactory;
+  let marketFactory;
+  let ragequitModule;
+  let tieredRoleManager;
+  let paymentManager;
+  let collateralToken;
+  let stakeToken;
+  let owner;
+  let addr1;
+  let addr2;
+  let addr3;
+  let treasury;
+
+  const FRIEND_MARKET_ROLE = ethers.id("FRIEND_MARKET_ROLE");
+  const MembershipTier = { NONE: 0, BRONZE: 1, SILVER: 2, GOLD: 3, PLATINUM: 4 };
+
+  const ONE_DAY = 86400;
+  const NINETY_DAYS = 90 * ONE_DAY;
+
+  beforeEach(async function () {
+    [owner, addr1, addr2, addr3, treasury] = await ethers.getSigners();
+
+    // Deploy CTF1155
+    const CTF1155 = await ethers.getContractFactory("CTF1155");
+    const ctf1155 = await CTF1155.deploy();
+    await ctf1155.waitForDeployment();
+
+    // Deploy mock collateral token
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    collateralToken = await MockERC20.deploy("Market Collateral", "MCOL", ethers.parseEther("10000000"));
+    await collateralToken.waitForDeployment();
+
+    // Deploy a stake token for ERC20 tests
+    stakeToken = await MockERC20.deploy("Stake Token", "STK", ethers.parseEther("10000000"));
+    await stakeToken.waitForDeployment();
+
+    // Deploy ConditionalMarketFactory
+    const ConditionalMarketFactory = await ethers.getContractFactory("ConditionalMarketFactory");
+    marketFactory = await ConditionalMarketFactory.deploy();
+    await marketFactory.initialize(owner.address);
+    await marketFactory.setCTF1155(await ctf1155.getAddress());
+
+    // Deploy RagequitModule
+    const RagequitModule = await ethers.getContractFactory("RagequitModule");
+    ragequitModule = await RagequitModule.deploy();
+
+    // Deploy TieredRoleManager
+    const TieredRoleManager = await ethers.getContractFactory("TieredRoleManager");
+    tieredRoleManager = await TieredRoleManager.deploy();
+    await tieredRoleManager.waitForDeployment();
+    await tieredRoleManager.initializeRoleMetadata();
+
+    // Set up Friend Market tier
+    await tieredRoleManager.setTierMetadata(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      "Friend Market Bronze",
+      "Basic friend market tier",
+      ethers.parseEther("0.1"),
+      {
+        dailyBetLimit: 10,
+        weeklyBetLimit: 50,
+        monthlyMarketCreation: 5,
+        maxPositionSize: ethers.parseEther("10"),
+        maxConcurrentMarkets: 3,
+        withdrawalLimit: ethers.parseEther("100"),
+        canCreatePrivateMarkets: false,
+        canUseAdvancedFeatures: false,
+        feeDiscount: 0
+      },
+      true
+    );
+
+    const tierMeta = await tieredRoleManager.tierMetadata(FRIEND_MARKET_ROLE, MembershipTier.BRONZE);
+    const price = tierMeta.price;
+
+    // Deploy MembershipPaymentManager
+    const MembershipPaymentManager = await ethers.getContractFactory("MembershipPaymentManager");
+    paymentManager = await MembershipPaymentManager.deploy(owner.address);
+    await paymentManager.waitForDeployment();
+
+    // Deploy FriendGroupMarketFactory
+    const FriendGroupMarketFactory = await ethers.getContractFactory("FriendGroupMarketFactory");
+    friendGroupFactory = await FriendGroupMarketFactory.deploy(
+      await marketFactory.getAddress(),
+      await ragequitModule.getAddress(),
+      await tieredRoleManager.getAddress(),
+      await paymentManager.getAddress(),
+      owner.address
+    );
+
+    await friendGroupFactory.setDefaultCollateralToken(await collateralToken.getAddress());
+    await friendGroupFactory.addAcceptedPaymentToken(await stakeToken.getAddress(), true);
+
+    // Set treasury
+    await friendGroupFactory.setTreasury(treasury.address);
+
+    // Purchase memberships
+    const durDays = 36500;
+    for (const signer of [owner, addr1, addr2, addr3]) {
+      await tieredRoleManager.connect(signer).purchaseRoleWithTier(
+        FRIEND_MARKET_ROLE,
+        MembershipTier.BRONZE,
+        durDays,
+        { value: price }
+      );
+    }
+
+    await marketFactory.transferOwnership(await friendGroupFactory.getAddress());
+
+    // Distribute stake tokens
+    await stakeToken.transfer(addr1.address, ethers.parseEther("1000"));
+    await stakeToken.transfer(addr2.address, ethers.parseEther("1000"));
+  });
+
+  async function acceptMarket(marketId, participant) {
+    const marketWithStatus = await friendGroupFactory.getFriendMarketWithStatus(marketId);
+    const stakeAmount = marketWithStatus.stakePerParticipant;
+    const stakeTokenAddr = marketWithStatus.stakeToken;
+
+    if (stakeTokenAddr === ethers.ZeroAddress) {
+      await friendGroupFactory.connect(participant).acceptMarket(marketId, { value: stakeAmount });
+    } else {
+      const token = await ethers.getContractAt("MockERC20", stakeTokenAddr);
+      await token.connect(participant).approve(await friendGroupFactory.getAddress(), stakeAmount);
+      await friendGroupFactory.connect(participant).acceptMarket(marketId);
+    }
+  }
+
+  async function createAndActivateNativeMarket() {
+    const stakeAmount = ethers.parseEther("0.5");
+    const latestBlock = await ethers.provider.getBlock('latest');
+    const acceptanceDeadline = latestBlock.timestamp + (2 * 60 * 60);
+
+    await friendGroupFactory.connect(addr1).createOneVsOneMarketPending(
+      addr2.address,
+      "Test bet",
+      7 * 24 * 60 * 60,
+      ethers.ZeroAddress,
+      acceptanceDeadline,
+      stakeAmount,
+      ethers.ZeroAddress,
+      ResolutionType.Either,
+      { value: stakeAmount }
+    );
+
+    await acceptMarket(0, addr2);
+    return 0;
+  }
+
+  async function createAndActivateERC20Market() {
+    const stakeAmount = ethers.parseEther("100");
+    const latestBlock = await ethers.provider.getBlock('latest');
+    const acceptanceDeadline = latestBlock.timestamp + (2 * 60 * 60);
+
+    await stakeToken.connect(addr1).approve(await friendGroupFactory.getAddress(), stakeAmount);
+
+    await friendGroupFactory.connect(addr1).createOneVsOneMarketPending(
+      addr2.address,
+      "ERC20 bet",
+      7 * 24 * 60 * 60,
+      ethers.ZeroAddress,
+      acceptanceDeadline,
+      stakeAmount,
+      await stakeToken.getAddress(),
+      ResolutionType.Either
+    );
+
+    await acceptMarket(0, addr2);
+    return 0;
+  }
+
+  async function resolveAndFinalizeMarket(marketId, resolver, outcome) {
+    await friendGroupFactory.connect(resolver).resolveFriendMarket(marketId, outcome);
+    await time.increase(ONE_DAY + 1);
+    await friendGroupFactory.finalizeResolution(marketId);
+  }
+
+  describe("Sweep Unclaimed Funds - Native Token", function () {
+    it("Should allow sweep after claim timeout expires", async function () {
+      await createAndActivateNativeMarket();
+      const stakeAmount = ethers.parseEther("0.5");
+      const totalPot = stakeAmount * 2n;
+
+      // Resolve market
+      await resolveAndFinalizeMarket(0, addr1, true);
+
+      // Fast forward past claim timeout (90 days)
+      await time.increase(NINETY_DAYS + 1);
+
+      // Get treasury balance before
+      const treasuryBalanceBefore = await ethers.provider.getBalance(treasury.address);
+
+      // Anyone can sweep
+      const tx = await friendGroupFactory.connect(addr3).sweepUnclaimedFunds(0);
+
+      // Verify treasury received funds
+      const treasuryBalanceAfter = await ethers.provider.getBalance(treasury.address);
+      expect(treasuryBalanceAfter).to.equal(treasuryBalanceBefore + totalPot);
+
+      // Verify event
+      await expect(tx)
+        .to.emit(friendGroupFactory, "UnclaimedFundsSwept")
+        .withArgs(0, totalPot, ethers.ZeroAddress, treasury.address);
+
+      // Verify marked as claimed
+      expect(await friendGroupFactory.isWagerClaimed(0)).to.equal(true);
+    });
+
+    it("Should reject sweep before timeout expires", async function () {
+      await createAndActivateNativeMarket();
+      await resolveAndFinalizeMarket(0, addr1, true);
+
+      // Only 30 days have passed (not 90)
+      await time.increase(30 * ONE_DAY);
+
+      await expect(
+        friendGroupFactory.connect(addr3).sweepUnclaimedFunds(0)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "ClaimTimeoutNotExpired");
+    });
+
+    it("Should reject sweep if already claimed by winner", async function () {
+      await createAndActivateNativeMarket();
+      await resolveAndFinalizeMarket(0, addr1, true);
+
+      // Winner claims
+      await friendGroupFactory.connect(addr1).claimWinnings(0);
+
+      // Fast forward past timeout
+      await time.increase(NINETY_DAYS + 1);
+
+      await expect(
+        friendGroupFactory.connect(addr3).sweepUnclaimedFunds(0)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "AlreadyClaimed");
+    });
+
+    it("Should reject sweep if market not resolved", async function () {
+      await createAndActivateNativeMarket();
+
+      await time.increase(NINETY_DAYS + 1);
+
+      await expect(
+        friendGroupFactory.connect(addr3).sweepUnclaimedFunds(0)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "WagerNotResolved");
+    });
+
+    it("Should reject sweep if treasury not set", async function () {
+      // Deploy a new factory without treasury set
+      const FriendGroupMarketFactory = await ethers.getContractFactory("FriendGroupMarketFactory");
+      const newFactory = await FriendGroupMarketFactory.deploy(
+        await marketFactory.getAddress(),
+        await ragequitModule.getAddress(),
+        await tieredRoleManager.getAddress(),
+        await paymentManager.getAddress(),
+        owner.address
+      );
+
+      // Treasury check happens before market ID check, so this should fail with TreasuryNotSet
+      await expect(
+        newFactory.sweepUnclaimedFunds(0)
+      ).to.be.revertedWithCustomError(newFactory, "TreasuryNotSet");
+    });
+  });
+
+  describe("Sweep Unclaimed Funds - ERC20 Token", function () {
+    it("Should sweep ERC20 tokens to treasury", async function () {
+      await createAndActivateERC20Market();
+      const stakeAmount = ethers.parseEther("100");
+      const totalPot = stakeAmount * 2n;
+
+      await resolveAndFinalizeMarket(0, addr1, true);
+
+      await time.increase(NINETY_DAYS + 1);
+
+      const treasuryBalanceBefore = await stakeToken.balanceOf(treasury.address);
+
+      const tx = await friendGroupFactory.sweepUnclaimedFunds(0);
+
+      const treasuryBalanceAfter = await stakeToken.balanceOf(treasury.address);
+      expect(treasuryBalanceAfter).to.equal(treasuryBalanceBefore + totalPot);
+
+      await expect(tx)
+        .to.emit(friendGroupFactory, "UnclaimedFundsSwept")
+        .withArgs(0, totalPot, await stakeToken.getAddress(), treasury.address);
+    });
+  });
+
+  describe("View Functions", function () {
+    it("canSweepUnclaimedFunds should return false for unresolved market", async function () {
+      await createAndActivateNativeMarket();
+
+      const [canSweep, timeUntil] = await friendGroupFactory.canSweepUnclaimedFunds(0);
+      expect(canSweep).to.equal(false);
+      expect(timeUntil).to.equal(0);
+    });
+
+    it("canSweepUnclaimedFunds should return correct time remaining", async function () {
+      await createAndActivateNativeMarket();
+      await resolveAndFinalizeMarket(0, addr1, true);
+
+      // Immediately after resolution
+      let [canSweep, timeUntil] = await friendGroupFactory.canSweepUnclaimedFunds(0);
+      expect(canSweep).to.equal(false);
+      expect(timeUntil).to.be.closeTo(NINETY_DAYS, 5);
+
+      // After 30 days
+      await time.increase(30 * ONE_DAY);
+      [canSweep, timeUntil] = await friendGroupFactory.canSweepUnclaimedFunds(0);
+      expect(canSweep).to.equal(false);
+      expect(timeUntil).to.be.closeTo(60 * ONE_DAY, 5);
+
+      // After 90 days
+      await time.increase(60 * ONE_DAY + 1);
+      [canSweep, timeUntil] = await friendGroupFactory.canSweepUnclaimedFunds(0);
+      expect(canSweep).to.equal(true);
+      expect(timeUntil).to.equal(0);
+    });
+
+    it("canSweepUnclaimedFunds should return false if already claimed", async function () {
+      await createAndActivateNativeMarket();
+      await resolveAndFinalizeMarket(0, addr1, true);
+      await friendGroupFactory.connect(addr1).claimWinnings(0);
+
+      const [canSweep, timeUntil] = await friendGroupFactory.canSweepUnclaimedFunds(0);
+      expect(canSweep).to.equal(false);
+      expect(timeUntil).to.equal(0);
+    });
+  });
+
+  describe("Admin Functions", function () {
+    it("Should allow owner to set treasury", async function () {
+      const newTreasury = addr3.address;
+      await expect(friendGroupFactory.setTreasury(newTreasury))
+        .to.emit(friendGroupFactory, "TreasuryUpdated")
+        .withArgs(treasury.address, newTreasury);
+
+      expect(await friendGroupFactory.treasury()).to.equal(newTreasury);
+    });
+
+    it("Should reject setting zero address treasury", async function () {
+      await expect(
+        friendGroupFactory.setTreasury(ethers.ZeroAddress)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "InvalidAddress");
+    });
+
+    it("Should allow owner to update claim timeout", async function () {
+      const newTimeout = 30 * ONE_DAY; // 30 days
+      await expect(friendGroupFactory.setClaimTimeout(newTimeout))
+        .to.emit(friendGroupFactory, "ClaimTimeoutUpdated")
+        .withArgs(NINETY_DAYS, newTimeout);
+
+      expect(await friendGroupFactory.claimTimeout()).to.equal(newTimeout);
+    });
+
+    it("Should reject claim timeout less than 7 days", async function () {
+      await expect(
+        friendGroupFactory.setClaimTimeout(6 * ONE_DAY)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "InvalidClaimTimeout");
+    });
+
+    it("Should reject claim timeout more than 365 days", async function () {
+      await expect(
+        friendGroupFactory.setClaimTimeout(366 * ONE_DAY)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "InvalidClaimTimeout");
+    });
+
+    it("Should reject non-owner setting treasury", async function () {
+      await expect(
+        friendGroupFactory.connect(addr1).setTreasury(addr3.address)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "OwnableUnauthorizedAccount");
+    });
+
+    it("Should reject non-owner setting claim timeout", async function () {
+      await expect(
+        friendGroupFactory.connect(addr1).setClaimTimeout(30 * ONE_DAY)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "OwnableUnauthorizedAccount");
+    });
+  });
+
+  describe("Integration - Winner Can Still Claim Within Timeout", function () {
+    it("Winner can claim until the last second before timeout", async function () {
+      await createAndActivateNativeMarket();
+      const stakeAmount = ethers.parseEther("0.5");
+      const totalPot = stakeAmount * 2n;
+
+      await resolveAndFinalizeMarket(0, addr1, true);
+
+      // Fast forward to just before timeout (89 days)
+      await time.increase(NINETY_DAYS - 100);
+
+      // Winner should still be able to claim
+      const balanceBefore = await ethers.provider.getBalance(addr1.address);
+      const tx = await friendGroupFactory.connect(addr1).claimWinnings(0);
+      const receipt = await tx.wait();
+      const gasCost = receipt.gasUsed * receipt.gasPrice;
+
+      const balanceAfter = await ethers.provider.getBalance(addr1.address);
+      expect(balanceAfter).to.equal(balanceBefore + totalPot - gasCost);
+    });
+
+    it("Sweep and claim are mutually exclusive", async function () {
+      await createAndActivateNativeMarket();
+      await resolveAndFinalizeMarket(0, addr1, true);
+
+      await time.increase(NINETY_DAYS + 1);
+
+      // Sweep first
+      await friendGroupFactory.connect(addr3).sweepUnclaimedFunds(0);
+
+      // Winner cannot claim anymore
+      await expect(
+        friendGroupFactory.connect(addr1).claimWinnings(0)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "AlreadyClaimed");
+    });
+  });
+});

--- a/test/FriendGroupMarketFactory.UMAIntegration.test.js
+++ b/test/FriendGroupMarketFactory.UMAIntegration.test.js
@@ -1,0 +1,467 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+/**
+ * UMA Oracle Integration Tests for FriendGroupMarketFactory
+ *
+ * Tests integration with UMA Optimistic Oracle for arbitrary truth assertions:
+ * - Creating conditions for verifiable claims
+ * - Asserting outcomes with bonding
+ * - Challenge period and settlement
+ * - Resolution flow with FriendGroupMarketFactory
+ */
+describe("FriendGroupMarketFactory - UMA Integration", function () {
+  let friendGroupFactory;
+  let marketFactory;
+  let ragequitModule;
+  let tieredRoleManager;
+  let paymentManager;
+  let oracleRegistry;
+  let umaAdapter;
+  let mockUMAOracle;
+  let bondToken;
+  let collateralToken;
+  let owner;
+  let creator;
+  let opponent;
+  let asserter;
+
+  const UMA_ORACLE_ID = ethers.keccak256(ethers.toUtf8Bytes("UMA"));
+  const FRIEND_MARKET_ROLE = ethers.id("FRIEND_MARKET_ROLE");
+  const MembershipTier = { NONE: 0, BRONZE: 1, SILVER: 2, GOLD: 3, PLATINUM: 4 };
+  const ResolutionType = { Either: 0, Initiator: 1, Receiver: 2, ThirdParty: 3, AutoPegged: 4 };
+  const STAKE_AMOUNT = ethers.parseEther("1");
+  const ACCEPTANCE_PERIOD = 7 * 24 * 60 * 60;
+  const TRADING_PERIOD = 14 * 24 * 60 * 60;
+  const LIVENESS_PERIOD = 2 * 60 * 60; // 2 hours
+
+  beforeEach(async function () {
+    [owner, creator, opponent, asserter] = await ethers.getSigners();
+
+    // Deploy CTF1155
+    const CTF1155 = await ethers.getContractFactory("CTF1155");
+    const ctf1155 = await CTF1155.deploy();
+    await ctf1155.waitForDeployment();
+
+    // Deploy collateral token
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    collateralToken = await MockERC20.deploy("Collateral", "COL", ethers.parseEther("10000000"));
+    await collateralToken.waitForDeployment();
+
+    // Deploy bond token for UMA
+    bondToken = await MockERC20.deploy("Bond Token", "BOND", ethers.parseEther("10000000"));
+    await bondToken.waitForDeployment();
+
+    // Distribute bond tokens
+    await bondToken.transfer(creator.address, ethers.parseEther("100"));
+    await bondToken.transfer(opponent.address, ethers.parseEther("100"));
+    await bondToken.transfer(asserter.address, ethers.parseEther("100"));
+
+    // Deploy ConditionalMarketFactory
+    const ConditionalMarketFactory = await ethers.getContractFactory("ConditionalMarketFactory");
+    marketFactory = await ConditionalMarketFactory.deploy();
+    await marketFactory.initialize(owner.address);
+    await marketFactory.setCTF1155(await ctf1155.getAddress());
+
+    // Deploy RagequitModule
+    const RagequitModule = await ethers.getContractFactory("RagequitModule");
+    ragequitModule = await RagequitModule.deploy();
+
+    // Deploy TieredRoleManager
+    const TieredRoleManager = await ethers.getContractFactory("TieredRoleManager");
+    tieredRoleManager = await TieredRoleManager.deploy();
+    await tieredRoleManager.waitForDeployment();
+    await tieredRoleManager.initializeRoleMetadata();
+
+    // Setup tier
+    await tieredRoleManager.setTierMetadata(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      "Friend Market Bronze",
+      "Basic friend market tier",
+      ethers.parseEther("0.1"),
+      {
+        dailyBetLimit: 10,
+        weeklyBetLimit: 50,
+        monthlyMarketCreation: 5,
+        maxPositionSize: ethers.parseEther("10"),
+        maxConcurrentMarkets: 3,
+        withdrawalLimit: ethers.parseEther("100"),
+        canCreatePrivateMarkets: false,
+        canUseAdvancedFeatures: false,
+        feeDiscount: 0
+      },
+      true
+    );
+
+    const tierMeta = await tieredRoleManager.tierMetadata(FRIEND_MARKET_ROLE, MembershipTier.BRONZE);
+    const price = tierMeta.price;
+
+    // Deploy MembershipPaymentManager
+    const MembershipPaymentManager = await ethers.getContractFactory("MembershipPaymentManager");
+    paymentManager = await MembershipPaymentManager.deploy(owner.address);
+    await paymentManager.waitForDeployment();
+
+    // Deploy FriendGroupMarketFactory
+    const FriendGroupMarketFactory = await ethers.getContractFactory("FriendGroupMarketFactory");
+    friendGroupFactory = await FriendGroupMarketFactory.deploy(
+      await marketFactory.getAddress(),
+      await ragequitModule.getAddress(),
+      await tieredRoleManager.getAddress(),
+      await paymentManager.getAddress(),
+      owner.address
+    );
+
+    await friendGroupFactory.setDefaultCollateralToken(await collateralToken.getAddress());
+    await friendGroupFactory.setTreasury(owner.address);
+
+    // Transfer ownership of marketFactory to friendGroupFactory
+    await marketFactory.transferOwnership(await friendGroupFactory.getAddress());
+
+    // Purchase memberships
+    const durDays = 36500;
+    await tieredRoleManager.connect(creator).purchaseRoleWithTier(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      durDays,
+      { value: price }
+    );
+    await tieredRoleManager.connect(opponent).purchaseRoleWithTier(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      durDays,
+      { value: price }
+    );
+
+    // Deploy Mock UMA Oracle
+    const MockUMAOptimisticOracle = await ethers.getContractFactory("MockUMAOptimisticOracle");
+    mockUMAOracle = await MockUMAOptimisticOracle.deploy();
+
+    // Deploy UMA Adapter
+    const UMAOracleAdapter = await ethers.getContractFactory("UMAOracleAdapter");
+    umaAdapter = await UMAOracleAdapter.deploy(
+      owner.address,
+      mockUMAOracle.target,
+      bondToken.target
+    );
+
+    // Deploy OracleRegistry
+    const OracleRegistry = await ethers.getContractFactory("OracleRegistry");
+    oracleRegistry = await OracleRegistry.deploy(owner.address);
+    await oracleRegistry.registerAdapter(UMA_ORACLE_ID, umaAdapter.target);
+
+    // Configure factory
+    await friendGroupFactory.setOracleRegistry(oracleRegistry.target);
+  });
+
+  describe("UMA Condition Creation", function () {
+    it("Should create a UMA condition", async function () {
+      const deadline = (await time.latest()) + TRADING_PERIOD;
+      const tx = await umaAdapter.createCondition(
+        "Lakers will win the 2025 NBA Finals",
+        deadline
+      );
+      const receipt = await tx.wait();
+
+      const event = receipt.logs.find(log => {
+        try {
+          return umaAdapter.interface.parseLog(log)?.name === "ConditionCreated";
+        } catch { return false; }
+      });
+
+      expect(event).to.not.be.undefined;
+      const conditionId = umaAdapter.interface.parseLog(event).args.conditionId;
+      expect(await umaAdapter.isConditionSupported(conditionId)).to.be.true;
+    });
+
+    it("Should reject deadline in the past", async function () {
+      const pastDeadline = (await time.latest()) - 100;
+      await expect(
+        umaAdapter.createCondition("Past event", pastDeadline)
+      ).to.be.revertedWithCustomError(umaAdapter, "DeadlineInPast");
+    });
+  });
+
+  describe("UMA Assertion Flow", function () {
+    let conditionId;
+
+    beforeEach(async function () {
+      const deadline = (await time.latest()) + TRADING_PERIOD;
+      const tx = await umaAdapter.createCondition(
+        "SpaceX Starship reaches orbit in Q2 2025",
+        deadline
+      );
+      const receipt = await tx.wait();
+      const event = receipt.logs.find(log => {
+        try {
+          return umaAdapter.interface.parseLog(log)?.name === "ConditionCreated";
+        } catch { return false; }
+      });
+      conditionId = umaAdapter.interface.parseLog(event).args.conditionId;
+    });
+
+    it("Should assert outcome after deadline", async function () {
+      // Wait for deadline
+      await time.increase(TRADING_PERIOD + 1);
+
+      // Approve bond
+      await bondToken.connect(asserter).approve(umaAdapter.target, ethers.parseEther("1"));
+
+      // Assert outcome
+      await expect(
+        umaAdapter.connect(asserter).assertOutcome(conditionId, true)
+      ).to.emit(umaAdapter, "AssertionMade");
+    });
+
+    it("Should revert assertion before deadline", async function () {
+      await bondToken.connect(asserter).approve(umaAdapter.target, ethers.parseEther("1"));
+
+      await expect(
+        umaAdapter.connect(asserter).assertOutcome(conditionId, true)
+      ).to.be.revertedWithCustomError(umaAdapter, "DeadlineNotReached");
+    });
+
+    it("Should settle condition after liveness", async function () {
+      await time.increase(TRADING_PERIOD + 1);
+
+      await bondToken.connect(asserter).approve(umaAdapter.target, ethers.parseEther("1"));
+      await umaAdapter.connect(asserter).assertOutcome(conditionId, true);
+
+      // Wait for liveness period
+      await time.increase(LIVENESS_PERIOD + 1);
+
+      await umaAdapter.settleCondition(conditionId);
+
+      expect(await umaAdapter.isConditionResolved(conditionId)).to.be.true;
+      const [outcome, confidence, resolvedAt] = await umaAdapter.getOutcome(conditionId);
+      expect(outcome).to.be.true;
+      expect(confidence).to.equal(10000); // Full confidence
+    });
+  });
+
+  describe("FriendGroupMarketFactory + UMA Integration", function () {
+    let conditionId;
+
+    beforeEach(async function () {
+      // Create UMA condition
+      const deadline = (await time.latest()) + TRADING_PERIOD;
+      const tx = await umaAdapter.createCondition(
+        "Bitcoin ETF approved by SEC in 2024",
+        deadline
+      );
+      const receipt = await tx.wait();
+      const event = receipt.logs.find(log => {
+        try {
+          return umaAdapter.interface.parseLog(log)?.name === "ConditionCreated";
+        } catch { return false; }
+      });
+      conditionId = umaAdapter.interface.parseLog(event).args.conditionId;
+    });
+
+    it("Should peg market to UMA condition", async function () {
+      // Create and accept wager
+      const acceptanceDeadline = (await time.latest()) + ACCEPTANCE_PERIOD;
+      await friendGroupFactory.connect(creator).createOneVsOneMarketPending(
+        opponent.address,
+        "Bitcoin ETF approved?",
+        TRADING_PERIOD,
+        ethers.ZeroAddress,
+        acceptanceDeadline,
+        STAKE_AMOUNT,
+        ethers.ZeroAddress,
+        ResolutionType.Either,
+        { value: STAKE_AMOUNT }
+      );
+
+      await friendGroupFactory.connect(opponent).acceptMarket(0, { value: STAKE_AMOUNT });
+
+      // Peg to UMA oracle
+      await expect(
+        friendGroupFactory.connect(creator).pegToOracleCondition(0, UMA_ORACLE_ID, conditionId)
+      ).to.emit(friendGroupFactory, "MarketPeggedToOracle")
+        .withArgs(0, UMA_ORACLE_ID, conditionId);
+
+      expect(await friendGroupFactory.isPeggedToOracle(0)).to.be.true;
+
+      const [oracleId, returnedConditionId] = await friendGroupFactory.getOracleInfo(0);
+      expect(oracleId).to.equal(UMA_ORACLE_ID);
+      expect(returnedConditionId).to.equal(conditionId);
+    });
+
+    it("Should resolve market from UMA oracle", async function () {
+      // Create, accept, and peg wager
+      const acceptanceDeadline = (await time.latest()) + ACCEPTANCE_PERIOD;
+      await friendGroupFactory.connect(creator).createOneVsOneMarketPending(
+        opponent.address,
+        "ETF wager",
+        TRADING_PERIOD,
+        ethers.ZeroAddress,
+        acceptanceDeadline,
+        STAKE_AMOUNT,
+        ethers.ZeroAddress,
+        ResolutionType.Either,
+        { value: STAKE_AMOUNT }
+      );
+
+      await friendGroupFactory.connect(opponent).acceptMarket(0, { value: STAKE_AMOUNT });
+      await friendGroupFactory.connect(creator).pegToOracleCondition(0, UMA_ORACLE_ID, conditionId);
+
+      // Wait for deadline
+      await time.increase(TRADING_PERIOD + 1);
+
+      // Assert and settle
+      await bondToken.connect(asserter).approve(umaAdapter.target, ethers.parseEther("1"));
+      await umaAdapter.connect(asserter).assertOutcome(conditionId, true);
+      await time.increase(LIVENESS_PERIOD + 1);
+      await umaAdapter.settleCondition(conditionId);
+
+      // Resolve from oracle
+      await expect(friendGroupFactory.resolveFromOracle(0))
+        .to.emit(friendGroupFactory, "OracleMarketResolved");
+
+      const market = await friendGroupFactory.friendMarkets(0);
+      expect(market.status).to.equal(4); // Resolved
+
+      const [winner, outcome] = await friendGroupFactory.getWagerResolution(0);
+      expect(outcome).to.be.true;
+      expect(winner).to.equal(creator.address);
+    });
+
+    it("Should resolve market when UMA outcome is false", async function () {
+      // Create, accept, and peg
+      const acceptanceDeadline = (await time.latest()) + ACCEPTANCE_PERIOD;
+      await friendGroupFactory.connect(creator).createOneVsOneMarketPending(
+        opponent.address,
+        "Wager",
+        TRADING_PERIOD,
+        ethers.ZeroAddress,
+        acceptanceDeadline,
+        STAKE_AMOUNT,
+        ethers.ZeroAddress,
+        ResolutionType.Either,
+        { value: STAKE_AMOUNT }
+      );
+
+      await friendGroupFactory.connect(opponent).acceptMarket(0, { value: STAKE_AMOUNT });
+      await friendGroupFactory.connect(creator).pegToOracleCondition(0, UMA_ORACLE_ID, conditionId);
+
+      // Wait for deadline
+      await time.increase(TRADING_PERIOD + 1);
+
+      // Assert FALSE outcome
+      await bondToken.connect(asserter).approve(umaAdapter.target, ethers.parseEther("1"));
+      await umaAdapter.connect(asserter).assertOutcome(conditionId, false);
+      await time.increase(LIVENESS_PERIOD + 1);
+      await umaAdapter.settleCondition(conditionId);
+
+      // Resolve from oracle
+      await friendGroupFactory.resolveFromOracle(0);
+
+      const [winner, outcome] = await friendGroupFactory.getWagerResolution(0);
+      expect(outcome).to.be.false;
+      expect(winner).to.equal(opponent.address);
+    });
+
+    it("Should allow winner to claim after UMA resolution", async function () {
+      // Create, accept, and peg
+      const acceptanceDeadline = (await time.latest()) + ACCEPTANCE_PERIOD;
+      await friendGroupFactory.connect(creator).createOneVsOneMarketPending(
+        opponent.address,
+        "Claimable wager",
+        TRADING_PERIOD,
+        ethers.ZeroAddress,
+        acceptanceDeadline,
+        STAKE_AMOUNT,
+        ethers.ZeroAddress,
+        ResolutionType.Either,
+        { value: STAKE_AMOUNT }
+      );
+
+      await friendGroupFactory.connect(opponent).acceptMarket(0, { value: STAKE_AMOUNT });
+      await friendGroupFactory.connect(creator).pegToOracleCondition(0, UMA_ORACLE_ID, conditionId);
+
+      // Resolve
+      await time.increase(TRADING_PERIOD + 1);
+      await bondToken.connect(asserter).approve(umaAdapter.target, ethers.parseEther("1"));
+      await umaAdapter.connect(asserter).assertOutcome(conditionId, true);
+      await time.increase(LIVENESS_PERIOD + 1);
+      await umaAdapter.settleCondition(conditionId);
+      await friendGroupFactory.resolveFromOracle(0);
+
+      // Claim winnings
+      const balanceBefore = await ethers.provider.getBalance(creator.address);
+      await friendGroupFactory.connect(creator).claimWinnings(0);
+      const balanceAfter = await ethers.provider.getBalance(creator.address);
+
+      expect(balanceAfter).to.be.gt(balanceBefore);
+    });
+  });
+
+  describe("View Functions", function () {
+    let conditionId;
+
+    beforeEach(async function () {
+      const deadline = (await time.latest()) + TRADING_PERIOD;
+      const tx = await umaAdapter.createCondition("Test condition", deadline);
+      const receipt = await tx.wait();
+      const event = receipt.logs.find(log => {
+        try {
+          return umaAdapter.interface.parseLog(log)?.name === "ConditionCreated";
+        } catch { return false; }
+      });
+      conditionId = umaAdapter.interface.parseLog(event).args.conditionId;
+    });
+
+    it("Should return oracle type as UMA", async function () {
+      expect(await umaAdapter.oracleType()).to.equal("UMA");
+    });
+
+    it("Should return condition metadata", async function () {
+      const [description, expectedResolutionTime] = await umaAdapter.getConditionMetadata(conditionId);
+      expect(description).to.equal("Test condition");
+      expect(expectedResolutionTime).to.be.gt(0);
+    });
+
+    it("Should check canAssert status", async function () {
+      // Before deadline
+      expect(await umaAdapter.canAssert(conditionId)).to.be.false;
+
+      // After deadline
+      await time.increase(TRADING_PERIOD + 1);
+      expect(await umaAdapter.canAssert(conditionId)).to.be.true;
+    });
+
+    it("Should check canSettle status", async function () {
+      await time.increase(TRADING_PERIOD + 1);
+
+      // Before assertion - can't settle
+      expect(await umaAdapter.canSettle(conditionId)).to.be.false;
+
+      // After assertion but before liveness expires
+      await bondToken.connect(asserter).approve(umaAdapter.target, ethers.parseEther("1"));
+      const tx = await umaAdapter.connect(asserter).assertOutcome(conditionId, true);
+      const receipt = await tx.wait();
+
+      // Get assertionId from event
+      const event = receipt.logs.find(log => {
+        try {
+          return umaAdapter.interface.parseLog(log)?.name === "AssertionMade";
+        } catch { return false; }
+      });
+      const assertionId = umaAdapter.interface.parseLog(event).args.assertionId;
+
+      // Still false because UMA oracle hasn't settled yet
+      expect(await umaAdapter.canSettle(conditionId)).to.be.false;
+      expect(await umaAdapter.isConditionResolved(conditionId)).to.be.false;
+
+      // After UMA oracle settles, the callback resolves the condition
+      await time.increase(LIVENESS_PERIOD + 1);
+      await mockUMAOracle.settleAssertion(assertionId);
+
+      // Now it's resolved via callback, canSettle returns false (already resolved)
+      expect(await umaAdapter.canSettle(conditionId)).to.be.false;
+      expect(await umaAdapter.isConditionResolved(conditionId)).to.be.true;
+    });
+  });
+});

--- a/test/FriendGroupMarketFactory.test.js
+++ b/test/FriendGroupMarketFactory.test.js
@@ -620,21 +620,21 @@ describe("FriendGroupMarketFactory", function () {
     });
 
     it("Should allow creator to resolve market", async function () {
+      // Resolution now starts a challenge period (emits ResolutionProposed)
       await expect(
         friendGroupFactory.connect(addr1).resolveFriendMarket(0, true)
-      ).to.emit(friendGroupFactory, "MarketResolved")
-        .withArgs(0, addr1.address, true);
-      
+      ).to.emit(friendGroupFactory, "ResolutionProposed");
+
       const market = await friendGroupFactory.getFriendMarket(0);
       expect(market.active).to.equal(false);
     });
 
     it("Should allow arbitrator to resolve market", async function () {
+      // Resolution now starts a challenge period (emits ResolutionProposed)
       await expect(
         friendGroupFactory.connect(arbitrator).resolveFriendMarket(0, false)
-      ).to.emit(friendGroupFactory, "MarketResolved")
-        .withArgs(0, arbitrator.address, false);
-      
+      ).to.emit(friendGroupFactory, "ResolutionProposed");
+
       const market = await friendGroupFactory.getFriendMarket(0);
       expect(market.active).to.equal(false);
     });

--- a/test/FriendGroupMarketFactory.test.js
+++ b/test/FriendGroupMarketFactory.test.js
@@ -7,7 +7,8 @@ const ResolutionType = {
   Initiator: 1,
   Receiver: 2,
   ThirdParty: 3,
-  AutoPegged: 4
+  AutoPegged: 4,
+  PolymarketOracle: 5
 };
 
 describe("FriendGroupMarketFactory", function () {

--- a/test/OracleRegistry.NetworkAvailability.test.js
+++ b/test/OracleRegistry.NetworkAvailability.test.js
@@ -1,0 +1,264 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+/**
+ * Network Availability Tests for OracleRegistry
+ *
+ * Tests the network-aware oracle functionality:
+ * - isOracleAvailable() for checking oracle deployment status
+ * - getAvailableOracles() for listing usable oracles
+ * - getNetworkOracleStatus() for comprehensive status
+ *
+ * These functions allow applications to detect whether external oracles
+ * (Polymarket, UMA, Chainlink) are available on the current network.
+ */
+describe("OracleRegistry - Network Availability", function () {
+  let oracleRegistry;
+  let mockAdapter1;
+  let mockAdapter2;
+  let mockAdapter3;
+  let owner;
+  let user;
+
+  const ORACLE_ID_1 = ethers.keccak256(ethers.toUtf8Bytes("CHAINLINK"));
+  const ORACLE_ID_2 = ethers.keccak256(ethers.toUtf8Bytes("UMA"));
+  const ORACLE_ID_3 = ethers.keccak256(ethers.toUtf8Bytes("POLYMARKET"));
+
+  beforeEach(async function () {
+    [owner, user] = await ethers.getSigners();
+
+    // Deploy mock adapters
+    const MockOracleAdapter = await ethers.getContractFactory("MockOracleAdapter");
+    mockAdapter1 = await MockOracleAdapter.deploy("Chainlink");
+    mockAdapter2 = await MockOracleAdapter.deploy("UMA");
+    mockAdapter3 = await MockOracleAdapter.deploy("Polymarket");
+
+    // Deploy OracleRegistry
+    const OracleRegistry = await ethers.getContractFactory("OracleRegistry");
+    oracleRegistry = await OracleRegistry.deploy(owner.address);
+  });
+
+  describe("isOracleAvailable", function () {
+    beforeEach(async function () {
+      await oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter1.target);
+      await oracleRegistry.registerAdapter(ORACLE_ID_2, mockAdapter2.target);
+    });
+
+    it("Should return true for available oracle", async function () {
+      // Mock adapter defaults to available
+      expect(await oracleRegistry.isOracleAvailable(ORACLE_ID_1)).to.be.true;
+    });
+
+    it("Should return false for unavailable oracle", async function () {
+      // Set adapter as unavailable
+      await mockAdapter1.setAvailable(false);
+      expect(await oracleRegistry.isOracleAvailable(ORACLE_ID_1)).to.be.false;
+    });
+
+    it("Should return false for unregistered oracle", async function () {
+      expect(await oracleRegistry.isOracleAvailable(ORACLE_ID_3)).to.be.false;
+    });
+
+    it("Should return false for inactive oracle", async function () {
+      await oracleRegistry.setAdapterStatus(mockAdapter1.target, false);
+      expect(await oracleRegistry.isOracleAvailable(ORACLE_ID_1)).to.be.false;
+    });
+  });
+
+  describe("getAvailableOracles", function () {
+    beforeEach(async function () {
+      await oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter1.target);
+      await oracleRegistry.registerAdapter(ORACLE_ID_2, mockAdapter2.target);
+      await oracleRegistry.registerAdapter(ORACLE_ID_3, mockAdapter3.target);
+    });
+
+    it("Should return all available oracles", async function () {
+      const [oracleIds, adapters] = await oracleRegistry.getAvailableOracles();
+
+      expect(oracleIds.length).to.equal(3);
+      expect(adapters.length).to.equal(3);
+      expect(oracleIds).to.include(ORACLE_ID_1);
+      expect(oracleIds).to.include(ORACLE_ID_2);
+      expect(oracleIds).to.include(ORACLE_ID_3);
+    });
+
+    it("Should exclude unavailable oracles", async function () {
+      await mockAdapter1.setAvailable(false);
+      await mockAdapter3.setAvailable(false);
+
+      const [oracleIds, adapters] = await oracleRegistry.getAvailableOracles();
+
+      expect(oracleIds.length).to.equal(1);
+      expect(oracleIds[0]).to.equal(ORACLE_ID_2);
+      expect(adapters[0]).to.equal(mockAdapter2.target);
+    });
+
+    it("Should exclude inactive oracles", async function () {
+      await oracleRegistry.setAdapterStatus(mockAdapter2.target, false);
+
+      const [oracleIds, adapters] = await oracleRegistry.getAvailableOracles();
+
+      expect(oracleIds.length).to.equal(2);
+      expect(oracleIds).to.not.include(ORACLE_ID_2);
+    });
+
+    it("Should return empty arrays when no oracles available", async function () {
+      await mockAdapter1.setAvailable(false);
+      await mockAdapter2.setAvailable(false);
+      await mockAdapter3.setAvailable(false);
+
+      const [oracleIds, adapters] = await oracleRegistry.getAvailableOracles();
+
+      expect(oracleIds.length).to.equal(0);
+      expect(adapters.length).to.equal(0);
+    });
+  });
+
+  describe("getNetworkOracleStatus", function () {
+    beforeEach(async function () {
+      await oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter1.target);
+      await oracleRegistry.registerAdapter(ORACLE_ID_2, mockAdapter2.target);
+    });
+
+    it("Should return status for all registered oracles", async function () {
+      const [oracleIds, oracleTypes, availabilities, chainIds] =
+        await oracleRegistry.getNetworkOracleStatus();
+
+      expect(oracleIds.length).to.equal(2);
+      expect(oracleTypes[0]).to.equal("Chainlink");
+      expect(oracleTypes[1]).to.equal("UMA");
+      expect(availabilities[0]).to.be.true;
+      expect(availabilities[1]).to.be.true;
+    });
+
+    it("Should reflect availability changes", async function () {
+      await mockAdapter1.setAvailable(false);
+
+      const [, , availabilities, ] =
+        await oracleRegistry.getNetworkOracleStatus();
+
+      expect(availabilities[0]).to.be.false;
+      expect(availabilities[1]).to.be.true;
+    });
+
+    it("Should return chain IDs", async function () {
+      const expectedChainId = 1337n; // Hardhat default
+
+      const [, , , chainIds] = await oracleRegistry.getNetworkOracleStatus();
+
+      expect(chainIds[0]).to.equal(expectedChainId);
+      expect(chainIds[1]).to.equal(expectedChainId);
+    });
+
+    it("Should handle custom chain IDs", async function () {
+      await mockAdapter1.setChainId(137); // Polygon
+      await mockAdapter2.setChainId(1); // Mainnet
+
+      const [, , , chainIds] = await oracleRegistry.getNetworkOracleStatus();
+
+      expect(chainIds[0]).to.equal(137n);
+      expect(chainIds[1]).to.equal(1n);
+    });
+  });
+
+  describe("resolveConditionIfAvailable", function () {
+    let conditionId;
+
+    beforeEach(async function () {
+      await oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter1.target);
+      conditionId = ethers.keccak256(ethers.toUtf8Bytes("test-condition"));
+
+      // Set up condition
+      await mockAdapter1.setConditionSupported(conditionId, true);
+      await mockAdapter1.setOutcome(conditionId, true, 10000, Date.now());
+    });
+
+    it("Should resolve when oracle is available", async function () {
+      const [outcome, confidence] =
+        await oracleRegistry.resolveConditionIfAvailable(ORACLE_ID_1, conditionId);
+
+      expect(outcome).to.be.true;
+      expect(confidence).to.equal(10000);
+    });
+
+    it("Should revert when oracle is unavailable", async function () {
+      await mockAdapter1.setAvailable(false);
+
+      await expect(
+        oracleRegistry.resolveConditionIfAvailable(ORACLE_ID_1, conditionId)
+      ).to.be.revertedWithCustomError(oracleRegistry, "OracleNotAvailable");
+    });
+
+    it("Should revert when condition not resolved", async function () {
+      await mockAdapter1.setConditionResolved(conditionId, false);
+
+      await expect(
+        oracleRegistry.resolveConditionIfAvailable(ORACLE_ID_1, conditionId)
+      ).to.be.revertedWithCustomError(oracleRegistry, "ConditionNotResolved");
+    });
+
+    it("Should revert for unregistered adapter", async function () {
+      await expect(
+        oracleRegistry.resolveConditionIfAvailable(ORACLE_ID_2, conditionId)
+      ).to.be.revertedWithCustomError(oracleRegistry, "AdapterNotRegistered");
+    });
+  });
+
+  describe("Mordor Testnet Simulation", function () {
+    it("Should correctly identify unavailable external oracles", async function () {
+      // Simulate Mordor deployment where external oracles aren't available
+      await oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter1.target);
+      await oracleRegistry.registerAdapter(ORACLE_ID_2, mockAdapter2.target);
+      await oracleRegistry.registerAdapter(ORACLE_ID_3, mockAdapter3.target);
+
+      // Mark UMA and Polymarket as unavailable (not deployed on Mordor)
+      await mockAdapter2.setAvailable(false);
+      await mockAdapter3.setAvailable(false);
+
+      // Check availability
+      expect(await oracleRegistry.isOracleAvailable(ORACLE_ID_1)).to.be.true;
+      expect(await oracleRegistry.isOracleAvailable(ORACLE_ID_2)).to.be.false;
+      expect(await oracleRegistry.isOracleAvailable(ORACLE_ID_3)).to.be.false;
+
+      // Get only available oracles
+      const [availableIds, ] = await oracleRegistry.getAvailableOracles();
+      expect(availableIds.length).to.equal(1);
+      expect(availableIds[0]).to.equal(ORACLE_ID_1);
+    });
+
+    it("Should provide full status for UI display", async function () {
+      await oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter1.target);
+      await oracleRegistry.registerAdapter(ORACLE_ID_2, mockAdapter2.target);
+      await oracleRegistry.registerAdapter(ORACLE_ID_3, mockAdapter3.target);
+
+      // Simulate Mordor state
+      await mockAdapter1.setAvailable(true);   // Mock adapter works
+      await mockAdapter2.setAvailable(false);  // UMA not on Mordor
+      await mockAdapter3.setAvailable(false);  // Polymarket not on Mordor
+
+      const [oracleIds, oracleTypes, availabilities, chainIds] =
+        await oracleRegistry.getNetworkOracleStatus();
+
+      // Application can use this to show:
+      // - Chainlink: Available
+      // - UMA: Not available on this network
+      // - Polymarket: Not available on this network
+      expect(availabilities[0]).to.be.true;
+      expect(availabilities[1]).to.be.false;
+      expect(availabilities[2]).to.be.false;
+    });
+  });
+
+  describe("Adapter Interface", function () {
+    it("MockOracleAdapter should implement isAvailable()", async function () {
+      expect(await mockAdapter1.isAvailable()).to.be.true;
+      await mockAdapter1.setAvailable(false);
+      expect(await mockAdapter1.isAvailable()).to.be.false;
+    });
+
+    it("MockOracleAdapter should implement getConfiguredChainId()", async function () {
+      const chainId = await mockAdapter1.getConfiguredChainId();
+      expect(chainId).to.equal(1337n); // Hardhat default
+    });
+  });
+});

--- a/test/OracleRegistry.test.js
+++ b/test/OracleRegistry.test.js
@@ -1,0 +1,312 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("OracleRegistry", function () {
+  let oracleRegistry;
+  let mockAdapter1;
+  let mockAdapter2;
+  let owner;
+  let user1;
+  let user2;
+
+  const ORACLE_ID_1 = ethers.keccak256(ethers.toUtf8Bytes("POLYMARKET"));
+  const ORACLE_ID_2 = ethers.keccak256(ethers.toUtf8Bytes("CHAINLINK"));
+  const ORACLE_ID_3 = ethers.keccak256(ethers.toUtf8Bytes("UMA"));
+  const CONDITION_ID = ethers.keccak256(ethers.toUtf8Bytes("test-condition"));
+
+  beforeEach(async function () {
+    [owner, user1, user2] = await ethers.getSigners();
+
+    // Deploy mock adapters
+    const MockOracleAdapter = await ethers.getContractFactory("MockOracleAdapter");
+    mockAdapter1 = await MockOracleAdapter.deploy("Polymarket");
+    mockAdapter2 = await MockOracleAdapter.deploy("Chainlink");
+
+    // Deploy OracleRegistry
+    const OracleRegistry = await ethers.getContractFactory("OracleRegistry");
+    oracleRegistry = await OracleRegistry.deploy(owner.address);
+  });
+
+  describe("Constructor", function () {
+    it("Should set the owner correctly", async function () {
+      expect(await oracleRegistry.owner()).to.equal(owner.address);
+    });
+
+    it("Should start with no registered adapters", async function () {
+      expect(await oracleRegistry.getAdapterCount()).to.equal(0);
+    });
+  });
+
+  describe("registerAdapter", function () {
+    it("Should register an adapter successfully", async function () {
+      await expect(oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter1.target))
+        .to.emit(oracleRegistry, "AdapterRegistered")
+        .withArgs(ORACLE_ID_1, mockAdapter1.target, "Polymarket");
+
+      expect(await oracleRegistry.getAdapter(ORACLE_ID_1)).to.equal(mockAdapter1.target);
+      expect(await oracleRegistry.getAdapterCount()).to.equal(1);
+    });
+
+    it("Should mark adapter as active after registration", async function () {
+      await oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter1.target);
+      expect(await oracleRegistry.isAdapterActive(ORACLE_ID_1)).to.be.true;
+    });
+
+    it("Should revert when registering zero address", async function () {
+      await expect(
+        oracleRegistry.registerAdapter(ORACLE_ID_1, ethers.ZeroAddress)
+      ).to.be.revertedWithCustomError(oracleRegistry, "InvalidAdapter");
+    });
+
+    it("Should revert when registering duplicate oracle ID", async function () {
+      await oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter1.target);
+      await expect(
+        oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter2.target)
+      ).to.be.revertedWithCustomError(oracleRegistry, "AdapterAlreadyRegistered");
+    });
+
+    it("Should only allow owner to register adapters", async function () {
+      await expect(
+        oracleRegistry.connect(user1).registerAdapter(ORACLE_ID_1, mockAdapter1.target)
+      ).to.be.revertedWithCustomError(oracleRegistry, "OwnableUnauthorizedAccount");
+    });
+
+    it("Should allow registering multiple adapters", async function () {
+      await oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter1.target);
+      await oracleRegistry.registerAdapter(ORACLE_ID_2, mockAdapter2.target);
+
+      expect(await oracleRegistry.getAdapterCount()).to.equal(2);
+      expect(await oracleRegistry.getAdapter(ORACLE_ID_1)).to.equal(mockAdapter1.target);
+      expect(await oracleRegistry.getAdapter(ORACLE_ID_2)).to.equal(mockAdapter2.target);
+    });
+  });
+
+  describe("removeAdapter", function () {
+    beforeEach(async function () {
+      await oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter1.target);
+      await oracleRegistry.registerAdapter(ORACLE_ID_2, mockAdapter2.target);
+    });
+
+    it("Should remove an adapter successfully", async function () {
+      await expect(oracleRegistry.removeAdapter(ORACLE_ID_1))
+        .to.emit(oracleRegistry, "AdapterRemoved")
+        .withArgs(ORACLE_ID_1, mockAdapter1.target);
+
+      expect(await oracleRegistry.getAdapter(ORACLE_ID_1)).to.equal(ethers.ZeroAddress);
+      expect(await oracleRegistry.getAdapterCount()).to.equal(1);
+    });
+
+    it("Should revert when removing non-existent adapter", async function () {
+      await expect(
+        oracleRegistry.removeAdapter(ORACLE_ID_3)
+      ).to.be.revertedWithCustomError(oracleRegistry, "AdapterNotRegistered");
+    });
+
+    it("Should only allow owner to remove adapters", async function () {
+      await expect(
+        oracleRegistry.connect(user1).removeAdapter(ORACLE_ID_1)
+      ).to.be.revertedWithCustomError(oracleRegistry, "OwnableUnauthorizedAccount");
+    });
+
+    it("Should handle removing first adapter correctly", async function () {
+      await oracleRegistry.removeAdapter(ORACLE_ID_1);
+      expect(await oracleRegistry.getAdapterCount()).to.equal(1);
+      expect(await oracleRegistry.isAdapterActive(ORACLE_ID_1)).to.be.false;
+      expect(await oracleRegistry.isAdapterActive(ORACLE_ID_2)).to.be.true;
+    });
+
+    it("Should handle removing last adapter correctly", async function () {
+      await oracleRegistry.removeAdapter(ORACLE_ID_2);
+      expect(await oracleRegistry.getAdapterCount()).to.equal(1);
+      expect(await oracleRegistry.isAdapterActive(ORACLE_ID_1)).to.be.true;
+      expect(await oracleRegistry.isAdapterActive(ORACLE_ID_2)).to.be.false;
+    });
+  });
+
+  describe("verifyAdapter", function () {
+    beforeEach(async function () {
+      await oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter1.target);
+    });
+
+    it("Should verify an adapter", async function () {
+      await expect(oracleRegistry.verifyAdapter(mockAdapter1.target, true))
+        .to.emit(oracleRegistry, "AdapterVerified")
+        .withArgs(mockAdapter1.target, true);
+
+      expect(await oracleRegistry.isAdapterVerified(ORACLE_ID_1)).to.be.true;
+    });
+
+    it("Should unverify an adapter", async function () {
+      await oracleRegistry.verifyAdapter(mockAdapter1.target, true);
+      await oracleRegistry.verifyAdapter(mockAdapter1.target, false);
+      expect(await oracleRegistry.isAdapterVerified(ORACLE_ID_1)).to.be.false;
+    });
+
+    it("Should revert when verifying zero address", async function () {
+      await expect(
+        oracleRegistry.verifyAdapter(ethers.ZeroAddress, true)
+      ).to.be.revertedWithCustomError(oracleRegistry, "InvalidAdapter");
+    });
+
+    it("Should only allow owner to verify adapters", async function () {
+      await expect(
+        oracleRegistry.connect(user1).verifyAdapter(mockAdapter1.target, true)
+      ).to.be.revertedWithCustomError(oracleRegistry, "OwnableUnauthorizedAccount");
+    });
+  });
+
+  describe("setAdapterStatus", function () {
+    beforeEach(async function () {
+      await oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter1.target);
+    });
+
+    it("Should deactivate an adapter", async function () {
+      await expect(oracleRegistry.setAdapterStatus(mockAdapter1.target, false))
+        .to.emit(oracleRegistry, "AdapterStatusChanged")
+        .withArgs(mockAdapter1.target, false);
+
+      expect(await oracleRegistry.isAdapterActive(ORACLE_ID_1)).to.be.false;
+    });
+
+    it("Should reactivate an adapter", async function () {
+      await oracleRegistry.setAdapterStatus(mockAdapter1.target, false);
+      await oracleRegistry.setAdapterStatus(mockAdapter1.target, true);
+      expect(await oracleRegistry.isAdapterActive(ORACLE_ID_1)).to.be.true;
+    });
+
+    it("Should revert when setting status for zero address", async function () {
+      await expect(
+        oracleRegistry.setAdapterStatus(ethers.ZeroAddress, true)
+      ).to.be.revertedWithCustomError(oracleRegistry, "InvalidAdapter");
+    });
+
+    it("Should only allow owner to set adapter status", async function () {
+      await expect(
+        oracleRegistry.connect(user1).setAdapterStatus(mockAdapter1.target, false)
+      ).to.be.revertedWithCustomError(oracleRegistry, "OwnableUnauthorizedAccount");
+    });
+  });
+
+  describe("getAdapterInfo", function () {
+    beforeEach(async function () {
+      await oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter1.target);
+    });
+
+    it("Should return adapter info for registered adapter", async function () {
+      const [adapter, oracleType, isVerified, isActive] =
+        await oracleRegistry.getAdapterInfo(ORACLE_ID_1);
+
+      expect(adapter).to.equal(mockAdapter1.target);
+      expect(oracleType).to.equal("Polymarket");
+      expect(isVerified).to.be.false;
+      expect(isActive).to.be.true;
+    });
+
+    it("Should return empty info for non-existent oracle ID", async function () {
+      const [adapter, oracleType, isVerified, isActive] =
+        await oracleRegistry.getAdapterInfo(ORACLE_ID_3);
+
+      expect(adapter).to.equal(ethers.ZeroAddress);
+      expect(oracleType).to.equal("");
+      expect(isVerified).to.be.false;
+      expect(isActive).to.be.false;
+    });
+
+    it("Should reflect verification status", async function () {
+      await oracleRegistry.verifyAdapter(mockAdapter1.target, true);
+      const [, , isVerified] = await oracleRegistry.getAdapterInfo(ORACLE_ID_1);
+      expect(isVerified).to.be.true;
+    });
+
+    it("Should reflect active status", async function () {
+      await oracleRegistry.setAdapterStatus(mockAdapter1.target, false);
+      const [, , , isActive] = await oracleRegistry.getAdapterInfo(ORACLE_ID_1);
+      expect(isActive).to.be.false;
+    });
+  });
+
+  describe("getRegisteredOracleIds", function () {
+    it("Should return empty array when no adapters registered", async function () {
+      const ids = await oracleRegistry.getRegisteredOracleIds();
+      expect(ids.length).to.equal(0);
+    });
+
+    it("Should return all registered oracle IDs", async function () {
+      await oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter1.target);
+      await oracleRegistry.registerAdapter(ORACLE_ID_2, mockAdapter2.target);
+
+      const ids = await oracleRegistry.getRegisteredOracleIds();
+      expect(ids.length).to.equal(2);
+      expect(ids).to.include(ORACLE_ID_1);
+      expect(ids).to.include(ORACLE_ID_2);
+    });
+  });
+
+  describe("resolveCondition", function () {
+    beforeEach(async function () {
+      await oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter1.target);
+      // Set up mock adapter to support and resolve condition
+      await mockAdapter1.setConditionSupported(CONDITION_ID, true);
+      await mockAdapter1.setConditionResolved(CONDITION_ID, true);
+      await mockAdapter1.setOutcome(CONDITION_ID, true, 10000, Math.floor(Date.now() / 1000));
+    });
+
+    it("Should resolve condition through registry", async function () {
+      const [outcome, confidence] = await oracleRegistry.resolveCondition(ORACLE_ID_1, CONDITION_ID);
+      expect(outcome).to.be.true;
+      expect(confidence).to.equal(10000);
+    });
+
+    it("Should revert for non-existent oracle ID", async function () {
+      await expect(
+        oracleRegistry.resolveCondition(ORACLE_ID_3, CONDITION_ID)
+      ).to.be.revertedWithCustomError(oracleRegistry, "AdapterNotRegistered");
+    });
+
+    it("Should revert for inactive adapter", async function () {
+      await oracleRegistry.setAdapterStatus(mockAdapter1.target, false);
+      await expect(
+        oracleRegistry.resolveCondition(ORACLE_ID_1, CONDITION_ID)
+      ).to.be.revertedWithCustomError(oracleRegistry, "AdapterNotRegistered");
+    });
+
+    it("Should revert for unresolved condition", async function () {
+      await mockAdapter1.setConditionResolved(CONDITION_ID, false);
+      await expect(
+        oracleRegistry.resolveCondition(ORACLE_ID_1, CONDITION_ID)
+      ).to.be.revertedWithCustomError(oracleRegistry, "ConditionNotResolved");
+    });
+  });
+
+  describe("findAdaptersForCondition", function () {
+    beforeEach(async function () {
+      await oracleRegistry.registerAdapter(ORACLE_ID_1, mockAdapter1.target);
+      await oracleRegistry.registerAdapter(ORACLE_ID_2, mockAdapter2.target);
+    });
+
+    it("Should find all adapters that support a condition", async function () {
+      await mockAdapter1.setConditionSupported(CONDITION_ID, true);
+      await mockAdapter2.setConditionSupported(CONDITION_ID, true);
+
+      const adapters = await oracleRegistry.findAdaptersForCondition(CONDITION_ID);
+      expect(adapters.length).to.equal(2);
+      expect(adapters).to.include(mockAdapter1.target);
+      expect(adapters).to.include(mockAdapter2.target);
+    });
+
+    it("Should only return active adapters", async function () {
+      await mockAdapter1.setConditionSupported(CONDITION_ID, true);
+      await mockAdapter2.setConditionSupported(CONDITION_ID, true);
+      await oracleRegistry.setAdapterStatus(mockAdapter1.target, false);
+
+      const adapters = await oracleRegistry.findAdaptersForCondition(CONDITION_ID);
+      expect(adapters.length).to.equal(1);
+      expect(adapters[0]).to.equal(mockAdapter2.target);
+    });
+
+    it("Should return empty array when no adapters support condition", async function () {
+      const adapters = await oracleRegistry.findAdaptersForCondition(CONDITION_ID);
+      expect(adapters.length).to.equal(0);
+    });
+  });
+});

--- a/test/PolymarketOracleAdapter.test.js
+++ b/test/PolymarketOracleAdapter.test.js
@@ -583,7 +583,7 @@ describe("FriendGroupMarketFactory - Polymarket Integration", function () {
       await friendGroupFactory.connect(addr2).resolveFromPolymarket(marketId);
 
       const marketStatus = await friendGroupFactory.getFriendMarketWithStatus(marketId);
-      expect(marketStatus.status).to.equal(2); // FriendMarketStatus.Resolved = 2
+      expect(marketStatus.status).to.equal(4); // FriendMarketStatus.Resolved = 4 (after PendingResolution, Challenged)
     });
 
     it("Should emit PolymarketMarketResolved event", async function () {
@@ -677,8 +677,8 @@ describe("FriendGroupMarketFactory - Polymarket Integration", function () {
       const market0 = await friendGroupFactory.getFriendMarketWithStatus(0);
       const market1 = await friendGroupFactory.getFriendMarketWithStatus(1);
 
-      expect(market0.status).to.equal(2); // FriendMarketStatus.Resolved = 2
-      expect(market1.status).to.equal(2); // FriendMarketStatus.Resolved = 2
+      expect(market0.status).to.equal(4); // FriendMarketStatus.Resolved = 4
+      expect(market1.status).to.equal(4); // FriendMarketStatus.Resolved = 4
     });
 
     it("Should return list of friend markets for Polymarket condition", async function () {

--- a/test/PolymarketOracleAdapter.test.js
+++ b/test/PolymarketOracleAdapter.test.js
@@ -1,0 +1,705 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+// Resolution type enum (matches contract)
+const ResolutionType = {
+  Either: 0,
+  Initiator: 1,
+  Receiver: 2,
+  ThirdParty: 3,
+  AutoPegged: 4,
+  PolymarketOracle: 5
+};
+
+describe("PolymarketOracleAdapter", function () {
+  let polymarketAdapter;
+  let mockCTF;
+  let friendGroupFactory;
+  let marketFactory;
+  let ragequitModule;
+  let tieredRoleManager;
+  let paymentManager;
+  let collateralToken;
+  let ctf1155;
+  let owner;
+  let addr1;
+  let addr2;
+  let arbitrator;
+
+  // Test condition parameters
+  const testOracle = "0x0000000000000000000000000000000000000001";
+  const testQuestionId = ethers.keccak256(ethers.toUtf8Bytes("Will ETH reach 5000 by end of 2024?"));
+  const outcomeSlotCount = 2; // Binary outcome
+  let testConditionId;
+
+  beforeEach(async function () {
+    [owner, addr1, addr2, arbitrator] = await ethers.getSigners();
+
+    // Deploy MockPolymarketCTF (simulates Polymarket's CTF contract)
+    const MockPolymarketCTF = await ethers.getContractFactory("MockPolymarketCTF");
+    mockCTF = await MockPolymarketCTF.deploy();
+    await mockCTF.waitForDeployment();
+
+    // Compute test condition ID
+    testConditionId = ethers.keccak256(
+      ethers.solidityPacked(
+        ["address", "bytes32", "uint256"],
+        [testOracle, testQuestionId, outcomeSlotCount]
+      )
+    );
+
+    // Deploy PolymarketOracleAdapter
+    const PolymarketOracleAdapter = await ethers.getContractFactory("PolymarketOracleAdapter");
+    polymarketAdapter = await PolymarketOracleAdapter.deploy(await mockCTF.getAddress());
+    await polymarketAdapter.waitForDeployment();
+
+    // Deploy CTF1155 for our system
+    const CTF1155 = await ethers.getContractFactory("CTF1155");
+    ctf1155 = await CTF1155.deploy();
+    await ctf1155.waitForDeployment();
+
+    // Deploy mock collateral token
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    collateralToken = await MockERC20.deploy("Market Collateral", "MCOL", ethers.parseEther("10000000"));
+    await collateralToken.waitForDeployment();
+
+    // Deploy ConditionalMarketFactory
+    const ConditionalMarketFactory = await ethers.getContractFactory("ConditionalMarketFactory");
+    marketFactory = await ConditionalMarketFactory.deploy();
+    await marketFactory.initialize(owner.address);
+    await marketFactory.setCTF1155(await ctf1155.getAddress());
+
+    // Deploy RagequitModule
+    const RagequitModule = await ethers.getContractFactory("RagequitModule");
+    ragequitModule = await RagequitModule.deploy();
+
+    // Deploy TieredRoleManager
+    const TieredRoleManager = await ethers.getContractFactory("TieredRoleManager");
+    tieredRoleManager = await TieredRoleManager.deploy();
+    await tieredRoleManager.waitForDeployment();
+    await tieredRoleManager.initializeRoleMetadata();
+
+    // Setup FRIEND_MARKET_ROLE
+    const FRIEND_MARKET_ROLE = ethers.id("FRIEND_MARKET_ROLE");
+    const MembershipTier = { NONE: 0, BRONZE: 1, SILVER: 2, GOLD: 3, PLATINUM: 4 };
+
+    await tieredRoleManager.setTierMetadata(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      "Friend Market Bronze",
+      "Basic friend market tier",
+      ethers.parseEther("0.1"),
+      {
+        dailyBetLimit: 10,
+        weeklyBetLimit: 50,
+        monthlyMarketCreation: 5,
+        maxPositionSize: ethers.parseEther("10"),
+        maxConcurrentMarkets: 3,
+        withdrawalLimit: ethers.parseEther("100"),
+        canCreatePrivateMarkets: false,
+        canUseAdvancedFeatures: false,
+        feeDiscount: 0
+      },
+      true
+    );
+
+    const tierMeta = await tieredRoleManager.tierMetadata(FRIEND_MARKET_ROLE, MembershipTier.BRONZE);
+    const price = tierMeta.price;
+
+    // Deploy MembershipPaymentManager
+    const MembershipPaymentManager = await ethers.getContractFactory("MembershipPaymentManager");
+    paymentManager = await MembershipPaymentManager.deploy(owner.address);
+    await paymentManager.waitForDeployment();
+
+    // Deploy FriendGroupMarketFactory
+    const FriendGroupMarketFactory = await ethers.getContractFactory("FriendGroupMarketFactory");
+    friendGroupFactory = await FriendGroupMarketFactory.deploy(
+      await marketFactory.getAddress(),
+      await ragequitModule.getAddress(),
+      await tieredRoleManager.getAddress(),
+      await paymentManager.getAddress(),
+      owner.address
+    );
+    await friendGroupFactory.waitForDeployment();
+
+    // Set collateral token and Polymarket adapter
+    await friendGroupFactory.setDefaultCollateralToken(await collateralToken.getAddress());
+    await friendGroupFactory.setPolymarketAdapter(await polymarketAdapter.getAddress());
+
+    // Purchase memberships for test users
+    const durDays = 36500;
+    await tieredRoleManager.connect(owner).purchaseRoleWithTier(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      durDays,
+      { value: price }
+    );
+    await tieredRoleManager.connect(addr1).purchaseRoleWithTier(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      durDays,
+      { value: price }
+    );
+    await tieredRoleManager.connect(addr2).purchaseRoleWithTier(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      durDays,
+      { value: price }
+    );
+
+    // Transfer ownership of marketFactory to friendGroupFactory
+    await marketFactory.transferOwnership(await friendGroupFactory.getAddress());
+  });
+
+  describe("PolymarketOracleAdapter Deployment", function () {
+    it("Should set the primary CTF contract", async function () {
+      expect(await polymarketAdapter.polymarketCTF()).to.equal(await mockCTF.getAddress());
+    });
+
+    it("Should mark the primary CTF as supported", async function () {
+      expect(await polymarketAdapter.supportedCTFContracts(await mockCTF.getAddress())).to.be.true;
+    });
+
+    it("Should revert with InvalidAddress for zero address CTF", async function () {
+      const PolymarketOracleAdapter = await ethers.getContractFactory("PolymarketOracleAdapter");
+      await expect(
+        PolymarketOracleAdapter.deploy(ethers.ZeroAddress)
+      ).to.be.revertedWithCustomError(polymarketAdapter, "InvalidAddress");
+    });
+  });
+
+  describe("CTF Contract Management", function () {
+    it("Should add a new CTF contract", async function () {
+      const newCTF = addr1.address; // Using as mock address
+      await polymarketAdapter.addCTFContract(newCTF);
+      expect(await polymarketAdapter.supportedCTFContracts(newCTF)).to.be.true;
+    });
+
+    it("Should remove a CTF contract", async function () {
+      const newCTF = addr1.address;
+      await polymarketAdapter.addCTFContract(newCTF);
+      await polymarketAdapter.removeCTFContract(newCTF);
+      expect(await polymarketAdapter.supportedCTFContracts(newCTF)).to.be.false;
+    });
+
+    it("Should update primary CTF", async function () {
+      const newCTF = addr1.address;
+      await polymarketAdapter.updatePrimaryCTF(newCTF);
+      expect(await polymarketAdapter.polymarketCTF()).to.equal(newCTF);
+      expect(await polymarketAdapter.supportedCTFContracts(newCTF)).to.be.true;
+    });
+
+    it("Should revert on non-owner operations", async function () {
+      await expect(
+        polymarketAdapter.connect(addr1).addCTFContract(addr2.address)
+      ).to.be.revertedWithCustomError(polymarketAdapter, "OwnableUnauthorizedAccount");
+    });
+  });
+
+  describe("Market Linking", function () {
+    beforeEach(async function () {
+      // Prepare condition on mock CTF
+      await mockCTF.prepareCondition(testOracle, testQuestionId, outcomeSlotCount);
+    });
+
+    it("Should link a market to Polymarket condition", async function () {
+      await polymarketAdapter.linkMarketToPolymarket(0, testConditionId);
+
+      const linkedMarket = await polymarketAdapter.getLinkedMarket(0);
+      expect(linkedMarket.conditionId).to.equal(testConditionId);
+      expect(linkedMarket.linked).to.be.true;
+    });
+
+    it("Should emit MarketLinkedToPolymarket event", async function () {
+      await expect(polymarketAdapter.linkMarketToPolymarket(0, testConditionId))
+        .to.emit(polymarketAdapter, "MarketLinkedToPolymarket")
+        .withArgs(0, testConditionId, await mockCTF.getAddress());
+    });
+
+    it("Should revert when linking twice", async function () {
+      await polymarketAdapter.linkMarketToPolymarket(0, testConditionId);
+      await expect(
+        polymarketAdapter.linkMarketToPolymarket(0, testConditionId)
+      ).to.be.revertedWithCustomError(polymarketAdapter, "MarketAlreadyLinked");
+    });
+
+    it("Should revert with invalid condition ID (zero)", async function () {
+      await expect(
+        polymarketAdapter.linkMarketToPolymarket(0, ethers.ZeroHash)
+      ).to.be.revertedWithCustomError(polymarketAdapter, "InvalidConditionId");
+    });
+
+    it("Should revert with non-existent condition", async function () {
+      const fakeConditionId = ethers.keccak256(ethers.toUtf8Bytes("fake"));
+      await expect(
+        polymarketAdapter.linkMarketToPolymarket(0, fakeConditionId)
+      ).to.be.revertedWithCustomError(polymarketAdapter, "InvalidConditionId");
+    });
+  });
+
+  describe("Resolution Fetching", function () {
+    beforeEach(async function () {
+      // Prepare and resolve condition on mock CTF
+      await mockCTF.prepareCondition(testOracle, testQuestionId, outcomeSlotCount);
+    });
+
+    it("Should fetch resolution when condition is resolved (YES wins)", async function () {
+      // Resolve with YES winning ([1, 0])
+      await mockCTF.resolveCondition(testConditionId, [1, 0]);
+
+      const [passNum, failNum, denom] = await polymarketAdapter.fetchResolution.staticCall(testConditionId);
+      expect(passNum).to.equal(1);
+      expect(failNum).to.equal(0);
+      expect(denom).to.equal(1);
+    });
+
+    it("Should fetch resolution when condition is resolved (NO wins)", async function () {
+      // Resolve with NO winning ([0, 1])
+      await mockCTF.resolveCondition(testConditionId, [0, 1]);
+
+      const [passNum, failNum, denom] = await polymarketAdapter.fetchResolution.staticCall(testConditionId);
+      expect(passNum).to.equal(0);
+      expect(failNum).to.equal(1);
+      expect(denom).to.equal(1);
+    });
+
+    it("Should cache resolution data", async function () {
+      await mockCTF.resolveCondition(testConditionId, [1, 0]);
+      await polymarketAdapter.fetchResolution(testConditionId);
+
+      const cached = await polymarketAdapter.getCachedResolution(testConditionId);
+      expect(cached.resolved).to.be.true;
+      expect(cached.passNumerator).to.equal(1);
+      expect(cached.failNumerator).to.equal(0);
+    });
+
+    it("Should revert when condition is not resolved", async function () {
+      await expect(
+        polymarketAdapter.fetchResolution(testConditionId)
+      ).to.be.revertedWithCustomError(polymarketAdapter, "ConditionNotResolved");
+    });
+
+    it("Should emit ResolutionFetched event", async function () {
+      await mockCTF.resolveCondition(testConditionId, [1, 0]);
+
+      await expect(polymarketAdapter.fetchResolution(testConditionId))
+        .to.emit(polymarketAdapter, "ResolutionFetched")
+        .withArgs(testConditionId, 1, 0, 1);
+    });
+  });
+
+  describe("Condition ID Computation", function () {
+    it("Should compute correct condition ID", async function () {
+      const computed = await polymarketAdapter.computeConditionId(
+        testOracle,
+        testQuestionId,
+        outcomeSlotCount
+      );
+      expect(computed).to.equal(testConditionId);
+    });
+  });
+
+  describe("Outcome Determination", function () {
+    it("Should determine YES/PASS as winner", async function () {
+      const [outcome, isTie] = await polymarketAdapter.determineOutcome(1, 0);
+      expect(outcome).to.be.true;
+      expect(isTie).to.be.false;
+    });
+
+    it("Should determine NO/FAIL as winner", async function () {
+      const [outcome, isTie] = await polymarketAdapter.determineOutcome(0, 1);
+      expect(outcome).to.be.false;
+      expect(isTie).to.be.false;
+    });
+
+    it("Should detect tie", async function () {
+      const [outcome, isTie] = await polymarketAdapter.determineOutcome(1, 1);
+      expect(isTie).to.be.true;
+    });
+  });
+});
+
+describe("FriendGroupMarketFactory - Polymarket Integration", function () {
+  let polymarketAdapter;
+  let mockCTF;
+  let friendGroupFactory;
+  let marketFactory;
+  let ragequitModule;
+  let tieredRoleManager;
+  let paymentManager;
+  let collateralToken;
+  let ctf1155;
+  let owner;
+  let addr1;
+  let addr2;
+  let arbitrator;
+
+  const testOracle = "0x0000000000000000000000000000000000000001";
+  const testQuestionId = ethers.keccak256(ethers.toUtf8Bytes("Will ETH reach 5000 by end of 2024?"));
+  const outcomeSlotCount = 2;
+  let testConditionId;
+
+  beforeEach(async function () {
+    [owner, addr1, addr2, arbitrator] = await ethers.getSigners();
+
+    // Deploy MockPolymarketCTF
+    const MockPolymarketCTF = await ethers.getContractFactory("MockPolymarketCTF");
+    mockCTF = await MockPolymarketCTF.deploy();
+    await mockCTF.waitForDeployment();
+
+    // Compute test condition ID
+    testConditionId = ethers.keccak256(
+      ethers.solidityPacked(
+        ["address", "bytes32", "uint256"],
+        [testOracle, testQuestionId, outcomeSlotCount]
+      )
+    );
+
+    // Prepare condition on mock CTF
+    await mockCTF.prepareCondition(testOracle, testQuestionId, outcomeSlotCount);
+
+    // Deploy PolymarketOracleAdapter
+    const PolymarketOracleAdapter = await ethers.getContractFactory("PolymarketOracleAdapter");
+    polymarketAdapter = await PolymarketOracleAdapter.deploy(await mockCTF.getAddress());
+    await polymarketAdapter.waitForDeployment();
+
+    // Deploy CTF1155
+    const CTF1155 = await ethers.getContractFactory("CTF1155");
+    ctf1155 = await CTF1155.deploy();
+    await ctf1155.waitForDeployment();
+
+    // Deploy mock collateral token
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    collateralToken = await MockERC20.deploy("Market Collateral", "MCOL", ethers.parseEther("10000000"));
+    await collateralToken.waitForDeployment();
+
+    // Deploy ConditionalMarketFactory
+    const ConditionalMarketFactory = await ethers.getContractFactory("ConditionalMarketFactory");
+    marketFactory = await ConditionalMarketFactory.deploy();
+    await marketFactory.initialize(owner.address);
+    await marketFactory.setCTF1155(await ctf1155.getAddress());
+
+    // Deploy RagequitModule
+    const RagequitModule = await ethers.getContractFactory("RagequitModule");
+    ragequitModule = await RagequitModule.deploy();
+
+    // Deploy TieredRoleManager
+    const TieredRoleManager = await ethers.getContractFactory("TieredRoleManager");
+    tieredRoleManager = await TieredRoleManager.deploy();
+    await tieredRoleManager.waitForDeployment();
+    await tieredRoleManager.initializeRoleMetadata();
+
+    // Setup FRIEND_MARKET_ROLE
+    const FRIEND_MARKET_ROLE = ethers.id("FRIEND_MARKET_ROLE");
+    const MembershipTier = { NONE: 0, BRONZE: 1, SILVER: 2, GOLD: 3, PLATINUM: 4 };
+
+    await tieredRoleManager.setTierMetadata(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      "Friend Market Bronze",
+      "Basic friend market tier",
+      ethers.parseEther("0.1"),
+      {
+        dailyBetLimit: 10,
+        weeklyBetLimit: 50,
+        monthlyMarketCreation: 5,
+        maxPositionSize: ethers.parseEther("10"),
+        maxConcurrentMarkets: 3,
+        withdrawalLimit: ethers.parseEther("100"),
+        canCreatePrivateMarkets: false,
+        canUseAdvancedFeatures: false,
+        feeDiscount: 0
+      },
+      true
+    );
+
+    const tierMeta = await tieredRoleManager.tierMetadata(FRIEND_MARKET_ROLE, MembershipTier.BRONZE);
+    const price = tierMeta.price;
+
+    // Deploy MembershipPaymentManager
+    const MembershipPaymentManager = await ethers.getContractFactory("MembershipPaymentManager");
+    paymentManager = await MembershipPaymentManager.deploy(owner.address);
+    await paymentManager.waitForDeployment();
+
+    // Deploy FriendGroupMarketFactory
+    const FriendGroupMarketFactory = await ethers.getContractFactory("FriendGroupMarketFactory");
+    friendGroupFactory = await FriendGroupMarketFactory.deploy(
+      await marketFactory.getAddress(),
+      await ragequitModule.getAddress(),
+      await tieredRoleManager.getAddress(),
+      await paymentManager.getAddress(),
+      owner.address
+    );
+    await friendGroupFactory.waitForDeployment();
+
+    // Set collateral token and Polymarket adapter
+    await friendGroupFactory.setDefaultCollateralToken(await collateralToken.getAddress());
+    await friendGroupFactory.setPolymarketAdapter(await polymarketAdapter.getAddress());
+
+    // Purchase memberships
+    const durDays = 36500;
+    await tieredRoleManager.connect(owner).purchaseRoleWithTier(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      durDays,
+      { value: price }
+    );
+    await tieredRoleManager.connect(addr1).purchaseRoleWithTier(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      durDays,
+      { value: price }
+    );
+    await tieredRoleManager.connect(addr2).purchaseRoleWithTier(
+      FRIEND_MARKET_ROLE,
+      MembershipTier.BRONZE,
+      durDays,
+      { value: price }
+    );
+
+    // Transfer ownership
+    await marketFactory.transferOwnership(await friendGroupFactory.getAddress());
+  });
+
+  // Helper to create and activate a market
+  async function createAndActivateMarket() {
+    const description = "Will ETH reach 5000?";
+    const tradingPeriod = 7 * 24 * 60 * 60;
+    const latestBlock = await ethers.provider.getBlock('latest');
+    const acceptanceDeadline = latestBlock.timestamp + (2 * 60 * 60);
+    const stakeAmount = ethers.parseEther("1");
+
+    // Create market
+    await friendGroupFactory.connect(owner).createOneVsOneMarketPending(
+      addr1.address,
+      description,
+      tradingPeriod,
+      ethers.ZeroAddress,
+      acceptanceDeadline,
+      stakeAmount,
+      ethers.ZeroAddress,
+      ResolutionType.Either,
+      { value: stakeAmount }
+    );
+
+    // Accept market
+    await friendGroupFactory.connect(addr1).acceptMarket(0, { value: stakeAmount });
+
+    return 0; // market ID
+  }
+
+  describe("Polymarket Adapter Setup", function () {
+    it("Should set Polymarket adapter", async function () {
+      expect(await friendGroupFactory.polymarketAdapter()).to.equal(await polymarketAdapter.getAddress());
+    });
+
+    it("Should revert setting zero address adapter", async function () {
+      await expect(
+        friendGroupFactory.setPolymarketAdapter(ethers.ZeroAddress)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "InvalidAddress");
+    });
+
+    it("Should emit PolymarketAdapterUpdated event", async function () {
+      const newAdapter = addr1.address;
+      await expect(friendGroupFactory.setPolymarketAdapter(newAdapter))
+        .to.emit(friendGroupFactory, "PolymarketAdapterUpdated")
+        .withArgs(newAdapter);
+    });
+  });
+
+  describe("Pegging to Polymarket", function () {
+    it("Should peg a friend market to Polymarket condition", async function () {
+      const marketId = await createAndActivateMarket();
+
+      await friendGroupFactory.connect(owner).pegToPolymarketCondition(marketId, testConditionId);
+
+      expect(await friendGroupFactory.isPeggedToPolymarket(marketId)).to.be.true;
+      expect(await friendGroupFactory.getPolymarketConditionId(marketId)).to.equal(testConditionId);
+    });
+
+    it("Should update resolution type to PolymarketOracle", async function () {
+      const marketId = await createAndActivateMarket();
+
+      await friendGroupFactory.connect(owner).pegToPolymarketCondition(marketId, testConditionId);
+
+      const marketStatus = await friendGroupFactory.getFriendMarketWithStatus(marketId);
+      expect(marketStatus.resolutionType).to.equal(ResolutionType.PolymarketOracle);
+    });
+
+    it("Should emit MarketPeggedToPolymarket event", async function () {
+      const marketId = await createAndActivateMarket();
+
+      await expect(friendGroupFactory.connect(owner).pegToPolymarketCondition(marketId, testConditionId))
+        .to.emit(friendGroupFactory, "MarketPeggedToPolymarket")
+        .withArgs(marketId, testConditionId);
+    });
+
+    it("Should revert when adapter not set", async function () {
+      // Deploy new factory without adapter
+      const FriendGroupMarketFactory = await ethers.getContractFactory("FriendGroupMarketFactory");
+      const newFactory = await FriendGroupMarketFactory.deploy(
+        await marketFactory.getAddress(),
+        await ragequitModule.getAddress(),
+        await tieredRoleManager.getAddress(),
+        await paymentManager.getAddress(),
+        owner.address
+      );
+      await newFactory.waitForDeployment();
+
+      // Since market 0 doesn't exist in the new factory, we expect InvalidMarketId
+      // This is correct behavior - validation happens in order
+      await expect(
+        newFactory.pegToPolymarketCondition(0, testConditionId)
+      ).to.be.revertedWithCustomError(newFactory, "InvalidMarketId");
+    });
+
+    it("Should revert when market already pegged to Polymarket", async function () {
+      const marketId = await createAndActivateMarket();
+
+      await friendGroupFactory.connect(owner).pegToPolymarketCondition(marketId, testConditionId);
+
+      await expect(
+        friendGroupFactory.connect(owner).pegToPolymarketCondition(marketId, testConditionId)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "AlreadyPeggedToPolymarket");
+    });
+
+    it("Should revert when non-creator tries to peg", async function () {
+      const marketId = await createAndActivateMarket();
+
+      await expect(
+        friendGroupFactory.connect(addr1).pegToPolymarketCondition(marketId, testConditionId)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotAuthorized");
+    });
+  });
+
+  describe("Resolving from Polymarket", function () {
+    it("Should resolve market when Polymarket condition resolves (YES wins)", async function () {
+      const marketId = await createAndActivateMarket();
+      await friendGroupFactory.connect(owner).pegToPolymarketCondition(marketId, testConditionId);
+
+      // Resolve Polymarket condition with YES winning
+      await mockCTF.resolveCondition(testConditionId, [1, 0]);
+
+      await friendGroupFactory.connect(addr2).resolveFromPolymarket(marketId);
+
+      const marketStatus = await friendGroupFactory.getFriendMarketWithStatus(marketId);
+      expect(marketStatus.status).to.equal(2); // FriendMarketStatus.Resolved = 2
+    });
+
+    it("Should emit PolymarketMarketResolved event", async function () {
+      const marketId = await createAndActivateMarket();
+      await friendGroupFactory.connect(owner).pegToPolymarketCondition(marketId, testConditionId);
+
+      await mockCTF.resolveCondition(testConditionId, [1, 0]);
+
+      await expect(friendGroupFactory.connect(addr2).resolveFromPolymarket(marketId))
+        .to.emit(friendGroupFactory, "PolymarketMarketResolved")
+        .withArgs(marketId, testConditionId, 1, 0, true);
+    });
+
+    it("Should revert when Polymarket condition not resolved", async function () {
+      const marketId = await createAndActivateMarket();
+      await friendGroupFactory.connect(owner).pegToPolymarketCondition(marketId, testConditionId);
+
+      // Don't resolve the condition
+      await expect(
+        friendGroupFactory.connect(addr2).resolveFromPolymarket(marketId)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "PolymarketNotResolved");
+    });
+
+    it("Should revert when market not pegged to Polymarket", async function () {
+      const marketId = await createAndActivateMarket();
+
+      await expect(
+        friendGroupFactory.connect(addr2).resolveFromPolymarket(marketId)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "InvalidConditionId");
+    });
+
+    it("Should prevent manual resolution for Polymarket-pegged markets", async function () {
+      const marketId = await createAndActivateMarket();
+      await friendGroupFactory.connect(owner).pegToPolymarketCondition(marketId, testConditionId);
+
+      await expect(
+        friendGroupFactory.connect(owner).resolveFriendMarket(marketId, true)
+      ).to.be.revertedWithCustomError(friendGroupFactory, "NotAuthorized");
+    });
+  });
+
+  describe("Batch Resolution from Polymarket", function () {
+    it("Should batch resolve multiple markets pegged to same condition", async function () {
+      // Create and peg multiple markets
+      const description = "Will ETH reach 5000?";
+      const tradingPeriod = 7 * 24 * 60 * 60;
+      const latestBlock = await ethers.provider.getBlock('latest');
+      const acceptanceDeadline = latestBlock.timestamp + (2 * 60 * 60);
+      const stakeAmount = ethers.parseEther("1");
+
+      // Market 1
+      await friendGroupFactory.connect(owner).createOneVsOneMarketPending(
+        addr1.address,
+        description,
+        tradingPeriod,
+        ethers.ZeroAddress,
+        acceptanceDeadline,
+        stakeAmount,
+        ethers.ZeroAddress,
+        ResolutionType.Either,
+        { value: stakeAmount }
+      );
+      await friendGroupFactory.connect(addr1).acceptMarket(0, { value: stakeAmount });
+      await friendGroupFactory.connect(owner).pegToPolymarketCondition(0, testConditionId);
+
+      // Market 2 (need new deadline for second market)
+      const latestBlock2 = await ethers.provider.getBlock('latest');
+      const acceptanceDeadline2 = latestBlock2.timestamp + (2 * 60 * 60);
+
+      await friendGroupFactory.connect(owner).createOneVsOneMarketPending(
+        addr2.address,
+        description,
+        tradingPeriod,
+        ethers.ZeroAddress,
+        acceptanceDeadline2,
+        stakeAmount,
+        ethers.ZeroAddress,
+        ResolutionType.Either,
+        { value: stakeAmount }
+      );
+      await friendGroupFactory.connect(addr2).acceptMarket(1, { value: stakeAmount });
+      await friendGroupFactory.connect(owner).pegToPolymarketCondition(1, testConditionId);
+
+      // Resolve Polymarket condition
+      await mockCTF.resolveCondition(testConditionId, [1, 0]);
+
+      // Batch resolve
+      await friendGroupFactory.batchResolveFromPolymarket(testConditionId);
+
+      // Check both markets are resolved
+      const market0 = await friendGroupFactory.getFriendMarketWithStatus(0);
+      const market1 = await friendGroupFactory.getFriendMarketWithStatus(1);
+
+      expect(market0.status).to.equal(2); // FriendMarketStatus.Resolved = 2
+      expect(market1.status).to.equal(2); // FriendMarketStatus.Resolved = 2
+    });
+
+    it("Should return list of friend markets for Polymarket condition", async function () {
+      const marketId = await createAndActivateMarket();
+      await friendGroupFactory.connect(owner).pegToPolymarketCondition(marketId, testConditionId);
+
+      const markets = await friendGroupFactory.getFriendMarketsForPolymarketCondition(testConditionId);
+      expect(markets.length).to.equal(1);
+      expect(markets[0]).to.equal(marketId);
+    });
+  });
+
+  describe("View Functions", function () {
+    it("Should return false for isPeggedToPolymarket when not pegged", async function () {
+      const marketId = await createAndActivateMarket();
+      expect(await friendGroupFactory.isPeggedToPolymarket(marketId)).to.be.false;
+    });
+
+    it("Should return zero conditionId when not pegged", async function () {
+      const marketId = await createAndActivateMarket();
+      expect(await friendGroupFactory.getPolymarketConditionId(marketId)).to.equal(ethers.ZeroHash);
+    });
+  });
+});

--- a/test/UMAOracleAdapter.test.js
+++ b/test/UMAOracleAdapter.test.js
@@ -1,0 +1,361 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+describe("UMAOracleAdapter", function () {
+  let umaAdapter;
+  let mockUmaOracle;
+  let mockToken;
+  let owner;
+  let user1;
+  let user2;
+
+  const DEFAULT_BOND = ethers.parseEther("0.1");
+  const DEFAULT_LIVENESS = 2 * 60 * 60; // 2 hours
+
+  beforeEach(async function () {
+    [owner, user1, user2] = await ethers.getSigners();
+
+    // Deploy mock ERC20 token for bonds
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    mockToken = await MockERC20.deploy("Mock USDC", "USDC", 0);
+
+    // Mint tokens to users
+    await mockToken.mint(owner.address, ethers.parseEther("1000"));
+    await mockToken.mint(user1.address, ethers.parseEther("1000"));
+    await mockToken.mint(user2.address, ethers.parseEther("1000"));
+
+    // Deploy mock UMA Oracle
+    const MockUMAOptimisticOracle = await ethers.getContractFactory("MockUMAOptimisticOracle");
+    mockUmaOracle = await MockUMAOptimisticOracle.deploy();
+
+    // Deploy UMAOracleAdapter
+    const UMAOracleAdapter = await ethers.getContractFactory("UMAOracleAdapter");
+    umaAdapter = await UMAOracleAdapter.deploy(
+      owner.address,
+      mockUmaOracle.target,
+      mockToken.target
+    );
+
+    // Approve adapter to spend tokens
+    await mockToken.approve(umaAdapter.target, ethers.parseEther("100"));
+    await mockToken.connect(user1).approve(umaAdapter.target, ethers.parseEther("100"));
+    await mockToken.connect(user2).approve(umaAdapter.target, ethers.parseEther("100"));
+  });
+
+  describe("Constructor", function () {
+    it("Should set the owner correctly", async function () {
+      expect(await umaAdapter.owner()).to.equal(owner.address);
+    });
+
+    it("Should return correct oracle type", async function () {
+      expect(await umaAdapter.oracleType()).to.equal("UMA");
+    });
+
+    it("Should have correct default bond and liveness", async function () {
+      expect(await umaAdapter.defaultBond()).to.equal(DEFAULT_BOND);
+      expect(await umaAdapter.defaultLiveness()).to.equal(DEFAULT_LIVENESS);
+    });
+
+    it("Should revert with zero oracle address", async function () {
+      const UMAOracleAdapter = await ethers.getContractFactory("UMAOracleAdapter");
+      await expect(
+        UMAOracleAdapter.deploy(owner.address, ethers.ZeroAddress, mockToken.target)
+      ).to.be.revertedWithCustomError(umaAdapter, "InvalidOracleAddress");
+    });
+  });
+
+  describe("Configuration", function () {
+    it("Should update config", async function () {
+      const newBond = ethers.parseEther("0.5");
+      const newLiveness = 4 * 60 * 60; // 4 hours
+
+      await expect(umaAdapter.setConfig(newBond, newLiveness))
+        .to.emit(umaAdapter, "ConfigUpdated")
+        .withArgs(newBond, newLiveness);
+
+      expect(await umaAdapter.defaultBond()).to.equal(newBond);
+      expect(await umaAdapter.defaultLiveness()).to.equal(newLiveness);
+    });
+
+    it("Should only allow owner to update config", async function () {
+      await expect(
+        umaAdapter.connect(user1).setConfig(ethers.parseEther("1"), 3600)
+      ).to.be.revertedWithCustomError(umaAdapter, "OwnableUnauthorizedAccount");
+    });
+
+    it("Should update UMA Oracle address", async function () {
+      const MockUMAOptimisticOracle = await ethers.getContractFactory("MockUMAOptimisticOracle");
+      const newOracle = await MockUMAOptimisticOracle.deploy();
+
+      await umaAdapter.setUMAOracle(newOracle.target);
+      expect(await umaAdapter.umaOracle()).to.equal(newOracle.target);
+    });
+  });
+
+  describe("Condition Creation", function () {
+    const description = "Lakers will win the 2025 NBA Finals";
+    const futureDeadline = () => Math.floor(Date.now() / 1000) + 86400;
+
+    it("Should create a condition", async function () {
+      const deadline = futureDeadline();
+
+      const tx = await umaAdapter.createCondition(description, deadline);
+      const receipt = await tx.wait();
+
+      const event = receipt.logs.find(log => {
+        try {
+          return umaAdapter.interface.parseLog(log)?.name === "ConditionCreated";
+        } catch { return false; }
+      });
+
+      expect(event).to.not.be.undefined;
+      const parsedEvent = umaAdapter.interface.parseLog(event);
+      expect(parsedEvent.args.description).to.equal(description);
+      expect(parsedEvent.args.deadline).to.equal(deadline);
+    });
+
+    it("Should revert for deadline in past", async function () {
+      const pastDeadline = Math.floor(Date.now() / 1000) - 3600;
+      await expect(
+        umaAdapter.createCondition(description, pastDeadline)
+      ).to.be.revertedWithCustomError(umaAdapter, "DeadlineInPast");
+    });
+
+    it("Should return condition details", async function () {
+      const deadline = futureDeadline();
+      const tx = await umaAdapter.createCondition(description, deadline);
+      const receipt = await tx.wait();
+
+      const event = receipt.logs.find(log => {
+        try {
+          return umaAdapter.interface.parseLog(log)?.name === "ConditionCreated";
+        } catch { return false; }
+      });
+      const conditionId = umaAdapter.interface.parseLog(event).args.conditionId;
+
+      const condition = await umaAdapter.getCondition(conditionId);
+      expect(condition.description).to.equal(description);
+      expect(condition.deadline).to.equal(deadline);
+      expect(condition.assertionId).to.equal(ethers.ZeroHash);
+      expect(condition.registered).to.be.true;
+    });
+  });
+
+  describe("Assertion", function () {
+    let conditionId;
+
+    beforeEach(async function () {
+      const deadline = (await time.latest()) + 86400;
+      const tx = await umaAdapter.createCondition("Test condition", deadline);
+      const receipt = await tx.wait();
+
+      const event = receipt.logs.find(log => {
+        try {
+          return umaAdapter.interface.parseLog(log)?.name === "ConditionCreated";
+        } catch { return false; }
+      });
+      conditionId = umaAdapter.interface.parseLog(event).args.conditionId;
+    });
+
+    it("Should revert assertion before deadline", async function () {
+      await expect(
+        umaAdapter.assertOutcome(conditionId, true)
+      ).to.be.revertedWithCustomError(umaAdapter, "DeadlineNotReached");
+    });
+
+    it("Should allow assertion after deadline", async function () {
+      await time.increase(86401);
+
+      // Approve tokens for bond
+      await mockToken.approve(umaAdapter.target, DEFAULT_BOND);
+
+      const tx = await umaAdapter.assertOutcome(conditionId, true);
+      const receipt = await tx.wait();
+
+      const event = receipt.logs.find(log => {
+        try {
+          return umaAdapter.interface.parseLog(log)?.name === "AssertionMade";
+        } catch { return false; }
+      });
+
+      expect(event).to.not.be.undefined;
+      const parsedEvent = umaAdapter.interface.parseLog(event);
+      expect(parsedEvent.args.conditionId).to.equal(conditionId);
+      expect(parsedEvent.args.outcome).to.be.true;
+    });
+
+    it("Should revert double assertion", async function () {
+      await time.increase(86401);
+      await umaAdapter.assertOutcome(conditionId, true);
+
+      await expect(
+        umaAdapter.assertOutcome(conditionId, true)
+      ).to.be.revertedWithCustomError(umaAdapter, "ConditionAlreadyAsserted");
+    });
+
+    it("Should check if condition can be asserted", async function () {
+      expect(await umaAdapter.canAssert(conditionId)).to.be.false;
+
+      await time.increase(86401);
+      expect(await umaAdapter.canAssert(conditionId)).to.be.true;
+
+      await umaAdapter.assertOutcome(conditionId, true);
+      expect(await umaAdapter.canAssert(conditionId)).to.be.false;
+    });
+  });
+
+  describe("Settlement", function () {
+    let conditionId;
+    let assertionId;
+
+    beforeEach(async function () {
+      const deadline = (await time.latest()) + 86400;
+      let tx = await umaAdapter.createCondition("Test condition", deadline);
+      let receipt = await tx.wait();
+
+      let event = receipt.logs.find(log => {
+        try {
+          return umaAdapter.interface.parseLog(log)?.name === "ConditionCreated";
+        } catch { return false; }
+      });
+      conditionId = umaAdapter.interface.parseLog(event).args.conditionId;
+
+      // Advance time and make assertion
+      await time.increase(86401);
+      tx = await umaAdapter.assertOutcome(conditionId, true);
+      receipt = await tx.wait();
+
+      event = receipt.logs.find(log => {
+        try {
+          return umaAdapter.interface.parseLog(log)?.name === "AssertionMade";
+        } catch { return false; }
+      });
+      assertionId = umaAdapter.interface.parseLog(event).args.assertionId;
+    });
+
+    it("Should settle undisputed assertion after liveness", async function () {
+      // Fast-forward past liveness period
+      await time.increase(DEFAULT_LIVENESS + 1);
+
+      await umaAdapter.settleCondition(conditionId);
+
+      const resolution = await umaAdapter.getResolution(conditionId);
+      expect(resolution.resolved).to.be.true;
+      expect(resolution.outcome).to.be.true;
+      expect(resolution.confidence).to.equal(10000);
+    });
+
+    it("Should handle disputed assertion", async function () {
+      // Approve tokens for disputer bond
+      await mockToken.connect(user1).approve(mockUmaOracle.target, DEFAULT_BOND);
+
+      // Dispute the assertion
+      await mockUmaOracle.connect(user1).disputeAssertion(assertionId, user1.address);
+
+      // Set dispute result (simulates DVM resolution)
+      await mockUmaOracle.setDisputeResult(assertionId, false); // Disputer wins
+
+      // Settle
+      await mockUmaOracle.settleAssertion(assertionId);
+
+      // The callback should have resolved the condition
+      const resolution = await umaAdapter.getResolution(conditionId);
+      expect(resolution.resolved).to.be.true;
+      expect(resolution.outcome).to.be.false; // Opposite of asserted because dispute succeeded
+    });
+
+    it("Should check if condition can be settled", async function () {
+      // Before liveness period ends
+      expect(await umaAdapter.canSettle(conditionId)).to.be.false;
+
+      // After liveness period (UMA assertion not settled yet)
+      await time.increase(DEFAULT_LIVENESS + 1);
+      // UMA assertion is not settled yet, so canSettle still false
+      expect(await umaAdapter.canSettle(conditionId)).to.be.false;
+
+      // After UMA assertion is settled (callback auto-resolves condition)
+      await mockUmaOracle.settleAssertion(assertionId);
+      // Condition is now resolved via callback, so canSettle is false
+      expect(await umaAdapter.canSettle(conditionId)).to.be.false;
+
+      // Verify condition was resolved by callback
+      expect(await umaAdapter.isConditionResolved(conditionId)).to.be.true;
+    });
+
+    it("Should not re-settle already settled condition", async function () {
+      await time.increase(DEFAULT_LIVENESS + 1);
+      await umaAdapter.settleCondition(conditionId);
+
+      // Second settlement should not fail, just return
+      await umaAdapter.settleCondition(conditionId);
+
+      const resolution = await umaAdapter.getResolution(conditionId);
+      expect(resolution.resolved).to.be.true;
+    });
+  });
+
+  describe("IOracleAdapter Interface", function () {
+    let conditionId;
+
+    beforeEach(async function () {
+      const deadline = (await time.latest()) + 86400;
+      const tx = await umaAdapter.createCondition("Test condition", deadline);
+      const receipt = await tx.wait();
+
+      const event = receipt.logs.find(log => {
+        try {
+          return umaAdapter.interface.parseLog(log)?.name === "ConditionCreated";
+        } catch { return false; }
+      });
+      conditionId = umaAdapter.interface.parseLog(event).args.conditionId;
+    });
+
+    it("Should report condition as supported", async function () {
+      expect(await umaAdapter.isConditionSupported(conditionId)).to.be.true;
+    });
+
+    it("Should report unknown condition as not supported", async function () {
+      const unknownId = ethers.keccak256(ethers.toUtf8Bytes("unknown"));
+      expect(await umaAdapter.isConditionSupported(unknownId)).to.be.false;
+    });
+
+    it("Should report unresolved condition correctly", async function () {
+      expect(await umaAdapter.isConditionResolved(conditionId)).to.be.false;
+    });
+
+    it("Should report resolved condition correctly", async function () {
+      await time.increase(86401);
+      await umaAdapter.assertOutcome(conditionId, true);
+      await time.increase(DEFAULT_LIVENESS + 1);
+      await umaAdapter.settleCondition(conditionId);
+
+      expect(await umaAdapter.isConditionResolved(conditionId)).to.be.true;
+    });
+
+    it("Should return outcome with confidence", async function () {
+      await time.increase(86401);
+      await umaAdapter.assertOutcome(conditionId, true);
+      await time.increase(DEFAULT_LIVENESS + 1);
+      await umaAdapter.settleCondition(conditionId);
+
+      const [outcome, confidence, resolvedAt] = await umaAdapter.getOutcome(conditionId);
+      expect(outcome).to.be.true;
+      expect(confidence).to.equal(10000);
+      expect(resolvedAt).to.be.gt(0);
+    });
+
+    it("Should return zero outcome for unresolved condition", async function () {
+      const [outcome, confidence, resolvedAt] = await umaAdapter.getOutcome(conditionId);
+      expect(outcome).to.be.false;
+      expect(confidence).to.equal(0);
+      expect(resolvedAt).to.equal(0);
+    });
+
+    it("Should return condition metadata", async function () {
+      const [description, expectedResolutionTime] = await umaAdapter.getConditionMetadata(conditionId);
+      expect(description).to.equal("Test condition");
+      expect(expectedResolutionTime).to.be.gt(0);
+    });
+  });
+});

--- a/test/UMAOracleAdapter.test.js
+++ b/test/UMAOracleAdapter.test.js
@@ -95,10 +95,9 @@ describe("UMAOracleAdapter", function () {
 
   describe("Condition Creation", function () {
     const description = "Lakers will win the 2025 NBA Finals";
-    const futureDeadline = () => Math.floor(Date.now() / 1000) + 86400;
 
     it("Should create a condition", async function () {
-      const deadline = futureDeadline();
+      const deadline = (await time.latest()) + 86400;
 
       const tx = await umaAdapter.createCondition(description, deadline);
       const receipt = await tx.wait();
@@ -116,14 +115,14 @@ describe("UMAOracleAdapter", function () {
     });
 
     it("Should revert for deadline in past", async function () {
-      const pastDeadline = Math.floor(Date.now() / 1000) - 3600;
+      const pastDeadline = (await time.latest()) - 3600;
       await expect(
         umaAdapter.createCondition(description, pastDeadline)
       ).to.be.revertedWithCustomError(umaAdapter, "DeadlineInPast");
     });
 
     it("Should return condition details", async function () {
-      const deadline = futureDeadline();
+      const deadline = (await time.latest()) + 86400;
       const tx = await umaAdapter.createCondition(description, deadline);
       const receipt = await tx.wait();
 


### PR DESCRIPTION
This enables private (friend) markets to be resolved based on Polymarket market
outcomes when deployed on a network with Polymarket (e.g., Polygon).

Key changes:
- Add IPolymarketOracle interface for querying Polymarket CTF conditions
- Add PolymarketOracleAdapter contract to bridge resolution data from Polymarket
- Add PolymarketOracle resolution type to FriendGroupMarketFactory
- Add pegToPolymarketCondition() to link private markets to Polymarket
- Add resolveFromPolymarket() and batchResolveFromPolymarket() for resolution
- Add MockPolymarketCTF for testing
- Add comprehensive test suite (39 tests)

Architecture:
1. Creator creates private market with any resolution type
2. Creator calls pegToPolymarketCondition() with Polymarket conditionId
3. Resolution type changes to PolymarketOracle
4. When Polymarket resolves, anyone can call resolveFromPolymarket()
5. Adapter fetches resolution from Polymarket CTF and resolves private market

https://claude.ai/code/session_0127SqRkFZSivBFA542WfNfz