### PR TITLE
Scope wagers and membership to the active network on testnet/mainnet switch

### DIFF
--- a/frontend/src/components/fairwins/MyMarketsModal.css
+++ b/frontend/src/components/fairwins/MyMarketsModal.css
@@ -94,6 +94,27 @@
   margin: 0.25rem 0 0 0;
 }
 
+/* Network tag — signals which network's wagers are being shown so testnet
+   wagers are never mistaken for mainnet ones (and vice versa). */
+.mm-network-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--text-primary, #E6EDF3);
+  background: rgba(76, 154, 255, 0.15);
+  border: 1px solid rgba(76, 154, 255, 0.45);
+}
+
+.mm-network-tag-testnet {
+  color: #F5C451;
+  background: rgba(245, 196, 81, 0.12);
+  border-color: rgba(245, 196, 81, 0.45);
+}
+
 .mm-close-btn {
   background: var(--bg-primary, #0E141B);
   border: 2px solid var(--text-secondary, #AAB6C2);

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -6,6 +6,7 @@ import { useLazyIpfsEnvelope } from '../../hooks/useIpfs'
 import { useFriendMarkets } from '../../contexts/FriendMarketsContext.js'
 import { WagerStatus as MarketStatus, DisputeStatus, WAGER_DEFAULTS } from '../../constants/wagerDefaults'
 import { getContractAddress } from '../../config/contracts'
+import { getNetwork } from '../../config/networks'
 import { WAGER_REGISTRY_ABI } from '../../abis/WagerRegistry'
 import { getFeeOverrides } from '../../utils/feeOverrides'
 import { getTransactionUrl } from '../../config/blockExplorer'
@@ -30,8 +31,12 @@ function MyMarketsModal({
   onClose,
   friendMarkets = []
 }) {
-  const { isConnected, account } = useWallet()
+  const { isConnected, account, chainId } = useWallet()
   const { signer, isCorrectNetwork, switchNetwork } = useWeb3()
+
+  // Active network metadata, used to scope/label the wagers shown so it's
+  // clear they belong to the selected network (testnet vs mainnet).
+  const activeNetwork = useMemo(() => (chainId ? getNetwork(chainId) : null), [chainId])
   const { dismissedIds, dismissMarket, dismissMarkets } = useFriendMarkets()
 
   const { markets: marketsWithEnvelopes, fetchEnvelope } = useLazyIpfsEnvelope(friendMarkets)
@@ -154,8 +159,18 @@ function MyMarketsModal({
       ...decryptableMarkets.map(m => ({ ...m, marketType: 'friend' }))
     ]
 
+    // Only show wagers that belong to the active network. Wagers are tagged
+    // with the chainId they were read from (see FriendMarketsContext); after a
+    // testnet ↔ mainnet switch this drops wagers that only exist on the other
+    // network instead of displaying them as if they were available here.
+    // Legacy/untagged wagers (no chainId) fall through so we never hide data
+    // written before this tagging existed.
+    const onActiveChain = allMarkets.filter(
+      m => m.chainId == null || !chainId || m.chainId === chainId
+    )
+
     // Remove duplicates by id
-    const uniqueMarkets = allMarkets.reduce((acc, market) => {
+    const uniqueMarkets = onActiveChain.reduce((acc, market) => {
       const key = `${market.marketType}-${market.id}`
       if (!acc[key]) acc[key] = market
       return acc
@@ -278,7 +293,7 @@ function MyMarketsModal({
     history.sort(byNewest)
 
     return { participating, created, history }
-  }, [markets, decryptableMarkets, userPositions, account, marketTypeFilter, statusFilter, dismissedIds])
+  }, [markets, decryptableMarkets, userPositions, account, marketTypeFilter, statusFilter, dismissedIds, chainId])
 
   // Derive the selected market from the live categorized lists so the detail
   // view reflects fresh data (e.g., decryptedMetadata) after decryption
@@ -536,8 +551,18 @@ function MyMarketsModal({
             <div className="mm-brand">
               <span className="mm-brand-icon">&#128202;</span>
               <h2 id="my-markets-modal-title">My Wagers</h2>
+              {activeNetwork && (
+                <span
+                  className={`mm-network-tag${activeNetwork.isTestnet ? ' mm-network-tag-testnet' : ''}`}
+                  title={`Showing wagers on ${activeNetwork.name}`}
+                >
+                  {activeNetwork.name}
+                </span>
+              )}
             </div>
-            <p className="mm-subtitle">Manage your wagers and positions</p>
+            <p className="mm-subtitle">
+              Manage your wagers and positions on {activeNetwork?.name || 'the current network'}
+            </p>
           </div>
           <button
             className="mm-close-btn"

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -112,6 +112,29 @@ export function getContractAddress(contractName) {
 }
 
 /**
+ * Get a contract address for a specific chain id.
+ *
+ * Unlike `getContractAddress`, which is bound to the build-time
+ * VITE_NETWORK_ID, this resolves against the per-chain deployment record so
+ * runtime network switches (testnet ↔ mainnet) read the right deployment.
+ * Returns undefined when the chain has no deployment for that contract — which
+ * is the correct signal for "not available on this network" (e.g. a testnet
+ * membership must not appear active on mainnet).
+ *
+ * Falls back to `getContractAddress` (env overrides + active chain) when no
+ * chainId is supplied so existing callers keep their current behavior.
+ *
+ * @param {string} contractName - Name of the contract
+ * @param {number} [chainId] - Target chain id
+ * @returns {string|undefined} Contract address
+ */
+export function getContractAddressForChain(contractName, chainId) {
+  if (chainId == null) return getContractAddress(contractName)
+  const chainContracts = NETWORK_CONTRACTS[chainId]
+  return chainContracts ? chainContracts[contractName] : undefined
+}
+
+/**
  * Network configuration, derived from VITE_NETWORK_ID
  */
 const NETWORK_INFO_BY_CHAIN = {

--- a/frontend/src/contexts/FriendMarketsContext.jsx
+++ b/frontend/src/contexts/FriendMarketsContext.jsx
@@ -1,26 +1,45 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
-import { useAccount } from 'wagmi'
+import { useAccount, useChainId } from 'wagmi'
 import { fetchFriendMarketsForUser } from '../utils/blockchainService'
 import { FriendMarketsContext } from './FriendMarketsContext'
 
 const STORAGE_KEY = 'friendMarkets'
 const DISMISSED_STORAGE_PREFIX = 'mywagers_dismissed:'
 
-function loadFromStorage() {
+// The wager cache is scoped per chain so that wagers fetched on the testnet
+// don't leak into the mainnet view (and vice versa) after a network switch.
+// Each entry is also tagged with the `chainId` it was read from, which lets
+// the UI filter/label wagers defensively even if a legacy (unscoped) cache is
+// still present.
+function storageKey(chainId) {
+  return chainId ? `${STORAGE_KEY}:${chainId}` : STORAGE_KEY
+}
+
+function loadFromStorage(chainId) {
   try {
-    const stored = localStorage.getItem(STORAGE_KEY)
+    const stored = localStorage.getItem(storageKey(chainId))
     return stored ? JSON.parse(stored) : []
   } catch {
     return []
   }
 }
 
-function saveToStorage(markets) {
+function saveToStorage(chainId, markets) {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(markets))
+    localStorage.setItem(storageKey(chainId), JSON.stringify(markets))
   } catch {
     // localStorage may be full or unavailable — non-fatal
   }
+}
+
+// Stamp each market with the chain it belongs to and a chain-qualified
+// uniqueId so identical market ids on different chains never collide.
+function tagMarkets(markets, chainId) {
+  return markets.map(m => ({
+    ...m,
+    chainId,
+    uniqueId: `${chainId || 'unknown'}-${m.contractAddress || 'unknown'}-${m.id}`,
+  }))
 }
 
 function dismissedKey(address) {
@@ -48,12 +67,20 @@ function saveDismissed(address, ids) {
 
 export function FriendMarketsProvider({ children }) {
   const { address, isConnected } = useAccount()
-  const [friendMarkets, setFriendMarkets] = useState(() => loadFromStorage())
+  const chainId = useChainId()
+  const [friendMarkets, setFriendMarkets] = useState(() => loadFromStorage(chainId))
   const [loading, setLoading] = useState(false)
   const [dismissedIdsArr, setDismissedIdsArr] = useState(() => loadDismissed(address))
 
-  // Fetch friend markets from blockchain when wallet connects
+  // Fetch friend markets from blockchain when the wallet connects or the
+  // active network changes. The chainId dependency is essential: when the
+  // user toggles testnet ↔ mainnet we must re-query the chain rather than
+  // keep showing wagers that only exist on the previous network.
   useEffect(() => {
+    // Immediately swap to the selected network's cached wagers (or nothing)
+    // so stale wagers from the previous network don't linger during the fetch.
+    setFriendMarkets(loadFromStorage(chainId))
+
     if (!address || !isConnected) return
 
     let cancelled = false
@@ -64,13 +91,10 @@ export function FriendMarketsProvider({ children }) {
         const blockchainMarkets = await fetchFriendMarketsForUser(address)
         if (cancelled) return
 
-        const marketsWithUniqueIds = blockchainMarkets.map(m => ({
-          ...m,
-          uniqueId: `${m.contractAddress || 'unknown'}-${m.id}`
-        }))
+        const marketsWithUniqueIds = tagMarkets(blockchainMarkets, chainId)
 
         setFriendMarkets(marketsWithUniqueIds)
-        saveToStorage(marketsWithUniqueIds)
+        saveToStorage(chainId, marketsWithUniqueIds)
       } catch (error) {
         console.error('[FriendMarketsContext] Error fetching friend markets:', error)
         if (!cancelled && attempt < 2) {
@@ -85,7 +109,7 @@ export function FriendMarketsProvider({ children }) {
 
     fetchMarkets()
     return () => { cancelled = true }
-  }, [address, isConnected])
+  }, [address, isConnected, chainId])
 
   // Manual refresh
   const refresh = useCallback(async () => {
@@ -93,26 +117,23 @@ export function FriendMarketsProvider({ children }) {
     setLoading(true)
     try {
       const blockchainMarkets = await fetchFriendMarketsForUser(address)
-      const marketsWithUniqueIds = blockchainMarkets.map(m => ({
-        ...m,
-        uniqueId: `${m.contractAddress || 'unknown'}-${m.id}`
-      }))
+      const marketsWithUniqueIds = tagMarkets(blockchainMarkets, chainId)
       setFriendMarkets(marketsWithUniqueIds)
-      saveToStorage(marketsWithUniqueIds)
+      saveToStorage(chainId, marketsWithUniqueIds)
     } catch (error) {
       console.error('[FriendMarketsContext] Error refreshing friend markets:', error)
     }
     setLoading(false)
-  }, [address, isConnected])
+  }, [address, isConnected, chainId])
 
   // Optimistic add after creation (before next blockchain fetch)
   const addMarket = useCallback((market) => {
     setFriendMarkets(prev => {
-      const updated = [...prev, market]
-      saveToStorage(updated)
+      const updated = [...prev, { ...market, chainId }]
+      saveToStorage(chainId, updated)
       return updated
     })
-  }, [])
+  }, [chainId])
 
   // Reload the dismissed set when the active account changes so we don't
   // leak one wallet's dismissed list into another.

--- a/frontend/src/contexts/WalletContext.jsx
+++ b/frontend/src/contexts/WalletContext.jsx
@@ -164,7 +164,7 @@ export function WalletProvider({ children }) {
    * If a role exists on-chain but not locally, add it
    * If a role exists locally but not on-chain, remove it (expired)
    */
-  const syncRolesWithBlockchain = useCallback(async (walletAddress, localRoles) => {
+  const syncRolesWithBlockchain = useCallback(async (walletAddress, localRoles, activeChainId) => {
     const premiumRoles = ['WAGER_PARTICIPANT']
     const adminRoles = ['ADMIN', 'GUARDIAN', 'ACCOUNT_MODERATOR', 'ROLE_MANAGER']
     const allSyncedRoles = [...premiumRoles, ...adminRoles]
@@ -178,7 +178,7 @@ export function WalletProvider({ children }) {
     // Check each role on-chain (both premium and admin roles)
     for (const roleName of allSyncedRoles) {
       try {
-        const hasOnChain = await hasRoleOnChain(walletAddress, roleName)
+        const hasOnChain = await hasRoleOnChain(walletAddress, roleName, activeChainId)
         const hasLocally = localRoles.includes(roleName)
 
         console.log(`[RoleSync] ${roleName}: onChain=${hasOnChain}, local=${hasLocally}`)
@@ -228,7 +228,7 @@ export function WalletProvider({ children }) {
    * Load roles from both localStorage and blockchain
    * Blockchain is the source of truth for premium roles
    */
-  const loadRoles = useCallback(async (walletAddress) => {
+  const loadRoles = useCallback(async (walletAddress, activeChainId) => {
     setRolesLoading(true)
     setBlockchainSynced(false)
     try {
@@ -236,8 +236,8 @@ export function WalletProvider({ children }) {
       const localRoles = getUserRoles(walletAddress)
       setRoles(localRoles)
 
-      // Then sync with blockchain (authoritative source)
-      const { roles: syncedRoles } = await syncRolesWithBlockchain(walletAddress, localRoles)
+      // Then sync with blockchain (authoritative source) for the active chain
+      const { roles: syncedRoles } = await syncRolesWithBlockchain(walletAddress, localRoles, activeChainId)
       setRoles(syncedRoles)
       setBlockchainSynced(true)
     } catch (error) {
@@ -254,8 +254,8 @@ export function WalletProvider({ children }) {
    */
   const refreshRoles = useCallback(async () => {
     if (!address) return
-    await loadRoles(address)
-  }, [address, loadRoles])
+    await loadRoles(address, chainId)
+  }, [address, chainId, loadRoles])
 
   // Fetch wallet balances
   const fetchBalances = useCallback(async (walletAddress) => {
@@ -277,17 +277,21 @@ export function WalletProvider({ children }) {
     }
   }, [provider])
 
-  // Load RVAC roles when wallet connects
+  // Load RVAC roles when the wallet connects or the active network changes.
+  // Membership (the paid WAGER_PARTICIPANT role) lives in a per-chain
+  // MembershipManager, so a testnet ↔ mainnet switch must re-query the chain
+  // — otherwise a testnet membership would appear active on mainnet where it
+  // doesn't exist. chainId is included in the deps to force that re-query.
   useEffect(() => {
     if (isConnected && address) {
-      loadRoles(address)
+      loadRoles(address, chainId)
       fetchBalances(address)
     } else {
       setRoles([])
       setBalances({ native: '0', wnative: '0', tokens: {} })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [address, isConnected])
+  }, [address, isConnected, chainId])
 
   // Refresh balances manually
   const refreshBalances = useCallback(() => {

--- a/frontend/src/test/FriendMarketsContext.test.jsx
+++ b/frontend/src/test/FriendMarketsContext.test.jsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { useContext } from 'react'
+
+// Controllable wagmi mocks so we can simulate a testnet ↔ mainnet switch.
+let mockAccount = { address: '0xabc0000000000000000000000000000000000001', isConnected: true }
+let mockChainId = 80002
+vi.mock('wagmi', () => ({
+  useAccount: () => mockAccount,
+  useChainId: () => mockChainId,
+}))
+
+// The blockchain fetch returns different wager sets per chain so we can assert
+// the view follows the active network.
+const fetchMock = vi.fn()
+vi.mock('../utils/blockchainService', () => ({
+  fetchFriendMarketsForUser: (...args) => fetchMock(...args),
+}))
+
+import { FriendMarketsProvider } from '../contexts/FriendMarketsContext.jsx'
+import { FriendMarketsContext } from '../contexts/FriendMarketsContext'
+
+function Consumer() {
+  const { friendMarkets } = useContext(FriendMarketsContext)
+  return (
+    <div>
+      <span data-testid="count">{friendMarkets.length}</span>
+      <span data-testid="ids">{friendMarkets.map(m => `${m.id}@${m.chainId}`).join(',')}</span>
+    </div>
+  )
+}
+
+function renderProvider() {
+  return render(
+    <FriendMarketsProvider>
+      <Consumer />
+    </FriendMarketsProvider>
+  )
+}
+
+describe('FriendMarketsContext chain scoping', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    fetchMock.mockReset()
+    mockAccount = { address: '0xabc0000000000000000000000000000000000001', isConnected: true }
+    mockChainId = 80002
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('tags fetched wagers with the active chain id and caches them per chain', async () => {
+    fetchMock.mockResolvedValue([{ id: '1', contractAddress: '0xfactory' }])
+
+    await act(async () => {
+      renderProvider()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('count').textContent).toBe('1')
+    })
+    expect(screen.getByTestId('ids').textContent).toBe('1@80002')
+
+    // Cache is stored under a chain-scoped key, not the global one.
+    expect(localStorage.getItem('friendMarkets:80002')).toBeTruthy()
+    expect(localStorage.getItem('friendMarkets')).toBeNull()
+  })
+
+  it('re-queries the chain and swaps the view when the network switches', async () => {
+    fetchMock.mockImplementation(async () => {
+      // Return data appropriate to whichever chain is currently active.
+      return mockChainId === 80002
+        ? [{ id: '1', contractAddress: '0xfactory' }, { id: '2', contractAddress: '0xfactory' }]
+        : []
+    })
+
+    const { rerender } = await act(async () => renderProvider())
+
+    await waitFor(() => {
+      expect(screen.getByTestId('count').textContent).toBe('2')
+    })
+
+    // Switch to mainnet (137), where this user has no wagers.
+    mockChainId = 137
+    await act(async () => {
+      rerender(
+        <FriendMarketsProvider>
+          <Consumer />
+        </FriendMarketsProvider>
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('count').textContent).toBe('0')
+    })
+
+    // The fetch was re-issued for the new network.
+    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/frontend/src/test/MyMarketsModal.test.jsx
+++ b/frontend/src/test/MyMarketsModal.test.jsx
@@ -194,7 +194,7 @@ describe('MyMarketsModal', () => {
         )
       })
 
-      expect(screen.getByText('Manage your wagers and positions')).toBeInTheDocument()
+      expect(screen.getByText(/Manage your wagers and positions/)).toBeInTheDocument()
     })
 
     it('should have close button', async () => {

--- a/frontend/src/test/contractsConfig.test.js
+++ b/frontend/src/test/contractsConfig.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import { DEPLOYED_CONTRACTS, getContractAddress } from '../config/contracts'
+import { DEPLOYED_CONTRACTS, getContractAddress, getContractAddressForChain } from '../config/contracts'
 
 // Each contract slot is either an empty placeholder (pre-deploy state) or a
 // 0x-prefixed 40-character hex address (post-sync:frontend-contracts state).
@@ -81,5 +81,28 @@ describe('contracts config', () => {
     // - VITE_FRIENDGROUPMARKETFACTORY_ADDRESS (uppercase name)
     // - VITE_FRIEND_GROUP_MARKET_FACTORY_ADDRESS (snake_case conversion)
     // These are verified through manual testing and integration tests.
+  })
+
+  describe('getContractAddressForChain', () => {
+    it('resolves the membership manager for the Amoy testnet', () => {
+      // Amoy (80002) has a v2 deployment with a real MembershipManager.
+      expect(getContractAddressForChain('membershipManager', 80002)).toMatch(
+        /^0x[0-9a-fA-F]{40}$/
+      )
+    })
+
+    it('returns undefined on a chain with no deployment (e.g. Polygon mainnet)', () => {
+      // Polygon mainnet (137) has no contracts deployed yet — membership and
+      // wager reads must resolve to undefined so a testnet membership is never
+      // surfaced as active on mainnet.
+      expect(getContractAddressForChain('membershipManager', 137)).toBeUndefined()
+      expect(getContractAddressForChain('wagerRegistry', 137)).toBeUndefined()
+    })
+
+    it('falls back to the active-chain lookup when no chainId is given', () => {
+      expect(getContractAddressForChain('roleManager')).toEqual(
+        getContractAddress('roleManager')
+      )
+    })
   })
 })

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -6,7 +6,8 @@
  */
 
 import { ethers } from 'ethers'
-import { getContractAddress, NETWORK_CONFIG, DEPLOYMENT_BLOCKS, DEPLOYED_CONTRACTS } from '../config/contracts'
+import { getContractAddress, getContractAddressForChain, NETWORK_CONFIG, DEPLOYMENT_BLOCKS, DEPLOYED_CONTRACTS } from '../config/contracts'
+import { getNetwork } from '../config/networks'
 import { ERC20_ABI } from '../abis/ERC20'
 import { ZK_KEY_MANAGER_ABI } from '../abis/ZKKeyManager'
 import { DEX_ADDRESSES } from '../constants/dex'
@@ -110,9 +111,16 @@ export function canUserViewMarket(market, userAddress) {
 
 /**
  * Get a provider for reading from the blockchain
+ * @param {number} [chainId] - Optional chain id. When supplied, returns a
+ *   provider pointed at that chain's RPC (from networks.js) so reads target
+ *   the user's selected network rather than the build-time default.
  * @returns {ethers.JsonRpcProvider}
  */
-export function getProvider() {
+export function getProvider(chainId) {
+  if (chainId != null) {
+    const net = getNetwork(chainId)
+    if (net?.rpcUrl) return new ethers.JsonRpcProvider(net.rpcUrl)
+  }
   return new ethers.JsonRpcProvider(NETWORK_CONFIG.rpcUrl)
 }
 
@@ -929,7 +937,7 @@ export function getRoleHash(roleName) {
  * @param {string} roleName - Role name or constant
  * @returns {Promise<boolean>} True if user has the role on-chain
  */
-export async function hasRoleOnChain(userAddress, roleName) {
+export async function hasRoleOnChain(userAddress, roleName, chainId) {
   // Skip blockchain calls in test environment
   if (import.meta.env.VITE_SKIP_BLOCKCHAIN_CALLS === 'true') {
     return false
@@ -941,12 +949,17 @@ export async function hasRoleOnChain(userAddress, roleName) {
     return false
   }
 
-  const provider = getProvider()
+  const provider = getProvider(chainId)
+  // Resolve addresses against the selected chain when one is given so a
+  // membership on testnet is not read as active on mainnet (where the
+  // MembershipManager isn't deployed) and vice versa.
+  const resolveAddress = (name) =>
+    chainId != null ? getContractAddressForChain(name, chainId) : getContractAddress(name)
 
   // Paid memberships (WAGER_PARTICIPANT) live in MembershipManager and are
   // gated by a (Tier, expiry) pair — read via hasActiveRole.
   if (roleName === 'WAGER_PARTICIPANT' || roleName === 'Wager Participant') {
-    const mmAddress = getContractAddress('membershipManager')
+    const mmAddress = resolveAddress('membershipManager')
     if (!mmAddress) return false
     try {
       const mm = new ethers.Contract(mmAddress, MEMBERSHIP_MANAGER_ABI, provider)
@@ -966,13 +979,13 @@ export async function hasRoleOnChain(userAddress, roleName) {
   ]
   const candidates = []
   if (roleName === 'ROLE_MANAGER') {
-    const addr = getContractAddress('membershipManager')
+    const addr = resolveAddress('membershipManager')
     if (addr) candidates.push(addr)
   } else {
-    const wager = getContractAddress('wagerRegistry')
+    const wager = resolveAddress('wagerRegistry')
     if (wager) candidates.push(wager)
     if (roleName === 'ADMIN') {
-      const mm = getContractAddress('membershipManager')
+      const mm = resolveAddress('membershipManager')
       if (mm) candidates.push(mm)
     }
   }


### PR DESCRIPTION
## Problem

When the site switched from testnet to mainnet (and vice versa), the user's **wagers** and **membership** carried over from the previous network with no indication they weren't available on the newly-selected one:

- **Wagers** were cached in `localStorage` under a single global key and `FriendMarketsContext` only refetched on wallet connect — not on network change — so testnet wagers kept displaying on mainnet.
- **Membership/roles** were only loaded on wallet connect, and the on-chain read used the build-time RPC/addresses, so a testnet membership appeared active on mainnet.

## Changes

### Wagers — only show the selected network's wagers
- `FriendMarketsContext` now:
  - caches wagers under a **per-chain** key (`friendMarkets:<chainId>`),
  - **tags** each wager with the `chainId` it was read from,
  - **re-queries the chain** and swaps the displayed set whenever the active network changes (chainId added to the fetch effect).
- `MyMarketsModal` defensively filters wagers to the active chain (legacy untagged wagers still pass through, so no data is lost) and shows a **network tag/label** in the header so it's clear which network's wagers are listed.

### Membership — re-query the chain on switch
- `WalletContext` re-queries roles/membership when the active chain changes.
- `hasRoleOnChain` and `getProvider` accept an optional `chainId`; a new `getContractAddressForChain` resolves addresses against the **selected chain's** deployment record. A testnet membership therefore reads as **inactive** on a chain with no deployment (e.g. Polygon mainnet) rather than leaking across networks.

## Tests
- New `FriendMarketsContext.test.jsx` — verifies per-chain caching, wager tagging, and refetch/swap on network switch.
- Extended `contractsConfig.test.js` — covers chain-aware address resolution (Amoy resolves, mainnet returns `undefined`, no-chainId falls back).
- Full suite green: **779 tests passing**, lint clean.

https://claude.ai/code/session_01Xq4JxoS86k155cwHMk6v7A

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xq4JxoS86k155cwHMk6v7A)_