### PR TITLE
feat(wagers): per-user EnumerableSet index for O(N_user) lookups

### DIFF
--- a/contracts/interfaces/IWagerRegistry.sol
+++ b/contracts/interfaces/IWagerRegistry.sol
@@ -81,4 +81,8 @@ interface IWagerRegistry {
     function getWager(uint256 wagerId) external view returns (Wager memory);
     function isAllowedToken(address token) external view returns (bool);
     function nextWagerId() external view returns (uint256);
+
+    function getUserWagerCount(address user) external view returns (uint256);
+    function getUserWagerIds(address user, uint256 offset, uint256 limit) external view returns (uint256[] memory);
+    function getUserWagers(address user, uint256 offset, uint256 limit) external view returns (Wager[] memory);
 }

--- a/contracts/wagers/WagerRegistry.sol
+++ b/contracts/wagers/WagerRegistry.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/utils/Pausable.sol";
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
@@ -23,6 +24,7 @@ import "../oracles/IOracleAdapter.sol";
 ///         on this contract. See docs/system-overview/account-moderation.md.
 contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausable {
     using SafeERC20 for IERC20;
+    using EnumerableSet for EnumerableSet.UintSet;
 
     bytes32 public constant WAGER_PARTICIPANT_ROLE = keccak256("WAGER_PARTICIPANT_ROLE");
     bytes32 public constant GUARDIAN_ROLE = keccak256("GUARDIAN_ROLE");
@@ -42,6 +44,11 @@ contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausab
     mapping(uint256 => Wager) private _wagers;
     mapping(address => bool) private _frozen;
     uint256 private _nextWagerId = 1;
+
+    /// @notice Append-only per-user index of every wager a participant has been part of.
+    ///         Populated in `createWager` for both creator and opponent; never removed.
+    ///         Enables O(N_user) lookup without log scans (avoids `eth_getLogs` block-range limits).
+    mapping(address => EnumerableSet.UintSet) private _userWagerIds;
 
     event MembershipManagerUpdated(address indexed manager);
     event PolymarketAdapterUpdated(address indexed adapter);
@@ -236,6 +243,9 @@ contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausab
         w.metadataHash = metadataHash;
         w.polymarketConditionId = polymarketConditionId;
 
+        _userWagerIds[msg.sender].add(wagerId);
+        _userWagerIds[opponent].add(wagerId);
+
         emit WagerCreated(wagerId, msg.sender, opponent, token, creatorStake, opponentStake, resolutionType, metadataHash);
         if (resolutionType == ResolutionType.Polymarket) {
             emit PolymarketLinked(wagerId, polymarketConditionId, creatorIsYes);
@@ -390,5 +400,42 @@ contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausab
 
     function nextWagerId() external view returns (uint256) {
         return _nextWagerId;
+    }
+
+    function getUserWagerCount(address user) external view returns (uint256) {
+        return _userWagerIds[user].length();
+    }
+
+    /// @notice Paginated slice of a user's wager IDs. `offset` and `limit` are clamped
+    ///         to the available range so callers can safely page past the end.
+    function getUserWagerIds(address user, uint256 offset, uint256 limit)
+        public
+        view
+        returns (uint256[] memory ids)
+    {
+        EnumerableSet.UintSet storage set = _userWagerIds[user];
+        uint256 total = set.length();
+        if (offset >= total || limit == 0) return new uint256[](0);
+        uint256 end = offset + limit;
+        if (end > total) end = total;
+        uint256 n = end - offset;
+        ids = new uint256[](n);
+        for (uint256 i = 0; i < n; i++) {
+            ids[i] = set.at(offset + i);
+        }
+    }
+
+    /// @notice Paginated slice of a user's wagers as full structs. Order matches
+    ///         `getUserWagerIds(user, offset, limit)`.
+    function getUserWagers(address user, uint256 offset, uint256 limit)
+        external
+        view
+        returns (Wager[] memory wagers)
+    {
+        uint256[] memory ids = getUserWagerIds(user, offset, limit);
+        wagers = new Wager[](ids.length);
+        for (uint256 i = 0; i < ids.length; i++) {
+            wagers[i] = _wagers[ids[i]];
+        }
     }
 }

--- a/deployments/amoy-chain80002-v2.json
+++ b/deployments/amoy-chain80002-v2.json
@@ -9,7 +9,7 @@
   "contracts": {
     "polymarketAdapter": "0x423d2Ca885d67E46062CFF732Eff952f4F736136",
     "membershipManager": "0xFaEbF662aa591fF95e97306b413522efC958540f",
-    "wagerRegistry": "0x39f1CbC680cDc9831b6dF4D9e4719D3748720aBA",
+    "wagerRegistry": "0x61B0c8eb77266b401d0b7de8ac0e82548D1E4e0B",
     "keyRegistry": "0xb314c4Ee52D9D89bf7FEE66a43aBeAc7D047a5Cb",
     "chainlinkDataFeedAdapter": "0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23",
     "chainlinkFunctionsAdapter": "0x074fC18C1E322a7537b53B8B2Bf0762629E3b532",
@@ -19,5 +19,5 @@
     "mockPolymarketCTF": "0x95F40ea10E6C51892783c4E7721Ada1425917e22"
   },
   "saltPrefix": "FairWins-P2P-v2.0-",
-  "timestamp": "2026-05-22T23:42:28.536Z"
+  "timestamp": "2026-05-23T22:11:39.261Z"
 }

