### PR TITLE
fix(oracles): adapter ownership under deterministic deploy + Amoy v2 deploy

### DIFF
--- a/contracts/oracles/ChainlinkDataFeedOracleAdapter.sol
+++ b/contracts/oracles/ChainlinkDataFeedOracleAdapter.sol
@@ -47,7 +47,7 @@ contract ChainlinkDataFeedOracleAdapter is IOracleAdapter, Ownable, ReentrancyGu
     error InvalidDeadline();
     error MarketAlreadyLinked();
 
-    constructor() Ownable(msg.sender) {}
+    constructor(address admin) Ownable(admin) {}
 
     // ========== Admin ==========
 

--- a/contracts/oracles/ChainlinkFunctionsOracleAdapter.sol
+++ b/contracts/oracles/ChainlinkFunctionsOracleAdapter.sol
@@ -49,7 +49,7 @@ contract ChainlinkFunctionsOracleAdapter is IOracleAdapter, FunctionsClient, Con
     error AlreadyResolved();
     error MarketAlreadyLinked();
 
-    constructor(address _router) FunctionsClient(_router) ConfirmedOwner(msg.sender) {
+    constructor(address admin, address _router) FunctionsClient(_router) ConfirmedOwner(admin) {
         if (_router == address(0)) revert RouterHasNoCode();
         router = _router;
     }

--- a/contracts/oracles/UMAOptimisticOracleV3Adapter.sol
+++ b/contracts/oracles/UMAOptimisticOracleV3Adapter.sol
@@ -75,7 +75,7 @@ contract UMAOptimisticOracleV3Adapter is
         _;
     }
 
-    constructor(address _oo) Ownable(msg.sender) {
+    constructor(address admin, address _oo) Ownable(admin) {
         if (_oo == address(0)) revert InvalidAddress();
         oo = OptimisticOracleV3Interface(_oo);
     }

--- a/deployments/amoy-chain80002-v2.json
+++ b/deployments/amoy-chain80002-v2.json
@@ -1,0 +1,23 @@
+{
+  "network": "amoy",
+  "chainId": 80002,
+  "deployer": "0x52502d049571C7893447b86c4d8B38e6184bF6e1",
+  "treasury": "0x52502d049571C7893447b86c4d8B38e6184bF6e1",
+  "paymentToken": "0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582",
+  "wmatic": "0x0ae690AAD8663aaB12a671A6A0d74242332de85f",
+  "polymarketCTF": "0x95F40ea10E6C51892783c4E7721Ada1425917e22",
+  "contracts": {
+    "polymarketAdapter": "0x423d2Ca885d67E46062CFF732Eff952f4F736136",
+    "membershipManager": "0xFaEbF662aa591fF95e97306b413522efC958540f",
+    "wagerRegistry": "0x39f1CbC680cDc9831b6dF4D9e4719D3748720aBA",
+    "keyRegistry": "0xb314c4Ee52D9D89bf7FEE66a43aBeAc7D047a5Cb",
+    "chainlinkDataFeedAdapter": "0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23",
+    "chainlinkFunctionsAdapter": "0x074fC18C1E322a7537b53B8B2Bf0762629E3b532",
+    "umaAdapter": "0xcEa9b4A01CcD3aA6545ea834a268C69e7eEfee88"
+  },
+  "mocks": {
+    "mockPolymarketCTF": "0x95F40ea10E6C51892783c4E7721Ada1425917e22"
+  },
+  "saltPrefix": "FairWins-P2P-v2.0-",
+  "timestamp": "2026-05-22T23:42:28.536Z"
+}

--- a/frontend/src/abis/ChainlinkDataFeedOracleAdapter.js
+++ b/frontend/src/abis/ChainlinkDataFeedOracleAdapter.js
@@ -1,0 +1,592 @@
+// Auto-generated from artifacts/contracts/oracles/ChainlinkDataFeedOracleAdapter.sol/ChainlinkDataFeedOracleAdapter.json
+// Regenerate by re-running scripts/deploy/deploy.js (recompiles) then copying ABI.
+export const CHAINLINK_DATA_FEED_ORACLE_ADAPTER_ABI = [
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "admin",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AlreadyResolved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ConditionAlreadyRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ConditionNotRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DeadlineNotReached",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FeedNotAllowed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidComparisonOp",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidDeadline",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MarketAlreadyLinked",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "StaleFeedData",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "answer",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      }
+    ],
+    "name": "ConditionEvaluated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expectedResolutionTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "ConditionRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "confidence",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "resolvedAt",
+        "type": "uint256"
+      }
+    ],
+    "name": "ConditionResolved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "feed",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "allowed",
+        "type": "bool"
+      }
+    ],
+    "name": "FeedAllowed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "friendMarketId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "MarketLinked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "allowedFeeds",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "conditions",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "feed",
+        "type": "address"
+      },
+      {
+        "internalType": "int256",
+        "name": "threshold",
+        "type": "int256"
+      },
+      {
+        "internalType": "enum ChainlinkDataFeedOracleAdapter.Comparison",
+        "name": "op",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint64",
+        "name": "deadline",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "registered",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "evaluate",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getConditionMetadata",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expectedResolutionTime",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getConfiguredChainId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getOutcome",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "confidence",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "resolvedAt",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isAvailable",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isConditionResolved",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isConditionSupported",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "friendMarketId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "linkMarket",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "marketToCondition",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oracleType",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "feed",
+        "type": "address"
+      },
+      {
+        "internalType": "int256",
+        "name": "threshold",
+        "type": "int256"
+      },
+      {
+        "internalType": "enum ChainlinkDataFeedOracleAdapter.Comparison",
+        "name": "op",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint64",
+        "name": "deadline",
+        "type": "uint64"
+      }
+    ],
+    "name": "registerCondition",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "resolutionCache",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint64",
+        "name": "resolvedAt",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint96",
+        "name": "confidence",
+        "type": "uint96"
+      },
+      {
+        "internalType": "bool",
+        "name": "exists",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "feed",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "allowed",
+        "type": "bool"
+      }
+    ],
+    "name": "setFeedAllowed",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+];

--- a/frontend/src/abis/ChainlinkFunctionsOracleAdapter.js
+++ b/frontend/src/abis/ChainlinkFunctionsOracleAdapter.js
@@ -1,0 +1,662 @@
+// Auto-generated from artifacts/contracts/oracles/ChainlinkFunctionsOracleAdapter.sol/ChainlinkFunctionsOracleAdapter.json
+// Regenerate by re-running scripts/deploy/deploy.js (recompiles) then copying ABI.
+export const CHAINLINK_FUNCTIONS_ORACLE_ADAPTER_ABI = [
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "admin",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_router",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AlreadyResolved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ConditionAlreadyRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ConditionNotRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidResponseLength",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MarketAlreadyLinked",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyRouterCanFulfill",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "RequestAlreadyPending",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "RouterHasNoCode",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnknownRequestId",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expectedResolutionTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "ConditionRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "confidence",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "resolvedAt",
+        "type": "uint256"
+      }
+    ],
+    "name": "ConditionResolved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "friendMarketId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "MarketLinked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferRequested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "requestId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "err",
+        "type": "bytes"
+      }
+    ],
+    "name": "RequestFailed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RequestFulfilled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RequestSent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "requestId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ResolutionRequested",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "conditionToPendingRequest",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "conditions",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "sourceHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "encodedRequest",
+        "type": "bytes"
+      },
+      {
+        "internalType": "uint64",
+        "name": "subscriptionId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint32",
+        "name": "gasLimit",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "donId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "registered",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getConditionMetadata",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expectedResolutionTime",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getConfiguredChainId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getOutcome",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "confidence",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "resolvedAt",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "requestId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "response",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "err",
+        "type": "bytes"
+      }
+    ],
+    "name": "handleOracleFulfillment",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isAvailable",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isConditionResolved",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isConditionSupported",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "friendMarketId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "linkMarket",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "marketToCondition",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oracleType",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "encodedRequest",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "sourceHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint64",
+        "name": "subscriptionId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint32",
+        "name": "gasLimit",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "donId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "registerCondition",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "requestResolution",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "requestId",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "requestToCondition",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "resolutionCache",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint64",
+        "name": "resolvedAt",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint96",
+        "name": "confidence",
+        "type": "uint96"
+      },
+      {
+        "internalType": "bool",
+        "name": "exists",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "router",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+];

