### PR TITLE
fix: allow both parties to resolve wagers and add resolution window

### DIFF
--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -689,10 +689,15 @@ function MyMarketsModal({
                       getTimeRemaining={getTimeRemaining}
                       account={account}
                       userPositions={userPositions}
+                      canResolve={canResolve}
                       canOpenDispute={canOpenDispute}
+                      onOpenResolution={handleOpenResolution}
                       onOpenDispute={handleOpenDispute}
                       onDecrypt={handleDecryptMarket}
                       isDecrypting={isMarketDecrypting(selectedMarket?.id)}
+                      signer={signer}
+                      isCorrectNetwork={isCorrectNetwork}
+                      switchNetwork={switchNetwork}
                     />
                   ) : categorizedMarkets.participating.length === 0 ? (
                     <div className="mm-empty-state">
@@ -717,6 +722,8 @@ function MyMarketsModal({
                       onClearExpired={handleClearExpired}
                       onClearAllExpired={handleClearAllExpired}
                       statusFilter={statusFilter}
+                      showResolveCountdown
+                      onResolve={handleOpenResolution}
                     />
                   )}
                 </div>
@@ -1112,8 +1119,22 @@ function ResolveButtonWithCountdown({ market, onResolve, account, variant = 'com
   const [timeRemaining, setTimeRemaining] = useState(null)
   const [canResolveNow, setCanResolveNow] = useState(false)
 
-  // Check if user is creator
-  const isCreator = market.creator?.toLowerCase() === account?.toLowerCase()
+  const userAddr = account?.toLowerCase()
+  const isCreator = market.creator?.toLowerCase() === userAddr
+  const isOpponent = market.participants?.length > 1 &&
+    market.participants[1]?.toLowerCase() === userAddr
+  const isArbitrator = market.arbitrator &&
+    market.arbitrator !== ethers.ZeroAddress &&
+    market.arbitrator.toLowerCase() === userAddr
+
+  const resType = market.resolutionType ?? 0
+  const isAuthorized = (() => {
+    if (resType === 0) return isCreator || isOpponent || isArbitrator
+    if (resType === 1) return isCreator
+    if (resType === 2) return isOpponent
+    if (resType === 3) return isArbitrator
+    return false
+  })()
 
   // Get end time
   const endTime = useMemo(() => {
@@ -1129,7 +1150,7 @@ function ResolveButtonWithCountdown({ market, onResolve, account, variant = 'com
 
   // Update countdown every second
   useEffect(() => {
-    if (!endTime || !isCreator) return
+    if (!endTime || !isAuthorized) return
 
     const updateCountdown = () => {
       const now = Date.now()
@@ -1148,10 +1169,9 @@ function ResolveButtonWithCountdown({ market, onResolve, account, variant = 'com
     const interval = setInterval(updateCountdown, 1000)
 
     return () => clearInterval(interval)
-  }, [endTime, isCreator])
+  }, [endTime, isAuthorized])
 
-  // Don't show if not creator
-  if (!isCreator) return null
+  if (!isAuthorized) return null
 
   // If already resolved, disputed, or cancelled, don't show
   const status = market.computedStatus || market.status
@@ -1547,7 +1567,7 @@ function MarketDetailView({
             )}
           </div>
         )}
-        {isCreatorView && (
+        {onOpenResolution && (
           <ResolveButtonWithCountdown
             market={market}
             onResolve={onOpenResolution}
@@ -1555,7 +1575,7 @@ function MarketDetailView({
             variant="full"
           />
         )}
-        {isCreatorView && canRespondToDispute?.(market) && (
+        {canRespondToDispute?.(market) && (
           <button
             type="button"
             className="mm-btn-warning"
@@ -1567,7 +1587,7 @@ function MarketDetailView({
             Respond to Dispute
           </button>
         )}
-        {!isCreatorView && canOpenDispute?.(market) && (
+        {canOpenDispute?.(market) && (
           <button
             type="button"
             className="mm-btn-secondary"
@@ -1670,6 +1690,8 @@ function ResolutionModal({
         setError('This wager is not active. It may have already been resolved or is still pending acceptance.')
       } else if (err.reason?.includes('NotAuthorized') || err.message?.includes('NotAuthorized')) {
         setError('You are not authorized to resolve this wager based on its resolution type.')
+      } else if (err.reason?.includes('ResolveExpired') || err.message?.includes('ResolveExpired')) {
+        setError('The resolution deadline has passed. This wager can no longer be resolved and may be eligible for a refund.')
       } else {
         setError(err.reason || err.shortMessage || err.message || 'Failed to resolve wager. Please try again.')
       }

--- a/frontend/src/constants/wagerDefaults.js
+++ b/frontend/src/constants/wagerDefaults.js
@@ -48,6 +48,11 @@ export const WAGER_DEFAULTS = {
 
   /** Maximum trading period in seconds (mirrors contract MAX_TRADING_PERIOD). */
   MAX_TRADING_PERIOD_SECONDS: 21 * 24 * 60 * 60,
+
+  /** Extra window (seconds) added to resolveDeadline beyond the trading end
+   *  so that participants have time to declare a winner after the event ends.
+   *  48 hours keeps the UX generous without approaching MAX_RESOLVE_WINDOW. */
+  RESOLUTION_WINDOW_SECONDS: 48 * 60 * 60,
 }
 
 // ── Wager status strings (friend / P2P markets) ────────────────────

--- a/frontend/src/hooks/useFriendMarketCreation.js
+++ b/frontend/src/hooks/useFriendMarketCreation.js
@@ -4,7 +4,7 @@ import { useWeb3 } from './useWeb3'
 import { getContractAddress } from '../config/contracts'
 import { WAGER_REGISTRY_ABI } from '../abis/WagerRegistry'
 import { MEMBERSHIP_MANAGER_ABI } from '../abis/MembershipManager'
-import { ResolutionType, ORACLE_RESOLUTION_TYPES } from '../constants/wagerDefaults'
+import { ResolutionType, ORACLE_RESOLUTION_TYPES, WAGER_DEFAULTS } from '../constants/wagerDefaults'
 import {
   uploadEncryptedEnvelope,
   buildEncryptedIpfsReference
@@ -184,7 +184,7 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
         const hours = parseInt(raw, 10) || 48
         acceptDeadline = Math.floor(Date.now() / 1000) + hours * 3600
       }
-      const resolveDeadline = acceptDeadline + tradingPeriodSeconds
+      const resolveDeadline = acceptDeadline + tradingPeriodSeconds + (WAGER_DEFAULTS.RESOLUTION_WINDOW_SECONDS || 48 * 3600)
 
       // Participants
       const opponent = data.data.opponent || data.data.participants?.[0]
@@ -331,7 +331,7 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
         arbitrator,
         creator: userAddress,
         acceptanceDeadline: new Date(acceptDeadline * 1000).toISOString(),
-        endDate: new Date(resolveDeadline * 1000).toISOString(),
+        endDate: new Date((acceptDeadline + tradingPeriodSeconds) * 1000).toISOString(),
         tradingPeriod: Math.max(1, Math.ceil(tradingPeriodSeconds / 86400)).toString(),
         createdAt: new Date().toISOString(),
         status: 'pending',


### PR DESCRIPTION
Two bugs fixed:

1. The receiver (opponent) could only see "Open Dispute" but not
   "Resolve Market" — ResolveButtonWithCountdown was hardcoded to
   creator-only. Now checks resolutionType to authorize the correct
   party (Either: both, Creator: creator, Opponent: opponent,
   ThirdParty: arbitrator). The participating tab also passes resolve
   props to MarketDetailView.

2. Resolution submission reverted with "execution reverted (unknown
   custom error)" because resolveDeadline on-chain equaled the displayed
   end date. The resolve button appeared after that deadline, exactly
   when the contract started rejecting. New wagers now add a 48-hour
   resolution window beyond the trading end so participants have time
   to declare a winner. The metadata endDate stores the trading end
   (not resolveDeadline) so the UI shows the correct "ENDS" time.
   ResolveExpired is now handled with a clear error message.

https://claude.ai/code/session_01Geb52p8LwbJCWZEcKPqQ8j