### PR TITLE
feat: store metadataUri on-chain so both participants can decrypt wager messages

### DIFF
--- a/contracts/interfaces/IWagerRegistry.sol
+++ b/contracts/interfaces/IWagerRegistry.sol
@@ -23,6 +23,7 @@ interface IWagerRegistry {
         address winner;
         bytes32 metadataHash;
         bytes32 polymarketConditionId;
+        string  metadataUri;
     }
 
     event WagerCreated(
@@ -33,7 +34,8 @@ interface IWagerRegistry {
         uint128 creatorStake,
         uint128 opponentStake,
         ResolutionType resolutionType,
-        bytes32 metadataHash
+        bytes32 metadataHash,
+        string  metadataUri
     );
     event WagerAccepted(uint256 indexed wagerId, address indexed opponent);
     event WagerCancelled(uint256 indexed wagerId);
@@ -63,7 +65,8 @@ interface IWagerRegistry {
         ResolutionType resolutionType,
         bytes32 polymarketConditionId,
         bool creatorIsYes,
-        bytes32 metadataHash
+        bytes32 metadataHash,
+        string calldata metadataUri
     ) external returns (uint256 wagerId);
 
     function acceptWager(uint256 wagerId) external;

--- a/contracts/wagers/WagerRegistry.sol
+++ b/contracts/wagers/WagerRegistry.sol
@@ -185,7 +185,8 @@ contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausab
         ResolutionType resolutionType,
         bytes32 polymarketConditionId,
         bool creatorIsYes,
-        bytes32 metadataHash
+        bytes32 metadataHash,
+        string calldata metadataUri
     ) external nonReentrant whenNotPaused notFrozen(msg.sender) returns (uint256 wagerId) {
         if (opponent == address(0)) revert ZeroAddress();
         if (opponent == msg.sender) revert SelfWager();
@@ -242,11 +243,12 @@ contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausab
         w.creatorIsYes = creatorIsYes;
         w.metadataHash = metadataHash;
         w.polymarketConditionId = polymarketConditionId;
+        w.metadataUri = metadataUri;
 
         _userWagerIds[msg.sender].add(wagerId);
         _userWagerIds[opponent].add(wagerId);
 
-        emit WagerCreated(wagerId, msg.sender, opponent, token, creatorStake, opponentStake, resolutionType, metadataHash);
+        emit WagerCreated(wagerId, msg.sender, opponent, token, creatorStake, opponentStake, resolutionType, metadataHash, metadataUri);
         if (resolutionType == ResolutionType.Polymarket) {
             emit PolymarketLinked(wagerId, polymarketConditionId, creatorIsYes);
         } else if (_isExtensibleOracleType(resolutionType)) {

--- a/deployments/amoy-chain80002-v2.json
+++ b/deployments/amoy-chain80002-v2.json
@@ -9,7 +9,7 @@
   "contracts": {
     "polymarketAdapter": "0x423d2Ca885d67E46062CFF732Eff952f4F736136",
     "membershipManager": "0xFaEbF662aa591fF95e97306b413522efC958540f",
-    "wagerRegistry": "0x61B0c8eb77266b401d0b7de8ac0e82548D1E4e0B",
+    "wagerRegistry": "0x66c7fa8cB1642Fc5e94Fa92928f1d6333c8d657f",
     "keyRegistry": "0xb314c4Ee52D9D89bf7FEE66a43aBeAc7D047a5Cb",
     "chainlinkDataFeedAdapter": "0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23",
     "chainlinkFunctionsAdapter": "0x074fC18C1E322a7537b53B8B2Bf0762629E3b532",
@@ -19,5 +19,5 @@
     "mockPolymarketCTF": "0x95F40ea10E6C51892783c4E7721Ada1425917e22"
   },
   "saltPrefix": "FairWins-P2P-v2.0-",
-  "timestamp": "2026-05-23T22:11:39.261Z"
+  "timestamp": "2026-05-24T02:29:26.974Z"
 }

--- a/frontend/src/abis/WagerRegistry.js
+++ b/frontend/src/abis/WagerRegistry.js
@@ -595,6 +595,12 @@ export const WAGER_REGISTRY_ABI = [
         "internalType": "bytes32",
         "name": "metadataHash",
         "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "metadataUri",
+        "type": "string"
       }
     ],
     "name": "WagerCreated",
