### PR TITLE
fix: resolve wager acceptance failure caused by proposalId collision

### DIFF
--- a/contracts/markets/FriendGroupMarketFactory.sol
+++ b/contracts/markets/FriendGroupMarketFactory.sol
@@ -1245,7 +1245,9 @@ contract FriendGroupMarketFactory is Ownable, ReentrancyGuard {
         uint256 totalStaked = marketTotalStaked[friendMarketId];
 
         // Deploy underlying market in ConditionalMarketFactory
-        uint256 proposalId = friendMarketId + PROPOSAL_ID_OFFSET;
+        // Use hash-based proposalId to avoid collisions between factory deployments.
+        // Including address(this) ensures each factory instance generates unique IDs.
+        uint256 proposalId = uint256(keccak256(abi.encodePacked(address(this), friendMarketId)));
         address collateral = defaultCollateralToken != address(0) ? defaultCollateralToken : market.stakeToken;
 
         // Approve collateral transfer to ConditionalMarketFactory

--- a/frontend/src/abis/FriendGroupMarketFactory.js
+++ b/frontend/src/abis/FriendGroupMarketFactory.js
@@ -123,9 +123,23 @@ export const FRIEND_GROUP_MARKET_FACTORY_ABI = [
     type: 'function'
   },
   {
-    inputs: [{ name: 'user', type: 'address' }],
-    name: 'getUserMarkets',
+    inputs: [],
+    name: 'getMyMarkets',
     outputs: [{ name: '', type: 'uint256[]' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [{ name: 'ids', type: 'uint256[]' }],
+    name: 'getFriendMarketsBatch',
+    outputs: [
+      { name: 'statuses', type: 'uint8[]' },
+      { name: 'creators', type: 'address[]' },
+      { name: 'stakeTokens', type: 'address[]' },
+      { name: 'stakeAmounts', type: 'uint256[]' },
+      { name: 'acceptedCounts', type: 'uint256[]' },
+      { name: 'acceptanceDeadlines', type: 'uint256[]' }
+    ],
     stateMutability: 'view',
     type: 'function'
   },
@@ -314,6 +328,15 @@ export const FRIEND_GROUP_MARKET_FACTORY_ABI = [
   },
 
   // Events
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, name: 'friendMarketId', type: 'uint256' },
+      { indexed: true, name: 'member', type: 'address' }
+    ],
+    name: 'MemberAdded',
+    type: 'event'
+  },
   {
     anonymous: false,
     inputs: [

--- a/frontend/src/test/FriendMarketsModal.test.jsx
+++ b/frontend/src/test/FriendMarketsModal.test.jsx
@@ -377,7 +377,7 @@ describe('FriendMarketsModal', () => {
     it('should display market type selection by default', () => {
       renderWithProviders(<FriendMarketsModal {...defaultProps} />)
 
-      expect(screen.getByText('Choose Market Type')).toBeInTheDocument()
+      expect(screen.getByText('Choose Wager Type')).toBeInTheDocument()
       expect(screen.getByText('1 vs 1')).toBeInTheDocument()
       expect(screen.getByText('Small Group')).toBeInTheDocument()
       expect(screen.getByText('Event Tracking')).toBeInTheDocument()
@@ -423,7 +423,7 @@ describe('FriendMarketsModal', () => {
       await userEvent.click(screen.getByText('1 vs 1'))
       await userEvent.click(screen.getByText('Back'))
 
-      expect(screen.getByText('Choose Market Type')).toBeInTheDocument()
+      expect(screen.getByText('Choose Wager Type')).toBeInTheDocument()
     })
 
     it('should display type badge in form header', async () => {
@@ -438,7 +438,7 @@ describe('FriendMarketsModal', () => {
       renderWithProviders(<FriendMarketsModal {...defaultProps} />)
 
       await userEvent.click(screen.getByText('1 vs 1'))
-      await userEvent.click(screen.getByRole('button', { name: /create market/i }))
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
 
       await waitFor(() => {
         expect(screen.getByText(/description is required/i)).toBeInTheDocument()
@@ -450,7 +450,7 @@ describe('FriendMarketsModal', () => {
 
       await userEvent.click(screen.getByText('1 vs 1'))
       await userEvent.type(screen.getByLabelText(/what's the bet/i), 'Short')
-      await userEvent.click(screen.getByRole('button', { name: /create market/i }))
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
 
       await waitFor(() => {
         expect(screen.getByText(/at least 10 characters/i)).toBeInTheDocument()
@@ -463,7 +463,7 @@ describe('FriendMarketsModal', () => {
       await userEvent.click(screen.getByText('1 vs 1'))
       await userEvent.type(screen.getByLabelText(/what's the bet/i), 'Patriots will win the Super Bowl')
       await userEvent.type(screen.getByLabelText(/opponent address/i), 'invalid-address')
-      await userEvent.click(screen.getByRole('button', { name: /create market/i }))
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
 
       await waitFor(() => {
         expect(screen.getByText(/invalid ethereum address/i)).toBeInTheDocument()
@@ -480,7 +480,7 @@ describe('FriendMarketsModal', () => {
         screen.getByLabelText(/opponent address/i),
         '0x1234567890123456789012345678901234567890'
       )
-      await userEvent.click(screen.getByRole('button', { name: /create market/i }))
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
 
       await waitFor(() => {
         expect(screen.getByText(/cannot bet against yourself/i)).toBeInTheDocument()
@@ -506,7 +506,7 @@ describe('FriendMarketsModal', () => {
       await userEvent.type(screen.getByLabelText(/what's the bet/i), 'BTC will reach $100k by end of year')
       // Need at least 2 members to pass minimum count check and hit address validation
       await userEvent.type(screen.getByLabelText(/member addresses/i), '0xinvalid, 0xalsobad')
-      await userEvent.click(screen.getByRole('button', { name: /create market/i }))
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
 
       await waitFor(() => {
         // Error message includes the truncated address
@@ -523,7 +523,7 @@ describe('FriendMarketsModal', () => {
         screen.getByLabelText(/member addresses/i),
         '0xabcdef1234567890123456789012345678901234, 0x9876543210987654321098765432109876543210'
       )
-      await userEvent.click(screen.getByRole('button', { name: /create market/i }))
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
 
       await waitFor(() => {
         expect(screen.getByText(/at least 3 members required/i)).toBeInTheDocument()
@@ -540,7 +540,7 @@ describe('FriendMarketsModal', () => {
         screen.getByLabelText(/opponent address/i),
         '0xabcdef1234567890123456789012345678901234'
       )
-      await userEvent.click(screen.getByRole('button', { name: /create market/i }))
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
 
       await waitFor(() => {
         expect(onCreate).toHaveBeenCalled()
@@ -559,7 +559,7 @@ describe('FriendMarketsModal', () => {
         screen.getByLabelText(/opponent address/i),
         '0xabcdef1234567890123456789012345678901234'
       )
-      await userEvent.click(screen.getByRole('button', { name: /create market/i }))
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
 
       await waitFor(() => {
         expect(screen.getByText('Market Created!')).toBeInTheDocument()
@@ -578,7 +578,7 @@ describe('FriendMarketsModal', () => {
         screen.getByLabelText(/opponent address/i),
         '0xabcdef1234567890123456789012345678901234'
       )
-      await userEvent.click(screen.getByRole('button', { name: /create market/i }))
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /create another/i })).toBeInTheDocument()
@@ -595,7 +595,7 @@ describe('FriendMarketsModal', () => {
         screen.getByLabelText(/opponent address/i),
         '0xabcdef1234567890123456789012345678901234'
       )
-      await userEvent.click(screen.getByRole('button', { name: /create market/i }))
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
 
       await waitFor(() => {
         expect(screen.getByText('Market Created!')).toBeInTheDocument()
@@ -603,7 +603,7 @@ describe('FriendMarketsModal', () => {
 
       await userEvent.click(screen.getByRole('button', { name: /create another/i }))
 
-      expect(screen.getByText('Choose Market Type')).toBeInTheDocument()
+      expect(screen.getByText('Choose Wager Type')).toBeInTheDocument()
     })
 
     it('should have Copy Link button in success state', async () => {
@@ -616,7 +616,7 @@ describe('FriendMarketsModal', () => {
         screen.getByLabelText(/opponent address/i),
         '0xabcdef1234567890123456789012345678901234'
       )
-      await userEvent.click(screen.getByRole('button', { name: /create market/i }))
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /copy link/i })).toBeInTheDocument()
@@ -792,7 +792,7 @@ describe('FriendMarketsModal', () => {
 
       await userEvent.click(screen.getByText('1 vs 1'))
       // Button should be enabled (not disabled) when wallet is connected
-      const createButton = screen.getByRole('button', { name: /create market/i })
+      const createButton = screen.getByRole('button', { name: /create wager/i })
       expect(createButton).not.toBeDisabled()
     })
 
@@ -802,7 +802,7 @@ describe('FriendMarketsModal', () => {
 
       await userEvent.click(screen.getByText('1 vs 1'))
       // Leave description empty and try to submit
-      await userEvent.click(screen.getByRole('button', { name: /create market/i }))
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
 
       await waitFor(() => {
         // Should show validation error

--- a/frontend/src/test/MarketAcceptanceModal.test.jsx
+++ b/frontend/src/test/MarketAcceptanceModal.test.jsx
@@ -159,13 +159,14 @@ describe('MarketAcceptanceModal', () => {
     it('should display participant count', () => {
       render(<MarketAcceptanceModal {...defaultProps} />)
 
-      expect(screen.getByText('2')).toBeInTheDocument()
+      // Participant count shown as "X / Y accepted"
+      expect(screen.getByText(/2 accepted/)).toBeInTheDocument()
     })
 
     it('should display acceptance progress', () => {
       render(<MarketAcceptanceModal {...defaultProps} />)
 
-      expect(screen.getByText('1 / 2')).toBeInTheDocument()
+      expect(screen.getByText('1 / 2 accepted')).toBeInTheDocument()
     })
 
     it('should display market type', () => {
@@ -178,7 +179,7 @@ describe('MarketAcceptanceModal', () => {
       const marketData = createMockMarketData({ isEncrypted: true })
       render(<MarketAcceptanceModal {...defaultProps} marketData={marketData} />)
 
-      expect(screen.getByText('Private Market')).toBeInTheDocument()
+      expect(screen.getByText('Private Wager')).toBeInTheDocument()
     })
 
     it('should show decrypt prompt for encrypted markets when user can decrypt', () => {
@@ -195,7 +196,7 @@ describe('MarketAcceptanceModal', () => {
       })
       render(<MarketAcceptanceModal {...defaultProps} marketData={marketData} />)
 
-      expect(screen.getByText('Unlock Market Details')).toBeInTheDocument()
+      expect(screen.getByText('Unlock Wager Details')).toBeInTheDocument()
     })
 
     it('should display stake with non-stablecoin symbol', () => {
@@ -294,7 +295,7 @@ describe('MarketAcceptanceModal', () => {
 
       render(<MarketAcceptanceModal {...defaultProps} />)
 
-      expect(screen.getByText(/You are not invited to this market/)).toBeInTheDocument()
+      expect(screen.getByText(/You are not invited to this wager/)).toBeInTheDocument()
     })
   })
 
@@ -302,7 +303,7 @@ describe('MarketAcceptanceModal', () => {
     it('should show review step initially', () => {
       render(<MarketAcceptanceModal {...defaultProps} />)
 
-      expect(screen.getByText('Review Market Offer')).toBeInTheDocument()
+      expect(screen.getByText('Review Offer')).toBeInTheDocument()
       expect(screen.getByText('Accept Offer')).toBeInTheDocument()
     })
 
@@ -333,7 +334,7 @@ describe('MarketAcceptanceModal', () => {
       expect(screen.getByText('Confirm Offer Acceptance')).toBeInTheDocument()
 
       await userEvent.click(screen.getByText('Back'))
-      expect(screen.getByText('Review Market Offer')).toBeInTheDocument()
+      expect(screen.getByText('Review Offer')).toBeInTheDocument()
     })
 
     it('should display safety warning in confirm step', async () => {
@@ -342,7 +343,7 @@ describe('MarketAcceptanceModal', () => {
       await userEvent.click(screen.getByText('Accept Offer'))
 
       expect(screen.getByText('Important Safety Information')).toBeInTheDocument()
-      expect(screen.getByText(/Only accept markets from people you know/)).toBeInTheDocument()
+      expect(screen.getByText(/Only accept offers from people you know/)).toBeInTheDocument()
     })
 
     it('should call onClose when Decline Offer is clicked', async () => {

--- a/frontend/src/test/MarketAcceptancePage.test.jsx
+++ b/frontend/src/test/MarketAcceptancePage.test.jsx
@@ -105,7 +105,7 @@ describe('MarketAcceptancePage', () => {
       renderWithRouter('')
 
       await waitFor(() => {
-        expect(screen.getByText('No market ID provided')).toBeInTheDocument()
+        expect(screen.getByText('No wager ID provided')).toBeInTheDocument()
       })
     })
 
@@ -133,7 +133,7 @@ describe('MarketAcceptancePage', () => {
 
       // Either loading or connect wallet message should appear
       await waitFor(() => {
-        const hasLoading = screen.queryByText('Loading market details...')
+        const hasLoading = screen.queryByText('Loading offer details...')
         const hasConnectPrompt = screen.queryByText(/connect your wallet/i)
         expect(hasLoading || hasConnectPrompt).toBeTruthy()
       })
@@ -145,8 +145,8 @@ describe('MarketAcceptancePage', () => {
       renderWithRouter('')
 
       await waitFor(() => {
-        expect(screen.getByText('Unable to Load Market')).toBeInTheDocument()
-        expect(screen.getByText('No market ID provided')).toBeInTheDocument()
+        expect(screen.getByText('Unable to Load Offer')).toBeInTheDocument()
+        expect(screen.getByText('No wager ID provided')).toBeInTheDocument()
       })
     })
 
@@ -173,7 +173,7 @@ describe('MarketAcceptancePage', () => {
 
       await waitFor(() => {
         expect(screen.getByTestId('market-description')).toHaveTextContent(
-          'Connect wallet to view full market details'
+          'Connect wallet to view full offer details'
         )
       })
     })

--- a/test/FriendGroupMarketFactory.test.js
+++ b/test/FriendGroupMarketFactory.test.js
@@ -497,8 +497,8 @@ describe("FriendGroupMarketFactory", function () {
         { value: stakeAmount }
       );
 
-      // Initially only creator is member
-      const ownerMarkets = await friendGroupFactory.getUserMarkets(owner.address);
+      // Verify creator can see their own markets via getMyMarkets
+      const ownerMarkets = await friendGroupFactory.connect(owner).getMyMarkets();
       expect(ownerMarkets.length).to.equal(1);
     });
   });
@@ -751,11 +751,19 @@ describe("FriendGroupMarketFactory", function () {
       expect(market.description).to.equal("Bet 1");
     });
 
-    it("Should return user markets correctly", async function () {
-      const addr1Markets = await friendGroupFactory.getUserMarkets(addr1.address);
+    it("Should return user markets correctly via getMyMarkets", async function () {
+      const addr1Markets = await friendGroupFactory.connect(addr1).getMyMarkets();
       expect(addr1Markets.length).to.equal(2);
       expect(addr1Markets[0]).to.equal(0);
       expect(addr1Markets[1]).to.equal(1);
+    });
+
+    it("Should emit MemberAdded events during market creation", async function () {
+      // MemberAdded events should have been emitted for both participants
+      // when the 1v1 market was created
+      const filter = friendGroupFactory.filters.MemberAdded(0, null);
+      const events = await friendGroupFactory.queryFilter(filter);
+      expect(events.length).to.be.greaterThanOrEqual(2);
     });
 
     it("Should check membership correctly", async function () {


### PR DESCRIPTION
The acceptMarket transaction was reverting with "Market already exists"
because _activateMarket generated proposalIds using a simple offset
(friendMarketId + PROPOSAL_ID_OFFSET) which collided with IDs created
by a previous FriendGroupMarketFactory deployment pointing to the same
ConditionalMarketFactory.

Contract fix:
- Use hash-based proposalId (keccak256 of factory address + marketId)
  to guarantee uniqueness across factory deployments

Frontend fix (MarketAcceptanceModal):
- Add staticCall pre-flight simulation before sending the transaction
  so revert reasons are caught early without wasting gas
- Add mapping of downstream revert reason strings (e.g. "Market already
  exists", "Requires owner or MARKET_MAKER_ROLE") to user-friendly
  error messages
- Strip verbose ethers v6 CALL_EXCEPTION details from the UI display

https://claude.ai/code/session_011Csv3fPwr4MCynaHiA5CGy