### PR TITLE
fix: auto-set acceptance deadline to midpoint between now and end time

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -8,6 +8,7 @@ import {
   WAGER_DEFAULTS,
   getDefaultEndDateTime,
   getDefaultAcceptanceDeadline,
+  getMidpointAcceptanceDeadline,
   toDateTimeLocal
 } from '../../constants/wagerDefaults'
 import { ResolutionType } from '../../constants/wagerDefaults'
@@ -123,7 +124,7 @@ function FriendMarketsModal({
     // to match PolymarketOracleAdapter's payouts ordering (YES=0, NO=1).
     creatorSide: '',
     // Multi-party acceptance fields
-    acceptanceDeadline: getDefaultAcceptanceDeadline(),
+    acceptanceDeadline: getMidpointAcceptanceDeadline(getDefaultEndDateTime()),
     minAcceptanceThreshold: String(WAGER_DEFAULTS.MIN_ACCEPTANCE_THRESHOLD),
     // Leverage/odds for Bookmaker markets (200 = 2x equal stakes, 10000 = 100x)
     oddsMultiplier: WAGER_DEFAULTS.ODDS_MULTIPLIER,
@@ -180,7 +181,7 @@ function FriendMarketsModal({
       arbitratorResolved: '',
       oracleConditionId: '',
       creatorSide: '',
-      acceptanceDeadline: getDefaultAcceptanceDeadline(),
+      acceptanceDeadline: getMidpointAcceptanceDeadline(getDefaultEndDateTime()),
       minAcceptanceThreshold: String(WAGER_DEFAULTS.MIN_ACCEPTANCE_THRESHOLD),
       oddsMultiplier: WAGER_DEFAULTS.ODDS_MULTIPLIER
     })
@@ -220,7 +221,7 @@ function FriendMarketsModal({
             resolutionType: ResolutionType.Polymarket,
             oracleConditionId: initialPolymarketMarket.conditionId,
             description: seeded,
-            ...(linkedEnd ? { endDateTime: linkedEnd } : {}),
+            ...(linkedEnd ? { endDateTime: linkedEnd, acceptanceDeadline: getMidpointAcceptanceDeadline(linkedEnd) } : {}),
           }
         })
       }
@@ -300,6 +301,12 @@ function FriendMarketsModal({
         // adapters register different ids, so carrying state across is wrong.
         // (Side preference IS preserved: YES/NO maps the same way for all.)
         updated.oracleConditionId = ''
+      }
+
+      // Auto-set acceptance deadline to the midpoint between now and the end
+      // time whenever the end time changes.
+      if (field === 'endDateTime') {
+        updated.acceptanceDeadline = getMidpointAcceptanceDeadline(value)
       }
 
       return updated
@@ -590,13 +597,13 @@ function FriendMarketsModal({
 
     // Validate acceptance deadline
     const acceptanceDeadline = new Date(formData.acceptanceDeadline)
-    const minAcceptanceDate = new Date(now.getTime() + 60 * 60 * 1000) // At least 1 hour from now
+    const minAcceptanceDate = new Date(now.getTime() + 5 * 60 * 1000) // At least 5 minutes from now
     const maxAcceptanceDate = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000) // Max 30 days from now
 
     if (!formData.acceptanceDeadline || isNaN(acceptanceDeadline.getTime())) {
       newErrors.acceptanceDeadline = 'Please select a valid acceptance deadline'
     } else if (acceptanceDeadline < minAcceptanceDate) {
-      newErrors.acceptanceDeadline = 'Acceptance deadline must be at least 1 hour from now'
+      newErrors.acceptanceDeadline = 'Acceptance deadline must be at least 5 minutes from now'
     } else if (acceptanceDeadline > maxAcceptanceDate) {
       newErrors.acceptanceDeadline = 'Acceptance deadline must be within 30 days'
     } else if (acceptanceDeadline >= endDate) {
@@ -1264,12 +1271,12 @@ function FriendMarketsModal({
                         type="datetime-local"
                         value={formData.acceptanceDeadline}
                         onChange={(e) => handleFormChange('acceptanceDeadline', e.target.value)}
-                        min={new Date(Date.now() + 60 * 60 * 1000).toISOString().slice(0, 16)}
+                        min={new Date(Date.now() + 5 * 60 * 1000).toISOString().slice(0, 16)}
                         max={new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 16)}
                         disabled={submitting}
                         className={`fm-datetime-input ${errors.acceptanceDeadline ? 'error' : ''}`}
                       />
-                      <span className="fm-hint">How long do participants have to accept? (min: 1 hour, max: 30 days)</span>
+                      <span className="fm-hint">Auto-set to halfway between now and end time (min: 5 min)</span>
                       {errors.acceptanceDeadline && <span className="fm-error">{errors.acceptanceDeadline}</span>}
                     </div>
 

--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -7,7 +7,6 @@ import { useDex } from '../../hooks/useDex'
 import {
   WAGER_DEFAULTS,
   getDefaultEndDateTime,
-  getDefaultAcceptanceDeadline,
   getMidpointAcceptanceDeadline,
   toDateTimeLocal
 } from '../../constants/wagerDefaults'

--- a/frontend/src/constants/wagerDefaults.js
+++ b/frontend/src/constants/wagerDefaults.js
@@ -143,6 +143,20 @@ export const getDefaultAcceptanceDeadline = (hours = WAGER_DEFAULTS.ACCEPTANCE_D
 }
 
 /**
+ * Returns an ISO datetime-local string set to the midpoint between
+ * the current wall-clock time and the given end time.
+ * Falls back to the fixed-hour default when endDateTime is missing or invalid.
+ */
+export const getMidpointAcceptanceDeadline = (endDateTime) => {
+  if (!endDateTime) return getDefaultAcceptanceDeadline()
+  const now = Date.now()
+  const end = new Date(endDateTime).getTime()
+  if (Number.isNaN(end) || end <= now) return getDefaultAcceptanceDeadline()
+  const midpoint = now + (end - now) / 2
+  return new Date(midpoint).toISOString().slice(0, 16)
+}
+
+/**
  * Convert any datetime-like value into the `<input type="datetime-local">`
  * string format (`YYYY-MM-DDTHH:mm`) in the user's local timezone.
  * Used when seeding the end-date field from a linked Polymarket's endDate.


### PR DESCRIPTION
The acceptance time picker had a 1-hour minimum that prevented setting
short acceptance windows for near-term wagers. Now the acceptance
deadline auto-calculates to halfway between wall clock time and the
end time whenever the end time changes, with a 5-minute minimum.

https://claude.ai/code/session_01WW8UBpzsXoHnrhB8JeP8XF