### PR TITLE
fix(frontend): validate MembershipManager contract exists before calling paymentToken()

### DIFF
--- a/frontend/src/components/wallet/WalletButton.jsx
+++ b/frontend/src/components/wallet/WalletButton.jsx
@@ -47,7 +47,7 @@ function WalletButton({ className = '' }) {
   const navigate = useNavigate()
   const { showModal } = useModal()
   const { balances, loading: balanceLoading } = useDex()
-  const { mode: networkMode, isTestnet, network, switchMode: switchNetworkMode, isSwitching: isNetworkSwitching } = useNetworkMode()
+  const { isTestnet, network, switchMode: switchNetworkMode, isSwitching: isNetworkSwitching } = useNetworkMode()
   const { hasRole, rolesLoading, refreshRoles } = useWalletRoles()
   const {
     roleDetails,

--- a/frontend/src/components/wallet/WalletButton.jsx
+++ b/frontend/src/components/wallet/WalletButton.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { useAccount, useConnect, useDisconnect, useChainId } from 'wagmi'
 import { useNavigate } from 'react-router-dom'
 import { useDex } from '../../hooks/useDex'
-import { useUserPreferences } from '../../hooks/useUserPreferences'
+import { useNetworkMode } from '../../hooks/useNetworkMode'
 import { useWalletRoles } from '../../hooks'
 import { useRoleDetails } from '../../hooks/useRoleDetails'
 import { useTheme } from '../../hooks/useTheme'
@@ -47,7 +47,7 @@ function WalletButton({ className = '' }) {
   const navigate = useNavigate()
   const { showModal } = useModal()
   const { balances, loading: balanceLoading } = useDex()
-  const { preferences, setDemoMode } = useUserPreferences()
+  const { mode: networkMode, isTestnet, network, switchMode: switchNetworkMode, isSwitching: isNetworkSwitching } = useNetworkMode()
   const { hasRole, rolesLoading, refreshRoles } = useWalletRoles()
   const {
     roleDetails,
@@ -198,10 +198,6 @@ function WalletButton({ className = '' }) {
   const handleDisconnect = () => {
     disconnect()
     setIsOpen(false)
-  }
-
-  const handleToggleDemoMode = () => {
-    setDemoMode(!preferences.demoMode)
   }
 
   const handleOpenPurchaseModal = (preselectedRole = null, action = 'purchase') => {
@@ -380,7 +376,7 @@ function WalletButton({ className = '' }) {
                     <span className="usc-balance">
                       {balanceLoading ? 'Loading...' : `${parseFloat(balances?.usc || 0).toFixed(2)} USC`}
                     </span>
-                    <span className="network-info">Chain ID: {chainId}</span>
+                    <span className="network-info">{network?.name || `Chain ${chainId}`}</span>
                   </div>
                 </div>
               </div>
@@ -432,18 +428,19 @@ function WalletButton({ className = '' }) {
                 </button>
               </div>
 
-              {/* Data Source Toggle */}
+              {/* Network Toggle */}
               <div className="dropdown-section">
                 <div className="toggle-row">
                   <span className="toggle-label">
-                    {preferences.demoMode ? '🎭 Demo Mode' : '🌐 Live Mode'}
+                    {isTestnet ? 'Amoy Testnet' : 'Polygon Mainnet'}
                   </span>
                   <button
-                    onClick={handleToggleDemoMode}
+                    onClick={() => switchNetworkMode('toggle')}
                     className="toggle-btn"
-                    aria-label={`Switch to ${preferences.demoMode ? 'Live' : 'Demo'} Mode`}
+                    disabled={isNetworkSwitching}
+                    aria-label={`Switch to ${isTestnet ? 'Polygon Mainnet' : 'Amoy Testnet'}`}
                   >
-                    {preferences.demoMode ? 'Go Live' : 'Use Demo'}
+                    {isNetworkSwitching ? 'Switching...' : isTestnet ? 'Mainnet' : 'Testnet'}
                   </button>
                 </div>
               </div>

--- a/frontend/src/contexts/WalletContext.jsx
+++ b/frontend/src/contexts/WalletContext.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useAccount, useConnect, useDisconnect, useChainId, useSwitchChain, useWalletClient } from 'wagmi'
 import { ethers } from 'ethers'
-import { isSupportedChainId, getNetwork, listSupportedChainIds, PRIMARY_CHAIN_ID } from '../config/networks'
+import { isSupportedChainId, getNetwork, PRIMARY_CHAIN_ID } from '../config/networks'
 import {
   getUserRoles,
   addUserRole,

--- a/frontend/src/contexts/WalletContext.jsx
+++ b/frontend/src/contexts/WalletContext.jsx
@@ -108,23 +108,30 @@ export function WalletProvider({ children }) {
     return () => { cancelled = true }
   }, [isConnected, address, walletClient])
 
-  // Check network compatibility. Only emit a network error when the wallet
-  // is on a chain we don't recognize (anything other than Polygon Amoy or
-  // local Hardhat).
+  // Auto-switch to Amoy (PRIMARY_CHAIN_ID) when the wallet connects on an
+  // unsupported chain. If the switch fails, show a network error instead.
   useEffect(() => {
-    if (isConnected && !isSupportedChainId(chainId)) {
-      const supported = listSupportedChainIds()
-        .map((id) => getNetwork(id)?.name)
-        .filter(Boolean)
-        .join(' or ')
-      const primary = getNetwork(PRIMARY_CHAIN_ID)
-      setNetworkError(
-        `Wrong network. Please switch to ${supported || primary?.name || 'a supported network'}.`
-      )
-    } else {
+    if (!isConnected) {
       setNetworkError(null)
+      return
     }
-  }, [chainId, isConnected])
+    if (isSupportedChainId(chainId)) {
+      setNetworkError(null)
+      return
+    }
+    // Wallet is on an unsupported chain — try switching automatically
+    switchChain(
+      { chainId: PRIMARY_CHAIN_ID },
+      {
+        onError: () => {
+          const primary = getNetwork(PRIMARY_CHAIN_ID)
+          setNetworkError(
+            `Please switch to ${primary?.name || 'Polygon Amoy'} in your wallet.`
+          )
+        },
+      }
+    )
+  }, [chainId, isConnected, switchChain])
 
   // Clear stale WalletConnect data on mount if not connected
   // This prevents "failed to process inbound message" errors from stale sessions

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -1043,46 +1043,59 @@ export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tie
   // v2 path: MembershipManager.purchaseTier(role, tier). Price is fixed in the contract.
   const mmAddress = getContractAddress('membershipManager')
   if (mmAddress) {
-    const roleHash = getRoleHash(roleName)
-    if (!roleHash) throw new Error(`Unknown role: ${roleName}`)
-    const validTier = [1, 2, 3, 4].includes(tier) ? tier : MembershipTier.BRONZE
-    const tierName = TIER_NAMES[validTier] || 'Bronze'
-
-    const mm = new ethers.Contract(mmAddress, MEMBERSHIP_MANAGER_ABI, signer)
-    const paymentTokenAddr = await mm.paymentToken()
-    const paymentToken = new ethers.Contract(paymentTokenAddr, ERC20_ABI, signer)
-
-    // Pull the configured price from the contract
-    const tierCfg = await mm.getTierConfig(roleHash, validTier)
-    const price = tierCfg.priceUSDC // 6-decimals
-
-    const userAddress = await signer.getAddress()
-    const balance = await paymentToken.balanceOf(userAddress)
-    if (balance < price) {
-      throw new Error(
-        `Insufficient USDC balance. Have ${ethers.formatUnits(balance, 6)}, need ${ethers.formatUnits(price, 6)}.`
+    // Verify the contract is actually deployed before calling into it.
+    // When the address has no code (wrong network, not yet deployed, etc.)
+    // ethers returns 0x from every call, producing a confusing BAD_DATA error.
+    const provider = signer.provider
+    const code = await provider.getCode(mmAddress)
+    if (!code || code === '0x') {
+      console.warn(
+        `[purchaseRole] MembershipManager has no code at ${mmAddress} — falling through to legacy path`
       )
-    }
+    } else {
+      const roleHash = getRoleHash(roleName)
+      if (!roleHash) throw new Error(`Unknown role: ${roleName}`)
+      const validTier = [1, 2, 3, 4].includes(tier) ? tier : MembershipTier.BRONZE
+      const tierName = TIER_NAMES[validTier] || 'Bronze'
 
-    const allowance = await paymentToken.allowance(userAddress, mmAddress)
-    if (allowance < price) {
-      const approveTx = await paymentToken.approve(mmAddress, price)
-      await approveTx.wait()
-    }
+      const mm = new ethers.Contract(mmAddress, MEMBERSHIP_MANAGER_ABI, signer)
+      const paymentTokenAddr = await mm.paymentToken()
+      if (!paymentTokenAddr || paymentTokenAddr === ethers.ZeroAddress) {
+        throw new Error('MembershipManager has no payment token configured. Contact the DAO administrator.')
+      }
+      const paymentToken = new ethers.Contract(paymentTokenAddr, ERC20_ABI, signer)
 
-    const tx = await mm.purchaseTier(roleHash, validTier)
-    const receipt = await tx.wait()
-    return {
-      hash: receipt.hash,
-      blockNumber: receipt.blockNumber,
-      status: receipt.status === 1 ? 'success' : 'failed',
-      gasUsed: receipt.gasUsed.toString(),
-      roleName,
-      tier: validTier,
-      tierName,
-      amount: parseFloat(ethers.formatUnits(price, 6)),
-      roleGrantedOnChain: receipt.status === 1,
-      roleGrantTxHash: receipt.hash,
+      const tierCfg = await mm.getTierConfig(roleHash, validTier)
+      const price = tierCfg.priceUSDC // 6-decimals
+
+      const userAddress = await signer.getAddress()
+      const balance = await paymentToken.balanceOf(userAddress)
+      if (balance < price) {
+        throw new Error(
+          `Insufficient USDC balance. Have ${ethers.formatUnits(balance, 6)}, need ${ethers.formatUnits(price, 6)}.`
+        )
+      }
+
+      const allowance = await paymentToken.allowance(userAddress, mmAddress)
+      if (allowance < price) {
+        const approveTx = await paymentToken.approve(mmAddress, price)
+        await approveTx.wait()
+      }
+
+      const tx = await mm.purchaseTier(roleHash, validTier)
+      const receipt = await tx.wait()
+      return {
+        hash: receipt.hash,
+        blockNumber: receipt.blockNumber,
+        status: receipt.status === 1 ? 'success' : 'failed',
+        gasUsed: receipt.gasUsed.toString(),
+        roleName,
+        tier: validTier,
+        tierName,
+        amount: parseFloat(ethers.formatUnits(price, 6)),
+        roleGrantedOnChain: receipt.status === 1,
+        roleGrantTxHash: receipt.hash,
+      }
     }
   }
 
@@ -1091,7 +1104,9 @@ export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tie
     const paymentProcessorAddress = getContractAddress('paymentProcessor')
 
     if (!paymentProcessorAddress) {
-      throw new Error('PaymentProcessor not deployed on this network.')
+      throw new Error(
+        'No purchase contract found on this network. Please verify you are connected to the correct chain and that contracts are deployed.'
+      )
     }
 
     const stableContract = new ethers.Contract(stableAddress, ERC20_ABI, signer)


### PR DESCRIPTION
When the MembershipManager contract has no deployed code at its configured
address (wrong network, not yet deployed, chain reset), ethers.js returns
0x from every call and throws a confusing BAD_DATA decode error. This adds
a getCode() check that falls through to the legacy PaymentProcessor path
when the contract is absent, and also guards against a zero-address
paymentToken response.

https://claude.ai/code/session_01DSXXSi9NMvfvUnguYRbQHy