### PR TITLE
feat(wagers): surface market selection at top with resolution-type tabs

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.css
+++ b/frontend/src/components/fairwins/FriendMarketsModal.css
@@ -1532,6 +1532,53 @@
   font-size: 0.9rem;
 }
 
+/* ── Resolution-type tabs (oracle / Bookmaker flows) ─────────────────── */
+.fm-resolution-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.fm-resolution-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.5rem 0.85rem;
+  background: var(--bg-primary, #0E141B);
+  border: 1px solid var(--border-color, #23303D);
+  border-radius: 999px;
+  color: var(--text-primary, #1F2933);
+  font-weight: 600;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.fm-resolution-tab:hover:not(:disabled) {
+  border-color: var(--brand-primary, #36B37E);
+}
+
+.fm-resolution-tab.active {
+  border-color: var(--brand-primary, #36B37E);
+  background: rgba(54, 179, 126, 0.12);
+  color: var(--brand-primary, #36B37E);
+}
+
+.fm-resolution-tab.locked {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.fm-resolution-tab:disabled:not(.locked) {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.fm-resolution-tab-lock {
+  flex-shrink: 0;
+  opacity: 0.8;
+}
+
 /* ── Oracle condition picker ─────────────────────────────────────────── */
 .fm-oracle-picker {
   display: flex;

--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -64,6 +64,28 @@ const RESOLUTION_TYPE_HINTS = {
   [ResolutionType.UMA]: 'Settles via UMA Optimistic Oracle — someone posts the bond and the assertion stands after the liveness window',
 }
 
+// Oracle resolution types in enum order. Rendered as tabs (always shown; locked
+// when the adapter/CTF isn't reachable on the active chain) so users can see
+// every settlement source at a glance instead of a filtered dropdown.
+const ORACLE_TAB_TYPES = [
+  ResolutionType.Polymarket,
+  ResolutionType.ChainlinkDataFeed,
+  ResolutionType.ChainlinkFunctions,
+  ResolutionType.UMA,
+]
+
+// Short labels for the resolution tab strip — the full RESOLUTION_TYPE_LABELS
+// are too long to read comfortably as tabs.
+const RESOLUTION_TAB_LABELS = {
+  [ResolutionType.Either]: 'Either Party',
+  [ResolutionType.Creator]: 'Creator',
+  [ResolutionType.Opponent]: 'Opponent',
+  [ResolutionType.Polymarket]: 'Polymarket',
+  [ResolutionType.ChainlinkDataFeed]: 'Chainlink Data Feed',
+  [ResolutionType.ChainlinkFunctions]: 'Chainlink Functions',
+  [ResolutionType.UMA]: 'UMA',
+}
+
 /**
  * FriendMarketsModal
  *
@@ -134,6 +156,49 @@ function FriendMarketsModal({
     }
     return WAGER_DEFAULTS.RESOLUTION_TYPE
   }, [resolutionCategory, availableOracleResolutionTypes])
+
+  // The oracle ('oracle') and Bookmaker ('all') flows present the settlement
+  // source as a tab strip at the top of the form (with the market/condition
+  // picker right under it) instead of a dropdown buried below the stake fields.
+  // The participant-only flow keeps its simple "Who Can Resolve?" dropdown.
+  const useResolutionTabs = resolutionCategory === 'oracle' || resolutionCategory === 'all'
+
+  // Availability + locked-reason per oracle resolution type, reusing the same
+  // gates as `availableOracleResolutionTypes`. Unavailable oracles render as
+  // locked tabs rather than being hidden.
+  const oracleAvailability = useMemo(() => ({
+    [ResolutionType.Polymarket]: {
+      enabled: polymarketSidebetsEnabled,
+      lockedReason: 'Requires the Polymarket CTF. Switch to Polygon (Amoy or Mainnet) to use it.',
+    },
+    [ResolutionType.ChainlinkDataFeed]: {
+      enabled: Boolean(chainlinkDataFeedAdapter),
+      lockedReason: "Chainlink Data Feed adapter isn't deployed on this network yet.",
+    },
+    [ResolutionType.ChainlinkFunctions]: {
+      enabled: Boolean(chainlinkFunctionsAdapter),
+      lockedReason: "Chainlink Functions adapter isn't deployed on this network yet.",
+    },
+    [ResolutionType.UMA]: {
+      enabled: Boolean(umaAdapter),
+      lockedReason: "UMA Optimistic Oracle adapter isn't deployed on this network yet.",
+    },
+  }), [polymarketSidebetsEnabled, chainlinkDataFeedAdapter, chainlinkFunctionsAdapter, umaAdapter])
+
+  // Resolution types rendered as tabs. Oracle types are always shown (locked
+  // when unavailable). The Bookmaker ('all') flow also lists the participant
+  // settlement choices first.
+  const resolutionTabTypes = useMemo(() => {
+    if (resolutionCategory === 'oracle') return ORACLE_TAB_TYPES
+    return [...PARTICIPANT_RESOLUTION_TYPES, ...ORACLE_TAB_TYPES]
+  }, [resolutionCategory])
+
+  // A tab is locked only for oracle types whose adapter/CTF isn't reachable.
+  const isTabLocked = useCallback(
+    (t) => Boolean(oracleAvailability[t]) && !oracleAvailability[t].enabled,
+    [oracleAvailability]
+  )
+  const anyOracleEnabled = ORACLE_TAB_TYPES.some((t) => oracleAvailability[t]?.enabled)
 
   // Chain-aware token metadata for the Stake Token dropdown. Recomputed
   // whenever the user switches Testnet/Mainnet so the right addresses are
@@ -958,6 +1023,276 @@ function FriendMarketsModal({
               {creationStep === 'form' && (
                 <form className="fm-form" onSubmit={handleSubmit}>
                   <div className="fm-form-grid">
+                    {/* Settlement source + market selection — surfaced at the very
+                        top of the oracle / Bookmaker flows so users pick the
+                        resource they're betting on (Polymarket event / oracle
+                        condition) first. The source is chosen via tabs; oracle
+                        sources that aren't reachable on the active chain render as
+                        locked tabs. */}
+                    {useResolutionTabs && (
+                      <>
+                        <div className="fm-form-group fm-form-full">
+                          <label id="fm-resolution-tabs-label">
+                            {resolutionCategory === 'oracle' ? 'Which oracle settles this?' : 'How does this settle?'}
+                          </label>
+                          <div
+                            className="fm-resolution-tabs"
+                            role="tablist"
+                            aria-labelledby="fm-resolution-tabs-label"
+                          >
+                            {resolutionTabTypes.map((t) => {
+                              const locked = isTabLocked(t)
+                              const active = formData.resolutionType === t
+                              return (
+                                <button
+                                  key={t}
+                                  type="button"
+                                  role="tab"
+                                  aria-selected={active}
+                                  aria-disabled={locked}
+                                  disabled={submitting || locked}
+                                  title={locked ? oracleAvailability[t]?.lockedReason : undefined}
+                                  className={`fm-resolution-tab ${active ? 'active' : ''} ${locked ? 'locked' : ''}`}
+                                  onClick={() => { if (!locked) handleFormChange('resolutionType', t) }}
+                                >
+                                  <span className="fm-resolution-tab-label">{RESOLUTION_TAB_LABELS[t]}</span>
+                                  {locked && (
+                                    <svg className="fm-resolution-tab-lock" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                                      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                                      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                                    </svg>
+                                  )}
+                                </button>
+                              )
+                            })}
+                          </div>
+                          <span className="fm-hint">
+                            {isTabLocked(formData.resolutionType)
+                              ? oracleAvailability[formData.resolutionType]?.lockedReason
+                              : RESOLUTION_TYPE_HINTS[formData.resolutionType]}
+                            {resolutionCategory === 'oracle' && !anyOracleEnabled && (
+                              <em style={{ display: 'block', marginTop: '0.25rem', opacity: 0.75 }}>
+                                No oracle is available on this network. Switch to a chain with the
+                                Polymarket CTF (Polygon Amoy or Mainnet) or a deployed Chainlink/UMA
+                                adapter, or create a wager that your friends settle instead.
+                              </em>
+                            )}
+                          </span>
+                        </div>
+
+                        {/* Linked Market — Polymarket event lookup */}
+                        {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') &&
+                         formData.resolutionType === ResolutionType.Polymarket && (
+                          <div className="fm-form-group fm-form-full">
+                            <label htmlFor="fm-polymarket-search">
+                              Linked Polymarket Event <span className="fm-required">*</span>
+                            </label>
+
+                            {selectedPolymarketMarket && (
+                              <div className="fm-polymarket-selected">
+                                <div className="fm-polymarket-selected-body">
+                                  <strong>{selectedPolymarketMarket.question}</strong>
+                                  <div className="fm-polymarket-meta">
+                                    {selectedPolymarketMarket.endDate && (
+                                      <span>Wager ends {formatDate(selectedPolymarketMarket.endDate)} (locked to linked market)</span>
+                                    )}
+                                    {selectedPolymarketMarket.outcomes?.length > 0 && (
+                                      <span>
+                                        {selectedPolymarketMarket.outcomes
+                                          .map((o) => `${o.name}${o.price != null ? ` ${Math.round(o.price * 100)}¢` : ''}`)
+                                          .join(' · ')}
+                                      </span>
+                                    )}
+                                  </div>
+                                  <code className="fm-polymarket-cid">{selectedPolymarketMarket.conditionId}</code>
+                                </div>
+                                <button
+                                  type="button"
+                                  className="fm-link-btn"
+                                  onClick={clearPolymarketSelection}
+                                  disabled={submitting}
+                                >
+                                  Change
+                                </button>
+                              </div>
+                            )}
+
+                            {selectedPolymarketMarket ? (
+                              <div className={`fm-polymarket-browse-accordion ${polymarketBrowserOpen ? 'open' : ''}`}>
+                                <button
+                                  type="button"
+                                  className="fm-polymarket-browse-toggle"
+                                  onClick={() => setPolymarketBrowserOpen(o => !o)}
+                                  aria-expanded={polymarketBrowserOpen}
+                                  aria-controls="fm-polymarket-browse-panel"
+                                  disabled={submitting}
+                                >
+                                  <span>Browse other Polymarket events</span>
+                                  <svg
+                                    className="fm-polymarket-browse-chevron"
+                                    width="16"
+                                    height="16"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    strokeWidth="2"
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    aria-hidden="true"
+                                  >
+                                    <polyline points="6 9 12 15 18 9" />
+                                  </svg>
+                                </button>
+                                {polymarketBrowserOpen && (
+                                  <div id="fm-polymarket-browse-panel" className="fm-polymarket-browse-panel">
+                                    <span className="fm-hint">
+                                      Browse top markets by category, or search for a specific event. Picking a different one will replace your current selection.
+                                    </span>
+                                    <PolymarketBrowser
+                                      variant="inline"
+                                      showFilters
+                                      limit={20}
+                                      selectedConditionId={selectedPolymarketMarket?.conditionId}
+                                      onSelectMarket={handleSelectPolymarketMarket}
+                                    />
+                                  </div>
+                                )}
+                              </div>
+                            ) : (
+                              <>
+                                <span className="fm-hint">
+                                  Browse top markets by category, or search for a specific event. Pick one and the wager will settle automatically when that Polymarket market resolves.
+                                </span>
+
+                                <PolymarketBrowser
+                                  variant="inline"
+                                  showFilters
+                                  limit={20}
+                                  selectedConditionId={selectedPolymarketMarket?.conditionId}
+                                  onSelectMarket={handleSelectPolymarketMarket}
+                                />
+                              </>
+                            )}
+
+                            {errors.oracleConditionId && (
+                              <span className="fm-error">{errors.oracleConditionId}</span>
+                            )}
+                          </div>
+                        )}
+
+                        {/* Oracle condition picker — Chainlink Data Feed / Chainlink Functions / UMA */}
+                        {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') &&
+                         isExtensibleOracleType(formData.resolutionType) && (
+                          <div className="fm-form-group fm-form-full">
+                            <label htmlFor="fm-oracle-condition-picker">
+                              Oracle condition <span className="fm-required">*</span>
+                            </label>
+                            <OracleConditionPicker
+                              kind={
+                                formData.resolutionType === ResolutionType.ChainlinkDataFeed ? 'datafeed' :
+                                formData.resolutionType === ResolutionType.ChainlinkFunctions ? 'functions' :
+                                'uma'
+                              }
+                              adapterAddress={
+                                formData.resolutionType === ResolutionType.ChainlinkDataFeed ? chainlinkDataFeedAdapter :
+                                formData.resolutionType === ResolutionType.ChainlinkFunctions ? chainlinkFunctionsAdapter :
+                                umaAdapter
+                              }
+                              value={formData.oracleConditionId}
+                              onChange={(id) => handleFormChange('oracleConditionId', id || '')}
+                              error={errors.oracleConditionId}
+                              disabled={submitting}
+                            />
+                          </div>
+                        )}
+
+                        {/* Generic YES/NO side picker for the non-Polymarket oracle types.
+                            Polymarket has its own outcome-named side picker below — we
+                            skip it for the new types and use a binary YES/NO labelling
+                            that maps to the contract's creatorIsYes bool. */}
+                        {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') &&
+                         isExtensibleOracleType(formData.resolutionType) && (
+                          <div className="fm-form-group fm-form-full">
+                            <label>
+                              Your side of the bet <span className="fm-required">*</span>
+                            </label>
+                            <span className="fm-hint">
+                              The oracle will return a YES or NO outcome. Pick which side you&apos;re taking — your opponent gets the other.
+                            </span>
+                            <div className="fm-side-picker">
+                              {[
+                                { idx: '0', label: 'YES' },
+                                { idx: '1', label: 'NO' },
+                              ].map(({ idx, label }) => {
+                                const active = formData.creatorSide === idx
+                                return (
+                                  <button
+                                    key={idx}
+                                    type="button"
+                                    className={`fm-side-btn ${active ? 'active' : ''}`}
+                                    onClick={() => handleFormChange('creatorSide', idx)}
+                                    disabled={submitting}
+                                    aria-pressed={active}
+                                  >
+                                    <span className="fm-side-btn-label">I&apos;m taking {label}</span>
+                                  </button>
+                                )
+                              })}
+                            </div>
+                            {errors.creatorSide && (
+                              <span className="fm-error">{errors.creatorSide}</span>
+                            )}
+                          </div>
+                        )}
+
+                        {/* Creator side — which outcome of the linked Polymarket are you taking? */}
+                        {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') &&
+                         formData.resolutionType === ResolutionType.Polymarket &&
+                         selectedPolymarketMarket && (
+                          <div className="fm-form-group fm-form-full">
+                            <label>
+                              Your side of the bet <span className="fm-required">*</span>
+                            </label>
+                            <span className="fm-hint">
+                              Pick which outcome you&apos;re taking. Your opponent will be on the other side, and the bet description will say so explicitly.
+                            </span>
+                            <div className="fm-side-picker">
+                              {['0', '1'].map((idx) => {
+                                const outcome = selectedPolymarketMarket.outcomes?.[Number(idx)]
+                                const fallback = idx === '0' ? 'YES' : 'NO'
+                                const name = outcome?.name || fallback
+                                const active = formData.creatorSide === idx
+                                return (
+                                  <button
+                                    key={idx}
+                                    type="button"
+                                    className={`fm-side-btn ${active ? 'active' : ''}`}
+                                    onClick={() => handleSelectCreatorSide(idx)}
+                                    disabled={submitting}
+                                    aria-pressed={active}
+                                  >
+                                    <span className="fm-side-btn-label">I&apos;m taking {name}</span>
+                                  </button>
+                                )
+                              })}
+                            </div>
+                            {formData.creatorSide !== '' && (
+                              <span className="fm-hint">
+                                Your opponent will be taking{' '}
+                                <strong>
+                                  {selectedPolymarketMarket.outcomes?.[formData.creatorSide === '0' ? 1 : 0]?.name
+                                    || (formData.creatorSide === '0' ? 'NO' : 'YES')}
+                                </strong>.
+                              </span>
+                            )}
+                            {errors.creatorSide && (
+                              <span className="fm-error">{errors.creatorSide}</span>
+                            )}
+                          </div>
+                        )}
+                      </>
+                    )}
+
                     <div className="fm-form-group fm-form-full">
                       <label htmlFor="fm-description">
                         What&apos;s the bet? <span className="fm-required">*</span>
@@ -1091,14 +1426,12 @@ function FriendMarketsModal({
                       </div>
                     )}
 
-                    {/* Resolution Type selector. The options are pre-filtered by
-                        `resolutionCategory` (participant vs oracle) so each flow
-                        only surfaces the relevant settlement choices. */}
-                    {resolutionOptionTypes.length > 0 ? (
+                    {/* Resolution Type selector (participant flow only). The
+                        oracle / Bookmaker flows render a tab strip at the top of
+                        the form instead — see the settlement section above. */}
+                    {!useResolutionTabs && resolutionOptionTypes.length > 0 && (
                       <div className="fm-form-group fm-form-full">
-                        <label htmlFor="fm-resolution-type">
-                          {resolutionCategory === 'oracle' ? 'Which oracle settles this?' : 'Who Can Resolve?'}
-                        </label>
+                        <label htmlFor="fm-resolution-type">Who Can Resolve?</label>
                         <select
                           id="fm-resolution-type"
                           value={formData.resolutionType}
@@ -1112,23 +1445,6 @@ function FriendMarketsModal({
                         </select>
                         <span className="fm-hint">
                           {RESOLUTION_TYPE_HINTS[formData.resolutionType]}
-                          {resolutionCategory === 'oracle' && !polymarketSidebetsEnabled && (
-                            <em style={{ display: 'block', marginTop: '0.25rem', opacity: 0.75 }}>
-                              Linked Market (Polymarket) settlement requires a chain with the Polymarket CTF. Switch to Polygon (Amoy or Mainnet) to use it.
-                            </em>
-                          )}
-                        </span>
-                      </div>
-                    ) : (
-                      <div className="fm-form-group fm-form-full">
-                        <label>Oracle Settlement</label>
-                        <div className="fm-readonly-value">
-                          No oracle is available on this network.
-                        </div>
-                        <span className="fm-hint">
-                          Switch to a chain with the Polymarket CTF (Polygon Amoy or Mainnet) or a
-                          deployed Chainlink/UMA adapter, or create a wager that your friends settle
-                          instead.
                         </span>
                       </div>
                     )}
@@ -1249,217 +1565,6 @@ function FriendMarketsModal({
                         </div>
                       )
                     })()}
-
-                    {/* Linked Market — Polymarket event lookup */}
-                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') &&
-                     formData.resolutionType === ResolutionType.Polymarket && (
-                      <div className="fm-form-group fm-form-full">
-                        <label htmlFor="fm-polymarket-search">
-                          Linked Polymarket Event <span className="fm-required">*</span>
-                        </label>
-
-                        {selectedPolymarketMarket && (
-                          <div className="fm-polymarket-selected">
-                            <div className="fm-polymarket-selected-body">
-                              <strong>{selectedPolymarketMarket.question}</strong>
-                              <div className="fm-polymarket-meta">
-                                {selectedPolymarketMarket.endDate && (
-                                  <span>Wager ends {formatDate(selectedPolymarketMarket.endDate)} (locked to linked market)</span>
-                                )}
-                                {selectedPolymarketMarket.outcomes?.length > 0 && (
-                                  <span>
-                                    {selectedPolymarketMarket.outcomes
-                                      .map((o) => `${o.name}${o.price != null ? ` ${Math.round(o.price * 100)}¢` : ''}`)
-                                      .join(' · ')}
-                                  </span>
-                                )}
-                              </div>
-                              <code className="fm-polymarket-cid">{selectedPolymarketMarket.conditionId}</code>
-                            </div>
-                            <button
-                              type="button"
-                              className="fm-link-btn"
-                              onClick={clearPolymarketSelection}
-                              disabled={submitting}
-                            >
-                              Change
-                            </button>
-                          </div>
-                        )}
-
-                        {selectedPolymarketMarket ? (
-                          <div className={`fm-polymarket-browse-accordion ${polymarketBrowserOpen ? 'open' : ''}`}>
-                            <button
-                              type="button"
-                              className="fm-polymarket-browse-toggle"
-                              onClick={() => setPolymarketBrowserOpen(o => !o)}
-                              aria-expanded={polymarketBrowserOpen}
-                              aria-controls="fm-polymarket-browse-panel"
-                              disabled={submitting}
-                            >
-                              <span>Browse other Polymarket events</span>
-                              <svg
-                                className="fm-polymarket-browse-chevron"
-                                width="16"
-                                height="16"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                aria-hidden="true"
-                              >
-                                <polyline points="6 9 12 15 18 9" />
-                              </svg>
-                            </button>
-                            {polymarketBrowserOpen && (
-                              <div id="fm-polymarket-browse-panel" className="fm-polymarket-browse-panel">
-                                <span className="fm-hint">
-                                  Browse top markets by category, or search for a specific event. Picking a different one will replace your current selection.
-                                </span>
-                                <PolymarketBrowser
-                                  variant="inline"
-                                  showFilters
-                                  limit={20}
-                                  selectedConditionId={selectedPolymarketMarket?.conditionId}
-                                  onSelectMarket={handleSelectPolymarketMarket}
-                                />
-                              </div>
-                            )}
-                          </div>
-                        ) : (
-                          <>
-                            <span className="fm-hint">
-                              Browse top markets by category, or search for a specific event. Pick one and the wager will settle automatically when that Polymarket market resolves.
-                            </span>
-
-                            <PolymarketBrowser
-                              variant="inline"
-                              showFilters
-                              limit={20}
-                              selectedConditionId={selectedPolymarketMarket?.conditionId}
-                              onSelectMarket={handleSelectPolymarketMarket}
-                            />
-                          </>
-                        )}
-
-                        {errors.oracleConditionId && (
-                          <span className="fm-error">{errors.oracleConditionId}</span>
-                        )}
-                      </div>
-                    )}
-
-                    {/* Oracle condition picker — Chainlink Data Feed / Chainlink Functions / UMA */}
-                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') &&
-                     isExtensibleOracleType(formData.resolutionType) && (
-                      <div className="fm-form-group fm-form-full">
-                        <label htmlFor="fm-oracle-condition-picker">
-                          Oracle condition <span className="fm-required">*</span>
-                        </label>
-                        <OracleConditionPicker
-                          kind={
-                            formData.resolutionType === ResolutionType.ChainlinkDataFeed ? 'datafeed' :
-                            formData.resolutionType === ResolutionType.ChainlinkFunctions ? 'functions' :
-                            'uma'
-                          }
-                          adapterAddress={
-                            formData.resolutionType === ResolutionType.ChainlinkDataFeed ? chainlinkDataFeedAdapter :
-                            formData.resolutionType === ResolutionType.ChainlinkFunctions ? chainlinkFunctionsAdapter :
-                            umaAdapter
-                          }
-                          value={formData.oracleConditionId}
-                          onChange={(id) => handleFormChange('oracleConditionId', id || '')}
-                          error={errors.oracleConditionId}
-                          disabled={submitting}
-                        />
-                      </div>
-                    )}
-
-                    {/* Generic YES/NO side picker for the non-Polymarket oracle types.
-                        Polymarket has its own outcome-named side picker below — we
-                        skip it for the new types and use a binary YES/NO labelling
-                        that maps to the contract's creatorIsYes bool. */}
-                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') &&
-                     isExtensibleOracleType(formData.resolutionType) && (
-                      <div className="fm-form-group fm-form-full">
-                        <label>
-                          Your side of the bet <span className="fm-required">*</span>
-                        </label>
-                        <span className="fm-hint">
-                          The oracle will return a YES or NO outcome. Pick which side you&apos;re taking — your opponent gets the other.
-                        </span>
-                        <div className="fm-side-picker">
-                          {[
-                            { idx: '0', label: 'YES' },
-                            { idx: '1', label: 'NO' },
-                          ].map(({ idx, label }) => {
-                            const active = formData.creatorSide === idx
-                            return (
-                              <button
-                                key={idx}
-                                type="button"
-                                className={`fm-side-btn ${active ? 'active' : ''}`}
-                                onClick={() => handleFormChange('creatorSide', idx)}
-                                disabled={submitting}
-                                aria-pressed={active}
-                              >
-                                <span className="fm-side-btn-label">I&apos;m taking {label}</span>
-                              </button>
-                            )
-                          })}
-                        </div>
-                        {errors.creatorSide && (
-                          <span className="fm-error">{errors.creatorSide}</span>
-                        )}
-                      </div>
-                    )}
-
-                    {/* Creator side — which outcome of the linked Polymarket are you taking? */}
-                    {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') &&
-                     formData.resolutionType === ResolutionType.Polymarket &&
-                     selectedPolymarketMarket && (
-                      <div className="fm-form-group fm-form-full">
-                        <label>
-                          Your side of the bet <span className="fm-required">*</span>
-                        </label>
-                        <span className="fm-hint">
-                          Pick which outcome you&apos;re taking. Your opponent will be on the other side, and the bet description will say so explicitly.
-                        </span>
-                        <div className="fm-side-picker">
-                          {['0', '1'].map((idx) => {
-                            const outcome = selectedPolymarketMarket.outcomes?.[Number(idx)]
-                            const fallback = idx === '0' ? 'YES' : 'NO'
-                            const name = outcome?.name || fallback
-                            const active = formData.creatorSide === idx
-                            return (
-                              <button
-                                key={idx}
-                                type="button"
-                                className={`fm-side-btn ${active ? 'active' : ''}`}
-                                onClick={() => handleSelectCreatorSide(idx)}
-                                disabled={submitting}
-                                aria-pressed={active}
-                              >
-                                <span className="fm-side-btn-label">I&apos;m taking {name}</span>
-                              </button>
-                            )
-                          })}
-                        </div>
-                        {formData.creatorSide !== '' && (
-                          <span className="fm-hint">
-                            Your opponent will be taking{' '}
-                            <strong>
-                              {selectedPolymarketMarket.outcomes?.[formData.creatorSide === '0' ? 1 : 0]?.name
-                                || (formData.creatorSide === '0' ? 'NO' : 'YES')}
-                            </strong>.
-                          </span>
-                        )}
-                        {errors.creatorSide && (
-                          <span className="fm-error">{errors.creatorSide}</span>
-                        )}
-                      </div>
-                    )}
 
                     {/* Privacy / Encryption Toggle */}
                     <div className="fm-form-group fm-form-full">

--- a/frontend/src/test/FriendMarketsModal.test.jsx
+++ b/frontend/src/test/FriendMarketsModal.test.jsx
@@ -319,16 +319,28 @@ describe('FriendMarketsModal', () => {
       expect(labels).not.toContain('Third Party Arbitrator')
     })
 
-    it('oracle category shows only oracle resolution options', () => {
+    it('oracle category shows oracle resolution tabs (not a dropdown)', () => {
       renderWithProviders(
         <FriendMarketsModal {...defaultProps} resolutionCategory="oracle" />
       )
-      // The oracle flow relabels the selector and excludes participant options.
-      const select = screen.getByLabelText(/which oracle settles this/i)
-      const labels = Array.from(select.querySelectorAll('option')).map(o => o.textContent)
-      expect(labels).not.toContain('Either Party')
-      expect(labels.length).toBeGreaterThan(0)
-      labels.forEach(l => expect(l).toMatch(/Polymarket|Chainlink|UMA/))
+      // The oracle flow renders settlement sources as tabs at the top of the
+      // form (no <select> dropdown), and excludes the participant-settled options.
+      expect(screen.queryByRole('combobox', { name: /which oracle settles this/i })).not.toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: /polymarket/i })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: /chainlink data feed/i })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: /chainlink functions/i })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: /^uma$/i })).toBeInTheDocument()
+      expect(screen.queryByRole('tab', { name: /either party/i })).not.toBeInTheDocument()
+    })
+
+    it('locks oracle tabs whose source is unavailable on the active chain', () => {
+      // On Hardhat (1337) the Polymarket CTF is unreachable, so the Polymarket
+      // tab is shown locked/disabled rather than hidden.
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} resolutionCategory="oracle" />,
+        { chainId: 1337 }
+      )
+      expect(screen.getByRole('tab', { name: /polymarket/i })).toBeDisabled()
     })
 
     it('no longer renders a type-selector or Back link', () => {
@@ -338,8 +350,11 @@ describe('FriendMarketsModal', () => {
     })
 
     it('no longer renders the Active/Past tab strip', () => {
+      // The modal's only tablist is now the resolution-source strip; the old
+      // Active/Past navigation tabs are gone.
       renderWithProviders(<FriendMarketsModal {...defaultProps} />)
-      expect(screen.queryByRole('tablist')).not.toBeInTheDocument()
+      expect(screen.queryByRole('tab', { name: /^active$/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('tab', { name: /^past$/i })).not.toBeInTheDocument()
     })
   })
 
@@ -677,9 +692,9 @@ describe('FriendMarketsModal', () => {
         { chainId: 80002 }
       )
 
-      // Switch resolution type to Polymarket so the inline browser renders.
-      const dropdown = screen.getByLabelText(/who can resolve/i)
-      await userEvent.selectOptions(dropdown, '4')  // ResolutionType.Polymarket = 4
+      // Switch resolution type to Polymarket (via the tab strip) so the inline
+      // browser renders.
+      await userEvent.click(screen.getByRole('tab', { name: /polymarket/i }))
 
       // Pick the (single) mocked market.
       await userEvent.click(screen.getByTestId(`pmb-pick-${polymarketMarket.conditionId}`))
@@ -698,29 +713,32 @@ describe('FriendMarketsModal', () => {
     // picker have their own unit tests.
     const STUB_CONDITION_ID = STUB_ORACLE_CONDITION_ID
 
+    // Tab names in the resolution strip, keyed by oracle picker `kind`.
+    const TAB_NAME = {
+      datafeed: /chainlink data feed/i,
+      functions: /chainlink functions/i,
+      uma: /^uma$/i,
+    }
+
     async function pickKindAndSide(kind, sideLabel) {
-      // Open the resolution-type dropdown and switch to the desired oracle.
-      const RT = { ChainlinkDataFeed: 5, ChainlinkFunctions: 6, UMA: 7 }[
-        kind === 'datafeed' ? 'ChainlinkDataFeed' : kind === 'functions' ? 'ChainlinkFunctions' : 'UMA'
-      ]
-      await userEvent.selectOptions(screen.getByLabelText(/who can resolve/i), String(RT))
+      // Switch to the desired oracle via the resolution-type tab strip.
+      await userEvent.click(screen.getByRole('tab', { name: TAB_NAME[kind] }))
       // Click the stub picker's "Pick" button → conditionId lands in formData.
       await userEvent.click(await screen.findByTestId(`mock-pick-${kind}`))
       // Side picker: generic YES/NO buttons.
       await userEvent.click(screen.getByRole('button', { name: new RegExp(`i'm taking ${sideLabel}`, 'i') }))
     }
 
-    it('renders the 3 new dropdown options on a Polygon-family chain', async () => {
+    it('renders the 3 new oracle tabs on a Polygon-family chain', async () => {
       renderWithProviders(<FriendMarketsModal {...defaultProps} />, { chainId: 80002 })
-      const dropdown = screen.getByLabelText(/who can resolve/i)
-      expect(dropdown).toContainHTML('Chainlink Data Feed')
-      expect(dropdown).toContainHTML('Chainlink Functions')
-      expect(dropdown).toContainHTML('UMA Optimistic Oracle')
+      expect(screen.getByRole('tab', { name: /chainlink data feed/i })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: /chainlink functions/i })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: /^uma$/i })).toBeInTheDocument()
     })
 
     it('renders the picker + generic side picker for ChainlinkDataFeed', async () => {
       renderWithProviders(<FriendMarketsModal {...defaultProps} />, { chainId: 80002 })
-      await userEvent.selectOptions(screen.getByLabelText(/who can resolve/i), '5')
+      await userEvent.click(screen.getByRole('tab', { name: /chainlink data feed/i }))
       expect(await screen.findByTestId('mock-oracle-picker-datafeed')).toBeInTheDocument()
       // Generic YES/NO buttons.
       expect(screen.getByRole('button', { name: /I'm taking YES/i })).toBeInTheDocument()
@@ -789,7 +807,7 @@ describe('FriendMarketsModal', () => {
         screen.getByLabelText(/opponent address/i),
         '0xabcdef1234567890123456789012345678901234'
       )
-      await userEvent.selectOptions(screen.getByLabelText(/who can resolve/i), '6')
+      await userEvent.click(screen.getByRole('tab', { name: /chainlink functions/i }))
       // Don't pick a condition — go straight to submit. Side stays empty too.
       await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
       await waitFor(() => {
@@ -812,7 +830,7 @@ describe('FriendMarketsModal', () => {
         screen.getByLabelText(/opponent address/i),
         '0xabcdef1234567890123456789012345678901234'
       )
-      await userEvent.selectOptions(screen.getByLabelText(/who can resolve/i), '5')
+      await userEvent.click(screen.getByRole('tab', { name: /chainlink data feed/i }))
       await userEvent.click(await screen.findByTestId('mock-pick-datafeed'))
       // Don't click YES/NO.
       await userEvent.click(screen.getByRole('button', { name: /create wager/i }))
@@ -829,10 +847,10 @@ describe('FriendMarketsModal', () => {
         { chainId: 80002 }
       )
       // Pick a DataFeed condition first.
-      await userEvent.selectOptions(screen.getByLabelText(/who can resolve/i), '5')
+      await userEvent.click(screen.getByRole('tab', { name: /chainlink data feed/i }))
       await userEvent.click(await screen.findByTestId('mock-pick-datafeed'))
       // Switch to UMA → picker should reset (data-value attribute on the stub goes back to '').
-      await userEvent.selectOptions(screen.getByLabelText(/who can resolve/i), '7')
+      await userEvent.click(screen.getByRole('tab', { name: /^uma$/i }))
       const umaPicker = await screen.findByTestId('mock-oracle-picker-uma')
       expect(umaPicker).toHaveAttribute('data-value', '')
     })


### PR DESCRIPTION
## Problem

In the oracle-resolved and Bookmaker wager creation flows, the settlement
configuration was awkwardly ordered. The user picked the settlement source from a
`<select>` dropdown labelled *"Which oracle settles this?"* that sat **below** the
stake/date fields, and the actual market/condition picker (Polymarket browser,
Chainlink/UMA condition picker) rendered even further down. Users had to scroll
past several fields before they could find and pick the event they wanted to bet
on. (See the mobile screenshots that prompted this.)

## Changes

- **Market selection moved to the top.** The settlement-source selector and the
  market/condition picker now render at the very top of the form, so the first
  thing the user does is pick the resource they're betting on.
- **Oracle source is now a tab strip** instead of a dropdown. Each resolution
  source is a tab; the active tab's picker (Polymarket browser + category chips,
  or the Chainlink/UMA condition picker) renders directly beneath it.
- **Locked tabs for unavailable sources.** Oracle sources that aren't reachable on
  the active chain (e.g. Polymarket off Polygon, or a Chainlink/UMA adapter not
  deployed) now render as **locked tabs** — greyed, with a 🔒 icon and a tooltip
  explaining why and how to enable them — instead of being silently hidden. A hint
  below the strip repeats the reason for mobile users (no hover).

## Scope

Applies to the **Oracle Settles (1v1)** flow (`resolutionCategory='oracle'`) and
the **Bookmaker** flow (`resolutionCategory='all'`). The participant-settled
"Friends Decide" flow keeps its existing *"Who Can Resolve?"* dropdown unchanged.

No contract, hook, or data-source changes — the submitted payload
(`resolutionType` / `oracleConditionId` / `creatorSide`) is identical; only the
input UI differs.

## Files

- `frontend/src/components/fairwins/FriendMarketsModal.jsx` — tab strip + relocated
  market/condition pickers; participant dropdown gated behind `!useResolutionTabs`.
- `frontend/src/components/fairwins/FriendMarketsModal.css` — `.fm-resolution-tabs`
  / `.fm-resolution-tab` styling (matches existing `fm-*` tokens).
- `frontend/src/test/FriendMarketsModal.test.jsx` — updated oracle/bookmaker tests
  to drive the tab strip; added a locked-tab test.

## Verification

- `npm test -- FriendMarketsModal` → 46/46 pass.
- Full frontend suite → 792/792 pass.
- `npm run lint` on changed files → clean.

https://claude.ai/code/session_01EEdrjC5fFxqYkaVaU1TyhQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEdrjC5fFxqYkaVaU1TyhQ)_