### PR TITLE
fix(frontend): make wager creation modal scrollable

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.css
+++ b/frontend/src/components/fairwins/FriendMarketsModal.css
@@ -126,11 +126,29 @@
   cursor: not-allowed;
 }
 
+/* Scrollable content region (between header and bottom of modal) */
+.fm-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 1.25rem 1.5rem;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Step panel — fills the content area so .fm-form-actions can stick to the bottom */
+.fm-panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
 /* Form */
 .fm-form {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
 }
 
 .fm-form-grid {


### PR DESCRIPTION
## Summary
- `FriendMarketsModal` wraps each step in `<div class="fm-content"><div class="fm-panel">`, but neither class had base CSS — they were only declared inside the mobile media query. Combined with the modal's `max-height: min(640px, 100vh)` + `overflow: hidden`, the form rendered at its natural height and got clipped on both desktop and mobile with no scrollbar.
- Adds base rules so `.fm-content` becomes the scrollable region between the fixed header and the bottom of the modal (`flex: 1; min-height: 0; overflow-y: auto`), and `.fm-panel` + `.fm-form` stay a flex column so `.fm-form-actions` (`margin-top: auto`) still pins to the bottom.

## Test plan
- [x] `npx vitest run src/test/FriendMarketsModal.test.jsx` — 44 tests pass
- [ ] Open the Wagers modal on desktop: header stays pinned, form scrolls, Cancel / Create Wager stay anchored at the bottom
- [ ] Repeat on a narrow viewport (<640px): mobile media query padding (1rem) still applies, single-column grid, scroll works
- [ ] Success step (post-create) still renders the QR + actions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)