### PR TITLE
fix(frontend): accept any supported chain, not just one EXPECTED_CHAIN_ID

### DIFF
--- a/frontend/src/config/networks.js
+++ b/frontend/src/config/networks.js
@@ -126,6 +126,16 @@ export function isDexAvailable(chainId) {
   return Boolean(getNetwork(chainId)?.dex)
 }
 
+/**
+ * Whether a chainId is a supported network. Used by the wallet/web3 contexts
+ * to allow either Mordor (limited functionality) or Polygon Amoy (primary)
+ * without prompting the user to switch — the per-chain capabilities map
+ * controls what features each chain can actually do.
+ */
+export function isSupportedChainId(chainId) {
+  return Object.prototype.hasOwnProperty.call(NETWORKS, chainId)
+}
+
 export function listSupportedChainIds() {
   return Object.keys(NETWORKS).map((id) => parseInt(id, 10))
 }

--- a/frontend/src/contexts/WalletContext.jsx
+++ b/frontend/src/contexts/WalletContext.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useAccount, useConnect, useDisconnect, useChainId, useSwitchChain, useWalletClient } from 'wagmi'
 import { ethers } from 'ethers'
-import { EXPECTED_CHAIN_ID, getExpectedChain } from '../wagmi'
+import { isSupportedChainId, getNetwork, listSupportedChainIds, PRIMARY_CHAIN_ID } from '../config/networks'
 import {
   getUserRoles,
   addUserRole,
@@ -108,11 +108,20 @@ export function WalletProvider({ children }) {
     return () => { cancelled = true }
   }, [isConnected, address, walletClient])
 
-  // Check network compatibility
+  // Check network compatibility. The app supports multiple chains (Mordor
+  // and Polygon Amoy today); a network error is only emitted when the
+  // wallet is on a chain we don't recognize. The LimitedFunctionalityBanner
+  // handles steering Mordor users toward Amoy.
   useEffect(() => {
-    if (isConnected && chainId !== EXPECTED_CHAIN_ID) {
-      const expectedChain = getExpectedChain()
-      setNetworkError(`Wrong network. Please switch to ${expectedChain.name} (Chain ID: ${EXPECTED_CHAIN_ID})`)
+    if (isConnected && !isSupportedChainId(chainId)) {
+      const supported = listSupportedChainIds()
+        .map((id) => getNetwork(id)?.name)
+        .filter(Boolean)
+        .join(' or ')
+      const primary = getNetwork(PRIMARY_CHAIN_ID)
+      setNetworkError(
+        `Wrong network. Please switch to ${supported || primary?.name || 'a supported network'}.`
+      )
     } else {
       setNetworkError(null)
     }
@@ -383,14 +392,18 @@ export function WalletProvider({ children }) {
     }
   }, [disconnect])
 
-  // Switch to correct network
+  // Switch to the configured primary network (Polygon Amoy post-migration).
+  // This is invoked from the network-error banner / "Switch Network" button;
+  // users on Mordor are not directed here because Mordor is supported.
   const switchNetwork = useCallback(async () => {
+    const target = PRIMARY_CHAIN_ID
     try {
-      await switchChain({ chainId: EXPECTED_CHAIN_ID })
+      await switchChain({ chainId: target })
       return true
     } catch (error) {
       console.error('Error switching network:', error)
-      throw new Error(`Please manually switch to ${getExpectedChain().name} in your wallet`)
+      const targetNet = getNetwork(target)
+      throw new Error(`Please manually switch to ${targetNet?.name || 'Polygon Amoy'} in your wallet`)
     }
   }, [switchChain])
 
@@ -475,9 +488,12 @@ export function WalletProvider({ children }) {
     }
   }, [address])
 
-  // Computed values
+  // Computed values. "Correct" here means any supported chain — Mordor or
+  // Polygon Amoy. Per-chain feature gates (e.g. polymarketSidebets only on
+  // Amoy) are enforced via the capabilities map in networks.js, not by
+  // refusing to load the app on Mordor.
   const isCorrectNetwork = useMemo(
-    () => isConnected && chainId === EXPECTED_CHAIN_ID,
+    () => isConnected && isSupportedChainId(chainId),
     [isConnected, chainId]
   )
 

--- a/frontend/src/contexts/Web3Context.jsx
+++ b/frontend/src/contexts/Web3Context.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useAccount, useConnect, useDisconnect, useChainId, useSwitchChain } from 'wagmi'
 import { ethers } from 'ethers'
-import { EXPECTED_CHAIN_ID, getExpectedChain } from '../wagmi'
+import { isSupportedChainId, getNetwork, listSupportedChainIds, PRIMARY_CHAIN_ID } from '../config/networks'
 import { Web3Context } from './Web3Context'
 
 export function Web3Provider({ children }) {
@@ -44,15 +44,25 @@ export function Web3Provider({ children }) {
     return () => { ignore = true }
   }, [isConnected, address])
 
