### PR TITLE
feat: default to Polygon Amoy across the stack

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -29,8 +29,8 @@ jobs:
           docker build \
             --build-arg VITE_WALLETCONNECT_PROJECT_ID="${{ secrets.VITE_WALLETCONNECT_PROJECT_ID || 'c30d7d7a8d575fe3dcc72ed55e5b287e' }}" \
             --build-arg VITE_APP_URL="${{ vars.VITE_APP_URL || 'https://fairwins.app' }}" \
-            --build-arg VITE_NETWORK_ID="${{ vars.VITE_NETWORK_ID || '63' }}" \
-            --build-arg VITE_RPC_URL="${{ vars.VITE_RPC_URL || 'https://rpc.mordor.etccooperative.org' }}" \
+            --build-arg VITE_NETWORK_ID="${{ vars.VITE_NETWORK_ID || '80002' }}" \
+            --build-arg VITE_RPC_URL="${{ vars.VITE_RPC_URL || 'https://rpc-amoy.polygon.technology' }}" \
             --build-arg VITE_IPFS_GATEWAY="${{ vars.VITE_IPFS_GATEWAY || 'https://gateway.pinata.cloud' }}" \
             --build-arg VITE_PINATA_JWT="${{ secrets.VITE_PINATA_JWT || '' }}" \
             -t us-central1-docker.pkg.dev/chippr-bots-site-wp/prediction-dao/app:${{ github.sha }} .

--- a/.github/workflows/deploy-contracts.yml
+++ b/.github/workflows/deploy-contracts.yml
@@ -1,4 +1,4 @@
-name: Deploy DAO Contracts to Mordor Testnet
+name: Deploy DAO Contracts
 
 on:
   workflow_dispatch:
@@ -6,9 +6,10 @@ on:
       network:
         description: 'Target network for deployment'
         required: false
-        default: 'mordor'
+        default: 'amoy'
         type: choice
         options:
+          - amoy
           - mordor
   push:
     branches:
@@ -50,10 +51,10 @@ jobs:
       - name: Compile contracts
         run: npm run compile
 
-      - name: Deploy contracts to Mordor testnet (Deterministic)
+      - name: Deploy contracts (Deterministic)
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-          NETWORK: ${{ github.event.inputs.network || 'mordor' }}
+          NETWORK: ${{ github.event.inputs.network || 'amoy' }}
         run: |
           if [ -z "$PRIVATE_KEY" ]; then
             echo "❌ ERROR: PRIVATE_KEY secret not configured"
@@ -82,32 +83,47 @@ jobs:
       - name: Extract deployment addresses
         id: extract
         if: success()
+        env:
+          NETWORK: ${{ github.event.inputs.network || 'amoy' }}
         run: |
           # Extract contract addresses from deployment log
           echo "📝 Extracting deployment information..."
-          
+
+          # Resolve per-network display values
+          if [ "$NETWORK" = "mordor" ]; then
+            NETWORK_LABEL="Mordor Testnet (Chain ID: 63)"
+            EXPLORER_NAME="Blockscout"
+            EXPLORER_BASE="https://etc-mordor.blockscout.com"
+            RPC_URL="https://rpc.mordor.etccooperative.org"
+          else
+            NETWORK_LABEL="Polygon Amoy (Chain ID: 80002)"
+            EXPLORER_NAME="Polygonscan"
+            EXPLORER_BASE="https://amoy.polygonscan.com"
+            RPC_URL="https://rpc-amoy.polygon.technology"
+          fi
+
           if [ -f deployment.log ]; then
             # Create a summary of deployed contracts
             echo "## 🎉 Contract Deployment Summary" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Network:** Mordor Testnet (Chain ID: 63)" >> $GITHUB_STEP_SUMMARY
+            echo "**Network:** $NETWORK_LABEL" >> $GITHUB_STEP_SUMMARY
             echo "**Deployed at:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Deployed Contracts" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            
+
             # Extract contract addresses
             grep -E "(WelfareMetricRegistry|ProposalRegistry|ConditionalMarketFactory|PrivacyCoordinator|OracleResolver|RagequitModule|FutarchyGovernor) deployed to:" deployment.log | while IFS= read -r line; do
               contract=$(echo "$line" | awk '{print $1}')
               address=$(echo "$line" | awk '{print $NF}')
               echo "- **$contract**: \`$address\`" >> $GITHUB_STEP_SUMMARY
