### PR TITLE
fix: wager creation error hidden by state race + add staticCall pre-c…

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -864,7 +864,10 @@ function FriendMarketsModal({
       console.error('Error creating friend market:', error)
       const errorMessage = error.message || 'Failed to create market. Please try again.'
       setErrors({ submit: errorMessage })
-      setTxProgress(prev => ({ ...prev, error: errorMessage }))
+      // Reset step to 'idle' so the error banner is visible
+      // (TransactionProgress unmounts when submitting=false, and
+      // the error banner only shows when txProgress.step === 'idle')
+      setTxProgress({ step: 'idle', message: '', txHash: null, error: errorMessage })
     } finally {
       setSubmitting(false)
     }


### PR DESCRIPTION
…heck

Root cause: when a transaction failed after signing, the catch block set txProgress.error but left txProgress.step as 'create'. Meanwhile setSubmitting(false) caused TransactionProgress to unmount (it requires submitting=true). The error banner only renders when txProgress.step === 'idle'. Result: both error display paths were disabled simultaneously, so the user saw the form silently reset with no feedback.

Changes:
- Reset txProgress.step to 'idle' in catch block so fm-error-banner becomes visible when submitting goes false
- Add staticCall simulation before wallet prompt to catch contract reverts (InvalidDeadline, MembershipRequired, etc.) BEFORE the user signs, giving immediate error feedback instead of a doomed transaction
- Remove hardcoded gasLimit=1000000n which was skipping gas estimation and allowing reverts to pass through to signing
- Parse revert reasons in staticCall catch for user-friendly messages

https://claude.ai/code/session_01GnSbmmJLdNFPcSutP3MKAa