### PR TITLE
test: pre-launch coverage — PolymarketOracleAdapter unit suite + lifecycle E2E

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:fork": "hardhat test test/fork/*.test.js",
     "test:all": "hardhat test test/**/*.test.js",
     "test:gas": "REPORT_GAS=true hardhat test",
-    "test:coverage": "hardhat coverage --testfiles '{test/!(BatchOperations|DAOFactory).test.js,test/integration/!(factory)/**/*.test.js}'",
+    "test:coverage": "hardhat coverage --testfiles '{test/!(BatchOperations|DAOFactory).test.js,test/oracles/*.test.js,test/integration/!(factory)/**/*.test.js}'",
     "deploy:local": "hardhat run scripts/deploy/deploy.js --network localhost",
     "deploy:mordor": "hardhat run scripts/deploy/deploy-deterministic.js --network mordor",
     "deploy:deterministic": "hardhat run scripts/deploy/deploy-deterministic.js",

--- a/test/integration/fairwins/Lifecycle.test.js
+++ b/test/integration/fairwins/Lifecycle.test.js
@@ -1,0 +1,150 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time, loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+
+// End-to-end USER-FLOW coverage: full lifecycle journeys through the deployed
+// stack (MembershipManager + PolymarketOracleAdapter + WagerRegistry), proving
+// the happy and unhappy paths users actually take, with real token transfers
+// and membership accounting. Complements the per-function WagerRegistry unit
+// tests by exercising the flows end-to-end.
+const Tier = { None: 0, Bronze: 1 };
+const Resolution = { Either: 0, Creator: 1, Opponent: 2, ThirdParty: 3, Polymarket: 4 };
+const Status = { None: 0, Open: 1, Active: 2, Resolved: 3, Cancelled: 4, Refunded: 5 };
+const ROLE = ethers.keccak256(ethers.toUtf8Bytes("WAGER_PARTICIPANT_ROLE"));
+const usdc = (n) => ethers.parseUnits(String(n), 6);
+
+async function buildStack(concurrentLimit) {
+  const [admin, alice, bob, carol, treasury] = await ethers.getSigners();
+  const MockERC20 = await ethers.getContractFactory("MockERC20");
+  const token = await MockERC20.deploy("USD Coin", "USDC", 0);
+  const wmatic = await MockERC20.deploy("Wrapped Matic", "WMATIC", 0);
+
+  const Ctf = await ethers.getContractFactory("MockPolymarketCTF");
+  const ctf = await Ctf.deploy();
+  const Adapter = await ethers.getContractFactory("PolymarketOracleAdapter");
+  const adapter = await Adapter.deploy(admin.address, await ctf.getAddress());
+
+  const Mgr = await ethers.getContractFactory("MembershipManager");
+  const mgr = await Mgr.deploy(admin.address, await token.getAddress(), treasury.address);
+  await mgr.connect(admin).setTier(ROLE, Tier.Bronze, usdc(50), 30,
+    { monthlyMarketCreation: 1000, maxConcurrentMarkets: concurrentLimit }, true);
+
+  const Reg = await ethers.getContractFactory("WagerRegistry");
+  const reg = await Reg.deploy(admin.address, await mgr.getAddress(), await adapter.getAddress(),
+    [await token.getAddress(), await wmatic.getAddress()]);
+  await mgr.connect(admin).setAuthorizedCaller(await reg.getAddress(), true);
+
+  for (const u of [alice, bob, carol]) {
+    await token.mint(u.address, usdc(100_000));
+    await token.connect(u).approve(await mgr.getAddress(), ethers.MaxUint256);
+    await token.connect(u).approve(await reg.getAddress(), ethers.MaxUint256);
+    await mgr.connect(u).purchaseTier(ROLE, Tier.Bronze);
+  }
+  return { reg, mgr, token, ctf, adapter, admin, alice, bob, carol };
+}
+const fix = () => buildStack(10);
+const lowLimitFix = () => buildStack(2);
+
+async function open(fx, opts = {}) {
+  const { reg, token, alice, bob } = fx;
+  const now = await time.latest();
+  const resType = opts.resType ?? Resolution.Either;
+  let conditionId = ethers.ZeroHash;
+  if (resType === Resolution.Polymarket) {
+    const qid = ethers.id("q-" + Math.random());
+    conditionId = await fx.ctf.getConditionId(fx.admin.address, qid, 2);
+    await fx.ctf.prepareCondition(fx.admin.address, qid, 2);
+  }
+  const tx = await reg.connect(alice).createWager(
+    bob.address, ethers.ZeroAddress, await token.getAddress(),
+    usdc(10), usdc(10), now + 1800, now + 7200,
+    resType, conditionId, opts.creatorIsYes ?? true, ethers.id("m"), ""
+  );
+  const rc = await tx.wait();
+  const id = Number(rc.logs.map((l) => { try { return reg.interface.parseLog(l); } catch { return null; } })
+    .find((p) => p && p.name === "WagerCreated").args.wagerId);
+  return { id, conditionId };
+}
+
+describe("FairWins lifecycle (end-to-end user flows)", function () {
+  it("HAPPY: membership → create → accept → manual resolve (Either) → claim payout", async () => {
+    const fx = await loadFixture(fix);
+    const { id } = await open(fx);
+    await fx.reg.connect(fx.bob).acceptWager(id);
+    expect((await fx.reg.getWager(id)).status).to.equal(Status.Active);
+    await fx.reg.connect(fx.alice).declareWinner(id, fx.alice.address);
+    const before = await fx.token.balanceOf(fx.alice.address);
+    await fx.reg.connect(fx.alice).claimPayout(id);
+    expect((await fx.token.balanceOf(fx.alice.address)) - before).to.equal(usdc(20));
+    expect((await fx.reg.getWager(id)).status).to.equal(Status.Resolved);
+  });
+
+  it("HAPPY: Polymarket oracle wager → accept → auto-resolve YES → creator claims", async () => {
+    const fx = await loadFixture(fix);
+    const { id, conditionId } = await open(fx, { resType: Resolution.Polymarket, creatorIsYes: true });
+    await fx.reg.connect(fx.bob).acceptWager(id);
+    await fx.ctf.resolveCondition(conditionId, [1, 0]); // YES wins
+    await fx.reg.connect(fx.carol).autoResolveFromPolymarket(id); // permissionless
+    expect((await fx.reg.getWager(id)).winner).to.equal(fx.alice.address);
+    const before = await fx.token.balanceOf(fx.alice.address);
+    await fx.reg.connect(fx.alice).claimPayout(id);
+    expect((await fx.token.balanceOf(fx.alice.address)) - before).to.equal(usdc(20));
+  });
+
+  it("UNHAPPY: opponent never accepts → creator refunded after accept deadline", async () => {
+    const fx = await loadFixture(fix);
+    const { id } = await open(fx);
+    const before = await fx.token.balanceOf(fx.alice.address);
+    await time.increase(1801);
+    await fx.reg.connect(fx.alice).claimRefund(id);
+    expect((await fx.token.balanceOf(fx.alice.address)) - before).to.equal(usdc(10));
+    expect((await fx.reg.getWager(id)).status).to.equal(Status.Refunded);
+  });
+
+  it("UNHAPPY: oracle never resolves → both parties refunded after resolve deadline", async () => {
+    const fx = await loadFixture(fix);
+    const { id } = await open(fx, { resType: Resolution.Polymarket });
+    await fx.reg.connect(fx.bob).acceptWager(id);
+    const aB = await fx.token.balanceOf(fx.alice.address);
+    const bB = await fx.token.balanceOf(fx.bob.address);
+    await time.increase(7201);
+    await fx.reg.connect(fx.carol).claimRefund(id);
+    expect((await fx.token.balanceOf(fx.alice.address)) - aB).to.equal(usdc(10));
+    expect((await fx.token.balanceOf(fx.bob.address)) - bB).to.equal(usdc(10));
+  });
+
+  it("MEMBERSHIP: concurrent-limit enforced, freed when a wager closes", async () => {
+    const fx = await loadFixture(lowLimitFix); // maxConcurrentMarkets = 2
+    const a = await open(fx);
+    const b = await open(fx);
+    // third create exceeds the concurrent limit
+    await expect(open(fx)).to.be.revertedWithCustomError(fx.reg, "MembershipDenied");
+    // close one (cancel the still-Open wager) → frees a slot
+    await fx.reg.connect(fx.alice).cancelOpen(a.id);
+    await expect(open(fx)).to.not.be.reverted;
+  });
+
+  it("ADMIN PAUSE: blocks new wagers but in-flight settlement + claim still work", async () => {
+    const fx = await loadFixture(fix);
+    const { id } = await open(fx);
+    await fx.reg.connect(fx.bob).acceptWager(id);
+    await fx.reg.connect(fx.admin).pause();
+    await expect(open(fx)).to.be.revertedWithCustomError(fx.reg, "EnforcedPause");
+    // settlement + claim are intentionally NOT pause-gated
+    await fx.reg.connect(fx.alice).declareWinner(id, fx.bob.address);
+    await expect(fx.reg.connect(fx.bob).claimPayout(id)).to.not.be.reverted;
+    await fx.reg.connect(fx.admin).unpause();
+    await expect(open(fx)).to.not.be.reverted;
+  });
+
+  it("ADMIN FREEZE: a frozen winner cannot claim until unfrozen", async () => {
+    const fx = await loadFixture(fix);
+    const { id } = await open(fx);
+    await fx.reg.connect(fx.bob).acceptWager(id);
+    await fx.reg.connect(fx.alice).declareWinner(id, fx.alice.address);
+    await fx.reg.connect(fx.admin).freezeAccount(fx.alice.address, "review");
+    await expect(fx.reg.connect(fx.alice).claimPayout(id)).to.be.revertedWithCustomError(fx.reg, "AccountFrozenError");
+    await fx.reg.connect(fx.admin).unfreezeAccount(fx.alice.address);
+    await expect(fx.reg.connect(fx.alice).claimPayout(id)).to.not.be.reverted;
+  });
+});

