### PR TITLE
fix(encryption): use X25519 for 1v1 envelopes that add recipients via KeyRegistry

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -770,9 +770,12 @@ function FriendMarketsModal({
             )
           }
 
-          // Create encrypted envelope for creator
-          const { envelope } = await createEncrypted(marketMetadata)
-          // Add opponent as recipient using their on-chain public key (no shared secret)
+          // 1v1 encrypted: force X25519 so we can add the opponent using the
+          // X25519 public key returned by the on-chain KeyRegistry. The X-Wing
+          // (v2.0) path can't be used here because the registry only stores
+          // 32-byte X25519 keys; addRecipientByPublicKey would then read an
+          // undefined `ephemeralPublicKey` off an X-Wing wrapped-key entry.
+          const { envelope } = await createEncrypted(marketMetadata, { algorithm: 'x25519' })
           finalMetadata = addRecipientByPublicKey(envelope, opponentAddress, opponentKey)
         } else {
           // Group markets: start with creator as only recipient

--- a/frontend/src/hooks/useEncryption.js
+++ b/frontend/src/hooks/useEncryption.js
@@ -457,7 +457,15 @@ export function useEncryption() {
     if (!account || !keyPairs.x25519?.privateKey) {
       throw new Error('Encryption keys not initialized')
     }
-    // Use the low-level addRecipient which accepts {address, publicKey} directly
+    if (isXWingEnvelope(envelope)) {
+      // The on-chain KeyRegistry only stores 32-byte X25519 keys, so we have
+      // no X-Wing key to encrypt for. Callers should create X25519 envelopes
+      // when they intend to add a recipient via on-chain lookup.
+      throw new Error(
+        'addRecipientByPublicKey: cannot add an X-Wing recipient using an X25519 key. ' +
+        'Create the envelope with { algorithm: "x25519" } when the recipient comes from KeyRegistry.'
+      )
+    }
     return addRecipient(envelope, account, keyPairs.x25519.privateKey, {
       address: recipientAddress,
       publicKey: recipientPublicKey


### PR DESCRIPTION
## Summary

- **Bug**: Creating an encrypted 1v1 wager threw `Error: hex string expected, got undefined` and never reached `createWager`.
- **Cause**: `createEncrypted(marketMetadata)` now defaults to **X-Wing** (v2.0 post-quantum), but the on-chain `KeyRegistry` only stores 32-byte X25519 keys. After producing an X-Wing envelope, the modal called `addRecipientByPublicKey(...)`, which unconditionally routes through legacy X25519 `addRecipient`. That function reads `wrappedKeyEntry.ephemeralPublicKey` — a field that's only present on X25519 envelopes; X-Wing envelopes use `xwingCiphertext`. The undefined field tripped `hexToBytes(undefined)` deep in noble-ciphers, which surfaces as ethers' "hex string expected, got undefined".
- **Fix**: Force `{ algorithm: 'x25519' }` in the 1v1 encrypted path so we can encrypt for the opponent using the X25519 public key returned by the registry. Group/creator-only path keeps X-Wing. Also guard `addRecipientByPublicKey` with `isXWingEnvelope(...)` so any future caller that mixes envelope types gets a readable error instead of a cryptic crash.

## Changes

- `frontend/src/components/fairwins/FriendMarketsModal.jsx` — 1v1 encrypted branch calls `createEncrypted(marketMetadata, { algorithm: 'x25519' })`.
- `frontend/src/hooks/useEncryption.js` — `addRecipientByPublicKey` throws a descriptive error if the envelope is X-Wing while we only have an X25519 key for the recipient.

## Note for the future

Eventually we can route X-Wing too, but it requires the registry to also store X-Wing public keys (1216 bytes, vs 32 for X25519) so an opponent's X-Wing key is discoverable. Until then, on-chain-lookup envelopes must be X25519.

## Test plan

- [x] `cd frontend && npm test -- --run` — 774 passing
- [x] `cd frontend && npm run lint` — 0 errors (same 2 pre-existing warnings in WalletButton.jsx)
- [ ] Manual: create an encrypted 1v1 wager between two registered accounts; confirm the wager is created (no `hex string expected` console error) and that both parties can decrypt the description on the My Wagers / Acceptance views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)