### PR TITLE
Remove third-party arbitration from the 1v1 wager create UX

### DIFF
--- a/docs/fairwins-functional-testing-checklist.md
+++ b/docs/fairwins-functional-testing-checklist.md
@@ -127,7 +127,7 @@ A manual testing checklist for validating all functional flows of the FairWins p
 | [ ] | CRE-03 | Create 1v1 wager with WMATIC | 1. Same as CRE-01 but select WMATIC | WMATIC approval + creation; wager created |  |
 | [ ] | CRE-04 | Create wager with Creator Only resolution | 1. Create 1v1 2. Set resolution type to "Creator Only" | Wager created; only creator can propose resolution after end date |  |
 | [ ] | CRE-05 | Create wager with Opponent Only resolution | 1. Create 1v1 2. Set resolution type to "Opponent Only" | Wager created; only opponent can propose resolution |  |
-| [ ] | CRE-06 | Create wager with Third Party resolution | 1. Create 1v1 2. Set resolution type to "Third Party" 3. Enter arbitrator address | Wager created with designated arbitrator; arbitrator address stored on-chain |  |
+| ~~[ ]~~ | ~~CRE-06~~ | ~~Create wager with Third Party resolution~~ | **REMOVED** — Third Party (arbiter) resolution is no longer offered in the create UI. A designated arbiter cannot discover the wagers they oversee (the WagerRegistry per-user index and the subgraph/event queries surface only creator and opponent), so they could never resolve them. The "Third Party Arbitrator" option and arbitrator address input have been removed from the create form. | n/a |  |
 | [ ] | CRE-07 | Create private (encrypted) wager | 1. Create 1v1 2. Toggle "Private Wager" ON 3. Ensure opponent has registered key 4. Complete creation | Wager created; metadata encrypted and stored on IPFS; on-chain metadataUri = `encrypted:ipfs://<CID>` |  |
 | [ ] | CRE-08 | Create wager with custom acceptance deadline | 1. Create 1v1 2. Set acceptance deadline to 24 hours | Wager created with specified deadline; deadline enforced on-chain |  |
 | [ ] | CRE-09 | Create wager with custom end date | 1. Create 1v1 2. Set end date to 14 days | Wager created; resolveDeadline reflects chosen end date |  |
@@ -165,7 +165,7 @@ A manual testing checklist for validating all functional flows of the FairWins p
 | [ ] | CRE-21 | Create wager with zero stake | 1. Set stake amount to 0 | Form validation prevents submission; or contract reverts "ZeroStake" |  |
 | [ ] | CRE-22 | Create wager exceeding max stake (1,000) | 1. Set stake amount to 1,001 | Form validation prevents submission; or contract reverts |  |
 | [ ] | CRE-23 | Create wager with insufficient balance | 1. Set stake to 500 USDC with only 100 USDC in wallet | Error: "Insufficient balance"; transaction not submitted |  |
-| [ ] | CRE-24 | Create Third Party wager without arbitrator | 1. Select "Third Party" resolution 2. Leave arbitrator field empty | Validation error: arbitrator required; creation blocked |  |
+| ~~[ ]~~ | ~~CRE-24~~ | ~~Create Third Party wager without arbitrator~~ | **REMOVED** — Third Party resolution is no longer selectable in the create UI (see CRE-06). The "Third Party" option no longer appears in the resolution-type dropdown, so there is no arbitrator field to leave empty. | n/a |  |
 | [ ] | CRE-25 | Create wager with invalid opponent address | 1. Enter malformed address as opponent | Form validation catches invalid address; creation blocked |  |
 | [ ] | CRE-26 | Create Polymarket wager with already-resolved condition | 1. Select a Polymarket market that has already resolved | Error: "ConditionAlreadyResolved"; creation blocked |  |
 | [ ] | CRE-27 | Create wager with non-allowlisted token | 1. Attempt to use a token not in the allowlist | Error: "NotAllowedToken"; creation blocked |  |
@@ -228,7 +228,7 @@ A manual testing checklist for validating all functional flows of the FairWins p
 
 ## 7. Manual Resolution
 
-**Preconditions:** Active wager exists. Trading period (end date) has passed. Wager uses manual resolution type (Either Party, Creator Only, Opponent Only, or Third Party).
+**Preconditions:** Active wager exists. Trading period (end date) has passed. Wager uses manual resolution type (Either Party, Creator Only, or Opponent Only). Third Party (arbiter) resolution is no longer offered when creating wagers — see CRE-06.
 
 ### Happy Path
 
