### PR TITLE
fix(my-wagers): hide & clear expired pending offers

### DIFF
--- a/docs/fairwins-functional-testing-checklist.md
+++ b/docs/fairwins-functional-testing-checklist.md
@@ -405,6 +405,9 @@ A manual testing checklist for validating all functional flows of the FairWins p
 | [ ] | DSH-11 | Empty state - no wagers | 1. Connect wallet that has never created or participated in wagers 2. Open My Wagers | Empty state message displayed; no errors |  |
 | [ ] | DSH-12 | Loading state | 1. Navigate to My Wagers with slow connection | Loading spinner/skeleton shown while data fetches |  |
 | [ ] | DSH-13 | Decrypt encrypted wager in list | 1. Open My Wagers with encrypted wagers 2. Wager should auto-decrypt | Encrypted wagers show decrypted description (lazy-loaded); non-participants see "Encrypted Market" |  |
+| [ ] | DSH-14 | Expired pending offers hidden by default | 1. Have a pending offer whose acceptance deadline has passed 2. Open My Wagers (default "All Status") | Expired offer does not appear in Participating/Created list; empty state shown if it was the only entry |  |
+| [ ] | DSH-15 | Expired filter surfaces expired offers | 1. With expired offers present 2. Set Status filter to "Expired" | Expired rows appear; Time Left reads "Expired" (not the resolve-deadline countdown); row carries a Clear action |  |
+| [ ] | DSH-16 | Clear expired offer (local dismiss) | 1. View an expired offer 2. Click "Clear" (or "Reclaim & Clear" as creator) | Row disappears; dismissed id persisted under `mywagers_dismissed:<account>` so it stays hidden across reloads; creator variant also calls claimRefund on-chain |  |
 
 ---
 

--- a/frontend/cypress/e2e/fast/13-dashboard.cy.js
+++ b/frontend/cypress/e2e/fast/13-dashboard.cy.js
@@ -338,4 +338,105 @@ describe('Dashboard', () => {
       }
     })
   })
+
+  // ---------------------------------------------------------------------------
+  // DSH-14..DSH-16: Expired pending offers (My Wagers cleanup)
+  //
+  // These cover the UI-only contract: an offer whose acceptanceDeadline has
+  // passed must be hidden by default, must surface under the Expired filter
+  // with "Expired" in the Time Left column (not e.g. "23h 6m" from the
+  // resolve deadline), and must be clearable from the user's local view.
+  // The on-chain refund path is exercised by REF-01 in the full tier; here
+  // we only assert what the user sees and what localStorage records.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Connect, then seed localStorage with the supplied friend-market list and
+   * reload so FriendMarketsContext picks them up from cache. The on-chain
+   * fetch fails (no Hardhat) and the catch path preserves localStorage,
+   * matching the wallet-disconnected-from-node scenario in production caches.
+   */
+  function seedFriendMarketsAndOpen(markets) {
+    connectAndVisitDashboard()
+    cy.window().then((win) => {
+      win.localStorage.setItem('friendMarkets', JSON.stringify(markets))
+    })
+    cy.reload()
+    cy.get('body', { timeout: 10000 }).should('be.visible')
+    // Re-connect via UI after reload (wagmi auto-reconnect may not fire).
+    cy.get('body').then(($body) => {
+      if ($body.find('.wallet-connect-button, button[aria-label="Connect Wallet"]').length > 0) {
+        cy.get('.wallet-connect-button, button[aria-label="Connect Wallet"]', { timeout: 10000 })
+          .click()
+        cy.get('.connector-option:not(.unavailable)', { timeout: 5000 })
+          .first()
+          .click()
+      }
+    })
+    cy.get('.quick-action-card').contains('My Wagers').click()
+    cy.get('[role="dialog"], .my-markets-modal', { timeout: 5000 }).should('be.visible')
+  }
+
+  /** Build a synthetic friend-market record for an opponent-side expired offer. */
+  function expiredOfferAsOpponent(id = 'exp-1') {
+    return {
+      id,
+      uniqueId: `0xMOCK-${id}`,
+      contractAddress: '0xMOCK',
+      creator: '0x00000000000000000000000000000000000000aa', // not the test account
+      opponent: TEST_ACCOUNT,
+      participants: ['0x00000000000000000000000000000000000000aa', TEST_ACCOUNT],
+      description: 'DSH-14 Expired Friend Offer',
+      status: 'pending_acceptance',
+      acceptanceDeadline: Date.now() - 60 * 60 * 1000,
+      endDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      stakeAmount: '1',
+      stakeTokenSymbol: 'USDC',
+      acceptedCount: 0,
+    }
+  }
+
+  it('[DSH-14] Expired pending offers hidden from default Participating view', () => {
+    seedFriendMarketsAndOpen([expiredOfferAsOpponent('exp-14')])
+
+    // Default Participating tab + "All Status" filter → expired offer hidden.
+    cy.get('.mm-empty-state', { timeout: 5000 }).should('be.visible')
+    cy.contains('.mm-table-row', 'DSH-14 Expired Friend Offer').should('not.exist')
+  })
+
+  it('[DSH-15] Expired filter surfaces expired offers with "Expired" time-left and a Clear button', () => {
+    seedFriendMarketsAndOpen([expiredOfferAsOpponent('exp-15')])
+
+    cy.get('.mm-filter-bar .mm-filter-select').last().select('expired')
+    cy.get('.mm-filter-bar .mm-filter-select').last().should('have.value', 'expired')
+
+    cy.contains('.mm-table-row', 'DSH-15', { timeout: 5000 }).should('be.visible')
+      .within(() => {
+        // Time-left column reads "Expired" (not e.g. "23h 6m" from endDate).
+        cy.get('.mm-time-expired').should('have.text', 'Expired')
+        // Opponent-side action is just "Clear" (creator's variant adds "Reclaim").
+        cy.contains('button', /^Clear$/).should('be.visible')
+      })
+  })
+
+  it('[DSH-16] Clear button dismisses an expired offer and persists to localStorage', () => {
+    seedFriendMarketsAndOpen([expiredOfferAsOpponent('exp-16')])
+
+    cy.get('.mm-filter-bar .mm-filter-select').last().select('expired')
+    cy.contains('.mm-table-row', 'DSH-16').should('be.visible')
+
+    cy.contains('button', /^Clear$/).click({ force: true })
+
+    // Row gone from the list and the dismissed set recorded under the
+    // wallet's per-account key.
+    cy.contains('.mm-table-row', 'DSH-16').should('not.exist')
+    cy.window().then((win) => {
+      const raw = win.localStorage.getItem(
+        `mywagers_dismissed:${TEST_ACCOUNT.toLowerCase()}`
+      )
+      expect(raw).to.exist
+      const ids = JSON.parse(raw)
+      expect(ids).to.include('exp-16')
+    })
+  })
 })

