### PR TITLE
feat: add wager withdraw and decline functionality

### DIFF
--- a/contracts/interfaces/IWagerRegistry.sol
+++ b/contracts/interfaces/IWagerRegistry.sol
@@ -39,6 +39,7 @@ interface IWagerRegistry {
     );
     event WagerAccepted(uint256 indexed wagerId, address indexed opponent);
     event WagerCancelled(uint256 indexed wagerId);
+    event WagerDeclined(uint256 indexed wagerId, address indexed opponent);
     event WagerResolved(uint256 indexed wagerId, address indexed winner, address indexed by);
     event WagerRefunded(uint256 indexed wagerId, address indexed creator, address indexed opponent);
     event PayoutClaimed(uint256 indexed wagerId, address indexed winner, uint256 amount);
@@ -71,6 +72,7 @@ interface IWagerRegistry {
 
     function acceptWager(uint256 wagerId) external;
     function cancelOpen(uint256 wagerId) external;
+    function declineWager(uint256 wagerId) external;
     function declareWinner(uint256 wagerId, address winner) external;
     function autoResolveFromPolymarket(uint256 wagerId) external;
     function autoResolveFromOracle(uint256 wagerId) external;

--- a/contracts/wagers/WagerRegistry.sol
+++ b/contracts/wagers/WagerRegistry.sol
@@ -273,12 +273,31 @@ contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausab
         if (w.status != Status.Open) revert NotOpen();
         if (msg.sender != w.creator) revert NotCreator();
 
-        w.status = Status.Cancelled;
-        // Close membership counter
-        membershipManager.recordClose(w.creator, WAGER_PARTICIPANT_ROLE);
+        IERC20 token = IERC20(w.token);
+        uint128 refund = w.creatorStake;
+        address creator = w.creator;
 
-        IERC20(w.token).safeTransfer(w.creator, w.creatorStake);
+        membershipManager.recordClose(creator, WAGER_PARTICIPANT_ROLE);
+        delete _wagers[wagerId];
+
+        token.safeTransfer(creator, refund);
         emit WagerCancelled(wagerId);
+    }
+
+    function declineWager(uint256 wagerId) external nonReentrant notFrozen(msg.sender) {
+        Wager storage w = _wagers[wagerId];
+        if (w.status != Status.Open) revert NotOpen();
+        if (msg.sender != w.opponent) revert NotOpponent();
+
+        IERC20 token = IERC20(w.token);
+        uint128 refund = w.creatorStake;
+        address creator = w.creator;
+
+        membershipManager.recordClose(creator, WAGER_PARTICIPANT_ROLE);
+        delete _wagers[wagerId];
+
+        token.safeTransfer(creator, refund);
+        emit WagerDeclined(wagerId, msg.sender);
     }
 
     function declareWinner(uint256 wagerId, address winner) external nonReentrant notFrozen(msg.sender) {

--- a/frontend/src/abis/WagerRegistry.js
+++ b/frontend/src/abis/WagerRegistry.js
@@ -557,6 +557,25 @@ export const WAGER_REGISTRY_ABI = [
       {
         "indexed": true,
         "internalType": "address",
+        "name": "opponent",
+        "type": "address"
+      }
+    ],
+    "name": "WagerDeclined",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "wagerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "creator",
         "type": "address"
       },
@@ -782,6 +801,19 @@ export const WAGER_REGISTRY_ABI = [
       }
     ],
     "name": "cancelOpen",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "wagerId",
+        "type": "uint256"
+      }
+    ],
+    "name": "declineWager",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/frontend/src/components/fairwins/MarketAcceptanceModal.css
+++ b/frontend/src/components/fairwins/MarketAcceptanceModal.css
@@ -561,6 +561,21 @@
   border-color: var(--text-secondary);
 }
 
