### PR TITLE
Remove market browse categories from nav, fix oracle status when disconnected

### DIFF
--- a/frontend/src/components/fairwins/Dashboard.jsx
+++ b/frontend/src/components/fairwins/Dashboard.jsx
@@ -238,13 +238,15 @@ function HowItWorksGuide() {
 // ORACLE INFO PANEL
 // ============================================================================
 
-function OracleInfoPanel() {
+function OracleInfoPanel({ isConnected }) {
   const oracles = [
-    { name: 'Polymarket', description: 'Peg wagers to Polymarket event outcomes', status: 'available', icon: '\uD83C\uDFAF' },
-    { name: 'Chainlink', description: 'Price feed-based resolution', status: 'available', icon: '\uD83D\uDD17' },
-    { name: 'UMA', description: 'Custom truth assertions', status: 'available', icon: '\u2696\uFE0F' },
-    { name: 'Manual', description: 'Creator-resolved with challenge period', status: 'available', icon: '\u270B' }
+    { name: 'Polymarket', description: 'Peg wagers to Polymarket event outcomes', icon: '\uD83C\uDFAF' },
+    { name: 'Chainlink', description: 'Price feed-based resolution', icon: '\uD83D\uDD17' },
+    { name: 'UMA', description: 'Custom truth assertions', icon: '\u2696\uFE0F' },
+    { name: 'Manual', description: 'Creator-resolved with challenge period', icon: '\u270B' }
   ]
+
+  const status = isConnected ? 'available' : 'offline'
 
   return (
     <div className="oracle-info-panel">
@@ -257,8 +259,8 @@ function OracleInfoPanel() {
               <span className="oracle-name">{oracle.name}</span>
               <span className="oracle-description">{oracle.description}</span>
             </div>
-            <span className={`oracle-status ${oracle.status}`}>
-              {oracle.status === 'available' ? 'Available' : 'Offline'}
+            <span className={`oracle-status ${status}`}>
+              {isConnected ? 'Available' : 'Not Connected'}
             </span>
           </div>
         ))}
@@ -361,7 +363,7 @@ function Dashboard() {
           <HowItWorksGuide />
         </section>
         <section className="dashboard-section">
-          <OracleInfoPanel />
+          <OracleInfoPanel isConnected={isConnected} />
         </section>
       </div>
     )
@@ -430,7 +432,7 @@ function Dashboard() {
 
       {/* Oracle Info */}
       <section className="dashboard-section">
-        <OracleInfoPanel />
+        <OracleInfoPanel isConnected={isConnected} />
       </section>
     </div>
   )

--- a/frontend/src/components/fairwins/SidebarNav.jsx
+++ b/frontend/src/components/fairwins/SidebarNav.jsx
@@ -4,32 +4,10 @@ import './SidebarNav.css'
 
 // Import SVG icons
 import dashboardIcon from '../../assets/dashboard_no_text.svg'
-import trendingIcon from '../../assets/trending_no_text.svg'
-import politicsIcon from '../../assets/politics_no_text.svg'
-import sportsIcon from '../../assets/sports_no_text.svg'
-import financeIcon from '../../assets/finance_no_text.svg'
-import techIcon from '../../assets/tech_no_text.svg'
-import popCultureIcon from '../../assets/pop-culture_no_text.svg'
-import cryptoIcon from '../../assets/crypto_no_text.svg'
-import weatherIcon from '../../assets/weather_no_text.svg'
-import otherMarketsIcon from '../../assets/other_markets_no_text.svg'
-import allMarketsIcon from '../../assets/all_markets_no_text.svg'
 
 const CATEGORIES = [
   // P2P Wager Management
-  { id: 'dashboard', name: 'My Wagers', icon: dashboardIcon },
-  // Browse Markets (for finding events to wager on)
-  { id: 'trending', name: 'Trending', icon: trendingIcon, section: 'browse' },
-  { id: 'sports', name: 'Sports', icon: sportsIcon, section: 'browse' },
-  { id: 'crypto', name: 'Crypto', icon: cryptoIcon, section: 'browse' },
-  { id: 'politics', name: 'Politics', icon: politicsIcon, section: 'browse' },
-  { id: 'finance', name: 'Finance', icon: financeIcon, section: 'browse' },
-  { id: 'tech', name: 'Tech', icon: techIcon, section: 'browse' },
-  { id: 'pop-culture', name: 'Pop Culture', icon: popCultureIcon, section: 'browse' },
-  { id: 'weather', name: 'Weather', icon: weatherIcon, section: 'browse' },
-  { id: 'other', name: 'Other Markets', icon: otherMarketsIcon, section: 'browse' },
-  { id: 'perpetuals', name: 'Perpetuals', icon: '\uD83D\uDCC8', isEmoji: true, section: 'browse' },
-  { id: 'all-table', name: 'All Markets Table', icon: allMarketsIcon, powerUser: true, section: 'browse' }
+  { id: 'dashboard', name: 'My Wagers', icon: dashboardIcon }
 ]
 
 function SidebarNav({ selectedCategory = 'dashboard', onCategoryChange, userRoles = [] }) {
@@ -68,46 +46,16 @@ function SidebarNav({ selectedCategory = 'dashboard', onCategoryChange, userRole
     return true
   })
 
-  // On mobile, render as bottom navigation bar
+  // On mobile, no bottom nav needed with only the dashboard
   if (isMobile) {
-    return (
-      <nav 
-        className="bottom-nav-bar"
-        role="navigation"
-        aria-label="Market categories"
-      >
-        <div className="bottom-nav-scroll">
-          {visibleCategories.map((category) => (
-            <button
-              key={category.id}
-              className={`bottom-nav-item ${selectedCategory === category.id ? 'active' : ''}`}
-              onClick={() => handleCategoryClick(category.id)}
-              onKeyDown={(e) => handleKeyDown(e, category.id)}
-              aria-current={selectedCategory === category.id ? 'page' : undefined}
-              aria-label={`View ${category.name}`}
-            >
-              <span className="bottom-nav-icon" aria-hidden="true">
-                {category.isEmoji ? (
-                  <span className="category-emoji">{category.icon}</span>
-                ) : typeof category.icon === 'string' && category.icon.endsWith('.svg') ? (
-                  <img src={category.icon} alt="" className="category-icon-img" />
-                ) : (
-                  category.icon
-                )}
-              </span>
-              <span className="bottom-nav-label">{category.name}</span>
-            </button>
-          ))}
-        </div>
-      </nav>
-    )
+    return null
   }
 
   // Desktop: render as sidebar
   return (
-    <aside 
+    <aside
       className={`sidebar-nav ${isExpanded ? 'expanded' : 'collapsed'}`}
-      aria-label="Market categories"
+      aria-label="Navigation"
     >
       <div className="sidebar-header">
         <button
@@ -121,17 +69,12 @@ function SidebarNav({ selectedCategory = 'dashboard', onCategoryChange, userRole
             {isExpanded ? '◀' : '▶'}
           </span>
         </button>
-        {isExpanded && <h2>Categories</h2>}
+        {isExpanded && <h2>Navigation</h2>}
       </div>
 
       <nav className="category-list">
-        {visibleCategories.map((category, index) => (
+        {visibleCategories.map((category) => (
           <React.Fragment key={category.id}>
-            {index > 0 && category.section === 'browse' && visibleCategories[index - 1]?.section !== 'browse' && (
-              <div className="sidebar-divider" aria-hidden="true">
-                {isExpanded && <span className="divider-label">Browse Markets</span>}
-              </div>
-            )}
             <button
               className={`category-item ${selectedCategory === category.id ? 'active' : ''}`}
               onClick={() => handleCategoryClick(category.id)}

--- a/frontend/src/test/SidebarNav.test.jsx
+++ b/frontend/src/test/SidebarNav.test.jsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { axe } from 'vitest-axe'
 import SidebarNav from '../components/fairwins/SidebarNav'
+import { useIsMobile } from '../hooks/useMediaQuery'
 
 // Mock the useIsMobile hook
 vi.mock('../hooks/useMediaQuery', () => ({
@@ -20,7 +21,7 @@ describe('SidebarNav Component', () => {
     it('renders sidebar navigation', () => {
       render(<SidebarNav onCategoryChange={mockOnCategoryChange} />)
       // aside element has complementary role by default
-      expect(screen.getByRole('complementary', { name: /market categories/i })).toBeInTheDocument()
+      expect(screen.getByRole('complementary', { name: /navigation/i })).toBeInTheDocument()
     })
 
     it('renders toggle button', () => {
@@ -28,11 +29,11 @@ describe('SidebarNav Component', () => {
       expect(screen.getByRole('button', { name: /expand sidebar/i })).toBeInTheDocument()
     })
 
-    it('renders all category buttons', () => {
+    it('renders the My Wagers category button', () => {
       render(<SidebarNav onCategoryChange={mockOnCategoryChange} />)
       const categoryButtons = screen.getAllByRole('button')
-      // Should have toggle button + 12 category buttons (including "Weather", "Perpetuals" and "All Markets Table")
-      expect(categoryButtons.length).toBe(13)
+      // Should have toggle button + 1 category button (My Wagers / dashboard)
+      expect(categoryButtons.length).toBe(2)
     })
 
     it('starts in collapsed state by default', () => {
@@ -46,36 +47,36 @@ describe('SidebarNav Component', () => {
     it('expands sidebar when toggle button is clicked', async () => {
       const user = userEvent.setup()
       render(<SidebarNav onCategoryChange={mockOnCategoryChange} />)
-      
+
       const toggleButton = screen.getByRole('button', { name: /expand sidebar/i })
       await user.click(toggleButton)
-      
+
       expect(screen.getByRole('button', { name: /collapse sidebar/i })).toBeInTheDocument()
-      expect(screen.getByRole('heading', { name: /categories/i })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: /navigation/i })).toBeInTheDocument()
     })
 
     it('collapses sidebar when toggle button is clicked again', async () => {
       const user = userEvent.setup()
       render(<SidebarNav onCategoryChange={mockOnCategoryChange} />)
-      
+
       const expandButton = screen.getByRole('button', { name: /expand sidebar/i })
       await user.click(expandButton)
-      
+
       const collapseButton = screen.getByRole('button', { name: /collapse sidebar/i })
       await user.click(collapseButton)
-      
+
       expect(screen.getByRole('button', { name: /expand sidebar/i })).toBeInTheDocument()
-      expect(screen.queryByRole('heading', { name: /categories/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('heading', { name: /navigation/i })).not.toBeInTheDocument()
     })
 
     it('toggle button is keyboard accessible', async () => {
       const user = userEvent.setup()
       render(<SidebarNav onCategoryChange={mockOnCategoryChange} />)
-      
+
       const toggleButton = screen.getByRole('button', { name: /expand sidebar/i })
       toggleButton.focus()
       expect(toggleButton).toHaveFocus()
-      
+
       await user.keyboard('{Enter}')
       expect(screen.getByRole('button', { name: /collapse sidebar/i })).toBeInTheDocument()
     })
@@ -83,42 +84,42 @@ describe('SidebarNav Component', () => {
     it('toggle button responds to Space key', async () => {
       const user = userEvent.setup()
       render(<SidebarNav onCategoryChange={mockOnCategoryChange} />)
-      
+
       const toggleButton = screen.getByRole('button', { name: /expand sidebar/i })
       toggleButton.focus()
-      
+
       await user.keyboard(' ')
       expect(screen.getByRole('button', { name: /collapse sidebar/i })).toBeInTheDocument()
     })
   })
 
   describe('Category Selection', () => {
-    it('calls onCategoryChange when a category is clicked', async () => {
+    it('calls onCategoryChange when My Wagers is clicked', async () => {
       const user = userEvent.setup()
       render(<SidebarNav onCategoryChange={mockOnCategoryChange} />)
-      
-      const sportsButton = screen.getByRole('button', { name: /view sports/i })
-      await user.click(sportsButton)
-      
-      expect(mockOnCategoryChange).toHaveBeenCalledWith('sports')
+
+      const dashboardButton = screen.getByRole('button', { name: /view my wagers/i })
+      await user.click(dashboardButton)
+
+      expect(mockOnCategoryChange).toHaveBeenCalledWith('dashboard')
     })
 
     it('highlights selected category', () => {
-      render(<SidebarNav selectedCategory="sports" onCategoryChange={mockOnCategoryChange} />)
-      
-      const sportsButton = screen.getByRole('button', { name: /view sports/i })
-      expect(sportsButton).toHaveAttribute('aria-current', 'page')
+      render(<SidebarNav selectedCategory="dashboard" onCategoryChange={mockOnCategoryChange} />)
+
+      const dashboardButton = screen.getByRole('button', { name: /view my wagers/i })
+      expect(dashboardButton).toHaveAttribute('aria-current', 'page')
     })
 
     it('category buttons are keyboard accessible', async () => {
       const user = userEvent.setup()
       render(<SidebarNav onCategoryChange={mockOnCategoryChange} />)
-      
-      const financeButton = screen.getByRole('button', { name: /view finance/i })
-      financeButton.focus()
-      
+
+      const dashboardButton = screen.getByRole('button', { name: /view my wagers/i })
+      dashboardButton.focus()
+
       await user.keyboard('{Enter}')
-      expect(mockOnCategoryChange).toHaveBeenCalledWith('finance')
+      expect(mockOnCategoryChange).toHaveBeenCalledWith('dashboard')
     })
   })
 
@@ -132,24 +133,24 @@ describe('SidebarNav Component', () => {
     it('has no accessibility violations in expanded state', async () => {
       const user = userEvent.setup()
       const { container } = render(<SidebarNav onCategoryChange={mockOnCategoryChange} />)
-      
+
       const toggleButton = screen.getByRole('button', { name: /expand sidebar/i })
       await user.click(toggleButton)
-      
+
       const results = await axe(container)
       expect(results).toHaveNoViolations()
     })
 
     it('provides tooltips for collapsed category items', () => {
       render(<SidebarNav onCategoryChange={mockOnCategoryChange} />)
-      
-      const sportsButton = screen.getByRole('button', { name: /view sports/i })
-      expect(sportsButton).toHaveAttribute('title', 'Sports')
+
+      const dashboardButton = screen.getByRole('button', { name: /view my wagers/i })
+      expect(dashboardButton).toHaveAttribute('title', 'My Wagers')
     })
 
     it('toggle button has proper ARIA attributes', () => {
       render(<SidebarNav onCategoryChange={mockOnCategoryChange} />)
-      
+
       const toggleButton = screen.getByRole('button', { name: /expand sidebar/i })
       expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
       expect(toggleButton).toHaveAttribute('aria-label', 'Expand sidebar')
@@ -160,30 +161,42 @@ describe('SidebarNav Component', () => {
     it('does not expand on mouse hover', async () => {
       const user = userEvent.setup()
       const { container } = render(<SidebarNav onCategoryChange={mockOnCategoryChange} />)
-      
+
       const sidebar = container.querySelector('aside')
       await user.hover(sidebar)
-      
+
       // Sidebar should remain collapsed
       expect(screen.getByRole('button', { name: /expand sidebar/i })).toBeInTheDocument()
-      expect(screen.queryByRole('heading', { name: /categories/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('heading', { name: /navigation/i })).not.toBeInTheDocument()
     })
 
     it('maintains expanded state after category selection', async () => {
       const user = userEvent.setup()
       render(<SidebarNav onCategoryChange={mockOnCategoryChange} />)
-      
+
       // Expand sidebar
       const toggleButton = screen.getByRole('button', { name: /expand sidebar/i })
       await user.click(toggleButton)
-      
+
       // Select a category
-      const sportsButton = screen.getByRole('button', { name: /view sports/i })
-      await user.click(sportsButton)
-      
+      const dashboardButton = screen.getByRole('button', { name: /view my wagers/i })
+      await user.click(dashboardButton)
+
       // Sidebar should still be expanded
       expect(screen.getByRole('button', { name: /collapse sidebar/i })).toBeInTheDocument()
-      expect(screen.getByRole('heading', { name: /categories/i })).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: /navigation/i })).toBeInTheDocument()
+    })
+  })
+
+  describe('Mobile Rendering', () => {
+    it('returns null on mobile (no bottom nav)', () => {
+      vi.mocked(useIsMobile).mockReturnValue(true)
+
+      const { container } = render(<SidebarNav onCategoryChange={mockOnCategoryChange} />)
+      expect(container.innerHTML).toBe('')
+
+      // Reset to desktop
+      vi.mocked(useIsMobile).mockReturnValue(false)
     })
   })
 })


### PR DESCRIPTION
- Remove all market browsing categories (Trending, Sports, Crypto, Politics,
  Finance, Tech, Pop Culture, Weather, Other Markets, Perpetuals, All Markets
  Table) from SidebarNav, keeping only "My Wagers" dashboard
- Remove mobile bottom nav bar since only one destination remains
- Make OracleInfoPanel show "Not Connected" instead of "Available" when
  wallet is not connected
- Remove unused SVG icon imports and "Browse Markets" divider

https://claude.ai/code/session_015nJb7h5upYzhdWXTSjLYZw