-              echo "  - [View on Blockscout](https://etc-mordor.blockscout.com/address/$address)" >> $GITHUB_STEP_SUMMARY
+              echo "  - [View on $EXPLORER_NAME]($EXPLORER_BASE/address/$address)" >> $GITHUB_STEP_SUMMARY
             done
-            
+
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### Blockscout Links" >> $GITHUB_STEP_SUMMARY
-            echo "- [Mordor Testnet Explorer](https://etc-mordor.blockscout.com/)" >> $GITHUB_STEP_SUMMARY
-            echo "- [Mordor Testnet RPC](https://rpc.mordor.etccooperative.org)" >> $GITHUB_STEP_SUMMARY
+            echo "### Network Links" >> $GITHUB_STEP_SUMMARY
+            echo "- [$NETWORK_LABEL Explorer]($EXPLORER_BASE/)" >> $GITHUB_STEP_SUMMARY
+            echo "- [$NETWORK_LABEL RPC]($RPC_URL)" >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Upload deployment logs
@@ -121,22 +137,33 @@ jobs:
       - name: Comment on PR (if applicable)
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
+        env:
+          NETWORK: ${{ github.event.inputs.network || 'amoy' }}
         with:
           script: |
             const fs = require('fs');
             let logContent = '';
-            
+
             try {
               logContent = fs.readFileSync('deployment.log', 'utf8');
             } catch (error) {
               console.log('No deployment log found');
               return;
             }
-            
+
+            const network = process.env.NETWORK || 'amoy';
+            const networkLabel = network === 'mordor'
+              ? 'Mordor Testnet (Chain ID: 63)'
+              : 'Polygon Amoy (Chain ID: 80002)';
+            const explorerName = network === 'mordor' ? 'Blockscout' : 'Polygonscan';
+            const explorerBase = network === 'mordor'
+              ? 'https://etc-mordor.blockscout.com'
+              : 'https://amoy.polygonscan.com';
+
             // Extract contract addresses
             const contracts = [];
             const lines = logContent.split('\n');
-            
+
             for (const line of lines) {
               if (line.includes('deployed to:')) {
                 const match = line.match(/(\w+) deployed to: (0x[a-fA-F0-9]{40})/);
@@ -148,20 +175,20 @@ jobs:
                 }
               }
             }
-            
+
             if (contracts.length === 0) {
               return;
             }
-            
+
             let comment = '## 🚀 Contract Deployment Results\n\n';
-            comment += '**Network:** Mordor Testnet (Chain ID: 63)\n\n';
+            comment += `**Network:** ${networkLabel}\n\n`;
             comment += '### Deployed Contracts\n\n';
-            
+
             for (const contract of contracts) {
               comment += `- **${contract.name}**: \`${contract.address}\`\n`;
-              comment += `  - [View on Blockscout](https://etc-mordor.blockscout.com/address/${contract.address})\n`;
+              comment += `  - [View on ${explorerName}](${explorerBase}/address/${contract.address})\n`;
             }
-            
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,16 +2,30 @@
 # Copy this file to .env for local development
 
 # Network Configuration
+# Default: Polygon Amoy (primary post ETC->Amoy migration)
+# For Polygon Amoy testnet: 80002
 # For local development (Hardhat): 1337
-# For Mordor testnet (Ethereum Classic): 63
+# For Mordor testnet (limited functionality): 63
 # For Ethereum Classic mainnet: 61
-VITE_NETWORK_ID=63
+VITE_NETWORK_ID=80002
 
 # RPC URL for connecting to blockchain
+# Polygon Amoy: https://rpc-amoy.polygon.technology
 # Local: http://localhost:8545
 # Mordor: https://rpc.mordor.etccooperative.org
 # Ethereum Classic: https://etc.rivet.link
