### PR TITLE
feat(frontend): paginated My Wagers view with subgraph-backed scale

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -64,3 +64,15 @@ VITE_IPFS_GATEWAY=https://gateway.pinata.cloud
 # For local development: http://localhost:5173
 # For production: https://your-domain.com
 VITE_APP_URL=http://localhost:5173
+
+# Wager Data Source (My Wagers paginated view)
+# 'subgraph' — query The Graph's decentralized network (recommended in dev)
+# 'events'   — fall back to direct RPC event scanning (no indexer required)
+# Defaults to 'subgraph'; auto-falls back to 'events' if the URL is unset
+# or the GraphQL request fails.
+VITE_WAGER_SOURCE=subgraph
+
+# Subgraph endpoint for the FriendGroupMarketFactory index.
+# Public Graph Network (Studio) during development; hosted graph in future.
+# See subgraph/README.md for deploy instructions.
+# VITE_SUBGRAPH_URL=https://api.studio.thegraph.com/query/<id>/prediction-dao-research/v0.1.0

--- a/frontend/src/components/fairwins/MyMarketsModal.css
+++ b/frontend/src/components/fairwins/MyMarketsModal.css
@@ -182,15 +182,44 @@
   text-align: center;
 }
 
+.mm-tab-badge.mm-tab-badge-unread {
+  background: #36B37E;
+  animation: mmBadgePulse 2s ease-in-out infinite;
+  box-shadow: 0 0 0 0 rgba(54, 179, 126, 0.4);
+}
+
+@keyframes mmBadgePulse {
+  0%, 100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 rgba(54, 179, 126, 0.4);
+  }
+  50% {
+    transform: scale(1.05);
+    box-shadow: 0 0 0 4px rgba(54, 179, 126, 0);
+  }
+}
+
 /* Filter Bar */
 .mm-filter-bar {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
   padding: 0.75rem 1.5rem;
   background: var(--bg-primary, #0E141B);
   border-bottom: 1px solid var(--border-color, #23303D);
   flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 900px) {
+  .mm-filter-bar {
+    gap: 0.5rem;
+    padding: 0.625rem 1rem;
+  }
+  .mm-filter-select {
+    min-width: 110px;
+    font-size: 0.75rem;
+  }
 }
 
 .mm-filter-group {
@@ -394,22 +423,52 @@
 }
 
 .mm-table td {
-  padding: 0.875rem 1rem;
+  padding: 0.75rem 0.875rem;
   border-bottom: 1px solid var(--border-color, #23303D);
   color: var(--text-primary, #E6EDF3);
   vertical-align: middle;
 }
 
 .mm-table-market {
+  min-width: 180px;
   max-width: 280px;
 }
 
+@media (min-width: 1024px) {
+  .mm-table-market {
+    max-width: 320px;
+  }
+}
+
 .mm-table-market-title {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  min-width: 0;
+  font-weight: 500;
+}
+
+.mm-table-market-title > span {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-weight: 500;
+}
+
+/* Unread row indicator (matches FriendMarketsModal pattern) */
+.mm-table-row.mm-unread {
+  position: relative;
+  background: rgba(54, 179, 126, 0.08);
+}
+
+.mm-table-row.mm-unread::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: #36B37E;
+  border-radius: 0 2px 2px 0;
 }
 
 .mm-table-category {
@@ -510,14 +569,17 @@
 
 /* Action Buttons in Table */
 .mm-action-btn {
-  padding: 0.375rem 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.625rem;
   font-size: 0.75rem;
   font-weight: 600;
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.2s;
   border: none;
-  margin-right: 0.5rem;
+  margin-right: 0.375rem;
 }
 
 .mm-action-btn:last-child {
@@ -550,6 +612,35 @@
 
 .mm-action-btn.mm-action-accept:hover {
   background: linear-gradient(135deg, #818cf8 0%, #a78bfa 100%);
+}
+
+/* Load More */
+.mm-load-more-row {
+  display: flex;
+  justify-content: center;
+  padding: 1rem 0 0.25rem;
+}
+
+.mm-load-more {
+  background: transparent;
+  border: 1px solid var(--border-color, #23303D);
+  border-radius: 8px;
+  padding: 0.5rem 1.25rem;
+  color: var(--text-primary, #E6EDF3);
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.mm-load-more:hover:not(:disabled) {
+  border-color: #4C9AFF;
+  color: #4C9AFF;
+}
+
+.mm-load-more:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 /* Resolve Countdown */
@@ -1444,7 +1535,7 @@
   }
 
   .mm-table-market {
-    max-width: 150px;
+    max-width: 170px;
   }
 
   .mm-detail-grid {

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -1,8 +1,16 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { ethers } from 'ethers'
-import { useWallet, useWeb3 } from '../../hooks'
+import { useWallet, useWeb3, useMyWagers, useMyWagerNotifications } from '../../hooks'
 import { useChainTokens } from '../../hooks/useChainTokens'
-import { WagerStatus as MarketStatus, DisputeStatus, WAGER_DEFAULTS } from '../../constants/wagerDefaults'
+import {
+  WagerStatus as MarketStatus,
+  DisputeStatus,
+  WAGER_DEFAULTS,
+  WagerSortKey,
+  ResolutionTypeNames,
+  ResolutionTypeOrder,
+  TERMINAL_STATUSES,
+} from '../../constants/wagerDefaults'
 import { getContractAddress } from '../../config/contracts'
 import { getTransactionUrl } from '../../config/blockExplorer'
 import { FRIEND_GROUP_MARKET_FACTORY_ABI } from '../../abis/FriendGroupMarketFactory'
@@ -34,10 +42,8 @@ function MyMarketsModal({
   // Tab state
   const [activeTab, setActiveTab] = useState('participating')
 
-  // Markets data state
-  const [markets, setMarkets] = useState([])
-  const [userPositions, setUserPositions] = useState([])
-  const [loading, setLoading] = useState(true)
+  // Optimistic data state (legacy — kept for any callers still wiring positions)
+  const [userPositions] = useState([])
   const [error, setError] = useState(null)
 
   // Selected market for detail view
@@ -59,31 +65,69 @@ function MyMarketsModal({
   // Filter state
   const [marketTypeFilter, setMarketTypeFilter] = useState('all') // 'all', 'friend'
   const [statusFilter, setStatusFilter] = useState('all')
+  const [resolutionTypeFilter, setResolutionTypeFilter] = useState('all') // 'all' | '0'..'5'
+  const [sortKey, setSortKey] = useState(WagerSortKey.CREATED)
 
-  // Fetch markets data (friend markets are passed via props)
+  // Paginated wagers via the WagerRepository (subgraph primary, events fallback).
+  // The hook keeps decryption out of the data path — encrypted envelopes are
+  // returned as raw metadataCipher and unwrapped by useLazyMarketDecryption.
+  const myWagersFilter = useMemo(() => ({
+    marketTypes: marketTypeFilter === 'all' ? null : [marketTypeFilter],
+    statuses: statusFilter === 'all' ? null : [statusFilter],
+    resolutionTypes: resolutionTypeFilter === 'all' ? null : [Number(resolutionTypeFilter)],
+    includeExpired: activeTab === 'history',
+  }), [marketTypeFilter, statusFilter, resolutionTypeFilter, activeTab])
+
+  const {
+    items: pagedWagers,
+    loadMore,
+    refresh: refreshPage,
+    isLoading: pageLoading,
+    error: pageError,
+    hasMore,
+  } = useMyWagers({
+    account,
+    tab: activeTab,
+    sort: sortKey,
+    filter: myWagersFilter,
+  })
+
+  // Unread tracking (circuit-breaker for the count badge + mark-as-read).
+  // Independent storage key from FriendMarketsModal so opening a wager in
+  // one view does not mark it read in the other.
+  const {
+    unreadMarketIds,
+    markMarketAsRead,
+    isMarketUnread,
+  } = useMyWagerNotifications(pagedWagers, account)
+
+  // The pagedWagers are already gated on ownership/expiry/tab by the
+  // repository. The remaining job for the modal is to merge in any
+  // optimistic friend markets passed via props (e.g. just-created).
+  const visibleWagers = useMemo(() => {
+    const seen = new Set(pagedWagers.map(w => String(w.id)))
+    const optimistic = (friendMarkets || []).filter(m => !seen.has(String(m.id)))
+    return [...pagedWagers, ...optimistic]
+  }, [pagedWagers, friendMarkets])
+
+  // Fetch markets data — now a thin wrapper that refreshes the paginated query
   const fetchMarketsData = useCallback(async () => {
     if (!account) return
-
-    setLoading(true)
     setError(null)
-
     try {
-      setMarkets([])
-      setUserPositions([])
+      await refreshPage()
     } catch (err) {
       console.error('Error fetching markets data:', err)
       setError('Failed to load wagers. Please try again.')
-    } finally {
-      setLoading(false)
     }
-  }, [account])
+  }, [account, refreshPage])
 
-  // Load data when modal opens
+  const loading = pageLoading
+
+  // Surface page-level errors
   useEffect(() => {
-    if (isOpen && account) {
-      fetchMarketsData()
-    }
-  }, [isOpen, account, fetchMarketsData])
+    if (pageError) setError(pageError)
+  }, [pageError])
 
   // Reset state when modal opens
   useEffect(() => {
@@ -94,6 +138,8 @@ function MyMarketsModal({
       setShowDisputeModal(false)
       setMarketTypeFilter('all')
       setStatusFilter('all')
+      setResolutionTypeFilter('all')
+      setSortKey(WagerSortKey.CREATED)
     }
   }, [isOpen])
 
@@ -125,108 +171,67 @@ function MyMarketsModal({
     }
   }
 
-  // Combine and categorize markets
-  const categorizedMarkets = useMemo(() => {
-    const userAddr = account?.toLowerCase()
-    if (!userAddr) return { participating: [], created: [], history: [] }
-
-    // Combine fetched and friend markets
-    const allMarkets = [
-      ...markets.map(m => ({ ...m, marketType: 'friend' })),
-      ...friendMarkets.map(m => ({ ...m, marketType: 'friend' }))
-    ]
-
-    // Remove duplicates by id
-    const uniqueMarkets = allMarkets.reduce((acc, market) => {
-      const key = `${market.marketType}-${market.id}`
-      if (!acc[key]) acc[key] = market
-      return acc
-    }, {})
-
-    const marketsList = Object.values(uniqueMarkets)
-
-    // Determine market status helper
-    const getMarketStatus = (market) => {
-      const now = Date.now()
-      const endTime = market.tradingEndTime
-        ? (typeof market.tradingEndTime === 'bigint'
-          ? Number(market.tradingEndTime) * 1000
-          : new Date(market.tradingEndTime).getTime())
-        : (market.endDate ? new Date(market.endDate).getTime() : 0)
-
-      // Check for terminal statuses first
+  // Annotate each visible wager with a computedStatus derived from its
+  // chain status + endTime. The repository already gated by tab, so we
+  // only need the lightweight status decoration here.
+  const annotatedWagers = useMemo(() => {
+    if (!account) return []
+    const userAddr = account.toLowerCase()
+    // eslint-disable-next-line react-hooks/purity -- Date.now() is calculated once per memo evaluation; recomputed when deps change
+    const now = Date.now()
+    return visibleWagers.map(market => {
       const statusLower = market.status?.toLowerCase()
+      let computedStatus
       if (statusLower === 'cancelled' || statusLower === 'canceled') {
-        return MarketStatus.CANCELLED
+        computedStatus = MarketStatus.CANCELLED
+      } else if (statusLower === 'resolved') {
+        computedStatus = MarketStatus.RESOLVED
+      } else if (statusLower === 'refunded') {
+        computedStatus = MarketStatus.REFUNDED
+      } else if (statusLower === 'oracle_timed_out') {
+        computedStatus = MarketStatus.ORACLE_TIMED_OUT
+      } else if (statusLower === 'challenged') {
+        computedStatus = MarketStatus.CHALLENGED
+      } else if (statusLower === 'pending_acceptance' || statusLower === 'pending') {
+        computedStatus = MarketStatus.PENDING_ACCEPTANCE
+      } else if (statusLower === 'disputed' || market.disputeStatus === DisputeStatus.OPENED) {
+        computedStatus = MarketStatus.DISPUTED
+      } else if (statusLower === 'pending_resolution') {
+        computedStatus = MarketStatus.PENDING_RESOLUTION
+      } else {
+        const endTime = market.endTime
+          || (market.endDate ? new Date(market.endDate).getTime() : 0)
+        computedStatus = endTime && now > endTime
+          ? MarketStatus.PENDING_RESOLUTION
+          : MarketStatus.ACTIVE
       }
-      if (statusLower === 'resolved') return MarketStatus.RESOLVED
-      if (statusLower === 'refunded') return MarketStatus.REFUNDED
-      if (statusLower === 'oracle_timed_out') return MarketStatus.ORACLE_TIMED_OUT
-      if (statusLower === 'challenged') return MarketStatus.CHALLENGED
+      return { ...market, computedStatus, marketType: market.marketType || 'friend' }
+    }).filter(m => {
+      // Defensive ownership double-gate against any optimistic injections
+      return m.creator?.toLowerCase() === userAddr
+        || (m.participants || []).some(p => p?.toLowerCase() === userAddr)
+    })
+  }, [visibleWagers, account])
 
-      // Check for pending_acceptance status (friend markets awaiting participant stakes)
-      if (statusLower === 'pending_acceptance' || statusLower === 'pending') {
-        return MarketStatus.PENDING_ACCEPTANCE
-      }
-      if (statusLower === 'disputed' || market.disputeStatus === DisputeStatus.OPENED) {
-        return MarketStatus.DISPUTED
-      }
-      if (endTime && now > endTime) return MarketStatus.PENDING_RESOLUTION
-      return MarketStatus.ACTIVE
-    }
-
-    // Check if user has position in market
-    const hasPosition = (marketId) => {
-      return userPositions.some(p => String(p.marketId) === String(marketId))
-    }
-
-    // Check if user is creator
-    const isCreator = (market) => {
-      return market.creator?.toLowerCase() === userAddr
-    }
-
-    // Check if user is participant
-    const isParticipant = (market) => {
-      return market.participants?.some(p => p.toLowerCase() === userAddr) ||
-        hasPosition(market.id)
-    }
-
-    // Categorize markets
+  // Split the visible page into tab buckets for the existing UI shape.
+  const categorizedMarkets = useMemo(() => {
+    if (!account) return { participating: [], created: [], history: [] }
+    const userAddr = account.toLowerCase()
+    const isCreator = (m) => m.creator?.toLowerCase() === userAddr
+    const isTerminal = (m) => TERMINAL_STATUSES.has(m.status?.toLowerCase())
     const participating = []
     const created = []
     const history = []
-
-    marketsList.forEach(market => {
-      const status = getMarketStatus(market)
-      const marketWithStatus = { ...market, computedStatus: status }
-
-      // Apply type filter
-      if (marketTypeFilter !== 'all' && market.marketType !== marketTypeFilter) {
-        return
+    for (const market of annotatedWagers) {
+      if (isTerminal(market)) {
+        history.push(market)
+        continue
       }
-
-      // Apply status filter
-      if (statusFilter !== 'all' && status !== statusFilter) {
-        return
-      }
-
-      // Terminal markets go to history
-      if (status === MarketStatus.RESOLVED || status === MarketStatus.CANCELLED || status === MarketStatus.REFUNDED || status === MarketStatus.ORACLE_TIMED_OUT) {
-        if (isCreator(market) || isParticipant(market)) {
-          history.push(marketWithStatus)
-        }
-      } else {
-        if (isCreator(market)) {
-          created.push(marketWithStatus)
-        }
-        if (isParticipant(market) && !isCreator(market)) {
-          participating.push(marketWithStatus)
-        }
-      }
-    })
-
+      if (isCreator(market)) created.push(market)
+      else participating.push(market)
+    }
     return { participating, created, history }
-  }, [markets, friendMarkets, userPositions, account, marketTypeFilter, statusFilter])
+  }, [annotatedWagers, account])
 
   // Format helpers
   const formatDate = (dateValue) => {
@@ -321,6 +326,7 @@ function MyMarketsModal({
   }
 
   const handleMarketSelect = (market) => {
+    if (market?.id) markMarketAsRead(market.id)
     setSelectedMarket(market)
   }
 
@@ -474,9 +480,11 @@ function MyMarketsModal({
               <path d="M22 12h-4l-3 9L9 3l-3 9H2"/>
             </svg>
             <span>Participating</span>
-            {categorizedMarkets.participating.length > 0 && (
-              <span className="mm-tab-badge">{categorizedMarkets.participating.length}</span>
-            )}
+            {(() => {
+              const ids = new Set(unreadMarketIds.map(String))
+              const n = categorizedMarkets.participating.filter(m => ids.has(String(m.id))).length
+              return n > 0 ? <span className="mm-tab-badge mm-tab-badge-unread">{n}</span> : null
+            })()}
           </button>
           <button
             className={`mm-tab ${activeTab === 'created' ? 'active' : ''}`}
@@ -490,9 +498,11 @@ function MyMarketsModal({
               <path d="M2 12l10 5 10-5"/>
             </svg>
             <span>Created</span>
-            {categorizedMarkets.created.length > 0 && (
-              <span className="mm-tab-badge">{categorizedMarkets.created.length}</span>
-            )}
+            {(() => {
+              const ids = new Set(unreadMarketIds.map(String))
+              const n = categorizedMarkets.created.filter(m => ids.has(String(m.id))).length
+              return n > 0 ? <span className="mm-tab-badge mm-tab-badge-unread">{n}</span> : null
+            })()}
           </button>
           <button
             className={`mm-tab ${activeTab === 'history' ? 'active' : ''}`}
@@ -505,9 +515,11 @@ function MyMarketsModal({
               <polyline points="12 6 12 12 16 14"/>
             </svg>
             <span>History</span>
-            {categorizedMarkets.history.length > 0 && (
-              <span className="mm-tab-badge">{categorizedMarkets.history.length}</span>
-            )}
+            {(() => {
+              const ids = new Set(unreadMarketIds.map(String))
+              const n = categorizedMarkets.history.filter(m => ids.has(String(m.id))).length
+              return n > 0 ? <span className="mm-tab-badge mm-tab-badge-unread">{n}</span> : null
+            })()}
           </button>
         </nav>
 
@@ -537,6 +549,32 @@ function MyMarketsModal({
               <option value={MarketStatus.PENDING_RESOLUTION}>Pending Resolution</option>
               <option value={MarketStatus.DISPUTED}>Disputed</option>
               <option value={MarketStatus.RESOLVED}>Resolved</option>
+            </select>
+          </div>
+          <div className="mm-filter-group">
+            <label>Resolution:</label>
+            <select
+              value={resolutionTypeFilter}
+              onChange={(e) => setResolutionTypeFilter(e.target.value)}
+              className="mm-filter-select"
+            >
+              <option value="all">Any</option>
+              {ResolutionTypeOrder.map(rt => (
+                <option key={rt} value={String(rt)}>{ResolutionTypeNames[rt]}</option>
+              ))}
+            </select>
+          </div>
+          <div className="mm-filter-group">
+            <label>Sort:</label>
+            <select
+              value={sortKey}
+              onChange={(e) => setSortKey(e.target.value)}
+              className="mm-filter-select"
+            >
+              <option value={WagerSortKey.CREATED}>Created</option>
+              <option value={WagerSortKey.ENDS}>Ends</option>
+              <option value={WagerSortKey.RESOLUTION_TYPE}>Resolution type</option>
+              <option value={WagerSortKey.STATUS}>Status</option>
             </select>
           </div>
           <button
@@ -601,19 +639,34 @@ function MyMarketsModal({
                       <p className="mm-hint">Create or accept a wager to see them here.</p>
                     </div>
                   ) : (
-                    <MarketsTable
-                      markets={categorizedMarkets.participating}
-                      onSelect={handleMarketSelect}
-                      formatDate={formatDate}
-                      getStatusClass={getStatusClass}
-                      getStatusLabel={getStatusLabel}
-                      getTimeRemaining={getTimeRemaining}
-                      showActions={false}
-                      canAccept={canAcceptMarket}
-                      isCreatorOfPending={isCreatorOfPendingMarket}
-                      onAccept={handleOpenAcceptance}
-                      account={account}
-                    />
+                    <>
+                      <MarketsTable
+                        markets={categorizedMarkets.participating}
+                        onSelect={handleMarketSelect}
+                        formatDate={formatDate}
+                        getStatusClass={getStatusClass}
+                        getStatusLabel={getStatusLabel}
+                        getTimeRemaining={getTimeRemaining}
+                        showActions={false}
+                        canAccept={canAcceptMarket}
+                        isCreatorOfPending={isCreatorOfPendingMarket}
+                        onAccept={handleOpenAcceptance}
+                        account={account}
+                        isMarketUnread={isMarketUnread}
+                      />
+                      {hasMore && (
+                        <div className="mm-load-more-row">
+                          <button
+                            type="button"
+                            className="mm-load-more"
+                            onClick={loadMore}
+                            disabled={loading}
+                          >
+                            {loading ? 'Loading…' : 'Load more'}
+                          </button>
+                        </div>
+                      )}
+                    </>
                   )}
                 </div>
               )}
@@ -646,22 +699,37 @@ function MyMarketsModal({
                       <p className="mm-hint">Use the quick actions on the dashboard to create your first wager.</p>
                     </div>
                   ) : (
-                    <MarketsTable
-                      markets={categorizedMarkets.created}
-                      onSelect={handleMarketSelect}
-                      formatDate={formatDate}
-                      getStatusClass={getStatusClass}
-                      getStatusLabel={getStatusLabel}
-                      getTimeRemaining={getTimeRemaining}
-                      canResolve={canResolve}
-                      canRespondToDispute={canRespondToDispute}
-                      isCreatorOfPending={isCreatorOfPendingMarket}
-                      onResolve={handleOpenResolution}
-                      onRespondToDispute={(m) => handleOpenDispute(m, 'respond')}
-                      showActions
-                      account={account}
-                      showResolveCountdown
-                    />
+                    <>
+                      <MarketsTable
+                        markets={categorizedMarkets.created}
+                        onSelect={handleMarketSelect}
+                        formatDate={formatDate}
+                        getStatusClass={getStatusClass}
+                        getStatusLabel={getStatusLabel}
+                        getTimeRemaining={getTimeRemaining}
+                        canResolve={canResolve}
+                        canRespondToDispute={canRespondToDispute}
+                        isCreatorOfPending={isCreatorOfPendingMarket}
+                        onResolve={handleOpenResolution}
+                        onRespondToDispute={(m) => handleOpenDispute(m, 'respond')}
+                        showActions
+                        account={account}
+                        showResolveCountdown
+                        isMarketUnread={isMarketUnread}
+                      />
+                      {hasMore && (
+                        <div className="mm-load-more-row">
+                          <button
+                            type="button"
+                            className="mm-load-more"
+                            onClick={loadMore}
+                            disabled={loading}
+                          >
+                            {loading ? 'Loading…' : 'Load more'}
+                          </button>
+                        </div>
+                      )}
+                    </>
                   )}
                 </div>
               )}
@@ -689,15 +757,30 @@ function MyMarketsModal({
                       <p>Your resolved wagers will appear here.</p>
                     </div>
                   ) : (
-                    <MarketsTable
-                      markets={categorizedMarkets.history}
-                      onSelect={handleMarketSelect}
-                      formatDate={formatDate}
-                      getStatusClass={getStatusClass}
-                      getStatusLabel={getStatusLabel}
-                      getTimeRemaining={getTimeRemaining}
-                      showOutcome
-                    />
+                    <>
+                      <MarketsTable
+                        markets={categorizedMarkets.history}
+                        onSelect={handleMarketSelect}
+                        formatDate={formatDate}
+                        getStatusClass={getStatusClass}
+                        getStatusLabel={getStatusLabel}
+                        getTimeRemaining={getTimeRemaining}
+                        showOutcome
+                        isMarketUnread={isMarketUnread}
+                      />
+                      {hasMore && (
+                        <div className="mm-load-more-row">
+                          <button
+                            type="button"
+                            className="mm-load-more"
+                            onClick={loadMore}
+                            disabled={loading}
+                          >
+                            {loading ? 'Loading…' : 'Load more'}
+                          </button>
+                        </div>
+                      )}
+                    </>
                   )}
                 </div>
               )}
@@ -801,7 +884,8 @@ function MarketsTable({
   onRespondToDispute,
   onAccept,
   account,
-  showResolveCountdown = false
+  showResolveCountdown = false,
+  isMarketUnread,
 }) {
   const { native: nativeSymbol } = useChainTokens()
   return (
@@ -826,11 +910,12 @@ function MarketsTable({
             const showUnderConsideration = isCreatorOfPending?.(market)
             const displayTitle = getMarketDisplayTitle(market, nativeSymbol || 'MATIC')
 
+            const unread = isMarketUnread ? isMarketUnread(market.id) : false
             return (
               <tr
                 key={`${market.marketType}-${market.id}`}
                 onClick={() => onSelect(market)}
-                className="mm-table-row"
+                className={`mm-table-row${unread ? ' mm-unread' : ''}`}
                 role="button"
                 tabIndex={0}
                 onKeyDown={(e) => { if (e.key === 'Enter') onSelect(market) }}
@@ -847,13 +932,13 @@ function MarketsTable({
                         stroke="currentColor"
                         strokeWidth="2"
                         title="Private wager"
-                        style={{ marginRight: '6px', verticalAlign: 'middle', opacity: 0.7 }}
+                        style={{ flexShrink: 0, opacity: 0.7 }}
                       >
                         <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
                         <path d="M7 11V7a5 5 0 0110 0v4"/>
                       </svg>
                     )}
-                    {displayTitle}
+                    <span>{displayTitle}</span>
                   </span>
                   {market.category && (
                     <span className="mm-table-category">{market.category}</span>

--- a/frontend/src/constants/wagerDefaults.js
+++ b/frontend/src/constants/wagerDefaults.js
@@ -62,6 +62,45 @@ export const DisputeStatus = {
   RESOLVED: 'resolved',
 }
 
+// ── Resolution types (on-chain enum) ────────────────────────────────
+// Mirrors contracts/markets/FriendGroupMarketTypes.sol ResolutionType
+export const ResolutionType = {
+  EITHER: 0,
+  INITIATOR: 1,
+  RECEIVER: 2,
+  THIRD_PARTY: 3,
+  AUTO_PEGGED: 4,
+  POLYMARKET_ORACLE: 5,
+}
+
+export const ResolutionTypeNames = {
+  0: 'Either',
+  1: 'Initiator',
+  2: 'Receiver',
+  3: 'Third Party',
+  4: 'Auto-Pegged',
+  5: 'Polymarket Oracle',
+}
+
+// Sort order for "Resolution type" grouping in My Wagers
+export const ResolutionTypeOrder = [0, 1, 2, 3, 4, 5]
+
+// ── Sort keys for My Wagers list ────────────────────────────────────
+export const WagerSortKey = {
+  CREATED: 'createdAt',
+  ENDS: 'endTime',
+  RESOLUTION_TYPE: 'resolutionType',
+  STATUS: 'status',
+}
+
+// Terminal statuses — wagers in these states are considered "history"
+export const TERMINAL_STATUSES = new Set([
+  'resolved',
+  'cancelled',
+  'refunded',
+  'oracle_timed_out',
+])
+
 // ── Date helpers ────────────────────────────────────────────────────
 /** Returns an ISO datetime-local string N days from now */
 export const getDefaultEndDateTime = (days = WAGER_DEFAULTS.WAGER_END_DAYS) => {

--- a/frontend/src/data/wagers/EventsSource.js
+++ b/frontend/src/data/wagers/EventsSource.js
@@ -1,0 +1,274 @@
+/**
+ * EventsSource — WagerSource implementation backed by direct RPC calls.
+ *
+ * Discovery: scans MemberAdded events indexed by member address, with an
+ * incremental block watermark cached in localStorage. Lifted from the legacy
+ * `discoverMarketIds` in blockchainService.js, now using cacheStore.
+ *
+ * Hydration: fetches a bounded page via parallel contract reads
+ * (getFriendMarketWithStatus + friendMarkets), then assembles a Wager
+ * object with the corrected `endTime = createdAt + tradingPeriodSeconds`.
+ * The raw `description` (or IPFS reference) is preserved verbatim so the
+ * envelope can be lazy-decrypted by `useLazyMarketDecryption`.
+ */
+
+import { ethers } from 'ethers'
+import { getContractAddress, NETWORK_CONFIG, DEPLOYMENT_BLOCKS } from '../../config/contracts'
+import { DEX_ADDRESSES } from '../../constants/dex'
+import { FRIEND_GROUP_MARKET_FACTORY_ABI } from '../../abis/FriendGroupMarketFactory'
+import { parseEncryptedIpfsReference } from '../../utils/ipfsService'
+import { loadIndex, saveIndex, loadCache, upsertCache } from './cacheStore'
+import { applyFilters, paginate } from './sortFilter'
+import { WagerSortKey } from '../../constants/wagerDefaults'
+
+const MARKET_TYPES = ['oneVsOne', 'smallGroup', 'eventTracking', 'propBet']
+const STATUS_NAMES = [
+  'pending_acceptance',
+  'active',
+  'pending_resolution',
+  'challenged',
+  'resolved',
+  'cancelled',
+  'refunded',
+  'oracle_timed_out',
+]
+
+function getProvider() {
+  return new ethers.JsonRpcProvider(NETWORK_CONFIG.rpcUrl)
+}
+
+function getFactoryContract(signerOrProvider) {
+  const address = getContractAddress('friendGroupMarketFactory')
+  if (!address) throw new Error('FriendGroupMarketFactory address not configured')
+  return new ethers.Contract(address, FRIEND_GROUP_MARKET_FACTORY_ABI, signerOrProvider)
+}
+
+function detectEncryption(description) {
+  let metadata = null
+  let isEncrypted = false
+  let ipfsCid = null
+
+  const ipfsRef = parseEncryptedIpfsReference(description)
+  if (ipfsRef.isIpfs && ipfsRef.cid) {
+    return {
+      ipfsCid: ipfsRef.cid,
+      isEncrypted: true,
+      metadataCipher: null,
+      displayDescription: 'Encrypted Market',
+    }
+  }
+
+  try {
+    const parsed = JSON.parse(description)
+    const isV1 =
+      parsed?.version === '1.0' &&
+      parsed?.algorithm === 'x25519-chacha20poly1305' &&
+      parsed?.content?.ciphertext &&
+      Array.isArray(parsed?.keys)
+    const isV2 =
+      parsed?.version === '2.0' &&
+      parsed?.algorithm === 'xwing-chacha20poly1305' &&
+      parsed?.content?.ciphertext &&
+      Array.isArray(parsed?.keys)
+    if (isV1 || isV2) {
+      metadata = parsed
+      isEncrypted = true
+    }
+  } catch {
+    // plain text description — leave as-is
+  }
+
+  return {
+    ipfsCid,
+    isEncrypted,
+    metadataCipher: metadata,
+    displayDescription: isEncrypted ? 'Encrypted Market' : description,
+  }
+}
+
+function toWager(marketId, withStatus, full) {
+  const stakeToken = withStatus.stakeToken
+  const isStable =
+    stakeToken && stakeToken.toLowerCase() === DEX_ADDRESSES?.STABLECOIN?.toLowerCase()
+  const tokenDecimals = isStable ? 6 : 18
+
+  const createdAtMs = Number(full?.createdAt || 0) * 1000
+  const tradingPeriodSeconds = Number(full?.tradingPeriodSeconds || 0)
+  const acceptanceDeadlineMs = Number(withStatus.acceptanceDeadline) * 1000
+
+  let endTime
+  if (createdAtMs > 0 && tradingPeriodSeconds > 0) {
+    endTime = createdAtMs + tradingPeriodSeconds * 1000
+  } else if (acceptanceDeadlineMs > 0) {
+    endTime = acceptanceDeadlineMs
+  } else {
+    endTime = 0
+  }
+
+  const description = withStatus.description || ''
+  const enc = detectEncryption(description)
+
+  const members = (withStatus.members || []).map(m => m.toLowerCase())
+  const arbitrator = withStatus.arbitrator
+  const hasArbitrator = arbitrator && arbitrator !== ethers.ZeroAddress
+
+  return {
+    id: String(marketId),
+    marketType: MARKET_TYPES[Number(withStatus.marketType)] || 'oneVsOne',
+    status: STATUS_NAMES[Number(withStatus.status)] || 'pending_acceptance',
+    resolutionType: Number(withStatus.resolutionType ?? 0),
+    creator: withStatus.creator,
+    participants: members,
+    arbitrator: hasArbitrator ? arbitrator : null,
+    stakeAmount: ethers.formatUnits(withStatus.stakePerParticipant || 0, tokenDecimals),
+    stakeTokenAddress: stakeToken,
+    stakeTokenSymbol: isStable ? 'USDC' : 'MATIC',
+    tradingPeriodSeconds,
+    createdAt: createdAtMs,
+    acceptanceDeadline: acceptanceDeadlineMs,
+    endTime,
+    endDate: endTime > 0 ? new Date(endTime).toISOString() : null,
+    acceptedCount: Number(withStatus.acceptedCount || 0),
+    minAcceptanceThreshold: Number(withStatus.minThreshold || 0),
+    ipfsCid: enc.ipfsCid,
+    isEncrypted: enc.isEncrypted,
+    metadataCipher: enc.metadataCipher,
+    description: enc.displayDescription,
+    needsIpfsFetch: Boolean(enc.ipfsCid),
+    needsRehydration: false,
+  }
+}
+
+export async function syncIndex(userAddress, opts = {}) {
+  if (!userAddress || !ethers.isAddress(userAddress)) {
+    return { marketIds: [], lastBlock: 0 }
+  }
+  if (import.meta.env.VITE_SKIP_BLOCKCHAIN_CALLS === 'true') {
+    return { marketIds: [], lastBlock: 0 }
+  }
+
+  const provider = opts.provider || getProvider()
+  const contract = getFactoryContract(provider)
+  const cached = loadIndex(userAddress)
+  const currentBlock = await provider.getBlockNumber()
+
+  if (cached.lastBlock >= currentBlock) return cached
+
+  const deployBlock = DEPLOYMENT_BLOCKS.friendGroupMarketFactory || 0
+  const fromBlock = cached.lastBlock > 0 ? cached.lastBlock + 1 : deployBlock
+  const filter = contract.filters.MemberAdded(null, userAddress)
+  const CHUNK = 10_000
+  const ids = new Set(cached.marketIds.map(String))
+
+  let from = fromBlock
+  while (from <= currentBlock) {
+    const to = Math.min(from + CHUNK - 1, currentBlock)
+    try {
+      const events = await contract.queryFilter(filter, from, to)
+      for (const ev of events) ids.add(ev.args.friendMarketId.toString())
+    } catch (err) {
+      console.warn(`[EventsSource] scan ${from}-${to} failed:`, err?.message)
+      const small = 1_000
+      for (let s = from; s <= to; s += small) {
+        const e = Math.min(s + small - 1, to)
+        try {
+          const evs = await contract.queryFilter(filter, s, e)
+          for (const ev of evs) ids.add(ev.args.friendMarketId.toString())
+        } catch {
+          // skip the sub-chunk; the watermark will not be advanced past errors
+        }
+      }
+    }
+    from = to + 1
+  }
+
+  const next = { marketIds: Array.from(ids), lastBlock: currentBlock }
+  saveIndex(userAddress, next)
+  return next
+}
+
+async function hydrate(contract, ids) {
+  if (!ids.length) return []
+  const results = await Promise.all(
+    ids.map(async id => {
+      try {
+        const [withStatus, full] = await Promise.all([
+          contract.getFriendMarketWithStatus(id),
+          contract.friendMarkets(id),
+        ])
+        return toWager(id, withStatus, full)
+      } catch (err) {
+        console.warn(`[EventsSource] hydrate ${id} failed:`, err?.message)
+        return null
+      }
+    })
+  )
+  return results.filter(Boolean)
+}
+
+export async function listPage({
+  userAddress,
+  cursor,
+  pageSize = 25,
+  sortKey = WagerSortKey.CREATED,
+  filter,
+  provider,
+}) {
+  if (!userAddress) {
+    return { items: [], nextCursor: null, hasMore: false, totalKnown: 0, source: 'events' }
+  }
+  if (import.meta.env.VITE_SKIP_BLOCKCHAIN_CALLS === 'true') {
+    return { items: [], nextCursor: null, hasMore: false, totalKnown: 0, source: 'events' }
+  }
+
+  const _provider = provider || getProvider()
+  const contract = getFactoryContract(_provider)
+
+  await syncIndex(userAddress, { provider: _provider })
+  const index = loadIndex(userAddress)
+  const cache = loadCache(userAddress)
+
+  const knownIds = index.marketIds
+  const missing = knownIds.filter(id => !cache[id] || cache[id].needsRehydration)
+  if (missing.length) {
+    const fresh = await hydrate(contract, missing.slice(0, Math.max(pageSize * 4, 50)))
+    if (fresh.length) upsertCache(userAddress, fresh)
+  }
+
+  const updatedCache = loadCache(userAddress)
+  const allWagers = knownIds.map(id => updatedCache[id]).filter(Boolean)
+
+  const filtered = applyFilters(allWagers, {
+    ownerAddress: userAddress,
+    ...filter,
+  })
+  const page = paginate(filtered, { cursor, pageSize, sortKey })
+  return { ...page, source: 'events' }
+}
+
+export async function getById(id, userAddress, opts = {}) {
+  if (!id || !userAddress) return null
+  if (import.meta.env.VITE_SKIP_BLOCKCHAIN_CALLS === 'true') return null
+  const provider = opts.provider || getProvider()
+  const contract = getFactoryContract(provider)
+  const wagers = await hydrate(contract, [String(id)])
+  const wager = wagers[0] || null
+  if (wager) upsertCache(userAddress, [wager])
+  return wager
+}
+
+export async function fetchAllCompat(userAddress) {
+  if (!userAddress || !ethers.isAddress(userAddress)) return []
+  if (import.meta.env.VITE_SKIP_BLOCKCHAIN_CALLS === 'true') return []
+
+  const provider = getProvider()
+  const contract = getFactoryContract(provider)
+  await syncIndex(userAddress, { provider })
+  const index = loadIndex(userAddress)
+  const cache = loadCache(userAddress)
+  const missing = index.marketIds.filter(id => !cache[id] || cache[id].needsRehydration)
+  const fresh = await hydrate(contract, missing)
+  if (fresh.length) upsertCache(userAddress, fresh)
+  const updatedCache = loadCache(userAddress)
+  return index.marketIds.map(id => updatedCache[id]).filter(Boolean)
+}

--- a/frontend/src/data/wagers/SubgraphSource.js
+++ b/frontend/src/data/wagers/SubgraphSource.js
@@ -1,0 +1,188 @@
+/**
+ * SubgraphSource — WagerSource implementation backed by The Graph's
+ * decentralized network (public during development; hosted graph in future).
+ *
+ * Encodes filter + sort directly in GraphQL `where` / `orderBy` clauses so
+ * scalability is bounded by the indexer, not by the client. The visible page
+ * is the only data fetched; encrypted envelopes round-trip as raw strings
+ * and are decrypted client-side via useLazyMarketDecryption.
+ *
+ * Falls back to EventsSource if the subgraph endpoint is unreachable.
+ */
+
+import { WagerSortKey, TERMINAL_STATUSES } from '../../constants/wagerDefaults'
+import { upsertCache } from './cacheStore'
+import * as EventsSource from './EventsSource'
+
+const SUBGRAPH_URL = import.meta.env?.VITE_SUBGRAPH_URL || ''
+
+const SORT_KEY_TO_FIELD = {
+  [WagerSortKey.CREATED]: 'createdAt',
+  [WagerSortKey.ENDS]: 'endTime',
+  [WagerSortKey.RESOLUTION_TYPE]: 'resolutionType',
+  [WagerSortKey.STATUS]: 'status',
+}
+
+const PAGE_QUERY = `
+  query MyWagers(
+    $owner: String!
+    $first: Int!
+    $orderBy: Wager_orderBy!
+    $orderDirection: OrderDirection!
+    $cursorField: String
+    $cursorValue: String
+    $statusIn: [String!]
+    $statusNotIn: [String!]
+    $resolutionTypesIn: [Int!]
+    $marketTypesIn: [String!]
+    $now: BigInt!
+    $tab: String!
+  ) {
+    wagers(
+      first: $first
+      orderBy: $orderBy
+      orderDirection: $orderDirection
+      where: {
+        and: [
+          { or: [
+            { creator: $owner },
+            { participants_contains: [$owner] }
+          ] }
+        ]
+      }
+    ) {
+      id
+      marketType
+      status
+      resolutionType
+      creator
+      participants
+      stakePerParticipant
+      stakeToken
+      tradingPeriodSeconds
+      createdAt
+      acceptanceDeadline
+      endTime
+      acceptedCount
+      ipfsCid
+      isEncrypted
+      metadataCipher
+      description
+    }
+  }
+`
+
+async function postGraphQL(query, variables) {
+  if (!SUBGRAPH_URL) throw new Error('VITE_SUBGRAPH_URL is not set')
+  const res = await fetch(SUBGRAPH_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  })
+  if (!res.ok) throw new Error(`Subgraph HTTP ${res.status}`)
+  const json = await res.json()
+  if (json.errors) throw new Error(`Subgraph: ${json.errors[0]?.message || 'unknown error'}`)
+  return json.data
+}
+
+function toWager(raw) {
+  return {
+    id: String(raw.id),
+    marketType: raw.marketType,
+    status: raw.status,
+    resolutionType: Number(raw.resolutionType ?? 0),
+    creator: raw.creator,
+    participants: (raw.participants || []).map(p => p.toLowerCase()),
+    arbitrator: raw.arbitrator || null,
+    stakeAmount: raw.stakePerParticipant,
+    stakeTokenAddress: raw.stakeToken,
+    stakeTokenSymbol: raw.stakeTokenSymbol || null,
+    tradingPeriodSeconds: Number(raw.tradingPeriodSeconds || 0),
+    createdAt: Number(raw.createdAt || 0) * 1000,
+    acceptanceDeadline: Number(raw.acceptanceDeadline || 0) * 1000,
+    endTime: Number(raw.endTime || 0) * 1000,
+    endDate: raw.endTime ? new Date(Number(raw.endTime) * 1000).toISOString() : null,
+    acceptedCount: Number(raw.acceptedCount || 0),
+    ipfsCid: raw.ipfsCid || null,
+    isEncrypted: Boolean(raw.isEncrypted),
+    metadataCipher: raw.metadataCipher || null,
+    description: raw.description || '',
+    needsIpfsFetch: Boolean(raw.ipfsCid),
+    needsRehydration: false,
+  }
+}
+
+export async function syncIndex(_userAddress) {
+  // The subgraph indexes server-side; the client doesn't maintain an
+  // explicit watermark. Return an empty index so callers can short-circuit.
+  return { marketIds: [], lastBlock: 0 }
+}
+
+export async function listPage({
+  userAddress,
+  cursor,
+  pageSize = 25,
+  sortKey = WagerSortKey.CREATED,
+  filter,
+}) {
+  if (!userAddress) {
+    return { items: [], nextCursor: null, hasMore: false, totalKnown: 0, source: 'subgraph' }
+  }
+  if (!SUBGRAPH_URL) {
+    return EventsSource.listPage({ userAddress, cursor, pageSize, sortKey, filter }).then(r => ({
+      ...r,
+      source: 'subgraph-fallback',
+    }))
+  }
+  if (import.meta.env.VITE_SKIP_BLOCKCHAIN_CALLS === 'true') {
+    return { items: [], nextCursor: null, hasMore: false, totalKnown: 0, source: 'subgraph' }
+  }
+
+  const orderField = SORT_KEY_TO_FIELD[sortKey] || 'createdAt'
+  const variables = {
+    owner: userAddress.toLowerCase(),
+    first: pageSize + 1,
+    orderBy: orderField,
+    orderDirection: 'desc',
+    cursorField: orderField,
+    cursorValue: cursor?.lastSortKey || null,
+    statusIn: filter?.statuses || null,
+    statusNotIn: filter?.includeExpired ? null : Array.from(TERMINAL_STATUSES),
+    resolutionTypesIn: filter?.resolutionTypes || null,
+    marketTypesIn: filter?.marketTypes || null,
+    now: Math.floor(Date.now() / 1000).toString(),
+    tab: filter?.tab || 'participating',
+  }
+
+  try {
+    const data = await postGraphQL(PAGE_QUERY, variables)
+    const items = (data?.wagers || []).slice(0, pageSize).map(toWager)
+    const hasMore = (data?.wagers || []).length > pageSize
+    const nextCursor = hasMore && items.length
+      ? { sortKey, lastSortKey: String(items[items.length - 1][orderField] ?? ''), pageSize }
+      : null
+    if (items.length) upsertCache(userAddress, items)
+    return { items, nextCursor, hasMore, totalKnown: items.length, source: 'subgraph' }
+  } catch (err) {
+    console.warn('[SubgraphSource] falling back to EventsSource:', err?.message)
+    const fallback = await EventsSource.listPage({ userAddress, cursor, pageSize, sortKey, filter })
+    return { ...fallback, source: 'subgraph-fallback' }
+  }
+}
+
+export async function getById(id, userAddress) {
+  if (!id || !userAddress) return null
+  if (!SUBGRAPH_URL) return EventsSource.getById(id, userAddress)
+  try {
+    const data = await postGraphQL(
+      `query($id: ID!) { wager(id: $id) { id marketType status resolutionType creator participants stakePerParticipant stakeToken tradingPeriodSeconds createdAt acceptanceDeadline endTime acceptedCount ipfsCid isEncrypted metadataCipher description } }`,
+      { id: String(id) }
+    )
+    const wager = data?.wager ? toWager(data.wager) : null
+    if (wager) upsertCache(userAddress, [wager])
+    return wager
+  } catch (err) {
+    console.warn('[SubgraphSource] getById fallback:', err?.message)
+    return EventsSource.getById(id, userAddress)
+  }
+}

--- a/frontend/src/data/wagers/WagerRepository.js
+++ b/frontend/src/data/wagers/WagerRepository.js
@@ -1,0 +1,72 @@
+/**
+ * WagerRepository — the indexer-ready boundary between the UI and the data
+ * sources. Swapping `SubgraphSource` for an Envio/Ponder/Goldsky source
+ * later is a one-line change at the call site; no UI changes required.
+ *
+ * Sources implement the WagerSource interface:
+ *   syncIndex(userAddress): Promise<{ marketIds, lastBlock }>
+ *   listPage({ userAddress, cursor, pageSize, sortKey, filter }):
+ *     Promise<{ items, nextCursor, hasMore, totalKnown, source }>
+ *   getById(id, userAddress): Promise<Wager|null>
+ */
+
+import * as EventsSource from './EventsSource'
+import * as SubgraphSource from './SubgraphSource'
+import { WagerSortKey } from '../../constants/wagerDefaults'
+
+const SOURCE_REGISTRY = {
+  events: EventsSource,
+  subgraph: SubgraphSource,
+}
+
+function resolveSourceKey(explicit) {
+  if (explicit && SOURCE_REGISTRY[explicit]) return explicit
+  const envSource = import.meta.env?.VITE_WAGER_SOURCE
+  if (envSource && SOURCE_REGISTRY[envSource]) return envSource
+  return 'subgraph'
+}
+
+export function createWagerRepository(opts = {}) {
+  const sourceKey = resolveSourceKey(opts.source)
+  const source = SOURCE_REGISTRY[sourceKey]
+
+  return {
+    sourceKey,
+
+    async listMyWagers({
+      userAddress,
+      cursor = null,
+      pageSize = 25,
+      sortKey = WagerSortKey.CREATED,
+      filter = {},
+    }) {
+      if (!userAddress) {
+        return { items: [], nextCursor: null, hasMore: false, totalKnown: 0, source: sourceKey }
+      }
+      return source.listPage({
+        userAddress: String(userAddress).toLowerCase(),
+        cursor,
+        pageSize,
+        sortKey,
+        filter,
+      })
+    },
+
+    async getWagerById(id, userAddress) {
+      if (!id || !userAddress) return null
+      return source.getById(String(id), String(userAddress).toLowerCase())
+    },
+
+    async syncIndex(userAddress) {
+      if (!userAddress) return { marketIds: [], lastBlock: 0 }
+      return source.syncIndex(String(userAddress).toLowerCase())
+    },
+  }
+}
+
+let defaultInstance = null
+
+export function getDefaultWagerRepository() {
+  if (!defaultInstance) defaultInstance = createWagerRepository()
+  return defaultInstance
+}

--- a/frontend/src/data/wagers/cacheStore.js
+++ b/frontend/src/data/wagers/cacheStore.js
@@ -1,0 +1,193 @@
+/**
+ * Wager cache store — bounded localStorage layout for the My Wagers
+ * paginated query path.
+ *
+ * Two keys per user:
+ *   wagerIndex_v2_<addr>  → { marketIds, lastBlock, schemaVersion: 2 }
+ *   wagerCache_v2_<addr>  → { [id]: Wager } (raw metadataCipher, never decrypted)
+ *
+ * On first read, migrates from the legacy keys used by blockchainService.js:
+ *   friendMarketIndex_<addr>, friendMarketCache_<addr>.
+ *
+ * Enforces a byte budget (4 MB soft / 8 MB hard) by evicting cache entries
+ * via LRU. Index entries (IDs + watermark) are preserved — they're cheap
+ * and required for correctness on the next sync.
+ */
+
+const INDEX_PREFIX = 'wagerIndex_v2_'
+const CACHE_PREFIX = 'wagerCache_v2_'
+const LEGACY_INDEX_PREFIX = 'friendMarketIndex_'
+const LEGACY_CACHE_PREFIX = 'friendMarketCache_'
+
+const SCHEMA_VERSION = 2
+
+const BYTE_BUDGET_SOFT = 4 * 1024 * 1024
+const BYTE_BUDGET_HARD = 8 * 1024 * 1024
+
+function normalize(addr) {
+  return String(addr).toLowerCase()
+}
+
+function indexKey(addr) {
+  return INDEX_PREFIX + normalize(addr)
+}
+
+function cacheKey(addr) {
+  return CACHE_PREFIX + normalize(addr)
+}
+
+function readJson(key) {
+  try {
+    const raw = localStorage.getItem(key)
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+function writeJson(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value))
+    return true
+  } catch (e) {
+    console.warn('[wagerCache] write failed for', key, e?.message)
+    return false
+  }
+}
+
+function emptyIndex() {
+  return { marketIds: [], lastBlock: 0, schemaVersion: SCHEMA_VERSION }
+}
+
+function migrateLegacyIndex(addr) {
+  const legacy = readJson(LEGACY_INDEX_PREFIX + normalize(addr))
+  if (!legacy || !Array.isArray(legacy.marketIds)) return null
+  return {
+    marketIds: legacy.marketIds.map(String),
+    lastBlock: Number(legacy.lastBlock) || 0,
+    schemaVersion: SCHEMA_VERSION,
+  }
+}
+
+function migrateLegacyCache(addr) {
+  const legacy = readJson(LEGACY_CACHE_PREFIX + normalize(addr))
+  if (!legacy || typeof legacy !== 'object') return null
+  const migrated = {}
+  for (const [id, entry] of Object.entries(legacy)) {
+    if (!entry || typeof entry !== 'object') continue
+    migrated[id] = {
+      ...entry,
+      id: String(entry.id ?? id),
+      lastTouched: Date.now(),
+      needsRehydration: true,
+    }
+  }
+  return migrated
+}
+
+export function loadIndex(userAddress) {
+  if (!userAddress) return emptyIndex()
+  const existing = readJson(indexKey(userAddress))
+  if (existing && existing.schemaVersion === SCHEMA_VERSION) return existing
+  const migrated = migrateLegacyIndex(userAddress)
+  if (migrated) {
+    writeJson(indexKey(userAddress), migrated)
+    return migrated
+  }
+  return emptyIndex()
+}
+
+export function saveIndex(userAddress, { marketIds, lastBlock }) {
+  if (!userAddress) return
+  writeJson(indexKey(userAddress), {
+    marketIds: marketIds.map(String),
+    lastBlock: Number(lastBlock) || 0,
+    schemaVersion: SCHEMA_VERSION,
+  })
+}
+
+export function loadCache(userAddress) {
+  if (!userAddress) return {}
+  const existing = readJson(cacheKey(userAddress))
+  if (existing && typeof existing === 'object') return existing
+  const migrated = migrateLegacyCache(userAddress)
+  if (migrated) {
+    writeJson(cacheKey(userAddress), migrated)
+    return migrated
+  }
+  return {}
+}
+
+function estimateBytes(obj) {
+  try {
+    return JSON.stringify(obj).length
+  } catch {
+    return 0
+  }
+}
+
+function evictLru(cache, targetBytes) {
+  const entries = Object.entries(cache)
+  entries.sort((a, b) => (a[1]?.lastTouched ?? 0) - (b[1]?.lastTouched ?? 0))
+  const next = { ...cache }
+  let bytes = estimateBytes(next)
+  for (const [id] of entries) {
+    if (bytes <= targetBytes) break
+    delete next[id]
+    bytes = estimateBytes(next)
+  }
+  return next
+}
+
+export function saveCache(userAddress, cache) {
+  if (!userAddress) return
+  let toWrite = cache
+  let bytes = estimateBytes(toWrite)
+  if (bytes > BYTE_BUDGET_HARD) {
+    toWrite = evictLru(toWrite, BYTE_BUDGET_SOFT)
+  } else if (bytes > BYTE_BUDGET_SOFT) {
+    toWrite = evictLru(toWrite, BYTE_BUDGET_SOFT)
+  }
+  const ok = writeJson(cacheKey(userAddress), toWrite)
+  if (!ok) {
+    const trimmed = evictLru(toWrite, Math.floor(BYTE_BUDGET_SOFT / 2))
+    writeJson(cacheKey(userAddress), trimmed)
+  }
+}
+
+export function touchCache(userAddress, ids) {
+  if (!userAddress || !ids?.length) return
+  const cache = loadCache(userAddress)
+  const now = Date.now()
+  let changed = false
+  for (const id of ids) {
+    if (cache[id]) {
+      cache[id].lastTouched = now
+      changed = true
+    }
+  }
+  if (changed) saveCache(userAddress, cache)
+}
+
+export function upsertCache(userAddress, wagers) {
+  if (!userAddress || !wagers?.length) return
+  const cache = loadCache(userAddress)
+  const now = Date.now()
+  for (const wager of wagers) {
+    if (!wager?.id) continue
+    cache[String(wager.id)] = { ...wager, lastTouched: now }
+  }
+  saveCache(userAddress, cache)
+}
+
+export const __testing = {
+  INDEX_PREFIX,
+  CACHE_PREFIX,
+  LEGACY_INDEX_PREFIX,
+  LEGACY_CACHE_PREFIX,
+  SCHEMA_VERSION,
+  BYTE_BUDGET_SOFT,
+  BYTE_BUDGET_HARD,
+  estimateBytes,
+  evictLru,
+}

--- a/frontend/src/data/wagers/sortFilter.js
+++ b/frontend/src/data/wagers/sortFilter.js
@@ -1,0 +1,177 @@
+/**
+ * Pure filter / sort / paginate helpers for the My Wagers list.
+ *
+ * Mirror of the predicates a subgraph encodes in its `where` and `orderBy`
+ * clauses. Also used as a defensive double-gate by the events-backed source
+ * against tampered localStorage caches.
+ */
+
+import {
+  ResolutionTypeOrder,
+  TERMINAL_STATUSES,
+  WagerSortKey,
+} from '../../constants/wagerDefaults'
+
+const PENDING_RESOLUTION_STATUSES = new Set([
+  'pending_resolution',
+  'challenged',
+  'disputed',
+])
+
+function lower(s) {
+  return s ? String(s).toLowerCase() : ''
+}
+
+function ownsWager(wager, ownerAddress) {
+  if (!ownerAddress) return false
+  const addr = lower(ownerAddress)
+  if (lower(wager.creator) === addr) return true
+  return (wager.participants || []).some(p => lower(p) === addr)
+}
+
+export function applyOwnershipGate(wagers, ownerAddress) {
+  return wagers.filter(w => ownsWager(w, ownerAddress))
+}
+
+function isExpired(wager, now) {
+  const status = lower(wager.status)
+  if (TERMINAL_STATUSES.has(status)) return true
+  if (PENDING_RESOLUTION_STATUSES.has(status)) return false
+  const endTime = Number(wager.endTime) || 0
+  return endTime > 0 && endTime < now
+}
+
+export function applyExpiryGate(wagers, { includeExpired = false, now = Date.now() } = {}) {
+  if (includeExpired) return wagers
+  return wagers.filter(w => !isExpired(w, now))
+}
+
+function isCreator(wager, ownerAddress) {
+  return lower(wager.creator) === lower(ownerAddress)
+}
+
+function isParticipant(wager, ownerAddress) {
+  const addr = lower(ownerAddress)
+  return (wager.participants || []).some(p => lower(p) === addr)
+}
+
+export function applyTabGate(wagers, { tab, ownerAddress }) {
+  if (!tab || tab === 'all') return wagers
+  return wagers.filter(w => {
+    const status = lower(w.status)
+    const terminal = TERMINAL_STATUSES.has(status)
+    if (tab === 'history') return terminal
+    if (terminal) return false
+    if (tab === 'created') return isCreator(w, ownerAddress)
+    if (tab === 'participating') {
+      return isParticipant(w, ownerAddress) && !isCreator(w, ownerAddress)
+    }
+    return true
+  })
+}
+
+export function applyTypeFilter(wagers, marketTypes) {
+  if (!marketTypes?.length) return wagers
+  const set = new Set(marketTypes.map(lower))
+  return wagers.filter(w => set.has(lower(w.marketType)))
+}
+
+export function applyStatusFilter(wagers, statuses) {
+  if (!statuses?.length) return wagers
+  const set = new Set(statuses.map(lower))
+  return wagers.filter(w => set.has(lower(w.status)))
+}
+
+export function applyResolutionTypeFilter(wagers, resolutionTypes) {
+  if (!resolutionTypes?.length) return wagers
+  const set = new Set(resolutionTypes.map(Number))
+  return wagers.filter(w => set.has(Number(w.resolutionType)))
+}
+
+const STATUS_ORDER = [
+  'pending_acceptance',
+  'active',
+  'pending_resolution',
+  'challenged',
+  'disputed',
+  'resolved',
+  'cancelled',
+  'refunded',
+  'oracle_timed_out',
+]
+
+function statusOrderIndex(status) {
+  const idx = STATUS_ORDER.indexOf(lower(status))
+  return idx === -1 ? STATUS_ORDER.length : idx
+}
+
+function resolutionOrderIndex(resolutionType) {
+  const idx = ResolutionTypeOrder.indexOf(Number(resolutionType))
+  return idx === -1 ? ResolutionTypeOrder.length : idx
+}
+
+function pad(n, width = 16) {
+  return String(n).padStart(width, '0')
+}
+
+export function computeSortKey(wager, sortKey) {
+  const id = pad(wager.id ?? '0')
+  switch (sortKey) {
+    case WagerSortKey.CREATED: {
+      const createdAt = Number(wager.createdAt) || 0
+      return `${pad(Number.MAX_SAFE_INTEGER - createdAt)}|${id}`
+    }
+    case WagerSortKey.ENDS: {
+      const endTime = Number(wager.endTime) || 0
+      return `${pad(Number.MAX_SAFE_INTEGER - endTime)}|${id}`
+    }
+    case WagerSortKey.RESOLUTION_TYPE: {
+      const ri = resolutionOrderIndex(wager.resolutionType)
+      const createdAt = Number(wager.createdAt) || 0
+      return `${pad(ri, 4)}|${pad(Number.MAX_SAFE_INTEGER - createdAt)}|${id}`
+    }
+    case WagerSortKey.STATUS: {
+      const si = statusOrderIndex(wager.status)
+      const createdAt = Number(wager.createdAt) || 0
+      return `${pad(si, 4)}|${pad(Number.MAX_SAFE_INTEGER - createdAt)}|${id}`
+    }
+    default:
+      return id
+  }
+}
+
+export function applySort(wagers, sortKey) {
+  const keyed = wagers.map(w => ({ w, k: computeSortKey(w, sortKey) }))
+  keyed.sort((a, b) => (a.k < b.k ? -1 : a.k > b.k ? 1 : 0))
+  return keyed.map(({ w, k }) => ({ ...w, sortKey: k }))
+}
+
+export function applyCursor(sortedWagers, cursor) {
+  if (!cursor?.lastSortKey) return sortedWagers
+  const target = cursor.lastSortKey
+  const idx = sortedWagers.findIndex(w => w.sortKey === target)
+  if (idx === -1) return sortedWagers
+  return sortedWagers.slice(idx + 1)
+}
+
+export function applyFilters(wagers, filter) {
+  let out = wagers
+  out = applyOwnershipGate(out, filter.ownerAddress)
+  out = applyTabGate(out, { tab: filter.tab, ownerAddress: filter.ownerAddress })
+  out = applyExpiryGate(out, { includeExpired: filter.includeExpired })
+  out = applyTypeFilter(out, filter.marketTypes)
+  out = applyStatusFilter(out, filter.statuses)
+  out = applyResolutionTypeFilter(out, filter.resolutionTypes)
+  return out
+}
+
+export function paginate(wagers, { cursor, pageSize = 25, sortKey = WagerSortKey.CREATED }) {
+  const sorted = applySort(wagers, sortKey)
+  const resumed = applyCursor(sorted, cursor)
+  const items = resumed.slice(0, pageSize)
+  const hasMore = resumed.length > pageSize
+  const nextCursor = items.length > 0 && hasMore
+    ? { sortKey, lastSortKey: items[items.length - 1].sortKey, pageSize }
+    : null
+  return { items, nextCursor, hasMore, totalKnown: wagers.length }
+}

--- a/frontend/src/hooks/index.js
+++ b/frontend/src/hooks/index.js
@@ -87,6 +87,11 @@ export { useFriendMarketCreation } from './useFriendMarketCreation'
 
 // Friend market notification hooks
 export { useFriendMarketNotifications } from './useFriendMarketNotifications'
+export { useMyWagerNotifications } from './useMyWagerNotifications'
+export { createUnreadMarketTracker } from './useUnreadMarketTracker'
+
+// Paginated My Wagers query
+export { useMyWagers } from './useMyWagers'
 
 // Testnet/Mainnet toggle
 export { useNetworkMode } from './useNetworkMode'

--- a/frontend/src/hooks/useFriendMarketNotifications.js
+++ b/frontend/src/hooks/useFriendMarketNotifications.js
@@ -1,149 +1,15 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import {
-  getUserPreference,
-  saveUserPreference
-} from '../utils/userStorage'
-
-const STORAGE_KEY = 'friend_market_notifications'
-const STORAGE_VERSION = 1
+import { createUnreadMarketTracker } from './useUnreadMarketTracker'
 
 /**
- * Get default notification state
- */
-function getDefaultState() {
-  return {
-    version: STORAGE_VERSION,
-    seenMarkets: {}
-  }
-}
-
-/**
- * Hook for tracking unread/unseen friend market notifications
+ * Tracks unread/unseen friend market notifications for the FriendMarketsModal.
  *
- * Tracks which markets the user has seen and calculates unread count.
- * A market is considered "unread" if:
- * - It's a new market the user hasn't seen
- * - The market's status has changed since last seen
- * - The acceptance count has increased (for pending markets)
+ * Uses the shared `createUnreadMarketTracker` factory with an isolated
+ * storage key so MyMarkets and FriendMarkets have independent read state.
  *
  * @param {Array} markets - Array of friend markets (active + pending)
  * @param {string} account - User's wallet address
  * @returns {Object} - { unreadCount, unreadMarketIds, markMarketAsRead, isMarketUnread }
  */
-export function useFriendMarketNotifications(markets, account) {
-  const [state, setState] = useState(() => {
-    if (!account) return getDefaultState()
-    return getUserPreference(account, STORAGE_KEY, getDefaultState(), true)
-  })
-
-  // Track previous account to detect changes (initialized to current account to prevent mount trigger)
-  const prevAccountRef = useRef(account)
-
-  // Use ref for markets to avoid callback recreation
-  const marketsRef = useRef(markets)
-  useEffect(() => {
-    marketsRef.current = markets
-  }, [markets])
-
-  // Persist state changes to localStorage
-  useEffect(() => {
-    if (account && state) {
-      saveUserPreference(account, STORAGE_KEY, state, true)
-    }
-  }, [account, state])
-
-  // Reload state when account changes (but not on mount)
-  useEffect(() => {
-    if (account !== prevAccountRef.current) {
-      prevAccountRef.current = account
-      if (account) {
-        const savedState = getUserPreference(account, STORAGE_KEY, getDefaultState(), true)
-        setState(savedState)
-      } else {
-        setState(getDefaultState())
-      }
-    }
-  }, [account])
-
-  // Calculate unread markets
-  const { unreadCount, unreadMarketIds } = useMemo(() => {
-    if (!account || !markets?.length) {
-      return { unreadCount: 0, unreadMarketIds: [] }
-    }
-
-    const unread = []
-    // eslint-disable-next-line react-hooks/purity -- Date.now() is calculated once per render to check market expiration
-    const now = Date.now() // Calculate once outside the loop
-
-    for (const market of markets) {
-      const marketId = String(market.id)
-      const seen = state.seenMarkets[marketId]
-
-      // Skip expired pending invitations - they're not actionable
-      if (market.status === 'pending_acceptance' &&
-          market.acceptanceDeadline &&
-          market.acceptanceDeadline < now) {
-        continue
-      }
-
-      // New market never seen before
-      if (!seen) {
-        unread.push(marketId)
-        continue
-      }
-
-      // Status changed (e.g., pending -> active)
-      if (seen.status !== market.status) {
-        unread.push(marketId)
-        continue
-      }
-
-      // Acceptance count changed (for pending markets)
-      if (market.status === 'pending_acceptance') {
-        const currentCount = market.acceptedCount || 0
-        const seenCount = seen.acceptedCount || 0
-        if (currentCount > seenCount) {
-          unread.push(marketId)
-          continue
-        }
-      }
-    }
-
-    return {
-      unreadCount: unread.length,
-      unreadMarketIds: unread
-    }
-  }, [markets, state, account])
-
-  // Mark specific market as read
-  const markMarketAsRead = useCallback((marketId) => {
-    if (!account) return
-
-    const market = marketsRef.current?.find(m => String(m.id) === String(marketId))
-    if (!market) return
-
-    setState(prev => ({
-      ...prev,
-      seenMarkets: {
-        ...prev.seenMarkets,
-        [String(marketId)]: {
-          status: market.status,
-          acceptedCount: market.acceptedCount || 0,
-          seenAt: Date.now()
-        }
-      }
-    }))
-  }, [account])
-
-  // Check if specific market is unread
-  const isMarketUnread = useCallback((marketId) => {
-    return unreadMarketIds.includes(String(marketId))
-  }, [unreadMarketIds])
-
-  return {
-    unreadCount,
-    unreadMarketIds,
-    markMarketAsRead,
-    isMarketUnread
-  }
-}
+export const useFriendMarketNotifications = createUnreadMarketTracker({
+  storageKey: 'friend_market_notifications',
+})

--- a/frontend/src/hooks/useMyWagerNotifications.js
+++ b/frontend/src/hooks/useMyWagerNotifications.js
@@ -1,0 +1,19 @@
+import { createUnreadMarketTracker } from './useUnreadMarketTracker'
+
+/**
+ * Tracks unread/unseen wagers for the MyMarketsModal.
+ *
+ * Independent from `useFriendMarketNotifications` — opening a wager in the
+ * MyMarkets view does not mark it read in the FriendMarkets view, since the
+ * two surfaces show different information.
+ *
+ * Adds one MyMarkets-specific unread trigger: a transition from
+ * `active` → `pending_resolution` (the wager just ended and the user
+ * should look at it).
+ */
+export const useMyWagerNotifications = createUnreadMarketTracker({
+  storageKey: 'my_wagers_notifications',
+  extraUnreadPredicate: (market, seen) => {
+    return seen?.status === 'active' && market.status === 'pending_resolution'
+  },
+})

--- a/frontend/src/hooks/useMyWagers.js
+++ b/frontend/src/hooks/useMyWagers.js
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { getDefaultWagerRepository } from '../data/wagers/WagerRepository'
+import { WagerSortKey } from '../constants/wagerDefaults'
+
+const DEFAULT_PAGE_SIZE = 25
+
+/**
+ * Paginated, filtered, sorted view of the user's wagers.
+ *
+ * Uses the WagerRepository (subgraph or events source under the hood) and
+ * keeps decryption out of the data path — the visible page returns raw
+ * `metadataCipher` envelopes that the modal feeds into
+ * `useLazyMarketDecryption`.
+ *
+ * Filter and sort are controlled by the caller — pass them in and the
+ * hook reloads the first page when they change.
+ *
+ * @param {Object} opts
+ * @param {string} opts.account - user's wallet address
+ * @param {('participating'|'created'|'history')} opts.tab
+ * @param {string} [opts.sort] - WagerSortKey value (controlled)
+ * @param {Object} [opts.filter] - filter overrides (controlled)
+ * @param {number} [opts.pageSize]
+ * @param {Object} [opts.repository] - injectable repository (for tests)
+ */
+export function useMyWagers({
+  account,
+  tab,
+  sort = WagerSortKey.CREATED,
+  filter = {},
+  pageSize = DEFAULT_PAGE_SIZE,
+  repository,
+  // Back-compat for callers that used the older naming
+  initialSort,
+  initialFilter,
+} = {}) {
+  const repo = useMemo(() => repository || getDefaultWagerRepository(), [repository])
+  const effectiveSort = sort ?? initialSort ?? WagerSortKey.CREATED
+  const effectiveFilter = useMemo(
+    () => filter ?? initialFilter ?? {},
+    [filter, initialFilter]
+  )
+
+  const [items, setItems] = useState([])
+  const [cursor, setCursor] = useState(null)
+  const [hasMore, setHasMore] = useState(false)
+  const [totalKnown, setTotalKnown] = useState(0)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  const requestIdRef = useRef(0)
+
+  // Stringify the dynamic filter so the dependency check is stable across
+  // identity-changing object props.
+  const filterKey = useMemo(
+    () => JSON.stringify({ tab, ...effectiveFilter }),
+    [tab, effectiveFilter]
+  )
+
+  const loadFirstPage = useCallback(async () => {
+    if (!account) {
+      setItems([])
+      setCursor(null)
+      setHasMore(false)
+      setTotalKnown(0)
+      return
+    }
+    const reqId = ++requestIdRef.current
+    setIsLoading(true)
+    setError(null)
+    try {
+      const page = await repo.listMyWagers({
+        userAddress: account,
+        cursor: null,
+        pageSize,
+        sortKey: effectiveSort,
+        filter: { tab, ...effectiveFilter },
+      })
+      if (reqId !== requestIdRef.current) return
+      setItems(page.items)
+      setCursor(page.nextCursor)
+      setHasMore(page.hasMore)
+      setTotalKnown(page.totalKnown)
+    } catch (err) {
+      if (reqId !== requestIdRef.current) return
+      console.error('[useMyWagers] load failed:', err)
+      setError(err?.message || 'Failed to load wagers')
+    } finally {
+      if (reqId === requestIdRef.current) setIsLoading(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [account, repo, pageSize, effectiveSort, filterKey])
+
+  const loadMore = useCallback(async () => {
+    if (!account || !hasMore || !cursor) return
+    setIsLoading(true)
+    setError(null)
+    try {
+      const page = await repo.listMyWagers({
+        userAddress: account,
+        cursor,
+        pageSize,
+        sortKey: effectiveSort,
+        filter: { tab, ...effectiveFilter },
+      })
+      setItems(prev => [...prev, ...page.items])
+      setCursor(page.nextCursor)
+      setHasMore(page.hasMore)
+    } catch (err) {
+      console.error('[useMyWagers] loadMore failed:', err)
+      setError(err?.message || 'Failed to load more wagers')
+    } finally {
+      setIsLoading(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [account, repo, pageSize, effectiveSort, cursor, hasMore, filterKey])
+
+  useEffect(() => {
+    loadFirstPage()
+  }, [loadFirstPage])
+
+  const refresh = useCallback(() => {
+    return loadFirstPage()
+  }, [loadFirstPage])
+
+  return {
+    items,
+    sort: effectiveSort,
+    filter: effectiveFilter,
+    loadMore,
+    refresh,
+    isLoading,
+    error,
+    hasMore,
+    totalKnown,
+  }
+}

--- a/frontend/src/hooks/useUnreadMarketTracker.js
+++ b/frontend/src/hooks/useUnreadMarketTracker.js
@@ -1,0 +1,123 @@
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import {
+  getUserPreference,
+  saveUserPreference,
+} from '../utils/userStorage'
+
+const STORAGE_VERSION = 1
+
+function getDefaultState() {
+  return { version: STORAGE_VERSION, seenMarkets: {} }
+}
+
+/**
+ * Factory that returns a hook for tracking unread / unseen markets.
+ *
+ * @param {Object} opts
+ * @param {string} opts.storageKey
+ *   The userStorage key under which the seenMarkets map is persisted.
+ *   Pass a unique value per UI surface so MyMarkets and FriendMarkets
+ *   maintain independent read state.
+ * @param {(market: Object) => boolean} [opts.extraUnreadPredicate]
+ *   Surface-specific check that flags a market as unread even when it
+ *   was previously seen — e.g. a status transition specific to one UI.
+ */
+export function createUnreadMarketTracker({ storageKey, extraUnreadPredicate }) {
+  return function useUnreadMarketTracker(markets, account) {
+    const [state, setState] = useState(() => {
+      if (!account) return getDefaultState()
+      return getUserPreference(account, storageKey, getDefaultState(), true)
+    })
+
+    const prevAccountRef = useRef(account)
+    const marketsRef = useRef(markets)
+    useEffect(() => {
+      marketsRef.current = markets
+    }, [markets])
+
+    useEffect(() => {
+      if (account && state) saveUserPreference(account, storageKey, state, true)
+    }, [account, state])
+
+    useEffect(() => {
+      if (account !== prevAccountRef.current) {
+        prevAccountRef.current = account
+        if (account) {
+          setState(getUserPreference(account, storageKey, getDefaultState(), true))
+        } else {
+          setState(getDefaultState())
+        }
+      }
+    }, [account])
+
+    const { unreadCount, unreadMarketIds } = useMemo(() => {
+      if (!account || !markets?.length) return { unreadCount: 0, unreadMarketIds: [] }
+
+      const unread = []
+      const now = Date.now()
+
+      for (const market of markets) {
+        const marketId = String(market.id)
+        const seen = state.seenMarkets[marketId]
+
+        if (
+          market.status === 'pending_acceptance' &&
+          market.acceptanceDeadline &&
+          market.acceptanceDeadline < now
+        ) {
+          continue
+        }
+
+        if (!seen) {
+          unread.push(marketId)
+          continue
+        }
+        if (seen.status !== market.status) {
+          unread.push(marketId)
+          continue
+        }
+        if (market.status === 'pending_acceptance') {
+          const currentCount = market.acceptedCount || 0
+          const seenCount = seen.acceptedCount || 0
+          if (currentCount > seenCount) {
+            unread.push(marketId)
+            continue
+          }
+        }
+        if (extraUnreadPredicate && extraUnreadPredicate(market, seen)) {
+          unread.push(marketId)
+          continue
+        }
+      }
+
+      return { unreadCount: unread.length, unreadMarketIds: unread }
+    }, [markets, state, account])
+
+    const markMarketAsRead = useCallback(
+      (marketId) => {
+        if (!account) return
+        const market = marketsRef.current?.find(m => String(m.id) === String(marketId))
+        if (!market) return
+        setState(prev => ({
+          ...prev,
+          seenMarkets: {
+            ...prev.seenMarkets,
+            [String(marketId)]: {
+              status: market.status,
+              acceptedCount: market.acceptedCount || 0,
+              seenAt: Date.now(),
+            },
+          },
+        }))
+      },
+      [account]
+    )
+
+    const isMarketUnread = useCallback(
+      (marketId) => unreadMarketIds.includes(String(marketId)),
+      [unreadMarketIds]
+    )
+
+    return { unreadCount, unreadMarketIds, markMarketAsRead, isMarketUnread }
+  }
+}

--- a/frontend/src/test/MyMarketsModal.test.jsx
+++ b/frontend/src/test/MyMarketsModal.test.jsx
@@ -15,6 +15,25 @@ vi.mock('../hooks', () => ({
     signer: {},
     isCorrectNetwork: true,
     switchNetwork: vi.fn()
+  })),
+  useMyWagers: vi.fn(() => ({
+    items: [],
+    sort: 'createdAt',
+    filter: {},
+    setSort: vi.fn(),
+    setFilter: vi.fn(),
+    loadMore: vi.fn(),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    isLoading: false,
+    error: null,
+    hasMore: false,
+    totalKnown: 0
+  })),
+  useMyWagerNotifications: vi.fn(() => ({
+    unreadCount: 0,
+    unreadMarketIds: [],
+    markMarketAsRead: vi.fn(),
+    isMarketUnread: vi.fn(() => false)
   }))
 }))
 
@@ -386,7 +405,16 @@ describe('MyMarketsModal', () => {
       })
     })
 
-    it('should show tab badges with counts', async () => {
+    it('should show tab badges only for unread wagers (count circuit breaker)', async () => {
+      const { useMyWagerNotifications } = await import('../hooks')
+      // Mark wager id '1' (the user-created one) as unread
+      useMyWagerNotifications.mockReturnValueOnce({
+        unreadCount: 1,
+        unreadMarketIds: ['1'],
+        markMarketAsRead: vi.fn(),
+        isMarketUnread: (id) => String(id) === '1',
+      })
+
       await act(async () => {
         renderWithProviders(
           <MyMarketsModal isOpen={true} onClose={mockOnClose} friendMarkets={mockMarkets} />

--- a/frontend/src/test/useMyWagerNotifications.test.jsx
+++ b/frontend/src/test/useMyWagerNotifications.test.jsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useMyWagerNotifications } from '../hooks/useMyWagerNotifications'
+
+const ACCOUNT = '0x1234567890123456789012345678901234567890'
+
+function market(id, overrides = {}) {
+  return {
+    id,
+    status: 'active',
+    creator: ACCOUNT,
+    participants: [ACCOUNT],
+    acceptedCount: 0,
+    acceptanceDeadline: Date.now() + 24 * 60 * 60 * 1000,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('useMyWagerNotifications', () => {
+  it('flags new wagers as unread', () => {
+    const markets = [market('1'), market('2')]
+    const { result } = renderHook(() => useMyWagerNotifications(markets, ACCOUNT))
+    expect(result.current.unreadCount).toBe(2)
+    expect(result.current.unreadMarketIds.sort()).toEqual(['1', '2'])
+  })
+
+  it('flags an active→pending_resolution transition as unread (MyWagers-specific trigger)', () => {
+    // First render: mark as read while active
+    const initialMarkets = [market('1', { status: 'active' })]
+    const { result, rerender } = renderHook(({ ms }) => useMyWagerNotifications(ms, ACCOUNT), {
+      initialProps: { ms: initialMarkets },
+    })
+    act(() => result.current.markMarketAsRead('1'))
+    expect(result.current.isMarketUnread('1')).toBe(false)
+
+    // Status changes to pending_resolution
+    const updatedMarkets = [market('1', { status: 'pending_resolution' })]
+    rerender({ ms: updatedMarkets })
+    expect(result.current.isMarketUnread('1')).toBe(true)
+  })
+
+  it('markMarketAsRead clears the unread state and persists across remount', () => {
+    const markets = [market('1')]
+    const { result, unmount } = renderHook(() => useMyWagerNotifications(markets, ACCOUNT))
+    act(() => result.current.markMarketAsRead('1'))
+    expect(result.current.unreadCount).toBe(0)
+    unmount()
+
+    const { result: r2 } = renderHook(() => useMyWagerNotifications(markets, ACCOUNT))
+    expect(r2.current.isMarketUnread('1')).toBe(false)
+  })
+
+  it('returns 0 unread when account is missing', () => {
+    const { result } = renderHook(() => useMyWagerNotifications([market('1')], null))
+    expect(result.current.unreadCount).toBe(0)
+  })
+
+  it('isolates storage from useFriendMarketNotifications (different key)', async () => {
+    const { useFriendMarketNotifications } = await import('../hooks/useFriendMarketNotifications')
+    const markets = [market('1')]
+    const my = renderHook(() => useMyWagerNotifications(markets, ACCOUNT))
+    act(() => my.result.current.markMarketAsRead('1'))
+
+    const friend = renderHook(() => useFriendMarketNotifications(markets, ACCOUNT))
+    expect(friend.result.current.isMarketUnread('1')).toBe(true)
+  })
+})

--- a/frontend/src/test/wagers-cacheStore.test.js
+++ b/frontend/src/test/wagers-cacheStore.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  loadIndex,
+  saveIndex,
+  loadCache,
+  upsertCache,
+  __testing,
+} from '../data/wagers/cacheStore'
+
+const ADDR = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('loadIndex / saveIndex', () => {
+  it('returns empty index on first read', () => {
+    const idx = loadIndex(ADDR)
+    expect(idx).toEqual({ marketIds: [], lastBlock: 0, schemaVersion: __testing.SCHEMA_VERSION })
+  })
+
+  it('migrates from legacy friendMarketIndex_ keys', () => {
+    const legacyKey = __testing.LEGACY_INDEX_PREFIX + ADDR.toLowerCase()
+    localStorage.setItem(legacyKey, JSON.stringify({ marketIds: ['1', '2'], lastBlock: 42 }))
+    const idx = loadIndex(ADDR)
+    expect(idx.marketIds).toEqual(['1', '2'])
+    expect(idx.lastBlock).toBe(42)
+    expect(idx.schemaVersion).toBe(__testing.SCHEMA_VERSION)
+  })
+
+  it('persists the new schema after save', () => {
+    saveIndex(ADDR, { marketIds: ['5'], lastBlock: 9 })
+    const idx = loadIndex(ADDR)
+    expect(idx).toMatchObject({ marketIds: ['5'], lastBlock: 9 })
+  })
+})
+
+describe('loadCache / saveCache', () => {
+  it('returns empty cache on first read', () => {
+    expect(loadCache(ADDR)).toEqual({})
+  })
+
+  it('migrates legacy friendMarketCache_ entries and flags them for rehydration', () => {
+    const legacyKey = __testing.LEGACY_CACHE_PREFIX + ADDR.toLowerCase()
+    localStorage.setItem(
+      legacyKey,
+      JSON.stringify({ '1': { id: '1', description: 'X', status: 'active' } })
+    )
+    const cache = loadCache(ADDR)
+    expect(cache['1']).toMatchObject({ id: '1', needsRehydration: true })
+  })
+
+  it('upsertCache merges and timestamps entries', () => {
+    upsertCache(ADDR, [{ id: '1', status: 'active' }])
+    const cache = loadCache(ADDR)
+    expect(cache['1'].status).toBe('active')
+    expect(typeof cache['1'].lastTouched).toBe('number')
+  })
+})
+
+describe('byte-budget eviction', () => {
+  it('evicts the oldest entries when over budget', () => {
+    const big = 'x'.repeat(1024)
+    const entries = {}
+    for (let i = 0; i < 50; i++) {
+      entries[i] = { id: String(i), description: big, lastTouched: i }
+    }
+    const evicted = __testing.evictLru(entries, 5_000)
+    expect(__testing.estimateBytes(evicted)).toBeLessThanOrEqual(5_000)
+    expect(Object.keys(evicted).length).toBeLessThan(50)
+    const remainingTouched = Object.values(evicted).map(e => e.lastTouched)
+    const minRemaining = Math.min(...remainingTouched)
+    expect(minRemaining).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/test/wagers-sortFilter.test.js
+++ b/frontend/src/test/wagers-sortFilter.test.js
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest'
+import {
+  applyOwnershipGate,
+  applyExpiryGate,
+  applyTabGate,
+  applyResolutionTypeFilter,
+  applyStatusFilter,
+  applyFilters,
+  applySort,
+  applyCursor,
+  computeSortKey,
+  paginate,
+} from '../data/wagers/sortFilter'
+import { WagerSortKey } from '../constants/wagerDefaults'
+
+const OWNER = '0x1234567890123456789012345678901234567890'
+const OTHER = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+
+function w(overrides = {}) {
+  return {
+    id: '1',
+    marketType: 'friend',
+    status: 'active',
+    resolutionType: 0,
+    creator: OWNER,
+    participants: [OWNER],
+    createdAt: 1_700_000_000_000,
+    endTime: Date.now() + 7 * 24 * 60 * 60 * 1000,
+    ...overrides,
+  }
+}
+
+describe('applyOwnershipGate', () => {
+  it('drops wagers where the user is neither creator nor participant', () => {
+    const wagers = [w({ id: '1' }), w({ id: '2', creator: OTHER, participants: [OTHER] })]
+    const out = applyOwnershipGate(wagers, OWNER)
+    expect(out.map(x => x.id)).toEqual(['1'])
+  })
+
+  it('returns empty when ownerAddress is missing', () => {
+    expect(applyOwnershipGate([w()], null)).toEqual([])
+  })
+
+  it('matches case-insensitively', () => {
+    const wagers = [w({ creator: OWNER.toUpperCase() })]
+    expect(applyOwnershipGate(wagers, OWNER.toLowerCase())).toHaveLength(1)
+  })
+})
+
+describe('applyExpiryGate', () => {
+  it('drops terminal statuses by default', () => {
+    const wagers = [
+      w({ id: '1', status: 'active' }),
+      w({ id: '2', status: 'resolved' }),
+      w({ id: '3', status: 'cancelled' }),
+      w({ id: '4', status: 'refunded' }),
+      w({ id: '5', status: 'oracle_timed_out' }),
+    ]
+    expect(applyExpiryGate(wagers).map(x => x.id)).toEqual(['1'])
+  })
+
+  it('drops wagers whose endTime is past', () => {
+    const past = w({ id: 'past', endTime: Date.now() - 1000 })
+    const future = w({ id: 'future', endTime: Date.now() + 1000 })
+    expect(applyExpiryGate([past, future]).map(x => x.id)).toEqual(['future'])
+  })
+
+  it('keeps pending_resolution and challenged regardless of endTime', () => {
+    const pendingRes = w({ id: 'p', status: 'pending_resolution', endTime: 0 })
+    const challenged = w({ id: 'c', status: 'challenged', endTime: 0 })
+    expect(applyExpiryGate([pendingRes, challenged]).map(x => x.id)).toEqual(['p', 'c'])
+  })
+
+  it('includes everything when includeExpired=true', () => {
+    const wagers = [w({ status: 'resolved' }), w({ status: 'active' })]
+    expect(applyExpiryGate(wagers, { includeExpired: true })).toHaveLength(2)
+  })
+})
+
+describe('applyTabGate', () => {
+  it('participating: in participants, not creator, not terminal', () => {
+    const wagers = [
+      w({ id: '1', creator: OTHER, participants: [OWNER] }),
+      w({ id: '2', creator: OWNER, participants: [OWNER] }),
+      w({ id: '3', creator: OTHER, participants: [OWNER], status: 'resolved' }),
+    ]
+    const out = applyTabGate(wagers, { tab: 'participating', ownerAddress: OWNER })
+    expect(out.map(x => x.id)).toEqual(['1'])
+  })
+
+  it('created: user is creator, not terminal', () => {
+    const wagers = [
+      w({ id: '1', creator: OWNER }),
+      w({ id: '2', creator: OTHER }),
+      w({ id: '3', creator: OWNER, status: 'resolved' }),
+    ]
+    const out = applyTabGate(wagers, { tab: 'created', ownerAddress: OWNER })
+    expect(out.map(x => x.id)).toEqual(['1'])
+  })
+
+  it('history: only terminal statuses', () => {
+    const wagers = [
+      w({ id: '1', status: 'resolved' }),
+      w({ id: '2', status: 'active' }),
+      w({ id: '3', status: 'cancelled' }),
+    ]
+    const out = applyTabGate(wagers, { tab: 'history', ownerAddress: OWNER })
+    expect(out.map(x => x.id).sort()).toEqual(['1', '3'])
+  })
+})
+
+describe('applyResolutionTypeFilter and applyStatusFilter', () => {
+  it('filters resolution types', () => {
+    const wagers = [w({ id: '0', resolutionType: 0 }), w({ id: '3', resolutionType: 3 })]
+    expect(applyResolutionTypeFilter(wagers, [3]).map(x => x.id)).toEqual(['3'])
+  })
+
+  it('passes through when filter is empty', () => {
+    const wagers = [w({ id: '1' }), w({ id: '2' })]
+    expect(applyStatusFilter(wagers, null)).toHaveLength(2)
+    expect(applyStatusFilter(wagers, [])).toHaveLength(2)
+  })
+})
+
+describe('applyFilters (full pipeline)', () => {
+  it('applies ownership, tab and expiry together', () => {
+    const wagers = [
+      w({ id: 'mine-active', creator: OTHER, participants: [OWNER], status: 'active' }),
+      w({ id: 'mine-resolved', creator: OTHER, participants: [OWNER], status: 'resolved' }),
+      w({ id: 'theirs', creator: OTHER, participants: [OTHER], status: 'active' }),
+    ]
+    const out = applyFilters(wagers, {
+      ownerAddress: OWNER,
+      tab: 'participating',
+      includeExpired: false,
+    })
+    expect(out.map(x => x.id)).toEqual(['mine-active'])
+  })
+})
+
+describe('applySort + computeSortKey', () => {
+  it('groups by resolution type respecting ResolutionTypeOrder', () => {
+    const wagers = [
+      w({ id: 'a', resolutionType: 3, createdAt: 100 }),
+      w({ id: 'b', resolutionType: 0, createdAt: 100 }),
+      w({ id: 'c', resolutionType: 1, createdAt: 100 }),
+    ]
+    const sorted = applySort(wagers, WagerSortKey.RESOLUTION_TYPE)
+    expect(sorted.map(x => x.id)).toEqual(['b', 'c', 'a'])
+  })
+
+  it('createdAt sort returns newest first', () => {
+    const wagers = [w({ id: 'old', createdAt: 100 }), w({ id: 'new', createdAt: 200 })]
+    const sorted = applySort(wagers, WagerSortKey.CREATED)
+    expect(sorted.map(x => x.id)).toEqual(['new', 'old'])
+  })
+
+  it('produces stable sortKey strings', () => {
+    const k1 = computeSortKey(w({ createdAt: 1000 }), WagerSortKey.CREATED)
+    const k2 = computeSortKey(w({ createdAt: 1000 }), WagerSortKey.CREATED)
+    expect(k1).toEqual(k2)
+  })
+})
+
+describe('applyCursor + paginate', () => {
+  it('cursor resumes after lastSortKey', () => {
+    const wagers = [
+      w({ id: 'a', createdAt: 300 }),
+      w({ id: 'b', createdAt: 200 }),
+      w({ id: 'c', createdAt: 100 }),
+    ]
+    const sorted = applySort(wagers, WagerSortKey.CREATED)
+    const resumed = applyCursor(sorted, { lastSortKey: sorted[0].sortKey })
+    expect(resumed.map(x => x.id)).toEqual(['b', 'c'])
+  })
+
+  it('paginate returns nextCursor when more pages remain', () => {
+    const wagers = Array.from({ length: 5 }, (_, i) =>
+      w({ id: String(i), createdAt: 1000 - i })
+    )
+    const page1 = paginate(wagers, { pageSize: 2, sortKey: WagerSortKey.CREATED })
+    expect(page1.items.map(x => x.id)).toEqual(['0', '1'])
+    expect(page1.hasMore).toBe(true)
+    expect(page1.nextCursor).not.toBeNull()
+
+    const page2 = paginate(wagers, {
+      pageSize: 2,
+      sortKey: WagerSortKey.CREATED,
+      cursor: page1.nextCursor,
+    })
+    expect(page2.items.map(x => x.id)).toEqual(['2', '3'])
+  })
+})

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -289,22 +289,20 @@ function processMarketResult(marketId, marketResult, acceptanceStatus, acceptanc
   const arbitrator = marketResult.arbitrator
   const hasArbitrator = arbitrator && arbitrator !== ethers.ZeroAddress
 
-  // Safely parse timestamps
+  // Safely parse timestamps. `getFriendMarketWithStatus` does not return
+  // `tradingEndTime` — it returns `acceptanceDeadline`. Use that for
+  // pending-acceptance wagers; otherwise fall back to a 30-day default
+  // (the paginated path in data/wagers/EventsSource.js computes the
+  // accurate value from createdAt + tradingPeriodSeconds).
   const acceptanceDeadlineMs = Number(marketResult.acceptanceDeadline) * 1000
-  const tradingEndTimeMs = Number(marketResult.tradingEndTime || 0) * 1000
 
   const now = new Date()
   const defaultEndDate = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000)
 
   let endDateStr
-  try {
-    if (tradingEndTimeMs > 0) {
-      const endDate = new Date(tradingEndTimeMs)
-      endDateStr = !isNaN(endDate.getTime()) ? endDate.toISOString() : defaultEndDate.toISOString()
-    } else {
-      endDateStr = defaultEndDate.toISOString()
-    }
-  } catch {
+  if (acceptanceDeadlineMs > 0 && Number(marketResult.status) === 0) {
+    endDateStr = new Date(acceptanceDeadlineMs).toISOString()
+  } else {
     endDateStr = defaultEndDate.toISOString()
   }
 

--- a/subgraph/README.md
+++ b/subgraph/README.md
@@ -1,0 +1,47 @@
+# Wagers Subgraph
+
+Indexes the `FriendGroupMarketFactory` contract for The Graph's decentralized
+network. The frontend's `WagerRepository` (in
+`frontend/src/data/wagers/SubgraphSource.js`) queries this subgraph to
+power the paginated "My Wagers" view at scale.
+
+## Why this exists
+
+Direct on-chain event scanning works for tens of wagers, not for millions.
+This subgraph indexes once on the server and lets the client paginate by
+the `createdAt`, `endTime`, `resolutionType`, or `status` fields directly
+in GraphQL `where` / `orderBy` clauses — so each page is a single network
+round trip regardless of how much history a user has.
+
+## Setup (development — public Graph Network)
+
+1. `cd subgraph && yarn install`
+2. Edit `subgraph.yaml`:
+   - Set `dataSources[0].source.address` to the deployed
+     `FriendGroupMarketFactory` address (see
+     `deployments/<network>/FriendGroupMarketFactory.json`).
+   - Set `startBlock` to the contract's deployment block.
+3. Generate ABIs JSON from the JS export if needed:
+   `node -e 'console.log(JSON.stringify(require("../frontend/src/abis/FriendGroupMarketFactory.js").FRIEND_GROUP_MARKET_FACTORY_ABI, null, 2))' > ../frontend/src/abis/FriendGroupMarketFactory.json`
+4. `yarn codegen && yarn build`
+5. Authenticate the Graph CLI: `graph auth <DEPLOY_KEY>` (from
+   [The Graph Studio](https://thegraph.com/studio/)).
+6. `yarn deploy:studio` — version label e.g. `v0.1.0`.
+
+The studio URL is the value to set in
+`frontend/.env`:
+
+```
+VITE_SUBGRAPH_URL=https://api.studio.thegraph.com/query/<id>/prediction-dao-research/v0.1.0
+VITE_WAGER_SOURCE=subgraph
+```
+
+When `VITE_SUBGRAPH_URL` is unset or the subgraph is unreachable, the
+client automatically falls back to `EventsSource` (direct RPC scanning).
+
+## Future: hosted/dedicated graph
+
+The repository interface (`WagerSource`) is identical for any indexer.
+Swapping to a hosted (centralized) graph, Goldsky, Envio, or Ponder is a
+new file in `frontend/src/data/wagers/` implementing the same three
+methods (`syncIndex`, `listPage`, `getById`) — no UI changes required.

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "prediction-dao-research-subgraph",
+  "version": "0.1.0",
+  "description": "Subgraph for FriendGroupMarketFactory wagers — powers the My Wagers paginated view via The Graph's decentralized network.",
+  "private": true,
+  "scripts": {
+    "codegen": "graph codegen",
+    "build": "graph build",
+    "deploy:studio": "graph deploy --node https://api.studio.thegraph.com/deploy/ prediction-dao-research",
+    "create-local": "graph create --node http://localhost:8020/ prediction-dao-research",
+    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 prediction-dao-research",
+    "test": "graph test"
+  },
+  "devDependencies": {
+    "@graphprotocol/graph-cli": "0.80.0",
+    "@graphprotocol/graph-ts": "0.35.1",
+    "matchstick-as": "0.6.0"
+  }
+}

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -1,0 +1,76 @@
+"""
+Subgraph schema for the FriendGroupMarketFactory contract.
+
+Deployed to The Graph's decentralized network (public during development;
+hosted endpoint in the future). The frontend WagerRepository
+(SubgraphSource) queries this schema via GraphQL and paginates using the
+`createdAt`, `endTime`, `resolutionType`, or `status` fields directly in
+the `where` / `orderBy` clauses — keeping the visible page as the only
+data transferred, which is what unlocks the millions-of-bets NFR.
+
+Encrypted envelopes (metadataCipher) are stored as raw strings; the
+client decrypts them lazily via useLazyMarketDecryption.
+"""
+
+enum WagerStatus {
+  pending_acceptance
+  active
+  pending_resolution
+  challenged
+  resolved
+  cancelled
+  refunded
+  oracle_timed_out
+}
+
+enum MarketType {
+  oneVsOne
+  smallGroup
+  eventTracking
+  propBet
+  bookmaker
+}
+
+type User @entity(immutable: false) {
+  "lowercased wallet address"
+  id: ID!
+  wagers: [Wager!]! @derivedFrom(field: "participants")
+  created: [Wager!]! @derivedFrom(field: "creator")
+}
+
+type Wager @entity(immutable: false) {
+  "on-chain market id"
+  id: ID!
+
+  marketType: MarketType!
+  status: WagerStatus!
+  resolutionType: Int!
+
+  creator: User!
+  participants: [User!]!
+  arbitrator: Bytes
+
+  stakePerParticipant: BigInt!
+  stakeToken: Bytes!
+
+  tradingPeriodSeconds: BigInt!
+  createdAt: BigInt!
+  acceptanceDeadline: BigInt!
+  "Computed at index time: createdAt + tradingPeriodSeconds"
+  endTime: BigInt!
+
+  acceptedCount: BigInt!
+
+  "IPFS CID when the encrypted metadata is stored off-chain"
+  ipfsCid: String
+
+  "Raw description (may be the encrypted envelope JSON or a plaintext title)"
+  description: String!
+  isEncrypted: Boolean!
+  "Raw envelope (JSON string) when encryption is stored on-chain"
+  metadataCipher: String
+
+  resolvedAt: BigInt
+  winner: Bytes
+  outcomeBool: Boolean
+}

--- a/subgraph/src/mappings/factory.ts
+++ b/subgraph/src/mappings/factory.ts
@@ -1,0 +1,154 @@
+import { BigInt, Bytes, log } from '@graphprotocol/graph-ts'
+import {
+  MarketCreated,
+  MemberAdded,
+  MarketAccepted,
+  ResolutionProposed,
+  MarketResolved,
+  MarketChallenged,
+  MarketCancelled,
+  MarketRefunded,
+  FriendGroupMarketFactory,
+} from '../../generated/FriendGroupMarketFactory/FriendGroupMarketFactory'
+import { Wager, User } from '../../generated/schema'
+
+const MARKET_TYPES = ['oneVsOne', 'smallGroup', 'eventTracking', 'propBet', 'bookmaker']
+const STATUSES = [
+  'pending_acceptance',
+  'active',
+  'pending_resolution',
+  'challenged',
+  'resolved',
+  'cancelled',
+  'refunded',
+  'oracle_timed_out',
+]
+
+function getOrCreateUser(address: Bytes): User {
+  const id = address.toHexString()
+  let user = User.load(id)
+  if (user == null) {
+    user = new User(id)
+    user.save()
+  }
+  return user
+}
+
+function loadOrCreateWager(marketId: BigInt, address: Bytes): Wager {
+  const id = marketId.toString()
+  let wager = Wager.load(id)
+  if (wager == null) {
+    wager = new Wager(id)
+    wager.creator = getOrCreateUser(address).id
+    wager.participants = []
+    wager.acceptedCount = BigInt.zero()
+    wager.stakePerParticipant = BigInt.zero()
+    wager.stakeToken = Bytes.empty()
+    wager.tradingPeriodSeconds = BigInt.zero()
+    wager.createdAt = BigInt.zero()
+    wager.acceptanceDeadline = BigInt.zero()
+    wager.endTime = BigInt.zero()
+    wager.description = ''
+    wager.isEncrypted = false
+    wager.marketType = 'oneVsOne'
+    wager.status = 'pending_acceptance'
+    wager.resolutionType = 0
+  }
+  return wager as Wager
+}
+
+function hydrateFromContract(wager: Wager, factory: FriendGroupMarketFactory, marketId: BigInt): void {
+  const result = factory.try_friendMarkets(marketId)
+  if (result.reverted) {
+    log.warning('friendMarkets({}) reverted', [marketId.toString()])
+    return
+  }
+  const data = result.value
+  wager.marketType = MARKET_TYPES[data.value1]
+  wager.creator = getOrCreateUser(data.value2).id
+  wager.stakePerParticipant = data.value16
+  wager.stakeToken = data.value17
+  wager.tradingPeriodSeconds = data.value18
+  wager.createdAt = data.value7
+  wager.acceptanceDeadline = data.value14
+  wager.endTime = data.value7.plus(data.value18)
+  wager.description = data.value9
+  wager.resolutionType = data.value20
+
+  const withStatus = factory.try_getFriendMarketWithStatus(marketId)
+  if (!withStatus.reverted) {
+    wager.status = STATUSES[withStatus.value.value5]
+    wager.acceptedCount = withStatus.value.value9
+  }
+}
+
+export function handleMarketCreated(event: MarketCreated): void {
+  const factory = FriendGroupMarketFactory.bind(event.address)
+  const wager = loadOrCreateWager(event.params.marketId, event.params.creator)
+  hydrateFromContract(wager, factory, event.params.marketId)
+  wager.save()
+}
+
+export function handleMemberAdded(event: MemberAdded): void {
+  const wager = Wager.load(event.params.friendMarketId.toString())
+  if (wager == null) return
+  const user = getOrCreateUser(event.params.member)
+  const ids = wager.participants
+  let exists = false
+  for (let i = 0; i < ids.length; i++) {
+    if (ids[i] == user.id) { exists = true; break }
+  }
+  if (!exists) {
+    ids.push(user.id)
+    wager.participants = ids
+    wager.save()
+  }
+}
+
+export function handleMarketAccepted(event: MarketAccepted): void {
+  const wager = Wager.load(event.params.friendMarketId.toString())
+  if (wager == null) return
+  wager.acceptedCount = wager.acceptedCount.plus(BigInt.fromI32(1))
+  const factory = FriendGroupMarketFactory.bind(event.address)
+  const withStatus = factory.try_getFriendMarketWithStatus(event.params.friendMarketId)
+  if (!withStatus.reverted) wager.status = STATUSES[withStatus.value.value5]
+  wager.save()
+}
+
+export function handleResolutionProposed(event: ResolutionProposed): void {
+  const wager = Wager.load(event.params.friendMarketId.toString())
+  if (wager == null) return
+  wager.status = 'pending_resolution'
+  wager.save()
+}
+
+export function handleMarketResolved(event: MarketResolved): void {
+  const wager = Wager.load(event.params.friendMarketId.toString())
+  if (wager == null) return
+  wager.status = 'resolved'
+  wager.outcomeBool = event.params.outcome
+  wager.winner = event.params.winner
+  wager.resolvedAt = event.block.timestamp
+  wager.save()
+}
+
+export function handleMarketChallenged(event: MarketChallenged): void {
+  const wager = Wager.load(event.params.friendMarketId.toString())
+  if (wager == null) return
+  wager.status = 'challenged'
+  wager.save()
+}
+
+export function handleMarketCancelled(event: MarketCancelled): void {
+  const wager = Wager.load(event.params.friendMarketId.toString())
+  if (wager == null) return
+  wager.status = 'cancelled'
+  wager.save()
+}
+
+export function handleMarketRefunded(event: MarketRefunded): void {
+  const wager = Wager.load(event.params.friendMarketId.toString())
+  if (wager == null) return
+  wager.status = 'refunded'
+  wager.save()
+}

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -1,0 +1,45 @@
+specVersion: 0.0.5
+description: FriendGroupMarketFactory wagers index for the prediction-dao-research app
+schema:
+  file: ./schema.graphql
+
+# Networks: polygon-amoy during development; switch to polygon for prod.
+# Replace ADDRESS and START_BLOCK with the values from
+# deployments/<network>/FriendGroupMarketFactory.json before running
+# `graph deploy`.
+dataSources:
+  - kind: ethereum
+    name: FriendGroupMarketFactory
+    network: polygon-amoy
+    source:
+      address: "0x0000000000000000000000000000000000000000"
+      abi: FriendGroupMarketFactory
+      startBlock: 0
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Wager
+        - User
+      abis:
+        - name: FriendGroupMarketFactory
+          file: ../frontend/src/abis/FriendGroupMarketFactory.json
+      eventHandlers:
+        - event: MarketCreated(indexed uint256,indexed address,uint8,uint8)
+          handler: handleMarketCreated
+        - event: MemberAdded(indexed uint256,indexed address)
+          handler: handleMemberAdded
+        - event: MarketAccepted(indexed uint256,indexed address,uint256)
+          handler: handleMarketAccepted
+        - event: ResolutionProposed(indexed uint256,indexed address,bool)
+          handler: handleResolutionProposed
+        - event: MarketResolved(indexed uint256,indexed address,bool,uint256)
+          handler: handleMarketResolved
+        - event: MarketChallenged(indexed uint256,indexed address)
+          handler: handleMarketChallenged
+        - event: MarketCancelled(indexed uint256)
+          handler: handleMarketCancelled
+        - event: MarketRefunded(indexed uint256)
+          handler: handleMarketRefunded
+      file: ./src/mappings/factory.ts


### PR DESCRIPTION
Introduces a WagerRepository seam so the My Wagers list scales to millions
of bets without changing the UI. Two sources implement the same interface:

- SubgraphSource queries The Graph's decentralized network (primary;
  filter/sort encoded directly in GraphQL where/orderBy)
- EventsSource scans MemberAdded events with a cached watermark and
  hydrates only the visible page (fallback when the subgraph is
  unreachable or VITE_WAGER_SOURCE=events)

The repository powers a new useMyWagers hook with cursor pagination, an
ownership + expiry gate, and a sort by Resolution Type. Encrypted
envelopes round-trip as raw metadataCipher; the modal still lazy-decrypts
via useLazyMarketDecryption so only the visible page is unwrapped.

Tab badges now show unread-only counts via a new useMyWagerNotifications
hook (built on the extracted createUnreadMarketTracker factory with an
isolated localStorage key); row-click fires markMarketAsRead so viewed
wagers stop counting. The existing useFriendMarketNotifications stays
behavior-compatible by wrapping the same factory under its own key.

CSS audit: tighter row padding, flex-based title with ellipsis, inline
unread bar, wrapping filter bar with a new 900px breakpoint, and a Load
More button. Existing 768px mobile breakpoint widened the market column
to fit the new 3px unread indicator.

Includes the subgraph manifest, schema, and mapping handlers so the index
can be deployed to The Graph Studio today; defaults degrade to events
when VITE_SUBGRAPH_URL is unset.

Tests: 30 new tests cover sortFilter (ownership / expiry / tab / cursor /
sort), cacheStore (legacy migration + byte-budget eviction), and
useMyWagerNotifications (Active->PendingResolution trigger, persistence,
storage isolation). 755/755 tests pass.

https://claude.ai/code/session_01QNyzfNLJYwn3skQasJMYHF