### PR TITLE
feat(frontend): add Polymarket top-markets browser to dashboard and wager modal

### DIFF
--- a/frontend/src/components/fairwins/Dashboard.jsx
+++ b/frontend/src/components/fairwins/Dashboard.jsx
@@ -8,6 +8,7 @@ import { ROLES } from '../../contexts/RoleContext'
 import { WAGER_DEFAULTS, WagerStatus } from '../../constants/wagerDefaults'
 import FriendMarketsModal from './FriendMarketsModal'
 import MyMarketsModal from './MyMarketsModal'
+import PolymarketBrowser from './PolymarketBrowser'
 import QRScanner from '../ui/QRScanner'
 import PremiumPurchaseModal from '../ui/PremiumPurchaseModal'
 import { useFriendMarkets } from '../../contexts/FriendMarketsContext.js'
@@ -420,6 +421,9 @@ function Dashboard() {
   const [showMyWagers, setShowMyWagers] = useState(false)
   const [showQrScanner, setShowQrScanner] = useState(false)
   const [bannerDismissed, setBannerDismissed] = useState(false)
+  // Pre-fill payload for the create-wager modal when launched from a
+  // Polymarket card. Cleared on modal close so subsequent opens start clean.
+  const [initialPolymarketMarket, setInitialPolymarketMarket] = useState(null)
 
   // Friend markets from shared context (single fetch, no duplication)
   const { friendMarkets, loading: wagersLoading } = useFriendMarkets()
@@ -553,6 +557,12 @@ function Dashboard() {
     setShowMyWagers(true)
   }, [])
 
