### PR TITLE
feat(frontend): condition picker + 3 new oracle types in createWager dropdown

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.css
+++ b/frontend/src/components/fairwins/FriendMarketsModal.css
@@ -1485,3 +1485,171 @@
   font-weight: 600;
   font-size: 0.9rem;
 }
+
+/* ── Oracle condition picker ─────────────────────────────────────────── */
+.fm-oracle-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.fm-oracle-picker--unavailable {
+  background: var(--bg-tertiary, rgba(255, 255, 255, 0.04));
+  padding: 0.75rem;
+  border-radius: 4px;
+}
+
+.fm-oracle-picker-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  max-height: 16rem;
+  overflow-y: auto;
+  padding: 0.25rem;
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  border-radius: 6px;
+  background: var(--bg-secondary, rgba(0, 0, 0, 0.25));
+}
+
+.fm-oracle-picker-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-primary, #fff);
+  text-align: left;
+  cursor: pointer;
+  font-size: 0.875rem;
+  transition: background 0.12s, border-color 0.12s;
+}
+
+.fm-oracle-picker-row:hover:not(:disabled) {
+  background: var(--bg-hover, rgba(255, 255, 255, 0.06));
+  border-color: var(--border-color, rgba(255, 255, 255, 0.18));
+}
+
+.fm-oracle-picker-row.is-selected {
+  border-color: var(--accent-color, #00b76f);
+  background: rgba(0, 183, 111, 0.08);
+}
+
+.fm-oracle-picker-row.is-stale,
+.fm-oracle-picker-row:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.fm-oracle-picker-row--idle,
+.fm-oracle-picker-row--empty,
+.fm-oracle-picker-row--error {
+  background: transparent;
+  cursor: default;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.7));
+  font-style: italic;
+}
+
+.fm-oracle-picker-row-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.fm-oracle-picker-row-head code {
+  font-family: monospace;
+  font-size: 0.85em;
+  color: var(--text-primary, #fff);
+}
+
+.fm-oracle-picker-row-meta {
+  font-size: 0.8125rem;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.66));
+  line-height: 1.3;
+}
+
+.fm-oracle-picker-badge {
+  font-size: 0.6875rem;
+  padding: 0.1rem 0.4rem;
+  background: rgba(255, 100, 100, 0.18);
+  color: #ffb4b4;
+  border-radius: 99px;
+  font-style: normal;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.fm-oracle-picker-manual-toggle {
+  margin-top: 0.25rem;
+}
+
+.fm-oracle-picker-manual {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+
+.fm-oracle-picker-manual label {
+  flex: 1 1 18rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.8125rem;
+}
+
+.fm-oracle-picker-manual input {
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.12));
+  border-radius: 4px;
+  background: var(--bg-secondary, rgba(0, 0, 0, 0.3));
+  color: var(--text-primary, #fff);
+  font-family: monospace;
+  font-size: 0.8125rem;
+}
+
+.fm-oracle-picker-btn {
+  padding: 0.4rem 0.8rem;
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.16));
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-primary, #fff);
+  cursor: pointer;
+  font-size: 0.8125rem;
+}
+
+.fm-oracle-picker-btn.primary {
+  background: var(--accent-color, #00b76f);
+  border-color: transparent;
+  font-weight: 600;
+}
+
+.fm-oracle-picker-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.fm-oracle-picker-current {
+  font-size: 0.8125rem;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.7));
+}
+
+.fm-oracle-picker-current code {
+  font-family: monospace;
+  color: var(--text-primary, #fff);
+}
+
+.fm-oracle-picker-clear {
+  margin-left: 0.5rem;
+  padding: 0.15rem 0.5rem;
+  background: transparent;
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.15));
+  border-radius: 3px;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.7));
+  font-size: 0.75rem;
+  cursor: pointer;
+}

--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -17,6 +17,8 @@ import { isEnsName } from '../../utils/validation'
 import { useChainTokens } from '../../hooks/useChainTokens'
 import { usePolymarketSearch } from '../../hooks/usePolymarketSearch'
 import PolymarketBrowser from './PolymarketBrowser'
+import OracleConditionPicker from './OracleConditionPicker'
+import { getContractAddress } from '../../config/contracts'
 import { formatUSD, getMarketUrl } from './marketHelpers'
 import TransactionProgress from './TransactionProgress'
 import './FriendMarketsModal.css'
