### PR TITLE
feat(frontend): auto-start QR scanner, fix scan icon, accept ENS for opponent/arbitrator

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.css
+++ b/frontend/src/components/fairwins/FriendMarketsModal.css
@@ -492,19 +492,38 @@
   min-width: 0;
 }
 
+/* Wrapper so the AddressInput component (which has its own .container) takes
+   the remaining row width next to the QR scan button. */
+.fm-input-with-action .fm-address-input-wrap {
+  flex: 1;
+  min-width: 0;
+}
+
 .fm-scan-btn,
 .fm-lookup-btn {
   display: flex;
   align-items: center;
   justify-content: center;
+  align-self: stretch;
   width: 42px;
   min-width: 42px;
+  height: 44px;
   background: var(--bg-primary, #0E141B);
   border: 1px solid var(--border-color, #23303D);
   border-radius: 8px;
   color: var(--text-secondary, #AAB6C2);
   cursor: pointer;
   transition: all 0.2s ease;
+}
+
+/* When the adjacent field is the AddressInput (which can grow vertically
+   with the resolved-address hint), keep the QR button at the input row. */
+.fm-input-with-action:has(.fm-address-input-wrap) {
+  align-items: flex-start;
+}
+
+.fm-input-with-action:has(.fm-address-input-wrap) .fm-scan-btn {
+  align-self: flex-start;
 }
 
 .fm-scan-btn:hover:not(:disabled),

--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -15,6 +15,8 @@ import { getContractAddress } from '../../config/contracts'
 import { getTransactionUrl } from '../../config/blockExplorer'
 import { FRIEND_GROUP_MARKET_FACTORY_ABI, ResolutionType as _ResolutionType } from '../../abis/FriendGroupMarketFactory'
 import QRScanner from '../ui/QRScanner'
+import AddressInput from '../ui/AddressInput'
+import { isEnsName } from '../../utils/validation'
 import { useChainTokens } from '../../hooks/useChainTokens'
 import { usePolymarketSearch } from '../../hooks/usePolymarketSearch'
 import PolymarketBrowser from './PolymarketBrowser'
@@ -183,6 +185,10 @@ function FriendMarketsModal({
   const [formData, setFormData] = useState({
     description: '',
     opponent: '',
+    // ENS-resolved opponent address. `opponent` holds the raw input (may be
+    // an ENS name); `opponentResolved` is the 0x address used for validation
+    // and contract submission.
+    opponentResolved: '',
     members: '',
     memberLimit: WAGER_DEFAULTS.MEMBER_LIMIT,
     endDateTime: getDefaultEndDateTime(),
@@ -190,6 +196,7 @@ function FriendMarketsModal({
     stakeTokenId: WAGER_DEFAULTS.STAKE_TOKEN_ID,
     customStakeTokenAddress: '', // Used when stakeTokenId is 'CUSTOM'
     arbitrator: '',
+    arbitratorResolved: '',
     peggedMarketId: '',
     // Multi-party acceptance fields
     acceptanceDeadline: getDefaultAcceptanceDeadline(),
@@ -249,6 +256,7 @@ function FriendMarketsModal({
     setFormData({
       description: '',
       opponent: '',
+      opponentResolved: '',
       members: '',
       memberLimit: WAGER_DEFAULTS.MEMBER_LIMIT,
       endDateTime: getDefaultEndDateTime(),
@@ -256,6 +264,7 @@ function FriendMarketsModal({
       stakeTokenId: WAGER_DEFAULTS.STAKE_TOKEN_ID,
       customStakeTokenAddress: '',
       arbitrator: '',
+      arbitratorResolved: '',
       peggedMarketId: '',
       acceptanceDeadline: getDefaultAcceptanceDeadline(),
       minAcceptanceThreshold: String(WAGER_DEFAULTS.MIN_ACCEPTANCE_THRESHOLD),
@@ -323,8 +332,12 @@ function FriendMarketsModal({
     }
   }
 
-  const handleFormChange = (field, value) => {
+  const handleFormChange = useCallback((field, value) => {
     setFormData(prev => {
+      // Skip no-op updates so callbacks driven by useEffect (e.g. the
+      // AddressInput resolved-address callback) don't cause re-render loops.
+      if (prev[field] === value) return prev
+
       const updated = { ...prev, [field]: value }
 
       // Clear arbitrator/linked-market state when switching to a resolution
@@ -333,20 +346,20 @@ function FriendMarketsModal({
           value !== ResolutionType.ThirdParty &&
           value !== ResolutionType.PolymarketOracle) {
         updated.arbitrator = ''
+        updated.arbitratorResolved = ''
         updated.peggedMarketId = ''
       }
 
       return updated
     })
 
-    if (errors[field]) {
-      setErrors(prev => {
-        const newErrors = { ...prev }
-        delete newErrors[field]
-        return newErrors
-      })
-    }
-  }
+    setErrors(prev => {
+      if (!prev[field]) return prev
+      const newErrors = { ...prev }
+      delete newErrors[field]
+      return newErrors
+    })
+  }, [])
 
   // QR Scanner handlers
   const openQrScanner = (target) => {
@@ -396,9 +409,12 @@ function FriendMarketsModal({
       }
     }
 
-    // Update the appropriate field
+    // Update the appropriate field. Also mirror the value into the
+    // *Resolved field so validation/submission skip the ENS resolution path
+    // for a scanned hex address.
     if (qrScanTarget && /^0x[a-fA-F0-9]{40}$/.test(address)) {
       handleFormChange(qrScanTarget, address)
+      handleFormChange(`${qrScanTarget}Resolved`, address)
     }
 
     setQrScannerOpen(false)
@@ -585,13 +601,17 @@ function FriendMarketsModal({
     }
 
     if (friendMarketType === 'oneVsOne') {
-      if (!formData.opponent.trim()) {
+      const rawOpponent = formData.opponent.trim()
+      const resolvedOpponent = (formData.opponentResolved || '').trim()
+      if (!rawOpponent) {
         newErrors.opponent = 'Opponent address is required'
-      } else if (!/^0x[a-fA-F0-9]{40}$/.test(formData.opponent.trim())) {
-        newErrors.opponent = 'Invalid Ethereum address'
-      } else if (formData.opponent.toLowerCase() === '0x0000000000000000000000000000000000000000') {
+      } else if (!resolvedOpponent) {
+        newErrors.opponent = isEnsName(rawOpponent)
+          ? 'Could not resolve ENS name — check the name and try again'
+          : 'Enter a valid Ethereum address or ENS name'
+      } else if (resolvedOpponent.toLowerCase() === '0x0000000000000000000000000000000000000000') {
         newErrors.opponent = 'Cannot use the zero address'
-      } else if (formData.opponent.toLowerCase() === account?.toLowerCase()) {
+      } else if (resolvedOpponent.toLowerCase() === account?.toLowerCase()) {
         newErrors.opponent = 'Cannot bet against yourself'
       }
     }
@@ -700,11 +720,15 @@ function FriendMarketsModal({
     if ((friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker')) {
       if (formData.resolutionType === ResolutionType.ThirdParty) {
         // Arbitrator address is required for ThirdParty resolution
-        if (!formData.arbitrator || !formData.arbitrator.trim()) {
+        const rawArb = (formData.arbitrator || '').trim()
+        const resolvedArb = (formData.arbitratorResolved || '').trim()
+        if (!rawArb) {
           newErrors.arbitrator = 'Arbitrator address is required for third party resolution'
-        } else if (!/^0x[a-fA-F0-9]{40}$/.test(formData.arbitrator.trim())) {
-          newErrors.arbitrator = 'Invalid arbitrator address'
-        } else if (formData.arbitrator.toLowerCase() === '0x0000000000000000000000000000000000000000') {
+        } else if (!resolvedArb) {
+          newErrors.arbitrator = isEnsName(rawArb)
+            ? 'Could not resolve ENS name — check the name and try again'
+            : 'Enter a valid Ethereum address or ENS name'
+        } else if (resolvedArb.toLowerCase() === '0x0000000000000000000000000000000000000000') {
           newErrors.arbitrator = 'Cannot use the zero address'
         }
       } else if (formData.resolutionType === ResolutionType.PolymarketOracle) {
@@ -787,7 +811,7 @@ function FriendMarketsModal({
         stakeAmount: formData.stakeAmount,
         stakeToken: stakeToken.symbol,
         endDateTime: formData.endDateTime,
-        arbitrator: formData.arbitrator || null,
+        arbitrator: formData.arbitratorResolved || null,
         createdAt: new Date().toISOString(),
         attributes: [
           { trait_type: 'Market Source', value: 'friend' },
@@ -799,9 +823,11 @@ function FriendMarketsModal({
       let finalMetadata = marketMetadata
 
       if (enableEncryption) {
-        // Look up opponent's on-chain encryption key before creating envelope
+        // Look up opponent's on-chain encryption key before creating envelope.
+        // Use the ENS-resolved address (falls back to raw input when the user
+        // typed a hex address, since onResolvedChange mirrors that value).
         const opponentAddress = friendMarketType === 'oneVsOne'
-          ? formData.opponent
+          ? formData.opponentResolved
           : null // For group markets, encrypt for creator only initially
 
         if (friendMarketType === 'oneVsOne' && opponentAddress) {
@@ -838,6 +864,12 @@ function FriendMarketsModal({
         marketType: friendMarketType,
         data: {
           ...formData,
+          // Downstream hooks (useFriendMarketCreation) read `opponent` and
+          // `arbitrator` as 0x addresses. Substitute the ENS-resolved values
+          // so a user can enter `name.eth` and the contract still gets a hex
+          // address.
+          opponent: formData.opponentResolved || formData.opponent,
+          arbitrator: formData.arbitratorResolved || formData.arbitrator,
           // Pass calculated trading period so WalletButton uses the user's selected end date
           tradingPeriod: tradingPeriodDays,
           // Pass actual token address so WalletButton can use correct decimals
@@ -873,10 +905,10 @@ function FriendMarketsModal({
         endDate: endDate.toISOString(),
         tradingPeriod: tradingPeriodDays,
         participants: friendMarketType === 'oneVsOne'
-          ? [account, formData.opponent]
+          ? [account, formData.opponentResolved]
           : [account, ...formData.members.split(',').map(a => a.trim())],
         creator: account,
-        arbitrator: formData.arbitrator || null,
+        arbitrator: formData.arbitratorResolved || null,
         createdAt: new Date().toISOString(),
         status: 'pending_acceptance',
         // Acceptance flow fields
@@ -1355,15 +1387,18 @@ function FriendMarketsModal({
                           Opponent Address <span className="fm-required">*</span>
                         </label>
                         <div className="fm-input-with-action">
-                          <input
-                            id="fm-opponent"
-                            type="text"
-                            value={formData.opponent}
-                            onChange={(e) => handleFormChange('opponent', e.target.value)}
-                            placeholder="0x..."
-                            disabled={submitting}
-                            className={errors.opponent ? 'error' : ''}
-                          />
+                          <div className="fm-address-input-wrap">
+                            <AddressInput
+                              id="fm-opponent"
+                              value={formData.opponent}
+                              onChange={(e) => handleFormChange('opponent', e.target.value)}
+                              onResolvedChange={(addr) => handleFormChange('opponentResolved', addr || '')}
+                              placeholder="0x... or ENS name (e.g., vitalik.eth)"
+                              disabled={submitting}
+                              error={!!errors.opponent}
+                              errorMessage={errors.opponent}
+                            />
+                          </div>
                           <button
                             type="button"
                             className="fm-scan-btn"
@@ -1372,16 +1407,11 @@ function FriendMarketsModal({
                             title="Scan QR code"
                             aria-label="Scan QR code"
                           >
-                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                              <rect x="3" y="3" width="7" height="7"/>
-                              <rect x="14" y="3" width="7" height="7"/>
-                              <rect x="3" y="14" width="7" height="7"/>
-                              <rect x="14" y="14" width="3" height="3"/>
-                              <path d="M17 14h4v4h-4zM14 17v4h4"/>
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                              <path d="M3 3h8v8H3V3zm2 2v4h4V5H5zm8-2h8v8h-8V3zm2 2v4h4V5h-4zM3 13h8v8H3v-8zm2 2v4h4v-4H5zm10-2h2v2h-2v-2zm4 0h2v2h-2v-2zm-4 4h2v2h-2v-2zm2 2h2v2h-2v-2zm2-2h2v2h-2v-2zm0 4h2v2h-2v-2z"/>
                             </svg>
                           </button>
                         </div>
-                        {errors.opponent && <span className="fm-error">{errors.opponent}</span>}
                       </div>
                     )}
 
@@ -1643,15 +1673,18 @@ function FriendMarketsModal({
                           Arbitrator Address <span className="fm-required">*</span>
                         </label>
                         <div className="fm-input-with-action">
-                          <input
-                            id="fm-arbitrator"
-                            type="text"
-                            value={formData.arbitrator}
-                            onChange={(e) => handleFormChange('arbitrator', e.target.value)}
-                            placeholder="0x... (trusted third party address)"
-                            disabled={submitting}
-                            className={errors.arbitrator ? 'error' : ''}
-                          />
+                          <div className="fm-address-input-wrap">
+                            <AddressInput
+                              id="fm-arbitrator"
+                              value={formData.arbitrator}
+                              onChange={(e) => handleFormChange('arbitrator', e.target.value)}
+                              onResolvedChange={(addr) => handleFormChange('arbitratorResolved', addr || '')}
+                              placeholder="0x... or ENS name (trusted third party)"
+                              disabled={submitting}
+                              error={!!errors.arbitrator}
+                              errorMessage={errors.arbitrator}
+                            />
+                          </div>
                           <button
                             type="button"
                             className="fm-scan-btn"
@@ -1660,16 +1693,11 @@ function FriendMarketsModal({
                             title="Scan QR code"
                             aria-label="Scan QR code"
                           >
-                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                              <rect x="3" y="3" width="7" height="7"/>
-                              <rect x="14" y="3" width="7" height="7"/>
-                              <rect x="3" y="14" width="7" height="7"/>
-                              <rect x="14" y="14" width="3" height="3"/>
-                              <path d="M17 14h4v4h-4zM14 17v4h4"/>
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                              <path d="M3 3h8v8H3V3zm2 2v4h4V5H5zm8-2h8v8h-8V3zm2 2v4h4V5h-4zM3 13h8v8H3v-8zm2 2v4h4v-4H5zm10-2h2v2h-2v-2zm4 0h2v2h-2v-2zm-4 4h2v2h-2v-2zm2 2h2v2h-2v-2zm2-2h2v2h-2v-2zm0 4h2v2h-2v-2z"/>
                             </svg>
                           </button>
                         </div>
-                        {errors.arbitrator && <span className="fm-error">{errors.arbitrator}</span>}
                       </div>
                     )}
 

--- a/frontend/src/components/ui/QRScanner.jsx
+++ b/frontend/src/components/ui/QRScanner.jsx
@@ -4,6 +4,7 @@ import './QRScanner.css'
 
 function QRScanner({ isOpen, onClose, onScanSuccess }) {
   const [scanning, setScanning] = useState(false)
+  const [starting, setStarting] = useState(false)
   const [error, setError] = useState(null)
   const [cameras, setCameras] = useState([])
   const [selectedCamera, setSelectedCamera] = useState(null)
@@ -79,11 +80,24 @@ function QRScanner({ isOpen, onClose, onScanSuccess }) {
     }
   }, [isOpen, handleClose])
 
+  // Auto-start scanning as soon as a camera is selected.
+  // Skipping the "press Start" step is the intended UX — tapping a QR button
+  // in the parent should immediately activate the camera.
+  useEffect(() => {
+    if (!isOpen || !selectedCamera || scanning || starting || error) return
+    if (html5QrCodeRef.current) return
+    startScanning()
+    // startScanning closes over selectedCamera; re-running on its change is
+    // already covered by the deps. Other state values are checked above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, selectedCamera, scanning, starting, error])
+
   const startScanning = async () => {
     if (!selectedCamera || html5QrCodeRef.current) return
 
     try {
       setError(null)
+      setStarting(true)
       const html5QrCode = new Html5Qrcode('qr-reader')
       html5QrCodeRef.current = html5QrCode
 
@@ -106,7 +120,10 @@ function QRScanner({ isOpen, onClose, onScanSuccess }) {
       setScanning(true)
     } catch (err) {
       console.error('Error starting scanner:', err)
+      html5QrCodeRef.current = null
       setError('Failed to start camera. Please check permissions.')
+    } finally {
+      setStarting(false)
     }
   }
 
@@ -180,11 +197,11 @@ function QRScanner({ isOpen, onClose, onScanSuccess }) {
         <div className="qr-scanner-content">
           <div className="scanner-container">
             <div id="qr-reader" ref={scannerRef}></div>
-            
+
             {!scanning && !error && (
               <div className="scanner-placeholder">
                 <span className="camera-icon">📷</span>
-                <p>Camera preview will appear here</p>
+                <p>{starting || selectedCamera ? 'Starting camera…' : 'Detecting cameras…'}</p>
               </div>
             )}
 
@@ -204,7 +221,7 @@ function QRScanner({ isOpen, onClose, onScanSuccess }) {
                   id="camera-select"
                   value={selectedCamera || ''}
                   onChange={handleCameraChange}
-                  disabled={scanning}
+                  disabled={starting}
                 >
                   {cameras.map((camera) => (
                     <option key={camera.id} value={camera.id}>
@@ -215,17 +232,8 @@ function QRScanner({ isOpen, onClose, onScanSuccess }) {
               </div>
             )}
 
-            <div className="scanner-actions">
-              {!scanning ? (
-                <button
-                  className="start-scan-btn"
-                  onClick={startScanning}
-                  disabled={!selectedCamera || !!error}
-                  aria-label="Start scanning QR code"
-                >
-                  📷 Start Scanning
-                </button>
-              ) : (
+            {scanning && (
+              <div className="scanner-actions">
                 <button
                   className="stop-scan-btn"
                   onClick={stopScanning}
@@ -233,14 +241,14 @@ function QRScanner({ isOpen, onClose, onScanSuccess }) {
                 >
                   ⏹️ Stop Scanning
                 </button>
-              )}
-            </div>
+              </div>
+            )}
           </div>
 
           <div className="scanner-instructions">
             <h3>How to Scan</h3>
             <ol>
-              <li>Click "Start Scanning" to activate your camera</li>
+              <li>Allow camera access when prompted</li>
               <li>Point your camera at a market QR code</li>
               <li>Hold steady until the code is detected</li>
               <li>You'll be automatically redirected to the market</li>

--- a/frontend/src/test/FriendMarketsModal.test.jsx
+++ b/frontend/src/test/FriendMarketsModal.test.jsx
@@ -123,9 +123,18 @@ vi.mock('wagmi', () => ({
   useWalletClient: () => ({
     data: null // Return null to prevent EIP-1193 provider errors and trigger window.ethereum fallback path in tests
   }),
+  // ENS resolution hooks used by AddressInput / useEnsResolution. Tests
+  // don't exercise real ENS, so stub these as resolved no-ops.
+  useEnsAddress: () => ({ data: null, isLoading: false, isError: false, error: null }),
+  useEnsName: () => ({ data: null, isLoading: false, isError: false, error: null }),
   WagmiProvider: ({ children }) => children,
   createConfig: vi.fn(() => ({})),
   http: vi.fn(() => ({})),
+}))
+
+// wagmi/chains is imported by useEnsResolution
+vi.mock('wagmi/chains', () => ({
+  mainnet: { id: 1 },
 }))
 
 // Mock wagmi/connectors
@@ -469,8 +478,11 @@ describe('FriendMarketsModal', () => {
       await userEvent.type(screen.getByLabelText(/opponent address/i), 'invalid-address')
       await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
 
+      // The field now accepts ENS names too, so the error wording is broader.
       await waitFor(() => {
-        expect(screen.getByText(/invalid ethereum address/i)).toBeInTheDocument()
+        expect(
+          screen.getByText(/valid ethereum address or ENS name/i)
+        ).toBeInTheDocument()
       })
     })
 

--- a/frontend/src/test/QRScanner.test.jsx
+++ b/frontend/src/test/QRScanner.test.jsx
@@ -56,7 +56,7 @@ describe('QRScanner Component', () => {
       expect(screen.getByText('Scan QR Code')).toBeInTheDocument()
     })
 
-    it('displays scanner placeholder initially', () => {
+    it('shows a starting/detecting indicator before the camera is live', () => {
       render(
         <QRScanner
           isOpen={true}
@@ -64,7 +64,11 @@ describe('QRScanner Component', () => {
           onScanSuccess={mockOnScanSuccess}
         />
       )
-      expect(screen.getByText('Camera preview will appear here')).toBeInTheDocument()
+      // Auto-start UX: the user never sees a "press to scan" landing page —
+      // either we're detecting cameras or we're starting the stream.
+      expect(
+        screen.getByText(/Detecting cameras…|Starting camera…/)
+      ).toBeInTheDocument()
     })
 
     it('displays scanner instructions', () => {
@@ -76,7 +80,7 @@ describe('QRScanner Component', () => {
         />
       )
       expect(screen.getByText('How to Scan')).toBeInTheDocument()
-      expect(screen.getByText(/Click "Start Scanning"/i)).toBeInTheDocument()
+      expect(screen.getByText(/Allow camera access when prompted/i)).toBeInTheDocument()
     })
 
     it('displays privacy note', () => {
@@ -92,7 +96,7 @@ describe('QRScanner Component', () => {
       ).toBeInTheDocument()
     })
 
-    it('displays start scanning button', () => {
+    it('does not render a manual "Start Scanning" button (scanning auto-starts)', () => {
       render(
         <QRScanner
           isOpen={true}
@@ -100,7 +104,7 @@ describe('QRScanner Component', () => {
           onScanSuccess={mockOnScanSuccess}
         />
       )
-      expect(screen.getByLabelText('Start scanning QR code')).toBeInTheDocument()
+      expect(screen.queryByLabelText('Start scanning QR code')).not.toBeInTheDocument()
     })
   })
 
@@ -201,8 +205,6 @@ describe('QRScanner Component', () => {
 
   describe('Error Handling', () => {
     it('displays error message when camera access fails', async () => {
-      // This test would need more complex mocking of Html5Qrcode
-      // For now, we just verify the error state can be displayed
       const { Html5Qrcode } = await import('html5-qrcode')
       Html5Qrcode.getCameras = vi.fn().mockRejectedValue(new Error('No cameras'))
 
@@ -214,10 +216,10 @@ describe('QRScanner Component', () => {
         />
       )
 
-      // Wait for error to be displayed
       await waitFor(() => {
-        const startButton = screen.getByLabelText('Start scanning QR code')
-        expect(startButton).toBeInTheDocument()
+        expect(
+          screen.getByText(/Unable to access camera/i)
+        ).toBeInTheDocument()
       })
     })
   })


### PR DESCRIPTION
The Friend Markets 1v1 flow had three frictions when entering an opponent's
address. Tapping the QR icon opened a modal that required a second click on
"Start Scanning" before the camera engaged. The QR button's SVG used
fill="none" stroke="currentColor" with no explicit stroke on child shapes,
so on some renderers the icon was invisible. And the opponent field
validated only hex addresses, so ENS names like name.eth were rejected even
though the app already ships an AddressInput + useEnsResolution stack.

- QRScanner auto-starts the stream as soon as a camera is selected;
  the placeholder/Start-button screen is gone, replaced by a brief
  "Starting camera…" state.
- Both QR buttons in FriendMarketsModal use a filled-path SVG that paints
  reliably against the dark background and keeps the green hover color.
- Opponent and Arbitrator fields now use AddressInput, tracking the ENS-
  resolved address in formData.opponentResolved / arbitratorResolved.
  Validation and submission use the resolved 0x address; the contract path
  is unchanged.
- handleFormChange is memoized and short-circuits no-op updates to avoid
  the re-render loop introduced by AddressInput's onResolvedChange effect.
- Existing QRScanner and FriendMarketsModal unit tests updated to reflect
  the auto-start UX, the new validation copy, and the new wagmi ENS hooks.

https://claude.ai/code/session_01ChEBGVYai4XjKfthKozt2Z