+  const handlePolymarketCardClick = useCallback((market) => {
+    setInitialPolymarketMarket(market)
+    setCreateWagerType('oneVsOne')
+    setShowCreateWager(true)
+  }, [])
+
   const handleQrScanSuccess = useCallback((decodedText) => {
     setShowQrScanner(false)
 
@@ -642,6 +652,15 @@ function Dashboard() {
         <QuickActions onAction={handleQuickAction} />
       </section>
 
+      {/* Top Polymarket markets — self-gates on chain capability, renders
+          nothing on chains without Polymarket support. */}
+      <section className="dashboard-section">
+        <PolymarketBrowser
+          variant="feed"
+          onSelectMarket={handlePolymarketCardClick}
+        />
+      </section>
+
       {/* How It Works (collapsible) */}
       <section className="dashboard-section">
         <HowItWorksGuide />
@@ -691,9 +710,11 @@ function Dashboard() {
         onClose={() => {
           setShowCreateWager(false)
           setCreateWagerType(null)
+          setInitialPolymarketMarket(null)
         }}
         initialTab="create"
         initialType={createWagerType}
+        initialPolymarketMarket={initialPolymarketMarket}
         activeMarkets={activeFriendMarkets}
         pastMarkets={pastFriendMarkets}
       />

--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -17,6 +17,7 @@ import { FRIEND_GROUP_MARKET_FACTORY_ABI, ResolutionType as _ResolutionType } fr
 import QRScanner from '../ui/QRScanner'
 import { useChainTokens } from '../../hooks/useChainTokens'
 import { usePolymarketSearch } from '../../hooks/usePolymarketSearch'
+import PolymarketBrowser from './PolymarketBrowser'
 
 // Fallback so the UI renders even if the enum export is missing in some environments
 const ResolutionType = _ResolutionType ?? {
@@ -92,7 +93,8 @@ function FriendMarketsModal({
   pendingTransaction = null,
   onClearPendingTransaction = () => {},
   initialTab = null,
-  initialType = null
+  initialType = null,
+  initialPolymarketMarket = null
 }) {
   const { isConnected, account } = useWallet()
   const { signer, isCorrectNetwork, switchNetwork } = useWeb3()
@@ -216,19 +218,11 @@ function FriendMarketsModal({
   const [qrScannerOpen, setQrScannerOpen] = useState(false)
   const [qrScanTarget, setQrScanTarget] = useState(null) // 'opponent' or 'arbitrator'
 
-  // Polymarket event search state — drives the consolidated "Linked Market"
-  // resolution flow. We keep the local query state so the input is controlled,
-  // and selectedPolymarketMarket holds the picked event after the user clicks
-  // a result.
-  const [polymarketQuery, setPolymarketQuery] = useState('')
+  // Polymarket event selection — the PolymarketBrowser component below handles
+  // browsing/searching internally. We only need to track the picked market so
+  // its conditionId can be committed to formData.peggedMarketId.
   const [selectedPolymarketMarket, setSelectedPolymarketMarket] = useState(null)
-  const {
-    results: polymarketResults,
-    isLoading: polymarketLoading,
-    error: polymarketError,
-    search: searchPolymarket,
-    clear: clearPolymarket,
-  } = usePolymarketSearch({ limit: 10 })
+  const { clear: clearPolymarket } = usePolymarketSearch({ limit: 10 })
 
   // Market acceptance modal state
   const [acceptanceModalOpen, setAcceptanceModalOpen] = useState(false)
@@ -268,7 +262,6 @@ function FriendMarketsModal({
       oddsMultiplier: WAGER_DEFAULTS.ODDS_MULTIPLIER
     })
     setErrors({})
-    setPolymarketQuery('')
     setSelectedPolymarketMarket(null)
     clearPolymarket()
     setEnableEncryption(true)
@@ -289,8 +282,20 @@ function FriendMarketsModal({
       setSelectedMarket(null)
       setErrors({})
       resetForm()
+      // When opened from a Polymarket card on the dashboard, jump the user
+      // straight into the linked-market resolution flow with the chosen
+      // market and question pre-filled.
+      if (initialPolymarketMarket?.conditionId) {
+        setSelectedPolymarketMarket(initialPolymarketMarket)
+        setFormData((prev) => ({
+          ...prev,
+          resolutionType: ResolutionType.PolymarketOracle,
+          peggedMarketId: initialPolymarketMarket.conditionId,
+          description: prev.description || initialPolymarketMarket.question || '',
+        }))
+      }
     }
-  }, [isOpen, resetForm, initialTab, initialType])
+  }, [isOpen, resetForm, initialTab, initialType, initialPolymarketMarket])
 
   const handleClose = useCallback(() => {
     if (!submitting) {
@@ -405,22 +410,14 @@ function FriendMarketsModal({
     setQrScanTarget(null)
   }
 
-  // Polymarket event search — debounced via the hook. Picking a result
-  // commits the condition id to formData so submit-time validation passes.
-  const handlePolymarketQueryChange = (value) => {
-    setPolymarketQuery(value)
-    setSelectedPolymarketMarket(null)
-    handleFormChange('peggedMarketId', '')
-    searchPolymarket(value)
-  }
-
+  // Polymarket event selection — picking a market commits the condition id to
+  // formData so submit-time validation passes.
   const handleSelectPolymarketMarket = (market) => {
     setSelectedPolymarketMarket(market)
     handleFormChange('peggedMarketId', market.conditionId)
   }
 
   const clearPolymarketSelection = () => {
-    setPolymarketQuery('')
     setSelectedPolymarketMarket(null)
     handleFormChange('peggedMarketId', '')
     clearPolymarket()
@@ -1677,14 +1674,14 @@ function FriendMarketsModal({
                     )}
 
                     {/* Linked Market — Polymarket event lookup */}
-                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') &&
+                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker' || friendMarketType === 'smallGroup') &&
                      formData.resolutionType === ResolutionType.PolymarketOracle && (
                       <div className="fm-form-group fm-form-full">
                         <label htmlFor="fm-polymarket-search">
                           Linked Polymarket Event <span className="fm-required">*</span>
                         </label>
 
-                        {selectedPolymarketMarket ? (
+                        {selectedPolymarketMarket && (
                           <div className="fm-polymarket-selected">
                             <div className="fm-polymarket-selected-body">
                               <strong>{selectedPolymarketMarket.question}</strong>
@@ -1711,55 +1708,24 @@ function FriendMarketsModal({
                               Change
                             </button>
                           </div>
-                        ) : (
-                          <>
-                            <input
-                              id="fm-polymarket-search"
-                              type="search"
-                              value={polymarketQuery}
-                              onChange={(e) => handlePolymarketQueryChange(e.target.value)}
-                              placeholder="Search Polymarket events by name (e.g. 'US election', 'BTC 100k')"
-                              disabled={submitting}
-                              className={errors.peggedMarketId ? 'error' : ''}
-                              autoComplete="off"
-                            />
-                            <span className="fm-hint">
-                              Type an event name to search Polymarket. Pick a result to link this wager — it&apos;ll settle automatically when the Polymarket market resolves.
-                            </span>
-
-                            {polymarketLoading && (
-                              <div className="fm-polymarket-status">Searching Polymarket…</div>
-                            )}
-                            {polymarketError && (
-                              <div className="fm-polymarket-status fm-error">
-                                {polymarketError}
-                              </div>
-                            )}
-                            {!polymarketLoading && !polymarketError && polymarketQuery && polymarketResults.length === 0 && (
-                              <div className="fm-polymarket-status">No matching Polymarket events.</div>
-                            )}
-                            {polymarketResults.length > 0 && (
-                              <ul className="fm-polymarket-results" role="listbox">
-                                {polymarketResults.map((m) => (
-                                  <li key={m.conditionId}>
-                                    <button
-                                      type="button"
-                                      className="fm-polymarket-result"
-                                      onClick={() => handleSelectPolymarketMarket(m)}
-                                      disabled={submitting}
-                                    >
-                                      <span className="fm-polymarket-result-title">{m.question}</span>
-                                      <span className="fm-polymarket-result-meta">
-                                        {m.endDate && <span>Ends {formatDate(m.endDate)}</span>}
-                                        {m.volume != null && <span>Vol ${Math.round(m.volume).toLocaleString()}</span>}
-                                      </span>
-                                    </button>
-                                  </li>
-                                ))}
-                              </ul>
-                            )}
-                          </>
                         )}
+
+                        <span className="fm-hint">
+                          Browse top markets by category, or search for a specific event. Pick one and the wager will settle automatically when that Polymarket market resolves.
+                        </span>
+
+                        <PolymarketBrowser
+                          variant="inline"
+                          showFilters
+                          limit={20}
+                          selectedConditionId={selectedPolymarketMarket?.conditionId}
+                          onSelectMarket={(m) => {
+                            handleSelectPolymarketMarket(m)
+                            if (!formData.description) {
+                              setFormData((prev) => ({ ...prev, description: m.question || prev.description }))
+                            }
+                          }}
+                        />
 
                         {errors.peggedMarketId && (
                           <span className="fm-error">{errors.peggedMarketId}</span>

--- a/frontend/src/components/fairwins/PolymarketBrowser.css
+++ b/frontend/src/components/fairwins/PolymarketBrowser.css
@@ -1,0 +1,322 @@
+/* Polymarket browser — shared between the dashboard feed and the in-modal
+   market picker. Variants are toggled via `.pmb--feed` and `.pmb--inline`. */
+
+.pmb {
+  --pmb-accent: #2d9cdb;
+  --pmb-accent-soft: rgba(45, 156, 219, 0.12);
+  --pmb-border: var(--border-color, rgba(255, 255, 255, 0.08));
+  --pmb-surface: var(--surface-2, rgba(255, 255, 255, 0.03));
+  --pmb-surface-hover: var(--surface-3, rgba(255, 255, 255, 0.06));
+}
+
+.pmb--feed {
+  margin-bottom: 2rem;
+}
+
+.pmb--inline {
+  margin-top: 1rem;
+  padding: 0.75rem;
+  background: var(--pmb-surface);
+  border: 1px solid var(--pmb-border);
+  border-radius: 10px;
+}
+
+.pmb__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--pmb-border);
+}
+
+.pmb__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.pmb__subtitle {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+/* Search row (inline variant) */
+
+.pmb__search-row {
+  position: relative;
+  margin-bottom: 0.5rem;
+}
+
+.pmb__search-input {
+  width: 100%;
+  padding: 0.5rem 2rem 0.5rem 0.75rem;
+  background: var(--input-bg, rgba(0, 0, 0, 0.2));
+  color: var(--text-primary);
+  border: 1px solid var(--pmb-border);
+  border-radius: 8px;
+  font-size: 0.9rem;
+}
+
+.pmb__search-input:focus {
+  outline: none;
+  border-color: var(--pmb-accent);
+  box-shadow: 0 0 0 2px var(--pmb-accent-soft);
+}
+
+.pmb__search-clear {
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+}
+
+.pmb__search-clear:hover {
+  color: var(--text-primary);
+}
+
+/* Filter chips */
+
+.pmb__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.75rem;
+}
+
+.pmb__chip {
+  padding: 0.3rem 0.7rem;
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--pmb-border);
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.pmb__chip:hover {
+  border-color: var(--pmb-accent);
+  color: var(--text-primary);
+}
+
+.pmb__chip--active {
+  background: var(--pmb-accent-soft);
+  border-color: var(--pmb-accent);
+  color: var(--pmb-accent);
+}
+
+.pmb__chip--clear {
+  font-style: italic;
+  opacity: 0.8;
+}
+
+/* Error / empty / loading */
+
+.pmb__error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0.8rem;
+  background: rgba(220, 53, 69, 0.08);
+  color: #ff8a90;
+  border: 1px solid rgba(220, 53, 69, 0.3);
+  border-radius: 8px;
+  font-size: 0.85rem;
+  margin-bottom: 0.75rem;
+}
+
+.pmb__retry {
+  padding: 0.3rem 0.7rem;
+  background: rgba(220, 53, 69, 0.15);
+  color: #ff8a90;
+  border: 1px solid rgba(220, 53, 69, 0.4);
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.pmb__retry:hover {
+  background: rgba(220, 53, 69, 0.25);
+}
+
+.pmb__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1.5rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.pmb__empty p {
+  margin: 0;
+}
+
+.pmb__link {
+  background: transparent;
+  border: none;
+  color: var(--pmb-accent);
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+  font-size: 0.85rem;
+}
+
+/* Grid */
+
+.pmb__grid {
+  display: grid;
+  gap: 0.75rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.pmb__grid--feed {
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+}
+
+.pmb__grid--inline {
+  grid-template-columns: 1fr;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.pmb__card-wrapper {
+  display: flex;
+}
+
+.pmb__card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.85rem;
+  text-align: left;
+  background: var(--pmb-surface);
+  border: 1px solid var(--pmb-border);
+  border-radius: 10px;
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.pmb__card:hover {
+  background: var(--pmb-surface-hover);
+  border-color: var(--pmb-accent);
+  transform: translateY(-1px);
+}
+
+.pmb__card:focus-visible {
+  outline: 2px solid var(--pmb-accent);
+  outline-offset: 2px;
+}
+
+.pmb__card--selected {
+  border-color: var(--pmb-accent);
+  background: var(--pmb-accent-soft);
+}
+
+.pmb__card--skeleton {
+  height: 110px;
+  background: linear-gradient(
+    90deg,
+    var(--pmb-surface) 0%,
+    var(--pmb-surface-hover) 50%,
+    var(--pmb-surface) 100%
+  );
+  background-size: 200% 100%;
+  animation: pmb-shimmer 1.4s infinite;
+  pointer-events: none;
+}
+
+@keyframes pmb-shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+
+.pmb__card-question {
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--text-primary);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.pmb__card-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.pmb__card-tag {
+  text-transform: capitalize;
+  padding: 0.15rem 0.5rem;
+  background: var(--pmb-accent-soft);
+  color: var(--pmb-accent);
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.pmb__card-volume {
+  font-weight: 500;
+}
+
+.pmb__card-outcome {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 0.4rem;
+  border-top: 1px solid var(--pmb-border);
+  font-size: 0.85rem;
+}
+
+.pmb__card-outcome-name {
+  color: var(--text-secondary);
+  text-transform: capitalize;
+}
+
+.pmb__card-outcome-price {
+  font-weight: 600;
+  color: var(--pmb-accent);
+}
+
+.pmb__card-selected-badge {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.1rem 0.4rem;
+  background: var(--pmb-accent);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 600;
+  border-radius: 4px;
+}
+
+@media (max-width: 640px) {
+  .pmb__grid--feed {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/components/fairwins/PolymarketBrowser.jsx
+++ b/frontend/src/components/fairwins/PolymarketBrowser.jsx
@@ -1,0 +1,320 @@
+import { useState, useMemo, useCallback, useEffect } from 'react'
+import { useChainTokens } from '../../hooks/useChainTokens'
+import { useUserPreferences } from '../../hooks/useUserPreferences'
+import { useFriendMarkets } from '../../contexts/FriendMarketsContext.js'
+import {
+  usePolymarketSearch,
+  usePolymarketTopMarkets,
+} from '../../hooks/usePolymarketSearch'
+import './PolymarketBrowser.css'
+
+// Canonical filter chips. Slugs match Polymarket's `tag_slug` values; labels
+// are what the user sees.
+const QUICK_FILTERS = [
+  { slug: 'politics', label: 'Politics' },
+  { slug: 'sports', label: 'Sports' },
+  { slug: 'crypto', label: 'Crypto' },
+  { slug: 'pop-culture', label: 'Pop Culture' },
+  { slug: 'business', label: 'Business' },
+  { slug: 'tech', label: 'Tech' },
+]
+
+const SEARCH_DEBOUNCE_MS = 350
+
+const formatVolume = (v) => {
+  if (v == null || Number.isNaN(v)) return null
+  if (v >= 1_000_000) return `$${(v / 1_000_000).toFixed(1)}M`
+  if (v >= 1_000) return `$${(v / 1_000).toFixed(1)}K`
+  return `$${Math.round(v)}`
+}
+
+const normaliseCategoryString = (c) => {
+  if (!c) return ''
+  if (Array.isArray(c)) return c.join(' ').toLowerCase()
+  return String(c).toLowerCase()
+}
+
+/**
+ * Build a Set of category slugs/keywords gleaned from the user's prior friend
+ * markets. We don't have a structured category on past wagers, so we
+ * substring-match against the description as a first pass.
+ */
+function buildHistoryCategorySet(friendMarkets) {
+  const set = new Set()
+  for (const m of friendMarkets || []) {
+    const desc = (m?.description || '').toLowerCase()
+    for (const { slug } of QUICK_FILTERS) {
+      if (desc.includes(slug.replace('-', ' ')) || desc.includes(slug)) {
+        set.add(slug)
+      }
+    }
+  }
+  return set
+}
+
+/**
+ * Reusable Polymarket market browser. Used as a dashboard feed (variant="feed")
+ * and as an in-modal market picker (variant="inline"). Self-gates on chain
+ * capability — returns null on chains without Polymarket support.
+ */
+function PolymarketBrowser({
+  onSelectMarket,
+  variant = 'feed',
+  defaultCategories,
+  limit = 12,
+  showFilters = true,
+  selectedConditionId = null,
+  className = '',
+}) {
+  const { capabilities } = useChainTokens()
+  const polymarketSidebetsEnabled = Boolean(capabilities?.polymarketSidebets)
+
+  const { preferences } = useUserPreferences()
+  const { friendMarkets } = useFriendMarkets()
+
+  // Filter state. We avoid an effect-driven sync from preferences by deriving
+  // the effective filter set: if the user has touched the chips, use their
+  // local state; otherwise fall back to the prop or the saved preference
+  // (which may arrive async after the wallet connects).
+  const [userTouched, setUserTouched] = useState(false)
+  const [localCategories, setLocalCategories] = useState(() => {
+    if (Array.isArray(defaultCategories)) return defaultCategories
+    return Array.isArray(preferences?.polymarketCategories) ? preferences.polymarketCategories : []
+  })
+  const activeCategories = useMemo(() => {
+    if (userTouched) return localCategories
+    if (Array.isArray(defaultCategories)) return defaultCategories
+    return Array.isArray(preferences?.polymarketCategories) ? preferences.polymarketCategories : []
+  }, [userTouched, localCategories, defaultCategories, preferences])
+
+  const [query, setQuery] = useState('')
+  const trimmedQuery = query.trim()
+
+  const {
+    results: topResults,
+    isLoading: topLoading,
+    error: topError,
+    refresh: refreshTop,
+  } = usePolymarketTopMarkets({ categories: activeCategories, limit })
+
+  const {
+    results: searchResults,
+    isLoading: searchLoading,
+    error: searchError,
+    search: runSearch,
+    clear: clearSearch,
+  } = usePolymarketSearch({ limit })
+
+  // Debounce-and-fire search whenever the query changes.
+  useEffect(() => {
+    if (!trimmedQuery) {
+      clearSearch()
+      return undefined
+    }
+    const handle = setTimeout(() => runSearch(trimmedQuery), SEARCH_DEBOUNCE_MS)
+    return () => clearTimeout(handle)
+  }, [trimmedQuery, runSearch, clearSearch])
+
+  const isSearchMode = trimmedQuery.length > 0
+  const rawResults = isSearchMode ? searchResults : topResults
+  const isLoading = isSearchMode ? searchLoading : topLoading
+  const error = isSearchMode ? searchError : topError
+
+  // History-boost ranking. Boost factor mixes user's saved category prefs
+  // with categories inferred from their past wagers.
+  const historySlugs = useMemo(() => buildHistoryCategorySet(friendMarkets), [friendMarkets])
+  const savedSlugs = useMemo(
+    () => new Set(preferences?.polymarketCategories || []),
+    [preferences?.polymarketCategories],
+  )
+
+  const rankedResults = useMemo(() => {
+    const scored = (rawResults || []).map((m) => {
+      const cat = normaliseCategoryString(m.category)
+      let boost = 1
+      for (const slug of savedSlugs) {
+        if (cat.includes(slug.replace('-', ' ')) || cat.includes(slug)) {
+          boost += 0.5
+          break
+        }
+      }
+      for (const slug of historySlugs) {
+        if (cat.includes(slug.replace('-', ' ')) || cat.includes(slug)) {
+          boost += 0.5
+          break
+        }
+      }
+      const volume = Number(m.volume) || 0
+      // Search results return relevance-ordered already — skip volume in their score
+      // but keep history/category nudge so familiar markets still float up.
+      const score = isSearchMode ? boost : (volume || 1) * boost
+      return { market: m, score }
+    })
+    scored.sort((a, b) => b.score - a.score)
+    return scored.map((s) => s.market)
+  }, [rawResults, savedSlugs, historySlugs, isSearchMode])
+
+  const toggleCategory = useCallback((slug) => {
+    // First touch: snapshot the currently-shown filter set so toggles operate
+    // on it (the lazy initialiser may have missed the async-loaded preferences).
+    const base = userTouched ? localCategories : activeCategories
+    setUserTouched(true)
+    setLocalCategories(
+      base.includes(slug) ? base.filter((s) => s !== slug) : [...base, slug]
+    )
+    if (trimmedQuery) {
+      setQuery('')
+    }
+  }, [userTouched, localCategories, activeCategories, trimmedQuery])
+
+  const clearAllFilters = useCallback(() => {
+    setUserTouched(true)
+    setLocalCategories([])
+  }, [])
+
+  const handleRetry = useCallback(() => {
+    if (isSearchMode) {
+      runSearch(trimmedQuery)
+    } else {
+      refreshTop()
+    }
+  }, [isSearchMode, runSearch, trimmedQuery, refreshTop])
+
+  if (!polymarketSidebetsEnabled) return null
+
+  const rootClassName = `pmb pmb--${variant}${className ? ` ${className}` : ''}`
+
+  return (
+    <section className={rootClassName} aria-label="Polymarket markets">
+      {variant === 'feed' && (
+        <div className="pmb__header">
+          <h3 className="pmb__title">Top from Polymarket</h3>
+          <span className="pmb__subtitle">Tap a market to start a wager</span>
+        </div>
+      )}
+
+      {variant === 'inline' && (
+        <div className="pmb__search-row">
+          <input
+            type="text"
+            className="pmb__search-input"
+            placeholder="Search Polymarket events…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            aria-label="Search Polymarket events"
+          />
+          {query && (
+            <button
+              type="button"
+              className="pmb__search-clear"
+              onClick={() => setQuery('')}
+              aria-label="Clear search"
+            >
+              ×
+            </button>
+          )}
+        </div>
+      )}
+
+      {showFilters && (
+        <div className="pmb__filters" role="group" aria-label="Category filters">
+          {QUICK_FILTERS.map(({ slug, label }) => {
+            const isActive = activeCategories.includes(slug)
+            return (
+              <button
+                key={slug}
+                type="button"
+                className={`pmb__chip ${isActive ? 'pmb__chip--active' : ''}`}
+                onClick={() => toggleCategory(slug)}
+                aria-pressed={isActive}
+              >
+                {label}
+              </button>
+            )
+          })}
+          {activeCategories.length > 0 && (
+            <button
+              type="button"
+              className="pmb__chip pmb__chip--clear"
+              onClick={clearAllFilters}
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <div className="pmb__error" role="alert">
+          <span>Could not load Polymarket markets: {error}</span>
+          <button type="button" className="pmb__retry" onClick={handleRetry}>
+            Retry
+          </button>
+        </div>
+      )}
+
+      {isLoading && !error && (
+        <div className={`pmb__grid pmb__grid--${variant}`} aria-busy="true">
+          {Array.from({ length: variant === 'inline' ? 4 : 6 }).map((_, i) => (
+            <div key={i} className="pmb__card pmb__card--skeleton" aria-hidden="true" />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && !error && rankedResults.length === 0 && (
+        <div className="pmb__empty">
+          {isSearchMode ? (
+            <p>No matching Polymarket events.</p>
+          ) : activeCategories.length > 0 ? (
+            <>
+              <p>No active markets match these categories.</p>
+              <button type="button" className="pmb__link" onClick={clearAllFilters}>
+                Browse all categories
+              </button>
+            </>
+          ) : (
+            <p>No active Polymarket markets right now.</p>
+          )}
+        </div>
+      )}
+
+      {!isLoading && !error && rankedResults.length > 0 && (
+        <ul className={`pmb__grid pmb__grid--${variant}`} role="list">
+          {rankedResults.map((m) => {
+            const isSelected = selectedConditionId && m.conditionId === selectedConditionId
+            const topOutcome = m.outcomes?.[0]
+            const vol = formatVolume(m.volume)
+            return (
+              <li key={m.conditionId} className="pmb__card-wrapper">
+                <button
+                  type="button"
+                  className={`pmb__card ${isSelected ? 'pmb__card--selected' : ''}`}
+                  onClick={() => onSelectMarket?.(m)}
+                >
+                  <div className="pmb__card-question">{m.question}</div>
+                  <div className="pmb__card-meta">
+                    {m.category && (
+                      <span className="pmb__card-tag">{normaliseCategoryString(m.category)}</span>
+                    )}
+                    {vol && <span className="pmb__card-volume">{vol} vol</span>}
+                  </div>
+                  {topOutcome && topOutcome.price != null && (
+                    <div className="pmb__card-outcome">
+                      <span className="pmb__card-outcome-name">{topOutcome.name}</span>
+                      <span className="pmb__card-outcome-price">
+                        {Math.round(topOutcome.price * 100)}¢
+                      </span>
+                    </div>
+                  )}
+                  {isSelected && <span className="pmb__card-selected-badge">Selected</span>}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+export default PolymarketBrowser

--- a/frontend/src/contexts/UserPreferencesContext.jsx
+++ b/frontend/src/contexts/UserPreferencesContext.jsx
@@ -19,6 +19,7 @@ export function UserPreferencesProvider({ children }) {
     recentSearches: [],
     favoriteMarkets: [],
     defaultSlippage: 0.5,
+    polymarketCategories: [],
   })
   const [isLoading, setIsLoading] = useState(false)
 
@@ -32,6 +33,7 @@ export function UserPreferencesProvider({ children }) {
         recentSearches: [],
         favoriteMarkets: [],
         defaultSlippage: 0.5,
+        polymarketCategories: [],
       })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -43,11 +45,13 @@ export function UserPreferencesProvider({ children }) {
       const recentSearches = getUserPreference(walletAddress, 'recent_searches', [], true)
       const favoriteMarkets = getUserPreference(walletAddress, 'favorite_markets', [], true)
       const defaultSlippage = getUserPreference(walletAddress, 'default_slippage', 0.5, true)
+      const polymarketCategories = getUserPreference(walletAddress, 'polymarket_categories', [], true)
 
       setPreferences({
         recentSearches,
         favoriteMarkets,
         defaultSlippage,
+        polymarketCategories,
       })
     } catch (error) {
       console.error('Error loading user preferences:', error)
@@ -111,6 +115,14 @@ export function UserPreferencesProvider({ children }) {
     setPreferences(prev => ({ ...prev, defaultSlippage: slippage }))
   }, [account])
 
+  const setPolymarketCategories = useCallback((categories) => {
+    if (!account) return
+
+    const next = Array.isArray(categories) ? categories : []
+    saveUserPreference(account, 'polymarket_categories', next, true)
+    setPreferences(prev => ({ ...prev, polymarketCategories: next }))
+  }, [account])
+
   const clearAllPreferences = useCallback(() => {
     if (!account) return
 
@@ -119,6 +131,7 @@ export function UserPreferencesProvider({ children }) {
       recentSearches: [],
       favoriteMarkets: [],
       defaultSlippage: 0.5,
+      polymarketCategories: [],
     })
   }, [account])
 
@@ -129,6 +142,7 @@ export function UserPreferencesProvider({ children }) {
     clearRecentSearches,
     toggleFavoriteMarket,
     setDefaultSlippage,
+    setPolymarketCategories,
     savePreference,
     clearAllPreferences,
   }

--- a/frontend/src/hooks/usePolymarketSearch.js
+++ b/frontend/src/hooks/usePolymarketSearch.js
@@ -80,37 +80,9 @@ export function usePolymarketSearch({ limit = DEFAULT_LIMIT } = {}) {
       // The Gamma API has historically returned both raw arrays and
       // { data: [] } wrappers, so normalise.
       const items = Array.isArray(data) ? data : Array.isArray(data?.data) ? data.data : []
-
-      const normalised = items.map((m) => {
-        const outcomes = (() => {
-          try {
-            const names = typeof m.outcomes === 'string' ? JSON.parse(m.outcomes) : m.outcomes
-            const prices = typeof m.outcomePrices === 'string' ? JSON.parse(m.outcomePrices) : m.outcomePrices
-            if (!Array.isArray(names)) return []
-            return names.map((name, i) => ({
-              name,
-              price: prices?.[i] != null ? Number(prices[i]) : null,
-            }))
-          } catch {
-            return []
-          }
-        })()
-
-        return {
-          id: m.id ?? m.marketId ?? null,
-          slug: m.slug || null,
-          question: m.question || m.title || m.name || '',
-          description: m.description || '',
-          category: m.category || m.categories || null,
-          conditionId: m.conditionId || m.condition_id || null,
-          endDate: m.endDate || m.end_date_iso || null,
-          volume: m.volume != null ? Number(m.volume) : null,
-          liquidity: m.liquidity != null ? Number(m.liquidity) : null,
-          active: m.active !== false,
-          closed: m.closed === true,
-          outcomes,
-        }
-      }).filter((m) => m.conditionId) // can only peg markets that have a condition id
+      const normalised = items
+        .map(normaliseGammaMarket)
+        .filter((m) => m.conditionId) // can only peg markets that have a condition id
 
       setResults(normalised)
     } catch (err) {
@@ -150,6 +122,136 @@ export function usePolymarketSearch({ limit = DEFAULT_LIMIT } = {}) {
     search,
     runSearch,
     clear,
+  }
+}
+
+/**
+ * Normalise a Gamma `/markets` response item into the same shape used by
+ * `usePolymarketSearch`. Extracted so the top-markets hook can reuse it.
+ */
+function normaliseGammaMarket(m) {
+  const outcomes = (() => {
+    try {
+      const names = typeof m.outcomes === 'string' ? JSON.parse(m.outcomes) : m.outcomes
+      const prices = typeof m.outcomePrices === 'string' ? JSON.parse(m.outcomePrices) : m.outcomePrices
+      if (!Array.isArray(names)) return []
+      return names.map((name, i) => ({
+        name,
+        price: prices?.[i] != null ? Number(prices[i]) : null,
+      }))
+    } catch {
+      return []
+    }
+  })()
+
+  return {
+    id: m.id ?? m.marketId ?? null,
+    slug: m.slug || null,
+    question: m.question || m.title || m.name || '',
+    description: m.description || '',
+    category: m.category || m.categories || null,
+    conditionId: m.conditionId || m.condition_id || null,
+    endDate: m.endDate || m.end_date_iso || null,
+    volume: m.volume != null ? Number(m.volume) : null,
+    liquidity: m.liquidity != null ? Number(m.liquidity) : null,
+    active: m.active !== false,
+    closed: m.closed === true,
+    image: m.image || m.icon || null,
+    outcomes,
+  }
+}
+
+/**
+ * Load the currently top-by-volume Polymarket markets, optionally filtered by
+ * category/tag slugs. Used by the dashboard feed and the in-modal market
+ * browser. Mirrors the `usePolymarketSearch` lifecycle (per-chain `apiBase`,
+ * `AbortController` cleanup) so behaviour stays consistent.
+ *
+ * Usage:
+ *   const { results, isLoading, error, refresh } = usePolymarketTopMarkets({
+ *     categories: ['politics', 'sports'],
+ *     limit: 12,
+ *   })
+ *
+ * Gamma's `/markets` endpoint sorts by `volume` desc when given
+ * `order=volume&ascending=false`. Multiple tag slugs are comma-joined under
+ * `tag_slug=` — the Gamma API treats them as OR.
+ */
+export function usePolymarketTopMarkets({ categories = [], limit = 12 } = {}) {
+  const wagmiChainId = useChainId()
+  const chainId = wagmiChainId || getCurrentChainId()
+  const network = getNetwork(chainId)
+  const apiBase = network?.polymarket?.gammaApiUrl || 'https://gamma-api.polymarket.com'
+
+  const [results, setResults] = useState([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  const abortRef = useRef(null)
+  // Stabilise the categories array against new references on every render —
+  // the parent often passes a fresh array literal, which would otherwise loop
+  // the effect.
+  const categoriesKey = Array.isArray(categories) ? categories.slice().sort().join(',') : ''
+
+  const fetchTop = useCallback(async () => {
+    if (abortRef.current) {
+      abortRef.current.abort()
+    }
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const params = new URLSearchParams({
+        limit: String(limit),
+        active: 'true',
+        closed: 'false',
+        order: 'volume',
+        ascending: 'false',
+      })
+      if (categoriesKey) {
+        params.set('tag_slug', categoriesKey)
+      }
+      const url = `${apiBase.replace(/\/$/, '')}/markets?${params.toString()}`
+      const res = await fetch(url, {
+        signal: controller.signal,
+        headers: { Accept: 'application/json' },
+      })
+
+      if (!res.ok) {
+        throw new Error(`Polymarket Gamma API returned ${res.status}`)
+      }
+
+      const data = await res.json()
+      const items = Array.isArray(data) ? data : Array.isArray(data?.data) ? data.data : []
+      const normalised = items
+        .map(normaliseGammaMarket)
+        .filter((m) => m.conditionId)
+      setResults(normalised)
+    } catch (err) {
+      if (err.name === 'AbortError') return
+      logger.warn?.('[usePolymarketTopMarkets] failed:', err)
+      setError(err.message || 'Polymarket top-markets fetch failed')
+      setResults([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [apiBase, limit, categoriesKey])
+
+  useEffect(() => {
+    fetchTop()
+    return () => {
+      if (abortRef.current) abortRef.current.abort()
+    }
+  }, [fetchTop])
+
+  return {
+    results,
+    isLoading,
+    error,
+    refresh: fetchTop,
   }
 }
 

--- a/frontend/src/pages/WalletPage.css
+++ b/frontend/src/pages/WalletPage.css
@@ -859,3 +859,38 @@
   transform: translateY(-1px);
 }
 
+
+/* Polymarket category preferences */
+.polymarket-category-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.5rem;
+  margin: 0.75rem 0 1rem;
+}
+
+.polymarket-category-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.75rem;
+  background: var(--surface-2, rgba(255, 255, 255, 0.03));
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  border-radius: 8px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.polymarket-category-option:hover {
+  border-color: #2d9cdb;
+}
+
+.polymarket-category-option.checked {
+  background: rgba(45, 156, 219, 0.12);
+  border-color: #2d9cdb;
+  color: #2d9cdb;
+}
+
+.polymarket-category-option input[type="checkbox"] {
+  accent-color: #2d9cdb;
+}

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -1,7 +1,9 @@
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useWallet, useWalletConnection, useWalletRoles } from '../hooks'
 import { useEncryption } from '../hooks/useEncryption'
+import { useUserPreferences } from '../hooks/useUserPreferences'
+import { useChainTokens } from '../hooks/useChainTokens'
 import { useModal } from '../hooks/useUI'
 import { ROLES, ROLE_INFO } from '../contexts/RoleContext'
 import { hasRegisteredKey, ensureKeyRegistered } from '../utils/keyRegistryService'
@@ -30,12 +32,28 @@ const getConnectorInfo = (connector) => {
   return connector.name || connector.id
 }
 
+// Canonical Polymarket category slugs — kept here to keep WalletPage
+// self-contained. Order matches PolymarketBrowser's quick-filter row.
+const POLYMARKET_CATEGORY_OPTIONS = [
+  { slug: 'politics', label: 'Politics' },
+  { slug: 'sports', label: 'Sports' },
+  { slug: 'crypto', label: 'Crypto' },
+  { slug: 'pop-culture', label: 'Pop Culture' },
+  { slug: 'business', label: 'Business' },
+  { slug: 'science', label: 'Science' },
+  { slug: 'entertainment', label: 'Entertainment' },
+  { slug: 'tech', label: 'Tech' },
+]
+
 function WalletPage() {
   const { address, isConnected, connectors, provider, signer } = useWallet()
   const { connectWallet, disconnectWallet } = useWalletConnection()
   const { showModal, hideModal } = useModal()
   const { roles, hasRole } = useWalletRoles()
   const { isInitialized, isInitializing, ensureInitialized } = useEncryption()
+  const { preferences, setPolymarketCategories } = useUserPreferences()
+  const { capabilities } = useChainTokens()
+  const polymarketSidebetsEnabled = Boolean(capabilities?.polymarketSidebets)
   const navigate = useNavigate()
   const [activeTab, setActiveTab] = useState('account')
   const [connectingConnectorId, setConnectingConnectorId] = useState(null)
@@ -140,6 +158,19 @@ function WalletPage() {
     }
   }, [activeTab, isConnected, keyRegistered, handleCheckKeyStatus])
 
+  const selectedPolymarketCategories = useMemo(
+    () => preferences?.polymarketCategories || [],
+    [preferences?.polymarketCategories],
+  )
+
+  const togglePolymarketCategory = useCallback((slug) => {
+    if (!isConnected) return
+    const next = selectedPolymarketCategories.includes(slug)
+      ? selectedPolymarketCategories.filter((s) => s !== slug)
+      : [...selectedPolymarketCategories, slug]
+    setPolymarketCategories(next)
+  }, [isConnected, selectedPolymarketCategories, setPolymarketCategories])
+
   const shortenAddress = (address) => {
     if (!address) return ''
     return `${address.substring(0, 6)}...${address.substring(address.length - 4)}`
@@ -216,6 +247,7 @@ function WalletPage() {
                 <button role="tab" aria-selected={activeTab === 'account'} className={`tab ${activeTab === 'account' ? 'active' : ''}`} onClick={() => setActiveTab('account')}>Account</button>
                 <button role="tab" aria-selected={activeTab === 'membership'} className={`tab ${activeTab === 'membership' ? 'active' : ''}`} onClick={() => setActiveTab('membership')}>Membership</button>
                 <button role="tab" aria-selected={activeTab === 'security'} className={`tab ${activeTab === 'security' ? 'active' : ''}`} onClick={() => setActiveTab('security')}>Security</button>
+                <button role="tab" aria-selected={activeTab === 'preferences'} className={`tab ${activeTab === 'preferences' ? 'active' : ''}`} onClick={() => setActiveTab('preferences')}>Preferences</button>
                 <button role="tab" aria-selected={activeTab === 'swap'} className={`tab ${activeTab === 'swap' ? 'active' : ''}`} onClick={() => setActiveTab('swap')}>Swap</button>
               </div>
 
@@ -335,6 +367,49 @@ function WalletPage() {
                           </button>
                         )}
                       </div>
+                    </div>
+                  </div>
+                )}
+
+                {activeTab === 'preferences' && (
+                  <div className="preferences-section" role="tabpanel">
+                    <div className="section">
+                      <h3>Polymarket Categories</h3>
+                      <p className="section-description">
+                        Pick the categories you care about. Your dashboard feed will surface markets in these categories first, and the in-wager market browser uses them as the default filter.
+                      </p>
+
+                      {!polymarketSidebetsEnabled && (
+                        <div className="key-error" role="note">
+                          Polymarket integration is only available on Polygon chains. Switch your network to use these preferences.
+                        </div>
+                      )}
+
+                      <div className="polymarket-category-grid">
+                        {POLYMARKET_CATEGORY_OPTIONS.map(({ slug, label }) => {
+                          const checked = selectedPolymarketCategories.includes(slug)
+                          return (
+                            <label key={slug} className={`polymarket-category-option ${checked ? 'checked' : ''}`}>
+                              <input
+                                type="checkbox"
+                                checked={checked}
+                                onChange={() => togglePolymarketCategory(slug)}
+                              />
+                              <span>{label}</span>
+                            </label>
+                          )
+                        })}
+                      </div>
+
+                      {selectedPolymarketCategories.length > 0 && (
+                        <button
+                          type="button"
+                          className="key-action-btn secondary"
+                          onClick={() => setPolymarketCategories([])}
+                        >
+                          Clear all
+                        </button>
+                      )}
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
Introduces a shared PolymarketBrowser component that ranks active Polymarket
markets by 24h volume with a boost for categories the user has wagered on
before or selected on /wallet > Preferences. The dashboard surfaces it as a
"Top from Polymarket" feed; clicking a card opens the create-wager modal
pre-filled with the picked event so the user finishes only stake and opponent.

The same component renders inline inside FriendMarketsModal whenever a user
picks "Linked Market (Polymarket)" — for 1v1 friend wagers, bookmaker, and
small-group wagers — replacing the bare search box with category quick-filters
and a proper retry on API failure.

- usePolymarketSearch.js: extract normaliseGammaMarket helper and add a
  sibling usePolymarketTopMarkets hook (volume-sorted, tag-filterable).
- UserPreferencesContext: persist polymarketCategories per wallet.
- WalletPage: new Preferences tab with a category picker.
- Dashboard: render PolymarketBrowser feed and route card clicks into the
  create-wager modal via a new initialPolymarketMarket prop.