### PR TITLE
Collapse the Private Wager encryption explainer behind a disclosure

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.css
+++ b/frontend/src/components/fairwins/FriendMarketsModal.css
@@ -1149,6 +1149,55 @@
   color: var(--text-muted, #7A8590);
 }
 
+/* Collapsible "How encryption works" disclosure — the header acts as the toggle. */
+.fm-encryption-info-toggle {
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  margin-bottom: 0; /* spacing comes from the details block only when expanded */
+  cursor: pointer;
+  text-align: left;
+}
+
+.fm-encryption-info-toggle:hover {
+  color: var(--text-primary, #E6EDF3);
+}
+
+.fm-encryption-chevron {
+  margin-left: auto;
+  transition: transform 0.2s ease;
+}
+
+.fm-encryption-chevron.open {
+  transform: rotate(180deg);
+}
+
+/* Expanded explainer body (hint + field breakdown + notes). */
+.fm-encryption-details {
+  margin-top: 0.625rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.fm-encryption-details .fm-hint {
+  margin: 0;
+}
+
+.fm-encryption-subhead {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-secondary, #AAB6C2);
+}
+
+.fm-encryption-note {
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--text-secondary, #AAB6C2);
+}
+
 .fm-encryption-fields {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -292,6 +292,9 @@ function FriendMarketsModal({
 
   // Encryption state
   const [enableEncryption, setEnableEncryption] = useState(true) // Default to encrypted for privacy
+  // The "What gets encrypted?" field breakdown is collapsed by default to save
+  // space; the user expands it only if they want the detail.
+  const [showEncryptionDetails, setShowEncryptionDetails] = useState(false)
 
   // Reset form function - memoized to prevent stale closures
   const resetForm = useCallback(() => {
@@ -1601,64 +1604,69 @@ function FriendMarketsModal({
                           </div>
                         )}
 
-                        <span className="fm-hint">
-                          {enableEncryption
-                            ? 'End-to-end encrypted. Only participants can decrypt wager details.'
-                            : 'Wager details will be publicly visible on the blockchain.'}
-                        </span>
+                        {!enableEncryption && (
+                          <span className="fm-hint">
+                            Wager details will be publicly visible on the blockchain.
+                          </span>
+                        )}
 
+                        {/* Encryption explainer is collapsed by default to save space;
+                            the toggle + badge convey the state, details are one click away. */}
                         {enableEncryption && (
                           <div className="fm-encryption-info">
-                            <div className="fm-encryption-info-header">
+                            <button
+                              type="button"
+                              className="fm-encryption-info-header fm-encryption-info-toggle"
+                              onClick={() => setShowEncryptionDetails(v => !v)}
+                              aria-expanded={showEncryptionDetails}
+                              aria-controls="fm-encryption-details"
+                            >
                               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                                 <circle cx="12" cy="12" r="10"/>
                                 <path d="M12 16v-4M12 8h.01"/>
                               </svg>
-                              <span>What gets encrypted?</span>
-                            </div>
-                            <div className="fm-encryption-fields">
-                              <div className="fm-field-encrypted">
-                                <span className="fm-field-icon">🔒</span>
-                                <span>Bet description &amp; terms</span>
-                              </div>
-                              <div className="fm-field-encrypted">
-                                <span className="fm-field-icon">🔒</span>
-                                <span>Wager metadata</span>
-                              </div>
-                              <div className="fm-field-public">
-                                <span className="fm-field-icon">🌐</span>
-                                <span>Participant addresses</span>
-                              </div>
-                              <div className="fm-field-public">
-                                <span className="fm-field-icon">🌐</span>
-                                <span>Stake amount &amp; token</span>
-                              </div>
-                              <div className="fm-field-public">
-                                <span className="fm-field-icon">🌐</span>
-                                <span>Wager timing</span>
-                              </div>
-                            </div>
-                          </div>
-                        )}
+                              <span>How encryption works</span>
+                              <svg
+                                className={`fm-encryption-chevron ${showEncryptionDetails ? 'open' : ''}`}
+                                width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+                                aria-hidden="true"
+                              >
+                                <polyline points="6 9 12 15 18 9"/>
+                              </svg>
+                            </button>
 
-                        {enableEncryption && !encryptionInitialized && !encryptionInitializing && (
-                          <div className="fm-encryption-warning">
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                              <circle cx="12" cy="12" r="10"/>
-                              <path d="M12 16v-4M12 8h.01"/>
-                            </svg>
-                            <span>You&apos;ll be asked to sign a message to derive your encryption keys</span>
-                          </div>
-                        )}
-                        {enableEncryption && (friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') && (
-                          <div className="fm-encryption-info" style={{ marginTop: '0.5rem' }}>
-                            <div className="fm-encryption-info-header">
-                              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                                <circle cx="12" cy="12" r="10"/>
-                                <path d="M12 16v-4M12 8h.01"/>
-                              </svg>
-                              <span>Your opponent must have registered their encryption key to create an encrypted wager.</span>
-                            </div>
+                            {showEncryptionDetails && (
+                              <div id="fm-encryption-details" className="fm-encryption-details">
+                                <p className="fm-hint">
+                                  End-to-end encrypted. Only participants can decrypt wager details.
+                                </p>
+
+                                <div className="fm-encryption-subhead">What gets encrypted?</div>
+                                <div className="fm-encryption-fields">
+                                  <div className="fm-field-encrypted"><span className="fm-field-icon">🔒</span><span>Bet description &amp; terms</span></div>
+                                  <div className="fm-field-encrypted"><span className="fm-field-icon">🔒</span><span>Wager metadata</span></div>
+                                  <div className="fm-field-public"><span className="fm-field-icon">🌐</span><span>Participant addresses</span></div>
+                                  <div className="fm-field-public"><span className="fm-field-icon">🌐</span><span>Stake amount &amp; token</span></div>
+                                  <div className="fm-field-public"><span className="fm-field-icon">🌐</span><span>Wager timing</span></div>
+                                </div>
+
+                                {!encryptionInitialized && !encryptionInitializing && (
+                                  <div className="fm-encryption-warning">
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                                      <circle cx="12" cy="12" r="10"/>
+                                      <path d="M12 16v-4M12 8h.01"/>
+                                    </svg>
+                                    <span>You&apos;ll be asked to sign a message to derive your encryption keys</span>
+                                  </div>
+                                )}
+
+                                {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') && (
+                                  <p className="fm-encryption-note">
+                                    Your opponent must have registered their encryption key to create an encrypted wager.
+                                  </p>
+                                )}
+                              </div>
+                            )}
                           </div>
                         )}
                         {encryptionInitializing && (

--- a/frontend/src/test/FriendMarketsModal.test.jsx
+++ b/frontend/src/test/FriendMarketsModal.test.jsx
@@ -231,6 +231,30 @@ describe('FriendMarketsModal', () => {
     global.window.ethereum = undefined
   })
 
+  describe('Private Wager encryption disclosure', () => {
+    it('collapses the whole encryption explainer behind one disclosure, keeping toggle + badge', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<FriendMarketsModal {...defaultProps} />)
+
+      // Encryption is on by default: the toggle + badge stay visible…
+      const toggle = await screen.findByRole('button', { name: /how encryption works/i })
+      expect(toggle).toHaveAttribute('aria-expanded', 'false')
+      expect(screen.getByText(/End-to-End Encrypted/i)).toBeInTheDocument()
+      // …but the explainer body (hint + field breakdown) is hidden until expanded.
+      expect(screen.queryByText(/Only participants can decrypt/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Bet description & terms/i)).not.toBeInTheDocument()
+
+      await user.click(toggle)
+      expect(toggle).toHaveAttribute('aria-expanded', 'true')
+      expect(await screen.findByText(/Only participants can decrypt/i)).toBeInTheDocument()
+      expect(screen.getByText(/Bet description & terms/i)).toBeInTheDocument()
+
+      await user.click(toggle)
+      expect(toggle).toHaveAttribute('aria-expanded', 'false')
+      expect(screen.queryByText(/Bet description & terms/i)).not.toBeInTheDocument()
+    })
+  })
+
   describe('Modal Visibility', () => {
     it('should not render when isOpen is false', () => {
       const { container } = renderWithProviders(


### PR DESCRIPTION
## Summary

The **Private Wager** section on the create form expanded its full encryption explainer by default — a one-line hint, a 5-row "What gets encrypted?" field breakdown, the sign-message note, and the opponent-key note — which took up too much vertical space.

This tucks the whole explainer behind a single **"How encryption works"** disclosure:
- **Collapsed by default.** The header is a button (chevron + `aria-expanded`); clicking it reveals the details only if the user is interested.
- **Always visible:** the Private Wager toggle and the "End-to-End Encrypted" badge, so the privacy state is still clear at a glance.
- **Outside the disclosure:** the transient "Deriving encryption keys…" status (active feedback during submit).
- When encryption is **off**, the "publicly visible on the blockchain" hint still shows as before (no disclosure).

## Layout

Before (always expanded):
```
[x] (lock) Private Wager     [shield] End-to-End Encrypted
End-to-end encrypted. Only participants can decrypt.
(i) What gets encrypted?
   (lock) Bet description & terms
   (lock) Wager metadata
   (globe) Participant addresses
   (globe) Stake amount & token
   (globe) Wager timing
(!) You'll be asked to sign a message to derive keys
(i) Your opponent must have registered their key
```

After (collapsed by default):
```
[x] (lock) Private Wager     [shield] End-to-End Encrypted
(i) How encryption works                              v
```

## Tests

New assertion in `FriendMarketsModal.test.jsx`: the explainer body (hint + field breakdown) is hidden by default, appears on expand, collapses again, and the toggle + badge stay visible. ESLint clean.

## Accessibility

The disclosure header is a real `<button>` with `aria-expanded` and `aria-controls`; the chevron is `aria-hidden`.

Generated with Claude Code.