### PR TITLE
fix: resolution/dispute bugs and add claim refund

### DIFF
--- a/frontend/src/components/fairwins/MyMarketsModal.css
+++ b/frontend/src/components/fairwins/MyMarketsModal.css
@@ -1132,6 +1132,19 @@
   text-decoration: none;
 }
 
+.mm-refund-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.mm-refund-hint {
+  margin: 0;
+  color: var(--text-secondary, #6b7280);
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
 .mm-tx-link:hover {
   text-decoration: underline;
 }

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -698,6 +698,10 @@ function MyMarketsModal({
                       signer={signer}
                       isCorrectNetwork={isCorrectNetwork}
                       switchNetwork={switchNetwork}
+                      onRefunded={() => {
+                        setSelectedMarketId(null)
+                        fetchMarketsData?.()
+                      }}
                     />
                   ) : categorizedMarkets.participating.length === 0 ? (
                     <div className="mm-empty-state">
@@ -754,6 +758,10 @@ function MyMarketsModal({
                       isCorrectNetwork={isCorrectNetwork}
                       switchNetwork={switchNetwork}
                       onWithdraw={() => {
+                        setSelectedMarketId(null)
+                        fetchMarketsData?.()
+                      }}
+                      onRefunded={() => {
                         setSelectedMarketId(null)
                         fetchMarketsData?.()
                       }}
@@ -1278,7 +1286,8 @@ function MarketDetailView({
   signer,
   isCorrectNetwork,
   switchNetwork,
-  onWithdraw
+  onWithdraw,
+  onRefunded
 }) {
   const isCreator = market.creator?.toLowerCase() === account?.toLowerCase()
   const position = userPositions?.find(p => String(p.marketId) === String(market.id))
@@ -1343,6 +1352,59 @@ function MarketDetailView({
       }
     } finally {
       setWithdrawing(false)
+    }
+  }
+
+  const [refunding, setRefunding] = useState(false)
+  const [refundError, setRefundError] = useState(null)
+  const [refundSuccess, setRefundSuccess] = useState(false)
+  const [refundTxHash, setRefundTxHash] = useState(null)
+
+  const status = market.computedStatus || market.status
+  const isParticipant = market.participants?.some(
+    p => p.toLowerCase() === account?.toLowerCase()
+  )
+  const showRefundButton = isParticipant && signer &&
+    status === MarketStatus.PENDING_RESOLUTION && !refundSuccess
+
+  const handleClaimRefund = async () => {
+    if (!signer) return
+
+    if (!isCorrectNetwork) {
+      try {
+        await switchNetwork()
+      } catch {
+        setRefundError('Please switch to the correct network')
+        return
+      }
+    }
+
+    setRefunding(true)
+    setRefundError(null)
+
+    try {
+      const registry = new ethers.Contract(
+        getContractAddress('wagerRegistry'),
+        WAGER_REGISTRY_ABI,
+        signer
+      )
+      const tx = await registry.claimRefund(market.wagerId ?? market.id)
+      setRefundTxHash(tx.hash)
+      await tx.wait()
+      setRefundSuccess(true)
+      onRefunded?.(market)
+    } catch (err) {
+      const reason = err?.reason || err?.shortMessage || err?.message || ''
+      if (err?.code === 'ACTION_REJECTED' || err?.code === 4001 ||
+          reason.toLowerCase().includes('user rejected')) {
+        setRefundError('Transaction was cancelled in your wallet.')
+      } else if (reason.includes('NotRefundable')) {
+        setRefundError('This wager is not yet refundable. The resolution window may still be open — try resolving instead.')
+      } else {
+        setRefundError(reason || 'Failed to claim refund. Please try again.')
+      }
+    } finally {
+      setRefunding(false)
     }
   }
 
@@ -1600,6 +1662,53 @@ function MarketDetailView({
             </svg>
             Open Dispute
           </button>
+        )}
+        {refundSuccess && (
+          <div className="mm-withdraw-success">
+            <span className="mm-withdraw-success-icon">&#10003;</span>
+            <p>Refund claimed successfully. Stakes have been returned to both participants.</p>
+            {refundTxHash && (
+              <a
+                href={`https://amoy.polygonscan.com/tx/${refundTxHash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mm-tx-link"
+              >
+                View Transaction
+              </a>
+            )}
+          </div>
+        )}
+        {showRefundButton && (
+          <div className="mm-refund-section">
+            <button
+              type="button"
+              className="mm-btn-secondary"
+              onClick={handleClaimRefund}
+              disabled={refunding}
+            >
+              {refunding ? (
+                <>
+                  <span className="mm-spinner-small"></span>
+                  Claiming Refund...
+                </>
+              ) : (
+                <>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <polyline points="1 4 1 10 7 10"/>
+                    <path d="M3.51 15a9 9 0 102.13-9.36L1 10"/>
+                  </svg>
+                  Claim Refund
+                </>
+              )}
+            </button>
+            <p className="mm-refund-hint">
+              If the resolution window has expired without a winner declared, both participants can reclaim their stakes.
+            </p>
+            {refundError && (
+              <p className="mm-withdraw-error">{refundError}</p>
+            )}
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **Both parties can now resolve wagers** — `ResolveButtonWithCountdown` was hardcoded to creator-only; now checks `resolutionType` (Either: both, Creator: creator, Opponent: opponent, ThirdParty: arbitrator). The Participating tab passes resolve props to detail and table views.
- **Fix "execution reverted" on resolution submit** — `resolveDeadline` on-chain equaled the displayed end date, so the resolve button appeared exactly when the contract started rejecting. New wagers add a 48-hour resolution window; metadata `endDate` now stores the trading end (not `resolveDeadline`). `ResolveExpired` gets a clear error message.
- **Add Claim Refund button** — when a wager is past its resolution deadline with no winner declared, participants can reclaim stakes via `WagerRegistry.claimRefund()`. Handles `NotRefundable` gracefully if the resolution window is still open.

## Test plan

- [x] All 777 existing tests pass
- [ ] Verify receiver sees "Resolve Market" button on a wager with `resolutionType = Either`
- [ ] Verify creator can still resolve from the Created tab
- [ ] Create a new wager and confirm `resolveDeadline` is 48h after the displayed end date
- [ ] Confirm "Claim Refund" appears on a wager in Pending Resolution status
- [ ] Confirm refund succeeds on-chain for expired wagers and shows tx link
- [ ] Confirm refund shows helpful error when resolution window is still open

https://claude.ai/code/session_01Geb52p8LwbJCWZEcKPqQ8j

---
_Generated by [Claude Code](https://claude.ai/code/session_01Geb52p8LwbJCWZEcKPqQ8j)_