### PR TITLE
fix: bronze members blocked from creating wagers due to stale concurrent count

### DIFF
--- a/contracts/interfaces/IWagerRegistry.sol
+++ b/contracts/interfaces/IWagerRegistry.sol
@@ -78,6 +78,7 @@ interface IWagerRegistry {
     function autoResolveFromOracle(uint256 wagerId) external;
     function claimPayout(uint256 wagerId) external;
     function claimRefund(uint256 wagerId) external;
+    function batchExpireOpen(uint256[] calldata wagerIds) external;
 
     function freezeAccount(address user, string calldata reason) external;
     function unfreezeAccount(address user) external;

--- a/contracts/wagers/WagerRegistry.sol
+++ b/contracts/wagers/WagerRegistry.sol
@@ -409,6 +409,26 @@ contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausab
         }
     }
 
+    // ---------- Batch expire ----------
+
+    /// @notice Expire Open wagers whose accept deadline has passed, refund the
+    ///         creator's stake, and release the concurrent-limit slot on
+    ///         MembershipManager. Any address may call this (the refund always
+    ///         goes to the original creator). Silently skips wager IDs that are
+    ///         not eligible (wrong status, deadline not yet reached, etc.).
+    function batchExpireOpen(uint256[] calldata wagerIds) external nonReentrant whenNotPaused {
+        for (uint256 i = 0; i < wagerIds.length; i++) {
+            Wager storage w = _wagers[wagerIds[i]];
+            if (w.status != Status.Open) continue;
+            if (block.timestamp <= w.acceptDeadline) continue;
+
+            w.status = Status.Refunded;
+            membershipManager.recordClose(w.creator, WAGER_PARTICIPANT_ROLE);
+            IERC20(w.token).safeTransfer(w.creator, w.creatorStake);
+            emit WagerRefunded(wagerIds[i], w.creator, address(0));
+        }
+    }
+
     // ---------- Views ----------
 
     function getWager(uint256 wagerId) external view returns (Wager memory) {

--- a/frontend/src/abis/WagerRegistry.js
+++ b/frontend/src/abis/WagerRegistry.js
@@ -834,6 +834,19 @@ export const WAGER_REGISTRY_ABI = [
   {
     "inputs": [
       {
+        "internalType": "uint256[]",
+        "name": "wagerIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "batchExpireOpen",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "wagerId",
         "type": "uint256"

--- a/frontend/src/components/ui/PremiumPurchaseModal.jsx
+++ b/frontend/src/components/ui/PremiumPurchaseModal.jsx
@@ -186,7 +186,7 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
       const provider = new ethers.BrowserProvider(window.ethereum)
       const signer = await provider.getSigner()
 
-      const receipt = await purchaseRoleWithStablecoin(signer, ROLE_KEY, selectedPrice, tierValue)
+      const receipt = await purchaseRoleWithStablecoin(signer, ROLE_KEY, selectedPrice, tierValue, action)
       grantRole(ROLE_KEY)
       recordRolePurchase(account, ROLE_KEY, {
         price: selectedPrice,

--- a/frontend/src/components/wallet/RoleDetailsCard.jsx
+++ b/frontend/src/components/wallet/RoleDetailsCard.jsx
@@ -41,13 +41,17 @@ export function RoleDetailsCard({ role, onUpgrade, onExtend, compact = false, is
     expirationDate,
     wagersCreated,
     wagerLimit,
-    canCreateWager
+    canCreateWager,
+    activeWagers = 0,
+    concurrentLimit = 0,
   } = role
 
   const displayName = ROLE_DISPLAY_NAMES[roleName] || roleName
   const description = ROLE_DESCRIPTIONS[roleName] || ''
 
-  const isAtLimit = wagerLimit > 0 && !canCreateWager
+  const isMonthlyLimit = wagerLimit > 0 && wagersCreated >= wagerLimit
+  const isConcurrentLimit = concurrentLimit > 0 && activeWagers >= concurrentLimit
+  const isAtLimit = (wagerLimit > 0 || concurrentLimit > 0) && !canCreateWager
   const isExpiringSoon = daysRemaining !== null && daysRemaining <= 7 && daysRemaining > 0
   const needsAttention = isFrozen || isExpired || isAtLimit || isExpiringSoon
 
@@ -85,8 +89,16 @@ export function RoleDetailsCard({ role, onUpgrade, onExtend, compact = false, is
             {wagerLimit > 0 && (
               <div className="detail-row">
                 <span className="detail-label">Wagers:</span>
-                <span className={`detail-value ${isAtLimit ? 'at-limit' : ''}`}>
+                <span className={`detail-value ${isMonthlyLimit ? 'at-limit' : ''}`}>
                   {wagersCreated} / {wagerLimit} this month
+                </span>
+              </div>
+            )}
+            {concurrentLimit > 0 && (
+              <div className="detail-row">
+                <span className="detail-label">Active:</span>
+                <span className={`detail-value ${isConcurrentLimit ? 'at-limit' : ''}`}>
+                  {activeWagers} / {concurrentLimit} concurrent
                 </span>
               </div>
             )}
@@ -162,18 +174,28 @@ export function RoleDetailsCard({ role, onUpgrade, onExtend, compact = false, is
             <span className="stat-label">Wagers This Month</span>
             <div className="usage-bar-container">
               <div
-                className={`usage-bar ${isAtLimit ? 'at-limit' : ''}`}
+                className={`usage-bar ${isMonthlyLimit ? 'at-limit' : ''}`}
                 style={{ width: `${Math.min(100, (wagersCreated / wagerLimit) * 100)}%` }}
               />
             </div>
-            <span className={`stat-value ${isAtLimit ? 'at-limit' : ''}`}>
+            <span className={`stat-value ${isMonthlyLimit ? 'at-limit' : ''}`}>
               {wagersCreated} / {wagerLimit}
             </span>
-            {isAtLimit && (
-              <span className="stat-sublabel warning">
-                Limit reached — upgrade for more
-              </span>
-            )}
+          </div>
+        )}
+
+        {concurrentLimit > 0 && (
+          <div className="role-stat">
+            <span className="stat-label">Active Wagers</span>
+            <div className="usage-bar-container">
+              <div
+                className={`usage-bar ${isConcurrentLimit ? 'at-limit' : ''}`}
+                style={{ width: `${Math.min(100, (activeWagers / concurrentLimit) * 100)}%` }}
+              />
+            </div>
+            <span className={`stat-value ${isConcurrentLimit ? 'at-limit' : ''}`}>
+              {activeWagers} / {concurrentLimit}
+            </span>
           </div>
         )}
 
@@ -182,9 +204,14 @@ export function RoleDetailsCard({ role, onUpgrade, onExtend, compact = false, is
             Your {displayName} access has expired. Renew to continue creating wagers.
           </div>
         )}
-        {isAtLimit && !isExpired && !isFrozen && (
+        {isConcurrentLimit && !isMonthlyLimit && !isExpired && !isFrozen && (
           <div className="role-alert at-limit">
-            You've reached your monthly limit. Upgrade your tier for higher limits.
+            Concurrent wager limit reached. Close or refund expired wagers to free up slots, or upgrade your tier.
+          </div>
+        )}
+        {isMonthlyLimit && !isExpired && !isFrozen && (
+          <div className="role-alert at-limit">
+            Monthly wager limit reached. Upgrade your tier for higher limits.
           </div>
         )}
         {isExpiringSoon && !isExpired && !isAtLimit && !isFrozen && (

--- a/frontend/src/hooks/useFriendMarketCreation.js
+++ b/frontend/src/hooks/useFriendMarketCreation.js
@@ -3,6 +3,7 @@ import { ethers } from 'ethers'
 import { useWeb3 } from './useWeb3'
 import { getContractAddress } from '../config/contracts'
 import { WAGER_REGISTRY_ABI } from '../abis/WagerRegistry'
+import { MEMBERSHIP_MANAGER_ABI } from '../abis/MembershipManager'
 import { ResolutionType, ORACLE_RESOLUTION_TYPES } from '../constants/wagerDefaults'
 import {
   uploadEncryptedEnvelope,
@@ -18,6 +19,47 @@ const ERC20_ABI = [
 ]
 
 export { ResolutionType, ORACLE_RESOLUTION_TYPES }
+
+const WAGER_PARTICIPANT_ROLE = ethers.keccak256(ethers.toUtf8Bytes('WAGER_PARTICIPANT_ROLE'))
+
+async function expireStaleWagers(registry, userAddress, onProgress) {
+  try {
+    const membershipManagerAddr = getContractAddress('membershipManager')
+    if (!membershipManagerAddr) return
+
+    const provider = registry.runner?.provider || registry.provider
+    const mgr = new ethers.Contract(membershipManagerAddr, MEMBERSHIP_MANAGER_ABI, provider)
+    const membership = await mgr.getMembership(userAddress, WAGER_PARTICIPANT_ROLE)
+    const tierNum = Number(membership.tier)
+    if (tierNum === 0) return
+
+    const cfg = await mgr.getTierConfig(WAGER_PARTICIPANT_ROLE, tierNum)
+    const concurrentLimit = Number(cfg.limits.maxConcurrentMarkets)
+    const activeCount = Number(membership.activeCount)
+    if (concurrentLimit === 0 || activeCount < concurrentLimit) return
+
+    const count = await registry.getUserWagerCount(userAddress)
+    if (count === 0n) return
+
+    const wagers = await registry.getUserWagers(userAddress, 0, count)
+    const ids = await registry.getUserWagerIds(userAddress, 0, count)
+    const now = Math.floor(Date.now() / 1000)
+    const expiredIds = []
+
+    for (let i = 0; i < wagers.length; i++) {
+      if (Number(wagers[i].status) === 1 && Number(wagers[i].acceptDeadline) < now) {
+        expiredIds.push(ids[i])
+      }
+    }
+    if (expiredIds.length === 0) return
+
+    onProgress({ step: 'cleanup', message: `Cleaning up ${expiredIds.length} expired wager(s)...` })
+    const tx = await registry.batchExpireOpen(expiredIds)
+    await tx.wait()
+  } catch (e) {
+    console.debug('[expireStaleWagers] cleanup skipped:', e.message)
+  }
+}
 
 // localStorage helpers — preserved for backward-compat with FriendMarketsModal callers
 const PENDING_TX_KEY = 'pendingFriendMarketTx'
@@ -213,6 +255,12 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
         await approveTx.wait()
       }
 
+      // Auto-cleanup expired Open wagers that still count toward the
+      // concurrent limit. Without this, acceptDeadline-expired wagers
+      // inflate activeCount and block new creation even when the user
+      // has fewer truly-active wagers than their tier allows.
+      await expireStaleWagers(registry, userAddress, onProgress)
+
       // Simulate to catch reverts pre-wallet-prompt
       try {
         onProgress({ step: 'create', message: 'Validating transaction...' })
@@ -310,7 +358,7 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
 
 export function translateRevert(reason) {
   if (!reason) return 'Unknown contract error.'
-  if (reason.includes('MembershipDenied')) return 'Your Friend Market membership is inactive or you have reached the monthly/concurrent wager limit. Purchase or upgrade your tier to continue.'
+  if (reason.includes('MembershipDenied')) return 'Your membership is inactive or you have reached your wager limit. If you have expired wagers, try again — they will be cleaned up automatically. Otherwise, upgrade your tier for higher limits.'
   if (reason.includes('SelfWager')) return 'Cannot wager against yourself.'
   if (reason.includes('NotAllowedToken')) return 'Stake token is not on the allowlist. Use USDC or WMATIC.'
   if (reason.includes('BadDeadlines')) return 'Invalid deadlines. Accept window must be within 30 days; resolve window within 180 days.'

--- a/frontend/src/hooks/useRoleDetails.js
+++ b/frontend/src/hooks/useRoleDetails.js
@@ -84,12 +84,15 @@ export function useRoleDetails() {
       details.tier = Number(m.tier)
       details.tierName = TIER_NAMES[details.tier] || 'Unknown'
       details.tierColor = TIER_COLORS[details.tier] || '#666'
-      details.wagersCreated = Number(m.monthCount)
       details.activeWagers = Number(m.activeCount)
+
+      const now = Math.floor(Date.now() / 1000)
+      const ROLLING_WINDOW = 30 * 24 * 3600
+      const monthAnchor = Number(m.monthAnchor)
+      details.wagersCreated = (now >= monthAnchor + ROLLING_WINDOW) ? 0 : Number(m.monthCount)
 
       const expiresAt = Number(m.expiresAt)
       if (expiresAt > 0) {
-        const now = Math.floor(Date.now() / 1000)
         details.expiration = expiresAt
         details.expirationDate = new Date(expiresAt * 1000)
         details.isExpired = expiresAt <= now
@@ -103,7 +106,6 @@ export function useRoleDetails() {
           const cfg = await mgr.getTierConfig(roleBytes, details.tier)
           details.wagerLimit = Number(cfg.limits.monthlyMarketCreation)
           details.concurrentLimit = Number(cfg.limits.maxConcurrentMarkets)
-          // 0 = unlimited
           const monthlyOk = details.wagerLimit === 0 || details.wagersCreated < details.wagerLimit
           const concurrentOk = details.concurrentLimit === 0 || details.activeWagers < details.concurrentLimit
           details.canCreateWager = details.isActive && monthlyOk && concurrentOk

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -1042,27 +1042,23 @@ const PAYMENT_PROCESSOR_ABI = [
 ]
 
 /**
- * Purchase a role using the active chain's stablecoin (USDC on Polygon Amoy)
- * with tiered membership. Calls PaymentProcessor.purchaseTierWithToken,
- * which handles both the payment and role granting atomically.
+ * Purchase, upgrade, or extend a membership using the active chain's stablecoin.
  *
  * @param {ethers.Signer} signer - Connected wallet signer
  * @param {string} roleName - Name of the role being purchased
  * @param {number} priceUSD - Price in USD (converted to stablecoin units, 6 decimals)
  * @param {number} tier - Membership tier (1=Bronze, 2=Silver, 3=Gold, 4=Platinum), defaults to Bronze
+ * @param {string} action - 'purchase' (default), 'upgrade', or 'extend'
  * @returns {Promise<Object>} Transaction receipt with roleGranted status
  */
-export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tier = MembershipTier.BRONZE) {
+export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tier = MembershipTier.BRONZE, action = 'purchase') {
   if (!signer) {
     throw new Error('Wallet not connected')
   }
 
-  // v2 path: MembershipManager.purchaseTier(role, tier). Price is fixed in the contract.
+  // v2 path: MembershipManager.purchaseTier / upgradeTier / extendMembership.
   const mmAddress = getContractAddress('membershipManager')
   if (mmAddress) {
-    // Verify the contract is actually deployed before calling into it.
-    // When the address has no code (wrong network, not yet deployed, etc.)
-    // ethers returns 0x from every call, producing a confusing BAD_DATA error.
     const provider = signer.provider
     const code = await provider.getCode(mmAddress)
     if (!code || code === '0x') {
@@ -1081,11 +1077,20 @@ export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tie
         throw new Error('MembershipManager has no payment token configured. Contact the DAO administrator.')
       }
       const paymentToken = new ethers.Contract(paymentTokenAddr, ERC20_ABI, signer)
-
-      const tierCfg = await mm.getTierConfig(roleHash, validTier)
-      const price = tierCfg.priceUSDC // 6-decimals
-
       const userAddress = await signer.getAddress()
+
+      // Determine the price the contract will charge
+      let price
+      if (action === 'upgrade') {
+        const membership = await mm.getMembership(userAddress, roleHash)
+        const currentCfg = await mm.getTierConfig(roleHash, membership.tier)
+        const newCfg = await mm.getTierConfig(roleHash, validTier)
+        price = newCfg.priceUSDC - currentCfg.priceUSDC
+      } else {
+        const tierCfg = await mm.getTierConfig(roleHash, validTier)
+        price = tierCfg.priceUSDC
+      }
+
       const balance = await paymentToken.balanceOf(userAddress)
       if (balance < price) {
         throw new Error(
@@ -1099,7 +1104,14 @@ export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tie
         await approveTx.wait()
       }
 
-      const tx = await mm.purchaseTier(roleHash, validTier)
+      let tx
+      if (action === 'upgrade') {
+        tx = await mm.upgradeTier(roleHash, validTier)
+      } else if (action === 'extend') {
+        tx = await mm.extendMembership(roleHash)
+      } else {
+        tx = await mm.purchaseTier(roleHash, validTier)
+      }
       const receipt = await tx.wait()
       return {
         hash: receipt.hash,

--- a/test/WagerRegistry.test.js
+++ b/test/WagerRegistry.test.js
@@ -846,4 +846,89 @@ describe("WagerRegistry", function () {
       expect(wagers.length).to.equal(0);
     });
   });
+
+  describe("batchExpireOpen", () => {
+    it("refunds expired Open wagers and decrements activeCount", async () => {
+      const fx = await loadFixture(deployFixture);
+      const { reg, mgr, usdcToken, alice, bob, charlie } = fx;
+
+      const id1 = await createDefault(reg, fx);
+      const id2 = await createDefault(reg, fx);
+
+      const m1 = await mgr.getMembership(alice.address, WAGER_PARTICIPANT_ROLE);
+      expect(m1.activeCount).to.equal(2);
+
+      const balBefore = await usdcToken.balanceOf(alice.address);
+      await time.increase(3601);
+      await reg.connect(charlie).batchExpireOpen([id1, id2]);
+      const balAfter = await usdcToken.balanceOf(alice.address);
+
+      expect(balAfter - balBefore).to.equal(usdc(20));
+
+      const m2 = await mgr.getMembership(alice.address, WAGER_PARTICIPANT_ROLE);
+      expect(m2.activeCount).to.equal(0);
+
+      expect((await reg.getWager(id1)).status).to.equal(Status.Refunded);
+      expect((await reg.getWager(id2)).status).to.equal(Status.Refunded);
+    });
+
+    it("skips non-expired and non-Open wagers silently", async () => {
+      const fx = await loadFixture(deployFixture);
+      const { reg, mgr, alice, bob } = fx;
+
+      const id1 = await createDefault(reg, fx);
+      const id2 = await createDefault(reg, fx);
+      await reg.connect(bob).acceptWager(id2);
+
+      await time.increase(3601);
+      await reg.connect(alice).batchExpireOpen([id1, id2, 9999]);
+
+      expect((await reg.getWager(id1)).status).to.equal(Status.Refunded);
+      expect((await reg.getWager(id2)).status).to.equal(Status.Active);
+
+      const m = await mgr.getMembership(alice.address, WAGER_PARTICIPANT_ROLE);
+      expect(m.activeCount).to.equal(1);
+    });
+
+    it("frees concurrent slots so new wagers can be created", async () => {
+      const fx = await loadFixture(deployFixture);
+      const { reg, mgr, admin, alice, bob, usdcToken } = fx;
+
+      await mgr.connect(admin).setTier(
+        WAGER_PARTICIPANT_ROLE, Tier.Bronze,
+        usdc(50), 30,
+        { monthlyMarketCreation: 100, maxConcurrentMarkets: 3 },
+        true
+      );
+
+      await createDefault(reg, fx);
+      await createDefault(reg, fx);
+      await createDefault(reg, fx);
+
+      const now = await time.latest();
+      await expect(
+        reg.connect(alice).createWager(
+          bob.address, ethers.ZeroAddress, await usdcToken.getAddress(),
+          usdc(10), usdc(10), now + 7200, now + 86400,
+          Resolution.Either, ethers.ZeroHash, false, ethers.id("test"), ""
+        )
+      ).to.be.revertedWithCustomError(reg, "MembershipDenied");
+
+      await time.increase(3601);
+
+      const ids = await reg.getUserWagerIds(alice.address, 0, 10);
+      await reg.batchExpireOpen(Array.from(ids));
+
+      const m = await mgr.getMembership(alice.address, WAGER_PARTICIPANT_ROLE);
+      expect(m.activeCount).to.equal(0);
+
+      const now2 = await time.latest();
+      await reg.connect(alice).createWager(
+        bob.address, ethers.ZeroAddress, await usdcToken.getAddress(),
+        usdc(10), usdc(10), now2 + 7200, now2 + 86400,
+        Resolution.Either, ethers.ZeroHash, false, ethers.id("test"), ""
+      );
+      expect((await mgr.getMembership(alice.address, WAGER_PARTICIPANT_ROLE)).activeCount).to.equal(1);
+    });
+  });
 });


### PR DESCRIPTION
Expired Open wagers (past acceptDeadline, never accepted) still counted
toward the concurrent-wager limit because recordClose was only called on
explicit claimRefund. A Bronze user with 5 total wagers created (2 expired,
3 truly active) hit the concurrent limit of 5 and was unable to create more.

Changes:
- Add WagerRegistry.batchExpireOpen() to refund and release concurrent
  slots for expired Open wagers in a single transaction
- Frontend auto-detects and cleans up expired wagers before creating new
  ones (expireStaleWagers helper in useFriendMarketCreation)
- RoleDetailsCard now shows both monthly and concurrent usage with
  distinct limit-reached messages instead of generic "monthly limit"
- useRoleDetails accounts for the 30-day rolling window reset when
  computing wagersCreated (matching the contract's checkCanCreate logic)
- Updated MembershipDenied error message to guide users on expired wagers

https://claude.ai/code/session_01C8MzmhXq4ZDN8p8HU1nymG