### PR TITLE
005: Arbitrating tab + Dashboard button-driven flow tests

### DIFF
--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -151,7 +151,7 @@ function MyMarketsModal({
   // Combine and categorize markets
   const categorizedMarkets = useMemo(() => {
     const userAddr = account?.toLowerCase()
-    if (!userAddr) return { participating: [], created: [], history: [] }
+    if (!userAddr) return { participating: [], created: [], arbitrating: [], history: [] }
 
     // Combine fetched and friend markets
     const allMarkets = [
@@ -237,9 +237,16 @@ function MyMarketsModal({
         hasPosition(market.id)
     }
 
+    // Check if the connected wallet is the (neutral) arbitrator for the wager.
+    const isArbitrator = (market) => {
+      const arb = market.arbitrator?.toLowerCase()
+      return !!arb && arb !== '0x0000000000000000000000000000000000000000' && arb === userAddr
+    }
+
     // Categorize markets
     const participating = []
     const created = []
+    const arbitrating = []
     const history = []
 
     marketsList.forEach(market => {
@@ -272,7 +279,7 @@ function MyMarketsModal({
         status === MarketStatus.DRAW ||
         status === MarketStatus.ORACLE_TIMED_OUT
       ) {
-        if (isCreator(market) || isParticipant(market)) {
+        if (isCreator(market) || isParticipant(market) || isArbitrator(market)) {
           history.push(marketWithStatus)
         }
       } else {
@@ -281,6 +288,11 @@ function MyMarketsModal({
         }
         if (isParticipant(market) && !isCreator(market)) {
           participating.push(marketWithStatus)
+        }
+        // The neutral arbitrator (not a participant) sees the wagers they oversee
+        // under "Arbitrating" so they can resolve them.
+        if (isArbitrator(market) && !isCreator(market) && !isParticipant(market)) {
+          arbitrating.push(marketWithStatus)
         }
       }
     })
@@ -292,9 +304,10 @@ function MyMarketsModal({
       (Number(b.id) || 0) - (Number(a.id) || 0)
     participating.sort(byNewest)
     created.sort(byNewest)
+    arbitrating.sort(byNewest)
     history.sort(byNewest)
 
-    return { participating, created, history }
+    return { participating, created, arbitrating, history }
   }, [markets, decryptableMarkets, userPositions, account, marketTypeFilter, statusFilter, dismissedIds, chainId])
 
   // Derive the selected market from the live categorized lists so the detail
@@ -306,6 +319,7 @@ function MyMarketsModal({
     const all = [
       ...categorizedMarkets.participating,
       ...categorizedMarkets.created,
+      ...categorizedMarkets.arbitrating,
       ...categorizedMarkets.history,
     ]
     return all.find(m => String(m.id) === String(selectedMarketId)) || null
@@ -611,6 +625,20 @@ function MyMarketsModal({
               <span className="mm-tab-badge">{categorizedMarkets.created.length}</span>
             )}
           </button>
+          {categorizedMarkets.arbitrating.length > 0 && (
+            <button
+              className={`mm-tab ${activeTab === 'arbitrating' ? 'active' : ''}`}
+              onClick={() => { setActiveTab('arbitrating'); setSelectedMarketId(null) }}
+              role="tab"
+              aria-selected={activeTab === 'arbitrating'}
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M12 3v18M5 7h14M5 7l-3 6a4 4 0 008 0L5 7zM19 7l-3 6a4 4 0 008 0l-5-6z"/>
+              </svg>
+              <span>Arbitrating</span>
+              <span className="mm-tab-badge">{categorizedMarkets.arbitrating.length}</span>
+            </button>
+          )}
           <button
             className={`mm-tab ${activeTab === 'history' ? 'active' : ''}`}
             onClick={() => { setActiveTab('history'); setSelectedMarketId(null) }}
@@ -804,6 +832,54 @@ function MyMarketsModal({
                       showResolveCountdown
                       onClearExpired={handleClearExpired}
                       onClearAllExpired={handleClearAllExpired}
+                      statusFilter={statusFilter}
+                    />
+                  )}
+                </div>
+              )}
+
+              {/* Arbitrating Tab — wagers the connected wallet resolves as the neutral arbitrator */}
+              {activeTab === 'arbitrating' && (
+                <div role="tabpanel" className="mm-panel">
+                  {selectedMarket ? (
+                    <MarketDetailView
+                      market={selectedMarket}
+                      onBack={handleBackToList}
+                      formatDate={formatDate}
+                      formatAddress={formatAddress}
+                      getStatusClass={getStatusClass}
+                      getStatusLabel={getStatusLabel}
+                      getTimeRemaining={getTimeRemaining}
+                      account={account}
+                      userPositions={userPositions}
+                      canResolve={canResolve}
+                      onOpenResolution={handleOpenResolution}
+                      onDecrypt={handleDecryptMarket}
+                      isDecrypting={isMarketDecrypting(selectedMarket?.id)}
+                      signer={signer}
+                      isCorrectNetwork={isCorrectNetwork}
+                      switchNetwork={switchNetwork}
+                    />
+                  ) : categorizedMarkets.arbitrating.length === 0 ? (
+                    <div className="mm-empty-state">
+                      <div className="mm-empty-icon">&#9878;</div>
+                      <h3>Nothing to Arbitrate</h3>
+                      <p>You aren&apos;t the arbitrator on any active wagers.</p>
+                      <p className="mm-hint">When someone names you as the neutral resolver, those wagers appear here.</p>
+                    </div>
+                  ) : (
+                    <MarketsTable
+                      markets={categorizedMarkets.arbitrating}
+                      onSelect={handleMarketSelect}
+                      formatDate={formatDate}
+                      getStatusClass={getStatusClass}
+                      getStatusLabel={getStatusLabel}
+                      getTimeRemaining={getTimeRemaining}
+                      canResolve={canResolve}
+                      onResolve={handleOpenResolution}
+                      showActions
+                      account={account}
+                      showResolveCountdown
                       statusFilter={statusFilter}
                     />
                   )}

--- a/frontend/src/test/Dashboard.test.jsx
+++ b/frontend/src/test/Dashboard.test.jsx
@@ -4,6 +4,19 @@ import { MemoryRouter } from 'react-router-dom'
 import Dashboard from '../components/fairwins/Dashboard'
 import { UserPreferencesContext, WalletContext, FriendMarketsContext, UIContext, DexContext } from '../contexts'
 
+// Stub the create modal to record the props each QuickActions card opens it with,
+// so we can assert the button → flow wiring (participant / oracle / all) without
+// rendering the heavy modal internals.
+vi.mock('../components/fairwins/FriendMarketsModal', () => ({
+  default: ({ isOpen, initialType, resolutionCategory }) => isOpen ? (
+    <div
+      data-testid="friend-modal"
+      data-initial-type={initialType}
+      data-resolution-category={resolutionCategory}
+    />
+  ) : null,
+}))
+
 describe('Dashboard Component', () => {
   const defaultWalletContext = {
     account: '0x1234567890abcdef1234567890abcdef12345678',
@@ -123,6 +136,37 @@ describe('Dashboard Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  describe('QuickActions button flows', () => {
+    const openVia = (cardText) => {
+      renderWithProviders(<Dashboard />)
+      fireEvent.click(screen.getByText(cardText))
+      return screen.getByTestId('friend-modal')
+    }
+
+    it('"Friends Decide (1v1)" opens the participant flow', () => {
+      const modal = openVia('Friends Decide (1v1)')
+      expect(modal).toHaveAttribute('data-initial-type', 'oneVsOne')
+      expect(modal).toHaveAttribute('data-resolution-category', 'participant')
+    })
+
+    it('"Oracle Settles (1v1)" opens the oracle flow (lands on Polymarket search)', () => {
+      const modal = openVia('Oracle Settles (1v1)')
+      expect(modal).toHaveAttribute('data-initial-type', 'oneVsOne')
+      expect(modal).toHaveAttribute('data-resolution-category', 'oracle')
+    })
+
+    it('"Bookmaker" opens the all-resolution flow', () => {
+      const modal = openVia('Bookmaker')
+      expect(modal).toHaveAttribute('data-initial-type', 'bookmaker')
+      expect(modal).toHaveAttribute('data-resolution-category', 'all')
+    })
+
+    it('the create modal is closed until a card is clicked', () => {
+      renderWithProviders(<Dashboard />)
+      expect(screen.queryByTestId('friend-modal')).not.toBeInTheDocument()
+    })
   })
 
   describe('Rendering', () => {

--- a/frontend/src/test/MyMarketsModal.test.jsx
+++ b/frontend/src/test/MyMarketsModal.test.jsx
@@ -768,6 +768,49 @@ describe('MyMarketsModal', () => {
     })
   })
 
+  describe('Arbitrating tab (005)', () => {
+    const me = '0x1234567890123456789012345678901234567890'
+    const creator = '0xAAaAAAAaaAAaaAaAAaaaAaAaAAAAaAAaAaaaAAaA'
+    const opponent = '0xBBbBBBBbbBBbbBbBBbbbBbBbBBBBbBBbBbbbBBbB'
+
+    it('shows an "Arbitrating" tab listing wagers where the wallet is the arbitrator', async () => {
+      const user = userEvent.setup()
+      const arbWager = {
+        id: '77', description: 'Arbitrated Wager', creator, participants: [creator, opponent],
+        arbitrator: me, status: 'active', marketType: 'friend',
+        tradingEndTime: BigInt(Math.floor(Date.now() / 1000) + 86400),
+      }
+      await act(async () => {
+        renderWithProviders(
+          <MyMarketsModal isOpen={true} onClose={mockOnClose} friendMarkets={[arbWager]} />
+        )
+      })
+
+      const arbTab = await screen.findByRole('tab', { name: /arbitrating/i })
+      await user.click(arbTab)
+      await waitFor(() => {
+        expect(screen.getByText('Arbitrated Wager')).toBeInTheDocument()
+      })
+    })
+
+    it('does not show the Arbitrating tab when the wallet arbitrates nothing', async () => {
+      const ownWager = {
+        id: '78', description: 'My Own Wager', creator: me, participants: [me, opponent],
+        status: 'active', marketType: 'friend',
+        tradingEndTime: BigInt(Math.floor(Date.now() / 1000) + 86400),
+      }
+      await act(async () => {
+        renderWithProviders(
+          <MyMarketsModal isOpen={true} onClose={mockOnClose} friendMarkets={[ownWager]} />
+        )
+      })
+      await waitFor(() => {
+        expect(screen.getByRole('tab', { name: /created/i })).toBeInTheDocument()
+      })
+      expect(screen.queryByRole('tab', { name: /arbitrating/i })).not.toBeInTheDocument()
+    })
+  })
+
   describe('Accessibility', () => {
     it('should have proper tab roles', async () => {
       await act(async () => {


### PR DESCRIPTION
## Summary

The remaining pieces of the 005 UI vertical, in a fresh PR (the create side landed in #637).

### Arbitrating tab (T013) — `MyMarketsModal`
- New **Arbitrating** bucket in the categorization: wagers where the connected wallet is the **neutral arbitrator** (`arbitrator == account`, and not creator/opponent).
- A 4th tab (shown only when non-empty) + panel listing those wagers with the arbitrator's **resolve action** (the existing `ResolveButtonWithCountdown` already authorizes the arbitrator for ThirdParty). Terminal arbitrated wagers fall into History.
- Reuses the existing **FR-010 'terms unavailable'** degradation via the shared `MarketDetailView` — so a decryption failure never hides the resolve action.

### Dashboard button-driven flow tests
The in-app 'landing' buttons (QuickActions) previously had no click-through coverage. Added tests that stub `FriendMarketsModal` to record props and assert each card opens the right flow:
- **Friends Decide (1v1)** → `resolutionCategory='participant'`
- **Oracle Settles (1v1)** → `resolutionCategory='oracle'` (the Polymarket-search flow fixed in #636)
- **Bookmaker** → `resolutionCategory='all'`
- modal stays closed until a card is clicked.

## Tests
- `MyMarketsModal`: 35 passing (incl. Arbitrating tab shown when arbitrating / hidden otherwise).
- `Dashboard`: 15 passing (incl. 4 button-flow tests).
- ESLint clean.

## Activation note
Live arbitrator **discovery** (`getUserWagers(arbitrator)`) needs the gated **v3 contract deploy**; the tab + tests work against mocked data now and activate fully once v3 ships. Resolution authority already exists on-chain.

Generated with Claude Code.