--- a/frontend/src/components/fairwins/MyMarketsModal.css
+++ b/frontend/src/components/fairwins/MyMarketsModal.css
@@ -614,6 +614,42 @@
   background: linear-gradient(135deg, #818cf8 0%, #a78bfa 100%);
 }
 
+.mm-action-btn.mm-action-clear {
+  background: rgba(229, 83, 61, 0.12);
+  color: #E5533D;
+  border: 1px solid rgba(229, 83, 61, 0.35);
+}
+
+.mm-action-btn.mm-action-clear:hover {
+  background: rgba(229, 83, 61, 0.22);
+}
+
+/* Expired offer treatment */
+.mm-status-badge.status-expired {
+  background: rgba(229, 83, 61, 0.15);
+  color: #E5533D;
+}
+
+.mm-table-row-expired {
+  opacity: 0.7;
+}
+
+.mm-time-expired {
+  color: #E5533D;
+  font-weight: 600;
+}
+
+.mm-table-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.5rem 0.75rem 0.25rem;
+}
+
+.mm-btn-small {
+  font-size: 0.75rem;
+  padding: 0.35rem 0.75rem;
+}
+
 /* Load More */
 .mm-load-more-row {
   display: flex;

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -3,6 +3,7 @@ import { ethers } from 'ethers'
 import { useWallet, useWeb3 } from '../../hooks'
 import { useLazyMarketDecryption } from '../../hooks/useEncryption'
 import { useLazyIpfsEnvelope } from '../../hooks/useIpfs'
+import { useFriendMarkets } from '../../contexts/FriendMarketsContext.js'
 import { WagerStatus as MarketStatus, DisputeStatus, WAGER_DEFAULTS } from '../../constants/wagerDefaults'
 import { getContractAddress } from '../../config/contracts'
 import { WAGER_REGISTRY_ABI } from '../../abis/WagerRegistry'
@@ -29,6 +30,7 @@ function MyMarketsModal({
 }) {
   const { isConnected, account } = useWallet()
   const { signer, isCorrectNetwork, switchNetwork } = useWeb3()
+  const { dismissedIds, dismissMarket, dismissMarkets } = useFriendMarkets()
 
   const { markets: marketsWithEnvelopes, fetchEnvelope } = useLazyIpfsEnvelope(friendMarkets)
   const { markets: decryptableMarkets, decryptMarket, isMarketDecrypting } = useLazyMarketDecryption(marketsWithEnvelopes)
@@ -168,19 +170,31 @@ function MyMarketsModal({
           ? Number(market.tradingEndTime) * 1000
           : new Date(market.tradingEndTime).getTime())
         : (market.endDate ? new Date(market.endDate).getTime() : 0)
+      const acceptanceDeadlineMs = market.acceptanceDeadline
+        ? (typeof market.acceptanceDeadline === 'bigint'
+          ? Number(market.acceptanceDeadline) * 1000
+          : Number(market.acceptanceDeadline))
+        : 0
 
       // Check for terminal statuses first
       const statusLower = market.status?.toLowerCase()
       if (statusLower === 'cancelled' || statusLower === 'canceled') {
         return MarketStatus.CANCELLED
       }
+      if (statusLower === 'declined') return MarketStatus.DECLINED
       if (statusLower === 'resolved') return MarketStatus.RESOLVED
       if (statusLower === 'refunded') return MarketStatus.REFUNDED
       if (statusLower === 'oracle_timed_out') return MarketStatus.ORACLE_TIMED_OUT
       if (statusLower === 'challenged') return MarketStatus.CHALLENGED
 
-      // Check for pending_acceptance status (friend markets awaiting participant stakes)
+      // Pending acceptance: surface as EXPIRED once the accept window has
+      // closed without acceptance, so the row shows the right time-left and
+      // can be cleared by the user. The on-chain status is still Open until
+      // someone calls claimRefund/cancelOpen.
       if (statusLower === 'pending_acceptance' || statusLower === 'pending') {
+        if (acceptanceDeadlineMs > 0 && now > acceptanceDeadlineMs) {
+          return MarketStatus.EXPIRED
+        }
         return MarketStatus.PENDING_ACCEPTANCE
       }
       if (statusLower === 'disputed' || market.disputeStatus === DisputeStatus.OPENED) {
@@ -212,6 +226,9 @@ function MyMarketsModal({
     const history = []
 
     marketsList.forEach(market => {
+      // Always drop dismissed wagers from view (per-account localStorage)
+      if (dismissedIds?.has(String(market.id))) return
+
       const status = getMarketStatus(market)
       const marketWithStatus = { ...market, computedStatus: status }
 
@@ -220,13 +237,23 @@ function MyMarketsModal({
         return
       }
 
-      // Apply status filter
-      if (statusFilter !== 'all' && status !== statusFilter) {
+      // Apply status filter. The default ("all") view also hides expired
+      // offers so they don't clutter the list — pick "Expired" explicitly
+      // to see them.
+      if (statusFilter === 'all') {
+        if (status === MarketStatus.EXPIRED) return
+      } else if (status !== statusFilter) {
         return
       }
 
       // Terminal markets go to history
-      if (status === MarketStatus.RESOLVED || status === MarketStatus.CANCELLED || status === MarketStatus.REFUNDED || status === MarketStatus.ORACLE_TIMED_OUT) {
+      if (
+        status === MarketStatus.RESOLVED ||
+        status === MarketStatus.CANCELLED ||
+        status === MarketStatus.DECLINED ||
+        status === MarketStatus.REFUNDED ||
+        status === MarketStatus.ORACLE_TIMED_OUT
+      ) {
         if (isCreator(market) || isParticipant(market)) {
           history.push(marketWithStatus)
         }
@@ -241,7 +268,7 @@ function MyMarketsModal({
     })
 
     return { participating, created, history }
-  }, [markets, decryptableMarkets, userPositions, account, marketTypeFilter, statusFilter])
+  }, [markets, decryptableMarkets, userPositions, account, marketTypeFilter, statusFilter, dismissedIds])
 
   // Derive the selected market from the live categorized lists so the detail
   // view reflects fresh data (e.g., decryptedMetadata) after decryption
@@ -293,6 +320,7 @@ function MyMarketsModal({
       case MarketStatus.RESOLVED: return 'status-resolved'
       case MarketStatus.CANCELLED: return 'status-cancelled'
       case MarketStatus.DECLINED: return 'status-cancelled'
+      case MarketStatus.EXPIRED: return 'status-expired'
       case MarketStatus.REFUNDED: return 'status-cancelled'
       case MarketStatus.ORACLE_TIMED_OUT: return 'status-cancelled'
       default: return 'status-default'
@@ -309,6 +337,7 @@ function MyMarketsModal({
       case MarketStatus.RESOLVED: return 'Resolved'
       case MarketStatus.CANCELLED: return 'Cancelled'
       case MarketStatus.DECLINED: return 'Declined'
+      case MarketStatus.EXPIRED: return 'Expired'
       case MarketStatus.REFUNDED: return 'Refunded'
       case MarketStatus.ORACLE_TIMED_OUT: return 'Timed Out'
       default: return status
@@ -462,6 +491,44 @@ function MyMarketsModal({
     fetchMarketsData()
   }
 
+  // Clear an expired offer from the user's view. For the creator this also
+  // calls claimRefund on-chain so the stake comes back; for an invited
+  // opponent (no stake at risk) we just hide locally and let the creator
+  // reclaim on their own.
+  const handleClearExpired = useCallback(async (market) => {
+    const userAddr = account?.toLowerCase()
+    const isCreator = userAddr && market.creator?.toLowerCase() === userAddr
+
+    if (isCreator && signer) {
+      try {
+        if (!isCorrectNetwork) {
+          try { await switchNetwork() } catch { /* user declined */ }
+        }
+        const registry = new ethers.Contract(
+          getContractAddress('wagerRegistry'),
+          WAGER_REGISTRY_ABI,
+          signer
+        )
+        const tx = await registry.claimRefund(market.wagerId ?? market.id)
+        await tx.wait()
+      } catch (err) {
+        const reason = err?.reason || err?.shortMessage || err?.message || ''
+        const userRejected = err?.code === 'ACTION_REJECTED' ||
+          err?.code === 4001 || reason.toLowerCase().includes('user rejected')
+        if (userRejected) return // leave row visible so they can retry
+        // Anything else (e.g. NotRefundable because the chain advanced state)
+        // we still dismiss locally — the user's intent is clear.
+        console.warn('[MyMarkets] claimRefund failed, dismissing locally:', err)
+      }
+    }
+
+    dismissMarket(market.id)
+  }, [account, signer, isCorrectNetwork, switchNetwork, dismissMarket])
+
+  const handleClearAllExpired = useCallback((markets) => {
+    dismissMarkets(markets.map(m => m.id))
+  }, [dismissMarkets])
+
   if (!isOpen) return null
 
   return (
@@ -568,6 +635,7 @@ function MyMarketsModal({
               <option value={MarketStatus.PENDING_RESOLUTION}>Pending Resolution</option>
               <option value={MarketStatus.DISPUTED}>Disputed</option>
               <option value={MarketStatus.RESOLVED}>Resolved</option>
+              <option value={MarketStatus.EXPIRED}>Expired</option>
             </select>
           </div>
           <button
@@ -646,6 +714,9 @@ function MyMarketsModal({
                       isCreatorOfPending={isCreatorOfPendingMarket}
                       onAccept={handleOpenAcceptance}
                       account={account}
+                      onClearExpired={handleClearExpired}
+                      onClearAllExpired={handleClearAllExpired}
+                      statusFilter={statusFilter}
                     />
                   )}
                 </div>
@@ -703,6 +774,9 @@ function MyMarketsModal({
                       showActions
                       account={account}
                       showResolveCountdown
+                      onClearExpired={handleClearExpired}
+                      onClearAllExpired={handleClearAllExpired}
+                      statusFilter={statusFilter}
                     />
                   )}
                 </div>
@@ -849,9 +923,40 @@ function MarketsTable({
   onResolve,
   onRespondToDispute,
   onAccept,
+  onClearExpired,
+  onClearAllExpired,
+  statusFilter,
   account,
   showResolveCountdown = false
 }) {
+  const expiredMarkets = useMemo(
+    () => markets.filter(m => m.computedStatus === MarketStatus.EXPIRED),
+    [markets]
+  )
+  const showClearAll =
+    statusFilter === MarketStatus.EXPIRED &&
+    expiredMarkets.length > 0 &&
+    typeof onClearAllExpired === 'function'
+
+  // Pick the appropriate countdown source for each row. Pending offers use
+  // the *acceptance* deadline, not the trading/resolve deadline — those are
+  // unrelated for an un-accepted wager, and using endDate is what made
+  // expired offers report "tomorrow" instead of "Expired".
+  const rowTimeLeft = (market) => {
+    const isPending =
+      market.computedStatus === MarketStatus.PENDING_ACCEPTANCE ||
+      market.computedStatus === MarketStatus.EXPIRED
+    const endTime = isPending && market.acceptanceDeadline
+      ? market.acceptanceDeadline
+      : (market.tradingEndTime || market.endDate)
+    if (market.computedStatus === MarketStatus.EXPIRED) return 'Expired'
+    return getTimeRemaining(endTime)
+  }
+
+  const tableHasActionsColumn =
+    showActions || canAccept || showResolveCountdown ||
+    (typeof onClearExpired === 'function' && expiredMarkets.length > 0)
+
   return (
     <div className="mm-table-container">
       <table className="mm-table" role="table">
@@ -861,24 +966,26 @@ function MarketsTable({
             <th>Type</th>
             <th>{showOutcome ? 'Outcome' : 'Time Left'}</th>
             <th>Status</th>
-            {(showActions || canAccept || showResolveCountdown) && <th>Actions</th>}
+            {tableHasActionsColumn && <th>Actions</th>}
           </tr>
         </thead>
         <tbody>
           {markets.map((market) => {
-            const endTime = market.tradingEndTime || market.endDate
-            const timeLeft = getTimeRemaining(endTime)
+            const timeLeft = rowTimeLeft(market)
+            const isExpired = market.computedStatus === MarketStatus.EXPIRED
             const showResolveBtn = showActions && canResolve?.(market)
             const showDisputeBtn = showActions && canRespondToDispute?.(market)
-            const showAcceptBtn = canAccept?.(market)
-            const showUnderConsideration = isCreatorOfPending?.(market)
+            const showAcceptBtn = !isExpired && canAccept?.(market)
+            const showUnderConsideration = !isExpired && isCreatorOfPending?.(market)
+            const isCreator = market.creator?.toLowerCase() === account?.toLowerCase()
+            const showClearBtn = isExpired && typeof onClearExpired === 'function'
             const displayTitle = getMarketDisplayTitle(market)
 
             return (
               <tr
                 key={`${market.marketType}-${market.id}`}
                 onClick={() => onSelect(market)}
-                className="mm-table-row"
+                className={`mm-table-row${isExpired ? ' mm-table-row-expired' : ''}`}
                 role="button"
                 tabIndex={0}
                 onKeyDown={(e) => { if (e.key === 'Enter') onSelect(market) }}
@@ -917,6 +1024,8 @@ function MarketsTable({
                     <span className={`mm-outcome ${market.outcome === 'Pass' || market.outcome === 'Yes' ? 'positive' : 'negative'}`}>
                       {market.outcome || 'N/A'}
                     </span>
+                  ) : isExpired ? (
+                    <span className="mm-time-expired">Expired</span>
                   ) : (
                     timeLeft
                   )}
@@ -926,7 +1035,7 @@ function MarketsTable({
                     {showUnderConsideration ? 'Under Consideration' : getStatusLabel(market.computedStatus)}
                   </span>
                 </td>
-                {(showActions || showAcceptBtn || showUnderConsideration || showResolveCountdown) && (
+                {tableHasActionsColumn && (
                   <td className="mm-table-actions" onClick={(e) => e.stopPropagation()}>
                     {showAcceptBtn && (
                       <button
@@ -937,7 +1046,7 @@ function MarketsTable({
                         View Offer
                       </button>
                     )}
-                    {showResolveCountdown && (
+                    {showResolveCountdown && !isExpired && (
                       <ResolveButtonWithCountdown
                         market={market}
                         onResolve={onResolve}
@@ -962,6 +1071,15 @@ function MarketsTable({
                         Respond
                       </button>
                     )}
+                    {showClearBtn && (
+                      <button
+                        className="mm-action-btn mm-action-clear"
+                        onClick={(e) => { e.stopPropagation(); onClearExpired(market) }}
+                        title={isCreator ? 'Reclaim stake and clear' : 'Clear from list'}
+                      >
+                        {isCreator ? 'Reclaim & Clear' : 'Clear'}
+                      </button>
+                    )}
                   </td>
                 )}
               </tr>
@@ -969,6 +1087,18 @@ function MarketsTable({
           })}
         </tbody>
       </table>
+      {showClearAll && (
+        <div className="mm-table-footer">
+          <button
+            type="button"
+            className="mm-btn-secondary mm-btn-small"
+            onClick={() => onClearAllExpired(expiredMarkets)}
+            title="Hide all expired offers from this list"
+          >
+            Clear all expired ({expiredMarkets.length})
+          </button>
+        </div>
+      )}
     </div>
   )
 }
@@ -1132,7 +1262,22 @@ function MarketDetailView({
 }) {
   const isCreator = market.creator?.toLowerCase() === account?.toLowerCase()
   const position = userPositions?.find(p => String(p.marketId) === String(market.id))
-  const endTime = market.tradingEndTime || market.endDate
+  // For un-accepted offers, the relevant deadline is the *acceptance*
+  // deadline, not the trading/resolve window — the latter is what made
+  // expired offers show "tomorrow" in the list/detail view.
+  const isPendingLike =
+    market.computedStatus === MarketStatus.PENDING_ACCEPTANCE ||
+    market.computedStatus === MarketStatus.EXPIRED
+  const endTime = isPendingLike && market.acceptanceDeadline
+    ? market.acceptanceDeadline
+    : (market.tradingEndTime || market.endDate)
+  const isExpired = market.computedStatus === MarketStatus.EXPIRED
+  const endLabel = isHistoryView
+    ? 'Ended'
+    : isPendingLike
+      ? 'Accept by'
+      : 'Ends'
+  const remainingDisplay = isExpired ? 'Expired' : getTimeRemaining(endTime)
 
   const [withdrawing, setWithdrawing] = useState(false)
   const [withdrawError, setWithdrawError] = useState(null)
@@ -1266,13 +1411,13 @@ function MarketDetailView({
           </span>
         </div>
         <div className="mm-detail-item">
-          <span className="mm-detail-label">{isHistoryView ? 'Ended' : 'Ends'}</span>
+          <span className="mm-detail-label">{endLabel}</span>
           <span className="mm-detail-value">{formatDate(endTime)}</span>
         </div>
         {!isHistoryView && (
           <div className="mm-detail-item">
-            <span className="mm-detail-label">Time Remaining</span>
-            <span className="mm-detail-value mm-time-remaining">{getTimeRemaining(endTime)}</span>
+            <span className="mm-detail-label">{isExpired ? 'Status' : 'Time Remaining'}</span>
+            <span className={`mm-detail-value mm-time-remaining${isExpired ? ' mm-time-expired' : ''}`}>{remainingDisplay}</span>
           </div>
         )}
         {market.totalLiquidity && (

--- a/frontend/src/contexts/FriendMarketsContext.jsx
+++ b/frontend/src/contexts/FriendMarketsContext.jsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useAccount } from 'wagmi'
 import { fetchFriendMarketsForUser } from '../utils/blockchainService'
 import { FriendMarketsContext } from './FriendMarketsContext'
 
 const STORAGE_KEY = 'friendMarkets'
+const DISMISSED_STORAGE_PREFIX = 'mywagers_dismissed:'
 
 function loadFromStorage() {
   try {
@@ -22,10 +23,34 @@ function saveToStorage(markets) {
   }
 }
 
+function dismissedKey(address) {
+  return `${DISMISSED_STORAGE_PREFIX}${(address || '').toLowerCase()}`
+}
+
+function loadDismissed(address) {
+  if (!address) return []
+  try {
+    const stored = localStorage.getItem(dismissedKey(address))
+    return stored ? JSON.parse(stored) : []
+  } catch {
+    return []
+  }
+}
+
+function saveDismissed(address, ids) {
+  if (!address) return
+  try {
+    localStorage.setItem(dismissedKey(address), JSON.stringify(ids))
+  } catch {
+    // non-fatal
+  }
+}
+
 export function FriendMarketsProvider({ children }) {
   const { address, isConnected } = useAccount()
   const [friendMarkets, setFriendMarkets] = useState(() => loadFromStorage())
   const [loading, setLoading] = useState(false)
+  const [dismissedIdsArr, setDismissedIdsArr] = useState(() => loadDismissed(address))
 
   // Fetch friend markets from blockchain when wallet connects
   useEffect(() => {
@@ -89,8 +114,67 @@ export function FriendMarketsProvider({ children }) {
     })
   }, [])
 
+  // Reload the dismissed set when the active account changes so we don't
+  // leak one wallet's dismissed list into another.
+  useEffect(() => {
+    setDismissedIdsArr(loadDismissed(address))
+  }, [address])
+
+  const dismissedIds = useMemo(() => new Set(dismissedIdsArr.map(String)), [dismissedIdsArr])
+
+  const dismissMarket = useCallback((marketId) => {
+    if (marketId == null) return
+    const id = String(marketId)
+    setDismissedIdsArr(prev => {
+      if (prev.includes(id)) return prev
+      const next = [...prev, id]
+      saveDismissed(address, next)
+      return next
+    })
+  }, [address])
+
+  const dismissMarkets = useCallback((marketIds) => {
+    const incoming = (marketIds || []).filter(v => v != null).map(String)
+    if (incoming.length === 0) return
+    setDismissedIdsArr(prev => {
+      const merged = Array.from(new Set([...prev, ...incoming]))
+      if (merged.length === prev.length) return prev
+      saveDismissed(address, merged)
+      return merged
+    })
+  }, [address])
+
+  const restoreMarket = useCallback((marketId) => {
+    if (marketId == null) return
+    const id = String(marketId)
+    setDismissedIdsArr(prev => {
+      if (!prev.includes(id)) return prev
+      const next = prev.filter(x => x !== id)
+      saveDismissed(address, next)
+      return next
+    })
+  }, [address])
+
+  const isDismissed = useCallback(
+    (marketId) => dismissedIds.has(String(marketId)),
+    [dismissedIds]
+  )
+
   return (
-    <FriendMarketsContext.Provider value={{ friendMarkets, loading, refresh, addMarket, setFriendMarkets }}>
+    <FriendMarketsContext.Provider
+      value={{
+        friendMarkets,
+        loading,
+        refresh,
+        addMarket,
+        setFriendMarkets,
+        dismissedIds,
+        dismissMarket,
+        dismissMarkets,
+        restoreMarket,
+        isDismissed,
+      }}
+    >
       {children}
     </FriendMarketsContext.Provider>
   )

--- a/frontend/src/test/MyMarketsModal.test.jsx
+++ b/frontend/src/test/MyMarketsModal.test.jsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, within, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MyMarketsModal from '../components/fairwins/MyMarketsModal'
-import { WalletContext, ThemeContext, UIContext } from '../contexts'
+import { WalletContext, ThemeContext, UIContext, FriendMarketsContext } from '../contexts'
 import { BrowserRouter } from 'react-router-dom'
 
 // Mock hooks
@@ -93,20 +93,36 @@ describe('MyMarketsModal', () => {
     modal: null
   }
 
+  const defaultFriendMarketsContext = {
+    friendMarkets: [],
+    loading: false,
+    refresh: vi.fn(),
+    addMarket: vi.fn(),
+    setFriendMarkets: vi.fn(),
+    dismissedIds: new Set(),
+    dismissMarket: vi.fn(),
+    dismissMarkets: vi.fn(),
+    restoreMarket: vi.fn(),
+    isDismissed: vi.fn(() => false),
+  }
+
   const renderWithProviders = (component, options = {}) => {
     const {
       walletContext = defaultWalletContext,
       themeContext = defaultThemeContext,
-      uiContext = defaultUIContext
+      uiContext = defaultUIContext,
+      friendMarketsContext = defaultFriendMarketsContext
     } = options
 
     return render(
       <BrowserRouter>
         <ThemeContext.Provider value={themeContext}>
           <WalletContext.Provider value={walletContext}>
-            <UIContext.Provider value={uiContext}>
-              {component}
-            </UIContext.Provider>
+            <FriendMarketsContext.Provider value={friendMarketsContext}>
+              <UIContext.Provider value={uiContext}>
+                {component}
+              </UIContext.Provider>
+            </FriendMarketsContext.Provider>
           </WalletContext.Provider>
         </ThemeContext.Provider>
       </BrowserRouter>
@@ -425,6 +441,71 @@ describe('MyMarketsModal', () => {
       await waitFor(() => {
         expect(screen.getByText('Test Wager 2')).toBeInTheDocument()
       })
+    })
+
+    it('should hide expired pending offers from the default list', async () => {
+      const expiredMarket = {
+        id: '99',
+        description: 'Expired Offer',
+        creator: '0xABCDEF1234567890ABCDEF1234567890ABCDEF12',
+        participants: ['0x1234567890123456789012345678901234567890'],
+        status: 'pending_acceptance',
+        acceptanceDeadline: Date.now() - 60 * 60 * 1000,
+        endDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        marketType: 'friend'
+      }
+
+      await act(async () => {
+        renderWithProviders(
+          <MyMarketsModal isOpen={true} onClose={mockOnClose} friendMarkets={[expiredMarket]} />
+        )
+      })
+
+      // Default Participating tab + 'all' status filter → expired offer hidden
+      expect(screen.queryByText('Expired Offer')).not.toBeInTheDocument()
+      expect(screen.getByText(/No Active Positions/i)).toBeInTheDocument()
+    })
+
+    it('shows expired offers with "Expired" time-left and Clear button when filter is Expired', async () => {
+      const user = userEvent.setup()
+      const dismissMarket = vi.fn()
+      const expiredMarket = {
+        id: '99',
+        description: 'Expired Offer',
+        creator: '0xABCDEF1234567890ABCDEF1234567890ABCDEF12',
+        participants: ['0x1234567890123456789012345678901234567890'],
+        status: 'pending_acceptance',
+        acceptanceDeadline: Date.now() - 60 * 60 * 1000,
+        endDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        marketType: 'friend'
+      }
+
+      await act(async () => {
+        renderWithProviders(
+          <MyMarketsModal isOpen={true} onClose={mockOnClose} friendMarkets={[expiredMarket]} />,
+          {
+            friendMarketsContext: {
+              ...defaultFriendMarketsContext,
+              dismissMarket,
+            }
+          }
+        )
+      })
+
+      const statusSelect = screen.getAllByRole('combobox')[1]
+      await user.selectOptions(statusSelect, 'expired')
+
+      await waitFor(() => {
+        expect(screen.getByText('Expired Offer')).toBeInTheDocument()
+      })
+
+      // Time-left cell reads "Expired", not "tomorrow"
+      expect(screen.getAllByText('Expired').length).toBeGreaterThan(0)
+
+      // Invitee (not creator) → button label is just "Clear"
+      const clearBtn = screen.getByRole('button', { name: /^clear$/i })
+      await user.click(clearBtn)
+      expect(dismissMarket).toHaveBeenCalledWith('99')
     })
 
     it('should show tab badges only for unread wagers (count circuit breaker)', async () => {


### PR DESCRIPTION
## Summary

- Pending offers whose acceptance deadline has passed now resolve to a new `EXPIRED` computed status in My Wagers, fixing the "23h 6m" / tomorrow countdown shown on offers the acceptance modal correctly labels "Expired."
- Expired offers are hidden from the default Status=All view and reachable via a new **Expired** filter option.
- Each expired row carries a Clear action (per-account dismissed list in localStorage). When the user is the creator, it is a **Reclaim & Clear** that calls `claimRefund` on-chain first so the locked stake comes back, then dismisses locally.

## Bug reproduction (from the issue screenshot)

The offer modal reads "Accept by: Expired" but the My Wagers row shows Time Left "23h 6m" with status "Pending Acceptance" — no way for the user to clean up the offer. After this PR:

- The row is hidden by default.
- Selecting Status: Expired surfaces it with "Expired" in Time Left.
- The user can Clear it from the list; the creator can additionally reclaim funds in the same click.

## What's in this PR

- frontend/src/components/fairwins/MyMarketsModal.jsx
  - `getMarketStatus` returns EXPIRED when `pending_acceptance` + `acceptanceDeadline` in past; also recognizes the `declined` terminal state added in #606.
  - Default Status=All view drops EXPIRED; dismissed ids always filtered.
  - Time Left for pending offers uses `acceptanceDeadline`, not the trading/resolve deadline.
  - New `MarketsTable` Actions cell: Clear / Reclaim & Clear. Footer Clear-all-expired button when filtered to Expired.
  - Detail view labels swap to "Accept by" + "Status: Expired" for pending/expired offers.
- frontend/src/contexts/FriendMarketsContext.jsx
  - Adds per-account `dismissedIds`, `dismissMarket`, `dismissMarkets`, `restoreMarket`, `isDismissed`. Persisted under `mywagers_dismissed:<account>` so wallets do not leak dismissed lists into one another.
- Styling for the new status badge/row/buttons in `MyMarketsModal.css`.
- Test coverage:
  - `frontend/src/test/MyMarketsModal.test.jsx` — 2 new vitest cases (hide-by-default; visible-with-Clear under Expired filter, calling `dismissMarket` with the right id).
  - `frontend/cypress/e2e/fast/13-dashboard.cy.js` — [DSH-14] / [DSH-15] / [DSH-16] fast-tier specs matching the new test-suite structure from #608.
- `docs/fairwins-functional-testing-checklist.md` — DSH-14..DSH-16 entries.

## On-chain interaction

The Reclaim path uses the existing `claimRefund(wagerId)` on `WagerRegistry`. The full [REF-01] on-chain coverage in `cypress/e2e/full/11-refund-timeout.cy.js` already owns that path; this PR does not duplicate it.

## Test plan

- [ ] CI: vitest (777 → 779 tests, all passing locally)
- [ ] CI: frontend lint clean on touched files
- [ ] CI: fast-tier Cypress DSH-14..DSH-16 (locally the entire 13-dashboard.cy.js fails to set up the wallet connector under headless mock provider — same as origin/main; verifying in CI environment)
- [ ] Manual: open My Wagers with the expired offer from the screenshot — confirm hidden by default, visible under Expired filter with "Expired" time-left
- [ ] Manual: as opponent, click Clear → row disappears, stays gone after reload
- [ ] Manual: as creator, click Reclaim & Clear → wallet prompts for claimRefund, stake returned, row gone after success
- [ ] Manual: switch wallets — confirm one account's dismissed list does not affect the other

🤖 Generated with [Claude Code](https://claude.com/claude-code)