-VITE_RPC_URL=https://rpc.mordor.etccooperative.org
+VITE_RPC_URL=https://rpc-amoy.polygon.technology
+
+# Optional: Polygon Amoy specific RPC override (used by Amoy chain entry when
+# VITE_RPC_URL is not set)
+# VITE_RPC_URL_AMOY=https://rpc-amoy.polygon.technology
+
+# Polymarket testnet USDC on Amoy (required for Polymarket-pegged side bets)
+# VITE_AMOY_USDC=0x...
+
+# Polymarket Conditional Tokens Framework address on Amoy (required for
+# settle-by-referenced-lookup against Polymarket markets)
+# VITE_AMOY_POLYMARKET_CTF=0x...
 
 # Contract Addresses (update after deployment)
 # VITE_CONTRACT_ADDRESS=0x1234567890123456789012345678901234567890

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -57,7 +57,7 @@ function AppContent() {
       {/* Development warning banner - always visible */}
       <DevelopmentWarningBanner />
 
-      {/* Limited-functionality banner - shows when on Mordor, hidden on Amoy */}
+      {/* Limited-functionality banner - shows on chains marked limited (e.g. Mordor) */}
       <LimitedFunctionalityBanner />
 
       {/* Development warning modal - shows once per session */}

--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -12,6 +12,7 @@ import {
   getDefaultAcceptanceDeadline
 } from '../../constants/wagerDefaults'
 import { getContractAddress } from '../../config/contracts'
+import { getTransactionUrl } from '../../config/blockExplorer'
 import { FRIEND_GROUP_MARKET_FACTORY_ABI, ResolutionType as _ResolutionType } from '../../abis/FriendGroupMarketFactory'
 import QRScanner from '../ui/QRScanner'
 import { useChainTokens } from '../../hooks/useChainTokens'
@@ -2535,13 +2536,14 @@ function MarketsCompactTable({
  */
 function ResolveInline({ market, onResolve, resolveState }) {
   const [showChoices, setShowChoices] = useState(false)
+  const { chainId } = useWeb3()
 
   if (resolveState?.marketId === market.id && resolveState?.step === 'success') {
     return (
       <div className="fm-resolve-inline">
         <span>Resolution proposed!</span>
         {resolveState.txHash && (
-          <a href={`https://etc-mordor.blockscout.com/tx/${resolveState.txHash}`} target="_blank" rel="noopener noreferrer">
+          <a href={getTransactionUrl(chainId, resolveState.txHash)} target="_blank" rel="noopener noreferrer">
             View tx
           </a>
         )}

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -3,6 +3,7 @@ import { ethers } from 'ethers'
 import { useWallet, useWeb3 } from '../../hooks'
 import { WagerStatus as MarketStatus, DisputeStatus, WAGER_DEFAULTS } from '../../constants/wagerDefaults'
 import { getContractAddress } from '../../config/contracts'
+import { getTransactionUrl } from '../../config/blockExplorer'
 import { FRIEND_GROUP_MARKET_FACTORY_ABI } from '../../abis/FriendGroupMarketFactory'
 import MarketAcceptanceModal from './MarketAcceptanceModal'
 import './MyMarketsModal.css'
@@ -1285,6 +1286,7 @@ function ResolutionModal({
   isCorrectNetwork,
   switchNetwork
 }) {
+  const { chainId } = useWeb3()
   const [selectedOutcome, setSelectedOutcome] = useState(null)
   const [resolutionNotes, setResolutionNotes] = useState('')
   const [submitting, setSubmitting] = useState(false)
@@ -1529,7 +1531,7 @@ function ResolutionModal({
               </p>
               {txHash && (
                 <p className="mm-success-hint">
-                  <a href={`https://etc-mordor.blockscout.com/tx/${txHash}`} target="_blank" rel="noopener noreferrer">
+                  <a href={getTransactionUrl(chainId, txHash)} target="_blank" rel="noopener noreferrer">
                     View transaction
                   </a>
                 </p>

--- a/frontend/src/components/ui/PremiumPurchaseModal.jsx
+++ b/frontend/src/components/ui/PremiumPurchaseModal.jsx
@@ -1225,7 +1225,7 @@ function PremiumPurchaseModal({ isOpen = true, onClose, preselectedRole = null, 
                       </div>
                       {result.txHash && (
                         <a
-                          href={getTransactionUrl(chainId || 63, result.txHash)}
+                          href={getTransactionUrl(chainId, result.txHash)}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="ppm-tx-link"

--- a/frontend/src/hooks/useTreasuryVault.js
+++ b/frontend/src/hooks/useTreasuryVault.js
@@ -13,7 +13,7 @@
 
 import { useState, useCallback, useEffect, useMemo } from 'react'
 import { ethers } from 'ethers'
-import { getContractAddress, DEPLOYED_CONTRACTS } from '../config/contracts'
+import { getContractAddress, DEPLOYED_CONTRACTS, NETWORK_CONFIG } from '../config/contracts'
 
 // Minimal TreasuryVault ABI (human-readable format)
 const TREASURY_VAULT_ABI = [
@@ -89,7 +89,7 @@ export function useTreasuryVault({ signer, provider, account } = {}) {
   const readProvider = useMemo(() => {
     if (provider) return provider
     // Create a fallback provider if none provided
-    const rpcUrl = import.meta.env.VITE_RPC_URL || 'https://rpc.mordor.etccooperative.org'
+    const rpcUrl = import.meta.env.VITE_RPC_URL || NETWORK_CONFIG.rpcUrl
     return new ethers.JsonRpcProvider(rpcUrl)
   }, [provider])
 

--- a/frontend/src/thirdweb.js
+++ b/frontend/src/thirdweb.js
@@ -26,13 +26,37 @@ export const thirdwebClient = createThirdwebClient({
   clientId,
 })
 
-// Get network ID from environment or default to Mordor testnet
-const networkId = import.meta.env.VITE_NETWORK_ID 
-  ? parseInt(import.meta.env.VITE_NETWORK_ID, 10) 
-  : 63
+// Get network ID from environment or default to Polygon Amoy (the primary
+// post-migration). Mordor is still supported for limited-functionality access
+// but is no longer the default.
+const networkId = import.meta.env.VITE_NETWORK_ID
+  ? parseInt(import.meta.env.VITE_NETWORK_ID, 10)
+  : 80002
 
-// Get RPC URL from environment
-const rpcUrl = import.meta.env.VITE_RPC_URL || 'https://rpc.mordor.etccooperative.org'
+// Get RPC URL from environment, falling back to the Amoy public RPC.
+const rpcUrl =
+  import.meta.env.VITE_RPC_URL ||
+  import.meta.env.VITE_RPC_URL_AMOY ||
+  'https://rpc-amoy.polygon.technology'
+
+// Define Polygon Amoy testnet for ThirdWeb (primary post-migration)
+export const polygonAmoy = defineChain({
+  id: 80002,
+  name: 'Polygon Amoy',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'MATIC',
+    symbol: 'MATIC',
+  },
+  rpc: networkId === 80002 ? rpcUrl : 'https://rpc-amoy.polygon.technology',
+  blockExplorers: [
+    {
+      name: 'Polygonscan',
+      url: 'https://amoy.polygonscan.com',
+    },
+  ],
+  testnet: true,
+})
 
 // Define Ethereum Classic mainnet for ThirdWeb
 export const ethereumClassic = defineChain({
@@ -62,7 +86,7 @@ export const mordor = defineChain({
     name: 'Mordor Ether',
     symbol: 'METC',
   },
-  rpc: rpcUrl,
+  rpc: networkId === 63 ? rpcUrl : 'https://rpc.mordor.etccooperative.org',
   blockExplorers: [
     {
       name: 'Blockscout',
@@ -94,10 +118,11 @@ export const getThirdwebChain = () => {
       return mordor
     case 1337:
       return hardhat
+    case 80002:
     default:
-      return mordor
+      return polygonAmoy
   }
 }
 
 // All supported chains for ThirdWeb
-export const supportedChains = [ethereumClassic, mordor, hardhat]
+export const supportedChains = [polygonAmoy, ethereumClassic, mordor, hardhat]

--- a/frontend/src/utils/dataFetcher.js
+++ b/frontend/src/utils/dataFetcher.js
@@ -121,7 +121,7 @@ export async function fetchMarkets(demoMode, _contracts = null, options = {}) {
   }
 
   try {
-    // Fetch from Mordor testnet (with request deduplication)
+    // Fetch from the active chain (with request deduplication)
     logger.log('Live mode - fetching from blockchain (cache miss or refresh)')
     const requestKey = forceRefresh ? 'fetchMarkets:force' : 'fetchMarkets:normal'
     const markets = await deduplicateRequest(requestKey, () => fetchMarketsFromBlockchain())

--- a/package.json
+++ b/package.json
@@ -18,11 +18,13 @@
     "deploy:mordor": "hardhat run scripts/deploy/deploy-deterministic.js --network mordor",
     "deploy:amoy": "hardhat run scripts/deploy/deploy-deterministic.js --network amoy",
     "deploy:deterministic": "hardhat run scripts/deploy/deploy-deterministic.js",
-    "sync:frontend-contracts": "node scripts/utils/sync-frontend-contracts.js --network mordor --chainId 63",
+    "sync:frontend-contracts": "node scripts/utils/sync-frontend-contracts.js --network amoy --chainId 80002",
+    "sync:frontend-contracts:mordor": "node scripts/utils/sync-frontend-contracts.js --network mordor --chainId 63",
     "sync:frontend-contracts:amoy": "node scripts/utils/sync-frontend-contracts.js --network amoy --chainId 80002",
     "test:frontend": "npm --prefix frontend run test:run",
     "lock:sync": "npm install --package-lock-only && npm --prefix frontend install --package-lock-only",
-    "seed:testnet": "hardhat run scripts/operations/seed-testnet.js --network mordor",
+    "seed:testnet": "hardhat run scripts/operations/seed-testnet.js --network amoy",
+    "seed:mordor": "hardhat run scripts/operations/seed-testnet.js --network mordor",
     "seed:amoy": "hardhat run scripts/operations/seed-testnet.js --network amoy",
     "seed:local": "hardhat run scripts/operations/seed-testnet.js --network localhost",
     "node": "hardhat node",
@@ -34,8 +36,8 @@
     "floppy:test": "node ./scripts/operations/floppy-key/index.js test",
     "floppy:info": "node ./scripts/operations/floppy-key/index.js info",
     "floppy:store-admin": "node ./scripts/operations/floppy-key/store-admin-key.js",
-    "purchase:friend-market": "npx hardhat run ./scripts/operations/purchase-friend-market-membership.js --network mordor",
-    "create:friend-bet": "npx hardhat run ./scripts/operations/create-friend-market-bet.js --network mordor"
+    "purchase:friend-market": "npx hardhat run ./scripts/operations/purchase-friend-market-membership.js --network amoy",
+    "create:friend-bet": "npx hardhat run ./scripts/operations/create-friend-market-bet.js --network amoy"
   },
   "keywords": [
     "futarchy",

--- a/scripts/admin/lib/addresses.js
+++ b/scripts/admin/lib/addresses.js
@@ -38,7 +38,7 @@ function loadDeploymentFile(filename) {
  */
 function getDeploymentFilename(prefix) {
   const network = hre.network.name;
-  const chainId = hre.network.config.chainId || 63;
+  const chainId = hre.network.config.chainId || 80002;
   return `${network}-chain${chainId}-${prefix}.json`;
 }
 

--- a/scripts/utils/sync-frontend-contracts.js
+++ b/scripts/utils/sync-frontend-contracts.js
@@ -71,8 +71,8 @@ function main() {
   const repoRoot = path.join(__dirname, '..', '..')
   const deploymentsDir = path.join(repoRoot, 'deployments')
 
-  const network = args.network || 'mordor'
-  const chainId = Number.isFinite(args.chainId) ? args.chainId : 63
+  const network = args.network || 'amoy'
+  const chainId = Number.isFinite(args.chainId) ? args.chainId : 80002
 
   const deploymentFile = args.deploymentFile
     ? path.resolve(repoRoot, args.deploymentFile)


### PR DESCRIPTION
The chain map already had Amoy as PRIMARY_CHAIN_ID, but several entry
points still fell back to ETC/Mordor. This switches the remaining
defaults so a fresh checkout/deploy lands on Amoy unless explicitly
overridden.

- Cloud Run build: VITE_NETWORK_ID/VITE_RPC_URL default to Amoy
- Contract deploy workflow: default network input + summary/PR comment
  links are network-aware (Polygonscan vs Blockscout)
- frontend/.env.example: documents Amoy as the default
- thirdweb.js: defaults to Amoy, exports a polygonAmoy chain alongside
  the existing ETC/Mordor/Hardhat definitions
- useTreasuryVault: read-only RPC fallback uses NETWORK_CONFIG.rpcUrl
  instead of a hardcoded Mordor URL
- MyMarketsModal/FriendMarketsModal: tx links use getTransactionUrl(chainId, hash)
  instead of hardcoded etc-mordor.blockscout.com
- PremiumPurchaseModal: drop the `chainId || 63` fallback (getNetwork
  already falls back to PRIMARY_CHAIN_ID)
- package.json: sync:frontend-contracts and seed:testnet default to amoy;
  preserved :mordor variants for the legacy chain
- scripts: sync-frontend-contracts and admin/lib/addresses chainId
  defaults updated to 80002