+.ma-btn-danger {
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  background: #dc2626;
+  color: #fff;
+}
+
+.ma-btn-danger:hover {
+  background: #b91c1c;
+}
+
 /* Confirmation Step */
 .ma-confirmation {
   text-align: left;

--- a/frontend/src/components/fairwins/MarketAcceptanceModal.jsx
+++ b/frontend/src/components/fairwins/MarketAcceptanceModal.jsx
@@ -86,7 +86,7 @@ function MarketAcceptanceModal({
     initializeKeys
   } = useEncryption()
 
-  const [step, setStep] = useState('review') // 'review', 'confirm', 'processing', 'success', 'error'
+  const [step, setStep] = useState('review') // 'review', 'confirm', 'confirmDecline', 'processing', 'success', 'declined', 'error'
   const [error, setError] = useState(null)
   const [txHash, setTxHash] = useState(null)
   const [timeRemaining, setTimeRemaining] = useState(0)
@@ -427,9 +427,49 @@ function MarketAcceptanceModal({
     }
   }
 
-  const handleDecline = () => {
-    // Just close - no on-chain action needed
-    onClose()
+  const handleDecline = async () => {
+    if (!signer) {
+      setError('Please connect your wallet')
+      return
+    }
+
+    if (!isCorrectNetwork) {
+      try {
+        await switchNetwork()
+      } catch {
+        setError('Please switch to the correct network')
+        return
+      }
+    }
+
+    setStep('processing')
+    setError(null)
+
+    try {
+      const contract = new ethers.Contract(
+        contractAddress,
+        contractABI,
+        signer
+      )
+      const tx = await contract.declineWager(marketId)
+      setTxHash(tx.hash)
+      await tx.wait()
+      setStep('declined')
+    } catch (err) {
+      let errorMessage = 'Failed to decline the offer.'
+      const reason = err?.reason || err?.data?.message || err?.message || ''
+      if (reason.includes('NotOpen')) {
+        errorMessage = 'This wager is no longer open. It may have been cancelled or already accepted.'
+      } else if (reason.includes('NotOpponent')) {
+        errorMessage = 'Only the invited participant can decline this offer.'
+      } else if (reason.includes('AccountFrozenError')) {
+        errorMessage = 'Your account is currently frozen. Please contact support.'
+      } else if (reason.includes('user rejected') || reason.includes('ACTION_REJECTED')) {
+        errorMessage = 'Transaction was cancelled in your wallet.'
+      }
+      setError(errorMessage)
+      setStep('error')
+    }
   }
 
   const handleRetry = () => {
@@ -691,7 +731,7 @@ function MarketAcceptanceModal({
               {/* Action buttons */}
               {canAccept && (
                 <div className="ma-actions">
-                  <button className="ma-btn-secondary" onClick={handleDecline}>
+                  <button className="ma-btn-secondary" onClick={() => setStep('confirmDecline')}>
                     Decline Offer
                   </button>
                   <button
@@ -808,6 +848,58 @@ function MarketAcceptanceModal({
                   I Understand, Accept Offer
                 </button>
               </div>
+            </div>
+          )}
+
+          {step === 'confirmDecline' && (
+            <div className="ma-confirmation">
+              <h3>Decline This Offer?</h3>
+              <p className="ma-stake-notice">
+                This will permanently decline the wager and return the creator&apos;s stake.
+                This action cannot be undone.
+              </p>
+              <div className="ma-confirm-details">
+                <div className="ma-confirm-row">
+                  <span>Wager:</span>
+                  <span>
+                    {(decryptedDescription || marketData?.description)?.slice(0, 50)}
+                    {(decryptedDescription || marketData?.description)?.length > 50 ? '...' : ''}
+                  </span>
+                </div>
+                <div className="ma-confirm-row">
+                  <span>Created By:</span>
+                  <span className="ma-address">{formatAddress(marketData?.creator)}</span>
+                </div>
+              </div>
+              <div className="ma-actions">
+                <button className="ma-btn-secondary" onClick={() => setStep('review')}>
+                  Back
+                </button>
+                <button className="ma-btn-danger" onClick={handleDecline}>
+                  Confirm Decline
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step === 'declined' && (
+            <div className="ma-success">
+              <div className="ma-success-icon" style={{ background: 'var(--color-warning, #f59e0b)' }}>&#10003;</div>
+              <h3>Offer Declined</h3>
+              <p>The creator&apos;s funds have been returned. This wager has been removed.</p>
+              {txHash && (
+                <a
+                  href={getTransactionUrl(chainId, txHash)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="ma-tx-link"
+                >
+                  View Transaction
+                </a>
+              )}
+              <button className="ma-btn-primary" onClick={onClose}>
+                Done
+              </button>
             </div>
           )}
 

--- a/frontend/src/components/fairwins/MyMarketsModal.css
+++ b/frontend/src/components/fairwins/MyMarketsModal.css
@@ -1048,6 +1048,72 @@
   cursor: not-allowed;
 }
 
+.mm-withdraw-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.mm-withdraw-error {
+  color: #DC3545;
+  font-size: 0.813rem;
+  margin: 0;
+}
+
+.mm-withdraw-success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  background: rgba(16, 185, 129, 0.08);
+  border: 1px solid rgba(16, 185, 129, 0.25);
+  border-radius: 8px;
+}
+
+.mm-withdraw-success-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(16, 185, 129, 0.15);
+  color: #10b981;
+  font-size: 1.125rem;
+}
+
+.mm-withdraw-success p {
+  margin: 0;
+  color: #10b981;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.mm-tx-link {
+  color: var(--text-accent, #6366f1);
+  font-size: 0.813rem;
+  text-decoration: none;
+}
+
+.mm-tx-link:hover {
+  text-decoration: underline;
+}
+
+.mm-spinner-small {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: mm-spin 0.6s linear infinite;
+}
+
+@keyframes mm-spin {
+  to { transform: rotate(360deg); }
+}
+
 /* Encrypted-data section in the detail view */
 .mm-encrypted-section {
   background: rgba(108, 92, 231, 0.06);

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -292,6 +292,7 @@ function MyMarketsModal({
       case MarketStatus.DISPUTED: return 'status-disputed'
       case MarketStatus.RESOLVED: return 'status-resolved'
       case MarketStatus.CANCELLED: return 'status-cancelled'
+      case MarketStatus.DECLINED: return 'status-cancelled'
       case MarketStatus.REFUNDED: return 'status-cancelled'
       case MarketStatus.ORACLE_TIMED_OUT: return 'status-cancelled'
       default: return 'status-default'
@@ -307,6 +308,7 @@ function MyMarketsModal({
       case MarketStatus.DISPUTED: return 'Disputed'
       case MarketStatus.RESOLVED: return 'Resolved'
       case MarketStatus.CANCELLED: return 'Cancelled'
+      case MarketStatus.DECLINED: return 'Declined'
       case MarketStatus.REFUNDED: return 'Refunded'
       case MarketStatus.ORACLE_TIMED_OUT: return 'Timed Out'
       default: return status
@@ -670,6 +672,13 @@ function MyMarketsModal({
                       isCreatorView
                       onDecrypt={handleDecryptMarket}
                       isDecrypting={isMarketDecrypting(selectedMarket?.id)}
+                      signer={signer}
+                      isCorrectNetwork={isCorrectNetwork}
+                      switchNetwork={switchNetwork}
+                      onWithdraw={() => {
+                        setSelectedMarket(null)
+                        fetchMarketsData?.()
+                      }}
                     />
                   ) : categorizedMarkets.created.length === 0 ? (
                     <div className="mm-empty-state">
@@ -1115,11 +1124,62 @@ function MarketDetailView({
   onOpenDispute,
   onRespondToDispute,
   isCreatorView = false,
-  isHistoryView = false
+  isHistoryView = false,
+  signer,
+  isCorrectNetwork,
+  switchNetwork,
+  onWithdraw
 }) {
   const isCreator = market.creator?.toLowerCase() === account?.toLowerCase()
   const position = userPositions?.find(p => String(p.marketId) === String(market.id))
   const endTime = market.tradingEndTime || market.endDate
+
+  const [withdrawing, setWithdrawing] = useState(false)
+  const [withdrawError, setWithdrawError] = useState(null)
+  const [withdrawSuccess, setWithdrawSuccess] = useState(false)
+  const [withdrawTxHash, setWithdrawTxHash] = useState(null)
+
+  const handleWithdraw = async () => {
+    if (!signer) return
+
+    if (!isCorrectNetwork) {
+      try {
+        await switchNetwork()
+      } catch {
+        setWithdrawError('Please switch to the correct network')
+        return
+      }
+    }
+
+    setWithdrawing(true)
+    setWithdrawError(null)
+
+    try {
+      const contract = new ethers.Contract(
+        getContractAddress('wagerRegistry'),
+        WAGER_REGISTRY_ABI,
+        signer
+      )
+      const tx = await contract.cancelOpen(market.wagerId ?? market.id)
+      setWithdrawTxHash(tx.hash)
+      await tx.wait()
+      setWithdrawSuccess(true)
+      onWithdraw?.(market)
+    } catch (err) {
+      const reason = err?.reason || err?.data?.message || err?.message || ''
+      if (reason.includes('user rejected') || reason.includes('ACTION_REJECTED')) {
+        setWithdrawError('Transaction was cancelled in your wallet.')
+      } else if (reason.includes('NotOpen')) {
+        setWithdrawError('This wager is no longer open.')
+      } else if (reason.includes('NotCreator')) {
+        setWithdrawError('Only the creator can withdraw this offer.')
+      } else {
+        setWithdrawError('Failed to withdraw the offer. Please try again.')
+      }
+    } finally {
+      setWithdrawing(false)
+    }
+  }
 
   return (
     <div className="mm-detail">
@@ -1298,6 +1358,50 @@ function MarketDetailView({
 
       {/* Actions */}
       <div className="mm-detail-actions">
+        {isCreatorView && isCreator && (market.computedStatus || market.status) === MarketStatus.PENDING_ACCEPTANCE && !withdrawSuccess && (
+          <div className="mm-withdraw-section">
+            <button
+              type="button"
+              className="mm-btn-danger"
+              onClick={handleWithdraw}
+              disabled={withdrawing}
+            >
+              {withdrawing ? (
+                <>
+                  <span className="mm-spinner-small"></span>
+                  Withdrawing...
+                </>
+              ) : (
+                <>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <polyline points="1 4 1 10 7 10"/>
+                    <path d="M3.51 15a9 9 0 102.13-9.36L1 10"/>
+                  </svg>
+                  Withdraw Offer
+                </>
+              )}
+            </button>
+            {withdrawError && (
+              <p className="mm-withdraw-error">{withdrawError}</p>
+            )}
+          </div>
+        )}
+        {withdrawSuccess && (
+          <div className="mm-withdraw-success">
+            <span className="mm-withdraw-success-icon">&#10003;</span>
+            <p>Offer withdrawn. Your funds have been returned.</p>
+            {withdrawTxHash && (
+              <a
+                href={`https://amoy.polygonscan.com/tx/${withdrawTxHash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mm-tx-link"
+              >
+                View Transaction
+              </a>
+            )}
+          </div>
+        )}
         {isCreatorView && (
           <ResolveButtonWithCountdown
             market={market}

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -676,7 +676,7 @@ function MyMarketsModal({
                       isCorrectNetwork={isCorrectNetwork}
                       switchNetwork={switchNetwork}
                       onWithdraw={() => {
-                        setSelectedMarket(null)
+                        setSelectedMarketId(null)
                         fetchMarketsData?.()
                       }}
                     />

--- a/frontend/src/constants/wagerDefaults.js
+++ b/frontend/src/constants/wagerDefaults.js
@@ -60,6 +60,7 @@ export const WagerStatus = {
   RESOLVED: 'resolved',
   EXPIRED: 'expired',
   CANCELLED: 'cancelled',
+  DECLINED: 'declined',
   REFUNDED: 'refunded',
   ORACLE_TIMED_OUT: 'oracle_timed_out',
 }
@@ -123,6 +124,7 @@ export const WagerSortKey = {
 export const TERMINAL_STATUSES = new Set([
   'resolved',
   'cancelled',
+  'declined',
   'refunded',
   'oracle_timed_out',
 ])

--- a/frontend/src/test/MarketAcceptanceModal.test.jsx
+++ b/frontend/src/test/MarketAcceptanceModal.test.jsx
@@ -346,13 +346,24 @@ describe('MarketAcceptanceModal', () => {
       expect(screen.getByText(/Only accept offers from people you know/)).toBeInTheDocument()
     })
 
-    it('should call onClose when Decline Offer is clicked', async () => {
-      const onClose = vi.fn()
-      render(<MarketAcceptanceModal {...defaultProps} onClose={onClose} />)
+    it('should show confirmation step when Decline Offer is clicked', async () => {
+      render(<MarketAcceptanceModal {...defaultProps} />)
 
       await userEvent.click(screen.getByText('Decline Offer'))
 
-      expect(onClose).toHaveBeenCalledTimes(1)
+      expect(screen.getByText('Decline This Offer?')).toBeInTheDocument()
+      expect(screen.getByText('Back')).toBeInTheDocument()
+      expect(screen.getByText('Confirm Decline')).toBeInTheDocument()
+    })
+
+    it('should return to review step when Back is clicked from decline confirmation', async () => {
+      render(<MarketAcceptanceModal {...defaultProps} />)
+
+      await userEvent.click(screen.getByText('Decline Offer'))
+      expect(screen.getByText('Decline This Offer?')).toBeInTheDocument()
+
+      await userEvent.click(screen.getByText('Back'))
+      expect(screen.getByText('Review Offer')).toBeInTheDocument()
     })
   })
 

--- a/test/WagerRegistry.test.js
+++ b/test/WagerRegistry.test.js
@@ -254,7 +254,7 @@ describe("WagerRegistry", function () {
   });
 
   describe("cancelOpen", () => {
-    it("refunds creator and closes membership slot", async () => {
+    it("refunds creator, closes membership slot, and zeroes storage", async () => {
       const fx = await loadFixture(deployFixture);
       const { reg, alice, usdcToken, mgr } = fx;
       const id = await createDefault(reg, fx);
@@ -263,6 +263,10 @@ describe("WagerRegistry", function () {
       expect(await usdcToken.balanceOf(alice.address) - balBefore).to.equal(usdc(10));
       const m = await mgr.getMembership(alice.address, WAGER_PARTICIPANT_ROLE);
       expect(m.activeCount).to.equal(0);
+      // Wager struct should be zeroed
+      const w = await reg.getWager(id);
+      expect(w.status).to.equal(Status.None);
+      expect(w.creator).to.equal(ethers.ZeroAddress);
     });
 
     it("rejects non-creator", async () => {
@@ -278,6 +282,61 @@ describe("WagerRegistry", function () {
       await fx.reg.connect(fx.bob).acceptWager(id);
       await expect(fx.reg.connect(fx.alice).cancelOpen(id))
         .to.be.revertedWithCustomError(fx.reg, "NotOpen");
+    });
+  });
+
+  describe("declineWager", () => {
+    it("opponent can decline and creator gets refund", async () => {
+      const fx = await loadFixture(deployFixture);
+      const { reg, alice, bob, usdcToken, mgr } = fx;
+      const id = await createDefault(reg, fx);
+      const balBefore = await usdcToken.balanceOf(alice.address);
+      await reg.connect(bob).declineWager(id);
+      expect(await usdcToken.balanceOf(alice.address) - balBefore).to.equal(usdc(10));
+      const m = await mgr.getMembership(alice.address, WAGER_PARTICIPANT_ROLE);
+      expect(m.activeCount).to.equal(0);
+    });
+
+    it("zeroes wager storage after decline", async () => {
+      const fx = await loadFixture(deployFixture);
+      const { reg, bob } = fx;
+      const id = await createDefault(reg, fx);
+      await reg.connect(bob).declineWager(id);
+      const w = await reg.getWager(id);
+      expect(w.status).to.equal(Status.None);
+      expect(w.creator).to.equal(ethers.ZeroAddress);
+    });
+
+    it("emits WagerDeclined event", async () => {
+      const fx = await loadFixture(deployFixture);
+      const { reg, bob } = fx;
+      const id = await createDefault(reg, fx);
+      await expect(reg.connect(bob).declineWager(id))
+        .to.emit(reg, "WagerDeclined")
+        .withArgs(id, bob.address);
+    });
+
+    it("rejects non-opponent", async () => {
+      const fx = await loadFixture(deployFixture);
+      const id = await createDefault(fx.reg, fx);
+      await expect(fx.reg.connect(fx.alice).declineWager(id))
+        .to.be.revertedWithCustomError(fx.reg, "NotOpponent");
+    });
+
+    it("rejects if not Open (already accepted)", async () => {
+      const fx = await loadFixture(deployFixture);
+      const id = await createDefault(fx.reg, fx);
+      await fx.reg.connect(fx.bob).acceptWager(id);
+      await expect(fx.reg.connect(fx.bob).declineWager(id))
+        .to.be.revertedWithCustomError(fx.reg, "NotOpen");
+    });
+
+    it("frozen opponent cannot decline", async () => {
+      const fx = await loadFixture(deployFixture);
+      const id = await createDefault(fx.reg, fx);
+      await fx.reg.connect(fx.admin).freezeAccount(fx.bob.address, "test");
+      await expect(fx.reg.connect(fx.bob).declineWager(id))
+        .to.be.revertedWithCustomError(fx.reg, "AccountFrozenError");
     });
   });
 


### PR DESCRIPTION
Allow creators to withdraw pending offers (calling cancelOpen on-chain)
and counterparties to explicitly decline offers (new declineWager contract
function). Both actions return the creator's stake and zero out wager
storage for on-chain cleanup. The decline flow includes a confirmation
step to prevent accidental actions.

https://claude.ai/code/session_017BNoXxrAowmF8Ns3Vg3mnB