### PR TITLE
Fix bookmaker wagers collapsing to even-money 1v1 on read

### DIFF
--- a/frontend/src/components/fairwins/MyMarketsModal.css
+++ b/frontend/src/components/fairwins/MyMarketsModal.css
@@ -508,6 +508,12 @@
   color: #36B37E;
 }
 
+/* Bookmaker (odds) wagers — distinct from even-money friend wagers */
+.mm-type-badge.mm-type-bookmaker {
+  background: rgba(255, 171, 0, 0.15);
+  color: #FFAB00;
+}
+
 /* Status Badge */
 .mm-status-badge {
   display: inline-block;

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -482,6 +482,9 @@ function MyMarketsModal({
       participants: market.participants || [],
       arbitrator: market.arbitrator || null,
       marketType: market.type || 'oneVsOne',
+      // Opponent's odds for a bookmaker wager (200 = even money). Surfaced so
+      // the acceptance modal shows the real payout instead of defaulting to 1v1.
+      opponentOddsMultiplier: market.opponentOddsMultiplier || market.oddsMultiplier || WAGER_DEFAULTS.ODDS_MULTIPLIER,
       status: market.status,
       acceptanceDeadline: typeof market.acceptanceDeadline === 'number'
         ? market.acceptanceDeadline
@@ -1415,8 +1418,10 @@ function MarketDetailView({
           </span>
         </div>
         <div className="mm-detail-meta">
-          <span className={`mm-type-badge mm-type-${market.marketType}`}>
-            {market.marketType === 'friend' ? 'Friend Wager' : 'Wager'}
+          <span className={`mm-type-badge mm-type-${market.type === 'bookmaker' ? 'bookmaker' : market.marketType}`}>
+            {market.type === 'bookmaker'
+              ? `Bookmaker${market.oddsMultiplier ? ` · ${market.oddsMultiplier / 100}x` : ''}`
+              : market.marketType === 'friend' ? 'Friend Wager' : 'Wager'}
           </span>
           {market.category && <span className="mm-category-tag">{market.category}</span>}
         </div>

--- a/frontend/src/constants/wagerDefaults.js
+++ b/frontend/src/constants/wagerDefaults.js
@@ -62,6 +62,40 @@ export const WAGER_DEFAULTS = {
   MAX_RESOLVE_WINDOW_SECONDS: 180 * 24 * 60 * 60,
 }
 
+/**
+ * Derive a wager's subtype and the opponent's odds multiplier from the
+ * asymmetric on-chain stakes.
+ *
+ * v2 WagerRegistry has no `marketType` field — a bookmaker wager is encoded
+ * purely as `creatorStake !== opponentStake`, where the opponent risks
+ * `opponentStake` to win the whole pot (`creatorStake + opponentStake`). The
+ * creation path mirrors this: `creatorStake = opponentStake * (odds - 100) / 100`.
+ * Inverting that, the opponent's payout multiplier in basis points is
+ * `(creatorStake + opponentStake) / opponentStake * 100` (200 = 2× = even money).
+ *
+ * Accepts raw stakes as BigInt | string | number (wei or unit — only the ratio
+ * matters). Returns `{ type, oddsMultiplier }`.
+ */
+export function deriveWagerType(creatorStake, opponentStake) {
+  let creator
+  let opponent
+  try {
+    creator = BigInt(creatorStake ?? 0)
+    opponent = BigInt(opponentStake ?? 0)
+  } catch {
+    creator = 0n
+    opponent = 0n
+  }
+  // Equal (or unknown) stakes are an even-money 1v1; no odds to surface.
+  if (opponent <= 0n || creator === opponent) {
+    return { type: 'oneVsOne', oddsMultiplier: WAGER_DEFAULTS.ODDS_MULTIPLIER }
+  }
+  return {
+    type: 'bookmaker',
+    oddsMultiplier: Number(((creator + opponent) * 100n) / opponent),
+  }
+}
+
 // ── Wager status strings (friend / P2P markets) ────────────────────
 export const WagerStatus = {
   PENDING_ACCEPTANCE: 'pending_acceptance',

--- a/frontend/src/pages/MarketAcceptancePage.jsx
+++ b/frontend/src/pages/MarketAcceptancePage.jsx
@@ -5,7 +5,7 @@ import { useWallet, useWeb3 } from '../hooks'
 import MarketAcceptanceModal from '../components/fairwins/MarketAcceptanceModal'
 import { WAGER_REGISTRY_ABI } from '../abis/WagerRegistry'
 import { getContractAddress, DEPLOYED_CONTRACTS } from '../config/contracts'
-import { WAGER_DEFAULTS } from '../constants/wagerDefaults'
+import { WAGER_DEFAULTS, deriveWagerType } from '../constants/wagerDefaults'
 import { parseEncryptedIpfsReference } from '../utils/ipfsService'
 import './MarketAcceptancePage.css'
 
@@ -119,6 +119,12 @@ function MarketAcceptancePage() {
         // The opponent puts up opponentStake on acceptance; that's what the modal cares about.
         const stakePerParticipant = ethers.formatUnits(w.opponentStake, decimals)
 
+        // v2 WagerRegistry has no marketType field — a bookmaker wager is encoded
+        // as asymmetric stakes (creatorStake !== opponentStake). Derive the subtype
+        // and the opponent's odds from raw stakes so the offer shows real bookmaker
+        // terms instead of collapsing to even-money 1v1.
+        const { type: wagerType, oddsMultiplier } = deriveWagerType(w.creatorStake, w.opponentStake)
+
         const rawDescription = w.metadataUri || ''
         const ipfsRef = parseEncryptedIpfsReference(rawDescription)
         const ipfsCid = ipfsRef.cid || getIpfsCid(rawDescription) || urlCid || null
@@ -158,7 +164,8 @@ function MarketAcceptancePage() {
           creator: w.creator,
           participants: opponentAddr && opponentAddr !== ethers.ZeroAddress ? [w.creator, opponentAddr] : [w.creator],
           arbitrator: (w.arbitrator && w.arbitrator !== ethers.ZeroAddress) ? w.arbitrator : null,
-          marketType: 'oneVsOne',
+          marketType: wagerType,
+          opponentOddsMultiplier: oddsMultiplier,
           status: statusName,
           acceptanceDeadline: acceptanceDeadlineMs,
           resolveDeadline: resolveDeadlineMs,

--- a/frontend/src/test/deriveWagerType.test.js
+++ b/frontend/src/test/deriveWagerType.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { deriveWagerType, WAGER_DEFAULTS } from '../constants/wagerDefaults'
+
+/**
+ * deriveWagerType reconstructs the wager subtype + opponent odds from the
+ * asymmetric on-chain stakes, since v2 WagerRegistry stores no marketType field.
+ * Mirrors the creation formula in useFriendMarketCreation:
+ *   creatorStake = opponentStake * (odds - 100) / 100
+ */
+describe('deriveWagerType', () => {
+  it('treats equal stakes as an even-money 1v1', () => {
+    const { type, oddsMultiplier } = deriveWagerType(10n, 10n)
+    expect(type).toBe('oneVsOne')
+    expect(oddsMultiplier).toBe(WAGER_DEFAULTS.ODDS_MULTIPLIER) // 200 = 2x = even
+  })
+
+  it('detects a 3x bookmaker (creator stakes 2x the opponent)', () => {
+    // odds = 300 → creatorStake = opponentStake * (300-100)/100 = 2 * opponent
+    const { type, oddsMultiplier } = deriveWagerType(20n, 10n)
+    expect(type).toBe('bookmaker')
+    expect(oddsMultiplier).toBe(300)
+  })
+
+  it('detects a 5x bookmaker', () => {
+    // odds = 500 → creatorStake = 4 * opponent
+    const { type, oddsMultiplier } = deriveWagerType(40n, 10n)
+    expect(type).toBe('bookmaker')
+    expect(oddsMultiplier).toBe(500)
+  })
+
+  it('handles the inverse (creator is the favorite, opponent stakes more)', () => {
+    // creatorStake < opponentStake → still asymmetric → bookmaker
+    const { type, oddsMultiplier } = deriveWagerType(5n, 10n)
+    expect(type).toBe('bookmaker')
+    expect(oddsMultiplier).toBe(150) // (5+10)/10 * 100
+  })
+
+  it('works with large wei BigInts (USDC 6dp)', () => {
+    const opponent = 10_000_000n // 10 USDC
+    const creator = 20_000_000n // 20 USDC → 3x
+    const { type, oddsMultiplier } = deriveWagerType(creator, opponent)
+    expect(type).toBe('bookmaker')
+    expect(oddsMultiplier).toBe(300)
+  })
+
+  it('accepts string and number stake inputs', () => {
+    expect(deriveWagerType('20', '10')).toEqual({ type: 'bookmaker', oddsMultiplier: 300 })
+    expect(deriveWagerType(10, 10)).toEqual({
+      type: 'oneVsOne',
+      oddsMultiplier: WAGER_DEFAULTS.ODDS_MULTIPLIER,
+    })
+  })
+
+  it('falls back to even-money 1v1 for zero / unparsable opponent stake', () => {
+    expect(deriveWagerType(10n, 0n)).toEqual({
+      type: 'oneVsOne',
+      oddsMultiplier: WAGER_DEFAULTS.ODDS_MULTIPLIER,
+    })
+    expect(deriveWagerType('oops', 'nope')).toEqual({
+      type: 'oneVsOne',
+      oddsMultiplier: WAGER_DEFAULTS.ODDS_MULTIPLIER,
+    })
+  })
+})

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -10,7 +10,7 @@ import { getContractAddress, NETWORK_CONFIG, DEPLOYMENT_BLOCKS, DEPLOYED_CONTRAC
 import { ERC20_ABI } from '../abis/ERC20'
 import { ZK_KEY_MANAGER_ABI } from '../abis/ZKKeyManager'
 import { DEX_ADDRESSES } from '../constants/dex'
-import { WAGER_DEFAULTS } from '../constants/wagerDefaults'
+import { WAGER_DEFAULTS, deriveWagerType } from '../constants/wagerDefaults'
 import { FRIEND_GROUP_MARKET_FACTORY_ABI } from '../abis/FriendGroupMarketFactory'
 import { WAGER_REGISTRY_ABI } from '../abis/WagerRegistry'
 import { MEMBERSHIP_MANAGER_ABI } from '../abis/MembershipManager'
@@ -412,12 +412,22 @@ function toWagerShape(id, w) {
     description = `Wager #${id}`
   }
 
+  // v2 WagerRegistry has no marketType field — a bookmaker wager is encoded as
+  // asymmetric stakes (creatorStake !== opponentStake). Derive the subtype and
+  // the opponent's odds from the raw on-chain stakes so the table badge and the
+  // acceptance modal reflect bookmaker terms instead of collapsing to even-money
+  // 1v1. Derivation uses raw wei (ratio is decimals-independent).
+  const { type: wagerType, oddsMultiplier } = deriveWagerType(w.creatorStake, w.opponentStake)
+
   return {
     id: String(id),
     creator: w.creator,
     opponent: w.opponent,
     arbitrator: (w.arbitrator && w.arbitrator !== ethers.ZeroAddress) ? w.arbitrator : null,
     participants: [w.creator, w.opponent].filter(a => a && a !== ethers.ZeroAddress),
+    type: wagerType,
+    oddsMultiplier,
+    opponentOddsMultiplier: oddsMultiplier,
     creatorStake: ethers.formatUnits(w.creatorStake, decimals),
     opponentStake: ethers.formatUnits(w.opponentStake, decimals),
     stakeAmount: ethers.formatUnits(w.opponentStake, decimals),


### PR DESCRIPTION
## Problem

A bookmaker wager did not read correctly on the opponent side: after acceptance, both sides saw it as a 1v1 for even money, and the wager table showed the type as "Friend Wager".

## Root cause

The v2 `WagerRegistry` contract has **no `marketType` field** — a bookmaker bet is encoded purely as **asymmetric stakes** (`creatorStake != opponentStake`), where the opponent risks `opponentStake` to win the whole pot. Creation mirrors this:

```
creatorStake = opponentStake * (odds - 100) / 100   // 200 = even money
```

But the chain read path threw that information away:

- **`blockchainService.toWagerShape`** (the active hydration path: `fetchWagersForUserV2` → `FriendMarketsContext` → `MyMarketsModal`) read `creatorStake`/`opponentStake` but never derived the subtype or odds.
- **`MarketAcceptancePage`** (the deep-link/QR path the opponent actually uses) hardcoded `marketType: 'oneVsOne'` and passed no odds.
- **`MyMarketsModal`** table badge only knew the hardcoded `'friend'` category, and `handleOpenAcceptance` passed no `opponentOddsMultiplier`, so the acceptance modal fell back to the `200` (even-money) default and hid the odds row.

The creator's localStorage cache masked the bug initially; once both sides re-read from chain after acceptance, the wager collapsed to even-money 1v1.

## Fix

- Add **`deriveWagerType(creatorStake, opponentStake)`** to `wagerDefaults.js` — single source of truth that reconstructs `{ type, oddsMultiplier }` from raw on-chain stakes (inverting the creation formula; `200` = even money). Accepts BigInt/string/number and is decimals-independent.
- **`blockchainService.toWagerShape`**: surface `type`, `oddsMultiplier`, `opponentOddsMultiplier`.
- **`MarketAcceptancePage`**: derive `marketType` + `opponentOddsMultiplier` from `getWager` instead of hardcoding `oneVsOne`.
- **`MyMarketsModal`**: table badge now renders `Bookmaker · Nx` for asymmetric wagers; `handleOpenAcceptance` forwards `opponentOddsMultiplier` so the acceptance modal shows the real stake/odds/payout.
- Added a distinct bookmaker badge style and unit tests for `deriveWagerType`.

No contract changes — the on-chain stakes already carry the bookmaker terms; this teaches the read/display layer to interpret them.

## Testing

- New `deriveWagerType.test.js` (7 cases: even money, 3x/5x bookmaker, inverse favorite, USDC 6dp wei, string/number inputs, zero/unparsable fallback).
- Existing suites still green: `MarketAcceptancePage`, `MarketAcceptanceModal`, `MyMarketsModal` — **90/90 passing**.
- Lint clean on all changed files.

https://claude.ai/code/session_01H2iBQXZtHjcSo3cXjhrJno

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2iBQXZtHjcSo3cXjhrJno)_