-  // Check network compatibility
+  // Check network compatibility. The app supports multiple networks (Mordor
+  // and Polygon Amoy today); only emit a network error when the connected
+  // chain is not in the supported set. The LimitedFunctionalityBanner takes
+  // care of steering users from limited chains (Mordor) to the primary
+  // (Amoy) — this hook only fires for chains we don't recognize at all.
   useEffect(() => {
     let ignore = false
 
     const checkNetwork = async () => {
-      if (isConnected && chainId !== EXPECTED_CHAIN_ID) {
-        const expectedChain = getExpectedChain()
+      if (isConnected && !isSupportedChainId(chainId)) {
+        const supported = listSupportedChainIds()
+          .map((id) => getNetwork(id)?.name)
+          .filter(Boolean)
+          .join(' or ')
+        const primary = getNetwork(PRIMARY_CHAIN_ID)
         if (!ignore) {
-          setNetworkError(`Wrong network. Please switch to ${expectedChain.name} (Chain ID: ${EXPECTED_CHAIN_ID})`)
+          setNetworkError(
+            `Wrong network. Please switch to ${supported || primary?.name || 'a supported network'}.`
+          )
         }
       } else {
         if (!ignore) {
@@ -99,13 +109,19 @@ export function Web3Provider({ children }) {
   }, [disconnect])
 
   const handleSwitchNetwork = useCallback(async () => {
+    // Switch to the configured primary chain (Polygon Amoy post-migration).
+    // If the user is on Mordor that's already a supported chain — they only
+    // see this code path when they're on an unrecognized network.
+    const target = PRIMARY_CHAIN_ID
     try {
-      await switchChain({ chainId: EXPECTED_CHAIN_ID })
+      await switchChain({ chainId: target })
     } catch (error) {
       console.error('Error switching network:', error)
-      
-      // If switching failed, show instructions
-      alert(`Please manually switch to the correct network in MetaMask:\nNetwork: ${getExpectedChain().name}\nChain ID: ${EXPECTED_CHAIN_ID}`)
+      const targetNet = getNetwork(target)
+      alert(
+        `Please manually switch to the correct network in your wallet:\n` +
+        `Network: ${targetNet?.name || 'Polygon Amoy'}\nChain ID: ${target}`
+      )
     }
   }, [switchChain])
 
@@ -119,9 +135,11 @@ export function Web3Provider({ children }) {
     provider,
     signer,
     
-    // Network state
+    // Network state — "correct" means any supported chain (Mordor or Amoy).
+    // Use capabilities from networks.js to decide whether a feature is
+    // available on the connected chain rather than gating on chain identity.
     networkError,
-    isCorrectNetwork: isConnected && chainId === EXPECTED_CHAIN_ID,
+    isCorrectNetwork: isConnected && isSupportedChainId(chainId),
     
     // Actions
     connectWallet,


### PR DESCRIPTION
## Summary

After the Polygon Amoy migration landed (PR #568), users connecting on Amoy were greeted with `Wrong network. Please switch to Mordor (Chain ID: 63)` (and conversely, Mordor users would have seen the same warning aimed at Amoy). Root cause: `Web3Context.jsx` and `WalletContext.jsx` both did `chainId !== EXPECTED_CHAIN_ID` — a strict equality check against a single primary chain. Both Mordor and Amoy are supported chains; which features each one offers is governed by the per-chain `capabilities` map in `networks.js`, not by chain identity.

## Changes

- `frontend/src/config/networks.js`: add `isSupportedChainId(chainId)` helper — returns true for any chain in the `NETWORKS` map.
- `frontend/src/contexts/Web3Context.jsx` + `WalletContext.jsx`:
  - Replace `chainId === EXPECTED_CHAIN_ID` with `isSupportedChainId(chainId)`.
  - Network error message now lists every supported chain by name ("Polygon Amoy or Mordor") instead of one.
  - "Switch Network" button still targets `PRIMARY_CHAIN_ID` (Amoy) — only reached for chains we don't recognize at all.
  - Drop the now-unused `EXPECTED_CHAIN_ID`/`getExpectedChain` imports.

## Behavior after deploy

| User connects on | Result |
|---|---|
| Polygon Amoy (80002) | No banner, full functionality |
| Mordor (63) | No "wrong network" error; `LimitedFunctionalityBanner` (already on main) shows with one-click switch to Amoy for Polymarket-pegged side bets |
| Any other chain | Banner asks to switch, listing both supported chains by name |

The Polymarket-pegged side-bet UI in `FriendMarketsModal` continues to gate on `capabilities.polymarketSidebets`, so Mordor users still see the regular friend-market flow but not the Polymarket peg option.

## Test plan

- [x] `npm --prefix frontend run build` — clean
- [x] `npm --prefix frontend run test:run` — 796/796 pass
- [ ] Manual smoke on `fairwins.app`:
  - Connect on Amoy → expect no warning, app loads
  - Connect on Mordor → expect limited-functionality banner, no wrong-network error
  - Connect on Ethereum mainnet → expect "switch to Polygon Amoy or Mordor" banner

https://claude.ai/code/session_0129UVr6T2VrD9GHh2TZSyMc

---
_Generated by [Claude Code](https://claude.ai/code/session_0129UVr6T2VrD9GHh2TZSyMc)_