@@ -238,7 +238,7 @@ A manual testing checklist for validating all functional flows of the FairWins p
 | [ ] | RES-02 | Resolve (Either Party) - opponent proposes | 1. As opponent on Either Party wager 2. Propose resolution (False = opponent wins) | Resolution proposed; same flow as RES-01 but initiated by opponent |  |
 | [ ] | RES-03 | Resolve (Creator Only) | 1. As creator on Creator Only wager 2. Propose resolution | Resolution accepted; only creator can propose |  |
 | [ ] | RES-04 | Resolve (Opponent Only) | 1. As opponent on Opponent Only wager 2. Propose resolution | Resolution accepted; only opponent can propose |  |
-| [ ] | RES-05 | Resolve (Third Party) - arbitrator resolves | 1. As designated arbitrator 2. Call resolution with outcome 3. Confirm transaction | Wager resolved immediately (no challenge period for Third Party); winner recorded |  |
+| ~~[ ]~~ | ~~RES-05~~ | ~~Resolve (Third Party) - arbitrator resolves~~ | **REMOVED** — Third Party wagers can no longer be created (see CRE-06). The on-chain `declareWinner` arbiter branch is retained for any pre-existing wagers, but the flow is no longer exercised via the UI. | n/a |  |
 | [ ] | RES-06 | Finalize resolution after challenge period (no challenge) | 1. Resolution proposed 24+ hours ago 2. No challenge filed 3. Click "Finalize" | Wager status transitions to Resolved; winner can now claim |  |
 
 ### Non-Happy Path
@@ -248,7 +248,7 @@ A manual testing checklist for validating all functional flows of the FairWins p
 | [ ] | RES-07 | Propose resolution before end date | 1. Active wager still within trading period 2. Attempt to propose resolution | Error: "NotPendingResolution"; resolution blocked until end date passes |  |
 | [ ] | RES-08 | Opponent proposes on Creator Only wager | 1. Creator Only resolution type 2. Opponent attempts to propose | Error: "NotAuthorized"; only creator allowed |  |
 | [ ] | RES-09 | Creator proposes on Opponent Only wager | 1. Opponent Only type 2. Creator attempts to propose | Error: "NotAuthorized"; only opponent allowed |  |
-| [ ] | RES-10 | Non-arbitrator proposes on Third Party wager | 1. Third Party type 2. Creator or opponent attempts to propose | Error: "NotAuthorized"; only designated arbitrator allowed |  |
+| ~~[ ]~~ | ~~RES-10~~ | ~~Non-arbitrator proposes on Third Party wager~~ | **REMOVED** — Third Party wagers can no longer be created (see CRE-06). | n/a |  |
 | [ ] | RES-11 | Propose resolution after resolve deadline | 1. Active wager past resolveDeadline 2. Attempt to propose | Error: "ResolveExpired"; refund path available instead |  |
 | [ ] | RES-12 | Manual resolution on oracle-type wager | 1. Polymarket/Chainlink/UMA wager 2. Attempt declareWinner | Error: oracle-resolved types cannot use manual resolution |  |
 | [ ] | RES-13 | Propose with winner not a participant | 1. Attempt to declare a third-party address as winner | Error: "WinnerNotParticipant"; winner must be creator or opponent |  |
@@ -637,17 +637,12 @@ These scenarios combine multiple sections above into full lifecycle tests. They 
 | 4 | Creator (or anyone) calls claimRefund | REF-01 |
 | 5 | Creator receives stake back | REF-01 |
 
-### E2E-04: Unhappy Path - Challenged Resolution
+### ~~E2E-04: Unhappy Path - Challenged Resolution~~
 
-| Step | Action | Reference Tests |
-|------|--------|-----------------|
-| 1 | Creator creates 1v1 wager with Third Party arbitrator | CRE-06 |
-| 2 | Opponent accepts | ACC-01 |
-| 3 | Wager end date passes | - |
-| 4 | Arbitrator declares creator as winner | RES-05 |
-| 5 | (If challenge period applies) Opponent challenges | CHL-01 |
-| 6 | Arbitrator re-resolves dispute | CHL-02 |
-| 7 | Final winner claims | CLM-01 |
+**REMOVED** — this end-to-end flow depended on the Third Party arbitrator option, which is no
+longer offered when creating wagers (a designated arbiter cannot discover the wagers they
+oversee; see CRE-06). The on-chain arbiter resolution branch is retained for any pre-existing
+wagers but is no longer reachable through the create UI.
 
 ### E2E-05: Unhappy Path - Oracle Timeout
 

