### PR TITLE
fix: display correct USDC balance when DEX is not configured

### DIFF
--- a/frontend/src/config/networks.js
+++ b/frontend/src/config/networks.js
@@ -33,11 +33,11 @@ const NETWORKS = {
     nativeCurrency: { decimals: 18, name: 'MATIC', symbol: 'MATIC' },
     rpcUrl: import.meta.env?.VITE_RPC_URL_AMOY || 'https://rpc-amoy.polygon.technology',
     explorer: { name: 'Polygonscan', baseUrl: 'https://amoy.polygonscan.com' },
-    // Polymarket testnet USDC on Amoy. The exact address must be set per
-    // deployment via VITE_AMOY_USDC — there is no committed default because
-    // Polymarket's testnet configuration changes from time to time.
+    // USDC on Amoy. Defaults to the Circle faucet USDC deployed alongside
+    // our contracts (same as paymentToken in contracts.js). Override via
+    // VITE_AMOY_USDC if a different token is needed.
     stablecoin: {
-      address: import.meta.env?.VITE_AMOY_USDC || null,
+      address: import.meta.env?.VITE_AMOY_USDC || '0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582',
       symbol: 'USDC',
       name: 'USD Coin',
       decimals: 6,

--- a/frontend/src/contexts/DexContext.jsx
+++ b/frontend/src/contexts/DexContext.jsx
@@ -84,6 +84,12 @@ export function DexProvider({ children }) {
   const [quotingPrice, setQuotingPrice] = useState(false)
   const [slippage, setSlippage] = useState(DEFAULT_SLIPPAGE)
 
+  // Stablecoin contract for balance reads — available even when DEX is not.
+  const stableContract = useMemo(() => {
+    if (!provider || !stableConfig?.address) return null
+    return new ethers.Contract(stableConfig.address, ERC20_ABI, provider)
+  }, [provider, stableConfig])
+
   const contracts = useMemo(() => {
     if (!provider || !isDexAvailable) return null
 
@@ -100,14 +106,26 @@ export function DexProvider({ children }) {
       return
     }
 
-    if (!provider || !address || !contracts) return
+    if (!provider || !address) return
+    // Need at least stableContract or full DEX contracts to fetch anything useful
+    if (!stableContract && !contracts) return
 
     try {
       setLoading(true)
 
       const nativeBalance = await provider.getBalance(address)
-      const wnativeBalance = await contracts.wnative.balanceOf(address)
-      const stableBalance = await contracts.stable.balanceOf(address)
+
+      // Fetch wnative only when DEX contracts are available
+      const wnativeBalance = contracts
+        ? await contracts.wnative.balanceOf(address)
+        : 0n
+
+      // Fetch stable balance from DEX contracts if available, otherwise
+      // fall back to the standalone stableContract
+      const stableReader = contracts?.stable || stableContract
+      const stableBalance = stableReader
+        ? await stableReader.balanceOf(address)
+        : 0n
 
       const newBalances = {
         native: ethers.formatEther(nativeBalance),
@@ -129,7 +147,7 @@ export function DexProvider({ children }) {
     } finally {
       setLoading(false)
     }
-  }, [provider, address, contracts, tokens.STABLE.decimals])
+  }, [provider, address, contracts, stableContract, tokens.STABLE.decimals])
 
   // Reset balances when chain changes so the user doesn't see stale numbers.
   useEffect(() => {


### PR DESCRIPTION
The USDC balance always showed 0.00 because fetchBalances in DexContext
required full DEX contracts (swap router, quoter, etc.) which are null on
Amoy when Uniswap env vars are missing. This decouples the ERC20 balance
read from DEX availability and adds the deployed USDC address as a
default for Polygon Amoy.

https://claude.ai/code/session_018raW9cid7t4ES4tNysexsj