@@ -51,6 +53,24 @@ function FriendMarketsModal({
   // Polymarket CTF is reachable (Polygon Amoy and Mainnet).
   const { capabilities } = useChainTokens()
   const polymarketSidebetsEnabled = Boolean(capabilities?.polymarketSidebets)
+
+  // Adapter addresses for the extensible oracle resolution types. Each option
+  // in the resolution-type dropdown self-gates on the adapter being deployed
+  // on the active chain — synced into frontend/src/config/contracts.js by
+  // `npm run sync:frontend-contracts`.
+  const chainlinkDataFeedAdapter  = getContractAddress('chainlinkDataFeedAdapter')
+  const chainlinkFunctionsAdapter = getContractAddress('chainlinkFunctionsAdapter')
+  const umaAdapter                = getContractAddress('umaAdapter')
+  const hasOracleAdapter = {
+    [ResolutionType.ChainlinkDataFeed]:  Boolean(chainlinkDataFeedAdapter),
+    [ResolutionType.ChainlinkFunctions]: Boolean(chainlinkFunctionsAdapter),
+    [ResolutionType.UMA]:                Boolean(umaAdapter),
+  }
+  const isExtensibleOracleType = (t) => (
+    t === ResolutionType.ChainlinkDataFeed ||
+    t === ResolutionType.ChainlinkFunctions ||
+    t === ResolutionType.UMA
+  )
 
   // Chain-aware token metadata for the Stake Token dropdown. Recomputed
   // whenever the user switches Testnet/Mainnet so the right addresses are
@@ -227,6 +247,17 @@ function FriendMarketsModal({
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [isOpen, handleClose])
 
+  // Whenever the user switches AWAY from Polymarket resolution, drop the
+  // selected Polymarket market so the linked-market UI doesn't bleed into
+  // the new oracle-condition flow. We can't do this inside handleFormChange's
+  // setFormData callback because selectedPolymarketMarket is separate state.
+  useEffect(() => {
+    if (formData.resolutionType !== ResolutionType.Polymarket && selectedPolymarketMarket) {
+      setSelectedPolymarketMarket(null)
+      setPolymarketBrowserOpen(false)
+    }
+  }, [formData.resolutionType, selectedPolymarketMarket])
+
   const handleBackdropClick = (e) => {
     if (e.target === e.currentTarget) {
       handleClose()
@@ -249,15 +280,26 @@ function FriendMarketsModal({
 
       // Clear arbitrator/linked-market state when switching to a resolution
       // type that doesn't need it.
+      const valueIsOracleResolved = value === ResolutionType.Polymarket ||
+        value === ResolutionType.ChainlinkDataFeed ||
+        value === ResolutionType.ChainlinkFunctions ||
+        value === ResolutionType.UMA
       if (field === 'resolutionType' &&
           value !== ResolutionType.ThirdParty &&
-          value !== ResolutionType.Polymarket) {
+          !valueIsOracleResolved) {
         updated.arbitrator = ''
         updated.arbitratorResolved = ''
-        updated.oracleConditionId = ''
       }
-      if (field === 'resolutionType' && value !== ResolutionType.Polymarket) {
+      if (field === 'resolutionType' && !valueIsOracleResolved) {
+        // Leaving the oracle family entirely → clear conditionId + side.
+        updated.oracleConditionId = ''
         updated.creatorSide = ''
+      }
+      if (field === 'resolutionType' && valueIsOracleResolved && prev.resolutionType !== value) {
+        // Switching among oracle types resets the conditionId — different
+        // adapters register different ids, so carrying state across is wrong.
+        // (Side preference IS preserved: YES/NO maps the same way for all.)
+        updated.oracleConditionId = ''
       }
 
       return updated
@@ -617,6 +659,22 @@ function FriendMarketsModal({
             }
           }
         }
+      } else if (isExtensibleOracleType(formData.resolutionType)) {
+        // The same oracle conditionId field, validated the same way as the
+        // Polymarket branch above but with messaging that reflects the
+        // generic picker UX.
+        const cid = (formData.oracleConditionId || '').trim()
+        if (!cid) {
+          newErrors.oracleConditionId = 'Pick (or paste) a registered conditionId for the chosen oracle'
+        } else if (!/^0x[a-fA-F0-9]{64}$/.test(cid)) {
+          newErrors.oracleConditionId = 'Invalid conditionId (expected 0x + 64 hex chars)'
+        }
+        if (formData.creatorSide !== '0' && formData.creatorSide !== '1') {
+          newErrors.creatorSide = 'Pick which side of the bet you are taking (YES or NO)'
+        }
+        // We don't have an off-chain "linked market end date" for these, so
+        // the standard MIN/MAX deadline checks (run earlier in this function)
+        // already cover the deadline path.
       }
     }
 
@@ -1083,6 +1141,15 @@ function FriendMarketsModal({
                           {polymarketSidebetsEnabled && (
                             <option value={ResolutionType.Polymarket}>Linked Market (Polymarket)</option>
                           )}
+                          {hasOracleAdapter[ResolutionType.ChainlinkDataFeed] && (
+                            <option value={ResolutionType.ChainlinkDataFeed}>Chainlink Data Feed (price condition)</option>
+                          )}
+                          {hasOracleAdapter[ResolutionType.ChainlinkFunctions] && (
+                            <option value={ResolutionType.ChainlinkFunctions}>Chainlink Functions (custom request)</option>
+                          )}
+                          {hasOracleAdapter[ResolutionType.UMA] && (
+                            <option value={ResolutionType.UMA}>UMA Optimistic Oracle (claim assertion)</option>
+                          )}
                         </select>
                         <span className="fm-hint">
                           {formData.resolutionType === ResolutionType.Either && 'Either you or your opponent can resolve the wager'}
@@ -1090,6 +1157,9 @@ function FriendMarketsModal({
                           {formData.resolutionType === ResolutionType.Opponent && 'Only your opponent can resolve the wager'}
                           {formData.resolutionType === ResolutionType.ThirdParty && 'A designated arbitrator will resolve disputes'}
                           {formData.resolutionType === ResolutionType.Polymarket && 'Settles automatically when the linked Polymarket market resolves'}
+                          {formData.resolutionType === ResolutionType.ChainlinkDataFeed && 'Settles automatically once the price feed reading at the deadline passes the threshold'}
+                          {formData.resolutionType === ResolutionType.ChainlinkFunctions && 'Settles when the Chainlink Functions DON returns a result (admin-registered request)'}
+                          {formData.resolutionType === ResolutionType.UMA && 'Settles via UMA Optimistic Oracle — someone posts the bond and the assertion stands after the liveness window'}
                           {!polymarketSidebetsEnabled && (
                             <em style={{ display: 'block', marginTop: '0.25rem', opacity: 0.75 }}>
                               Linked Market settlement requires a chain with the Polymarket CTF. Switch to Polygon (Amoy or Mainnet) to use it.
@@ -1356,6 +1426,71 @@ function FriendMarketsModal({
 
                         {errors.oracleConditionId && (
                           <span className="fm-error">{errors.oracleConditionId}</span>
+                        )}
+                      </div>
+                    )}
+
+                    {/* Oracle condition picker — Chainlink Data Feed / Chainlink Functions / UMA */}
+                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker' || friendMarketType === 'smallGroup') &&
+                     isExtensibleOracleType(formData.resolutionType) && (
+                      <div className="fm-form-group fm-form-full">
+                        <label htmlFor="fm-oracle-condition-picker">
+                          Oracle condition <span className="fm-required">*</span>
+                        </label>
+                        <OracleConditionPicker
+                          kind={
+                            formData.resolutionType === ResolutionType.ChainlinkDataFeed ? 'datafeed' :
+                            formData.resolutionType === ResolutionType.ChainlinkFunctions ? 'functions' :
+                            'uma'
+                          }
+                          adapterAddress={
+                            formData.resolutionType === ResolutionType.ChainlinkDataFeed ? chainlinkDataFeedAdapter :
+                            formData.resolutionType === ResolutionType.ChainlinkFunctions ? chainlinkFunctionsAdapter :
+                            umaAdapter
+                          }
+                          value={formData.oracleConditionId}
+                          onChange={(id) => handleFormChange('oracleConditionId', id || '')}
+                          error={errors.oracleConditionId}
+                          disabled={submitting}
+                        />
+                      </div>
+                    )}
+
+                    {/* Generic YES/NO side picker for the non-Polymarket oracle types.
+                        Polymarket has its own outcome-named side picker below — we
+                        skip it for the new types and use a binary YES/NO labelling
+                        that maps to the contract's creatorIsYes bool. */}
+                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker' || friendMarketType === 'smallGroup') &&
+                     isExtensibleOracleType(formData.resolutionType) && (
+                      <div className="fm-form-group fm-form-full">
+                        <label>
+                          Your side of the bet <span className="fm-required">*</span>
+                        </label>
+                        <span className="fm-hint">
+                          The oracle will return a YES or NO outcome. Pick which side you&apos;re taking — your opponent gets the other.
+                        </span>
+                        <div className="fm-side-picker">
+                          {[
+                            { idx: '0', label: 'YES' },
+                            { idx: '1', label: 'NO' },
+                          ].map(({ idx, label }) => {
+                            const active = formData.creatorSide === idx
+                            return (
+                              <button
+                                key={idx}
+                                type="button"
+                                className={`fm-side-btn ${active ? 'active' : ''}`}
+                                onClick={() => handleFormChange('creatorSide', idx)}
+                                disabled={submitting}
+                                aria-pressed={active}
+                              >
+                                <span className="fm-side-btn-label">I&apos;m taking {label}</span>
+                              </button>
+                            )
+                          })}
+                        </div>
+                        {errors.creatorSide && (
+                          <span className="fm-error">{errors.creatorSide}</span>
                         )}
                       </div>
                     )}

--- a/frontend/src/components/fairwins/OracleConditionPicker.jsx
+++ b/frontend/src/components/fairwins/OracleConditionPicker.jsx
@@ -1,0 +1,201 @@
+import { useState } from 'react'
+import { ethers } from 'ethers'
+import { useOracleConditions } from '../../hooks/useOracleConditions'
+
+const KIND_LABELS = {
+  datafeed:  'Chainlink Data Feed',
+  functions: 'Chainlink Functions',
+  uma:       'UMA Optimistic Oracle',
+}
+
+const KIND_HELP = {
+  datafeed:  'Conditions are price-feed predicates pre-registered by an admin (e.g. "ETH/USD > $3000 by 2026-12-31"). Pick one — the wager settles automatically when the deadline passes and the feed crosses the threshold.',
+  functions: 'Conditions are Chainlink Functions requests pre-registered by an admin. The DON runs the request after the wager is accepted and reports a boolean outcome.',
+  uma:       'Conditions are UMA Optimistic Oracle assertions pre-registered by an admin. Anyone can later post the bond, assert the outcome, and after the liveness window the wager settles.',
+}
+
+function shortBytes32(b32) {
+  if (!b32 || typeof b32 !== 'string') return ''
+  return `${b32.slice(0, 10)}…${b32.slice(-6)}`
+}
+
+function isBytes32Hex(s) {
+  return /^0x[a-fA-F0-9]{64}$/.test((s || '').trim())
+}
+
+function formatTimestamp(secs) {
+  if (!secs || secs <= 0) return '—'
+  try {
+    const d = new Date(Number(secs) * 1000)
+    if (Number.isNaN(d.getTime())) return '—'
+    return d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+  } catch { return '—' }
+}
+
+function formatThreshold(bi, decimals = 8) {
+  if (bi === undefined || bi === null) return ''
+  try {
+    return ethers.formatUnits(bi, decimals)
+  } catch { return String(bi) }
+}
+
+/**
+ * OracleConditionPicker
+ *
+ * Drop-in input for the create-wager modal when the resolution type is one of
+ * the three oracle-extensible kinds (ChainlinkDataFeed / ChainlinkFunctions /
+ * UMA). Lists admin-pre-registered conditions for the adapter so the user
+ * picks instead of pasting a raw bytes32. Falls back to a paste-in textbox
+ * when no conditions are registered yet OR when the user explicitly opts into
+ * manual entry (advanced users debugging or hand-rolling).
+ *
+ * Props:
+ *   kind            'datafeed' | 'functions' | 'uma'
+ *   adapterAddress  Adapter contract address (0x...). Falsy ⇒ render an
+ *                   error hint that the adapter isn't deployed on this chain.
+ *   value           Currently-selected conditionId (bytes32 hex).
+ *   onChange(id)    Called when the user picks or pastes a new conditionId.
+ *                   `id` is always the trimmed bytes32 hex string (or '' to clear).
+ *   error           Optional validation message to display under the picker.
+ *   disabled        Disables every interactive element (e.g. while submitting).
+ */
+function OracleConditionPicker({ kind, adapterAddress, value, onChange, error, disabled = false }) {
+  const [manualMode, setManualMode] = useState(false)
+  const [pasteValue, setPasteValue] = useState('')
+
+  const { conditions, loading, error: loadError, refresh } = useOracleConditions(adapterAddress, kind)
+
+  if (!adapterAddress || !ethers.isAddress(adapterAddress)) {
+    return (
+      <div className="fm-oracle-picker fm-oracle-picker--unavailable">
+        <span className="fm-error">
+          {KIND_LABELS[kind] || 'This oracle'} is not deployed on this network.
+          Switch chains or pick a different resolution type.
+        </span>
+      </div>
+    )
+  }
+
+  const handleSelect = (id) => onChange?.(id)
+
+  const handlePaste = () => {
+    const trimmed = (pasteValue || '').trim()
+    if (!isBytes32Hex(trimmed)) {
+      // Surface inline; the parent modal also re-validates.
+      onChange?.(trimmed) // pass through so parent shows its own error
+      return
+    }
+    onChange?.(trimmed)
+  }
+
+  return (
+    <div className="fm-oracle-picker" data-kind={kind}>
+      <span className="fm-hint">{KIND_HELP[kind]}</span>
+
+      {!manualMode && (
+        <div className="fm-oracle-picker-list" role="listbox" aria-label="Registered conditions">
+          {loading && <div className="fm-oracle-picker-row fm-oracle-picker-row--idle">Loading registered conditions…</div>}
+          {!loading && loadError && (
+            <div className="fm-oracle-picker-row fm-oracle-picker-row--error">
+              <strong>Couldn&apos;t read conditions from chain.</strong> {loadError}
+              <button type="button" className="fm-oracle-picker-btn" onClick={refresh} disabled={disabled}>Retry</button>
+            </div>
+          )}
+          {!loading && !loadError && conditions.length === 0 && (
+            <div className="fm-oracle-picker-row fm-oracle-picker-row--empty">
+              No conditions registered on this adapter yet. Ask an admin to register one in
+              <code> /admin → Oracle Adapters</code>, then refresh.
+              <button type="button" className="fm-oracle-picker-btn" onClick={refresh} disabled={disabled}>Refresh</button>
+            </div>
+          )}
+          {conditions.map((c) => {
+            const selected = value && value.toLowerCase() === c.conditionId.toLowerCase()
+            const stale = c.isResolved
+            return (
+              <button
+                key={c.conditionId}
+                type="button"
+                role="option"
+                aria-selected={selected}
+                disabled={disabled || stale}
+                className={`fm-oracle-picker-row ${selected ? 'is-selected' : ''} ${stale ? 'is-stale' : ''}`}
+                onClick={() => handleSelect(c.conditionId)}
+                data-testid={`oracle-condition-${c.conditionId}`}
+              >
+                <div className="fm-oracle-picker-row-head">
+                  <code>{shortBytes32(c.conditionId)}</code>
+                  {stale && <span className="fm-oracle-picker-badge">resolved — cannot reuse</span>}
+                </div>
+                {kind === 'datafeed' && c.feed && (
+                  <div className="fm-oracle-picker-row-meta">
+                    Feed <code>{c.feed.slice(0, 6)}…{c.feed.slice(-4)}</code> {c.opLabel} {formatThreshold(c.threshold)} · settles after {formatTimestamp(c.deadline)}
+                  </div>
+                )}
+                {kind === 'uma' && c.description && (
+                  <div className="fm-oracle-picker-row-meta">&ldquo;{c.description}&rdquo;</div>
+                )}
+                {kind === 'functions' && (
+                  <div className="fm-oracle-picker-row-meta">Chainlink Functions request (admin-registered)</div>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      )}
+
+      <div className="fm-oracle-picker-manual-toggle">
+        <label className="fm-toggle-label">
+          <input
+            type="checkbox"
+            checked={manualMode}
+            onChange={(e) => setManualMode(e.target.checked)}
+            disabled={disabled}
+          />
+          <span>Paste conditionId manually</span>
+        </label>
+      </div>
+
+      {manualMode && (
+        <div className="fm-oracle-picker-manual">
+          <label>
+            conditionId (bytes32)
+            <input
+              type="text"
+              placeholder="0x + 64 hex chars"
+              value={pasteValue}
+              onChange={(e) => setPasteValue(e.target.value)}
+              disabled={disabled}
+            />
+          </label>
+          <button
+            type="button"
+            className="fm-oracle-picker-btn primary"
+            onClick={handlePaste}
+            disabled={disabled || !pasteValue.trim()}
+          >Use this conditionId</button>
+          {value && (
+            <div className="fm-oracle-picker-current">
+              Current selection: <code>{shortBytes32(value)}</code>
+            </div>
+          )}
+        </div>
+      )}
+
+      {value && !manualMode && (
+        <div className="fm-oracle-picker-current">
+          Selected: <code>{shortBytes32(value)}</code>{' '}
+          <button
+            type="button"
+            className="fm-oracle-picker-clear"
+            onClick={() => handleSelect('')}
+            disabled={disabled}
+          >Clear</button>
+        </div>
+      )}
+
+      {error && <span className="fm-error">{error}</span>}
+    </div>
+  )
+}
+
+export default OracleConditionPicker

--- a/frontend/src/hooks/useOracleConditions.js
+++ b/frontend/src/hooks/useOracleConditions.js
@@ -1,0 +1,179 @@
+import { useEffect, useMemo, useState, useCallback } from 'react'
+import { ethers } from 'ethers'
+import { useWeb3 } from './useWeb3'
+
+// IOracleAdapter event signature — all 3 adapters inherit it.
+const CONDITION_REGISTERED_EVENT =
+  'event ConditionRegistered(bytes32 indexed conditionId, string description, uint256 expectedResolutionTime)'
+
+// Per-adapter read fragments. The hook reads the right subset based on `kind`
+// so the picker can show meaningful metadata for each oracle type without
+// pulling the full ABI.
+const READ_FRAGMENTS = {
+  datafeed: [
+    'function isConditionResolved(bytes32) view returns (bool)',
+    'function getConditionMetadata(bytes32) view returns (string description, uint256 expectedResolutionTime)',
+    'function conditions(bytes32) view returns (address feed, int256 threshold, uint8 op, uint64 deadline, bool registered)',
+  ],
+  functions: [
+    'function isConditionResolved(bytes32) view returns (bool)',
+    'function getConditionMetadata(bytes32) view returns (string description, uint256 expectedResolutionTime)',
+  ],
+  uma: [
+    'function isConditionResolved(bytes32) view returns (bool)',
+    'function getConditionMetadata(bytes32) view returns (string description, uint256 expectedResolutionTime)',
+  ],
+}
+
+// Chainlink Data Feed comparison-op labels (mirror of the contract enum).
+const COMPARISON_LABELS = ['>', '>=', '<', '<=', '==']
+
+/**
+ * useOracleConditions
+ *
+ * Subscribes to ConditionRegistered events on an oracle adapter and enriches
+ * each row with whatever per-condition state the adapter exposes (resolved
+ * status, deadline, claim text, etc). Used by OracleConditionPicker so users
+ * can pick a pre-registered conditionId instead of pasting a raw bytes32.
+ *
+ * @param {string} adapterAddress  Adapter contract address (0x...). Hook
+ *                                  returns empty + idle when this is falsy.
+ * @param {'datafeed'|'functions'|'uma'} kind  Selects the extra fields read
+ *                                              for each condition. Falls back
+ *                                              to the IOracleAdapter view-only
+ *                                              surface when the kind is unknown.
+ * @param {object} options
+ * @param {number} [options.fromBlock=0]  Block to start the log scan at.
+ *                                         Public Amoy RPC handles full-range
+ *                                         queries for sparse events, but
+ *                                         callers can pin it tighter via
+ *                                         DEPLOYMENT_BLOCKS for big chains.
+ *
+ * Returns { conditions, loading, error, refresh }:
+ *   conditions: [{
+ *     conditionId:           '0x…',  // bytes32 hex
+ *     description:           string, // from getConditionMetadata (UMA only)
+ *     expectedResolutionTime:number, // unix seconds (DataFeed=deadline, UMA=liveness, Functions=0)
+ *     isResolved:            boolean,
+ *     // DataFeed extras (undefined for the other kinds):
+ *     feed?:      '0x…',
+ *     threshold?: bigint,
+ *     opLabel?:   '>' | '>=' | '<' | '<=' | '==' ,
+ *     deadline?:  number,
+ *   }, ...]
+ */
+export function useOracleConditions(adapterAddress, kind, { fromBlock = 0 } = {}) {
+  const { provider } = useWeb3()
+  const [conditions, setConditions] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  const adapterValid = useMemo(
+    () => Boolean(adapterAddress && ethers.isAddress(adapterAddress)),
+    [adapterAddress],
+  )
+
+  // `READ_FRAGMENTS[kind]` is keyed only by `kind`, but reading it inline
+  // would create a fresh array every render (object literal identity) and
+  // make the `fetchAll` useCallback identity churn → infinite useEffect loop.
+  // Memoize on `kind`.
+  const fragments = useMemo(
+    () => READ_FRAGMENTS[kind] || READ_FRAGMENTS.functions,
+    [kind],
+  )
+
+  const fetchAll = useCallback(async () => {
+    if (!adapterValid || !provider) {
+      setConditions([])
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      const iface = new ethers.Interface([CONDITION_REGISTERED_EVENT])
+      const contract = new ethers.Contract(adapterAddress, [CONDITION_REGISTERED_EVENT, ...fragments], provider)
+
+      // 1. Pull every ConditionRegistered log emitted by this adapter.
+      const logs = await contract.queryFilter(contract.filters.ConditionRegistered(), fromBlock, 'latest')
+
+      // 2. Dedupe in case the admin re-emitted (shouldn't happen on the live
+      //    adapters but cheap insurance against future changes).
+      const seen = new Set()
+      const ordered = []
+      for (const log of logs) {
+        const parsed = iface.parseLog(log)
+        const id = parsed.args.conditionId
+        if (seen.has(id)) continue
+        seen.add(id)
+        ordered.push({ log, conditionId: id, fromEventDescription: parsed.args.description, fromEventExpected: Number(parsed.args.expectedResolutionTime) })
+      }
+
+      // 3. Per-condition enrichment in parallel. We tolerate individual
+      //    failures (e.g. condition was deleted by a future contract change)
+      //    so a single broken row doesn't blank the whole list.
+      const enriched = await Promise.all(ordered.map(async (row) => {
+        const out = {
+          conditionId: row.conditionId,
+          description: row.fromEventDescription || '',
+          expectedResolutionTime: row.fromEventExpected,
+          isResolved: false,
+        }
+        try {
+          out.isResolved = await contract.isConditionResolved(row.conditionId)
+        } catch { /* tolerate */ }
+        try {
+          const meta = await contract.getConditionMetadata(row.conditionId)
+          // UMA stores claim text in `description`; DataFeed/Functions return '' here.
+          if (meta?.description) out.description = meta.description
+          // Replace event-emitted expected time with the canonical view (UMA reports liveness; DataFeed reports deadline).
+          if (meta?.expectedResolutionTime) out.expectedResolutionTime = Number(meta.expectedResolutionTime)
+        } catch { /* tolerate */ }
+
+        // DataFeed-specific enrichment.
+        if (kind === 'datafeed') {
+          try {
+            const cfg = await contract.conditions(row.conditionId)
+            out.feed = cfg.feed
+            out.threshold = cfg.threshold
+            out.opLabel = COMPARISON_LABELS[Number(cfg.op)] || '?'
+            out.deadline = Number(cfg.deadline)
+          } catch { /* tolerate */ }
+        }
+
+        return out
+      }))
+
+      // 4. Stable sort: unresolved first (so users see actionable rows up top),
+      //    then by expected resolution time ascending.
+      enriched.sort((a, b) => {
+        if (a.isResolved !== b.isResolved) return a.isResolved ? 1 : -1
+        return (a.expectedResolutionTime || 0) - (b.expectedResolutionTime || 0)
+      })
+
+      setConditions(enriched)
+    } catch (e) {
+      setError(e?.shortMessage || e?.message || String(e))
+      setConditions([])
+    } finally {
+      setLoading(false)
+    }
+  }, [adapterAddress, adapterValid, provider, fragments, kind, fromBlock])
+
+  useEffect(() => {
+    fetchAll()
+  }, [fetchAll])
+
+  // Live updates: re-fetch when a new ConditionRegistered fires while the
+  // picker is open. Cheap — adapters are owner-write-only and emit sparsely.
+  useEffect(() => {
+    if (!adapterValid || !provider) return undefined
+    const contract = new ethers.Contract(adapterAddress, [CONDITION_REGISTERED_EVENT], provider)
+    const onRegistered = () => fetchAll()
+    contract.on('ConditionRegistered', onRegistered)
+    return () => contract.off('ConditionRegistered', onRegistered)
+  }, [adapterAddress, adapterValid, provider, fetchAll])
+
+  return { conditions, loading, error, refresh: fetchAll }
+}
+
+export default useOracleConditions

--- a/frontend/src/test/FriendMarketsModal.test.jsx
+++ b/frontend/src/test/FriendMarketsModal.test.jsx
@@ -103,6 +103,23 @@ vi.mock('qrcode.react', () => ({
   ),
 }))
 
+// Mock the contracts config so the modal sees the v2 Amoy adapter addresses
+// during tests (the real module reads VITE_NETWORK_ID at module-load time,
+// defaulting to 63 / Mordor which has no v2 contracts). The new oracle-type
+// dropdown options gate on these addresses being non-empty.
+vi.mock('../config/contracts', async (importOriginal) => {
+  const actual = await importOriginal()
+  const stubs = {
+    chainlinkDataFeedAdapter: '0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23',
+    chainlinkFunctionsAdapter: '0x074fC18C1E322a7537b53B8B2Bf0762629E3b532',
+    umaAdapter: '0xcEa9b4A01CcD3aA6545ea834a268C69e7eEfee88',
+  }
+  return {
+    ...actual,
+    getContractAddress: (name) => stubs[name] ?? actual.getContractAddress(name),
+  }
+})
+
 // Stub PolymarketBrowser so the linked-market UI renders without making
 // real gamma-api calls. Exposes a button per (mocked) market that fires
 // the modal's onSelectMarket handler.
@@ -124,6 +141,24 @@ vi.mock('../components/fairwins/PolymarketBrowser', () => ({
       </div>
     )
   }
+}))
+
+// Stub OracleConditionPicker so the modal's new oracle-extensible flow can
+// be tested without going through useOracleConditions (which has its own
+// unit tests). The stub exposes a Pick button per kind that fires onChange
+// with a canonical conditionId so we can assert downstream wiring.
+const STUB_ORACLE_CONDITION_ID = '0x' + 'cd'.repeat(32)
+vi.mock('../components/fairwins/OracleConditionPicker', () => ({
+  default: ({ kind, adapterAddress, value, onChange, error }) => (
+    <div data-testid={`mock-oracle-picker-${kind}`} data-adapter={adapterAddress || ''} data-value={value || ''}>
+      <button
+        type="button"
+        data-testid={`mock-pick-${kind}`}
+        onClick={() => onChange?.(STUB_ORACLE_CONDITION_ID)}
+      >Pick a {kind} condition</button>
+      {error && <span data-testid={`mock-picker-error-${kind}`}>{error}</span>}
+    </div>
+  )
 }))
 
 const renderWithProviders = (ui, { isConnected = true, account = '0x1234567890123456789012345678901234567890', isCorrectNetwork = true, chainId = 61 } = {}) => {
@@ -636,6 +671,152 @@ describe('FriendMarketsModal', () => {
       await waitFor(() => {
         expect(screen.getByText(polymarketMarket.question)).toBeInTheDocument()
       })
+    })
+  })
+
+  describe('Oracle-extensible wagers (ChainlinkDataFeed / Functions / UMA)', () => {
+    // The picker hits ethers via the hook. We stub the picker itself at the
+    // top of this file so these tests focus on modal wiring — the hook +
+    // picker have their own unit tests.
+    const STUB_CONDITION_ID = STUB_ORACLE_CONDITION_ID
+
+    async function pickKindAndSide(kind, sideLabel) {
+      // Open the resolution-type dropdown and switch to the desired oracle.
+      const RT = { ChainlinkDataFeed: 5, ChainlinkFunctions: 6, UMA: 7 }[
+        kind === 'datafeed' ? 'ChainlinkDataFeed' : kind === 'functions' ? 'ChainlinkFunctions' : 'UMA'
+      ]
+      await userEvent.selectOptions(screen.getByLabelText(/who can resolve/i), String(RT))
+      // Click the stub picker's "Pick" button → conditionId lands in formData.
+      await userEvent.click(await screen.findByTestId(`mock-pick-${kind}`))
+      // Side picker: generic YES/NO buttons.
+      await userEvent.click(screen.getByRole('button', { name: new RegExp(`i'm taking ${sideLabel}`, 'i') }))
+    }
+
+    it('renders the 3 new dropdown options on a Polygon-family chain', async () => {
+      renderWithProviders(<FriendMarketsModal {...defaultProps} />, { chainId: 80002 })
+      const dropdown = screen.getByLabelText(/who can resolve/i)
+      expect(dropdown).toContainHTML('Chainlink Data Feed')
+      expect(dropdown).toContainHTML('Chainlink Functions')
+      expect(dropdown).toContainHTML('UMA Optimistic Oracle')
+    })
+
+    it('renders the picker + generic side picker for ChainlinkDataFeed', async () => {
+      renderWithProviders(<FriendMarketsModal {...defaultProps} />, { chainId: 80002 })
+      await userEvent.selectOptions(screen.getByLabelText(/who can resolve/i), '5')
+      expect(await screen.findByTestId('mock-oracle-picker-datafeed')).toBeInTheDocument()
+      // Generic YES/NO buttons.
+      expect(screen.getByRole('button', { name: /I'm taking YES/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /I'm taking NO/i })).toBeInTheDocument()
+    })
+
+    it('forwards resolutionType=5 + oracleConditionId + creatorIsYes=true to onCreate (DataFeed YES)', async () => {
+      const onCreate = vi.fn().mockResolvedValue({ id: 'wager-dfy' })
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} onCreate={onCreate} />,
+        { chainId: 80002 }
+      )
+      await userEvent.type(
+        screen.getByLabelText(/what's the bet/i),
+        'ETH closes above 3000 by year end — Chainlink Data Feed test'
+      )
+      await userEvent.type(
+        screen.getByLabelText(/opponent address/i),
+        '0xabcdef1234567890123456789012345678901234'
+      )
+      await pickKindAndSide('datafeed', 'YES')
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
+      await waitFor(() => expect(onCreate).toHaveBeenCalled())
+      expect(onCreate.mock.calls[0][0].data).toEqual(expect.objectContaining({
+        resolutionType: 5,
+        oracleConditionId: STUB_CONDITION_ID,
+        creatorIsYes: true,
+      }))
+    })
+
+    it('forwards resolutionType=7 + creatorIsYes=false for UMA NO', async () => {
+      const onCreate = vi.fn().mockResolvedValue({ id: 'wager-umano' })
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} onCreate={onCreate} />,
+        { chainId: 80002 }
+      )
+      await userEvent.type(
+        screen.getByLabelText(/what's the bet/i),
+        'UMA assertion: Patriots win Super Bowl LX'
+      )
+      await userEvent.type(
+        screen.getByLabelText(/opponent address/i),
+        '0xabcdef1234567890123456789012345678901234'
+      )
+      await pickKindAndSide('uma', 'NO')
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
+      await waitFor(() => expect(onCreate).toHaveBeenCalled())
+      expect(onCreate.mock.calls[0][0].data).toEqual(expect.objectContaining({
+        resolutionType: 7,
+        oracleConditionId: STUB_CONDITION_ID,
+        creatorIsYes: false,
+      }))
+    })
+
+    it('rejects submit when no condition is picked', async () => {
+      const onCreate = vi.fn()
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} onCreate={onCreate} />,
+        { chainId: 80002 }
+      )
+      await userEvent.type(
+        screen.getByLabelText(/what's the bet/i),
+        'Chainlink Functions: some custom request'
+      )
+      await userEvent.type(
+        screen.getByLabelText(/opponent address/i),
+        '0xabcdef1234567890123456789012345678901234'
+      )
+      await userEvent.selectOptions(screen.getByLabelText(/who can resolve/i), '6')
+      // Don't pick a condition — go straight to submit. Side stays empty too.
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
+      await waitFor(() => {
+        expect(screen.getByText(/Pick \(or paste\) a registered conditionId/i)).toBeInTheDocument()
+      })
+      expect(onCreate).not.toHaveBeenCalled()
+    })
+
+    it('rejects submit when a condition is picked but no side is chosen', async () => {
+      const onCreate = vi.fn()
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} onCreate={onCreate} />,
+        { chainId: 80002 }
+      )
+      await userEvent.type(
+        screen.getByLabelText(/what's the bet/i),
+        'Chainlink Data Feed test — no side picked'
+      )
+      await userEvent.type(
+        screen.getByLabelText(/opponent address/i),
+        '0xabcdef1234567890123456789012345678901234'
+      )
+      await userEvent.selectOptions(screen.getByLabelText(/who can resolve/i), '5')
+      await userEvent.click(await screen.findByTestId('mock-pick-datafeed'))
+      // Don't click YES/NO.
+      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
+      await waitFor(() => {
+        expect(screen.getByText(/Pick which side of the bet you are taking/i)).toBeInTheDocument()
+      })
+      expect(onCreate).not.toHaveBeenCalled()
+    })
+
+    it('clears oracleConditionId when switching between oracle types', async () => {
+      const onCreate = vi.fn().mockResolvedValue({ id: 'wager-switch' })
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} onCreate={onCreate} />,
+        { chainId: 80002 }
+      )
+      // Pick a DataFeed condition first.
+      await userEvent.selectOptions(screen.getByLabelText(/who can resolve/i), '5')
+      await userEvent.click(await screen.findByTestId('mock-pick-datafeed'))
+      // Switch to UMA → picker should reset (data-value attribute on the stub goes back to '').
+      await userEvent.selectOptions(screen.getByLabelText(/who can resolve/i), '7')
+      const umaPicker = await screen.findByTestId('mock-oracle-picker-uma')
+      expect(umaPicker).toHaveAttribute('data-value', '')
     })
   })
 

--- a/frontend/src/test/OracleConditionPicker.test.jsx
+++ b/frontend/src/test/OracleConditionPicker.test.jsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import OracleConditionPicker from '../components/fairwins/OracleConditionPicker'
+
+// Mock the hook so we can drive the picker's loading / list / error states
+// from the test side. The hook is unit-tested separately in
+// useOracleConditions.test.jsx; this file only validates the UI surface.
+const { hookReturn } = vi.hoisted(() => ({ hookReturn: { current: { conditions: [], loading: false, error: null, refresh: () => {} } } }))
+vi.mock('../hooks/useOracleConditions', () => ({
+  useOracleConditions: () => hookReturn.current,
+}))
+
+const ADAPTER = '0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23'
+
+beforeEach(() => {
+  hookReturn.current = { conditions: [], loading: false, error: null, refresh: vi.fn() }
+})
+
+describe('OracleConditionPicker', () => {
+  it('renders the unavailable banner when the adapter address is missing', () => {
+    render(<OracleConditionPicker kind="datafeed" adapterAddress="" value="" onChange={vi.fn()} />)
+    expect(screen.getByText(/Chainlink Data Feed is not deployed/i)).toBeInTheDocument()
+  })
+
+  it('shows a Loading row while the hook is loading', () => {
+    hookReturn.current.loading = true
+    render(<OracleConditionPicker kind="datafeed" adapterAddress={ADAPTER} value="" onChange={vi.fn()} />)
+    expect(screen.getByText(/Loading registered conditions/i)).toBeInTheDocument()
+  })
+
+  it('shows an empty-state row with a Refresh button when there are no conditions', () => {
+    const refresh = vi.fn()
+    hookReturn.current.refresh = refresh
+    render(<OracleConditionPicker kind="uma" adapterAddress={ADAPTER} value="" onChange={vi.fn()} />)
+    expect(screen.getByText(/No conditions registered/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Refresh/i }))
+    expect(refresh).toHaveBeenCalled()
+  })
+
+  it('shows an error row + Retry button when the hook surfaces an error', () => {
+    const refresh = vi.fn()
+    hookReturn.current = { conditions: [], loading: false, error: 'RPC down', refresh }
+    render(<OracleConditionPicker kind="functions" adapterAddress={ADAPTER} value="" onChange={vi.fn()} />)
+    expect(screen.getByText(/Couldn't read conditions from chain/i)).toBeInTheDocument()
+    expect(screen.getByText(/RPC down/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Retry/i }))
+    expect(refresh).toHaveBeenCalled()
+  })
+
+  it('renders a clickable row per registered condition and calls onChange when picked', async () => {
+    hookReturn.current.conditions = [
+      { conditionId: '0x' + 'aa'.repeat(32), description: '', expectedResolutionTime: 1700000000, isResolved: false, feed: '0xF0d50568e3A7e8259E16663972b11910F89BD8e7', threshold: 300000000000n, opLabel: '>', deadline: 1700000000 },
+      { conditionId: '0x' + 'bb'.repeat(32), description: '', expectedResolutionTime: 1700001000, isResolved: false, feed: '0xF0d50568e3A7e8259E16663972b11910F89BD8e7', threshold: 350000000000n, opLabel: '>=', deadline: 1700001000 },
+    ]
+    const onChange = vi.fn()
+    render(<OracleConditionPicker kind="datafeed" adapterAddress={ADAPTER} value="" onChange={onChange} />)
+
+    const rows = screen.getAllByRole('option')
+    expect(rows).toHaveLength(2)
+    await userEvent.click(rows[0])
+    expect(onChange).toHaveBeenCalledWith('0x' + 'aa'.repeat(32))
+  })
+
+  it('marks resolved conditions stale + disables them', () => {
+    hookReturn.current.conditions = [
+      { conditionId: '0x' + 'cc'.repeat(32), description: 'Stale claim', expectedResolutionTime: 7200, isResolved: true },
+    ]
+    render(<OracleConditionPicker kind="uma" adapterAddress={ADAPTER} value="" onChange={vi.fn()} />)
+    const row = screen.getByRole('option')
+    expect(row).toBeDisabled()
+    expect(screen.getByText(/resolved — cannot reuse/i)).toBeInTheDocument()
+  })
+
+  it('renders adapter-specific row metadata', () => {
+    hookReturn.current.conditions = [
+      { conditionId: '0x' + 'dd'.repeat(32), description: 'Did the Patriots win Super Bowl LX?', expectedResolutionTime: 7200, isResolved: false },
+    ]
+    render(<OracleConditionPicker kind="uma" adapterAddress={ADAPTER} value="" onChange={vi.fn()} />)
+    expect(screen.getByText(/Did the Patriots win Super Bowl LX\?/i)).toBeInTheDocument()
+  })
+
+  it('marks the selected row as aria-selected', () => {
+    const cid = '0x' + 'ee'.repeat(32)
+    hookReturn.current.conditions = [
+      { conditionId: cid, description: '', expectedResolutionTime: 0, isResolved: false },
+    ]
+    render(<OracleConditionPicker kind="functions" adapterAddress={ADAPTER} value={cid} onChange={vi.fn()} />)
+    expect(screen.getByRole('option')).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('toggles manual paste mode and fires onChange with the pasted bytes32', async () => {
+    const onChange = vi.fn()
+    render(<OracleConditionPicker kind="datafeed" adapterAddress={ADAPTER} value="" onChange={onChange} />)
+    await userEvent.click(screen.getByLabelText(/Paste conditionId manually/i))
+    const input = screen.getByPlaceholderText(/0x \+ 64 hex chars/i)
+    await userEvent.type(input, '0x' + 'ff'.repeat(32))
+    await userEvent.click(screen.getByRole('button', { name: /Use this conditionId/i }))
+    expect(onChange).toHaveBeenCalledWith('0x' + 'ff'.repeat(32))
+  })
+
+  it('shows the current selection with a Clear button', async () => {
+    const onChange = vi.fn()
+    const cid = '0x' + '12'.repeat(32)
+    hookReturn.current.conditions = [{ conditionId: cid, description: '', expectedResolutionTime: 0, isResolved: false }]
+    render(<OracleConditionPicker kind="functions" adapterAddress={ADAPTER} value={cid} onChange={onChange} />)
+    await userEvent.click(screen.getByRole('button', { name: /Clear/i }))
+    expect(onChange).toHaveBeenCalledWith('')
+  })
+
+  it('surfaces an external error message from the parent', () => {
+    render(<OracleConditionPicker kind="datafeed" adapterAddress={ADAPTER} value="" onChange={vi.fn()} error="Pick a condition first." />)
+    expect(screen.getByText('Pick a condition first.')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/useOracleConditions.test.jsx
+++ b/frontend/src/test/useOracleConditions.test.jsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useOracleConditions } from '../hooks/useOracleConditions'
+
+// Stable mocks — vi.hoisted so they survive the vi.mock factory hoisting.
+const { stableWeb3, stub, fakeIface } = vi.hoisted(() => {
+  const stub = {
+    filters: { ConditionRegistered: () => ({ topics: [] }) },
+    queryFilter: () => Promise.resolve([]),
+    on: () => {},
+    off: () => {},
+    isConditionResolved: () => Promise.resolve(false),
+    getConditionMetadata: () => Promise.resolve({ description: '', expectedResolutionTime: 0n }),
+    conditions: () => Promise.resolve({
+      feed: '0x0000000000000000000000000000000000000000',
+      threshold: 0n,
+      op: 0,
+      deadline: 0n,
+      registered: false,
+    }),
+  }
+  // Each log carries a `__parsed` field that our fake Interface.parseLog
+  // returns verbatim. Sidesteps real ABI encoding for the test.
+  const fakeIface = {
+    parseLog: (log) => log.__parsed,
+  }
+  return {
+    stableWeb3: { provider: { isFakeProvider: true } },
+    stub,
+    fakeIface,
+  }
+})
+
+vi.mock('../hooks/useWeb3', () => ({
+  useWeb3: () => stableWeb3,
+}))
+
+vi.mock('ethers', async () => {
+  const real = await vi.importActual('ethers')
+  function FakeContract() { return stub }
+  function FakeInterface() { return fakeIface }
+  return {
+    ...real,
+    ethers: {
+      ...real.ethers,
+      Contract: FakeContract,
+      Interface: FakeInterface,
+      isAddress: (s) => /^0x[a-fA-F0-9]{40}$/.test(String(s || '').trim()),
+      formatUnits: real.ethers.formatUnits,
+    },
+  }
+})
+
+const ADAPTER = '0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23'
+
+function logFor(conditionId, { description = '', expected = 0n } = {}) {
+  // Test-only log shape: real ethers Log fields are irrelevant because our
+  // fake Interface.parseLog just returns `__parsed`.
+  return {
+    topics: [],
+    data: '0x',
+    __parsed: { args: { conditionId, description, expectedResolutionTime: expected } },
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Reset stub methods to defaults — they're regular fns above, but tests
+  // overwrite them with vi.fn so we need to restore identity each time.
+  stub.queryFilter = vi.fn(() => Promise.resolve([]))
+  stub.on = vi.fn()
+  stub.off = vi.fn()
+  stub.isConditionResolved = vi.fn(() => Promise.resolve(false))
+  stub.getConditionMetadata = vi.fn(() => Promise.resolve({ description: '', expectedResolutionTime: 0n }))
+  stub.conditions = vi.fn(() => Promise.resolve({
+    feed: '0x0000000000000000000000000000000000000000',
+    threshold: 0n,
+    op: 0,
+    deadline: 0n,
+    registered: false,
+  }))
+})
+
+describe('useOracleConditions', () => {
+  it('returns empty + idle when no adapter address is supplied', async () => {
+    const { result } = renderHook(() => useOracleConditions('', 'datafeed'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.conditions).toEqual([])
+    expect(stub.queryFilter).not.toHaveBeenCalled()
+  })
+
+  it('returns empty for an invalid adapter address', async () => {
+    const { result } = renderHook(() => useOracleConditions('0xnotreallyhex', 'datafeed'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.conditions).toEqual([])
+    expect(stub.queryFilter).not.toHaveBeenCalled()
+  })
+
+  it('DataFeed: returns one condition row, enriched with feed/threshold/op/deadline', async () => {
+    stub.queryFilter = vi.fn(() => Promise.resolve([
+      logFor('0x' + 'aa'.repeat(32), { expected: 1700000000n }),
+    ]))
+    stub.isConditionResolved = vi.fn(() => Promise.resolve(false))
+    stub.conditions = vi.fn(() => Promise.resolve({
+      feed: '0xF0d50568e3A7e8259E16663972b11910F89BD8e7',
+      threshold: 300000000000n,
+      op: 0,  // GT
+      deadline: 1700000000n,
+      registered: true,
+    }))
+    stub.getConditionMetadata = vi.fn(() => Promise.resolve({
+      description: '',
+      expectedResolutionTime: 1700000000n,
+    }))
+
+    const { result } = renderHook(() => useOracleConditions(ADAPTER, 'datafeed'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.conditions).toHaveLength(1)
+    const row = result.current.conditions[0]
+    expect(row.conditionId).toBe('0x' + 'aa'.repeat(32))
+    expect(row.isResolved).toBe(false)
+    expect(row.feed).toBe('0xF0d50568e3A7e8259E16663972b11910F89BD8e7')
+    expect(row.threshold).toBe(300000000000n)
+    expect(row.opLabel).toBe('>')
+    expect(row.deadline).toBe(1700000000)
+    expect(row.expectedResolutionTime).toBe(1700000000)
+  })
+
+  it('UMA: surfaces claim text in description via getConditionMetadata', async () => {
+    stub.queryFilter = vi.fn(() => Promise.resolve([
+      logFor('0x' + 'cc'.repeat(32)),
+    ]))
+    stub.getConditionMetadata = vi.fn(() => Promise.resolve({
+      description: 'ETH closes above 3000 on 2026-12-31',
+      expectedResolutionTime: 7200n,
+    }))
+
+    const { result } = renderHook(() => useOracleConditions(ADAPTER, 'uma'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.conditions).toHaveLength(1)
+    expect(result.current.conditions[0].description).toBe('ETH closes above 3000 on 2026-12-31')
+    expect(result.current.conditions[0].expectedResolutionTime).toBe(7200)
+  })
+
+  it('sorts unresolved conditions before resolved ones', async () => {
+    stub.queryFilter = vi.fn(() => Promise.resolve([
+      logFor('0x' + '11'.repeat(32), { expected: 100n }),
+      logFor('0x' + '22'.repeat(32), { expected: 200n }),
+    ]))
+    // First conditionId (11..) is RESOLVED, second (22..) is NOT.
+    let call = 0
+    stub.isConditionResolved = vi.fn(() => Promise.resolve(++call === 1))
+
+    const { result } = renderHook(() => useOracleConditions(ADAPTER, 'functions'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.conditions).toHaveLength(2)
+    expect(result.current.conditions[0].isResolved).toBe(false)
+    expect(result.current.conditions[0].conditionId).toBe('0x' + '22'.repeat(32))
+    expect(result.current.conditions[1].isResolved).toBe(true)
+    expect(result.current.conditions[1].conditionId).toBe('0x' + '11'.repeat(32))
+  })
+
+  it('exposes the queryFilter error via `error` and clears the list', async () => {
+    stub.queryFilter = vi.fn(() => Promise.reject(new Error('RPC down')))
+    const { result } = renderHook(() => useOracleConditions(ADAPTER, 'datafeed'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toMatch(/rpc down/i)
+    expect(result.current.conditions).toEqual([])
+  })
+
+  it('subscribes to and tears down ConditionRegistered listener', async () => {
+    const { result, unmount } = renderHook(() => useOracleConditions(ADAPTER, 'functions'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(stub.on).toHaveBeenCalledWith('ConditionRegistered', expect.any(Function))
+    unmount()
+    expect(stub.off).toHaveBeenCalledWith('ConditionRegistered', expect.any(Function))
+  })
+
+  it('dedupes when the same conditionId is registered twice', async () => {
+    stub.queryFilter = vi.fn(() => Promise.resolve([
+      logFor('0x' + 'ab'.repeat(32)),
+      logFor('0x' + 'ab'.repeat(32)),  // duplicate — should be deduped
+    ]))
+    const { result } = renderHook(() => useOracleConditions(ADAPTER, 'functions'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.conditions).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

Closes the last item from the original full-scope plan: users can now create wagers settled by **ChainlinkDataFeed**, **ChainlinkFunctions**, or **UMA** adapters directly from the modal, picking a pre-registered conditionId from a list instead of pasting a raw bytes32.

| | |
|---|---|
| Branch | \`feat/oracle-condition-picker\` (off latest \`main\`, post-#591) |
| Files | 7 changed, +1171 / -3 |
| Tests | **774/774** frontend (was 748; +26 new) |

## What's in

### Hook: \`frontend/src/hooks/useOracleConditions.js\`
Subscribes to \`ConditionRegistered\` events on the supplied adapter and enriches each row:
- **All kinds**: \`isConditionResolved\` so stale rows are badged + disabled.
- **DataFeed**: \`conditions(id)\` → \`feed\`/\`threshold\`/\`op\`/\`deadline\` for a one-line summary.
- **UMA**: \`getConditionMetadata\` so the claim text surfaces.
- **Functions**: no extras (CBOR isn't user-facing).

Sorts unresolved-first then by \`expectedResolutionTime\`. Subscribes to live events so the picker refreshes when an admin adds a new condition.

### Component: \`frontend/src/components/fairwins/OracleConditionPicker.jsx\`
- Lists registered conditions with kind-specific metadata.
- Resolved conditions get a \"resolved — cannot reuse\" badge, unselectable.
- Empty/loading/error states all render hints + Refresh/Retry.
- \"Paste conditionId manually\" toggle for advanced users.
- \"Adapter not deployed on this chain\" hint when the address is missing.

### Modal wiring (\`FriendMarketsModal.jsx\`)
- 3 new dropdown options, each self-gated on its adapter address being present in \`DEPLOYED_CONTRACTS\`.
- New JSX block renders \`<OracleConditionPicker>\` + a generic YES/NO side picker when an extensible type is selected.
- \`handleFormChange\` clears \`oracleConditionId\` on oracle-to-oracle switches (different adapters → different id spaces).
- \`useEffect\` clears \`selectedPolymarketMarket\` when leaving Polymarket so the linked-market panel doesn't bleed into the new picker.
- \`validateForm\` extended with an \`else if (isExtensibleOracleType(...))\` branch (conditionId required + bytes32 shape + side picked).

## Test coverage (+26)

| File | Tests | Covers |
|---|---|---|
| \`useOracleConditions.test.jsx\` | 8 | Empty/invalid address guards · enrichment for each kind · sort order · error path · live-listener teardown · dedupe |
| \`OracleConditionPicker.test.jsx\` | 11 | Unavailable banner · loading/empty/error states · selection · stale badge · metadata · aria · manual paste · clear · error prop |
| \`FriendMarketsModal.test.jsx\` (new block) | 6 | Dropdown surfacing · picker + side picker render · DataFeed YES + UMA NO submission payloads · validation rejections · oracleConditionId reset on switch |

## How to test in the browser

\`\`\`
cd frontend && npm run dev
\`\`\`

1. As the admin EOA (\`0x5250…6e1\`) on Polygon Amoy, go to \`/admin → Oracle Adapters\` (PR #591) and register at least one condition on the ChainlinkDataFeed adapter.
2. Open \`/dashboard → New Wager\`.
3. \"Who Can Resolve?\" dropdown now offers Chainlink Data Feed / Chainlink Functions / UMA Optimistic Oracle.
4. Pick \"Chainlink Data Feed (price condition)\" → picker lists your registered conditions with feed/threshold/deadline metadata. Select one.
5. Pick a side (I'm taking YES / NO).
6. Submit. Transaction confirms with \`resolutionType=5\`, \`polymarketConditionId=<picked>\`, \`creatorIsYes=<chosen>\`.
7. Sanity: try the same path with UMA + Functions. Try \"Paste conditionId manually\" as the picker fallback.
8. Wrong chain: connect ETC Classic (chainId 61) — the 3 new dropdown options should be hidden.

## Out of scope (no follow-up planned)

- Letting users register conditions from inside the modal (registration lives in /admin per PR #591).
- Multi-pick / batch registration.
- \"Preview the on-chain effect\" pre-submit modal — the picker already surfaces enough metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)