@@ -862,6 +868,11 @@ export const WAGER_REGISTRY_ABI = [
         "internalType": "bytes32",
         "name": "metadataHash",
         "type": "bytes32"
+      },
+      {
+        "internalType": "string",
+        "name": "metadataUri",
+        "type": "string"
       }
     ],
     "name": "createWager",
@@ -1074,6 +1085,11 @@ export const WAGER_REGISTRY_ABI = [
             "internalType": "bytes32",
             "name": "polymarketConditionId",
             "type": "bytes32"
+          },
+          {
+            "internalType": "string",
+            "name": "metadataUri",
+            "type": "string"
           }
         ],
         "internalType": "struct IWagerRegistry.Wager[]",
@@ -1170,6 +1186,11 @@ export const WAGER_REGISTRY_ABI = [
             "internalType": "bytes32",
             "name": "polymarketConditionId",
             "type": "bytes32"
+          },
+          {
+            "internalType": "string",
+            "name": "metadataUri",
+            "type": "string"
           }
         ],
         "internalType": "struct IWagerRegistry.Wager",

--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -879,7 +879,9 @@ function FriendMarketsModal({
           }
         },
         // Encryption fields
-        isEncrypted: enableEncryption
+        isEncrypted: enableEncryption,
+        ipfsCid: result?.ipfsCid || null,
+        metadataHash: result?.metadataHash || null,
       }
 
       setCreatedMarket(newMarket)

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { ethers } from 'ethers'
 import { useWallet, useWeb3 } from '../../hooks'
+import { useLazyMarketDecryption } from '../../hooks/useEncryption'
+import { useLazyIpfsEnvelope } from '../../hooks/useIpfs'
 import { WagerStatus as MarketStatus, DisputeStatus, WAGER_DEFAULTS } from '../../constants/wagerDefaults'
 import { getContractAddress } from '../../config/contracts'
 import { WAGER_REGISTRY_ABI } from '../../abis/WagerRegistry'