--- a/frontend/src/abis/UMAOptimisticOracleV3Adapter.js
+++ b/frontend/src/abis/UMAOptimisticOracleV3Adapter.js
@@ -1,0 +1,671 @@
+// Auto-generated from artifacts/contracts/oracles/UMAOptimisticOracleV3Adapter.sol/UMAOptimisticOracleV3Adapter.json
+// Regenerate by re-running scripts/deploy/deploy.js (recompiles) then copying ABI.
+export const UMA_OPTIMISTIC_ORACLE_V3_ADAPTER_ABI = [
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "admin",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_oo",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AlreadyResolved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AssertionAlreadyPending",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ConditionAlreadyRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ConditionNotRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LivenessTooShort",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MarketAlreadyLinked",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OOHasNoCode",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "SafeERC20FailedOperation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnauthorizedCallback",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnknownAssertion",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assertionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "AssertionDisputed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assertionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "asserter",
+        "type": "address"
+      }
+    ],
+    "name": "AssertionMade",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expectedResolutionTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "ConditionRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "confidence",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "resolvedAt",
+        "type": "uint256"
+      }
+    ],
+    "name": "ConditionResolved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "friendMarketId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "MarketLinked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "MIN_LIVENESS",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "asserter",
+        "type": "address"
+      }
+    ],
+    "name": "assertResolution",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "assertionId",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "assertionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "assertionDisputedCallback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "assertionId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "assertedTruthfully",
+        "type": "bool"
+      }
+    ],
+    "name": "assertionResolvedCallback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "assertionToCondition",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "conditionToAssertion",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "conditions",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "claim",
+        "type": "bytes"
+      },
+      {
+        "internalType": "address",
+        "name": "bondCurrency",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bondAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint64",
+        "name": "liveness",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "registered",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getConditionMetadata",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expectedResolutionTime",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getConfiguredChainId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getOutcome",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "confidence",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "resolvedAt",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isAvailable",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isConditionResolved",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isConditionSupported",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "friendMarketId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "linkMarket",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "marketToCondition",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oo",
+    "outputs": [
+      {
+        "internalType": "contract OptimisticOracleV3Interface",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oracleType",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "claim",
+        "type": "bytes"
+      },
+      {
+        "internalType": "address",
+        "name": "bondCurrency",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bondAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint64",
+        "name": "liveness",
+        "type": "uint64"
+      }
+    ],
+    "name": "registerCondition",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "resolutionCache",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint64",
+        "name": "resolvedAt",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint96",
+        "name": "confidence",
+        "type": "uint96"
+      },
+      {
+        "internalType": "bool",
+        "name": "exists",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+];

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -48,13 +48,16 @@ const AMOY_CONTRACTS = {
   deployer: '0x52502d049571C7893447b86c4d8B38e6184bF6e1',
   treasury: '0x52502d049571C7893447b86c4d8B38e6184bF6e1',
   // v2 core (populated by `npm run sync:frontend-contracts -- --network amoy --chainId 80002`)
-  wagerRegistry: '',
-  membershipManager: '',
-  keyRegistry: '',
-  polymarketAdapter: '',
+  wagerRegistry: '0x39f1CbC680cDc9831b6dF4D9e4719D3748720aBA',
+  membershipManager: '0xFaEbF662aa591fF95e97306b413522efC958540f',
+  keyRegistry: '0xb314c4Ee52D9D89bf7FEE66a43aBeAc7D047a5Cb',
+  polymarketAdapter: '0x423d2Ca885d67E46062CFF732Eff952f4F736136',
   // Stake / payment tokens (Circle USDC + Wrapped MATIC on Amoy)
   paymentToken: '0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582',
   wmatic: '0x0ae690AAD8663aaB12a671A6A0d74242332de85f',
+  chainlinkDataFeedAdapter: '0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23',
+  chainlinkFunctionsAdapter: '0x074fC18C1E322a7537b53B8B2Bf0762629E3b532',
+  umaAdapter: '0xcEa9b4A01CcD3aA6545ea834a268C69e7eEfee88',
 }
 
 const NETWORK_CONTRACTS = {

--- a/frontend/src/constants/wagerDefaults.js
+++ b/frontend/src/constants/wagerDefaults.js
@@ -73,27 +73,43 @@ export const DisputeStatus = {
 }
 
 // ── Resolution types (on-chain enum) ────────────────────────────────
-// Mirrors contracts/markets/FriendGroupMarketTypes.sol ResolutionType
+// Mirrors `enum ResolutionType` in contracts/interfaces/IWagerRegistry.sol.
+// Keep in lock-step with the contract — value ordering is wire-stable.
 export const ResolutionType = {
-  EITHER: 0,
-  INITIATOR: 1,
-  RECEIVER: 2,
-  THIRD_PARTY: 3,
-  AUTO_PEGGED: 4,
-  POLYMARKET_ORACLE: 5,
+  Either: 0,
+  Creator: 1,
+  Opponent: 2,
+  ThirdParty: 3,
+  Polymarket: 4,
+  ChainlinkDataFeed: 5,
+  ChainlinkFunctions: 6,
+  UMA: 7,
 }
+
+// Resolution types that require an `oracleConditionId` to be passed to
+// WagerRegistry.createWager (called `polymarketConditionId` on-chain for
+// legacy naming). Anything in this set needs a pre-registered conditionId
+// on the corresponding adapter.
+export const ORACLE_RESOLUTION_TYPES = new Set([
+  ResolutionType.Polymarket,
+  ResolutionType.ChainlinkDataFeed,
+  ResolutionType.ChainlinkFunctions,
+  ResolutionType.UMA,
+])
 
 export const ResolutionTypeNames = {
   0: 'Either',
-  1: 'Initiator',
-  2: 'Receiver',
+  1: 'Creator',
+  2: 'Opponent',
   3: 'Third Party',
-  4: 'Auto-Pegged',
-  5: 'Polymarket Oracle',
+  4: 'Polymarket',
+  5: 'Chainlink Data Feed',
+  6: 'Chainlink Functions',
+  7: 'UMA Optimistic Oracle',
 }
 
-// Sort order for "Resolution type" grouping in My Wagers
-export const ResolutionTypeOrder = [0, 1, 2, 3, 4, 5]
+// Sort order for "Resolution type" grouping in My Wagers. Mirrors enum order.
+export const ResolutionTypeOrder = [0, 1, 2, 3, 4, 5, 6, 7]
 
 // ── Sort keys for My Wagers list ────────────────────────────────────
 export const WagerSortKey = {

--- a/frontend/src/hooks/useFriendMarketCreation.js
+++ b/frontend/src/hooks/useFriendMarketCreation.js
@@ -3,6 +3,7 @@ import { ethers } from 'ethers'
 import { useWeb3 } from './useWeb3'
 import { getContractAddress } from '../config/contracts'
 import { WAGER_REGISTRY_ABI } from '../abis/WagerRegistry'
+import { ResolutionType, ORACLE_RESOLUTION_TYPES } from '../constants/wagerDefaults'
 import {
   uploadEncryptedEnvelope,
   buildEncryptedIpfsReference
@@ -16,14 +17,7 @@ const ERC20_ABI = [
   'function symbol() view returns (string)',
 ]
 
-// New ResolutionType enum — matches WagerRegistry contract
-export const ResolutionType = {
-  Either: 0,
-  Creator: 1,
-  Opponent: 2,
-  ThirdParty: 3,
-  Polymarket: 4,
-}
+export { ResolutionType, ORACLE_RESOLUTION_TYPES }
 
 // localStorage helpers — preserved for backward-compat with FriendMarketsModal callers
 const PENDING_TX_KEY = 'pendingFriendMarketTx'

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -250,6 +250,7 @@ module.exports = {
       url: process.env.AMOY_RPC_URL || "https://rpc-amoy.polygon.technology",
       chainId: 80002,
       accounts: floppyKeys,
+      ...(process.env.GAS_PRICE_WEI ? { gasPrice: Number(process.env.GAS_PRICE_WEI) } : {}),
     },
     // Example: Mainnet with floppy keystore (uncomment when ready to use)
     // Requires: npm run floppy:mount && npm run floppy:create (one-time setup)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3044,116 +3044,6 @@
         "events": "^3.2.0"
       }
     },
-    "node_modules/@ledgerhq/hw-transport-node-hid": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-5.26.0.tgz",
-      "integrity": "sha512-qhaefZVZatJ6UuK8Wb6WSFNOLWc2mxcv/xgsfKi5HJCIr4bPF/ecIeN+7fRcEaycxj4XykY6Z4A7zDVulfFH4w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@ledgerhq/devices": "^5.26.0",
-        "@ledgerhq/errors": "^5.26.0",
-        "@ledgerhq/hw-transport": "^5.26.0",
-        "@ledgerhq/hw-transport-node-hid-noevents": "^5.26.0",
-        "@ledgerhq/logs": "^5.26.0",
-        "lodash": "^4.17.20",
-        "node-hid": "1.3.0",
-        "usb": "^1.6.3"
-      }
-    },
-    "node_modules/@ledgerhq/hw-transport-node-hid-noevents": {
-      "version": "5.51.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-node-hid-noevents/-/hw-transport-node-hid-noevents-5.51.1.tgz",
-      "integrity": "sha512-9wFf1L8ZQplF7XOY2sQGEeOhpmBRzrn+4X43kghZ7FBDoltrcK+s/D7S+7ffg3j2OySyP6vIIIgloXylao5Scg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@ledgerhq/devices": "^5.51.1",
-        "@ledgerhq/errors": "^5.50.0",
-        "@ledgerhq/hw-transport": "^5.51.1",
-        "@ledgerhq/logs": "^5.50.0",
-        "node-hid": "2.1.1"
-      }
-    },
-    "node_modules/@ledgerhq/hw-transport-node-hid-noevents/node_modules/@ledgerhq/hw-transport": {
-      "version": "5.51.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-5.51.1.tgz",
-      "integrity": "sha512-6wDYdbWrw9VwHIcoDnqWBaDFyviyjZWv6H9vz9Vyhe4Qd7TIFmbTl/eWs6hZvtZBza9K8y7zD8ChHwRI4s9tSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@ledgerhq/devices": "^5.51.1",
-        "@ledgerhq/errors": "^5.50.0",
-        "events": "^3.3.0"
-      }
-    },
-    "node_modules/@ledgerhq/hw-transport-node-hid-noevents/node_modules/node-addon-api": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@ledgerhq/hw-transport-node-hid-noevents/node_modules/node-hid": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/node-hid/-/node-hid-2.1.1.tgz",
-      "integrity": "sha512-Skzhqow7hyLZU93eIPthM9yjot9lszg9xrKxESleEs05V2NcbUptZc5HFqzjOkSmL0sFlZFr3kmvaYebx06wrw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "(MIT OR X11)",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^3.0.2",
-        "prebuild-install": "^6.0.0"
-      },
-      "bin": {
-        "hid-showdevices": "src/show-devices.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@ledgerhq/hw-transport-node-hid-noevents/node_modules/prebuild-install": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.4.tgz",
-      "integrity": "sha512-Z4vpywnK1lBg+zdPCVCsKq0xO66eEV9rWo2zrROGGiRS4JtueBOdlB1FnY8lcy7JsUud/Q3ijUxyWN26Ika0vQ==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.21.0",
-        "npmlog": "^4.0.1",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@ledgerhq/hw-transport-u2f": {
       "version": "5.26.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-5.26.0.tgz",
@@ -8159,77 +8049,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/are-we-there-yet": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
-    },
-    "node_modules/are-we-there-yet/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/are-we-there-yet/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/are-we-there-yet/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/are-we-there-yet/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -8685,20 +8504,6 @@
       "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/blakejs": {
@@ -10007,15 +9812,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/constant-case": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
@@ -10414,21 +10210,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "mimic-response": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -10508,15 +10289,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -10557,21 +10329,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/detect-port": {
@@ -12576,18 +12333,6 @@
         "safe-buffer": "^5.1.1"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "dev": true,
-      "license": "(MIT OR WTFPL)",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/express": {
       "version": "4.22.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
@@ -13114,15 +12859,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -13204,94 +12940,6 @@
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "node_modules/gauge/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gauge/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gauge/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/gauge/node_modules/string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gauge/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/gaxios": {
       "version": "5.1.3",
@@ -13527,15 +13175,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/glob": {
       "version": "10.5.0",
@@ -14361,15 +14000,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true
     },
     "node_modules/hash-base": {
       "version": "3.1.2",
@@ -16536,21 +16166,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/min-document": {
       "version": "2.19.2",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.2.tgz",
@@ -16644,15 +16259,6 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/mkdirp-promise": {
       "version": "5.0.1",
@@ -17012,15 +16618,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/napi-build-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/ndjson": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-2.0.0.tgz",
@@ -17080,30 +16677,6 @@
       "license": "MIT",
       "dependencies": {
         "lower-case": "^1.1.1"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
-      "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "semver": "^5.4.1"
-      }
-    },
-    "node_modules/node-abi/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/node-addon-api": {
@@ -17203,28 +16776,6 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
-    "node_modules/node-hid": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/node-hid/-/node-hid-1.3.0.tgz",
-      "integrity": "sha512-BA6G4V84kiNd1uAChub/Z/5s/xS3EHBCxotQ0nyYrUG65mXewUDHE1tWOSqA2dp3N+mV0Ffq9wo2AW9t4p/G7g==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "(MIT OR X11)",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.14.0",
-        "node-abi": "^2.18.0",
-        "prebuild-install": "^5.3.4"
-      },
-      "bin": {
-        "hid-showdevices": "src/show-devices.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/node-metamask": {
       "version": "1.1.2",
       "resolved": "git+ssh://git@github.com/UMAprotocol/node-metamask.git#36b33cb82558bafcd3ab0dcfbd35b26c2c0a2584",
@@ -17264,15 +16815,6 @@
       "engines": {
         "node": ">=12.19"
       }
-    },
-    "node_modules/noop-logger": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-      "integrity": "sha512-6kM8CLXvuW5crTxsAtva2YLrRrDaiTIkIePWs9moLHqbFWT94WpNFjwS/5dfLfECg5i/lkmw3aoqVidxt23TEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/nopt": {
       "version": "3.0.6",
@@ -17331,22 +16873,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
       }
     },
     "node_modules/nth-check": {
@@ -18229,39 +17755,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
-      "integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^2.7.0",
-        "noop-logger": "^0.1.1",
-        "npmlog": "^4.0.1",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^3.0.3",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0",
-        "which-pm-runs": "^1.0.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/precond": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
@@ -18830,36 +18323,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/read-pkg": {
@@ -20181,20 +19644,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/simple-get": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-      "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "decompress-response": "^4.2.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -21080,40 +20529,6 @@
       },
       "engines": {
         "node": ">=4.5"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tar/node_modules/minipass": {
@@ -22222,32 +21637,6 @@
       "integrity": "sha512-3AChu4NiXquPfeckE5R5cGdiHCMWJx1dwCWOmWIL4KHAziJNOFIYJlpGFeKDvwLPHovZRCxK3cYlwzqI9Vp+Gg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/usb": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/usb/-/usb-1.9.2.tgz",
-      "integrity": "sha512-dryNz030LWBPAf6gj8vyq0Iev3vPbCLHCT8dBw3gQRXRzVNsIdeuU+VjPp3ksmSPkeMAl1k+kQ14Ij0QHyeiAg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-addon-api": "^4.2.0",
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
-    },
-    "node_modules/usb/node_modules/node-addon-api": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/utf-8-validate": {
       "version": "5.0.10",
@@ -23629,18 +23018,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/which-pm-runs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
-      "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -23661,18 +23038,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
-      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "node_modules/widest-line": {

--- a/scripts/deploy/deploy.js
+++ b/scripts/deploy/deploy.js
@@ -234,7 +234,7 @@ async function main() {
   if (Object.keys(feedMap).length > 0) {
     const cl = await deployDeterministic(
       "ChainlinkDataFeedOracleAdapter",
-      [],
+      [deployer.address],
       generateSalt(SALT_PREFIXES.V2 + "ChainlinkDataFeedOracleAdapter"),
       deployer
     );
@@ -260,7 +260,7 @@ async function main() {
   if (fnRouter && ethers.isAddress(fnRouter)) {
     const fn = await deployDeterministic(
       "ChainlinkFunctionsOracleAdapter",
-      [fnRouter],
+      [deployer.address, fnRouter],
       generateSalt(SALT_PREFIXES.V2 + "ChainlinkFunctionsOracleAdapter"),
       deployer
     );
@@ -281,7 +281,7 @@ async function main() {
   if (ooAddr && ethers.isAddress(ooAddr)) {
     const uma = await deployDeterministic(
       "UMAOptimisticOracleV3Adapter",
-      [ooAddr],
+      [deployer.address, ooAddr],
       generateSalt(SALT_PREFIXES.V2 + "UMAOptimisticOracleV3Adapter"),
       deployer
     );

--- a/scripts/estimate-amoy-deployment.js
+++ b/scripts/estimate-amoy-deployment.js
@@ -1,148 +1,204 @@
 /**
  * estimate-amoy-deployment.js — Estimate Amoy deployment cost in POL
  *
- * Deploys every contract from scripts/deploy/01..04 to an in-process Hardhat
- * network, captures real gas used, then multiplies by the live Amoy gas price.
+ * Deploys the current v2 contract set to an in-process Hardhat network,
+ * captures real gas used for each contract and each post-deploy
+ * configuration tx, then multiplies by the live Amoy gas price.
+ *
+ * Mirrors scripts/deploy/deploy.js, so the number reflects what
+ *   npx hardhat run scripts/deploy/deploy.js --network amoy
+ * actually spends.
  *
  * Usage:
  *   npx hardhat run scripts/estimate-amoy-deployment.js
- *   DEPLOY_PERPETUALS=true npx hardhat run scripts/estimate-amoy-deployment.js
  */
 
-const hre = require("hardhat");
 const { ethers } = require("hardhat");
+
+const {
+  WAGER_PARTICIPANT_TIERS,
+  ROLE_HASHES,
+  CHAINLINK_DATA_FEEDS,
+  CHAINLINK_FUNCTIONS_ROUTER,
+  UMA_OOV3,
+} = require("./deploy/lib/constants");
 
 const AMOY_RPC = process.env.AMOY_RPC_URL || "https://rpc-amoy.polygon.technology";
 
 // Singleton-factory CALL adds a constant overhead per deterministic deploy
 // (CALL + memory expansion + the factory's CREATE2). Empirically ~55k on top
-// of the raw CREATE cost. We add it per contract below.
+// of the raw CREATE cost.
 const SINGLETON_FACTORY_OVERHEAD = 55_000n;
 
-async function deploy(name, args = [], libraries = {}) {
-  const factory = await ethers.getContractFactory(name, { libraries });
+// ResolutionType enum ordinals (must match IWagerRegistry.sol)
+const RT = { Either: 0, Creator: 1, Opponent: 2, ThirdParty: 3, Polymarket: 4, ChainlinkDataFeed: 5, ChainlinkFunctions: 6, UMA: 7 };
+
+const USDC_DECIMALS = 6;
+function toUSDC(price18) { return price18 / (10n ** 12n); }
+
+async function deploy(name, args = []) {
+  const factory = await ethers.getContractFactory(name);
   const contract = await factory.deploy(...args);
-  const tx = contract.deploymentTransaction();
-  const receipt = await tx.wait();
+  const receipt = await contract.deploymentTransaction().wait();
   return { name, gasUsed: receipt.gasUsed, address: await contract.getAddress(), contract };
 }
 
-async function tryInit(c, ...args) {
-  try {
-    if (typeof c.initialize === "function") {
-      const tx = await c.initialize(...args);
-      await tx.wait();
-    }
-  } catch {}
+async function sendTx(label, txPromise) {
+  const tx = await txPromise;
+  const receipt = await tx.wait();
+  return { name: label, gasUsed: receipt.gasUsed };
 }
 
 async function main() {
   const [deployer] = await ethers.getSigners();
-  const includePerpetuals = (process.env.DEPLOY_PERPETUALS ?? "false").toLowerCase() === "true";
-  const PLACEHOLDER = "0xec6Ed68627749b9C244a25A6d0bAC8962043fdcB";
-  const TREASURY = "0x93F7ee39C02d99289E3c29696f1F3a70656d0772";
+  const treasury = deployer.address;
+  const NETWORK = "amoy";
 
-  console.log("Deploying contracts to in-process Hardhat to measure gas...\n");
-  const results = [];
+  console.log("Deploying current v2 contracts to in-process Hardhat to measure gas...\n");
+  const deploys = [];
+  const txs = [];
 
-  // 01-core
-  const rmc = await deploy("RoleManagerCore"); results.push(rmc);
-  const welfare = await deploy("WelfareMetricRegistry"); results.push(welfare);
-  const proposals = await deploy("ProposalRegistry"); results.push(proposals);
-  const cmf = await deploy("ConditionalMarketFactory"); results.push(cmf);
-  const privacy = await deploy("PrivacyCoordinator"); results.push(privacy);
-  const oracle = await deploy("OracleResolver"); results.push(oracle);
-  const ragequit = await deploy("RagequitModule"); results.push(ragequit);
-  await tryInit(ragequit.contract, deployer.address, PLACEHOLDER, TREASURY);
-  const futarchy = await deploy("FutarchyGovernor"); results.push(futarchy);
-  const tmf = await deploy("TokenMintFactory", [rmc.address]); results.push(tmf);
-  const daoFactory = await deploy(
-    "DAOFactory",
-    [welfare.address, proposals.address, cmf.address, privacy.address, oracle.address, ragequit.address, futarchy.address]
-  );
-  results.push(daoFactory);
+  // Amoy has no canonical Polymarket CTF — deploy a mock per deploy.js.
+  const mockCTF = await deploy("MockPolymarketCTF"); deploys.push(mockCTF);
 
-  // 02-rbac
-  const trm = await deploy("TieredRoleManager"); results.push(trm);
-  const tierRegistry = await deploy("TierRegistry"); results.push(tierRegistry);
-  const usage = await deploy("UsageTracker"); results.push(usage);
-  const membership = await deploy("MembershipManager"); results.push(membership);
-  const payment = await deploy("PaymentProcessor"); results.push(payment);
-  const mpm = await deploy("MembershipPaymentManager", [TREASURY]); results.push(mpm);
+  // PolymarketOracleAdapter
+  const adapter = await deploy("PolymarketOracleAdapter", [mockCTF.address]);
+  deploys.push(adapter);
 
-  // 03-markets (libraries first)
-  const ctf = await deploy("CTF1155"); results.push(ctf);
-  const fgrLib = await deploy("FriendGroupResolutionLib"); results.push(fgrLib);
-  const fgcLib = await deploy("FriendGroupClaimsLib"); results.push(fgcLib);
-  const fgcrLib = await deploy("FriendGroupCreationLib"); results.push(fgcrLib);
-  const fgmf = await deploy(
-    "FriendGroupMarketFactory",
-    [cmf.address, ragequit.address, trm.address, mpm.address, deployer.address],
-    {
-      FriendGroupResolutionLib: fgrLib.address,
-      FriendGroupClaimsLib: fgcLib.address,
-      FriendGroupCreationLib: fgcrLib.address,
-    }
-  );
-  results.push(fgmf);
+  // Configured Amoy tokens (used in ctors only; no transfers happen here)
+  const AMOY_USDC = "0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582";
+  const AMOY_WMATIC = "0x0ae690AAD8663aaB12a671A6A0d74242332de85f";
 
-  // 04-registries
-  const correlation = await deploy("MarketCorrelationRegistry"); results.push(correlation);
-  const nullifier = await deploy("NullifierRegistry"); results.push(nullifier);
+  // MembershipManager (now AccessControl-based — "role manager" refactor lives here)
+  const mgr = await deploy("MembershipManager", [deployer.address, AMOY_USDC, treasury]);
+  deploys.push(mgr);
 
-  // Optional perpetuals
-  if (includePerpetuals) {
-    const fre = await deploy("FundingRateEngine"); results.push(fre);
-    const perp = await deploy(
-      "PerpetualFuturesFactory",
-      [fre.address, deployer.address, deployer.address]
-    );
-    results.push(perp);
+  // Seed WAGER_PARTICIPANT tiers (4 transactions — replaces the old 8 from
+  // FRIEND_MARKET + MARKET_MAKER).
+  for (const cfg of WAGER_PARTICIPANT_TIERS) {
+    const limits = {
+      monthlyMarketCreation: cfg.limits.monthlyMarketCreation > 2n ** 32n - 1n ? 0 : Number(cfg.limits.monthlyMarketCreation),
+      maxConcurrentMarkets:  cfg.limits.maxConcurrentMarkets  > 2n ** 32n - 1n ? 0 : Number(cfg.limits.maxConcurrentMarkets),
+    };
+    txs.push(await sendTx(
+      `setTier WAGER_PARTICIPANT tier=${cfg.tier}`,
+      mgr.contract.setTier(ROLE_HASHES.WAGER_PARTICIPANT_ROLE, cfg.tier, toUSDC(cfg.price), 30, limits, true),
+    ));
   }
 
-  // Fetch live Amoy gas price
+  // WagerRegistry (AccessControl + GUARDIAN + ACCOUNT_MODERATOR roles)
+  const reg = await deploy("WagerRegistry", [deployer.address, mgr.address, adapter.address, [AMOY_USDC, AMOY_WMATIC]]);
+  deploys.push(reg);
+
+  txs.push(await sendTx(
+    "setAuthorizedCaller(WagerRegistry)",
+    mgr.contract.setAuthorizedCaller(reg.address, true),
+  ));
+
+  // --- Chainlink Data Feed adapter (Amoy has ETH/USD configured) ---
+  const cl = await deploy("ChainlinkDataFeedOracleAdapter"); deploys.push(cl);
+  const feedMap = CHAINLINK_DATA_FEEDS[NETWORK] || {};
+  for (const [pair, addr] of Object.entries(feedMap)) {
+    txs.push(await sendTx(`setFeedAllowed Chainlink ${pair}`, cl.contract.setFeedAllowed(addr, true)));
+  }
+  txs.push(await sendTx(
+    "setOracleAdapter(ChainlinkDataFeed)",
+    reg.contract.setOracleAdapter(RT.ChainlinkDataFeed, cl.address),
+  ));
+
+  // --- Chainlink Functions adapter ---
+  const fnRouter = CHAINLINK_FUNCTIONS_ROUTER[NETWORK];
+  // deploy.js requires a real router; on Amoy this is the canonical address.
+  // To measure deploy gas on in-process Hardhat where that router doesn't
+  // exist, deploy MockFunctionsRouter and use its address.
+  const mockRouter = await deploy("MockFunctionsRouter"); deploys.push(mockRouter);
+  const fn = await deploy("ChainlinkFunctionsOracleAdapter", [mockRouter.address]); deploys.push(fn);
+  txs.push(await sendTx(
+    "setOracleAdapter(ChainlinkFunctions)",
+    reg.contract.setOracleAdapter(RT.ChainlinkFunctions, fn.address),
+  ));
+
+  // --- UMA Optimistic Oracle V3 adapter ---
+  // Same mock-routing trick — UMA OOv3 on Amoy is real, but here we use a mock
+  // to satisfy the constructor and measure deploy gas faithfully.
+  const mockOO = await deploy("MockOptimisticOracleV3"); deploys.push(mockOO);
+  const uma = await deploy("UMAOptimisticOracleV3Adapter", [mockOO.address]); deploys.push(uma);
+  txs.push(await sendTx(
+    "setOracleAdapter(UMA)",
+    reg.contract.setOracleAdapter(RT.UMA, uma.address),
+  ));
+
+  // KeyRegistry
+  const key = await deploy("KeyRegistry"); deploys.push(key);
+
+  // One-time Safe Singleton Factory bootstrap on a clean network (~60k @ 100 gwei).
+  const SINGLETON_FACTORY_DEPLOY_GAS = 60_000n;
+
+  // --- Live Amoy gas price ---
   console.log("\nFetching Amoy gas price from", AMOY_RPC);
   const amoy = new ethers.JsonRpcProvider(AMOY_RPC);
   const fee = await amoy.getFeeData();
-  // Use maxFeePerGas (EIP-1559 ceiling) if available, else gasPrice
   const gasPriceWei = fee.maxFeePerGas ?? fee.gasPrice;
   console.log("Amoy maxFeePerGas:", ethers.formatUnits(gasPriceWei, "gwei"), "gwei");
   console.log("Amoy gasPrice:    ", ethers.formatUnits(fee.gasPrice, "gwei"), "gwei");
 
-  // Report
-  let totalGas = 0n;
-  console.log("\n%s  %s  %s", "Contract".padEnd(34), "Gas (raw)".padStart(12), "Gas +factory".padStart(14));
-  console.log("─".repeat(66));
-  for (const r of results) {
+  // --- Drop mock-only rows from the cost roll-up but show them in the table ---
+  // On real Amoy, MockFunctionsRouter and MockOptimisticOracleV3 are NOT
+  // deployed (the real router/OO already exist). We exclude them from the
+  // total but list them for transparency.
+  const MOCKS_NOT_ON_AMOY = new Set(["MockFunctionsRouter", "MockOptimisticOracleV3"]);
+
+  console.log("\nContract deploys (gas, including singleton-factory CALL overhead):");
+  console.log("─".repeat(82));
+  console.log("%s  %s  %s  %s", "Contract".padEnd(40), "Gas (raw)".padStart(12), "Gas +fac".padStart(12), "On Amoy?".padStart(10));
+  console.log("─".repeat(82));
+  let deployGas = 0n;
+  for (const r of deploys) {
     const adjusted = r.gasUsed + SINGLETON_FACTORY_OVERHEAD;
-    totalGas += adjusted;
+    const includeOnAmoy = !MOCKS_NOT_ON_AMOY.has(r.name);
+    if (includeOnAmoy) deployGas += adjusted;
     console.log(
-      "%s  %s  %s",
-      r.name.padEnd(34),
+      "%s  %s  %s  %s",
+      r.name.padEnd(40),
       r.gasUsed.toString().padStart(12),
-      adjusted.toString().padStart(14)
+      adjusted.toString().padStart(12),
+      (includeOnAmoy ? "yes" : "skip").padStart(10),
     );
   }
-  console.log("─".repeat(66));
-  console.log("%s  %s  %s", "TOTAL".padEnd(34), "".padStart(12), totalGas.toString().padStart(14));
 
-  // Cost in POL using two gas-price scenarios
-  const lowGwei = 30n;       // typical Amoy floor
-  const midPriceWei = gasPriceWei;
-  const highGwei = 100n;     // congested
+  console.log("\nPost-deploy configuration txs:");
+  console.log("─".repeat(82));
+  let txGas = 0n;
+  for (const t of txs) {
+    txGas += t.gasUsed;
+    console.log("%s  %s", t.name.padEnd(50), t.gasUsed.toString().padStart(12));
+  }
+
+  const totalGas = deployGas + txGas + SINGLETON_FACTORY_DEPLOY_GAS;
+  console.log("\n" + "─".repeat(82));
+  console.log("%s  %s", "Contract-deploy gas subtotal (Amoy)".padEnd(50), deployGas.toString().padStart(12));
+  console.log("%s  %s", "Post-deploy tx gas subtotal".padEnd(50), txGas.toString().padStart(12));
+  console.log("%s  %s", "Safe Singleton Factory bootstrap (one-time)".padEnd(50), SINGLETON_FACTORY_DEPLOY_GAS.toString().padStart(12));
+  console.log("%s  %s", "TOTAL".padEnd(50), totalGas.toString().padStart(12));
+
+  // --- Cost in POL ---
+  const lowGwei = 30n;
+  const highGwei = 100n;
 
   const costLow  = totalGas * lowGwei * 10n**9n;
-  const costMid  = totalGas * midPriceWei;
+  const costMid  = totalGas * gasPriceWei;
   const costHigh = totalGas * highGwei * 10n**9n;
 
   console.log("\nDeployment cost estimates (total gas =", totalGas.toString(), ")");
-  console.log("─".repeat(66));
-  console.log(`  @  30 gwei (low):     ${ethers.formatEther(costLow)} POL`);
-  console.log(`  @ ~${ethers.formatUnits(midPriceWei, "gwei")} gwei (live): ${ethers.formatEther(costMid)} POL`);
-  console.log(`  @ 100 gwei (high):    ${ethers.formatEther(costHigh)} POL`);
+  console.log("─".repeat(82));
+  console.log(`  @  30 gwei (low):      ${ethers.formatEther(costLow)} POL`);
+  console.log(`  @ ~${ethers.formatUnits(gasPriceWei, "gwei")} gwei (live):  ${ethers.formatEther(costMid)} POL`);
+  console.log(`  @ 100 gwei (high):     ${ethers.formatEther(costHigh)} POL`);
 
-  console.log("\nNote: gas figures include constructor execution but exclude post-deploy");
-  console.log("configuration txs (setCTF1155, setDefaultCollateralToken, role grants, etc).");
+  console.log("\nNotes:");
+  console.log("  • Excludes MockFunctionsRouter + MockOptimisticOracleV3 (real ones exist on Amoy).");
+  console.log("  • Assumes Amoy USDC + WMATIC are used (no MockERC20 deploys).");
+  console.log("  • Re-running on already-deployed CREATE2 addresses is free (SingletonFactory short-circuits).");
 }
 
 main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/utils/sync-frontend-contracts.js
+++ b/scripts/utils/sync-frontend-contracts.js
@@ -158,6 +158,9 @@ function main() {
         membershipManager: deployed.membershipManager,
         keyRegistry: deployed.keyRegistry,
         polymarketAdapter: deployed.polymarketAdapter,
+        chainlinkDataFeedAdapter: deployed.chainlinkDataFeedAdapter,
+        chainlinkFunctionsAdapter: deployed.chainlinkFunctionsAdapter,
+        umaAdapter: deployed.umaAdapter,
         paymentToken: deployment.paymentToken,
         wmatic: deployment.wmatic,
       }

--- a/test/fork/AmoyOracles.fork.test.js
+++ b/test/fork/AmoyOracles.fork.test.js
@@ -34,8 +34,9 @@ describeFork("Amoy oracle adapters (fork)", function () {
   });
 
   it("ChainlinkDataFeedOracleAdapter is available and ETH/USD feed has fresh data", async () => {
+    const [admin] = await ethers.getSigners();
     const Adapter = await ethers.getContractFactory("ChainlinkDataFeedOracleAdapter");
-    const adapter = await Adapter.deploy();
+    const adapter = await Adapter.deploy(admin.address);
     expect(await adapter.isAvailable()).to.equal(true);
 
     // Verify the live feed returns a non-zero answer and a sane updatedAt.
@@ -49,15 +50,17 @@ describeFork("Amoy oracle adapters (fork)", function () {
   });
 
   it("ChainlinkFunctionsOracleAdapter is available against the real Functions router", async () => {
+    const [admin] = await ethers.getSigners();
     const Adapter = await ethers.getContractFactory("ChainlinkFunctionsOracleAdapter");
-    const adapter = await Adapter.deploy(AMOY.FUNCTIONS_ROUTER);
+    const adapter = await Adapter.deploy(admin.address, AMOY.FUNCTIONS_ROUTER);
     expect(await adapter.isAvailable()).to.equal(true);
     expect(await adapter.router()).to.equal(AMOY.FUNCTIONS_ROUTER);
   });
 
   it("UMAOptimisticOracleV3Adapter is available against the real OOv3 and reads defaultIdentifier", async () => {
+    const [admin] = await ethers.getSigners();
     const Adapter = await ethers.getContractFactory("UMAOptimisticOracleV3Adapter");
-    const adapter = await Adapter.deploy(AMOY.UMA_OOV3);
+    const adapter = await Adapter.deploy(admin.address, AMOY.UMA_OOV3);
     expect(await adapter.isAvailable()).to.equal(true);
     const oo = await ethers.getContractAt(
       "@uma/core/contracts/optimistic-oracle-v3/interfaces/OptimisticOracleV3Interface.sol:OptimisticOracleV3Interface",

--- a/test/integration/oracle/WagerRegistry_ChainlinkDataFeed.test.js
+++ b/test/integration/oracle/WagerRegistry_ChainlinkDataFeed.test.js
@@ -29,7 +29,7 @@ describe("WagerRegistry + ChainlinkDataFeedOracleAdapter (integration)", functio
     const Agg = await ethers.getContractFactory("MockChainlinkAggregator");
     const feed = await Agg.deploy(0n, 8, await time.latest());
     const ClAdapter = await ethers.getContractFactory("ChainlinkDataFeedOracleAdapter");
-    const clAdapter = await ClAdapter.deploy();
+    const clAdapter = await ClAdapter.deploy(admin.address);
     await clAdapter.setFeedAllowed(await feed.getAddress(), true);
 
     const MembershipManager = await ethers.getContractFactory("MembershipManager");

--- a/test/integration/oracle/WagerRegistry_ChainlinkFunctions.test.js
+++ b/test/integration/oracle/WagerRegistry_ChainlinkFunctions.test.js
@@ -28,7 +28,7 @@ describe("WagerRegistry + ChainlinkFunctionsOracleAdapter (integration)", functi
     const Router = await ethers.getContractFactory("MockFunctionsRouter");
     const router = await Router.deploy();
     const FnAdapter = await ethers.getContractFactory("ChainlinkFunctionsOracleAdapter");
-    const fnAdapter = await FnAdapter.deploy(await router.getAddress());
+    const fnAdapter = await FnAdapter.deploy(admin.address, await router.getAddress());
 
     const MembershipManager = await ethers.getContractFactory("MembershipManager");
     const mgr = await MembershipManager.deploy(admin.address, await usdcToken.getAddress(), treasury.address);

--- a/test/integration/oracle/WagerRegistry_OracleRegistry.test.js
+++ b/test/integration/oracle/WagerRegistry_OracleRegistry.test.js
@@ -31,7 +31,7 @@ describe("WagerRegistry oracle registry", function () {
     const Agg = await ethers.getContractFactory("MockChainlinkAggregator");
     const feed = await Agg.deploy(0n, 8, await time.latest());
     const ClAdapter = await ethers.getContractFactory("ChainlinkDataFeedOracleAdapter");
-    const clAdapter = await ClAdapter.deploy();
+    const clAdapter = await ClAdapter.deploy(admin.address);
     await clAdapter.setFeedAllowed(await feed.getAddress(), true);
 
     const Membership = await ethers.getContractFactory("MembershipManager");

--- a/test/integration/oracle/WagerRegistry_UMA.test.js
+++ b/test/integration/oracle/WagerRegistry_UMA.test.js
@@ -27,7 +27,7 @@ describe("WagerRegistry + UMAOptimisticOracleV3Adapter (integration)", function 
     const OO = await ethers.getContractFactory("MockOptimisticOracleV3");
     const oo = await OO.deploy();
     const UmaAdapter = await ethers.getContractFactory("UMAOptimisticOracleV3Adapter");
-    const umaAdapter = await UmaAdapter.deploy(await oo.getAddress());
+    const umaAdapter = await UmaAdapter.deploy(admin.address, await oo.getAddress());
 
     const MembershipManager = await ethers.getContractFactory("MembershipManager");
     const mgr = await MembershipManager.deploy(admin.address, await usdcToken.getAddress(), treasury.address);

--- a/test/oracles/AdapterDeterministicOwnership.test.js
+++ b/test/oracles/AdapterDeterministicOwnership.test.js
@@ -1,0 +1,71 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { ensureSingletonFactory, SINGLETON_FACTORY_ADDRESS } = (() => {
+  const helpers = require("../../scripts/deploy/lib/helpers");
+  const { SINGLETON_FACTORY_ADDRESS } = require("../../scripts/deploy/lib/constants");
+  return { ensureSingletonFactory: helpers.ensureSingletonFactory, SINGLETON_FACTORY_ADDRESS };
+})();
+
+// Regression for the bug where `Ownable(msg.sender)` (and `ConfirmedOwner(msg.sender)`)
+// in adapter constructors made the Safe Singleton Factory the owner under CREATE2-via-
+// factory deploys, leaving the EOA deployer unable to call onlyOwner functions.
+//
+// Each adapter must now accept an explicit `admin` constructor arg and use that for
+// ownership. These tests assemble an initcode with `admin = deployer.address` and
+// route it through the SingletonFactory (the exact path scripts/deploy/deploy.js
+// takes), then assert `owner()` is the deployer — not the factory.
+
+async function deployViaFactory(deployer, factoryFactory, args, saltSeed) {
+  const initCode = (await factoryFactory.getDeployTransaction(...args)).data;
+  const salt = ethers.id(saltSeed);
+  const initCodeHash = ethers.keccak256(initCode);
+  const predicted = ethers.getCreate2Address(SINGLETON_FACTORY_ADDRESS, salt, initCodeHash);
+  const tx = await deployer.sendTransaction({
+    to: SINGLETON_FACTORY_ADDRESS,
+    data: ethers.concat([salt, initCode]),
+  });
+  await tx.wait();
+  const code = await ethers.provider.getCode(predicted);
+  expect(code, "factory CREATE2 deploy failed").to.not.equal("0x");
+  return predicted;
+}
+
+describe("Adapter deterministic-deploy ownership", function () {
+  before(async function () {
+    await ensureSingletonFactory();
+  });
+
+  it("ChainlinkDataFeedOracleAdapter: owner is admin arg, not the factory", async () => {
+    const [deployer] = await ethers.getSigners();
+    const F = await ethers.getContractFactory("ChainlinkDataFeedOracleAdapter");
+    const addr = await deployViaFactory(deployer, F, [deployer.address], "cdf-ownership-regression");
+    const adapter = F.attach(addr);
+    expect(await adapter.owner()).to.equal(deployer.address);
+    expect(await adapter.owner()).to.not.equal(SINGLETON_FACTORY_ADDRESS);
+    // setFeedAllowed should now be callable by deployer.
+    const feedAddr = "0x000000000000000000000000000000000000dEaD";
+    await expect(adapter.connect(deployer).setFeedAllowed(feedAddr, true)).to.not.be.reverted;
+  });
+
+  it("UMAOptimisticOracleV3Adapter: owner is admin arg, not the factory", async () => {
+    const [deployer] = await ethers.getSigners();
+    const OO = await ethers.getContractFactory("MockOptimisticOracleV3");
+    const oo = await OO.deploy();
+    const F = await ethers.getContractFactory("UMAOptimisticOracleV3Adapter");
+    const addr = await deployViaFactory(deployer, F, [deployer.address, await oo.getAddress()], "uma-ownership-regression");
+    const adapter = F.attach(addr);
+    expect(await adapter.owner()).to.equal(deployer.address);
+    expect(await adapter.owner()).to.not.equal(SINGLETON_FACTORY_ADDRESS);
+  });
+
+  it("ChainlinkFunctionsOracleAdapter: owner is admin arg, not the factory", async () => {
+    const [deployer] = await ethers.getSigners();
+    const Router = await ethers.getContractFactory("MockFunctionsRouter");
+    const router = await Router.deploy();
+    const F = await ethers.getContractFactory("ChainlinkFunctionsOracleAdapter");
+    const addr = await deployViaFactory(deployer, F, [deployer.address, await router.getAddress()], "fn-ownership-regression");
+    const adapter = F.attach(addr);
+    expect(await adapter.owner()).to.equal(deployer.address);
+    expect(await adapter.owner()).to.not.equal(SINGLETON_FACTORY_ADDRESS);
+  });
+});

--- a/test/oracles/ChainlinkDataFeedOracleAdapter.test.js
+++ b/test/oracles/ChainlinkDataFeedOracleAdapter.test.js
@@ -10,7 +10,7 @@ describe("ChainlinkDataFeedOracleAdapter", function () {
     const Agg = await ethers.getContractFactory("MockChainlinkAggregator");
     const feed = await Agg.deploy(3000_00000000n, 8, await time.latest());
     const Adapter = await ethers.getContractFactory("ChainlinkDataFeedOracleAdapter");
-    const adapter = await Adapter.deploy();
+    const adapter = await Adapter.deploy(admin.address);
     await adapter.connect(admin).setFeedAllowed(await feed.getAddress(), true);
     return { adapter, feed, admin, alice };
   }

--- a/test/oracles/ChainlinkFunctionsOracleAdapter.test.js
+++ b/test/oracles/ChainlinkFunctionsOracleAdapter.test.js
@@ -8,7 +8,7 @@ describe("ChainlinkFunctionsOracleAdapter", function () {
     const Router = await ethers.getContractFactory("MockFunctionsRouter");
     const router = await Router.deploy();
     const Adapter = await ethers.getContractFactory("ChainlinkFunctionsOracleAdapter");
-    const adapter = await Adapter.deploy(await router.getAddress());
+    const adapter = await Adapter.deploy(admin.address, await router.getAddress());
     return { adapter, router, admin, alice };
   }
 
@@ -30,9 +30,9 @@ describe("ChainlinkFunctionsOracleAdapter", function () {
   });
 
   it("isAvailable=false when router has no code (constructed against EOA)", async () => {
-    const [, , , eoa] = await ethers.getSigners();
+    const [admin, , , eoa] = await ethers.getSigners();
     const Adapter = await ethers.getContractFactory("ChainlinkFunctionsOracleAdapter");
-    const adapter = await Adapter.deploy(eoa.address);
+    const adapter = await Adapter.deploy(admin.address, eoa.address);
     expect(await adapter.isAvailable()).to.equal(false);
   });
 

--- a/test/oracles/UMAOptimisticOracleV3Adapter.test.js
+++ b/test/oracles/UMAOptimisticOracleV3Adapter.test.js
@@ -12,7 +12,7 @@ describe("UMAOptimisticOracleV3Adapter", function () {
     const OO = await ethers.getContractFactory("MockOptimisticOracleV3");
     const oo = await OO.deploy();
     const Adapter = await ethers.getContractFactory("UMAOptimisticOracleV3Adapter");
-    const adapter = await Adapter.deploy(await oo.getAddress());
+    const adapter = await Adapter.deploy(admin.address, await oo.getAddress());
     // Fund alice and approve adapter
     await bond.mint(alice.address, usdc(1000));
     await bond.connect(alice).approve(await adapter.getAddress(), ethers.MaxUint256);
@@ -38,9 +38,9 @@ describe("UMAOptimisticOracleV3Adapter", function () {
   });
 
   it("isAvailable=false when OO addr has no code", async () => {
-    const [, , , eoa] = await ethers.getSigners();
+    const [admin, , , eoa] = await ethers.getSigners();
     const Adapter = await ethers.getContractFactory("UMAOptimisticOracleV3Adapter");
-    const adapter = await Adapter.deploy(eoa.address);
+    const adapter = await Adapter.deploy(admin.address, eoa.address);
     expect(await adapter.isAvailable()).to.equal(false);
   });
 


### PR DESCRIPTION
## Summary

- Patches `Ownable(msg.sender)` / `ConfirmedOwner(msg.sender)` bug in 3 new oracle adapters that made the SingletonFactory the owner under CREATE2 deploys, blocking all post-deploy admin calls (`setFeedAllowed`, etc.). Adapters now take an explicit `address admin` constructor arg.
- Live v2 deploy on Amoy from admin hot wallet `0x5250…6e1` (0.316 POL @ 30 gwei). All 8 contracts deployed + wired; deployment record committed.
- Frontend address sync: `AMOY_CONTRACTS` block updated with all 7 deployed addresses; `sync-frontend-contracts.js` learns the 3 new adapter keys.
- Frontend `ResolutionType` enum in `wagerDefaults.js` unified to the canonical 8-value on-chain enum (was a stale 6-value from a deleted v1 contract). `useFriendMarketCreation` re-exports from there. **Modal not touched** — see below.
- ABIs exported for the 3 new adapters.
- New regression test (`test/oracles/AdapterDeterministicOwnership.test.js`) that deploys each adapter via SingletonFactory and asserts `owner() == deployer`, catching the bug if anyone re-introduces it.

## Live Amoy v2 addresses (chain 80002)

| Contract | Address |
|---|---|
| MockPolymarketCTF | `0x95F40ea10E6C51892783c4E7721Ada1425917e22` |
| PolymarketOracleAdapter | `0x423d2Ca885d67E46062CFF732Eff952f4F736136` |
| MembershipManager | `0xFaEbF662aa591fF95e97306b413522efC958540f` |
| WagerRegistry | `0x39f1CbC680cDc9831b6dF4D9e4719D3748720aBA` |
| ChainlinkDataFeedOracleAdapter | `0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23` |
| ChainlinkFunctionsOracleAdapter | `0x074fC18C1E322a7537b53B8B2Bf0762629E3b532` |
| UMAOptimisticOracleV3Adapter | `0xcEa9b4A01CcD3aA6545ea834a268C69e7eEfee88` |
| KeyRegistry | `0xb314c4Ee52D9D89bf7FEE66a43aBeAc7D047a5Cb` |

## Why the contract patch

When deploy.js calls `SingletonFactory.create2(salt, initcode)`, `msg.sender` inside the new contract's constructor is the SingletonFactory address, not the deployer EOA. The 3 new adapters used `Ownable(msg.sender)` (or `ConfirmedOwner(msg.sender)` for Functions), making the factory their owner. `setFeedAllowed`, `registerCondition`, `linkMarket` — all `onlyOwner` — became unreachable. The first deploy attempt aborted on `setFeedAllowed(ETH/USD)`. The patched adapters take `address admin` and call `Ownable(admin)` instead, matching the pattern already used by `MembershipManager` and `WagerRegistry`.

## Out of scope (deliberately deferred)

The original ask was to "wire the full functionality into the UX." On audit I found pre-existing tech debt that has to be unwound before layering the 3 new oracle types on top:

1. **`FriendMarketsModal` `polymarketConditionId` not wired.** The modal receives `initialPolymarketMarket` from `Dashboard` but never threads it into the form / hook payload. Even the existing Polymarket resolution flow can't be used end-to-end through the modal as written.
2. **No admin condition-registration UI.** Each new adapter needs admin calls (`setFeedAllowed` → `registerCondition` → `linkMarket`) before a user can reference a `conditionId` in `createWager`. That's a separate admin screen.
3. **No on-chain condition picker.** Users would currently have to paste a 32-byte hex string. Need a picker that reads registered conditions.

All three are in the follow-up PR(s) plan. The modal still imports its enum from `abis/FriendGroupMarketFactory` (the stale 6-value `Initiator/Receiver/AutoPegged` set); migrating it depends on fixing #1 first.

## Costs

| Step | Gas | Cost @ 30 gwei |
|---|---:|---:|
| First deploy (4 contracts + 5 config txs + 1 failed setFeedAllowed) | 7,070k | 0.212 POL |
| Resume after fix (3 adapters + KeyRegistry + 4 wiring txs) | 3,500k | 0.105 POL |
| **Total** | **~10.6M** | **0.316 POL** |

Wallet ended at 0.307 POL (budget 0.5 POL).

## Test plan

- [x] 137/137 hardhat tests pass — \`npx hardhat test\`
- [x] Regression test verifies admin-via-ctor for all 3 adapters under SingletonFactory CREATE2
- [x] 725/725 frontend tests pass — \`cd frontend && npm test -- --run\`
- [x] Production frontend build succeeds — \`npm run build\`
- [x] On-chain \`owner()\` verification on Amoy: all 3 adapters owned by deployer EOA
- [x] On-chain wiring verified: ETH/USD feed allowlisted on ChainlinkDataFeed adapter, all 3 adapters bound to their \`ResolutionType\` on \`WagerRegistry\`
- [ ] Manual browser smoke test (not run — modal flow for new types is out of scope for this PR; existing Polymarket flow predates this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)