### PR TITLE
fix(010): UAT footer & policy-document corrections

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/008-runtime-chain-consistency"
+  "feature_directory": "specs/010-footer-policy-fixes"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,5 +49,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/008-runtime-chain-consistency/plan.md
+at specs/010-footer-policy-fixes/plan.md
 <!-- SPECKIT END -->

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import AnnouncementRegion from './components/ui/AnnouncementRegion'
 import LandingPage from './components/LandingPage'
 import Dashboard from './components/fairwins/Dashboard'
 import Header from './components/Header'
+import Footer from './components/Footer'
 
 // add-ons
 import WalletPage from './pages/WalletPage'
@@ -37,6 +38,8 @@ function AppLayout() {
       {/* Spec 007 (US4): client-side eligibility notice gate before any app content. */}
       <EntryGate />
       <Outlet />
+      {/* Spec 010 (US2): condensed legal/policy footer inside the app. */}
+      <Footer variant="condensed" />
     </>
   )
 }

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -7,6 +7,7 @@ import { useEnsResolution } from '../hooks/useEnsResolution'
 import { useChainTokens } from '../hooks/useChainTokens'
 import { ROLES, ADMIN_ROLES } from '../contexts/RoleContext'
 import { isValidEthereumAddress } from '../utils/validation'
+import { ACCOUNT_MODERATION_PATH } from '../constants/legalLinks'
 import { NETWORK_CONFIG, DEPLOYED_CONTRACTS, getContractAddressForChain } from '../config/contracts'
 import { getProvider } from '../utils/blockchainService'
 import { MEMBERSHIP_MANAGER_ABI } from '../abis/MembershipManager'
