### PR TITLE
fix: display USDC balance instead of hardcoded "USC" in wallet dropdown

### DIFF
--- a/frontend/src/components/wallet/WalletButton.css
+++ b/frontend/src/components/wallet/WalletButton.css
@@ -139,7 +139,7 @@
   font-weight: 500;
 }
 
-.usc-balance {
+.usdc-balance {
   font-size: 0.875rem;
   color: var(--success-color, #4caf50);
   font-weight: 600;

--- a/frontend/src/components/wallet/WalletButton.jsx
+++ b/frontend/src/components/wallet/WalletButton.jsx
@@ -373,8 +373,8 @@ function WalletButton({ className = '' }) {
                   <BlockiesAvatar address={address} size={40} />
                   <div className="account-details">
                     <span className="account-address-full">{shortenAddress(address)}</span>
-                    <span className="usc-balance">
-                      {balanceLoading ? 'Loading...' : `${parseFloat(balances?.usc || 0).toFixed(2)} USC`}
+                    <span className="usdc-balance">
+                      {balanceLoading ? 'Loading...' : `${parseFloat(balances?.stable || 0).toFixed(2)} USDC`}
                     </span>
                     <span className="network-info">{network?.name || `Chain ${chainId}`}</span>
                   </div>


### PR DESCRIPTION
The wallet button was reading balances?.usc (undefined) and labeling it
"USC". Changed to balances?.stable which is the actual USDC balance from
DexContext, and updated the label to "USDC".

https://claude.ai/code/session_01DmRx2L8hJE5ueUWFTXqC4R