--- a/frontend/src/abis/WagerRegistry.js
+++ b/frontend/src/abis/WagerRegistry.js
@@ -32,6 +32,38 @@ export const WAGER_REGISTRY_ABI = [
   },
   {
     "inputs": [],
+    "name": "AccessControlBadConfirmation",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "neededRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "AccessControlUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      }
+    ],
+    "name": "AccountFrozenError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "AdapterNotSet",
     "type": "error"
   },
@@ -126,25 +158,13 @@ export const WAGER_REGISTRY_ABI = [
     "type": "error"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "owner",
-        "type": "address"
-      }
-    ],
-    "name": "OwnableInvalidOwner",
+    "inputs": [],
+    "name": "OracleAdapterNotSet",
     "type": "error"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
-    ],
-    "name": "OwnableUnauthorizedAccount",
+    "inputs": [],
+    "name": "OracleConditionRequired",
     "type": "error"
   },
   {
@@ -185,6 +205,11 @@ export const WAGER_REGISTRY_ABI = [
   },
   {
     "inputs": [],
+    "name": "UnsupportedOracleResolutionType",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "WinnerNotParticipant",
     "type": "error"
   },
@@ -204,6 +229,50 @@ export const WAGER_REGISTRY_ABI = [
       {
         "indexed": true,
         "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "by",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "reason",
+        "type": "string"
+      }
+    ],
+    "name": "AccountFrozen",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "by",
+        "type": "address"
+      }
+    ],
+    "name": "AccountUnfrozen",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "manager",
         "type": "address"
       }
