### PR TITLE
fix(frontend): wire Polymarket-pegged side bets end-to-end

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -10,7 +10,7 @@ import {
   getDefaultAcceptanceDeadline,
   toDateTimeLocal
 } from '../../constants/wagerDefaults'
-import { ResolutionType as _ResolutionType } from '../../abis/FriendGroupMarketFactory'
+import { ResolutionType } from '../../constants/wagerDefaults'
 import QRScanner from '../ui/QRScanner'
 import AddressInput from '../ui/AddressInput'
 import { isEnsName } from '../../utils/validation'
@@ -20,16 +20,6 @@ import PolymarketBrowser from './PolymarketBrowser'
 import { formatUSD, getMarketUrl } from './marketHelpers'
 import TransactionProgress from './TransactionProgress'
 import './FriendMarketsModal.css'
-
-// Fallback so the UI renders even if the enum export is missing in some environments
-const ResolutionType = _ResolutionType ?? {
-  Either: 0,
-  Initiator: 1,
-  Receiver: 2,
-  ThirdParty: 3,
-  AutoPegged: 4,
-  PolymarketOracle: 5,
-}
 
 // Stake token options derived from the active chain's tokens. The token
 // metadata is sourced from useDex() at render time so the Testnet/Mainnet
@@ -107,7 +97,7 @@ function FriendMarketsModal({
     customStakeTokenAddress: '', // Used when stakeTokenId is 'CUSTOM'
     arbitrator: '',
     arbitratorResolved: '',
-    peggedMarketId: '',
+    oracleConditionId: '',
     // Which outcome of a linked Polymarket the creator is taking. Stored as
     // the 0-based outcome index ('' = unset, '0' = YES/first, '1' = NO/second)
     // to match PolymarketOracleAdapter's payouts ordering (YES=0, NO=1).
@@ -138,7 +128,7 @@ function FriendMarketsModal({
 
   // Polymarket event selection — the PolymarketBrowser component below handles
   // browsing/searching internally. We only need to track the picked market so
-  // its conditionId can be committed to formData.peggedMarketId.
+  // its conditionId can be committed to formData.oracleConditionId.
   const [selectedPolymarketMarket, setSelectedPolymarketMarket] = useState(null)
   // Once a market is linked, the browse/search area collapses behind an
   // accordion so the form stays compact. Users can re-open it to swap markets
@@ -168,7 +158,7 @@ function FriendMarketsModal({
       customStakeTokenAddress: '',
       arbitrator: '',
       arbitratorResolved: '',
-      peggedMarketId: '',
+      oracleConditionId: '',
       creatorSide: '',
       acceptanceDeadline: getDefaultAcceptanceDeadline(),
       minAcceptanceThreshold: String(WAGER_DEFAULTS.MIN_ACCEPTANCE_THRESHOLD),
@@ -207,8 +197,8 @@ function FriendMarketsModal({
           const linkedEnd = toDateTimeLocal(initialPolymarketMarket.endDate)
           return {
             ...prev,
-            resolutionType: ResolutionType.PolymarketOracle,
-            peggedMarketId: initialPolymarketMarket.conditionId,
+            resolutionType: ResolutionType.Polymarket,
+            oracleConditionId: initialPolymarketMarket.conditionId,
             description: seeded,
             ...(linkedEnd ? { endDateTime: linkedEnd } : {}),
           }
@@ -261,12 +251,12 @@ function FriendMarketsModal({
       // type that doesn't need it.
       if (field === 'resolutionType' &&
           value !== ResolutionType.ThirdParty &&
-          value !== ResolutionType.PolymarketOracle) {
+          value !== ResolutionType.Polymarket) {
         updated.arbitrator = ''
         updated.arbitratorResolved = ''
-        updated.peggedMarketId = ''
+        updated.oracleConditionId = ''
       }
-      if (field === 'resolutionType' && value !== ResolutionType.PolymarketOracle) {
+      if (field === 'resolutionType' && value !== ResolutionType.Polymarket) {
         updated.creatorSide = ''
       }
 
@@ -365,7 +355,7 @@ function FriendMarketsModal({
     setSelectedPolymarketMarket(market)
     setPolymarketBrowserOpen(false)
     setFormData(prev => {
-      const updated = { ...prev, peggedMarketId: market.conditionId }
+      const updated = { ...prev, oracleConditionId: market.conditionId }
       // Lock the wager's end time to the linked market so the side bet can't
       // resolve before (or long after) Polymarket does.
       const linkedEnd = toDateTimeLocal(market.endDate)
@@ -387,10 +377,10 @@ function FriendMarketsModal({
       }
       return updated
     })
-    if (errors.peggedMarketId) {
+    if (errors.oracleConditionId) {
       setErrors(prev => {
         const newErrors = { ...prev }
-        delete newErrors.peggedMarketId
+        delete newErrors.oracleConditionId
         return newErrors
       })
     }
@@ -410,7 +400,7 @@ function FriendMarketsModal({
     // so the user can pick their own again.
     setFormData(prev => ({
       ...prev,
-      peggedMarketId: '',
+      oracleConditionId: '',
       creatorSide: '',
       endDateTime: getDefaultEndDateTime(),
     }))
@@ -541,7 +531,7 @@ function FriendMarketsModal({
     const now = new Date()
     const minDate = new Date(now.getTime() + WAGER_DEFAULTS.MIN_TRADING_PERIOD_SECONDS * 1000)
     const maxDate = new Date(now.getTime() + WAGER_DEFAULTS.MAX_TRADING_PERIOD_SECONDS * 1000)
-    const isLinkedMarket = formData.resolutionType === ResolutionType.PolymarketOracle &&
+    const isLinkedMarket = formData.resolutionType === ResolutionType.Polymarket &&
       selectedPolymarketMarket?.endDate
 
     if (!formData.endDateTime || isNaN(endDate.getTime())) {
@@ -597,18 +587,35 @@ function FriendMarketsModal({
         } else if (resolvedArb.toLowerCase() === '0x0000000000000000000000000000000000000000') {
           newErrors.arbitrator = 'Cannot use the zero address'
         }
-      } else if (formData.resolutionType === ResolutionType.PolymarketOracle) {
+      } else if (formData.resolutionType === ResolutionType.Polymarket) {
         // Polymarket condition id (bytes32 hex) is required.
-        const cid = (formData.peggedMarketId || '').trim()
+        const cid = (formData.oracleConditionId || '').trim()
         if (!cid) {
-          newErrors.peggedMarketId = 'Pick a Polymarket event to link this wager to'
+          newErrors.oracleConditionId = 'Pick a Polymarket event to link this wager to'
         } else if (!/^0x[a-fA-F0-9]{64}$/.test(cid)) {
-          newErrors.peggedMarketId = 'Invalid Polymarket condition id (expected 0x + 64 hex chars)'
+          newErrors.oracleConditionId = 'Invalid Polymarket condition id (expected 0x + 64 hex chars)'
         }
         // Creator must declare which side of the linked market they're taking
         // so the bet description unambiguously identifies who is on which side.
         if (formData.creatorSide !== '0' && formData.creatorSide !== '1') {
           newErrors.creatorSide = 'Pick which side of the linked market you are taking'
+        }
+        // Linked-market deadline guards: the standard MIN/MAX deadline checks
+        // are skipped for linked markets (we lock endDateTime to the Polymarket
+        // end date). Re-validate against the linked market's own clock so we
+        // don't submit a wager whose accept window outlives the Polymarket.
+        if (selectedPolymarketMarket?.endDate) {
+          const linkedEnd = new Date(selectedPolymarketMarket.endDate)
+          if (!Number.isNaN(linkedEnd.getTime())) {
+            if (linkedEnd.getTime() <= Date.now()) {
+              newErrors.oracleConditionId = 'This Polymarket has already ended. Pick an active market.'
+            } else if (formData.acceptanceDeadline) {
+              const acceptEnd = new Date(formData.acceptanceDeadline)
+              if (!Number.isNaN(acceptEnd.getTime()) && acceptEnd.getTime() >= linkedEnd.getTime()) {
+                newErrors.acceptanceDeadline = 'Acceptance deadline must be before the linked market ends.'
+              }
+            }
+          }
         }
       }
     }
@@ -723,6 +730,17 @@ function FriendMarketsModal({
       const tradingPeriodSeconds = Math.max(rawSeconds, WAGER_DEFAULTS.MIN_TRADING_PERIOD_SECONDS)
       const tradingPeriodDays = Math.max(1, Math.ceil(tradingPeriodSeconds / (60 * 60 * 24)))
 
+      // Translate UI-side semantics into contract-facing semantics:
+      //  - creatorSide ('0' = first Polymarket outcome, '1' = second) → creatorIsYes (bool).
+      //    PolymarketOracleAdapter.getOutcome returns `payouts[0] > payouts[1]`, so picking
+      //    outcome index 0 means the creator wins iff that outcome wins ⇒ creatorIsYes = true.
+      //  - oracleConditionId (form field) → passed straight to the hook; the hook forwards it
+      //    to the contract's still-named `polymarketConditionId` arg.
+      // creatorIsYes only matters for oracle-resolved wagers; default true for the others.
+      const creatorIsYes = formData.creatorSide === '0' || formData.creatorSide === ''
+        ? true
+        : false
+
       // Build submit data with token address for WalletButton
       const submitData = {
         type: 'friend',
@@ -735,6 +753,8 @@ function FriendMarketsModal({
           // address.
           opponent: formData.opponentResolved || formData.opponent,
           arbitrator: formData.arbitratorResolved || formData.arbitrator,
+          // Translated UI → contract semantics (see comment above).
+          creatorIsYes,
           // Pass calculated trading period so downstream uses the user's selected end date.
           // `tradingPeriodSeconds` is the source of truth; `tradingPeriod` (days)
           // is kept for any legacy consumers that still parse it.
@@ -1057,19 +1077,19 @@ function FriendMarketsModal({
                           className="fm-select"
                         >
                           <option value={ResolutionType.Either}>Either Party</option>
-                          <option value={ResolutionType.Initiator}>Creator Only</option>
-                          <option value={ResolutionType.Receiver}>Opponent Only</option>
+                          <option value={ResolutionType.Creator}>Creator Only</option>
+                          <option value={ResolutionType.Opponent}>Opponent Only</option>
                           <option value={ResolutionType.ThirdParty}>Third Party Arbitrator</option>
                           {polymarketSidebetsEnabled && (
-                            <option value={ResolutionType.PolymarketOracle}>Linked Market (Polymarket)</option>
+                            <option value={ResolutionType.Polymarket}>Linked Market (Polymarket)</option>
                           )}
                         </select>
                         <span className="fm-hint">
                           {formData.resolutionType === ResolutionType.Either && 'Either you or your opponent can resolve the wager'}
-                          {formData.resolutionType === ResolutionType.Initiator && 'Only you (the creator) can resolve the wager'}
-                          {formData.resolutionType === ResolutionType.Receiver && 'Only your opponent can resolve the wager'}
+                          {formData.resolutionType === ResolutionType.Creator && 'Only you (the creator) can resolve the wager'}
+                          {formData.resolutionType === ResolutionType.Opponent && 'Only your opponent can resolve the wager'}
                           {formData.resolutionType === ResolutionType.ThirdParty && 'A designated arbitrator will resolve disputes'}
-                          {formData.resolutionType === ResolutionType.PolymarketOracle && 'Settles automatically when the linked Polymarket market resolves'}
+                          {formData.resolutionType === ResolutionType.Polymarket && 'Settles automatically when the linked Polymarket market resolves'}
                           {!polymarketSidebetsEnabled && (
                             <em style={{ display: 'block', marginTop: '0.25rem', opacity: 0.75 }}>
                               Linked Market settlement requires a chain with the Polymarket CTF. Switch to Polygon (Amoy or Mainnet) to use it.
@@ -1144,7 +1164,7 @@ function FriendMarketsModal({
                       own end time so the side bet can't settle before (or
                       long after) the linked event.
                     */}
-                    {!(formData.resolutionType === ResolutionType.PolymarketOracle && selectedPolymarketMarket) && (
+                    {!(formData.resolutionType === ResolutionType.Polymarket && selectedPolymarketMarket) && (
                       <div className="fm-form-group">
                         <label htmlFor="fm-end-date">
                           End Date &amp; Time <span className="fm-required">*</span>
@@ -1242,7 +1262,7 @@ function FriendMarketsModal({
 
                     {/* Linked Market — Polymarket event lookup */}
                     {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker' || friendMarketType === 'smallGroup') &&
-                     formData.resolutionType === ResolutionType.PolymarketOracle && (
+                     formData.resolutionType === ResolutionType.Polymarket && (
                       <div className="fm-form-group fm-form-full">
                         <label htmlFor="fm-polymarket-search">
                           Linked Polymarket Event <span className="fm-required">*</span>
@@ -1334,15 +1354,15 @@ function FriendMarketsModal({
                           </>
                         )}
 
-                        {errors.peggedMarketId && (
-                          <span className="fm-error">{errors.peggedMarketId}</span>
+                        {errors.oracleConditionId && (
+                          <span className="fm-error">{errors.oracleConditionId}</span>
                         )}
                       </div>
                     )}
 
                     {/* Creator side — which outcome of the linked Polymarket are you taking? */}
                     {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker' || friendMarketType === 'smallGroup') &&
-                     formData.resolutionType === ResolutionType.PolymarketOracle &&
+                     formData.resolutionType === ResolutionType.Polymarket &&
                      selectedPolymarketMarket && (
                       <div className="fm-form-group fm-form-full">
                         <label>

--- a/frontend/src/hooks/useFriendMarketCreation.js
+++ b/frontend/src/hooks/useFriendMarketCreation.js
@@ -155,11 +155,35 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
 
       // Resolution
       const resolutionType = parseInt(data.data.resolutionType, 10) || ResolutionType.Either
-      const polymarketConditionId = data.data.polymarketConditionId || ethers.ZeroHash
+      // The form field is `oracleConditionId` (future-proof: same slot serves Polymarket
+      // and the upcoming ChainlinkDataFeed / ChainlinkFunctions / UMA adapters). The
+      // contract param is still named `polymarketConditionId` for legacy reasons; we
+      // rebind here so the contract call is unambiguous.
+      // Fall back to the legacy key for any external callers that still set it.
+      const oracleConditionId = data.data.oracleConditionId ?? data.data.polymarketConditionId ?? ''
+      const polymarketConditionId = oracleConditionId || ethers.ZeroHash
       const creatorIsYes = Boolean(data.data.creatorIsYes ?? true)
       const arbitrator = (resolutionType === ResolutionType.ThirdParty)
         ? (data.data.arbitrator || ethers.ZeroAddress)
         : ethers.ZeroAddress
+
+      // Defense-in-depth: the modal's validateForm should have caught these
+      // mismatches before submit. If something slipped through (e.g. a future
+      // caller invokes the hook directly), surface a clear error rather than
+      // let the contract revert with a cryptic custom error.
+      const oracleResolved = ORACLE_RESOLUTION_TYPES.has(resolutionType)
+      if (oracleResolved && polymarketConditionId === ethers.ZeroHash) {
+        throw new Error(
+          'Oracle-resolved wagers require a conditionId. ' +
+          'Pick a Polymarket market (or other oracle condition) before submitting.'
+        )
+      }
+      if (!oracleResolved && polymarketConditionId !== ethers.ZeroHash) {
+        throw new Error(
+          'A conditionId was supplied for a non-oracle resolution type. ' +
+          'Either change the resolution type or clear the conditionId.'
+        )
+      }
 
       // Metadata (encrypted envelope → IPFS, or plaintext)
       let metadataReference
@@ -284,7 +308,7 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
   return { createFriendMarket, loadPendingTransaction, clearPendingTransaction }
 }
 
-function translateRevert(reason) {
+export function translateRevert(reason) {
   if (!reason) return 'Unknown contract error.'
   if (reason.includes('MembershipDenied')) return 'Your Friend Market membership is inactive or you have reached the monthly/concurrent wager limit. Purchase or upgrade your tier to continue.'
   if (reason.includes('SelfWager')) return 'Cannot wager against yourself.'
@@ -294,6 +318,12 @@ function translateRevert(reason) {
   if (reason.includes('ConditionAlreadyResolved')) return 'That Polymarket condition is already resolved. Pick an unresolved one.'
   if (reason.includes('PolymarketRequired')) return 'Polymarket resolution requires a non-zero conditionId.'
   if (reason.includes('PolymarketDisallowed')) return 'Polymarket conditionId must be zero unless resolutionType=Polymarket.'
+  // Order: the new oracle-extensible reverts must check BEFORE the legacy
+  // `AdapterNotSet`, since substring matching would otherwise route
+  // `OracleAdapterNotSet` to the legacy "Polymarket adapter" message.
+  if (reason.includes('OracleConditionRequired')) return 'Oracle-resolved wagers require a non-zero conditionId.'
+  if (reason.includes('OracleAdapterNotSet')) return 'No oracle adapter is configured on-chain for this resolution type.'
+  if (reason.includes('UnsupportedOracleResolutionType')) return 'This resolution type is not supported by the registry.'
   if (reason.includes('AdapterNotSet')) return 'Polymarket adapter not configured on-chain.'
   if (reason.includes('ArbitratorRequired')) return 'ThirdParty resolution requires an arbitrator.'
   if (reason.includes('ArbitratorDisallowed')) return 'Only ThirdParty resolution allows an arbitrator.'

--- a/frontend/src/test/FriendMarketsModal.test.jsx
+++ b/frontend/src/test/FriendMarketsModal.test.jsx
@@ -103,7 +103,30 @@ vi.mock('qrcode.react', () => ({
   ),
 }))
 
-const renderWithProviders = (ui, { isConnected = true, account = '0x1234567890123456789012345678901234567890', isCorrectNetwork = true } = {}) => {
+// Stub PolymarketBrowser so the linked-market UI renders without making
+// real gamma-api calls. Exposes a button per (mocked) market that fires
+// the modal's onSelectMarket handler.
+vi.mock('../components/fairwins/PolymarketBrowser', () => ({
+  default: ({ onSelectMarket, selectedConditionId }) => {
+    const mockMarkets = (globalThis.__mockPolymarketBrowserMarkets__ || [])
+    return (
+      <div data-testid="mock-polymarket-browser" data-selected={selectedConditionId || ''}>
+        {mockMarkets.map((m) => (
+          <button
+            key={m.conditionId}
+            type="button"
+            onClick={() => onSelectMarket?.(m)}
+            data-testid={`pmb-pick-${m.conditionId}`}
+          >
+            {m.question}
+          </button>
+        ))}
+      </div>
+    )
+  }
+}))
+
+const renderWithProviders = (ui, { isConnected = true, account = '0x1234567890123456789012345678901234567890', isCorrectNetwork = true, chainId = 61 } = {}) => {
   mockWalletState.isConnected = isConnected
   mockWalletState.account = isConnected ? account : null
   mockWeb3State.isCorrectNetwork = isCorrectNetwork
@@ -119,7 +142,7 @@ const renderWithProviders = (ui, { isConnected = true, account = '0x123456789012
   mockUseDisconnect.mockReturnValue({
     disconnect: vi.fn()
   })
-  mockUseChainId.mockReturnValue(61)
+  mockUseChainId.mockReturnValue(chainId)
   mockUseSwitchChain.mockReturnValue({
     switchChain: vi.fn()
   })
@@ -454,6 +477,165 @@ describe('FriendMarketsModal', () => {
       fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' })
 
       expect(onClose).toHaveBeenCalled()
+    })
+  })
+
+  describe('Polymarket-pegged wagers', () => {
+    const polymarketMarket = {
+      conditionId: '0x' + 'a'.repeat(64),
+      question: 'Will the Patriots win the Super Bowl?',
+      endDate: new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString(),
+      outcomes: [
+        { name: 'Yes', price: 0.42 },
+        { name: 'No', price: 0.58 },
+      ],
+    }
+
+    beforeEach(() => {
+      globalThis.__mockPolymarketBrowserMarkets__ = [polymarketMarket]
+    })
+
+    it('seeds the form when initialPolymarketMarket is provided', () => {
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} initialPolymarketMarket={polymarketMarket} />,
+        { chainId: 80002 }
+      )
+      // The seeded market card is visible in the "selected market" panel.
+      expect(screen.getByText(polymarketMarket.question)).toBeInTheDocument()
+    })
+
+    it('forwards oracleConditionId + creatorIsYes + resolutionType=4 to onCreate', async () => {
+      const onCreate = vi.fn().mockResolvedValue({ id: 'wager-1' })
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} onCreate={onCreate} initialPolymarketMarket={polymarketMarket} />,
+        { chainId: 80002 }
+      )
+
+      await userEvent.type(
+        screen.getByLabelText(/what's the bet/i),
+        'Patriots win the Super Bowl - pegged to Polymarket'
+      )
+      await userEvent.type(
+        screen.getByLabelText(/opponent address/i),
+        '0xabcdef1234567890123456789012345678901234'
+      )
+
+      // Pick "I'm taking Yes" (first outcome — creatorSide '0' → creatorIsYes true).
+      // The side picker buttons are rendered from selectedPolymarketMarket.outcomes.
+      await userEvent.click(screen.getByRole('button', { name: /i'm taking yes/i }))
+
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
+
+      await waitFor(() => {
+        expect(onCreate).toHaveBeenCalled()
+      })
+      const callArg = onCreate.mock.calls[0][0]
+      expect(callArg.data).toEqual(expect.objectContaining({
+        oracleConditionId: polymarketMarket.conditionId,
+        creatorIsYes: true,
+        resolutionType: 4,  // canonical enum: Polymarket = 4
+      }))
+    })
+
+    it('forwards creatorIsYes=false when the creator picks outcome index 1', async () => {
+      const onCreate = vi.fn().mockResolvedValue({ id: 'wager-2' })
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} onCreate={onCreate} initialPolymarketMarket={polymarketMarket} />,
+        { chainId: 80002 }
+      )
+
+      await userEvent.type(
+        screen.getByLabelText(/what's the bet/i),
+        'Patriots win the Super Bowl - pegged to Polymarket'
+      )
+      await userEvent.type(
+        screen.getByLabelText(/opponent address/i),
+        '0xabcdef1234567890123456789012345678901234'
+      )
+
+      await userEvent.click(screen.getByRole('button', { name: /i'm taking no/i }))
+
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
+
+      await waitFor(() => {
+        expect(onCreate).toHaveBeenCalled()
+      })
+      const callArg = onCreate.mock.calls[0][0]
+      expect(callArg.data.creatorIsYes).toBe(false)
+    })
+
+    it('rejects submit when no side is chosen', async () => {
+      const onCreate = vi.fn()
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} onCreate={onCreate} initialPolymarketMarket={polymarketMarket} />,
+        { chainId: 80002 }
+      )
+
+      await userEvent.type(
+        screen.getByLabelText(/what's the bet/i),
+        'Patriots win the Super Bowl - pegged to Polymarket'
+      )
+      await userEvent.type(
+        screen.getByLabelText(/opponent address/i),
+        '0xabcdef1234567890123456789012345678901234'
+      )
+
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText(/pick which side/i)).toBeInTheDocument()
+      })
+      expect(onCreate).not.toHaveBeenCalled()
+    })
+
+    it('rejects submit when the linked Polymarket has already ended', async () => {
+      const stale = {
+        ...polymarketMarket,
+        endDate: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      }
+      const onCreate = vi.fn()
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} onCreate={onCreate} initialPolymarketMarket={stale} />,
+        { chainId: 80002 }
+      )
+
+      await userEvent.type(
+        screen.getByLabelText(/what's the bet/i),
+        'Patriots win the Super Bowl - pegged to Polymarket'
+      )
+      await userEvent.type(
+        screen.getByLabelText(/opponent address/i),
+        '0xabcdef1234567890123456789012345678901234'
+      )
+      await userEvent.click(screen.getByRole('button', { name: /i'm taking yes/i }))
+
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText(/already ended/i)).toBeInTheDocument()
+      })
+      expect(onCreate).not.toHaveBeenCalled()
+    })
+
+    it('picking a market via the inline PolymarketBrowser surfaces it as the selected market', async () => {
+      // No initialPolymarketMarket — user picks via the (mocked) browser instead.
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} />,
+        { chainId: 80002 }
+      )
+
+      // Switch resolution type to Polymarket so the inline browser renders.
+      const dropdown = screen.getByLabelText(/who can resolve/i)
+      await userEvent.selectOptions(dropdown, '4')  // ResolutionType.Polymarket = 4
+
+      // Pick the (single) mocked market.
+      await userEvent.click(screen.getByTestId(`pmb-pick-${polymarketMarket.conditionId}`))
+
+      // After pick the modal collapses the browser and shows the picked market.
+      // The selected-market panel renders the question text (same as in the seed test).
+      await waitFor(() => {
+        expect(screen.getByText(polymarketMarket.question)).toBeInTheDocument()
+      })
     })
   })
 

--- a/frontend/src/test/useFriendMarketCreation.translateRevert.test.js
+++ b/frontend/src/test/useFriendMarketCreation.translateRevert.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { translateRevert, ResolutionType, ORACLE_RESOLUTION_TYPES } from '../hooks/useFriendMarketCreation'
+
+// Light unit tests for the hook surface that's deterministic + pure:
+//  - `translateRevert(reason)` maps contract revert reasons to user-friendly strings.
+//  - The exported enum + Set match the on-chain enum and the canonical wagerDefaults.
+//
+// End-to-end hook behavior (signer wiring, gas estimation, on-chain submission)
+// is covered indirectly via `FriendMarketsModal.test.jsx` with a mocked
+// `onCreate`. That keeps these tests fast and avoids mocking ethers + wagmi.
+
+describe('useFriendMarketCreation: translateRevert', () => {
+  it('maps the legacy Polymarket reverts', () => {
+    expect(translateRevert('execution reverted: PolymarketRequired'))
+      .toMatch(/non-zero conditionId/i)
+    expect(translateRevert('execution reverted: PolymarketDisallowed'))
+      .toMatch(/must be zero/i)
+    expect(translateRevert('execution reverted: AdapterNotSet'))
+      .toMatch(/polymarket adapter/i)
+  })
+
+  it('maps the new oracle-extensible reverts', () => {
+    expect(translateRevert('execution reverted: OracleConditionRequired'))
+      .toMatch(/oracle-resolved wagers require a non-zero conditionId/i)
+    expect(translateRevert('execution reverted: OracleAdapterNotSet'))
+      .toMatch(/no oracle adapter is configured/i)
+    expect(translateRevert('execution reverted: UnsupportedOracleResolutionType'))
+      .toMatch(/not supported by the registry/i)
+  })
+
+  it('maps shared reverts (deadlines, membership, etc.)', () => {
+    expect(translateRevert('execution reverted: BadDeadlines'))
+      .toMatch(/invalid deadlines/i)
+    expect(translateRevert('execution reverted: MembershipDenied'))
+      .toMatch(/membership is inactive/i)
+    expect(translateRevert('execution reverted: SelfWager'))
+      .toMatch(/wager against yourself/i)
+    expect(translateRevert('execution reverted: NotAllowedToken'))
+      .toMatch(/allowlist/i)
+    expect(translateRevert('execution reverted: ConditionAlreadyResolved'))
+      .toMatch(/already resolved/i)
+  })
+
+  it('falls back to a generic message for unknown reasons', () => {
+    expect(translateRevert('out of gas: 0x1234'))
+      .toMatch(/transaction will fail/i)
+  })
+
+  it('returns a sentinel for empty input', () => {
+    expect(translateRevert('')).toBe('Unknown contract error.')
+    expect(translateRevert(null)).toBe('Unknown contract error.')
+    expect(translateRevert(undefined)).toBe('Unknown contract error.')
+  })
+})
+
+describe('useFriendMarketCreation: exported enum + ORACLE_RESOLUTION_TYPES', () => {
+  it('exports the canonical 8-value ResolutionType', () => {
+    expect(ResolutionType.Either).toBe(0)
+    expect(ResolutionType.Creator).toBe(1)
+    expect(ResolutionType.Opponent).toBe(2)
+    expect(ResolutionType.ThirdParty).toBe(3)
+    expect(ResolutionType.Polymarket).toBe(4)
+    expect(ResolutionType.ChainlinkDataFeed).toBe(5)
+    expect(ResolutionType.ChainlinkFunctions).toBe(6)
+    expect(ResolutionType.UMA).toBe(7)
+  })
+
+  it('flags every oracle-resolved type in ORACLE_RESOLUTION_TYPES', () => {
+    expect(ORACLE_RESOLUTION_TYPES.has(ResolutionType.Polymarket)).toBe(true)
+    expect(ORACLE_RESOLUTION_TYPES.has(ResolutionType.ChainlinkDataFeed)).toBe(true)
+    expect(ORACLE_RESOLUTION_TYPES.has(ResolutionType.ChainlinkFunctions)).toBe(true)
+    expect(ORACLE_RESOLUTION_TYPES.has(ResolutionType.UMA)).toBe(true)
+  })
+
+  it('does NOT flag the local resolution types', () => {
+    expect(ORACLE_RESOLUTION_TYPES.has(ResolutionType.Either)).toBe(false)
+    expect(ORACLE_RESOLUTION_TYPES.has(ResolutionType.Creator)).toBe(false)
+    expect(ORACLE_RESOLUTION_TYPES.has(ResolutionType.Opponent)).toBe(false)
+    expect(ORACLE_RESOLUTION_TYPES.has(ResolutionType.ThirdParty)).toBe(false)
+  })
+})

--- a/scripts/smoke-modal-fix-amoy.js
+++ b/scripts/smoke-modal-fix-amoy.js
@@ -1,0 +1,236 @@
+/**
+ * smoke-modal-fix-amoy.js — Replay the patched modal's contract calls on Amoy.
+ *
+ * Acts as a non-spending equivalent of the manual browser smoke test for
+ * PR #590 (fix/polymarket-pegged-modal-hook-wiring). Uses `createWager.staticCall`
+ * so nothing is actually mined; the contract's argument-validation branches
+ * are exercised end-to-end with the exact (resolutionType, polymarketConditionId,
+ * creatorIsYes) tuples the patched modal+hook now produce.
+ *
+ * Run:
+ *   node scripts/smoke-modal-fix-amoy.js
+ *
+ * Expectations (printed PASS/FAIL inline):
+ *
+ *   A. Polymarket-pegged path WITH a non-zero conditionId:
+ *      → contract accepts the args, reverts only at MembershipDenied (admin
+ *        isn't a paid member). Proves the modal's NEW args are valid.
+ *
+ *   B. Polymarket-pegged path with zero conditionId (the pre-fix payload):
+ *      → reverts PolymarketRequired. Proves the contract still rejects what
+ *        the old modal was sending.
+ *
+ *   C. ChainlinkDataFeed slot with non-zero conditionId (the OLD modal's
+ *      mis-mapping of "PolymarketOracle = 5"):
+ *      → reverts ConditionAlreadyResolved or similar adapter-side error
+ *        (NOT PolymarketRequired). Proves the routing is now correct: the
+ *        slot 5 goes through the Chainlink path, not the Polymarket one.
+ *
+ *   D. ChainlinkDataFeed slot with zero conditionId:
+ *      → reverts OracleConditionRequired (the NEW error class).
+ *
+ *   E. Either resolution with a stray non-zero conditionId:
+ *      → reverts PolymarketDisallowed. Sanity check that non-oracle types
+ *        still require a zero conditionId.
+ *
+ *   F. Either resolution with zero conditionId:
+ *      → reverts MembershipDenied (all arg validation passed, only the
+ *        membership gate stops it).
+ */
+
+const { ethers } = require('ethers');
+require('dotenv').config();
+
+const AMOY_RPC = process.env.AMOY_RPC_URL || 'https://rpc-amoy.polygon.technology';
+const ADMIN_PK = process.env.PRIVATE_KEY;
+
+// v2 Amoy deployment (from PR #589 deployment record)
+const WAGER_REGISTRY = '0x39f1CbC680cDc9831b6dF4D9e4719D3748720aBA';
+const USDC           = '0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582';
+
+const RT = {
+  Either: 0, Creator: 1, Opponent: 2, ThirdParty: 3,
+  Polymarket: 4, ChainlinkDataFeed: 5, ChainlinkFunctions: 6, UMA: 7,
+};
+
+// Minimal ABI — just what we need for the static-call simulation.
+const ABI = [
+  'function createWager(address opponent, address arbitrator, address token, uint128 creatorStake, uint128 opponentStake, uint64 acceptDeadline, uint64 resolveDeadline, uint8 resolutionType, bytes32 polymarketConditionId, bool creatorIsYes, bytes32 metadataHash) external returns (uint256)',
+  // Custom errors so ethers can decode them for clearer output.
+  'error MembershipDenied()',
+  'error PolymarketRequired()',
+  'error PolymarketDisallowed()',
+  'error OracleConditionRequired()',
+  'error OracleAdapterNotSet()',
+  'error UnsupportedOracleResolutionType()',
+  'error ConditionAlreadyResolved()',
+  'error AdapterNotSet()',
+  'error ZeroAddress()',
+  'error SelfWager()',
+  'error NotAllowedToken()',
+  'error ZeroStake()',
+  'error BadDeadlines()',
+  'error ArbitratorRequired()',
+  'error ArbitratorDisallowed()',
+];
+
+// Pull the custom-error name out of an ethers static-call error.
+function classifyRevert(err) {
+  // ethers v6 puts the decoded custom error under err.revert.name (if it
+  // could decode against the contract ABI we passed). Fall through to
+  // string matching on shortMessage / message otherwise.
+  const name = err?.revert?.name;
+  if (name) return name;
+  const msg = (err?.shortMessage || err?.reason || err?.message || '').toString();
+  // Try to extract a Solidity custom-error name. ethers sometimes prints
+  // them as `Error: VM Exception ...: custom error <selector>` or raw "0x<sel>".
+  const customError = msg.match(/custom error '([^']+)'/i)?.[1]
+    || msg.match(/reverted with custom error\s+([A-Za-z]+)/)?.[1];
+  if (customError) return customError;
+  // Plain-string matches for the named errors we care about.
+  for (const errName of [
+    'MembershipDenied', 'PolymarketRequired', 'PolymarketDisallowed',
+    'OracleConditionRequired', 'OracleAdapterNotSet', 'UnsupportedOracleResolutionType',
+    'ConditionAlreadyResolved', 'AdapterNotSet', 'NotAllowedToken',
+    'ZeroAddress', 'SelfWager', 'ZeroStake', 'BadDeadlines',
+    'ArbitratorRequired', 'ArbitratorDisallowed',
+  ]) {
+    if (msg.includes(errName)) return errName;
+  }
+  return msg.split('\n')[0].slice(0, 120) || '(unknown revert)';
+}
+
+async function tryStatic(reg, args, label) {
+  try {
+    await reg.createWager.staticCall(...args);
+    return { label, status: 'SUCCEEDED', detail: '(static call did not revert; would have minted on-chain)' };
+  } catch (e) {
+    return { label, status: 'REVERTED', detail: classifyRevert(e) };
+  }
+}
+
+(async () => {
+  if (!ADMIN_PK) throw new Error('PRIVATE_KEY missing from env');
+  const p = new ethers.JsonRpcProvider(AMOY_RPC);
+  const w = new ethers.Wallet(ADMIN_PK, p);
+  console.log('Admin EOA:', w.address);
+  console.log('Network:  Amoy (chainId', (await p.getNetwork()).chainId.toString() + ')');
+
+  const reg = new ethers.Contract(WAGER_REGISTRY, ABI, w);
+
+  // Build a baseline args tuple that passes early validation (allowed token,
+  // non-zero stakes, sane deadlines, opponent != self, no arbitrator).
+  const now = Math.floor(Date.now() / 1000);
+  const baseline = {
+    opponent: '0x0000000000000000000000000000000000000bad', // anything non-self, non-zero, non-eq
+    arbitrator: ethers.ZeroAddress,
+    token: USDC,
+    creatorStake: ethers.parseUnits('1', 6),  // 1 USDC (we won't actually transfer)
+    opponentStake: ethers.parseUnits('1', 6),
+    acceptDeadline: now + 7 * 24 * 3600,  // +7d
+    resolveDeadline: now + 30 * 24 * 3600, // +30d
+    metadataHash: ethers.keccak256(ethers.toUtf8Bytes('smoke-test')),
+  };
+
+  // Mocked conditionId for the staticCall tests — any non-zero 32-byte value.
+  const fakeCid = '0x' + 'ab'.repeat(32);
+
+  const matrix = [
+    {
+      label: 'A. Polymarket(4) + non-zero conditionId + creatorIsYes=true',
+      args: [
+        baseline.opponent, baseline.arbitrator, baseline.token,
+        baseline.creatorStake, baseline.opponentStake,
+        baseline.acceptDeadline, baseline.resolveDeadline,
+        RT.Polymarket, fakeCid, true,
+        baseline.metadataHash,
+      ],
+      // The Polymarket adapter on Amoy uses MockPolymarketCTF, which returns
+      // false (not resolved) for any unset conditionId. So the
+      // _isConditionResolved branch passes → next gate is membership. Expect
+      // MembershipDenied for the admin EOA (no tier purchased).
+      // (If MockPolymarketCTF doesn't even decode the call, getOutcome's
+      // try/catch falls through to "not resolved" — same effect.)
+      expect: 'MembershipDenied',
+    },
+    {
+      label: 'B. Polymarket(4) + zero conditionId (the OLD modal payload)',
+      args: [
+        baseline.opponent, baseline.arbitrator, baseline.token,
+        baseline.creatorStake, baseline.opponentStake,
+        baseline.acceptDeadline, baseline.resolveDeadline,
+        RT.Polymarket, ethers.ZeroHash, true,
+        baseline.metadataHash,
+      ],
+      expect: 'PolymarketRequired',
+    },
+    {
+      label: 'C. ChainlinkDataFeed(5) + non-zero conditionId',
+      args: [
+        baseline.opponent, baseline.arbitrator, baseline.token,
+        baseline.creatorStake, baseline.opponentStake,
+        baseline.acceptDeadline, baseline.resolveDeadline,
+        RT.ChainlinkDataFeed, fakeCid, true,
+        baseline.metadataHash,
+      ],
+      // Adapter IS registered (PR #589). For an unregistered conditionId,
+      // ChainlinkDataFeedOracleAdapter.isConditionResolved checks the
+      // resolutionCache mapping; default is false. So the stale-condition
+      // gate passes → next gate is membership.
+      expect: 'MembershipDenied',
+    },
+    {
+      label: 'D. ChainlinkDataFeed(5) + zero conditionId',
+      args: [
+        baseline.opponent, baseline.arbitrator, baseline.token,
+        baseline.creatorStake, baseline.opponentStake,
+        baseline.acceptDeadline, baseline.resolveDeadline,
+        RT.ChainlinkDataFeed, ethers.ZeroHash, true,
+        baseline.metadataHash,
+      ],
+      expect: 'OracleConditionRequired',
+    },
+    {
+      label: 'E. Either(0) + stray non-zero conditionId',
+      args: [
+        baseline.opponent, baseline.arbitrator, baseline.token,
+        baseline.creatorStake, baseline.opponentStake,
+        baseline.acceptDeadline, baseline.resolveDeadline,
+        RT.Either, fakeCid, true,
+        baseline.metadataHash,
+      ],
+      expect: 'PolymarketDisallowed',
+    },
+    {
+      label: 'F. Either(0) + zero conditionId (the boring happy path)',
+      args: [
+        baseline.opponent, baseline.arbitrator, baseline.token,
+        baseline.creatorStake, baseline.opponentStake,
+        baseline.acceptDeadline, baseline.resolveDeadline,
+        RT.Either, ethers.ZeroHash, true,
+        baseline.metadataHash,
+      ],
+      expect: 'MembershipDenied',
+    },
+  ];
+
+  console.log('\nReplaying patched-modal contract calls via staticCall...\n');
+  console.log(' #  Scenario'.padEnd(76), 'Got'.padEnd(34), 'Expected');
+  console.log('─'.repeat(150));
+
+  let pass = 0, fail = 0;
+  for (const t of matrix) {
+    const r = await tryStatic(reg, t.args, t.label);
+    const ok = r.detail === t.expect || (r.status === 'SUCCEEDED' && t.expect === 'SUCCEEDED');
+    const mark = ok ? '✓' : '✗';
+    if (ok) pass++; else fail++;
+    console.log(
+      `${mark} ${t.label}`.padEnd(76),
+      r.detail.padEnd(34),
+      t.expect,
+    );
+  }
+  console.log('─'.repeat(150));
+  console.log(`\nResult: ${pass}/${pass + fail} scenarios behaved as expected.`);
+  if (fail > 0) process.exit(1);
+})().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

Three-layer mismatch between modal / hook / contract meant Polymarket-pegged wagers couldn't be created via the UI:

| Layer | Bug |
|---|---|
| **Modal enum import** | Stale `FriendGroupMarketFactory.ResolutionType` (v1) put `PolymarketOracle = 5`, but the v2 contract has `Polymarket = 4` and `ChainlinkDataFeed = 5`. Submissions routed to the wrong adapter slot → `OracleAdapterNotSet` revert. |
| **Form field name** | Modal stored picked conditionId in `formData.peggedMarketId`; hook reads `data.data.polymarketConditionId`. Result: contract received `bytes32(0)` → `PolymarketRequired` revert. |
| **Side picker** | `creatorSide` ('0'\|'1') was never translated to `creatorIsYes` (bool). Hook defaulted to `true`. **Silent bug**: creators picking outcome index 1 lost wagers they should have won. |

## What changed

### `FriendMarketsModal.jsx`
- Imports `ResolutionType` from `constants/wagerDefaults` (canonical 8-value enum, matches `IWagerRegistry.sol`). Removed stale fallback.
- Renamed `peggedMarketId` → `oracleConditionId` (future-proof; same slot will serve ChainlinkDataFeed/Functions/UMA in follow-up PRs).
- Renamed `Initiator`/`Receiver`/`PolymarketOracle` → `Creator`/`Opponent`/`Polymarket` throughout. JSX labels unchanged.
- Submit handler explicitly maps `creatorSide` → `creatorIsYes` (`'0'` ⇒ `true`, `'1'` ⇒ `false`). Verified against `PolymarketOracleAdapter.getOutcome` returning `payouts[0] > payouts[1]`.
- Validation hardening for the Polymarket branch:
  - Reject when no market picked (no oracleConditionId).
  - Reject when no side chosen.
  - Reject when linked Polymarket has already ended.
  - Reject when acceptance deadline ≥ linked market end (closes the gap that bypassed the standard min/max deadline checks).

### `useFriendMarketCreation.js`
- Reads `data.data.oracleConditionId` (with legacy `polymarketConditionId` fallback for any external caller).
- Defense-in-depth guards throw clearly when modal validation is bypassed: oracle resolutionType + zero conditionId, or non-oracle + non-zero conditionId.
- `translateRevert` learns `OracleConditionRequired`, `OracleAdapterNotSet`, `UnsupportedOracleResolutionType`. Critical ordering: the new oracle checks must precede the legacy `AdapterNotSet` substring match (caught by the new unit test).
- `translateRevert` exported (was top-level) so the unit test can hit it without mocking the whole hook.

### Tests
- **`FriendMarketsModal.test.jsx`**: new `Polymarket-pegged wagers` describe block (5 tests). Adds a `chainId` option to `renderWithProviders` so tests can opt into `polymarketSidebets: true` (chainId 80002). Mocks `PolymarketBrowser` to a stub that fires `onSelectMarket` from a button click.
- **`useFriendMarketCreation.translateRevert.test.js`** (new): 8 tests covering legacy reverts, new oracle reverts, shared reverts, empty-input sentinel, and the canonical enum + `ORACLE_RESOLUTION_TYPES`.

## Verified locally

| | |
|---|---|
| Frontend tests | **739/739** (was 725; +14 in this PR) |
| Hardhat tests | **137/137** |
| Production build | ✓ green |

## Out of scope (deferred to follow-ups)

- ChainlinkDataFeed / ChainlinkFunctions / UMA in the resolution-type dropdown — needs admin pre-registration UX first.
- Admin condition-registration screen (`setFeedAllowed` / `registerCondition` / `linkMarket` on each adapter).
- On-chain condition picker that lists pre-registered conditions instead of paste-a-bytes32.
- Deleting the now-dead `ResolutionType` export from `abis/FriendGroupMarketFactory.js` — untouched to minimize blast radius; pure dead code post-this-PR.

## Test plan

### Automated (already run)
- [x] `cd frontend && npx vitest run` — 739/739
- [x] `cd frontend && npm run build` — green
- [x] `npx hardhat test` — 137/137

### Manual browser smoke (still required)
Needs admin wallet `0x5250…6e1` with WAGER_PARTICIPANT tier purchased on Amoy v2 deployment.

1. `cd frontend && npm run dev`, connect MetaMask to Polygon Amoy.
2. **Path A — Dashboard card click**: open the Polymarket browser on the dashboard, pick an active market. Modal opens with the market preselected. Type a description + opponent address, click \"I'm taking Yes\", submit. Inspect the staticCall args (wagmi devtools or network tab) — confirm `resolutionType = 4`, `polymarketConditionId = <picked>`, `creatorIsYes = true`.
3. **Path B — Inline browser pick**: open the modal directly via the dashboard CTA, switch the resolution dropdown to \"Linked Market (Polymarket)\", pick a market from the inline browser, choose a side, submit. Same assertions as A.
4. **Sad paths**: try submit without picking a market → error \"Pick a Polymarket event\". Pick a market that ended in the past (use dev tools or wait) → error \"already ended\".
5. **Wrong chain**: connect to ETC mainnet (chainId 61) → the Polymarket dropdown option should not appear.
6. After a successful submit, query `WagerRegistry.getWager(<id>)` on Amoy. Confirm `w.resolutionType == 4`, `w.polymarketConditionId == <expected>`, `w.creatorIsYes == <expected>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)