--- a/test/oracles/PolymarketOracleAdapter.test.js
+++ b/test/oracles/PolymarketOracleAdapter.test.js
@@ -1,0 +1,241 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+
+// Dedicated unit coverage for PolymarketOracleAdapter (previously only exercised
+// indirectly through WagerRegistry integration). Covers CTF management, market
+// linking + every error path, resolution fetch/caching, getOutcome (incl. the
+// tie sentinel), and the IOracleAdapter view surface.
+describe("PolymarketOracleAdapter (unit)", function () {
+  async function fix() {
+    const [admin, other] = await ethers.getSigners();
+    const Ctf = await ethers.getContractFactory("MockPolymarketCTF");
+    const ctf = await Ctf.deploy();
+    const Adapter = await ethers.getContractFactory("PolymarketOracleAdapter");
+    const adapter = await Adapter.deploy(admin.address, await ctf.getAddress());
+    return { adapter, ctf, admin, other };
+  }
+
+  // Prepares a binary condition and (optionally) resolves it with `payouts`.
+  async function condition(ctf, admin, payouts) {
+    const questionId = ethers.id("q-" + Math.random());
+    const id = await ctf.getConditionId(admin.address, questionId, 2);
+    await ctf.prepareCondition(admin.address, questionId, 2);
+    if (payouts) await ctf.resolveCondition(id, payouts);
+    return id;
+  }
+
+  describe("constructor & basics", () => {
+    it("sets owner to admin, primary CTF, and marks it supported", async () => {
+      const { adapter, ctf, admin } = await loadFixture(fix);
+      expect(await adapter.owner()).to.equal(admin.address);
+      expect(await adapter.polymarketCTF()).to.equal(await ctf.getAddress());
+      expect(await adapter.supportedCTFContracts(await ctf.getAddress())).to.equal(true);
+    });
+
+    it("reverts on zero admin (Ownable) or zero CTF (InvalidAddress)", async () => {
+      const { ctf, admin } = await loadFixture(fix);
+      const Adapter = await ethers.getContractFactory("PolymarketOracleAdapter");
+      // Ownable(admin) runs first, so a zero admin reverts in OZ's constructor.
+      await expect(Adapter.deploy(ethers.ZeroAddress, await ctf.getAddress()))
+        .to.be.revertedWithCustomError(Adapter, "OwnableInvalidOwner");
+      await expect(Adapter.deploy(admin.address, ethers.ZeroAddress))
+        .to.be.revertedWithCustomError(Adapter, "InvalidAddress");
+    });
+
+    it("reports oracleType, availability, and configured chain id", async () => {
+      const { adapter } = await loadFixture(fix);
+      expect(await adapter.oracleType()).to.equal("Polymarket");
+      expect(await adapter.isAvailable()).to.equal(true); // CTF has code
+      expect(await adapter.getConfiguredChainId()).to.equal((await ethers.provider.getNetwork()).chainId);
+    });
+  });
+
+  describe("CTF management (onlyOwner)", () => {
+    it("addCTFContract adds + emits; rejects non-owner and zero", async () => {
+      const { adapter, admin, other } = await loadFixture(fix);
+      const newCtf = "0x000000000000000000000000000000000000bEEF";
+      await expect(adapter.connect(admin).addCTFContract(newCtf))
+        .to.emit(adapter, "CTFContractAdded").withArgs(newCtf);
+      expect(await adapter.supportedCTFContracts(newCtf)).to.equal(true);
+      await expect(adapter.connect(other).addCTFContract("0x000000000000000000000000000000000000bEAF"))
+        .to.be.revertedWithCustomError(adapter, "OwnableUnauthorizedAccount");
+      await expect(adapter.connect(admin).addCTFContract(ethers.ZeroAddress))
+        .to.be.revertedWithCustomError(adapter, "InvalidAddress");
+    });
+
+    it("removeCTFContract removes + emits", async () => {
+      const { adapter, ctf, admin } = await loadFixture(fix);
+      await expect(adapter.connect(admin).removeCTFContract(await ctf.getAddress()))
+        .to.emit(adapter, "CTFContractRemoved");
+      expect(await adapter.supportedCTFContracts(await ctf.getAddress())).to.equal(false);
+    });
+
+    it("updatePrimaryCTF switches the primary + marks supported + emits", async () => {
+      const { adapter, ctf, admin } = await loadFixture(fix);
+      const Ctf2 = await ethers.getContractFactory("MockPolymarketCTF");
+      const ctf2 = await Ctf2.deploy();
+      await expect(adapter.connect(admin).updatePrimaryCTF(await ctf2.getAddress()))
+        .to.emit(adapter, "PrimaryCtfUpdated").withArgs(await ctf.getAddress(), await ctf2.getAddress());
+      expect(await adapter.polymarketCTF()).to.equal(await ctf2.getAddress());
+      expect(await adapter.supportedCTFContracts(await ctf2.getAddress())).to.equal(true);
+      await expect(adapter.connect(admin).updatePrimaryCTF(ethers.ZeroAddress))
+        .to.be.revertedWithCustomError(adapter, "InvalidAddress");
+    });
+  });
+
+  describe("market linking (onlyOwner)", () => {
+    it("links a prepared binary condition + emits; isMarketLinked/getLinkedMarket reflect it", async () => {
+      const { adapter, ctf, admin } = await loadFixture(fix);
+      const id = await condition(ctf, admin);
+      await expect(adapter.connect(admin).linkMarketToPolymarket(1, id))
+        .to.emit(adapter, "MarketLinkedToPolymarket");
+      expect(await adapter.isMarketLinked(1)).to.equal(true);
+      const lm = await adapter.getLinkedMarket(1);
+      expect(lm.conditionId).to.equal(id);
+      expect(lm.linked).to.equal(true);
+    });
+
+    it("rejects: non-owner, unsupported CTF, already-linked, zero conditionId, unprepared, non-binary", async () => {
+      const { adapter, ctf, admin, other } = await loadFixture(fix);
+      const id = await condition(ctf, admin);
+      await expect(adapter.connect(other).linkMarketToPolymarket(1, id))
+        .to.be.revertedWithCustomError(adapter, "OwnableUnauthorizedAccount");
+      await expect(adapter.connect(admin).linkMarketToPolymarketWithCTF(1, id, "0x000000000000000000000000000000000000dEaD"))
+        .to.be.revertedWithCustomError(adapter, "CTFNotSupported");
+      await expect(adapter.connect(admin).linkMarketToPolymarket(1, ethers.ZeroHash))
+        .to.be.revertedWithCustomError(adapter, "InvalidConditionId");
+      // unprepared condition id
+      await expect(adapter.connect(admin).linkMarketToPolymarket(1, ethers.id("never-prepared")))
+        .to.be.revertedWithCustomError(adapter, "InvalidConditionId");
+      // non-binary (3 slots)
+      const qid = ethers.id("tri");
+      const triId = await ctf.getConditionId(admin.address, qid, 3);
+      await ctf.prepareCondition(admin.address, qid, 3);
+      await expect(adapter.connect(admin).linkMarketToPolymarket(2, triId))
+        .to.be.revertedWith("Only binary conditions supported");
+      // already linked
+      await adapter.connect(admin).linkMarketToPolymarket(1, id);
+      await expect(adapter.connect(admin).linkMarketToPolymarket(1, id))
+        .to.be.revertedWithCustomError(adapter, "MarketAlreadyLinked");
+    });
+
+    it("unlinkMarket clears the link; reverts MarketNotLinked otherwise", async () => {
+      const { adapter, ctf, admin } = await loadFixture(fix);
+      const id = await condition(ctf, admin);
+      await adapter.connect(admin).linkMarketToPolymarket(1, id);
+      await expect(adapter.connect(admin).unlinkMarket(1)).to.emit(adapter, "MarketUnlinked").withArgs(1);
+      expect(await adapter.isMarketLinked(1)).to.equal(false);
+      await expect(adapter.connect(admin).unlinkMarket(1)).to.be.revertedWithCustomError(adapter, "MarketNotLinked");
+    });
+  });
+
+  describe("fetchResolution + caching", () => {
+    it("caches a resolved condition and reverts ConditionNotResolved for an unresolved one", async () => {
+      const { adapter, ctf, admin } = await loadFixture(fix);
+      const resolved = await condition(ctf, admin, [3, 1]);
+      await adapter.fetchResolution(resolved);
+      const cached = await adapter.getCachedResolution(resolved);
+      expect(cached.resolved).to.equal(true);
+      expect(cached.passNumerator).to.equal(3n);
+      expect(cached.failNumerator).to.equal(1n);
+      expect(cached.denominator).to.equal(4n);
+      expect(cached.cachedAt).to.be.greaterThan(0n);
+
+      const unresolved = await condition(ctf, admin);
+      await expect(adapter.fetchResolution(unresolved)).to.be.revertedWithCustomError(adapter, "ConditionNotResolved");
+    });
+
+    it("fetchResolutionFromCTF reverts CTFNotSupported for an unknown CTF", async () => {
+      const { adapter, ctf, admin } = await loadFixture(fix);
+      const id = await condition(ctf, admin, [1, 0]);
+      await expect(adapter.fetchResolutionFromCTF(id, "0x000000000000000000000000000000000000dEaD"))
+        .to.be.revertedWithCustomError(adapter, "CTFNotSupported");
+      // (FetchFailed is a defensive catch around a CTF that reverts on
+      // isResolved/getPayout*; it needs a purpose-built reverting mock and is
+      // left to the fuzzer/manual review.)
+    });
+  });
+
+  describe("getOutcome", () => {
+    async function outcome(adapter, id) {
+      const r = await adapter.getOutcome(id);
+      return { outcome: r[0], confidence: r[1], resolvedAt: r[2] };
+    }
+    it("unresolved -> (false, 0, 0)", async () => {
+      const { adapter, ctf, admin } = await loadFixture(fix);
+      const id = await condition(ctf, admin);
+      const r = await outcome(adapter, id);
+      expect(r.resolvedAt).to.equal(0n);
+    });
+    it("decisive YES [1,0] -> true; decisive NO [0,1] -> false (uncached + cached)", async () => {
+      const { adapter, ctf, admin } = await loadFixture(fix);
+      const yes = await condition(ctf, admin, [1, 0]);
+      let r = await outcome(adapter, yes);
+      expect(r.outcome).to.equal(true); expect(r.resolvedAt).to.be.greaterThan(0n); expect(r.confidence).to.equal(10000n);
+      await adapter.fetchResolution(yes); // now cached
+      r = await outcome(adapter, yes);
+      expect(r.outcome).to.equal(true); expect(r.resolvedAt).to.be.greaterThan(0n);
+
+      const no = await condition(ctf, admin, [0, 1]);
+      r = await outcome(adapter, no);
+      expect(r.outcome).to.equal(false); expect(r.resolvedAt).to.be.greaterThan(0n);
+    });
+    it("TIE [1,1] -> unresolved sentinel (false, 0, 0) on both paths", async () => {
+      const { adapter, ctf, admin } = await loadFixture(fix);
+      const tie = await condition(ctf, admin, [1, 1]);
+      let r = await outcome(adapter, tie);
+      expect(r.resolvedAt).to.equal(0n);
+      await adapter.fetchResolution(tie);
+      r = await outcome(adapter, tie);
+      expect(r.resolvedAt).to.equal(0n);
+    });
+  });
+
+  describe("view + pure helpers", () => {
+    it("isConditionResolved reflects CTF + cache", async () => {
+      const { adapter, ctf, admin } = await loadFixture(fix);
+      const id = await condition(ctf, admin);
+      expect(await adapter.isConditionResolved(id)).to.equal(false);
+      await ctf.resolveCondition(id, [1, 0]);
+      expect(await adapter.isConditionResolved(id)).to.equal(true); // live
+    });
+
+    it("isConditionSupported: false for unknown, true once prepared", async () => {
+      const { adapter, ctf, admin } = await loadFixture(fix);
+      expect(await adapter.isConditionSupported(ethers.id("unknown"))).to.equal(false);
+      const id = await condition(ctf, admin);
+      expect(await adapter.isConditionSupported(id)).to.equal(true);
+    });
+
+    it("getResolutionForMarket: resolved data, unresolved->false, MarketNotLinked", async () => {
+      const { adapter, ctf, admin } = await loadFixture(fix);
+      await expect(adapter.getResolutionForMarket(99)).to.be.revertedWithCustomError(adapter, "MarketNotLinked");
+      const id = await condition(ctf, admin, [2, 5]);
+      await adapter.connect(admin).linkMarketToPolymarket(1, id);
+      const r = await adapter.getResolutionForMarket.staticCall(1);
+      expect(r.resolved).to.equal(true);
+      expect(r.passNumerator).to.equal(2n);
+      expect(r.failNumerator).to.equal(5n);
+      // a linked-but-unresolved market reports resolved=false
+      const id2 = await condition(ctf, admin);
+      await adapter.connect(admin).linkMarketToPolymarket(2, id2);
+      const r2 = await adapter.getResolutionForMarket.staticCall(2);
+      expect(r2.resolved).to.equal(false);
+    });
+
+    it("determineOutcome: tie, YES, NO", async () => {
+      const { adapter } = await loadFixture(fix);
+      expect(await adapter.determineOutcome(1, 1)).to.deep.equal([false, true]);
+      expect(await adapter.determineOutcome(3, 1)).to.deep.equal([true, false]);
+      expect(await adapter.determineOutcome(0, 1)).to.deep.equal([false, false]);
+    });
+
+    it("computeConditionId matches the CTF formula", async () => {
+      const { adapter, ctf, admin } = await loadFixture(fix);
+      const qid = ethers.id("x");
+      expect(await adapter.computeConditionId(admin.address, qid, 2))
+        .to.equal(await ctf.getConditionId(admin.address, qid, 2));
+    });
+  });
+});