@@ -575,7 +576,7 @@ function AdminPanel() {
                 A frozen account cannot create wagers, accept wagers, cancel, declare a winner,
                 claim payouts, or claim refunds on WagerRegistry. Polymarket auto-resolution is
                 permissionless and continues to work — but the winner still cannot claim while
-                frozen. See <a href="/docs/system-overview/account-moderation" target="_blank" rel="noreferrer">policy</a>.
+                frozen. See <a href={ACCOUNT_MODERATION_PATH} target="_blank" rel="noopener noreferrer">policy</a>.
               </p>
               <div className="admin-form">
                 <label>

--- a/frontend/src/components/Footer.css
+++ b/frontend/src/components/Footer.css
@@ -1,0 +1,51 @@
+/**
+ * Condensed in-app footer (Spec 010 — US2, FR-007).
+ *
+ * The full landing-page variant reuses the existing `.landing-footer` rules in
+ * LandingPage.css; this file styles only the condensed footer rendered inside the
+ * authenticated app. Colors use theme.css tokens so light/dark both keep contrast.
+ */
+
+.app-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem 1.5rem;
+  max-width: 1200px;
+  margin: 3rem auto 0;
+  padding: 1.25rem 1.5rem;
+  border-top: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+}
+
+.app-footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.25rem;
+}
+
+.app-footer-links a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.app-footer-links a:hover,
+.app-footer-links a:focus-visible {
+  color: var(--accent-color, var(--brand-secondary));
+  text-decoration: underline;
+}
+
+.app-footer-copyright {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+@media (max-width: 600px) {
+  .app-footer {
+    flex-direction: column;
+    align-items: flex-start;
+    margin-top: 2rem;
+  }
+}

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,0 +1,103 @@
+import { useState } from 'react'
+import { SHOW_ALL_ORACLE_MODELS } from '../constants/wagerDefaults'
+import { LEGAL_LINKS } from '../constants/legalLinks'
+import './Footer.css'
+
+/**
+ * Shared site footer (Spec 010 — US2, FR-005/006/007/008/009).
+ *
+ *   variant="full"      → landing-page footer (brand + Oracles/Docs/Legal/Community) + copyright.
+ *   variant="condensed" → in-app footer: legal/policy links + copyright only (no marketing columns).
+ *
+ * The copyright year is derived from the current date so it never goes stale (FR-008),
+ * and the legal links come from the single LEGAL_LINKS source so the two footers can't
+ * drift and never point at the external marketing site (FR-006/009, SC-002).
+ */
+export default function Footer({ variant = 'full' }) {
+  const year = new Date().getFullYear()
+  const copyright = `© ${year} ChipprRobotics LLC. Apache License 2.0`
+
+  if (variant === 'condensed') {
+    return (
+      <footer className="app-footer">
+        <nav className="app-footer-links" aria-label="Legal">
+          {LEGAL_LINKS.map((l) => (
+            <a key={l.href} href={l.href}>{l.label}</a>
+          ))}
+        </nav>
+        <p className="app-footer-copyright">{copyright}</p>
+      </footer>
+    )
+  }
+
+  return (
+    <footer className="landing-footer">
+      <div className="container">
+        <div className="footer-content">
+          <div className="footer-section footer-brand">
+            <FooterBrand />
+            <p>P2P wager management layer with multi-oracle resolution.</p>
+          </div>
+          <div className="footer-section">
+            <h4>Oracles</h4>
+            <ul>
+              <li><a href="https://polymarket.com" target="_blank" rel="noopener noreferrer">Polymarket</a></li>
+              {SHOW_ALL_ORACLE_MODELS && (
+                <>
+                  <li><a href="https://chain.link" target="_blank" rel="noopener noreferrer">Chainlink</a></li>
+                  <li><a href="https://uma.xyz" target="_blank" rel="noopener noreferrer">UMA Protocol</a></li>
+                </>
+              )}
+            </ul>
+          </div>
+          <div className="footer-section">
+            <h4>Docs</h4>
+            <ul>
+              <li><a href="https://docs.FairWins.app/user-guide/getting-started/" target="_blank" rel="noopener noreferrer">User Guide</a></li>
+              <li><a href="https://docs.FairWins.app/developer-guide/setup/" target="_blank" rel="noopener noreferrer">Developer Docs</a></li>
+              <li><a href="https://docs.FairWins.app/security/" target="_blank" rel="noopener noreferrer">Security Audits</a></li>
+            </ul>
+          </div>
+          <div className="footer-section">
+            <h4>Legal</h4>
+            <ul>
+              {LEGAL_LINKS.map((l) => (
+                <li key={l.href}><a href={l.href}>{l.label}</a></li>
+              ))}
+            </ul>
+          </div>
+          <div className="footer-section">
+            <h4>Community</h4>
+            <ul>
+              <li><a href="https://x.com/fairwins_app" target="_blank" rel="noopener noreferrer">Twitter / X</a></li>
+              <li><a href="https://discord.gg/rkYvPFdRRr" target="_blank" rel="noopener noreferrer">Discord</a></li>
+              <li><a href="https://github.com/chippr-robotics/prediction-dao-research" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+            </ul>
+          </div>
+        </div>
+        <div className="footer-bottom">
+          <p>{copyright}</p>
+        </div>
+      </div>
+    </footer>
+  )
+}
+
+/** Brand logo with a text fallback if the SVG fails to load (matches prior landing behavior). */
+function FooterBrand() {
+  const [logoError, setLogoError] = useState(false)
+  if (logoError) {
+    return <div className="footer-logo-fallback" aria-label="FairWins">FW</div>
+  }
+  return (
+    <img
+      src="/assets/logo_fairwins.svg"
+      alt="FairWins"
+      className="footer-logo"
+      width="40"
+      height="40"
+      loading="lazy"
+      onError={() => setLogoError(true)}
+    />
+  )
+}

--- a/frontend/src/components/LandingPage.jsx
+++ b/frontend/src/components/LandingPage.jsx
@@ -2,22 +2,17 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import Header from './Header'
 import LiveStats from './fairwins/LiveStats'
+import Footer from './Footer'
 import { useChainTokens } from '../hooks/useChainTokens'
-import { SHOW_ALL_ORACLE_MODELS } from '../constants/wagerDefaults'
 import './LandingPage.css'
 
 function LandingPage() {
   const navigate = useNavigate()
-  const [logoErrors, setLogoErrors] = useState({ fairwins: false })
   const [visibleSections, setVisibleSections] = useState(new Set())
   const { native: nativeSymbol, networkName } = useChainTokens()
 
   const handleGetStarted = () => {
     navigate('/app')
-  }
-
-  const handleLogoError = (platform) => {
-    setLogoErrors(prev => ({ ...prev, [platform]: true }))
   }
 
   // Intersection observer for scroll-triggered animations
@@ -396,59 +391,7 @@ function LandingPage() {
       </section>
 
       {/* Footer */}
-      <footer className="landing-footer">
-        <div className="container">
-          <div className="footer-content">
-            <div className="footer-section footer-brand">
-              {!logoErrors.fairwins ? (
-                <img
-                  src="/assets/logo_fairwins.svg"
-                  alt="FairWins"
-                  className="footer-logo"
-                  width="40"
-                  height="40"
-                  loading="lazy"
-                  onError={() => handleLogoError('fairwins')}
-                />
-              ) : (
-                <div className="footer-logo-fallback" aria-label="FairWins">FW</div>
-              )}
-              <p>P2P wager management layer with multi-oracle resolution.</p>
-            </div>
-            <div className="footer-section">
-              <h4>Oracles</h4>
-              <ul>
-                <li><a href="https://polymarket.com" target="_blank" rel="noopener noreferrer">Polymarket</a></li>
-                {SHOW_ALL_ORACLE_MODELS && (
-                  <>
-                    <li><a href="https://chain.link" target="_blank" rel="noopener noreferrer">Chainlink</a></li>
-                    <li><a href="https://uma.xyz" target="_blank" rel="noopener noreferrer">UMA Protocol</a></li>
-                  </>
-                )}
-              </ul>
-            </div>
-            <div className="footer-section">
-              <h4>Docs</h4>
-              <ul>
-                <li><a href="https://docs.FairWins.app/user-guide/getting-started/" target="_blank" rel="noopener noreferrer">User Guide</a></li>
-                <li><a href="https://docs.FairWins.app/developer-guide/setup/" target="_blank" rel="noopener noreferrer">Developer Docs</a></li>
-                <li><a href="https://docs.FairWins.app/security/" target="_blank" rel="noopener noreferrer">Security Audits</a></li>
-              </ul>
-            </div>
-            <div className="footer-section">
-              <h4>Community</h4>
-              <ul>
-                <li><a href="https://x.com/fairwins_app" target="_blank" rel="noopener noreferrer">Twitter / X</a></li>
-                <li><a href="https://discord.gg/rkYvPFdRRr" target="_blank" rel="noopener noreferrer">Discord</a></li>
-                <li><a href="https://github.com/chippr-robotics/prediction-dao-research" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-              </ul>
-            </div>
-          </div>
-          <div className="footer-bottom">
-            <p>&copy; 2024 ChipprRobotics LLC. Apache License 2.0</p>
-          </div>
-        </div>
-      </footer>
+      <Footer />
     </div>
   )
 }

--- a/frontend/src/components/compliance/EntryGate.css
+++ b/frontend/src/components/compliance/EntryGate.css
@@ -1,0 +1,95 @@
+/**
+ * Entry-gate notice readability (Spec 010 — US3, FR-010/FR-013).
+ *
+ * The entry-gate-* classes previously had no styles, so the eligibility notice ran
+ * edge-to-edge and was hard to read (UAT). This presents it as a centered, padded,
+ * scrollable card with comfortable spacing, responsive down to ~360px. Colors use
+ * theme.css tokens so light and dark both keep WCAG-AA contrast.
+ */
+
+.entry-gate-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 1.5rem 1rem;
+  overflow-y: auto;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.entry-gate {
+  width: 100%;
+  max-width: 40rem;
+  margin: auto;
+  padding: 2rem;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  line-height: 1.6;
+}
+
+.entry-gate h2 {
+  margin: 0 0 1rem;
+  line-height: 1.25;
+}
+
+.entry-gate p {
+  margin: 0 0 1rem;
+}
+
+.entry-gate ul {
+  margin: 0 0 1rem;
+  padding-left: 1.5rem;
+}
+
+.entry-gate li {
+  margin: 0 0 0.5rem;
+}
+
+.entry-gate a {
+  color: var(--accent-color, var(--brand-secondary));
+}
+
+.entry-gate-warning {
+  padding: 0.75rem 1rem;
+  border-left: 3px solid var(--warning-color, #f59e0b);
+  background: rgba(245, 166, 35, 0.08);
+  color: var(--text-secondary);
+}
+
+.entry-gate-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.entry-gate-actions .confirm-btn {
+  flex: 1 1 8rem;
+  padding: 0.75rem 1.25rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.entry-gate-actions .confirm-btn.primary {
+  background: var(--primary-button, var(--brand-primary));
+  color: var(--primary-button-text, #fff);
+  border-color: transparent;
+}
+
+.entry-gate-actions .confirm-btn:hover {
+  filter: brightness(0.97);
+}
+
+@media (max-width: 480px) {
+  .entry-gate {
+    padding: 1.5rem 1.25rem;
+  }
+}

--- a/frontend/src/components/compliance/EntryGate.jsx
+++ b/frontend/src/components/compliance/EntryGate.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { getCurrentDocument } from '../../utils/legalDocs'
+import './EntryGate.css'
 
 /**
  * EntryGate (Spec 007 — US4, FR-031/FR-033/FR-034)

--- a/frontend/src/components/compliance/MembershipAttestation.jsx
+++ b/frontend/src/components/compliance/MembershipAttestation.jsx
@@ -41,6 +41,11 @@ export default function MembershipAttestation({ onChange }) {
         wagered, or returned as winnings, and are <strong>non-refundable</strong> — including if
         you are later restricted, suspended, or unable to access the platform.
       </p>
+      <p className="membership-attestation-review">
+        Before agreeing, please read the{' '}
+        <a href="/terms" target="_blank" rel="noopener noreferrer">Terms &amp; Conditions</a> and{' '}
+        <a href="/risk" target="_blank" rel="noopener noreferrer">Risk Disclosure</a>.
+      </p>
       <fieldset>
         <legend>By purchasing or upgrading, I confirm and agree:</legend>
         {ATTESTATIONS.map((a) => (

--- a/frontend/src/components/ui/PremiumPurchaseModal.jsx
+++ b/frontend/src/components/ui/PremiumPurchaseModal.jsx
@@ -8,6 +8,7 @@ import { recordRolePurchase } from '../../utils/roleStorage'
 import { purchaseRoleWithStablecoin, getUserTierOnChain } from '../../utils/blockchainService'
 import { ensureKeyRegistered } from '../../utils/keyRegistryService'
 import { getCurrentDocument } from '../../utils/legalDocs'
+import { ACCOUNT_MODERATION_PATH } from '../../constants/legalLinks'
 import MembershipAttestation from '../compliance/MembershipAttestation'
 import { getTransactionUrl } from '../../config/blockExplorer'
 import './PremiumPurchaseModal.css'
@@ -464,7 +465,7 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
                         An <strong>Account Moderator</strong> can freeze your account for cause
                         (fraud, abuse, court order, etc.). A frozen account cannot create or accept
                         wagers, or claim payouts or refunds, until unfrozen. See{' '}
-                        <a href="/docs/system-overview/account-moderation" target="_blank" rel="noreferrer">
+                        <a href={ACCOUNT_MODERATION_PATH} target="_blank" rel="noopener noreferrer">
                           Account Moderation policy
                         </a>.
                       </li>

--- a/frontend/src/components/wallet/RoleDetailsCard.jsx
+++ b/frontend/src/components/wallet/RoleDetailsCard.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { TIER_NAMES } from '../../hooks/useRoleDetails'
+import { ACCOUNT_MODERATION_PATH } from '../../constants/legalLinks'
 import './RoleDetailsCard.css'
 
 const ROLE_DISPLAY_NAMES = {
@@ -150,7 +151,7 @@ export function RoleDetailsCard({ role, onUpgrade, onExtend, compact = false, is
             <strong>This account is currently frozen by a platform moderator.</strong>
             <div>You cannot create or accept wagers, or claim payouts or refunds, until unfrozen.</div>
             {freezeReason && <div>Reason: {freezeReason}</div>}
-            <a href="/docs/system-overview/account-moderation" target="_blank" rel="noreferrer">
+            <a href={ACCOUNT_MODERATION_PATH} target="_blank" rel="noopener noreferrer">
               Account moderation policy
             </a>
           </div>

--- a/frontend/src/constants/legalLinks.js
+++ b/frontend/src/constants/legalLinks.js
@@ -1,0 +1,23 @@
+/**
+ * Shared legal/policy document links (Spec 010 — FR-002 / FR-006 / FR-009).
+ *
+ * Single source of truth for the in-app policy routes referenced by the footer
+ * (Footer.jsx) and by the compliance surfaces that link to them (membership
+ * purchase modal, admin freeze note, role-details card). Every href is an
+ * IN-APP route — never the external marketing/docs site (SC-002).
+ *
+ * The Account Moderation policy is a section within the Terms document, reached
+ * by the `#account-moderation` anchor (see legal/terms.md + LegalDocPage's
+ * scroll-to-hash behavior).
+ */
+
+/** Deep link to the Account Moderation section inside the in-app Terms document. */
+export const ACCOUNT_MODERATION_PATH = '/terms#account-moderation'
+
+/** Ordered policy/legal links shown in the footer (both variants). */
+export const LEGAL_LINKS = [
+  { label: 'Terms & Conditions', href: '/terms' },
+  { label: 'Risk Disclosure', href: '/risk' },
+  { label: 'Privacy Policy', href: '/privacy' },
+  { label: 'Account Moderation', href: ACCOUNT_MODERATION_PATH },
+]

--- a/frontend/src/legal/terms.md
+++ b/frontend/src/legal/terms.md
@@ -154,6 +154,12 @@ You will indemnify and hold harmless FairWins and Chippr Robotics LLC and their 
 
 We may restrict, suspend, or terminate your access to the Service at any time, including for suspected ineligibility, circumvention, sanctions concerns, or breach, **without notice and without refund**. Settled on-chain Wagers are unaffected by termination.
 
+### Account Moderation
+
+An **Account Moderator** is a protocol role that can freeze — and later unfreeze — an individual account for cause. Cause includes suspected fraud or abuse, sanctions or eligibility concerns, or a court order or other lawful demand. While an account is frozen it cannot create or accept wagers, cancel, declare a winner, or claim payouts or refunds on the WagerRegistry. Permissionless on-chain resolution (for example Polymarket auto-resolution) may still occur, but a frozen account cannot claim until it is unfrozen. Freezing is an on-chain action recorded on the WagerRegistry; it does not entitle you to any refund of membership or other fees and does not affect already-settled Wagers.
+
+Separately, a **Guardian-Role** holder may pause the protocol in response to a security incident, which temporarily blocks all wager creation, acceptance, and settlement for everyone until the protocol is unpaused.
+
 ## 22. Governing Law; Arbitration; Class Action Waiver
 
 **22.1 Governing law.** These Terms are governed by the laws of `[GOVERNING LAW JURISDICTION]`, without regard to conflict-of-laws rules.

--- a/frontend/src/pages/legal/LegalDocPage.css
+++ b/frontend/src/pages/legal/LegalDocPage.css
@@ -1,0 +1,90 @@
+/**
+ * Legal document page readability (Spec 010 — US3, FR-011/FR-012/FR-013).
+ *
+ * The legal-doc-* classes previously had no styles, so the long legal text ran
+ * edge-to-edge and was hard to read (UAT). This constrains the measure, adds
+ * margins/padding and vertical rhythm, and stays responsive down to ~360px.
+ * Colors use theme.css tokens so light and dark both keep WCAG-AA contrast.
+ */
+
+.legal-doc-page {
+  max-width: 72ch;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 4rem;
+  color: var(--text-primary);
+  line-height: 1.65;
+}
+
+.legal-doc-page h1 {
+  margin: 0 0 0.5rem;
+  line-height: 1.25;
+}
+
+.legal-doc-version {
+  margin: 0 0 1rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  word-break: break-all;
+}
+
+.legal-doc-nav {
+  margin: 0 0 2rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 0.95rem;
+}
+
+.legal-doc-nav a {
+  color: var(--accent-color, var(--brand-secondary));
+}
+
+.legal-doc-body {
+  /* scroll-margin so #fragment deep-links don't tuck headings under a sticky header */
+  scroll-margin-top: 1rem;
+}
+
+.legal-doc-body h2,
+.legal-doc-body h3,
+.legal-doc-body h4,
+.legal-doc-body h5,
+.legal-doc-body h6 {
+  margin: 2rem 0 0.75rem;
+  line-height: 1.3;
+  scroll-margin-top: 1rem;
+}
+
+.legal-doc-body p {
+  margin: 0 0 1rem;
+}
+
+.legal-doc-body ul {
+  margin: 0 0 1rem;
+  padding-left: 1.5rem;
+}
+
+.legal-doc-body li {
+  margin: 0 0 0.4rem;
+}
+
+.legal-doc-body blockquote {
+  margin: 0 0 1rem;
+  padding: 0.5rem 1rem;
+  border-left: 3px solid var(--border-color);
+  color: var(--text-secondary);
+}
+
+.legal-doc-body code {
+  word-break: break-word;
+}
+
+.legal-doc-body hr {
+  margin: 2rem 0;
+  border: none;
+  border-top: 1px solid var(--border-color);
+}
+
+@media (max-width: 480px) {
+  .legal-doc-page {
+    padding: 1.5rem 1rem 3rem;
+  }
+}

--- a/frontend/src/pages/legal/LegalDocPage.jsx
+++ b/frontend/src/pages/legal/LegalDocPage.jsx
@@ -1,5 +1,6 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { getCurrentDocument } from '../../utils/legalDocs'
+import './LegalDocPage.css'
 
 /**
  * Versioned legal-document pages (Spec 007 — FR-017/FR-024, SC-010/SC-015).
@@ -39,11 +40,29 @@ function renderInline(text, keyPrefix) {
   return nodes
 }
 
+/** Slugify heading text into a URL-fragment-safe id (e.g. "Account Moderation" → "account-moderation"). */
+function slugify(text) {
+  return text
+    .toLowerCase()
+    .replace(/[`*_[\]()]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
 function renderMarkdown(md) {
   const lines = md.split('\n')
   const blocks = []
   let list = null
   let para = []
+  // Heading ids must be unique within the document (duplicate ids are an a11y violation).
+  const seenIds = new Set()
+  const uniqueId = (base) => {
+    let id = base || 'section'
+    let n = 2
+    while (seenIds.has(id)) id = `${base}-${n++}`
+    seenIds.add(id)
+    return id
+  }
 
   const flushPara = () => {
     if (para.length) {
@@ -68,7 +87,7 @@ function renderMarkdown(md) {
       flushPara(); flushList()
       const level = Math.min(h[1].length + 1, 6) // shift down one (page owns the h1)
       const Tag = `h${level}`
-      blocks.push(<Tag key={`h${idx}`}>{renderInline(h[2], `h${idx}`)}</Tag>)
+      blocks.push(<Tag key={`h${idx}`} id={uniqueId(slugify(h[2]))}>{renderInline(h[2], `h${idx}`)}</Tag>)
       return
     }
     const li = line.match(/^[-*]\s+(.*)$/)
@@ -92,6 +111,20 @@ function renderMarkdown(md) {
 
 export function LegalDocPage({ docType }) {
   const doc = useMemo(() => getCurrentDocument(docType), [docType])
+
+  // Deep-link support: scroll to the #fragment section once the doc has rendered
+  // (SPA navigation paints the content client-side, so the browser's native
+  // fragment scroll can fire before the target exists). FR-002 / SC-003.
+  useEffect(() => {
+    if (!doc || typeof window === 'undefined' || !window.location.hash) return
+    const id = decodeURIComponent(window.location.hash.slice(1))
+    const el = id && document.getElementById(id)
+    if (!el) return
+    const reduce = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches
+    try {
+      el.scrollIntoView({ behavior: reduce ? 'auto' : 'smooth', block: 'start' })
+    } catch { /* jsdom: scrollIntoView not implemented */ }
+  }, [doc])
 
   if (!doc) {
     return (

--- a/frontend/src/test/Footer.test.jsx
+++ b/frontend/src/test/Footer.test.jsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import Footer from '../components/Footer'
+import { LEGAL_LINKS } from '../constants/legalLinks'
+import appSource from '../App.jsx?raw'
+
+/**
+ * Spec 010 (US2 — FR-005/006/007/008/009, SC-002/004/005).
+ */
+describe('Footer', () => {
+  it('condensed variant: legal links in-app + current-year copyright, no marketing columns', () => {
+    const { container } = render(<Footer variant="condensed" />)
+    const footer = container.querySelector('footer')
+    expect(footer).toBeTruthy()
+
+    // every legal link present and pointing at an in-app route
+    for (const { label, href } of LEGAL_LINKS) {
+      const link = within(footer).getByRole('link', { name: new RegExp(label.replace('&', '&'), 'i') })
+      expect(link).toHaveAttribute('href', href)
+      expect(href.startsWith('/')).toBe(true)
+    }
+    // Account Moderation deep-links into Terms
+    expect(within(footer).getByRole('link', { name: /Account Moderation/i }))
+      .toHaveAttribute('href', '/terms#account-moderation')
+
+    // current, dynamic year — never the stale 2024
+    const year = new Date().getFullYear()
+    expect(footer.textContent).toContain(String(year))
+    expect(footer.textContent).not.toContain('2024')
+
+    // condensed omits the landing marketing columns
+    expect(screen.queryByText('Polymarket')).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /Community/i })).not.toBeInTheDocument()
+  })
+
+  it('full variant: keeps marketing columns AND adds the legal links', () => {
+    render(<Footer variant="full" />)
+    expect(screen.getByText('Polymarket')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /^Legal$/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Privacy Policy/i })).toHaveAttribute('href', '/privacy')
+    const year = new Date().getFullYear()
+    expect(screen.getByText(new RegExp(`${year}.*ChipprRobotics`))).toBeInTheDocument()
+  })
+
+  it('defaults to the full variant', () => {
+    render(<Footer />)
+    expect(screen.getByText('Polymarket')).toBeInTheDocument()
+  })
+
+  it('is wired into the in-app layout as the condensed variant (FR-005)', () => {
+    expect(appSource).toContain('<Footer variant="condensed" />')
+  })
+})

--- a/frontend/src/test/LegalDocPage.test.jsx
+++ b/frontend/src/test/LegalDocPage.test.jsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { TermsPage } from '../pages/legal/LegalDocPage'
+
+/**
+ * Spec 010 (FR-003): the in-app Terms document carries an Account Moderation
+ * section reachable via the #account-moderation anchor, and renderMarkdown
+ * assigns a slug id to every heading (enables /terms#... deep links).
+ */
+describe('LegalDocPage heading anchors (Spec 010 — FR-003)', () => {
+  it('renders an Account Moderation heading with id="account-moderation"', () => {
+    const { container } = render(<TermsPage />)
+    const el = container.querySelector('#account-moderation')
+    expect(el).toBeTruthy()
+    expect(el.textContent).toMatch(/Account Moderation/i)
+    expect(/^H[1-6]$/.test(el.tagName)).toBe(true)
+  })
+
+  it('assigns a slug id to every heading in the document body', () => {
+    const { container } = render(<TermsPage />)
+    const headings = container.querySelectorAll(
+      '.legal-doc-body h2, .legal-doc-body h3, .legal-doc-body h4, .legal-doc-body h5, .legal-doc-body h6',
+    )
+    expect(headings.length).toBeGreaterThan(0)
+    headings.forEach((h) => expect(h.id).toMatch(/^[a-z0-9-]+$/))
+  })
+})

--- a/frontend/src/test/MembershipAttestation.test.jsx
+++ b/frontend/src/test/MembershipAttestation.test.jsx
@@ -48,4 +48,10 @@ describe('MembershipAttestation (T043)', () => {
     expect(screen.getByText(/no regulator or authority/i)).toBeInTheDocument()
     expect(screen.getByText(/VPN, proxy/i)).toBeInTheDocument()
   })
+
+  it('links the Terms & Conditions and Risk Disclosure for review (Spec 010 — FR-001)', () => {
+    render(<MembershipAttestation onChange={() => {}} />)
+    expect(screen.getByRole('link', { name: /Terms & Conditions/i })).toHaveAttribute('href', '/terms')
+    expect(screen.getByRole('link', { name: /Risk Disclosure/i })).toHaveAttribute('href', '/risk')
+  })
 })

--- a/frontend/src/test/compliance.accessibility.test.jsx
+++ b/frontend/src/test/compliance.accessibility.test.jsx
@@ -7,6 +7,7 @@ import EntryGate from '../components/compliance/EntryGate'
 import MembershipAttestation from '../components/compliance/MembershipAttestation'
 import DenyListAdmin from '../components/admin/DenyListAdmin'
 import { TermsPage } from '../pages/legal/LegalDocPage'
+import Footer from '../components/Footer'
 
 /**
  * Spec 007 (FR-053 / SC-015): the new compliance trust surfaces must meet WCAG 2.1 AA.
@@ -32,6 +33,11 @@ describe('Compliance UI accessibility (T054, FR-053)', () => {
 
   it('Legal document page (Terms) has no axe violations', async () => {
     const { container } = render(<TermsPage />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('Footer (condensed in-app) has no axe violations (Spec 010)', async () => {
+    const { container } = render(<Footer variant="condensed" />)
     expect(await axe(container)).toHaveNoViolations()
   })
 

--- a/frontend/src/test/moderationLinks.test.jsx
+++ b/frontend/src/test/moderationLinks.test.jsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { ACCOUNT_MODERATION_PATH } from '../constants/legalLinks'
+import modalSource from '../components/ui/PremiumPurchaseModal.jsx?raw'
+import adminSource from '../components/AdminPanel.jsx?raw'
+import roleSource from '../components/wallet/RoleDetailsCard.jsx?raw'
+
+/**
+ * Spec 010 (FR-002 / SC-002): every "Account Moderation policy" link points at the
+ * in-app Terms section (/terms#account-moderation), never the external docs/marketing
+ * site. Verified at the source level so the external URL cannot be reintroduced.
+ */
+const SURFACES = [
+  ['PremiumPurchaseModal', modalSource],
+  ['AdminPanel', adminSource],
+  ['RoleDetailsCard', roleSource],
+]
+
+describe('Account Moderation policy links (Spec 010 — FR-002 / SC-002)', () => {
+  it('the shared path is an in-app Terms anchor, not an external URL', () => {
+    expect(ACCOUNT_MODERATION_PATH).toBe('/terms#account-moderation')
+    expect(ACCOUNT_MODERATION_PATH.startsWith('/')).toBe(true)
+  })
+
+  it.each(SURFACES)('%s links the moderation policy in-app (no external docs URL)', (_name, src) => {
+    expect(src).toContain('ACCOUNT_MODERATION_PATH')
+    expect(src).not.toContain('/docs/system-overview/account-moderation')
+  })
+})

--- a/specs/010-footer-policy-fixes/checklists/requirements.md
+++ b/specs/010-footer-policy-fixes/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Footer & Policy-Document Corrections (UAT)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Two scope decisions were resolved with the user during specification (no open
+  [NEEDS CLARIFICATION] markers remain):
+  1. **Account Moderation policy** → added as a **section within the in-app Terms &
+     Conditions** and deep-linked (not a new standalone document).
+  2. **In-app footer** → **condensed** variant (legal/policy links + copyright),
+     omitting the landing-page marketing columns.
+- Reasonable defaults recorded in the Assumptions section (e.g., dynamic copyright year,
+  preserving purchase state when opening a policy mid-flow). Adjust there if a default is wrong.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.

--- a/specs/010-footer-policy-fixes/contracts/ui-contracts.md
+++ b/specs/010-footer-policy-fixes/contracts/ui-contracts.md
@@ -1,0 +1,73 @@
+# UI / Behavioral Contracts: Footer & Policy-Document Corrections
+
+This is a frontend feature with no network API. The "contracts" below are the observable
+behaviors and component interfaces that tests and reviewers verify. Each maps to spec
+requirements (FR-/SC-) and is independently checkable.
+
+## C1 — `Footer` component interface
+
+```
+Footer({ variant?: 'full' | 'condensed' })   // default 'full'
+```
+
+Guarantees:
+- **C1.1** Renders a single `<footer>` landmark.
+- **C1.2** `variant="full"` renders the existing landing sections (brand, Oracles, Docs,
+  Community) with unchanged class names, **plus** a Legal links group. (FR-006; keeps
+  `LandingPage.oracle.test` green.)
+- **C1.3** `variant="condensed"` renders only the Legal links group + the copyright/license
+  line (no marketing columns). (FR-007)
+- **C1.4** Both variants render the Legal links, each pointing to an in-app route:
+  Terms→`/terms`, Risk→`/risk`, Privacy→`/privacy`, Account Moderation→`/terms#account-moderation`.
+  No Legal link targets an external/marketing host. (FR-006, FR-009, SC-002)
+- **C1.5** The copyright line shows the current calendar year via `new Date().getFullYear()`
+  and contains no hardcoded past year. (FR-008, SC-005)
+
+## C2 — In-app footer presence
+
+Guarantees:
+- **C2.1** `AppLayout` renders `<Footer variant="condensed" />`, so a footer landmark is
+  present on `/app`, `/main`, `/fairwins`, `/wallet`, `/friend-market/accept`, `/admin`. (FR-005, SC-004)
+- **C2.2** The landing route `/` renders `<Footer />` (full). (SC-004)
+
+## C3 — Account Moderation link target (all surfaces)
+
+Guarantees:
+- **C3.1** Every "Account Moderation policy" / freeze-policy link resolves to
+  `/terms#account-moderation` — in `PremiumPurchaseModal`, `AdminPanel`, and `RoleDetailsCard`.
+  (FR-002, SC-002, SC-003)
+- **C3.2** No remaining anchor in `frontend/src` (non-test) points to
+  `/docs/system-overview/account-moderation` or the external docs/marketing host for the
+  moderation policy. (SC-002)
+- **C3.3** From the purchase modal the link opens without destroying the in-progress purchase
+  (e.g. `target="_blank"`). (FR-004, SC-007)
+
+## C4 — Terms Account-Moderation section + anchor
+
+Guarantees:
+- **C4.1** Rendering `/terms` produces a heading whose text is "Account Moderation" and whose
+  element `id` is `account-moderation`. (FR-003)
+- **C4.2** `renderMarkdown` attaches a slug `id` to every heading it emits. (FR-003 enabler)
+- **C4.3** When `/terms#account-moderation` is opened, the matching element is scrolled into
+  view after render (respecting `prefers-reduced-motion`). (FR-002, SC-003)
+- **C4.4** `getCurrentDocument('terms').hash === hashDocVersion(content)` still holds after the
+  edit (format `/^[0-9a-f]{64}$/`). (FR-014)
+
+## C5 — Readability
+
+Guarantees (verified via styling + accessibility checks; exact pixel values are tasks-level):
+- **C5.1** The entry-gate notice body text has non-zero horizontal padding/margin and a
+  constrained width; no text is flush to the viewport edge at 360px. (FR-010, SC-006)
+- **C5.2** Legal-document body (`legal-doc-body`) has a constrained reading measure
+  (≈70ch/720px max-width, centered), horizontal padding, and clear paragraph/heading spacing;
+  no horizontal overflow from 360px to desktop. (FR-011, FR-012, SC-006)
+- **C5.3** Readability CSS uses theme tokens; light and dark themes both meet WCAG 2.1 AA
+  contrast; link focus styles and heading semantics are preserved; axe reports no new
+  violations on the legal pages and footer. (FR-013, SC-008)
+
+## C6 — Regression guards (must remain green)
+
+- **C6.1** `EntryGate.test`: T&C link `href="/terms"`, Risk link `href="/risk"` unchanged.
+- **C6.2** `MembershipAttestation.test`: the required eligibility/risk attestations still present.
+- **C6.3** `LandingPage.oracle.test`: footer oracle links still rendered by the full variant.
+- **C6.4** `legalDocs.test`: canonicalization/hash invariants still pass.

--- a/specs/010-footer-policy-fixes/data-model.md
+++ b/specs/010-footer-policy-fixes/data-model.md
@@ -1,0 +1,79 @@
+# Phase 1 Data Model: Footer & Policy-Document Corrections
+
+This feature is presentation-layer; it introduces **no new persisted data** and no schema
+changes. The "entities" below are the conceptual objects the UI composes from existing sources.
+
+## Policy Document (existing — reused)
+
+The canonical, content-addressed legal document served in-app.
+
+| Field | Description | Source |
+|-------|-------------|--------|
+| `docType` | `'terms' \| 'risk' \| 'privacy'` | `utils/legalDocs.js` `DOC_TYPES` |
+| `label` | Human title (e.g. "Terms & Conditions") | `REGISTRY[docType].label` |
+| `route` | In-app route (`/terms`, `/risk`, `/privacy`) | `REGISTRY[docType].route` |
+| `content` | Raw markdown (`*.md?raw`) | `frontend/src/legal/*.md` |
+| `hash` | SHA-256 of canonicalized content (the version id) | `hashDocVersion(content)` |
+| `material` | Re-consent flag | `REGISTRY[docType].material` |
+
+- **Validation/invariants**: `hash` MUST equal `hashDocVersion(content)` (already enforced by
+  `legalDocs.test.js`). Canonicalization is **frozen** — not modified by this feature.
+- **Change in this feature**: `terms.md` gains an **Account Moderation** section ⇒ the Terms
+  `content` and therefore `hash` change to a new material version. No registry/schema change.
+
+## Account Moderation Section (new content within Terms)
+
+Not a standalone entity — a **referenced section** inside the Terms document.
+
+| Aspect | Value |
+|--------|-------|
+| Location | New section/subheading in `frontend/src/legal/terms.md` (near §21 Suspension & Termination) |
+| Heading text | `Account Moderation` (unnumbered, so the slug is clean) |
+| Anchor id | `account-moderation` (slugified heading id emitted by `renderMarkdown`) |
+| Deep link | `/terms#account-moderation` |
+| Content | Who may freeze an account (Account Moderator role), grounds (fraud, abuse, court order, sanctions/eligibility concerns), effects (cannot create/accept wagers, claim payouts or refunds until unfrozen), relation to on-chain enforcement and to §21 |
+
+## Footer (new component, two variants)
+
+A site-wide region rendered from a shared `Footer` component.
+
+| Field | `full` (landing) | `condensed` (in-app) |
+|-------|------------------|----------------------|
+| Brand blurb | shown | hidden |
+| Oracles / Docs / Community columns | shown | hidden |
+| Legal/policy links | shown (Legal group) | shown (primary content) |
+| Copyright + license line | shown | shown |
+| Copyright year | `new Date().getFullYear()` (dynamic) | same |
+
+- **Legal link set** (shared constant, both variants):
+  - Terms & Conditions → `/terms`
+  - Risk Disclosure → `/risk`
+  - Privacy Policy → `/privacy`
+  - Account Moderation → `/terms#account-moderation`
+- **Invariants**: every legal link resolves to an **in-app route** (FR-009); the displayed year
+  is never a hardcoded past year (FR-008).
+
+## Compliance Attestation surfaces (existing — links corrected)
+
+The consent/warning surfaces that reference policy documents.
+
+| Surface | File | Policy references | Change |
+|---------|------|-------------------|--------|
+| Entry gate | `compliance/EntryGate.jsx` | T&C `/terms`, Risk `/risk` (already links) | readability CSS only |
+| Membership attestation | `compliance/MembershipAttestation.jsx` | "Terms & Conditions and the Risk Disclosure" (plain text) | see note* |
+| Purchase warning card | `ui/PremiumPurchaseModal.jsx` | "Account Moderation policy" (broken external) | → `/terms#account-moderation` (new tab) |
+| Admin freeze note | `AdminPanel.jsx` | "policy" (broken external) | → `/terms#account-moderation` |
+| Role details | `wallet/RoleDetailsCard.jsx` | "Account Moderation policy" (broken external) | → `/terms#account-moderation` |
+
+\* *Note on the membership attestation*: the spec's "wager attestations do not link to risk or
+T&C" maps here — the checkbox label text references the documents as plain text. The links the
+user needs (Terms/Risk) are reachable from the **purchase warning card / surrounding modal
+copy**; making those policy references in the modal into links satisfies US1. Whether to also
+linkify words *inside* an individual checkbox label is an implementation detail for `/speckit-tasks`
+(linkifying within a `<label>` is acceptable but must not interfere with the checkbox hit target).
+
+## State transitions
+
+None introduced. The only state-ish behavior is unchanged: the entry-gate acknowledgement in
+`localStorage` and on-chain accepted-Terms-hash recording at purchase (which will record the new
+Terms version hash going forward — expected).

--- a/specs/010-footer-policy-fixes/plan.md
+++ b/specs/010-footer-policy-fixes/plan.md
@@ -1,0 +1,127 @@
+# Implementation Plan: Footer & Policy-Document Corrections (UAT)
+
+**Branch**: `feat/010-footer-policy-fixes` | **Date**: 2026-06-08 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/010-footer-policy-fixes/spec.md`
+
+## Summary
+
+A UAT pass found a cluster of trust-surface defects in the FairWins frontend: legal/policy
+documents are hard to reach or unreachable from where users attest to them, one policy link
+is broken (it points at an external docs URL that lands on the marketing site), the footer is
+missing inside the authenticated app and shows a stale `© 2024`, and the consent text and
+legal documents have no margins and are hard to read.
+
+The fix is **frontend-only** (no contracts, no backend): wire the policy references in the
+membership-purchase surfaces to the in-app documents, add an **Account Moderation** section to
+the in-app Terms and deep-link to it, surface a **condensed legal footer** inside the app while
+adding the legal links and a **dynamic copyright year** to the shared footer, and add the
+missing **readability CSS** for the entry-gate notice and the legal-document pages. The
+existing versioned-legal-doc system (`utils/legalDocs.js`, hash-by-content) and routes
+(`/terms`, `/risk`, `/privacy`) are reused unchanged in mechanism.
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES2020+), React 18 function components + hooks
+
+**Primary Dependencies**: `react-router-dom` (routing/SPA), existing `utils/legalDocs.js`
+(content-addressed legal-doc registry, `@noble/hashes`). **No new runtime dependencies.**
+
+**Storage**: N/A. (Entry-gate acknowledgement already persists in `localStorage`; unchanged.)
+
+**Testing**: Vitest + React Testing Library for unit/integration; existing axe-based
+accessibility tests (`src/test/compliance.accessibility.test.jsx`); Lighthouse/axe in CI.
+
+**Target Platform**: Modern evergreen browsers; **mobile-first** (UAT was on a ~360px phone)
+through desktop. Light and dark themes (`theme.css` CSS variables).
+
+**Project Type**: Web frontend — single-page app, **no backend** (per the project's fixed
+no-backend footprint). All policy documents are in-app routes.
+
+**Performance Goals**: No measurable perf budget; changes are CSS + small JSX/markdown edits.
+No new bundle dependencies; no regression to bundle size of note.
+
+**Constraints**: WCAG 2.1 AA must hold (contrast, focus, semantics); no `continue-on-error`
+in CI lint/test/build; all policy links resolve to in-app routes (never the external
+site); dark + light theme must both render the new CSS correctly; no new markdown library
+(extend the existing dependency-free renderer).
+
+**Scale/Scope**: ~4 components touched, 2 new files (shared `Footer` + its CSS), 2 new CSS
+files (entry-gate, legal-doc page), 1 markdown doc edited (Terms), the markdown renderer
+extended for heading anchors, plus tests. ~6–8 source files + tests.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Applies? | Assessment |
+|-----------|----------|------------|
+| **I. Security-First Smart Contracts** | No | No `contracts/` changes. No on-chain code touched. Gate N/A. |
+| **II. Test-First & Coverage** | **Yes** | Vitest tests added/updated alongside behavior: footer (condensed variant in app, legal links, dynamic year, full variant preserved), moderation link target on all three surfaces, Terms Account-Moderation section + heading anchor + SPA scroll-to-hash, accessibility (axe) for legal pages and footer. Existing `EntryGate.test`, `MembershipAttestation.test`, `LandingPage.oracle.test`, `legalDocs.test` must stay green. |
+| **III. Honest State, No Mocks/Placeholders** | **Yes** | No mock data introduced. Copyright year is computed from the real current date (not hardcoded). The Account-Moderation policy is real prose added to the canonical Terms. Adding it **bumps the Terms content hash** — this is the system's honest versioning behavior (a new material version; `material: true` already set), not a workaround. Documented in research.md. |
+| **IV. Fail Loudly in CI** | **Yes** | No `continue-on-error` added. Lint/test/build/accessibility steps keep failing the pipeline on error. |
+| **V. Accessible, Consistent Frontend** | **Yes (primary gate)** | New readability CSS uses existing `theme.css` tokens so light/dark contrast is preserved; link semantics, focus order, and heading structure are retained; axe/Lighthouse must pass with no new violations; ESLint must stay clean. No hardcoded contract addresses/ABIs involved. |
+
+**Additional constraints**: Tech stack unchanged (React + Vite + Vitest); no new core
+technology; no key-management or deployment surface touched; no archived code imported.
+
+**Result**: ✅ PASS — no violations. Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-footer-policy-fixes/
+├── plan.md              # This file (/speckit-plan output)
+├── spec.md              # Feature spec (/speckit-specify output)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output — validation/run guide
+├── contracts/
+│   └── ui-contracts.md   # Phase 1 output — observable UI/behavioral contracts
+└── checklists/
+    └── requirements.md   # Spec quality checklist (/speckit-specify output)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/
+├── components/
+│   ├── Footer.jsx                     # NEW — shared footer; variant="full" | "condensed"
+│   ├── Footer.css                     # NEW — condensed (app) footer styles; full reuses landing-footer rules
+│   ├── LandingPage.jsx                # EDIT — replace inline <footer> with <Footer /> (full)
+│   ├── LandingPage.css                # EDIT (minor) — keep .landing-footer rules; add a Legal section if needed
+│   ├── AdminPanel.jsx                 # EDIT — moderation policy link → /terms#account-moderation
+│   ├── compliance/
+│   │   ├── EntryGate.jsx              # EDIT — import EntryGate.css (readability)
+│   │   └── EntryGate.css              # NEW — margins/padding/max-width/line-length, responsive, theme-aware
+│   ├── ui/
+│   │   └── PremiumPurchaseModal.jsx   # EDIT — moderation policy link → /terms#account-moderation
+│   └── wallet/
+│       └── RoleDetailsCard.jsx        # EDIT — moderation policy link → /terms#account-moderation
+├── pages/legal/
+│   ├── LegalDocPage.jsx               # EDIT — heading id anchors in renderMarkdown + scroll-to-hash on mount; import css
+│   └── LegalDocPage.css               # NEW — readable max-width/margins/spacing, responsive, theme-aware
+├── legal/
+│   └── terms.md                       # EDIT — add "Account Moderation" section (anchor target)
+├── App.jsx                            # EDIT — render <Footer variant="condensed" /> in AppLayout
+└── test/
+    ├── Footer.test.jsx                # NEW — variants, legal links, dynamic year, in-app presence
+    ├── PremiumPurchaseModal.*.test.jsx# EDIT/NEW — moderation link target assertion
+    ├── LegalDocPage.test.jsx          # NEW/EDIT — Account-Moderation heading + id anchor render
+    └── compliance.accessibility.test.jsx # EDIT — extend axe coverage to legal page + footer
+```
+
+**Structure Decision**: Standard `frontend/` React + Vite layout (Option 2, frontend only —
+there is no backend). The single notable structural choice is introducing a **shared `Footer`
+component** rather than editing two footers: it centralizes the dynamic year (so FR-008 cannot
+regress in one place) and the legal-link list (FR-006), and is rendered as `variant="full"` on
+the landing page and `variant="condensed"` inside `AppLayout`. The full variant reproduces the
+existing `.landing-footer` markup and class names verbatim so `LandingPage.oracle.test.jsx`
+stays green.
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally empty.

--- a/specs/010-footer-policy-fixes/quickstart.md
+++ b/specs/010-footer-policy-fixes/quickstart.md
@@ -1,0 +1,68 @@
+# Quickstart / Validation Guide: Footer & Policy-Document Corrections
+
+How to run and validate this feature end-to-end. Implementation details live in `tasks.md`;
+the observable behaviors are defined in [contracts/ui-contracts.md](./contracts/ui-contracts.md).
+
+## Prerequisites
+
+- Node + repo deps installed (`npm install` at repo root, or `cd frontend && npm install`).
+- Branch: `feat/010-footer-policy-fixes`.
+
+## Run the app
+
+```bash
+npm run frontend            # Vite dev server (from repo root)
+# then open the printed localhost URL
+```
+
+## Automated checks
+
+```bash
+npm run test:frontend       # full Vitest suite — all green, incl. new tests
+# focused runs while iterating:
+cd frontend
+npx vitest run src/test/Footer.test.jsx
+npx vitest run src/test/LegalDocPage.test.jsx
+npx vitest run src/test/PremiumPurchaseModal*.test.jsx
+npx vitest run src/test/EntryGate.test.jsx src/test/MembershipAttestation.test.jsx \
+               src/test/LandingPage.oracle.test.jsx src/test/legalDocs.test.js   # regression guards
+npx vitest run src/test/compliance.accessibility.test.jsx                        # axe
+npm run lint                # ESLint must be clean (Principle IV/V)
+```
+
+Expected: the new tests assert C1–C5; the regression guards (C6) stay green; lint passes.
+
+## Manual validation (maps to Success Criteria)
+
+1. **In-app footer present + condensed (SC-004, FR-005/007)**
+   - Connect/enter the app, go to `/app` and `/wallet`. A footer is visible at the bottom with
+     legal links + copyright, and **without** the Oracles/Docs/Community marketing columns.
+
+2. **Current year (SC-005, FR-008)**
+   - Footer copyright reads `© 2026 …` (current year), on both the landing page and in-app.
+
+3. **Policy links from compliance surfaces (SC-001/002/003, FR-001/002)**
+   - Open the membership purchase ("Get Wager Access") flow. In the operator-powers warning,
+     activate **Account Moderation policy** → a new tab opens `/terms` scrolled to the
+     **Account Moderation** section; the purchase modal is still open and intact when you return.
+   - Repeat from the Admin panel freeze note and the wallet Role details card — all land on the
+     same in-app section, none navigate to the external/marketing site.
+
+4. **Footer legal links (FR-006/009)**
+   - From the footer, open Terms, Risk Disclosure, Privacy Policy, and Account Moderation — each
+     opens the in-app document (Account Moderation → Terms at the right section). None leave the app.
+
+5. **Readability on mobile (SC-006, FR-010/011/012)**
+   - In devtools, set the viewport to **360px** wide. Open the entry-gate notice and each legal
+     document: body text has clear left/right margins (not flush to the edge), comfortable line
+     length, and there is **no horizontal scrollbar**.
+
+6. **Accessibility + theme (SC-008, FR-013)**
+   - Toggle dark/light theme: legal pages and footer remain readable with good contrast.
+   - Run an axe/Lighthouse pass on `/terms` and an in-app page: no new violations; links are
+     keyboard-focusable with visible focus.
+
+## Done / acceptance
+
+All automated checks pass (new + regression), and the six manual checks above behave as
+described. See `spec.md` Success Criteria for the authoritative pass/fail conditions.

--- a/specs/010-footer-policy-fixes/research.md
+++ b/specs/010-footer-policy-fixes/research.md
@@ -1,0 +1,105 @@
+# Phase 0 Research: Footer & Policy-Document Corrections
+
+This feature has no open `NEEDS CLARIFICATION` markers (the two scope forks were resolved with
+the user during `/speckit-specify`). Research here records the technical decisions behind the
+plan, grounded in the actual code on `origin/main`.
+
+## Decision 1 — Account Moderation policy: section within in-app Terms (deep-linked)
+
+- **Decision**: Add an **Account Moderation** section to `frontend/src/legal/terms.md` and point
+  every "Account Moderation policy" reference at `/terms#account-moderation`. Do **not** create a
+  new standalone document or route.
+- **Rationale**: Matches the product decision captured during specification, and the in-app
+  no-backend pattern: Terms/Risk/Privacy are already the canonical in-app docs served from
+  `utils/legalDocs.js`. Terms already carries a *Suspension and Termination* section (§21) that
+  the moderation content fits beside. One canonical, content-addressed source avoids a second
+  versioned document to maintain.
+- **Alternatives considered**:
+  - *New standalone `/account-moderation` doc + route* — rejected: more surface, a second hash to
+    record/maintain, and the user chose the Terms-section option.
+  - *Keep it external, fix the URL* — rejected: depends on the external docs site and conflicts
+    with FR-002/FR-009 (keep users in-app), and the broader feedback to pull policy docs in-app.
+
+## Decision 2 — There are THREE broken moderation links, not one
+
+- **Finding**: The external `/docs/system-overview/account-moderation` link appears in:
+  - `components/ui/PremiumPurchaseModal.jsx:467` ("Account Moderation policy")
+  - `components/AdminPanel.jsx:578` ("policy")
+  - `components/wallet/RoleDetailsCard.jsx:153` ("Account Moderation policy")
+  - (also a non-link description string in `contexts/RoleContext.js:46` — left as prose.)
+- **Decision**: Repoint **all three** anchors to `/terms#account-moderation`. SC-002 ("zero
+  references send the user to the external/marketing site") is only met if all are fixed.
+- **Rationale**: The spec scopes the fix to "anywhere in the app", not just the purchase modal.
+
+## Decision 3 — Deep-link anchors require renderer + scroll changes
+
+- **Finding**: `LegalDocPage.jsx`'s `renderMarkdown` emits headings as `<h2..h6>` **without `id`
+  attributes**, so `/terms#account-moderation` has nothing to scroll to, and as an SPA the doc is
+  rendered client-side after navigation (native fragment scroll can fire before paint).
+- **Decision**:
+  1. Extend `renderMarkdown` to attach a slugified `id` to every heading (e.g. text → lowercase,
+     non-alphanumerics → `-`, collapse repeats, trim). Add the Terms heading as an **unnumbered**
+     `### Account Moderation` so its slug is exactly `account-moderation`.
+  2. Add a `useEffect` in `LegalDocPage` that, when `window.location.hash` is present, scrolls the
+     matching element into view after render (and respects `prefers-reduced-motion`).
+- **Rationale**: Generating heading ids is a small, dependency-free change that also improves
+  accessibility/navigability for all legal docs, not just this anchor.
+- **Alternatives considered**: pinning a hand-written `<a name>` in markdown (renderer doesn't
+  support raw HTML; rejected); adding a markdown library (violates "no new bundle dep"; rejected).
+
+## Decision 4 — Opening a policy from the purchase modal preserves state via new tab
+
+- **Decision**: Keep `target="_blank" rel="noopener noreferrer"` on the moderation link in the
+  purchase modal (it already uses a new tab). The same applies to any policy link reachable from
+  an in-progress purchase.
+- **Rationale**: Satisfies FR-004 (don't lose the in-progress purchase) with zero state-management
+  complexity — the modal stays mounted in the original tab. The entry-gate T&C/Risk links stay
+  same-tab (no in-progress state to lose there) so `EntryGate.test` href assertions are unaffected.
+
+## Decision 5 — Shared `Footer` component with full/condensed variants
+
+- **Decision**: Introduce `components/Footer.jsx` (+ `Footer.css`). `variant="full"` reproduces the
+  current landing footer markup/classNames verbatim **plus** a Legal links group; `variant="condensed"`
+  renders just the legal/policy links + copyright. Landing renders `<Footer />`; `AppLayout` renders
+  `<Footer variant="condensed" />`.
+- **Rationale**: Centralizes the dynamic year (FR-008) and the legal-link list (FR-006/FR-009) so
+  they can't drift between the two footers; satisfies "footer in app" (FR-005) and "condensed legal
+  footer" (the chosen option) without duplicating the copyright line in two files.
+- **Implementation notes**: The full variant must keep the `SHOW_ALL_ORACLE_MODELS` conditional and
+  the logo-fallback behavior currently in `LandingPage.jsx` so `LandingPage.oracle.test.jsx` (which
+  asserts footer oracle links) stays green. Class names for the full variant are unchanged so the
+  existing `.landing-footer` CSS continues to apply.
+- **Alternatives considered**: Editing the landing footer in place and adding a separate `AppFooter`
+  — rejected for duplicating the year + legal links (DRY / FR-008 regression risk).
+
+## Decision 6 — Dynamic copyright year
+
+- **Decision**: Render the year with `new Date().getFullYear()` (shows `2026` now, auto-updates).
+- **Rationale**: Satisfies "should be 2026" without a future stale-year recurrence (FR-008/SC-005).
+- **Testing note**: To keep the test deterministic across calendar years, assert the rendered year
+  equals `new Date().getFullYear()` (or use fake timers), not a literal `2026`.
+
+## Decision 7 — Readability CSS via existing theme tokens
+
+- **Finding**: `entry-gate*` and `legal-doc-*` class names have **no CSS anywhere** — that is why
+  the text is flush to the edges ("no margin").
+- **Decision**: Add `compliance/EntryGate.css` and `pages/legal/LegalDocPage.css`, imported by their
+  components. Use `theme.css` variables (`--text-primary`, `--bg-secondary`, `--border-color`, …)
+  for color so light/dark both pass contrast. Constrain legal-doc body to a comfortable measure
+  (~`70ch` / ~720px max-width, centered), add horizontal padding (≥16px on mobile), generous
+  paragraph/heading spacing, and list indentation; make it responsive down to ~360px with no
+  horizontal overflow. Style the entry-gate dialog as a padded, max-width, scrollable card.
+- **Rationale**: Smallest change that fixes readability (FR-010/011/012) while preserving WCAG AA
+  (Principle V). No structural/JSX change needed beyond the CSS import.
+
+## Decision 8 — Terms hash bump is expected and safe
+
+- **Finding**: `legalDocs.test.js` derives the expected hash dynamically
+  (`expect(doc.hash).toBe(hashDocVersion(doc.content))`) and only format-checks (`/^[0-9a-f]{64}$/`).
+  No test pins a literal Terms hash. The accepted-Terms hash recorded on-chain at purchase comes
+  from `getCurrentDocument('terms').hash`.
+- **Decision**: Treat the hash change from adding the Account-Moderation section as a normal new
+  **material** Terms version. No code change to the hashing/canonicalization (frozen by design).
+- **Rationale**: Honest versioning (Principle III). Returning users re-consent on their next
+  consequential on-chain act per existing `requiresReconsent` logic — correct, not a regression.
+  No fixture updates required; re-run `legalDocs.test.js` to confirm.

--- a/specs/010-footer-policy-fixes/spec.md
+++ b/specs/010-footer-policy-fixes/spec.md
@@ -1,0 +1,171 @@
+# Feature Specification: Footer & Policy-Document Corrections (UAT)
+
+**Feature Branch**: `feat/010-footer-policy-fixes`
+
+**Created**: 2026-06-08
+
+**Status**: Draft
+
+**Input**: UAT testing feedback — "footer has 2024 date, should be 2026; the wager attestations do not link to the risk or T&C; the 'account moderation policy' sends user to the main FairWins site; need to add risks and T&C and other policy docs to footer; need footer in app; the formatting on the first entry text and the risk and policy documents need to be formatted for readability — currently there is no margin so it is hard to read."
+
+## Overview
+
+A round of user-acceptance testing surfaced a cluster of trust-surface defects in the
+FairWins web app: legal/policy documents that users are asked to agree to are hard to
+reach, one policy link is broken (it sends users off to the marketing site), the footer
+is missing inside the app and shows a stale copyright year, and the consent text and
+legal documents are uncomfortable to read because they have no margins. These are all
+compliance- and trust-relevant: users are attesting that they have *read and agree to*
+documents they currently cannot easily open or read. This feature corrects those issues.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Reach the policies I'm agreeing to (Priority: P1)
+
+A user going through the membership purchase ("Get Wager Access") flow is presented with
+attestations stating they have read and agree to the Terms & Conditions and the Risk
+Disclosure, and warning text that references the Account Moderation policy. The user wants
+to actually open and read each of those documents before ticking the boxes and paying.
+
+**Why this priority**: Asking users to attest that they have "read and agree to" documents
+they cannot open — and pointing the one available link (Account Moderation policy) at the
+wrong destination (the marketing site) — is the most serious problem found. It undermines
+informed consent and the integrity of the on-chain Terms-acceptance record. Every paying
+user hits this surface.
+
+**Independent Test**: From the membership purchase modal, tap each policy reference
+(Terms & Conditions, Risk Disclosure, Account Moderation policy) and confirm each opens the
+correct in-app document — and that returning leaves the purchase in progress intact. This
+delivers value on its own: users can read what they sign.
+
+**Acceptance Scenarios**:
+
+1. **Given** the membership purchase attestations are shown, **When** the user activates the "Terms & Conditions" reference, **Then** the in-app Terms & Conditions document opens.
+2. **Given** the membership purchase attestations are shown, **When** the user activates the "Risk Disclosure" reference, **Then** the in-app Risk Disclosure document opens.
+3. **Given** the warning text referencing the Account Moderation policy is shown, **When** the user activates "Account Moderation policy", **Then** the in-app Terms & Conditions document opens at the Account Moderation section — and the user is **not** sent to the external/marketing site.
+4. **Given** the user opens a policy document from within the purchase flow, **When** they return to the app, **Then** their in-progress purchase (selected tier, ticked attestations) is not lost.
+
+---
+
+### User Story 2 - Find the policies and current info from the footer (Priority: P2)
+
+A user anywhere in the app (not just on the public landing page) wants a consistent place to
+find the Terms & Conditions, Risk Disclosure, Privacy Policy, and Account Moderation policy,
+and to see accurate site information.
+
+**Why this priority**: A footer with the policy documents is the conventional, expected place
+to find them, and the documents must be reachable from inside the authenticated app, not only
+the marketing page. The stale "2024" copyright also reads as an abandoned/untrustworthy site.
+
+**Independent Test**: Navigate to an authenticated app view and confirm a footer is present
+containing working links to all policy documents and a current copyright year.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is on an authenticated app view, **When** the page is displayed, **Then** a footer is visible (it is not limited to the landing page).
+2. **Given** the footer is visible, **When** the user reads it, **Then** it lists Terms & Conditions, Risk Disclosure, Privacy Policy, and the Account Moderation policy, each as a working link to the corresponding in-app document.
+3. **Given** the footer is visible, **When** the user reads the copyright line, **Then** it shows the current year (2026), not a stale year, and will not become stale in future years.
+4. **Given** the in-app footer, **When** it is displayed, **Then** it presents a condensed set of content (policy/legal links plus copyright) rather than the full marketing columns.
+
+---
+
+### User Story 3 - Read the consent text and legal docs comfortably (Priority: P3)
+
+A user (often on a phone) reading the pre-entry notice ("Before you enter FairWins") and the
+legal/policy documents wants the text to be comfortable to read rather than crammed edge-to-edge.
+
+**Why this priority**: Readable presentation of consent and legal text supports informed
+agreement and basic quality, but the content is already present and legible — this is the
+polish layer on top of US1/US2.
+
+**Independent Test**: Open the pre-entry notice and each legal document on a narrow mobile
+viewport and a desktop viewport and confirm the text has comfortable margins and line length
+and is not flush against the screen edges.
+
+**Acceptance Scenarios**:
+
+1. **Given** the pre-entry "Before you enter FairWins" notice on a mobile viewport, **When** it is displayed, **Then** the body text has clear horizontal margins/padding and is not flush against the screen edges.
+2. **Given** a legal document (Terms, Risk, or Privacy) on any viewport, **When** it is displayed, **Then** the text has comfortable margins, a constrained reading width, and clear spacing between paragraphs and sections.
+3. **Given** the readability changes, **When** measured against accessibility standards, **Then** contrast, focus order, and semantic structure continue to meet WCAG 2.1 AA.
+
+---
+
+### Edge Cases
+
+- **Opening a policy mid-purchase**: activating a policy link inside the purchase modal must not discard the user's selected tier or ticked attestations (e.g., open the document in a new tab/window or otherwise preserve state).
+- **Deep link to a section**: the Account Moderation reference targets a specific section within the Terms document; if the user lands on the document, that section should be brought into view.
+- **Long documents on small screens**: legal documents are long; they must remain scrollable and navigable on narrow viewports without horizontal overflow.
+- **Year rollover**: the copyright year must remain correct across calendar-year boundaries without a code change.
+- **Footer not crowding content**: adding a footer inside the app must not overlap or hide the existing pre-entry gate or primary app content.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Policy links from compliance surfaces (US1)**
+
+- **FR-001**: Every reference to "Terms & Conditions", "Risk Disclosure", and "Account Moderation policy" within the membership purchase/upgrade attestation and confirmation text MUST be a working link that opens the corresponding in-app policy document.
+- **FR-002**: The "Account Moderation policy" reference MUST resolve to the in-app Terms & Conditions document at its Account Moderation section, and MUST NOT navigate the user to the external/marketing site or the documentation site.
+- **FR-003**: The in-app Terms & Conditions document MUST include an "Account Moderation" section that describes account freezing/moderation (who can freeze an account, on what grounds, and the consequences), exposed via a stable anchor that the Account Moderation reference targets.
+- **FR-004**: Activating any policy link from within an in-progress purchase flow MUST preserve the user's in-progress state (selected tier and ticked attestations are not lost on return).
+
+**Footer (US2)**
+
+- **FR-005**: A footer MUST be present on authenticated app views, not only on the public landing page.
+- **FR-006**: The footer MUST include working links to all in-app policy/legal documents: Terms & Conditions, Risk Disclosure, Privacy Policy, and the Account Moderation policy.
+- **FR-007**: The in-app footer MUST present a condensed set of content — policy/legal links plus the copyright/license line — and omit the marketing columns (Oracles, Docs, Community) shown on the landing-page footer.
+- **FR-008**: The footer copyright line MUST display the current calendar year (2026 at time of writing) and MUST update automatically over time so it never displays a stale year.
+- **FR-009**: All footer policy links MUST resolve to in-app routes and MUST NOT send users to the external/marketing site.
+
+**Readability (US3)**
+
+- **FR-010**: The pre-entry "Before you enter FairWins" notice MUST render its body text with adequate horizontal margins/padding and a comfortable reading width on both mobile and desktop viewports, so text is not flush against the screen edges.
+- **FR-011**: The in-app legal/policy documents (Terms & Conditions, Risk Disclosure, Privacy Policy) MUST render with readable formatting: adequate margins/padding, a constrained line length, and clear spacing between paragraphs and section headings.
+- **FR-012**: Readability formatting MUST be responsive and work across narrow mobile widths (≈360px) through desktop widths without horizontal overflow.
+
+**Cross-cutting**
+
+- **FR-013**: All changes (links, footer, formatting) MUST preserve WCAG 2.1 AA conformance — link semantics, focus order, contrast, and document structure — consistent with the project's accessibility standard.
+- **FR-014**: The displayed in-force document version identifier (the version/hash already shown for the legal documents and the accepted-Terms attestation) MUST remain correct and consistent after these changes.
+
+### Key Entities *(include if feature involves data)*
+
+- **Policy Document**: A user-facing legal/policy document (Terms & Conditions, Risk Disclosure, Privacy Policy) reachable at an in-app location and carrying a version identifier. The Account Moderation policy is represented as a referenced **section** within the Terms & Conditions document rather than a standalone document.
+- **Footer**: A site-wide region listing the policy documents and a copyright/license line, presented in a full variant on the landing page and a condensed (legal-links + copyright) variant inside the app.
+- **Compliance Attestation**: The consent statements shown at the entry gate and at membership purchase that reference the policy documents; the references are the links US1 must make functional.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of policy references in the membership purchase/upgrade attestation and confirmation text are activatable links that open the correct in-app document.
+- **SC-002**: 0 policy/legal references anywhere in the app (entry gate, purchase flow, footer) send the user to the external/marketing or documentation site; all resolve to in-app documents.
+- **SC-003**: A user can open the Account Moderation policy and land on the relevant Account Moderation content in a single tap/click from the purchase warning text.
+- **SC-004**: A footer containing working Terms, Risk, Privacy, and Account Moderation links is present on 100% of authenticated app views as well as the landing page.
+- **SC-005**: The footer copyright year matches the current calendar year on every view, with no hard-coded past year.
+- **SC-006**: On a 360px-wide mobile viewport, the pre-entry notice and every legal document display body text with a non-zero horizontal margin (no text touching the screen edge) and no horizontal scrolling.
+- **SC-007**: Opening any policy document from an in-progress purchase and returning leaves the purchase resumable without re-entering selections.
+- **SC-008**: Accessibility checks (automated axe/Lighthouse audits used by the project) pass with no new violations introduced by these changes.
+
+## Assumptions
+
+- The footer copyright year is derived from the current date (so it shows 2026 now and updates automatically), which satisfies the "should be 2026" feedback without a future stale-year recurrence.
+- The policy documents in scope are the three existing in-app documents (Terms & Conditions, Risk Disclosure, Privacy Policy) plus the Account Moderation policy, which — per the product decision captured during specification — is added as a section within the Terms & Conditions document and deep-linked, rather than as a new standalone document/route.
+- The in-app footer is the condensed (legal-links + copyright) variant, per the product decision captured during specification; the landing-page footer keeps its existing fuller layout.
+- Policy links opened from within the membership purchase modal open without destroying the in-progress purchase (e.g., in a new tab), to honor FR-004.
+- The existing in-app document routes and version/hash mechanism are reused; no new backend or server-side rendering is introduced (consistent with the project's no-backend footprint).
+- The "Terms & Conditions" and "Risk Disclosure" references on the pre-entry "Before you enter FairWins" gate are already in-app links and require only the readability treatment (US3); the broken/plain-text references are in the membership purchase attestations and confirmation text.
+- The red annotation near the "Opponent Address" field in one UAT screenshot is not part of the written feedback and is therefore out of scope for this feature.
+
+### Out of Scope
+
+- Rewriting legal content beyond adding the Account Moderation section to the Terms.
+- Any change to the opponent-address / QR-share area (handled by feature 009).
+- Changes to membership pricing, tiers, or purchase logic.
+- Adding new standalone policy documents or routes beyond the Account Moderation section within Terms.
+
+### Dependencies
+
+- The existing in-app legal-document pages and their version/hash registry.
+- The existing footer used on the landing page (source of the condensed in-app variant).
+- The existing membership purchase/attestation flow and pre-entry gate.

--- a/specs/010-footer-policy-fixes/tasks.md
+++ b/specs/010-footer-policy-fixes/tasks.md
@@ -1,0 +1,198 @@
+---
+
+description: "Task list for Footer & Policy-Document Corrections (UAT)"
+---
+
+# Tasks: Footer & Policy-Document Corrections (UAT)
+
+**Input**: Design documents from `/specs/010-footer-policy-fixes/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/ui-contracts.md, quickstart.md
+
+**Tests**: INCLUDED — the project constitution (Principle II, Test-First, NON-NEGOTIABLE) requires Vitest coverage alongside behavior.
+
+**Organization**: Tasks are grouped by user story (US1=P1, US2=P2, US3=P3) so each can be implemented and tested independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1 / US2 / US3 (setup, foundational, polish carry no story label)
+- All paths are repo-relative under `frontend/`.
+
+## Path Conventions
+
+Web frontend only (no backend): source in `frontend/src/`, tests in `frontend/src/test/`. Commands run from repo root unless noted.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish a known-green baseline before changes.
+
+- [X] T001 Establish a green baseline: run `npm run test:frontend` and `npm run lint` from repo root and record the current pass state (no code changes).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: One shared module both US1 (link targets) and US2 (footer links) depend on, so the legal routes and the moderation anchor never drift.
+
+**⚠️ CRITICAL**: Complete before starting US1 or US2.
+
+- [X] T002 Create shared legal-link constants in `frontend/src/constants/legalLinks.js` — export `LEGAL_LINKS` (ordered: `{ label:'Terms & Conditions', href:'/terms' }`, `{ label:'Risk Disclosure', href:'/risk' }`, `{ label:'Privacy Policy', href:'/privacy' }`, `{ label:'Account Moderation', href:'/terms#account-moderation' }`) and `ACCOUNT_MODERATION_PATH = '/terms#account-moderation'`. No external/marketing hosts.
+
+**Checkpoint**: Shared constants ready — US1 and US2 can begin (US3 has no dependency on this).
+
+---
+
+## Phase 3: User Story 1 - Reach the policies I'm agreeing to (Priority: P1) 🎯 MVP
+
+**Goal**: Every policy reference in the membership-purchase/compliance surfaces is a working link to the correct in-app document, and the Account Moderation policy resolves to an in-app Terms section (never the external/marketing site), without losing an in-progress purchase.
+
+**Independent Test**: From the purchase modal, activate Terms / Risk / Account Moderation references → each opens the right in-app document (Account Moderation → `/terms` scrolled to its section); none navigate to the external site; the purchase remains intact on return.
+
+### Tests for User Story 1 ⚠️ (write first, must FAIL before implementation)
+
+- [X] T003 [P] [US1] In `frontend/src/test/LegalDocPage.test.jsx` (new), assert: rendering `/terms` produces a heading with text "Account Moderation" whose element `id` is `account-moderation`, and that `renderMarkdown` emits a slug `id` on every heading. (Contract C4.1/C4.2)
+- [X] T004 [P] [US1] In `frontend/src/test/moderationLinks.test.jsx` (new), assert the moderation link in `PremiumPurchaseModal`, `AdminPanel`, and `RoleDetailsCard` has `href="/terms#account-moderation"` (and `target="_blank"` in the modal), and that none render `/docs/system-overview/account-moderation`. (Contract C3.1/C3.2/C3.3)
+- [X] T005 [P] [US1] In `frontend/src/test/MembershipAttestation.test.jsx` (edit), assert "Terms & Conditions" and "Risk Disclosure" are rendered as in-app links (`href="/terms"`, `href="/risk"`) reachable from the attestation section, without breaking the existing eligibility/risk attestation checks. (Contract maps to FR-001 scenarios 1–2)
+
+### Implementation for User Story 1
+
+- [X] T006 [US1] Add an unnumbered "Account Moderation" section to `frontend/src/legal/terms.md` (placed beside §21 Suspension and Termination): who may freeze an account (Account Moderator role), grounds (fraud, abuse, court order, sanctions/eligibility concerns), effects (cannot create/accept wagers, claim payouts or refunds until unfrozen), and relation to on-chain enforcement.
+- [X] T007 [US1] Extend `renderMarkdown` in `frontend/src/pages/legal/LegalDocPage.jsx` to attach a slugified `id` to every heading (text → lowercase, non-alphanumerics → `-`, collapse/trim); add a small `slugify` helper. (Enables `#account-moderation`.)
+- [X] T008 [US1] Add a scroll-to-hash `useEffect` in `frontend/src/pages/legal/LegalDocPage.jsx`: on mount/when `window.location.hash` is set, scroll the matching element into view after render, respecting `prefers-reduced-motion`. (Contract C4.3)
+- [X] T009 [P] [US1] Repoint the moderation link in `frontend/src/components/ui/PremiumPurchaseModal.jsx` (line ~467) to `ACCOUNT_MODERATION_PATH` from `constants/legalLinks.js`; keep `target="_blank" rel="noopener noreferrer"` so the in-progress purchase is preserved (FR-004).
+- [X] T010 [P] [US1] Repoint the moderation link in `frontend/src/components/AdminPanel.jsx` (line ~578) to `ACCOUNT_MODERATION_PATH`.
+- [X] T011 [P] [US1] Repoint the moderation link in `frontend/src/components/wallet/RoleDetailsCard.jsx` (line ~153) to `ACCOUNT_MODERATION_PATH`.
+- [X] T012 [US1] In `frontend/src/components/compliance/MembershipAttestation.jsx`, render "Terms & Conditions" → `/terms` and "Risk Disclosure" → `/risk` as in-app links (new tab) within the attestation section (e.g. a dedicated review line/intro paragraph), keeping the checkbox label/toggle semantics intact (link click must not toggle the checkbox).
+- [X] T013 [US1] Run `frontend/src/test/legalDocs.test.js` to confirm the Terms content/hash change keeps canonicalization & hash invariants green (no fixture edits expected; FR-014/Contract C4.4).
+
+**Checkpoint**: US1 fully functional — all policy references reachable in-app, no external leak, purchase preserved.
+
+---
+
+## Phase 4: User Story 2 - Find the policies and current info from the footer (Priority: P2)
+
+**Goal**: A footer is present inside the app (condensed: legal links + copyright), the shared footer lists all policy documents as in-app links, and the copyright year is current and auto-updating.
+
+**Independent Test**: On `/app` (and `/wallet`) a footer is visible with working Terms/Risk/Privacy/Account-Moderation links and a current-year copyright; the landing footer still shows its marketing columns; no footer link leaves the app.
+
+### Tests for User Story 2 ⚠️ (write first, must FAIL before implementation)
+
+- [X] T014 [P] [US2] In `frontend/src/test/Footer.test.jsx` (new), assert: condensed variant renders the four legal links with their in-app hrefs (incl. `/terms#account-moderation`) plus a copyright whose year equals `new Date().getFullYear()` and is not the literal "2024"; full variant additionally renders the Oracles/Docs/Community sections. (Contracts C1.1–C1.5)
+- [X] T015 [P] [US2] In `frontend/src/test/Footer.test.jsx`, assert that rendering an `AppLayout` route shows a `<footer>` landmark (condensed) and the landing route shows the full footer. (Contracts C2.1/C2.2)
+
+### Implementation for User Story 2
+
+- [X] T016 [US2] Create `frontend/src/components/Footer.jsx` — `Footer({ variant = 'full' })`: dynamic year via `new Date().getFullYear()`; legal links from `LEGAL_LINKS`. Full variant reproduces the existing `.landing-footer` markup/class names (brand + `SHOW_ALL_ORACLE_MODELS` oracle conditional + Docs + Community + logo-fallback handling) **plus** a Legal links group; condensed variant renders only the Legal links group + copyright/license line.
+- [X] T017 [P] [US2] Create `frontend/src/components/Footer.css` — styles for the condensed/app footer and the Legal links group, using `theme.css` tokens, responsive; the full variant continues to rely on the existing `.landing-footer` rules in `LandingPage.css`.
+- [X] T018 [US2] Refactor `frontend/src/components/LandingPage.jsx` to render `<Footer />` in place of the inline `<footer>` (lines ~398–451), moving the logo-fallback state and `SHOW_ALL_ORACLE_MODELS` usage into `Footer`; keep `LandingPage.oracle.test.jsx` green (Contract C6.3).
+- [X] T019 [US2] Render `<Footer variant="condensed" />` after `<Outlet />` in `AppLayout` in `frontend/src/App.jsx`.
+
+**Checkpoint**: US1 + US2 both work independently — footer present everywhere with current year and in-app policy links.
+
+---
+
+## Phase 5: User Story 3 - Read the consent text and legal docs comfortably (Priority: P3)
+
+**Goal**: The entry-gate notice and the legal documents render with comfortable margins, constrained width, and clear spacing, responsive from ~360px to desktop, preserving WCAG 2.1 AA in light and dark themes.
+
+**Independent Test**: At a 360px viewport, the "Before you enter FairWins" notice and each legal doc have clear horizontal margins (not flush to edges), comfortable line length, and no horizontal scrolling; axe reports no new violations.
+
+### Tests for User Story 3 ⚠️ (write first, must FAIL before implementation)
+
+- [X] T020 [P] [US3] Extend `frontend/src/test/compliance.accessibility.test.jsx` with axe checks for the rendered `LegalDocPage` (`/terms`) and `EntryGate`, asserting no new violations, and that each component imports its stylesheet (smoke check that the CSS is wired). (Contract C5.3)
+
+### Implementation for User Story 3
+
+- [X] T021 [P] [US3] Create `frontend/src/components/compliance/EntryGate.css` (style `entry-gate-overlay`/`entry-gate`/`entry-gate-warning`/`entry-gate-actions`: padding, max-width card, line-height, scrollable on small screens, responsive to 360px, `theme.css` tokens) and import it in `frontend/src/components/compliance/EntryGate.jsx`. (FR-010, Contract C5.1)
+- [X] T022 [P] [US3] Create `frontend/src/pages/legal/LegalDocPage.css` (style `legal-doc-page`/`legal-doc-version`/`legal-doc-nav`/`legal-doc-body`: ~70ch/720px max-width centered, horizontal padding ≥16px mobile, paragraph/heading spacing, list indentation, responsive, `theme.css` tokens) and import it in `frontend/src/pages/legal/LegalDocPage.jsx`. (FR-011/FR-012, Contract C5.2)
+
+**Checkpoint**: All three stories independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T023 [P] Guard (SC-002): grep `frontend/src` excluding `test/` for `/docs/system-overview/account-moderation` and any external moderation-policy host — expect zero matches.
+- [X] T024 Run `npm run test:frontend` and `npm run lint` from repo root — entire suite green (new tests + regression guards C6.1–C6.4), lint clean.
+- [X] T025 Execute `specs/010-footer-policy-fixes/quickstart.md` manual validation: in-app condensed footer, current year, the three link flows (modal/admin/role), footer legal links, 360px readability of gate + legal docs, dark/light contrast, and an axe/Lighthouse pass on `/terms` and an app page.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies.
+- **Foundational (Phase 2 / T002)**: after Setup; blocks US1 and US2 (both import `legalLinks.js`). US3 does not depend on it.
+- **User Stories (Phase 3–5)**: after Foundational, the three stories are independent and may run in parallel.
+- **Polish (Phase 6)**: after the desired stories are complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: needs T002. Internally: T006/T007 before T003 can pass; T008 depends on T007; T009–T011 depend on T002 (parallel to each other); T012 independent; T013 after T006.
+- **US2 (P2)**: needs T002. Internally: T016 before T018/T019; T017 parallel to T016. Independently testable (footer links are strings; does not require US1's anchor to exist).
+- **US3 (P3)**: no dependency on T002 or other stories; CSS files are independent of each other ([P]).
+
+### Within Each User Story
+
+- Tests are written first and must FAIL before implementation.
+- For US1, the Terms section + heading-anchor (T006/T007) is the "model" layer before the scroll behavior and link wiring.
+
+### Parallel Opportunities
+
+- After T002: **US1, US2, and US3 can be worked in parallel** by different developers.
+- US1 link fixes T009 / T010 / T011 are parallel (separate files).
+- US3 CSS files T021 / T022 are parallel; the US3 test T020 can be written in parallel.
+- All `[P]` test tasks within a story can be authored together.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Author US1 tests together (they should fail initially):
+Task: "LegalDocPage.test.jsx — Account Moderation heading + id anchor"
+Task: "moderationLinks.test.jsx — all three links → /terms#account-moderation"
+Task: "MembershipAttestation.test.jsx — T&C/Risk rendered as in-app links"
+
+# Then the three independent link fixes in parallel:
+Task: "Repoint moderation link in PremiumPurchaseModal.jsx"
+Task: "Repoint moderation link in AdminPanel.jsx"
+Task: "Repoint moderation link in RoleDetailsCard.jsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1 Setup → Phase 2 Foundational (T002).
+2. Phase 3 US1 (tests → Terms section/anchor → scroll → link fixes → attestation links → hash check).
+3. **STOP and VALIDATE**: policy references reachable in-app, zero external leak, purchase preserved.
+4. Ship — the compliance-critical defects are resolved.
+
+### Incremental Delivery
+
+1. Foundation ready (T002).
+2. US1 → validate → ship (MVP).
+3. US2 (footer in-app + legal links + current year) → validate → ship.
+4. US3 (readability CSS) → validate → ship.
+5. Phase 6 polish + quickstart sign-off.
+
+### Parallel Team Strategy
+
+After T002: Dev A → US1, Dev B → US2, Dev C → US3. They touch largely disjoint files (US1: terms.md/LegalDocPage.jsx/modal/admin/role/attestation; US2: Footer.*/LandingPage.jsx/App.jsx; US3: EntryGate.css/LegalDocPage.css). Coordinate only on `LegalDocPage.jsx` (US1 edits JS logic, US3 adds a CSS import — small, non-conflicting).
+
+---
+
+## Notes
+
+- `[P]` = different files, no incomplete-task dependency. `[Story]` maps each task to a user story for traceability.
+- Verify each story's tests fail before implementing it (TDD per Constitution Principle II).
+- Adding the Account Moderation section bumps the Terms version hash — expected, honest versioning (Principle III); returning users re-consent on their next on-chain act via existing logic.
+- Keep all policy links pointing at in-app routes — no external/marketing hosts (SC-002, FR-009).
+- Commit after each task or logical group; keep CI green (no `continue-on-error` — Principle IV).


### PR DESCRIPTION
## Summary

Frontend-only corrections from UAT feedback on the FairWins trust surfaces. Spec: `specs/010-footer-policy-fixes/`.

| UAT note | Fix |
|----------|-----|
| Footer shows **2024** | Dynamic copyright year (auto-updating; shows 2026) |
| Wager attestations don't link to Risk/T&C | Terms & Conditions / Risk Disclosure now linked (new tab) in the membership attestation |
| "Account Moderation policy" sent users to the main site | Repointed **all three** broken links to in-app `/terms#account-moderation` |
| Add policy docs to footer | Legal links (Terms / Risk / Privacy / Account Moderation) added to the footer |
| No footer in app | Condensed legal footer rendered inside `AppLayout` |
| Entry text & legal docs have no margin | New readability CSS for legal docs + entry-gate notice (responsive to 360px) |

## Approach

- **Shared `Footer` component** — `full` (landing) + `condensed` (in-app) variants; one `LEGAL_LINKS` source so the two footers can't drift and the year can't go stale.
- **Account Moderation** is a new section within the in-app **Terms** (per product decision), deep-linked. `renderMarkdown` now emits slug `id`s on every heading and `LegalDocPage` scrolls to the `#fragment` on load.
- **`ACCOUNT_MODERATION_PATH`** constant fixes the broken link in `PremiumPurchaseModal`, `AdminPanel`, and `RoleDetailsCard` (was an external `/docs/system-overview/...` URL on all three).
- Readability is pure CSS using `theme.css` tokens (light + dark), no structural changes.

> Note: adding the Account Moderation section bumps the **Terms version hash**. This is the system's honest versioning behavior — returning users re-consent on their next on-chain act via existing logic.

## Testing

- Full frontend suite: **875 tests / 71 files passing** (4 new/edited test files; all regression guards green).
- `eslint .`: **0 errors** (2 pre-existing warnings in untouched files).
- Source guard: **0** remaining references to the external account-moderation URL in non-test source.
- Verified in-browser at 360px: legal-doc margins, deep-link scroll, landing footer 2026 + legal links, condensed in-app footer (no marketing columns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
