### PR TITLE
Remove group wagers; split 1v1 into participant- vs oracle-resolved flows

### DIFF
--- a/frontend/cypress/e2e/fast/13-dashboard.cy.js
+++ b/frontend/cypress/e2e/fast/13-dashboard.cy.js
@@ -38,18 +38,19 @@ describe('Dashboard', () => {
   // ---------------------------------------------------------------------------
   // DSH-01: Quick action cards visible
   // ---------------------------------------------------------------------------
-  it('[DSH-01] Quick action cards visible (Create 1v1, Group, Scan QR, My Wagers)', () => {
+  it('[DSH-01] Quick action cards visible (1v1 Friends, 1v1 Oracle, Bookmaker, Scan QR, My Wagers)', () => {
     connectAndVisitDashboard()
 
-    // The quick-actions-grid should contain exactly 4 action cards.
+    // The quick-actions-grid should contain exactly 5 action cards.
     cy.get('.quick-actions-grid', { timeout: 10000 }).should('be.visible')
-    cy.get('.quick-action-card').should('have.length', 4)
+    cy.get('.quick-action-card').should('have.length', 5)
 
     // Verify each action card title.
-    cy.get('.quick-action-card').eq(0).should('contain.text', 'New 1v1 Wager')
-    cy.get('.quick-action-card').eq(1).should('contain.text', 'Group Wager')
-    cy.get('.quick-action-card').eq(2).should('contain.text', 'Scan QR Code')
-    cy.get('.quick-action-card').eq(3).should('contain.text', 'My Wagers')
+    cy.get('.quick-action-card').eq(0).should('contain.text', 'Friends Decide (1v1)')
+    cy.get('.quick-action-card').eq(1).should('contain.text', 'Oracle Settles (1v1)')
+    cy.get('.quick-action-card').eq(2).should('contain.text', 'Bookmaker')
+    cy.get('.quick-action-card').eq(3).should('contain.text', 'Scan QR Code')
+    cy.get('.quick-action-card').eq(4).should('contain.text', 'My Wagers')
   })
 
   // ---------------------------------------------------------------------------

--- a/frontend/cypress/e2e/fast/22-accessibility.cy.js
+++ b/frontend/cypress/e2e/fast/22-accessibility.cy.js
@@ -140,7 +140,7 @@ describe('Accessibility', () => {
     connectAndVisit()
 
     // Open the create wager modal via quick action.
-    cy.get('.quick-action-card').contains('New 1v1 Wager').click()
+    cy.get('.quick-action-card').contains('Friends Decide (1v1)').click()
 
     // The modal should open with dialog role and aria-modal.
     cy.get('[role="dialog"]', { timeout: 5000 }).should('be.visible')
@@ -159,7 +159,7 @@ describe('Accessibility', () => {
       .should('not.exist')
 
     // Re-open and test backdrop click.
-    cy.get('.quick-action-card').contains('New 1v1 Wager').click()
+    cy.get('.quick-action-card').contains('Friends Decide (1v1)').click()
     cy.get('[role="dialog"]', { timeout: 5000 }).should('be.visible')
 
     // Click the backdrop (outside the modal content).
@@ -210,7 +210,7 @@ describe('Accessibility', () => {
     connectAndVisit()
 
     // Open create wager modal.
-    cy.get('.quick-action-card').contains('New 1v1 Wager').click()
+    cy.get('.quick-action-card').contains('Friends Decide (1v1)').click()
     cy.get('[role="dialog"]', { timeout: 5000 }).should('be.visible')
 
     // Try to submit with empty fields — this should trigger validation errors.
@@ -307,7 +307,7 @@ describe('Accessibility', () => {
     connectAndVisit()
 
     // Open create wager modal to test the datetime input.
-    cy.get('.quick-action-card').contains('New 1v1 Wager').click()
+    cy.get('.quick-action-card').contains('Friends Decide (1v1)').click()
     cy.get('[role="dialog"]', { timeout: 5000 }).should('be.visible')
 
     // The datetime-local input should have a min and max constraint.

--- a/frontend/cypress/e2e/full/04-wager-creation-tx.cy.js
+++ b/frontend/cypress/e2e/full/04-wager-creation-tx.cy.js
@@ -60,14 +60,6 @@ function openAndFillWagerForm(config = {}) {
     cy.wait(500)
   }
 
-  // Fill members (group)
-  if (config.members) {
-    cy.get('#fm-members, [role="dialog"] input[placeholder*="0x1"]')
-      .first()
-      .clear()
-      .type(config.members)
-  }
-
   // Set stake amount
   if (config.stake) {
     cy.get('#fm-stake, [role="dialog"] input[type="number"]')
@@ -396,30 +388,19 @@ describe('Wager Creation with Real Transactions', () => {
   })
 
   // ---------------------------------------------------------------------------
-  // CRE-10: Small group wager
+  // CRE-10: Group wagers are not offered (v2 contract is 1v1 only)
   // ---------------------------------------------------------------------------
-  it('[CRE-10] Create small group wager', () => {
+  it('[CRE-10] Group wager creation is not available', () => {
     connectWalletAndVisit(0)
 
-    openAndFillWagerForm({
-      type: 'smallGroup',
-      description: 'CRE-10: Group wager for the squad',
-      members: `${TEST_ACCOUNTS[1]}, ${TEST_ACCOUNTS[2]}, ${TEST_ACCOUNTS[3]}`,
-      stake: 10,
-      encrypted: false,
-    })
+    // No "Group Wager" entry card on the dashboard.
+    cy.contains('.quick-action-card', /group wager/i).should('not.exist')
 
-    submitWagerForm()
-
-    // Group wagers follow the same creation flow
-    cy.get('[role="dialog"], .modal', { timeout: 30000 }).invoke('text').then((text) => {
-      const lower = text.toLowerCase()
-      const validOutcome = lower.includes('created') ||
-                          lower.includes('success') ||
-                          lower.includes('share') ||
-                          lower.includes('error') ||
-                          lower.includes('failed')
-      expect(validOutcome).to.be.true
+    // And the 1v1 creation form exposes no member-address / group inputs.
+    cy.openCreateWagerModal('oneVsOne')
+    cy.get('[role="dialog"]').within(() => {
+      cy.get('#fm-members').should('not.exist')
+      cy.get('#fm-min-threshold').should('not.exist')
     })
   })
 

--- a/frontend/cypress/e2e/full/05-wager-acceptance.cy.js
+++ b/frontend/cypress/e2e/full/05-wager-acceptance.cy.js
@@ -295,50 +295,11 @@ describe('Wager Acceptance', () => {
   })
 
   // ---------------------------------------------------------------------------
-  // ACC-05: Group wager — threshold met
+  // ACC-06: Unaccepted wager stays pending
   // ---------------------------------------------------------------------------
-  it('[ACC-05] Group wager threshold met activates market', () => {
-    connectAndVisit(0)
-
-    // Create group wager
-    cy.openCreateWagerModal('smallGroup')
-    cy.get('#fm-description, [role="dialog"] input[type="text"]')
-      .first()
-      .clear()
-      .type('ACC-05: Group wager threshold test')
-    cy.get('#fm-members, [role="dialog"] input[placeholder*="0x1"]')
-      .first()
-      .clear()
-      .type(`${TEST_ACCOUNTS[1]}, ${TEST_ACCOUNTS[2]}`)
-    cy.get('#fm-stake, [role="dialog"] input[type="number"]')
-      .first()
-      .clear()
-      .type('5')
-
-    cy.get('[role="dialog"]').then(($modal) => {
-      const encToggle = $modal.find('input[type="checkbox"]')
-      if (encToggle.length > 0 && encToggle.is(':checked')) {
-        cy.wrap(encToggle.first()).uncheck({ force: true })
-      }
-    })
-
-    cy.get('[role="dialog"], .modal')
-      .find('button[type="submit"], button')
-      .filter(':contains("Create")')
-      .click({ force: true })
-
-    cy.get('[role="dialog"], .modal', { timeout: 45000 }).invoke('text').then((text) => {
-      const lower = text.toLowerCase()
-      expect(lower.includes('created') || lower.includes('success') || lower.includes('share') || lower.includes('error')).to.be.true
-    })
-  })
-
-  // ---------------------------------------------------------------------------
-  // ACC-06: Group wager — threshold not met
-  // ---------------------------------------------------------------------------
-  it('[ACC-06] Group wager threshold not met stays pending', () => {
-    // This test verifies that a group wager stays in pending state
-    // when not enough participants have accepted
+  it('[ACC-06] Unaccepted wager stays pending acceptance', () => {
+    // A 1v1 wager that the opponent hasn't accepted yet stays in the
+    // pending-acceptance state.
     connectAndVisit(0)
 
     cy.openMyWagers('created')

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -188,12 +188,15 @@ Cypress.Commands.add('disableDemoMode', () => {
 
 /**
  * Open the wager creation modal for a specific type.
- * @param {'oneVsOne'|'smallGroup'|'bookmaker'} type
+ * Group wagers are no longer supported — the v2 contract is 1v1 only. The
+ * 1v1 flow is split into participant-resolved ("Friends Decide") and
+ * oracle-resolved ("Oracle Settles") cards.
+ * @param {'oneVsOne'|'oracle'|'bookmaker'} type
  */
 Cypress.Commands.add('openCreateWagerModal', (type = 'oneVsOne') => {
   const buttonMap = {
-    oneVsOne: /create 1v1|1v1 wager|create wager/i,
-    smallGroup: /create group|group wager/i,
+    oneVsOne: /friends decide|1v1|create wager/i,
+    oracle: /oracle settles/i,
     bookmaker: /bookmaker/i,
   }
 

--- a/frontend/src/components/fairwins/Dashboard.jsx
+++ b/frontend/src/components/fairwins/Dashboard.jsx
@@ -28,7 +28,7 @@ const formatAddress = (addr) => {
 function QuickActions({ onAction }) {
   const actions = [
     {
-      id: 'create-1v1',
+      id: 'create-1v1-friends',
       icon: (
         <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
           <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
@@ -37,21 +37,31 @@ function QuickActions({ onAction }) {
           <path d="M16 3.13a4 4 0 0 1 0 7.75" />
         </svg>
       ),
-      title: 'New 1v1 Wager',
-      description: 'Challenge a friend to a direct bet'
+      title: 'Friends Decide (1v1)',
+      description: 'You and a friend settle the outcome'
     },
     {
-      id: 'create-group',
+      id: 'create-1v1-oracle',
       icon: (
         <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-          <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
-          <circle cx="9" cy="7" r="4" />
-          <line x1="23" y1="11" x2="17" y2="11" />
-          <line x1="20" y1="8" x2="20" y2="14" />
+          <circle cx="12" cy="12" r="10" />
+          <line x1="2" y1="12" x2="22" y2="12" />
+          <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
         </svg>
       ),
-      title: 'Group Wager',
-      description: 'Create a pool for 3-10 friends'
+      title: 'Oracle Settles (1v1)',
+      description: 'Auto-settles from Polymarket, Chainlink or UMA'
+    },
+    {
+      id: 'create-bookmaker',
+      icon: (
+        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <line x1="12" y1="1" x2="12" y2="23" />
+          <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+        </svg>
+      ),
+      title: 'Bookmaker',
+      description: 'Offer odds and let a friend take the other side'
     },
     {
       id: 'scan-qr',
@@ -324,7 +334,10 @@ function Dashboard() {
 
   // Modal state
   const [showCreateWager, setShowCreateWager] = useState(false)
-  const [createWagerType, setCreateWagerType] = useState(null) // 'oneVsOne' or 'smallGroup'
+  const [createWagerType, setCreateWagerType] = useState(null) // 'oneVsOne' or 'bookmaker'
+  // Narrows the modal's resolution choices: 'participant' (people settle),
+  // 'oracle' (oracle settles), or 'all' (both — used by the Bookmaker card).
+  const [createResolutionCategory, setCreateResolutionCategory] = useState('all')
   const [showMyWagers, setShowMyWagers] = useState(false)
   const [showQrScanner, setShowQrScanner] = useState(false)
   const [bannerDismissed, setBannerDismissed] = useState(false)
@@ -337,12 +350,19 @@ function Dashboard() {
 
   const handleQuickAction = useCallback((actionId) => {
     switch (actionId) {
-      case 'create-1v1':
+      case 'create-1v1-friends':
         setCreateWagerType('oneVsOne')
+        setCreateResolutionCategory('participant')
         setShowCreateWager(true)
         break
-      case 'create-group':
-        setCreateWagerType('smallGroup')
+      case 'create-1v1-oracle':
+        setCreateWagerType('oneVsOne')
+        setCreateResolutionCategory('oracle')
+        setShowCreateWager(true)
+        break
+      case 'create-bookmaker':
+        setCreateWagerType('bookmaker')
+        setCreateResolutionCategory('all')
         setShowCreateWager(true)
         break
       case 'my-wagers':
@@ -359,6 +379,9 @@ function Dashboard() {
   const handlePolymarketCardClick = useCallback((market) => {
     setInitialPolymarketMarket(market)
     setCreateWagerType('oneVsOne')
+    // A Polymarket card pre-selects an oracle (Polymarket) condition, so open
+    // straight into the oracle-resolved flow.
+    setCreateResolutionCategory('oracle')
     setShowCreateWager(true)
   }, [])
 
@@ -471,9 +494,11 @@ function Dashboard() {
         onClose={() => {
           setShowCreateWager(false)
           setCreateWagerType(null)
+          setCreateResolutionCategory('all')
           setInitialPolymarketMarket(null)
         }}
         initialType={createWagerType}
+        resolutionCategory={createResolutionCategory}
         initialPolymarketMarket={initialPolymarketMarket}
       />
 

--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -28,13 +28,49 @@ import './FriendMarketsModal.css'
 // toggle picks up the right addresses without a reload.
 const CUSTOM_TOKEN_OPTION = { id: 'CUSTOM', symbol: 'Custom', name: 'Custom Token', address: '', icon: '🔧' }
 
+// Participant-resolved (people settle it) resolution types, in enum order.
+// Oracle-resolved types are computed per-chain at render time (adapter-gated).
+const PARTICIPANT_RESOLUTION_TYPES = [
+  ResolutionType.Either,
+  ResolutionType.Creator,
+  ResolutionType.Opponent,
+  ResolutionType.ThirdParty,
+]
+
+// Dropdown labels + helper text for every resolution type. Kept here so the
+// participant/oracle flows render from a single mapped source instead of a
+// hand-maintained option list.
+const RESOLUTION_TYPE_LABELS = {
+  [ResolutionType.Either]: 'Either Party',
+  [ResolutionType.Creator]: 'Creator Only',
+  [ResolutionType.Opponent]: 'Opponent Only',
+  [ResolutionType.ThirdParty]: 'Third Party Arbitrator',
+  [ResolutionType.Polymarket]: 'Linked Market (Polymarket)',
+  [ResolutionType.ChainlinkDataFeed]: 'Chainlink Data Feed (price condition)',
+  [ResolutionType.ChainlinkFunctions]: 'Chainlink Functions (custom request)',
+  [ResolutionType.UMA]: 'UMA Optimistic Oracle (claim assertion)',
+}
+const RESOLUTION_TYPE_HINTS = {
+  [ResolutionType.Either]: 'Either you or your opponent can resolve the wager',
+  [ResolutionType.Creator]: 'Only you (the creator) can resolve the wager',
+  [ResolutionType.Opponent]: 'Only your opponent can resolve the wager',
+  [ResolutionType.ThirdParty]: 'A designated arbitrator will resolve disputes',
+  [ResolutionType.Polymarket]: 'Settles automatically when the linked Polymarket market resolves',
+  [ResolutionType.ChainlinkDataFeed]: 'Settles automatically once the price feed reading at the deadline passes the threshold',
+  [ResolutionType.ChainlinkFunctions]: 'Settles when the Chainlink Functions DON returns a result (admin-registered request)',
+  [ResolutionType.UMA]: 'Settles via UMA Optimistic Oracle — someone posts the bond and the assertion stands after the liveness window',
+}
+
 /**
  * FriendMarketsModal
  *
- * Focused modal for creating a new friend market (1v1, Small Group,
- * Event Tracking, or Bookmaker). Opens directly into the form for the
- * provided initialType, defaulting to 1v1. Viewing/managing existing
- * wagers lives in MyMarketsModal.
+ * Focused modal for creating a new 1v1 friend market (either a standard
+ * even-stakes wager or a Bookmaker odds wager). Opens directly into the form
+ * for the provided initialType, defaulting to 1v1. The `resolutionCategory`
+ * prop narrows the resolution choices to participant-resolved or
+ * oracle-resolved so each flow can present the right configuration. Group/event
+ * wagers are not supported — the v2 WagerRegistry contract is 1v1 only.
+ * Viewing/managing existing wagers lives in MyMarketsModal.
  */
 function FriendMarketsModal({
   isOpen,
@@ -43,6 +79,7 @@ function FriendMarketsModal({
   pendingTransaction = null,
   onClearPendingTransaction = () => {},
   initialType = null,
+  resolutionCategory = 'all',
   initialPolymarketMarket = null
 }) {
   const { isConnected, account } = useWallet()
@@ -61,16 +98,39 @@ function FriendMarketsModal({
   const chainlinkDataFeedAdapter  = getContractAddress('chainlinkDataFeedAdapter')
   const chainlinkFunctionsAdapter = getContractAddress('chainlinkFunctionsAdapter')
   const umaAdapter                = getContractAddress('umaAdapter')
-  const hasOracleAdapter = {
-    [ResolutionType.ChainlinkDataFeed]:  Boolean(chainlinkDataFeedAdapter),
-    [ResolutionType.ChainlinkFunctions]: Boolean(chainlinkFunctionsAdapter),
-    [ResolutionType.UMA]:                Boolean(umaAdapter),
-  }
   const isExtensibleOracleType = (t) => (
     t === ResolutionType.ChainlinkDataFeed ||
     t === ResolutionType.ChainlinkFunctions ||
     t === ResolutionType.UMA
   )
+
+  // Resolution choices are split into two flows, driven by `resolutionCategory`:
+  //   - 'participant' → people settle it (Either / Creator / Opponent / ThirdParty)
+  //   - 'oracle'      → an oracle settles it (Polymarket / Chainlink / UMA), each
+  //                     self-gated on being reachable/deployed on the active chain
+  //   - 'all'         → both (used by the Bookmaker card)
+  // The Set/order mirrors `enum ResolutionType` in IWagerRegistry.sol.
+  const availableOracleResolutionTypes = useMemo(() => [
+    ...(polymarketSidebetsEnabled ? [ResolutionType.Polymarket] : []),
+    ...(chainlinkDataFeedAdapter ? [ResolutionType.ChainlinkDataFeed] : []),
+    ...(chainlinkFunctionsAdapter ? [ResolutionType.ChainlinkFunctions] : []),
+    ...(umaAdapter ? [ResolutionType.UMA] : []),
+  ], [polymarketSidebetsEnabled, chainlinkDataFeedAdapter, chainlinkFunctionsAdapter, umaAdapter])
+
+  const resolutionOptionTypes = useMemo(() => {
+    if (resolutionCategory === 'participant') return PARTICIPANT_RESOLUTION_TYPES
+    if (resolutionCategory === 'oracle') return availableOracleResolutionTypes
+    return [...PARTICIPANT_RESOLUTION_TYPES, ...availableOracleResolutionTypes]
+  }, [resolutionCategory, availableOracleResolutionTypes])
+
+  // Default resolution to pre-select when the modal opens, per category.
+  const defaultResolutionType = useMemo(() => {
+    if (resolutionCategory === 'participant') return ResolutionType.Either
+    if (resolutionCategory === 'oracle') {
+      return availableOracleResolutionTypes[0] ?? ResolutionType.Polymarket
+    }
+    return WAGER_DEFAULTS.RESOLUTION_TYPE
+  }, [resolutionCategory, availableOracleResolutionTypes])
 
   // Chain-aware token metadata for the Stake Token dropdown. Recomputed
   // whenever the user switches Testnet/Mainnet so the right addresses are
@@ -109,8 +169,6 @@ function FriendMarketsModal({
     // an ENS name); `opponentResolved` is the 0x address used for validation
     // and contract submission.
     opponentResolved: '',
-    members: '',
-    memberLimit: WAGER_DEFAULTS.MEMBER_LIMIT,
     endDateTime: getDefaultEndDateTime(),
     stakeAmount: WAGER_DEFAULTS.STAKE_AMOUNT,
     stakeTokenId: WAGER_DEFAULTS.STAKE_TOKEN_ID,
@@ -122,9 +180,8 @@ function FriendMarketsModal({
     // the 0-based outcome index ('' = unset, '0' = YES/first, '1' = NO/second)
     // to match PolymarketOracleAdapter's payouts ordering (YES=0, NO=1).
     creatorSide: '',
-    // Multi-party acceptance fields
+    // Deterministic accept-by time (midpoint of now → end).
     acceptanceDeadline: getMidpointAcceptanceDeadline(getDefaultEndDateTime()),
-    minAcceptanceThreshold: String(WAGER_DEFAULTS.MIN_ACCEPTANCE_THRESHOLD),
     // Leverage/odds for Bookmaker markets (200 = 2x equal stakes, 10000 = 100x)
     oddsMultiplier: WAGER_DEFAULTS.ODDS_MULTIPLIER,
     // Resolution type: 0=Either, 1=Initiator, 2=Receiver, 3=ThirdParty, 4=AutoPegged
@@ -170,8 +227,6 @@ function FriendMarketsModal({
       description: '',
       opponent: '',
       opponentResolved: '',
-      members: '',
-      memberLimit: WAGER_DEFAULTS.MEMBER_LIMIT,
       endDateTime: getDefaultEndDateTime(),
       stakeAmount: WAGER_DEFAULTS.STAKE_AMOUNT,
       stakeTokenId: WAGER_DEFAULTS.STAKE_TOKEN_ID,
@@ -181,8 +236,8 @@ function FriendMarketsModal({
       oracleConditionId: '',
       creatorSide: '',
       acceptanceDeadline: getMidpointAcceptanceDeadline(getDefaultEndDateTime()),
-      minAcceptanceThreshold: String(WAGER_DEFAULTS.MIN_ACCEPTANCE_THRESHOLD),
-      oddsMultiplier: WAGER_DEFAULTS.ODDS_MULTIPLIER
+      oddsMultiplier: WAGER_DEFAULTS.ODDS_MULTIPLIER,
+      resolutionType: defaultResolutionType
     })
     setErrors({})
     setSelectedPolymarketMarket(null)
@@ -190,7 +245,7 @@ function FriendMarketsModal({
     clearPolymarket()
     lastAutoDescriptionRef.current = ''
     setEnableEncryption(true)
-  }, [clearPolymarket])
+  }, [clearPolymarket, defaultResolutionType])
 
   // Reset modal state when opened. Always lands on the form for the
   // provided initialType (1v1 by default), since this modal is now
@@ -497,7 +552,9 @@ function FriendMarketsModal({
       newErrors.description = 'Description must be at least 10 characters'
     }
 
-    if (friendMarketType === 'oneVsOne') {
+    // Every supported wager type (1v1 and Bookmaker) is a head-to-head bet with
+    // a single opponent — the v2 contract has no group mode.
+    {
       const rawOpponent = formData.opponent.trim()
       const resolvedOpponent = (formData.opponentResolved || '').trim()
       if (!rawOpponent) {
@@ -510,47 +567,6 @@ function FriendMarketsModal({
         newErrors.opponent = 'Cannot use the zero address'
       } else if (resolvedOpponent.toLowerCase() === account?.toLowerCase()) {
         newErrors.opponent = 'Cannot bet against yourself'
-      }
-    }
-
-    if (friendMarketType === 'smallGroup' || friendMarketType === 'eventTracking') {
-      if (!formData.members.trim()) {
-        newErrors.members = 'Member addresses are required'
-      } else {
-        const addresses = formData.members.split(',').map(a => a.trim()).filter(a => a)
-        const minMembers = friendMarketType === 'eventTracking' ? 3 : 2
-        const maxMembers = 10
-
-        if (addresses.length < minMembers) {
-          newErrors.members = `At least ${minMembers} members required`
-        } else if (addresses.length > maxMembers) {
-          newErrors.members = `Maximum ${maxMembers} members allowed`
-        } else {
-          // Check for invalid addresses
-          for (const addr of addresses) {
-            if (!/^0x[a-fA-F0-9]{40}$/.test(addr)) {
-              newErrors.members = `Invalid address: "${addr}"`
-              break
-            }
-            if (addr.toLowerCase() === '0x0000000000000000000000000000000000000000') {
-              newErrors.members = 'Cannot use the zero address'
-              break
-            }
-          }
-          
-          // Check for duplicates
-          if (!newErrors.members) {
-            const lowerAddresses = addresses.map(a => a.toLowerCase())
-            const uniqueAddresses = new Set(lowerAddresses)
-            if (uniqueAddresses.size !== addresses.length) {
-              newErrors.members = 'Duplicate addresses are not allowed'
-            }
-            // Check if creator is in the list
-            if (account && lowerAddresses.includes(account.toLowerCase())) {
-              newErrors.members = 'Cannot include your own address in member list'
-            }
-          }
-        }
       }
     }
 
@@ -601,19 +617,8 @@ function FriendMarketsModal({
       setFormData(prev => ({ ...prev, acceptanceDeadline: freshDeadline }))
     }
 
-    // Validate minimum threshold for group markets
-    if (friendMarketType === 'smallGroup' || friendMarketType === 'eventTracking') {
-      const threshold = parseInt(formData.minAcceptanceThreshold, 10)
-      const memberCount = formData.members.split(',').filter(m => m.trim()).length + 1 // +1 for creator
-      if (isNaN(threshold) || threshold < 2) {
-        newErrors.minAcceptanceThreshold = 'Minimum threshold must be at least 2'
-      } else if (threshold > memberCount) {
-        newErrors.minAcceptanceThreshold = `Threshold cannot exceed total participants (${memberCount})`
-      }
-    }
-
     // Validate arbitrator/market ID based on resolution type
-    if ((friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker')) {
+    {
       if (formData.resolutionType === ResolutionType.ThirdParty) {
         // Arbitrator address is required for ThirdParty resolution
         const rawArb = (formData.arbitrator || '').trim()
@@ -686,7 +691,7 @@ function FriendMarketsModal({
 
     setErrors(newErrors)
     return Object.keys(newErrors).length === 0
-  }, [formData, friendMarketType, account, STAKE_TOKEN_OPTIONS, selectedPolymarketMarket?.endDate])
+  }, [formData, account, STAKE_TOKEN_OPTIONS, selectedPolymarketMarket?.endDate])
 
   const handleSubmit = async (e) => {
     e.preventDefault()
@@ -753,14 +758,13 @@ function FriendMarketsModal({
       let finalMetadata = marketMetadata
 
       if (enableEncryption) {
-        // Look up opponent's on-chain encryption key before creating envelope.
-        // Use the ENS-resolved address (falls back to raw input when the user
-        // typed a hex address, since onResolvedChange mirrors that value).
-        const opponentAddress = friendMarketType === 'oneVsOne'
-          ? formData.opponentResolved
-          : null // For group markets, encrypt for creator only initially
+        // Every wager type (1v1 + Bookmaker) is head-to-head, so we always
+        // encrypt to the single opponent. Use the ENS-resolved address (falls
+        // back to raw input when the user typed a hex address, since
+        // onResolvedChange mirrors that value).
+        const opponentAddress = formData.opponentResolved
 
-        if (friendMarketType === 'oneVsOne' && opponentAddress) {
+        if (opponentAddress) {
           const opponentKey = await lookupOpponentKey(opponentAddress)
           if (!opponentKey) {
             throw new Error(
@@ -778,8 +782,8 @@ function FriendMarketsModal({
           const { envelope } = await createEncrypted(marketMetadata, { algorithm: 'x25519' })
           finalMetadata = addRecipientByPublicKey(envelope, opponentAddress, opponentKey)
         } else {
-          // Group markets: start with creator as only recipient
-          // Other participants will be added as they accept
+          // Defensive fallback: validation guarantees an opponent, but if one
+          // is somehow missing, encrypt to the creator only rather than crash.
           const { envelope } = await createEncrypted(marketMetadata)
           finalMetadata = envelope
         }
@@ -847,9 +851,9 @@ function FriendMarketsModal({
 
       // Calculate acceptance deadline info
       const acceptanceDeadline = new Date(freshAcceptanceDeadline)
-      const minThreshold = friendMarketType === 'oneVsOne'
-        ? WAGER_DEFAULTS.MIN_ACCEPTANCE_THRESHOLD
-        : parseInt(formData.minAcceptanceThreshold, 10) || WAGER_DEFAULTS.MIN_ACCEPTANCE_THRESHOLD
+      // 1v1 head-to-head: both sides (creator + opponent) must be in for the
+      // wager to activate.
+      const minThreshold = WAGER_DEFAULTS.MIN_ACCEPTANCE_THRESHOLD
 
       // Created market with acceptance flow fields
       const newMarket = {
@@ -864,9 +868,7 @@ function FriendMarketsModal({
         endDateTime: formData.endDateTime,
         endDate: endDate.toISOString(),
         tradingPeriod: tradingPeriodDays,
-        participants: friendMarketType === 'oneVsOne'
-          ? [account, formData.opponentResolved]
-          : [account, ...formData.members.split(',').map(a => a.trim())],
+        participants: [account, formData.opponentResolved],
         creator: account,
         arbitrator: formData.arbitratorResolved || null,
         createdAt: new Date().toISOString(),
@@ -917,8 +919,7 @@ function FriendMarketsModal({
   const getTypeLabel = (type) => {
     switch (type) {
       case 'oneVsOne': return '1v1'
-      case 'smallGroup': return 'Group'
-      case 'eventTracking': return 'Event'
+      case 'bookmaker': return 'Bookmaker'
       default: return type
     }
   }
@@ -1006,7 +1007,7 @@ function FriendMarketsModal({
                       {errors.description && <span className="fm-error">{errors.description}</span>}
                     </div>
 
-                    {friendMarketType === 'oneVsOne' && (
+                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') && (
                       <div className="fm-form-group fm-form-full">
                         <label htmlFor="fm-opponent">
                           Opponent Address <span className="fm-required">*</span>
@@ -1040,26 +1041,6 @@ function FriendMarketsModal({
                       </div>
                     )}
 
-                    {(friendMarketType === 'smallGroup' || friendMarketType === 'eventTracking') && (
-                      <div className="fm-form-group fm-form-full">
-                        <label htmlFor="fm-members">
-                          Member Addresses <span className="fm-required">*</span>
-                        </label>
-                        <input
-                          id="fm-members"
-                          type="text"
-                          value={formData.members}
-                          onChange={(e) => handleFormChange('members', e.target.value)}
-                          placeholder="0x123..., 0x456..., 0x789..."
-                          disabled={submitting}
-                          className={errors.members ? 'error' : ''}
-                        />
-                        <span className="fm-hint">
-                          Comma-separated ({friendMarketType === 'eventTracking' ? '3-10' : '2-10'} members)
-                        </span>
-                        {errors.members && <span className="fm-error">{errors.members}</span>}
-                      </div>
-                    )}
 
                     <div className="fm-form-group">
                       <label htmlFor="fm-stake">
@@ -1139,10 +1120,14 @@ function FriendMarketsModal({
                       </div>
                     )}
 
-                    {/* Resolution Type selector - for 1v1 and Bookmaker markets */}
-                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') && (
+                    {/* Resolution Type selector. The options are pre-filtered by
+                        `resolutionCategory` (participant vs oracle) so each flow
+                        only surfaces the relevant settlement choices. */}
+                    {resolutionOptionTypes.length > 0 ? (
                       <div className="fm-form-group fm-form-full">
-                        <label htmlFor="fm-resolution-type">Who Can Resolve?</label>
+                        <label htmlFor="fm-resolution-type">
+                          {resolutionCategory === 'oracle' ? 'Which oracle settles this?' : 'Who Can Resolve?'}
+                        </label>
                         <select
                           id="fm-resolution-type"
                           value={formData.resolutionType}
@@ -1150,37 +1135,29 @@ function FriendMarketsModal({
                           disabled={submitting}
                           className="fm-select"
                         >
-                          <option value={ResolutionType.Either}>Either Party</option>
-                          <option value={ResolutionType.Creator}>Creator Only</option>
-                          <option value={ResolutionType.Opponent}>Opponent Only</option>
-                          <option value={ResolutionType.ThirdParty}>Third Party Arbitrator</option>
-                          {polymarketSidebetsEnabled && (
-                            <option value={ResolutionType.Polymarket}>Linked Market (Polymarket)</option>
-                          )}
-                          {hasOracleAdapter[ResolutionType.ChainlinkDataFeed] && (
-                            <option value={ResolutionType.ChainlinkDataFeed}>Chainlink Data Feed (price condition)</option>
-                          )}
-                          {hasOracleAdapter[ResolutionType.ChainlinkFunctions] && (
-                            <option value={ResolutionType.ChainlinkFunctions}>Chainlink Functions (custom request)</option>
-                          )}
-                          {hasOracleAdapter[ResolutionType.UMA] && (
-                            <option value={ResolutionType.UMA}>UMA Optimistic Oracle (claim assertion)</option>
-                          )}
+                          {resolutionOptionTypes.map((t) => (
+                            <option key={t} value={t}>{RESOLUTION_TYPE_LABELS[t]}</option>
+                          ))}
                         </select>
                         <span className="fm-hint">
-                          {formData.resolutionType === ResolutionType.Either && 'Either you or your opponent can resolve the wager'}
-                          {formData.resolutionType === ResolutionType.Creator && 'Only you (the creator) can resolve the wager'}
-                          {formData.resolutionType === ResolutionType.Opponent && 'Only your opponent can resolve the wager'}
-                          {formData.resolutionType === ResolutionType.ThirdParty && 'A designated arbitrator will resolve disputes'}
-                          {formData.resolutionType === ResolutionType.Polymarket && 'Settles automatically when the linked Polymarket market resolves'}
-                          {formData.resolutionType === ResolutionType.ChainlinkDataFeed && 'Settles automatically once the price feed reading at the deadline passes the threshold'}
-                          {formData.resolutionType === ResolutionType.ChainlinkFunctions && 'Settles when the Chainlink Functions DON returns a result (admin-registered request)'}
-                          {formData.resolutionType === ResolutionType.UMA && 'Settles via UMA Optimistic Oracle — someone posts the bond and the assertion stands after the liveness window'}
-                          {!polymarketSidebetsEnabled && (
+                          {RESOLUTION_TYPE_HINTS[formData.resolutionType]}
+                          {resolutionCategory === 'oracle' && !polymarketSidebetsEnabled && (
                             <em style={{ display: 'block', marginTop: '0.25rem', opacity: 0.75 }}>
-                              Linked Market settlement requires a chain with the Polymarket CTF. Switch to Polygon (Amoy or Mainnet) to use it.
+                              Linked Market (Polymarket) settlement requires a chain with the Polymarket CTF. Switch to Polygon (Amoy or Mainnet) to use it.
                             </em>
                           )}
+                        </span>
+                      </div>
+                    ) : (
+                      <div className="fm-form-group fm-form-full">
+                        <label>Oracle Settlement</label>
+                        <div className="fm-readonly-value">
+                          No oracle is available on this network.
+                        </div>
+                        <span className="fm-hint">
+                          Switch to a chain with the Polymarket CTF (Polygon Amoy or Mainnet) or a
+                          deployed Chainlink/UMA adapter, or create a wager that your friends settle
+                          instead.
                         </span>
                       </div>
                     )}
@@ -1302,27 +1279,6 @@ function FriendMarketsModal({
                       )
                     })()}
 
-                    {/* Minimum Threshold - only for group markets */}
-                    {(friendMarketType === 'smallGroup' || friendMarketType === 'eventTracking') && (
-                      <div className="fm-form-group">
-                        <label htmlFor="fm-min-threshold">
-                          Minimum Participants to Activate
-                        </label>
-                        <input
-                          id="fm-min-threshold"
-                          type="number"
-                          value={formData.minAcceptanceThreshold}
-                          onChange={(e) => handleFormChange('minAcceptanceThreshold', e.target.value)}
-                          min="2"
-                          max={Math.max(2, formData.members.split(',').filter(m => m.trim()).length + 1)}
-                          disabled={submitting}
-                          className={errors.minAcceptanceThreshold ? 'error' : ''}
-                        />
-                        <span className="fm-hint">Wager activates when this many participants accept (including you)</span>
-                        {errors.minAcceptanceThreshold && <span className="fm-error">{errors.minAcceptanceThreshold}</span>}
-                      </div>
-                    )}
-
                     {/* Arbitrator address field — for Third Party resolution */}
                     {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') &&
                      formData.resolutionType === ResolutionType.ThirdParty && (
@@ -1360,7 +1316,7 @@ function FriendMarketsModal({
                     )}
 
                     {/* Linked Market — Polymarket event lookup */}
-                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker' || friendMarketType === 'smallGroup') &&
+                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') &&
                      formData.resolutionType === ResolutionType.Polymarket && (
                       <div className="fm-form-group fm-form-full">
                         <label htmlFor="fm-polymarket-search">
@@ -1460,7 +1416,7 @@ function FriendMarketsModal({
                     )}
 
                     {/* Oracle condition picker — Chainlink Data Feed / Chainlink Functions / UMA */}
-                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker' || friendMarketType === 'smallGroup') &&
+                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') &&
                      isExtensibleOracleType(formData.resolutionType) && (
                       <div className="fm-form-group fm-form-full">
                         <label htmlFor="fm-oracle-condition-picker">
@@ -1489,7 +1445,7 @@ function FriendMarketsModal({
                         Polymarket has its own outcome-named side picker below — we
                         skip it for the new types and use a binary YES/NO labelling
                         that maps to the contract's creatorIsYes bool. */}
-                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker' || friendMarketType === 'smallGroup') &&
+                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') &&
                      isExtensibleOracleType(formData.resolutionType) && (
                       <div className="fm-form-group fm-form-full">
                         <label>
@@ -1525,7 +1481,7 @@ function FriendMarketsModal({
                     )}
 
                     {/* Creator side — which outcome of the linked Polymarket are you taking? */}
-                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker' || friendMarketType === 'smallGroup') &&
+                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') &&
                      formData.resolutionType === ResolutionType.Polymarket &&
                      selectedPolymarketMarket && (
                       <div className="fm-form-group fm-form-full">
@@ -1648,7 +1604,7 @@ function FriendMarketsModal({
                             <span>You&apos;ll be asked to sign a message to derive your encryption keys</span>
                           </div>
                         )}
-                        {enableEncryption && friendMarketType === 'oneVsOne' && (
+                        {enableEncryption && (friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') && (
                           <div className="fm-encryption-info" style={{ marginTop: '0.5rem' }}>
                             <div className="fm-encryption-info-header">
                               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">

--- a/frontend/src/components/fairwins/OnboardingTutorial.jsx
+++ b/frontend/src/components/fairwins/OnboardingTutorial.jsx
@@ -273,8 +273,8 @@ const buildTutorialSteps = (stable) => [
           <div className="next-step-item">
             <span className="next-icon">&#127942;</span>
             <div className="next-content">
-              <strong>Create a Group Wager</strong>
-              <span>Set up a pool for 3-10 friends</span>
+              <strong>Let an Oracle Settle It</strong>
+              <span>Auto-settle a 1v1 from Polymarket, Chainlink or UMA</span>
             </div>
           </div>
           <div className="next-step-item">

--- a/frontend/src/test/Dashboard.test.jsx
+++ b/frontend/src/test/Dashboard.test.jsx
@@ -148,16 +148,18 @@ describe('Dashboard Component', () => {
   describe('Quick Actions', () => {
     it('should render all quick action cards', () => {
       renderWithProviders(<Dashboard />)
-      expect(screen.getByText('New 1v1 Wager')).toBeInTheDocument()
-      expect(screen.getByText('Group Wager')).toBeInTheDocument()
+      expect(screen.getByText('Friends Decide (1v1)')).toBeInTheDocument()
+      expect(screen.getByText('Oracle Settles (1v1)')).toBeInTheDocument()
+      expect(screen.getByText('Bookmaker')).toBeInTheDocument()
       expect(screen.getByText('Scan QR Code')).toBeInTheDocument()
       expect(screen.getByText('My Wagers')).toBeInTheDocument()
     })
 
     it('should have quick action descriptions', () => {
       renderWithProviders(<Dashboard />)
-      expect(screen.getByText('Challenge a friend to a direct bet')).toBeInTheDocument()
-      expect(screen.getByText('Create a pool for 3-10 friends')).toBeInTheDocument()
+      expect(screen.getByText('You and a friend settle the outcome')).toBeInTheDocument()
+      expect(screen.getByText('Auto-settles from Polymarket, Chainlink or UMA')).toBeInTheDocument()
+      expect(screen.getByText('Offer odds and let a friend take the other side')).toBeInTheDocument()
     })
   })
 

--- a/frontend/src/test/FriendMarketsModal.test.jsx
+++ b/frontend/src/test/FriendMarketsModal.test.jsx
@@ -289,14 +289,44 @@ describe('FriendMarketsModal', () => {
       expect(screen.getByLabelText(/opponent address/i)).toBeInTheDocument()
     })
 
-    it('opens into the Small Group form when initialType="smallGroup"', () => {
-      renderWithProviders(<FriendMarketsModal {...defaultProps} initialType="smallGroup" />)
-      expect(screen.getByLabelText(/member addresses/i)).toBeInTheDocument()
+    it('opens into the Bookmaker form (with opponent + odds) when initialType="bookmaker"', () => {
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} initialType="bookmaker" resolutionCategory="all" />
+      )
+      expect(screen.getByLabelText(/opponent address/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/opponent.*odds/i)).toBeInTheDocument()
     })
 
-    it('opens into the Event Tracking form when initialType="eventTracking"', () => {
-      renderWithProviders(<FriendMarketsModal {...defaultProps} initialType="eventTracking" />)
-      expect(screen.getByLabelText(/member addresses/i)).toBeInTheDocument()
+    it('no longer offers group / member-address inputs', () => {
+      renderWithProviders(<FriendMarketsModal {...defaultProps} />)
+      expect(screen.queryByLabelText(/member addresses/i)).not.toBeInTheDocument()
+      expect(screen.queryByLabelText(/minimum participants/i)).not.toBeInTheDocument()
+    })
+
+    it('participant category shows only people-settled resolution options', () => {
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} resolutionCategory="participant" />
+      )
+      const select = screen.getByLabelText(/who can resolve/i)
+      const labels = Array.from(select.querySelectorAll('option')).map(o => o.textContent)
+      expect(labels).toEqual([
+        'Either Party',
+        'Creator Only',
+        'Opponent Only',
+        'Third Party Arbitrator',
+      ])
+    })
+
+    it('oracle category shows only oracle resolution options', () => {
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} resolutionCategory="oracle" />
+      )
+      // The oracle flow relabels the selector and excludes participant options.
+      const select = screen.getByLabelText(/which oracle settles this/i)
+      const labels = Array.from(select.querySelectorAll('option')).map(o => o.textContent)
+      expect(labels).not.toContain('Either Party')
+      expect(labels.length).toBeGreaterThan(0)
+      labels.forEach(l => expect(l).toMatch(/Polymarket|Chainlink|UMA/))
     })
 
     it('no longer renders a type-selector or Back link', () => {
@@ -370,30 +400,16 @@ describe('FriendMarketsModal', () => {
       expect(stakeInput).toHaveAttribute('min', '0.1')
     })
 
-    it('should validate member addresses for group markets', async () => {
-      renderWithProviders(<FriendMarketsModal {...defaultProps} initialType="smallGroup" />)
-
-      await userEvent.type(screen.getByLabelText(/what's the bet/i), 'BTC will reach $100k by end of year')
-      await userEvent.type(screen.getByLabelText(/member addresses/i), '0xinvalid, 0xalsobad')
-      await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
-
-      await waitFor(() => {
-        expect(screen.getByText(/Invalid address:/i)).toBeInTheDocument()
-      })
-    })
-
-    it('should validate minimum members for event tracking', async () => {
-      renderWithProviders(<FriendMarketsModal {...defaultProps} initialType="eventTracking" />)
-
-      await userEvent.type(screen.getByLabelText(/what's the bet/i), 'Who will win the tournament')
-      await userEvent.type(
-        screen.getByLabelText(/member addresses/i),
-        '0xabcdef1234567890123456789012345678901234, 0x9876543210987654321098765432109876543210'
+    it('should require an opponent address for a Bookmaker wager', async () => {
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} initialType="bookmaker" resolutionCategory="all" />
       )
+
+      await userEvent.type(screen.getByLabelText(/what's the bet/i), 'Patriots will win the Super Bowl')
       await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
 
       await waitFor(() => {
-        expect(screen.getByText(/at least 3 members required/i)).toBeInTheDocument()
+        expect(screen.getByText(/opponent address is required/i)).toBeInTheDocument()
       })
     })
 


### PR DESCRIPTION
## Why

A user tried to create a wager with two other addresses (a "group wager") on fairwins.app and hit **"Valid opponent address required for 1v1 wager."**

The investigation found that group wagers are **dead UI**: the v2 `WagerRegistry` contract and `useFriendMarketCreation` hook are strictly 1v1 (a single `creator`/`opponent` pair, two stakes, one winner). The "Group Wager" card, the member-address input, and the activation-threshold input all funnel into a 1v1-only submission path that throws at `useFriendMarketCreation.js:217-220`. Multi-party support only ever existed in the archived v1 contract and was never ported to v2.

Per the decision on the issue, this PR removes the unsupported group UI and reworks 1v1 creation into two clearly separated, self-configuring flows, and wires up the previously-unreachable Bookmaker variant.

## What changed

**Dashboard**
- Replaced the `1v1` + `Group Wager` cards with three creation cards:
  - **Friends Decide (1v1)** → participant-resolved (Either / Creator / Opponent / Third-Party)
  - **Oracle Settles (1v1)** → oracle-resolved (Polymarket / Chainlink Data Feed / Chainlink Functions / UMA)
  - **Bookmaker** → 1v1-with-odds (was defined in the modal but had no entry point)
- Threads a `resolutionCategory` (`participant` | `oracle` | `all`) into the modal. Polymarket dashboard cards now open straight into the oracle flow.

**FriendMarketsModal**
- New `resolutionCategory` prop filters the resolution selector to just the relevant settlement options and seeds a sensible default. The oracle flow relabels the selector ("Which oracle settles this?") and gives the existing Polymarket/Chainlink/UMA config pickers a dedicated screen, with an informative empty state when no oracle is available on the chain.
- Removed all group/event code: member-address + activation-threshold inputs, their validation, the group encryption branch, and the group submit branches.
- The opponent field, opponent-key encryption, and arbitrator/oracle config now render for **Bookmaker** too (it's a 1v1 variant with asymmetric stakes).

**Tests / copy**
- Updated `FriendMarketsModal.test.jsx` and `Dashboard.test.jsx` (removed group cases; added participant/oracle/bookmaker category coverage).
- Updated Cypress specs (`13-dashboard`, `22-accessibility`, `04-wager-creation-tx`, `05-wager-acceptance`, `commands.js`) and onboarding copy.

No contract changes — the contract is already 1v1; this is a frontend restructuring.

## Verification
- `npm test` — **784 unit tests pass** (47 files), including the reworked modal/dashboard suites.
- `npm run lint` — clean (0 errors; the 2 remaining warnings are pre-existing, in untouched files).
- `vite build` — succeeds.

Manual smoke test to run: open the Wagers dashboard → confirm three creation cards and **no** Group card; Friends-Decide shows only participant resolution options; Oracle shows only oracle options with the picker prominent; Bookmaker shows the odds slider + opponent field. No path reaches "Valid opponent address required".

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBwNwizs68rXCeH49jt5Fd)_