@@ -216,18 +285,49 @@ export const WAGER_REGISTRY_ABI = [
     "inputs": [
       {
         "indexed": true,
-        "internalType": "address",
-        "name": "previousOwner",
-        "type": "address"
+        "internalType": "enum IWagerRegistry.ResolutionType",
+        "name": "resolutionType",
+        "type": "uint8"
       },
       {
         "indexed": true,
         "internalType": "address",
-        "name": "newOwner",
+        "name": "adapter",
         "type": "address"
       }
     ],
-    "name": "OwnershipTransferred",
+    "name": "OracleAdapterUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "wagerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "enum IWagerRegistry.ResolutionType",
+        "name": "resolutionType",
+        "type": "uint8"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "creatorIsYes",
+        "type": "bool"
+      }
+    ],
+    "name": "OracleConditionLinked",
     "type": "event"
   },
   {
@@ -304,6 +404,81 @@ export const WAGER_REGISTRY_ABI = [
       }
     ],
     "name": "PolymarketLinked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
     "type": "event"
   },
   {
@@ -477,7 +652,33 @@ export const WAGER_REGISTRY_ABI = [
   },
   {
     "inputs": [],
-    "name": "FRIEND_MARKET_ROLE",
+    "name": "ACCOUNT_MODERATOR_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "GUARDIAN_ROLE",
     "outputs": [
       {
         "internalType": "bytes32",
@@ -515,6 +716,19 @@ export const WAGER_REGISTRY_ABI = [
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "WAGER_PARTICIPANT_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -523,6 +737,19 @@ export const WAGER_REGISTRY_ABI = [
       }
     ],
     "name": "acceptWager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "wagerId",
+        "type": "uint256"
+      }
+    ],
+    "name": "autoResolveFromOracle",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -669,6 +896,197 @@ export const WAGER_REGISTRY_ABI = [
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "reason",
+        "type": "string"
+      }
+    ],
+    "name": "freezeAccount",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      }
+    ],
+    "name": "getUserWagerCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "limit",
+        "type": "uint256"
+      }
+    ],
+    "name": "getUserWagerIds",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "ids",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "offset",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "limit",
+        "type": "uint256"
+      }
+    ],
+    "name": "getUserWagers",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "creator",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "opponent",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "arbitrator",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "uint128",
+            "name": "creatorStake",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "opponentStake",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint64",
+            "name": "acceptDeadline",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "resolveDeadline",
+            "type": "uint64"
+          },
+          {
+            "internalType": "enum IWagerRegistry.ResolutionType",
+            "name": "resolutionType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "enum IWagerRegistry.Status",
+            "name": "status",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bool",
+            "name": "paid",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "creatorIsYes",
+            "type": "bool"
+          },
+          {
+            "internalType": "address",
+            "name": "winner",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "metadataHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "polymarketConditionId",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct IWagerRegistry.Wager[]",
+        "name": "wagers",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "wagerId",
         "type": "uint256"
@@ -765,12 +1183,73 @@ export const WAGER_REGISTRY_ABI = [
   {
     "inputs": [
       {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "token",
         "type": "address"
       }
     ],
     "name": "isAllowedToken",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      }
+    ],
+    "name": "isFrozen",
     "outputs": [
       {
         "internalType": "bool",
@@ -808,11 +1287,17 @@ export const WAGER_REGISTRY_ABI = [
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "owner",
+    "inputs": [
+      {
+        "internalType": "enum IWagerRegistry.ResolutionType",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "name": "oracleAdapters",
     "outputs": [
       {
-        "internalType": "address",
+        "internalType": "contract IOracleAdapter",
         "name": "",
         "type": "address"
       }
@@ -854,8 +1339,37 @@ export const WAGER_REGISTRY_ABI = [
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "renounceOwnership",
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "callerConfirmation",
+        "type": "address"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -869,6 +1383,24 @@ export const WAGER_REGISTRY_ABI = [
       }
     ],
     "name": "setMembershipManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "enum IWagerRegistry.ResolutionType",
+        "name": "rtype",
+        "type": "uint8"
+      },
+      {
+        "internalType": "address",
+        "name": "adapter",
+        "type": "address"
+      }
+    ],
+    "name": "setOracleAdapter",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -907,12 +1439,31 @@ export const WAGER_REGISTRY_ABI = [
   {
     "inputs": [
       {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
-        "name": "newOwner",
+        "name": "user",
         "type": "address"
       }
     ],
-    "name": "transferOwnership",
+    "name": "unfreezeAccount",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -924,4 +1475,4 @@ export const WAGER_REGISTRY_ABI = [
     "stateMutability": "nonpayable",
     "type": "function"
   }
-];
+]

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -48,7 +48,7 @@ const AMOY_CONTRACTS = {
   deployer: '0x52502d049571C7893447b86c4d8B38e6184bF6e1',
   treasury: '0x52502d049571C7893447b86c4d8B38e6184bF6e1',
   // v2 core (populated by `npm run sync:frontend-contracts -- --network amoy --chainId 80002`)
-  wagerRegistry: '0x39f1CbC680cDc9831b6dF4D9e4719D3748720aBA',
+  wagerRegistry: '0x61B0c8eb77266b401d0b7de8ac0e82548D1E4e0B',
   membershipManager: '0xFaEbF662aa591fF95e97306b413522efC958540f',
   keyRegistry: '0xb314c4Ee52D9D89bf7FEE66a43aBeAc7D047a5Cb',
   polymarketAdapter: '0x423d2Ca885d67E46062CFF732Eff952f4F736136',

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -390,61 +390,60 @@ function processMarketResult(marketId, marketResult, acceptanceStatus, acceptanc
  * @param {string} userAddress - User's wallet address
  * @returns {Promise<Array>} Array of friend market objects
  */
+const WAGER_STATUS_NAMES = ['none', 'pending', 'active', 'resolved', 'cancelled', 'refunded']
+
+function toWagerShape(id, w) {
+  const tokenAddr = w.token
+  const paymentToken = (DEPLOYED_CONTRACTS?.paymentToken || '').toLowerCase()
+  const isUSDC = tokenAddr && tokenAddr.toLowerCase() === paymentToken
+  const decimals = isUSDC ? 6 : 18
+  return {
+    id: String(id),
+    creator: w.creator,
+    opponent: w.opponent,
+    arbitrator: (w.arbitrator && w.arbitrator !== ethers.ZeroAddress) ? w.arbitrator : null,
+    participants: [w.creator, w.opponent].filter(a => a && a !== ethers.ZeroAddress),
+    creatorStake: ethers.formatUnits(w.creatorStake, decimals),
+    opponentStake: ethers.formatUnits(w.opponentStake, decimals),
+    stakeAmount: ethers.formatUnits(w.opponentStake, decimals),
+    stakeToken: tokenAddr,
+    stakeTokenAddress: tokenAddr,
+    stakeTokenSymbol: isUSDC ? 'USDC' : 'tokens',
+    resolutionType: Number(w.resolutionType),
+    status: WAGER_STATUS_NAMES[Number(w.status)] || 'unknown',
+    winner: (w.winner && w.winner !== ethers.ZeroAddress) ? w.winner : null,
+    paid: w.paid,
+    acceptanceDeadline: Number(w.acceptDeadline) * 1000,
+    endDate: new Date(Number(w.resolveDeadline) * 1000).toISOString(),
+    polymarketConditionId: w.polymarketConditionId,
+    creatorIsYes: w.creatorIsYes,
+    metadataHash: w.metadataHash,
+    description: `Wager #${id}`,
+  }
+}
+
 async function fetchWagersForUserV2(userAddress, provider, registryAddress) {
   const registry = new ethers.Contract(registryAddress, WAGER_REGISTRY_ABI, provider)
 
-  // Filter WagerCreated events where the user is either creator or opponent.
-  const createdAsCreator = registry.filters.WagerCreated(null, userAddress, null)
-  const createdAsOpponent = registry.filters.WagerCreated(null, null, userAddress)
-  const fromBlock = (DEPLOYMENT_BLOCKS && DEPLOYMENT_BLOCKS.wagerRegistry) || 0
+  // O(N_user) read via the contract's per-user EnumerableSet.UintSet index.
+  // Avoids `eth_getLogs` — public RPCs (e.g. Polygon Amoy) reject `toBlock: 'latest'`
+  // on the full deploy-to-tip range.
+  const count = Number(await registry.getUserWagerCount(userAddress))
+  if (count === 0) return []
 
-  const [evA, evB] = await Promise.all([
-    registry.queryFilter(createdAsCreator, fromBlock, 'latest').catch(() => []),
-    registry.queryFilter(createdAsOpponent, fromBlock, 'latest').catch(() => []),
-  ])
-  const events = [...evA, ...evB]
-  const ids = Array.from(new Set(events.map(e => e.args.wagerId.toString())))
-
-  if (ids.length === 0) return []
-
-  const wagers = await Promise.all(ids.map(async (id) => {
-    try {
-      const w = await registry.getWager(id)
-      const tokenAddr = w.token
-      const usdc = (DEPLOYED_CONTRACTS?.paymentToken || '').toLowerCase()
-      const isUSDC = tokenAddr && tokenAddr.toLowerCase() === usdc
-      const decimals = isUSDC ? 6 : 18
-      const statusNames = ['none', 'pending', 'active', 'resolved', 'cancelled', 'refunded']
-      return {
-        id: String(id),
-        creator: w.creator,
-        opponent: w.opponent,
-        arbitrator: (w.arbitrator && w.arbitrator !== ethers.ZeroAddress) ? w.arbitrator : null,
-        participants: [w.creator, w.opponent].filter(a => a && a !== ethers.ZeroAddress),
-        creatorStake: ethers.formatUnits(w.creatorStake, decimals),
-        opponentStake: ethers.formatUnits(w.opponentStake, decimals),
-        stakeAmount: ethers.formatUnits(w.opponentStake, decimals),
-        stakeToken: tokenAddr,
-        stakeTokenAddress: tokenAddr,
-        stakeTokenSymbol: isUSDC ? 'USDC' : 'tokens',
-        resolutionType: Number(w.resolutionType),
-        status: statusNames[Number(w.status)] || 'unknown',
-        winner: (w.winner && w.winner !== ethers.ZeroAddress) ? w.winner : null,
-        paid: w.paid,
-        acceptanceDeadline: Number(w.acceptDeadline) * 1000,
-        endDate: new Date(Number(w.resolveDeadline) * 1000).toISOString(),
-        polymarketConditionId: w.polymarketConditionId,
-        creatorIsYes: w.creatorIsYes,
-        metadataHash: w.metadataHash,
-        description: `Wager #${id}`,
-      }
-    } catch (e) {
-      console.warn(`Failed to load wager ${id}:`, e.message)
-      return null
+  const PAGE = 100
+  const wagers = []
+  for (let offset = 0; offset < count; offset += PAGE) {
+    const limit = Math.min(PAGE, count - offset)
+    const [ids, structs] = await Promise.all([
+      registry.getUserWagerIds(userAddress, offset, limit),
+      registry.getUserWagers(userAddress, offset, limit),
+    ])
+    for (let i = 0; i < ids.length; i++) {
+      wagers.push(toWagerShape(String(ids[i]), structs[i]))
     }
-  }))
-
-  return wagers.filter(Boolean)
+  }
+  return wagers
 }
 
 export async function fetchFriendMarketsForUser(userAddress) {

--- a/scripts/deploy/deploy.js
+++ b/scripts/deploy/deploy.js
@@ -207,10 +207,12 @@ async function main() {
   }
 
   // -------- WagerRegistry --------
+  // Salt suffix bumped (`-userindex`) when the per-user EnumerableSet index was added
+  // to force a fresh deterministic address; old wagers stay on the prior registry.
   const regDeploy = await deployDeterministic(
     "WagerRegistry",
     [deployer.address, mgrDeploy.address, adapter.address, [usdc, wmatic]],
-    generateSalt(SALT_PREFIXES.V2 + "WagerRegistry"),
+    generateSalt(SALT_PREFIXES.V2 + "WagerRegistry-userindex"),
     deployer
   );
   deployments.wagerRegistry = regDeploy.address;
@@ -247,6 +249,8 @@ async function main() {
         await tx.wait();
         console.log(`  ✓ allowlisted Chainlink ${pair}: ${addr}`);
       }
+    }
+    if (!cl.alreadyDeployed || !regDeploy.alreadyDeployed) {
       const wireTx = await wagerRegistry.connect(deployer).setOracleAdapter(RT.ChainlinkDataFeed, cl.address);
       await wireTx.wait();
       console.log(`  ✓ ChainlinkDataFeedOracleAdapter wired into WagerRegistry`);
@@ -266,11 +270,13 @@ async function main() {
     );
     oracleDeployments.chainlinkFunctionsAdapter = fn.address;
     deployments.chainlinkFunctionsAdapter = fn.address;
-    if (!fn.alreadyDeployed) {
+    if (!fn.alreadyDeployed || !regDeploy.alreadyDeployed) {
       const wireTx = await wagerRegistry.connect(deployer).setOracleAdapter(RT.ChainlinkFunctions, fn.address);
       await wireTx.wait();
       console.log(`  ✓ ChainlinkFunctionsOracleAdapter wired into WagerRegistry`);
-      console.log(`  ⚠️  add ${fn.address} as a consumer on your LINK subscription before calling registerCondition`);
+      if (!fn.alreadyDeployed) {
+        console.log(`  ⚠️  add ${fn.address} as a consumer on your LINK subscription before calling registerCondition`);
+      }
     }
   } else {
     console.log(`Skipping ChainlinkFunctionsOracleAdapter on ${networkName}: no router configured`);
@@ -287,7 +293,7 @@ async function main() {
     );
     oracleDeployments.umaAdapter = uma.address;
     deployments.umaAdapter = uma.address;
-    if (!uma.alreadyDeployed) {
+    if (!uma.alreadyDeployed || !regDeploy.alreadyDeployed) {
       const wireTx = await wagerRegistry.connect(deployer).setOracleAdapter(RT.UMA, uma.address);
       await wireTx.wait();
       console.log(`  ✓ UMAOptimisticOracleV3Adapter wired into WagerRegistry`);

--- a/test/WagerRegistry.test.js
+++ b/test/WagerRegistry.test.js
@@ -637,4 +637,117 @@ describe("WagerRegistry", function () {
       expect(await reg.isFrozen(bob.address)).to.be.true;
     });
   });
+
+  describe("per-user wager index", () => {
+    it("appends new wager IDs for both creator and opponent", async () => {
+      const fx = await loadFixture(deployFixture);
+      const { reg, alice, bob } = fx;
+      const id = await createDefault(reg, fx);
+      expect(await reg.getUserWagerCount(alice.address)).to.equal(1);
+      expect(await reg.getUserWagerCount(bob.address)).to.equal(1);
+      const aliceIds = await reg.getUserWagerIds(alice.address, 0, 10);
+      const bobIds = await reg.getUserWagerIds(bob.address, 0, 10);
+      expect(aliceIds.map(Number)).to.deep.equal([id]);
+      expect(bobIds.map(Number)).to.deep.equal([id]);
+    });
+
+    it("accumulates IDs across multiple wagers per user", async () => {
+      const fx = await loadFixture(deployFixture);
+      const { reg, alice, bob, charlie } = fx;
+      const id1 = await createDefault(reg, fx); // alice vs bob
+      const id2 = await createDefault(reg, fx, { opponent: charlie.address }); // alice vs charlie
+      const id3 = await createDefault(reg, fx, { _signer: bob, opponent: charlie.address }); // bob vs charlie
+
+      expect(await reg.getUserWagerCount(alice.address)).to.equal(2);
+      expect(await reg.getUserWagerCount(bob.address)).to.equal(2);
+      expect(await reg.getUserWagerCount(charlie.address)).to.equal(2);
+
+      const aliceIds = (await reg.getUserWagerIds(alice.address, 0, 10)).map(Number);
+      const bobIds = (await reg.getUserWagerIds(bob.address, 0, 10)).map(Number);
+      const charlieIds = (await reg.getUserWagerIds(charlie.address, 0, 10)).map(Number);
+      expect(aliceIds).to.deep.equal([id1, id2]);
+      expect(bobIds).to.deep.equal([id1, id3]);
+      expect(charlieIds).to.deep.equal([id2, id3]);
+    });
+
+    it("paginates with clamped offset and limit", async () => {
+      const fx = await loadFixture(deployFixture);
+      const { reg, alice } = fx;
+      const ids = [];
+      for (let i = 0; i < 5; i++) ids.push(await createDefault(reg, fx));
+
+      // full page
+      const full = (await reg.getUserWagerIds(alice.address, 0, 5)).map(Number);
+      expect(full).to.deep.equal(ids);
+
+      // limit larger than remaining clamps to end
+      const overshoot = (await reg.getUserWagerIds(alice.address, 3, 100)).map(Number);
+      expect(overshoot).to.deep.equal(ids.slice(3));
+
+      // offset past end returns empty
+      const past = await reg.getUserWagerIds(alice.address, 5, 10);
+      expect(past.length).to.equal(0);
+
+      // zero limit returns empty
+      const zero = await reg.getUserWagerIds(alice.address, 0, 0);
+      expect(zero.length).to.equal(0);
+
+      // mid-range slice
+      const mid = (await reg.getUserWagerIds(alice.address, 1, 2)).map(Number);
+      expect(mid).to.deep.equal(ids.slice(1, 3));
+    });
+
+    it("getUserWagers returns full structs in the same order as getUserWagerIds", async () => {
+      const fx = await loadFixture(deployFixture);
+      const { reg, alice, bob } = fx;
+      const id1 = await createDefault(reg, fx);
+      const id2 = await createDefault(reg, fx);
+      const ids = (await reg.getUserWagerIds(alice.address, 0, 10)).map(Number);
+      const wagers = await reg.getUserWagers(alice.address, 0, 10);
+      expect(ids).to.deep.equal([id1, id2]);
+      expect(wagers.length).to.equal(2);
+      expect(wagers[0].creator).to.equal(alice.address);
+      expect(wagers[0].opponent).to.equal(bob.address);
+      expect(wagers[0].status).to.equal(Status.Open);
+      expect(wagers[1].creator).to.equal(alice.address);
+    });
+
+    it("index is append-only across the full lifecycle (accept / cancel / declare / refund)", async () => {
+      const fx = await loadFixture(deployFixture);
+      const { reg, alice, bob } = fx;
+
+      // 1) accepted
+      const accepted = await createDefault(reg, fx);
+      await reg.connect(bob).acceptWager(accepted);
+      await reg.connect(alice).declareWinner(accepted, alice.address);
+
+      // 2) cancelled
+      const cancelled = await createDefault(reg, fx);
+      await reg.connect(alice).cancelOpen(cancelled);
+
+      // 3) refunded (Open → past acceptDeadline)
+      const refunded = await createDefault(reg, fx);
+      await time.increase(3700);
+      await reg.connect(alice).claimRefund(refunded);
+
+      // All three IDs still present, in creation order
+      const aliceIds = (await reg.getUserWagerIds(alice.address, 0, 10)).map(Number);
+      const bobIds = (await reg.getUserWagerIds(bob.address, 0, 10)).map(Number);
+      expect(aliceIds).to.deep.equal([accepted, cancelled, refunded]);
+      expect(bobIds).to.deep.equal([accepted, cancelled, refunded]);
+      expect(await reg.getUserWagerCount(alice.address)).to.equal(3);
+      expect(await reg.getUserWagerCount(bob.address)).to.equal(3);
+    });
+
+    it("returns zero count and empty page for a user not party to any wager", async () => {
+      const fx = await loadFixture(deployFixture);
+      const { reg } = fx;
+      const stranger = ethers.Wallet.createRandom().address;
+      expect(await reg.getUserWagerCount(stranger)).to.equal(0);
+      const ids = await reg.getUserWagerIds(stranger, 0, 50);
+      expect(ids.length).to.equal(0);
+      const wagers = await reg.getUserWagers(stranger, 0, 50);
+      expect(wagers.length).to.equal(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- **Bug**: "My Wagers" page was empty on Polygon Amoy even though wagers existed on-chain. Root cause: `fetchWagersForUserV2` called `registry.queryFilter(..., 'latest')`, and the public Amoy RPC (`https://rpc-amoy.polygon.technology`) rejects `toBlock: 'latest'` with `block range exceeds configured limit` even on small windows. The `.catch(() => [])` swallowed the error, so the UI showed "No Active Positions" silently.
- **Fix**: Add an append-only `EnumerableSet.UintSet` per user inside `WagerRegistry`. The frontend now does an O(N_user) read via three new paginated view functions and never touches `eth_getLogs`.
- **Scope**: Contract + interface + tests + deploy script + frontend fetcher. Deployed fresh to Amoy at `0x61B0c8eb77266b401d0b7de8ac0e82548D1E4e0B` with oracle adapters re-wired.

### Contract changes — `contracts/wagers/WagerRegistry.sol`
- `using EnumerableSet for EnumerableSet.UintSet`
- `mapping(address => EnumerableSet.UintSet) private _userWagerIds` (append-only across the full lifecycle — keeps every wager a user has ever been part of, which is what the participating/created/history tabs need)
- `createWager` appends `wagerId` to both creator's and opponent's sets
- Three new view functions, clamping `offset`/`limit` rather than reverting:
  - `getUserWagerCount(address)`
  - `getUserWagerIds(address, offset, limit)`
  - `getUserWagers(address, offset, limit)` — returns full `Wager` structs in one call

### Deploy — `scripts/deploy/deploy.js`
- Bumped `WagerRegistry` salt suffix to `-userindex` so the new bytecode lands at a fresh deterministic address (existing testnet wagers stay on the prior registry).
- Adapter-wiring conditions now also re-wire oracle adapters into the registry whenever `regDeploy.alreadyDeployed === false` (previously gated only on the adapter's own freshness).

### Frontend — `frontend/src/utils/blockchainService.js`
- `fetchWagersForUserV2` rewritten: `getUserWagerCount` then parallel `getUserWagerIds` + `getUserWagers` calls in 100-item pages.
- Extracted `toWagerShape` from the old per-wager normalization. The event-scan path is gone.

### Tests
- 6 new tests under `describe('per-user wager index', ...)`: append on createWager, multi-wager accumulation, pagination edges (offset past end / oversized limit / zero limit / mid-slice), bulk-getter parity with the IDs getter, append-only invariant across accept/cancel/declare/refund, empty-user sanity.
- All 58 `WagerRegistry.test.js` tests pass. All 23 oracle integration tests pass. All 774 frontend tests pass.

## Test plan

- [x] `npx hardhat test test/WagerRegistry.test.js` — 58 passing
- [x] `npx hardhat test test/integration/oracle/WagerRegistry_*.test.js` — 23 passing
- [x] `cd frontend && npm test -- --run` — 774 passing
- [x] `cd frontend && npm run lint` — 0 errors (2 pre-existing warnings unchanged)
- [x] Deployed to Polygon Amoy (`0x61B0c8eb77266b401d0b7de8ac0e82548D1E4e0B`, tx `0x54ae261895f0679e552993f86b6bca6b35e09d8f6c0afd49513d6222bd42135e`)
- [x] `sync:frontend-contracts` ran; `frontend/src/config/contracts.js` updated; ABI regenerated from compiled artifact
- [ ] Manual UX smoke against Amoy: open My Wagers as the two test addresses from the original report, create a fresh wager between them, confirm it appears immediately with no `eth_getLogs` calls in the network tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)