### PR TITLE
fix(wagers): correct resolve timing, clarify outcomes, honest finality UX

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.css
+++ b/frontend/src/components/fairwins/FriendMarketsModal.css
@@ -764,6 +764,25 @@
   gap: 0.75rem;
 }
 
+/* Explicit exit from the share screen (Minor bug #3) */
+.fm-success-done {
+  display: block;
+  width: 100%;
+  margin-top: 0.75rem;
+  padding: 0.625rem;
+  background: none;
+  border: none;
+  color: var(--text-secondary, #AAB6C2);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.fm-success-done:hover {
+  color: var(--text-primary, #E6EDF3);
+}
+
 /* Responsive Styles */
 @media (max-width: 640px) {
   .friend-markets-modal-backdrop {

--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -1257,7 +1257,7 @@ function FriendMarketsModal({
                           disabled={submitting}
                           className={`fm-datetime-input ${errors.endDateTime ? 'error' : ''}`}
                         />
-                        <span className="fm-hint">When does this wager end? (min: 1 hour, max: 21 days)</span>
+                        <span className="fm-hint">When does this wager end? You can resolve it once this time passes. (min: 1 hour, max: 21 days)</span>
                         {errors.endDateTime && <span className="fm-error">{errors.endDateTime}</span>}
                       </div>
                     )}
@@ -1270,8 +1270,29 @@ function FriendMarketsModal({
                           ? new Date(formData.acceptanceDeadline).toLocaleString()
                           : '—'}
                       </div>
-                      <span className="fm-hint">Automatically set to halfway between now and end time</span>
+                      <span className="fm-hint">Halfway between now and the end time — your opponent must accept before this.</span>
                     </div>
+
+                    {/* Resolution window — derived from the end time so the full timeline is
+                        clear before the user commits (Bug #1). Resolve allowed in
+                        [end time, end time + 48h]; refundable after that. */}
+                    {formData.endDateTime && !Number.isNaN(new Date(formData.endDateTime).getTime()) && (() => {
+                      const end = new Date(formData.endDateTime)
+                      const windowMs = (WAGER_DEFAULTS.RESOLUTION_WINDOW_SECONDS || 48 * 3600) * 1000
+                      const resolveClose = new Date(end.getTime() + windowMs)
+                      return (
+                        <div className="fm-form-group">
+                          <label>Resolution Window</label>
+                          <div className="fm-readonly-value">
+                            {end.toLocaleString()} → {resolveClose.toLocaleString()}
+                          </div>
+                          <span className="fm-hint">
+                            You have 48 hours after the end time to resolve. If unresolved by{' '}
+                            {resolveClose.toLocaleString()}, both stakes can be refunded.
+                          </span>
+                        </div>
+                      )
+                    })()}
 
                     {/* Minimum Threshold - only for group markets */}
                     {(friendMarketType === 'smallGroup' || friendMarketType === 'eventTracking') && (
@@ -1856,6 +1877,13 @@ function FriendMarketsModal({
                       Copy Link
                     </button>
                   </div>
+                  <button
+                    type="button"
+                    className="fm-success-done"
+                    onClick={handleClose}
+                  >
+                    Done — back to My Wagers
+                  </button>
                 </div>
               )}
             </div>

--- a/frontend/src/components/fairwins/MarketAcceptanceModal.jsx
+++ b/frontend/src/components/fairwins/MarketAcceptanceModal.jsx
@@ -13,6 +13,7 @@ import {
 import { DEX_ADDRESSES } from '../../constants/dex'
 import { WAGER_DEFAULTS } from '../../constants/wagerDefaults'
 import { getTransactionUrl } from '../../config/blockExplorer'
+import { getFeeOverrides } from '../../utils/feeOverrides'
 import './MarketAcceptanceModal.css'
 
 // Helper to format stake amount as USD (rounded to nearest cent)
@@ -363,7 +364,8 @@ function MarketAcceptanceModal({
 
       let tx
       console.log('Sending acceptWager transaction...')
-      tx = await contract.acceptWager(marketId)
+      const feeOverrides = await getFeeOverrides(signer.provider)
+      tx = await contract.acceptWager(marketId, feeOverrides)
 
       setTxHash(tx.hash)
       await tx.wait()

--- a/frontend/src/components/fairwins/MyMarketsModal.css
+++ b/frontend/src/components/fairwins/MyMarketsModal.css
@@ -1352,6 +1352,10 @@
 
 .mm-outcome-btn {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
   padding: 1rem;
   background: var(--bg-primary, #0E141B);
   border: 2px solid var(--border-color, #23303D);
@@ -1361,6 +1365,18 @@
   color: var(--text-primary, #E6EDF3);
   cursor: pointer;
   transition: all 0.2s;
+}
+
+.mm-outcome-title {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.mm-outcome-addr {
+  font-size: 0.75rem;
+  font-weight: 500;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  opacity: 0.75;
 }
 
 .mm-outcome-btn:hover:not(:disabled) {

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -7,6 +7,7 @@ import { useFriendMarkets } from '../../contexts/FriendMarketsContext.js'
 import { WagerStatus as MarketStatus, DisputeStatus, WAGER_DEFAULTS } from '../../constants/wagerDefaults'
 import { getContractAddress } from '../../config/contracts'
 import { WAGER_REGISTRY_ABI } from '../../abis/WagerRegistry'
+import { getFeeOverrides } from '../../utils/feeOverrides'
 import MarketAcceptanceModal from './MarketAcceptanceModal'
 import './MyMarketsModal.css'
 
@@ -411,9 +412,16 @@ function MyMarketsModal({
     return false
   }
 
+  // Disputes are intentionally disabled (Bug #3 — honest UX).
+  // The WagerRegistry contract resolves immediately and finally via declareWinner();
+  // there is no on-chain challenge/dispute function, so we must not surface a dispute
+  // affordance (the DisputeModal is a non-functional placeholder). These checks return
+  // false so the wiring stays intact for a future on-chain dispute feature.
+  const DISPUTES_ENABLED = false
+
   // Check if user can open dispute
   const canOpenDispute = (market) => {
-    if (!account) return false
+    if (!DISPUTES_ENABLED || !account) return false
     const status = market.computedStatus || MarketStatus.ACTIVE
     const hasPos = userPositions.some(p => String(p.marketId) === String(market.id))
     const isParticipant = market.participants?.some(p => p.toLowerCase() === account.toLowerCase()) || hasPos
@@ -422,7 +430,7 @@ function MyMarketsModal({
 
   // Check if user can respond to dispute (as market maker)
   const canRespondToDispute = (market) => {
-    if (!account) return false
+    if (!DISPUTES_ENABLED || !account) return false
     const isCreator = market.creator?.toLowerCase() === account.toLowerCase()
     const status = market.computedStatus || MarketStatus.ACTIVE
     return isCreator && status === MarketStatus.DISPUTED
@@ -843,6 +851,7 @@ function MyMarketsModal({
       {showResolutionModal && resolutionMarket && (
         <ResolutionModal
           market={resolutionMarket}
+          account={account}
           onClose={() => setShowResolutionModal(false)}
           onResolved={() => {
             setShowResolutionModal(false)
@@ -1125,6 +1134,13 @@ function MarketsTable({
  * @param {string} variant - 'compact' (table) or 'full' (detail view)
  */
 function ResolveButtonWithCountdown({ market, onResolve, account, variant = 'compact' }) {
+  // Tick every second so the resolve window opens automatically without a reload.
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
+  }, [])
+
   const userAddr = account?.toLowerCase()
   const isCreator = market.creator?.toLowerCase() === userAddr
   const isOpponent = market.participants?.length > 1 &&
@@ -1149,6 +1165,43 @@ function ResolveButtonWithCountdown({ market, onResolve, account, variant = 'com
       status === 'canceled' || status === 'refunded' || status === 'expired' ||
       status === 'declined' || status === 'pending_acceptance') {
     return null
+  }
+
+  // Resolve-window gate (Bug #1). Resolution is only allowed in
+  // [tradingEndTime, resolveDeadlineTime]:
+  //   - before tradingEndTime  → show a countdown, no resolve button
+  //   - after resolveDeadlineTime → nothing (the Claim Refund flow takes over)
+  // tradingEndTime is the user's chosen end time `E`; resolveDeadlineTime = E + 48h.
+  // Fall back to "resolvable" when the timestamps are missing (e.g. legacy wagers).
+  const tradingEndTime = market.tradingEndTime
+  const resolveDeadlineTime = market.resolveDeadlineTime
+  if (typeof resolveDeadlineTime === 'number' && now > resolveDeadlineTime) {
+    return null
+  }
+  if (typeof tradingEndTime === 'number' && now < tradingEndTime) {
+    const diff = tradingEndTime - now
+    const days = Math.floor(diff / 86400000)
+    const hours = Math.floor((diff % 86400000) / 3600000)
+    const minutes = Math.floor((diff % 3600000) / 60000)
+    const label = days > 0 ? `${days}d ${hours}h` : hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`
+    if (variant === 'full') {
+      return (
+        <div className="mm-resolve-countdown-full" title="Resolution opens after the wager's end time">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
+          </svg>
+          Resolution opens in <strong>{label}</strong>
+        </div>
+      )
+    }
+    return (
+      <span className="mm-resolve-countdown" title="Resolution opens after the wager's end time">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
+        </svg>
+        {label}
+      </span>
+    )
   }
 
   if (variant === 'full') {
@@ -1636,6 +1689,7 @@ function MarketDetailView({
  */
 function ResolutionModal({
   market,
+  account,
   onClose,
   onResolved,
   signer,
@@ -1649,9 +1703,28 @@ function ResolutionModal({
   const [txHash, setTxHash] = useState(null)
   const [step, setStep] = useState('select') // 'select', 'confirm', 'success'
 
+  // Canonical outcome keys preserve the on-chain mapping:
+  //   outcomes[0] => creator wins, outcomes[1] => opponent wins.
   const outcomes = market.marketType === 'friend'
     ? ['Pass', 'Fail']
     : ['Yes', 'No']
+
+  // Participant-anchored display labels so the resolver clearly sees which party each
+  // choice pays out, instead of an ambiguous "Pass/Fail" (Bug #2).
+  const fmtParty = (addr) => {
+    if (!addr) return 'Unknown'
+    const short = `${addr.slice(0, 6)}…${addr.slice(-4)}`
+    const isYou = account && addr.toLowerCase() === account.toLowerCase()
+    return isYou ? `${short} (You)` : short
+  }
+  const outcomeLabels = {
+    [outcomes[0]]: { title: 'Creator wins', who: fmtParty(market.creator) },
+    [outcomes[1]]: { title: 'Opponent wins', who: fmtParty(market.opponent) },
+  }
+  const labelFor = (outcome) => {
+    const meta = outcomeLabels[outcome]
+    return meta ? `${meta.title} — ${meta.who}` : outcome
+  }
 
   const handleSubmit = async () => {
     if (!selectedOutcome) {
@@ -1666,6 +1739,12 @@ function ResolutionModal({
 
     if (!signer) {
       setError('Please connect your wallet to resolve this wager.')
+      return
+    }
+
+    // Resolve-window guard (Bug #1): block resolution before the wager's end time `E`.
+    if (typeof market.tradingEndTime === 'number' && Date.now() < market.tradingEndTime) {
+      setError('This wager cannot be resolved yet. Resolution opens after the wager’s end time.')
       return
     }
 
@@ -1693,7 +1772,8 @@ function ResolutionModal({
         notes: resolutionNotes,
       })
 
-      const tx = await registry.declareWinner(market.id, winner)
+      const feeOverrides = await getFeeOverrides(signer.provider)
+      const tx = await registry.declareWinner(market.id, winner, feeOverrides)
       setTxHash(tx.hash)
 
       const receipt = await tx.wait()
@@ -1784,13 +1864,13 @@ function ResolutionModal({
               <div className="mm-resolution-market-info">
                 <h4>{getMarketDisplayTitle(market)}</h4>
                 <p className="mm-resolution-hint">
-                  Select the winning outcome for this wager. This action will distribute
-                  winnings to participants who chose correctly.
+                  Select the winning party for this wager. This pays out the entire pot to
+                  the chosen participant and is final once confirmed on-chain.
                 </p>
               </div>
 
               <div className="mm-resolution-outcomes">
-                <label className="mm-outcome-label">Select Outcome</label>
+                <label className="mm-outcome-label">Who won?</label>
                 <div className="mm-outcome-options">
                   {outcomes.map(outcome => (
                     <button
@@ -1800,7 +1880,8 @@ function ResolutionModal({
                       onClick={() => setSelectedOutcome(outcome)}
                       disabled={submitting}
                     >
-                      {outcome}
+                      <span className="mm-outcome-title">{outcomeLabels[outcome]?.title || outcome}</span>
+                      <span className="mm-outcome-addr">{outcomeLabels[outcome]?.who}</span>
                     </button>
                   ))}
                 </div>
@@ -1861,11 +1942,11 @@ function ResolutionModal({
                 <div className="mm-confirmation-icon">&#9888;</div>
                 <h4>Confirm Resolution</h4>
                 <p>
-                  You are about to resolve this wager with outcome: <strong>{selectedOutcome}</strong>
+                  You are about to resolve this wager in favour of: <strong>{labelFor(selectedOutcome)}</strong>
                 </p>
                 <p className="mm-confirmation-warning">
-                  This action cannot be undone. Participants will have a window to dispute
-                  the resolution if they disagree.
+                  This action cannot be undone. The full pot is paid to the winner immediately
+                  and the result is final.
                 </p>
               </div>
 
@@ -1902,13 +1983,12 @@ function ResolutionModal({
           {step === 'success' && (
             <div className="mm-success-state">
               <div className="mm-success-icon">&#9989;</div>
-              <h4>Resolution Proposed!</h4>
+              <h4>Wager Resolved</h4>
               <p>
-                Resolution proposed with outcome: <strong>{selectedOutcome}</strong>
+                Winnings sent to: <strong>{labelFor(selectedOutcome)}</strong>
               </p>
               <p className="mm-success-hint">
-                The other party has a 24-hour challenge window to dispute this resolution.
-                If unchallenged, the resolution will be finalized automatically.
+                The full pot has been paid out on-chain. This result is final.
               </p>
               {txHash && (
                 <p className="mm-success-hint">

--- a/frontend/src/hooks/useEncryption.js
+++ b/frontend/src/hooks/useEncryption.js
@@ -172,6 +172,34 @@ export function useEncryption() {
     // Create and store the promise to prevent concurrent requests
     initializationPromise = (async () => {
       try {
+        // Reuse a cached session signature if one exists, deriving keypairs WITHOUT a
+        // wallet popup. This makes initialization idempotent across hook instances and
+        // rapid sequential calls, so the encryption-terms message is only ever signed
+        // once per session (Minor bug #1 — repeated signature prompts on wager creation).
+        const cached = getCachedSignatureData(account)
+        if (cached?.signature) {
+          const x25519Keys = deriveKeyPairFromSignature(cached.signature)
+          const xwingKeys = deriveXWingKeyPairFromSignature(cached.signature)
+          setSignature(cached.signature)
+          setCachedVersion(cached.version)
+          setKeyPairs({
+            x25519: {
+              publicKey: x25519Keys.publicKey,
+              privateKey: x25519Keys.privateKey
+            },
+            xwing: {
+              publicKey: xwingKeys.publicKey,
+              secretKey: xwingKeys.secretKey
+            }
+          })
+          console.log('[useEncryption] Reused cached session signature (no wallet popup)')
+          return {
+            signature: cached.signature,
+            publicKey: x25519Keys.publicKey,
+            xwingPublicKey: xwingKeys.publicKey
+          }
+        }
+
         // Derive X25519 keypair (also gets the signature and version)
         const x25519Result = await deriveKeyPair(signer)
         const signingVersion = x25519Result.version || 2 // Default to current version

--- a/frontend/src/hooks/useFriendMarketCreation.js
+++ b/frontend/src/hooks/useFriendMarketCreation.js
@@ -9,6 +9,7 @@ import {
   uploadEncryptedEnvelope,
   buildEncryptedIpfsReference
 } from '../utils/ipfsService'
+import { getFeeOverrides } from '../utils/feeOverrides'
 
 const ERC20_ABI = [
   'function balanceOf(address owner) view returns (uint256)',
@@ -184,7 +185,19 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
         const hours = parseInt(raw, 10) || 48
         acceptDeadline = Math.floor(Date.now() / 1000) + hours * 3600
       }
-      const resolveDeadline = acceptDeadline + tradingPeriodSeconds + (WAGER_DEFAULTS.RESOLUTION_WINDOW_SECONDS || 48 * 3600)
+      // Timing model: a single user-chosen end time `E` (tradingEnd) drives everything.
+      //   - acceptDeadline  = midpoint(now, E)            (set upstream by the form)
+      //   - tradingEnd      = E   → resolution opens here
+      //   - resolveDeadline = E + 48h → resolution closes; after this stakes are refundable
+      // Anchor resolveDeadline to E directly. The previous formula
+      // (acceptDeadline + tradingPeriodSeconds + 48h) overshot to ~1.5*E + 48h because
+      // acceptDeadline is the midpoint, which broke the resolve-window gate downstream.
+      const RESOLUTION_WINDOW = WAGER_DEFAULTS.RESOLUTION_WINDOW_SECONDS || 48 * 3600
+      const parsedEnd = data.data.endDateTime ? new Date(data.data.endDateTime) : null
+      const tradingEnd = (parsedEnd && !Number.isNaN(parsedEnd.getTime()))
+        ? Math.floor(parsedEnd.getTime() / 1000)
+        : acceptDeadline + tradingPeriodSeconds // fallback when no explicit end time
+      const resolveDeadline = tradingEnd + RESOLUTION_WINDOW
 
       // Participants
       const opponent = data.data.opponent || data.data.participants?.[0]
@@ -277,12 +290,14 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
       }
 
       onProgress({ step: 'create', message: 'Please confirm in your wallet...' })
+      const feeOverrides = await getFeeOverrides(activeSigner.provider)
       const tx = await registry.createWager(
         opponent, arbitrator, stakeTokenAddress,
         creatorStakeWei, opponentStakeWei,
         acceptDeadline, resolveDeadline,
         resolutionType, polymarketConditionId, creatorIsYes,
-        metadataHash, metadataReference
+        metadataHash, metadataReference,
+        feeOverrides
       )
       onProgress({ step: 'create', message: 'Waiting for confirmation...', txHash: tx.hash })
       savePendingTransaction({ step: 'create', txHash: tx.hash, data: data.data })
@@ -331,7 +346,7 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
         arbitrator,
         creator: userAddress,
         acceptanceDeadline: new Date(acceptDeadline * 1000).toISOString(),
-        endDate: new Date((acceptDeadline + tradingPeriodSeconds) * 1000).toISOString(),
+        endDate: new Date(tradingEnd * 1000).toISOString(),
         tradingPeriod: Math.max(1, Math.ceil(tradingPeriodSeconds / 86400)).toString(),
         createdAt: new Date().toISOString(),
         status: 'pending',

--- a/frontend/src/test/feeOverrides.test.js
+++ b/frontend/src/test/feeOverrides.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { getFeeOverrides } from '../utils/feeOverrides'
+
+const GWEI = 1_000_000_000n
+const MIN_PRIORITY = 30n * GWEI
+
+function mockProvider(chainId, feeData) {
+  return {
+    getNetwork: async () => ({ chainId: BigInt(chainId) }),
+    getFeeData: async () => feeData,
+  }
+}
+
+describe('getFeeOverrides', () => {
+  it('returns empty object for non-Polygon chains (wallet defaults)', async () => {
+    const provider = mockProvider(1, {
+      maxFeePerGas: 50n * GWEI,
+      maxPriorityFeePerGas: 0n,
+    })
+    expect(await getFeeOverrides(provider)).toEqual({})
+  })
+
+  it('applies a priority-fee floor on Polygon Amoy when the RPC reports ~0', async () => {
+    const provider = mockProvider(80002, {
+      maxFeePerGas: 100n * GWEI,
+      maxPriorityFeePerGas: 0n,
+    })
+    const { maxFeePerGas, maxPriorityFeePerGas } = await getFeeOverrides(provider)
+    expect(maxPriorityFeePerGas).toBe(MIN_PRIORITY)
+    // maxFee carries the priority bump on top of the node's maxFee.
+    expect(maxFeePerGas).toBe(100n * GWEI + MIN_PRIORITY)
+    expect(maxFeePerGas >= maxPriorityFeePerGas).toBe(true)
+  })
+
+  it('keeps the node-suggested priority fee when it already exceeds the floor', async () => {
+    const provider = mockProvider(137, {
+      maxFeePerGas: 200n * GWEI,
+      maxPriorityFeePerGas: 50n * GWEI,
+    })
+    const { maxFeePerGas, maxPriorityFeePerGas } = await getFeeOverrides(provider)
+    expect(maxPriorityFeePerGas).toBe(50n * GWEI)
+    // No bump needed, so maxFee is left as the node's suggestion.
+    expect(maxFeePerGas).toBe(200n * GWEI)
+  })
+
+  it('falls back to empty object when fee estimation throws', async () => {
+    const provider = {
+      getNetwork: async () => ({ chainId: 80002n }),
+      getFeeData: async () => { throw new Error('rpc down') },
+    }
+    expect(await getFeeOverrides(provider)).toEqual({})
+  })
+
+  it('returns empty object when provider lacks the required methods', async () => {
+    expect(await getFeeOverrides(null)).toEqual({})
+    expect(await getFeeOverrides({})).toEqual({})
+  })
+})

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -430,6 +430,14 @@ function toWagerShape(id, w) {
     paid: w.paid,
     acceptanceDeadline: Number(w.acceptDeadline) * 1000,
     endDate: new Date(Number(w.resolveDeadline) * 1000).toISOString(),
+    // Explicit ms timestamps for the resolve-window gate (Bug #1):
+    //   resolveDeadlineTime = on-chain resolveDeadline (resolution closes / refund opens)
+    //   tradingEndTime      = resolveDeadline - 48h = the user's chosen end time `E`
+    //                         (resolution opens). Resolution is only allowed in
+    //                         [tradingEndTime, resolveDeadlineTime].
+    resolveDeadlineTime: Number(w.resolveDeadline) * 1000,
+    tradingEndTime: Number(w.resolveDeadline) * 1000 -
+      (WAGER_DEFAULTS.RESOLUTION_WINDOW_SECONDS || 48 * 3600) * 1000,
     polymarketConditionId: w.polymarketConditionId,
     creatorIsYes: w.creatorIsYes,
     metadataHash: w.metadataHash,

--- a/frontend/src/utils/feeOverrides.js
+++ b/frontend/src/utils/feeOverrides.js
@@ -1,0 +1,51 @@
+/**
+ * EIP-1559 fee overrides for user-facing write transactions.
+ *
+ * On Polygon networks (mainnet 137, Amoy testnet 80002) the RPC frequently reports a
+ * near-zero `maxPriorityFeePerGas`. ethers then populates the transaction with that value,
+ * and wallets surface it as a "$0 / 0 POL site-suggested" gas option — forcing the user to
+ * pick a fee manually (Minor bug #2). To avoid that, we apply a sensible priority-fee floor
+ * so the wallet shows a usable, non-zero suggestion.
+ *
+ * For every other network we return an empty object, leaving fee estimation entirely to the
+ * wallet / ethers defaults.
+ */
+
+const POLYGON_CHAIN_IDS = new Set([137, 80002])
+// 30 gwei — comfortably above Polygon's typical minimum priority fee.
+const MIN_PRIORITY_FEE_WEI = 30_000_000_000n
+
+/**
+ * @param {ethers.Provider} provider
+ * @returns {Promise<{maxFeePerGas?: bigint, maxPriorityFeePerGas?: bigint}>}
+ */
+export async function getFeeOverrides(provider) {
+  try {
+    if (!provider?.getFeeData || !provider?.getNetwork) return {}
+
+    const network = await provider.getNetwork()
+    const chainId = Number(network?.chainId)
+    if (!POLYGON_CHAIN_IDS.has(chainId)) return {}
+
+    const fee = await provider.getFeeData()
+    const suggestedPriority = fee.maxPriorityFeePerGas ?? 0n
+    const suggestedMaxFee = fee.maxFeePerGas ?? 0n
+
+    // Floor the priority fee; if the node already suggests more, keep its value.
+    const priority = suggestedPriority > MIN_PRIORITY_FEE_WEI
+      ? suggestedPriority
+      : MIN_PRIORITY_FEE_WEI
+
+    // Carry any priority bump onto the node's maxFee so the tx stays valid
+    // (maxFee must be >= base fee + priority). Guarantee a minimum headroom too.
+    const priorityBump = priority > suggestedPriority ? priority - suggestedPriority : 0n
+    let maxFee = suggestedMaxFee + priorityBump
+    const floorMaxFee = priority * 2n
+    if (maxFee < floorMaxFee) maxFee = floorMaxFee
+
+    return { maxFeePerGas: maxFee, maxPriorityFeePerGas: priority }
+  } catch {
+    // Never block a transaction on fee estimation — fall back to wallet defaults.
+    return {}
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the end-to-end wager bugs found during manual testing of the create → accept → resolve flow. All changes are frontend-only (no contract changes / redeploy).

The two biggest bugs stem from a mismatch between the UI and the on-chain reality of `WagerRegistry.declareWinner()`, which resolves **immediately and finally** with instant payout — there is **no on-chain event-end gate and no dispute/challenge function**.

### Timing model (the key fix)
A single user input — the **end time `E`** — now drives the whole lifecycle:

```
now ──[ accept = ½(now→E) ]──► acceptDeadline ──► E ──[ 48h resolve window ]──► E+48h ──► refund
```

## Bugs fixed

**#1 — Markets could be resolved before the end time.**
- Root cause: `resolveDeadline` was computed as `acceptDeadline + tradingPeriodSeconds + 48h` ≈ `1.5·E + 48h`. Since the resolve gate derives `tradingEnd = resolveDeadline − 48h`, this was wrong. Now `resolveDeadline = E + 48h` exactly (`useFriendMarketCreation.js`).
- `toWagerShape` exposes `tradingEndTime` (= `E`) and `resolveDeadlineTime`.
- `ResolveButtonWithCountdown` only offers Resolve during `[E, E+48h]`: a live countdown before `E`, the button during the 48h window, nothing after (the existing Claim Refund flow takes over). A matching guard was added to the resolution modal.
- The creation form now shows the full timeline (acceptance midpoint + the 48h resolution window + refund) before the user commits.

**#2 — Resolution screen showed ambiguous "Pass / Fail".**
- Choices are relabeled **"Creator wins / Opponent wins"** with the participant address and a "(You)" tag; the winner label is carried through the confirm and success steps.

**#3 — Neither party could dispute after resolution.**
- The contract cannot support a dispute (resolution is immediate and final). The misleading "Resolution Proposed / 24-hour challenge window" copy is rewritten to state the result is final, and the non-functional dispute entry points are disabled (wiring left in place behind a flag for a future on-chain feature).

## Minor fixes
- **Repeated signature prompts:** `initializeKeys` now reuses the cached session signature before prompting, so the encryption-terms message is signed at most once per session.
- **$0 site-suggested gas:** new `getFeeOverrides()` applies a Polygon priority-fee floor (createWager / acceptWager / declareWinner) so the wallet shows a usable suggestion. Covered by `feeOverrides.test.js`.
- **No exit from the share screen:** added an explicit "Done — back to My Wagers" button.

## Testing
- `npm run lint` — clean (2 pre-existing warnings, unrelated).
- `npm test` — **782 passed** (47 files), including 5 new `getFeeOverrides` tests.
- `npm run build` — succeeds.

Manual E2E verification steps are described in the linked plan.

https://claude.ai/code/session_01BDX5kUkab9khwTDzyB66V3

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDX5kUkab9khwTDzyB66V3)_