### PR DESCRIPTION
## Pre-launch test-coverage improvements

Separate from #626 (Polygon bring-up) so that PR stays scoped. **Stacked on `chore/polygon-mainnet-frontend-config`** because the new tests exercise #626's contract changes (the Polymarket tie fix + the admin-owner adapter constructor); retarget to `main` once #626 merges.

### Coverage review findings (baseline, solidity-coverage)
| Contract | Stmts | Branch | Notes |
|---|---|---|---|
| WagerRegistry | 96.9% | 79.8% | strong (70 unit cases) |
| KeyRegistry | 100% | 100% | — |
| MembershipManager | 87.2% | 59.8% | branch coverage thin |
| **PolymarketOracleAdapter** | **34.2%** | **21.0%** | **worst — no unit test** |
| Chainlink/UMA adapters | 64–68% | 40–43% | unit tests existed but weren't *measured* |

Two measurement/quality gaps: the Polymarket adapter (a money-resolution contract) had **no dedicated unit test**, and the `test:coverage` glob **excluded `test/oracles/`**, so adapter unit coverage wasn't counted at all.

### Changes
- **`test/oracles/PolymarketOracleAdapter.test.js`** (19 cases) — constructor/ownership, CTF management (onlyOwner + events), market linking with every error path, fetch/cache, `getOutcome` (decisive + tie sentinel, cached + uncached), view/pure helpers.
- **`test/integration/fairwins/Lifecycle.test.js`** (7 end-to-end journeys) — membership→create→accept→manual-resolve→claim; Polymarket auto-resolve→claim; accept-timeout refund; oracle-never-resolves both-refund; concurrent-limit enforcement + slot release; pause blocks creation but not settlement; frozen winner blocked then restored.
- **`package.json`** — include `test/oracles/*.test.js` in the coverage glob so adapter coverage is measured.

**Full hardhat suite: 187 passing** (was 161).

### Still recommended (follow-ups, not in this PR)
- The Cypress "full" E2E suite is heavily **stubbed** (assertions are only `cy.get('body').should('be.visible')`): `oracle-resolution`, `refund-timeout`, `frozen-accounts`, `paused-protocol`, `expired-membership`, `admin-panel`, and all 6 `23-lifecycle-e2e` scenarios. These advertise coverage they don't provide — implement or delete. `09-challenge-dispute` is likely **obsolete** (dispute feature removed in #625).
- MembershipManager branch coverage (59.8%) — rolling-window rollover, upgrade/extend math, withdraw edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)