### PR TITLE
fix(frontend): restore wager modal scroll + spacing CSS

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.css
+++ b/frontend/src/components/fairwins/FriendMarketsModal.css
@@ -126,11 +126,172 @@
   cursor: not-allowed;
 }
 
+/* Tab Navigation */
+.fm-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--border-color, #23303D);
+  background: var(--bg-primary, #0E141B);
+  flex-shrink: 0;
+}
+
+.fm-tab {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.875rem 1rem;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-secondary, #AAB6C2);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.fm-tab:hover:not(:disabled) {
+  color: var(--text-primary, #E6EDF3);
+  background: rgba(54, 179, 126, 0.05);
+}
+
+.fm-tab.active {
+  color: #36B37E;
+  border-bottom-color: #36B37E;
+  background: rgba(54, 179, 126, 0.08);
+}
+
+.fm-tab:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.fm-tab svg {
+  flex-shrink: 0;
+}
+
+.fm-tab-badge {
+  background: #36B37E;
+  color: white;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.15rem 0.4rem;
+  border-radius: 10px;
+  min-width: 18px;
+  text-align: center;
+}
+
+/* Content Area - scrolls within the fixed-height modal */
+.fm-content {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 1.25rem 1.5rem;
+}
+
+.fm-panel {
+  height: 100%;
+}
+
+/* Section Title */
+.fm-section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary, #E6EDF3);
+  margin: 0 0 1rem 0;
+  text-align: center;
+}
+
+/* Type Selection */
+.fm-type-selection {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.fm-type-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.fm-type-card {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  background: var(--bg-primary, #0E141B);
+  border: 1px solid var(--border-color, #23303D);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-align: left;
+}
+
+.fm-type-card:hover {
+  border-color: #36B37E;
+  background: rgba(54, 179, 126, 0.08);
+  transform: translateX(4px);
+}
+
+.fm-type-icon {
+  font-size: 2rem;
+  flex-shrink: 0;
+}
+
+.fm-type-info {
+  flex: 1;
+}
+
+.fm-type-info h4 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary, #E6EDF3);
+  margin: 0 0 0.25rem 0;
+}
+
+.fm-type-info p {
+  font-size: 0.8rem;
+  color: var(--text-secondary, #AAB6C2);
+  margin: 0;
+}
+
+.fm-type-arrow {
+  color: var(--text-secondary, #AAB6C2);
+  flex-shrink: 0;
+  transition: transform 0.2s;
+}
+
+.fm-type-card:hover .fm-type-arrow {
+  color: #36B37E;
+  transform: translateX(4px);
+}
+
 /* Form */
 .fm-form {
   display: flex;
   flex-direction: column;
   height: 100%;
+}
+
+.fm-form-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.25rem;
+}
+
+.fm-form-type-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  background: rgba(54, 179, 126, 0.15);
+  color: #36B37E;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.375rem 0.75rem;
+  border-radius: 20px;
 }
 
 .fm-form-grid {


### PR DESCRIPTION
The FriendMarketsModal refactor that focused the modal on creation
(e807e17) accidentally deleted the styles for .fm-content, .fm-tabs,
.fm-tab, .fm-tab-badge, .fm-panel, .fm-section-title, .fm-type-*,
.fm-form-header, and .fm-form-type-badge. The JSX still renders all of
those classes, so the form lost its container padding, the tab strip
collapsed, and — most disruptive — the content area no longer scrolled
inside the fixed-height modal, leaving the bottom of the create-wager
form unreachable on mobile.

Restore the removed rules so .fm-content is a scrollable flex child
(flex: 1; min-height: 0; overflow-y: auto) with the original 1.25rem
1.5rem padding, and bring back the tab/type-card/form-header styling
that goes with them.