### PR TITLE
fix: allow camera=(self) in production nginx template so the QR scanner works

### DIFF
--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -100,7 +100,10 @@ server {
     add_header Strict-Transport-Security "max-age=31536000" always;
     # Least-privilege: disable powerful features the app does not use. (usb/hid/serial are
     # left unrestricted so browser-based hardware-wallet flows keep working.)
-    add_header Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), browsing-topics=()" always;
+    # camera=(self): the in-app QR scanner (html5-qrcode getUserMedia) needs the camera on
+    # this origin. Scoped to self so same-origin can scan while third-party iframes cannot;
+    # microphone stays fully disabled (the scanner needs video only).
+    add_header Permissions-Policy "accelerometer=(), camera=(self), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), browsing-topics=()" always;
     # Isolate the browsing context while still allowing the WalletConnect popup/redirect.
     add_header Cross-Origin-Opener-Policy "same-origin-allow-popups" always;
 

--- a/frontend/src/test/nginxCameraPolicy.test.js
+++ b/frontend/src/test/nginxCameraPolicy.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+// Regression guard for the in-app QR scanner camera permission.
+//
+// The browser blocks getUserMedia outright (no permission prompt) when the
+// origin serves `Permissions-Policy: camera=()`. The scanner therefore needs
+// `camera=(self)` on EVERY nginx config that can reach production.
+//
+// History: PR #644 fixed `nginx.conf` (used by frontend/Dockerfile) but the
+// production deploy uses the root Dockerfile -> `nginx.conf.template`, which
+// still served `camera=()`. The two files silently diverged and the live
+// scanner kept failing with "Unable to access camera". This test asserts both
+// files stay in sync so that divergence can't recur.
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const CONFIGS = [
+  resolve(__dirname, '../../nginx.conf'),
+  resolve(__dirname, '../../nginx.conf.template'),
+]
+
+describe('nginx Permissions-Policy camera scope', () => {
+  it.each(CONFIGS)('%s allows camera=(self) and not camera=()', (path) => {
+    const conf = readFileSync(path, 'utf8')
+    const policyLine = conf
+      .split('\n')
+      .find((l) => l.includes('add_header Permissions-Policy'))
+    expect(policyLine, `${path} is missing a Permissions-Policy header`).toBeTruthy()
+    expect(policyLine).toContain('camera=(self)')
+    // The empty allowlist blocks getUserMedia with no prompt — never ship it.
+    expect(policyLine).not.toMatch(/camera=\(\)/)
+  })
+})


### PR DESCRIPTION
## Problem

The in-app QR scanner shows **"Unable to access camera. Please check permissions."** immediately, and the browser **never prompts the user** for camera access — so the scanner is non-functional.

![scanner error](https://github.com/chippr-robotics/prediction-dao-research/assets/placeholder)

The "never prompts" symptom is the tell: when an origin serves `Permissions-Policy: camera=()`, the browser rejects `getUserMedia` outright with no permission dialog. This is an infra/header problem, not a JS bug.

## Root cause: two nginx configs diverged

There are two nginx configs and two Dockerfiles:

| File | Consumed by | camera value (before this PR) |
|------|-------------|-------------------------------|
| `frontend/nginx.conf` | `frontend/Dockerfile` (secondary) | `camera=(self)` ✅ (fixed in #644) |
| `frontend/nginx.conf.template` | **root `Dockerfile`** → `docker-entrypoint.sh` envsubst (**production / Cloud Run**) | `camera=()` ❌ |

PR #644 fixed `nginx.conf`, but **production builds from the root `Dockerfile`**, which serves `nginx.conf.template`. That template still carried `camera=()`, so the fix never reached the live origin. PR #645 only made the (pre-existing) denial legible — this is the underlying fix.

## Changes

- **`frontend/nginx.conf.template`**: set `camera=(self)`, mirroring `nginx.conf`. Scoped to same-origin so the app can scan while third-party iframes cannot; `microphone` stays fully disabled (the scanner needs video only).
- **`frontend/src/test/nginxCameraPolicy.test.js`**: regression guard asserting **both** nginx configs declare `camera=(self)` and never `camera=()`, so the two files can't silently diverge again — which is exactly what caused this bug.

## Verification

- `npx vitest run src/test/nginxCameraPolicy.test.js` → 2 passed
- `src/test/originLock.test.js` (renders the same template via envsubst) → still passes
- `src/test/QRScanner.test.jsx` → still passes

Takes effect once production redeploys from `main`.

https://claude.ai/code/session_01BKShyF5kVqPDk4CHv7XwHV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKShyF5kVqPDk4CHv7XwHV)_