### PR TITLE
fix(frontend): silence QR scanner close error and strip text chrome

### DIFF
--- a/frontend/src/components/ui/QRScanner.css
+++ b/frontend/src/components/ui/QRScanner.css
@@ -14,60 +14,45 @@
 }
 
 .qr-scanner-modal {
-  background: var(--bg-primary, #ffffff);
+  position: relative;
+  background: #000;
   border-radius: 16px;
   max-width: 600px;
   width: 90%;
   max-height: 90vh;
-  overflow-y: auto;
+  overflow: hidden;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
   animation: slideUp 0.3s ease-out;
 }
 
-.qr-scanner-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 20px 24px;
-  border-bottom: 1px solid var(--border-color, #e5e7eb);
-}
-
-.qr-scanner-header h2 {
-  margin: 0;
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: var(--text-primary, #1f2937);
-}
-
 .qr-scanner-close {
-  background: none;
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: rgba(0, 0, 0, 0.5);
   border: none;
   font-size: 2rem;
   line-height: 1;
   cursor: pointer;
-  color: var(--text-secondary, #6b7280);
+  color: #fff;
   padding: 0;
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 8px;
-  transition: background-color 0.2s, color 0.2s;
+  border-radius: 50%;
+  transition: background-color 0.2s;
+  z-index: 2;
 }
 
 .qr-scanner-close:hover {
-  background-color: var(--bg-secondary, #f3f4f6);
-  color: var(--text-primary, #1f2937);
+  background-color: rgba(0, 0, 0, 0.75);
 }
 
 .qr-scanner-close:focus {
-  outline: 2px solid var(--primary-color, #2563eb);
+  outline: 2px solid #fff;
   outline-offset: 2px;
-}
-
-.qr-scanner-content {
-  padding: 24px;
 }
 
 .scanner-container {
@@ -75,9 +60,7 @@
   width: 100%;
   min-height: 300px;
   background: #000;
-  border-radius: 12px;
   overflow: hidden;
-  margin-bottom: 20px;
 }
 
 #qr-reader {
@@ -85,10 +68,10 @@
 }
 
 #qr-reader video {
-  border-radius: 12px;
+  display: block;
+  width: 100%;
 }
 
-.scanner-placeholder,
 .scanner-error {
   position: absolute;
   top: 0;
@@ -96,242 +79,42 @@
   right: 0;
   bottom: 0;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
-  background: var(--bg-secondary, #f3f4f6);
-  color: var(--text-secondary, #6b7280);
+  background: #000;
 }
 
-.scanner-placeholder .camera-icon,
 .scanner-error .error-icon {
   font-size: 3rem;
 }
 
-.scanner-placeholder p,
-.scanner-error p {
-  margin: 0;
-  font-size: 1rem;
-  text-align: center;
-  padding: 0 20px;
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
-.scanner-error {
-  background: #fee;
-  color: #c00;
-}
-
-.scanner-controls {
-  margin-bottom: 24px;
-}
-
-.camera-select {
-  margin-bottom: 16px;
-}
-
-.camera-select label {
-  display: block;
-  font-size: 0.875rem;
-  font-weight: 600;
-  margin-bottom: 8px;
-  color: var(--text-primary, #1f2937);
-}
-
-.camera-select select {
-  width: 100%;
-  padding: 10px 12px;
-  border: 1px solid var(--border-color, #e5e7eb);
-  border-radius: 8px;
-  font-size: 0.875rem;
-  background: var(--bg-secondary, #f9fafb);
-  color: var(--text-primary, #1f2937);
-  cursor: pointer;
-}
-
-.camera-select select:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.camera-select select:focus {
-  outline: 2px solid var(--primary-color, #2563eb);
-  outline-offset: 0;
-  border-color: transparent;
-}
-
-.scanner-actions {
-  display: flex;
-  justify-content: center;
-}
-
-.start-scan-btn,
-.stop-scan-btn {
-  padding: 12px 32px;
-  border: none;
-  border-radius: 8px;
-  font-size: 1rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s;
-  font-family: inherit;
-}
-
-.start-scan-btn {
-  background: var(--primary-color, #2563eb);
-  color: white;
-}
-
-.start-scan-btn:hover:not(:disabled) {
-  background: var(--primary-hover, #1d4ed8);
-  transform: translateY(-1px);
-}
-
-.start-scan-btn:disabled {
-  background: var(--bg-secondary, #e5e7eb);
-  color: var(--text-secondary, #9ca3af);
-  cursor: not-allowed;
-}
-
-.stop-scan-btn {
-  background: #ef4444;
-  color: white;
-}
-
-.stop-scan-btn:hover {
-  background: #dc2626;
-  transform: translateY(-1px);
-}
-
-.start-scan-btn:active,
-.stop-scan-btn:active {
-  transform: translateY(0);
-}
-
-.start-scan-btn:focus,
-.stop-scan-btn:focus {
-  outline: 2px solid var(--primary-color, #2563eb);
-  outline-offset: 2px;
-}
-
-.scanner-instructions {
-  padding: 20px;
-  background: var(--bg-secondary, #f9fafb);
-  border-radius: 12px;
-  border: 1px solid var(--border-color, #e5e7eb);
-}
-
-.scanner-instructions h3 {
-  margin: 0 0 12px 0;
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--text-primary, #1f2937);
-}
-
-.scanner-instructions ol {
-  margin: 0 0 16px 0;
-  padding-left: 20px;
-}
-
-.scanner-instructions li {
-  margin-bottom: 8px;
-  font-size: 0.875rem;
-  color: var(--text-secondary, #6b7280);
-  line-height: 1.5;
-}
-
-.privacy-note {
-  margin: 0;
-  font-size: 0.875rem;
-  color: var(--text-secondary, #6b7280);
-  line-height: 1.5;
-  padding: 12px;
-  background: white;
-  border-radius: 8px;
-  border-left: 3px solid #10b981;
-}
-
-/* Dark mode support */
-@media (prefers-color-scheme: dark) {
-  .qr-scanner-modal {
-    background: var(--bg-primary, #1f2937);
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
   }
-
-  .qr-scanner-header {
-    border-bottom-color: var(--border-color, #374151);
-  }
-
-  .qr-scanner-header h2,
-  .camera-select label,
-  .scanner-instructions h3 {
-    color: var(--text-primary, #f9fafb);
-  }
-
-  .scanner-placeholder,
-  .scanner-instructions {
-    background: var(--bg-secondary, #374151);
-  }
-
-  .scanner-placeholder p,
-  .scanner-instructions li,
-  .privacy-note {
-    color: var(--text-secondary, #d1d5db);
-  }
-
-  .camera-select select {
-    background: var(--bg-secondary, #374151);
-    color: var(--text-primary, #f9fafb);
-    border-color: var(--border-color, #4b5563);
-  }
-
-  .start-scan-btn:disabled {
-    background: var(--bg-secondary, #4b5563);
-    color: var(--text-secondary, #6b7280);
-  }
-
-  .scanner-instructions {
-    border-color: var(--border-color, #4b5563);
-  }
-
-  .privacy-note {
-    background: #1f2937;
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 
-/* Responsive design */
 @media (max-width: 640px) {
   .qr-scanner-modal {
     width: 95%;
     max-height: 95vh;
   }
 
-  .qr-scanner-header {
-    padding: 16px 20px;
-  }
-
-  .qr-scanner-content {
-    padding: 20px;
-  }
-
   .scanner-container {
     min-height: 250px;
   }
 
-  .scanner-placeholder .camera-icon,
   .scanner-error .error-icon {
     font-size: 2rem;
-  }
-
-  .scanner-placeholder p,
-  .scanner-error p {
-    font-size: 0.875rem;
-  }
-
-  .scanner-instructions {
-    padding: 16px;
-  }
-
-  .scanner-instructions ol {
-    padding-left: 16px;
   }
 }

--- a/frontend/src/components/ui/QRScanner.jsx
+++ b/frontend/src/components/ui/QRScanner.jsx
@@ -1,30 +1,42 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { Html5Qrcode } from 'html5-qrcode'
+import { Html5Qrcode, Html5QrcodeScannerState } from 'html5-qrcode'
 import './QRScanner.css'
 
 function QRScanner({ isOpen, onClose, onScanSuccess }) {
   const [scanning, setScanning] = useState(false)
   const [starting, setStarting] = useState(false)
   const [error, setError] = useState(null)
-  const [cameras, setCameras] = useState([])
   const [selectedCamera, setSelectedCamera] = useState(null)
   const scannerRef = useRef(null)
   const html5QrCodeRef = useRef(null)
 
-  // Define stopScanning first as it's used by handleClose
-  const stopScanning = useCallback(async () => {
-    if (html5QrCodeRef.current && scanning) {
-      try {
-        await html5QrCodeRef.current.stop()
-        html5QrCodeRef.current = null
-        setScanning(false)
-      } catch (err) {
-        console.error('Error stopping scanner:', err)
-      }
+  // html5-qrcode throws "Cannot stop, scanner is not running or paused" if
+  // stop() is called outside the SCANNING/PAUSED states, which happens when
+  // the user closes the modal before start() has resolved.
+  const safeStop = useCallback(async () => {
+    const instance = html5QrCodeRef.current
+    if (!instance) return
+    if (html5QrCodeRef.current === instance) {
+      html5QrCodeRef.current = null
     }
-  }, [scanning])
+    try {
+      const state = instance.getState?.()
+      if (
+        state === Html5QrcodeScannerState.SCANNING ||
+        state === Html5QrcodeScannerState.PAUSED
+      ) {
+        await instance.stop()
+      }
+    } catch (err) {
+      console.error('Error stopping scanner:', err)
+    }
+  }, [])
 
-  // Define handleClose early so it can be used in useEffect
+  const stopScanning = useCallback(async () => {
+    await safeStop()
+    setScanning(false)
+  }, [safeStop])
+
   const handleClose = useCallback(async () => {
     await stopScanning()
     if (onClose) {
@@ -34,12 +46,9 @@ function QRScanner({ isOpen, onClose, onScanSuccess }) {
 
   useEffect(() => {
     if (isOpen) {
-      // Get available cameras
       Html5Qrcode.getCameras()
         .then((devices) => {
           if (devices && devices.length > 0) {
-            setCameras(devices)
-            // Prefer back camera on mobile
             const backCamera = devices.find((device) =>
               device.label.toLowerCase().includes('back')
             )
@@ -55,16 +64,10 @@ function QRScanner({ isOpen, onClose, onScanSuccess }) {
     }
 
     return () => {
-      // Cleanup on unmount
-      if (html5QrCodeRef.current) {
-        html5QrCodeRef.current
-          .stop()
-          .catch((err) => console.error('Error stopping scanner:', err))
-      }
+      safeStop()
     }
-  }, [isOpen])
+  }, [isOpen, safeStop])
 
-  // Handle Escape key press
   useEffect(() => {
     if (!isOpen) return
 
@@ -81,25 +84,22 @@ function QRScanner({ isOpen, onClose, onScanSuccess }) {
   }, [isOpen, handleClose])
 
   // Auto-start scanning as soon as a camera is selected.
-  // Skipping the "press Start" step is the intended UX — tapping a QR button
-  // in the parent should immediately activate the camera.
   useEffect(() => {
     if (!isOpen || !selectedCamera || scanning || starting || error) return
     if (html5QrCodeRef.current) return
     startScanning()
-    // startScanning closes over selectedCamera; re-running on its change is
-    // already covered by the deps. Other state values are checked above.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen, selectedCamera, scanning, starting, error])
 
   const startScanning = async () => {
     if (!selectedCamera || html5QrCodeRef.current) return
 
+    const html5QrCode = new Html5Qrcode('qr-reader')
+    html5QrCodeRef.current = html5QrCode
+
     try {
       setError(null)
       setStarting(true)
-      const html5QrCode = new Html5Qrcode('qr-reader')
-      html5QrCodeRef.current = html5QrCode
 
       await html5QrCode.start(
         selectedCamera,
@@ -108,19 +108,30 @@ function QRScanner({ isOpen, onClose, onScanSuccess }) {
           qrbox: { width: 250, height: 250 },
         },
         (decodedText) => {
-          // Success callback
           handleScanSuccess(decodedText)
         },
         () => {
-          // Error callback (scanning errors, not failures)
-          // This fires constantly while scanning, so we don't log it
+          // Per-frame decode failures fire continuously while scanning.
         }
       )
+
+      // The modal may have been closed while start() was in flight; if so,
+      // safeStop nulled the ref and we need to tear the new stream down now.
+      if (html5QrCodeRef.current !== html5QrCode) {
+        try {
+          await html5QrCode.stop()
+        } catch (err) {
+          console.error('Error stopping orphaned scanner:', err)
+        }
+        return
+      }
 
       setScanning(true)
     } catch (err) {
       console.error('Error starting scanner:', err)
-      html5QrCodeRef.current = null
+      if (html5QrCodeRef.current === html5QrCode) {
+        html5QrCodeRef.current = null
+      }
       setError('Failed to start camera. Please check permissions.')
     } finally {
       setStarting(false)
@@ -128,17 +139,14 @@ function QRScanner({ isOpen, onClose, onScanSuccess }) {
   }
 
   const handleScanSuccess = useCallback(async (decodedText) => {
-    // Stop scanning first
     await stopScanning()
 
-    // Parse the URL and extract market ID
     try {
       const url = new URL(decodedText)
       if (onScanSuccess) {
         onScanSuccess(decodedText, url)
       }
     } catch {
-      // If it's not a valid URL, still pass it along
       if (onScanSuccess) {
         onScanSuccess(decodedText)
       }
@@ -155,22 +163,6 @@ function QRScanner({ isOpen, onClose, onScanSuccess }) {
     e.stopPropagation()
   }
 
-  const handleCameraChange = async (e) => {
-    const newCameraId = e.target.value
-    
-    // If already scanning, restart with new camera
-    if (scanning) {
-      await stopScanning()
-      // Small delay to ensure cleanup, then set the new camera
-      setTimeout(() => {
-        setSelectedCamera(newCameraId)
-      }, 100)
-    } else {
-      // If not scanning, set immediately
-      setSelectedCamera(newCameraId)
-    }
-  }
-
   if (!isOpen) return null
 
   return (
@@ -179,84 +171,24 @@ function QRScanner({ isOpen, onClose, onScanSuccess }) {
       onClick={handleBackdropClick}
       role="dialog"
       aria-modal="true"
-      aria-labelledby="qr-scanner-title"
+      aria-label="QR code scanner"
       tabIndex={-1}
     >
       <div className="qr-scanner-modal" onClick={handleModalClick}>
-        <div className="qr-scanner-header">
-          <h2 id="qr-scanner-title">Scan QR Code</h2>
-          <button
-            className="qr-scanner-close"
-            onClick={handleClose}
-            aria-label="Close QR scanner"
-          >
-            ×
-          </button>
-        </div>
-
-        <div className="qr-scanner-content">
-          <div className="scanner-container">
-            <div id="qr-reader" ref={scannerRef}></div>
-
-            {!scanning && !error && (
-              <div className="scanner-placeholder">
-                <span className="camera-icon">📷</span>
-                <p>{starting || selectedCamera ? 'Starting camera…' : 'Detecting cameras…'}</p>
-              </div>
-            )}
-
-            {error && (
-              <div className="scanner-error">
-                <span className="error-icon">⚠️</span>
-                <p>{error}</p>
-              </div>
-            )}
-          </div>
-
-          <div className="scanner-controls">
-            {cameras.length > 1 && (
-              <div className="camera-select">
-                <label htmlFor="camera-select">Select Camera:</label>
-                <select
-                  id="camera-select"
-                  value={selectedCamera || ''}
-                  onChange={handleCameraChange}
-                  disabled={starting}
-                >
-                  {cameras.map((camera) => (
-                    <option key={camera.id} value={camera.id}>
-                      {camera.label || `Camera ${camera.id}`}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            )}
-
-            {scanning && (
-              <div className="scanner-actions">
-                <button
-                  className="stop-scan-btn"
-                  onClick={stopScanning}
-                  aria-label="Stop scanning QR code"
-                >
-                  ⏹️ Stop Scanning
-                </button>
-              </div>
-            )}
-          </div>
-
-          <div className="scanner-instructions">
-            <h3>How to Scan</h3>
-            <ol>
-              <li>Allow camera access when prompted</li>
-              <li>Point your camera at a market QR code</li>
-              <li>Hold steady until the code is detected</li>
-              <li>You'll be automatically redirected to the market</li>
-            </ol>
-            <p className="privacy-note">
-              🔒 Your camera feed is processed locally on your device and is not recorded or transmitted.
-            </p>
-          </div>
+        <button
+          className="qr-scanner-close"
+          onClick={handleClose}
+          aria-label="Close QR scanner"
+        >
+          ×
+        </button>
+        <div className="scanner-container">
+          <div id="qr-reader" ref={scannerRef}></div>
+          {error && (
+            <div className="scanner-error" role="alert" aria-label={error}>
+              <span className="error-icon" aria-hidden="true">⚠️</span>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/test/QRScanner.test.jsx
+++ b/frontend/src/test/QRScanner.test.jsx
@@ -6,17 +6,42 @@ import QRScanner from '../components/ui/QRScanner'
 
 // Mock html5-qrcode
 vi.mock('html5-qrcode', () => {
-  const MockHtml5Qrcode = vi.fn().mockImplementation(() => ({
-    start: vi.fn().mockResolvedValue(undefined),
-    stop: vi.fn().mockResolvedValue(undefined),
-  }))
+  const Html5QrcodeScannerState = {
+    UNKNOWN: 0,
+    NOT_STARTED: 1,
+    SCANNING: 2,
+    PAUSED: 3,
+  }
+
+  function MockHtml5QrcodeImpl() {
+    let state = Html5QrcodeScannerState.NOT_STARTED
+    return {
+      start: vi.fn().mockImplementation(async () => {
+        state = Html5QrcodeScannerState.SCANNING
+      }),
+      stop: vi.fn().mockImplementation(async () => {
+        if (
+          state !== Html5QrcodeScannerState.SCANNING &&
+          state !== Html5QrcodeScannerState.PAUSED
+        ) {
+          throw new Error('Cannot stop, scanner is not running or paused.')
+        }
+        state = Html5QrcodeScannerState.NOT_STARTED
+      }),
+      getState: vi.fn(() => state),
+    }
+  }
+  const MockHtml5Qrcode = vi.fn().mockImplementation(function () {
+    return MockHtml5QrcodeImpl()
+  })
   MockHtml5Qrcode.getCameras = vi.fn().mockResolvedValue([
     { id: 'camera1', label: 'Mock Camera 1' },
     { id: 'camera2', label: 'Mock Back Camera' }
   ])
-  
+
   return {
-    Html5Qrcode: MockHtml5Qrcode
+    Html5Qrcode: MockHtml5Qrcode,
+    Html5QrcodeScannerState,
   }
 })
 
@@ -44,7 +69,7 @@ describe('QRScanner Component', () => {
       expect(container.firstChild).toBeNull()
     })
 
-    it('renders when isOpen is true', () => {
+    it('renders the scanner dialog when isOpen is true', () => {
       render(
         <QRScanner
           isOpen={true}
@@ -53,47 +78,20 @@ describe('QRScanner Component', () => {
         />
       )
       expect(screen.getByRole('dialog')).toBeInTheDocument()
-      expect(screen.getByText('Scan QR Code')).toBeInTheDocument()
     })
 
-    it('shows a starting/detecting indicator before the camera is live', () => {
-      render(
+    it('renders only the camera view chrome — no instructional text', () => {
+      const { container } = render(
         <QRScanner
           isOpen={true}
           onClose={mockOnClose}
           onScanSuccess={mockOnScanSuccess}
         />
       )
-      // Auto-start UX: the user never sees a "press to scan" landing page —
-      // either we're detecting cameras or we're starting the stream.
-      expect(
-        screen.getByText(/Detecting cameras…|Starting camera…/)
-      ).toBeInTheDocument()
-    })
-
-    it('displays scanner instructions', () => {
-      render(
-        <QRScanner
-          isOpen={true}
-          onClose={mockOnClose}
-          onScanSuccess={mockOnScanSuccess}
-        />
-      )
-      expect(screen.getByText('How to Scan')).toBeInTheDocument()
-      expect(screen.getByText(/Allow camera access when prompted/i)).toBeInTheDocument()
-    })
-
-    it('displays privacy note', () => {
-      render(
-        <QRScanner
-          isOpen={true}
-          onClose={mockOnClose}
-          onScanSuccess={mockOnScanSuccess}
-        />
-      )
-      expect(
-        screen.getByText(/Your camera feed is processed locally/i)
-      ).toBeInTheDocument()
+      // The modal exposes the close button (a symbol) and the camera target;
+      // no headings, instructions, or privacy notes should appear.
+      expect(container.querySelectorAll('h1, h2, h3, p, ol, ul, li')).toHaveLength(0)
+      expect(container.querySelector('#qr-reader')).toBeInTheDocument()
     })
 
     it('does not render a manual "Start Scanning" button (scanning auto-starts)', () => {
@@ -122,7 +120,41 @@ describe('QRScanner Component', () => {
       const closeButton = screen.getByLabelText('Close QR scanner')
       await user.click(closeButton)
 
-      expect(mockOnClose).toHaveBeenCalledTimes(1)
+      await waitFor(() => {
+        expect(mockOnClose).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    it('does not log "Cannot stop" when closing before scanner has started', async () => {
+      const user = userEvent.setup()
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      render(
+        <QRScanner
+          isOpen={true}
+          onClose={mockOnClose}
+          onScanSuccess={mockOnScanSuccess}
+        />
+      )
+
+      // Close immediately — before start() has resolved, the scanner is in
+      // NOT_STARTED. Previously this would surface the html5-qrcode error.
+      const closeButton = screen.getByLabelText('Close QR scanner')
+      await user.click(closeButton)
+
+      await waitFor(() => {
+        expect(mockOnClose).toHaveBeenCalled()
+      })
+
+      const stopCalls = consoleErrorSpy.mock.calls.filter((args) =>
+        args.some(
+          (arg) =>
+            typeof arg === 'string' && arg.includes('Error stopping scanner')
+        )
+      )
+      expect(stopCalls).toHaveLength(0)
+
+      consoleErrorSpy.mockRestore()
     })
 
     it('calls onClose when backdrop is clicked', async () => {
@@ -138,7 +170,9 @@ describe('QRScanner Component', () => {
       const backdrop = container.querySelector('.qr-scanner-backdrop')
       await user.click(backdrop)
 
-      expect(mockOnClose).toHaveBeenCalledTimes(1)
+      await waitFor(() => {
+        expect(mockOnClose).toHaveBeenCalledTimes(1)
+      })
     })
 
     it('does not close when modal content is clicked', async () => {
@@ -171,7 +205,9 @@ describe('QRScanner Component', () => {
 
       await user.keyboard('{Escape}')
 
-      expect(mockOnClose).toHaveBeenCalledTimes(1)
+      await waitFor(() => {
+        expect(mockOnClose).toHaveBeenCalledTimes(1)
+      })
     })
   })
 
@@ -199,12 +235,12 @@ describe('QRScanner Component', () => {
 
       const dialog = screen.getByRole('dialog')
       expect(dialog).toHaveAttribute('aria-modal', 'true')
-      expect(dialog).toHaveAttribute('aria-labelledby', 'qr-scanner-title')
+      expect(dialog).toHaveAttribute('aria-label', 'QR code scanner')
     })
   })
 
   describe('Error Handling', () => {
-    it('displays error message when camera access fails', async () => {
+    it('exposes an alert role when camera access fails', async () => {
       const { Html5Qrcode } = await import('html5-qrcode')
       Html5Qrcode.getCameras = vi.fn().mockRejectedValue(new Error('No cameras'))
 
@@ -217,9 +253,9 @@ describe('QRScanner Component', () => {
       )
 
       await waitFor(() => {
-        expect(
-          screen.getByText(/Unable to access camera/i)
-        ).toBeInTheDocument()
+        const alert = screen.getByRole('alert')
+        expect(alert).toBeInTheDocument()
+        expect(alert).toHaveAttribute('aria-label', expect.stringMatching(/camera/i))
       })
     })
   })


### PR DESCRIPTION
The "Cannot stop, scanner is not running or paused" error fired when the
close button was pressed before html5-qrcode finished starting the camera:
`scanning` was still false, so stopScanning no-opped, then the effect
cleanup unconditionally called stop() on a NOT_STARTED scanner.

Gate every stop() call on getState() returning SCANNING or PAUSED, and
detect the close-during-start race so the orphaned stream is torn down
once start() resolves.

Also remove the heading, instructions, privacy note, camera selector and
button labels — the modal is now just the live camera preview with a
floating close button, per the requested UX.