### PR TITLE
Modal alignment: show Polymarket search in oracle flow + remove wager items from wallet dropdown

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -1038,8 +1038,14 @@ function FriendMarketsModal({
                         condition) first. The source is chosen via tabs; oracle
                         sources that aren't reachable on the active chain render as
                         locked tabs. */}
-                    {useResolutionTabs && !(resolutionCategory === 'oracle' && resolutionTabTypes.length <= 1) && (
+                    {useResolutionTabs && (
                       <>
+                        {/* Tab strip: hidden when there's only one settlement type to
+                            pick (e.g. the oracle flow with Polymarket-only exposure).
+                            The type-specific inputs below (Polymarket search, oracle
+                            condition pickers) still render, so the Polymarket search is
+                            always visible in the oracle flow. */}
+                        {!(resolutionCategory === 'oracle' && resolutionTabTypes.length <= 1) && (
                         <div className="fm-form-group fm-form-full">
                           <label id="fm-resolution-tabs-label">
                             {resolutionCategory === 'oracle' ? 'Which oracle settles this?' : 'How does this settle?'}
@@ -1088,6 +1094,7 @@ function FriendMarketsModal({
                             )}
                           </span>
                         </div>
+                        )}
 
                         {/* Linked Market — Polymarket event lookup */}
                         {(friendMarketType === 'oneVsOne' || friendMarketType === 'bookmaker') &&

--- a/frontend/src/components/wallet/WalletButton.jsx
+++ b/frontend/src/components/wallet/WalletButton.jsx
@@ -10,13 +10,10 @@ import { useModal } from '../../hooks/useUI'
 import { ROLES, ROLE_INFO } from '../../contexts/RoleContext'
 import { DEX_ADDRESSES, TOKENS } from '../../constants/dex'
 import { WAGER_DEFAULTS } from '../../constants/wagerDefaults'
-import { useFriendMarketCreation, loadPendingTransaction, clearPendingTransaction } from '../../hooks/useFriendMarketCreation'
-import { useFriendMarkets } from '../../contexts/FriendMarketsContext.js'
 import BlockiesAvatar from '../ui/BlockiesAvatar'
 import PremiumPurchaseModal from '../ui/PremiumPurchaseModal'
 import { RoleDetailsSection } from './RoleDetailsCard'
 import walletIcon from '../../assets/wallet_no_text.svg'
-import { FriendMarketsModal, MyMarketsModal } from '../fairwins'
 import './WalletButton.css'
 import './RoleDetailsCard.css'
 
@@ -37,9 +34,6 @@ import './RoleDetailsCard.css'
 
 function WalletButton({ className = '' }) {
   const [isOpen, setIsOpen] = useState(false)
-  const [showFriendMarketModal, setShowFriendMarketModal] = useState(false)
-  const [showMyMarketsModal, setShowMyMarketsModal] = useState(false)
-  const { friendMarkets } = useFriendMarkets()
   const { address, isConnected } = useAccount()
   const { connect, connectors, isPending: isConnecting } = useConnect()
   const { disconnect } = useDisconnect()
@@ -60,9 +54,6 @@ function WalletButton({ className = '' }) {
   const [connectorStatus, setConnectorStatus] = useState({})
   const [isCheckingConnectors, setIsCheckingConnectors] = useState(true)
   const [pendingConnector, setPendingConnector] = useState(null)
-
-  // v2: delegate wager creation to the central hook (drives WagerRegistry.createWager)
-  const { createFriendMarket: handleFriendMarketCreation } = useFriendMarketCreation()
 
   // Check connector availability on mount and when connectors change
   useEffect(() => {
@@ -228,17 +219,6 @@ function WalletButton({ className = '' }) {
     await Promise.all([refreshRoles(), refreshRoleDetails()])
   }
 
-  const handleOpenFriendMarket = () => {
-    setIsOpen(false)
-    setShowFriendMarketModal(true)
-  }
-
-  const handleOpenMyMarkets = () => {
-    setIsOpen(false)
-    setShowMyMarketsModal(true)
-  }
-
-
   const handleNavigateToAdmin = () => {
     setIsOpen(false)
     navigate('/admin')
@@ -393,19 +373,12 @@ function WalletButton({ className = '' }) {
                 />
               </div>
 
-              {/* Wagers Section - Unified */}
-              <div className="dropdown-section">
-                <span className="wallet-section-title">Wagers</span>
-                {hasRole(ROLES.WAGER_PARTICIPANT) ? (
-                  <button
-                    onClick={handleOpenFriendMarket}
-                    className="action-button friend-market-btn"
-                    role="menuitem"
-                  >
-                    <span aria-hidden="true">🎯</span>
-                    <span>Create Wager</span>
-                  </button>
-                ) : (
+              {/* Wager creation & management now live on the Dashboard, so the
+                  dropdown no longer carries "Create Wager" / "My Wagers". The
+                  membership upsell stays for non-members. */}
+              {!hasRole(ROLES.WAGER_PARTICIPANT) && (
+                <div className="dropdown-section">
+                  <span className="wallet-section-title">Wagers</span>
                   <div className="friend-market-promo">
                     <p className="promo-text">Create private wagers with friends!</p>
                     <button
@@ -417,16 +390,8 @@ function WalletButton({ className = '' }) {
                       <span>Get Access - from $2 USDC / month</span>
                     </button>
                   </div>
-                )}
-                <button
-                  onClick={handleOpenMyMarkets}
-                  className="action-button my-markets-btn"
-                  role="menuitem"
-                >
-                  <span aria-hidden="true">📋</span>
-                  <span>My Wagers</span>
-                </button>
-              </div>
+                </div>
+              )}
 
               {/* Network Toggle */}
               <div className="dropdown-section">
@@ -505,22 +470,6 @@ function WalletButton({ className = '' }) {
           )}
         </>
       )}
-
-      {/* My Wagers Modal */}
-      <MyMarketsModal
-        isOpen={showMyMarketsModal}
-        onClose={() => setShowMyMarketsModal(false)}
-        friendMarkets={friendMarkets}
-      />
-
-      {/* Create Wager Modal */}
-      <FriendMarketsModal
-        isOpen={showFriendMarketModal}
-        onClose={() => setShowFriendMarketModal(false)}
-        onCreate={handleFriendMarketCreation}
-        pendingTransaction={loadPendingTransaction()}
-        onClearPendingTransaction={clearPendingTransaction}
-      />
 
     </div>
   )

--- a/frontend/src/test/FriendMarketsModal.test.jsx
+++ b/frontend/src/test/FriendMarketsModal.test.jsx
@@ -357,6 +357,17 @@ describe('FriendMarketsModal', () => {
       expect(screen.queryByRole('tab', { name: /either party/i })).not.toBeInTheDocument()
     })
 
+    it('shows the Polymarket search in the oracle flow (visible even when the tab strip is suppressed)', async () => {
+      // Regression: under the default Polymarket-only exposure the oracle flow has
+      // a single settlement type, so the tab strip is hidden — but the Polymarket
+      // search (PolymarketBrowser) MUST still render. Previously the search was
+      // nested inside the (hidden) tab block and disappeared entirely.
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} initialType="oneVsOne" resolutionCategory="oracle" />
+      )
+      expect(await screen.findByTestId('mock-polymarket-browser')).toBeInTheDocument()
+    })
+
     it('locks oracle tabs whose source is unavailable on the active chain', () => {
       // On Hardhat (1337) the Polymarket CTF is unreachable, so the Polymarket
       // tab is shown locked/disabled rather than hidden.

--- a/frontend/src/test/WalletButton.test.jsx
+++ b/frontend/src/test/WalletButton.test.jsx
@@ -63,24 +63,8 @@ vi.mock('../hooks/useNetworkMode', () => ({
   })),
 }))
 
-// Mock modal components
-vi.mock('../components/fairwins/FriendMarketsModal', () => ({
-  default: ({ isOpen, onClose }) => isOpen ? (
-    <div role="dialog" aria-label="Create Wager Modal"><button onClick={onClose}>Close</button></div>
-  ) : null,
-  FriendMarketsModal: ({ isOpen, onClose }) => isOpen ? (
-    <div role="dialog" aria-label="Create Wager Modal"><button onClick={onClose}>Close</button></div>
-  ) : null
-}))
-
-vi.mock('../components/fairwins/MyMarketsModal', () => ({
-  default: ({ isOpen, onClose }) => isOpen ? (
-    <div role="dialog" aria-label="My Wagers Modal"><button onClick={onClose}>Close</button></div>
-  ) : null,
-  MyMarketsModal: ({ isOpen, onClose }) => isOpen ? (
-    <div role="dialog" aria-label="My Wagers Modal"><button onClick={onClose}>Close</button></div>
-  ) : null
-}))
+// FriendMarketsModal / MyMarketsModal are no longer mounted by WalletButton
+// (wager creation/management moved to the Dashboard), so no mocks are needed.
 
 vi.mock('../components/ui/PremiumPurchaseModal', () => ({
   default: ({ onClose }) => (
@@ -189,8 +173,12 @@ describe('WalletButton Component - Wagers', () => {
   })
 
   describe('Unified Wagers Section', () => {
-    it('displays Wagers section header in dropdown', async () => {
+    it('displays the Wagers upsell section for non-members', async () => {
       const user = userEvent.setup()
+      useWalletRoles.mockReturnValue({
+        roles: [],
+        hasRole: vi.fn(() => false)
+      })
       renderWithProviders(<WalletButton />)
 
       const button = screen.getByRole('button', { name: /wallet account/i })
@@ -201,7 +189,7 @@ describe('WalletButton Component - Wagers', () => {
       })
     })
 
-    it('shows Create Wager button for users with WAGER_PARTICIPANT role', async () => {
+    it('does not show "Create Wager" or "My Wagers" for members (moved to the Dashboard)', async () => {
       const user = userEvent.setup()
       useWalletRoles.mockReturnValue({
         roles: [ROLES.WAGER_PARTICIPANT],
@@ -213,9 +201,12 @@ describe('WalletButton Component - Wagers', () => {
       const button = screen.getByRole('button', { name: /wallet account/i })
       await user.click(button)
 
-      await waitFor(() => {
-        expect(screen.getByText('Create Wager')).toBeInTheDocument()
-      })
+      // Dropdown is open…
+      await screen.findByRole('menu')
+      // …but the wager entries are gone, and for a member the Wagers section is hidden.
+      expect(screen.queryByText('Create Wager')).not.toBeInTheDocument()
+      expect(screen.queryByText('My Wagers')).not.toBeInTheDocument()
+      expect(screen.queryByText('Wagers')).not.toBeInTheDocument()
     })
 
     it('shows purchase access prompt for users without WAGER_PARTICIPANT role', async () => {
@@ -235,16 +226,15 @@ describe('WalletButton Component - Wagers', () => {
       })
     })
 
-    it('shows My Wagers button for all connected users', async () => {
+    it('no longer shows the "My Wagers" entry in the dropdown', async () => {
       const user = userEvent.setup()
       renderWithProviders(<WalletButton />)
 
       const button = screen.getByRole('button', { name: /wallet account/i })
       await user.click(button)
 
-      await waitFor(() => {
-        expect(screen.getByText('My Wagers')).toBeInTheDocument()
-      })
+      await screen.findByRole('menu')
+      expect(screen.queryByText('My Wagers')).not.toBeInTheDocument()
     })
 
     it('hides Create Prediction Market button (removed feature)', async () => {
@@ -265,95 +255,4 @@ describe('WalletButton Component - Wagers', () => {
     })
   })
 
-  describe('Create Wager Feature', () => {
-    it('opens wager creation modal when Create Wager button is clicked', async () => {
-      const user = userEvent.setup()
-      useWalletRoles.mockReturnValue({
-        roles: [ROLES.WAGER_PARTICIPANT],
-        hasRole: vi.fn((role) => role === ROLES.WAGER_PARTICIPANT)
-      })
-
-      renderWithProviders(<WalletButton />)
-
-      const button = screen.getByRole('button', { name: /wallet account/i })
-      await user.click(button)
-
-      const createWagerBtn = await screen.findByText('Create Wager')
-      await user.click(createWagerBtn)
-
-      await waitFor(() => {
-        expect(screen.getByRole('dialog', { name: /create wager/i })).toBeInTheDocument()
-      })
-    })
-
-    it('closes dropdown when Create Wager button is clicked', async () => {
-      const user = userEvent.setup()
-      useWalletRoles.mockReturnValue({
-        roles: [ROLES.WAGER_PARTICIPANT],
-        hasRole: vi.fn((role) => role === ROLES.WAGER_PARTICIPANT)
-      })
-
-      renderWithProviders(<WalletButton />)
-
-      const button = screen.getByRole('button', { name: /wallet account/i })
-      await user.click(button)
-
-      const createWagerBtn = await screen.findByText('Create Wager')
-      await user.click(createWagerBtn)
-
-      await waitFor(() => {
-        expect(screen.queryByText('Wagers')).not.toBeInTheDocument()
-      })
-    })
-
-  })
-
-  describe('Wager and Market Integration', () => {
-    it('all wager actions are within a single Wagers section', async () => {
-      const user = userEvent.setup()
-      useWalletRoles.mockReturnValue({
-        roles: [ROLES.WAGER_PARTICIPANT, ROLES.WAGER_PARTICIPANT],
-        hasRole: vi.fn((role) => role === ROLES.WAGER_PARTICIPANT || role === ROLES.WAGER_PARTICIPANT)
-      })
-
-      renderWithProviders(<WalletButton />)
-
-      const button = screen.getByRole('button', { name: /wallet account/i })
-      await user.click(button)
-
-      await waitFor(() => {
-        // Only one Wagers section title should exist
-        const wagersSections = screen.getAllByText('Wagers')
-        const sectionTitle = wagersSections.find(el =>
-          el.className.includes('wallet-section-title')
-        ) || wagersSections[0]
-        expect(sectionTitle).toBeInTheDocument()
-
-        // My Wagers button should come after the section title
-        const myWagersBtn = screen.getByText('My Wagers')
-        expect(sectionTitle.compareDocumentPosition(myWagersBtn))
-          .toBe(Node.DOCUMENT_POSITION_FOLLOWING)
-      })
-    })
-  })
-
-  describe('Accessibility', () => {
-    it('Create Wager button has correct role', async () => {
-      const user = userEvent.setup()
-      useWalletRoles.mockReturnValue({
-        roles: [ROLES.WAGER_PARTICIPANT],
-        hasRole: vi.fn((role) => role === ROLES.WAGER_PARTICIPANT)
-      })
-
-      renderWithProviders(<WalletButton />)
-
-      const button = screen.getByRole('button', { name: /wallet account/i })
-      await user.click(button)
-
-      await waitFor(() => {
-        const createWagerBtn = screen.getByText('Create Wager').closest('button')
-        expect(createWagerBtn).toHaveAttribute('role', 'menuitem')
-      })
-    })
-  })
 })


### PR DESCRIPTION
## Summary

Part 1 of 2 of the wager-modal alignment work (PR 2 = the 005 arbitrator UI vertical, separate).

### 1. Oracle flow now shows the Polymarket search (the reported bug)
The 'Oracle Settles' Dashboard card opened the correct oracle flow, but the **Polymarket search was not visible**. Root cause: the Polymarket search (PolymarketBrowser) was nested *inside* the resolution **tab-strip** block, whose gate hides it when the oracle flow has a single settlement type — which is the **default `VITE_ORACLE_MODELS='polymarket-only'`** case (`ORACLE_TAB_TYPES = [Polymarket]`, length 1). So under the deployed Polymarket-only config the entire oracle block — tab strip *and* search — was suppressed.

**Fix:** gate that block on `useResolutionTabs` alone, and wrap only the **tab strip** in the 'more than one type' condition. The type-specific inputs (Polymarket search, oracle condition pickers) now always render. The oracle modal shows the Polymarket search again.

### 2. Removed 'Create Wager' / 'My Wagers' from the wallet dropdown
Per request. Removed the two entries plus their handlers, modal mounts, state, and now-unused imports. The membership **'Get Access'** upsell is preserved for non-members. This also removes the divergent `'all'`-mode create modal the dropdown used to open — so the **Dashboard cards are now the single, consistently-parameterized create-wager entry point** (Friends → participant, Oracle → Polymarket search, Bookmaker → all).

## Investigation note (premise correction)
A multi-agent map of the wiring found the Dashboard 'Friends Decide' and 'Oracle Settles' cards were **already** correctly differentiated (they open the same component with different `resolutionCategory` props) — the confusion was the missing Polymarket search (fixed here) and the wallet-dropdown's divergent modal (removed here). The marketing landing page (`/`) has no wager buttons; the wager buttons live on the Dashboard (`/app`).

## Tests
- New `FriendMarketsModal` regression: the oracle flow renders the Polymarket search even when the tab strip is suppressed (runs under the local `polymarket-only` regime where the bug occurred).
- `WalletButton` tests updated: assert 'Create Wager'/'My Wagers' are gone (members) and the upsell remains (non-members); removed the obsolete modal-open tests + mocks.
- ESLint clean.

## Follow-ups (not in this PR)
- Dashboard button-driven integration tests (click the QuickActions cards → assert flows), to lock the behavior end-to-end from the buttons.
- PR 2: the 005 arbitrator UI vertical (ThirdParty re-enable + arbitrator input + key-gate + encryption recipient + 'Arbitrating' tab).

Generated with Claude Code.