### PR TITLE
Show offer details on review page and use consistent wager/offer terminology

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -57,18 +57,18 @@ const getMarketDescription = (market) => {
   if (market.metadata && market.canView !== false) {
     // Decrypted metadata may have name, description, or question field
     const title = market.metadata.name || market.metadata.description || market.metadata.question
-    if (title && title !== 'Private Market' && title !== 'Encrypted Market') {
+    if (title && title !== 'Private Market' && title !== 'Private Wager' && title !== 'Encrypted Market' && title !== 'Encrypted Wager') {
       return title
     }
   }
 
   // Check raw description, skip placeholder values
   const desc = market.description
-  if (desc && desc !== 'Encrypted Market' && desc !== 'Private Market') {
+  if (desc && desc !== 'Encrypted Market' && desc !== 'Encrypted Wager' && desc !== 'Private Market' && desc !== 'Private Wager') {
     return desc
   }
 
-  // For encrypted/private markets, show stake and time info instead of "Market #X"
+  // For encrypted/private wagers, show stake and time info instead of generic label
   const stakeInfo = market.stakeAmount ? `${market.stakeAmount} ${market.stakeTokenSymbol || 'ETC'}` : ''
   return `Private Bet${stakeInfo ? ` - ${stakeInfo}` : ''}`
 }
@@ -408,7 +408,7 @@ function FriendMarketsModal({
       handleFormChange('peggedMarketId', marketLookupId)
     } catch (error) {
       console.error('Market lookup error:', error)
-      setMarketLookupError('Market not found or unable to fetch details')
+      setMarketLookupError('Wager not found or unable to fetch details')
     } finally {
       setMarketLookupLoading(false)
     }
@@ -507,7 +507,7 @@ function FriendMarketsModal({
       await tx.wait()
       console.log('Market cancelled successfully')
 
-      window.alert('Market cancelled. Stakes have been refunded.')
+      window.alert('Wager cancelled. Stakes have been refunded.')
       // Refresh to show updated state
       window.location.reload()
     } catch (error) {
@@ -685,9 +685,9 @@ function FriendMarketsModal({
         if (!formData.arbitrator || !formData.arbitrator.trim()) {
           newErrors.arbitrator = 'Linked market ID is required for auto-pegged resolution'
         } else if (!/^\d+$/.test(formData.arbitrator.trim())) {
-          newErrors.arbitrator = 'Market ID must be a number'
+          newErrors.arbitrator = 'Wager ID must be a number'
         } else if (parseInt(formData.arbitrator.trim(), 10) < 0) {
-          newErrors.arbitrator = 'Market ID must be a positive number'
+          newErrors.arbitrator = 'Wager ID must be a positive number'
         }
       }
     }
@@ -862,7 +862,7 @@ function FriendMarketsModal({
       setCreationStep('success')
     } catch (error) {
       console.error('Error creating friend market:', error)
-      const errorMessage = error.message || 'Failed to create market. Please try again.'
+      const errorMessage = error.message || 'Failed to create wager. Please try again.'
       setErrors({ submit: errorMessage })
       // Reset step to 'idle' so the error banner is visible
       // (TransactionProgress unmounts when submitting=false, and
@@ -956,7 +956,7 @@ function FriendMarketsModal({
       if (err.code === 'ACTION_REJECTED' || err.code === 4001) {
         setResolveError('Transaction rejected in wallet.')
       } else if (err.reason?.includes('NotActive') || err.message?.includes('NotActive')) {
-        setResolveError('Market is not active. It may already be resolved or still pending acceptance.')
+        setResolveError('Wager is not active. It may already be resolved or still pending acceptance.')
       } else if (err.reason?.includes('NotAuthorized') || err.message?.includes('NotAuthorized')) {
         setResolveError('You are not authorized to resolve this market.')
       } else {
@@ -1201,7 +1201,7 @@ function FriendMarketsModal({
               {/* Type Selection Step */}
               {creationStep === 'type' && (
                 <div className="fm-type-selection">
-                  <h3 className="fm-section-title">Choose Market Type</h3>
+                  <h3 className="fm-section-title">Choose Wager Type</h3>
                   <div className="fm-type-grid">
                     <button
                       className="fm-type-card"
@@ -1457,14 +1457,14 @@ function FriendMarketsModal({
                           <option value={ResolutionType.Initiator}>Creator Only</option>
                           <option value={ResolutionType.Receiver}>Opponent Only</option>
                           <option value={ResolutionType.ThirdParty}>Third Party Arbitrator</option>
-                          <option value={ResolutionType.AutoPegged}>Linked Market (Auto)</option>
+                          <option value={ResolutionType.AutoPegged}>Linked Wager (Auto)</option>
                         </select>
                         <span className="fm-hint">
-                          {formData.resolutionType === ResolutionType.Either && 'Either you or your opponent can resolve the market'}
-                          {formData.resolutionType === ResolutionType.Initiator && 'Only you (the creator) can resolve the market'}
-                          {formData.resolutionType === ResolutionType.Receiver && 'Only your opponent can resolve the market'}
+                          {formData.resolutionType === ResolutionType.Either && 'Either you or your opponent can resolve the wager'}
+                          {formData.resolutionType === ResolutionType.Initiator && 'Only you (the creator) can resolve the wager'}
+                          {formData.resolutionType === ResolutionType.Receiver && 'Only your opponent can resolve the wager'}
                           {formData.resolutionType === ResolutionType.ThirdParty && 'A designated arbitrator will resolve disputes'}
-                          {formData.resolutionType === ResolutionType.AutoPegged && 'Resolution follows a linked public market'}
+                          {formData.resolutionType === ResolutionType.AutoPegged && 'Resolution follows a linked public wager'}
                         </span>
                       </div>
                     )}
@@ -1593,7 +1593,7 @@ function FriendMarketsModal({
                         <label htmlFor="fm-arbitrator">
                           {formData.resolutionType === ResolutionType.ThirdParty
                             ? 'Arbitrator Address'
-                            : 'Linked Market ID'} <span className="fm-required">*</span>
+                            : 'Linked Wager ID'} <span className="fm-required">*</span>
                         </label>
                         <div className="fm-input-with-action">
                           <input
@@ -1603,7 +1603,7 @@ function FriendMarketsModal({
                             onChange={(e) => handleFormChange('arbitrator', e.target.value)}
                             placeholder={formData.resolutionType === ResolutionType.ThirdParty
                               ? '0x... (trusted third party address)'
-                              : 'Market ID to follow (e.g., 123)'}
+                              : 'Wager ID to follow (e.g., 123)'}
                             disabled={submitting}
                             className={errors.arbitrator ? 'error' : ''}
                           />
@@ -1651,7 +1651,7 @@ function FriendMarketsModal({
                               <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
                               <path d="M7 11V7a5 5 0 0110 0v4"/>
                             </svg>
-                            Private Market
+                            Private Wager
                           </span>
                         </label>
 
@@ -1667,7 +1667,7 @@ function FriendMarketsModal({
                         <span className="fm-hint">
                           {enableEncryption
                             ? 'End-to-end encrypted with X-Wing (quantum-resistant). Only participants can decrypt.'
-                            : 'Market details will be publicly visible on the blockchain.'}
+                            : 'Wager details will be publicly visible on the blockchain.'}
                         </span>
 
                         {enableEncryption && (
@@ -1735,7 +1735,7 @@ function FriendMarketsModal({
                               type="text"
                               value={marketLookupId}
                               onChange={(e) => setMarketLookupId(e.target.value)}
-                              placeholder="Enter market ID to look up..."
+                              placeholder="Enter wager ID to look up..."
                               disabled={submitting || marketLookupLoading}
                             />
                             <button
@@ -1872,7 +1872,7 @@ function FriendMarketsModal({
                           Creating...
                         </>
                       ) : (
-                        'Create Market'
+                        'Create Wager'
                       )}
                     </button>
                   </div>
@@ -2416,7 +2416,7 @@ function MarketsCompactTable({
                       fill="none"
                       stroke="currentColor"
                       strokeWidth="2"
-                      title={needsUnlock ? 'Click to unlock' : 'Encrypted market'}
+                      title={needsUnlock ? 'Click to unlock' : 'Encrypted wager'}
                     >
                       <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
                       <path d="M7 11V7a5 5 0 0110 0v4"/>
@@ -2559,7 +2559,7 @@ function MarketDetailView({
               fill="none"
               stroke="currentColor"
               strokeWidth="2"
-              title="Encrypted market"
+              title="Encrypted wager"
             >
               <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
               <path d="M7 11V7a5 5 0 0110 0v4"/>

--- a/frontend/src/components/fairwins/MarketAcceptanceModal.css
+++ b/frontend/src/components/fairwins/MarketAcceptanceModal.css
@@ -250,14 +250,126 @@
   font-size: 1rem;
 }
 
-/* Terms Grid */
-.ma-terms-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1rem;
-  margin-bottom: 1.5rem;
+/* Offer Details Section */
+.ma-offer-details {
+  margin-bottom: 1.25rem;
 }
 
+.ma-offer-details h4,
+.ma-financial-summary h4 {
+  margin: 0 0 0.75rem 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.ma-details-list {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.ma-detail-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.625rem 1rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.ma-detail-row:last-child {
+  border-bottom: none;
+}
+
+.ma-detail-label {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.ma-detail-value {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.ma-detail-value.ma-address {
+  font-family: 'Courier New', monospace;
+  font-size: 0.8125rem;
+}
+
+/* Financial Summary Section */
+.ma-financial-summary {
+  margin-bottom: 1.25rem;
+}
+
+.ma-financial-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+}
+
+.ma-financial-item {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  padding: 0.875rem;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.ma-financial-label {
+  display: block;
+  font-size: 0.6875rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.375rem;
+}
+
+.ma-financial-value {
+  display: block;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.ma-financial-stake {
+  background: linear-gradient(135deg, rgba(76, 154, 255, 0.12), rgba(76, 154, 255, 0.06));
+  border-color: rgba(76, 154, 255, 0.3);
+}
+
+.ma-financial-stake .ma-financial-value {
+  color: #4C9AFF;
+}
+
+.ma-financial-win {
+  background: rgba(54, 179, 126, 0.1);
+  border-color: rgba(54, 179, 126, 0.3);
+}
+
+.ma-financial-win .ma-financial-value {
+  color: #36B37E;
+}
+
+.ma-financial-lose {
+  background: rgba(239, 68, 68, 0.08);
+  border-color: rgba(239, 68, 68, 0.2);
+}
+
+.ma-financial-lose .ma-financial-value {
+  color: #ef4444;
+}
+
+.ma-arbitrator-note {
+  margin: 0.75rem 0 0 0;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+/* Legacy term styles (used in arbitrator info) */
 .ma-term {
   background: var(--bg-primary);
   border: 1px solid var(--border-color);
@@ -280,22 +392,7 @@
   color: var(--text-primary);
 }
 
-.ma-term .ma-address {
-  font-family: 'Courier New', monospace;
-  font-size: 0.875rem;
-}
-
-.ma-term-highlight {
-  background: linear-gradient(135deg, rgba(76, 154, 255, 0.15), rgba(54, 179, 126, 0.15));
-  border: 1px solid rgba(76, 154, 255, 0.3);
-}
-
-.ma-term-highlight .ma-value {
-  color: var(--color-success, #36B37E);
-}
-
 .ma-term-info {
-  grid-column: span 2;
   background: rgba(76, 154, 255, 0.1);
   border: 1px solid rgba(76, 154, 255, 0.3);
 }
@@ -718,12 +815,8 @@
     max-width: 100%;
   }
 
-  .ma-terms-grid {
+  .ma-financial-grid {
     grid-template-columns: 1fr;
-  }
-
-  .ma-term-info {
-    grid-column: span 1;
   }
 
   .ma-actions {

--- a/frontend/src/components/fairwins/MarketTile.jsx
+++ b/frontend/src/components/fairwins/MarketTile.jsx
@@ -26,7 +26,7 @@ function MarketTile({ market, onClick, isActive = false, compact = false }) {
     // First check decrypted metadata (from useDecryptedMarkets hook)
     if (market.metadata && market.canView !== false) {
       const title = market.metadata.name || market.metadata.description || market.metadata.question
-      if (title && title !== 'Private Market' && title !== 'Encrypted Market') {
+      if (title && title !== 'Private Market' && title !== 'Private Wager' && title !== 'Encrypted Market' && title !== 'Encrypted Wager') {
         return title
       }
     }
@@ -35,7 +35,7 @@ function MarketTile({ market, onClick, isActive = false, compact = false }) {
     if (market.marketType === 'friend') {
       const desc = market.description
       // Skip placeholder values
-      if (desc && desc !== 'Encrypted Market' && desc !== 'Private Market') {
+      if (desc && desc !== 'Encrypted Market' && desc !== 'Encrypted Wager' && desc !== 'Private Market' && desc !== 'Private Wager') {
         return desc
       }
       // If encrypted/private, show stake info
@@ -98,7 +98,7 @@ function MarketTile({ market, onClick, isActive = false, compact = false }) {
       </div>
 
       <h3 className="tile-title">
-        {isPrivateMarket && <span className="private-icon" title="Private Market">🔒 </span>}
+        {isPrivateMarket && <span className="private-icon" title="Private Wager">🔒 </span>}
         {displayTitle}
       </h3>
 

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -783,7 +783,7 @@ function getMarketDisplayTitle(market) {
   // First check decrypted metadata (from useDecryptedMarkets hook)
   if (market.metadata && market.canView !== false) {
     const title = market.metadata.name || market.metadata.description || market.metadata.question
-    if (title && title !== 'Private Market' && title !== 'Encrypted Market') {
+    if (title && title !== 'Private Market' && title !== 'Private Wager' && title !== 'Encrypted Market' && title !== 'Encrypted Wager') {
       return title
     }
   }
@@ -792,7 +792,7 @@ function getMarketDisplayTitle(market) {
   if (market.marketType === 'friend') {
     const desc = market.description
     // Skip placeholder values
-    if (desc && desc !== 'Encrypted Market' && desc !== 'Private Market') {
+    if (desc && desc !== 'Encrypted Market' && desc !== 'Encrypted Wager' && desc !== 'Private Market' && desc !== 'Private Wager') {
       return desc
     }
     // If encrypted/private, show stake and time info
@@ -1144,7 +1144,9 @@ function MarketDetailView({
       {market.description &&
        market.proposalTitle &&
        market.description !== 'Encrypted Market' &&
-       market.description !== 'Private Market' && (
+       market.description !== 'Encrypted Wager' &&
+       market.description !== 'Private Market' &&
+       market.description !== 'Private Wager' && (
         <div className="mm-detail-description">
           <p>{market.description}</p>
         </div>
@@ -1152,7 +1154,7 @@ function MarketDetailView({
 
       <div className="mm-detail-grid">
         <div className="mm-detail-item">
-          <span className="mm-detail-label">Market ID</span>
+          <span className="mm-detail-label">Wager ID</span>
           <span className="mm-detail-value">#{market.id}</span>
         </div>
         <div className="mm-detail-item">

--- a/frontend/src/components/fairwins/TransactionProgress.jsx
+++ b/frontend/src/components/fairwins/TransactionProgress.jsx
@@ -18,8 +18,8 @@ const STEP_CONFIGS = {
   friend_market: [
     { id: 'verify', label: 'Verify Role', description: 'Checking membership status' },
     { id: 'approve', label: 'Approve Token', description: 'Approving token spend', optional: true },
-    { id: 'create', label: 'Create Market', description: 'Confirm transaction in wallet' },
-    { id: 'complete', label: 'Complete', description: 'Market created successfully' }
+    { id: 'create', label: 'Create Wager', description: 'Confirm transaction in wallet' },
+    { id: 'complete', label: 'Complete', description: 'Wager created successfully' }
   ],
   accept_market: [
     { id: 'verify', label: 'Verify', description: 'Checking invitation' },

--- a/frontend/src/pages/MarketAcceptancePage.jsx
+++ b/frontend/src/pages/MarketAcceptancePage.jsx
@@ -81,7 +81,7 @@ function MarketAcceptancePage() {
   useEffect(() => {
     const fetchMarketData = async () => {
       if (!marketId) {
-        setError('No market ID provided')
+        setError('No wager ID provided')
         setLoading(false)
         return
       }
@@ -163,10 +163,14 @@ function MarketAcceptancePage() {
           // Format stake amount with correct decimals
           const stakeAmount = ethers.formatUnits(marketResult.stakePerParticipant, tokenDecimals)
 
+          // Get resolution type and odds from contract
+          const resolutionType = Number(marketResult.resolutionType)
+          const opponentOddsMultiplier = Number(marketResult.opponentOddsMultiplier)
+
           // Handle encrypted descriptions - show placeholder instead of JSON
           const rawDescription = marketResult.description
           const displayDescription = isEncryptedDescription(rawDescription)
-            ? 'Encrypted Market (details visible to participants)'
+            ? 'Encrypted Wager (details visible to participants)'
             : rawDescription
 
           // Get createdAt from full market result
@@ -220,6 +224,8 @@ function MarketAcceptancePage() {
             stakeTokenSymbol: tokenSymbol,
             acceptances,
             acceptedCount: Number(acceptanceStatus.accepted),
+            opponentOddsMultiplier,
+            resolutionType,
             // Add market end date info
             createdAt,
             tradingPeriodSeconds: tradingPeriodSeconds || tradingPeriodFromMetadata,
@@ -233,7 +239,7 @@ function MarketAcceptancePage() {
           if (urlCreator && urlStake) {
             setMarketData({
               id: marketId,
-              description: 'Market details will load when connected...',
+              description: 'Offer details will load when connected...',
               creator: urlCreator,
               participants: [],
               arbitrator: null,
@@ -248,7 +254,7 @@ function MarketAcceptancePage() {
               acceptedCount: 0
             })
           } else {
-            setError('Failed to load market data. Please ensure you are connected to the correct network.')
+            setError('Failed to load offer data. Please ensure you are connected to the correct network.')
           }
         }
       } else {
@@ -256,7 +262,7 @@ function MarketAcceptancePage() {
         if (urlCreator && urlStake) {
           setMarketData({
             id: marketId,
-            description: 'Connect wallet to view full market details',
+            description: 'Connect wallet to view full offer details',
             creator: urlCreator,
             participants: [],
             arbitrator: null,
@@ -271,7 +277,7 @@ function MarketAcceptancePage() {
             acceptedCount: 0
           })
         } else {
-          setError('Please connect your wallet to view market details')
+          setError('Please connect your wallet to view offer details')
         }
       }
 
@@ -295,7 +301,7 @@ function MarketAcceptancePage() {
     return (
       <div className="map-loading">
         <div className="map-spinner"></div>
-        <p>Loading market details...</p>
+        <p>Loading offer details...</p>
       </div>
     )
   }
@@ -304,7 +310,7 @@ function MarketAcceptancePage() {
     return (
       <div className="map-error">
         <div className="map-error-icon">&#9888;</div>
-        <h2>Unable to Load Market</h2>
+        <h2>Unable to Load Offer</h2>
         <p>{error}</p>
         <button className="map-btn" onClick={handleClose}>
           Go Back

--- a/frontend/src/wagmi.js
+++ b/frontend/src/wagmi.js
@@ -116,7 +116,7 @@ export const config = createConfig({
       projectId: walletConnectProjectId,
       metadata: {
         name: 'Prediction DAO',
-        description: 'Decentralized prediction markets on Ethereum Classic',
+        description: 'Decentralized prediction markets and wagers',
         url: appUrl,
         icons: [`${appUrl}/assets/fairwins_no-text_logo.svg`]
       },


### PR DESCRIPTION
- Redesign Review Offer page with structured sections: Offer Details,
  Financial Summary (what you're agreeing to), and Participants
- Add resolution type, arbitrator, token, and total pot to offer details
- Pass resolutionType and opponentOddsMultiplier from contract data
- Add "If You Lose" display so users see full risk picture
- Replace "market" with "wager"/"offer" across friend wager components:
  MarketAcceptanceModal, MarketAcceptancePage, FriendMarketsModal,
  MarketTile, MyMarketsModal, TransactionProgress
- Use centralized block explorer config instead of hardcoded Mordor URL
- Update WalletConnect description to be chain-agnostic

https://claude.ai/code/session_01GHBuT643MVT7pzLkFhS6rh