### PR TITLE
feat(admin): oracle adapter administration tab + cleanup dead enum

### DIFF
--- a/frontend/src/abis/FriendGroupMarketFactory.js
+++ b/frontend/src/abis/FriendGroupMarketFactory.js
@@ -3558,12 +3558,6 @@ export const FriendGroupMarketFactoryABI = [
 // Back-compat alias used by most importers
 export const FRIEND_GROUP_MARKET_FACTORY_ABI = FriendGroupMarketFactoryABI;
 
-// Enum mirrors for Solidity's ResolutionType
-export const ResolutionType = {
-  Either: 0,
-  Initiator: 1,
-  Receiver: 2,
-  ThirdParty: 3,
-  AutoPegged: 4,
-  PolymarketOracle: 5,
-};
+// Note: a stale v1 ResolutionType enum used to live here. It was deleted in the
+// admin/oracle PR — the canonical enum is `frontend/src/constants/wagerDefaults.js`
+// (8-value, mirrors `contracts/interfaces/IWagerRegistry.sol`).

--- a/frontend/src/components/AdminPanel.css
+++ b/frontend/src/components/AdminPanel.css
@@ -1466,3 +1466,118 @@
   justify-content: center;
   z-index: 1000;
 }
+
+/* ── Oracle adapter admin tab ─────────────────────────────────────────── */
+.oracle-adapters-subtabs {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.75rem 0 1rem;
+  flex-wrap: wrap;
+}
+
+.oracle-adapter-meta {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem 1.5rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  background: var(--bg-tertiary, rgba(255, 255, 255, 0.04));
+  border-radius: 6px;
+  font-size: 0.875rem;
+}
+
+.admin-form-section {
+  border-top: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  padding-top: 1rem;
+  margin-top: 1rem;
+}
+
+.admin-form-section:first-of-type {
+  border-top: none;
+  padding-top: 0;
+  margin-top: 0;
+}
+
+.admin-form-section h4 {
+  margin: 0 0 0.25rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary, #fff);
+}
+
+.admin-hint {
+  margin: 0.25rem 0 0.75rem;
+  font-size: 0.8125rem;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.66));
+  line-height: 1.4;
+}
+
+.admin-hint code {
+  background: var(--bg-tertiary, rgba(255, 255, 255, 0.08));
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  font-size: 0.85em;
+}
+
+.admin-form-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+  margin-bottom: 0.75rem;
+}
+
+.admin-form-row > label {
+  flex: 1 1 14rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.8125rem;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.7));
+}
+
+.admin-form-row > label.admin-form-full {
+  flex-basis: 100%;
+}
+
+.admin-form-row input,
+.admin-form-row select,
+.admin-form-row textarea {
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.12));
+  border-radius: 4px;
+  background: var(--bg-secondary, rgba(0, 0, 0, 0.3));
+  color: var(--text-primary, #fff);
+  font-size: 0.875rem;
+  font-family: inherit;
+}
+
+.admin-form-row textarea {
+  font-family: monospace;
+  font-size: 0.8125rem;
+  resize: vertical;
+}
+
+.admin-btn {
+  padding: 0.55rem 1rem;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.admin-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.admin-btn.primary {
+  background: var(--accent-color, #00b76f);
+  color: #fff;
+}
+
+.admin-btn.primary:hover:not(:disabled) {
+  background: var(--accent-hover, #00a060);
+}

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -9,6 +9,7 @@ import { ROLES, ADMIN_ROLES } from '../contexts/RoleContext'
 import { isValidEthereumAddress } from '../utils/validation'
 import { NETWORK_CONFIG, DEPLOYED_CONTRACTS, getContractAddress } from '../config/contracts'
 import { MEMBERSHIP_MANAGER_ABI } from '../abis/MembershipManager'
+import OracleAdaptersTab from './admin/OracleAdaptersTab'
 import './AdminPanel.css'
 
 const TIER_NAMES = { 1: 'Bronze', 2: 'Silver', 3: 'Gold', 4: 'Platinum' }
@@ -349,6 +350,12 @@ function AdminPanel() {
             className={`admin-panel-tab ${activeTab === 'treasury' ? 'active' : ''}`}
             onClick={() => setActiveTab('treasury')}>Treasury</button>
         )}
+
+        {isAdmin && (
+          <button role="tab" aria-selected={activeTab === 'oracle-adapters'}
+            className={`admin-panel-tab ${activeTab === 'oracle-adapters' ? 'active' : ''}`}
+            onClick={() => setActiveTab('oracle-adapters')}>Oracle Adapters</button>
+        )}
       </nav>
 
       <main className="admin-panel-content">
@@ -657,6 +664,16 @@ function AdminPanel() {
               </div>
             </div>
           </div>
+        )}
+
+        {activeTab === 'oracle-adapters' && isAdmin && (
+          <OracleAdaptersTab
+            signer={signer}
+            account={account}
+            contracts={DEPLOYED_CONTRACTS}
+            runTx={runTx}
+            pendingTx={pendingTx}
+          />
         )}
       </main>
     </div>

--- a/frontend/src/components/admin/OracleAdaptersTab.jsx
+++ b/frontend/src/components/admin/OracleAdaptersTab.jsx
@@ -1,0 +1,656 @@
+import { useState, useMemo, useEffect } from 'react'
+import { ethers } from 'ethers'
+
+// Minimal admin-only ABI fragments. The full ABIs live under
+// frontend/src/abis/{ChainlinkDataFeedOracleAdapter,ChainlinkFunctionsOracleAdapter,UMAOptimisticOracleV3Adapter}.js
+// but pulling them in here would balloon the bundle; the handful of admin
+// functions + owner() read fit in <30 lines.
+
+const COMMON_READS = [
+  'function owner() view returns (address)',
+]
+
+const CHAINLINK_DATA_FEED_ADMIN_ABI = [
+  ...COMMON_READS,
+  'function setFeedAllowed(address feed, bool allowed)',
+  'function registerCondition(bytes32 conditionId, address feed, int256 threshold, uint8 op, uint64 deadline)',
+  'function linkMarket(uint256 friendMarketId, bytes32 conditionId)',
+  'function allowedFeeds(address) view returns (bool)',
+]
+
+const CHAINLINK_FUNCTIONS_ADMIN_ABI = [
+  ...COMMON_READS,
+  'function registerCondition(bytes32 conditionId, bytes encodedRequest, bytes32 sourceHash, uint64 subscriptionId, uint32 gasLimit, bytes32 donId)',
+  'function linkMarket(uint256 friendMarketId, bytes32 conditionId)',
+]
+
+const UMA_ADMIN_ABI = [
+  ...COMMON_READS,
+  'function registerCondition(bytes32 conditionId, bytes claim, address bondCurrency, uint256 bondAmount, uint64 liveness)',
+  'function linkMarket(uint256 friendMarketId, bytes32 conditionId)',
+]
+
+// Chainlink Data Feed adapter's comparison operators (mirrors the contract's
+// `enum Comparison`). Frontend dropdown values match these ordinals.
+const COMPARISON_OPS = [
+  { value: 0, label: 'GT  (price > threshold)' },
+  { value: 1, label: 'GTE (price >= threshold)' },
+  { value: 2, label: 'LT  (price < threshold)' },
+  { value: 3, label: 'LTE (price <= threshold)' },
+  { value: 4, label: 'EQ  (price == threshold)' },
+]
+
+const ADAPTERS = [
+  { key: 'chainlinkDataFeed',  label: 'Chainlink Data Feed', addressKey: 'chainlinkDataFeedAdapter',  abi: CHAINLINK_DATA_FEED_ADMIN_ABI },
+  { key: 'chainlinkFunctions', label: 'Chainlink Functions', addressKey: 'chainlinkFunctionsAdapter', abi: CHAINLINK_FUNCTIONS_ADMIN_ABI },
+  { key: 'uma',                label: 'UMA Optimistic Oracle', addressKey: 'umaAdapter',              abi: UMA_ADMIN_ABI },
+]
+
+function isBytes32Hex(s) {
+  return /^0x[a-fA-F0-9]{64}$/.test((s || '').trim())
+}
+
+function isAddress(s) {
+  try { return ethers.isAddress((s || '').trim()) } catch { return false }
+}
+
+function shortAddr(a) {
+  if (!a || !ethers.isAddress(a)) return a || '—'
+  return a.slice(0, 6) + '…' + a.slice(-4)
+}
+
+/**
+ * OracleAdaptersTab
+ *
+ * Admin UI for the three oracle adapters wired into WagerRegistry as of v2:
+ *  - ChainlinkDataFeedOracleAdapter
+ *  - ChainlinkFunctionsOracleAdapter
+ *  - UMAOptimisticOracleV3Adapter
+ *
+ * Each adapter exposes admin-only `setFeedAllowed` (DataFeed only),
+ * `registerCondition`, and `linkMarket` functions. This tab lets the
+ * deployer EOA (the adapters' `owner()`) drive those calls from the UI
+ * instead of hand-rolling them in a script.
+ *
+ * Out of scope (separate PR): listing pre-registered conditions back to the
+ * user-facing create-wager flow. That needs event indexing; this tab is
+ * write-only for now.
+ */
+function OracleAdaptersTab({ signer, account, contracts, runTx, pendingTx }) {
+  const [activeAdapter, setActiveAdapter] = useState('chainlinkDataFeed')
+  const [adapterOwners, setAdapterOwners] = useState({})
+
+  // Resolve adapter addresses from the synced deployment record.
+  const adapterAddresses = useMemo(() => ({
+    chainlinkDataFeedAdapter: contracts?.chainlinkDataFeedAdapter,
+    chainlinkFunctionsAdapter: contracts?.chainlinkFunctionsAdapter,
+    umaAdapter: contracts?.umaAdapter,
+  }), [contracts])
+
+  // Read each adapter's owner() so the UI can warn the user if they're not
+  // the actual owner (in which case all writes will revert with onlyOwner).
+  useEffect(() => {
+    let cancelled = false
+    if (!signer || !signer.provider) return
+    ;(async () => {
+      const next = {}
+      for (const a of ADAPTERS) {
+        const addr = adapterAddresses[a.addressKey]
+        if (!addr || !ethers.isAddress(addr)) {
+          next[a.key] = null
+          continue
+        }
+        try {
+          const c = new ethers.Contract(addr, COMMON_READS, signer.provider)
+          next[a.key] = await c.owner()
+        } catch {
+          next[a.key] = null
+        }
+      }
+      if (!cancelled) setAdapterOwners(next)
+    })()
+    return () => { cancelled = true }
+  }, [signer, adapterAddresses])
+
+  // ── DataFeed forms ────────────────────────────────────────────────────────
+  const [dfFeed, setDfFeed]               = useState({ address: '', allow: true })
+  const [dfCondition, setDfCondition]     = useState({ conditionId: '', feed: '', threshold: '', op: 0, deadline: '' })
+  const [dfLink, setDfLink]               = useState({ friendMarketId: '', conditionId: '' })
+
+  // ── Functions forms ──────────────────────────────────────────────────────
+  const [fnCondition, setFnCondition]     = useState({ conditionId: '', encodedRequest: '0x', sourceHash: '', subscriptionId: '', gasLimit: '300000', donId: '' })
+  const [fnLink, setFnLink]               = useState({ friendMarketId: '', conditionId: '' })
+
+  // ── UMA forms ────────────────────────────────────────────────────────────
+  const [umaCondition, setUmaCondition]   = useState({ conditionId: '', claim: '', bondCurrency: '', bondAmount: '', liveness: '7200' })
+  const [umaLink, setUmaLink]             = useState({ friendMarketId: '', conditionId: '' })
+
+  function writer(addressKey, abi) {
+    const addr = adapterAddresses[addressKey]
+    if (!addr || !ethers.isAddress(addr) || !signer) return null
+    return new ethers.Contract(addr, abi, signer)
+  }
+
+  // ── Handlers ─────────────────────────────────────────────────────────────
+  const handleSetFeedAllowed = () => {
+    if (!isAddress(dfFeed.address)) return alert('Enter a valid feed address')
+    const c = writer('chainlinkDataFeedAdapter', CHAINLINK_DATA_FEED_ADMIN_ABI)
+    if (!c) return alert('ChainlinkDataFeedOracleAdapter is not deployed on this chain')
+    runTx(
+      () => c.setFeedAllowed(dfFeed.address.trim(), Boolean(dfFeed.allow)),
+      `ChainlinkDataFeed: feed ${shortAddr(dfFeed.address)} ${dfFeed.allow ? 'allowlisted' : 'removed'}`,
+    )
+  }
+
+  const handleDataFeedRegisterCondition = () => {
+    const f = dfCondition
+    if (!isBytes32Hex(f.conditionId)) return alert('conditionId must be a 0x-prefixed 32-byte hex string')
+    if (!isAddress(f.feed)) return alert('Feed address invalid')
+    if (!f.threshold || !/^-?\d+$/.test(String(f.threshold).trim())) return alert('Threshold must be an integer (raw feed units; e.g. 8-decimal scaled)')
+    if (!f.deadline) return alert('Pick a deadline (date/time)')
+    const deadlineSeconds = Math.floor(new Date(f.deadline).getTime() / 1000)
+    if (!Number.isFinite(deadlineSeconds) || deadlineSeconds <= Math.floor(Date.now() / 1000)) {
+      return alert('Deadline must be in the future')
+    }
+    const c = writer('chainlinkDataFeedAdapter', CHAINLINK_DATA_FEED_ADMIN_ABI)
+    if (!c) return alert('Adapter not deployed')
+    runTx(
+      () => c.registerCondition(f.conditionId.trim(), f.feed.trim(), BigInt(String(f.threshold).trim()), Number(f.op), BigInt(deadlineSeconds)),
+      `ChainlinkDataFeed: condition ${f.conditionId.slice(0, 10)}… registered`,
+    )
+  }
+
+  const handleDataFeedLink = () => {
+    if (!isBytes32Hex(dfLink.conditionId)) return alert('conditionId must be a 0x-prefixed 32-byte hex string')
+    if (!/^\d+$/.test((dfLink.friendMarketId || '').trim())) return alert('friendMarketId must be a non-negative integer')
+    const c = writer('chainlinkDataFeedAdapter', CHAINLINK_DATA_FEED_ADMIN_ABI)
+    if (!c) return alert('Adapter not deployed')
+    runTx(
+      () => c.linkMarket(BigInt(dfLink.friendMarketId.trim()), dfLink.conditionId.trim()),
+      `ChainlinkDataFeed: wager #${dfLink.friendMarketId} linked`,
+    )
+  }
+
+  const handleFunctionsRegisterCondition = () => {
+    const f = fnCondition
+    if (!isBytes32Hex(f.conditionId)) return alert('conditionId must be 0x + 64 hex')
+    if (!/^0x[a-fA-F0-9]*$/.test((f.encodedRequest || '').trim())) return alert('encodedRequest must be 0x-prefixed hex')
+    if (!isBytes32Hex(f.sourceHash)) return alert('sourceHash must be 0x + 64 hex')
+    if (!/^\d+$/.test((f.subscriptionId || '').trim())) return alert('subscriptionId must be a non-negative integer')
+    if (!/^\d+$/.test((f.gasLimit || '').trim())) return alert('gasLimit must be a non-negative integer')
+    if (!isBytes32Hex(f.donId)) return alert('donId must be 0x + 64 hex (right-pad if shorter)')
+    const c = writer('chainlinkFunctionsAdapter', CHAINLINK_FUNCTIONS_ADMIN_ABI)
+    if (!c) return alert('Adapter not deployed')
+    runTx(
+      () => c.registerCondition(
+        f.conditionId.trim(),
+        f.encodedRequest.trim(),
+        f.sourceHash.trim(),
+        BigInt(f.subscriptionId.trim()),
+        Number(f.gasLimit.trim()),
+        f.donId.trim(),
+      ),
+      `ChainlinkFunctions: condition ${f.conditionId.slice(0, 10)}… registered`,
+    )
+  }
+
+  const handleFunctionsLink = () => {
+    if (!isBytes32Hex(fnLink.conditionId)) return alert('conditionId invalid')
+    if (!/^\d+$/.test((fnLink.friendMarketId || '').trim())) return alert('friendMarketId must be a non-negative integer')
+    const c = writer('chainlinkFunctionsAdapter', CHAINLINK_FUNCTIONS_ADMIN_ABI)
+    if (!c) return alert('Adapter not deployed')
+    runTx(
+      () => c.linkMarket(BigInt(fnLink.friendMarketId.trim()), fnLink.conditionId.trim()),
+      `ChainlinkFunctions: wager #${fnLink.friendMarketId} linked`,
+    )
+  }
+
+  const handleUmaRegisterCondition = () => {
+    const f = umaCondition
+    if (!isBytes32Hex(f.conditionId)) return alert('conditionId must be 0x + 64 hex')
+    if (!(f.claim || '').trim()) return alert('claim is required (plain text — encoded as UTF-8 bytes)')
+    if (!isAddress(f.bondCurrency)) return alert('bondCurrency must be a valid ERC-20 address')
+    if (!/^\d+$/.test((f.bondAmount || '').trim())) return alert('bondAmount must be a non-negative integer (raw units; e.g. 6-dec USDC)')
+    if (!/^\d+$/.test((f.liveness || '').trim())) return alert('liveness must be a non-negative integer (seconds)')
+    const c = writer('umaAdapter', UMA_ADMIN_ABI)
+    if (!c) return alert('Adapter not deployed')
+    runTx(
+      () => c.registerCondition(
+        f.conditionId.trim(),
+        ethers.toUtf8Bytes(f.claim.trim()),
+        f.bondCurrency.trim(),
+        BigInt(f.bondAmount.trim()),
+        BigInt(f.liveness.trim()),
+      ),
+      `UMA: condition ${f.conditionId.slice(0, 10)}… registered`,
+    )
+  }
+
+  const handleUmaLink = () => {
+    if (!isBytes32Hex(umaLink.conditionId)) return alert('conditionId invalid')
+    if (!/^\d+$/.test((umaLink.friendMarketId || '').trim())) return alert('friendMarketId must be a non-negative integer')
+    const c = writer('umaAdapter', UMA_ADMIN_ABI)
+    if (!c) return alert('Adapter not deployed')
+    runTx(
+      () => c.linkMarket(BigInt(umaLink.friendMarketId.trim()), umaLink.conditionId.trim()),
+      `UMA: wager #${umaLink.friendMarketId} linked`,
+    )
+  }
+
+  // ── Owner-check banner ────────────────────────────────────────────────────
+  const activeMeta = ADAPTERS.find(a => a.key === activeAdapter)
+  const activeAddr = adapterAddresses[activeMeta.addressKey]
+  const activeOwner = adapterOwners[activeAdapter]
+  const isActualOwner = activeOwner && account &&
+    String(activeOwner).toLowerCase() === String(account).toLowerCase()
+
+  return (
+    <div className="admin-tab-content" role="tabpanel">
+      <div className="admin-card">
+        <div className="admin-card-header">
+          <h3>Oracle adapter administration</h3>
+          <p className="admin-hint">
+            Register and link conditions on the three v2 oracle adapters.
+            All writes require the adapter&apos;s <code>onlyOwner</code> — the deployer EOA.
+            Tip: condition IDs are arbitrary 32-byte identifiers; conventionally
+            <code> keccak256(question + bytes32 salt) </code> works well.
+          </p>
+        </div>
+
+        <nav className="oracle-adapters-subtabs" role="tablist" data-testid="oracle-adapters-subtabs">
+          {ADAPTERS.map(a => (
+            <button
+              key={a.key}
+              type="button"
+              role="tab"
+              aria-selected={activeAdapter === a.key}
+              className={`admin-panel-tab ${activeAdapter === a.key ? 'active' : ''}`}
+              onClick={() => setActiveAdapter(a.key)}
+            >
+              {a.label}
+            </button>
+          ))}
+        </nav>
+
+        <div className="oracle-adapter-meta">
+          <div className="status-row">
+            <span className="status-label">Adapter</span>
+            <span className="status-value">{shortAddr(activeAddr)}</span>
+          </div>
+          <div className="status-row">
+            <span className="status-label">Owner</span>
+            <span className={`status-value ${isActualOwner ? 'active' : 'paused'}`}>
+              {activeOwner ? `${shortAddr(activeOwner)} ${isActualOwner ? '(you)' : '(NOT you — writes will revert)'}` : '—'}
+            </span>
+          </div>
+        </div>
+
+        {/* ── Chainlink Data Feed ─────────────────────────────────────── */}
+        {activeAdapter === 'chainlinkDataFeed' && (
+          <>
+            <section className="admin-form-section">
+              <h4>Allowlist a Chainlink price feed</h4>
+              <p className="admin-hint">
+                Feeds must be allowlisted before they can back a condition. On Amoy the
+                ETH/USD feed at <code>0xF0d5…D8e7</code> was allowlisted at deploy time.
+              </p>
+              <div className="admin-form-row">
+                <label>
+                  Feed address
+                  <input
+                    type="text"
+                    placeholder="0x... (Chainlink AggregatorV3)"
+                    value={dfFeed.address}
+                    onChange={e => setDfFeed({ ...dfFeed, address: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+                <label>
+                  Allowed?
+                  <select
+                    value={dfFeed.allow ? '1' : '0'}
+                    onChange={e => setDfFeed({ ...dfFeed, allow: e.target.value === '1' })}
+                    disabled={pendingTx}
+                  >
+                    <option value="1">Yes (allow)</option>
+                    <option value="0">No (remove)</option>
+                  </select>
+                </label>
+                <button
+                  type="button"
+                  className="admin-btn primary"
+                  onClick={handleSetFeedAllowed}
+                  disabled={pendingTx}
+                >setFeedAllowed</button>
+              </div>
+            </section>
+
+            <section className="admin-form-section">
+              <h4>Register condition</h4>
+              <p className="admin-hint">
+                A condition is the predicate a wager auto-resolves on
+                (e.g. &ldquo;ETH/USD &gt; 3000 by Jan 31&rdquo;). The threshold is in the feed&apos;s
+                raw scaled units — ETH/USD on Chainlink is 8-decimal, so $3000 = <code>300000000000</code>.
+              </p>
+              <div className="admin-form-row">
+                <label>
+                  conditionId (bytes32)
+                  <input
+                    type="text"
+                    placeholder="0x + 64 hex chars"
+                    value={dfCondition.conditionId}
+                    onChange={e => setDfCondition({ ...dfCondition, conditionId: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+                <label>
+                  Feed
+                  <input
+                    type="text"
+                    placeholder="0x... (must be allowlisted)"
+                    value={dfCondition.feed}
+                    onChange={e => setDfCondition({ ...dfCondition, feed: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+              </div>
+              <div className="admin-form-row">
+                <label>
+                  Threshold (int256, raw feed units)
+                  <input
+                    type="text"
+                    placeholder="e.g. 300000000000 ($3000 in 8-dec)"
+                    value={dfCondition.threshold}
+                    onChange={e => setDfCondition({ ...dfCondition, threshold: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+                <label>
+                  Comparison
+                  <select
+                    value={dfCondition.op}
+                    onChange={e => setDfCondition({ ...dfCondition, op: Number(e.target.value) })}
+                    disabled={pendingTx}
+                  >
+                    {COMPARISON_OPS.map(o => (
+                      <option key={o.value} value={o.value}>{o.label}</option>
+                    ))}
+                  </select>
+                </label>
+                <label>
+                  Deadline
+                  <input
+                    type="datetime-local"
+                    value={dfCondition.deadline}
+                    onChange={e => setDfCondition({ ...dfCondition, deadline: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+                <button
+                  type="button"
+                  className="admin-btn primary"
+                  onClick={handleDataFeedRegisterCondition}
+                  disabled={pendingTx}
+                >registerCondition</button>
+              </div>
+            </section>
+
+            <section className="admin-form-section">
+              <h4>Link wager → condition</h4>
+              <p className="admin-hint">
+                Bind an existing on-chain wager (by id) to a registered condition so
+                <code> autoResolveFromOracle </code>can settle it.
+              </p>
+              <div className="admin-form-row">
+                <label>
+                  Wager id
+                  <input
+                    type="number"
+                    min="0"
+                    value={dfLink.friendMarketId}
+                    onChange={e => setDfLink({ ...dfLink, friendMarketId: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+                <label>
+                  conditionId (bytes32)
+                  <input
+                    type="text"
+                    placeholder="0x + 64 hex chars"
+                    value={dfLink.conditionId}
+                    onChange={e => setDfLink({ ...dfLink, conditionId: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+                <button
+                  type="button"
+                  className="admin-btn primary"
+                  onClick={handleDataFeedLink}
+                  disabled={pendingTx}
+                >linkMarket</button>
+              </div>
+            </section>
+          </>
+        )}
+
+        {/* ── Chainlink Functions ─────────────────────────────────────── */}
+        {activeAdapter === 'chainlinkFunctions' && (
+          <>
+            <section className="admin-form-section">
+              <h4>Register condition</h4>
+              <p className="admin-hint">
+                Chainlink Functions runs a JS source you supply on a DON.
+                <code>encodedRequest</code> is the CBOR-encoded request bytes produced by
+                <code> @chainlink/functions-toolkit</code>; <code>sourceHash</code> is the
+                <code> keccak256</code> of the JS source. The adapter must be added as a consumer
+                on your LINK subscription before the request will settle.
+              </p>
+              <div className="admin-form-row">
+                <label>
+                  conditionId (bytes32)
+                  <input
+                    type="text" placeholder="0x + 64 hex chars"
+                    value={fnCondition.conditionId}
+                    onChange={e => setFnCondition({ ...fnCondition, conditionId: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+                <label>
+                  sourceHash (bytes32)
+                  <input
+                    type="text" placeholder="keccak256 of JS source"
+                    value={fnCondition.sourceHash}
+                    onChange={e => setFnCondition({ ...fnCondition, sourceHash: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+              </div>
+              <div className="admin-form-row">
+                <label>
+                  subscriptionId (LINK)
+                  <input
+                    type="number" min="0"
+                    value={fnCondition.subscriptionId}
+                    onChange={e => setFnCondition({ ...fnCondition, subscriptionId: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+                <label>
+                  gasLimit
+                  <input
+                    type="number" min="0"
+                    value={fnCondition.gasLimit}
+                    onChange={e => setFnCondition({ ...fnCondition, gasLimit: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+                <label>
+                  donId (bytes32)
+                  <input
+                    type="text" placeholder="e.g. 0x66756e2d706f6c79676f6e2d616d6f792d310000000000000000000000000000"
+                    value={fnCondition.donId}
+                    onChange={e => setFnCondition({ ...fnCondition, donId: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+              </div>
+              <div className="admin-form-row">
+                <label className="admin-form-full">
+                  encodedRequest (CBOR bytes)
+                  <textarea
+                    rows={3}
+                    placeholder="0x... (CBOR-encoded Functions request bytes)"
+                    value={fnCondition.encodedRequest}
+                    onChange={e => setFnCondition({ ...fnCondition, encodedRequest: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+                <button
+                  type="button"
+                  className="admin-btn primary"
+                  onClick={handleFunctionsRegisterCondition}
+                  disabled={pendingTx}
+                >registerCondition</button>
+              </div>
+            </section>
+
+            <section className="admin-form-section">
+              <h4>Link wager → condition</h4>
+              <div className="admin-form-row">
+                <label>
+                  Wager id
+                  <input
+                    type="number" min="0"
+                    value={fnLink.friendMarketId}
+                    onChange={e => setFnLink({ ...fnLink, friendMarketId: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+                <label>
+                  conditionId (bytes32)
+                  <input
+                    type="text" placeholder="0x + 64 hex chars"
+                    value={fnLink.conditionId}
+                    onChange={e => setFnLink({ ...fnLink, conditionId: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+                <button
+                  type="button"
+                  className="admin-btn primary"
+                  onClick={handleFunctionsLink}
+                  disabled={pendingTx}
+                >linkMarket</button>
+              </div>
+            </section>
+          </>
+        )}
+
+        {/* ── UMA Optimistic Oracle V3 ────────────────────────────────── */}
+        {activeAdapter === 'uma' && (
+          <>
+            <section className="admin-form-section">
+              <h4>Register condition</h4>
+              <p className="admin-hint">
+                UMA OOv3 lets anyone assert a claim under a bond. The adapter escrows
+                the bond, calls OOv3, and waits out the liveness window. Bond and
+                liveness are per-condition — set them generously enough that disputing
+                bad claims is economically worthwhile.
+              </p>
+              <div className="admin-form-row">
+                <label>
+                  conditionId (bytes32)
+                  <input
+                    type="text" placeholder="0x + 64 hex chars"
+                    value={umaCondition.conditionId}
+                    onChange={e => setUmaCondition({ ...umaCondition, conditionId: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+                <label>
+                  Bond currency (ERC-20 address)
+                  <input
+                    type="text" placeholder="0x... (e.g. USDC)"
+                    value={umaCondition.bondCurrency}
+                    onChange={e => setUmaCondition({ ...umaCondition, bondCurrency: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+              </div>
+              <div className="admin-form-row">
+                <label>
+                  Bond amount (raw units)
+                  <input
+                    type="number" min="0"
+                    value={umaCondition.bondAmount}
+                    onChange={e => setUmaCondition({ ...umaCondition, bondAmount: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+                <label>
+                  Liveness (seconds, &gt;= 7200)
+                  <input
+                    type="number" min="7200"
+                    value={umaCondition.liveness}
+                    onChange={e => setUmaCondition({ ...umaCondition, liveness: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+              </div>
+              <div className="admin-form-row">
+                <label className="admin-form-full">
+                  Claim text
+                  <textarea
+                    rows={3}
+                    placeholder="Plain-English claim — e.g. 'ETH/USD closes above 3000 on 2026-12-31 at 23:59 UTC'"
+                    value={umaCondition.claim}
+                    onChange={e => setUmaCondition({ ...umaCondition, claim: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+                <button
+                  type="button"
+                  className="admin-btn primary"
+                  onClick={handleUmaRegisterCondition}
+                  disabled={pendingTx}
+                >registerCondition</button>
+              </div>
+            </section>
+
+            <section className="admin-form-section">
+              <h4>Link wager → condition</h4>
+              <div className="admin-form-row">
+                <label>
+                  Wager id
+                  <input
+                    type="number" min="0"
+                    value={umaLink.friendMarketId}
+                    onChange={e => setUmaLink({ ...umaLink, friendMarketId: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+                <label>
+                  conditionId (bytes32)
+                  <input
+                    type="text" placeholder="0x + 64 hex chars"
+                    value={umaLink.conditionId}
+                    onChange={e => setUmaLink({ ...umaLink, conditionId: e.target.value })}
+                    disabled={pendingTx}
+                  />
+                </label>
+                <button
+                  type="button"
+                  className="admin-btn primary"
+                  onClick={handleUmaLink}
+                  disabled={pendingTx}
+                >linkMarket</button>
+              </div>
+            </section>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default OracleAdaptersTab

--- a/frontend/src/test/OracleAdaptersTab.test.jsx
+++ b/frontend/src/test/OracleAdaptersTab.test.jsx
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import OracleAdaptersTab from '../components/admin/OracleAdaptersTab'
+
+// Mock ethers so the component never makes real RPC calls. We intercept
+// `new ethers.Contract(addr, abi, signerOrProvider).<fn>(...)` by returning
+// stub instances with the methods the tab calls.
+
+const { dataFeedStub, functionsStub, umaStub, txReceipt } = vi.hoisted(() => {
+  const txReceipt = { wait: vi.fn().mockResolvedValue({ status: 1 }) }
+  return {
+    txReceipt,
+    dataFeedStub: {
+      owner: vi.fn().mockResolvedValue('0x52502d049571C7893447b86c4d8B38e6184bF6e1'),
+      setFeedAllowed: vi.fn().mockResolvedValue(txReceipt),
+      registerCondition: vi.fn().mockResolvedValue(txReceipt),
+      linkMarket: vi.fn().mockResolvedValue(txReceipt),
+    },
+    functionsStub: {
+      owner: vi.fn().mockResolvedValue('0x52502d049571C7893447b86c4d8B38e6184bF6e1'),
+      registerCondition: vi.fn().mockResolvedValue(txReceipt),
+      linkMarket: vi.fn().mockResolvedValue(txReceipt),
+    },
+    umaStub: {
+      owner: vi.fn().mockResolvedValue('0x52502d049571C7893447b86c4d8B38e6184bF6e1'),
+      registerCondition: vi.fn().mockResolvedValue(txReceipt),
+      linkMarket: vi.fn().mockResolvedValue(txReceipt),
+    },
+  }
+})
+
+vi.mock('ethers', async () => {
+  const real = await vi.importActual('ethers')
+  const stubs = {
+    '0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23': dataFeedStub,
+    '0x074fC18C1E322a7537b53B8B2Bf0762629E3b532': functionsStub,
+    '0xcEa9b4A01CcD3aA6545ea834a268C69e7eEfee88': umaStub,
+  }
+  // `new ethers.Contract(addr, ...)` requires a constructor; use a real
+  // function expression so the `new` invocation returns the right stub.
+  function FakeContract(addr) {
+    return stubs[addr] || {}
+  }
+  return {
+    ...real,
+    ethers: {
+      ...real.ethers,
+      Contract: FakeContract,
+      isAddress: (s) => /^0x[a-fA-F0-9]{40}$/.test(String(s || '').trim()),
+      toUtf8Bytes: real.ethers.toUtf8Bytes,
+    },
+  }
+})
+
+const adminAccount = '0x52502d049571C7893447b86c4d8B38e6184bF6e1'
+
+const defaultProps = {
+  signer: { provider: {} },  // truthy is enough; ethers.Contract is mocked
+  account: adminAccount,
+  contracts: {
+    chainlinkDataFeedAdapter: '0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23',
+    chainlinkFunctionsAdapter: '0x074fC18C1E322a7537b53B8B2Bf0762629E3b532',
+    umaAdapter: '0xcEa9b4A01CcD3aA6545ea834a268C69e7eEfee88',
+  },
+  runTx: vi.fn((fn) => fn()),
+  pendingTx: false,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Suppress jsdom alert() bubbles in the validation tests.
+  vi.spyOn(window, 'alert').mockImplementation(() => {})
+})
+
+describe('OracleAdaptersTab', () => {
+  it('renders the three adapter sub-tabs', () => {
+    render(<OracleAdaptersTab {...defaultProps} />)
+    expect(screen.getByRole('tab', { name: /chainlink data feed/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /chainlink functions/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /uma optimistic oracle/i })).toBeInTheDocument()
+  })
+
+  it('shows the owner banner with "(you)" when account === adapter.owner()', async () => {
+    render(<OracleAdaptersTab {...defaultProps} />)
+    await waitFor(() => {
+      // Owner read populates async; once it resolves the (you) hint appears.
+      expect(screen.getByText(/\(you\)/i)).toBeInTheDocument()
+    })
+  })
+
+  it('warns when the connected account is NOT the adapter owner', async () => {
+    dataFeedStub.owner.mockResolvedValueOnce('0x9999999999999999999999999999999999999999')
+    render(
+      <OracleAdaptersTab
+        {...defaultProps}
+        account="0x1111111111111111111111111111111111111111"
+      />
+    )
+    await waitFor(() => {
+      expect(screen.getByText(/NOT you/i)).toBeInTheDocument()
+    })
+  })
+
+  it('Chainlink Data Feed: setFeedAllowed validates input + calls the adapter', async () => {
+    render(<OracleAdaptersTab {...defaultProps} />)
+
+    // Empty form → alert, no tx
+    await userEvent.click(screen.getByRole('button', { name: /setFeedAllowed/i }))
+    expect(dataFeedStub.setFeedAllowed).not.toHaveBeenCalled()
+
+    // Valid feed → calls the contract
+    const feedInput = screen.getByPlaceholderText(/Chainlink AggregatorV3/i)
+    await userEvent.type(feedInput, '0xF0d50568e3A7e8259E16663972b11910F89BD8e7')
+    await userEvent.click(screen.getByRole('button', { name: /setFeedAllowed/i }))
+
+    expect(defaultProps.runTx).toHaveBeenCalled()
+    expect(dataFeedStub.setFeedAllowed).toHaveBeenCalledWith(
+      '0xF0d50568e3A7e8259E16663972b11910F89BD8e7',
+      true
+    )
+  })
+
+  it('Chainlink Data Feed: registerCondition forwards the full arg tuple', async () => {
+    render(<OracleAdaptersTab {...defaultProps} />)
+
+    const cidInput     = screen.getAllByPlaceholderText(/0x \+ 64 hex chars/i)[0]
+    const feedInput    = screen.getAllByPlaceholderText(/must be allowlisted/i)[0]
+    const thresholdIn  = screen.getAllByPlaceholderText(/8-dec/i)[0]
+    const deadlineIn   = document.querySelector('input[type="datetime-local"]')
+
+    const futureDate = new Date(Date.now() + 7 * 24 * 3600 * 1000)
+    const isoLocal = futureDate.toISOString().slice(0, 16)
+
+    await userEvent.type(cidInput, '0x' + 'a'.repeat(64))
+    await userEvent.type(feedInput, '0xF0d50568e3A7e8259E16663972b11910F89BD8e7')
+    await userEvent.type(thresholdIn, '300000000000')
+    fireEvent.change(deadlineIn, { target: { value: isoLocal } })
+
+    await userEvent.click(screen.getByRole('button', { name: /^registerCondition$/i }))
+
+    expect(dataFeedStub.registerCondition).toHaveBeenCalledTimes(1)
+    const [conditionId, feed, threshold, op, deadline] = dataFeedStub.registerCondition.mock.calls[0]
+    expect(conditionId).toBe('0x' + 'a'.repeat(64))
+    expect(feed).toBe('0xF0d50568e3A7e8259E16663972b11910F89BD8e7')
+    expect(threshold).toBe(300000000000n)  // BigInt
+    expect(op).toBe(0)  // default = GT
+    expect(typeof deadline).toBe('bigint')
+    expect(Number(deadline)).toBeGreaterThan(Math.floor(Date.now() / 1000))
+  })
+
+  it('Chainlink Data Feed: linkMarket validates ids and bytes32', async () => {
+    render(<OracleAdaptersTab {...defaultProps} />)
+
+    // The third "0x + 64 hex chars" placeholder belongs to the linkMarket form.
+    const linkCidInput = screen.getAllByPlaceholderText(/0x \+ 64 hex chars/i)[1]
+    const wagerIdInputs = screen.getAllByRole('spinbutton')  // type=number inputs
+    const wagerIdInput = wagerIdInputs[wagerIdInputs.length - 1]
+
+    await userEvent.type(wagerIdInput, '42')
+    await userEvent.type(linkCidInput, '0x' + 'b'.repeat(64))
+    await userEvent.click(screen.getByRole('button', { name: /^linkMarket$/i }))
+
+    expect(dataFeedStub.linkMarket).toHaveBeenCalledTimes(1)
+    expect(dataFeedStub.linkMarket).toHaveBeenCalledWith(42n, '0x' + 'b'.repeat(64))
+  })
+
+  it('UMA: registerCondition converts the claim text to UTF-8 bytes', async () => {
+    render(<OracleAdaptersTab {...defaultProps} />)
+
+    // Switch to UMA sub-tab.
+    await userEvent.click(screen.getByRole('tab', { name: /uma optimistic oracle/i }))
+
+    // The register-condition form is the first "0x + 64 hex chars" cid input.
+    const cidInput = screen.getAllByPlaceholderText(/0x \+ 64 hex chars/i)[0]
+    const bondAddrInput = screen.getByPlaceholderText(/0x.*e\.g\. USDC/i)
+    const claimArea = screen.getByPlaceholderText(/Plain-English claim/i)
+    const numberInputs = screen.getAllByRole('spinbutton')
+    const [bondAmtInput, livenessInput] = numberInputs
+
+    await userEvent.type(cidInput, '0x' + 'c'.repeat(64))
+    await userEvent.type(bondAddrInput, '0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582')
+    await userEvent.type(bondAmtInput, '5000000')   // 5 USDC (6-dec raw)
+    await userEvent.clear(livenessInput)
+    await userEvent.type(livenessInput, '7200')
+    await userEvent.type(claimArea, 'ETH closes above 3000 on 2026-12-31')
+
+    await userEvent.click(screen.getByRole('button', { name: /^registerCondition$/i }))
+
+    expect(umaStub.registerCondition).toHaveBeenCalledTimes(1)
+    const [conditionId, claimBytes, bondCurrency, bondAmount, liveness] =
+      umaStub.registerCondition.mock.calls[0]
+    expect(conditionId).toBe('0x' + 'c'.repeat(64))
+    // claimBytes should be a Uint8Array of the UTF-8 encoded text.
+    expect(claimBytes).toBeInstanceOf(Uint8Array)
+    expect(new TextDecoder().decode(claimBytes)).toBe('ETH closes above 3000 on 2026-12-31')
+    expect(bondCurrency).toBe('0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582')
+    expect(bondAmount).toBe(5000000n)
+    expect(liveness).toBe(7200n)
+  })
+
+  it('Chainlink Functions: registerCondition forwards CBOR + numeric args', async () => {
+    render(<OracleAdaptersTab {...defaultProps} />)
+    await userEvent.click(screen.getByRole('tab', { name: /chainlink functions/i }))
+
+    const cidInput        = screen.getAllByPlaceholderText(/0x \+ 64 hex chars/i)[0]
+    const sourceHashInput = screen.getAllByPlaceholderText(/keccak256 of JS source/i)[0]
+    const donIdInput      = screen.getAllByPlaceholderText(/0x66756e/i)[0]
+    const encodedInput    = screen.getByPlaceholderText(/CBOR-encoded Functions request/i)
+    const numberInputs    = screen.getAllByRole('spinbutton')
+
+    const subscriptionInput = numberInputs[0]
+    const gasLimitInput     = numberInputs[1]
+
+    await userEvent.type(cidInput, '0x' + 'd'.repeat(64))
+    await userEvent.type(sourceHashInput, '0x' + 'e'.repeat(64))
+    await userEvent.type(donIdInput,
+      '0x66756e2d706f6c79676f6e2d616d6f792d310000000000000000000000000000')
+    await userEvent.type(subscriptionInput, '42')
+    await userEvent.clear(gasLimitInput)
+    await userEvent.type(gasLimitInput, '300000')
+    await userEvent.clear(encodedInput)
+    await userEvent.type(encodedInput, '0xdeadbeef')
+
+    await userEvent.click(screen.getByRole('button', { name: /^registerCondition$/i }))
+
+    expect(functionsStub.registerCondition).toHaveBeenCalledTimes(1)
+    const [conditionId, encodedRequest, sourceHash, subscriptionId, gasLimit, donId] =
+      functionsStub.registerCondition.mock.calls[0]
+    expect(conditionId).toBe('0x' + 'd'.repeat(64))
+    expect(encodedRequest).toBe('0xdeadbeef')
+    expect(sourceHash).toBe('0x' + 'e'.repeat(64))
+    expect(subscriptionId).toBe(42n)
+    expect(gasLimit).toBe(300000)
+    expect(donId).toBe('0x66756e2d706f6c79676f6e2d616d6f792d310000000000000000000000000000')
+  })
+
+  it('disables all submit buttons when pendingTx is true', () => {
+    render(<OracleAdaptersTab {...defaultProps} pendingTx />)
+    const buttons = screen.getAllByRole('button').filter(b => /setFeedAllowed|registerCondition|linkMarket/.test(b.textContent))
+    expect(buttons.length).toBeGreaterThan(0)
+    for (const b of buttons) expect(b).toBeDisabled()
+  })
+})

--- a/frontend/src/test/OracleAdaptersTab.test.jsx
+++ b/frontend/src/test/OracleAdaptersTab.test.jsx
@@ -8,10 +8,9 @@ import OracleAdaptersTab from '../components/admin/OracleAdaptersTab'
 // `new ethers.Contract(addr, abi, signerOrProvider).<fn>(...)` by returning
 // stub instances with the methods the tab calls.
 
-const { dataFeedStub, functionsStub, umaStub, txReceipt } = vi.hoisted(() => {
+const { dataFeedStub, functionsStub, umaStub } = vi.hoisted(() => {
   const txReceipt = { wait: vi.fn().mockResolvedValue({ status: 1 }) }
   return {
-    txReceipt,
     dataFeedStub: {
       owner: vi.fn().mockResolvedValue('0x52502d049571C7893447b86c4d8B38e6184bF6e1'),
       setFeedAllowed: vi.fn().mockResolvedValue(txReceipt),


### PR DESCRIPTION
## Summary

Lets the deployer EOA drive `setFeedAllowed` / `registerCondition` / `linkMarket` on the three v2 oracle adapters from the `/admin` UI instead of one-off scripts.

| | |
|---|---|
| Branch | `feat/admin-oracle-adapters-tab` (off latest `main`, post-#590) |
| Files | 5 changed, +1036 / -9 |
| Tests | **748/748** frontend (was 739; +9), build green |

## What's in

### New component: `frontend/src/components/admin/OracleAdaptersTab.jsx`
Three sub-tabs (one per adapter), each with the right shape of admin form:

| Adapter | Forms |
|---|---|
| **ChainlinkDataFeed** | `setFeedAllowed(feed, bool)` · `registerCondition(conditionId, feed, threshold, op, deadline)` · `linkMarket(wagerId, conditionId)` |
| **ChainlinkFunctions** | `registerCondition(conditionId, encodedRequest, sourceHash, subscriptionId, gasLimit, donId)` · `linkMarket` |
| **UMA** | `registerCondition(conditionId, claim, bondCurrency, bondAmount, liveness)` · `linkMarket` |

Reads each adapter's `owner()` async and surfaces a banner — green when the connected account matches, red **NOT you — writes will revert** when it doesn't. Reuses AdminPanel's existing `runTx` for tx submit + notifications + error handling. All submit buttons disable while `pendingTx`.

### Cleanup: `frontend/src/abis/FriendGroupMarketFactory.js`
Deleted the dead `ResolutionType` export. It came from a v1 contract that no longer exists; nothing has imported it since PR #590 unified all consumers on `frontend/src/constants/wagerDefaults.js`. Left a one-line tombstone pointing at the canonical enum.

### Wiring: `AdminPanel.jsx` + `AdminPanel.css`
Tab nav entry alongside Treasury, gated on `isAdmin`. New CSS classes for the form sections (`.admin-form-section`, `.admin-form-row`, `.admin-hint`, `.admin-btn`) — pure additions, no existing styles touched.

### Tests: `OracleAdaptersTab.test.jsx` (9)
- Sub-tabs render
- Owner banner matches/doesn't-match cases
- Each form's argument tuple is forwarded correctly (BigInt threshold, UTF-8 claim bytes, donId bytes32 passthrough, etc.)
- Global disable-while-pending gate

Uses `vi.hoisted` + a `FakeContract` function mock so `new ethers.Contract(addr, abi, signer)` returns per-address stubs without real RPC.

## Out of scope (deferred follow-up PR)

- **Condition picker** for the create-wager flow: list pre-registered conditions so users don't paste a raw bytes32. Needs event indexing (`ConditionRegistered` log subscriptions per adapter).
- **Modal dropdown surfacing** of `ChainlinkDataFeed` / `ChainlinkFunctions` / `UMA`. Depends on the picker; without it users couldn't bind a wager to a condition.

## How to test in the browser

```
cd frontend && npm run dev
```

1. Connect MetaMask as the admin EOA (`0x5250…6e1`) on Polygon Amoy.
2. Navigate to `/admin` → new **Oracle Adapters** tab is visible.
3. The active sub-tab's "Owner" row shows `0x5250…6e1 (you)`.
4. Click "Chainlink Data Feed" sub-tab → fill in:
   - Feed: `0xF0d50568e3A7e8259E16663972b11910F89BD8e7` (Amoy ETH/USD, already allowlisted at deploy)
   - Threshold: `300000000000` (= $3000 in 8-dec)
   - Comparison: GT
   - Deadline: pick a future date
   - conditionId: any 32-byte hex
   Click **registerCondition**. Wallet pops a tx. Confirm. Notification shows success.
5. Switch to **UMA** → register a bond-currency-USDC condition with a plain-English claim. Confirms `ethers.toUtf8Bytes(claim)` lands as bytes.
6. Sanity: connect with a non-admin wallet → tab is hidden; if you force the URL the page renders but writes revert against the on-chain owner check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)