@@ -27,6 +29,9 @@ function MyMarketsModal({
 }) {
   const { isConnected, account } = useWallet()
   const { signer, isCorrectNetwork, switchNetwork } = useWeb3()
+
+  const { markets: marketsWithEnvelopes, fetchEnvelope } = useLazyIpfsEnvelope(friendMarkets)
+  const { markets: decryptableMarkets, decryptMarket, isMarketDecrypting } = useLazyMarketDecryption(marketsWithEnvelopes)
 
   // Tab state
   const [activeTab, setActiveTab] = useState('participating')
@@ -56,6 +61,15 @@ function MyMarketsModal({
   // Filter state
   const [marketTypeFilter, setMarketTypeFilter] = useState('all') // 'all', 'friend'
   const [statusFilter, setStatusFilter] = useState('all')
+
+  const handleDecryptMarket = useCallback(async (marketId) => {
+    try {
+      await fetchEnvelope(marketId)
+      await decryptMarket(marketId)
+    } catch (err) {
+      console.error('[MyMarketsModal] Decryption failed:', err)
+    }
+  }, [fetchEnvelope, decryptMarket])
 
   // Fetch markets data (friend markets are passed via props)
   const fetchMarketsData = useCallback(async () => {
@@ -130,7 +144,7 @@ function MyMarketsModal({
     // Combine fetched and friend markets
     const allMarkets = [
       ...markets.map(m => ({ ...m, marketType: 'friend' })),
-      ...friendMarkets.map(m => ({ ...m, marketType: 'friend' }))
+      ...decryptableMarkets.map(m => ({ ...m, marketType: 'friend' }))
     ]
 
     // Remove duplicates by id
@@ -223,7 +237,7 @@ function MyMarketsModal({
     })
 
     return { participating, created, history }
-  }, [markets, friendMarkets, userPositions, account, marketTypeFilter, statusFilter])
+  }, [markets, decryptableMarkets, userPositions, account, marketTypeFilter, statusFilter])
 
   // Format helpers
   const formatDate = (dateValue) => {
@@ -589,6 +603,8 @@ function MyMarketsModal({
                       userPositions={userPositions}
                       canOpenDispute={canOpenDispute}
                       onOpenDispute={handleOpenDispute}
+                      onDecrypt={handleDecryptMarket}
+                      isDecrypting={isMarketDecrypting(selectedMarket?.id)}
                     />
                   ) : categorizedMarkets.participating.length === 0 ? (
                     <div className="mm-empty-state">
@@ -634,6 +650,8 @@ function MyMarketsModal({
                       onOpenResolution={handleOpenResolution}
                       onRespondToDispute={(m) => handleOpenDispute(m, 'respond')}
                       isCreatorView
+                      onDecrypt={handleDecryptMarket}
+                      isDecrypting={isMarketDecrypting(selectedMarket?.id)}
                     />
                   ) : categorizedMarkets.created.length === 0 ? (
                     <div className="mm-empty-state">
@@ -678,6 +696,8 @@ function MyMarketsModal({
                       account={account}
                       userPositions={userPositions}
                       isHistoryView
+                      onDecrypt={handleDecryptMarket}
+                      isDecrypting={isMarketDecrypting(selectedMarket?.id)}
                     />
                   ) : categorizedMarkets.history.length === 0 ? (
                     <div className="mm-empty-state">
@@ -758,7 +778,12 @@ function MyMarketsModal({
  * Get display title for a market, handling encrypted markets
  */
 function getMarketDisplayTitle(market) {
-  // First check decrypted metadata (from useDecryptedMarkets hook)
+  // Check decrypted metadata (from useLazyMarketDecryption hook)
+  if (market.decryptedMetadata) {
+    const title = market.decryptedMetadata.name || market.decryptedMetadata.description || market.decryptedMetadata.question
+    if (title) return title
+  }
+
   if (market.metadata && market.canView !== false) {
     const title = market.metadata.name || market.metadata.description || market.metadata.question
     if (title && title !== 'Private Market' && title !== 'Private Wager' && title !== 'Encrypted Market' && title !== 'Encrypted Wager') {
@@ -1062,6 +1087,8 @@ function MarketDetailView({
   getStatusLabel,
   getTimeRemaining,
   account,
+  onDecrypt,
+  isDecrypting,
   userPositions,
   canResolve: _canResolve,
   canOpenDispute,
@@ -1118,13 +1145,31 @@ function MarketDetailView({
         </div>
       </div>
 
-      {/* Show description if it's different from the title and not a placeholder */}
+      {/* Encrypted wager: show decrypt prompt or decrypted content */}
+      {market.isEncrypted && !market.decryptedMetadata && (
+        <div className="mm-detail-description">
+          {isDecrypting ? (
+            <p style={{ opacity: 0.7 }}>Decrypting...</p>
+          ) : (
+            <button
+              type="button"
+              className="mm-btn-primary"
+              onClick={() => onDecrypt?.(market.id)}
+              style={{ marginTop: '8px' }}
+            >
+              Decrypt Wager Details
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Show description if available and not a placeholder */}
       {market.description &&
-       market.proposalTitle &&
        market.description !== 'Encrypted Market' &&
        market.description !== 'Encrypted Wager' &&
        market.description !== 'Private Market' &&
-       market.description !== 'Private Wager' && (
+       market.description !== 'Private Wager' &&
+       !market.isEncrypted && (
         <div className="mm-detail-description">
           <p>{market.description}</p>
         </div>

--- a/frontend/src/components/fairwins/marketHelpers.js
+++ b/frontend/src/components/fairwins/marketHelpers.js
@@ -56,5 +56,9 @@ export const getMarketUrl = (market, fallbackCreator = '') => {
       : ''
   })
 
+  if (market.ipfsCid) {
+    params.set('cid', market.ipfsCid)
+  }
+
   return `${window.location.origin}/friend-market/accept?${params.toString()}`
 }

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -48,7 +48,7 @@ const AMOY_CONTRACTS = {
   deployer: '0x52502d049571C7893447b86c4d8B38e6184bF6e1',
   treasury: '0x52502d049571C7893447b86c4d8B38e6184bF6e1',
   // v2 core (populated by `npm run sync:frontend-contracts -- --network amoy --chainId 80002`)
-  wagerRegistry: '0x61B0c8eb77266b401d0b7de8ac0e82548D1E4e0B',
+  wagerRegistry: '0x66c7fa8cB1642Fc5e94Fa92928f1d6333c8d657f',
   membershipManager: '0xFaEbF662aa591fF95e97306b413522efC958540f',
   keyRegistry: '0xb314c4Ee52D9D89bf7FEE66a43aBeAc7D047a5Cb',
   polymarketAdapter: '0x423d2Ca885d67E46062CFF732Eff952f4F736136',

--- a/frontend/src/hooks/useFriendMarketCreation.js
+++ b/frontend/src/hooks/useFriendMarketCreation.js
@@ -221,7 +221,7 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
           creatorStakeWei, opponentStakeWei,
           acceptDeadline, resolveDeadline,
           resolutionType, polymarketConditionId, creatorIsYes,
-          metadataHash
+          metadataHash, metadataReference
         )
       } catch (simError) {
         const reason = simError.reason || simError.shortMessage || simError.message || ''
@@ -234,7 +234,7 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
         creatorStakeWei, opponentStakeWei,
         acceptDeadline, resolveDeadline,
         resolutionType, polymarketConditionId, creatorIsYes,
-        metadataHash
+        metadataHash, metadataReference
       )
       onProgress({ step: 'create', message: 'Waiting for confirmation...', txHash: tx.hash })
       savePendingTransaction({ step: 'create', txHash: tx.hash, data: data.data })
@@ -292,7 +292,7 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
 
       if (onMarketCreated) onMarketCreated(newMarket)
 
-      return { id: wagerId, txHash: receipt.hash, status: 'pending' }
+      return { id: wagerId, txHash: receipt.hash, status: 'pending', ipfsCid, metadataHash }
     } catch (error) {
       console.error('Error creating wager:', error)
       if (error.code === 'ACTION_REJECTED' || error.code === 4001) {

--- a/frontend/src/pages/MarketAcceptancePage.jsx
+++ b/frontend/src/pages/MarketAcceptancePage.jsx
@@ -65,6 +65,7 @@ function MarketAcceptancePage() {
   const urlToken = searchParams.get('token')
   const urlDeadline = searchParams.get('deadline')
   const urlSharedSignature = searchParams.get('sig') || null
+  const urlCid = searchParams.get('cid') || null
 
   useEffect(() => {
     const fetch = async () => {
@@ -118,11 +119,13 @@ function MarketAcceptancePage() {
         // The opponent puts up opponentStake on acceptance; that's what the modal cares about.
         const stakePerParticipant = ethers.formatUnits(w.opponentStake, decimals)
 
-        // Off-chain we may have the original description matching the on-chain metadataHash.
-        // For now we just show the metadataHash — the encrypted-envelope flow can resolve
-        // it via IPFS by hash lookup in a future enhancement.
-        const rawDescription = w.metadataHash
-        const displayDescription = `Wager #${marketId} — hash ${rawDescription.slice(0, 10)}…`
+        const rawDescription = w.metadataUri || ''
+        const ipfsRef = parseEncryptedIpfsReference(rawDescription)
+        const ipfsCid = ipfsRef.cid || getIpfsCid(rawDescription) || urlCid || null
+        const encrypted = ipfsRef.isIpfs || isEncryptedDescription(rawDescription) || Boolean(urlCid)
+        const displayDescription = encrypted
+          ? 'Encrypted Wager'
+          : (rawDescription || `Wager #${marketId}`)
 
         const opponentAddr = w.opponent
         const acceptances = {}
@@ -149,8 +152,8 @@ function MarketAcceptancePage() {
           id: marketId,
           description: displayDescription,
           rawDescription,
-          isEncrypted: isEncryptedDescription(rawDescription),
-          ipfsCid: getIpfsCid(rawDescription),
+          isEncrypted: encrypted,
+          ipfsCid,
           sharedSignature: urlSharedSignature,
           creator: w.creator,
           participants: opponentAddr && opponentAddr !== ethers.ZeroAddress ? [w.creator, opponentAddr] : [w.creator],
@@ -201,7 +204,7 @@ function MarketAcceptancePage() {
       }
     }
     fetch()
-  }, [marketId, provider, urlCreator, urlStake, urlToken, urlDeadline, urlSharedSignature])
+  }, [marketId, provider, urlCreator, urlStake, urlToken, urlDeadline, urlSharedSignature, urlCid])
 
   const handleClose = () => navigate('/')
   const handleAccepted = () => { setLoading(true); window.location.reload() }

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -397,6 +397,21 @@ function toWagerShape(id, w) {
   const paymentToken = (DEPLOYED_CONTRACTS?.paymentToken || '').toLowerCase()
   const isUSDC = tokenAddr && tokenAddr.toLowerCase() === paymentToken
   const decimals = isUSDC ? 6 : 18
+
+  const metadataUri = w.metadataUri || ''
+  const ipfsRef = parseEncryptedIpfsReference(metadataUri)
+  const isEncrypted = ipfsRef.isIpfs
+  const ipfsCid = ipfsRef.cid || null
+
+  let description
+  if (isEncrypted) {
+    description = 'Encrypted Wager'
+  } else if (metadataUri) {
+    description = metadataUri
+  } else {
+    description = `Wager #${id}`
+  }
+
   return {
     id: String(id),
     creator: w.creator,
@@ -418,7 +433,10 @@ function toWagerShape(id, w) {
     polymarketConditionId: w.polymarketConditionId,
     creatorIsYes: w.creatorIsYes,
     metadataHash: w.metadataHash,
-    description: `Wager #${id}`,
+    ipfsCid,
+    isEncrypted,
+    needsIpfsFetch: isEncrypted,
+    description,
   }
 }
 

--- a/test/WagerRegistry.test.js
+++ b/test/WagerRegistry.test.js
@@ -79,6 +79,7 @@ describe("WagerRegistry", function () {
       polymarketConditionId: ethers.ZeroHash,
       creatorIsYes: false,
       metadataHash: ethers.id("test"),
+      metadataUri: "ipfs://bafyTestCid123",
       ...overrides,
     };
     const signer = overrides._signer || alice;
@@ -87,7 +88,8 @@ describe("WagerRegistry", function () {
       params.creatorStake, params.opponentStake,
       params.acceptDeadline, params.resolveDeadline,
       params.resolutionType, params.polymarketConditionId,
-      params.creatorIsYes, params.metadataHash
+      params.creatorIsYes, params.metadataHash,
+      params.metadataUri
     );
     const receipt = await tx.wait();
     // Find WagerCreated event and extract wagerId
@@ -111,6 +113,41 @@ describe("WagerRegistry", function () {
       const m = await mgr.getMembership(alice.address, WAGER_PARTICIPANT_ROLE);
       expect(m.activeCount).to.equal(1);
       expect(m.monthCount).to.equal(1);
+    });
+
+    it("stores and returns metadataUri", async () => {
+      const fx = await loadFixture(deployFixture);
+      const uri = "ipfs://bafybeicCustomCid";
+      const wagerId = await createDefault(fx.reg, fx, { metadataUri: uri });
+      const w = await fx.reg.getWager(wagerId);
+      expect(w.metadataUri).to.equal(uri);
+    });
+
+    it("emits metadataUri in WagerCreated event", async () => {
+      const fx = await loadFixture(deployFixture);
+      const { reg, alice, bob, usdcToken } = fx;
+      const now = await time.latest();
+      const uri = "ipfs://bafybeicEventTest";
+      const hash = ethers.id("event-test");
+      await expect(
+        reg.connect(alice).createWager(
+          bob.address, ethers.ZeroAddress, await usdcToken.getAddress(),
+          usdc(10), usdc(10),
+          now + 3600, now + 86400,
+          Resolution.Either, ethers.ZeroHash, false,
+          hash, uri
+        )
+      ).to.emit(reg, "WagerCreated").withArgs(
+        1, alice.address, bob.address, await usdcToken.getAddress(),
+        usdc(10), usdc(10), Resolution.Either, hash, uri
+      );
+    });
+
+    it("supports empty metadataUri for plaintext wagers", async () => {
+      const fx = await loadFixture(deployFixture);
+      const wagerId = await createDefault(fx.reg, fx, { metadataUri: "" });
+      const w = await fx.reg.getWager(wagerId);
+      expect(w.metadataUri).to.equal("");
     });
 
     it("rejects SelfWager", async () => {

--- a/test/integration/oracle/WagerRegistry_ChainlinkDataFeed.test.js
+++ b/test/integration/oracle/WagerRegistry_ChainlinkDataFeed.test.js
@@ -72,7 +72,8 @@ describe("WagerRegistry + ChainlinkDataFeedOracleAdapter (integration)", functio
       Resolution.ChainlinkDataFeed,
       conditionId,
       opts.creatorIsYes ?? true,
-      ethers.id("meta")
+      ethers.id("meta"),
+      ""
     );
     const rcpt = await tx.wait();
     const ev = rcpt.logs.map(l => { try { return reg.interface.parseLog(l); } catch { return null; } })
@@ -122,7 +123,7 @@ describe("WagerRegistry + ChainlinkDataFeedOracleAdapter (integration)", functio
     await expect(fx.reg.connect(fx.alice).createWager(
       fx.bob.address, ethers.ZeroAddress, await fx.usdcToken.getAddress(),
       usdc(10), usdc(10), now + 1800, now + 7200,
-      Resolution.ChainlinkDataFeed, conditionId, true, ethers.id("meta")
+      Resolution.ChainlinkDataFeed, conditionId, true, ethers.id("meta"), ""
     )).to.be.revertedWithCustomError(fx.reg, "OracleAdapterNotSet");
   });
 
@@ -138,7 +139,7 @@ describe("WagerRegistry + ChainlinkDataFeedOracleAdapter (integration)", functio
     await expect(fx.reg.connect(fx.alice).createWager(
       fx.bob.address, ethers.ZeroAddress, await fx.usdcToken.getAddress(),
       usdc(10), usdc(10), now + 1800, now + 7200,
-      Resolution.ChainlinkDataFeed, conditionId, true, ethers.id("meta")
+      Resolution.ChainlinkDataFeed, conditionId, true, ethers.id("meta"), ""
     )).to.be.revertedWithCustomError(fx.reg, "ConditionAlreadyResolved");
   });
 

--- a/test/integration/oracle/WagerRegistry_ChainlinkFunctions.test.js
+++ b/test/integration/oracle/WagerRegistry_ChainlinkFunctions.test.js
@@ -70,7 +70,8 @@ describe("WagerRegistry + ChainlinkFunctionsOracleAdapter (integration)", functi
       Resolution.ChainlinkFunctions,
       conditionId,
       opts.creatorIsYes ?? true,
-      ethers.id("meta")
+      ethers.id("meta"),
+      ""
     );
     const rcpt = await tx.wait();
     const ev = rcpt.logs.map(l => { try { return reg.interface.parseLog(l); } catch { return null; } })
@@ -123,7 +124,7 @@ describe("WagerRegistry + ChainlinkFunctionsOracleAdapter (integration)", functi
     await expect(fx.reg.connect(fx.alice).createWager(
       fx.bob.address, ethers.ZeroAddress, await fx.usdcToken.getAddress(),
       usdc(10), usdc(10), now + 1800, now + 7200,
-      Resolution.ChainlinkFunctions, ethers.id("c"), true, ethers.id("meta")
+      Resolution.ChainlinkFunctions, ethers.id("c"), true, ethers.id("meta"), ""
     )).to.be.revertedWithCustomError(fx.reg, "OracleAdapterNotSet");
   });
 });

--- a/test/integration/oracle/WagerRegistry_OracleRegistry.test.js
+++ b/test/integration/oracle/WagerRegistry_OracleRegistry.test.js
@@ -100,7 +100,7 @@ describe("WagerRegistry oracle registry", function () {
       return fx.reg.connect(fx.alice).createWager(
         fx.bob.address, ethers.ZeroAddress, await fx.usdcToken.getAddress(),
         usdc(10), usdc(10), now + 1800, now + 7200,
-        resolutionType, conditionId, true, ethers.id("meta")
+        resolutionType, conditionId, true, ethers.id("meta"), ""
       );
     }
 
@@ -131,7 +131,7 @@ describe("WagerRegistry oracle registry", function () {
       const tx = await fx.reg.connect(fx.alice).createWager(
         fx.bob.address, ethers.ZeroAddress, await fx.usdcToken.getAddress(),
         usdc(10), usdc(10), now + 1800, now + 7200,
-        Resolution.Either, ethers.ZeroHash, true, ethers.id("meta")
+        Resolution.Either, ethers.ZeroHash, true, ethers.id("meta"), ""
       );
       const rcpt = await tx.wait();
       const ev = rcpt.logs.map(l => { try { return fx.reg.interface.parseLog(l); } catch { return null; } })
@@ -155,7 +155,7 @@ describe("WagerRegistry oracle registry", function () {
       const tx = await fx.reg.connect(fx.alice).createWager(
         fx.bob.address, ethers.ZeroAddress, await fx.usdcToken.getAddress(),
         usdc(10), usdc(10), now + 1800, now + 7200,
-        Resolution.Polymarket, cid, true, ethers.id("meta")
+        Resolution.Polymarket, cid, true, ethers.id("meta"), ""
       );
       const rcpt = await tx.wait();
       const ev = rcpt.logs.map(l => { try { return fx.reg.interface.parseLog(l); } catch { return null; } })

--- a/test/integration/oracle/WagerRegistry_UMA.test.js
+++ b/test/integration/oracle/WagerRegistry_UMA.test.js
@@ -75,7 +75,8 @@ describe("WagerRegistry + UMAOptimisticOracleV3Adapter (integration)", function 
       Resolution.UMA,
       conditionId,
       opts.creatorIsYes ?? true,
-      ethers.id("meta")
+      ethers.id("meta"),
+      ""
     );
     const rcpt = await tx.wait();
     const ev = rcpt.logs.map(l => { try { return reg.interface.parseLog(l); } catch { return null; } })
@@ -145,7 +146,7 @@ describe("WagerRegistry + UMAOptimisticOracleV3Adapter (integration)", function 
     await expect(fx.reg.connect(fx.alice).createWager(
       fx.bob.address, ethers.ZeroAddress, await fx.usdcToken.getAddress(),
       usdc(10), usdc(10), now + 1800, now + 7200,
-      Resolution.UMA, ethers.id("c"), true, ethers.id("meta")
+      Resolution.UMA, ethers.id("c"), true, ethers.id("meta"), ""
     )).to.be.revertedWithCustomError(fx.reg, "OracleAdapterNotSet");
   });
 });


### PR DESCRIPTION
The contract previously stored only metadataHash (keccak256 of the metadata
reference), making the IPFS CID irreversibly lost. Neither the creator nor
the opponent could retrieve the encrypted envelope to decrypt the wager
description after creation.

Contract: add string metadataUri to Wager struct and createWager signature.
Frontend: read metadataUri from contract, resolve IPFS CID, and trigger
existing decryption logic in MarketAcceptanceModal and MyMarketsModal.
Share URLs now include the CID as defense-in-depth.

https://claude.ai/code/session_01Gevku34XGNRkefK4Md8r9b