### PR TITLE
Fix key registration sending empty transaction data

### DIFF
--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -1123,14 +1123,12 @@ export async function registerZKKey(signer, publicKey) {
       throw new Error('ZKKeyManager contract not deployed yet. Please register your key later.')
     }
 
-    const zkKeyManagerContract = new ethers.Contract(
-      zkKeyManagerAddress,
-      ZK_KEY_MANAGER_ABI,
-      signer
-    )
+    // Explicitly encode function call data to avoid ethers v6 Contract proxy
+    // + BrowserProvider (wagmi transport) dropping the data field
+    const iface = new ethers.Interface(ZK_KEY_MANAGER_ABI)
+    const data = iface.encodeFunctionData('registerKey', [publicKey.trim()])
 
-    // Call registerKey function
-    const tx = await zkKeyManagerContract.registerKey(publicKey.trim())
+    const tx = await signer.sendTransaction({ to: zkKeyManagerAddress, data })
     const receipt = await tx.wait()
 
     return {

--- a/frontend/src/utils/keyRegistryService.js
+++ b/frontend/src/utils/keyRegistryService.js
@@ -134,8 +134,12 @@ export async function registerEncryptionKey(signer, publicKeyBytes) {
     throw new Error('ZKKeyManager contract not configured')
   }
 
-  const contract = new ethers.Contract(address, ZK_KEY_MANAGER_ABI, signer)
-  const tx = await contract.registerKey(publicKeyHex)
+  // Explicitly encode the function call data to avoid issues with ethers v6
+  // Contract proxy + BrowserProvider (wagmi transport) dropping the data field
+  const iface = new ethers.Interface(ZK_KEY_MANAGER_ABI)
+  const data = iface.encodeFunctionData('registerKey', [publicKeyHex])
+
+  const tx = await signer.sendTransaction({ to: address, data })
   const receipt = await tx.wait()
 
   // Invalidate cache for this user


### PR DESCRIPTION
The ethers v6 Contract proxy combined with BrowserProvider created from
wagmi's viem walletClient transport was dropping the `data` field,
causing transactions to be sent with empty calldata (data: ""). This
made every registerKey call revert as a plain ETH transfer to the
contract.

Fix by explicitly encoding function calldata via ethers.Interface and
sending with signer.sendTransaction(), bypassing the Contract proxy.

https://claude.ai/code/session_01Lj6Rk2f9merNSyw81bNESG