--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -34,7 +34,12 @@ const PARTICIPANT_RESOLUTION_TYPES = [
   ResolutionType.Either,
   ResolutionType.Creator,
   ResolutionType.Opponent,
-  ResolutionType.ThirdParty,
+  // ResolutionType.ThirdParty intentionally omitted: a designated arbiter has
+  // no way to discover the wagers they oversee (the WagerRegistry per-user
+  // index and the subgraph/event queries surface only the creator and
+  // opponent, never the arbiter), so they could never resolve them. The
+  // on-chain enum value and resolution branch remain for any pre-existing
+  // wagers; we just stop offering it as a create-time choice.
 ]
 
 // Dropdown labels + helper text for every resolution type. Kept here so the
@@ -44,7 +49,6 @@ const RESOLUTION_TYPE_LABELS = {
   [ResolutionType.Either]: 'Either Party',
   [ResolutionType.Creator]: 'Creator Only',
   [ResolutionType.Opponent]: 'Opponent Only',
-  [ResolutionType.ThirdParty]: 'Third Party Arbitrator',
   [ResolutionType.Polymarket]: 'Linked Market (Polymarket)',
   [ResolutionType.ChainlinkDataFeed]: 'Chainlink Data Feed (price condition)',
   [ResolutionType.ChainlinkFunctions]: 'Chainlink Functions (custom request)',
@@ -54,7 +58,6 @@ const RESOLUTION_TYPE_HINTS = {
   [ResolutionType.Either]: 'Either you or your opponent can resolve the wager',
   [ResolutionType.Creator]: 'Only you (the creator) can resolve the wager',
   [ResolutionType.Opponent]: 'Only your opponent can resolve the wager',
-  [ResolutionType.ThirdParty]: 'A designated arbitrator will resolve disputes',
   [ResolutionType.Polymarket]: 'Settles automatically when the linked Polymarket market resolves',
   [ResolutionType.ChainlinkDataFeed]: 'Settles automatically once the price feed reading at the deadline passes the threshold',
   [ResolutionType.ChainlinkFunctions]: 'Settles when the Chainlink Functions DON returns a result (admin-registered request)',
@@ -105,7 +108,7 @@ function FriendMarketsModal({
   )
 
   // Resolution choices are split into two flows, driven by `resolutionCategory`:
-  //   - 'participant' → people settle it (Either / Creator / Opponent / ThirdParty)
+  //   - 'participant' → people settle it (Either / Creator / Opponent)
   //   - 'oracle'      → an oracle settles it (Polymarket / Chainlink / UMA), each
   //                     self-gated on being reachable/deployed on the active chain
   //   - 'all'         → both (used by the Bookmaker card)
@@ -173,8 +176,6 @@ function FriendMarketsModal({
     stakeAmount: WAGER_DEFAULTS.STAKE_AMOUNT,
     stakeTokenId: WAGER_DEFAULTS.STAKE_TOKEN_ID,
     customStakeTokenAddress: '', // Used when stakeTokenId is 'CUSTOM'
-    arbitrator: '',
-    arbitratorResolved: '',
     oracleConditionId: '',
     // Which outcome of a linked Polymarket the creator is taking. Stored as
     // the 0-based outcome index ('' = unset, '0' = YES/first, '1' = NO/second)
@@ -184,7 +185,7 @@ function FriendMarketsModal({
     acceptanceDeadline: getMidpointAcceptanceDeadline(getDefaultEndDateTime()),
     // Leverage/odds for Bookmaker markets (200 = 2x equal stakes, 10000 = 100x)
     oddsMultiplier: WAGER_DEFAULTS.ODDS_MULTIPLIER,
-    // Resolution type: 0=Either, 1=Initiator, 2=Receiver, 3=ThirdParty, 4=AutoPegged
+    // Resolution type: 0=Either, 1=Creator, 2=Opponent, 4=Polymarket, 5/6/7=oracle adapters
     resolutionType: WAGER_DEFAULTS.RESOLUTION_TYPE
   })
 
@@ -201,7 +202,7 @@ function FriendMarketsModal({
 
   // QR Scanner state
   const [qrScannerOpen, setQrScannerOpen] = useState(false)
-  const [qrScanTarget, setQrScanTarget] = useState(null) // 'opponent' or 'arbitrator'
+  const [qrScanTarget, setQrScanTarget] = useState(null) // 'opponent'
 
   // Polymarket event selection — the PolymarketBrowser component below handles
   // browsing/searching internally. We only need to track the picked market so
@@ -231,8 +232,6 @@ function FriendMarketsModal({
       stakeAmount: WAGER_DEFAULTS.STAKE_AMOUNT,
       stakeTokenId: WAGER_DEFAULTS.STAKE_TOKEN_ID,
       customStakeTokenAddress: '',
-      arbitrator: '',
-      arbitratorResolved: '',
       oracleConditionId: '',
       creatorSide: '',
       acceptanceDeadline: getMidpointAcceptanceDeadline(getDefaultEndDateTime()),
@@ -333,18 +332,12 @@ function FriendMarketsModal({
 
       const updated = { ...prev, [field]: value }
 
-      // Clear arbitrator/linked-market state when switching to a resolution
-      // type that doesn't need it.
+      // Clear linked-market state when switching to a resolution type that
+      // doesn't need it.
       const valueIsOracleResolved = value === ResolutionType.Polymarket ||
         value === ResolutionType.ChainlinkDataFeed ||
         value === ResolutionType.ChainlinkFunctions ||
         value === ResolutionType.UMA
-      if (field === 'resolutionType' &&
-          value !== ResolutionType.ThirdParty &&
-          !valueIsOracleResolved) {
-        updated.arbitrator = ''
-        updated.arbitratorResolved = ''
-      }
       if (field === 'resolutionType' && !valueIsOracleResolved) {
         // Leaving the oracle family entirely → clear conditionId + side.
         updated.oracleConditionId = ''
@@ -617,22 +610,9 @@ function FriendMarketsModal({
       setFormData(prev => ({ ...prev, acceptanceDeadline: freshDeadline }))
     }
 
-    // Validate arbitrator/market ID based on resolution type
+    // Validate linked-market ID based on resolution type
     {
-      if (formData.resolutionType === ResolutionType.ThirdParty) {
-        // Arbitrator address is required for ThirdParty resolution
-        const rawArb = (formData.arbitrator || '').trim()
-        const resolvedArb = (formData.arbitratorResolved || '').trim()
-        if (!rawArb) {
-          newErrors.arbitrator = 'Arbitrator address is required for third party resolution'
-        } else if (!resolvedArb) {
-          newErrors.arbitrator = isEnsName(rawArb)
-            ? 'Could not resolve ENS name — check the name and try again'
-            : 'Enter a valid Ethereum address or ENS name'
-        } else if (resolvedArb.toLowerCase() === '0x0000000000000000000000000000000000000000') {
-          newErrors.arbitrator = 'Cannot use the zero address'
-        }
-      } else if (formData.resolutionType === ResolutionType.Polymarket) {
+      if (formData.resolutionType === ResolutionType.Polymarket) {
         // Polymarket condition id (bytes32 hex) is required.
         const cid = (formData.oracleConditionId || '').trim()
         if (!cid) {
@@ -746,7 +726,6 @@ function FriendMarketsModal({
         stakeAmount: formData.stakeAmount,
         stakeToken: stakeToken.symbol,
         endDateTime: formData.endDateTime,
-        arbitrator: formData.arbitratorResolved || null,
         createdAt: new Date().toISOString(),
         attributes: [
           { trait_type: 'Market Source', value: 'friend' },
@@ -823,12 +802,10 @@ function FriendMarketsModal({
         data: {
           ...formData,
           acceptanceDeadline: freshAcceptanceDeadline,
-          // Downstream hooks (useFriendMarketCreation) read `opponent` and
-          // `arbitrator` as 0x addresses. Substitute the ENS-resolved values
-          // so a user can enter `name.eth` and the contract still gets a hex
-          // address.
+          // Downstream hooks (useFriendMarketCreation) read `opponent` as a 0x
+          // address. Substitute the ENS-resolved value so a user can enter
+          // `name.eth` and the contract still gets a hex address.
           opponent: formData.opponentResolved || formData.opponent,
-          arbitrator: formData.arbitratorResolved || formData.arbitrator,
           // Translated UI → contract semantics (see comment above).
           creatorIsYes,
           // Pass calculated trading period so downstream uses the user's selected end date.
@@ -870,7 +847,6 @@ function FriendMarketsModal({
         tradingPeriod: tradingPeriodDays,
         participants: [account, formData.opponentResolved],
         creator: account,
-        arbitrator: formData.arbitratorResolved || null,
         createdAt: new Date().toISOString(),
         status: 'pending_acceptance',
         // Acceptance flow fields
@@ -929,11 +905,6 @@ function FriendMarketsModal({
     const date = new Date(dateString)
     if (Number.isNaN(date.getTime())) return 'N/A'
     return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-  }
-
-  const formatAddress = (address) => {
-    if (!address) return 'N/A'
-    return `${address.slice(0, 6)}...${address.slice(-4)}`
   }
 
   // Get selected stake token info for display
@@ -1278,42 +1249,6 @@ function FriendMarketsModal({
                         </div>
                       )
                     })()}
-
-                    {/* Arbitrator address field — for Third Party resolution */}
-                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') &&
-                     formData.resolutionType === ResolutionType.ThirdParty && (
-                      <div className="fm-form-group fm-form-full">
-                        <label htmlFor="fm-arbitrator">
-                          Arbitrator Address <span className="fm-required">*</span>
-                        </label>
-                        <div className="fm-input-with-action">
-                          <div className="fm-address-input-wrap">
-                            <AddressInput
-                              id="fm-arbitrator"
-                              value={formData.arbitrator}
-                              onChange={(e) => handleFormChange('arbitrator', e.target.value)}
-                              onResolvedChange={(addr) => handleFormChange('arbitratorResolved', addr || '')}
-                              placeholder="0x... or ENS name (trusted third party)"
-                              disabled={submitting}
-                              error={!!errors.arbitrator}
-                              errorMessage={errors.arbitrator}
-                            />
-                          </div>
-                          <button
-                            type="button"
-                            className="fm-scan-btn"
-                            onClick={() => openQrScanner('arbitrator')}
-                            disabled={submitting}
-                            title="Scan QR code"
-                            aria-label="Scan QR code"
-                          >
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                              <path d="M3 3h8v8H3V3zm2 2v4h4V5H5zm8-2h8v8h-8V3zm2 2v4h4V5h-4zM3 13h8v8H3v-8zm2 2v4h4v-4H5zm10-2h2v2h-2v-2zm4 0h2v2h-2v-2zm-4 4h2v2h-2v-2zm2 2h2v2h-2v-2zm2-2h2v2h-2v-2zm0 4h2v2h-2v-2z"/>
-                            </svg>
-                          </button>
-                        </div>
-                      </div>
-                    )}
 
                     {/* Linked Market — Polymarket event lookup */}
                     {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') &&
@@ -1800,12 +1735,6 @@ function FriendMarketsModal({
                       <span>Wager Ends</span>
                       <span>{createdMarket.endDateTime ? new Date(createdMarket.endDateTime).toLocaleString() : `${createdMarket.tradingPeriod} days`}</span>
                     </div>
-                    {createdMarket.arbitrator && (
-                      <div className="fm-detail-row">
-                        <span>Arbitrator</span>
-                        <span>{formatAddress(createdMarket.arbitrator)}</span>
-                      </div>
-                    )}
                   </div>
 
                   <div className="fm-success-actions">
@@ -1854,7 +1783,7 @@ function FriendMarketsModal({
         </div>
       </div>
 
-      {/* QR Scanner Modal — opens for opponent/arbitrator address fields */}
+      {/* QR Scanner Modal — opens for the opponent address field */}
       <QRScanner
         isOpen={qrScannerOpen}
         onClose={handleQrScannerClose}

--- a/frontend/src/hooks/useFriendMarketCreation.js
+++ b/frontend/src/hooks/useFriendMarketCreation.js
@@ -232,9 +232,13 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
       const oracleConditionId = data.data.oracleConditionId ?? data.data.polymarketConditionId ?? ''
       const polymarketConditionId = oracleConditionId || ethers.ZeroHash
       const creatorIsYes = Boolean(data.data.creatorIsYes ?? true)
-      const arbitrator = (resolutionType === ResolutionType.ThirdParty)
-        ? (data.data.arbitrator || ethers.ZeroAddress)
-        : ethers.ZeroAddress
+      // ThirdParty (arbiter) resolution is no longer offered in the create UI:
+      // a designated arbiter can't discover the wagers they oversee, so they
+      // could never resolve them. Every supported resolution type therefore
+      // submits the zero address, which is exactly what WagerRegistry requires
+      // for non-ThirdParty wagers (a non-zero arbitrator reverts
+      // ArbitratorDisallowed).
+      const arbitrator = ethers.ZeroAddress
 
       // Defense-in-depth: the modal's validateForm should have caught these
       // mismatches before submit. If something slipped through (e.g. a future

--- a/frontend/src/test/FriendMarketsModal.test.jsx
+++ b/frontend/src/test/FriendMarketsModal.test.jsx
@@ -309,12 +309,14 @@ describe('FriendMarketsModal', () => {
       )
       const select = screen.getByLabelText(/who can resolve/i)
       const labels = Array.from(select.querySelectorAll('option')).map(o => o.textContent)
+      // Third Party Arbitrator was removed: a designated arbiter can't discover
+      // the wagers they oversee, so they could never resolve them.
       expect(labels).toEqual([
         'Either Party',
         'Creator Only',
         'Opponent Only',
-        'Third Party Arbitrator',
       ])
+      expect(labels).not.toContain('Third Party Arbitrator')
     })
 
     it('oracle category shows only oracle resolution options', () => {


### PR DESCRIPTION
## Summary

The 1v1 wager flow offered a **Third Party Arbitrator** resolution option, but the designated arbiter could never actually use it. This PR removes the option from the create UX.

### Why

The investigation found the root cause is **discovery, not authorization**:

- Resolution already works on-chain — `WagerRegistry.declareWinner` authorizes `msg.sender == w.arbitrator` for `ThirdParty` wagers (`contracts/wagers/WagerRegistry.sol:318-319`).
- But the arbiter is **never indexed for lookup**: `createWager` adds only the creator and opponent to the per-user index (`WagerRegistry.sol:243-244`), the `WagerCreated` event omits the arbiter (`:250`), and the subgraph + frontend query only by creator/participant (`SubgraphSource.js`; `MyMarketsModal` has no "Arbitrating" tab).
- The contract also **requires** the arbiter to be neither creator nor opponent (`:202`), while every discovery path surfaces only creators and opponents — so an arbiter structurally has **no entry point** in the app to find, let alone resolve, their wagers.

Closing the gap robustly would require a contract redeploy (to index/emit the arbiter) plus subgraph + frontend work. The decision was to **remove the option** rather than ship a half-feature.

### Changes

- **`FriendMarketsModal.jsx`** — Remove `ResolutionType.ThirdParty` from `PARTICIPANT_RESOLUTION_TYPES` (the single source for the resolution-type dropdown). Remove the now-dead arbitrator form state, validation, address input + QR button, and success/metadata fields.
- **`useFriendMarketCreation.js`** — Always submit the zero arbitrator address, which is exactly what `WagerRegistry` requires for non-`ThirdParty` wagers.
- **Backward compatibility (left intact):** the on-chain `ThirdParty` enum value (wire-stable, no redeploy) and `declareWinner` branch, plus the display/resolution handling in `MyMarketsModal`/`MarketAcceptanceModal`, so any pre-existing arbiter wager still renders and can resolve.
- **`FriendMarketsModal.test.jsx`** — Updated to expect three participant resolution options.
- **`docs/fairwins-functional-testing-checklist.md`** — Marked the third-party cases as removed (CRE-06, CRE-24, RES-05, RES-10, E2E-04).

### Verification

- `npm run build` — clean.
- `npx vitest run` on the affected suites — 54 tests pass (the create modal now shows only **Either Party / Creator Only / Opponent Only**).
- `npx eslint` on changed files — clean.
- No contract changes, so `hardhat` tests are unaffected.

https://claude.ai/code/session_01Nqi69QfuQH3j3Z4bwsMXsr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nqi69QfuQH3j3Z4bwsMXsr)_