### PR TITLE
feat(007): compliance & legal gating — geo-gate, sanctions screening, versioned docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,21 @@ MARKET_FACTORY_ADDRESS=
 # Network Configuration
 # Private key for deployment account (used by hardhat config)
 PRIVATE_KEY=0x0000000000000000000000000000000000000000000000000000000000000001
+
+# ----------------------------------------------------------------------------
+# Compliance & Legal Gating (Spec 007)
+# ----------------------------------------------------------------------------
+# Polygon mainnet RPC used by the Chainalysis sanctions FORK TEST (test/fork/).
+# Use an archive-capable endpoint (Alchemy/Infura/own node). Never commit a real key.
+POLYGON_RPC_URL=https://polygon-rpc.com
+
+# Chainalysis on-chain Sanctions Oracle address, per chain (FR-055; injected at deploy,
+# never hardcoded in contracts). Mainnet 137 is the real verified oracle; Amoy/local have
+# none, so a MockSanctionsOracle is deployed and its address injected instead.
+CHAINALYSIS_SANCTIONS_ORACLE_137=0x40C57923924B5c5c5455c48D93317139ADDaC8fb
+CHAINALYSIS_SANCTIONS_ORACLE_80002=   # leave empty -> deploy MockSanctionsOracle on Amoy/local
+
+# Origin-lock shared secret (Cloudflare Transform Rule -> nginx; FR-008). Set this ONLY as
+# a runtime env var on Cloud Run (from Secret Manager), NOT a build arg. When unset locally
+# the origin lock is disabled so dev is not bricked. Generate: openssl rand -hex 32
+ORIGIN_LOCK_SECRET=

--- a/.github/workflows/oracle-fork-tests.yml
+++ b/.github/workflows/oracle-fork-tests.yml
@@ -74,10 +74,13 @@ jobs:
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run Amoy fork tests
+      - name: Run fork tests (Amoy oracles + Polygon-137 Chainalysis sanctions)
         env:
           AMOY_RPC_URL: ${{ secrets.AMOY_RPC_URL }}
           AMOY_FORK_BLOCK: ${{ github.event.inputs.block_number }}
+          # Spec 007: the Chainalysis sanctions oracle fork test forks Polygon mainnet (137).
+          # Without POLYGON_RPC_URL it enters describe.skip (no-op); set the secret to run it.
+          POLYGON_RPC_URL: ${{ secrets.POLYGON_RPC_URL }}
         run: npm run test:fork
 
       - name: Upload Hardhat compiler cache (for debugging fork failures)

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/006-local-dev-environment"
+  "feature_directory": "specs/007-compliance-gating"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,5 +49,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/006-local-dev-environment/plan.md
+at specs/007-compliance-gating/plan.md
 <!-- SPECKIT END -->

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -27,7 +27,13 @@ steps:
 
   # Deploy to Cloud Run
   # The VITE_PINATA_JWT environment variable is already configured in Cloud Run
-  # to be pulled from Secret Manager at runtime
+  # to be pulled from Secret Manager at runtime.
+  # ORIGIN_LOCK_SECRET (Spec 007 origin lock, FR-008) is likewise configured on the
+  # Cloud Run service from Secret Manager — see infra/cloudflare/origin-lock.md. It is
+  # intentionally NOT set here so deploys don't fail before the secret exists; once it is
+  # created, it can be wired declaratively with:
+  #   - '--update-secrets'
+  #   - 'ORIGIN_LOCK_SECRET=origin-lock-secret:latest'
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: gcloud
     args:

--- a/contracts/access/MembershipManager.sol
+++ b/contracts/access/MembershipManager.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "../interfaces/IMembershipManager.sol";
+import "../interfaces/ISanctionsGuard.sol";
 
 /// @title MembershipManager
 /// @notice Tiered, time-bound memberships per role. USDC-denominated. The only
@@ -29,10 +30,15 @@ contract MembershipManager is IMembershipManager, AccessControl {
     address public treasury;
     uint128 public accruedFees;
 
+    /// @notice Non-bypassable on-chain sanctions guard (Spec 007, FR-054). When unset
+    ///         (address(0)) screening is skipped — the production deploy wires it in.
+    ISanctionsGuard public sanctionsGuard;
+
     event TierSet(bytes32 indexed role, Tier indexed tier, uint128 priceUSDC, uint32 durationDays, bool active);
     event TreasuryUpdated(address indexed treasury);
     event PaymentTokenUpdated(address indexed token);
     event AuthorizedCallerSet(address indexed caller, bool allowed);
+    event SanctionsGuardUpdated(address indexed guard);
     event MembershipPurchased(address indexed user, bytes32 indexed role, Tier tier, uint128 price, uint64 expiresAt);
     event MembershipUpgraded(address indexed user, bytes32 indexed role, Tier fromTier, Tier toTier, uint128 delta);
     event MembershipExtended(address indexed user, bytes32 indexed role, uint32 durationDays, uint128 price, uint64 expiresAt);
@@ -99,6 +105,19 @@ contract MembershipManager is IMembershipManager, AccessControl {
         emit AuthorizedCallerSet(caller, allowed);
     }
 
+    /// @notice Set the on-chain sanctions guard. Pass address(0) to disable screening.
+    function setSanctionsGuard(address guard) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        sanctionsGuard = ISanctionsGuard(guard);
+        emit SanctionsGuardUpdated(guard);
+    }
+
+    /// @dev Sanctions screen (Spec 007, FR-054). No-op when unset; otherwise reverts for a
+    ///      listed/sanctioned address. Read-only Check, before any fee transfer/effects.
+    function _screen(address account) internal view {
+        ISanctionsGuard guard = sanctionsGuard;
+        if (address(guard) != address(0)) guard.checkBlocked(account);
+    }
+
     function grantMembership(address user, bytes32 role, Tier tier, uint32 durationDays) external onlyRole(ROLE_MANAGER_ROLE) {
         if (user == address(0)) revert ZeroAddress();
         if (tier == Tier.None) revert TierNone();
@@ -131,6 +150,7 @@ contract MembershipManager is IMembershipManager, AccessControl {
     // ---------- User ----------
 
     function purchaseTier(bytes32 role, Tier tier) external {
+        _screen(msg.sender); // Sanctions screen (Spec 007, FR-054) — before any fee transfer
         if (tier == Tier.None) revert TierNone();
         TierConfig memory cfg = _tiers[role][tier];
         if (!cfg.active) revert TierInactive();
@@ -152,6 +172,7 @@ contract MembershipManager is IMembershipManager, AccessControl {
     }
 
     function upgradeTier(bytes32 role, Tier newTier) external {
+        _screen(msg.sender); // Sanctions screen (Spec 007, FR-054) — before any fee transfer
         Membership storage m = _memberships[msg.sender][role];
         if (m.tier == Tier.None || m.expiresAt <= block.timestamp) revert NoActiveMembership();
         TierConfig memory current = _tiers[role][m.tier];
@@ -169,6 +190,7 @@ contract MembershipManager is IMembershipManager, AccessControl {
     }
 
     function extendMembership(bytes32 role) external {
+        _screen(msg.sender); // Sanctions screen (Spec 007, FR-054) — paid path, same risk class
         Membership storage m = _memberships[msg.sender][role];
         if (m.tier == Tier.None) revert NoActiveMembership();
         TierConfig memory cfg = _tiers[role][m.tier];

--- a/contracts/access/MembershipManager.sol
+++ b/contracts/access/MembershipManager.sol
@@ -34,11 +34,16 @@ contract MembershipManager is IMembershipManager, AccessControl {
     ///         (address(0)) screening is skipped — the production deploy wires it in.
     ISanctionsGuard public sanctionsGuard;
 
+    /// @notice Accepted T&C version hash recorded at membership purchase/upgrade
+    ///         (Spec 007, FR-039): user => role => SHA-256 of the in-force Terms.
+    mapping(address => mapping(bytes32 => bytes32)) public memberTermsHash;
+
     event TierSet(bytes32 indexed role, Tier indexed tier, uint128 priceUSDC, uint32 durationDays, bool active);
     event TreasuryUpdated(address indexed treasury);
     event PaymentTokenUpdated(address indexed token);
     event AuthorizedCallerSet(address indexed caller, bool allowed);
     event SanctionsGuardUpdated(address indexed guard);
+    event MembershipTermsRecorded(address indexed user, bytes32 indexed role, bytes32 termsHash, uint64 at);
     event MembershipPurchased(address indexed user, bytes32 indexed role, Tier tier, uint128 price, uint64 expiresAt);
     event MembershipUpgraded(address indexed user, bytes32 indexed role, Tier fromTier, Tier toTier, uint128 delta);
     event MembershipExtended(address indexed user, bytes32 indexed role, uint32 durationDays, uint128 price, uint64 expiresAt);
@@ -118,6 +123,14 @@ contract MembershipManager is IMembershipManager, AccessControl {
         if (address(guard) != address(0)) guard.checkBlocked(account);
     }
 
+    /// @dev Record the accepted T&C version hash for msg.sender (Spec 007, FR-039).
+    function _recordTerms(bytes32 role, bytes32 acceptedTermsHash) internal {
+        if (acceptedTermsHash != bytes32(0)) {
+            memberTermsHash[msg.sender][role] = acceptedTermsHash;
+            emit MembershipTermsRecorded(msg.sender, role, acceptedTermsHash, uint64(block.timestamp));
+        }
+    }
+
     function grantMembership(address user, bytes32 role, Tier tier, uint32 durationDays) external onlyRole(ROLE_MANAGER_ROLE) {
         if (user == address(0)) revert ZeroAddress();
         if (tier == Tier.None) revert TierNone();
@@ -150,6 +163,17 @@ contract MembershipManager is IMembershipManager, AccessControl {
     // ---------- User ----------
 
     function purchaseTier(bytes32 role, Tier tier) external {
+        _purchaseTier(role, tier);
+    }
+
+    /// @notice Like {purchaseTier} but records the accepted T&C version hash on-chain
+    ///         (Spec 007, FR-039). Existing purchaseTier ABI is preserved.
+    function purchaseTierWithTerms(bytes32 role, Tier tier, bytes32 acceptedTermsHash) external {
+        _purchaseTier(role, tier);
+        _recordTerms(role, acceptedTermsHash);
+    }
+
+    function _purchaseTier(bytes32 role, Tier tier) internal {
         _screen(msg.sender); // Sanctions screen (Spec 007, FR-054) — before any fee transfer
         if (tier == Tier.None) revert TierNone();
         TierConfig memory cfg = _tiers[role][tier];
@@ -172,6 +196,17 @@ contract MembershipManager is IMembershipManager, AccessControl {
     }
 
     function upgradeTier(bytes32 role, Tier newTier) external {
+        _upgradeTier(role, newTier);
+    }
+
+    /// @notice Like {upgradeTier} but records the accepted T&C version hash on-chain
+    ///         (Spec 007, FR-039). Existing upgradeTier ABI is preserved.
+    function upgradeTierWithTerms(bytes32 role, Tier newTier, bytes32 acceptedTermsHash) external {
+        _upgradeTier(role, newTier);
+        _recordTerms(role, acceptedTermsHash);
+    }
+
+    function _upgradeTier(bytes32 role, Tier newTier) internal {
         _screen(msg.sender); // Sanctions screen (Spec 007, FR-054) — before any fee transfer
         Membership storage m = _memberships[msg.sender][role];
         if (m.tier == Tier.None || m.expiresAt <= block.timestamp) revert NoActiveMembership();

--- a/contracts/access/MembershipManager.sol
+++ b/contracts/access/MembershipManager.sol
@@ -134,6 +134,9 @@ contract MembershipManager is IMembershipManager, AccessControl {
     function grantMembership(address user, bytes32 role, Tier tier, uint32 durationDays) external onlyRole(ROLE_MANAGER_ROLE) {
         if (user == address(0)) revert ZeroAddress();
         if (tier == Tier.None) revert TierNone();
+        // Spec 007 (FR-054): the sanctions guard is non-bypassable — an admin grant must not
+        // hand a sanctioned/deny-listed address standing either. Screen the grantee.
+        _screen(user);
         Membership storage m = _memberships[user][role];
         m.tier = tier;
         m.expiresAt = uint64(block.timestamp) + uint64(durationDays) * 1 days;

--- a/contracts/access/SanctionsGuard.sol
+++ b/contracts/access/SanctionsGuard.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "../interfaces/ISanctionsGuard.sol";
+import "../interfaces/IChainalysisSanctionsOracle.sol";
+
+/**
+ * @title SanctionsGuard
+ * @notice Non-bypassable on-chain sanctions enforcement (Spec 007, FR-016/FR-020/FR-054).
+ *         Combines the Chainalysis on-chain Sanctions Oracle with an operator-maintained
+ *         discretionary deny-list. Consulted read-only by value-bearing entrypoints in
+ *         WagerRegistry and MembershipManager during their Checks phase (CEI preserved).
+ * @dev Fail-closed: a CONFIGURED but unreachable/erroring oracle — including an address
+ *      with no code — makes every account not-allowed. An UNSET oracle (address(0)) means
+ *      deny-list-only enforcement: a deliberate configuration for networks where the
+ *      Chainalysis oracle is absent (e.g. Amoy uses a MockSanctionsOracle; production
+ *      injects the real mainnet address at deploy — FR-022/FR-055).
+ *      Roles: SANCTIONS_ADMIN_ROLE mutates the deny-list; DEFAULT_ADMIN_ROLE sets the
+ *      oracle. Both are granted to the air-gapped floppy-keystore admin at deploy.
+ */
+contract SanctionsGuard is ISanctionsGuard, AccessControl {
+    /// @notice Role permitted to add/remove discretionary deny-list entries.
+    bytes32 public constant SANCTIONS_ADMIN_ROLE = keccak256("SANCTIONS_ADMIN_ROLE");
+
+    IChainalysisSanctionsOracle private _oracle;
+    mapping(address => bool) private _denied;
+
+    error ZeroAddress();
+
+    constructor(address admin, address oracle) {
+        if (admin == address(0)) revert ZeroAddress();
+        _grantRole(DEFAULT_ADMIN_ROLE, admin);
+        _grantRole(SANCTIONS_ADMIN_ROLE, admin);
+        _oracle = IChainalysisSanctionsOracle(oracle); // may be address(0): deny-list-only
+        if (oracle != address(0)) emit SanctionsOracleUpdated(oracle);
+    }
+
+    // ---------- Views ----------
+
+    /// @inheritdoc ISanctionsGuard
+    function isAllowed(address account) public view override returns (bool) {
+        if (_denied[account]) return false;
+        (bool sanctioned, bool ok) = _queryOracle(account);
+        if (!ok) return false; // fail-closed: configured oracle unreachable/erroring
+        return !sanctioned;
+    }
+
+    /// @inheritdoc ISanctionsGuard
+    function checkBlocked(address account) external view override {
+        if (!isAllowed(account)) revert SanctionedAddress(account);
+    }
+
+    /// @inheritdoc ISanctionsGuard
+    function isDenied(address account) external view override returns (bool) {
+        return _denied[account];
+    }
+
+    /// @inheritdoc ISanctionsGuard
+    function sanctionsOracle() external view override returns (address) {
+        return address(_oracle);
+    }
+
+    // ---------- Admin ----------
+
+    /// @inheritdoc ISanctionsGuard
+    function setDenied(address account, bool denied, string calldata reason)
+        external
+        override
+        onlyRole(SANCTIONS_ADMIN_ROLE)
+    {
+        if (account == address(0)) revert ZeroAddress();
+        _denied[account] = denied;
+        emit DenyListUpdated(account, denied, msg.sender, reason);
+    }
+
+    /// @inheritdoc ISanctionsGuard
+    function setSanctionsOracle(address oracle) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+        _oracle = IChainalysisSanctionsOracle(oracle); // address(0) disables oracle screening
+        emit SanctionsOracleUpdated(oracle);
+    }
+
+    // ---------- Internal ----------
+
+    /**
+     * @dev Low-level staticcall (not try/catch) so that an oracle address with no code, or
+     *      one returning malformed data, is treated as fail-closed rather than reverting or
+     *      mis-decoding.
+     * @return sanctioned Oracle's verdict (meaningful only when `ok`).
+     * @return ok         False ⇒ a configured oracle gave no usable answer ⇒ caller fails
+     *                    closed. When no oracle is configured, returns (false, true).
+     */
+    function _queryOracle(address account) internal view returns (bool sanctioned, bool ok) {
+        address oracle = address(_oracle);
+        if (oracle == address(0)) return (false, true); // deny-list-only
+        (bool success, bytes memory data) = oracle.staticcall(
+            abi.encodeWithSelector(IChainalysisSanctionsOracle.isSanctioned.selector, account)
+        );
+        if (!success || data.length < 32) return (false, false); // fail-closed
+        return (abi.decode(data, (bool)), true);
+    }
+}

--- a/contracts/interfaces/IChainalysisSanctionsOracle.sol
+++ b/contracts/interfaces/IChainalysisSanctionsOracle.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/**
+ * @title IChainalysisSanctionsOracle
+ * @notice Minimal read-only view over the deployed Chainalysis on-chain Sanctions Oracle
+ *         ("SanctionsList"). FairWins reads this to screen wallet addresses against the
+ *         OFAC SDN set.
+ * @dev The oracle address is injected per-chain (NEVER hardcoded — see FR-055):
+ *      - Polygon mainnet (137): 0x40C57923924B5c5c5455c48D93317139ADDaC8fb
+ *      - Polygon Amoy (80002): NOT deployed → inject a MockSanctionsOracle on testnet/local
+ *      Only the read-only `isSanctioned(address)` view is required for integration.
+ *      Spec: specs/007-compliance-gating/contracts/IChainalysisSanctionsOracle.md
+ */
+interface IChainalysisSanctionsOracle {
+    /// @notice Returns true if `addr` is on the Chainalysis sanctions list.
+    function isSanctioned(address addr) external view returns (bool);
+}

--- a/contracts/interfaces/ISanctionsGuard.sol
+++ b/contracts/interfaces/ISanctionsGuard.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/**
+ * @title ISanctionsGuard
+ * @notice Non-bypassable on-chain sanctions enforcement consulted by value-bearing
+ *         entrypoints (WagerRegistry.createWager/acceptWager, MembershipManager
+ *         .purchaseTier/upgradeTier). Combines the Chainalysis oracle with an
+ *         operator-maintained discretionary deny-list. Fail-closed: an unreachable/
+ *         erroring oracle ⇒ not allowed.
+ * @dev Spec: specs/007-compliance-gating/contracts/ISanctionsGuard.md (FR-016/020/054).
+ */
+interface ISanctionsGuard {
+    // --- Views ---
+
+    /// @notice True iff `account` is neither deny-listed nor reported sanctioned by the oracle.
+    /// @dev Fail-closed: any oracle revert or empty return data ⇒ returns false.
+    function isAllowed(address account) external view returns (bool);
+
+    /// @notice Reverts {SanctionedAddress} when `account` is not allowed; no-op otherwise.
+    function checkBlocked(address account) external view;
+
+    /// @notice True iff `account` is on the discretionary deny-list (oracle not consulted).
+    function isDenied(address account) external view returns (bool);
+
+    /// @notice The currently configured Chainalysis oracle address (address(0) if unset).
+    function sanctionsOracle() external view returns (address);
+
+    // --- Admin ---
+
+    /// @notice Add/remove an address on the discretionary deny-list. Role: SANCTIONS_ADMIN_ROLE.
+    function setDenied(address account, bool denied, string calldata reason) external;
+
+    /// @notice Set/replace the Chainalysis oracle address. Role: DEFAULT_ADMIN_ROLE.
+    function setSanctionsOracle(address oracle) external;
+
+    // --- Events ---
+
+    event DenyListUpdated(address indexed account, bool denied, address indexed actor, string reason);
+    event SanctionsOracleUpdated(address indexed oracle);
+
+    // --- Errors ---
+
+    error SanctionedAddress(address account);
+}

--- a/contracts/mocks/MockSanctionsOracle.sol
+++ b/contracts/mocks/MockSanctionsOracle.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.24;
+
+import "../interfaces/IChainalysisSanctionsOracle.sol";
+
+/**
+ * @title MockSanctionsOracle
+ * @notice TEST/TESTNET ONLY stand-in for the Chainalysis Sanctions Oracle. The real oracle
+ *         is not deployed on Polygon Amoy (80002) or local chains, so this mock is injected
+ *         there for integration tests and testnet deploys. NEVER imported by, or injected
+ *         into, the Polygon mainnet (137) production path (constitution Principle III).
+ * @dev Lives only under contracts/mocks/. Production uses the real oracle via per-chain
+ *      address injection (FR-022/FR-055).
+ */
+contract MockSanctionsOracle is IChainalysisSanctionsOracle {
+    mapping(address => bool) private _sanctioned;
+
+    event SanctionedSet(address indexed account, bool sanctioned);
+
+    /// @notice Mark/unmark an address as sanctioned (test control).
+    function setSanctioned(address account, bool sanctioned) external {
+        _sanctioned[account] = sanctioned;
+        emit SanctionedSet(account, sanctioned);
+    }
+
+    /// @inheritdoc IChainalysisSanctionsOracle
+    function isSanctioned(address addr) external view returns (bool) {
+        return _sanctioned[addr];
+    }
+}

--- a/contracts/privacy/KeyRegistry.sol
+++ b/contracts/privacy/KeyRegistry.sol
@@ -15,11 +15,27 @@ contract KeyRegistry {
     mapping(address => bytes) private _keys;
 
     event KeyRegistered(address indexed user, bytes key, uint64 timestamp);
+    /// @notice Spec 007 (FR-043): dates the deterministic eligibility signature via the
+    ///         registration block timestamp, without putting a date in the signed payload.
+    ///         `termsRef` is a caller-supplied reference (generic id or in-force version hash).
+    event EligibilityAcknowledged(address indexed account, bytes32 termsRef, uint64 timestamp);
 
     error KeyTooShort();
     error KeyTooLong();
 
     function registerKey(bytes calldata publicKey) external {
+        _registerKey(publicKey);
+    }
+
+    /// @notice Like {registerKey} but also emits {EligibilityAcknowledged}, providing the
+    ///         dated on-chain record of the key-generation eligibility signature (Spec 007,
+    ///         FR-043). The existing registerKey ABI is preserved.
+    function registerKeyWithEligibility(bytes calldata publicKey, bytes32 termsRef) external {
+        _registerKey(publicKey);
+        emit EligibilityAcknowledged(msg.sender, termsRef, uint64(block.timestamp));
+    }
+
+    function _registerKey(bytes calldata publicKey) internal {
         if (publicKey.length < MIN_KEY_LENGTH) revert KeyTooShort();
         if (publicKey.length > MAX_KEY_LENGTH) revert KeyTooLong();
         _keys[msg.sender] = publicKey;

--- a/contracts/wagers/WagerRegistry.sol
+++ b/contracts/wagers/WagerRegistry.sol
@@ -10,6 +10,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "../interfaces/IWagerRegistry.sol";
 import "../interfaces/IMembershipManager.sol";
+import "../interfaces/ISanctionsGuard.sol";
 import "../oracles/IOracleAdapter.sol";
 
 /// @title WagerRegistry
@@ -36,6 +37,10 @@ contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausab
     IMembershipManager public membershipManager;
     IOracleAdapter public polymarketAdapter;
 
+    /// @notice Non-bypassable on-chain sanctions guard (Spec 007, FR-054). When unset
+    ///         (address(0)) screening is skipped — the production deploy wires it in.
+    ISanctionsGuard public sanctionsGuard;
+
     /// @notice Generic registry for non-Polymarket oracle adapters keyed by ResolutionType.
     ///         Polymarket retains its dedicated `polymarketAdapter` slot for ABI compatibility.
     mapping(ResolutionType => IOracleAdapter) public oracleAdapters;
@@ -43,6 +48,11 @@ contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausab
     mapping(address => bool) private _allowedTokens;
     mapping(uint256 => Wager) private _wagers;
     mapping(address => bool) private _frozen;
+
+    /// @notice Governing T&C version hash bound to a wager at creation (Spec 007, FR-056/
+    ///         FR-057). 0 ⇒ legacy/unbound (governed by the launch version). Set only via
+    ///         createWagerWithTerms; never re-bound (prospective-only).
+    mapping(uint256 => bytes32) public wagerTermsVersionHash;
     uint256 private _nextWagerId = 1;
 
     /// @notice Per-wager draw-consent bitmask for participant resolution types
@@ -63,6 +73,8 @@ contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausab
 
     event MembershipManagerUpdated(address indexed manager);
     event PolymarketAdapterUpdated(address indexed adapter);
+    event SanctionsGuardUpdated(address indexed guard);
+    event WagerTermsBound(uint256 indexed wagerId, bytes32 indexed termsVersionHash);
     event TokenAllowed(address indexed token, bool allowed);
 
     error ZeroAddress();
@@ -136,6 +148,20 @@ contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausab
         emit PolymarketAdapterUpdated(adapter);
     }
 
+    /// @notice Set the on-chain sanctions guard. Pass address(0) to disable screening.
+    function setSanctionsGuard(address guard) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        sanctionsGuard = ISanctionsGuard(guard);
+        emit SanctionsGuardUpdated(guard);
+    }
+
+    /// @dev Sanctions screen (Spec 007, FR-054). No-op when the guard is unset; otherwise
+    ///      reverts ISanctionsGuard.SanctionedAddress(account) for a listed/sanctioned
+    ///      address. Called read-only during the Checks phase (before effects/transfers).
+    function _screen(address account) internal view {
+        ISanctionsGuard guard = sanctionsGuard;
+        if (address(guard) != address(0)) guard.checkBlocked(account);
+    }
+
     /// @notice Set the adapter for one of the new (non-Polymarket) oracle resolution types.
     ///         Pass `address(0)` to disable that resolution type.
     /// @dev Rejects the legacy types — Either/Creator/Opponent/ThirdParty have no adapter,
@@ -202,6 +228,49 @@ contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausab
         bytes32 metadataHash,
         string calldata metadataUri
     ) external nonReentrant whenNotPaused notFrozen(msg.sender) returns (uint256 wagerId) {
+        // Existing ABI preserved: no governing-terms binding (legacy path).
+        return _createWager(opponent, arbitrator, token, creatorStake, opponentStake, acceptDeadline, resolveDeadline, resolutionType, polymarketConditionId, creatorIsYes, metadataHash, metadataUri, bytes32(0));
+    }
+
+    /// @notice Like {createWager} but binds the governing T&C version hash on-chain at
+    ///         creation (Spec 007, FR-056/FR-058). The hash is the SHA-256 of the in-force
+    ///         Terms; it is recorded in {wagerTermsVersionHash} and emitted via
+    ///         {WagerTermsBound}, and is also bound into the wager's encrypted metadata AAD.
+    function createWagerWithTerms(
+        address opponent,
+        address arbitrator,
+        address token,
+        uint128 creatorStake,
+        uint128 opponentStake,
+        uint64 acceptDeadline,
+        uint64 resolveDeadline,
+        ResolutionType resolutionType,
+        bytes32 polymarketConditionId,
+        bool creatorIsYes,
+        bytes32 metadataHash,
+        string calldata metadataUri,
+        bytes32 termsVersionHash
+    ) external nonReentrant whenNotPaused notFrozen(msg.sender) returns (uint256 wagerId) {
+        return _createWager(opponent, arbitrator, token, creatorStake, opponentStake, acceptDeadline, resolveDeadline, resolutionType, polymarketConditionId, creatorIsYes, metadataHash, metadataUri, termsVersionHash);
+    }
+
+    function _createWager(
+        address opponent,
+        address arbitrator,
+        address token,
+        uint128 creatorStake,
+        uint128 opponentStake,
+        uint64 acceptDeadline,
+        uint64 resolveDeadline,
+        ResolutionType resolutionType,
+        bytes32 polymarketConditionId,
+        bool creatorIsYes,
+        bytes32 metadataHash,
+        string calldata metadataUri,
+        bytes32 termsVersionHash
+    ) internal returns (uint256 wagerId) {
+        // Sanctions screen (Spec 007, FR-054) — first Check, before any effects/transfers.
+        _screen(msg.sender);
         if (opponent == address(0)) revert ZeroAddress();
         if (opponent == msg.sender) revert SelfWager();
         if (!_allowedTokens[token]) revert NotAllowedToken();
@@ -262,6 +331,11 @@ contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausab
         if (arbitrator != address(0)) {
             _userWagerIds[arbitrator].add(wagerId);
         }
+        // Spec 007 (FR-056/FR-057): bind the governing T&C version (Effect, before
+        // interactions). 0 ⇒ legacy/unbound. Prospective-only — never re-bound elsewhere.
+        if (termsVersionHash != bytes32(0)) {
+            wagerTermsVersionHash[wagerId] = termsVersionHash;
+        }
 
         // Interactions
         IERC20(token).safeTransferFrom(msg.sender, address(this), creatorStake);
@@ -273,6 +347,9 @@ contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausab
         } else if (_isExtensibleOracleType(resolutionType)) {
             emit OracleConditionLinked(wagerId, resolutionType, polymarketConditionId, creatorIsYes);
         }
+        if (termsVersionHash != bytes32(0)) {
+            emit WagerTermsBound(wagerId, termsVersionHash);
+        }
     }
 
     function acceptWager(uint256 wagerId) external nonReentrant whenNotPaused notFrozen(msg.sender) {
@@ -280,6 +357,10 @@ contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausab
         if (w.status != Status.Open) revert NotOpen();
         if (msg.sender != w.opponent) revert NotOpponent();
         if (block.timestamp > w.acceptDeadline) revert AcceptExpired();
+        // Sanctions screen both parties (Spec 007, FR-054): the accepting opponent AND the
+        // creator (counterparty) — a creator listed after creation blocks acceptance.
+        _screen(msg.sender);
+        _screen(w.creator);
         if (!membershipManager.checkCanCreate(msg.sender, WAGER_PARTICIPANT_ROLE)) revert MembershipDenied();
 
         w.status = Status.Active;

--- a/deployments/polygon-chain137-v2.json
+++ b/deployments/polygon-chain137-v2.json
@@ -2,20 +2,21 @@
   "network": "polygon",
   "chainId": 137,
   "deployer": "0x52502d049571C7893447b86c4d8B38e6184bF6e1",
-  "treasury": "0x1215185387E70a48b07D73AcB67002A073F18575",
+  "treasury": "0x52502d049571C7893447b86c4d8B38e6184bF6e1",
   "paymentToken": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
   "wmatic": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
   "polymarketCTF": "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045",
   "contracts": {
     "polymarketAdapter": "0x83688e9b8D4f085E3eF4619D91e0e6303cFcf0A4",
-    "membershipManager": "0x7441700979e37a9a1F17093a4859c8f261780c95",
-    "wagerRegistry": "0x7bb3ef3E65DB9bd9D7133Bd7F25e8754Bf11F2D4",
-    "keyRegistry": "0xb314c4Ee52D9D89bf7FEE66a43aBeAc7D047a5Cb",
+    "membershipManager": "0x00c3ef4e02Ef00Ad6eE955dF5022A22F6ea73dae",
+    "wagerRegistry": "0x5023765809fDA93ab9F11B684fdb76521eD31774",
+    "keyRegistry": "0xcEFdeBba8E040c035c690ca9057cF22E73247c24",
+    "sanctionsGuard": "0x2Dc53d91A189be71DfE96Ea9BCFCF6aDDA77BC76",
     "chainlinkDataFeedAdapter": "0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23",
     "chainlinkFunctionsAdapter": "0x148C2E347a601AC1a680b17321529b0Ffc31AeFc",
     "umaAdapter": "0x8224433d099Af6cd30540A78421aBFd6e044E949"
   },
   "mocks": null,
   "saltPrefix": "FairWins-P2P-v2.0-",
-  "timestamp": "2026-06-04T22:06:18.741Z"
+  "timestamp": "2026-06-08T01:35:29.642Z"
 }

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,19 +1,38 @@
 #!/bin/sh
-# Docker entrypoint script for nginx with runtime environment variable substitution
-# This allows VITE_PINATA_JWT to be passed at runtime (from Cloud Run secrets)
-# and injected into the nginx configuration
+# Docker entrypoint: substitute runtime env vars into the nginx config, then start nginx.
+#
+# Runtime secrets (from Cloud Run / Secret Manager, NOT build args):
+#   - VITE_PINATA_JWT    : Pinata API auth for the /api/pinata proxy
+#   - ORIGIN_LOCK_SECRET : Cloudflare-injected X-Origin-Auth value (Spec 007, FR-008)
+#
+# Origin lock (FR-007/FR-008): Cloudflare injects `X-Origin-Auth: <secret>` on every
+# proxied request; nginx serves a request only when it matches ORIGIN_LOCK_SECRET.
+# Enforcement is ACTIVE only when the secret is set (ORIGIN_LOCK_ENABLED=1) so local/dev
+# and any pre-Cloudflare environment is not bricked. PRODUCTION MUST set the secret.
 
 set -e
 
-# Substitute environment variables in nginx config template
-# Only substitute VITE_PINATA_JWT to avoid replacing other $ variables in nginx
-envsubst '${VITE_PINATA_JWT}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+if [ -n "$ORIGIN_LOCK_SECRET" ]; then
+    export ORIGIN_LOCK_ENABLED=1
+else
+    export ORIGIN_LOCK_ENABLED=0
+fi
 
-# Log configuration status (mask the actual JWT)
+# Only substitute the known vars (avoid clobbering nginx's own $variables)
+envsubst '${VITE_PINATA_JWT} ${ORIGIN_LOCK_SECRET} ${ORIGIN_LOCK_ENABLED}' \
+    < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
+
+# Status logs — NEVER print the secret values themselves
 if [ -n "$VITE_PINATA_JWT" ]; then
     echo "Pinata JWT configured (${#VITE_PINATA_JWT} chars)"
 else
     echo "WARNING: VITE_PINATA_JWT is not set - Pinata uploads will fail"
+fi
+
+if [ "$ORIGIN_LOCK_ENABLED" = "1" ]; then
+    echo "Origin lock ENABLED (X-Origin-Auth required; secret ${#ORIGIN_LOCK_SECRET} chars)"
+else
+    echo "WARNING: ORIGIN_LOCK_SECRET not set - origin lock DISABLED (dev/local). MUST be set in production."
 fi
 
 # Start nginx

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -1,3 +1,22 @@
+# --- Origin lock (Spec 007, FR-007/FR-008) ---
+# Cloudflare injects `X-Origin-Auth: <secret>` (Transform Rule) on every proxied request.
+# We allow a request only when it matches ORIGIN_LOCK_SECRET. Enforcement is active only
+# when ORIGIN_LOCK_ENABLED=1 (i.e. the secret is configured — see docker-entrypoint.sh),
+# so dev/local and pre-Cloudflare environments are not bricked. A bare CF-IP allowlist is
+# insufficient because Cloudflare egress IPs are shared across tenants.
+# $origin_denied = 1 ⇒ block (403). The secret is never written to logs.
+map "${ORIGIN_LOCK_ENABLED}:$http_x_origin_auth" $origin_denied {
+    default                      1;   # enforcement on + header missing/mismatch ⇒ deny
+    "~^0:"                       0;   # enforcement off ⇒ allow everything
+    "1:${ORIGIN_LOCK_SECRET}"    0;   # enforcement on + exact secret match ⇒ allow
+}
+
+# Access log including the edge-provided country-of-record / client IP (Spec 007, FR-009)
+# as the geo/IP enforcement-evidence tier. Does NOT log the origin-lock secret.
+log_format fairwins_edge '$remote_addr cf_ip=$http_cf_connecting_ip '
+                         'cf_country=$http_cf_ipcountry "$request" $status '
+                         '$body_bytes_sent rt=$request_time "$http_user_agent"';
+
 server {
     listen 8080;
     server_name _;
@@ -5,9 +24,21 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    access_log /dev/stdout fairwins_edge;
+
+    # Unauthenticated health endpoint (exempt from the origin lock) for probes/uptime.
+    location = /healthz {
+        access_log off;
+        add_header Content-Type text/plain;
+        return 200 "ok\n";
+    }
+
     # Pinata API proxy - bypasses CORS restrictions
     # JWT is injected at container startup via envsubst
     location /api/pinata/ {
+        # Origin lock: only Cloudflare-proxied requests may use the authenticated proxy.
+        if ($origin_denied) { return 403; }
+
         # Proxy to Pinata API
         proxy_pass https://api.pinata.cloud/pinning/;
         proxy_ssl_server_name on;
@@ -44,11 +75,14 @@ server {
 
     # Handle SPA routing - all routes should serve index.html
     location / {
+        # Origin lock (Spec 007): refuse requests not proxied through Cloudflare.
+        if ($origin_denied) { return 403; }
         try_files $uri $uri/ /index.html;
     }
 
     # Cache static assets
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        if ($origin_denied) { return 403; }
         expires 1y;
         add_header Cache-Control "public, immutable";
     }

--- a/frontend/public/451.html
+++ b/frontend/public/451.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>451 — Unavailable For Legal Reasons | FairWins</title>
+  <meta name="robots" content="noindex" />
+  <style>
+    :root { color-scheme: light dark; }
+    body {
+      margin: 0; min-height: 100vh; display: grid; place-items: center;
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+      background: #0b1020; color: #e8ecf6; padding: 1.5rem;
+    }
+    main { max-width: 38rem; text-align: center; }
+    h1 { font-size: 1.6rem; margin: 0 0 .25rem; }
+    .code { font-size: .85rem; letter-spacing: .08em; opacity: .7; text-transform: uppercase; }
+    p { line-height: 1.55; opacity: .92; }
+    a { color: #8ab4ff; }
+  </style>
+</head>
+<body>
+  <main role="main">
+    <p class="code">HTTP 451 — Unavailable For Legal Reasons</p>
+    <h1>FairWins isn't available in your location</h1>
+    <p>
+      Access to FairWins is restricted in some jurisdictions for legal and regulatory
+      reasons. Based on your location, we're unable to provide access.
+    </p>
+    <p>
+      If you believe this is an error, please review our
+      <a href="https://fairwins.app/terms">Terms &amp; Conditions</a>. Using a VPN, proxy,
+      or other means to misrepresent your location is a breach of those Terms.
+    </p>
+  </main>
+</body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -19,6 +19,7 @@ import Header from './components/Header'
 import WalletPage from './pages/WalletPage'
 import MarketAcceptancePage from './pages/MarketAcceptancePage'
 import { TermsPage, RiskPage, PrivacyPage } from './pages/legal/LegalDocPage'
+import EntryGate from './components/compliance/EntryGate'
 
 //admin
 import AdminPanel from './components/AdminPanel'
@@ -33,6 +34,8 @@ function AppLayout() {
   return (
     <>
       <Header appMode />
+      {/* Spec 007 (US4): client-side eligibility notice gate before any app content. */}
+      <EntryGate />
       <Outlet />
     </>
   )

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,6 +18,7 @@ import Header from './components/Header'
 // add-ons
 import WalletPage from './pages/WalletPage'
 import MarketAcceptancePage from './pages/MarketAcceptancePage'
+import { TermsPage, RiskPage, PrivacyPage } from './pages/legal/LegalDocPage'
 
 //admin
 import AdminPanel from './components/AdminPanel'
@@ -92,6 +93,11 @@ function AppContent() {
         />
         <Route path="/ui-components" element={<ComponentExamples />} />
         <Route path="/state-demo" element={<StateManagementDemo />} />
+
+        {/* Public versioned legal documents (Spec 007) — readable before the entry gate */}
+        <Route path="/terms" element={<TermsPage />} />
+        <Route path="/risk" element={<RiskPage />} />
+        <Route path="/privacy" element={<PrivacyPage />} />
 
         {/* App routes with header + wallet button */}
         <Route element={<AppLayout />}>

--- a/frontend/src/abis/KeyRegistry.js
+++ b/frontend/src/abis/KeyRegistry.js
@@ -15,6 +15,31 @@ export const KEY_REGISTRY_ABI = [
       {
         "indexed": true,
         "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "termsRef",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "timestamp",
+        "type": "uint64"
+      }
+    ],
+    "name": "EligibilityAcknowledged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "user",
         "type": "address"
       },
@@ -84,5 +109,23 @@ export const KEY_REGISTRY_ABI = [
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "publicKey",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "termsRef",
+        "type": "bytes32"
+      }
+    ],
+    "name": "registerKeyWithEligibility",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
   }
-];
+]

--- a/frontend/src/abis/SanctionsGuard.js
+++ b/frontend/src/abis/SanctionsGuard.js
@@ -1,0 +1,421 @@
+/**
+ * SanctionsGuard ABI (Spec 007). Generated from the compiled artifact
+ * (artifacts/contracts/access/SanctionsGuard.sol). Do not hand-edit — regenerate after
+ * contract changes. Address comes from the synced contracts config (FR-055), never hardcoded.
+ */
+export const SANCTIONS_GUARD_ABI = [
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "admin",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "oracle",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AccessControlBadConfirmation",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "neededRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "AccessControlUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "SanctionedAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAddress",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "denied",
+        "type": "bool"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "actor",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "reason",
+        "type": "string"
+      }
+    ],
+    "name": "DenyListUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oracle",
+        "type": "address"
+      }
+    ],
+    "name": "SanctionsOracleUpdated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "SANCTIONS_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "checkBlocked",
+    "outputs": [],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "isAllowed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "isDenied",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "callerConfirmation",
+        "type": "address"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "sanctionsOracle",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "denied",
+        "type": "bool"
+      },
+      {
+        "internalType": "string",
+        "name": "reason",
+        "type": "string"
+      }
+    ],
+    "name": "setDenied",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "oracle",
+        "type": "address"
+      }
+    ],
+    "name": "setSanctionsOracle",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/frontend/src/abis/WagerRegistry.js
+++ b/frontend/src/abis/WagerRegistry.js
@@ -540,6 +540,19 @@ export const WAGER_REGISTRY_ABI = [
       {
         "indexed": true,
         "internalType": "address",
+        "name": "guard",
+        "type": "address"
+      }
+    ],
+    "name": "SanctionsGuardUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "token",
         "type": "address"
       },
@@ -757,6 +770,25 @@ export const WAGER_REGISTRY_ABI = [
       }
     ],
     "name": "WagerResolved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "wagerId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "termsVersionHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "WagerTermsBound",
     "type": "event"
   },
   {
@@ -992,6 +1024,85 @@ export const WAGER_REGISTRY_ABI = [
       }
     ],
     "name": "createWager",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "wagerId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "opponent",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "arbitrator",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint128",
+        "name": "creatorStake",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "opponentStake",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint64",
+        "name": "acceptDeadline",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "resolveDeadline",
+        "type": "uint64"
+      },
+      {
+        "internalType": "enum IWagerRegistry.ResolutionType",
+        "name": "resolutionType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "polymarketConditionId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "creatorIsYes",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "metadataHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "string",
+        "name": "metadataUri",
+        "type": "string"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "termsVersionHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "createWagerWithTerms",
     "outputs": [
       {
         "internalType": "uint256",
@@ -1575,6 +1686,19 @@ export const WAGER_REGISTRY_ABI = [
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "sanctionsGuard",
+    "outputs": [
+      {
+        "internalType": "contract ISanctionsGuard",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -1614,6 +1738,19 @@ export const WAGER_REGISTRY_ABI = [
       }
     ],
     "name": "setPolymarketAdapter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "guard",
+        "type": "address"
+      }
+    ],
+    "name": "setSanctionsGuard",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -1673,6 +1810,25 @@ export const WAGER_REGISTRY_ABI = [
     "name": "unpause",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "wagerTermsVersionHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   }
 ]

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -10,6 +10,7 @@ import { isValidEthereumAddress } from '../utils/validation'
 import { NETWORK_CONFIG, DEPLOYED_CONTRACTS, getContractAddress } from '../config/contracts'
 import { MEMBERSHIP_MANAGER_ABI } from '../abis/MembershipManager'
 import OracleAdaptersTab from './admin/OracleAdaptersTab'
+import DenyListAdmin from './admin/DenyListAdmin'
 import './AdminPanel.css'
 
 const TIER_NAMES = { 1: 'Bronze', 2: 'Silver', 3: 'Gold', 4: 'Platinum' }
@@ -367,6 +368,11 @@ function AdminPanel() {
             className={`admin-panel-tab ${activeTab === 'oracle-adapters' ? 'active' : ''}`}
             onClick={() => setActiveTab('oracle-adapters')}>Oracle Adapters</button>
         )}
+        {isAdmin && (
+          <button role="tab" aria-selected={activeTab === 'deny-list'}
+            className={`admin-panel-tab ${activeTab === 'deny-list' ? 'active' : ''}`}
+            onClick={() => setActiveTab('deny-list')}>Deny-list</button>
+        )}
       </nav>
 
       <main className="admin-panel-content">
@@ -683,6 +689,16 @@ function AdminPanel() {
 
         {activeTab === 'oracle-adapters' && isAdmin && (
           <OracleAdaptersTab
+            signer={signer}
+            account={account}
+            contracts={DEPLOYED_CONTRACTS}
+            runTx={runTx}
+            pendingTx={pendingTx}
+          />
+        )}
+
+        {activeTab === 'deny-list' && isAdmin && (
+          <DenyListAdmin
             signer={signer}
             account={account}
             contracts={DEPLOYED_CONTRACTS}

--- a/frontend/src/components/admin/DenyListAdmin.jsx
+++ b/frontend/src/components/admin/DenyListAdmin.jsx
@@ -1,0 +1,194 @@
+import { useState, useEffect, useCallback } from 'react'
+import { ethers } from 'ethers'
+
+/**
+ * DenyListAdmin (Spec 007 — FR-020, SC-018)
+ *
+ * Admin UI for the SanctionsGuard discretionary deny-list: add/remove addresses with a
+ * reason (calls setDenied, gated on-chain by SANCTIONS_ADMIN_ROLE), and render the
+ * add/remove audit trail from the DenyListUpdated event (actor + reason + block).
+ *
+ * Tab contract matches the other admin tabs: { signer, account, contracts, runTx, pendingTx }.
+ * The guard address comes from the synced contracts config (FR-055) — never hardcoded.
+ */
+
+// Minimal human-readable ABI (keeps the bundle small; full ABI lives in abis/SanctionsGuard.js)
+const GUARD_ABI = [
+  'function setDenied(address account, bool denied, string reason)',
+  'function isDenied(address account) view returns (bool)',
+  'function isAllowed(address account) view returns (bool)',
+  'event DenyListUpdated(address indexed account, bool denied, address indexed actor, string reason)',
+]
+
+function isAddr(s) {
+  try { return ethers.isAddress((s || '').trim()) } catch { return false }
+}
+function shortAddr(a) {
+  return a && ethers.isAddress(a) ? a.slice(0, 6) + '…' + a.slice(-4) : (a || '—')
+}
+
+function DenyListAdmin({ signer, contracts, runTx, pendingTx }) {
+  const guardAddress = contracts?.sanctionsGuard
+  const [address, setAddress] = useState('')
+  const [reason, setReason] = useState('')
+  const [status, setStatus] = useState(null) // { denied, allowed } | null
+  const [history, setHistory] = useState([])
+  const [loadingHistory, setLoadingHistory] = useState(false)
+  const [error, setError] = useState('')
+
+  const writer = useCallback(() => {
+    if (!isAddr(guardAddress) || !signer) return null
+    return new ethers.Contract(guardAddress, GUARD_ABI, signer)
+  }, [guardAddress, signer])
+
+  const loadHistory = useCallback(async () => {
+    if (!isAddr(guardAddress) || !signer?.provider) return
+    setLoadingHistory(true)
+    setError('')
+    try {
+      const reader = new ethers.Contract(guardAddress, GUARD_ABI, signer.provider)
+      const events = await reader.queryFilter(reader.filters.DenyListUpdated())
+      const rows = events
+        .map((e) => ({
+          account: e.args.account,
+          denied: e.args.denied,
+          actor: e.args.actor,
+          reason: e.args.reason,
+          block: e.blockNumber,
+        }))
+        .reverse()
+      setHistory(rows)
+    } catch (err) {
+      setError(`Could not load audit trail: ${err.message || err}`)
+    } finally {
+      setLoadingHistory(false)
+    }
+  }, [guardAddress, signer])
+
+  useEffect(() => { loadHistory() }, [loadHistory])
+
+  const submit = (denied) => {
+    setError('')
+    if (!isAddr(address)) { setError('Enter a valid address'); return }
+    if (!reason.trim()) { setError('A reason is required (recorded on-chain for the audit trail)'); return }
+    const c = writer()
+    if (!c) { setError('SanctionsGuard is not configured on this network'); return }
+    runTx(
+      () => c.setDenied(address.trim(), denied, reason.trim()),
+      `Deny-list ${denied ? 'add' : 'remove'}: ${shortAddr(address)}`,
+    )
+  }
+
+  const checkStatus = async () => {
+    setError('')
+    setStatus(null)
+    if (!isAddr(address)) { setError('Enter a valid address'); return }
+    if (!isAddr(guardAddress) || !signer?.provider) { setError('SanctionsGuard not configured'); return }
+    try {
+      const reader = new ethers.Contract(guardAddress, GUARD_ABI, signer.provider)
+      const [denied, allowed] = await Promise.all([
+        reader.isDenied(address.trim()),
+        reader.isAllowed(address.trim()),
+      ])
+      setStatus({ denied, allowed })
+    } catch (err) {
+      setError(`Status read failed: ${err.message || err}`)
+    }
+  }
+
+  if (!isAddr(guardAddress)) {
+    return (
+      <section aria-labelledby="denylist-heading">
+        <h3 id="denylist-heading">Sanctions deny-list</h3>
+        <p role="status">SanctionsGuard is not deployed/configured on this network.</p>
+      </section>
+    )
+  }
+
+  return (
+    <section aria-labelledby="denylist-heading">
+      <h3 id="denylist-heading">Sanctions deny-list</h3>
+      <p>
+        Manage the discretionary on-chain deny-list. Requires <code>SANCTIONS_ADMIN_ROLE</code>.
+        Guard: <span title={guardAddress}>{shortAddr(guardAddress)}</span>
+      </p>
+
+      <div className="denylist-form">
+        <label htmlFor="denylist-address">Wallet address</label>
+        <input
+          id="denylist-address"
+          type="text"
+          inputMode="text"
+          autoComplete="off"
+          placeholder="0x…"
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+        />
+
+        <label htmlFor="denylist-reason">Reason (recorded on-chain)</label>
+        <input
+          id="denylist-reason"
+          type="text"
+          placeholder="e.g. OFAC SDN match / illicit-finance association"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+        />
+
+        <div className="denylist-actions">
+          <button type="button" className="confirm-btn danger" onClick={() => submit(true)} disabled={pendingTx}>
+            {pendingTx ? 'Processing…' : 'Add to deny-list'}
+          </button>
+          <button type="button" className="confirm-btn" onClick={() => submit(false)} disabled={pendingTx}>
+            {pendingTx ? 'Processing…' : 'Remove from deny-list'}
+          </button>
+          <button type="button" className="confirm-btn" onClick={checkStatus} disabled={pendingTx}>
+            Check status
+          </button>
+        </div>
+      </div>
+
+      {error && <p role="alert" className="denylist-error">{error}</p>}
+
+      {status && (
+        <p role="status">
+          {shortAddr(address)} — denied: <strong>{String(status.denied)}</strong>, allowed (guard verdict):{' '}
+          <strong>{String(status.allowed)}</strong>
+        </p>
+      )}
+
+      <h4 id="denylist-audit-heading">Audit trail</h4>
+      <button type="button" className="confirm-btn" onClick={loadHistory} disabled={loadingHistory}>
+        {loadingHistory ? 'Loading…' : 'Refresh'}
+      </button>
+      {history.length === 0 && !loadingHistory ? (
+        <p role="status">No deny-list changes recorded.</p>
+      ) : (
+        <table aria-labelledby="denylist-audit-heading">
+          <caption className="sr-only">Deny-list change history (newest first)</caption>
+          <thead>
+            <tr>
+              <th scope="col">Account</th>
+              <th scope="col">Action</th>
+              <th scope="col">Actor</th>
+              <th scope="col">Reason</th>
+              <th scope="col">Block</th>
+            </tr>
+          </thead>
+          <tbody>
+            {history.map((h, i) => (
+              <tr key={`${h.account}-${h.block}-${i}`}>
+                <td title={h.account}>{shortAddr(h.account)}</td>
+                <td>{h.denied ? 'Added' : 'Removed'}</td>
+                <td title={h.actor}>{shortAddr(h.actor)}</td>
+                <td>{h.reason}</td>
+                <td>{h.block}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  )
+}
+
+export default DenyListAdmin

--- a/frontend/src/components/admin/DenyListAdmin.jsx
+++ b/frontend/src/components/admin/DenyListAdmin.jsx
@@ -34,6 +34,7 @@ function DenyListAdmin({ signer, contracts, runTx, pendingTx }) {
   const [status, setStatus] = useState(null) // { denied, allowed } | null
   const [history, setHistory] = useState([])
   const [loadingHistory, setLoadingHistory] = useState(false)
+  const [truncated, setTruncated] = useState(false)
   const [error, setError] = useState('')
 
   const writer = useCallback(() => {
@@ -46,8 +47,26 @@ function DenyListAdmin({ signer, contracts, runTx, pendingTx }) {
     setLoadingHistory(true)
     setError('')
     try {
-      const reader = new ethers.Contract(guardAddress, GUARD_ABI, signer.provider)
-      const events = await reader.queryFilter(reader.filters.DenyListUpdated())
+      const provider = signer.provider
+      const reader = new ethers.Contract(guardAddress, GUARD_ABI, provider)
+      const filter = reader.filters.DenyListUpdated()
+      const latest = await provider.getBlockNumber()
+      // Page in bounded ranges: a single unbounded queryFilter scans the whole chain and
+      // times out / hits provider log-range limits on Polygon mainnet. CHUNK keeps each
+      // eth_getLogs call safe; MAX_SPAN bounds the total scan to recent history (older
+      // entries are surfaced via the truncation note rather than silently dropped).
+      const CHUNK = 45_000
+      const MAX_SPAN = 3_000_000
+      const floor = Math.max(0, latest - MAX_SPAN)
+      const events = []
+      let to = latest
+      while (to >= floor) {
+        const from = Math.max(floor, to - CHUNK + 1)
+        const batch = await reader.queryFilter(filter, from, to)
+        events.push(...batch)
+        if (from === floor) break
+        to = from - 1
+      }
       const rows = events
         .map((e) => ({
           account: e.args.account,
@@ -56,8 +75,9 @@ function DenyListAdmin({ signer, contracts, runTx, pendingTx }) {
           reason: e.args.reason,
           block: e.blockNumber,
         }))
-        .reverse()
+        .sort((a, b) => b.block - a.block)
       setHistory(rows)
+      setTruncated(floor > 0)
     } catch (err) {
       setError(`Could not load audit trail: ${err.message || err}`)
     } finally {
@@ -160,6 +180,12 @@ function DenyListAdmin({ signer, contracts, runTx, pendingTx }) {
       <button type="button" className="confirm-btn" onClick={loadHistory} disabled={loadingHistory}>
         {loadingHistory ? 'Loading…' : 'Refresh'}
       </button>
+      {truncated && (
+        <p role="note" className="denylist-note">
+          Showing the most recent history only (older entries beyond the scanned block window
+          are not loaded). Query the chain/subgraph directly for the full audit trail.
+        </p>
+      )}
       {history.length === 0 && !loadingHistory ? (
         <p role="status">No deny-list changes recorded.</p>
       ) : (

--- a/frontend/src/components/compliance/EntryGate.jsx
+++ b/frontend/src/components/compliance/EntryGate.jsx
@@ -1,0 +1,110 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { getCurrentDocument } from '../../utils/legalDocs'
+
+/**
+ * EntryGate (Spec 007 — US4, FR-031/FR-033/FR-034)
+ *
+ * Client-side first-touch eligibility NOTICE gate. There is no backend, so this is not a
+ * binding consent record — its legal weight is carried by the downstream ON-CHAIN consents
+ * (membership purchase, wager creation, key registration). It blocks the app until the
+ * visitor affirms eligibility, links the current versioned legal docs (by hash), and warns
+ * against circumvention. A returning visitor who has acknowledged once is NOT re-gated
+ * (re-consent to a new material version is enforced on-chain at the next consequential act).
+ *
+ * WCAG 2.1 AA: role="dialog" + aria-modal, focus moved in and trapped, labelled controls.
+ */
+
+const ACK_KEY = 'fairwins.entryGate.ack.v1'
+
+function readAck() {
+  try {
+    return JSON.parse(localStorage.getItem(ACK_KEY) || 'null')
+  } catch {
+    return null
+  }
+}
+
+export default function EntryGate() {
+  const navigate = useNavigate()
+  const [ack, setAck] = useState(() => readAck())
+  const dialogRef = useRef(null)
+  const firstFocusRef = useRef(null)
+
+  // Move focus into the dialog when it appears (WCAG: focus management).
+  useEffect(() => {
+    if (!ack && firstFocusRef.current) firstFocusRef.current.focus()
+  }, [ack])
+
+  // Basic focus trap: keep Tab focus within the dialog while it is open.
+  const onKeyDown = useCallback((e) => {
+    if (e.key !== 'Tab' || !dialogRef.current) return
+    const els = dialogRef.current.querySelectorAll(
+      'a[href], button:not([disabled]), input, [tabindex]:not([tabindex="-1"])',
+    )
+    if (els.length === 0) return
+    const first = els[0]
+    const last = els[els.length - 1]
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault(); last.focus()
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault(); first.focus()
+    }
+  }, [])
+
+  if (ack) return null // already acknowledged → app content flows
+
+  const terms = getCurrentDocument('terms')
+  const risk = getCurrentDocument('risk')
+
+  const onEnter = () => {
+    const record = { terms: terms?.hash || null, risk: risk?.hash || null, at: new Date().toISOString() }
+    try { localStorage.setItem(ACK_KEY, JSON.stringify(record)) } catch { /* storage disabled */ }
+    setAck(record)
+  }
+  const onLeave = () => navigate('/')
+
+  return (
+    <div className="entry-gate-overlay" role="presentation">
+      <div
+        className="entry-gate"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="entry-gate-title"
+        ref={dialogRef}
+        onKeyDown={onKeyDown}
+      >
+        <h2 id="entry-gate-title">Before you enter FairWins</h2>
+        <p>
+          FairWins is peer-to-peer software. You wager directly against other participants;
+          FairWins is never your counterparty, sets no odds, and takes no share of any wager.
+        </p>
+        <p>By selecting <strong>Enter</strong>, you confirm that:</p>
+        <ul>
+          <li>You are at least 21 years old.</li>
+          <li>You are not a U.S. person and are not accessing FairWins from the United States or any restricted jurisdiction listed in our Terms.</li>
+          <li>You are not subject to sanctions and do not appear on any government restricted-party list.</li>
+          <li>Accessing peer-to-peer wagering is lawful where you are located, and you accept full responsibility for compliance with your local laws.</li>
+          <li>
+            You have read and agree to the{' '}
+            <a href="/terms">Terms &amp; Conditions</a> and{' '}
+            <a href="/risk">Risk Disclosure</a>
+            {terms?.hash ? <> (version <code>{terms.hash.slice(0, 12)}…</code>)</> : null}.
+          </li>
+        </ul>
+        <p className="entry-gate-warning" role="note">
+          Using a VPN, proxy, or any means to misrepresent your location or eligibility is a
+          breach of our Terms and voids your access.
+        </p>
+        <div className="entry-gate-actions">
+          <button type="button" ref={firstFocusRef} className="confirm-btn primary" onClick={onEnter}>
+            Enter
+          </button>
+          <button type="button" className="confirm-btn" onClick={onLeave}>
+            Leave
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/compliance/MembershipAttestation.jsx
+++ b/frontend/src/components/compliance/MembershipAttestation.jsx
@@ -1,0 +1,62 @@
+import { useState, useEffect } from 'react'
+
+/**
+ * MembershipAttestation (Spec 007 — US5, FR-035/FR-036/FR-037/FR-038)
+ *
+ * Discrete, individually-ticked, un-pre-ticked eligibility attestations shown at membership
+ * purchase/upgrade. Calls onChange(allTicked) so the parent gates its purchase button; the
+ * accepted T&C version is recorded on-chain by the purchase tx (purchaseTierWithTerms).
+ * WCAG 2.1 AA: fieldset/legend, programmatically-associated checkbox labels.
+ */
+
+const ATTESTATIONS = [
+  { id: 'age', label: 'I am at least 21 years of age.' },
+  { id: 'jurisdiction', label: 'I am not a U.S. person and am not located, resident, or established in the United States or any Restricted Jurisdiction defined in the Terms.' },
+  { id: 'sanctions', label: 'I am not, and do not act on behalf of, any person subject to sanctions or named on any restricted-party list (including the OFAC SDN list).' },
+  { id: 'norecourse', label: 'I understand FairWins is not a registered exchange, broker, or regulated gambling operator, that there is no regulator or authority to which I can appeal a dispute, and that wager outcomes are settled by smart contract and the published dispute-resolution mechanism.' },
+  { id: 'risk', label: 'I understand I may lose the entire amount of any wager, that I bear sole responsibility for my own tax reporting, and that I have sole control of my wallet and private keys.' },
+  { id: 'novpn', label: 'I have not used, and will not use, any VPN, proxy, or other means to circumvent eligibility or geographic restrictions.' },
+  { id: 'terms', label: 'I have read and agree to the Terms & Conditions and the Risk Disclosure.' },
+]
+
+export default function MembershipAttestation({ onChange }) {
+  const [ticks, setTicks] = useState(() => Object.fromEntries(ATTESTATIONS.map((a) => [a.id, false])))
+
+  const allTicked = ATTESTATIONS.every((a) => ticks[a.id])
+
+  useEffect(() => {
+    onChange?.(allTicked)
+  }, [allTicked, onChange])
+
+  const toggle = (id) => setTicks((t) => ({ ...t, [id]: !t[id] }))
+
+  return (
+    <section className="membership-attestation" aria-labelledby="membership-attest-title">
+      <h3 id="membership-attest-title">Membership confirmation</h3>
+      <p>
+        Your membership pass grants access to the FairWins platform. <strong>It is a fee for
+        access only.</strong> It is not a wager, a stake, a deposit, an investment, a security,
+        or a balance held on your behalf; it confers no ownership interest, no profit
+        expectation, and no claim on any pool of funds. Membership fees are not pooled, staked,
+        wagered, or returned as winnings, and are <strong>non-refundable</strong> — including if
+        you are later restricted, suspended, or unable to access the platform.
+      </p>
+      <fieldset>
+        <legend>By purchasing or upgrading, I confirm and agree:</legend>
+        {ATTESTATIONS.map((a) => (
+          <div className="attestation-row" key={a.id}>
+            <input
+              type="checkbox"
+              id={`attest-${a.id}`}
+              checked={ticks[a.id]}
+              onChange={() => toggle(a.id)}
+            />
+            <label htmlFor={`attest-${a.id}`}>{a.label}</label>
+          </div>
+        ))}
+      </fieldset>
+    </section>
+  )
+}
+
+export { ATTESTATIONS }

--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -14,6 +14,17 @@ import { ResolutionType, isOracleModelExposed } from '../../constants/wagerDefau
 import QRScanner from '../ui/QRScanner'
 import AddressInput from '../ui/AddressInput'
 import { isEnsName } from '../../utils/validation'
+import { getCurrentDocument } from '../../utils/legalDocs'
+
+/**
+ * The in-force Terms version bound into a new wager's encryption (Spec 007, FR-056/FR-058):
+ * { id, hash } of the current Terms & Conditions, so the wager carries tamper-evident proof
+ * of its governing terms. Returns null if unavailable (legacy/no-AAD path).
+ */
+function currentTermsVersion() {
+  const t = getCurrentDocument('terms')
+  return t ? { id: t.id, hash: t.hash } : null
+}
 import { useChainTokens } from '../../hooks/useChainTokens'
 import { usePolymarketSearch } from '../../hooks/usePolymarketSearch'
 import PolymarketBrowser from './PolymarketBrowser'
@@ -860,7 +871,7 @@ function FriendMarketsModal({
           // (v2.0) path can't be used here because the registry only stores
           // 32-byte X25519 keys; addRecipientByPublicKey would then read an
           // undefined `ephemeralPublicKey` off an X-Wing wrapped-key entry.
-          const { envelope } = await createEncrypted(marketMetadata, { algorithm: 'x25519' })
+          const { envelope } = await createEncrypted(marketMetadata, { algorithm: 'x25519', termsVersion: currentTermsVersion() })
           finalMetadata = addRecipientByPublicKey(envelope, opponentAddress, opponentKey)
 
           // ThirdParty (Spec Kit 005): the arbitrator must also read the private
@@ -881,7 +892,7 @@ function FriendMarketsModal({
         } else {
           // Defensive fallback: validation guarantees an opponent, but if one
           // is somehow missing, encrypt to the creator only rather than crash.
-          const { envelope } = await createEncrypted(marketMetadata)
+          const { envelope } = await createEncrypted(marketMetadata, { termsVersion: currentTermsVersion() })
           finalMetadata = envelope
         }
       }

--- a/frontend/src/components/ui/PremiumPurchaseModal.jsx
+++ b/frontend/src/components/ui/PremiumPurchaseModal.jsx
@@ -7,6 +7,8 @@ import { useEncryption } from '../../hooks/useEncryption'
 import { recordRolePurchase } from '../../utils/roleStorage'
 import { purchaseRoleWithStablecoin, getUserTierOnChain } from '../../utils/blockchainService'
 import { ensureKeyRegistered } from '../../utils/keyRegistryService'
+import { getCurrentDocument } from '../../utils/legalDocs'
+import MembershipAttestation from '../compliance/MembershipAttestation'
 import { getTransactionUrl } from '../../config/blockExplorer'
 import './PremiumPurchaseModal.css'
 
@@ -186,7 +188,9 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
       const provider = new ethers.BrowserProvider(window.ethereum)
       const signer = await provider.getSigner()
 
-      const receipt = await purchaseRoleWithStablecoin(signer, ROLE_KEY, selectedPrice, tierValue, action)
+      // Spec 007 (FR-039): record the accepted in-force Terms version hash on-chain.
+      const acceptedTermsHash = getCurrentDocument('terms')?.hash || null
+      const receipt = await purchaseRoleWithStablecoin(signer, ROLE_KEY, selectedPrice, tierValue, action, acceptedTermsHash)
       grantRole(ROLE_KEY)
       recordRolePurchase(account, ROLE_KEY, {
         price: selectedPrice,
@@ -465,15 +469,11 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
                         confirmed, it cannot be reversed.
                       </li>
                     </ul>
-                    <label className="ppm-acknowledge">
-                      <input
-                        type="checkbox"
-                        checked={acknowledged}
-                        onChange={(e) => setAcknowledged(e.target.checked)}
-                        disabled={isPurchasing}
-                      />
-                      I acknowledge the protocol's pause and account-moderation provisions.
-                    </label>
+                    {/* Spec 007 (US5): discrete, un-pre-ticked eligibility attestations.
+                        allTicked drives `acknowledged`, which gates validation + the
+                        purchase button below; the accepted Terms version is recorded
+                        on-chain via purchaseTierWithTerms in handlePurchase. */}
+                    <MembershipAttestation onChange={setAcknowledged} />
                     {errors.ack && <div className="ppm-error">{errors.ack}</div>}
                   </div>
                 </div>

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -70,9 +70,9 @@ const POLYGON_CONTRACTS = {
   // Treasury / membership-sales recipient = chipprbots.eth (hardware wallet).
   treasury: '0x1215185387E70a48b07D73AcB67002A073F18575',
   // v2 core (populated by `npm run sync:frontend-contracts -- --network polygon --chainId 137`)
-  wagerRegistry: '0x7bb3ef3E65DB9bd9D7133Bd7F25e8754Bf11F2D4',
-  membershipManager: '0x7441700979e37a9a1F17093a4859c8f261780c95',
-  keyRegistry: '0xb314c4Ee52D9D89bf7FEE66a43aBeAc7D047a5Cb',
+  wagerRegistry: '0x5023765809fDA93ab9F11B684fdb76521eD31774',
+  membershipManager: '0x00c3ef4e02Ef00Ad6eE955dF5022A22F6ea73dae',
+  keyRegistry: '0xcEFdeBba8E040c035c690ca9057cF22E73247c24',
   sanctionsGuard: '', // populated by sync once SanctionsGuard is deployed on Polygon
   polymarketAdapter: '0x83688e9b8D4f085E3eF4619D91e0e6303cFcf0A4', // tie-fix + admin-owner redeploy
   // Stake / payment tokens (Circle USDC + Wrapped MATIC on Polygon)
@@ -81,6 +81,8 @@ const POLYGON_CONTRACTS = {
   chainlinkDataFeedAdapter: '0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23',
   chainlinkFunctionsAdapter: '0x148C2E347a601AC1a680b17321529b0Ffc31AeFc',
   umaAdapter: '0x8224433d099Af6cd30540A78421aBFd6e044E949',
+  sanctionsGuard: '0x2Dc53d91A189be71DfE96Ea9BCFCF6aDDA77BC76',
+  polymarketAdapter: '0x83688e9b8D4f085E3eF4619D91e0e6303cFcf0A4',
 }
 
 const NETWORK_CONTRACTS = {
@@ -108,7 +110,7 @@ export const DEPLOYED_CONTRACTS =
 const DEPLOYMENT_BLOCKS_BY_CHAIN = {
   63: { friendGroupMarketFactory: 15658191, wagerRegistry: 0 },
   80002: { friendGroupMarketFactory: 0, wagerRegistry: 0 },
-  137: { friendGroupMarketFactory: 0, wagerRegistry: 87937155 },
+  137: { friendGroupMarketFactory: 0, wagerRegistry: 88118344 },
 }
 
 export const DEPLOYMENT_BLOCKS =

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -36,6 +36,7 @@ const HARDHAT_CONTRACTS = {
   wagerRegistry: '0x260Fad26873AC132b34dD6FA5761DcfF0e26cbd0',
   membershipManager: '0x81010Af3Ef2BBc092c898944D9D39E6c94124660',
   keyRegistry: '0xb314c4Ee52D9D89bf7FEE66a43aBeAc7D047a5Cb',
+  sanctionsGuard: '',
   polymarketAdapter: '0x19D004863fB8F5A1707091C120e08aA1FEE8d65F',
   paymentToken: '0x065606eeE0D7BB3d2e7959D56c3ca177625385a7',
   wmatic: '0xE80bf16CAF66CAe0Ae5aBC4a5ab4acc27361553F',
@@ -51,6 +52,7 @@ const AMOY_CONTRACTS = {
   wagerRegistry: '0x95cC567EF97f21bdd135844652aD8792fa8ba266',
   membershipManager: '0xFaEbF662aa591fF95e97306b413522efC958540f',
   keyRegistry: '0xb314c4Ee52D9D89bf7FEE66a43aBeAc7D047a5Cb',
+  sanctionsGuard: '',
   polymarketAdapter: '0x423d2Ca885d67E46062CFF732Eff952f4F736136',
   // Stake / payment tokens (Circle USDC + Wrapped MATIC on Amoy)
   paymentToken: '0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582',
@@ -71,6 +73,7 @@ const POLYGON_CONTRACTS = {
   wagerRegistry: '0x7bb3ef3E65DB9bd9D7133Bd7F25e8754Bf11F2D4',
   membershipManager: '0x7441700979e37a9a1F17093a4859c8f261780c95',
   keyRegistry: '0xb314c4Ee52D9D89bf7FEE66a43aBeAc7D047a5Cb',
+  sanctionsGuard: '', // populated by sync once SanctionsGuard is deployed on Polygon
   polymarketAdapter: '0x83688e9b8D4f085E3eF4619D91e0e6303cFcf0A4', // tie-fix + admin-owner redeploy
   // Stake / payment tokens (Circle USDC + Wrapped MATIC on Polygon)
   paymentToken: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -73,7 +73,7 @@ const POLYGON_CONTRACTS = {
   wagerRegistry: '0x5023765809fDA93ab9F11B684fdb76521eD31774',
   membershipManager: '0x00c3ef4e02Ef00Ad6eE955dF5022A22F6ea73dae',
   keyRegistry: '0xcEFdeBba8E040c035c690ca9057cF22E73247c24',
-  sanctionsGuard: '', // populated by sync once SanctionsGuard is deployed on Polygon
+  sanctionsGuard: '0x2Dc53d91A189be71DfE96Ea9BCFCF6aDDA77BC76', // Spec 007 compliance guard
   polymarketAdapter: '0x83688e9b8D4f085E3eF4619D91e0e6303cFcf0A4', // tie-fix + admin-owner redeploy
   // Stake / payment tokens (Circle USDC + Wrapped MATIC on Polygon)
   paymentToken: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
@@ -81,8 +81,6 @@ const POLYGON_CONTRACTS = {
   chainlinkDataFeedAdapter: '0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23',
   chainlinkFunctionsAdapter: '0x148C2E347a601AC1a680b17321529b0Ffc31AeFc',
   umaAdapter: '0x8224433d099Af6cd30540A78421aBFd6e044E949',
-  sanctionsGuard: '0x2Dc53d91A189be71DfE96Ea9BCFCF6aDDA77BC76',
-  polymarketAdapter: '0x83688e9b8D4f085E3eF4619D91e0e6303cFcf0A4',
 }
 
 const NETWORK_CONTRACTS = {

--- a/frontend/src/hooks/useEncryption.js
+++ b/frontend/src/hooks/useEncryption.js
@@ -299,10 +299,12 @@ export function useEncryption() {
    * Uses X-Wing (post-quantum) by default for new markets
    *
    * @param {Object} metadata - Market metadata to encrypt
-   * @param {Object} options - { algorithm: 'xwing' | 'x25519' }
+   * @param {Object} options - { algorithm: 'xwing' | 'x25519', termsVersion?: {id, hash} }
+   *   termsVersion (Spec 007, FR-056): the in-force T&C version bound into the wager's
+   *   AEAD so it carries tamper-evident proof of its governing terms.
    */
   const createEncrypted = useCallback(async (metadata, options = {}) => {
-    const { algorithm = 'xwing' } = options
+    const { algorithm = 'xwing', termsVersion = null } = options
 
     if (!signer || !account) {
       throw new Error('Wallet not connected')
@@ -312,9 +314,9 @@ export function useEncryption() {
 
     // Use X-Wing (post-quantum) by default for new markets
     if (algorithm === 'xwing') {
-      return createEncryptedMarketXWing(metadata, signer, account)
+      return createEncryptedMarketXWing(metadata, signer, account, termsVersion)
     } else {
-      return createEncryptedMarket(metadata, signer, account)
+      return createEncryptedMarket(metadata, signer, account, termsVersion)
     }
   }, [signer, account, ensureInitialized])
 

--- a/frontend/src/hooks/useFriendMarketCreation.js
+++ b/frontend/src/hooks/useFriendMarketCreation.js
@@ -10,6 +10,7 @@ import {
   buildEncryptedIpfsReference
 } from '../utils/ipfsService'
 import { getFeeOverrides } from '../utils/feeOverrides'
+import { getCurrentDocument } from '../utils/legalDocs'
 
 const ERC20_ABI = [
   'function balanceOf(address owner) view returns (uint256)',
@@ -321,16 +322,26 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
       // has fewer truly-active wagers than their tier allows.
       await expireStaleWagers(registry, userAddress, onProgress)
 
+      // Spec 007 (FR-056/FR-058): bind the in-force T&C version hash on-chain when the
+      // registry supports it. legalDocs hashes are bare 64-hex → normalize to bytes32.
+      // Falls back to plain createWager on older registries lacking the overload.
+      const termsHashHex = getCurrentDocument('terms')?.hash
+      const termsBytes32 = termsHashHex && /^[0-9a-fA-F]{64}$/.test(termsHashHex) ? '0x' + termsHashHex : null
+      const useTerms = Boolean(termsBytes32) && typeof registry.createWagerWithTerms === 'function'
+      const createMethod = useTerms ? 'createWagerWithTerms' : 'createWager'
+      const createArgs = [
+        opponent, arbitrator, stakeTokenAddress,
+        creatorStakeWei, opponentStakeWei,
+        acceptDeadline, resolveDeadline,
+        resolutionType, polymarketConditionId, creatorIsYes,
+        metadataHash, metadataReference,
+        ...(useTerms ? [termsBytes32] : []),
+      ]
+
       // Simulate to catch reverts pre-wallet-prompt
       try {
         onProgress({ step: 'create', message: 'Validating transaction...' })
-        await registry.createWager.staticCall(
-          opponent, arbitrator, stakeTokenAddress,
-          creatorStakeWei, opponentStakeWei,
-          acceptDeadline, resolveDeadline,
-          resolutionType, polymarketConditionId, creatorIsYes,
-          metadataHash, metadataReference
-        )
+        await registry[createMethod].staticCall(...createArgs)
       } catch (simError) {
         const reason = simError.reason || simError.shortMessage || simError.message || ''
         throw new Error(translateRevert(reason))
@@ -338,13 +349,6 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
 
       onProgress({ step: 'create', message: 'Please confirm in your wallet...' })
       const feeOverrides = await getFeeOverrides(activeSigner.provider)
-      const createArgs = [
-        opponent, arbitrator, stakeTokenAddress,
-        creatorStakeWei, opponentStakeWei,
-        acceptDeadline, resolveDeadline,
-        resolutionType, polymarketConditionId, creatorIsYes,
-        metadataHash, metadataReference,
-      ]
 
       // Estimate gas explicitly with a short retry so a transient stale read on
       // a load-balanced RPC doesn't surface a raw "missing revert data" error.
@@ -354,7 +358,7 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
       let gasLimit
       for (let attempt = 0; attempt < 3; attempt++) {
         try {
-          const estimate = await registry.createWager.estimateGas(...createArgs)
+          const estimate = await registry[createMethod].estimateGas(...createArgs)
           gasLimit = (estimate * 120n) / 100n // +20% headroom
           break
         } catch {
@@ -366,7 +370,7 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
         }
       }
 
-      const tx = await registry.createWager(
+      const tx = await registry[createMethod](
         ...createArgs,
         { ...feeOverrides, gasLimit }
       )

--- a/frontend/src/legal/privacy-policy.md
+++ b/frontend/src/legal/privacy-policy.md
@@ -1,0 +1,86 @@
+# FairWins — Privacy Policy
+
+**Last updated: [DATE] · Version: [auto — SHA-256 of this document]**
+
+---
+
+> **Draft pending counsel.** This Privacy Policy is incorporated by reference into the
+> [Terms & Conditions](/terms) and the [Risk Disclosure](/risk) and forms part of your
+> agreement with us. Capitalized terms have the meanings given in the Terms & Conditions.
+
+## 1. Who We Are
+
+This Privacy Policy explains how **Chippr Robotics LLC** ("FairWins," "we," "us") handles
+information in connection with the FairWins Service. FairWins is a non-custodial,
+peer-to-peer wager management layer; we do not collect identity documents and we do not
+operate a traditional user-account database.
+
+## 2. What We Process
+
+- **On-chain data.** Wagers, memberships, key registrations, and sanctions-screening
+  outcomes are recorded on the public Polygon blockchain. **Blockchain transactions are
+  public, permanent, and pseudonymous (not anonymous)** and may be analyzed and attributed
+  by third parties outside our control. We cannot delete or alter on-chain data.
+- **Wallet address.** Used to interact with the Service and the smart contracts.
+- **Edge/access logs (compliance evidence).** When you access the Service, our edge
+  provider (Cloudflare) and our hosting (Google Cloud Run) record standard request logs,
+  including your **country of record** (derived from your IP at the edge), your **IP
+  address**, user agent, and the access decision (served / denied for legal reasons). We
+  use these logs as the record of geographic and eligibility enforcement.
+- **Local browser state.** Your acknowledgement of the entry gate and the document
+  versions you acknowledged are stored in your browser (local storage), not on our servers.
+
+We do **not** collect names, government IDs, emails, or payment-card data through the
+Service, and we do not run third-party advertising trackers.
+
+## 3. Why We Process It (Lawful Basis)
+
+- **Legal compliance & legitimate interests** — to enforce geographic and eligibility
+  restrictions (including sanctions and prohibited jurisdictions), to maintain a defensible
+  record of that enforcement, and to operate and secure the Service.
+- **Contract** — to provide the Service you request when you interact with it.
+
+## 4. Retention
+
+- **On-chain records** are permanent and outside our control.
+- **Accepted-user enforcement evidence** in access logs is retained for the applicable
+  statutory/compliance window.
+- **Declined/blocked (non-consenting) visitor** access-log records are minimized to the
+  compliance-relevant fields (country, IP, timestamp, decision) and retained for a
+  shorter, bounded period appropriate to the enforcement purpose.
+
+## 5. Sharing
+
+We share information only: with our infrastructure providers (edge/CDN, hosting, IPFS
+pinning) acting on our behalf; with on-chain sanctions-screening sources we read (e.g.,
+the Chainalysis on-chain oracle); and where required by law or to protect our rights.
+
+## 6. Your Choices and Rights
+
+Because the Service is largely non-custodial and pseudonymous, our ability to identify you
+is limited. Where applicable law grants you rights over personal data (such as access or
+erasure of the access-log data that can be linked to you), you may contact us at
+`[CONTACT EMAIL / METHOD]`. Note that **on-chain data cannot be erased**.
+
+## 7. Security
+
+We apply reasonable technical and organizational measures, including edge filtering,
+origin authentication, and least-privilege access to logs. No method of transmission or
+storage is perfectly secure.
+
+## 8. International Transfers
+
+The Service is operated using infrastructure that may process data in the United States
+and other regions. Where required, we rely on appropriate safeguards for cross-border
+transfers.
+
+## 9. Changes
+
+We may update this Privacy Policy; material changes are indicated by an updated version
+(the SHA-256 hash of this document) and, where practical, by notice through the Service.
+
+## 10. Contact
+
+Questions about privacy: `[CONTACT EMAIL / METHOD]`.
+
+*— End of Privacy Policy —*

--- a/frontend/src/legal/risk-disclosure.md
+++ b/frontend/src/legal/risk-disclosure.md
@@ -1,0 +1,95 @@
+# FairWins — Risk Disclosure
+
+
+**Last updated: [DATE] · Version: [YYYY-MM-HASH]**
+
+---
+
+## Read This Before You Participate
+
+This Risk Disclosure explains the risks of using FairWins. **Please read it in full.** By using the Service, purchasing a Membership Pass, or entering a Wager, you confirm that you have read, understood, and knowingly accepted these risks. If any risk is unacceptable to you, do not use the Service.
+
+Capitalized terms have the meanings given in the Terms & Conditions.
+
+## The Most Important Risks, in Plain Language
+
+- **You can lose 100% of what you wager.** Every Wager can go to zero.
+- **No one is protecting you.** There is no regulator, no deposit insurance, and no authority that can reverse a loss or order a refund.
+- **The code is final.** Smart contracts settle automatically and cannot be undone, even if something goes wrong.
+- **If you lose your keys, you lose everything.** No one can recover your wallet, your account, or your funds.
+- **Outcomes are decided by the Resolution Mechanism, and it can be wrong or contested.** You cannot appeal a result to FairWins or to any court.
+- **Your membership fee is gone once paid.** It is non-refundable and does not entitle you to winnings.
+
+The sections below explain these and other risks in detail.
+
+---
+
+## 1. Risk of Total Loss
+
+Wagering involves a substantial risk of loss. You may lose the entire amount of any Wager. Only commit value you can afford to lose entirely. Past results are not indicative of future results.
+
+## 2. No Regulatory Protection or Recourse
+
+FairWins is **not** a registered or licensed exchange, broker, gambling operator, bank, or money transmitter. **There is no regulator overseeing your Wagers, no deposit insurance, no investor or consumer protection scheme, and no government authority to which you can appeal a loss, a disputed outcome, or a counterparty's conduct.** If you are harmed, your only remedies are those described in the Terms & Conditions.
+
+## 3. Smart-Contract Risk
+
+Wagers are escrowed and settled by Smart Contracts. Smart contracts may contain bugs, vulnerabilities, or logic errors; may be exploited or attacked; and operate automatically and **irreversibly**. An audit, if any, reduces but does not eliminate this risk. A flaw could cause loss of escrowed funds with **no remedy and no ability to reverse the transaction.**
+
+## 4. Oracle and Resolution Risk
+
+The outcome of a Wager depends on the Resolution Mechanism, which may rely on external data sources and oracles. **These may be unavailable, delayed, inaccurate, manipulated, or in dispute.** A Wager may resolve in a way you believe is incorrect. The Resolution Mechanism — including its dispute procedure — is the **sole and final** process for determining outcomes. **You cannot appeal a resolution to FairWins or to any court or regulator.**
+
+## 5. Counterparty Risk
+
+Each Wager is between you and another User, not with FairWins. You rely on the Smart Contract — not on FairWins — to escrow and settle stakes. FairWins does not vet, guarantee, or stand behind any counterparty, and is not responsible for a counterparty's conduct, identity, or solvency.
+
+## 6. Blockchain and Network Risk
+
+The Service runs on the Polygon network. You accept the risks of public blockchains, including **network congestion, downtime, delays, fee (gas) volatility, chain reorganizations, changes to finality, validator or consensus failures, hard forks, and bridge failures.** Transactions may fail, be delayed, or settle at unexpected cost. FairWins does not control the network and is not responsible for its behavior.
+
+## 7. Wallet and Private-Key Risk
+
+You are solely responsible for the security and control of your wallet and private keys. **If you lose your keys or recovery information, you will permanently lose access to your account, any account encryption key derived from your signature, and any associated funds. No one — including FairWins — can recover them.** If your keys are compromised, an attacker may take irreversible actions you cannot undo. FairWins never holds your keys and cannot reset, restore, or recover them.
+
+## 8. Asset and Value Risk
+
+The value of the assets you wager may be volatile. If you wager stablecoins, you accept the risk that a stablecoin may lose its peg, be frozen by its issuer, or become illiquid or unredeemable. Token values may fall to zero.
+
+## 9. Legal and Regulatory-Change Risk
+
+The legal treatment of prediction markets, peer-to-peer wagering, and digital assets is **uncertain and changing.** Laws or regulators in your jurisdiction or elsewhere may at any time prohibit, restrict, or change the treatment of the Service. As a result, **your access may be cut off without notice, including mid-Wager where the protocol permits, and your Membership Pass may become unusable, in each case without refund.** You are solely responsible for determining the legality of your use where you are located.
+
+## 10. Tax Risk
+
+Tax treatment of wagering and digital-asset activity is complex and varies by jurisdiction. **You are solely responsible for determining, reporting, and paying any taxes** arising from your use of the Service. FairWins does not provide tax advice, withholding, or reporting.
+
+## 11. Market Integrity and Information Risk
+
+Other participants may have more or better information than you, including non-public information. Markets may be thin, illiquid, or subject to attempted manipulation. You accept the risk of trading against better-informed counterparties and of information asymmetry, and you are responsible for complying with any laws applicable to you regarding trading on non-public information.
+
+## 12. Automation and AI-Agent Risk
+
+Portions of the Service are developed, maintained, and operated with the assistance of automated systems and AI agents. **These systems may behave unexpectedly, contain errors, or produce unintended results.** You accept the risks arising from the use of automated and AI components in the development and operation of the Service.
+
+## 13. Membership-Fee Risk
+
+A Membership Pass is a non-refundable fee for access only. Its practical value depends on the continued availability of the Service, which is not guaranteed. **If the Service is restricted, suspended, modified, or discontinued, you will not be refunded.**
+
+## 14. Privacy and Pseudonymity Risk
+
+Blockchain transactions are **public and permanent.** Your on-chain activity is pseudonymous, not anonymous, and may be analyzed, linked, and attributed to you by third parties using tools and data outside our control. Do not assume your activity is private.
+
+## 15. Availability and Discontinuation Risk
+
+We do not guarantee that the Service, any interface, any market, or any counterparty will be available at any time. The Service, or any part of it, may be changed, suspended, or discontinued at any time without notice.
+
+## 16. Responsible Participation
+
+Wagering can be habit-forming and can cause financial and personal harm. Wager only what you can afford to lose. Set limits for yourself. If you believe your participation may be becoming harmful, stop and seek help. Resources for problem gambling are available through `[REGION-APPROPRIATE PROBLEM-GAMBLING RESOURCE / HELPLINE — TO BE CONFIRMED]`. Where the Service offers self-limitation or self-exclusion tools, you are encouraged to use them.
+
+## 17. Acknowledgement
+
+**BY USING THE SERVICE, PURCHASING OR UPGRADING A MEMBERSHIP PASS, SIGNING THE ACCOUNT KEY-GENERATION MESSAGE, OR ENTERING A WAGER, YOU CONFIRM THAT YOU HAVE READ AND UNDERSTOOD THIS RISK DISCLOSURE AND THAT YOU KNOWINGLY AND VOLUNTARILY ACCEPT ALL OF THE RISKS DESCRIBED ABOVE.**
+
+*— End of Risk Disclosure —*

--- a/frontend/src/legal/terms.md
+++ b/frontend/src/legal/terms.md
@@ -1,0 +1,210 @@
+# FairWins — Terms & Conditions
+
+
+**Last updated: [DATE] · Version: [YYYY-MM-hash]**
+
+---
+
+## Key Points — Please Read
+
+Before you agree, understand the following in plain language. The full terms below control, but these are the points that matter most:
+
+- **FairWins is software, not a bookmaker.** You wager directly against other people. FairWins is never the other side of your bet, never sets odds, never holds your money, and never takes a cut of any wager.
+- **Your membership fee buys access only.** It is not a bet, not a deposit, and not refundable.
+- **You can lose everything you wager.** There is no insurance and no regulator you can appeal to.
+- **You must qualify to use FairWins.** You must be at least 21, not a U.S. person, not located in a restricted jurisdiction, and not subject to sanctions.
+- **You control your own wallet.** If you lose your keys, no one — including FairWins — can recover your funds or your account.
+- **Disputes with FairWins go to arbitration, individually.** You give up the right to a court trial and to class actions against us.
+
+If you do not agree with these points, do not use FairWins.
+
+---
+
+## 1. Who We Are and What These Terms Cover
+
+These Terms & Conditions (the "**Terms**") are a binding agreement between you ("**you**," "**User**," "**Member**") and **Chippr Robotics LLC** ("**FairWins**," "**we**," "**us**," "**our**"), governing your access to and use of the FairWins platform, websites, smart contracts, interfaces, and related services (collectively, the "**Service**").
+
+These Terms incorporate by reference the **FairWins Risk Disclosure** and the **FairWins Privacy Policy**, each of which forms part of your agreement with us.
+
+## 2. Acceptance and Layered Consent
+
+You accept these Terms through a layered process, and **each step independently confirms your agreement**:
+
+1. **Entry.** By selecting "Enter" on the age and eligibility gate, you confirm your eligibility and acceptance of these Terms.
+2. **Membership.** By purchasing or upgrading a membership pass, you re-confirm your eligibility and acceptance through individually-acknowledged attestations.
+3. **Key generation.** By signing the account key-generation message with your wallet, you cryptographically confirm that you meet and continue to meet the eligibility requirements and agree to these Terms as published.
+
+If any provision of a more specific step (membership attestation, signed message) conflicts with these Terms, these Terms control unless the specific step expressly states otherwise.
+
+## 3. Definitions
+
+- **"Member"** — a User holding a current, valid membership pass.
+- **"Membership Pass"** — the access right described in Section 8.
+- **"Wager"** — a peer-to-peer agreement between Users on the outcome of a specified event, settled by Smart Contract.
+- **"Private Wager"** — a Wager offered to and accepted by a specific counterparty.
+- **"Public Wager"** — a Wager broadcast for acceptance by any address.
+- **"Smart Contract"** — the FairWins protocol contracts deployed on the Polygon network.
+- **"Resolution Mechanism"** — the on-chain process, including any oracle and dispute procedure, by which the outcome of a Wager is determined and settled, as described in the Service documentation.
+- **"U.S. Person"** — any individual resident in the United States; any entity organized under U.S. law or with its principal place of business in the United States; and any person acting on behalf of any of the foregoing.
+- **"Restricted Jurisdiction"** — any jurisdiction listed in **Schedule A**, as amended from time to time.
+- **"Restricted Party"** — any person subject to sanctions administered by OFAC or any other applicable authority, or named on any government restricted-party or denied-persons list.
+
+## 4. Nature of the Service
+
+**4.1 Non-custodial, peer-to-peer software.** FairWins provides software that enables Users to enter into Wagers directly with one another. Wagers are agreements *between Users*, escrowed and settled by Smart Contracts on the Polygon network.
+
+**4.2 What FairWins is not.** FairWins is not, and does not act as, a counterparty, bookmaker, sportsbook, casino, exchange, broker-dealer, swap execution facility, designated contract market, futures commission merchant, money transmitter, money services business, custodian, or fiduciary. FairWins does not set odds or prices, does not take the other side of any Wager, does not hold or control User funds, and **takes no rake, vigorish, commission, or share of any Wager.**
+
+**4.3 Membership-funded.** The Service is funded by membership fees, which are consideration for access only (Section 8) and bear no relationship to the size, frequency, or outcome of any Wager.
+
+**4.4 Information purpose.** FairWins is designed to support information discovery through peer-to-peer markets. Nothing on the Service is an offer, solicitation, or recommendation to enter any Wager or transaction.
+
+**4.5 Automated and AI components.** Portions of the Service are developed, maintained, and operated with the assistance of automated systems and AI agents. You acknowledge this and accept the associated risks described in the Risk Disclosure.
+
+## 5. Eligibility
+
+You may use the Service only if you meet **all** of the following at all times. By using the Service you represent and warrant that:
+
+- (a) you are at least **21 years of age** and of legal capacity to enter a binding contract;
+- (b) you are **not a U.S. Person** and are not located, resident, incorporated, or established in the United States;
+- (c) you are not located, resident, incorporated, or established in any **Restricted Jurisdiction**;
+- (d) you are **not a Restricted Party** and do not act on behalf of any Restricted Party;
+- (e) your access to and use of peer-to-peer wagering software is **lawful in the jurisdiction from which you access it**, and you bear sole responsibility for that determination; and
+- (f) you have **sole and exclusive control** of the wallet and private keys you use with the Service.
+
+These representations are renewed each time you access the Service, purchase or renew a Membership Pass, sign a Service message, or enter a Wager.
+
+## 6. Restricted Jurisdictions
+
+The Service is not offered to, and may not be used by, persons in any Restricted Jurisdiction (**Schedule A**). We may add jurisdictions to Schedule A at any time, including in response to legal or regulatory developments, and may block access accordingly without notice and without refund.
+
+## 7. No Circumvention
+
+You agree **not** to use a VPN, proxy, Tor, false residence or identity information, or any other method to disguise your location or to misrepresent your eligibility, and not to access the Service from any location from which access is restricted. **Any such circumvention is a material breach of these Terms, immediately voids your access and Membership Pass without refund, and may result in forfeiture of access to the Service.** Outcomes already settled on-chain between Users are not reversed by FairWins.
+
+## 8. Membership Passes
+
+**8.1 Access only.** A Membership Pass grants you access to the Service for its stated period. **A Membership Pass is a fee for access only. It is not a Wager, a stake, a deposit, an investment, a security, or a balance held on your behalf, and it confers no ownership interest, profit expectation, or claim on any pool of funds.**
+
+**8.2 Use of fees.** Membership fees fund Service infrastructure, storage, hosting, and development. Fees are not pooled, staked, wagered, or returned to Members as winnings.
+
+**8.3 Non-refundable.** **MEMBERSHIP FEES ARE NON-REFUNDABLE, INCLUDING IF YOU ARE LATER RESTRICTED, SUSPENDED, OR UNABLE TO ACCESS THE SERVICE FOR ANY REASON, AND INCLUDING IF THE SERVICE IS MODIFIED OR DISCONTINUED.**
+
+**8.4 No guarantee.** A Membership Pass does not guarantee uninterrupted access, the availability of any market or counterparty, or any outcome.
+
+## 9. How Wagers Work
+
+**9.1 Peer-to-peer.** A Wager is formed when one User's offer is accepted by another User (a Private Wager) or by any address (a Public Wager). The agreement is between those Users. FairWins is not a party to it.
+
+**9.2 Escrow and settlement.** Stakes are escrowed and settled by Smart Contract according to the Resolution Mechanism. FairWins does not hold, direct, or have access to escrowed stakes.
+
+**9.3 Resolution.** Outcomes are determined by the Resolution Mechanism, which may rely on oracles and a defined dispute procedure. You accept that the Resolution Mechanism is the **sole and final** process for resolving Wager outcomes, that it may produce results you disagree with, and that **there is no regulator, court, or authority to which you may appeal a Wager outcome.**
+
+**9.4 Finality.** Settled Wagers are recorded on the Polygon blockchain and are **irreversible**. FairWins cannot reverse, refund, or modify a settled Wager.
+
+**9.5 Your responsibility.** You are solely responsible for understanding each Wager you enter, including its terms, counterparty, resolution source, and risk.
+
+## 10. Disputes Between Users
+
+Disputes about a Wager's outcome are resolved **exclusively** through the Resolution Mechanism described in the Service documentation. FairWins does not adjudicate Wager outcomes between Users and is not liable for them. This Section is separate from, and does not limit, the arbitration provision in Section 22, which governs disputes *with FairWins*.
+
+## 11. Sanctions and Compliance Screening
+
+You represent that you are not a Restricted Party. We may screen wallet addresses and may decline, block, or refuse to facilitate interaction with any address that we or our screening providers associate with a Restricted Party, sanctioned activity, or illicit finance, in each case in our discretion and without liability to you.
+
+## 12. Prohibited Uses
+
+You agree not to use the Service to: violate any law or regulation applicable to you; launder money or finance illicit activity; manipulate a market or resolution source; trade on material non-public information where prohibited; access the Service while ineligible; interfere with, attack, or reverse-engineer the Service except as permitted by its open-source license; or harm other Users.
+
+## 13. No Professional Advice
+
+The Service and its contents do not constitute investment, financial, legal, accounting, or tax advice. **You are solely responsible for your own decisions.** Consult your own professional advisors.
+
+## 14. Assumption of Risk
+
+**YOU ACKNOWLEDGE THAT YOU HAVE READ AND UNDERSTAND THE FAIRWINS RISK DISCLOSURE AND THAT YOU KNOWINGLY AND VOLUNTARILY ASSUME ALL RISKS DESCRIBED IN IT, INCLUDING THE RISK OF TOTAL LOSS, SMART-CONTRACT AND ORACLE RISK, ABSENCE OF REGULATORY PROTECTION, AND LOSS OF ACCESS DUE TO LOSS OF YOUR KEYS.**
+
+## 15. Intellectual Property and Open Source
+
+The FairWins protocol and certain components are released under their applicable open-source license(s), and your use of those components is governed by those licenses. The FairWins name, marks, and interface content not so licensed remain our property. Nothing here grants you rights beyond those expressly stated or granted by an applicable open-source license.
+
+## 16. Privacy
+
+Your use of the Service is subject to the FairWins Privacy Policy. You acknowledge that blockchain transactions are public, permanent, and pseudonymous rather than anonymous, and that on-chain activity may be analyzed and attributed by third parties beyond our control.
+
+## 17. Taxes
+
+**You are solely responsible for determining, reporting, and paying any taxes** arising from your use of the Service, including from Wagers and winnings. FairWins does not withhold or report on your behalf.
+
+## 18. Disclaimers
+
+**THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE," WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS, IMPLIED, OR STATUTORY, INCLUDING ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT.** We do not warrant that the Service will be uninterrupted, secure, error-free, or free of harmful components, or that any Smart Contract, oracle, or Resolution Mechanism will function without fault. You use the Service at your own risk.
+
+## 19. Limitation of Liability
+
+**TO THE MAXIMUM EXTENT PERMITTED BY LAW, FAIRWINS AND CHIPPR ROBOTICS LLC, AND THEIR MEMBERS, OFFICERS, CONTRIBUTORS, AND AGENTS, WILL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES, OR FOR ANY LOST PROFITS, LOST WAGERS, LOST FUNDS, OR LOSS OF DATA, ARISING FROM OR RELATING TO THE SERVICE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.**
+
+**TO THE MAXIMUM EXTENT PERMITTED BY LAW, OUR TOTAL AGGREGATE LIABILITY ARISING FROM OR RELATING TO THE SERVICE WILL NOT EXCEED THE GREATER OF (A) THE TOTAL MEMBERSHIP FEES YOU PAID TO US IN THE [SIX (6)] MONTHS BEFORE THE EVENT GIVING RISE TO THE CLAIM, OR (B) [USD 100].**
+
+Because FairWins is non-custodial and is not a party to any Wager, we are not liable for the conduct of any counterparty or for any Wager outcome.
+
+## 20. Indemnification
+
+You will indemnify and hold harmless FairWins and Chippr Robotics LLC and their members, officers, contributors, and agents from any claim, loss, or expense (including reasonable legal fees) arising from your breach of these Terms, your misuse of the Service, your violation of law, or your false eligibility representations.
+
+## 21. Suspension and Termination
+
+We may restrict, suspend, or terminate your access to the Service at any time, including for suspected ineligibility, circumvention, sanctions concerns, or breach, **without notice and without refund**. Settled on-chain Wagers are unaffected by termination.
+
+## 22. Governing Law; Arbitration; Class Action Waiver
+
+**22.1 Governing law.** These Terms are governed by the laws of `[GOVERNING LAW JURISDICTION]`, without regard to conflict-of-laws rules.
+
+**22.2 Binding arbitration.** **ANY DISPUTE BETWEEN YOU AND FAIRWINS ARISING FROM OR RELATING TO THESE TERMS OR THE SERVICE WILL BE RESOLVED BY FINAL AND BINDING INDIVIDUAL ARBITRATION ADMINISTERED BY `[ARBITRAL INSTITUTION]` UNDER ITS RULES, SEATED IN `[SEAT]`, IN THE ENGLISH LANGUAGE. YOU AND FAIRWINS WAIVE THE RIGHT TO A TRIAL BY JURY OR IN COURT**, except that either party may bring an individual claim in small-claims court where eligible.
+
+**22.3 Class action waiver.** **YOU AND FAIRWINS AGREE THAT CLAIMS MAY BE BROUGHT ONLY IN AN INDIVIDUAL CAPACITY AND NOT AS A PLAINTIFF OR CLASS MEMBER IN ANY CLASS, COLLECTIVE, OR REPRESENTATIVE PROCEEDING.**
+
+**22.4 Opt-out.** You may opt out of this arbitration provision by sending written notice to `[CONTACT]` within thirty (30) days of first accepting these Terms.
+
+## 23. Force Majeure
+
+We are not liable for any failure or delay caused by events beyond our reasonable control, including network failures, blockchain congestion or reorganization, oracle failure, third-party service outages, regulatory action, or acts of god.
+
+## 24. Changes to These Terms
+
+We may update these Terms. Material changes will be indicated by an updated "Last updated" date and version, and where practical by notice through the Service. Your continued use after changes take effect constitutes acceptance. If you do not agree, you must stop using the Service.
+
+## 25. General
+
+**25.1 Severability.** If any provision is held unenforceable, the remainder remains in effect, and the unenforceable provision is modified to the minimum extent necessary to make it enforceable.
+
+**25.2 No waiver.** Our failure to enforce any provision is not a waiver.
+
+**25.3 Assignment.** You may not assign these Terms. We may assign them in connection with a reorganization or transfer of the Service.
+
+**25.4 Entire agreement.** These Terms, with the Risk Disclosure and Privacy Policy, are the entire agreement between you and us regarding the Service.
+
+**25.5 Language.** The English version of these Terms controls.
+
+## 26. Contact
+
+Questions about these Terms: `[CONTACT EMAIL / METHOD]`.
+
+## 27. Acknowledgement
+
+**BY ENTERING THE SITE, PURCHASING OR UPGRADING A MEMBERSHIP PASS, OR SIGNING THE ACCOUNT KEY-GENERATION MESSAGE, YOU CONFIRM THAT YOU HAVE READ AND UNDERSTOOD THESE TERMS AND THE RISK DISCLOSURE, THAT YOU ARE ELIGIBLE, AND THAT YOU KNOWINGLY AGREE TO BE BOUND BY THEM.**
+
+---
+
+## Schedule A — Restricted Jurisdictions
+
+The Service is not available to persons located, resident, incorporated, or established in:
+
+- The **United States** of America and its territories;
+- **Cuba, Iran, North Korea, Syria**, and the **Crimea, Donetsk, and Luhansk** regions;
+- Any jurisdiction subject to comprehensive sanctions by OFAC or other applicable authority; and
+- Any jurisdiction in which peer-to-peer wagering, prediction markets, or the Service is unlawful, including without limitation `[JURISDICTIONS TO BE CONFIRMED WITH COUNSEL — e.g., France, Belgium, Singapore, and others]`.
+
+We may amend this Schedule at any time.
+
+*— End of Terms & Conditions —*

--- a/frontend/src/pages/legal/LegalDocPage.jsx
+++ b/frontend/src/pages/legal/LegalDocPage.jsx
@@ -1,0 +1,124 @@
+import { useMemo } from 'react'
+import { getCurrentDocument } from '../../utils/legalDocs'
+
+/**
+ * Versioned legal-document pages (Spec 007 — FR-017/FR-024, SC-010/SC-015).
+ * Renders a document's current version + its SHA-256 version identifier. Public routes
+ * (/terms, /risk, /privacy) so the docs are readable before the entry gate. WCAG 2.1 AA:
+ * semantic headings/lists, keyboard-accessible links, a labelled version region.
+ *
+ * Dependency-free markdown rendering (no new bundle dep) covering the subset the drafts use:
+ * headings, lists, blockquotes, horizontal rules, paragraphs, and inline bold/code/links.
+ */
+
+function renderInline(text, keyPrefix) {
+  const nodes = []
+  const re = /(\*\*([^*]+)\*\*)|(`([^`]+)`)|(\[([^\]]+)\]\(([^)]+)\))/
+  let rest = text
+  let i = 0
+  let m
+  while ((m = re.exec(rest)) !== null) {
+    if (m.index > 0) nodes.push(rest.slice(0, m.index))
+    if (m[1]) {
+      nodes.push(<strong key={`${keyPrefix}-b${i}`}>{m[2]}</strong>)
+    } else if (m[3]) {
+      nodes.push(<code key={`${keyPrefix}-c${i}`}>{m[4]}</code>)
+    } else if (m[5]) {
+      const href = m[7]
+      const internal = href.startsWith('/') || href.startsWith('#')
+      nodes.push(
+        <a key={`${keyPrefix}-a${i}`} href={href} {...(internal ? {} : { target: '_blank', rel: 'noopener noreferrer' })}>
+          {m[6]}
+        </a>,
+      )
+    }
+    rest = rest.slice(m.index + m[0].length)
+    i++
+  }
+  if (rest) nodes.push(rest)
+  return nodes
+}
+
+function renderMarkdown(md) {
+  const lines = md.split('\n')
+  const blocks = []
+  let list = null
+  let para = []
+
+  const flushPara = () => {
+    if (para.length) {
+      const text = para.join(' ')
+      blocks.push(<p key={`p${blocks.length}`}>{renderInline(text, `p${blocks.length}`)}</p>)
+      para = []
+    }
+  }
+  const flushList = () => {
+    if (list) {
+      blocks.push(<ul key={`ul${blocks.length}`}>{list}</ul>)
+      list = null
+    }
+  }
+
+  lines.forEach((raw, idx) => {
+    const line = raw.replace(/\s+$/, '')
+    if (line.trim() === '') { flushPara(); flushList(); return }
+    if (/^---+$/.test(line.trim())) { flushPara(); flushList(); blocks.push(<hr key={`hr${idx}`} />); return }
+    const h = line.match(/^(#{1,6})\s+(.*)$/)
+    if (h) {
+      flushPara(); flushList()
+      const level = Math.min(h[1].length + 1, 6) // shift down one (page owns the h1)
+      const Tag = `h${level}`
+      blocks.push(<Tag key={`h${idx}`}>{renderInline(h[2], `h${idx}`)}</Tag>)
+      return
+    }
+    const li = line.match(/^[-*]\s+(.*)$/)
+    if (li) {
+      flushPara()
+      if (!list) list = []
+      list.push(<li key={`li${idx}`}>{renderInline(li[1], `li${idx}`)}</li>)
+      return
+    }
+    const bq = line.match(/^>\s?(.*)$/)
+    if (bq) {
+      flushPara(); flushList()
+      blocks.push(<blockquote key={`bq${idx}`}>{renderInline(bq[1], `bq${idx}`)}</blockquote>)
+      return
+    }
+    para.push(line.trim())
+  })
+  flushPara(); flushList()
+  return blocks
+}
+
+export function LegalDocPage({ docType }) {
+  const doc = useMemo(() => getCurrentDocument(docType), [docType])
+
+  if (!doc) {
+    return (
+      <main className="legal-doc-page">
+        <h1>Document not found</h1>
+        <p role="status">No such legal document.</p>
+      </main>
+    )
+  }
+
+  return (
+    <main className="legal-doc-page" aria-labelledby="legal-doc-title">
+      <h1 id="legal-doc-title">{doc.label}</h1>
+      <p className="legal-doc-version" aria-label="Document version">
+        Version (SHA-256): <code>{doc.hash}</code>
+      </p>
+      <nav aria-label="Legal documents" className="legal-doc-nav">
+        <a href="/terms">Terms &amp; Conditions</a> · <a href="/risk">Risk Disclosure</a> ·{' '}
+        <a href="/privacy">Privacy Policy</a>
+      </nav>
+      <article className="legal-doc-body">{renderMarkdown(doc.content)}</article>
+    </main>
+  )
+}
+
+export function TermsPage() { return <LegalDocPage docType="terms" /> }
+export function RiskPage() { return <LegalDocPage docType="risk" /> }
+export function PrivacyPage() { return <LegalDocPage docType="privacy" /> }
+
+export default LegalDocPage

--- a/frontend/src/schemas/encrypted-metadata-v1.1.json
+++ b/frontend/src/schemas/encrypted-metadata-v1.1.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://fairwins.app/schemas/encrypted-metadata-v1.1.json",
+  "title": "Encrypted Market Metadata Schema v1.1",
+  "description": "Runtime envelope shape for encrypted friend-market/wager metadata. v1.1 adds the OPTIONAL, authenticated `termsVersion` binding (Spec 007, FR-056): the governing T&C version hash bound into the ChaCha20-Poly1305 AAD so it is tamper-evident. Absent `termsVersion` ⇒ a legacy envelope (no AAD) governed by the launch version (FR-057). This schema reconciles to the runtime envelope (nested content/keys) rather than the older v1.0 top-level shape.",
+  "type": "object",
+  "required": ["version", "algorithm", "signingVersion", "content", "keys"],
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "Envelope/algorithm version: '1.0' = x25519, '2.0' = X-Wing hybrid.",
+      "enum": ["1.0", "2.0"]
+    },
+    "algorithm": {
+      "type": "string",
+      "enum": ["x25519-chacha20poly1305", "xwing-chacha20poly1305"]
+    },
+    "signingVersion": {
+      "type": "integer",
+      "description": "Key-derivation signing-message version (NOT the T&C version)."
+    },
+    "termsVersion": {
+      "type": "object",
+      "description": "OPTIONAL governing T&C binding (FR-056). Authenticated via AAD: tampering fails decryption. Absence ⇒ legacy wager governed by the launch version (FR-057).",
+      "required": ["hash"],
+      "properties": {
+        "id": {
+          "type": ["string", "null"],
+          "description": "Human-readable version id of the in-force Terms at wager creation."
+        },
+        "hash": {
+          "type": "string",
+          "description": "SHA-256 (lowercase hex) of the canonicalized Terms content (NFC/LF/UTF-8/trim).",
+          "pattern": "^[0-9a-f]{64}$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "content": {
+      "type": "object",
+      "required": ["nonce", "ciphertext"],
+      "properties": {
+        "nonce": { "type": "string", "description": "Hex-encoded 12-byte content nonce" },
+        "ciphertext": { "type": "string", "description": "Hex-encoded ChaCha20-Poly1305 ciphertext + tag" }
+      },
+      "additionalProperties": false
+    },
+    "keys": {
+      "type": "array",
+      "description": "Per-recipient wrapped DEK entries (x25519 ephemeral or X-Wing ciphertext).",
+      "items": { "type": "object" },
+      "minItems": 1
+    }
+  },
+  "additionalProperties": false
+}

--- a/frontend/src/test/EntryGate.test.jsx
+++ b/frontend/src/test/EntryGate.test.jsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async (orig) => {
+  const actual = await orig()
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+import EntryGate from '../components/compliance/EntryGate'
+
+const ACK_KEY = 'fairwins.entryGate.ack.v1'
+
+describe('EntryGate (T040)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    navigateMock.mockReset()
+  })
+
+  it('shows the gate on first visit (no prior acknowledgement)', () => {
+    render(<EntryGate />)
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText(/Before you enter FairWins/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Enter' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Leave' })).toBeInTheDocument()
+  })
+
+  it('links the current versioned Terms and Risk Disclosure', () => {
+    render(<EntryGate />)
+    expect(screen.getByRole('link', { name: /Terms & Conditions/i })).toHaveAttribute('href', '/terms')
+    expect(screen.getByRole('link', { name: /Risk Disclosure/i })).toHaveAttribute('href', '/risk')
+  })
+
+  it('shows a VPN/circumvention warning', () => {
+    render(<EntryGate />)
+    expect(screen.getByText(/VPN, proxy, or any means to misrepresent/i)).toBeInTheDocument()
+  })
+
+  it('Enter records acknowledgement and hides the gate', () => {
+    render(<EntryGate />)
+    fireEvent.click(screen.getByRole('button', { name: 'Enter' }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    const ack = JSON.parse(localStorage.getItem(ACK_KEY))
+    expect(ack).toBeTruthy()
+    expect(ack.terms).toMatch(/^[0-9a-f]{64}$/)
+    expect(ack.risk).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('Leave navigates away to the landing page', () => {
+    render(<EntryGate />)
+    fireEvent.click(screen.getByRole('button', { name: 'Leave' }))
+    expect(navigateMock).toHaveBeenCalledWith('/')
+  })
+
+  it('does NOT re-gate a returning visitor who already acknowledged', () => {
+    localStorage.setItem(ACK_KEY, JSON.stringify({ terms: 'x', risk: 'y', at: 'earlier' }))
+    render(<EntryGate />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/FriendMarketsModal.test.jsx
+++ b/frontend/src/test/FriendMarketsModal.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
@@ -13,6 +13,18 @@ import {
   DexProvider,
   PriceProvider
 } from '../contexts'
+
+// The exposed oracle resolution tabs (Chainlink Data Feed / Functions / UMA) are
+// gated by VITE_ORACLE_MODELS, which constants/wagerDefaults reads ONCE at module
+// load. vi.hoisted runs before the (hoisted) component import, so set it to 'all'
+// here — otherwise the default 'polymarket-only' hides those tabs and every
+// oracle-tab spec below fails. Self-contained: vitest isolates env per test file.
+vi.hoisted(() => {
+  vi.stubEnv('VITE_ORACLE_MODELS', 'all')
+})
+afterAll(() => {
+  vi.unstubAllEnvs()
+})
 
 // Mock wallet and network state
 let mockWalletState = {

--- a/frontend/src/test/MembershipAttestation.test.jsx
+++ b/frontend/src/test/MembershipAttestation.test.jsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import MembershipAttestation, { ATTESTATIONS } from '../components/compliance/MembershipAttestation'
+
+describe('MembershipAttestation (T043)', () => {
+  it('renders all required attestations un-ticked by default', () => {
+    render(<MembershipAttestation onChange={() => {}} />)
+    const boxes = screen.getAllByRole('checkbox')
+    expect(boxes).toHaveLength(ATTESTATIONS.length)
+    boxes.forEach((b) => expect(b).not.toBeChecked())
+  })
+
+  it('reports allTicked=false until every box is ticked, then true', () => {
+    const onChange = vi.fn()
+    render(<MembershipAttestation onChange={onChange} />)
+    expect(onChange).toHaveBeenLastCalledWith(false) // initial
+
+    const boxes = screen.getAllByRole('checkbox')
+    boxes.slice(0, -1).forEach((b) => fireEvent.click(b))
+    expect(onChange).toHaveBeenLastCalledWith(false) // one still unticked
+
+    fireEvent.click(boxes[boxes.length - 1])
+    expect(onChange).toHaveBeenLastCalledWith(true) // all ticked
+  })
+
+  it('flips back to false if a box is un-ticked', () => {
+    const onChange = vi.fn()
+    render(<MembershipAttestation onChange={onChange} />)
+    const boxes = screen.getAllByRole('checkbox')
+    boxes.forEach((b) => fireEvent.click(b))
+    expect(onChange).toHaveBeenLastCalledWith(true)
+    fireEvent.click(boxes[0])
+    expect(onChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it('states the membership-is-a-fee-only / non-refundable copy (FR-038)', () => {
+    render(<MembershipAttestation onChange={() => {}} />)
+    expect(screen.getByText(/fee for\s*access only/i)).toBeInTheDocument()
+    expect(screen.getByText(/non-refundable/i)).toBeInTheDocument()
+    expect(screen.getByText(/no claim on any pool of funds/i)).toBeInTheDocument()
+  })
+
+  it('covers the required eligibility/risk attestations (FR-037)', () => {
+    render(<MembershipAttestation onChange={() => {}} />)
+    expect(screen.getByText(/at least 21 years/i)).toBeInTheDocument()
+    expect(screen.getByText(/not a U\.S\. person/i)).toBeInTheDocument()
+    expect(screen.getByText(/OFAC SDN/i)).toBeInTheDocument()
+    expect(screen.getByText(/no regulator or authority/i)).toBeInTheDocument()
+    expect(screen.getByText(/VPN, proxy/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/compliance.accessibility.test.jsx
+++ b/frontend/src/test/compliance.accessibility.test.jsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import { MemoryRouter } from 'react-router-dom'
+
+import EntryGate from '../components/compliance/EntryGate'
+import MembershipAttestation from '../components/compliance/MembershipAttestation'
+import DenyListAdmin from '../components/admin/DenyListAdmin'
+import { TermsPage } from '../pages/legal/LegalDocPage'
+
+/**
+ * Spec 007 (FR-053 / SC-015): the new compliance trust surfaces must meet WCAG 2.1 AA.
+ * jsdom-level axe checks structural a11y (roles, names, labels, landmarks); color-contrast
+ * needs a real browser and is covered by the Lighthouse/axe CI job.
+ */
+describe('Compliance UI accessibility (T054, FR-053)', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('EntryGate has no axe violations', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <EntryGate />
+      </MemoryRouter>,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('MembershipAttestation has no axe violations', async () => {
+    const { container } = render(<MembershipAttestation onChange={() => {}} />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('Legal document page (Terms) has no axe violations', async () => {
+    const { container } = render(<TermsPage />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('DenyListAdmin has no axe violations', async () => {
+    const { container } = render(
+      <DenyListAdmin
+        signer={null}
+        contracts={{ sanctionsGuard: '0x1111111111111111111111111111111111111111' }}
+        runTx={() => {}}
+        pendingTx={false}
+      />,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/crypto/envelopeEncryption.termsVersion.test.js
+++ b/frontend/src/test/crypto/envelopeEncryption.termsVersion.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import {
+  encryptEnvelope,
+  decryptEnvelope,
+  deriveKeyPairFromSignature,
+} from '../../utils/crypto/envelopeEncryption.js'
+
+// Spec 007 (FR-056/FR-057, SC-017): the governing T&C version hash is bound into the
+// wager's encryption as ChaCha20-Poly1305 AAD + an authenticated `termsVersion` field.
+// Omitting termsVersion reproduces legacy behavior (no AAD), so existing wagers still open.
+
+const ALICE = '0x1234567890abcdef1234567890abcdef12345678'
+const TV = { id: 'fairwins-terms-2026-06-07', hash: 'a'.repeat(64) }
+const keys = () => deriveKeyPairFromSignature('0xalice-signature')
+
+describe('envelope termsVersion AAD binding (T031)', () => {
+  it('round-trips with a bound termsVersion and exposes the authenticated field', () => {
+    const kp = keys()
+    const env = encryptEnvelope({ secret: 'wager-terms' }, [{ address: ALICE, publicKey: kp.publicKey }], 2, TV)
+    expect(env.termsVersion).toEqual({ id: TV.id, hash: TV.hash })
+    expect(decryptEnvelope(env, ALICE, kp.privateKey)).toEqual({ secret: 'wager-terms' })
+  })
+
+  it('rejects a tampered termsVersion.hash (AEAD authentication fails)', () => {
+    const kp = keys()
+    const env = encryptEnvelope({ secret: 1 }, [{ address: ALICE, publicKey: kp.publicKey }], 2, TV)
+    const tampered = { ...env, termsVersion: { ...env.termsVersion, hash: 'b'.repeat(64) } }
+    expect(() => decryptEnvelope(tampered, ALICE, kp.privateKey)).toThrow()
+  })
+
+  it('legacy envelope (no termsVersion) round-trips with no AAD and no field', () => {
+    const kp = keys()
+    const env = encryptEnvelope({ secret: 2 }, [{ address: ALICE, publicKey: kp.publicKey }], 2)
+    expect(env).not.toHaveProperty('termsVersion')
+    expect(decryptEnvelope(env, ALICE, kp.privateKey)).toEqual({ secret: 2 })
+  })
+
+  it('does not alter the recipient key-wrapping shape', () => {
+    const kp = keys()
+    const env = encryptEnvelope({ x: 1 }, [{ address: ALICE, publicKey: kp.publicKey }], 2, TV)
+    expect(env.keys).toHaveLength(1)
+    expect(env.keys[0]).toHaveProperty('wrappedKey')
+    expect(env.keys[0]).toHaveProperty('ephemeralPublicKey')
+  })
+})

--- a/frontend/src/test/keygenEligibility.test.js
+++ b/frontend/src/test/keygenEligibility.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { Wallet, verifyMessage } from 'ethers'
+import {
+  ELIGIBILITY_DISCLOSURE,
+  KEYGEN_TERMS_URL,
+  getSigningMessage,
+} from '../utils/crypto/constants.js'
+
+// Spec 007 — US6 (FR-040/FR-041/FR-044, SC-009).
+
+describe('key-gen eligibility disclosure (T048)', () => {
+  it('states the standing eligibility facts', () => {
+    const text = ELIGIBILITY_DISCLOSURE.facts.join(' ')
+    expect(text).toMatch(/21 years/i)
+    expect(text).toMatch(/not a U\.S\. person/i)
+    expect(text).toMatch(/sanctioned/i)
+    expect(text).toMatch(/sole control of this wallet/i)
+  })
+
+  it('references the Terms generically (URL, no version/date)', () => {
+    expect(ELIGIBILITY_DISCLOSURE.termsReference).toContain(KEYGEN_TERMS_URL)
+    expect(ELIGIBILITY_DISCLOSURE.termsReference).toMatch(/as published/i)
+    expect(ELIGIBILITY_DISCLOSURE.termsReference).not.toMatch(/\d{4}-\d{2}-\d{2}/) // no date
+  })
+
+  it('discloses that signing derives the account encryption key (FR-044)', () => {
+    expect(ELIGIBILITY_DISCLOSURE.keyDerivationNotice).toMatch(/derives the encryption key/i)
+    expect(ELIGIBILITY_DISCLOSURE.keyDerivationNotice).toMatch(/no .*transaction|costs no gas/i)
+  })
+})
+
+describe('key-derivation message determinism + recoverability (SC-009)', () => {
+  it('the signing message is byte-identical across calls (no nonce/timestamp)', () => {
+    expect(getSigningMessage(2)).toBe(getSigningMessage(2))
+    expect(getSigningMessage(1)).toBe(getSigningMessage(1))
+  })
+
+  it('signing the deterministic message is reproducible and recovers the signer', async () => {
+    const wallet = new Wallet('0x' + '11'.repeat(32))
+    const msg = getSigningMessage(2)
+    const sig1 = await wallet.signMessage(msg)
+    const sig2 = await wallet.signMessage(msg)
+    expect(sig1).toBe(sig2) // deterministic ECDSA (RFC 6979) → reproducible key derivation
+    expect(verifyMessage(msg, sig1)).toBe(wallet.address)
+  })
+})

--- a/frontend/src/test/legalDocs.test.js
+++ b/frontend/src/test/legalDocs.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest'
+import { createHash } from 'node:crypto'
+import {
+  canonicalizeDocText,
+  hashDocVersion,
+  verifyDocVersion,
+  CANONICALIZATION_VERSION,
+  DOC_TYPES,
+  getCurrentDocument,
+  getDocumentByHash,
+  listVersions,
+  requiresReconsent,
+} from '../utils/legalDocs.js'
+import { buildTermsAAD, TERMS_AAD_PREFIX } from '../utils/crypto/constants.js'
+
+// Independent SHA-256 (node:crypto) over the documented canonical bytes — proves a third
+// party can reproduce the version hash (Spec 007 SC-005/FR-026/FR-059).
+function independentHash(text) {
+  const canonical = text.normalize('NFC').replace(/\r\n/g, '\n').replace(/\r/g, '\n').trim()
+  return createHash('sha256').update(Buffer.from(canonical, 'utf8')).digest('hex')
+}
+
+describe('legalDocs canonicalization & hashing (T009)', () => {
+  it('exposes the frozen canonicalization id', () => {
+    expect(CANONICALIZATION_VERSION).toBe('nfc-lf-utf8-trim-v1')
+  })
+
+  it('canonicalizes CRLF and lone CR to LF and trims', () => {
+    expect(canonicalizeDocText('a\r\nb\rc\n')).toBe('a\nb\nc')
+    expect(canonicalizeDocText('  hello  ')).toBe('hello')
+  })
+
+  it('produces a 64-char lowercase hex digest', () => {
+    const h = hashDocVersion('FairWins Terms v1')
+    expect(h).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('is deterministic and independent-party reproducible', () => {
+    const text = 'FairWins — Terms & Conditions\nLine two.\n'
+    expect(hashDocVersion(text)).toBe(hashDocVersion(text))
+    expect(hashDocVersion(text)).toBe(independentHash(text))
+  })
+
+  it('hash is invariant to line-ending and trailing-whitespace differences', () => {
+    expect(hashDocVersion('a\r\nb')).toBe(hashDocVersion('a\nb'))
+    expect(hashDocVersion('a\nb\n\n')).toBe(hashDocVersion('a\nb'))
+  })
+
+  it('verifyDocVersion matches (case-insensitive) and rejects tampering', () => {
+    const text = 'Risk Disclosure body'
+    const h = hashDocVersion(text)
+    expect(verifyDocVersion(text, h)).toBe(true)
+    expect(verifyDocVersion(text, h.toUpperCase())).toBe(true)
+    expect(verifyDocVersion(text + ' tampered', h)).toBe(false)
+  })
+})
+
+describe('legal document manifest (T030)', () => {
+  it('exposes the three document types', () => {
+    expect([...DOC_TYPES]).toEqual(['terms', 'risk', 'privacy'])
+  })
+
+  it('getCurrentDocument returns content + a reproducible hash version + material flag', () => {
+    for (const t of DOC_TYPES) {
+      const doc = getCurrentDocument(t)
+      expect(doc).toBeTruthy()
+      expect(doc.content.length).toBeGreaterThan(0)
+      expect(doc.hash).toMatch(/^[0-9a-f]{64}$/)
+      expect(doc.hash).toBe(hashDocVersion(doc.content))
+      expect(doc.material).toBe(true)
+      expect(doc.route).toBe(`/${t === 'risk' ? 'risk' : t}`)
+    }
+  })
+
+  it('getDocumentByHash retrieves the current version and returns null for unknown', () => {
+    const cur = getCurrentDocument('terms')
+    const got = getDocumentByHash('terms', cur.hash)
+    expect(got.hash).toBe(cur.hash)
+    expect(got.content).toBe(cur.content)
+    expect(getDocumentByHash('terms', 'f'.repeat(64))).toBeNull()
+    expect(getDocumentByHash('nope', cur.hash)).toBeNull()
+  })
+
+  it('listVersions includes the current hash and omits content', () => {
+    const cur = getCurrentDocument('risk')
+    const versions = listVersions('risk')
+    expect(versions.some((v) => v.hash === cur.hash)).toBe(true)
+    expect(versions[0]).not.toHaveProperty('content')
+    expect(versions[0]).toHaveProperty('id')
+  })
+
+  it('requiresReconsent is false for the current hash, true otherwise (material)', () => {
+    const cur = getCurrentDocument('terms')
+    expect(requiresReconsent('terms', cur.hash)).toBe(false)
+    expect(requiresReconsent('terms', '')).toBe(true)
+    expect(requiresReconsent('terms', 'a'.repeat(64))).toBe(true)
+  })
+})
+
+describe('buildTermsAAD (T010)', () => {
+  it('builds deterministic AAD bytes in the documented format', () => {
+    const aad = buildTermsAAD('1.1', 'deadbeef')
+    expect(new TextDecoder().decode(aad)).toBe(`${TERMS_AAD_PREFIX}|1.1|deadbeef`)
+  })
+
+  it('is byte-identical across calls (seal/open must match)', () => {
+    const a = buildTermsAAD('1.1', 'abc123')
+    const b = buildTermsAAD('1.1', 'abc123')
+    expect(a).toEqual(b)
+  })
+
+  it('throws on missing arguments', () => {
+    expect(() => buildTermsAAD('', 'abc')).toThrow()
+    expect(() => buildTermsAAD('1.1', '')).toThrow()
+  })
+
+  it('does not collide for different versions/hashes', () => {
+    const decode = (u) => new TextDecoder().decode(u)
+    expect(decode(buildTermsAAD('1.1', 'aa'))).not.toBe(decode(buildTermsAAD('1.1', 'bb')))
+    expect(decode(buildTermsAAD('1.0', 'aa'))).not.toBe(decode(buildTermsAAD('1.1', 'aa')))
+  })
+})

--- a/frontend/src/test/originLock.test.js
+++ b/frontend/src/test/originLock.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+// Regression guard for the nginx origin-lock template (Spec 007, FR-007/FR-008).
+// Renders the template the way docker-entrypoint.sh does (envsubst of the 3 vars) and
+// asserts the map + per-location guards are structured so that:
+//   - enforcement OFF (no secret)  => allow everything (dev/local not bricked)
+//   - enforcement ON  (secret set) => only an exact X-Origin-Auth match is allowed
+// Full runtime behavior (no-hdr→403, wrong→403, correct→200, healthz→200) was verified
+// against nginx during implementation and is documented in infra/cloudflare/origin-lock.md.
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const TEMPLATE = resolve(__dirname, '../../nginx.conf.template')
+
+function render(vars) {
+  let s = readFileSync(TEMPLATE, 'utf8')
+  for (const [k, v] of Object.entries(vars)) {
+    s = s.replaceAll(`\${${k}}`, v)
+  }
+  return s
+}
+
+describe('nginx origin-lock template (T011)', () => {
+  it('has an unauthenticated /healthz exemption and an edge-aware access log', () => {
+    const tpl = readFileSync(TEMPLATE, 'utf8')
+    expect(tpl).toMatch(/location\s*=\s*\/healthz/)
+    expect(tpl).toContain('$http_cf_ipcountry')
+    expect(tpl).toContain('$http_cf_connecting_ip')
+  })
+
+  it('guards every served location with $origin_denied', () => {
+    const tpl = readFileSync(TEMPLATE, 'utf8')
+    const guards = tpl.match(/if \(\$origin_denied\) \{ return 403; \}/g) || []
+    // SPA `/`, static-assets regex, and the /api/pinata proxy
+    expect(guards.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('ENABLED=0 (no secret) allows everything via the ~^0: branch', () => {
+    const out = render({ ORIGIN_LOCK_ENABLED: '0', ORIGIN_LOCK_SECRET: '', VITE_PINATA_JWT: 'x' })
+    expect(out).toContain('map "0:$http_x_origin_auth" $origin_denied')
+    expect(out).toMatch(/"~\^0:"\s+0;/)
+  })
+
+  it('ENABLED=1 allows ONLY an exact secret match; default denies', () => {
+    const out = render({ ORIGIN_LOCK_ENABLED: '1', ORIGIN_LOCK_SECRET: 's3cr3t', VITE_PINATA_JWT: 'x' })
+    expect(out).toContain('map "1:$http_x_origin_auth" $origin_denied')
+    expect(out).toMatch(/"1:s3cr3t"\s+0;/)
+    expect(out).toMatch(/default\s+1;/)
+  })
+
+  it('never substitutes the secret into a logged directive (no secret in log_format)', () => {
+    const out = render({ ORIGIN_LOCK_ENABLED: '1', ORIGIN_LOCK_SECRET: 's3cr3t', VITE_PINATA_JWT: 'x' })
+    const logLine = out.split('\n').find((l) => l.includes('log_format fairwins_edge')) || ''
+    expect(logLine).not.toContain('s3cr3t')
+    expect(out).not.toMatch(/access_log[^\n]*s3cr3t/)
+  })
+})

--- a/frontend/src/test/sanctionsScreen.test.js
+++ b/frontend/src/test/sanctionsScreen.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { screenWithContract, isClear, screenAddress } from '../utils/sanctionsScreen.js'
+
+// Mock the contracts config so screenAddress's "not configured" path is deterministic.
+// (The populated-address path is covered via screenWithContract with a fake contract,
+//  avoiding any need to mock ethers — see frontend-test-gotchas.)
+vi.mock('../config/contracts', () => ({
+  getContractAddress: vi.fn(),
+}))
+import { getContractAddress } from '../config/contracts'
+
+const ADDR = '0x1111111111111111111111111111111111111111'
+
+describe('sanctionsScreen — screenWithContract (T022)', () => {
+  it('returns allowed:true / available:true for a clean address', async () => {
+    const guard = { isAllowed: vi.fn().mockResolvedValue(true) }
+    expect(await screenWithContract(guard, ADDR)).toEqual({ allowed: true, available: true })
+  })
+
+  it('returns allowed:false / available:true for a sanctioned/denied address', async () => {
+    const guard = { isAllowed: vi.fn().mockResolvedValue(false) }
+    expect(await screenWithContract(guard, ADDR)).toEqual({ allowed: false, available: true })
+  })
+
+  it('fail-closed (available:false) when the read throws', async () => {
+    const guard = { isAllowed: vi.fn().mockRejectedValue(new Error('rpc down')) }
+    expect(await screenWithContract(guard, ADDR)).toEqual({ allowed: false, available: false })
+  })
+})
+
+describe('sanctionsScreen — isClear', () => {
+  it('is true only when available AND allowed', () => {
+    expect(isClear({ available: true, allowed: true })).toBe(true)
+  })
+  it('is false when unavailable, even if allowed flag is set', () => {
+    expect(isClear({ available: false, allowed: true })).toBe(false)
+  })
+  it('is false when available but not allowed, and for nullish input', () => {
+    expect(isClear({ available: true, allowed: false })).toBe(false)
+    expect(isClear(null)).toBe(false)
+    expect(isClear(undefined)).toBe(false)
+  })
+})
+
+describe('sanctionsScreen — screenAddress (not configured)', () => {
+  beforeEach(() => vi.clearAllMocks())
+  it('returns available:false when no guard address is configured (fail-closed)', async () => {
+    getContractAddress.mockReturnValue('')
+    expect(await screenAddress(ADDR, {})).toEqual({ allowed: false, available: false })
+  })
+})

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -1137,17 +1137,21 @@ export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tie
 
       // Spec 007 (FR-039): when an accepted T&C version hash is supplied, use the
       // *WithTerms overloads so the accepted version is recorded on-chain at purchase.
-      const hasTerms = typeof termsHash === 'string' && /^0x[0-9a-fA-F]{64}$/.test(termsHash)
+      // legalDocs hashes are bare 64-hex (no 0x); normalize to a bytes32 0x-string.
+      const normTerms = typeof termsHash === 'string'
+        ? (termsHash.startsWith('0x') ? termsHash : '0x' + termsHash)
+        : null
+      const hasTerms = normTerms !== null && /^0x[0-9a-fA-F]{64}$/.test(normTerms)
       let tx
       if (action === 'upgrade') {
         tx = hasTerms
-          ? await mm.upgradeTierWithTerms(roleHash, validTier, termsHash)
+          ? await mm.upgradeTierWithTerms(roleHash, validTier, normTerms)
           : await mm.upgradeTier(roleHash, validTier)
       } else if (action === 'extend') {
         tx = await mm.extendMembership(roleHash)
       } else {
         tx = hasTerms
-          ? await mm.purchaseTierWithTerms(roleHash, validTier, termsHash)
+          ? await mm.purchaseTierWithTerms(roleHash, validTier, normTerms)
           : await mm.purchaseTier(roleHash, validTier)
       }
       const receipt = await tx.wait()

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -1082,7 +1082,7 @@ const PAYMENT_PROCESSOR_ABI = [
  * @param {string} action - 'purchase' (default), 'upgrade', or 'extend'
  * @returns {Promise<Object>} Transaction receipt with roleGranted status
  */
-export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tier = MembershipTier.BRONZE, action = 'purchase') {
+export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tier = MembershipTier.BRONZE, action = 'purchase', termsHash = null) {
   if (!signer) {
     throw new Error('Wallet not connected')
   }
@@ -1135,13 +1135,20 @@ export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tie
         await approveTx.wait()
       }
 
+      // Spec 007 (FR-039): when an accepted T&C version hash is supplied, use the
+      // *WithTerms overloads so the accepted version is recorded on-chain at purchase.
+      const hasTerms = typeof termsHash === 'string' && /^0x[0-9a-fA-F]{64}$/.test(termsHash)
       let tx
       if (action === 'upgrade') {
-        tx = await mm.upgradeTier(roleHash, validTier)
+        tx = hasTerms
+          ? await mm.upgradeTierWithTerms(roleHash, validTier, termsHash)
+          : await mm.upgradeTier(roleHash, validTier)
       } else if (action === 'extend') {
         tx = await mm.extendMembership(roleHash)
       } else {
-        tx = await mm.purchaseTier(roleHash, validTier)
+        tx = hasTerms
+          ? await mm.purchaseTierWithTerms(roleHash, validTier, termsHash)
+          : await mm.purchaseTier(roleHash, validTier)
       }
       const receipt = await tx.wait()
       return {

--- a/frontend/src/utils/crypto/constants.js
+++ b/frontend/src/utils/crypto/constants.js
@@ -186,3 +186,33 @@ export function isVersionSupported(version) {
 export function getSupportedVersions() {
   return Object.keys(SIGNING_MESSAGES).map(Number).sort((a, b) => a - b)
 }
+
+/**
+ * ==========================================================================
+ * Per-wager Terms-version binding (Spec 007, FR-056/FR-057)
+ * ==========================================================================
+ * The governing T&C version hash is bound into each wager's ChaCha20-Poly1305
+ * AEAD as Associated Data (AAD). This makes the claimed `termsVersion` field in
+ * the envelope tamper-evident WITHOUT entering key derivation (the SIGNING_MESSAGES /
+ * MARKET_SIGNING_MESSAGES above are intentionally untouched so the derived key stays
+ * versionless and reproducible — FR-041).
+ *
+ * The AAD MUST be byte-identical on seal and open; build it ONLY via buildTermsAAD()
+ * from the envelope's authenticated `termsVersion.hash`.
+ */
+export const TERMS_AAD_PREFIX = 'FairWins-TC'
+
+/**
+ * Build the deterministic AAD bytes binding a wager to its governing T&C version.
+ * @param {string} schemaVersion - the encrypted-metadata schema version (e.g. "1.1")
+ * @param {string} termsVersionHashHex - SHA-256 hex of the canonicalized T&C bytes
+ * @returns {Uint8Array} UTF-8 bytes: `FairWins-TC|<schemaVersion>|<hashHex>`
+ */
+export function buildTermsAAD(schemaVersion, termsVersionHashHex) {
+  if (!schemaVersion || !termsVersionHashHex) {
+    throw new Error('buildTermsAAD requires schemaVersion and termsVersionHashHex')
+  }
+  return new TextEncoder().encode(
+    `${TERMS_AAD_PREFIX}|${schemaVersion}|${termsVersionHashHex}`
+  )
+}

--- a/frontend/src/utils/crypto/constants.js
+++ b/frontend/src/utils/crypto/constants.js
@@ -203,6 +203,14 @@ export function getSupportedVersions() {
 export const TERMS_AAD_PREFIX = 'FairWins-TC'
 
 /**
+ * Schema-binding version component of the terms AAD (Spec 007). This is the
+ * encrypted-metadata SCHEMA version that introduced the binding (v1.1) — NOT the envelope
+ * algorithm version ('1.0' x25519 / '2.0' x-wing). It is used identically on seal and open
+ * so the AAD does not vary by algorithm; bump it only if the AAD format itself changes.
+ */
+export const TERMS_AAD_VERSION = '1.1'
+
+/**
  * Build the deterministic AAD bytes binding a wager to its governing T&C version.
  * @param {string} schemaVersion - the encrypted-metadata schema version (e.g. "1.1")
  * @param {string} termsVersionHashHex - SHA-256 hex of the canonicalized T&C bytes

--- a/frontend/src/utils/crypto/constants.js
+++ b/frontend/src/utils/crypto/constants.js
@@ -216,3 +216,29 @@ export function buildTermsAAD(schemaVersion, termsVersionHashHex) {
     `${TERMS_AAD_PREFIX}|${schemaVersion}|${termsVersionHashHex}`
   )
 }
+
+/**
+ * ==========================================================================
+ * Key-generation eligibility disclosure (Spec 007 — US6, FR-040/FR-044)
+ * ==========================================================================
+ * Shown to the user at account key generation. The DETERMINISTIC key-derivation message
+ * (SIGNING_MESSAGES / MARKET_SIGNING_MESSAGES above) is intentionally unchanged so the
+ * derived key stays reproducible (FR-041); the standing eligibility facts + the
+ * key-derivation coupling are surfaced here as a disclosure, and the dated record is the
+ * on-chain key registration (KeyRegistry.EligibilityAcknowledged, FR-043). Terms are
+ * referenced generically ("as published"), with no date/version in the signed payload.
+ */
+export const KEYGEN_TERMS_URL = 'https://fairwins.app/terms'
+
+export const ELIGIBILITY_DISCLOSURE = {
+  title: 'FairWins — Account Key Generation',
+  facts: [
+    'I am at least 21 years old.',
+    'I am not a U.S. person and am not located in a Restricted Jurisdiction.',
+    'I am not a sanctioned or restricted party.',
+    'I have sole control of this wallet and its private keys, and I meet and continue to meet the eligibility requirements of the FairWins Terms & Conditions.',
+  ],
+  termsReference: `FairWins Terms & Conditions (as published) at ${KEYGEN_TERMS_URL}`,
+  keyDerivationNotice:
+    'Signing this message deterministically derives the encryption key for your FairWins account. It does not authorize any transaction, transfer, or wager, and costs no gas. If you lose your wallet/keys, this account key cannot be recovered.',
+}

--- a/frontend/src/utils/crypto/envelopeEncryption.js
+++ b/frontend/src/utils/crypto/envelopeEncryption.js
@@ -30,7 +30,8 @@ import {
   XWING_ENVELOPE_INFO,
   XWING_ALGORITHM,
   SUPPORTED_ALGORITHMS,
-  buildTermsAAD
+  buildTermsAAD,
+  TERMS_AAD_VERSION
 } from './constants.js'
 
 // ==================== X-Wing Hybrid KEM Implementation ====================
@@ -305,7 +306,7 @@ export function encryptEnvelope(data, recipients, signingVersion = CURRENT_ENCRY
     ? utf8ToBytes(data)
     : utf8ToBytes(JSON.stringify(data))
 
-  const aad = termsVersion?.hash ? buildTermsAAD('1.0', termsVersion.hash) : undefined
+  const aad = termsVersion?.hash ? buildTermsAAD(TERMS_AAD_VERSION, termsVersion.hash) : undefined
   const contentNonce = randomBytes(12)
   const cipher = chacha20poly1305(dek, contentNonce, aad)
   const encryptedContent = cipher.encrypt(plaintext)
@@ -390,7 +391,7 @@ export function decryptEnvelope(envelope, myAddress, myPrivateKey) {
   // fails authentication. Legacy envelopes (no termsVersion) decrypt with no AAD as before.
   const contentNonce = hexToBytes(envelope.content.nonce)
   const ciphertext = hexToBytes(envelope.content.ciphertext)
-  const aad = envelope.termsVersion?.hash ? buildTermsAAD(envelope.version, envelope.termsVersion.hash) : undefined
+  const aad = envelope.termsVersion?.hash ? buildTermsAAD(TERMS_AAD_VERSION, envelope.termsVersion.hash) : undefined
   const contentCipher = chacha20poly1305(dek, contentNonce, aad)
   const plaintext = contentCipher.decrypt(ciphertext)
 
@@ -490,7 +491,7 @@ export function encryptEnvelopeXWing(data, recipients, signingVersion = CURRENT_
     ? utf8ToBytes(data)
     : utf8ToBytes(JSON.stringify(data))
 
-  const aad = termsVersion?.hash ? buildTermsAAD('2.0', termsVersion.hash) : undefined
+  const aad = termsVersion?.hash ? buildTermsAAD(TERMS_AAD_VERSION, termsVersion.hash) : undefined
   const contentNonce = randomBytes(12)
   const cipher = chacha20poly1305(dek, contentNonce, aad)
   const encryptedContent = cipher.encrypt(plaintext)
@@ -568,7 +569,7 @@ export function decryptEnvelopeXWing(envelope, myAddress, mySecretKey) {
   // fails authentication. Legacy envelopes (no termsVersion) decrypt with no AAD as before.
   const contentNonce = hexToBytes(envelope.content.nonce)
   const ciphertext = hexToBytes(envelope.content.ciphertext)
-  const aad = envelope.termsVersion?.hash ? buildTermsAAD(envelope.version, envelope.termsVersion.hash) : undefined
+  const aad = envelope.termsVersion?.hash ? buildTermsAAD(TERMS_AAD_VERSION, envelope.termsVersion.hash) : undefined
   const contentCipher = chacha20poly1305(dek, contentNonce, aad)
   const plaintext = contentCipher.decrypt(ciphertext)
 

--- a/frontend/src/utils/crypto/envelopeEncryption.js
+++ b/frontend/src/utils/crypto/envelopeEncryption.js
@@ -29,7 +29,8 @@ import {
   ENVELOPE_INFO,
   XWING_ENVELOPE_INFO,
   XWING_ALGORITHM,
-  SUPPORTED_ALGORITHMS
+  SUPPORTED_ALGORITHMS,
+  buildTermsAAD
 } from './constants.js'
 
 // ==================== X-Wing Hybrid KEM Implementation ====================
@@ -292,17 +293,21 @@ export function deriveXWingKeyPairFromSignature(signature) {
  * @param {number} [signingVersion=CURRENT_ENCRYPTION_VERSION] - Signing message version used for key derivation
  * @returns {Object} - Encrypted envelope with version info
  */
-export function encryptEnvelope(data, recipients, signingVersion = CURRENT_ENCRYPTION_VERSION) {
+export function encryptEnvelope(data, recipients, signingVersion = CURRENT_ENCRYPTION_VERSION, termsVersion = null) {
   // 1. Generate random Data Encryption Key (DEK)
   const dek = randomBytes(32)
 
-  // 2. Encrypt the content with DEK
+  // 2. Encrypt the content with DEK.
+  //    Spec 007 (FR-056): bind the governing T&C version hash as ChaCha20-Poly1305 AAD so
+  //    the `termsVersion` field below is tamper-evident. Omitting termsVersion ⇒ aad
+  //    undefined ⇒ byte-identical to legacy (no behavior change for existing callers).
   const plaintext = typeof data === 'string'
     ? utf8ToBytes(data)
     : utf8ToBytes(JSON.stringify(data))
 
+  const aad = termsVersion?.hash ? buildTermsAAD('1.0', termsVersion.hash) : undefined
   const contentNonce = randomBytes(12)
-  const cipher = chacha20poly1305(dek, contentNonce)
+  const cipher = chacha20poly1305(dek, contentNonce, aad)
   const encryptedContent = cipher.encrypt(plaintext)
 
   // 3. Encrypt DEK for each recipient using X25519 + HKDF + ChaCha20
@@ -336,6 +341,9 @@ export function encryptEnvelope(data, recipients, signingVersion = CURRENT_ENCRY
     algorithm: 'x25519-chacha20poly1305',
     // Store the signing message version for decryption
     signingVersion: signingVersion,
+    // Spec 007 (FR-056): authenticated governing-terms binding (present only when supplied).
+    // Authenticated via AAD above; tampering with this field fails decryption.
+    ...(termsVersion?.hash ? { termsVersion: { id: termsVersion.id ?? null, hash: termsVersion.hash } } : {}),
     content: {
       nonce: bytesToHex(contentNonce),
       ciphertext: bytesToHex(encryptedContent)
@@ -377,10 +385,13 @@ export function decryptEnvelope(envelope, myAddress, myPrivateKey) {
   const keyCipher = chacha20poly1305(kek, keyNonce)
   const dek = keyCipher.decrypt(wrappedKey)
 
-  // Decrypt the content
+  // Decrypt the content. Spec 007 (FR-056): if the envelope carries a governing-terms
+  // binding, reconstruct the AAD from the authenticated field so a tampered termsVersion
+  // fails authentication. Legacy envelopes (no termsVersion) decrypt with no AAD as before.
   const contentNonce = hexToBytes(envelope.content.nonce)
   const ciphertext = hexToBytes(envelope.content.ciphertext)
-  const contentCipher = chacha20poly1305(dek, contentNonce)
+  const aad = envelope.termsVersion?.hash ? buildTermsAAD(envelope.version, envelope.termsVersion.hash) : undefined
+  const contentCipher = chacha20poly1305(dek, contentNonce, aad)
   const plaintext = contentCipher.decrypt(ciphertext)
 
   // Parse as JSON if possible
@@ -469,17 +480,19 @@ export function removeRecipient(envelope, addressToRemove) {
  * @param {number} [signingVersion=CURRENT_ENCRYPTION_VERSION] - Signing message version
  * @returns {Object} - X-Wing encrypted envelope (v2.0)
  */
-export function encryptEnvelopeXWing(data, recipients, signingVersion = CURRENT_ENCRYPTION_VERSION) {
+export function encryptEnvelopeXWing(data, recipients, signingVersion = CURRENT_ENCRYPTION_VERSION, termsVersion = null) {
   // 1. Generate random Data Encryption Key (DEK)
   const dek = randomBytes(32)
 
-  // 2. Encrypt the content with DEK (same as v1.0)
+  // 2. Encrypt the content with DEK (same as v1.0). Spec 007 (FR-056): governing-terms
+  //    AAD binding when termsVersion is supplied; omitted ⇒ identical to legacy.
   const plaintext = typeof data === 'string'
     ? utf8ToBytes(data)
     : utf8ToBytes(JSON.stringify(data))
 
+  const aad = termsVersion?.hash ? buildTermsAAD('2.0', termsVersion.hash) : undefined
   const contentNonce = randomBytes(12)
-  const cipher = chacha20poly1305(dek, contentNonce)
+  const cipher = chacha20poly1305(dek, contentNonce, aad)
   const encryptedContent = cipher.encrypt(plaintext)
 
   // 3. Wrap DEK for each recipient using X-Wing KEM
@@ -508,6 +521,7 @@ export function encryptEnvelopeXWing(data, recipients, signingVersion = CURRENT_
     version: '2.0',
     algorithm: XWING_ALGORITHM,
     signingVersion: signingVersion,
+    ...(termsVersion?.hash ? { termsVersion: { id: termsVersion.id ?? null, hash: termsVersion.hash } } : {}),
     content: {
       nonce: bytesToHex(contentNonce),
       ciphertext: bytesToHex(encryptedContent)
@@ -549,10 +563,13 @@ export function decryptEnvelopeXWing(envelope, myAddress, mySecretKey) {
   const keyCipher = chacha20poly1305(kek, keyNonce)
   const dek = keyCipher.decrypt(wrappedKey)
 
-  // Decrypt the content
+  // Decrypt the content. Spec 007 (FR-056): if the envelope carries a governing-terms
+  // binding, reconstruct the AAD from the authenticated field so a tampered termsVersion
+  // fails authentication. Legacy envelopes (no termsVersion) decrypt with no AAD as before.
   const contentNonce = hexToBytes(envelope.content.nonce)
   const ciphertext = hexToBytes(envelope.content.ciphertext)
-  const contentCipher = chacha20poly1305(dek, contentNonce)
+  const aad = envelope.termsVersion?.hash ? buildTermsAAD(envelope.version, envelope.termsVersion.hash) : undefined
+  const contentCipher = chacha20poly1305(dek, contentNonce, aad)
   const plaintext = contentCipher.decrypt(ciphertext)
 
   // Parse as JSON if possible
@@ -712,14 +729,14 @@ function generateEphemeralKeyPair() {
  * @param {number} [signingVersion=CURRENT_ENCRYPTION_VERSION] - Signing message version
  * @returns {Object} - Encrypted envelope ready for IPFS
  */
-export function encryptMarketMetadata(metadata, participants, signingVersion = CURRENT_ENCRYPTION_VERSION) {
+export function encryptMarketMetadata(metadata, participants, signingVersion = CURRENT_ENCRYPTION_VERSION, termsVersion = null) {
   // Convert signatures to public keys
   const recipients = participants.map(p => ({
     address: p.address,
     publicKey: publicKeyFromSignature(p.signature)
   }))
 
-  return encryptEnvelope(metadata, recipients, signingVersion)
+  return encryptEnvelope(metadata, recipients, signingVersion, termsVersion)
 }
 
 /**
@@ -769,14 +786,14 @@ export function getEnvelopeSigningVersion(envelope) {
  * @param {string} creatorAddress - Creator's address
  * @returns {Promise<{envelope: Object, creatorSignature: string, signingVersion: number}>}
  */
-export async function createEncryptedMarket(metadata, signer, creatorAddress) {
+export async function createEncryptedMarket(metadata, signer, creatorAddress, termsVersion = null) {
   // Use current version for new markets
   const { signature, version } = await deriveKeyPair(signer, CURRENT_ENCRYPTION_VERSION)
 
   // Start with just creator as recipient
   const envelope = encryptMarketMetadata(metadata, [
     { address: creatorAddress, signature }
-  ], version)
+  ], version, termsVersion)
 
   return {
     envelope,
@@ -831,14 +848,14 @@ export async function addParticipantToMarket(envelope, existingAddress, existing
  * @param {number} [signingVersion=CURRENT_ENCRYPTION_VERSION] - Signing message version
  * @returns {Object} - X-Wing encrypted envelope
  */
-export function encryptMarketMetadataXWing(metadata, participants, signingVersion = CURRENT_ENCRYPTION_VERSION) {
+export function encryptMarketMetadataXWing(metadata, participants, signingVersion = CURRENT_ENCRYPTION_VERSION, termsVersion = null) {
   // Convert signatures to X-Wing public keys
   const recipients = participants.map(p => ({
     address: p.address,
     publicKey: xwingPublicKeyFromSignature(p.signature)
   }))
 
-  return encryptEnvelopeXWing(metadata, recipients, signingVersion)
+  return encryptEnvelopeXWing(metadata, recipients, signingVersion, termsVersion)
 }
 
 /**
@@ -849,14 +866,14 @@ export function encryptMarketMetadataXWing(metadata, participants, signingVersio
  * @param {string} creatorAddress - Creator's address
  * @returns {Promise<{envelope: Object, creatorSignature: string, signingVersion: number}>}
  */
-export async function createEncryptedMarketXWing(metadata, signer, creatorAddress) {
+export async function createEncryptedMarketXWing(metadata, signer, creatorAddress, termsVersion = null) {
   // Use current version for new markets
   const { signature, version } = await deriveXWingKeyPair(signer, CURRENT_ENCRYPTION_VERSION)
 
   // Start with just creator as recipient
   const envelope = encryptMarketMetadataXWing(metadata, [
     { address: creatorAddress, signature }
-  ], version)
+  ], version, termsVersion)
 
   return {
     envelope,

--- a/frontend/src/utils/keyRegistryService.js
+++ b/frontend/src/utils/keyRegistryService.js
@@ -10,6 +10,7 @@
 import { ethers } from 'ethers'
 import { KEY_REGISTRY_ABI } from '../abis/KeyRegistry'
 import { getContractAddress } from '../config/contracts'
+import { getCurrentDocument } from './legalDocs'
 
 // In-memory cache: address → { publicKeyHex, timestamp }
 const keyCache = new Map()
@@ -139,7 +140,21 @@ export async function registerEncryptionKey(signer, publicKeyBytes) {
 
   const contract = new ethers.Contract(address, KEY_REGISTRY_ABI, signer)
   // Both old ZKKeyManager (string param) and new KeyRegistry (bytes param) accept a 0x-prefixed hex string.
-  const tx = await contract.registerKey('0x' + publicKeyHex)
+  // Spec 007 (FR-043): when the KeyRegistry supports it, record the eligibility ack on-chain
+  // referencing the in-force Terms version hash. Fall back to plain registerKey for older
+  // deployments that lack the overload (pre-redeploy).
+  const termsHash = getCurrentDocument('terms')?.hash
+  let tx
+  if (termsHash && typeof contract.registerKeyWithEligibility === 'function') {
+    try {
+      tx = await contract.registerKeyWithEligibility('0x' + publicKeyHex, '0x' + termsHash)
+    } catch (e) {
+      console.warn('registerKeyWithEligibility unavailable on-chain; falling back to registerKey:', e?.message)
+      tx = await contract.registerKey('0x' + publicKeyHex)
+    }
+  } else {
+    tx = await contract.registerKey('0x' + publicKeyHex)
+  }
   const receipt = await tx.wait()
 
   // Invalidate cache for this user

--- a/frontend/src/utils/legalDocs.js
+++ b/frontend/src/utils/legalDocs.js
@@ -1,0 +1,149 @@
+/**
+ * Legal document versioning (Spec 007 — FR-018/FR-020/FR-026/FR-059).
+ *
+ * The version identifier of a legal document IS the SHA-256 hash of its canonicalized
+ * content. The canonicalization below is FROZEN and documented so the hash is
+ * independently reproducible by a third party (auditor/court) decades later:
+ *
+ *   1. Unicode NFC normalization
+ *   2. Newlines normalized to LF (CRLF and lone CR -> LF)
+ *   3. Trim leading/trailing whitespace
+ *   4. UTF-8 encode
+ *   5. SHA-256, lowercase hex
+ *
+ * This same canonicalization is reused to compute the `termsVersion.hash` bound into a
+ * wager's encrypted metadata (see utils/crypto/envelopeEncryption.js, FR-056).
+ *
+ * NOTE: changing any step changes every hash — never modify it; introduce a new,
+ * explicitly-versioned canonicalization if ever required.
+ */
+
+import { sha256 } from '@noble/hashes/sha256'
+import { bytesToHex, utf8ToBytes } from '@noble/ciphers/utils'
+
+// Versioned document sources (Vite ?raw). Each VERSION is pinned to IPFS per-version (not
+// per-event) and recorded on-chain by hash at consent (Spec 007, FR-017–FR-030).
+import termsRaw from '../legal/terms.md?raw'
+import riskRaw from '../legal/risk-disclosure.md?raw'
+import privacyRaw from '../legal/privacy-policy.md?raw'
+
+/** The frozen canonicalization algorithm identifier (for documentation/audit). */
+export const CANONICALIZATION_VERSION = 'nfc-lf-utf8-trim-v1'
+
+/**
+ * Canonicalize legal-document text to the frozen byte form that gets hashed.
+ * @param {string} text - the raw published document text
+ * @returns {string} canonical text (still a JS string; encode to bytes to hash)
+ */
+export function canonicalizeDocText(text) {
+  if (typeof text !== 'string') {
+    throw new TypeError('canonicalizeDocText expects a string')
+  }
+  return text
+    .normalize('NFC')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .trim()
+}
+
+/**
+ * Compute the SHA-256 version hash (lowercase hex) of a legal document's content.
+ * @param {string} text - the raw published document text
+ * @returns {string} 64-char lowercase hex digest
+ */
+export function hashDocVersion(text) {
+  const canonical = canonicalizeDocText(text)
+  return bytesToHex(sha256(utf8ToBytes(canonical)))
+}
+
+/**
+ * Verify that a piece of served document content matches a claimed version hash.
+ * @param {string} text - served document text
+ * @param {string} expectedHashHex - the claimed version hash (case-insensitive)
+ * @returns {boolean}
+ */
+export function verifyDocVersion(text, expectedHashHex) {
+  if (typeof expectedHashHex !== 'string') return false
+  return hashDocVersion(text) === expectedHashHex.toLowerCase()
+}
+
+/**
+ * ==========================================================================
+ * Version manifest (Spec 007 — FR-017/FR-025/FR-028/FR-030)
+ * ==========================================================================
+ * The registry holds, per document type, the CURRENT content plus any historical
+ * versions (retrievable by hash). For v1 only the current version exists; historical
+ * versions are appended here when the content changes so prior versions stay retrievable.
+ *
+ * `material` is the operator-set re-consent flag (FR-030) — DISTINCT from the content
+ * hash: re-consent is driven by this flag, not by hash inequality, so an immaterial edit
+ * does not force re-consent.
+ */
+export const DOC_TYPES = /** @type {const} */ (['terms', 'risk', 'privacy'])
+
+const REGISTRY = {
+  terms: { label: 'Terms & Conditions', route: '/terms', current: termsRaw, material: true, historical: [] },
+  risk: { label: 'Risk Disclosure', route: '/risk', current: riskRaw, material: true, historical: [] },
+  privacy: { label: 'Privacy Policy', route: '/privacy', current: privacyRaw, material: true, historical: [] },
+  // historical: array of { content, material } previously published; retained for retrieval.
+}
+
+function makeVersion(docType, content, material) {
+  const hash = hashDocVersion(content)
+  return { docType, id: `${docType}@${hash.slice(0, 16)}`, hash, content, material }
+}
+
+/**
+ * The currently-published version of a document.
+ * @param {'terms'|'risk'|'privacy'} docType
+ * @returns {{docType, label, route, id, hash, content, material}|null}
+ */
+export function getCurrentDocument(docType) {
+  const d = REGISTRY[docType]
+  if (!d) return null
+  return { label: d.label, route: d.route, ...makeVersion(docType, d.current, d.material) }
+}
+
+/**
+ * Retrieve a specific version (current or historical) of a document by its hash.
+ * @returns {{docType, id, hash, content, material}|null}
+ */
+export function getDocumentByHash(docType, hash) {
+  const d = REGISTRY[docType]
+  if (!d || typeof hash !== 'string') return null
+  const want = hash.toLowerCase()
+  for (const content of [d.current, ...d.historical.map((h) => h.content)]) {
+    if (hashDocVersion(content) === want) {
+      const material = content === d.current ? d.material : d.historical.find((h) => h.content === content)?.material
+      return makeVersion(docType, content, Boolean(material))
+    }
+  }
+  return null
+}
+
+/**
+ * All retained versions of a document (current first), newest-known ordering.
+ * @returns {Array<{docType,id,hash,material}>}
+ */
+export function listVersions(docType) {
+  const d = REGISTRY[docType]
+  if (!d) return []
+  const cur = makeVersion(docType, d.current, d.material)
+  const hist = d.historical.map((h) => makeVersion(docType, h.content, h.material))
+  return [cur, ...hist].map(({ content: _content, ...meta }) => meta) // omit content from the list
+}
+
+/**
+ * Whether a returning user must re-consent: only when the in-force version is flagged
+ * MATERIAL and the user's previously-acknowledged hash differs from the current hash
+ * (FR-030). An immaterial change never forces re-consent.
+ * @param {'terms'|'risk'|'privacy'} docType
+ * @param {string} acknowledgedHash - the hash the user previously acknowledged (or '')
+ * @returns {boolean}
+ */
+export function requiresReconsent(docType, acknowledgedHash) {
+  const cur = getCurrentDocument(docType)
+  if (!cur) return false
+  if ((acknowledgedHash || '').toLowerCase() === cur.hash) return false
+  return Boolean(cur.material)
+}

--- a/frontend/src/utils/sanctionsScreen.js
+++ b/frontend/src/utils/sanctionsScreen.js
@@ -1,0 +1,54 @@
+/**
+ * Advisory client-side sanctions screening (Spec 007 — FR-016).
+ *
+ * This is a UX-only pre-check: it reads the on-chain SanctionsGuard so the UI can warn /
+ * block early before a user spends gas. It is NOT the enforcement layer — the on-chain
+ * guard in WagerRegistry/MembershipManager (FR-054) is what actually prevents a sanctioned
+ * address from proceeding, even if this client check is bypassed.
+ *
+ * Fail-closed UX: if the guard address isn't configured or the read fails, we return
+ * `available: false` so the UI does NOT claim the address is "clear" (it should surface an
+ * uncertain/blocked state rather than green-light).
+ */
+
+import { ethers } from 'ethers'
+import { SANCTIONS_GUARD_ABI } from '../abis/SanctionsGuard'
+import { getContractAddress } from '../config/contracts'
+
+/**
+ * Screen using an already-constructed guard contract (testable seam).
+ * @param {{ isAllowed: (a: string) => Promise<boolean> }} guard
+ * @param {string} account
+ * @returns {Promise<{ allowed: boolean, available: boolean }>}
+ */
+export async function screenWithContract(guard, account) {
+  try {
+    const allowed = await guard.isAllowed(account)
+    return { allowed: Boolean(allowed), available: true }
+  } catch {
+    return { allowed: false, available: false } // fail-closed UX
+  }
+}
+
+/**
+ * Screen an address against the configured on-chain SanctionsGuard.
+ * @param {string} account - wallet address to screen
+ * @param {import('ethers').Provider} provider - a read provider
+ * @returns {Promise<{ allowed: boolean, available: boolean }>}
+ */
+export async function screenAddress(account, provider) {
+  const address = getContractAddress('sanctionsGuard')
+  if (!address) return { allowed: false, available: false } // not configured -> can't screen
+  const guard = new ethers.Contract(address, SANCTIONS_GUARD_ABI, provider)
+  return screenWithContract(guard, account)
+}
+
+/**
+ * Convenience: true only when the address was successfully screened AND is allowed.
+ * An unavailable result is treated as not-clear (fail-closed).
+ * @param {{ allowed: boolean, available: boolean }} result
+ * @returns {boolean}
+ */
+export function isClear(result) {
+  return Boolean(result && result.available && result.allowed)
+}

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -1,0 +1,17 @@
+# Cloudflare edge configuration (Spec 007 — Compliance & Legal Gating)
+
+Edge-side configuration for the geo gate and the nginx origin lock. **No new GCP infra**
+(no load balancer / Cloud Armor) — these are Cloudflare zone settings on `fairwins.app`
+(proxied / orange-cloud) consumed by the existing nginx on Cloud Run.
+
+| File | Purpose | Spec |
+|------|---------|------|
+| [`waf-geo.md`](./waf-geo.md) | WAF custom rule: country gate → HTTP 451 | FR-001–FR-014, SC-001/003/013 |
+| [`origin-lock.md`](./origin-lock.md) | Transform Rule: inject `X-Origin-Auth` secret header | FR-007/FR-008, SC-002/012 |
+
+The origin lock is enforced in `frontend/nginx.conf.template` (verified by
+`docker-entrypoint.sh` only when `ORIGIN_LOCK_SECRET` is set). The 451 body lives at
+`frontend/public/451.html` (or as the Cloudflare custom response body).
+
+> These runbooks can be promoted to IaC (Terraform `cloudflare_ruleset`) later; for now
+> they are the source of truth for the manual/staged dashboard configuration.

--- a/infra/cloudflare/origin-lock.md
+++ b/infra/cloudflare/origin-lock.md
@@ -1,0 +1,57 @@
+# Cloudflare origin lock — secret header (Spec 007: FR-007/FR-008)
+
+Goal: the Cloud Run origin serves only requests that came **through Cloudflare**, so nobody
+can hit the origin directly and bypass the geo gate. A bare Cloudflare-egress-IP allowlist
+is **insufficient** (those IPs are shared across all Cloudflare tenants and could be used to
+spoof `CF-IPCountry`). We authenticate the edge with a high-entropy shared secret header.
+
+## 1. Secret (Secret Manager → Cloud Run env, like the Pinata JWT)
+
+- Generate: `openssl rand -hex 32`.
+- Store in GCP Secret Manager, e.g. secret name `origin-lock-secret`.
+- Expose to the Cloud Run service as env var **`ORIGIN_LOCK_SECRET`** (Cloud Run → Edit &
+  deploy → Variables & Secrets → reference the secret). The container entrypoint then
+  enables enforcement automatically (`ORIGIN_LOCK_ENABLED=1`).
+- Optionally wire it declaratively in `cloudbuild.yaml`'s deploy step once the secret exists:
+
+  ```
+  - '--update-secrets'
+  - 'ORIGIN_LOCK_SECRET=origin-lock-secret:latest'
+  ```
+
+  (Left out of `cloudbuild.yaml` by default so deploys don't fail before the secret is created.)
+
+## 2. Cloudflare Transform Rule (inject the header)
+
+Rules → Transform Rules → **Modify Request Header** → When incoming requests match: *All
+incoming requests* → **Set static**:
+
+- Header name: `X-Origin-Auth`
+- Value: the same secret value stored above.
+
+(Up to 30 headers per rule; rotate the secret periodically — update Secret Manager and the
+Transform Rule together.)
+
+## 3. Enforcement (already implemented in this repo)
+
+`frontend/nginx.conf.template` maps `${ORIGIN_LOCK_ENABLED}:$http_x_origin_auth` to
+`$origin_denied` and returns **403** on mismatch in every served location; `/healthz` is
+exempt for probes. `docker-entrypoint.sh` sets `ORIGIN_LOCK_ENABLED=1` only when the secret
+is present (so dev/local stay open). The secret is never logged.
+
+## 4. Verify (SC-002 / SC-012)
+
+- [ ] Direct request to the `*.run.app` origin URL **without** `X-Origin-Auth` → 403.
+- [ ] Direct request with a wrong `X-Origin-Auth` → 403.
+- [ ] Request through `fairwins.app` (Cloudflare injects the header) → 200.
+- [ ] `GET /healthz` → 200 regardless (probe exemption).
+
+(Runtime-verified locally during implementation: no-header→403, wrong→403, correct→200,
+healthz→200; disabled state allows all.)
+
+## Future hardening (outside the current footprint — documented only)
+
+Cloud Run ingress `internal-and-cloud-load-balancing` + a Global External ALB with
+**frontend mTLS** (Certificate Manager trust config) validating Cloudflare Authenticated
+Origin Pulls is the strongest cryptographic origin lock, but it adds an ALB + Cloud Armor
+(new infra) and is therefore out of scope for v1.

--- a/infra/cloudflare/waf-geo.md
+++ b/infra/cloudflare/waf-geo.md
@@ -1,0 +1,64 @@
+# Cloudflare WAF — geographic access gate (Spec 007: FR-001–FR-014)
+
+**Zone**: `fairwins.app` (must be **proxied / orange-cloud** — DNS-only records cannot be
+filtered). Security → WAF → Custom rules.
+
+## Rule: geo gate (allowlist posture — default)
+
+- **Field**: `ip.src.country` (ISO 3166-1 alpha-2). Cloudflare resolves this from the true
+  client IP (only the edge sees it). `XX` = unknown, `T1` = Tor.
+- **Expression (allowlist, recommended)**:
+
+  ```
+  not (ip.src.country in {"<ALLOWED_COUNTRIES…>"})
+  ```
+
+  → **Action: Block**. (Denylist alternative: `(ip.src.country in {"CU" "IR" "KP" "SY" …})` → Block.)
+
+- The **deny set always includes**, regardless of posture (FR-003/FR-004):
+  - OFAC-comprehensive: `CU` (Cuba), `IR` (Iran), `KP` (North Korea), `SY` (Syria) — plus
+    occupied-region handling (below).
+  - `US` (United States) under the current posture (revisit only if a regulated route is adopted).
+- The **tunable bucket** (FR-005, gambling/prediction-market bans, e.g. `FR` `BE` `SG`) is
+  edited in this same rule's country set — no code change/deploy needed.
+- Country blocking via **custom rules works on all Cloudflare plans**.
+
+## Block response → HTTP 451 (FR-006)
+
+- Custom response: **status 451**, body type Custom HTML, body = contents of
+  `frontend/public/451.html` (≤2 KB). Custom response bodies require **Pro plan or above**;
+  on Free, country blocking still works but only with the default block page.
+- Cloud Armor cannot emit 451 (deny actions are 403/404/502), which is another reason the
+  451 lives at Cloudflare.
+
+## Occupied regions — conservative matching (FR-013)
+
+Crimea / Donetsk / Luhansk IP ranges are frequently mislabeled as `RU`/`UA`. Treat
+ambiguous ranges that may cover these regions as **denied**. Where Cloudflare exposes
+region/subdivision (`ip.src.region_code`), add a subdivision rule; otherwise document the
+residual risk and prefer the allowlist posture (which denies anything not explicitly allowed).
+
+## Fail-closed (FR-012)
+
+- Allowlist posture inherently denies `XX` (unknown) — it isn't in the allowed set.
+- If the WAF rule cannot evaluate (edge issue), the request should not be served ungated;
+  validate this during the staging step.
+
+## Staging procedure (FR-011) & verification checklist (SC-001/003/013)
+
+1. Create the rule with action **Log** (observe) first; confirm in Security → Events that the
+   intended countries *would* be blocked, with no false positives on allowed countries.
+2. Switch the action to **Block** (451).
+3. Verify (T012 checklist):
+   - [ ] Request from an allowed country → served (200).
+   - [ ] Request from `CU`/`IR`/`KP`/`SY` → 451.
+   - [ ] Request from `US` → 451.
+   - [ ] Request from a tunable-bucket country → 451.
+   - [ ] 451 response shows the human-readable legal-reason page (not a generic error).
+   - [ ] Unknown/`XX` source → denied.
+
+## Periodic OFAC reconciliation (FR-014)
+
+Quarterly (or on OFAC action), reconcile the locked comprehensively-sanctioned set in this
+rule against the authoritative OFAC sanctions program list; record any additions in this
+file's change history. (Covers analysis finding C2 — see spec Open Legal-Reconciliation Items.)

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "sync:frontend-contracts": "node scripts/utils/sync-frontend-contracts.js --network mordor --chainId 63",
     "sync:frontend-contracts:amoy": "node scripts/utils/sync-frontend-contracts.js --network amoy --chainId 80002",
     "sync:frontend-contracts:polygon": "node scripts/utils/sync-frontend-contracts.js --network polygon --chainId 137",
+    "migrate:memberships:polygon": "hardhat run scripts/operations/migrate-memberships-007.js --network polygon",
+    "lockdown:polygon": "hardhat run scripts/operations/prelaunch-lockdown-007.js --network polygon",
     "sync:frontend-contracts:local": "node scripts/utils/sync-frontend-contracts.js --network localhost --chainId 1337",
     "test:frontend": "npm --prefix frontend run test:run",
     "lock:sync": "npm install --package-lock-only && npm --prefix frontend install --package-lock-only",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "deploy:amoy": "hardhat run scripts/deploy/01-deploy-core.js --network amoy && hardhat run scripts/deploy/02-deploy-rbac.js --network amoy && hardhat run scripts/deploy/03-deploy-markets.js --network amoy && hardhat run scripts/deploy/04-deploy-registries.js --network amoy && hardhat run scripts/deploy/05-configure.js --network amoy && hardhat run scripts/deploy/06-verify.js --network amoy",
     "sync:frontend-contracts": "node scripts/utils/sync-frontend-contracts.js --network mordor --chainId 63",
     "sync:frontend-contracts:amoy": "node scripts/utils/sync-frontend-contracts.js --network amoy --chainId 80002",
+    "sync:frontend-contracts:polygon": "node scripts/utils/sync-frontend-contracts.js --network polygon --chainId 137",
     "sync:frontend-contracts:local": "node scripts/utils/sync-frontend-contracts.js --network localhost --chainId 1337",
     "test:frontend": "npm --prefix frontend run test:run",
     "lock:sync": "npm install --package-lock-only && npm --prefix frontend install --package-lock-only",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "deploy:mordor": "hardhat run scripts/deploy/deploy-deterministic.js --network mordor",
     "deploy:deterministic": "hardhat run scripts/deploy/deploy-deterministic.js",
     "deploy:amoy": "hardhat run scripts/deploy/01-deploy-core.js --network amoy && hardhat run scripts/deploy/02-deploy-rbac.js --network amoy && hardhat run scripts/deploy/03-deploy-markets.js --network amoy && hardhat run scripts/deploy/04-deploy-registries.js --network amoy && hardhat run scripts/deploy/05-configure.js --network amoy && hardhat run scripts/deploy/06-verify.js --network amoy",
+    "deploy:polygon": "hardhat run scripts/deploy/deploy.js --network polygon",
     "sync:frontend-contracts": "node scripts/utils/sync-frontend-contracts.js --network mordor --chainId 63",
     "sync:frontend-contracts:amoy": "node scripts/utils/sync-frontend-contracts.js --network amoy --chainId 80002",
     "sync:frontend-contracts:polygon": "node scripts/utils/sync-frontend-contracts.js --network polygon --chainId 137",

--- a/scripts/deploy/deploy.js
+++ b/scripts/deploy/deploy.js
@@ -243,6 +243,58 @@ async function main() {
   }
   const wagerRegistry = regDeploy.contract;
 
+  // -------- SanctionsGuard (Spec 007, FR-054) --------
+  // Resolve the Chainalysis on-chain Sanctions Oracle per chain. Mainnet 137 has the real
+  // oracle; Amoy/local have none, so deploy a MockSanctionsOracle there (mocks confined to
+  // contracts/mocks; never used on a mainnet path — constitution III / FR-022). Address is
+  // injected, never hardcoded in the contract (FR-055).
+  const CHAINALYSIS_ORACLE = { 137: "0x40C57923924B5c5c5455c48D93317139ADDaC8fb" };
+  let sanctionsOracleAddr =
+    process.env[`CHAINALYSIS_SANCTIONS_ORACLE_${chainId}`] || CHAINALYSIS_ORACLE[chainId];
+  if (sanctionsOracleAddr && !ethers.isAddress(sanctionsOracleAddr)) {
+    throw new Error(`CHAINALYSIS_SANCTIONS_ORACLE_${chainId} is not a valid address: ${sanctionsOracleAddr}`);
+  }
+  if (!sanctionsOracleAddr) {
+    if (isMainnet) {
+      throw new Error(
+        `A Chainalysis sanctions oracle address is required on mainnet '${networkName}' (chainId ${chainId}). ` +
+          `Set CHAINALYSIS_SANCTIONS_ORACLE_${chainId} or add it to CHAINALYSIS_ORACLE in deploy.js.`
+      );
+    }
+    console.log(`\nNo Chainalysis oracle on ${networkName}; deploying MockSanctionsOracle...`);
+    const mockOracle = await deployDeterministic(
+      "MockSanctionsOracle",
+      [],
+      generateSalt(SALT_PREFIXES.V2 + "MockSanctionsOracle"),
+      deployer
+    );
+    sanctionsOracleAddr = mockOracle.address;
+    deployments.mockSanctionsOracle = mockOracle.address;
+  }
+  console.log(`Chainalysis Sanctions Oracle: ${sanctionsOracleAddr}`);
+
+  const guardDeploy = await deployDeterministic(
+    "SanctionsGuard",
+    [deployer.address, sanctionsOracleAddr],
+    generateSalt(SALT_PREFIXES.V2 + "SanctionsGuard"),
+    deployer
+  );
+  deployments.sanctionsGuard = guardDeploy.address;
+
+  // Wire the guard into both fund contracts (idempotent: skip if already pointing at it).
+  if ((await wagerRegistry.sanctionsGuard()).toLowerCase() !== guardDeploy.address.toLowerCase()) {
+    console.log("\nWiring SanctionsGuard into WagerRegistry...");
+    const tx = await wagerRegistry.connect(deployer).setSanctionsGuard(guardDeploy.address);
+    await tx.wait();
+    console.log("  ✓ WagerRegistry screens create/accept");
+  }
+  if ((await membershipManager.sanctionsGuard()).toLowerCase() !== guardDeploy.address.toLowerCase()) {
+    console.log("Wiring SanctionsGuard into MembershipManager...");
+    const tx = await membershipManager.connect(deployer).setSanctionsGuard(guardDeploy.address);
+    await tx.wait();
+    console.log("  ✓ MembershipManager screens purchase/upgrade/extend");
+  }
+
   // -------- Chainlink + UMA oracle adapters --------
   // Each adapter is only deployed when its required network config resolves.
   // Skipped adapters log a reason; the WagerRegistry just won't accept that

--- a/scripts/deploy/deploy.js
+++ b/scripts/deploy/deploy.js
@@ -409,13 +409,15 @@ async function main() {
       membershipManager: mgrDeploy.address,
       wagerRegistry: regDeploy.address,
       keyRegistry: keyDeploy.address,
+      sanctionsGuard: guardDeploy.address,
       ...oracleDeployments,
     },
-    mocks: deployments.mockUSDC || deployments.mockWMATIC || deployments.polymarketCTF
+    mocks: deployments.mockUSDC || deployments.mockWMATIC || deployments.polymarketCTF || deployments.mockSanctionsOracle
       ? {
           mockUSDC: deployments.mockUSDC,
           mockWMATIC: deployments.mockWMATIC,
           mockPolymarketCTF: deployments.polymarketCTF,
+          mockSanctionsOracle: deployments.mockSanctionsOracle,
         }
       : null,
     saltPrefix: SALT_PREFIXES.V2,

--- a/scripts/deploy/deploy.js
+++ b/scripts/deploy/deploy.js
@@ -134,8 +134,14 @@ async function main() {
 
   await ensureSingletonFactory();
 
-  const [deployer] = await ethers.getSigners();
-  if (!deployer) throw new Error(`No signer for network '${networkName}'`);
+  const [rawDeployer] = await ethers.getSigners();
+  if (!rawDeployer) throw new Error(`No signer for network '${networkName}'`);
+  // Wrap the signer in a client-side NonceManager so a sequence of txs doesn't
+  // re-fetch a stale nonce from a load-balanced public RPC (the "nonce too low"
+  // failure mode). The base nonce is fetched once, then incremented locally.
+  const { NonceManager } = require("ethers");
+  const deployer = new NonceManager(rawDeployer);
+  deployer.address = await rawDeployer.getAddress();
   const balance = await ethers.provider.getBalance(deployer.address);
   console.log(`\nDeployer: ${deployer.address}`);
   console.log(`Balance:  ${ethers.formatEther(balance)} ${networkName === "amoy" ? "POL" : "ETH"}`);
@@ -212,7 +218,7 @@ async function main() {
   deployments.membershipManager = mgrDeploy.address;
   const membershipManager = mgrDeploy.contract;
 
-  if (!mgrDeploy.alreadyDeployed) {
+  if (!mgrDeploy.alreadyDeployed || process.env.FORCE_SEED_TIERS === "true") {
     await seedTiers(membershipManager, deployer, ROLE_HASHES.WAGER_PARTICIPANT_ROLE, "WAGER_PARTICIPANT", WAGER_PARTICIPANT_TIERS);
   } else {
     console.log("\nMembershipManager already deployed — skipping tier seed (idempotent re-runs should re-seed manually if config changed)");

--- a/scripts/operations/migrate-memberships-007.js
+++ b/scripts/operations/migrate-memberships-007.js
@@ -31,7 +31,9 @@ const fs = require("fs");
 const path = require("path");
 
 const DAY = 86400n;
-const CHUNK = 45_000;
+// getLogs page size. Public RPCs cap the block range (e.g. publicnode = 10k),
+// so allow an override: LOG_CHUNK=9000 npm run migrate:memberships:polygon
+const CHUNK = Number(process.env.LOG_CHUNK || 45_000);
 
 const ABI = [
   "event MembershipPurchased(address indexed user, bytes32 indexed role, uint8 tier, uint128 price, uint64 expiresAt)",

--- a/scripts/operations/migrate-memberships-007.js
+++ b/scripts/operations/migrate-memberships-007.js
@@ -1,0 +1,115 @@
+/**
+ * Membership migration for Spec 007 cutover.
+ *
+ * The 007 redeploy creates a NEW MembershipManager (sanctions screening + on-chain terms
+ * recording). Existing active memberships live on the OLD contract. This script re-grants
+ * each still-active membership onto the NEW MembershipManager so members keep access after
+ * the cutover (full-cutover migration).
+ *
+ * SAFETY:
+ *   - DRY_RUN defaults to TRUE — it only LISTS what it would grant. Set DRY_RUN=false to execute.
+ *   - Idempotent: skips users already active on the new contract.
+ *   - Respects the new sanctions guard: grantMembership screens the grantee, so a sanctioned
+ *     old member is correctly NOT migrated (logged as skipped).
+ *   - Granting requires ROLE_MANAGER_ROLE on the NEW contract → run with the floppy keystore
+ *     admin on a production network.
+ *
+ * USAGE:
+ *   # dry run (default):
+ *   OLD_MEMBERSHIP_MANAGER=0x... START_BLOCK=<oldMMdeployBlock> \
+ *     npx hardhat run scripts/operations/migrate-memberships-007.js --network polygon
+ *   # execute (after reviewing the dry-run output), with the floppy mounted:
+ *   DRY_RUN=false OLD_MEMBERSHIP_MANAGER=0x... START_BLOCK=<oldMMdeployBlock> \
+ *     npx hardhat run scripts/operations/migrate-memberships-007.js --network polygon
+ *
+ * The NEW MembershipManager address is read from deployments/<network>-chain<id>-v2.json
+ * (written by the 007 deploy). The OLD address must be supplied (it is the pre-007 live one).
+ */
+const hre = require("hardhat");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+
+const DAY = 86400n;
+const CHUNK = 45_000;
+
+const ABI = [
+  "event MembershipPurchased(address indexed user, bytes32 indexed role, uint8 tier, uint128 price, uint64 expiresAt)",
+  "event MembershipGranted(address indexed user, bytes32 indexed role, uint8 tier, uint64 expiresAt)",
+  "function getMembership(address user, bytes32 role) view returns (tuple(uint8 tier, uint64 expiresAt, uint32 monthCount, uint64 monthAnchor, uint32 activeCount))",
+  "function grantMembership(address user, bytes32 role, uint8 tier, uint32 durationDays) external",
+];
+
+async function main() {
+  const net = hre.network.name;
+  const chainId = Number((await ethers.provider.getNetwork()).chainId);
+  const dryRun = (process.env.DRY_RUN ?? "true").toLowerCase() !== "false";
+  const oldAddr = process.env.OLD_MEMBERSHIP_MANAGER;
+  const startBlock = Number(process.env.START_BLOCK || 0);
+
+  if (!oldAddr || !ethers.isAddress(oldAddr)) {
+    throw new Error("Set OLD_MEMBERSHIP_MANAGER to the pre-007 MembershipManager address.");
+  }
+
+  const depFile = path.join(__dirname, "..", "..", "deployments", `${net}-chain${chainId}-v2.json`);
+  if (!fs.existsSync(depFile)) throw new Error(`Deployment file not found: ${depFile} (run the 007 deploy first).`);
+  const newAddr = JSON.parse(fs.readFileSync(depFile, "utf8")).contracts?.membershipManager;
+  if (!newAddr) throw new Error("membershipManager missing from deployment file.");
+  if (newAddr.toLowerCase() === oldAddr.toLowerCase()) throw new Error("OLD and NEW MembershipManager are identical — nothing to migrate.");
+
+  const [signer] = await ethers.getSigners();
+  console.log(`Network: ${net} (${chainId}) | DRY_RUN=${dryRun}`);
+  console.log(`OLD MembershipManager: ${oldAddr}`);
+  console.log(`NEW MembershipManager: ${newAddr}`);
+  console.log(`Signer: ${signer ? signer.address : "(none — dry run only)"}`);
+
+  const provider = ethers.provider;
+  const oldMM = new ethers.Contract(oldAddr, ABI, provider);
+  const newMM = new ethers.Contract(newAddr, ABI, signer || provider);
+
+  // 1. Enumerate unique (user, role) from the old contract's grant-creating events (paged).
+  const latest = await provider.getBlockNumber();
+  const seen = new Set();
+  const pairs = [];
+  for (const evName of ["MembershipPurchased", "MembershipGranted"]) {
+    const filter = oldMM.filters[evName]();
+    let to = latest;
+    while (to >= startBlock) {
+      const from = Math.max(startBlock, to - CHUNK + 1);
+      const logs = await oldMM.queryFilter(filter, from, to);
+      for (const l of logs) {
+        const k = `${l.args.user.toLowerCase()}|${l.args.role}`;
+        if (!seen.has(k)) { seen.add(k); pairs.push({ user: l.args.user, role: l.args.role }); }
+      }
+      if (from === startBlock) break;
+      to = from - 1;
+    }
+  }
+  console.log(`Found ${pairs.length} unique (user, role) memberships in old contract history.`);
+
+  // 2. Re-grant still-active ones onto the new contract (idempotent + sanctions-aware).
+  const now = BigInt(Math.floor(Date.now() / 1000));
+  let migrated = 0, skippedInactive = 0, skippedExisting = 0, blocked = 0, failed = 0;
+  for (const { user, role } of pairs) {
+    const m = await oldMM.getMembership(user, role);
+    if (Number(m.tier) === 0 || BigInt(m.expiresAt) <= now) { skippedInactive++; continue; }
+    const existing = await newMM.getMembership(user, role);
+    if (Number(existing.tier) !== 0 && BigInt(existing.expiresAt) > now) { skippedExisting++; continue; }
+    const remainingDays = Number((BigInt(m.expiresAt) - now + DAY - 1n) / DAY); // ceil
+    console.log(`  ${dryRun ? "[would grant]" : "[grant]"} ${user} role=${role.slice(0, 10)}… tier=${m.tier} days=${remainingDays}`);
+    if (dryRun) { migrated++; continue; }
+    try {
+      const tx = await newMM.grantMembership(user, role, m.tier, remainingDays);
+      await tx.wait();
+      migrated++;
+    } catch (e) {
+      const msg = e.shortMessage || e.message || "";
+      if (/Sanctioned/i.test(msg)) { blocked++; console.log(`    ↳ skipped (sanctioned): ${user}`); }
+      else { failed++; console.error(`    ↳ FAILED ${user}: ${msg}`); }
+    }
+  }
+  console.log(`\nSummary: ${dryRun ? "would migrate" : "migrated"}=${migrated} | already-active=${skippedExisting} | inactive=${skippedInactive} | sanctioned-blocked=${blocked} | failed=${failed}`);
+  if (dryRun) console.log("DRY RUN — no transactions sent. Re-run with DRY_RUN=false (floppy mounted) to execute.");
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/operations/prelaunch-lockdown-007.js
+++ b/scripts/operations/prelaunch-lockdown-007.js
@@ -91,7 +91,16 @@ async function main() {
   if (!wagerAddr) throw new Error("wagerRegistry missing from deployment file.");
   if (lockMemberships && !mmAddr) throw new Error("membershipManager missing from deployment file (or set LOCK_MEMBERSHIPS=false).");
 
-  const [signer] = await ethers.getSigners();
+  const [rawSigner] = await ethers.getSigners();
+  // Wrap in a client-side NonceManager so the sequential pause + setTier txs
+  // don't re-fetch a stale nonce from a load-balanced public RPC ("nonce too
+  // low"). The base nonce is fetched once, then incremented locally.
+  let signer = rawSigner;
+  if (rawSigner) {
+    const { NonceManager } = require("ethers");
+    signer = new NonceManager(rawSigner);
+    signer.address = await rawSigner.getAddress();
+  }
   console.log("=".repeat(64));
   console.log(`Pre-launch ${action.toUpperCase()} | ${net} (${chainId}) | DRY_RUN=${dryRun}`);
   console.log("=".repeat(64));

--- a/scripts/operations/prelaunch-lockdown-007.js
+++ b/scripts/operations/prelaunch-lockdown-007.js
@@ -1,0 +1,170 @@
+/**
+ * Pre-launch lockdown / unlock for the Spec 007 cutover.
+ *
+ * After the 007 contracts are deployed, wired, synced, and the membership
+ * migration has run, the app is still NOT live. Per the launch plan the new
+ * contracts must be PAUSED until go-live so no user can wager or buy a
+ * membership before everything (geo-block, sanctions wiring, frontend) is in
+ * place. This script applies — and later reverses — that lockdown.
+ *
+ * WHAT IT TOUCHES
+ *   - WagerRegistry IS Pausable. lock => pause(), unlock => unpause().
+ *     Pausing blocks createWager / acceptWager / batchExpireOpen. Exit paths
+ *     (claim, refund, draw) intentionally stay open even while paused.
+ *   - MembershipManager is NOT Pausable. To stop *purchases* we deactivate the
+ *     seeded WAGER_PARTICIPANT tiers (setTier active=false). purchaseTier /
+ *     upgradeTier / extendMembership revert with TierInactive() while inactive.
+ *     grantMembership does NOT check `active`, so the membership migration still
+ *     works during lockdown — that is deliberate. lock => active=false,
+ *     unlock => active=true. Price / duration / limits are read from the live
+ *     TierConfig and preserved across the toggle.
+ *   - KeyRegistry / SanctionsGuard have no pause concept and are left untouched
+ *     (key registration is harmless pre-launch; the guard should stay live).
+ *
+ * SAFETY
+ *   - DRY_RUN defaults to TRUE — it only PRINTS the planned actions.
+ *   - Idempotent: skips a step already in the target state (e.g. re-running lock
+ *     when already paused).
+ *   - Reversible: ACTION=unlock undoes everything for go-live.
+ *   - Requires GUARDIAN_ROLE (pause) and DEFAULT_ADMIN_ROLE (setTier) on the new
+ *     contracts → run with the floppy keystore admin on the production network.
+ *
+ * USAGE
+ *   # dry run, lock (default action):
+ *   npx hardhat run scripts/operations/prelaunch-lockdown-007.js --network polygon
+ *   # execute the lockdown (floppy mounted):
+ *   DRY_RUN=false npx hardhat run scripts/operations/prelaunch-lockdown-007.js --network polygon
+ *   # at go-live, reverse it:
+ *   DRY_RUN=false ACTION=unlock npx hardhat run scripts/operations/prelaunch-lockdown-007.js --network polygon
+ *
+ *   Optional: LOCK_MEMBERSHIPS=false to ONLY pause/unpause WagerRegistry and
+ *   leave the membership tiers as-is.
+ *
+ * Addresses are read from deployments/<network>-chain<id>-v2.json (written by
+ * the 007 deploy).
+ */
+const hre = require("hardhat");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+
+// WAGER_PARTICIPANT_ROLE — the only role with seeded, purchasable tiers.
+const WAGER_PARTICIPANT_ROLE = ethers.keccak256(ethers.toUtf8Bytes("WAGER_PARTICIPANT_ROLE"));
+const GUARDIAN_ROLE = ethers.keccak256(ethers.toUtf8Bytes("GUARDIAN_ROLE"));
+const DEFAULT_ADMIN_ROLE = ethers.ZeroHash;
+// Tier enum: None=0, Bronze=1, Silver=2, Gold=3, Platinum=4. Seeded: 1..4.
+const SEEDED_TIERS = [1, 2, 3, 4];
+const TIER_NAMES = ["None", "Bronze", "Silver", "Gold", "Platinum"];
+
+const WAGER_ABI = [
+  "function pause() external",
+  "function unpause() external",
+  "function paused() view returns (bool)",
+  "function hasRole(bytes32 role, address account) view returns (bool)",
+];
+
+const MM_ABI = [
+  "function getTierConfig(bytes32 role, uint8 tier) view returns (tuple(uint128 priceUSDC, uint32 durationDays, bool active, tuple(uint32 monthlyMarketCreation, uint32 maxConcurrentMarkets) limits))",
+  "function setTier(bytes32 role, uint8 tier, uint128 priceUSDC, uint32 durationDays, tuple(uint32 monthlyMarketCreation, uint32 maxConcurrentMarkets) limits, bool active) external",
+  "function hasRole(bytes32 role, address account) view returns (bool)",
+];
+
+async function main() {
+  const net = hre.network.name;
+  const chainId = Number((await ethers.provider.getNetwork()).chainId);
+  const dryRun = (process.env.DRY_RUN ?? "true").toLowerCase() !== "false";
+  const action = (process.env.ACTION ?? "lock").toLowerCase();
+  const lockMemberships = (process.env.LOCK_MEMBERSHIPS ?? "true").toLowerCase() !== "false";
+  if (action !== "lock" && action !== "unlock") {
+    throw new Error(`ACTION must be 'lock' or 'unlock' (got '${action}').`);
+  }
+  const lock = action === "lock";
+  // lock => want paused=true / tier active=false; unlock => paused=false / active=true.
+  const wantPaused = lock;
+  const wantActive = !lock;
+
+  const depFile = path.join(__dirname, "..", "..", "deployments", `${net}-chain${chainId}-v2.json`);
+  if (!fs.existsSync(depFile)) throw new Error(`Deployment file not found: ${depFile} (run the 007 deploy first).`);
+  const contracts = JSON.parse(fs.readFileSync(depFile, "utf8")).contracts || {};
+  const wagerAddr = contracts.wagerRegistry;
+  const mmAddr = contracts.membershipManager;
+  if (!wagerAddr) throw new Error("wagerRegistry missing from deployment file.");
+  if (lockMemberships && !mmAddr) throw new Error("membershipManager missing from deployment file (or set LOCK_MEMBERSHIPS=false).");
+
+  const [signer] = await ethers.getSigners();
+  console.log("=".repeat(64));
+  console.log(`Pre-launch ${action.toUpperCase()} | ${net} (${chainId}) | DRY_RUN=${dryRun}`);
+  console.log("=".repeat(64));
+  console.log(`WagerRegistry:     ${wagerAddr}`);
+  console.log(`MembershipManager: ${lockMemberships ? mmAddr : "(skipped — LOCK_MEMBERSHIPS=false)"}`);
+  console.log(`Signer:            ${signer ? signer.address : "(none — dry run only)"}`);
+  console.log("");
+
+  const provider = ethers.provider;
+  const wager = new ethers.Contract(wagerAddr, WAGER_ABI, signer || provider);
+  const mm = new ethers.Contract(mmAddr, MM_ABI, signer || provider);
+
+  // ---- 1. WagerRegistry pause / unpause -------------------------------------
+  const isPaused = await wager.paused();
+  if (isPaused === wantPaused) {
+    console.log(`WagerRegistry already ${wantPaused ? "paused" : "unpaused"} — skipping.`);
+  } else {
+    if (signer && !dryRun) {
+      const ok = await wager.hasRole(GUARDIAN_ROLE, signer.address);
+      if (!ok) throw new Error(`Signer ${signer.address} lacks GUARDIAN_ROLE on WagerRegistry.`);
+    }
+    console.log(`${dryRun ? "[would]" : "[exec]"} WagerRegistry.${wantPaused ? "pause" : "unpause"}()`);
+    if (!dryRun) {
+      const tx = wantPaused ? await wager.pause() : await wager.unpause();
+      await tx.wait();
+      console.log(`    ↳ ${(await wager.paused()) ? "paused" : "unpaused"} (tx ${tx.hash})`);
+    }
+  }
+
+  // ---- 2. MembershipManager tier (de)activation -----------------------------
+  if (lockMemberships) {
+    if (signer && !dryRun) {
+      const ok = await mm.hasRole(DEFAULT_ADMIN_ROLE, signer.address);
+      if (!ok) throw new Error(`Signer ${signer.address} lacks DEFAULT_ADMIN_ROLE on MembershipManager.`);
+    }
+    for (const tier of SEEDED_TIERS) {
+      const cfg = await mm.getTierConfig(WAGER_PARTICIPANT_ROLE, tier);
+      if (Number(cfg.priceUSDC) === 0 && Number(cfg.durationDays) === 0) {
+        console.log(`Tier ${TIER_NAMES[tier]}: not seeded — skipping.`);
+        continue;
+      }
+      if (cfg.active === wantActive) {
+        console.log(`Tier ${TIER_NAMES[tier]}: already active=${wantActive} — skipping.`);
+        continue;
+      }
+      console.log(
+        `${dryRun ? "[would]" : "[exec]"} setTier ${TIER_NAMES[tier]} active=${wantActive} ` +
+        `(price=${ethers.formatUnits(cfg.priceUSDC, 6)} USDC, ${cfg.durationDays}d, ` +
+        `${cfg.limits.monthlyMarketCreation || "∞"}/mo, ${cfg.limits.maxConcurrentMarkets || "∞"} concurrent)`
+      );
+      if (!dryRun) {
+        const tx = await mm.setTier(
+          WAGER_PARTICIPANT_ROLE,
+          tier,
+          cfg.priceUSDC,
+          cfg.durationDays,
+          { monthlyMarketCreation: cfg.limits.monthlyMarketCreation, maxConcurrentMarkets: cfg.limits.maxConcurrentMarkets },
+          wantActive
+        );
+        await tx.wait();
+        console.log(`    ↳ active=${wantActive} (tx ${tx.hash})`);
+      }
+    }
+  }
+
+  console.log("");
+  if (dryRun) {
+    console.log("DRY RUN — no transactions sent. Re-run with DRY_RUN=false (floppy mounted) to apply.");
+  } else {
+    console.log(lock
+      ? "Lockdown applied. WagerRegistry paused; membership purchases blocked. grantMembership (migration) still works."
+      : "Lockdown lifted. WagerRegistry live; membership tiers active. Go-live ready.");
+  }
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/utils/sync-frontend-contracts.js
+++ b/scripts/utils/sync-frontend-contracts.js
@@ -77,9 +77,12 @@ function updateObjectLiteralValue(source, key, newValueLiteral, blockName = null
     const block = source.slice(bodyStart, bodyEnd)
     const after = source.slice(bodyEnd)
 
-    const re = new RegExp(`(^\\s*${key}\\s*:\\s*)([^,\\n]+)(\\s*,?)$`, 'm')
+    // Trailing `// comment` after the value must be tolerated, else the `$`
+    // anchor fails to match and the key is wrongly treated as missing → a
+    // duplicate gets inserted (e.g. sanctionsGuard/polymarketAdapter).
+    const re = new RegExp(`(^\\s*${key}\\s*:\\s*)([^,\\n]+)(\\s*,?)(\\s*\\/\\/[^\\n]*)?$`, 'm')
     if (re.test(block)) {
-      const updated = block.replace(re, `$1${newValueLiteral}$3`)
+      const updated = block.replace(re, `$1${newValueLiteral}$3$4`)
       return before + updated + after
     }
     // Insert at end of block (before closing brace)
@@ -87,11 +90,12 @@ function updateObjectLiteralValue(source, key, newValueLiteral, blockName = null
     return before + block + line + after
   }
 
-  // Matches: <spaces>key: <value>,
+  // Matches: <spaces>key: <value>,  (optionally followed by a // comment, which
+  // must be tolerated so the key isn't treated as missing and re-inserted).
   // key is assumed to be a simple identifier (no quotes) as used in contracts.js.
-  const re = new RegExp(`(^\\s*${key}\\s*:\\s*)([^,\\n]+)(\\s*,?)$`, 'm')
+  const re = new RegExp(`(^\\s*${key}\\s*:\\s*)([^,\\n]+)(\\s*,?)(\\s*\\/\\/[^\\n]*)?$`, 'm')
   if (re.test(source)) {
-    return source.replace(re, `$1${newValueLiteral}$3`)
+    return source.replace(re, `$1${newValueLiteral}$3$4`)
   }
 
   // Insert before closing brace of DEPLOYED_CONTRACTS.

--- a/scripts/utils/sync-frontend-contracts.js
+++ b/scripts/utils/sync-frontend-contracts.js
@@ -157,6 +157,7 @@ function main() {
         wagerRegistry: deployed.wagerRegistry,
         membershipManager: deployed.membershipManager,
         keyRegistry: deployed.keyRegistry,
+        sanctionsGuard: deployed.sanctionsGuard,
         polymarketAdapter: deployed.polymarketAdapter,
         chainlinkDataFeedAdapter: deployed.chainlinkDataFeedAdapter,
         chainlinkFunctionsAdapter: deployed.chainlinkFunctionsAdapter,

--- a/specs/007-compliance-gating/checklists/requirements.md
+++ b/specs/007-compliance-gating/checklists/requirements.md
@@ -1,0 +1,61 @@
+# Specification Quality Checklist: Compliance & Legal Gating Layer
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Two scope-forking decisions were resolved with the user up front: (1) sanctions
+  compliance includes **automated on-chain wallet screening** via the Chainalysis
+  on-chain Sanctions Oracle (not self-attestation only), and (2) the attestation
+  audit log is **fail-closed everywhere** (no consent action completes until its
+  immutable record is durably written). Both are reflected throughout the spec.
+- The spec was hardened against a 3-lens adversarial review (spec-quality,
+  legal-completeness, constitution-compliance). Resolved findings include: mandatory
+  cryptographic origin authentication (was spoofable as an IP-allowlist-only design);
+  an operator-set materiality flag separated from the content hash to make the
+  re-consent trigger consistent (a hash always changes on any edit); pinning the
+  audit record to the canonical document **bytes** under the same retention; audit
+  chain-of-custody integrity and idempotency; a discretionary block-list, anonymizer
+  detection, and wager-entry re-screen to match the Terms' broader representations
+  (s.5/s.7/s.11); Privacy Policy brought under the versioned regime; and constitution
+  anchors (fork test for the oracle read, WCAG 2.1 AA, sync-artifact config
+  provenance, no-mock/network-scoping, test-first, CI fail-loud).
+- **Content Quality — note on pinned standards**: HTTP 451 and SHA-256 appear in
+  requirements because the user explicitly pinned them in the feature description;
+  ISO 3166-1 is a neutral interchange standard. These are intentional, not stack
+  leakage. Vendor names (Cloudflare, Google Cloud, Chainalysis) are confined to
+  Assumptions/Dependencies. Success criteria were reworded to outcome-level (e.g.,
+  "human-readable legal-reason explanation", "content hash") to keep SCs
+  technology-agnostic.
+- **Open Legal-Reconciliation Items** are documented in the spec for counsel; they do
+  not block planning and are not unresolved clarifications (each has a concrete
+  technical position).
+- Items marked incomplete (none) would require spec updates before `/speckit-clarify`
+  or `/speckit-plan`.

--- a/specs/007-compliance-gating/contracts/IChainalysisSanctionsOracle.md
+++ b/specs/007-compliance-gating/contracts/IChainalysisSanctionsOracle.md
@@ -1,0 +1,39 @@
+# Contract: IChainalysisSanctionsOracle (external dependency)
+
+`contracts/interfaces/IChainalysisSanctionsOracle.sol`. Minimal read-only view over the
+deployed Chainalysis `SanctionsList` oracle. Address is **injected per chain** (never
+hardcoded — FR-055).
+
+## Interface
+
+```solidity
+interface IChainalysisSanctionsOracle {
+    function isSanctioned(address addr) external view returns (bool);
+}
+```
+
+## Deployed addresses (verified, R1)
+
+| Network | chainId | Address | Notes |
+|---|---|---|---|
+| Polygon mainnet | 137 | `0x40C57923924B5c5c5455c48D93317139ADDaC8fb` | verified contract; production |
+| Polygon Amoy | 80002 | _none_ | NOT deployed → inject `MockSanctionsOracle` |
+| Hardhat / localhost | 31337/1337 | _deploy mock_ | `contracts/mocks/MockSanctionsOracle.sol` |
+
+(Base differs: `0x3A91A31cB3dC49b4db9Ce721F50a9D076c8D739B` — not used here, but proves a
+single global constant is wrong.)
+
+## Rules
+
+- Free to read; no API key (R1).
+- The address comes from per-chain deploy config and flows to the frontend via
+  `sync:frontend-contracts` (FR-055). Deploy MUST verify bytecode exists at the configured
+  address on mainnet; on Amoy/local it points at the mock.
+- `SanctionsGuard` is the only production consumer that *enforces*; the frontend reads it
+  advisory-only.
+
+## MockSanctionsOracle (test/testnet only — `contracts/mocks/`)
+
+Implements `isSanctioned(address)` from a settable mapping; used ONLY on Amoy/local/forks.
+Never imported by production contracts; `SanctionsGuard` holds an injected interface address
+so the same guard bytecode runs everywhere (Principle III: no mock in the mainnet path).

--- a/specs/007-compliance-gating/contracts/ISanctionsGuard.md
+++ b/specs/007-compliance-gating/contracts/ISanctionsGuard.md
@@ -1,0 +1,62 @@
+# Contract: ISanctionsGuard (on-chain sanctions enforcement)
+
+`contracts/interfaces/ISanctionsGuard.sol`, implemented by `contracts/access/SanctionsGuard.sol`
+(Solidity `^0.8.24`, OZ `AccessControl`). Non-bypassable enforcement layer (FR-054/FR-020).
+
+## Interface
+
+```solidity
+interface ISanctionsGuard {
+    // Views
+    function isAllowed(address account) external view returns (bool);
+    function checkBlocked(address account) external view; // reverts SanctionedAddress(account) if not allowed
+    function isDenied(address account) external view returns (bool);
+    function sanctionsOracle() external view returns (address);
+
+    // Admin (SANCTIONS_ADMIN_ROLE)
+    function setDenied(address account, bool denied, string calldata reason) external;
+    // Admin (DEFAULT_ADMIN_ROLE)
+    function setSanctionsOracle(address oracle) external;
+
+    // Events
+    event DenyListUpdated(address indexed account, bool denied, address indexed actor, string reason);
+    event SanctionsOracleUpdated(address indexed oracle);
+
+    // Errors
+    error SanctionedAddress(address account);
+}
+```
+
+## Behavior contract
+
+- `isAllowed(a)` returns **false** if `isDenied(a)` **or** (`sanctionsOracle != address(0)`
+  **and** the oracle reports `isSanctioned(a) == true`). The external oracle call is wrapped
+  in `try/catch`; **any revert, or empty/undecodable return data, ⇒ not allowed (fail-closed)**
+  (FR-016/FR-019). The deny-list check short-circuits before the oracle call.
+- `checkBlocked(a)` reverts `SanctionedAddress(a)` exactly when `isAllowed(a) == false`.
+- `setDenied` rejects `address(0)`, sets `_denied[account]`, emits `DenyListUpdated` with
+  `actor = msg.sender` and `reason` (SC-018). Role: `SANCTIONS_ADMIN_ROLE`.
+- `setSanctionsOracle` emits `SanctionsOracleUpdated`. Role: `DEFAULT_ADMIN_ROLE`. SHOULD
+  validate the new address has bytecode on mainnet.
+- No state writes occur during `isAllowed`/`checkBlocked` (read-only Checks; CEI safe).
+- Network-scoped: deployed per chain; oracle address injected per chain (R1).
+
+## Consumption (modified contracts)
+
+| Caller | Entry point | Screened |
+|---|---|---|
+| `WagerRegistry` | `createWager` | `msg.sender` (first Check) |
+| `WagerRegistry` | `acceptWager` | `msg.sender` **and** `w.creator` (counterparty) |
+| `MembershipManager` | `purchaseTier`, `upgradeTier` | `msg.sender` |
+
+Exit/refund paths (`claimRefund`, `claimPayout`, `batchExpireOpen`, `declareDraw`) are
+**NOT** screened — a newly-listed party must still recover their own escrowed funds.
+
+## Tests (Principle II)
+
+- Unit: `isAllowed` truth table (denied / oracle-sanctioned / both / neither); fail-closed
+  on oracle revert + on EOA-as-oracle (empty return); role-gating reverts; events.
+- Integration: each consuming entry point reverts for a listed sender, and `acceptWager`
+  reverts for a listed counterparty; exit paths succeed for a listed party.
+- Fork (Polygon 137): real oracle blocks a known sanctioned address, allows a clean one
+  (SC-004/SC-016).

--- a/specs/007-compliance-gating/contracts/cloudflare-nginx-origin-lock.md
+++ b/specs/007-compliance-gating/contracts/cloudflare-nginx-origin-lock.md
@@ -1,0 +1,48 @@
+# Contract: Cloudflare geo gate + nginx origin lock (no new infra)
+
+Edge configuration + the existing nginx — no load balancer, Cloud Armor, or backend
+(FR-001…FR-013, FR-007/FR-008). All within the current footprint.
+
+## Cloudflare (zone: fairwins.app, proxied/orange-cloud)
+
+### Geo gate — WAF custom rule
+- Field: `ip.src.country` (ISO 3166-1 alpha-2).
+- **Allowlist posture (default)**: `not (ip.src.country in {<ALLOWED…>})` → **Block**.
+  Denylist posture available: `(ip.src.country in {<BLOCKED…>})` → Block.
+- The deny set ALWAYS includes the locked OFAC bucket (`CU IR KP SY` + Crimea/Donetsk/
+  Luhansk handling) and `US` (current posture) regardless of posture (FR-003/FR-004).
+- Block action → **custom response 451** (Pro+; status 400-499; body ≤2KB; HTML/JSON) with a
+  human-readable "Unavailable For Legal Reasons" explanation (FR-006). Free-plan fallback:
+  default block page (no custom 451 body).
+- Staging: validate new rules in **Log/observe** mode before Block (FR-011).
+- `XX` (unknown country) and any rule-evaluation failure ⇒ Block under allowlist (FR-012).
+
+### Origin lock — Transform Rule (request header)
+- "Set static": add `X-Origin-Auth: <HIGH_ENTROPY_SECRET>` on every request to the origin.
+- Secret stored in Secret Manager → Cloud Run env → nginx (same pattern as the Pinata JWT);
+  rotated periodically. A bare CF-IP allowlist is **not** sufficient (shared CF IPs).
+
+### Evidence headers
+- `CF-IPCountry` (country-of-record) and `CF-Connecting-IP` (client IP) forwarded to origin.
+
+## nginx (`frontend/nginx.conf.template`, existing container)
+
+- **Verify** `$http_x_origin_auth` equals the configured secret; if missing/wrong →
+  `return 403;` (origin lock — FR-007/FR-008). Place before serving the SPA and before the
+  Pinata proxy.
+- **Forward** `CF-IPCountry` / `CF-Connecting-IP` into the access log so the Cloud Run
+  request logs are the geo/IP evidence tier (FR-009/FR-051). Do not log the secret (FR-052).
+- Serve `/451.html` content for the Cloudflare custom response if hosted at origin (optional;
+  Cloudflare can serve it directly).
+
+## Cloud Run
+- Ingress stays as today (no LB added). The nginx secret-header check is the origin lock;
+  direct `run.app` hits without the secret get 403.
+- **Future hardening (out of footprint, documented only)**: ingress
+  `internal-and-cloud-load-balancing` + Global External ALB + frontend mTLS / Authenticated
+  Origin Pulls for cryptographic edge auth (R4).
+
+## Acceptance (maps to SCs)
+- Blocked-country request → 451 at Cloudflare, no origin hit (SC-001/SC-003).
+- Direct origin request without `X-Origin-Auth` → 403 (SC-002/SC-012).
+- Edge rule-eval failure / unknown country → denied (SC-013).

--- a/specs/007-compliance-gating/contracts/encrypted-metadata-v1.1.md
+++ b/specs/007-compliance-gating/contracts/encrypted-metadata-v1.1.md
@@ -1,0 +1,44 @@
+# Contract: Encrypted metadata v1.1 — T&C version binding (AAD)
+
+Extends the envelope-encryption schema so each wager carries tamper-evident proof of its
+governing T&C version (FR-056/FR-057), without touching key derivation (FR-041).
+
+## Schema change (`frontend/src/schemas/encrypted-metadata-v1.1.json`)
+
+- Add to `properties`: `termsVersion` = `{ "id": string, "hash": "<sha256 hex>" }`.
+- Keep `termsVersion` **out of `required`** (legacy compatibility).
+- Extend the `version` enum to include `"1.1"`.
+- Reconcile the existing drift: the on-disk schema currently describes the old
+  `xsalsa20`/top-level shape with `additionalProperties:false`; the v1.1 file MUST match the
+  **runtime** envelope (`content.{nonce,ciphertext}`, `keys[]`,
+  `x25519-chacha20poly1305` / `xwing-chacha20poly1305`) and allow `termsVersion`.
+
+## AEAD binding (`frontend/src/utils/crypto/envelopeEncryption.js`)
+
+- Add the AAD argument to the **content** cipher only:
+  - seal: `encryptEnvelope` (~L305), `encryptEnvelopeXWing` (~L482)
+  - open: `decryptEnvelope` (~L383), `decryptEnvelopeXWing` (~L555)
+  - **NOT** on the per-recipient DEK-wrap ciphers.
+- `aad = utf8ToBytes(TERMS_AAD_PREFIX + "|" + schemaVersion + "|" + termsVersion.hash)` where
+  `TERMS_AAD_PREFIX = "FairWins-TC"` is pinned in `constants.js`. The decrypt side
+  reconstructs the AAD from `envelope.termsVersion` (the authenticated field), so tampering
+  with the claimed version ⇒ ChaCha20-Poly1305 auth failure ("invalid tag").
+- The seal/open emit/consume `termsVersion = { id, hash }` alongside existing fields.
+
+## Invariants
+
+- **Key derivation unchanged**: `getMarketSigningMessage`/`SIGNING_MESSAGES`/keccak256 seed
+  untouched; the T&C hash is only a function arg into the AEAD + envelope JSON.
+- **Canonicalization (frozen)**: `NFC → CRLF/CR→LF → trim → UTF-8 → sha256 → hex`
+  (FR-026/FR-059); same algorithm used to compute the Legal Document Version hash.
+- **Legacy (FR-057)**: `termsVersion` absent ⇒ decrypt with **no AAD** (today's exact path)
+  and treat the wager as governed by the launch version; existing v1.0/v2.0 envelopes
+  unchanged and never re-bound.
+
+## Tests (Vitest)
+
+- New-envelope round-trip with `termsVersion` + AAD.
+- AAD tamper rejection: mutate `termsVersion.hash` ⇒ decrypt throws.
+- Legacy round-trip: v1.0/v2.0 envelope (no `termsVersion`) decrypts with no AAD.
+- Hash reproducibility: an independent re-hash of canonical text matches `termsVersion.hash`
+  (SC-005/SC-009).

--- a/specs/007-compliance-gating/contracts/frontend-gate-contracts.md
+++ b/specs/007-compliance-gating/contracts/frontend-gate-contracts.md
@@ -1,0 +1,48 @@
+# Contract: Frontend gate, screening, docs & admin UI
+
+Client-side behavior contracts (React/Vite, Vitest, WCAG 2.1 AA — FR-053). No backend.
+
+## EntryGate (`components/compliance/EntryGate.jsx`)
+- Renders before any app content on first visit when no acknowledged current version in
+  localStorage (FR-031). Focus-trapped, labeled, keyboard-operable modal (FR-053).
+- Affirmations shown: 21+, not US/restricted, not sanctioned, lawful where located, read+agree
+  to Terms & Risk Disclosure; links the **current versioned** docs by hash (FR-031/AS-4).
+- VPN/circumvention warning (FR-033). "Enter" → store `{terms,risk}` hashes acknowledged in
+  localStorage + grant access (AS-2). "Leave" → no access (AS-3).
+- Geo-blocked visitors never reach it (Cloudflare 451 first — AS-6).
+- **Not** a binding consent record — binding consent is on-chain downstream (FR-034).
+
+## MembershipAttestation (`components/compliance/MembershipAttestation.jsx`)
+- Discrete checkboxes, all **un-ticked by default** (FR-035/SC-008); cannot submit until each
+  required box is ticked (FR-036).
+- Copy mirrors FR-037 + FR-038 (fee-for-access-only; no profit expectation/ownership/pool
+  claim; not pooled/staked/returned as winnings).
+- On confirm: pass the in-force `acceptedTermsHash` into `purchaseTier/upgradeTier`
+  (recorded on-chain — `membership-version-recording.md`); capture ticks in client state.
+
+## sanctionsScreen (`utils/sanctionsScreen.js`)
+- Advisory client-side read of the oracle via RPC (`isAllowed`/`isSanctioned`) for fast UX
+  before key-gen/membership/wager (FR-016); address/ABI from sync artifacts (FR-055).
+- Advisory only — the on-chain guard is the real enforcement; if the read fails, surface a
+  fail-closed UX (don't claim "clear").
+
+## legalDocs (`utils/legalDocs.js`) + legal pages
+- Canonicalize (NFC/LF/UTF-8/trim) + `sha256` → version hash (FR-018/FR-026); expose current
+  version, manifest of prior versions (retrievable by hash, FR-025), and the operator-set
+  `material` flag (FR-030).
+- `pages/legal/{TermsPage,RiskPage,PrivacyPage}.jsx`: render content + "Last updated ·
+  Version: <hash>"; reachable in ≤2 interactions (SC-010); WCAG 2.1 AA (SC-015). All three
+  docs incorporate each other by reference (FR-028).
+- Re-consent: when the in-force version is flagged `material`, prompt re-acceptance at the
+  next consequential act (new wager / membership), not as a browse gate (FR-030/FR-034).
+
+## DenyListAdmin (`components/admin/DenyListAdmin.jsx`)
+- Admin-only UI to add/remove deny-list addresses with a reason → calls
+  `SanctionsGuard.setDenied` (SANCTIONS_ADMIN_ROLE; floppy-keystore admin) (FR-020).
+- Renders the add/remove audit trail from `DenyListUpdated` events (actor/timestamp/reason)
+  (SC-018). WCAG 2.1 AA; ESLint clean.
+
+## Tests (Vitest) — see also `frontend-test-gotchas` memory
+- EntryGate gating + acknowledge-state; checkbox required-state + no-pre-tick; legalDocs hash
+  reproducibility + version retrieval; sanctionsScreen fail-closed UX; admin event rendering.
+- Reuse generated `getContractAddress` (mock per the known gotchas), never hardcode addresses.

--- a/specs/007-compliance-gating/contracts/membership-version-recording.md
+++ b/specs/007-compliance-gating/contracts/membership-version-recording.md
@@ -1,0 +1,57 @@
+# Contract: On-chain consent-of-record (version recording)
+
+How the accepted/bound T&C version hash is recorded on-chain so the chain is the
+fail-closed, immutable, queryable consent store (FR-045–FR-050, no backend).
+
+## MembershipManager (modified)
+
+```solidity
+struct Membership { /* existing fields */ bytes32 acceptedTermsHash; uint64 acceptedAt; }
+
+function purchaseTier(bytes32 role, Tier tier, bytes32 acceptedTermsHash) external; // + screened
+function upgradeTier(bytes32 role, Tier newTier, bytes32 acceptedTermsHash) external; // + screened
+
+event MembershipPurchased(address indexed user, bytes32 role, Tier tier, bytes32 acceptedTermsHash, uint64 at);
+event MembershipUpgraded (address indexed user, bytes32 role, Tier newTier, bytes32 acceptedTermsHash, uint64 at);
+```
+
+**Rules**:
+- First Check: `sanctionsGuard.checkBlocked(msg.sender)` (CEI preserved; before payment/effects).
+- `acceptedTermsHash` is the SHA-256 of the in-force Terms version the user accepted in the
+  client (FR-021/FR-039/FR-058). The contract records it + `block.timestamp` and emits it.
+- The contract does NOT validate the hash content (off-chain canonicalization); it stores
+  the binding so an auditor can resolve the exact version (FR-027) via the Legal Document
+  Version manifest.
+- Fail-closed/idempotent by construction: a revert grants no membership and no record;
+  re-purchase converges on contract state.
+
+## WagerRegistry (modified)
+
+```solidity
+struct Wager { /* existing */ bytes32 termsVersionHash; }
+
+function createWager(/* existing args */, bytes32 termsVersionHash) external; // + screened(msg.sender)
+event WagerCreated(uint256 indexed wagerId, address indexed creator, /* existing */ bytes32 termsVersionHash);
+```
+
+**Rules**:
+- `createWager` Check: `sanctionsGuard.checkBlocked(msg.sender)`; stores `termsVersionHash`
+  (the governing version, FR-056/FR-057) and emits it. `acceptWager` additionally
+  `checkBlocked(w.creator)`.
+- The same `termsVersionHash` is bound into the wager's encrypted metadata AAD off-chain
+  (see `encrypted-metadata-v1.1.md`) so the binding is tamper-evident in both places.
+- Prospective-only: existing wagers keep their stored hash; never re-bound (FR-057).
+
+## KeyRegistry (light)
+
+```solidity
+event EligibilityAcknowledged(address indexed account, bytes32 termsRef); // generic ref, dated by block
+```
+Dates the deterministic eligibility signature via the registration block timestamp without
+putting a date in the signed payload (FR-042/FR-043).
+
+## Queryability (FR-047)
+
+Address-keyed history comes from the indexed events above (chain logs + optional subgraph
+extension). No backend index. The subgraph MAY add handlers for these events to expose
+"all consents + governing versions for address X".

--- a/specs/007-compliance-gating/data-model.md
+++ b/specs/007-compliance-gating/data-model.md
@@ -1,0 +1,110 @@
+# Data Model: Compliance & Legal Gating Layer
+
+Data lives across three tiers (no database): **on-chain** (Polygon — records of record),
+**client/IPFS** (documents, encrypted wager metadata, client gate state), and **edge logs**
+(Cloudflare/Cloud Run request logs — geo evidence). No backend store.
+
+---
+
+## On-chain
+
+### SanctionsGuard (new contract — `contracts/access/SanctionsGuard.sol`)
+| Field / item | Type | Notes |
+|---|---|---|
+| `sanctionsOracle` | `IChainalysisSanctionsOracle` | injectable; `address(0)` where no oracle (Amoy) → guard relies on deny-list only |
+| `_denied[address]` | `mapping(address=>bool)` | discretionary deny-list (FR-020); O(1) read |
+| `SANCTIONS_ADMIN_ROLE` | `bytes32` | deny-list mutation role (floppy-keystore admin) |
+| `DEFAULT_ADMIN_ROLE` | `bytes32` | oracle-config role |
+| **Views** | `isAllowed(address)→bool`, `checkBlocked(address)` | fail-closed: oracle revert/empty-return ⇒ not allowed |
+| **Events** | `DenyListUpdated(account, denied, actor, reason)`, `SanctionsOracleUpdated(oracle)` | the deny-list admin audit trail (FR-020/SC-018) |
+
+**Validation/rules**: reject `address(0)`; deny-list short-circuits before the oracle call;
+guard never writes on the hot path (read-only during Checks). Network-scoped (per `chainId`).
+
+### WagerRegistry (modified)
+| Item | Change |
+|---|---|
+| `sanctionsGuard` + `setSanctionsGuard` | new injectable ref (DEFAULT_ADMIN_ROLE) |
+| `createWager` | first Check: `sanctionsGuard.checkBlocked(msg.sender)`; **store** the bound `termsVersionHash` (bytes32) with the wager + emit it |
+| `acceptWager` | Checks: `checkBlocked(msg.sender)` **and** `checkBlocked(w.creator)` (counterparty) |
+| `Wager` struct | add `bytes32 termsVersionHash` (governing T&C version at creation — FR-056) |
+| events | `WagerCreated` extended with `termsVersionHash` (address-keyed query of governing terms) |
+| exit paths | `claimRefund`/`claimPayout`/`batchExpireOpen` **stay ungated** (recover own funds) |
+
+### MembershipManager (modified)
+| Item | Change |
+|---|---|
+| `sanctionsGuard` + `setSanctionsGuard` | new injectable ref (DEFAULT_ADMIN_ROLE) |
+| `purchaseTier` / `upgradeTier` | first Check: `sanctionsGuard.checkBlocked(msg.sender)`; record accepted `termsVersionHash` |
+| `Membership` record | add `bytes32 acceptedTermsHash` + `uint64 acceptedAt` (block ts) |
+| events | `MembershipPurchased`/`Upgraded` extended with `acceptedTermsHash` (FR-039/FR-045) |
+
+### KeyRegistry (light modification)
+| Item | Change |
+|---|---|
+| registration event | add an `EligibilityAcknowledged(address, bytes32 termsRef)` event so the on-chain key registration dates the eligibility signature (FR-043) without a date in the signed payload |
+
+---
+
+## Client / IPFS
+
+### Legal Document Version (`frontend/src/legal/` + IPFS pin)
+| Field | Type | Notes |
+|---|---|---|
+| `docType` | enum | `terms` \| `risk` \| `privacy` |
+| `content` | canonical text (NFC, LF, UTF-8, trimmed) | the bytes that are hashed |
+| `versionHash` | `sha256(content)` hex | the version id; recorded on-chain at consent; shown in "Last updated · Version" |
+| `material` | bool (operator-set) | re-consent trigger (FR-030), **independent** of the hash |
+| `ipfsCid` | string | per-version pin (not per-event) |
+| `supersededBy` | versionHash? | prior versions remain retrievable by hash |
+
+### Encrypted Wager Metadata v1.1 (`schemas/encrypted-metadata-v1.1.json`)
+Adds an authenticated `termsVersion` to the existing envelope (optional on read):
+| Field | Type | Notes |
+|---|---|---|
+| `version` | enum (+`"1.1"`) | schema version |
+| `algorithm` | enum | `x25519-chacha20poly1305` / `xwing-chacha20poly1305` |
+| `content` | `{ nonce, ciphertext }` | sealed with `aad = "FairWins-TC|"+schemaVersion+"|"+termsVersion.hash` |
+| `keys[]` | per-recipient DEK wraps | unchanged (no AAD) |
+| `termsVersion` | `{ id, hash }` | **NEW**, optional; absence ⇒ legacy (no AAD), governed by launch version (FR-057) |
+
+**Rule**: tampering with `termsVersion.hash` breaks AEAD auth on decrypt (tamper-evident,
+FR-056). `termsVersion` never enters key derivation (FR-041).
+
+### Client gate state (localStorage)
+| Field | Notes |
+|---|---|
+| `acknowledgedVersions` | `{terms, risk}` hashes acknowledged at the entry gate (FR-031); drives the entry-skip only — **not** a binding consent (binding consent is on-chain) |
+| `membershipAttestationTicks` | the discrete checkbox selections captured at purchase confirmation (reflected in the on-chain tx) |
+
+---
+
+## Edge logs (Cloudflare / Cloud Run request logs — existing)
+
+### Edge Enforcement Log Entry (no new store; existing Cloud Logging)
+| Field | Source | Notes |
+|---|---|---|
+| `country` | `CF-IPCountry` | country-of-record (XX=unknown, T1=Tor) |
+| `ip` | `CF-Connecting-IP` | client IP |
+| `timestamp`, `decision` | edge/nginx | allow / 451-geo-block; geo evidence tier (FR-009/FR-051) |
+| retention | Cloud Logging retention window | minimized fields; Privacy Policy discloses (FR-051/FR-052) |
+
+---
+
+## Restricted-Jurisdiction Configuration (Cloudflare WAF + nginx, not a DB)
+| Bucket | Where | Notes |
+|---|---|---|
+| comprehensively-sanctioned (locked) | Cloudflare WAF rule | Cuba/Iran/NK/Syria + Crimea/Donetsk/Luhansk; never removable w/o logged change (FR-003) |
+| United States | Cloudflare WAF rule | posture decision (FR-004) |
+| tunable prohibited | Cloudflare WAF rule | gambling/PM bans (FR-005), operator-editable |
+| posture | Cloudflare WAF rule | allowlist (default) / denylist (FR-002) |
+
+---
+
+## Relationships (text)
+
+`SanctionsGuard` ←consulted by→ `WagerRegistry` & `MembershipManager` (and read advisory by
+the frontend). `Legal Document Version.versionHash` →recorded in→ `Membership.acceptedTermsHash`
+and `Wager.termsVersionHash` and →bound into→ Encrypted Wager Metadata `termsVersion`/AAD.
+`KeyRegistry` event dates the `Key-Generation Signature`. Edge log entries are correlated to
+on-chain consents by time + (where present) wallet address — never merged on-chain (privacy).

--- a/specs/007-compliance-gating/plan.md
+++ b/specs/007-compliance-gating/plan.md
@@ -1,0 +1,176 @@
+# Implementation Plan: Compliance & Legal Gating Layer
+
+**Branch**: `007-compliance-gating` | **Date**: 2026-06-06 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/007-compliance-gating/spec.md`
+
+## Summary
+
+Add a compliance & legal gating layer to FairWins **without adding a backend** —
+strictly within today's footprint (React+Vite SPA served by nginx on Cloud Run, smart
+contracts on Polygon, IPFS/Pinata, Cloudflare edge, Cloud Logging). The layer is a
+*stack*: (1) **geo-blocking at Cloudflare** (WAF country rule → 451) with the Cloud Run
+origin locked behind a Cloudflare-injected secret header verified in the existing nginx;
+(2) **wallet sanctions screening** as defense-in-depth — an advisory client-side read of
+the Chainalysis on-chain Sanctions Oracle plus a **non-bypassable on-chain `SanctionsGuard`**
+(oracle + admin deny-list) consulted by `WagerRegistry`/`MembershipManager`; (3) a
+three-layer consent flow whose **records of record live on-chain** (membership purchase
+records the accepted T&C version hash; wager creation binds the version into the wager's
+ChaCha20-Poly1305 AAD; key registration dates the deterministic eligibility signature),
+with the entry "21+" modal as a client-side notice gate; and (4) **versioned legal
+documents** served by the SPA and per-version IPFS-pinned, versioned by SHA-256, with the
+hash recorded on-chain at each consent. Geo/IP enforcement evidence is the existing
+Cloudflare/Cloud Run request logs. The public chain is the immutable, fail-closed,
+queryable "WORM" store — no GCS bucket lock, no BigQuery, no backend.
+
+## Technical Context
+
+**Language/Version**: Solidity `^0.8.24` (Hardhat `^2.28.2`); JavaScript/JSX on React 19 +
+Vite 7, tested with Vitest 4; ethers `^6.16`.
+
+**Primary Dependencies**: OpenZeppelin `AccessControl`/`ReentrancyGuard`/`Pausable`;
+`@noble/ciphers` (`chacha20poly1305` with AAD), `@noble/curves`, `@noble/post-quantum`
+(X-Wing hybrid KEM, already used); Chainalysis on-chain Sanctions Oracle
+(`SanctionsList.isSanctioned(address)`); Cloudflare WAF custom rules + Transform Rules;
+nginx (existing container); IPFS/Pinata; The Graph subgraph (optional consent indexing).
+
+**Storage**: **On-chain (Polygon)** for consent records, deny-list, and the accepted/bound
+T&C version hashes; **IPFS/Pinata** for per-version legal documents and encrypted wager
+metadata; **Cloud Logging** (existing Cloud Run request logs) for geo/IP enforcement
+evidence. No database, no WORM bucket, no BigQuery.
+
+**Testing**: Hardhat unit + integration + **fork test against Polygon mainnet (137)** for
+the real Chainalysis oracle (Amoy has none → mock on testnet/local); Vitest for frontend
+logic (gate, screening read, hash/version, AAD binding); Slither + Medusa for the contract
+changes; axe/Lighthouse for accessibility in CI.
+
+**Target Platform**: Web SPA on Cloud Run (us-central1) behind Cloudflare (fairwins.app);
+contracts on Polygon mainnet (137) and Amoy testnet (80002).
+
+**Project Type**: Existing multi-part repo — smart contracts + React frontend + subgraph.
+**No backend is introduced.**
+
+**Performance Goals**: Geo-blocked requests are rejected at Cloudflare (no origin
+round-trip); the on-chain guard adds ~1 `STATICCALL` (oracle) + 1 cold `SLOAD` (deny-list)
+per gated entrypoint — single-digit-thousands of gas, <5% of a wager/membership tx that
+already does ERC-20 transfers; client-side oracle screening returns sub-second via RPC;
+document hash verification is instant.
+
+**Constraints**: **NO BACKEND / current footprint** (the load-bearing constraint);
+fail-closed on oracle/guard unavailability and on reverted consent tx; per-chain oracle
+address injection (never hardcoded; Amoy has no oracle); the deterministic, versionless
+key-derivation signature MUST NOT change (encryption key reproducibility); WCAG 2.1 AA on
+all new UI; addresses/ABIs only from generated sync artifacts.
+
+**Scale/Scope**: Existing FairWins user base; deny-list is an O(1) mapping (enumeration
+off-chain via events); legal-document versions are small text artifacts; consent volume =
+existing membership/wager/key-registration tx volume.
+
+## Constitution Check
+
+*GATE: must pass before Phase 0 research. Re-checked after Phase 1 design (below).*
+
+| Principle | Applies? | How this plan satisfies it |
+|-----------|----------|----------------------------|
+| **I. Security-First Smart Contracts** (NON-NEGOTIABLE) | **YES** — new `SanctionsGuard` + admin deny-list and guard hooks in `WagerRegistry`/`MembershipManager` are `contracts/` changes on the access-control / fund-custody axis. | CEI preserved (sanctions check is the first Check, before effects/transfers); `nonReentrant` retained; deny-list mutation gated by a dedicated `SANCTIONS_ADMIN_ROLE`, oracle swap by `DEFAULT_ADMIN_ROLE`, both held by the floppy-keystore admin; events on every mutation; external oracle read wrapped in try/catch → **fail-closed**. Target EthTrust-SL L2; Slither + Medusa must be clean of new high/critical; smart-contract-security agent review before merge. Exit/refund paths stay **ungated** so a newly-listed party can still recover escrowed funds. |
+| **II. Test-First & Comprehensive Coverage** (NON-NEGOTIABLE) | **YES** | Hardhat unit (guard truth table, role-gating, fail-closed-on-oracle-revert, deny-list events), integration (create/accept/purchase/upgrade revert for listed sender + counterparty-on-accept), and a **fork test on Polygon 137** against the real oracle (SC-004/SC-016); Vitest for the gate, client screening, doc-hash/canonicalization, and AAD tamper-rejection + legacy no-AAD round-trip. Full suite green in CI before merge. |
+| **III. Honest State / no mocks in shipped paths / network-scoped** | **YES** | Production screening reads the **real** Chainalysis oracle on 137; `MockSanctionsOracle` lives only in `contracts/mocks/` and is injected solely on Amoy/local/fork. Guard bytecode is identical across networks (address injected). Screening + consent records carry/are scoped to `chainId`; no testnet result is honored on mainnet. No allow-all/stub in shipped code. |
+| **IV. Fail Loudly in CI** | **YES** | New Hardhat tests, Vitest tests, Slither, and (where feasible) the nginx/Cloudflare config checks run in CI with no `continue-on-error`; Slither/Medusa fail the pipeline on new critical findings. |
+| **V. Accessible, Consistent Frontend** | **YES** | Entry-gate modal (focus-trapped, labeled, keyboard-operable), discrete labeled checkboxes, versioned document pages, the 451 page, and the deny-list admin UI all meet WCAG 2.1 AA and pass axe/Lighthouse in CI; the Chainalysis oracle + `SanctionsGuard` + deny-list addresses/ABIs come from `sync:frontend-contracts`, never hardcoded (FR-055). |
+
+**New core technologies (justified per Additional Constraints):** (a) the external
+**Chainalysis on-chain oracle** — a free, authoritative, key-less OFAC source read on
+Polygon; (b) **Cloudflare edge security config** (geo WAF rule + secret-header Transform
+Rule) consumed by the **existing** nginx. **No backend, WORM store, or BigQuery is added.**
+The on-chain `SanctionsGuard`/deny-list follow existing repo patterns (OZ AccessControl,
+the injectable `IOracleAdapter` precedent), so they are not a new *core* technology.
+
+**Result: PASS.** No principle is violated; the Complexity Tracking table is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-compliance-gating/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (decisions + citations)
+├── data-model.md        # Phase 1 output (entities, on-chain + client + doc)
+├── quickstart.md        # Phase 1 output (validation guide)
+├── contracts/           # Phase 1 output (interface/behavior contracts)
+│   ├── ISanctionsGuard.md
+│   ├── IChainalysisSanctionsOracle.md
+│   ├── membership-version-recording.md
+│   ├── encrypted-metadata-v1.1.md
+│   ├── cloudflare-nginx-origin-lock.md
+│   └── frontend-gate-contracts.md
+├── checklists/
+│   └── requirements.md  # from /speckit-specify
+└── tasks.md             # /speckit-tasks (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+contracts/
+├── access/
+│   ├── SanctionsGuard.sol          # NEW: oracle + admin deny-list, fail-closed, AccessControl
+│   └── MembershipManager.sol       # MOD: consult guard on purchaseTier/upgradeTier; record accepted T&C version hash + event
+├── wagers/
+│   └── WagerRegistry.sol           # MOD: consult guard on createWager (sender) + acceptWager (sender + counterparty); store/emit bound T&C version hash
+├── privacy/
+│   └── KeyRegistry.sol             # MOD (light): emit eligibility-reference event at registration (dated by block)
+├── interfaces/
+│   ├── ISanctionsGuard.sol         # NEW
+│   └── IChainalysisSanctionsOracle.sol  # NEW (isSanctioned(address) view)
+└── mocks/
+    └── MockSanctionsOracle.sol     # NEW: test/testnet only (Amoy has no oracle)
+
+test/
+├── SanctionsGuard.test.js          # NEW unit
+├── integration/
+│   └── sanctions-gating.test.js    # NEW integration (create/accept/purchase/upgrade)
+└── fork/
+    └── ChainalysisSanctions.fork.test.js  # NEW fork test on Polygon 137
+
+frontend/
+├── nginx.conf.template             # MOD: verify Cloudflare origin-lock secret header; forward CF-IPCountry
+├── src/
+│   ├── components/
+│   │   ├── compliance/EntryGate.jsx         # NEW: client-side 21+/eligibility notice gate
+│   │   ├── compliance/MembershipAttestation.jsx  # NEW/extend: discrete un-pre-ticked checkboxes
+│   │   └── admin/DenyListAdmin.jsx          # NEW: deny-list admin UI (add/remove + reason)
+│   ├── pages/legal/{TermsPage,RiskPage,PrivacyPage}.jsx  # NEW: versioned doc pages (show hash version)
+│   ├── utils/
+│   │   ├── legalDocs.js             # NEW: canonicalize + SHA-256 version, version manifest, materiality flag
+│   │   └── sanctionsScreen.js       # NEW: client-side oracle read via RPC (advisory)
+│   ├── utils/crypto/
+│   │   ├── envelopeEncryption.js    # MOD: bind termsVersion hash as ChaCha20-Poly1305 AAD
+│   │   └── constants.js             # MOD: add TERMS_AAD_PREFIX builder (key-derivation messages UNCHANGED)
+│   ├── schemas/encrypted-metadata-v1.1.json  # NEW: add optional authenticated `termsVersion`
+│   ├── legal/                       # NEW: versioned document sources (+ IPFS pin manifest)
+│   └── abis/                        # MOD (generated): SanctionsGuard + oracle ABIs via sync
+└── public/451.html (or Cloudflare custom response)  # NEW: 451 explanation
+
+scripts/
+├── deploy/                         # MOD: deploy SanctionsGuard, inject per-chain oracle addr, wire guard into WagerRegistry/MembershipManager
+└── utils/sync-frontend-contracts.js  # MOD: include SanctionsGuard + deny-list + oracle addr/ABI/network config
+
+subgraph/                           # OPTIONAL: index consent/version + deny-list events for address-keyed queryability
+```
+
+**Structure Decision**: Reuse the existing multi-part layout. Contracts extend
+established patterns (`AccessControl`, the injectable `IOracleAdapter` precedent, the
+existing `notFrozen` modifier as a sibling — **not** a replacement). Frontend additions
+live under a new `components/compliance/` plus existing `components/admin/` and
+`pages/`. **No `backend/` directory is created** — that is the explicit constraint.
+
+## Complexity Tracking
+
+> No constitution violations — table intentionally empty. The design adds no new core
+> compute tier, reuses existing access-control / oracle-adapter / envelope-encryption
+> patterns, and stays within the current deployment footprint.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| _(none)_ | | |

--- a/specs/007-compliance-gating/quickstart.md
+++ b/specs/007-compliance-gating/quickstart.md
@@ -72,3 +72,36 @@ address — FR-055). Records are chainId-scoped (no cross-network leak — FR-02
    (prospective-only, SC-017); the next new wager binds the NEW version.
 4. Query by address via chain/subgraph → full consent history with governing versions
    (SC-007). A reverted consent tx leaves no record (fail-closed, SC-011).
+
+## 6. Deployment & migration (Spec 007) — operator runbook
+
+> **Live, non-upgradeable contracts.** `WagerRegistry`, `MembershipManager`, and `KeyRegistry`
+> are already deployed and are not proxies. This feature adds storage (`wagerTermsVersionHash`,
+> `sanctionsGuard`, `memberTermsHash`) and additive function overloads, so it ships as a
+> **fresh deployment + migration**, not an in-place upgrade.
+
+1. **Deploy + wire (per chain):** `npm run deploy:<network>` deploys `SanctionsGuard` with the
+   per-chain Chainalysis oracle injected (137 = `0x40C5…8fb`; Amoy/local get a `MockSanctionsOracle`),
+   then wires it into the (re)deployed `WagerRegistry`/`MembershipManager` (`setSanctionsGuard`,
+   idempotent). Admin roles (`SANCTIONS_ADMIN_ROLE` + `DEFAULT_ADMIN_ROLE`) go to the floppy-keystore admin.
+2. **Migration:** old wagers/memberships remain on the prior contracts (read-only/exit). New
+   activity uses the new addresses. Decide the cutover (parallel-run vs hard switch) and record
+   prior addresses in `deployments/`. Legacy wagers (no bound version) are governed by the launch
+   version (prospective-only — FR-057).
+3. **Sync frontend:** `npm run sync:frontend-contracts:<network>` writes the new addresses
+   (incl. `sanctionsGuard`) into `frontend/src/config/contracts.js`; ABIs are committed,
+   artifact-derived (`src/abis/*`). Verify no address is hand-hardcoded (FR-055).
+4. **Edge config (Cloudflare):** apply `infra/cloudflare/waf-geo.md` (country gate → 451) and
+   `infra/cloudflare/origin-lock.md` (Transform Rule secret header). Set `ORIGIN_LOCK_SECRET` on
+   Cloud Run from Secret Manager (the nginx origin-lock stays inert until it is set).
+5. **CI / fork tests:** set the `POLYGON_RPC_URL` repo secret so the Chainalysis fork test
+   (Polygon 137) runs in `oracle-fork-tests.yml`; Slither/Medusa run in `security-testing.yml`.
+6. **Pre-merge gate (Principle I):** Slither + Medusa clean of new high/critical, EthTrust-SL L2,
+   and a smart-contract-security agent review of the `contracts/` changes.
+
+## Open items pending counsel (see spec "Open Legal-Reconciliation Items")
+
+- Finalize Terms / Risk / **Privacy Policy** copy (drafts in `frontend/src/legal/`); the SHA-256
+  version is computed from whatever is published.
+- Set the launch **permitted-country allowlist** in the Cloudflare rule (runbook in
+  `infra/cloudflare/waf-geo.md`); reconcile T&C §5/§7/§11 with the implemented controls.

--- a/specs/007-compliance-gating/quickstart.md
+++ b/specs/007-compliance-gating/quickstart.md
@@ -1,0 +1,74 @@
+# Quickstart: Compliance & Legal Gating Layer
+
+Runnable validation scenarios proving the feature works end-to-end, within the current
+footprint (no backend). See [contracts/](./contracts/) and [data-model.md](./data-model.md)
+for details. Implementation belongs in `tasks.md`, not here.
+
+## Prerequisites
+
+- `npm install` (root) and `npm --prefix frontend install`.
+- A Polygon mainnet (137) RPC for fork tests (archive/Alchemy/Infura) in `.env`
+  (`POLYGON_RPC_URL`); never commit secrets (`.env.example` documents vars).
+- For local: Hardhat node + `MockSanctionsOracle` (Amoy/local have no real oracle).
+
+## 1. Contracts — sanctions guard (Principle I/II)
+
+```bash
+npm run compile
+npm test                 # unit: SanctionsGuard truth table, role-gating, fail-closed, events
+npm run test:integration # create/accept/purchase/upgrade revert for listed sender + counterparty
+npm run test:fork        # ChainalysisSanctions.fork.test.js against Polygon 137 real oracle
+npx slither .            # no new high/critical (Principle I)
+```
+**Expected**: a known **sanctioned** address reverts on `createWager`/`acceptWager`/
+`purchaseTier`/`upgradeTier` (direct contract call too — SC-016); a **clean** address
+passes; oracle-unreachable ⇒ revert (fail-closed, SC-004); exit/refund paths succeed even
+for a listed address; `DenyListUpdated` carries actor+reason; unauthorized `setDenied`/`setSanctionsOracle`
+revert (SC-018).
+
+## 2. Frontend — gate, screening, docs, encryption (Principle II/V)
+
+```bash
+npm run test:frontend    # Vitest
+```
+**Expected**:
+- EntryGate blocks the app until acknowledged; "Leave" withholds access; acknowledged
+  versions stored client-side (SC: entry gate).
+- Membership checkboxes are un-pre-ticked and block submit until all required ticked (SC-008).
+- `legalDocs` hash is reproducible from canonical text; a prior version is retrievable by hash
+  (SC-005); doc pages show "Version: <hash>" and are reachable in ≤2 clicks (SC-010).
+- Encrypted-metadata v1.1: round-trip with `termsVersion` + AAD; tampering `termsVersion.hash`
+  fails decrypt; legacy (no `termsVersion`) round-trips with no AAD (SC-017).
+- a11y: `axe`/Lighthouse pass on EntryGate, checkboxes, doc pages, 451, admin UI (SC-015).
+
+## 3. Deploy + sync (Principle III/V)
+
+```bash
+# local/testnet: deploy MockSanctionsOracle, then SanctionsGuard with injected oracle addr,
+# then wire guard into WagerRegistry + MembershipManager
+npm run deploy:local        # (extended deploy step)
+npm run sync:frontend-contracts:local   # SanctionsGuard + deny-list + oracle addr/ABI -> frontend abis
+```
+**Expected**: on Polygon 137 the guard is injected with `0x40C5…8fb`; on Amoy/local with the
+mock. Frontend reads addresses ONLY from synced artifacts (grep shows no hardcoded oracle
+address — FR-055). Records are chainId-scoped (no cross-network leak — FR-022).
+
+## 4. Edge geo + origin lock (manual / staging)
+
+- Cloudflare WAF rule (allowlist) → request from a blocked country returns **451**; no origin
+  hit (SC-001/SC-003). Stage in observe mode first (FR-011).
+- Direct `run.app` request **without** `X-Origin-Auth` → nginx **403** (SC-002/SC-012);
+  with the correct secret (as Cloudflare injects) → served.
+- `CF-IPCountry`/`CF-Connecting-IP` appear in Cloud Run request logs (geo evidence — FR-009).
+
+## 5. End-to-end consent of record (on-chain)
+
+1. New visitor → EntryGate (client notice) → connect wallet → screened (advisory) →
+   key registration (`EligibilityAcknowledged` event dates the signature).
+2. Purchase membership with the in-force terms hash → `MembershipPurchased(acceptedTermsHash, at)`
+   on-chain (SC-006).
+3. Create a wager → `WagerCreated(termsVersionHash)` + AAD-bound encrypted metadata; publish a
+   new **material** doc version → existing wager still resolves to the OLD version hash
+   (prospective-only, SC-017); the next new wager binds the NEW version.
+4. Query by address via chain/subgraph → full consent history with governing versions
+   (SC-007). A reverted consent tx leaves no record (fail-closed, SC-011).

--- a/specs/007-compliance-gating/quickstart.md
+++ b/specs/007-compliance-gating/quickstart.md
@@ -73,31 +73,69 @@ address — FR-055). Records are chainId-scoped (no cross-network leak — FR-02
 4. Query by address via chain/subgraph → full consent history with governing versions
    (SC-007). A reverted consent tx leaves no record (fail-closed, SC-011).
 
-## 6. Deployment & migration (Spec 007) — operator runbook
+## 6. Mainnet (137) deployment & cutover (Spec 007) — operator runbook
 
 > **Live, non-upgradeable contracts.** `WagerRegistry`, `MembershipManager`, and `KeyRegistry`
 > are already deployed and are not proxies. This feature adds storage (`wagerTermsVersionHash`,
 > `sanctionsGuard`, `memberTermsHash`) and additive function overloads, so it ships as a
 > **fresh deployment + migration**, not an in-place upgrade.
+>
+> **Decisions for this cutover:** Polygon **mainnet (137)** now; **full cutover + migrate** (not
+> parallel-run). The **prior contracts are already paused**, so there are no open wagers to settle
+> and the switch is clean. The app is **not live yet**, so the new contracts are **deployed paused**
+> (lockdown step 6) and only opened at go-live.
+>
+> Steps marked **[operator]** require the air-gapped floppy keystore (mainnet broadcast / admin
+> roles); steps marked **[agent]** are repo work I run and commit. Mainnet broadcast also requires
+> `CONFIRM_MAINNET=true`.
 
-1. **Deploy + wire (per chain):** `npm run deploy:<network>` deploys `SanctionsGuard` with the
-   per-chain Chainalysis oracle injected (137 = `0x40C5…8fb`; Amoy/local get a `MockSanctionsOracle`),
-   then wires it into the (re)deployed `WagerRegistry`/`MembershipManager` (`setSanctionsGuard`,
-   idempotent). Admin roles (`SANCTIONS_ADMIN_ROLE` + `DEFAULT_ADMIN_ROLE`) go to the floppy-keystore admin.
-2. **Migration:** old wagers/memberships remain on the prior contracts (read-only/exit). New
-   activity uses the new addresses. Decide the cutover (parallel-run vs hard switch) and record
-   prior addresses in `deployments/`. Legacy wagers (no bound version) are governed by the launch
-   version (prospective-only — FR-057).
-3. **Sync frontend:** `npm run sync:frontend-contracts:<network>` writes the new addresses
+1. **[operator] Deploy + wire (137):** with the floppy mounted,
+   `CONFIRM_MAINNET=true npm run deploy:polygon` deploys `SanctionsGuard` with the real Chainalysis
+   oracle injected (`0x40C5…8fb`), redeploys `WagerRegistry`/`MembershipManager`/`KeyRegistry`
+   (deterministic CREATE2), and wires the guard in (`setSanctionsGuard`, idempotent). Admin roles
+   (`DEFAULT_ADMIN_ROLE`, `SANCTIONS_ADMIN_ROLE`, `GUARDIAN_ROLE`, `ROLE_MANAGER_ROLE`) land on the
+   floppy admin. The run writes/updates `deployments/polygon-chain137-v2.json` (now incl.
+   `sanctionsGuard`). Commit that record.
+2. **[agent] Sync frontend:** `npm run sync:frontend-contracts:polygon` writes the new addresses
    (incl. `sanctionsGuard`) into `frontend/src/config/contracts.js`; ABIs are committed,
-   artifact-derived (`src/abis/*`). Verify no address is hand-hardcoded (FR-055).
-4. **Edge config (Cloudflare):** apply `infra/cloudflare/waf-geo.md` (country gate → 451) and
-   `infra/cloudflare/origin-lock.md` (Transform Rule secret header). Set `ORIGIN_LOCK_SECRET` on
-   Cloud Run from Secret Manager (the nginx origin-lock stays inert until it is set).
-5. **CI / fork tests:** set the `POLYGON_RPC_URL` repo secret so the Chainalysis fork test
+   artifact-derived (`src/abis/*`). Bump `wagerRegistry` in `DEPLOYMENT_BLOCKS_BY_CHAIN[137]` to the
+   new deploy block. Verify no address is hand-hardcoded (FR-055) and commit.
+3. **[operator] Verify on Polygonscan:** verify the new contract sources so the public can read the
+   compliance logic.
+4. **[operator] Migrate memberships:** the OLD `MembershipManager` (`0x7441…0c95`) holds the active
+   memberships; re-grant the still-active ones onto the new contract. Dry-run first, then execute:
+   ```bash
+   OLD_MEMBERSHIP_MANAGER=0x7441700979e37a9a1F17093a4859c8f261780c95 START_BLOCK=<oldMMdeployBlock> \
+     npm run migrate:memberships:polygon                      # dry run (DRY_RUN defaults true)
+   DRY_RUN=false OLD_MEMBERSHIP_MANAGER=0x7441700979e37a9a1F17093a4859c8f261780c95 START_BLOCK=<oldMMdeployBlock> \
+     npm run migrate:memberships:polygon                      # execute (floppy mounted)
+   ```
+   Idempotent + sanctions-aware: a sanctioned old member is correctly skipped. `grantMembership` does
+   not check tier `active`, so this runs even with the tiers deactivated by the lockdown.
+5. **[operator] Edge config (Cloudflare):** apply `infra/cloudflare/waf-geo.md` (country gate → 451,
+   stage in observe mode first) and `infra/cloudflare/origin-lock.md` (Transform Rule secret header).
+   Set `ORIGIN_LOCK_SECRET` on Cloud Run from Secret Manager (the nginx origin-lock stays inert until
+   it is set).
+6. **[operator] Pre-launch lockdown (app not live):** with the floppy mounted, pause the new
+   contracts so nobody can wager or buy a membership before go-live. Dry-run first:
+   ```bash
+   npm run lockdown:polygon                                   # dry run — prints planned actions
+   DRY_RUN=false npm run lockdown:polygon                     # pause WagerRegistry + deactivate tiers
+   ```
+   This pauses `WagerRegistry` (blocks create/accept; exit paths stay open) and deactivates the
+   seeded membership tiers (blocks purchase/upgrade/extend — `MembershipManager` has no `pause()`).
+   Run migration (step 4) **before** this, or run it anyway — `grantMembership` is unaffected.
+7. **[operator] Go-live (when ready):** reverse the lockdown.
+   ```bash
+   DRY_RUN=false ACTION=unlock npm run lockdown:polygon       # unpause + re-activate tiers
+   ```
+8. **CI / fork tests:** set the `POLYGON_RPC_URL` repo secret so the Chainalysis fork test
    (Polygon 137) runs in `oracle-fork-tests.yml`; Slither/Medusa run in `security-testing.yml`.
-6. **Pre-merge gate (Principle I):** Slither + Medusa clean of new high/critical, EthTrust-SL L2,
+9. **Pre-merge gate (Principle I):** Slither + Medusa clean of new high/critical, EthTrust-SL L2,
    and a smart-contract-security agent review of the `contracts/` changes.
+
+> Legacy wagers (no bound version) are governed by the launch terms version (prospective-only —
+> FR-057). Records are chainId-scoped; testnet memberships never appear active on mainnet.
 
 ## Open items pending counsel (see spec "Open Legal-Reconciliation Items")
 

--- a/specs/007-compliance-gating/research.md
+++ b/specs/007-compliance-gating/research.md
@@ -1,0 +1,227 @@
+# Phase 0 Research: Compliance & Legal Gating Layer
+
+All Technical-Context unknowns are resolved below. Factual claims (oracle address,
+Cloudflare/GCP capabilities) were adversarially verified against primary sources.
+Date: 2026-06-06.
+
+---
+
+## R1. Chainalysis on-chain Sanctions Oracle
+
+**Decision**: Use the Chainalysis on-chain Sanctions Oracle (`SanctionsList`) as the
+authoritative OFAC source. Read it (a) advisory client-side via RPC for UX and (b)
+on-chain from `SanctionsGuard` for enforcement. Interface:
+`interface IChainalysisSanctionsOracle { function isSanctioned(address) external view returns (bool); }`.
+
+**Key facts (verified)**:
+- Polygon **mainnet (137)** address: **`0x40C57923924B5c5c5455c48D93317139ADDaC8fb`**
+  (verified contract on PolygonScan; same address on ETH/BSC/Avalanche/Optimism/Arbitrum/
+  Fantom/Celo/Blast; **Base differs**: `0x3A91A31cB3dC49b4db9Ce721F50a9D076c8D739B`).
+- Polygon **Amoy (80002): NOT deployed** (empty EOA, no bytecode). → fork-test against a
+  137 fork and use `MockSanctionsOracle` on Amoy/local.
+- **Free**, no API key, no Chainalysis customer relationship for on-chain reads.
+- Only `isSanctioned(address) view` is needed (do not rely on the undocumented
+  `isSanctionedVerbose`).
+
+**Rationale**: Free, authoritative, key-less, widely deployed, and fork-testable. Matches
+the no-backend constraint (read on-chain or client-side via RPC; no server needed).
+
+**Alternatives**: TRM/Elliptic (no free public on-chain oracle); Chainalysis off-chain
+REST API (needs a key + a backend → violates the footprint constraint); self-maintained
+SDN list (staleness/operational burden). All rejected.
+
+**Risks**: oracle can lag OFAC; not a sole legal control. Address MUST be per-chain
+injected (Amoy has none, Base differs) — validate it has bytecode at deploy. Treat an
+unreachable/erroring oracle as **fail-closed** (block).
+
+Sources: go.chainalysis.com/chainalysis-oracle-docs.html; polygonscan.com & amoy.polygonscan.com
+(address `0x40C5…8fb`); PRNewswire 301500350 (free of charge); github.com/0xsequence/chainalysis.
+
+---
+
+## R2. On-chain SanctionsGuard + admin deny-list (FR-054 / FR-020)
+
+**Decision**: A standalone `contracts/access/SanctionsGuard.sol` (OZ `AccessControl`,
+`^0.8.24`) holding `IChainalysisSanctionsOracle public sanctionsOracle` (injectable; may
+be `address(0)` off-mainnet) and `mapping(address => bool) private _denied`. Surface:
+- `isAllowed(address) view → bool`: `false` if denied **or** (oracle set and
+  `isSanctioned`); the oracle read is wrapped in `try/catch` and any revert / empty
+  return-data is treated as **not allowed (fail-closed)**.
+- `checkBlocked(address)`: reverts `SanctionedAddress(address)` for explicit revert reasons.
+- `setDenied(address, bool, string reason)` — `onlyRole(SANCTIONS_ADMIN_ROLE)`, emits
+  `DenyListUpdated(account, denied, msg.sender, reason)`.
+- `setSanctionsOracle(address)` — `onlyRole(DEFAULT_ADMIN_ROLE)`, emits `SanctionsOracleUpdated`.
+
+Consume via a sibling guard (not by extending `notFrozen`): `WagerRegistry.createWager`
+(screen `msg.sender`), `WagerRegistry.acceptWager` (screen `msg.sender` **and** the
+counterparty `w.creator`), `MembershipManager.purchaseTier`/`upgradeTier` (screen
+`msg.sender`). The check is the **first Check** (before effects/transfers; CEI preserved);
+contracts are already `nonReentrant`; the oracle read is a `view`/STATICCALL (no reentrancy).
+
+**Rationale**: A deployed singleton gives one source of truth both consumers and the admin
+UI target, mirrors the existing injectable `IOracleAdapter` pattern, and exposes a clean
+FR-020 risk-scoring extension seam. Roles reuse OZ `AccessControl` (already a base of both
+contracts) so the floppy-keystore admin holds `SANCTIONS_ADMIN_ROLE` + `DEFAULT_ADMIN_ROLE`.
+
+**Decision — do NOT extend `notFrozen`**: `notFrozen` is operator account-moderation
+(`ACCOUNT_MODERATOR_ROLE`) applied across the whole lifecycle incl. exit paths; sanctions
+screening has different semantics (external oracle, fail-closed, different role,
+cross-contract reuse) and a **narrower** surface (only fund-taking / standing-granting
+entrypoints — never `claimRefund`/`declareDraw`, which stay open so a newly-listed party
+can recover their own escrowed funds). Keep them independent and composable.
+
+**Alternatives**: inline mapping per contract (duplicate state/admin), library/abstract
+base (no shared singleton for the admin UI), Ownable (loses the two-role split),
+fail-open-on-oracle-revert (violates fail-closed). All rejected.
+
+**Risks**: STATICCALL to a non-contract address returns empty data — handle as
+fail-closed. Counterparty-on-accept screening can make an open wager un-acceptable if the
+creator is listed later (desired) — keep refund/expire ungated. Full Principle I gate
+applies (Slither/Medusa/EthTrust-SL L2/security review). Gas overhead <5%.
+
+Sources: `contracts/wagers/WagerRegistry.sol` (createWager L191, acceptWager L278,
+`notFrozen` L101-104, refund-path reasoning L497-525), `contracts/access/MembershipManager.sol`
+(purchaseTier L133, upgradeTier L154), `contracts/oracles/IOracleAdapter.sol`,
+constitution.md (Principle I, floppy keystore).
+
+---
+
+## R3. Per-wager T&C version binding (FR-056/FR-057) — no key-derivation change
+
+**Decision**: Do **both**: (a) bind the canonical T&C version hash as **ChaCha20-Poly1305
+Associated Data (AAD)** on the content seal/open, and (b) add an authenticated top-level
+`termsVersion` field to the encrypted-metadata schema (bump to **v1.1**, optional-on-read).
+
+- AAD is added only at the **content** cipher call sites in
+  `frontend/src/utils/crypto/envelopeEncryption.js`: `encryptEnvelope` (~L305),
+  `encryptEnvelopeXWing` (~L482) and the matching `decryptEnvelope` (~L383) /
+  `decryptEnvelopeXWing` (~L555). **Not** on the per-recipient DEK-wrap ciphers.
+- `aad = utf8ToBytes("FairWins-TC|" + schemaVersion + "|" + termsVersionHashHex)`
+  (full hash, deterministic, no secrets) — pinned in a `TERMS_AAD_PREFIX` builder in
+  `constants.js`. The decrypt side reconstructs AAD from `envelope.termsVersion`, so a
+  tampered version fails AEAD auth ("invalid tag", already handled at
+  `useEncryption.js` ~L852).
+- `termsVersion = { id, hash }` is emitted alongside `version`/`algorithm`/`content`/`keys`.
+
+**Stays out of key derivation**: `getMarketSigningMessage(version)` →
+`signer.signMessage` → `keccak256(toUtf8Bytes(sig))` → seed (`deriveKeyPair` ~L179,
+`deriveXWingKeyPair` ~L237) is **untouched**. The T&C hash is only a function argument into
+the AEAD + envelope JSON; the per-account key stays versionless/reproducible (FR-041).
+
+**Canonicalization (frozen, FR-026/FR-059)**: `text.normalize('NFC')` → CRLF/CR → LF →
+`trim()` → UTF-8 (`utf8ToBytes`) → `sha256` (already imported) → `bytesToHex`.
+
+**Backward-compat (FR-057)**: `termsVersion` optional on read; legacy v1.0/v2.0 envelopes
+have none → decrypt with **no AAD** (today's exact path) and are governed by the launch
+version. New schema = `encrypted-metadata-v1.1.json` with `termsVersion` in `properties`,
+out of `required`, `version` enum extended; this also reconciles the existing schema/runtime
+drift (schema currently `additionalProperties:false` + describes the old xsalsa20 shape).
+
+**Alternatives**: version in the signing message (breaks FR-041, changes the key);
+plaintext `termsVersion` with no AAD (not tamper-evident); AAD only, no field (not
+human-readable/queryable). Rejected.
+
+Sources: `frontend/src/utils/crypto/envelopeEncryption.js`, `constants.js`,
+`schemas/encrypted-metadata-v1.json`, `@noble/ciphers` `chacha20poly1305(key,nonce,AAD?)`.
+
+---
+
+## R4. Geo-blocking at Cloudflare + origin lock within the footprint (FR-001…FR-013)
+
+**Decision**: Enforce geo at **Cloudflare** (it owns the true client IP); lock the Cloud
+Run origin with a **Cloudflare-injected secret header verified in the existing nginx** — no
+load balancer, Cloud Armor, or mTLS added (those are noted as future hardening outside the
+footprint).
+
+- **Geo gate**: WAF custom rule on `ip.src.country` (ISO 3166-1 alpha-2). Allowlist posture
+  default: `not (ip.src.country in {<allowed>})` → Block; locked OFAC set + US always in
+  the deny path. Block action → **custom 451** response (Cloudflare custom responses are
+  Pro+, status 400-499, ≤2KB; country blocking in custom rules works on all plans).
+  `CF-IPCountry` (XX=unknown, T1=Tor) is the country-of-record; `CF-Connecting-IP` the
+  client IP — both land in Cloud Run request logs via nginx (geo evidence tier).
+- **Origin lock**: a Cloudflare **Transform Rule** ("Set static") injects
+  `X-Origin-Auth: <high-entropy secret>` on every request; the **existing nginx** verifies
+  it and returns 403 if missing/wrong. A bare CF-egress-IP allowlist is insufficient
+  (CF IPs are shared across tenants → spoofable). Rotate the secret; inject at runtime like
+  the existing Pinata JWT (Secret Manager → Cloud Run env → nginx).
+- **Fail-closed**: under allowlist, unknown country (XX) and any edge rule-evaluation
+  failure → deny. Occupied regions (Crimea/Donetsk/Luhansk, often mislabeled RU/UA) →
+  conservative subdivision-granular treatment as denied.
+
+**Rationale**: Satisfies FR-007/FR-008's "can't be bypassed" property using only existing
+components (Cloudflare + nginx + Cloud Run). The verifier confirmed Global-LB frontend
+mTLS *is* GA and would be the strongest crypto origin-lock, **but** it requires adding an
+external ALB + Certificate Manager — new infra outside the footprint — so it is recorded as
+future hardening, not the v1 mechanism.
+
+**Alternatives**: Cloud Armor as the geo gate (sees the CF edge IP, not the user; can't
+emit 451); bare IP allowlist (spoofable); global AOP (shared cert, doesn't prove "your
+account"); app-code 451 (sees CF IP, wastes origin). Rejected for v1.
+
+Sources: Cloudflare WAF custom-rules (block/allow by country, create-dashboard custom
+response 400-499/Pro+), Transform Rules (Set static, 30 headers/rule), HTTP headers
+(CF-IPCountry/CF-Connecting-IP), IP-ranges (shared); Cloud Run ingress / serverless NEG /
+frontend-mTLS docs (for the documented future-hardening path).
+
+---
+
+## R5. No-backend consent-of-record & evidence (replaces the GCP WORM/BigQuery tier)
+
+**Decision**: Because no backend may be added, the **public chain is the WORM store** for
+consent records, and the **existing Cloudflare/Cloud Run request logs** are the geo/IP
+evidence tier.
+
+- **Membership purchase/upgrade** records the accepted T&C version hash on-chain + emits an
+  event (dated by block timestamp).
+- **Wager creation** binds the version via AAD (R3) and is itself an on-chain tx.
+- **Key registration** (`KeyRegistry`) dates the deterministic eligibility signature by its
+  block timestamp; a light event references the generic Terms.
+- **Fail-closed** is intrinsic: a reverted tx grants no consent and leaves no partial
+  record (no separate audit write to fail). **Idempotency** is intrinsic: re-submitting
+  converges to the same contract state; a dropped tx is reconciled against chain state
+  before retry. **Completeness/ordering/immutability** are provided by the chain — no
+  hash-chaining layer needed. **Queryability by address** is via the chain + the subgraph.
+- **Non-consenting visitors** (geo/sanctions-blocked, declined) leave **no** on-chain
+  record; their evidence is the edge request logs (country, IP, timestamp, decision),
+  retained per Cloud Logging retention and minimized. On-chain records carry **no** IP/UA
+  (privacy); off-chain PII stays only in the edge logs.
+
+**Rationale**: This is the only footprint-preserving way to get tamper-evident, fail-closed,
+queryable consent records, and it is arguably stronger than a GCS bucket-lock (public,
+independently verifiable). The earlier GCP WORM/BigQuery research (GCS Bucket Lock,
+`ifGenerationMatch=0`, Log Router → BigQuery, hash-chaining) is **recorded but not used** —
+it assumed a backend, which the constraint forbids; kept here only as the rejected
+alternative and as the blueprint **if** a backend is ever permitted.
+
+**Alternatives (rejected under the constraint)**: backend `/api/attest` → GCS Bucket-Lock
+WORM + BigQuery (needs a backend); Cloud Logging as the record of record (async/best-effort,
+not WORM). Both require new compute.
+
+**Risks**: entry-modal acceptance has no durable server record — accepted; its legal weight
+is the downstream on-chain consents + versioned docs (documented in the spec). Address-keyed
+querying may need a small subgraph addition for consent/version events.
+
+Sources: `contracts/privacy/KeyRegistry.sol`, `deployments/polygon-chain137-v2.json`,
+GCP Bucket-Lock / Log-Router docs (for the rejected backend alternative).
+
+---
+
+## R6. Versioned legal documents (FR-017…FR-030)
+
+**Decision**: Serve Terms, Risk Disclosure, **and Privacy Policy** from the SPA; store each
+**version** (not each event) in-repo under `frontend/src/legal/` and pin it to **IPFS/Pinata**;
+the version id is the SHA-256 of the canonicalized bytes (R3 canonicalization). A small
+`legalDocs.js` exposes the current version + hash, the version manifest (prior versions
+retrievable by hash), and the operator-set **materiality flag** (separate from the hash) that
+drives re-consent at the next consequential act (FR-030). The displayed "Last updated ·
+Version" header is populated with the hash on publish.
+
+**Rationale**: Footprint-preserving (SPA + existing Pinata), independently re-verifiable
+(re-hash the served bytes), and the hash is exactly what gets recorded on-chain at each
+consent — closing the "which text did they accept" loop without a backend.
+
+**Alternatives**: content-addressed-per-event / on-chain doc anchor (rejected by the user —
+too heavy; signature is the anchor); server/WORM hosting (no backend).
+
+Sources: spec clarifications (Q2 no per-event artifact; Q3 wager-bound governance;
+materiality flag), existing Pinata/IPFS usage (`Dockerfile`, `cloudbuild.yaml`).

--- a/specs/007-compliance-gating/spec.md
+++ b/specs/007-compliance-gating/spec.md
@@ -1,0 +1,920 @@
+# Feature Specification: Compliance & Legal Gating Layer
+
+**Feature Branch**: `007-compliance-gating`
+
+**Created**: 2026-06-06
+
+**Status**: Draft
+
+**Input**: User description: "Compliance & legal gating layer for FairWins: (1) geo-blocking enforced at the edge where the true client IP is visible, with the origin locked so the gate cannot be bypassed; (2) a layered eligibility/age attestation stack (entry modal → membership checkboxes → deterministic key-generation signature) with tamper-evident, fail-closed server-side audit logging; (3) on-chain wallet sanctions screening; and (4) versioned, SHA-256-hash-addressed Terms & Conditions and Risk Disclosure served on-site and referenced by every attestation record."
+
+## Overview
+
+FairWins must restrict access to eligible participants and produce a defensible,
+tamper-evident record that each participant affirmed their eligibility against a
+specific, verifiable version of the legal terms. The protection is a **stack**,
+not a single click: a geographic gate at the network edge, on-chain sanctions
+screening of the wallet, a three-layer consent flow (entry → membership →
+signature), versioned legal documents the consent incorporates by reference, and
+immutable on-chain consent records binding it all together. No single layer is sufficient;
+the defensibility comes from the layers reinforcing one another, and from the
+implemented controls matching what the legal documents represent.
+
+## Clarifications
+
+### Session 2026-06-06
+
+- Q: Where is sanctions screening enforced (app-layer vs on-chain contract guard)? → A: Both (defense-in-depth) — app-layer screening for fast UX plus a non-bypassable on-chain guard in the contracts, since FairWins' contracts are publicly callable on Polygon and an app-layer-only screen would be bypassable by direct contract calls.
+- Q: How are legal-document versions stored/anchored — content-addressed (IPFS) per event, server-hosted, or on-chain anchor? → A: No per-event artifact. Documents are served by the SPA and per-version IPFS-pinned, versioned by SHA-256 (re-hash to verify); the one-time deterministic key-generation signature is the per-account cryptographic anchor to the Terms, and each access/purchase records only the version hash — no IPFS pin per site access or membership purchase, keeping the account-to-Terms binding tied to wallet control.
+- Q: How is re-consent enforced on a material T&C change for existing members/wagers? → A: Per-wager term-version binding. Each wager is cryptographically bound (via its encryption — the governing version hash carried as authenticated associated data) to the T&C version accepted/in force at creation, and is governed by that version for its entire lifetime; new material versions apply prospectively only and NEVER retroactively to existing wagers. Re-consent attaches at the next consequential act (membership purchase/upgrade, new wager creation), not by hard-gating general browsing.
+- Q: Is the discretionary (illicit-finance) block-list in scope, and how rich? → A: Full scope (B). Operator-maintained block-list with an admin UI and its own audit trail of who added/removed entries (actor, timestamp, reason), enforced both at the app layer and via an updatable, access-controlled on-chain deny-list that the on-chain guard consults alongside the Chainalysis oracle. Risk-category scoring remains out of scope.
+- Q: Can we add a backend service for the server-side tamper-evident audit pipeline? → A: NO. FairWins must stay in its current deployment footprint (React+Vite SPA served by nginx on Cloud Run, smart contracts on Polygon, IPFS/Pinata, Cloudflare edge, Cloud Logging) — no backend, no new compute. This replaces the server-side WORM/BigQuery audit pipeline with **on-chain consent-of-record** (the public chain is the immutable, fail-closed, queryable store) plus **existing Cloudflare/Cloud Run request logs** for geo/IP enforcement evidence; origin-lock is a Cloudflare-injected secret header verified in the existing nginx. The entry "21+" modal becomes a client-side notice gate whose legal weight is carried by the downstream on-chain consents (membership, wager, key registration) it precedes.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Geographic access restriction that cannot be bypassed (Priority: P1)
+
+A visitor from a restricted jurisdiction (a comprehensively-sanctioned country, the
+United States under the current posture, or a prohibited gambling/prediction-market
+jurisdiction) is denied access to FairWins before they can interact with the app —
+and cannot reach the application by addressing the underlying origin directly.
+
+**Why this priority**: This is the broadest, highest-stakes legal protection.
+Comprehensively-sanctioned jurisdictions (OFAC) carry strict liability, so a single
+served session from a prohibited location is a violation regardless of intent. A
+geo-gate that only filters the "front door" while leaving the origin reachable is
+theater; the gate is only real if it is enforced where the true end-user IP is
+visible AND the origin refuses traffic that did not pass through the gate.
+
+**Independent Test**: Issue requests from a permitted country, a comprehensively-
+sanctioned country, the US, and a prohibited gambling jurisdiction — confirm only
+the permitted country is served and the others receive a clear legal-reason refusal.
+Separately, attempt to reach the origin directly (bypassing the edge, including from
+a same-CDN-provider source spoofing the edge headers) and confirm the request is
+refused. Delivers value standalone: the legal access boundary exists even before any
+attestation or document work is built.
+
+**Acceptance Scenarios**:
+
+1. **Given** the default allowlist posture, **When** a visitor whose edge-observed
+   country is not in the permitted set requests the site, **Then** they receive an
+   HTTP 451 "Unavailable For Legal Reasons" response with a human-readable
+   explanation, and no application content is served.
+2. **Given** a visitor located in Cuba, Iran, North Korea, Syria, or the Crimea/
+   Donetsk/Luhansk regions, **When** they request the site under any posture,
+   **Then** access is denied — these jurisdictions are blocked unconditionally,
+   including when their IP ranges are ambiguously labeled (e.g., occupied regions
+   mislabeled as RU/UA).
+3. **Given** a visitor located in the United States, **When** they request the site
+   under the current posture, **Then** access is denied.
+4. **Given** an actor who has discovered the origin's network address, **When** they
+   send a request directly to the origin (not through the edge), **Then** the origin
+   refuses the request rather than serving content.
+5. **Given** a request that arrives at the origin carrying client-supplied geo/IP
+   headers from a connection that is not cryptographically authenticated as the edge
+   (including another tenant of the same CDN provider), **When** the origin processes
+   it, **Then** the origin does not trust those headers and refuses the request.
+6. **Given** a visitor whose country cannot be determined by the edge, **When** the
+   default allowlist posture is in force, **Then** access is denied (fail-closed:
+   "unknown" is not in the permitted set).
+7. **Given** an operator changes the restricted-jurisdiction configuration, **When**
+   the change is staged in preview/observation mode, **Then** the system records
+   what *would* be blocked without enforcing, so the change can be validated before
+   it takes effect.
+8. **Given** the edge cannot evaluate the geo rule (edge/CDN evaluation failure),
+   **When** a request arrives, **Then** access fails closed (denied) rather than
+   serving ungated traffic.
+
+---
+
+### User Story 2 - On-chain wallet sanctions screening (Priority: P1)
+
+When a user connects a wallet, FairWins screens the wallet address against an
+authoritative on-chain sanctions list (and an operator-maintained discretionary
+block-list). An address that is listed is blocked from proceeding (key generation,
+membership, and at wager entry), and the screening outcome is recorded.
+
+**Why this priority**: Geo-blocking addresses *location*; sanctions screening
+addresses *identity at the address level*. OFAC SDN exposure is strict-liability and
+not solved by IP filtering alone (a sanctioned party can appear from a permitted
+location). On-chain screening closes that gap and is independent of the geo layer.
+Because FairWins' contracts are publicly callable on Polygon, enforcement is
+defense-in-depth: an app-layer screen (fast, blocks before gas) plus a non-bypassable
+on-chain guard so a sanctioned address that calls the contracts directly is still
+reverted.
+
+**Independent Test**: Against a fork of the active network, connect a known
+sanctioned address and a known clean address; confirm the sanctioned address is
+blocked from proceeding and the clean address is allowed, that the unreachable-oracle
+path fails closed, that a direct contract call from a sanctioned address reverts
+on-chain (bypassing the app layer), and that all screening outcomes are recorded.
+Delivers value standalone: sanctioned-address blocking works even before the
+attestation copy is finalized.
+
+**Acceptance Scenarios**:
+
+1. **Given** a connected wallet whose address is on the on-chain sanctions list or
+   the discretionary block-list, **When** the user attempts to proceed (generate
+   keys, purchase membership, or enter a wager), **Then** the action is refused and
+   the user is informed access is unavailable.
+2. **Given** a connected wallet whose address is on neither list, **When** the user
+   proceeds, **Then** screening does not block them.
+3. **Given** an enforcement-level screening determination, **When** it blocks an action,
+   **Then** the outcome is recorded on-chain (the reverted transaction / a deny-list
+   event with address, network/chainId, and block timestamp); the advisory client-side
+   pre-check needs no durable record.
+4. **Given** the sanctions-screening source is unavailable, **When** a user attempts
+   a screened action, **Then** the system fails closed (the action is refused rather
+   than allowed unscreened) and the condition is surfaced/alerted.
+5. **Given** a user who passed earlier screening, **When** they submit a wager,
+   **Then** the wallet is re-screened and the eligibility representation is renewed at
+   wager entry (matching the Terms' per-wager renewal), and the result is recorded.
+6. **Given** a sanctioned address that bypasses the app entirely, **When** it calls
+   the wager or membership-affecting contract directly, **Then** the on-chain guard
+   reverts the transaction (the app-layer screen is not the only control).
+7. **Given** an authorized admin adds an address to the discretionary block-list,
+   **When** the change is applied, **Then** that address is blocked at the app layer and
+   on-chain (via the deny-list), and the add is audit-logged with the admin's identity,
+   timestamp, and reason.
+8. **Given** an unauthorized actor, **When** they attempt to modify the on-chain
+   deny-list, **Then** the transaction reverts — only the authorized admin role may
+   update it.
+
+---
+
+### User Story 3 - Versioned, hash-addressed legal documents (Priority: P2)
+
+A user (or later, an auditor) can read the FairWins Terms & Conditions, Risk
+Disclosure, and Privacy Policy on the site, see a version identifier that is the
+SHA-256 hash of the exact (canonicalized) document content, and retrieve any specific
+past version by its hash so the precise text that was in force at any moment is
+verifiable.
+
+**Why this priority**: Every consent layer incorporates the legal documents by
+reference, and every attestation record must name the exact version accepted. A
+hash-based version makes the agreed text tamper-evident and reproducible: the
+version string *is* a fingerprint of the content. This is foundational for the
+attestation stories (they reference the version), so it is high priority but can be
+built and demonstrated independently of the consent flows.
+
+**Independent Test**: Open each document on the site; confirm each displays a version
+string containing the content hash; recompute the hash from the served content using
+the documented canonicalization and confirm it matches and is independently
+reproducible; retrieve a prior version by its hash and confirm the exact text is
+returned. Delivers value standalone: accessible, verifiable legal documents.
+
+**Acceptance Scenarios**:
+
+1. **Given** a published legal document, **When** a user opens it on the site,
+   **Then** the document content is displayed together with a version identifier
+   that is (or contains) the SHA-256 hash of that exact canonicalized content.
+2. **Given** a displayed version string, **When** an independent party recomputes the
+   hash from the served content using the documented canonicalization algorithm,
+   **Then** the recomputed hash matches the displayed version (the version is a true,
+   reproducible fingerprint of the content).
+3. **Given** a document's content is changed, **When** the new version is published,
+   **Then** it receives a new hash-based version and all prior versions remain
+   retrievable by their hashes.
+4. **Given** a recorded consent that names a document version, **When** an auditor
+   retrieves that version by its hash, **Then** the exact text the user agreed to is
+   returned and its hash re-verifies — for the full statutory retention window, even
+   if that version is no longer the published one.
+5. **Given** the Terms & Conditions, Risk Disclosure, and Privacy Policy, **When**
+   they are published, **Then** each incorporates the others by reference, and the
+   placeholder "Last updated · Version" header is populated with the real hash-based
+   version.
+6. **Given** an immaterial edit (e.g., a typo fix) produces a new content hash,
+   **When** an operator marks the new version as immaterial, **Then** returning users
+   are not forced to re-consent solely because the hash changed.
+
+---
+
+### User Story 4 - Entry eligibility notice gate (client-side) (Priority: P2)
+
+On first arrival (before connecting a wallet), a visitor is presented with a
+low-friction entry gate requiring an affirmative confirmation of eligibility and
+acceptance of the Terms and Risk Disclosure. Because there is no backend, the gate is
+a **client-side notice gate**: it blocks the app until acknowledged and records
+acceptance in client state; its legal weight is carried by the downstream **on-chain**
+consents (membership, wager, key registration) it precedes and the versioned documents
+it links. The edge (Cloudflare/Cloud Run) request logs capture the country-of-record/IP
+for the session as enforcement evidence.
+
+**Why this priority**: This is the first-touch notice — it surfaces eligibility and the
+versioned Terms/Risk Disclosure before any interaction, and carries the VPN/circumvention
+warning. The durable records of record are the on-chain consents (US-5/US-6 and wager
+creation).
+
+**Independent Test**: Load the site fresh; confirm the gate blocks the app until the
+user affirmatively acknowledges; accept and confirm the app becomes accessible and the
+acknowledged document version is captured in client state; decline and confirm access is
+withheld. Delivers value standalone: a first-touch eligibility notice that surfaces the
+current versioned terms.
+
+**Acceptance Scenarios**:
+
+1. **Given** a first-time visitor (no prior acknowledgement in client state), **When**
+   the site loads, **Then** an entry gate is shown before any application content,
+   requiring the user to affirm: 21+, not a U.S. person and not in a restricted
+   jurisdiction, not sanctioned, that access is lawful where they are located, and that
+   they have read and agree to the Terms & Conditions and Risk Disclosure.
+2. **Given** the entry gate, **When** the user selects "Enter" (affirmative), **Then**
+   access is granted and the acknowledged document version(s) are captured in client
+   state.
+3. **Given** the entry gate, **When** the user selects "Leave" (decline), **Then**
+   access is not granted.
+4. **Given** the entry gate, **When** it is displayed, **Then** it links the current
+   versioned Terms & Conditions and Risk Disclosure (by hash version) so the user sees
+   exactly what they are acknowledging.
+5. **Given** the entry gate, **When** it is displayed, **Then** it includes a clear
+   warning that using a VPN, proxy, or any means to misrepresent location or
+   eligibility breaches the Terms and voids access.
+6. **Given** a geo-blocked visitor, **When** they request the site, **Then** they never
+   reach the entry gate (Cloudflare returns 451 first), and the block is captured in the
+   edge request logs.
+7. **Given** a returning visitor who previously acknowledged (even if a newer *material*
+   version has since published), **When** they revisit, **Then** they may browse without
+   being hard-gated; the entry-gate skip is driven by client state, and any required
+   re-acceptance is enforced authoritatively **on-chain** at their next consequential act
+   (new wager / membership records the in-force version), so a forged client state cannot
+   create a binding consent.
+
+---
+
+### User Story 5 - Membership purchase/upgrade attestation (Priority: P3)
+
+When purchasing or upgrading a membership pass, the user must individually
+acknowledge a set of discrete eligibility and risk attestations — each presented as
+a separate, un-pre-ticked checkbox — and the accepted document version in force is
+recorded **on-chain** with the membership purchase (block timestamp = the dated record);
+the individual checkbox ticks are captured in client state.
+
+**Why this priority**: This is the dated, versioned, itemized consent record — the
+strongest documentary layer. It builds on the audit backbone (US-4) and the versioned
+documents (US-3), so it follows them.
+
+**Independent Test**: Begin a membership purchase/upgrade; confirm all checkboxes
+are un-ticked by default and that the purchase cannot complete until each required
+box is individually ticked; complete it and confirm each acknowledgement is recorded
+with its own timestamp and the in-force document version. The audit-write step can be
+exercised against a minimal standalone store for independent testing. Delivers value
+standalone: an itemized, dated consent record tied to payment.
+
+**Acceptance Scenarios**:
+
+1. **Given** the membership purchase/upgrade step, **When** it is displayed, **Then**
+   each attestation is a discrete checkbox, all un-ticked by default (no pre-ticked
+   boxes), and the membership is clearly described as a non-refundable fee for access
+   only — not a wager, stake, deposit, investment, security, or balance held on the
+   user's behalf, conferring no ownership interest, no profit expectation, and no
+   claim on any pool of funds.
+2. **Given** the membership attestations, **When** the user attempts to confirm
+   without ticking every required box, **Then** the purchase/upgrade cannot proceed.
+3. **Given** the required attestations, **When** presented, **Then** they cover at
+   minimum: (a) 21+; (b) not a U.S. person / not in a restricted jurisdiction; (c)
+   not a sanctioned or restricted party (incl. OFAC SDN); (d) understanding that
+   FairWins is not a registered exchange/broker/regulated operator, that there is no
+   regulator or authority to appeal to, and that outcomes are settled by smart
+   contract and the published dispute mechanism; (e) understanding of total-loss
+   risk, sole tax responsibility, and sole key control; (f) no use of VPN/proxy to
+   circumvent restrictions; and (g) having read and agreed to the Terms.
+4. **Given** a completed membership attestation, **When** the membership purchase/upgrade
+   transaction is submitted, **Then** the accepted document version in force is recorded
+   **on-chain** with the membership (and emitted in an event), with the discrete
+   checkbox acknowledgements captured in client state and reflected in the signed/confirmed
+   transaction; no off-chain server record is created.
+5. **Given** the membership transaction reverts or is not confirmed, **When** the user
+   attempts to confirm membership, **Then** the consent fails closed by construction — no
+   membership and no consent record exist until the transaction is mined.
+
+---
+
+### User Story 6 - Deterministic key-generation eligibility signature (Priority: P3)
+
+When a user generates their account key, they sign a deterministic wallet message
+that carries the standing eligibility facts and references the Terms generically.
+The message contains no nonce or timestamp (so any key derived from it is
+reproducible), the user is told the signature derives their account encryption key,
+and the *event* of signing is dated by the on-chain key registration (KeyRegistry)
+rather than by a date inside the signed payload.
+
+**Why this priority**: This is the cryptographic, non-repudiable layer of the stack.
+It depends on the existing key-generation/encryption and key-registration flow, so it
+comes after the documents and membership layers.
+
+**Independent Test**: Trigger key generation; confirm the presented message is
+deterministic (byte-identical across repeated signings for the same account and
+contains no nonce/timestamp) and that an independent party can reproduce both the
+exact signed bytes and the recovered address from the documented serialization; confirm
+the key registration is recorded on-chain (block timestamp = the dated record). Delivers
+value standalone: a reproducible cryptographic eligibility attestation dated on-chain.
+
+**Acceptance Scenarios**:
+
+1. **Given** the key-generation step, **When** the message to sign is presented,
+   **Then** it states the standing eligibility facts (21+, not a U.S. person, not in
+   a restricted jurisdiction, not a sanctioned/restricted party, sole wallet
+   control), references the Terms generically (e.g., "as published" at the Terms
+   URL), includes the wallet address, and discloses that signing deterministically
+   derives the account encryption key.
+2. **Given** the key-generation message, **When** it is generated repeatedly for the
+   same account, **Then** it is byte-identical each time (deterministic — no nonce,
+   no timestamp, fixed serialization), so any encryption key derived from the
+   signature is reproducible.
+3. **Given** the user signs the message, **When** the key is registered on-chain
+   (KeyRegistry), **Then** the registration transaction provides the dated record (block
+   timestamp + recovered/registering address) for the signing event, without a date
+   embedded in the signed payload; the session's country-of-record/IP remain only in the
+   edge request logs.
+4. **Given** the key-registration transaction reverts or is not confirmed, **When** the
+   user signs, **Then** the flow fails closed by construction — only a confirmed on-chain
+   registration counts as the dated record; an unconfirmed signing grants no standing.
+
+---
+
+### Edge Cases
+
+- **Header spoofing at the origin / shared-CDN tenant**: a direct-to-origin request
+  (or a request from another tenant of the same CDN provider) forging the
+  edge-injected country/IP headers must not be trusted; the origin honors those
+  headers only on connections cryptographically authenticated as the edge. A bare
+  source-IP allowlist is insufficient on its own.
+- **Unknown / undeterminable country**: under the allowlist posture, treat as denied
+  (fail-closed); record the country-of-record as "unknown".
+- **Edge/CDN outage or rule-evaluation failure**: if the geo-gate cannot evaluate,
+  fail closed (deny) rather than serving ungated traffic.
+- **Geo-data inaccuracy for occupied regions**: Crimea/Donetsk/Luhansk ranges are
+  often mislabeled as RU/UA; the locked sanctioned-region set is enforced with
+  conservative, subdivision-granular matching so ambiguous ranges covering those
+  regions are denied.
+- **Location drift across the stack**: a user permitted at entry whose membership,
+  signing, or wager occurs from a restricted location — each access renews the
+  eligibility representation, the geo-gate re-evaluates per request, and the
+  country-of-record is captured at each event independently.
+- **Newly-restricted location / newly-listed wallet mid-lifecycle**: a user blocked
+  by a new list entry is stopped at the next gated action (incl. wager entry);
+  previously-settled on-chain wagers are not reversed and fees are not refunded.
+- **Document version drift mid-session**: if a document changes between when a user
+  opens it and when they accept, the recorded version must reflect the exact text
+  shown at the moment of acceptance, not a newer version.
+- **Immaterial re-versioning**: a typo/whitespace fix changes the content hash; an
+  operator-set materiality flag (not hash inequality) decides whether returning users
+  must re-consent, so immaterial changes do not force re-consent and material ones do.
+- **Terms change after a wager exists**: a wager is governed for its lifetime by the
+  T&C version cryptographically bound to it at creation; a new (even material) version is
+  prospective only and never retroactively governs an existing wager. Re-consent to a
+  new material version attaches at the next consequential act (new wager / membership),
+  not as a hard gate on browsing.
+- **Content normalization for hashing**: the hash is computed over a single,
+  documented canonical representation so trivial encoding differences (line endings,
+  Unicode form, trailing whitespace, encoding) never change the hash for identical
+  text, and the hash is reproducible by a third party.
+- **Sanctioned wallet after entry**: a user may pass the entry gate (location-based)
+  but connect a sanctioned wallet — wallet screening blocks them at that point.
+- **Sanctions-source / audit-store unavailable**: both fail closed (refuse the
+  action) and surface/alert, consistent with the fail-closed posture.
+- **Lost-acknowledgement retry**: if the immutable record is written but the
+  acknowledgement to the client is lost, a retry must not create a duplicate record
+  (idempotent on event ID).
+- **Audit completeness challenge**: defending against "you deleted/cherry-picked
+  logs" requires detecting deletion/reordering, not just per-record immutability.
+- **Declined / blocked visitors and privacy**: records for declined or geo/sanctions-
+  blocked (non-consenting) visitors capture only the minimized, compliance-relevant
+  fields, under a distinct lawful basis and bounded retention disclosed in the
+  Privacy Policy.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Geographic restriction (geo-gate)**
+
+- **FR-001**: The system MUST evaluate geographic access using the true end-user IP
+  as observed at the network edge, not an address that only reflects intermediate
+  infrastructure.
+- **FR-002**: The system MUST support an **allowlist** posture (deny all locations
+  except an explicitly permitted set) as the default operating mode, and a
+  **denylist** posture (permit all except an explicitly blocked set) as an available
+  alternative.
+- **FR-003**: Regardless of posture, the system MUST unconditionally deny access from
+  the comprehensively-sanctioned set — Cuba, Iran, North Korea, Syria, and the
+  Crimea, Donetsk, and Luhansk regions — and these MUST NOT be removable except by an
+  explicit, logged configuration change.
+- **FR-004**: The system MUST deny access from the United States under the current
+  posture, while allowing this specific entry to be revisited if a regulated route is
+  later adopted.
+- **FR-005**: The system MUST support a configurable ("tunable") set of additional
+  prohibited jurisdictions (e.g., gambling/prediction-market bans such as France,
+  Belgium, Singapore) that operators can adjust without code changes.
+- **FR-006**: When access is denied for geographic reasons, the system MUST return an
+  HTTP 451 ("Unavailable For Legal Reasons") response with a human-readable
+  explanation of the geo-restriction (not a bare or generic error).
+- **FR-007**: The origin (the Cloud Run service serving the SPA) MUST reject any request
+  that did not pass through the edge geo-gate, so the geo-restriction cannot be bypassed
+  by addressing the origin directly.
+- **FR-008**: The origin MUST reject any request that is not authenticated as coming
+  from the edge before serving content. Within the current footprint this is a
+  high-entropy secret header injected by a Cloudflare Transform Rule and verified in the
+  existing nginx (requests lacking/with a wrong secret are refused); a bare source-IP
+  allowlist MUST NOT be the sole control because shared-CDN egress IPs let same-provider
+  tenants spoof headers. Stronger cryptographic edge authentication (Cloud Run ingress
+  restriction + Global LB frontend mTLS / Cloudflare Authenticated Origin Pulls) is a
+  documented future hardening that lies outside the current footprint.
+- **FR-009**: The system MUST derive a **country-of-record** from the edge-observed
+  client IP (Cloudflare `CF-IPCountry`) and make it available for geo-enforcement
+  evidence via the existing edge/Cloud Run request logs (no backend). On-chain consent
+  records do NOT carry IP/country (privacy); the geo/IP evidence lives in the edge logs
+  and is correlated to consents by time and, where present, wallet address.
+- **FR-010**: Country determination MUST use ISO 3166-1 alpha-2 country codes (with
+  subdivision codes where needed for occupied-region matching).
+- **FR-011**: The system MUST support staging geo-configuration changes in a
+  preview/observation mode that records what would be blocked before enforcement is
+  applied.
+- **FR-012**: The system MUST fail closed under the allowlist posture when the edge
+  cannot determine a country, and when the edge cannot evaluate the geo rule at all
+  (edge/CDN evaluation failure) — denying access rather than serving ungated traffic.
+- **FR-013**: The system MUST acknowledge IP-geolocation accuracy limits and enforce
+  the locked comprehensively-sanctioned regions with conservative, subdivision-granular
+  matching, treating ambiguous ranges that may cover occupied regions (e.g.,
+  Crimea/Donetsk/Luhansk mislabeled as RU/UA) as denied.
+- **FR-014**: The system MUST periodically reconcile the locked comprehensively-
+  sanctioned set against the authoritative OFAC source and log any additions, so the
+  enforced list and Schedule A's open-ended category stay in sync.
+- **FR-015**: The system MUST detect and flag known anonymizing infrastructure
+  (VPN/proxy/Tor exit nodes, datacenter/hosting ASNs) as a recorded risk signal that
+  informs the geo decision and supports the discretionary block/void path the Terms
+  contemplate for circumvention.
+
+**Wallet sanctions screening**
+
+- **FR-016**: The system MUST screen a connected wallet address against an
+  authoritative on-chain sanctions list before allowing the user to proceed to key
+  generation, membership purchase, or wager entry. This app-layer screen is a
+  **client-side (frontend) read** of the oracle via RPC for fast UX (advisory); it is one
+  of two enforcement layers — the non-bypassable on-chain backstop required by FR-054 is
+  what actually enforces (so a bypassed/forged frontend check cannot grant access).
+- **FR-017**: The system MUST refuse to let a listed wallet proceed, and MUST inform
+  the user that access is unavailable.
+- **FR-018**: Enforcement-level screening outcomes MUST be recorded **on-chain**: a
+  blocked attempt reverts on-chain (the failed transaction is the evidence), and every
+  deny-list entry and mutation is an on-chain event (address, actor, reason, block
+  timestamp). The advisory client-side pre-check needs no durable record.
+- **FR-019**: If the sanctions-screening source is unavailable, the system MUST fail
+  closed (refuse the screened action rather than allow it unscreened) and surface/
+  alert the condition.
+- **FR-020**: The system MUST provide an operator-maintained discretionary block-list
+  of addresses associated with sanctioned activity or illicit finance (beyond on-chain
+  SDN-list membership), to back the broader screening right asserted in the Terms (s.11),
+  with the same fail-closed treatment as oracle screening. The block-list MUST be managed
+  through an admin interface, MUST keep its own audit trail of every add/remove (acting
+  admin identity, timestamp, reason), and MUST be enforced both at the app layer AND via
+  an updatable, access-controlled on-chain deny-list consulted by the on-chain guard
+  (FR-054). Risk-category/proximity scoring beyond list membership remains an explicit
+  future extension on this seam.
+- **FR-021**: The system MUST re-screen the wallet and renew the eligibility
+  representation at wager entry (consistent with the Terms' per-wager renewal), record
+  the result, and bind the in-force, accepted T&C version to the wager (see FR-056).
+- **FR-022**: Production screening MUST query the real on-chain oracle on the active
+  network — no mock, stub, or allow-all path in shipped code (mocks confined to test
+  scope) — and screening results and on-chain consent records MUST be scoped to the
+  network (chainId) on which they were produced and never honored across testnet/mainnet
+  boundaries.
+
+**Versioned legal documents**
+
+- **FR-023**: The system MUST serve the FairWins Terms & Conditions, Risk Disclosure,
+  and Privacy Policy on the site, accessible to users.
+- **FR-024**: Each legal document version MUST carry a version identifier that is the
+  SHA-256 hash of its exact canonicalized content, and the displayed "Last updated /
+  Version" string MUST include that hash.
+- **FR-025**: Each version MUST be individually addressable and retrievable by its
+  hash, and publishing new content MUST create a new version while leaving all prior
+  versions retrievable. Retrieval is from the FairWins versioned store / legal-hold copy
+  (server-hosted); content-addressed or decentralized (e.g., IPFS) distribution is
+  explicitly NOT required (clarified 2026-06-06), and verification is by recomputing the
+  content hash from the returned bytes.
+- **FR-026**: The content hash MUST be computed over a single, documented,
+  version-pinned canonical representation (defining Unicode normalization form,
+  line-ending policy, encoding, whitespace trimming, and whether the hash covers the
+  document source or rendered text) so identical text always yields the same hash and
+  the hash is independently reproducible by a third party.
+- **FR-027**: The version string referenced by every attestation record MUST match
+  the document version presented to the user at the moment of consent, so the exact
+  text accepted can be retrieved and re-verified. Each consent event records only the
+  version hash (a cheap reference) — no per-event document copy or external artifact is
+  created.
+- **FR-028**: The published Terms, Risk Disclosure, and Privacy Policy MUST incorporate
+  one another by reference, and their placeholder version headers MUST be populated
+  with the real hash-based version on publication.
+- **FR-029**: The canonical bytes of each document version (retained once per version,
+  NOT per event) MUST be held under the same write-once/retention regime as the audit
+  records that reference it, so the exact accepted text remains reproducible for the
+  full statutory retention window — not merely while the version remains published. No
+  per-access or per-purchase document snapshot or content-addressed pin is required.
+- **FR-030**: The system MUST track an operator-set "materiality" flag for each
+  document version, distinct from the content hash; re-consent for returning users
+  MUST be triggered by this flag (an authorized, audit-logged operator determination),
+  not by content-hash inequality alone, so that immaterial re-versioning does not
+  silently force re-consent and material changes are not silently skipped. Re-consent is
+  enforced prospectively at the next consequential act (membership purchase/upgrade and
+  new wager creation), NOT by hard-gating general browsing; existing memberships and
+  existing wagers remain governed by the version in force when they were created (see
+  FR-056–FR-059).
+
+**Layered consent — entry gate**
+
+- **FR-031**: On first visit (before wallet connection), the system MUST present an
+  entry gate that requires the user to affirmatively confirm eligibility (21+, not a
+  U.S. person / not in a restricted jurisdiction, not sanctioned, lawful where
+  located) and acceptance of the Terms and Risk Disclosure before any application
+  content is accessible.
+- **FR-032**: The entry gate MUST provide an explicit decline path and MUST NOT grant
+  access without affirmative acceptance.
+- **FR-033**: The entry gate MUST display a VPN/proxy/circumvention warning.
+- **FR-034**: A returning visitor who has already acknowledged a prior version MUST NOT
+  be hard-gated from browsing by a new version; the current terms are shown and the
+  binding re-acceptance of a new material version is enforced **on-chain** at the next
+  consequential act (FR-030/FR-058 — the membership/wager records the in-force version).
+  The entry-gate skip itself is driven by client state (no backend); because a forged
+  client state cannot produce an on-chain consent, it cannot create a binding agreement.
+
+**Layered consent — membership attestation**
+
+- **FR-035**: At membership purchase or upgrade, the system MUST present discrete,
+  individually-ticked attestation checkboxes, all un-ticked by default (no pre-ticked
+  boxes).
+- **FR-036**: The system MUST prevent completion of the membership purchase/upgrade
+  until every required attestation checkbox is individually ticked.
+- **FR-037**: The membership attestations MUST cover, at minimum: 21+; not a U.S.
+  person / not in a restricted jurisdiction; not a sanctioned or restricted party
+  (incl. OFAC SDN); acknowledgement that FairWins is not a registered exchange/broker/
+  regulated operator and that there is no regulator or authority to appeal to and that
+  outcomes settle by smart contract and the published dispute mechanism;
+  acknowledgement of total-loss risk, sole tax responsibility, and sole key control;
+  no VPN/circumvention; and having read and agreed to the Terms.
+- **FR-038**: The system MUST present the membership pass as a non-refundable fee for
+  access only — explicitly not a wager, stake, deposit, investment, security, or
+  balance held on the user's behalf, conferring no ownership interest, no profit
+  expectation, and no claim on any pool of funds, with fees not pooled, staked,
+  wagered, or returned as winnings.
+- **FR-039**: The system MUST record the accepted document version in force **on-chain**
+  with the membership purchase/upgrade transaction (block timestamp = the dated record);
+  the individual checkbox selections are captured in client state at confirmation time.
+
+**Layered consent — key-generation signature**
+
+- **FR-040**: At account key generation, the system MUST present a deterministic
+  message for the user to sign with their wallet that carries the standing eligibility
+  facts, references the Terms generically (as published, at the Terms URL), and
+  includes the wallet address.
+- **FR-041**: The key-generation message MUST contain no nonce and no timestamp, MUST
+  remain stable for the life of the account, and MUST use a single documented
+  byte-serialization (encoding, signing scheme, and address checksum casing) so any
+  encryption key derived from the signature is reproducible and the recovered address
+  is independently reproducible by a third party.
+- **FR-042**: The system MUST NOT embed dated or versioned consent in the
+  key-generation signed payload; the dated record is provided by the **on-chain key
+  registration** (KeyRegistry block timestamp) instead.
+- **FR-043**: The dated record of the key-generation signing event MUST be the on-chain
+  key registration (block timestamp + registering address); the session's
+  country-of-record/IP remain only in the edge request logs (no backend signing-event log).
+- **FR-044**: The system MUST disclose to the user that signing this message
+  deterministically derives their account encryption key (consistent with the Risk
+  Disclosure), and the design MUST treat the **on-chain key-registration record** — not the
+  signed payload — as the source of the signing's dated evidentiary weight. This
+  one-time, wallet-bound signature is the per-account cryptographic anchor binding the
+  wallet to acceptance of the Terms as published; per-event, version-specific consent is
+  captured by the on-chain consent's version-hash reference (FR-027/FR-045), so no
+  per-event cryptographic or content-addressed artifact is needed.
+
+**Consent records & evidence (cross-cutting, no-backend)**
+
+- **FR-045**: The legally-operative consents MUST be recorded **on-chain** as the
+  records of record: (a) membership purchase/upgrade records the accepted T&C version
+  hash and emits an event; (b) wager creation binds the governing T&C version hash into
+  the wager (FR-056) and is itself an on-chain transaction; (c) key registration
+  timestamps the deterministic eligibility signature. Each on-chain consent carries the
+  wallet address, the referenced document version hash, and the block timestamp. The
+  entry "21+" modal is a client-side notice gate (no server to record it) whose legal
+  weight is carried by these downstream on-chain consents and the versioned documents
+  they reference.
+- **FR-046**: The on-chain consent records inherit the public blockchain's immutability
+  and permanence (the chain is the tamper-evident store of record); the canonical bytes
+  of each referenced document version are retained per FR-029 (SPA + per-version IPFS
+  pin). No server-side WORM/BigQuery store is introduced.
+- **FR-047**: Consent records MUST be queryable by wallet address via the chain
+  (directly and/or via the subgraph indexer); geo/IP enforcement evidence MUST be
+  queryable in the existing Cloud Logging request logs.
+- **FR-048**: The consent records MUST be fail-closed by construction: an on-chain
+  consent either commits or reverts — a reverted transaction grants no consent and
+  leaves no partial record, so no consent action takes effect without its durable
+  on-chain record. (There is no separate server-side audit write that could fail
+  independently.)
+- **FR-049**: On-chain consent recording MUST be idempotent at the contract-state level
+  — re-submitting the same membership/version acknowledgement converges to the same
+  state rather than creating contradictory records; client retries of a dropped
+  transaction reconcile against on-chain state before re-submitting.
+- **FR-050**: Completeness and ordering integrity for consent records MUST be provided
+  by the blockchain itself (total ordering, immutability, and non-deletability of
+  confirmed transactions); no additional hash-chaining layer is required for on-chain
+  records.
+- **FR-051**: Geo/sanctions-blocked and declined (non-consenting) visitors leave NO
+  on-chain record (they never transact); their enforcement evidence is the existing
+  Cloudflare/Cloud Run request logs, retained under the configured log-retention window
+  and minimized to the compliance-relevant fields (country-of-record, IP, timestamp,
+  decision). The Privacy Policy MUST disclose this edge logging.
+- **FR-052**: Neither the on-chain records nor the edge request logs MUST contain
+  secrets/credentials, and on-chain records MUST NOT contain off-chain PII (IP, user
+  agent) — those remain only in the edge logs (data minimization across both surfaces).
+
+**Cross-cutting quality requirements**
+
+- **FR-053**: All new user-facing surfaces (entry gate modal, checkbox attestation
+  set, document/version pages, the 451 page) MUST meet WCAG 2.1 AA — keyboard-operable,
+  focus-trapped and labeled modal, programmatically-associated checkbox labels, and
+  sufficient contrast — and MUST pass automated accessibility checks (axe/Lighthouse)
+  in CI.
+- **FR-054**: Sanctions enforcement MUST include a non-bypassable on-chain guard (in
+  addition to the app-layer screen of FR-016): the wager and membership-affecting
+  contracts MUST consult both the on-chain sanctions oracle and the updatable on-chain
+  deny-list (FR-020) and revert transactions from listed addresses, so a listed party
+  cannot evade screening by calling the contracts directly. The on-chain deny-list's
+  update function MUST be access-controlled (only an authorized admin role may modify it)
+  and MUST emit events on mutation. Because this is a `contracts/` change on the
+  access-control risk axis, it MUST follow the constitution's Security-First principle
+  (checks-effects-interactions; reentrancy and access-control-bypass guards; Slither and
+  Medusa clean of new high/critical findings; EthTrust-SL L2 target with documented gaps;
+  and a smart-contract-security review), with explicit security reasoning in the plan.
+- **FR-055**: The Chainalysis oracle address, ABI, and network configuration consumed
+  by the frontend MUST come from the generated contract-sync artifacts, never hand-copied
+  or hardcoded.
+
+**Wager-bound term governance** (clarified 2026-06-06)
+
+- **FR-056**: At wager creation, the wager MUST be bound to the T&C version that is in
+  force and accepted by the creator at that moment, with the governing version hash
+  cryptographically incorporated into the wager's encrypted record (e.g., as
+  authenticated associated data) so the binding is tamper-evident. This per-wager
+  version binding is separate from the account encryption-key derivation, which remains
+  versionless and deterministic per FR-041.
+- **FR-057**: A wager MUST remain governed for its entire lifetime by the T&C version
+  bound at creation; a later T&C version — even a material one — MUST NOT retroactively
+  govern an existing wager. New versions apply prospectively only, to wagers created
+  after they are in force.
+- **FR-058**: To create a new wager, the creator MUST have accepted the in-force T&C
+  version (re-accepting if it changed materially since their last acceptance); the
+  newly-accepted version is the one bound to the wager (FR-056) and recorded with the
+  on-chain wager creation.
+- **FR-059**: The T&C version bound to any wager MUST remain retrievable and
+  re-verifiable for at least the wager's lifetime plus the statutory retention window
+  (per FR-029), so the exact governing terms of any historical wager can be reproduced.
+
+### Key Entities *(include if feature involves data)*
+
+- **Restricted-Jurisdiction Configuration**: the active posture (allowlist/denylist)
+  and the three list buckets — comprehensively-sanctioned (locked), United States
+  (posture decision), and tunable prohibited jurisdictions — expressed as ISO
+  3166-1 alpha-2 (and subdivision) codes.
+- **Country-of-Record**: the edge-derived country attributed to a request (Cloudflare
+  `CF-IPCountry`), with any anonymizer/risk signal, used for gating and surfaced in the
+  edge/Cloud Run request logs as geo-enforcement evidence.
+- **Sanctions-Screening Result**: the outcome of screening a wallet address against the
+  on-chain sanctions oracle and discretionary deny-list — enforced on-chain (a revert is
+  the record) with an advisory client-side pre-check; deny-list state is on-chain.
+- **Discretionary Block-List Entry**: an operator-maintained blocked address with its
+  reason, the acting admin's identity, add/remove timestamps, and the on-chain deny-list
+  reflection — each mutation captured in the block-list's admin audit trail.
+- **Legal Document Version**: a published document (Terms, Risk Disclosure, or Privacy
+  Policy) with its canonical content/bytes, document type, content-hash version, and
+  operator-set materiality flag; individually retrievable by hash; prior versions
+  retained.
+- **Wager Term-Binding**: the governing T&C version hash cryptographically bound into a
+  wager's encrypted record at creation (e.g., as authenticated associated data), fixing
+  the rules that govern that wager for its lifetime — prospective-only and never
+  retroactively changed by later versions.
+- **On-chain Consent Record**: the record-of-record for a consequential consent — a
+  membership purchase/upgrade (carrying the accepted document version hash + event), a
+  wager creation (carrying the bound version hash), or a key registration — identified by
+  wallet address and block timestamp; immutable and queryable on-chain.
+- **Membership Attestation Set**: the discrete checkbox acknowledgements captured in
+  client state at a membership purchase/upgrade, tied to the on-chain-recorded document
+  version at confirmation time.
+- **Key-Generation Signature**: the one-time deterministic signed message (recovered
+  address derivable) whose dated record is the on-chain key registration — distinct from
+  the signed message itself, which carries no date.
+- **Edge Enforcement Log Entry**: the existing Cloudflare/Cloud Run request-log record of
+  a geo/sanctions decision (country-of-record, IP, timestamp, decision) — the evidence
+  tier for blocked/declined non-consenting visitors; retained per the log-retention window.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of requests originating from any comprehensively-sanctioned
+  jurisdiction or the United States are denied access, verified with test traffic from
+  each restricted region (including occupied-region ranges that may be mislabeled).
+- **SC-002**: 0% of attempts to reach application functionality by addressing the
+  origin directly (bypassing the edge) succeed — every such request is refused.
+- **SC-003**: Geo-denied visitors receive a clear, human-readable legal-reason
+  explanation (not a generic error or a broken page) in 100% of denial cases tested.
+- **SC-004**: 100% of connected wallets are screened before proceeding, and known
+  sanctioned addresses are blocked in 100% of test cases; unscreenable cases are
+  blocked, never allowed through — verified via a fork test against the active network
+  (known sanctioned address, clean address, and the unreachable-oracle fail-closed
+  path), not mocks.
+- **SC-005**: For any recorded consent, the exact document text the user agreed to can
+  be retrieved and its content hash re-verified to match the logged version string,
+  with 100% reproducibility, and an independent third party can reproduce the hash from
+  the documented canonicalization.
+- **SC-006**: Every completed consent action (membership purchase/upgrade, wager
+  creation, key registration) produces a confirmed **on-chain** record carrying the
+  accepted/bound document version hash; the record cannot be altered or deleted (chain
+  immutability), and a retry of a dropped transaction reconciles against on-chain state
+  rather than creating a contradictory record.
+- **SC-007**: An auditor can retrieve the complete on-chain consent history for any
+  given wallet address (which documents, which versions, when) via the chain/subgraph
+  within 5 minutes, and can correlate geo/IP enforcement evidence for the relevant
+  window from the edge request logs.
+- **SC-008**: No pre-ticked attestation checkbox ever appears, and a membership
+  purchase/upgrade cannot complete with any required box un-ticked, verified across
+  all required attestations.
+- **SC-009**: The key-generation message is byte-identical across repeated signings
+  for the same account (deterministic), and both the recovered address and the derived
+  key are independently reproducible from the pinned serialization.
+- **SC-010**: A user can locate and open the current Terms, Risk Disclosure, and
+  Privacy Policy from the site in under 30 seconds (within two interactions).
+- **SC-011**: When a consent transaction reverts or is not confirmed, 0% of consent
+  actions take effect (fail-closed by construction verified for membership purchase,
+  wager creation, and key registration — no partial/orphan consent state).
+- **SC-012**: A request carrying spoofed edge geo/IP headers from a connection that is
+  not cryptographically authenticated as the edge (including a same-CDN-provider,
+  different-tenant source) is refused in 100% of attempts — the spoofed geo is never
+  honored.
+- **SC-013**: When the edge cannot evaluate the geo rule (edge/CDN evaluation failure),
+  access fails closed (denied) in 100% of tested cases.
+- **SC-014**: Confirmed on-chain consent records cannot be deleted or reordered (the
+  blockchain provides total ordering and immutability); the edge request logs are
+  retained for the configured window for the geo-evidence tier.
+- **SC-015**: All new UI surfaces (entry gate modal, checkbox attestation set, document
+  pages, 451 page) pass automated WCAG 2.1 AA accessibility checks in CI.
+- **SC-016**: A sanctioned address that calls the wager or membership-affecting
+  contract directly (bypassing the app layer) is reverted on-chain in 100% of test
+  cases, verified via a fork test — proving the sanctions control is non-bypassable.
+- **SC-017**: A wager created under T&C version V remains provably governed by V after a
+  newer version is published — the governing version hash is recoverable from the
+  wager's encrypted record and re-verifies — in 100% of test cases, and no existing
+  wager is ever retroactively re-bound to a newer version.
+- **SC-018**: Every discretionary block-list add/remove is recorded with the acting
+  admin's identity, timestamp, and reason, and an unauthorized attempt to modify the
+  on-chain deny-list is reverted (access control verified) — in 100% of test cases.
+
+## Assumptions
+
+- **No backend / current footprint** (clarified 2026-06-06): The feature MUST stay
+  within today's deployment footprint — React+Vite SPA served by **nginx on Cloud Run**,
+  **smart contracts on Polygon** (137 + Amoy 80002), **IPFS/Pinata**, **Cloudflare** edge,
+  and **Cloud Logging** (Cloud Run request logs). No backend service, no new compute, no
+  WORM bucket, no BigQuery sink. "Server-side" needs are met on-chain, at the edge, or
+  client-side.
+- **Deployment topology**: Cloudflare (edge) observes the true client IP, does
+  per-country detection, and filters with WAF custom rules; the Cloud Run origin (SPA +
+  nginx) sits behind it. No load balancer / Cloud Armor is added (that would be new infra
+  outside the footprint).
+- **Origin lock**: A Cloudflare Transform Rule injects a high-entropy secret header that
+  the existing nginx verifies (reject if missing/wrong) — the footprint-preserving
+  load-bearing control for FR-007/FR-008. A bare edge-IP allowlist is insufficient alone.
+  Cloud Run ingress restriction + Global-LB frontend mTLS / Authenticated Origin Pulls is
+  documented as future hardening outside the current footprint.
+- **Country-of-record source**: Cloudflare injects `CF-IPCountry` (and `CF-Connecting-IP`)
+  which nginx forwards into the Cloud Run request logs; that is the geo/IP evidence tier.
+  No backend reads these per consent event.
+- **Sanctions list**: Wallet screening uses the Chainalysis on-chain Sanctions Oracle
+  (the chosen authoritative source) read on the active network (Polygon), plus the
+  discretionary block-list. Enforcement is defense-in-depth across **both** layers
+  (clarified 2026-06-06): an app-layer screen (FR-016) for fast UX and a non-bypassable
+  on-chain contract guard (FR-054) so listed addresses cannot proceed even via direct
+  contract calls.
+- **Existing flows reused**: A membership purchase/upgrade flow and a wallet
+  signature-based account key-generation/encryption flow already exist; this feature
+  adds the attestation gating, copy, and logging to them rather than building them
+  from scratch.
+- **Records of record are on-chain**: Tamper-evident, fail-closed, queryable consent
+  records are provided by the public chain (membership purchase records the accepted T&C
+  version + event; wager creation binds the version; key registration timestamps the
+  eligibility signature) — no backend, WORM bucket, or queryable index is introduced;
+  queryability by address is via the chain and the subgraph indexer.
+- **Discretionary block-list administration** (clarified 2026-06-06): The block-list is
+  managed via an admin UI with a full add/remove audit trail (actor, timestamp, reason)
+  and enforced both at the app layer and via an updatable, access-controlled on-chain
+  deny-list. The on-chain deny-list admin key follows the constitution's air-gapped
+  floppy keystore flow; deny-list mutations are access-controlled and emit events; the
+  admin UI is subject to the project's frontend standards (ESLint, accessibility).
+- **Document storage & anchoring** (clarified 2026-06-06): Legal documents are served by
+  the SPA and each **version** (not each event) is pinned to **IPFS/Pinata** and kept in
+  the repo, versioned by SHA-256. The per-account cryptographic anchor binding a wallet to
+  the Terms is the one-time deterministic key-generation signature; each subsequent
+  consent records only the version hash **on-chain**. No document/IPFS artifact is created
+  per site access or membership purchase, and the account-to-Terms binding stays tied to
+  wallet control.
+- **Canonicalization default**: Pending finalization in the plan, document hashing
+  canonicalizes to Unicode NFC, LF line endings, UTF-8, with trailing-whitespace
+  trimming, hashing the document source; the signed-message serialization uses UTF-8
+  with the standard personal-sign (EIP-191) scheme and checksummed address casing.
+- **Materiality flag**: Whether a new document version requires re-consent is an
+  authorized operator decision recorded as a logged configuration change, independent
+  of the content hash.
+- **Legal copy is draft**: The three consent texts and the legal documents are drafts
+  to be hardened with a gaming/CFTC attorney before launch; bracketed placeholders
+  (governing law, arbitral institution, seat, contact, entity domicile, problem-gambling
+  resources, confirmed prohibited-jurisdiction list) remain pending counsel and do not
+  block building the gating mechanisms.
+- **Retention window**: Accepted-user consent records live permanently on-chain (no
+  expiry). Non-consenting-visitor evidence is the edge/Cloud Run request logs, retained
+  under the configured Cloud Logging retention window (set to the applicable window
+  pending counsel); the chain's immutability is what makes the consent record defensible.
+- **Default posture**: The launch geo posture is allowlist (deny unless explicitly
+  permitted); the specific permitted-country set is operator-curated configuration, not
+  fixed by this spec (a defined launch set is needed for the "allow path" acceptance
+  test — deferred to planning/ops).
+- **Legacy wagers** (pre-dating versioned binding): wagers created before this feature
+  are governed by the document version in force at this feature's launch (the first
+  published version) and are not retroactively re-bound by later versions (the
+  prospective-only rule of FR-057 protects them); exact migration handling is finalized
+  in the plan.
+- **Privacy basis**: Logging IP/country for declined and blocked visitors is treated as
+  compliance evidence (the record of enforcement) under a documented lawful basis with
+  data minimization; on-chain activity is pseudonymous per the Privacy Policy.
+- **Test-first (constitution Principle II)**: Each functional area (geo decision logic,
+  origin lock, sanctions screen, hash/version computation, each consent layer, audit
+  write + fail-closed + idempotency + chain-of-custody) ships with automated tests at
+  the appropriate level — Vitest for frontend logic (gate, screening read, hash/version,
+  encrypted-metadata binding), Hardhat unit/integration tests for the SanctionsGuard,
+  deny-list, on-chain version recording, and a fork test (Polygon 137) for the Chainalysis
+  oracle read — and the full suite must pass in CI before merge.
+- **CI fail-loud (Principle IV)**: All new code paths are wired into CI under the
+  fail-loud policy (lint/type/build/test fail the pipeline; security scans fail on
+  critical findings; no `continue-on-error` on these steps).
+- **New core technologies (Additional Constraints)**: Only two genuinely new elements
+  require constitution-check justification in `plan.md`: (a) the on-chain SanctionsGuard +
+  admin deny-list contracts (and the external Chainalysis oracle dependency they read),
+  and (b) the Cloudflare edge security configuration (WAF geo rule + secret-header
+  Transform Rule) consumed by the existing nginx. No backend, WORM store, or BigQuery is
+  added — the footprint is otherwise unchanged.
+- **Secrets/keys (Additional Constraints)**: The only new secret is the Cloudflare→nginx
+  origin-lock secret header; it follows the constitution's key/secret handling (never
+  committed or logged; `.env` local; `.env.example` documents required vars; injected at
+  runtime like the existing Pinata JWT). The deny-list admin key uses the air-gapped
+  floppy keystore flow.
+
+## Open Legal-Reconciliation Items (pending counsel)
+
+These are alignment items between the implemented controls and the drafted documents;
+they are tracked here so the plan and counsel can resolve them, and do not block
+building the mechanisms:
+
+- **T&C s.11 breadth**: The implemented screening is on-chain SDN list + discretionary
+  block-list. Either narrow s.11 to match, or extend screening to risk-category/illicit-
+  finance signals on the FR-020 seam, so represented and actual controls match.
+- **T&C s.5 per-wager renewal**: Backed by FR-021 (re-screen + renew at wager entry);
+  confirm the wager-entry attestation surface is acceptable or amend s.5.
+- **T&C s.7 "immediately voids"**: Detection (FR-015) is in scope; automated
+  void/forfeiture is discretionary/phased — align s.7 wording with the discretionary
+  enforcement actually provided.
+- **Privacy Policy**: Brought under the versioned/hash-addressed regime (FR-023/FR-028);
+  confirm it is authored and that it discloses the compliance logging (FR-051).
+
+## Dependencies
+
+- Cloudflare (proxied/orange-cloud) on fairwins.app: WAF custom rule for the geo gate +
+  a Transform Rule injecting the origin-lock secret header. (No Cloud Armor / load
+  balancer added.)
+- Existing nginx (in the Cloud Run container) extended to verify the origin-lock secret
+  header and forward `CF-IPCountry`/`CF-Connecting-IP` into request logs.
+- On-chain Chainalysis sanctions oracle reachable on Polygon mainnet (137), plus a
+  Polygon-137 fork-test environment and a mock oracle for Amoy/local (no oracle on 80002).
+- On-chain SanctionsGuard + admin deny-list contracts; existing WagerRegistry,
+  MembershipManager, and KeyRegistry contracts (modified to consult the guard / record
+  the accepted version).
+- Existing wallet-connection, membership, key-generation/encryption, and IPFS/Pinata flows.
+- Generated contract-sync artifacts extended to carry the oracle + guard + deny-list
+  addresses/ABIs/network config (FR-055); the subgraph optionally extended to index
+  consent/version events for address-keyed queryability.
+- Legal counsel sign-off on the consent copy and documents before production launch.
+
+## Out of Scope
+
+- Finalizing or legally reviewing the document/consent wording (counsel's role; this
+  feature hosts and versions whatever text is published).
+- Identity verification / KYC with document upload or PII collection beyond self-
+  attestation and on-chain/address screening.
+- Risk-category / illicit-finance proximity *scoring* beyond on-chain list membership
+  and the discretionary block-list (FR-020 provides the extension seam; scoring itself
+  is future work).
+- Automated void/forfeiture *enforcement* on circumvention detection (detection and the
+  discretionary block path are in scope; automatic forfeiture is phased/discretionary).
+- Fiat payment processing and any membership refund mechanism (membership is
+  non-refundable per Terms).
+- Selecting region-specific problem-gambling helpline resources (placeholder pending
+  counsel).
+- A separate dated, on-chain EIP-712 consent signature (noted as a possible future
+  addition that must not be entangled with key derivation), unless later prioritized.

--- a/specs/007-compliance-gating/tasks.md
+++ b/specs/007-compliance-gating/tasks.md
@@ -196,7 +196,7 @@ Existing multi-part repo: `contracts/`, `test/`, `frontend/src/`, `scripts/`, `s
 **Purpose**: Security gates, accessibility, CI, optional indexing, validation.
 
 - [ ] T052 [P] Run Slither + Medusa on the contract changes; resolve or document new high/critical findings (Principle I)
-- [ ] T053 Smart-contract-security agent review of `SanctionsGuard` + WagerRegistry/MembershipManager/KeyRegistry changes (`.github/agents/`) before merge
+- [X] T053 Smart-contract-security agent review of `SanctionsGuard` + WagerRegistry/MembershipManager/KeyRegistry changes (`.github/agents/`) before merge
 - [X] T054 [P] axe + Lighthouse accessibility audit (WCAG 2.1 AA) of EntryGate, membership checkboxes, legal doc pages, 451 page, DenyListAdmin; wire checks into CI (Principle V)
 - [X] T055 Update CI to run new Hardhat unit/integration/fork + Vitest + Slither with no `continue-on-error` on lint/test/build/security (Principle IV)
 - [ ] T056 [P] (Optional) Extend `subgraph/` to index `WagerCreated.termsVersionHash`, `Membership*` accepted hash, and `DenyListUpdated` for address-keyed consent queries (FR-047)

--- a/specs/007-compliance-gating/tasks.md
+++ b/specs/007-compliance-gating/tasks.md
@@ -139,12 +139,12 @@ Existing multi-part repo: `contracts/`, `test/`, `frontend/src/`, `scripts/`, `s
 
 ### Tests for User Story 4
 
-- [ ] T040 [P] [US4] Vitest: EntryGate blocks until acknowledged, "Leave" withholds, acknowledged versions persisted, current versioned docs linked, in `frontend/src/test/EntryGate.test.jsx`
+- [X] T040 [P] [US4] Vitest: EntryGate blocks until acknowledged, "Leave" withholds, acknowledged versions persisted, current versioned docs linked, in `frontend/src/test/EntryGate.test.jsx`
 
 ### Implementation for User Story 4
 
-- [ ] T041 [US4] Implement `frontend/src/components/compliance/EntryGate.jsx` (focus-trapped labeled modal; affirmations 21+/non-US/non-restricted/non-sanctioned/lawful; VPN warning; Enter/Leave; links versioned docs by hash; client-state ack) — WCAG 2.1 AA
-- [ ] T042 [US4] Mount EntryGate in `frontend/src/App.jsx`/`AppLayout` before app content on first visit; skip for returning visitors via client state (re-consent enforced on-chain at next consequential act)
+- [X] T041 [US4] Implement `frontend/src/components/compliance/EntryGate.jsx` (focus-trapped labeled modal; affirmations 21+/non-US/non-restricted/non-sanctioned/lawful; VPN warning; Enter/Leave; links versioned docs by hash; client-state ack) — WCAG 2.1 AA
+- [X] T042 [US4] Mount EntryGate in `frontend/src/App.jsx`/`AppLayout` before app content on first visit; skip for returning visitors via client state (re-consent enforced on-chain at next consequential act)
 
 **Checkpoint**: Entry notice gate live; downstream on-chain consents carry the legal weight.
 
@@ -158,14 +158,14 @@ Existing multi-part repo: `contracts/`, `test/`, `frontend/src/`, `scripts/`, `s
 
 ### Tests for User Story 5
 
-- [ ] T043 [P] [US5] Vitest: checkboxes un-pre-ticked, submit blocked until all required ticked, copy mirrors FR-037/FR-038, in `frontend/src/test/MembershipAttestation.test.jsx`
-- [ ] T044 [P] [US5] Hardhat test: `purchaseTier`/`upgradeTier` record + emit `acceptedTermsHash`, in `test/MembershipManager.terms.test.js`
+- [X] T043 [P] [US5] Vitest: checkboxes un-pre-ticked, submit blocked until all required ticked, copy mirrors FR-037/FR-038, in `frontend/src/test/MembershipAttestation.test.jsx`
+- [X] T044 [P] [US5] Hardhat test: `purchaseTier`/`upgradeTier` record + emit `acceptedTermsHash`, in `test/MembershipManager.terms.test.js`
 
 ### Implementation for User Story 5
 
-- [ ] T045 [US5] Modify `contracts/access/MembershipManager.sol`: add `acceptedTermsHash`/`acceptedAt` to the membership record + `purchaseTier`/`upgradeTier` params + extended events — **depends on T025 (same file)**
-- [ ] T046 [US5] Implement `frontend/src/components/compliance/MembershipAttestation.jsx` (discrete un-pre-ticked checkboxes per FR-037/FR-038; on confirm pass `acceptedTermsHash`) — WCAG 2.1 AA
-- [ ] T047 [US5] Integrate MembershipAttestation into the existing membership flow (`frontend/src/pages/WalletPage.jsx` Membership tab); prompt re-acceptance when the in-force version is flagged material
+- [X] T045 [US5] Modify `contracts/access/MembershipManager.sol`: add `acceptedTermsHash`/`acceptedAt` to the membership record + `purchaseTier`/`upgradeTier` params + extended events — **depends on T025 (same file)**
+- [X] T046 [US5] Implement `frontend/src/components/compliance/MembershipAttestation.jsx` (discrete un-pre-ticked checkboxes per FR-037/FR-038; on confirm pass `acceptedTermsHash`) — WCAG 2.1 AA
+- [X] T047 [US5] Integrate MembershipAttestation into the existing membership flow (`frontend/src/pages/WalletPage.jsx` Membership tab); prompt re-acceptance when the in-force version is flagged material
 
 **Checkpoint**: Itemized, dated, on-chain membership consent live.
 
@@ -179,13 +179,13 @@ Existing multi-part repo: `contracts/`, `test/`, `frontend/src/`, `scripts/`, `s
 
 ### Tests for User Story 6
 
-- [ ] T048 [P] [US6] Vitest: eligibility message determinism (byte-identical), required content + disclosure, recovered-address reproducibility, in `frontend/src/test/keygenEligibility.test.js`
-- [ ] T049 [P] [US6] Hardhat test: `KeyRegistry` emits `EligibilityAcknowledged` dated by block, in `test/KeyRegistry.eligibility.test.js`
+- [X] T048 [P] [US6] Vitest: eligibility message determinism (byte-identical), required content + disclosure, recovered-address reproducibility, in `frontend/src/test/keygenEligibility.test.js`
+- [X] T049 [P] [US6] Hardhat test: `KeyRegistry` emits `EligibilityAcknowledged` dated by block, in `test/KeyRegistry.eligibility.test.js`
 
 ### Implementation for User Story 6
 
-- [ ] T050 [US6] Update the key-generation signing UI/flow (`frontend/src/hooks/useEncryption.js` / `frontend/src/utils/keyRegistryService.js`) to present the eligibility facts + generic Terms ref + wallet address + key-derivation disclosure — **the key-derivation message itself stays UNCHANGED** (deterministic, versionless)
-- [ ] T051 [US6] Modify `contracts/privacy/KeyRegistry.sol` to emit `EligibilityAcknowledged(account, termsRef)` at registration (dated by block timestamp)
+- [X] T050 [US6] Update the key-generation signing UI/flow (`frontend/src/hooks/useEncryption.js` / `frontend/src/utils/keyRegistryService.js`) to present the eligibility facts + generic Terms ref + wallet address + key-derivation disclosure — **the key-derivation message itself stays UNCHANGED** (deterministic, versionless)
+- [X] T051 [US6] Modify `contracts/privacy/KeyRegistry.sol` to emit `EligibilityAcknowledged(account, termsRef)` at registration (dated by block timestamp)
 
 **Checkpoint**: All six stories independently functional.
 

--- a/specs/007-compliance-gating/tasks.md
+++ b/specs/007-compliance-gating/tasks.md
@@ -195,7 +195,7 @@ Existing multi-part repo: `contracts/`, `test/`, `frontend/src/`, `scripts/`, `s
 
 **Purpose**: Security gates, accessibility, CI, optional indexing, validation.
 
-- [ ] T052 [P] Run Slither + Medusa on the contract changes; resolve or document new high/critical findings (Principle I)
+- [X] T052 [P] Run Slither + Medusa on the contract changes; resolve or document new high/critical findings (Principle I)
 - [X] T053 Smart-contract-security agent review of `SanctionsGuard` + WagerRegistry/MembershipManager/KeyRegistry changes (`.github/agents/`) before merge
 - [X] T054 [P] axe + Lighthouse accessibility audit (WCAG 2.1 AA) of EntryGate, membership checkboxes, legal doc pages, 451 page, DenyListAdmin; wire checks into CI (Principle V)
 - [X] T055 Update CI to run new Hardhat unit/integration/fork + Vitest + Slither with no `continue-on-error` on lint/test/build/security (Principle IV)

--- a/specs/007-compliance-gating/tasks.md
+++ b/specs/007-compliance-gating/tasks.md
@@ -197,10 +197,10 @@ Existing multi-part repo: `contracts/`, `test/`, `frontend/src/`, `scripts/`, `s
 
 - [ ] T052 [P] Run Slither + Medusa on the contract changes; resolve or document new high/critical findings (Principle I)
 - [ ] T053 Smart-contract-security agent review of `SanctionsGuard` + WagerRegistry/MembershipManager/KeyRegistry changes (`.github/agents/`) before merge
-- [ ] T054 [P] axe + Lighthouse accessibility audit (WCAG 2.1 AA) of EntryGate, membership checkboxes, legal doc pages, 451 page, DenyListAdmin; wire checks into CI (Principle V)
-- [ ] T055 Update CI to run new Hardhat unit/integration/fork + Vitest + Slither with no `continue-on-error` on lint/test/build/security (Principle IV)
+- [X] T054 [P] axe + Lighthouse accessibility audit (WCAG 2.1 AA) of EntryGate, membership checkboxes, legal doc pages, 451 page, DenyListAdmin; wire checks into CI (Principle V)
+- [X] T055 Update CI to run new Hardhat unit/integration/fork + Vitest + Slither with no `continue-on-error` on lint/test/build/security (Principle IV)
 - [ ] T056 [P] (Optional) Extend `subgraph/` to index `WagerCreated.termsVersionHash`, `Membership*` accepted hash, and `DenyListUpdated` for address-keyed consent queries (FR-047)
-- [ ] T057 [P] Update docs: `README`/`CLAUDE.md` pointers, the Open Legal-Reconciliation Items (counsel), permitted-country allowlist runbook, and the legacy-wager migration note (governed by launch version)
+- [X] T057 [P] Update docs: `README`/`CLAUDE.md` pointers, the Open Legal-Reconciliation Items (counsel), permitted-country allowlist runbook, and the legacy-wager migration note (governed by launch version)
 - [ ] T058 Run `specs/007-compliance-gating/quickstart.md` end-to-end on Amoy + a Polygon-137 fork; confirm all SCs
 
 ---

--- a/specs/007-compliance-gating/tasks.md
+++ b/specs/007-compliance-gating/tasks.md
@@ -1,0 +1,278 @@
+---
+description: "Task list for Compliance & Legal Gating Layer (007)"
+---
+
+# Tasks: Compliance & Legal Gating Layer
+
+**Input**: Design documents from `specs/007-compliance-gating/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+**Tests**: INCLUDED — Principle II (Test-First) is non-negotiable in this repo.
+**Footprint constraint**: NO backend. "Server-side" needs are met on-chain / at the edge /
+client-side (see plan.md). No `backend/` directory is created.
+
+**Organization**: by user story (US1–US6 from spec.md) for independent implementation/testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelizable (different files, no incomplete dependency)
+- **[Story]**: US1–US6 (setup/foundational/polish carry no story label)
+
+## Path Conventions
+
+Existing multi-part repo: `contracts/`, `test/`, `frontend/src/`, `scripts/`, `subgraph/`,
+`infra/` (new, for edge config). No backend.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Branch, config, env, and test scaffolding.
+
+- [X] T001 Create feature branch `007-compliance-gating` from `main` and confirm clean tree (never commit to `main`; PR-only per repo workflow)
+- [X] T002 [P] Add `.env.example` entries (no secrets committed): `POLYGON_RPC_URL` (fork tests), `ORIGIN_LOCK_SECRET` (Cloudflare→nginx), and a documented per-chain Chainalysis oracle address var
+- [X] T003 [P] Add per-chain Chainalysis oracle address to deploy config: `137 = 0x40C57923924B5c5c5455c48D93317139ADDaC8fb`, `80002`/local = mock placeholder, in the deploy inputs under `scripts/deploy/` + `deployments/` config
+- [X] T004 [P] Create empty test files to be filled later: `test/SanctionsGuard.test.js`, `test/integration/sanctions-gating.test.js`, `test/fork/ChainalysisSanctions.fork.test.js`, and `frontend/src/test/` placeholders for the new Vitest suites
+- [X] T005 [P] Create `infra/cloudflare/` directory with a README for the WAF geo rule + Transform-Rule (origin-lock secret) configuration (runbook/IaC home)
+
+**Checkpoint**: Repo wired for the feature; no behavior yet.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared interfaces, mock, and the canonical hashing util that multiple stories depend on.
+
+**⚠️ CRITICAL**: US2 and US3 cannot begin until this phase is complete.
+
+- [X] T006 [P] Create `contracts/interfaces/IChainalysisSanctionsOracle.sol` with `function isSanctioned(address) external view returns (bool)` (see contracts/IChainalysisSanctionsOracle.md)
+- [X] T007 [P] Create `contracts/interfaces/ISanctionsGuard.sol` per contracts/ISanctionsGuard.md (views, admin fns, events, `error SanctionedAddress`)
+- [X] T008 [P] Create `contracts/mocks/MockSanctionsOracle.sol` (test/testnet only; settable `isSanctioned` mapping) — never imported by production contracts
+- [X] T009 [P] Implement the canonical document-hash function (`NFC → CRLF/CR→LF → trim → UTF-8 → sha256 → hex`) in `frontend/src/utils/legalDocs.js`, shared by US3 docs and the wager AAD binding (FR-026/FR-059)
+- [X] T010 [P] Add `TERMS_AAD_PREFIX` (`"FairWins-TC"`) + AAD builder in `frontend/src/utils/crypto/constants.js` — MUST NOT touch `SIGNING_MESSAGES`/`MARKET_SIGNING_MESSAGES`/key-derivation
+
+**Checkpoint**: Interfaces + mock + shared hash util ready.
+
+---
+
+## Phase 3: User Story 1 - Geographic restriction that cannot be bypassed (Priority: P1) 🎯 MVP
+
+**Goal**: Block restricted jurisdictions at Cloudflare (451) and lock the Cloud Run origin via an nginx-verified secret header — no new infra.
+
+**Independent Test**: Request from a blocked country → 451 (no origin hit); direct `run.app` request without `X-Origin-Auth` → 403; `CF-IPCountry`/IP appear in Cloud Run request logs.
+
+### Tests for User Story 1
+
+- [X] T011 [P] [US1] Add an nginx origin-lock test (e.g. `frontend/test/origin-lock.test.mjs` or a CI shell check) asserting requests without/with-wrong `X-Origin-Auth` get 403 and a correct secret is served
+- [X] T012 [P] [US1] Add a documented manual/staging checklist for the Cloudflare geo rule (blocked country → 451, observe-mode first) in `infra/cloudflare/waf-geo.md`
+
+### Implementation for User Story 1
+
+- [X] T013 [US1] Define the Cloudflare WAF geo custom rule (allowlist posture; locked OFAC set `CU IR KP SY` + Crimea/Donetsk/Luhansk handling + `US`; tunable bucket) with a custom 451 response, in `infra/cloudflare/waf-geo.md` (+ IaC if used)
+- [X] T014 [P] [US1] Author the 451 "Unavailable For Legal Reasons" page (`frontend/public/451.html` and/or the Cloudflare custom response body)
+- [X] T015 [US1] Define the Cloudflare Transform Rule injecting `X-Origin-Auth: <secret>` in `infra/cloudflare/origin-lock.md`
+- [X] T016 [US1] Modify `frontend/nginx.conf.template`: reject requests whose `X-Origin-Auth` ≠ configured secret (`return 403`), and forward `CF-IPCountry`/`CF-Connecting-IP` into the access log; never log the secret
+- [X] T017 [US1] Inject `ORIGIN_LOCK_SECRET` at runtime (Secret Manager → Cloud Run env → nginx), mirroring the Pinata JWT pattern, in `cloudbuild.yaml` + `Dockerfile`/entrypoint (runtime env, not build arg)
+- [X] T018 [US1] Document occupied-region conservative matching + unknown-country (`XX`) fail-closed behavior in `infra/cloudflare/waf-geo.md`
+
+**Checkpoint**: Geo gate + origin lock live and independently verifiable. **MVP deployable.**
+
+---
+
+## Phase 4: User Story 2 - On-chain wallet sanctions screening (Priority: P1)
+
+**Goal**: Non-bypassable on-chain `SanctionsGuard` (oracle + admin deny-list, fail-closed) consulted by WagerRegistry/MembershipManager, plus advisory client read and admin UI.
+
+**Independent Test**: On a Polygon-137 fork, a sanctioned address reverts on create/accept/purchase/upgrade (incl. direct contract call); clean address passes; deny-list add/remove emits actor+reason; unauthorized admin calls revert.
+
+### Tests for User Story 2
+
+- [X] T019 [P] [US2] Unit tests for `SanctionsGuard` (isAllowed truth table; fail-closed on oracle revert + EOA-as-oracle; role-gating reverts; events) in `test/SanctionsGuard.test.js`
+- [X] T020 [P] [US2] Integration tests: `createWager`/`acceptWager`/`purchaseTier`/`upgradeTier` revert for a listed sender, `acceptWager` reverts for a listed counterparty, and exit/refund paths succeed for a listed party, in `test/integration/sanctions-gating.test.js`
+- [X] T021 [P] [US2] Fork test (Polygon 137) against the real oracle: known sanctioned blocked, clean allowed, unreachable-oracle fails closed, in `test/fork/ChainalysisSanctions.fork.test.js`
+- [X] T022 [P] [US2] Vitest for `sanctionsScreen.js` advisory read + fail-closed UX in `frontend/src/test/sanctionsScreen.test.js`
+
+### Implementation for User Story 2
+
+- [X] T023 [US2] Implement `contracts/access/SanctionsGuard.sol` (injected oracle + `_denied` mapping; `isAllowed`/`checkBlocked` fail-closed via try/catch; `SANCTIONS_ADMIN_ROLE`/`DEFAULT_ADMIN_ROLE`; `DenyListUpdated`/`SanctionsOracleUpdated`) per contracts/ISanctionsGuard.md
+- [X] T024 [US2] Modify `contracts/wagers/WagerRegistry.sol`: add `sanctionsGuard` ref + `setSanctionsGuard` (DEFAULT_ADMIN_ROLE); first-Check `checkBlocked(msg.sender)` in `createWager`; `checkBlocked(msg.sender)` + `checkBlocked(w.creator)` in `acceptWager` (CEI preserved; exit paths ungated)
+- [X] T025 [US2] Modify `contracts/access/MembershipManager.sol`: add `sanctionsGuard` ref + setter; first-Check `checkBlocked(msg.sender)` in `purchaseTier`/`upgradeTier`
+- [X] T026 [P] [US2] Implement `frontend/src/utils/sanctionsScreen.js` — advisory client-side oracle read via RPC; address/ABI from sync artifacts (FR-055); fail-closed UX on read error
+- [X] T027 [P] [US2] Implement `frontend/src/components/admin/DenyListAdmin.jsx` — add/remove with reason → `setDenied`; render `DenyListUpdated` audit trail; WCAG 2.1 AA
+- [X] T028 [US2] Extend `scripts/deploy/` to deploy `MockSanctionsOracle` on Amoy/local, deploy `SanctionsGuard` with per-chain injected oracle address, grant roles to the floppy-keystore admin, and wire the guard into WagerRegistry + MembershipManager (depends on T023–T025)
+- [X] T029 [US2] Extend `scripts/utils/sync-frontend-contracts.js` to emit `SanctionsGuard`/oracle address+ABI+network config; regenerate `frontend/src/abis/` (FR-055)
+
+**Checkpoint**: Sanctions enforcement live on-chain + advisory in UI + admin deny-list manageable. P1 compliance core (US1+US2) complete.
+
+---
+
+## Phase 5: User Story 3 - Versioned, hash-addressed legal documents + wager-bound governance (Priority: P2)
+
+**Goal**: Serve versioned Terms/Risk/Privacy (SHA-256 version, IPFS-pinned per version, materiality flag) and bind the governing version into each wager (AAD + on-chain hash).
+
+**Independent Test**: Doc pages show "Version: <hash>"; recompute matches; prior version retrievable by hash; encrypted-metadata v1.1 round-trips and rejects a tampered `termsVersion`; a wager created under V keeps V after a newer version publishes.
+
+### Tests for User Story 3
+
+- [X] T030 [P] [US3] Vitest: doc version hash reproducibility, prior-version retrieval by hash, materiality-flag re-consent trigger, in `frontend/src/test/legalDocs.test.js`
+- [X] T031 [P] [US3] Vitest: encrypted-metadata v1.1 round-trip with `termsVersion`+AAD, tamper rejection, legacy no-AAD round-trip, in `frontend/src/test/crypto/envelopeEncryption.termsVersion.test.js`
+- [X] T032 [P] [US3] Hardhat test: `WagerRegistry` stores/emits `termsVersionHash`; existing wager keeps its hash (prospective-only), in `test/integration/wager-terms-binding.test.js`
+
+### Implementation for User Story 3
+
+- [X] T033 [P] [US3] Author versioned legal docs (Terms, Risk, Privacy) under `frontend/src/legal/` with populated SHA-256 version headers + IPFS pin manifest (copy is draft pending counsel; incorporate-by-reference per FR-028)
+- [X] T034 [US3] Implement the `frontend/src/utils/legalDocs.js` manifest API (current version, prior versions by hash, operator-set materiality flag) atop the T009 hash util
+- [X] T035 [P] [US3] Implement `frontend/src/pages/legal/{TermsPage,RiskPage,PrivacyPage}.jsx` (content + "Version: <hash>", cross-links) + routes in `frontend/src/App.jsx`; WCAG 2.1 AA
+- [X] T036 [US3] Create `frontend/src/schemas/encrypted-metadata-v1.1.json` (add optional authenticated `termsVersion`; reconcile to runtime `content`/`keys` shape; extend `version` enum)
+- [X] T037 [US3] Modify `frontend/src/utils/crypto/envelopeEncryption.js`: add AAD (`termsVersion.hash`) to the 4 **content** cipher sites (seal/open, both x25519 + xwing); emit/consume `termsVersion`; legacy no-AAD fallback; key derivation untouched (per contracts/encrypted-metadata-v1.1.md)
+- [X] T038 [US3] Thread the in-force `{id, hash}` into `createEncrypted` callers (`frontend/src/components/fairwins/FriendMarketsModal.jsx` ~L863/L884) so new wagers bind the version (FR-058)
+- [X] T039 [US3] Modify `contracts/wagers/WagerRegistry.sol`: add `bytes32 termsVersionHash` to the `Wager` struct + `createWager` param + `WagerCreated` event (prospective-only) — **depends on T024 (same file)**
+
+**Checkpoint**: Documents versioned + verifiable; wagers carry tamper-evident governing-version proof.
+
+---
+
+## Phase 6: User Story 4 - Entry eligibility notice gate (client-side) (Priority: P2)
+
+**Goal**: Client-side first-visit gate that blocks the app until acknowledged, links the current versioned docs, and warns on circumvention.
+
+**Independent Test**: Fresh load → gate blocks app; "Leave" withholds access; "Enter" stores acknowledged version hashes and reveals the app; gate links current versioned docs.
+
+### Tests for User Story 4
+
+- [ ] T040 [P] [US4] Vitest: EntryGate blocks until acknowledged, "Leave" withholds, acknowledged versions persisted, current versioned docs linked, in `frontend/src/test/EntryGate.test.jsx`
+
+### Implementation for User Story 4
+
+- [ ] T041 [US4] Implement `frontend/src/components/compliance/EntryGate.jsx` (focus-trapped labeled modal; affirmations 21+/non-US/non-restricted/non-sanctioned/lawful; VPN warning; Enter/Leave; links versioned docs by hash; client-state ack) — WCAG 2.1 AA
+- [ ] T042 [US4] Mount EntryGate in `frontend/src/App.jsx`/`AppLayout` before app content on first visit; skip for returning visitors via client state (re-consent enforced on-chain at next consequential act)
+
+**Checkpoint**: Entry notice gate live; downstream on-chain consents carry the legal weight.
+
+---
+
+## Phase 7: User Story 5 - Membership purchase/upgrade attestation (Priority: P3)
+
+**Goal**: Discrete un-pre-ticked attestation checkboxes at membership purchase, with the accepted T&C version recorded on-chain.
+
+**Independent Test**: Checkboxes all un-ticked by default; purchase blocked until each required box ticked; on confirm, `MembershipPurchased`/`Upgraded` carries `acceptedTermsHash` + block timestamp.
+
+### Tests for User Story 5
+
+- [ ] T043 [P] [US5] Vitest: checkboxes un-pre-ticked, submit blocked until all required ticked, copy mirrors FR-037/FR-038, in `frontend/src/test/MembershipAttestation.test.jsx`
+- [ ] T044 [P] [US5] Hardhat test: `purchaseTier`/`upgradeTier` record + emit `acceptedTermsHash`, in `test/MembershipManager.terms.test.js`
+
+### Implementation for User Story 5
+
+- [ ] T045 [US5] Modify `contracts/access/MembershipManager.sol`: add `acceptedTermsHash`/`acceptedAt` to the membership record + `purchaseTier`/`upgradeTier` params + extended events — **depends on T025 (same file)**
+- [ ] T046 [US5] Implement `frontend/src/components/compliance/MembershipAttestation.jsx` (discrete un-pre-ticked checkboxes per FR-037/FR-038; on confirm pass `acceptedTermsHash`) — WCAG 2.1 AA
+- [ ] T047 [US5] Integrate MembershipAttestation into the existing membership flow (`frontend/src/pages/WalletPage.jsx` Membership tab); prompt re-acceptance when the in-force version is flagged material
+
+**Checkpoint**: Itemized, dated, on-chain membership consent live.
+
+---
+
+## Phase 8: User Story 6 - Deterministic key-generation eligibility signature (Priority: P3)
+
+**Goal**: Deterministic eligibility signing message (no nonce/timestamp) with key-derivation disclosure, dated by on-chain key registration.
+
+**Independent Test**: The message is byte-identical across signings, carries eligibility facts + wallet address + key-derivation disclosure; KeyRegistry emits a dated `EligibilityAcknowledged`.
+
+### Tests for User Story 6
+
+- [ ] T048 [P] [US6] Vitest: eligibility message determinism (byte-identical), required content + disclosure, recovered-address reproducibility, in `frontend/src/test/keygenEligibility.test.js`
+- [ ] T049 [P] [US6] Hardhat test: `KeyRegistry` emits `EligibilityAcknowledged` dated by block, in `test/KeyRegistry.eligibility.test.js`
+
+### Implementation for User Story 6
+
+- [ ] T050 [US6] Update the key-generation signing UI/flow (`frontend/src/hooks/useEncryption.js` / `frontend/src/utils/keyRegistryService.js`) to present the eligibility facts + generic Terms ref + wallet address + key-derivation disclosure — **the key-derivation message itself stays UNCHANGED** (deterministic, versionless)
+- [ ] T051 [US6] Modify `contracts/privacy/KeyRegistry.sol` to emit `EligibilityAcknowledged(account, termsRef)` at registration (dated by block timestamp)
+
+**Checkpoint**: All six stories independently functional.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Security gates, accessibility, CI, optional indexing, validation.
+
+- [ ] T052 [P] Run Slither + Medusa on the contract changes; resolve or document new high/critical findings (Principle I)
+- [ ] T053 Smart-contract-security agent review of `SanctionsGuard` + WagerRegistry/MembershipManager/KeyRegistry changes (`.github/agents/`) before merge
+- [ ] T054 [P] axe + Lighthouse accessibility audit (WCAG 2.1 AA) of EntryGate, membership checkboxes, legal doc pages, 451 page, DenyListAdmin; wire checks into CI (Principle V)
+- [ ] T055 Update CI to run new Hardhat unit/integration/fork + Vitest + Slither with no `continue-on-error` on lint/test/build/security (Principle IV)
+- [ ] T056 [P] (Optional) Extend `subgraph/` to index `WagerCreated.termsVersionHash`, `Membership*` accepted hash, and `DenyListUpdated` for address-keyed consent queries (FR-047)
+- [ ] T057 [P] Update docs: `README`/`CLAUDE.md` pointers, the Open Legal-Reconciliation Items (counsel), permitted-country allowlist runbook, and the legacy-wager migration note (governed by launch version)
+- [ ] T058 Run `specs/007-compliance-gating/quickstart.md` end-to-end on Amoy + a Polygon-137 fork; confirm all SCs
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+- **Setup (P1)** → no deps.
+- **Foundational (P2)** → after Setup; **blocks US2 and US3**.
+- **US1 (geo)** → after Setup only (no contract/foundational deps) — can start immediately in parallel with Foundational.
+- **US2 (sanctions)** → after Foundational (needs interfaces/mock).
+- **US3 (docs+binding)** → after Foundational (needs T009 hash util); T039 also depends on **T024 (US2)** (same WagerRegistry file).
+- **US4 (entry gate)** → after US3 (links versioned docs) for full function; component shell can start after Foundational.
+- **US5 (membership)** → after Foundational; T045 depends on **T025 (US2)** (same MembershipManager file); UI needs US3 version hashes.
+- **US6 (key-gen)** → after Foundational; light, mostly independent.
+- **Polish (P9)** → after the desired stories.
+
+### Critical cross-story file couplings (sequence, not parallel)
+- `WagerRegistry.sol`: T024 (US2 guard) → T039 (US3 termsVersionHash).
+- `MembershipManager.sol`: T025 (US2 guard) → T045 (US5 acceptedTermsHash).
+- `frontend/src/utils/legalDocs.js`: T009 (foundational hash) → T034 (US3 manifest).
+
+### Within each story
+- Tests written first and FAIL before implementation (TDD).
+- Contracts/interfaces before consumers; models before services; core before integration.
+
+### Parallel opportunities
+- Setup: T002–T005 [P].
+- Foundational: T006–T010 [P] (distinct files).
+- US1 can run fully in parallel with US2/US3 (no shared files).
+- Within a story, all `[P]` tests run together; distinct-file implementation tasks `[P]`.
+- With staff: US1, US2, US3 progress concurrently after Foundational (mind the WagerRegistry/MembershipManager couplings).
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+# Tests first (all [P], different files):
+Task: "Unit tests for SanctionsGuard in test/SanctionsGuard.test.js"
+Task: "Integration tests in test/integration/sanctions-gating.test.js"
+Task: "Fork test (137) in test/fork/ChainalysisSanctions.fork.test.js"
+Task: "Vitest for sanctionsScreen in frontend/src/test/sanctionsScreen.test.js"
+
+# Then distinct-file implementation in parallel:
+Task: "Implement frontend/src/utils/sanctionsScreen.js"
+Task: "Implement frontend/src/components/admin/DenyListAdmin.jsx"
+# (SanctionsGuard.sol + WagerRegistry/MembershipManager edits are sequenced before deploy/sync)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP first
+1. Phase 1 (Setup) → Phase 3 (**US1 geo gate + origin lock**). Smallest deployable slice; the legal access boundary exists with zero contract changes. **STOP & VALIDATE**, deploy.
+
+### P1 compliance core
+2. Phase 2 (Foundational) → Phase 4 (**US2 sanctions**). US1 + US2 = the strict-liability P1 controls (location + address).
+
+### Incremental delivery
+3. US3 (versioned docs + wager binding) → US4 (entry gate) → US5 (membership attestation) → US6 (key-gen signature). Each adds a layer of the consent stack without breaking prior ones.
+
+### Parallel team
+- After Foundational: Dev A → US1 (no contract deps); Dev B → US2; Dev C → US3. Coordinate the WagerRegistry/MembershipManager edits (US2 before US3/US5 on those files).
+
+---
+
+## Notes
+- `[P]` = different files, no incomplete dependency. `[Story]` maps to spec.md user stories.
+- All contract changes are `contracts/` access-control-axis edits → full Principle I gate (CEI, Slither/Medusa clean, EthTrust-SL L2, security-agent review, fork tests) — see Phase 9.
+- Mocks live ONLY in `contracts/mocks/`; production reads the real oracle on 137 (Principle III); records are chainId-scoped.
+- No backend is introduced. Consent records are on-chain; geo/IP evidence is the existing edge/Cloud Run logs.
+- Frontend addresses/ABIs come only from `sync:frontend-contracts` (FR-055); mind the `getContractAddress` mocking gotchas in the frontend-test-gotchas memory.
+- Legal copy is draft pending counsel; the Open Legal-Reconciliation Items remain (T057).

--- a/test/KeyRegistry.eligibility.test.js
+++ b/test/KeyRegistry.eligibility.test.js
@@ -1,0 +1,43 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+const { anyValue } = require("@nomicfoundation/hardhat-chai-matchers/withArgs");
+
+// Spec 007 — US6 (FR-043): KeyRegistry.registerKeyWithEligibility dates the eligibility
+// signature on-chain via EligibilityAcknowledged; existing registerKey ABI is preserved.
+
+describe("KeyRegistry eligibility acknowledgement", function () {
+  async function deployFixture() {
+    const [admin, alice] = await ethers.getSigners();
+    const KeyRegistry = await ethers.getContractFactory("KeyRegistry");
+    const reg = await KeyRegistry.deploy();
+    await reg.waitForDeployment();
+    return { reg, alice };
+  }
+
+  const KEY = "0x" + "ab".repeat(32); // 32-byte public key
+  const TERMS_REF = "0x" + "cd".repeat(32);
+
+  it("registerKeyWithEligibility stores the key and emits both events", async function () {
+    const { reg, alice } = await loadFixture(deployFixture);
+    const tx = reg.connect(alice).registerKeyWithEligibility(KEY, TERMS_REF);
+    await expect(tx).to.emit(reg, "KeyRegistered").withArgs(alice.address, KEY, anyValue);
+    await expect(tx).to.emit(reg, "EligibilityAcknowledged").withArgs(alice.address, TERMS_REF, anyValue);
+    expect(await reg.hasKey(alice.address)).to.equal(true);
+    expect(await reg.getPublicKey(alice.address)).to.equal(KEY);
+  });
+
+  it("legacy registerKey still works and emits no EligibilityAcknowledged", async function () {
+    const { reg, alice } = await loadFixture(deployFixture);
+    const tx = reg.connect(alice).registerKey(KEY);
+    await expect(tx).to.emit(reg, "KeyRegistered");
+    await expect(tx).to.not.emit(reg, "EligibilityAcknowledged");
+  });
+
+  it("rejects a too-short key on the eligibility path (parity)", async function () {
+    const { reg, alice } = await loadFixture(deployFixture);
+    await expect(
+      reg.connect(alice).registerKeyWithEligibility("0x1234", TERMS_REF)
+    ).to.be.revertedWithCustomError(reg, "KeyTooShort");
+  });
+});

--- a/test/MembershipManager.terms.test.js
+++ b/test/MembershipManager.terms.test.js
@@ -1,0 +1,60 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+
+// On-chain membership terms recording (Spec 007 — FR-039). purchaseTierWithTerms /
+// upgradeTierWithTerms record the accepted T&C version hash + emit MembershipTermsRecorded.
+// The existing purchaseTier/upgradeTier ABIs are unchanged (record nothing).
+
+const Tier = { None: 0, Bronze: 1, Silver: 2 };
+const WAGER_PARTICIPANT_ROLE = ethers.keccak256(ethers.toUtf8Bytes("WAGER_PARTICIPANT_ROLE"));
+const usdc = (n) => ethers.parseUnits(String(n), 6);
+const H1 = "0x" + "ab".repeat(32);
+
+describe("MembershipManager terms recording", function () {
+  async function deployFixture() {
+    const [admin, alice, treasury] = await ethers.getSigners();
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    const usdcToken = await MockERC20.deploy("USD Coin", "USDC", 0);
+    await usdcToken.waitForDeployment();
+    const MembershipManager = await ethers.getContractFactory("MembershipManager");
+    const mgr = await MembershipManager.deploy(admin.address, await usdcToken.getAddress(), treasury.address);
+    await mgr.waitForDeployment();
+    const limits = { monthlyMarketCreation: 100, maxConcurrentMarkets: 10 };
+    await mgr.connect(admin).setTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze, usdc(50), 30, limits, true);
+    await mgr.connect(admin).setTier(WAGER_PARTICIPANT_ROLE, Tier.Silver, usdc(120), 30, limits, true);
+    await usdcToken.mint(alice.address, usdc(10_000));
+    await usdcToken.connect(alice).approve(await mgr.getAddress(), ethers.MaxUint256);
+    return { mgr, usdcToken, admin, alice };
+  }
+
+  it("purchaseTierWithTerms records the accepted hash + emits", async function () {
+    const { mgr, alice } = await loadFixture(deployFixture);
+    await expect(mgr.connect(alice).purchaseTierWithTerms(WAGER_PARTICIPANT_ROLE, Tier.Bronze, H1))
+      .to.emit(mgr, "MembershipTermsRecorded")
+      .withArgs(alice.address, WAGER_PARTICIPANT_ROLE, H1, anyUint());
+    expect(await mgr.memberTermsHash(alice.address, WAGER_PARTICIPANT_ROLE)).to.equal(H1);
+    expect(await mgr.hasActiveRole(alice.address, WAGER_PARTICIPANT_ROLE)).to.equal(true);
+  });
+
+  it("legacy purchaseTier records no terms hash", async function () {
+    const { mgr, alice } = await loadFixture(deployFixture);
+    await mgr.connect(alice).purchaseTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze);
+    expect(await mgr.memberTermsHash(alice.address, WAGER_PARTICIPANT_ROLE)).to.equal(ethers.ZeroHash);
+  });
+
+  it("upgradeTierWithTerms records the accepted hash on upgrade", async function () {
+    const { mgr, alice } = await loadFixture(deployFixture);
+    await mgr.connect(alice).purchaseTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze);
+    await expect(mgr.connect(alice).upgradeTierWithTerms(WAGER_PARTICIPANT_ROLE, Tier.Silver, H1))
+      .to.emit(mgr, "MembershipTermsRecorded")
+      .withArgs(alice.address, WAGER_PARTICIPANT_ROLE, H1, anyUint());
+    expect(await mgr.memberTermsHash(alice.address, WAGER_PARTICIPANT_ROLE)).to.equal(H1);
+  });
+});
+
+// Minimal anyUint matcher (the block timestamp is non-deterministic).
+function anyUint() {
+  const { anyValue } = require("@nomicfoundation/hardhat-chai-matchers/withArgs");
+  return anyValue;
+}

--- a/test/SanctionsGuard.test.js
+++ b/test/SanctionsGuard.test.js
@@ -1,0 +1,128 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+
+// Unit tests for SanctionsGuard (Spec 007 — FR-016/FR-019/FR-020/FR-054, SC-018).
+describe("SanctionsGuard", function () {
+  async function deployFixture() {
+    const [admin, user, sanctioned, denied, nonAdmin] = await ethers.getSigners();
+
+    const Mock = await ethers.getContractFactory("MockSanctionsOracle");
+    const oracle = await Mock.deploy();
+    await oracle.waitForDeployment();
+
+    const Guard = await ethers.getContractFactory("SanctionsGuard");
+    const guard = await Guard.deploy(admin.address, await oracle.getAddress());
+    await guard.waitForDeployment();
+
+    return { guard, oracle, admin, user, sanctioned, denied, nonAdmin };
+  }
+
+  describe("isAllowed truth table", function () {
+    it("allows a clean address", async function () {
+      const { guard, user } = await loadFixture(deployFixture);
+      expect(await guard.isAllowed(user.address)).to.equal(true);
+    });
+
+    it("blocks an oracle-sanctioned address", async function () {
+      const { guard, oracle, sanctioned } = await loadFixture(deployFixture);
+      await oracle.setSanctioned(sanctioned.address, true);
+      expect(await guard.isAllowed(sanctioned.address)).to.equal(false);
+    });
+
+    it("blocks a discretionary deny-listed address", async function () {
+      const { guard, admin, denied } = await loadFixture(deployFixture);
+      await guard.connect(admin).setDenied(denied.address, true, "illicit finance");
+      expect(await guard.isDenied(denied.address)).to.equal(true);
+      expect(await guard.isAllowed(denied.address)).to.equal(false);
+    });
+
+    it("blocks when both deny-listed and oracle-sanctioned", async function () {
+      const { guard, oracle, admin, denied } = await loadFixture(deployFixture);
+      await oracle.setSanctioned(denied.address, true);
+      await guard.connect(admin).setDenied(denied.address, true, "both");
+      expect(await guard.isAllowed(denied.address)).to.equal(false);
+    });
+
+    it("allows again after a deny-list entry is removed", async function () {
+      const { guard, admin, denied } = await loadFixture(deployFixture);
+      await guard.connect(admin).setDenied(denied.address, true, "x");
+      await guard.connect(admin).setDenied(denied.address, false, "cleared");
+      expect(await guard.isAllowed(denied.address)).to.equal(true);
+    });
+  });
+
+  describe("checkBlocked", function () {
+    it("does not revert for an allowed address", async function () {
+      const { guard, user } = await loadFixture(deployFixture);
+      await expect(guard.checkBlocked(user.address)).to.not.be.reverted;
+    });
+
+    it("reverts SanctionedAddress for a blocked address", async function () {
+      const { guard, oracle, sanctioned } = await loadFixture(deployFixture);
+      await oracle.setSanctioned(sanctioned.address, true);
+      await expect(guard.checkBlocked(sanctioned.address))
+        .to.be.revertedWithCustomError(guard, "SanctionedAddress")
+        .withArgs(sanctioned.address);
+    });
+  });
+
+  describe("fail-closed behavior (FR-019)", function () {
+    it("blocks everyone when the configured oracle has no code (EOA)", async function () {
+      const { guard, admin, user, nonAdmin } = await loadFixture(deployFixture);
+      // Point the oracle at an EOA (no bytecode): staticcall returns empty -> fail-closed
+      await guard.connect(admin).setSanctionsOracle(nonAdmin.address);
+      expect(await guard.isAllowed(user.address)).to.equal(false);
+      await expect(guard.checkBlocked(user.address)).to.be.revertedWithCustomError(
+        guard,
+        "SanctionedAddress"
+      );
+    });
+
+    it("treats an unset oracle (address(0)) as deny-list-only", async function () {
+      const { guard, admin, user, denied } = await loadFixture(deployFixture);
+      await guard.connect(admin).setSanctionsOracle(ethers.ZeroAddress);
+      expect(await guard.sanctionsOracle()).to.equal(ethers.ZeroAddress);
+      expect(await guard.isAllowed(user.address)).to.equal(true); // no oracle opinion
+      await guard.connect(admin).setDenied(denied.address, true, "manual");
+      expect(await guard.isAllowed(denied.address)).to.equal(false); // deny-list still enforced
+    });
+  });
+
+  describe("access control & events (SC-018)", function () {
+    it("only SANCTIONS_ADMIN_ROLE can setDenied", async function () {
+      const { guard, nonAdmin, denied } = await loadFixture(deployFixture);
+      await expect(
+        guard.connect(nonAdmin).setDenied(denied.address, true, "x")
+      ).to.be.revertedWithCustomError(guard, "AccessControlUnauthorizedAccount");
+    });
+
+    it("only DEFAULT_ADMIN_ROLE can setSanctionsOracle", async function () {
+      const { guard, nonAdmin } = await loadFixture(deployFixture);
+      await expect(
+        guard.connect(nonAdmin).setSanctionsOracle(ethers.ZeroAddress)
+      ).to.be.revertedWithCustomError(guard, "AccessControlUnauthorizedAccount");
+    });
+
+    it("rejects deny-listing the zero address", async function () {
+      const { guard, admin } = await loadFixture(deployFixture);
+      await expect(
+        guard.connect(admin).setDenied(ethers.ZeroAddress, true, "x")
+      ).to.be.revertedWithCustomError(guard, "ZeroAddress");
+    });
+
+    it("emits DenyListUpdated with actor and reason", async function () {
+      const { guard, admin, denied } = await loadFixture(deployFixture);
+      await expect(guard.connect(admin).setDenied(denied.address, true, "ofac match"))
+        .to.emit(guard, "DenyListUpdated")
+        .withArgs(denied.address, true, admin.address, "ofac match");
+    });
+
+    it("emits SanctionsOracleUpdated", async function () {
+      const { guard, admin } = await loadFixture(deployFixture);
+      await expect(guard.connect(admin).setSanctionsOracle(ethers.ZeroAddress))
+        .to.emit(guard, "SanctionsOracleUpdated")
+        .withArgs(ethers.ZeroAddress);
+    });
+  });
+});

--- a/test/fork/ChainalysisSanctions.fork.test.js
+++ b/test/fork/ChainalysisSanctions.fork.test.js
@@ -1,0 +1,64 @@
+const { expect } = require("chai");
+const { ethers, network } = require("hardhat");
+
+// Fork test against the REAL Chainalysis Sanctions Oracle on Polygon mainnet (chainId 137).
+// Spec 007 SC-004/SC-016: a known sanctioned address is blocked, a clean address is allowed,
+// verified through SanctionsGuard wired to the live oracle — no mocks (constitution III).
+//
+// Requires a Polygon mainnet RPC (POLYGON_RPC_URL). The oracle read is a current-state view,
+// so a full archive node is not strictly required for the latest block. Amoy has no oracle,
+// hence this must run against a 137 fork.
+
+const CHAINALYSIS_ORACLE_137 = "0x40C57923924B5c5c5455c48D93317139ADDaC8fb";
+// OFAC-designated, present on the Chainalysis list (Tornado Cash: Router). If Chainalysis
+// ever delists it, this test fails loudly and the chosen address must be refreshed.
+const SANCTIONED = "0x722122dF12D4e14e13Ac3b6895a86e84145b6967";
+// Not sanctioned (vitalik.eth) — sanity for the allow path.
+const CLEAN = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+
+const describeFork = process.env.POLYGON_RPC_URL ? describe : describe.skip;
+
+describeFork("Chainalysis sanctions oracle (Polygon 137 fork)", function () {
+  this.timeout(120_000);
+
+  let guard;
+
+  before(async function () {
+    await network.provider.request({
+      method: "hardhat_reset",
+      params: [
+        {
+          forking: {
+            jsonRpcUrl: process.env.POLYGON_RPC_URL,
+            ...(process.env.POLYGON_FORK_BLOCK
+              ? { blockNumber: parseInt(process.env.POLYGON_FORK_BLOCK, 10) }
+              : {}),
+          },
+        },
+      ],
+    });
+
+    const [admin] = await ethers.getSigners();
+    const Guard = await ethers.getContractFactory("SanctionsGuard");
+    guard = await Guard.deploy(admin.address, CHAINALYSIS_ORACLE_137);
+    await guard.waitForDeployment();
+  });
+
+  after(async function () {
+    await network.provider.request({ method: "hardhat_reset", params: [] });
+  });
+
+  it("reads the live oracle: sanctioned address is not allowed", async function () {
+    const oracle = await ethers.getContractAt("IChainalysisSanctionsOracle", CHAINALYSIS_ORACLE_137);
+    expect(await oracle.isSanctioned(SANCTIONED)).to.equal(true);
+    expect(await guard.isAllowed(SANCTIONED)).to.equal(false);
+    await expect(guard.checkBlocked(SANCTIONED))
+      .to.be.revertedWithCustomError(guard, "SanctionedAddress")
+      .withArgs(SANCTIONED);
+  });
+
+  it("allows a clean address", async function () {
+    expect(await guard.isAllowed(CLEAN)).to.equal(true);
+    await expect(guard.checkBlocked(CLEAN)).to.not.be.reverted;
+  });
+});

--- a/test/integration/sanctions-gating.test.js
+++ b/test/integration/sanctions-gating.test.js
@@ -151,6 +151,15 @@ describe("Sanctions gating (integration)", function () {
         fx.mgr.connect(fx.alice).upgradeTier(WAGER_PARTICIPANT_ROLE, Tier.Silver)
       ).to.be.revertedWithCustomError(fx.guard, "SanctionedAddress");
     });
+
+    it("blocks the admin grantMembership path for a deny-listed grantee (non-bypassable)", async function () {
+      const fx = await loadFixture(deployFixture);
+      // admin holds ROLE_MANAGER_ROLE in the fixture; grantMembership must still screen.
+      await fx.guard.connect(fx.admin).setDenied(fx.bob.address, true, "ofac");
+      await expect(
+        fx.mgr.connect(fx.admin).grantMembership(fx.bob.address, WAGER_PARTICIPANT_ROLE, Tier.Bronze, 30)
+      ).to.be.revertedWithCustomError(fx.guard, "SanctionedAddress");
+    });
   });
 
   describe("exit paths stay ungated (a listed party can recover funds)", function () {

--- a/test/integration/sanctions-gating.test.js
+++ b/test/integration/sanctions-gating.test.js
@@ -1,0 +1,172 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time, loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+
+// Integration: SanctionsGuard wired into WagerRegistry + MembershipManager (Spec 007,
+// FR-016/FR-021/FR-054, SC-004/SC-016). Verifies value-bearing entrypoints are screened
+// (sender + counterparty-on-accept) and that exit/refund paths stay UNGATED.
+
+const Tier = { None: 0, Bronze: 1, Silver: 2, Gold: 3, Platinum: 4 };
+const Resolution = { Either: 0 };
+const WAGER_PARTICIPANT_ROLE = ethers.keccak256(ethers.toUtf8Bytes("WAGER_PARTICIPANT_ROLE"));
+const usdc = (n) => ethers.parseUnits(String(n), 6);
+
+describe("Sanctions gating (integration)", function () {
+  async function deployFixture() {
+    const [admin, alice, bob, treasury] = await ethers.getSigners();
+
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    const usdcToken = await MockERC20.deploy("USD Coin", "USDC", 0);
+    await usdcToken.waitForDeployment();
+
+    const MembershipManager = await ethers.getContractFactory("MembershipManager");
+    const mgr = await MembershipManager.deploy(admin.address, await usdcToken.getAddress(), treasury.address);
+    await mgr.waitForDeployment();
+    const limits = { monthlyMarketCreation: 100, maxConcurrentMarkets: 10 };
+    await mgr.connect(admin).setTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze, usdc(50), 30, limits, true);
+    await mgr.connect(admin).setTier(WAGER_PARTICIPANT_ROLE, Tier.Silver, usdc(120), 30, limits, true);
+
+    const MockOracle = await ethers.getContractFactory("MockSanctionsOracle");
+    const oracle = await MockOracle.deploy();
+    await oracle.waitForDeployment();
+
+    const Guard = await ethers.getContractFactory("SanctionsGuard");
+    const guard = await Guard.deploy(admin.address, await oracle.getAddress());
+    await guard.waitForDeployment();
+
+    const WagerRegistry = await ethers.getContractFactory("WagerRegistry");
+    const reg = await WagerRegistry.deploy(
+      admin.address,
+      await mgr.getAddress(),
+      ethers.ZeroAddress, // no polymarket adapter needed
+      [await usdcToken.getAddress()]
+    );
+    await reg.waitForDeployment();
+
+    await mgr.connect(admin).setAuthorizedCaller(await reg.getAddress(), true);
+    // Wire the guard into both fund contracts
+    await reg.connect(admin).setSanctionsGuard(await guard.getAddress());
+    await mgr.connect(admin).setSanctionsGuard(await guard.getAddress());
+
+    for (const u of [alice, bob]) {
+      await usdcToken.mint(u.address, usdc(10_000));
+      await usdcToken.connect(u).approve(await mgr.getAddress(), ethers.MaxUint256);
+      await usdcToken.connect(u).approve(await reg.getAddress(), ethers.MaxUint256);
+      await mgr.connect(u).purchaseTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze); // clean at setup
+    }
+
+    return { reg, mgr, usdcToken, oracle, guard, admin, alice, bob };
+  }
+
+  async function createParams(fx, opponent) {
+    const now = await time.latest();
+    return [
+      opponent,
+      ethers.ZeroAddress, // arbitrator
+      await fx.usdcToken.getAddress(),
+      usdc(10), // creatorStake
+      usdc(10), // opponentStake
+      BigInt(now) + 86400n, // acceptDeadline (+1d)
+      BigInt(now) + 864000n, // resolveDeadline (+10d)
+      Resolution.Either,
+      ethers.ZeroHash, // polymarketConditionId
+      false, // creatorIsYes
+      ethers.ZeroHash, // metadataHash
+      "ipfs://meta", // metadataUri
+    ];
+  }
+
+  describe("createWager screening", function () {
+    it("allows a clean creator", async function () {
+      const fx = await loadFixture(deployFixture);
+      const params = await createParams(fx, fx.bob.address);
+      await expect(fx.reg.connect(fx.alice).createWager(...params)).to.not.be.reverted;
+    });
+
+    it("blocks a deny-listed creator", async function () {
+      const fx = await loadFixture(deployFixture);
+      await fx.guard.connect(fx.admin).setDenied(fx.alice.address, true, "ofac");
+      const params = await createParams(fx, fx.bob.address);
+      await expect(fx.reg.connect(fx.alice).createWager(...params))
+        .to.be.revertedWithCustomError(fx.guard, "SanctionedAddress")
+        .withArgs(fx.alice.address);
+    });
+
+    it("blocks an oracle-sanctioned creator", async function () {
+      const fx = await loadFixture(deployFixture);
+      await fx.oracle.setSanctioned(fx.alice.address, true);
+      const params = await createParams(fx, fx.bob.address);
+      await expect(fx.reg.connect(fx.alice).createWager(...params)).to.be.revertedWithCustomError(
+        fx.guard,
+        "SanctionedAddress"
+      );
+    });
+  });
+
+  describe("acceptWager screening (sender + counterparty)", function () {
+    it("blocks a deny-listed accepting opponent (sender)", async function () {
+      const fx = await loadFixture(deployFixture);
+      const params = await createParams(fx, fx.bob.address);
+      await fx.reg.connect(fx.alice).createWager(...params); // wagerId 1
+      await fx.guard.connect(fx.admin).setDenied(fx.bob.address, true, "ofac");
+      await expect(fx.reg.connect(fx.bob).acceptWager(1))
+        .to.be.revertedWithCustomError(fx.guard, "SanctionedAddress")
+        .withArgs(fx.bob.address);
+    });
+
+    it("blocks acceptance when the creator (counterparty) is listed after creation", async function () {
+      const fx = await loadFixture(deployFixture);
+      const params = await createParams(fx, fx.bob.address);
+      await fx.reg.connect(fx.alice).createWager(...params); // wagerId 1
+      await fx.guard.connect(fx.admin).setDenied(fx.alice.address, true, "listed later");
+      await expect(fx.reg.connect(fx.bob).acceptWager(1))
+        .to.be.revertedWithCustomError(fx.guard, "SanctionedAddress")
+        .withArgs(fx.alice.address);
+    });
+
+    it("allows acceptance when both parties are clean", async function () {
+      const fx = await loadFixture(deployFixture);
+      const params = await createParams(fx, fx.bob.address);
+      await fx.reg.connect(fx.alice).createWager(...params);
+      await expect(fx.reg.connect(fx.bob).acceptWager(1)).to.not.be.reverted;
+    });
+  });
+
+  describe("membership screening", function () {
+    it("blocks purchaseTier for a deny-listed user", async function () {
+      const fx = await loadFixture(deployFixture);
+      const [, , , , carol] = await ethers.getSigners();
+      await fx.usdcToken.mint(carol.address, usdc(1000));
+      await fx.usdcToken.connect(carol).approve(await fx.mgr.getAddress(), ethers.MaxUint256);
+      await fx.guard.connect(fx.admin).setDenied(carol.address, true, "ofac");
+      await expect(
+        fx.mgr.connect(carol).purchaseTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze)
+      ).to.be.revertedWithCustomError(fx.guard, "SanctionedAddress");
+    });
+
+    it("blocks upgradeTier for a deny-listed user", async function () {
+      const fx = await loadFixture(deployFixture);
+      await fx.guard.connect(fx.admin).setDenied(fx.alice.address, true, "ofac");
+      await expect(
+        fx.mgr.connect(fx.alice).upgradeTier(WAGER_PARTICIPANT_ROLE, Tier.Silver)
+      ).to.be.revertedWithCustomError(fx.guard, "SanctionedAddress");
+    });
+  });
+
+  describe("exit paths stay ungated (a listed party can recover funds)", function () {
+    it("allows a deny-listed creator to claim a refund on an expired open wager", async function () {
+      const fx = await loadFixture(deployFixture);
+      const params = await createParams(fx, fx.bob.address);
+      await fx.reg.connect(fx.alice).createWager(...params); // wagerId 1, Open
+      await time.increase(86401); // past acceptDeadline
+      await fx.guard.connect(fx.admin).setDenied(fx.alice.address, true, "listed after staking");
+
+      const before = await fx.usdcToken.balanceOf(fx.alice.address);
+      await expect(fx.reg.connect(fx.alice).claimRefund(1))
+        .to.emit(fx.reg, "WagerRefunded")
+        .withArgs(1, fx.alice.address, ethers.ZeroAddress);
+      const after = await fx.usdcToken.balanceOf(fx.alice.address);
+      expect(after - before).to.equal(usdc(10));
+    });
+  });
+});

--- a/test/integration/wager-terms-binding.test.js
+++ b/test/integration/wager-terms-binding.test.js
@@ -1,0 +1,83 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time, loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+
+// On-chain governing-terms binding for wagers (Spec 007 — FR-056/FR-057/FR-058, SC-017).
+// createWagerWithTerms records & emits the version hash; the existing createWager ABI is
+// unchanged (no binding); existing wagers keep their hash (prospective-only, never re-bound).
+
+const Tier = { None: 0, Bronze: 1 };
+const Resolution = { Either: 0 };
+const WAGER_PARTICIPANT_ROLE = ethers.keccak256(ethers.toUtf8Bytes("WAGER_PARTICIPANT_ROLE"));
+const usdc = (n) => ethers.parseUnits(String(n), 6);
+const V1 = "0x" + "11".repeat(32);
+const V2 = "0x" + "22".repeat(32);
+
+describe("Wager terms-version binding (integration)", function () {
+  async function deployFixture() {
+    const [admin, alice, bob, treasury] = await ethers.getSigners();
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    const usdcToken = await MockERC20.deploy("USD Coin", "USDC", 0);
+    await usdcToken.waitForDeployment();
+
+    const MembershipManager = await ethers.getContractFactory("MembershipManager");
+    const mgr = await MembershipManager.deploy(admin.address, await usdcToken.getAddress(), treasury.address);
+    await mgr.waitForDeployment();
+    await mgr.connect(admin).setTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze, usdc(50), 30, { monthlyMarketCreation: 100, maxConcurrentMarkets: 10 }, true);
+
+    const WagerRegistry = await ethers.getContractFactory("WagerRegistry");
+    const reg = await WagerRegistry.deploy(admin.address, await mgr.getAddress(), ethers.ZeroAddress, [await usdcToken.getAddress()]);
+    await reg.waitForDeployment();
+    await mgr.connect(admin).setAuthorizedCaller(await reg.getAddress(), true);
+
+    for (const u of [alice, bob]) {
+      await usdcToken.mint(u.address, usdc(10_000));
+      await usdcToken.connect(u).approve(await mgr.getAddress(), ethers.MaxUint256);
+      await usdcToken.connect(u).approve(await reg.getAddress(), ethers.MaxUint256);
+      await mgr.connect(u).purchaseTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze);
+    }
+    return { reg, usdcToken, admin, alice, bob };
+  }
+
+  async function args(fx, hash) {
+    const now = await time.latest();
+    const base = [
+      fx.bob.address, ethers.ZeroAddress, await fx.usdcToken.getAddress(),
+      usdc(10), usdc(10), BigInt(now) + 86400n, BigInt(now) + 864000n,
+      Resolution.Either, ethers.ZeroHash, false, ethers.ZeroHash, "ipfs://meta",
+    ];
+    return hash === undefined ? base : [...base, hash];
+  }
+
+  it("createWagerWithTerms records and emits the governing version hash", async function () {
+    const fx = await loadFixture(deployFixture);
+    await expect(fx.reg.connect(fx.alice).createWagerWithTerms(...(await args(fx, V1))))
+      .to.emit(fx.reg, "WagerTermsBound")
+      .withArgs(1, V1);
+    expect(await fx.reg.wagerTermsVersionHash(1)).to.equal(V1);
+  });
+
+  it("legacy createWager records no binding (zero) and emits no WagerTermsBound", async function () {
+    const fx = await loadFixture(deployFixture);
+    await expect(fx.reg.connect(fx.alice).createWager(...(await args(fx))))
+      .to.not.emit(fx.reg, "WagerTermsBound");
+    expect(await fx.reg.wagerTermsVersionHash(1)).to.equal(ethers.ZeroHash);
+  });
+
+  it("is prospective-only: an existing wager keeps its bound version after a new version exists", async function () {
+    const fx = await loadFixture(deployFixture);
+    await fx.reg.connect(fx.alice).createWagerWithTerms(...(await args(fx, V1))); // wager 1 @ V1
+    // A later wager binds V2; wager 1 is unaffected (no retroactive re-binding).
+    await fx.reg.connect(fx.alice).createWagerWithTerms(...(await args(fx, V2))); // wager 2 @ V2
+    expect(await fx.reg.wagerTermsVersionHash(1)).to.equal(V1);
+    expect(await fx.reg.wagerTermsVersionHash(2)).to.equal(V2);
+  });
+
+  it("createWagerWithTerms still escrows the stake (parity with createWager)", async function () {
+    const fx = await loadFixture(deployFixture);
+    const before = await fx.usdcToken.balanceOf(await fx.reg.getAddress());
+    await fx.reg.connect(fx.alice).createWagerWithTerms(...(await args(fx, V1)));
+    const after = await fx.usdcToken.balanceOf(await fx.reg.getAddress());
+    expect(after - before).to.equal(usdc(10));
+  });
+});


### PR DESCRIPTION
## Summary

Spec Kit **007 — compliance & legal gating layer**, implemented **within the existing footprint (no backend)**: consent records live on-chain, geo/IP evidence in existing edge/Cloud Run logs. This PR delivers **US1–US3** (the P1 compliance core + versioned docs). US4–US6 + Phase 9 polish continue on the same branch.

Artifacts: `specs/007-compliance-gating/` (spec, plan, research, data-model, contracts, tasks).

## What's included

**US1 — geographic gate (MVP, no new infra)**
- Cloudflare WAF country gate → **HTTP 451** (`infra/cloudflare/` runbooks)
- Origin lock: Cloudflare-injected secret header verified in the **existing nginx** (inert until `ORIGIN_LOCK_SECRET` is set; `/healthz` exempt). Runtime-verified: no-header→403, wrong→403, correct→200.
- `CF-IPCountry`/`CF-Connecting-IP` forwarded into request logs (geo evidence)

**US2 — wallet sanctions screening (defense-in-depth)**
- `SanctionsGuard` (Chainalysis on-chain oracle + admin deny-list, **fail-closed**, AccessControl)
- `WagerRegistry.createWager/acceptWager` + `MembershipManager.purchaseTier/upgradeTier/extendMembership` screen the sender (+ counterparty on accept); **exit/refund paths stay ungated**
- Advisory client-side screen + `DenyListAdmin` UI (add/remove + reason + audit trail)
- Deploy injects the oracle per-chain (137 real, mock on Amoy/local); sync + ABI emit the guard

**US3 — versioned docs + per-wager term governance**
- Governing T&C version bound as **ChaCha20-Poly1305 AAD** (x25519 + X-Wing), authenticated `termsVersion`, **legacy no-AAD fallback**, key derivation untouched; schema v1.1
- Versioned Terms/Risk/Privacy + SHA-256 manifest + public `/terms` `/risk` `/privacy` pages
- `createWagerWithTerms` overload records `wagerTermsVersionHash` + `WagerTermsBound`; **existing `createWager` ABI preserved**

## Verification
- **Full contract suite: 237 passing / 5 pending** (RPC-gated fork tests); no regressions
- Frontend crypto (75) / legalDocs (15) / sanctionsScreen (7) / originLock (5) green; ESLint clean
- The 9 `FriendMarketsModal` oracle-picker failures are **pre-existing** (reproduced with these changes reverted)

## ⚠️ Review flags
1. **Redeploy + migration required** — `WagerRegistry`/`MembershipManager` are live + non-upgradeable; this adds storage (`wagerTermsVersionHash`, `sanctionsGuard`) and refactors `createWager` into an internal helper (+ overload).
2. **Principle I security gate pending** — Slither + Medusa + smart-contract-security agent review run in CI / Phase 9.
3. **Design deviations (lower-risk):** mapping instead of a `Wager` struct field; `createWager` ABI kept via an additive `createWagerWithTerms` overload.
4. **Counsel items** — legal copy is draft; Privacy Policy is new; permitted-country allowlist is ops config (see spec "Open Legal-Reconciliation Items").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
