### PR TITLE
fix: update Get USDC button link to Circle faucet (testnet) and Uniswap (mainnet)

### DIFF
--- a/frontend/src/components/wallet/WalletButton.jsx
+++ b/frontend/src/components/wallet/WalletButton.jsx
@@ -482,14 +482,14 @@ function WalletButton({ className = '' }) {
                   </button>
                 )}
                 <a
-                  href="https://v3.etcswap.org/#/swap"
+                  href={isTestnet ? "https://faucet.circle.com/" : "https://app.uniswap.org/swap?chain=polygon"}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="action-button get-usdc-btn"
                   role="menuitem"
                 >
                   <span aria-hidden="true">💰</span>
-                  <span>Get USC</span>
+                  <span>Get USDC</span>
                 </a>
                 <button
                   onClick={handleDisconnect}


### PR DESCRIPTION
The button previously pointed to ETCSwap (classic USD). Now links to
the Circle USDC faucet on testnet and Uniswap on Polygon mainnet.

https://claude.ai/code/session_01HjfyKgMztp1PhLmFCV65Sv