### PR TITLE
fix(frontend): resolve six E2E testing bugs (incl. create-wager estimateGas failure)

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -647,8 +647,16 @@ function FriendMarketsModal({
         if (selectedPolymarketMarket?.endDate) {
           const linkedEnd = new Date(selectedPolymarketMarket.endDate)
           if (!Number.isNaN(linkedEnd.getTime())) {
+            // The on-chain resolveDeadline (linkedEnd + 48h) must fall within the
+            // contract's MAX_RESOLVE_WINDOW (180d). Markets ending beyond that
+            // can't be wagered on yet — block with a clear message instead of
+            // letting createWager revert with BadDeadlines.
+            const maxLinkedEnd = Date.now() +
+              (WAGER_DEFAULTS.MAX_RESOLVE_WINDOW_SECONDS - WAGER_DEFAULTS.RESOLUTION_WINDOW_SECONDS) * 1000
             if (linkedEnd.getTime() <= Date.now()) {
               newErrors.oracleConditionId = 'This Polymarket has already ended. Pick an active market.'
+            } else if (linkedEnd.getTime() > maxLinkedEnd) {
+              newErrors.oracleConditionId = 'This market ends too far in the future to wager on (it must resolve within ~180 days). Pick a sooner-resolving market.'
             } else if (freshDeadline) {
               const acceptEnd = new Date(freshDeadline)
               if (!Number.isNaN(acceptEnd.getTime()) && acceptEnd.getTime() >= linkedEnd.getTime()) {

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -268,6 +268,15 @@ function MyMarketsModal({
       }
     })
 
+    // Sort each list newest-first. Wager `id` is sequential on-chain (higher =
+    // newer) and always present; createdAt is preferred when available.
+    const byNewest = (a, b) =>
+      (Number(b.createdAt) || 0) - (Number(a.createdAt) || 0) ||
+      (Number(b.id) || 0) - (Number(a.id) || 0)
+    participating.sort(byNewest)
+    created.sort(byNewest)
+    history.sort(byNewest)
+
     return { participating, created, history }
   }, [markets, decryptableMarkets, userPositions, account, marketTypeFilter, statusFilter, dismissedIds])
 
@@ -987,7 +996,6 @@ function MarketsTable({
         <thead>
           <tr>
             <th>Wager</th>
-            <th>Type</th>
             <th>{showOutcome ? 'Outcome' : 'Time Left'}</th>
             <th>Status</th>
             {tableHasActionsColumn && <th>Actions</th>}
@@ -1037,11 +1045,6 @@ function MarketsTable({
                   {market.category && (
                     <span className="mm-table-category">{market.category}</span>
                   )}
-                </td>
-                <td>
-                  <span className={`mm-type-badge mm-type-${market.marketType}`}>
-                    {market.marketType === 'friend' ? 'Friend' : 'Wager'}
-                  </span>
                 </td>
                 <td className="mm-table-time">
                   {showOutcome ? (

--- a/frontend/src/components/fairwins/OnboardingTutorial.css
+++ b/frontend/src/components/fairwins/OnboardingTutorial.css
@@ -747,6 +747,30 @@
   .onboarding-carousel {
     min-height: 350px;
   }
+
+  /* Compact the progress header + step dots so they don't dominate
+     the small-screen layout (mobile "breadcrumbs" were oversized). */
+  .onboarding-progress {
+    padding: 0.75rem 1rem 0;
+    gap: 0.75rem;
+  }
+
+  .progress-text {
+    font-size: 0.7rem;
+  }
+
+  .onboarding-dots {
+    gap: 0.375rem;
+    padding: 0.625rem 0;
+  }
+
+  .dot {
+    padding: 5px;
+  }
+
+  .dot.active {
+    width: 16px;
+  }
 }
 
 @media (max-width: 400px) {

--- a/frontend/src/components/fairwins/PolymarketBrowser.jsx
+++ b/frontend/src/components/fairwins/PolymarketBrowser.jsx
@@ -298,7 +298,6 @@ function PolymarketBrowser({
             <ul className={`pmb__grid pmb__grid--${variant}`} role="list">
               {rankedResults.map((m) => {
                 const isSelected = selectedConditionId && m.conditionId === selectedConditionId
-                const topOutcome = m.outcomes?.[0]
                 const vol = formatVolume(m.volume)
                 return (
                   <li key={m.conditionId} className="pmb__card-wrapper">
@@ -314,14 +313,6 @@ function PolymarketBrowser({
                         )}
                         {vol && <span className="pmb__card-volume">{vol} vol</span>}
                       </div>
-                      {topOutcome && topOutcome.price != null && (
-                        <div className="pmb__card-outcome">
-                          <span className="pmb__card-outcome-name">{topOutcome.name}</span>
-                          <span className="pmb__card-outcome-price">
-                            {Math.round(topOutcome.price * 100)}¢
-                          </span>
-                        </div>
-                      )}
                       {isSelected && <span className="pmb__card-selected-badge">Selected</span>}
                     </button>
                   </li>

--- a/frontend/src/constants/wagerDefaults.js
+++ b/frontend/src/constants/wagerDefaults.js
@@ -53,6 +53,13 @@ export const WAGER_DEFAULTS = {
    *  so that participants have time to declare a winner after the event ends.
    *  48 hours keeps the UX generous without approaching MAX_RESOLVE_WINDOW. */
   RESOLUTION_WINDOW_SECONDS: 48 * 60 * 60,
+
+  /** Hard caps enforced on-chain by WagerRegistry. acceptDeadline must be
+   *  within MAX_ACCEPT_WINDOW of now and resolveDeadline within
+   *  MAX_RESOLVE_WINDOW; exceeding either reverts with BadDeadlines. Mirrored
+   *  here so the client can clamp/validate before submitting. */
+  MAX_ACCEPT_WINDOW_SECONDS: 30 * 24 * 60 * 60,
+  MAX_RESOLVE_WINDOW_SECONDS: 180 * 24 * 60 * 60,
 }
 
 // ── Wager status strings (friend / P2P markets) ────────────────────

--- a/frontend/src/data/wagers/EventsSource.js
+++ b/frontend/src/data/wagers/EventsSource.js
@@ -19,7 +19,7 @@ import { FRIEND_GROUP_MARKET_FACTORY_ABI } from '../../abis/FriendGroupMarketFac
 import { parseEncryptedIpfsReference } from '../../utils/ipfsService'
 import { loadIndex, saveIndex, loadCache, upsertCache } from './cacheStore'
 import { applyFilters, paginate } from './sortFilter'
-import { WagerSortKey } from '../../constants/wagerDefaults'
+import { WagerSortKey, WAGER_DEFAULTS } from '../../constants/wagerDefaults'
 
 const MARKET_TYPES = ['oneVsOne', 'smallGroup', 'eventTracking', 'propBet']
 const STATUS_NAMES = [
@@ -128,6 +128,14 @@ function toWager(marketId, withStatus, full) {
     acceptanceDeadline: acceptanceDeadlineMs,
     endTime,
     endDate: endTime > 0 ? new Date(endTime).toISOString() : null,
+    // Canonical timing pair (mirrors blockchainService.toWagerShape) so the
+    // detail/list views show a consistent end across data sources. `endTime`
+    // here is the resolution-open time E (createdAt + tradingPeriodSeconds);
+    // resolution closes 48h later.
+    tradingEndTime: endTime > 0 ? endTime : undefined,
+    resolveDeadlineTime: endTime > 0
+      ? endTime + (WAGER_DEFAULTS.RESOLUTION_WINDOW_SECONDS || 48 * 3600) * 1000
+      : undefined,
     acceptedCount: Number(withStatus.acceptedCount || 0),
     minAcceptanceThreshold: Number(withStatus.minThreshold || 0),
     ipfsCid: enc.ipfsCid,

--- a/frontend/src/data/wagers/SubgraphSource.js
+++ b/frontend/src/data/wagers/SubgraphSource.js
@@ -10,7 +10,7 @@
  * Falls back to EventsSource if the subgraph endpoint is unreachable.
  */
 
-import { WagerSortKey, TERMINAL_STATUSES } from '../../constants/wagerDefaults'
+import { WagerSortKey, TERMINAL_STATUSES, WAGER_DEFAULTS } from '../../constants/wagerDefaults'
 import { upsertCache } from './cacheStore'
 import * as EventsSource from './EventsSource'
 
@@ -102,6 +102,14 @@ function toWager(raw) {
     acceptanceDeadline: Number(raw.acceptanceDeadline || 0) * 1000,
     endTime: Number(raw.endTime || 0) * 1000,
     endDate: raw.endTime ? new Date(Number(raw.endTime) * 1000).toISOString() : null,
+    // Canonical timing pair so the detail/list show a consistent end across
+    // sources. The subgraph's `endTime` is the resolution-open time E
+    // (createdAt + tradingPeriodSeconds, per schema.graphql); resolution
+    // closes 48h later.
+    tradingEndTime: raw.endTime ? Number(raw.endTime) * 1000 : undefined,
+    resolveDeadlineTime: raw.endTime
+      ? Number(raw.endTime) * 1000 + (WAGER_DEFAULTS.RESOLUTION_WINDOW_SECONDS || 48 * 3600) * 1000
+      : undefined,
     acceptedCount: Number(raw.acceptedCount || 0),
     ipfsCid: raw.ipfsCid || null,
     isEncrypted: Boolean(raw.isEncrypted),

--- a/frontend/src/hooks/useFriendMarketCreation.js
+++ b/frontend/src/hooks/useFriendMarketCreation.js
@@ -197,7 +197,21 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
       const tradingEnd = (parsedEnd && !Number.isNaN(parsedEnd.getTime()))
         ? Math.floor(parsedEnd.getTime() / 1000)
         : acceptDeadline + tradingPeriodSeconds // fallback when no explicit end time
-      const resolveDeadline = tradingEnd + RESOLUTION_WINDOW
+      let resolveDeadline = tradingEnd + RESOLUTION_WINDOW
+
+      // Clamp deadlines to the contract's accept/resolve windows so a far-future
+      // end (e.g. a Polymarket-linked market whose own end is months out, which
+      // bypasses the modal's 21-day bound) can't push past the on-chain caps and
+      // revert with BadDeadlines. We keep now < acceptDeadline < resolveDeadline.
+      const nowSec = Math.floor(Date.now() / 1000)
+      const SAFETY_BUFFER = 5 * 60 // 5 min, to absorb block-time skew
+      const maxAccept = nowSec + (WAGER_DEFAULTS.MAX_ACCEPT_WINDOW_SECONDS || 30 * 86400) - SAFETY_BUFFER
+      const maxResolve = nowSec + (WAGER_DEFAULTS.MAX_RESOLVE_WINDOW_SECONDS || 180 * 86400) - SAFETY_BUFFER
+      if (acceptDeadline > maxAccept) acceptDeadline = maxAccept
+      if (resolveDeadline > maxResolve) resolveDeadline = maxResolve
+      // Guarantee strict ordering even after clamping.
+      if (acceptDeadline <= nowSec) acceptDeadline = nowSec + 60
+      if (resolveDeadline <= acceptDeadline) resolveDeadline = acceptDeadline + RESOLUTION_WINDOW
 
       // Participants
       const opponent = data.data.opponent || data.data.participants?.[0]
@@ -259,13 +273,36 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
       }
       const metadataHash = ethers.keccak256(ethers.toUtf8Bytes(metadataReference))
 
-      // Approve stake token if needed
-      const currentAllowance = await stakeToken.allowance(userAddress, wagerRegistryAddress)
+      // Approve stake token if needed. We approve the full uint256 max rather
+      // than the exact stake so (a) subsequent wagers don't need a fresh
+      // approval each time (the exact-stake approval left allowance at 0 after
+      // every wager) and (b) a stale read on a load-balanced RPC node can't
+      // under-approve. After approving we poll the allowance until the freshly
+      // mined approval is actually visible to the RPC — otherwise createWager's
+      // gas estimation can land on a node that still sees allowance 0, and the
+      // transferFrom reverts ("transfer amount exceeds allowance", surfaced as
+      // an opaque "missing revert data" by some wallet RPCs).
+      let currentAllowance = await stakeToken.allowance(userAddress, wagerRegistryAddress)
       if (currentAllowance < creatorStakeWei) {
         onProgress({ step: 'approve', message: 'Approving token spend...' })
-        const approveTx = await stakeToken.approve(wagerRegistryAddress, creatorStakeWei)
+        const approveTx = await stakeToken.approve(wagerRegistryAddress, ethers.MaxUint256)
         onProgress({ step: 'approve', message: 'Waiting for approval confirmation...', txHash: approveTx.hash })
         await approveTx.wait()
+
+        // Wait until the approval is observable before continuing. Public RPCs
+        // are often load-balanced, so the node answering the next read/estimate
+        // may briefly lag the node that mined the approval.
+        for (let attempt = 0; attempt < 6; attempt++) {
+          currentAllowance = await stakeToken.allowance(userAddress, wagerRegistryAddress)
+          if (currentAllowance >= creatorStakeWei) break
+          await new Promise((resolve) => setTimeout(resolve, 1500 * (attempt + 1)))
+        }
+        if (currentAllowance < creatorStakeWei) {
+          throw new Error(
+            'Your token approval has not been confirmed yet. Please wait a few ' +
+            'seconds for it to finalize, then try creating the wager again.'
+          )
+        }
       }
 
       // Auto-cleanup expired Open wagers that still count toward the
@@ -291,13 +328,37 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
 
       onProgress({ step: 'create', message: 'Please confirm in your wallet...' })
       const feeOverrides = await getFeeOverrides(activeSigner.provider)
-      const tx = await registry.createWager(
+      const createArgs = [
         opponent, arbitrator, stakeTokenAddress,
         creatorStakeWei, opponentStakeWei,
         acceptDeadline, resolveDeadline,
         resolutionType, polymarketConditionId, creatorIsYes,
         metadataHash, metadataReference,
-        feeOverrides
+      ]
+
+      // Estimate gas explicitly with a short retry so a transient stale read on
+      // a load-balanced RPC doesn't surface a raw "missing revert data" error.
+      // The staticCall above already validated the args, so a failure here is
+      // almost always RPC lag rather than a genuine revert; fall back to a fixed
+      // limit after exhausting retries.
+      let gasLimit
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          const estimate = await registry.createWager.estimateGas(...createArgs)
+          gasLimit = (estimate * 120n) / 100n // +20% headroom
+          break
+        } catch {
+          if (attempt === 2) {
+            gasLimit = 800000n // generous fallback; the staticCall already passed
+            break
+          }
+          await new Promise((resolve) => setTimeout(resolve, 1500 * (attempt + 1)))
+        }
+      }
+
+      const tx = await registry.createWager(
+        ...createArgs,
+        { ...feeOverrides, gasLimit }
       )
       onProgress({ step: 'create', message: 'Waiting for confirmation...', txHash: tx.hash })
       savePendingTransaction({ step: 'create', txHash: tx.hash, data: data.data })
@@ -373,6 +434,12 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
 
 export function translateRevert(reason) {
   if (!reason) return 'Unknown contract error.'
+  if (reason.includes('insufficient allowance') || reason.includes('exceeds allowance')) {
+    return 'Your USDC approval has not been confirmed yet. Wait a few seconds for the approval to finalize, then try creating the wager again.'
+  }
+  if (reason.includes('insufficient balance') || reason.includes('exceeds balance')) {
+    return 'Insufficient token balance to cover your stake.'
+  }
   if (reason.includes('MembershipDenied')) return 'Your membership is inactive or you have reached your wager limit. If you have expired wagers, try again — they will be cleaned up automatically. Otherwise, upgrade your tier for higher limits.'
   if (reason.includes('SelfWager')) return 'Cannot wager against yourself.'
   if (reason.includes('NotAllowedToken')) return 'Stake token is not on the allowlist. Use USDC or WMATIC.'

--- a/frontend/src/test/useFriendMarketCreation.translateRevert.test.js
+++ b/frontend/src/test/useFriendMarketCreation.translateRevert.test.js
@@ -41,6 +41,18 @@ describe('useFriendMarketCreation: translateRevert', () => {
       .toMatch(/already resolved/i)
   })
 
+  it('maps ERC20 allowance/balance reverts to actionable guidance', () => {
+    // createWager pulls the stake via transferFrom; an unconfirmed approval
+    // surfaces as an allowance revert (sometimes stripped to "missing revert
+    // data" by wallet RPCs). Guide the user to wait for the approval instead.
+    expect(translateRevert('execution reverted: ERC20: transfer amount exceeds allowance'))
+      .toMatch(/approval has not been confirmed/i)
+    expect(translateRevert('ERC20: insufficient allowance'))
+      .toMatch(/approval has not been confirmed/i)
+    expect(translateRevert('execution reverted: ERC20: transfer amount exceeds balance'))
+      .toMatch(/insufficient token balance/i)
+  })
+
   it('falls back to a generic message for unknown reasons', () => {
     expect(translateRevert('out of gas: 0x1234'))
       .toMatch(/transaction will fail/i)


### PR DESCRIPTION
## Summary

Fixes the six issues found during end-to-end testing of the FairWins frontend. All changes are client-side (`frontend/src`); **no contract redeploy is required** — live diagnosis against the deployed Amoy registry (`0x66c7…d657f`) confirmed the contract accepts valid wagers.

| # | Bug | Fix |
|---|-----|-----|
| 1 | Onboarding splash "breadcrumbs" too large on mobile | Shrink the progress header + step dots inside the `≤640px` media query (`OnboardingTutorial.css`) |
| 2 | Wagers not sorted newest-first | Sort `participating`/`created`/`history` by `createdAt` then wager `id` desc (`MyMarketsModal.jsx`) |
| 3 | "Type" column wastes space | Remove the Type `<th>`/`<td>` from the table (detail-view badge kept) |
| 4 | Polymarket card shows "Yes 1¢" | Remove the outcome/price row; show only question + volume (`PolymarketBrowser.jsx`) |
| 5 | Wager "Ends" shows the wrong time for the non-creator | `EventsSource`/`SubgraphSource` now expose the canonical `tradingEndTime` (resolution-open `E`) + `resolveDeadlineTime` (`E+48h`), matching `toWagerShape`, so both sides display `E` |
| 6 | **Create wager fails on `estimateGas`** | See below |

## Bug #6 — root cause (diagnosed live)

I replayed the user's **exact failing calldata** against the deployed Amoy contract:
- `eth_call` → returns a wagerId; `eth_estimateGas` → 522k gas. **It succeeds.**
- Decoded: a valid 1‑USDC, resolutionType‑2 wager with valid deadlines.
- The user's live USDC **allowance to the registry was exactly 1 USDC** (the stake), balance 56 USDC.

The approval flow approved **exactly** the stake, so allowance returned to 0 after each wager. When the create transaction's gas estimation landed on a load‑balanced public RPC node that hadn't yet indexed the just‑mined approval, `transferFrom` read allowance 0 and reverted `ERC20: transfer amount exceeds allowance`; the wallet's RPC stripped the reason, so ethers reported `missing revert data … action="estimateGas", data=null`. The leftover **exactly‑1‑USDC** allowance (approve mined, createWager never executed) is the fingerprint of this race — reproduced directly with a stake‑10 / allowance‑1 call.

### Fix (`useFriendMarketCreation.js`)
- Approve `uint256` max instead of the exact stake (no re-approval per wager; no under-approval from a stale read).
- After approving, **poll the allowance** until the mined approval is visible before simulating/sending.
- Estimate gas with a short retry and pass an explicit `gasLimit` (with a generous fallback) so a transient stale read can't surface a raw error.
- Map ERC20 allowance/balance reverts in `translateRevert` to actionable guidance.

### Secondary hardening (latent, not the reported cause)
The contract caps `acceptDeadline ≤ 30d` / `resolveDeadline ≤ 180d` (revert `BadDeadlines`, selector `0x0201e564`, verified). The Polymarket‑linked path locks `endDateTime` to a far‑future market end and skips the 21‑day bound. Added: clamp deadlines to the contract windows in the hook, and block linking Polymarket markets that resolve beyond ~180d in the modal.

## Testing
- `npm run lint` — clean
- `npm run test` — **782 passing** (added 3 allowance/balance translation cases)
- `npm run build` — succeeds
- Live `eth_call`/`eth_estimateGas` replay of the exact failing calldata confirms the on-chain path is healthy.

https://claude.ai/code/session_011ZVZxxduEXgvLExScoEwiz

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZVZxxduEXgvLExScoEwiz)_