### PR TITLE
fix: reliably fetch and display active wagers for connected wallets

### DIFF
--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -1336,7 +1336,7 @@ export async function fetchFriendMarketsForUser(userAddress) {
     return markets.filter(m => m !== null)
   } catch (error) {
     console.error('Error fetching friend markets from blockchain:', error)
-    return []
+    throw error
   }
 }
 


### PR DESCRIPTION
Dashboard was only showing hardcoded mock data (empty in live mode) and
its modals received no friend market data. WalletButton's fetch silently
dropped empty results due to a length guard and had no retry logic.
fetchFriendMarketsForUser swallowed errors, making failed RPC calls
indistinguishable from "no markets".

- Dashboard: fetch friend markets from blockchain with retry, transform
  to wager format, pass data to MyMarketsModal and FriendMarketsModal
- WalletButton: always update state on successful fetch (remove length
  guard), add retry with exponential backoff, add cleanup on unmount
- blockchainService: re-throw errors from fetchFriendMarketsForUser so
  callers can distinguish "no markets" from "fetch failed"

https://claude.ai/code/session_01SrmZZmHaS9hiVaiTtdXv39