### PR TITLE
Spec: Polymarket search & category filter fix

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/012-wager-notifications"
+  "feature_directory": "specs/013-polymarket-search-filter"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,5 +49,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/012-wager-notifications/plan.md
+at specs/013-polymarket-search-filter/plan.md
 <!-- SPECKIT END -->

--- a/frontend/src/components/fairwins/PolymarketBrowser.css
+++ b/frontend/src/components/fairwins/PolymarketBrowser.css
@@ -385,3 +385,59 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* Event grouping — an event with multiple related markets renders as an
+   expandable row whose sub-markets are revealed on toggle. */
+.pmb__event {
+  list-style: none;
+  border: 1px solid var(--pmb-border);
+  border-radius: 10px;
+  background: var(--pmb-surface);
+  overflow: hidden;
+}
+
+.pmb__event-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.75rem;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.pmb__event-header:hover,
+.pmb__event-header:focus-visible {
+  background: var(--pmb-surface-hover);
+}
+
+.pmb__event-title {
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.pmb__event-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+  font-size: 0.8125rem;
+  opacity: 0.8;
+}
+
+.pmb__event-chevron {
+  opacity: 0.7;
+}
+
+.pmb__submarkets {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0 0.5rem 0.5rem;
+  list-style: none;
+}

--- a/frontend/src/components/fairwins/PolymarketBrowser.jsx
+++ b/frontend/src/components/fairwins/PolymarketBrowser.jsx
@@ -1,15 +1,14 @@
-import { useState, useMemo, useCallback, useEffect } from 'react'
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
 import { useChainTokens } from '../../hooks/useChainTokens'
 import { useUserPreferences } from '../../hooks/useUserPreferences'
-import { useFriendMarkets } from '../../contexts/FriendMarketsContext.js'
 import {
   usePolymarketSearch,
   usePolymarketTopMarkets,
 } from '../../hooks/usePolymarketSearch'
 import './PolymarketBrowser.css'
 
-// Canonical filter chips. Slugs match Polymarket's `tag_slug` values; labels
-// are what the user sees.
+// Canonical filter chips. Slugs map to Polymarket numeric tag ids inside the
+// hooks; labels are what the user sees.
 const QUICK_FILTERS = [
   { slug: 'politics', label: 'Politics' },
   { slug: 'sports', label: 'Sports' },
@@ -19,7 +18,7 @@ const QUICK_FILTERS = [
   { slug: 'tech', label: 'Tech' },
 ]
 
-const SEARCH_DEBOUNCE_MS = 350
+const SEARCH_DEBOUNCE_MS = 325
 
 const formatVolume = (v) => {
   if (v == null || Number.isNaN(v)) return null
@@ -28,34 +27,14 @@ const formatVolume = (v) => {
   return `$${Math.round(v)}`
 }
 
-const normaliseCategoryString = (c) => {
-  if (!c) return ''
-  if (Array.isArray(c)) return c.join(' ').toLowerCase()
-  return String(c).toLowerCase()
-}
-
-/**
- * Build a Set of category slugs/keywords gleaned from the user's prior friend
- * markets. We don't have a structured category on past wagers, so we
- * substring-match against the description as a first pass.
- */
-function buildHistoryCategorySet(friendMarkets) {
-  const set = new Set()
-  for (const m of friendMarkets || []) {
-    const desc = (m?.description || '').toLowerCase()
-    for (const { slug } of QUICK_FILTERS) {
-      if (desc.includes(slug.replace('-', ' ')) || desc.includes(slug)) {
-        set.add(slug)
-      }
-    }
-  }
-  return set
-}
-
 /**
  * Reusable Polymarket market browser. Used as a dashboard feed (variant="feed")
  * and as an in-modal market picker (variant="inline"). Self-gates on chain
  * capability — returns null on chains without Polymarket support.
+ *
+ * Results are grouped by event: an event with several related markets (e.g. a
+ * game's moneyline/spreads/over-unders) shows as one expandable row; a
+ * single-market event selects directly.
  */
 function PolymarketBrowser({
   onSelectMarket,
@@ -70,12 +49,10 @@ function PolymarketBrowser({
   const polymarketSidebetsEnabled = Boolean(capabilities?.polymarketSidebets)
 
   const { preferences } = useUserPreferences()
-  const { friendMarkets } = useFriendMarkets()
 
-  // Filter state. We avoid an effect-driven sync from preferences by deriving
-  // the effective filter set: if the user has touched the chips, use their
-  // local state; otherwise fall back to the prop or the saved preference
-  // (which may arrive async after the wallet connects).
+  // Filter state. Derive the effective filter set: if the user has touched the
+  // chips, use their local state; otherwise fall back to the prop or the saved
+  // preference (which may arrive async after the wallet connects).
   const [userTouched, setUserTouched] = useState(false)
   const [localCategories, setLocalCategories] = useState(() => {
     if (Array.isArray(defaultCategories)) return defaultCategories
@@ -89,6 +66,8 @@ function PolymarketBrowser({
 
   const [query, setQuery] = useState('')
   const trimmedQuery = query.trim()
+
+  const [expandedEventIds, setExpandedEventIds] = useState(() => new Set())
 
   // Feed-variant accordion state. Inline variant is always expanded.
   const [isExpanded, setIsExpanded] = useState(false)
@@ -106,88 +85,81 @@ function PolymarketBrowser({
     results: searchResults,
     isLoading: searchLoading,
     error: searchError,
-    search: runSearch,
+    runSearch,
     clear: clearSearch,
-  } = usePolymarketSearch({ limit })
+  } = usePolymarketSearch({ limit, categories: activeCategories })
 
-  // Debounce-and-fire search whenever the query changes.
+  // Single debounce: drive the (immediate) hook search from the input. The hook
+  // re-creates runSearch when the active categories change, so this effect also
+  // re-fires to keep search constrained to the selected categories.
+  const debounceRef = useRef(null)
   useEffect(() => {
     if (!trimmedQuery) {
       clearSearch()
       return undefined
     }
-    const handle = setTimeout(() => runSearch(trimmedQuery), SEARCH_DEBOUNCE_MS)
-    return () => clearTimeout(handle)
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => runSearch(trimmedQuery), SEARCH_DEBOUNCE_MS)
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
   }, [trimmedQuery, runSearch, clearSearch])
 
   const isSearchMode = trimmedQuery.length > 0
-  const rawResults = isSearchMode ? searchResults : topResults
+  const events = isSearchMode ? searchResults : topResults
   const isLoading = isSearchMode ? searchLoading : topLoading
   const error = isSearchMode ? searchError : topError
 
-  // History-boost ranking. Boost factor mixes user's saved category prefs
-  // with categories inferred from their past wagers.
-  const historySlugs = useMemo(() => buildHistoryCategorySet(friendMarkets), [friendMarkets])
-  const savedSlugs = useMemo(
-    () => new Set(preferences?.polymarketCategories || []),
-    [preferences?.polymarketCategories],
-  )
-
-  const rankedResults = useMemo(() => {
-    const scored = (rawResults || []).map((m) => {
-      const cat = normaliseCategoryString(m.category)
-      let boost = 1
-      for (const slug of savedSlugs) {
-        if (cat.includes(slug.replace('-', ' ')) || cat.includes(slug)) {
-          boost += 0.5
-          break
-        }
-      }
-      for (const slug of historySlugs) {
-        if (cat.includes(slug.replace('-', ' ')) || cat.includes(slug)) {
-          boost += 0.5
-          break
-        }
-      }
-      const volume = Number(m.volume) || 0
-      // Search results return relevance-ordered already — skip volume in their score
-      // but keep history/category nudge so familiar markets still float up.
-      const score = isSearchMode ? boost : (volume || 1) * boost
-      return { market: m, score }
-    })
-    scored.sort((a, b) => b.score - a.score)
-    return scored.map((s) => s.market)
-  }, [rawResults, savedSlugs, historySlugs, isSearchMode])
-
   const toggleCategory = useCallback((slug) => {
-    // First touch: snapshot the currently-shown filter set so toggles operate
-    // on it (the lazy initialiser may have missed the async-loaded preferences).
     const base = userTouched ? localCategories : activeCategories
     setUserTouched(true)
     setLocalCategories(
-      base.includes(slug) ? base.filter((s) => s !== slug) : [...base, slug]
+      base.includes(slug) ? base.filter((s) => s !== slug) : [...base, slug],
     )
-    if (trimmedQuery) {
-      setQuery('')
-    }
-  }, [userTouched, localCategories, activeCategories, trimmedQuery])
+    // NOTE: the query is intentionally preserved here so toggling a filter
+    // refines (not resets) an in-progress search.
+  }, [userTouched, localCategories, activeCategories])
 
   const clearAllFilters = useCallback(() => {
     setUserTouched(true)
     setLocalCategories([])
   }, [])
 
+  const toggleEvent = useCallback((eventId) => {
+    setExpandedEventIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(eventId)) next.delete(eventId)
+      else next.add(eventId)
+      return next
+    })
+  }, [])
+
   const handleRetry = useCallback(() => {
-    if (isSearchMode) {
-      runSearch(trimmedQuery)
-    } else {
-      refreshTop()
-    }
+    if (isSearchMode) runSearch(trimmedQuery)
+    else refreshTop()
   }, [isSearchMode, runSearch, trimmedQuery, refreshTop])
 
   if (!polymarketSidebetsEnabled) return null
 
   const rootClassName = `pmb pmb--${variant}${className ? ` ${className}` : ''}`
+
+  const renderMarketCard = (market) => {
+    const isSelected = selectedConditionId && market.conditionId === selectedConditionId
+    const vol = formatVolume(market.volume)
+    return (
+      <button
+        type="button"
+        className={`pmb__card ${isSelected ? 'pmb__card--selected' : ''}`}
+        onClick={() => onSelectMarket?.(market)}
+      >
+        <div className="pmb__card-question">{market.label || market.question}</div>
+        <div className="pmb__card-meta">
+          {vol && <span className="pmb__card-volume">{vol} vol</span>}
+        </div>
+        {isSelected && <span className="pmb__card-selected-badge">Selected</span>}
+      </button>
+    )
+  }
 
   return (
     <section className={rootClassName} aria-label="Polymarket markets">
@@ -277,7 +249,7 @@ function PolymarketBrowser({
             </div>
           )}
 
-          {!isLoading && !error && rankedResults.length === 0 && (
+          {!isLoading && !error && events.length === 0 && (
             <div className="pmb__empty">
               {isSearchMode ? (
                 <p>No matching Polymarket events.</p>
@@ -294,27 +266,46 @@ function PolymarketBrowser({
             </div>
           )}
 
-          {!isLoading && !error && rankedResults.length > 0 && (
+          {!isLoading && !error && events.length > 0 && (
             <ul className={`pmb__grid pmb__grid--${variant}`} role="list">
-              {rankedResults.map((m) => {
-                const isSelected = selectedConditionId && m.conditionId === selectedConditionId
-                const vol = formatVolume(m.volume)
+              {events.map((ev) => {
+                // Single-market event: select directly, no expand affordance.
+                if (ev.markets.length === 1) {
+                  return (
+                    <li key={ev.id} className="pmb__card-wrapper">
+                      {renderMarketCard(ev.markets[0])}
+                    </li>
+                  )
+                }
+
+                const isOpen = expandedEventIds.has(ev.id)
+                const vol = formatVolume(ev.volume)
                 return (
-                  <li key={m.conditionId} className="pmb__card-wrapper">
+                  <li key={ev.id} className="pmb__event">
                     <button
                       type="button"
-                      className={`pmb__card ${isSelected ? 'pmb__card--selected' : ''}`}
-                      onClick={() => onSelectMarket?.(m)}
+                      className="pmb__event-header"
+                      onClick={() => toggleEvent(ev.id)}
+                      aria-expanded={isOpen}
                     >
-                      <div className="pmb__card-question">{m.question}</div>
-                      <div className="pmb__card-meta">
-                        {m.category && (
-                          <span className="pmb__card-tag">{normaliseCategoryString(m.category)}</span>
-                        )}
+                      <span className="pmb__event-title">{ev.title}</span>
+                      <span className="pmb__event-meta">
+                        <span className="pmb__event-count">{ev.markets.length} markets</span>
                         {vol && <span className="pmb__card-volume">{vol} vol</span>}
-                      </div>
-                      {isSelected && <span className="pmb__card-selected-badge">Selected</span>}
+                        <span className="pmb__event-chevron" aria-hidden="true">
+                          {isOpen ? '▾' : '▸'}
+                        </span>
+                      </span>
                     </button>
+                    {isOpen && (
+                      <ul className="pmb__submarkets" role="list">
+                        {ev.markets.map((market) => (
+                          <li key={market.conditionId} className="pmb__card-wrapper">
+                            {renderMarketCard(market)}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
                   </li>
                 )
               })}

--- a/frontend/src/hooks/usePolymarketSearch.js
+++ b/frontend/src/hooks/usePolymarketSearch.js
@@ -1,155 +1,98 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useChainId } from 'wagmi'
 import { getNetwork, getCurrentChainId } from '../config/networks'
 import logger from '../utils/logger'
 
-const DEFAULT_LIMIT = 10
-const SEARCH_DEBOUNCE_MS = 400
+const DEFAULT_SEARCH_LIMIT = 10
+const DEFAULT_BROWSE_LIMIT = 12
+const DEFAULT_GAMMA_BASE = 'https://gamma-api.polymarket.com'
 
-/**
- * Search Polymarket events by name via the Gamma API.
- *
- * The Gamma API base URL is per-chain (set in networks.js); both Polygon
- * Amoy (testnet) and Polygon Mainnet share Polymarket's public Gamma
- * instance at gamma-api.polymarket.com by default.
- *
- * Usage:
- *   const { results, isLoading, error, search, clear } = usePolymarketSearch()
- *   search('US election')                       // returns markets matching the query
- *   const m = results[0]; m.conditionId         // pass to the LinkedMarket form
- *
- * Each result includes:
- *   - id, slug, question, category
- *   - conditionId (bytes32 — what the PolymarketOracle resolution type wants)
- *   - endDate, volume, liquidity, active, closed
- *   - outcomes: [{ name, price }]
- */
-export function usePolymarketSearch({ limit = DEFAULT_LIMIT } = {}) {
-  const wagmiChainId = useChainId()
-  const chainId = wagmiChainId || getCurrentChainId()
+// Verified Polymarket Gamma tag ids for the user-facing category chips.
+// (See specs/013-polymarket-search-filter/research.md, Decision 3.)
+const CATEGORY_TAG_IDS = {
+  politics: '2',
+  sports: '1',
+  crypto: '21',
+  'pop-culture': '596',
+  business: '107',
+  tech: '1401',
+}
+
+// Memoised slug -> numeric tag id, seeded with the verified ids above. Unseeded
+// slugs are resolved once via /tags/slug/{slug} and cached.
+const tagIdCache = new Map(Object.entries(CATEGORY_TAG_IDS))
+
+function apiBaseFor(chainId) {
   const network = getNetwork(chainId)
-  const apiBase = network?.polymarket?.gammaApiUrl || 'https://gamma-api.polymarket.com'
+  return network?.polymarket?.gammaApiUrl || DEFAULT_GAMMA_BASE
+}
 
-  const [results, setResults] = useState([])
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState(null)
-  const [lastQuery, setLastQuery] = useState('')
-
-  const debounceRef = useRef(null)
-  const abortRef = useRef(null)
-
-  const runSearch = useCallback(async (rawQuery) => {
-    const query = String(rawQuery || '').trim()
-    setLastQuery(query)
-
-    if (!query) {
-      setResults([])
-      setError(null)
-      return
-    }
-
-    if (abortRef.current) {
-      abortRef.current.abort()
-    }
-    const controller = new AbortController()
-    abortRef.current = controller
-
-    setIsLoading(true)
-    setError(null)
-
-    try {
-      // Gamma API: /markets supports `search` plus filters; we ask for active,
-      // unresolved markets first since those are what a side-bet wants to peg.
-      const params = new URLSearchParams({
-        search: query,
-        limit: String(limit),
-        active: 'true',
-        closed: 'false',
-      })
-      const url = `${apiBase.replace(/\/$/, '')}/markets?${params.toString()}`
-      const res = await fetch(url, {
-        signal: controller.signal,
-        headers: { Accept: 'application/json' },
-      })
-
-      if (!res.ok) {
-        throw new Error(`Polymarket Gamma API returned ${res.status}`)
-      }
-
-      const data = await res.json()
-      // The Gamma API has historically returned both raw arrays and
-      // { data: [] } wrappers, so normalise.
-      const items = Array.isArray(data) ? data : Array.isArray(data?.data) ? data.data : []
-      const normalised = items
-        .map(normaliseGammaMarket)
-        .filter((m) => m.conditionId) // can only peg markets that have a condition id
-
-      setResults(normalised)
-    } catch (err) {
-      if (err.name === 'AbortError') return
-      logger.warn?.('[usePolymarketSearch] failed:', err)
-      setError(err.message || 'Polymarket search failed')
-      setResults([])
-    } finally {
-      setIsLoading(false)
-    }
-  }, [apiBase, limit])
-
-  const search = useCallback((query) => {
-    if (debounceRef.current) clearTimeout(debounceRef.current)
-    debounceRef.current = setTimeout(() => runSearch(query), SEARCH_DEBOUNCE_MS)
-  }, [runSearch])
-
-  const clear = useCallback(() => {
-    if (debounceRef.current) clearTimeout(debounceRef.current)
-    if (abortRef.current) abortRef.current.abort()
-    setResults([])
-    setError(null)
-    setLastQuery('')
-    setIsLoading(false)
-  }, [])
-
-  useEffect(() => () => {
-    if (debounceRef.current) clearTimeout(debounceRef.current)
-    if (abortRef.current) abortRef.current.abort()
-  }, [])
-
-  return {
-    results,
-    isLoading,
-    error,
-    lastQuery,
-    search,
-    runSearch,
-    clear,
-  }
+function trimBase(base) {
+  return base.replace(/\/$/, '')
 }
 
 /**
- * Normalise a Gamma `/markets` response item into the same shape used by
- * `usePolymarketSearch`. Extracted so the top-markets hook can reuse it.
+ * Resolve a category slug to its numeric Gamma tag id. Returns the seeded id
+ * synchronously when known; otherwise fetches `/tags/slug/{slug}` once and
+ * caches it. Returns null when the slug cannot be resolved (so it applies no
+ * filter rather than silently widening results).
  */
-function normaliseGammaMarket(m) {
-  const outcomes = (() => {
-    try {
-      const names = typeof m.outcomes === 'string' ? JSON.parse(m.outcomes) : m.outcomes
-      const prices = typeof m.outcomePrices === 'string' ? JSON.parse(m.outcomePrices) : m.outcomePrices
-      if (!Array.isArray(names)) return []
-      return names.map((name, i) => ({
-        name,
-        price: prices?.[i] != null ? Number(prices[i]) : null,
-      }))
-    } catch {
-      return []
-    }
-  })()
+export async function ensureCategoryTagId(apiBase, slug) {
+  if (!slug) return null
+  if (tagIdCache.has(slug)) return tagIdCache.get(slug)
+  try {
+    const res = await fetch(`${trimBase(apiBase)}/tags/slug/${encodeURIComponent(slug)}`, {
+      headers: { Accept: 'application/json' },
+    })
+    if (!res.ok) return null
+    const tag = await res.json()
+    const id = tag?.id != null ? String(tag.id) : null
+    if (id) tagIdCache.set(slug, id)
+    return id
+  } catch (err) {
+    logger.warn?.('[ensureCategoryTagId] failed:', err)
+    return null
+  }
+}
 
+/** Synchronous lookup of a seeded category tag id (null when unseeded). */
+export function resolveCategoryTagId(slug) {
+  return tagIdCache.get(slug) || null
+}
+
+function parseJsonArray(value) {
+  if (Array.isArray(value)) return value
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+      return Array.isArray(parsed) ? parsed : null
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
+/**
+ * Normalise a Gamma market object into the shape the picker/linked-market form
+ * consumes. `label` is the short per-sub-market title used when an event is
+ * expanded (e.g. "Spain"), falling back to the full question.
+ */
+export function normaliseGammaMarket(m) {
+  const names = parseJsonArray(m.outcomes) || []
+  const prices = parseJsonArray(m.outcomePrices) || []
+  const outcomes = names.map((name, i) => ({
+    name,
+    price: prices[i] != null ? Number(prices[i]) : null,
+  }))
+
+  const question = m.question || m.title || m.name || ''
   return {
     id: m.id ?? m.marketId ?? null,
     slug: m.slug || null,
-    question: m.question || m.title || m.name || '',
+    question,
+    label: m.groupItemTitle || question,
     description: m.description || '',
-    category: m.category || m.categories || null,
     conditionId: m.conditionId || m.condition_id || null,
     endDate: m.endDate || m.end_date_iso || null,
     volume: m.volume != null ? Number(m.volume) : null,
@@ -161,42 +104,89 @@ function normaliseGammaMarket(m) {
   }
 }
 
+/** A market may back a wager only if it is active, unresolved, and has a condition id. */
+function isEligibleMarket(m) {
+  return Boolean(m.conditionId) && m.active === true && m.closed !== true
+}
+
 /**
- * Load the currently top-by-volume Polymarket markets, optionally filtered by
- * category/tag slugs. Used by the dashboard feed and the in-modal market
- * browser. Mirrors the `usePolymarketSearch` lifecycle (per-chain `apiBase`,
- * `AbortController` cleanup) so behaviour stays consistent.
+ * Group a Gamma event and its nested markets into a NormalizedEvent, keeping
+ * only eligible child markets (sorted by volume). Returns null when the event
+ * has no eligible markets, so empty events are dropped entirely.
+ * (See specs/013-polymarket-search-filter/data-model.md.)
+ */
+export function normaliseGammaEvent(ev) {
+  if (!ev || typeof ev !== 'object') return null
+  const children = (Array.isArray(ev.markets) ? ev.markets : [])
+    .map(normaliseGammaMarket)
+    .filter(isEligibleMarket)
+  if (children.length === 0) return null
+  children.sort((a, b) => (Number(b.volume) || 0) - (Number(a.volume) || 0))
+
+  const tags = Array.isArray(ev.tags) ? ev.tags : []
+  return {
+    id: String(ev.id ?? ev.slug ?? children[0].conditionId),
+    title: ev.title || ev.question || children[0].question || '',
+    slug: ev.slug || null,
+    category: tags[0]?.label || null,
+    tagIds: tags.map((t) => (t?.id != null ? String(t.id) : null)).filter(Boolean),
+    volume: ev.volume != null ? Number(ev.volume) : null,
+    image: ev.image || ev.icon || null,
+    markets: children,
+  }
+}
+
+function eventsFromPayload(data) {
+  if (Array.isArray(data)) return data
+  if (Array.isArray(data?.events)) return data.events
+  if (Array.isArray(data?.data)) return data.data
+  return []
+}
+
+/** Stable key for a categories array so effects don't loop on new references. */
+function categoriesKeyOf(categories) {
+  return Array.isArray(categories) ? categories.slice().sort().join(',') : ''
+}
+
+/**
+ * Search Polymarket events by free text via the Gamma `/public-search` endpoint,
+ * optionally constrained to selected categories. Results are returned grouped by
+ * event (each event holds its eligible child markets), relevance-ordered.
  *
  * Usage:
- *   const { results, isLoading, error, refresh } = usePolymarketTopMarkets({
- *     categories: ['politics', 'sports'],
- *     limit: 12,
- *   })
- *
- * Gamma's `/markets` endpoint sorts by `volume` desc when given
- * `order=volume&ascending=false`. Multiple tag slugs are comma-joined under
- * `tag_slug=` — the Gamma API treats them as OR.
+ *   const { results, isLoading, error, runSearch, clear } =
+ *     usePolymarketSearch({ limit, categories: ['sports'] })
  */
-export function usePolymarketTopMarkets({ categories = [], limit = 12 } = {}) {
+export function usePolymarketSearch({ limit = DEFAULT_SEARCH_LIMIT, categories = [] } = {}) {
   const wagmiChainId = useChainId()
   const chainId = wagmiChainId || getCurrentChainId()
-  const network = getNetwork(chainId)
-  const apiBase = network?.polymarket?.gammaApiUrl || 'https://gamma-api.polymarket.com'
+  const apiBase = apiBaseFor(chainId)
+  const catKey = categoriesKeyOf(categories)
 
   const [results, setResults] = useState([])
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState(null)
+  const [lastQuery, setLastQuery] = useState('')
 
   const abortRef = useRef(null)
-  // Stabilise the categories array against new references on every render —
-  // the parent often passes a fresh array literal, which would otherwise loop
-  // the effect.
-  const categoriesKey = Array.isArray(categories) ? categories.slice().sort().join(',') : ''
 
-  const fetchTop = useCallback(async () => {
-    if (abortRef.current) {
-      abortRef.current.abort()
+  // Seeded tag ids for the selected categories (sync; all chips are seeded).
+  const selectedTagIds = useMemo(
+    () => (catKey ? catKey.split(',').map(resolveCategoryTagId).filter(Boolean) : []),
+    [catKey],
+  )
+
+  const runSearch = useCallback(async (rawQuery) => {
+    const query = String(rawQuery || '').trim()
+    setLastQuery(query)
+
+    if (!query) {
+      setResults([])
+      setError(null)
+      return
     }
+
+    if (abortRef.current) abortRef.current.abort()
     const controller = new AbortController()
     abortRef.current = controller
 
@@ -204,32 +194,120 @@ export function usePolymarketTopMarkets({ categories = [], limit = 12 } = {}) {
     setError(null)
 
     try {
-      const params = new URLSearchParams({
-        limit: String(limit),
-        active: 'true',
-        closed: 'false',
-        order: 'volume',
-        ascending: 'false',
-      })
-      if (categoriesKey) {
-        params.set('tag_slug', categoriesKey)
-      }
-      const url = `${apiBase.replace(/\/$/, '')}/markets?${params.toString()}`
+      const params = new URLSearchParams({ q: query, limit_per_type: String(limit) })
+      const url = `${trimBase(apiBase)}/public-search?${params.toString()}`
       const res = await fetch(url, {
         signal: controller.signal,
         headers: { Accept: 'application/json' },
       })
-
-      if (!res.ok) {
-        throw new Error(`Polymarket Gamma API returned ${res.status}`)
-      }
+      if (!res.ok) throw new Error(`Polymarket Gamma API returned ${res.status}`)
 
       const data = await res.json()
-      const items = Array.isArray(data) ? data : Array.isArray(data?.data) ? data.data : []
-      const normalised = items
-        .map(normaliseGammaMarket)
-        .filter((m) => m.conditionId)
-      setResults(normalised)
+      let events = eventsFromPayload(data)
+        .map(normaliseGammaEvent)
+        .filter(Boolean)
+
+      // Constrain to selected categories (OR across categories) when active.
+      if (selectedTagIds.length > 0) {
+        events = events.filter((ev) => ev.tagIds.some((id) => selectedTagIds.includes(id)))
+      }
+
+      setResults(events)
+    } catch (err) {
+      if (err.name === 'AbortError') return
+      logger.warn?.('[usePolymarketSearch] failed:', err)
+      setError(err.message || 'Polymarket search failed')
+      setResults([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [apiBase, limit, selectedTagIds])
+
+  const clear = useCallback(() => {
+    if (abortRef.current) abortRef.current.abort()
+    setResults([])
+    setError(null)
+    setLastQuery('')
+    setIsLoading(false)
+  }, [])
+
+  useEffect(() => () => {
+    if (abortRef.current) abortRef.current.abort()
+  }, [])
+
+  return { results, isLoading, error, lastQuery, runSearch, clear }
+}
+
+/**
+ * Load top Polymarket events (grouped, with nested markets) ordered by volume,
+ * optionally filtered by one or more categories (OR semantics). Used by the
+ * dashboard feed and the in-modal browser.
+ *
+ * Usage:
+ *   const { results, isLoading, error, refresh } =
+ *     usePolymarketTopMarkets({ categories: ['politics', 'sports'], limit: 12 })
+ */
+export function usePolymarketTopMarkets({ categories = [], limit = DEFAULT_BROWSE_LIMIT } = {}) {
+  const wagmiChainId = useChainId()
+  const chainId = wagmiChainId || getCurrentChainId()
+  const apiBase = apiBaseFor(chainId)
+  const catKey = categoriesKeyOf(categories)
+
+  const [results, setResults] = useState([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  const abortRef = useRef(null)
+
+  const fetchTop = useCallback(async () => {
+    if (abortRef.current) abortRef.current.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    setIsLoading(true)
+    setError(null)
+
+    const buildUrl = (tagId) => {
+      const params = new URLSearchParams({
+        active: 'true',
+        closed: 'false',
+        order: 'volume',
+        ascending: 'false',
+        limit: String(limit),
+      })
+      if (tagId) params.set('tag_id', String(tagId))
+      return `${trimBase(apiBase)}/events?${params.toString()}`
+    }
+
+    const fetchEvents = async (tagId) => {
+      const res = await fetch(buildUrl(tagId), {
+        signal: controller.signal,
+        headers: { Accept: 'application/json' },
+      })
+      if (!res.ok) throw new Error(`Polymarket Gamma API returned ${res.status}`)
+      return eventsFromPayload(await res.json())
+    }
+
+    try {
+      const slugs = catKey ? catKey.split(',') : []
+      let raw
+      if (slugs.length === 0) {
+        raw = await fetchEvents(null)
+      } else {
+        // One request per selected category (OR); merge + de-dupe by event id.
+        const tagIds = (await Promise.all(slugs.map((s) => ensureCategoryTagId(apiBase, s)))).filter(Boolean)
+        const batches = await Promise.all(tagIds.map((id) => fetchEvents(id)))
+        raw = batches.flat()
+      }
+
+      const byId = new Map()
+      for (const ev of raw) {
+        const norm = normaliseGammaEvent(ev)
+        if (norm && !byId.has(norm.id)) byId.set(norm.id, norm)
+      }
+      const merged = Array.from(byId.values())
+      merged.sort((a, b) => (Number(b.volume) || 0) - (Number(a.volume) || 0))
+      setResults(merged.slice(0, limit))
     } catch (err) {
       if (err.name === 'AbortError') return
       logger.warn?.('[usePolymarketTopMarkets] failed:', err)
@@ -238,7 +316,7 @@ export function usePolymarketTopMarkets({ categories = [], limit = 12 } = {}) {
     } finally {
       setIsLoading(false)
     }
-  }, [apiBase, limit, categoriesKey])
+  }, [apiBase, limit, catKey])
 
   useEffect(() => {
     fetchTop()
@@ -247,12 +325,7 @@ export function usePolymarketTopMarkets({ categories = [], limit = 12 } = {}) {
     }
   }, [fetchTop])
 
-  return {
-    results,
-    isLoading,
-    error,
-    refresh: fetchTop,
-  }
+  return { results, isLoading, error, refresh: fetchTop }
 }
 
 export default usePolymarketSearch

--- a/frontend/src/test/PolymarketBrowser.test.jsx
+++ b/frontend/src/test/PolymarketBrowser.test.jsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+
+// Enable the picker (it self-gates on chain capability) and provide preferences.
+vi.mock('../hooks/useChainTokens', () => ({
+  useChainTokens: () => ({ capabilities: { polymarketSidebets: true } }),
+}))
+vi.mock('../hooks/useUserPreferences', () => ({
+  useUserPreferences: () => ({ preferences: {} }),
+}))
+
+import PolymarketBrowser from '../components/fairwins/PolymarketBrowser'
+import { installGammaFetch, urlHas, urlHasAll } from './helpers/mockGammaFetch'
+import {
+  searchKnicksPayload,
+  topEventsDefault,
+  sportsEvents,
+  cryptoEvents,
+} from './fixtures/polymarket'
+
+const renderInline = (props = {}) =>
+  render(<PolymarketBrowser variant="inline" {...props} />)
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('PolymarketBrowser — search & grouping (US1)', () => {
+  it('shows relevant grouped events; a multi-sub-market event expands and a single-market event selects directly', async () => {
+    installGammaFetch([
+      { match: urlHas('/public-search'), json: searchKnicksPayload },
+      { match: urlHas('/events'), json: topEventsDefault },
+    ])
+    const onSelectMarket = vi.fn()
+    renderInline({ onSelectMarket })
+
+    fireEvent.change(screen.getByLabelText('Search Polymarket events'), {
+      target: { value: 'knicks' },
+    })
+
+    // Grouped event row appears (3 sub-markets) — collapsed by default.
+    const eventHeader = await screen.findByRole('button', { name: /Pacers vs\. Knicks/ })
+    expect(eventHeader).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.getByText(/3 markets/)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Moneyline/ })).not.toBeInTheDocument()
+
+    // Expand → sub-markets revealed → select one.
+    fireEvent.click(eventHeader)
+    expect(eventHeader).toHaveAttribute('aria-expanded', 'true')
+    fireEvent.click(await screen.findByRole('button', { name: /Moneyline/ }))
+    expect(onSelectMarket).toHaveBeenCalledWith(
+      expect.objectContaining({ conditionId: '0xk1' }),
+    )
+
+    // Single-market event renders as a direct card.
+    fireEvent.click(screen.getByRole('button', { name: /Will the Knicks win the championship\?/ }))
+    expect(onSelectMarket).toHaveBeenCalledWith(
+      expect.objectContaining({ conditionId: '0xkt' }),
+    )
+  })
+})
+
+describe('PolymarketBrowser — category browse (US2)', () => {
+  it('narrows by category and unions multiple categories (OR), with multi-select chips', async () => {
+    installGammaFetch([
+      { match: urlHasAll('/events', 'tag_id=1'), json: sportsEvents },
+      { match: urlHasAll('/events', 'tag_id=21'), json: cryptoEvents },
+      { match: urlHas('/events'), json: topEventsDefault },
+    ])
+    renderInline()
+
+    // Default top events.
+    expect(await screen.findByText('Will the incumbent be re-elected?')).toBeInTheDocument()
+
+    // Sports only.
+    const sportsChip = screen.getByRole('button', { name: 'Sports' })
+    fireEvent.click(sportsChip)
+    expect(await screen.findByText('World Cup Winner')).toBeInTheDocument()
+    expect(sportsChip).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.queryByText('Will the incumbent be re-elected?')).not.toBeInTheDocument()
+
+    // Add Crypto → union of sports OR crypto.
+    fireEvent.click(screen.getByRole('button', { name: 'Crypto' }))
+    expect(await screen.findByText('Will BTC be above $100k?')).toBeInTheDocument()
+    expect(screen.getByText('World Cup Winner')).toBeInTheDocument()
+
+    // Clear → back to default top events.
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }))
+    expect(await screen.findByText('Will the incumbent be re-elected?')).toBeInTheDocument()
+  })
+})
+
+describe('PolymarketBrowser — search within category (US3)', () => {
+  it('preserves the typed query when toggling a category and constrains results to it', async () => {
+    installGammaFetch([
+      { match: urlHas('/public-search'), json: searchKnicksPayload },
+      { match: urlHas('/events'), json: topEventsDefault },
+    ])
+    renderInline()
+    const input = screen.getByLabelText('Search Polymarket events')
+
+    fireEvent.change(input, { target: { value: 'knicks' } })
+    await screen.findByRole('button', { name: /Pacers vs\. Knicks/ })
+
+    // Toggle Crypto: the fixture events are Sports-tagged, so the constrained
+    // search yields nothing — but the typed query must be preserved.
+    fireEvent.click(screen.getByRole('button', { name: 'Crypto' }))
+    expect(input).toHaveValue('knicks')
+    expect(await screen.findByText(/No matching Polymarket events/)).toBeInTheDocument()
+
+    // Removing the category broadens back to the query alone.
+    fireEvent.click(screen.getByRole('button', { name: 'Crypto' }))
+    expect(await screen.findByRole('button', { name: /Pacers vs\. Knicks/ })).toBeInTheDocument()
+    expect(input).toHaveValue('knicks')
+  })
+})
+
+describe('PolymarketBrowser — trustworthy states (US4)', () => {
+  it('shows an error with a working Retry on failure', async () => {
+    let failNext = true
+    const fetchMock = vi.fn(async (url) => {
+      if (String(url).includes('/public-search')) {
+        if (failNext) {
+          failNext = false
+          return { ok: false, status: 500, json: async () => ({}) }
+        }
+        return { ok: true, status: 200, json: async () => searchKnicksPayload }
+      }
+      return { ok: true, status: 200, json: async () => topEventsDefault }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderInline()
+    fireEvent.change(screen.getByLabelText('Search Polymarket events'), {
+      target: { value: 'knicks' },
+    })
+
+    const alert = await screen.findByRole('alert')
+    expect(within(alert).getByText(/Could not load Polymarket markets/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(await screen.findByRole('button', { name: /Pacers vs\. Knicks/ })).toBeInTheDocument()
+  })
+
+  it('shows a distinct empty state when a category has no markets', async () => {
+    installGammaFetch([
+      { match: urlHasAll('/events', 'tag_id=1'), json: [] },
+      { match: urlHas('/events'), json: topEventsDefault },
+    ])
+    renderInline()
+    await screen.findByText('Will the incumbent be re-elected?')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sports' }))
+    expect(await screen.findByText(/No active markets match these categories/)).toBeInTheDocument()
+  })
+
+  it('has no accessibility violations in the default and expanded states', async () => {
+    installGammaFetch([
+      { match: urlHas('/public-search'), json: searchKnicksPayload },
+      { match: urlHas('/events'), json: topEventsDefault },
+    ])
+    const { container } = renderInline()
+    await screen.findByText('Will the incumbent be re-elected?')
+    expect(await axe(container)).toHaveNoViolations()
+
+    fireEvent.change(screen.getByLabelText('Search Polymarket events'), {
+      target: { value: 'knicks' },
+    })
+    fireEvent.click(await screen.findByRole('button', { name: /Pacers vs\. Knicks/ }))
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/fixtures/polymarket.js
+++ b/frontend/src/test/fixtures/polymarket.js
@@ -1,0 +1,96 @@
+// Canned Gamma API payloads for Polymarket search/filter tests.
+// Shapes mirror the live API (verified 2026-06-13): /public-search returns
+// { events: [...] }; /events returns an array of events; each event has `tags`
+// and nested `markets`.
+
+const mkMarket = (over = {}) => ({
+  id: over.id ?? '0',
+  question: over.question ?? 'Will it happen?',
+  conditionId: 'conditionId' in over ? over.conditionId : '0xcond0',
+  slug: over.slug ?? 'market-slug',
+  endDate: over.endDate ?? '2026-12-31T00:00:00Z',
+  volume: over.volume ?? 1000,
+  active: over.active ?? true,
+  closed: over.closed ?? false,
+  groupItemTitle: over.groupItemTitle,
+  outcomes: over.outcomes ?? JSON.stringify(['Yes', 'No']),
+  outcomePrices: over.outcomePrices ?? JSON.stringify(['0.5', '0.5']),
+})
+
+const mkEvent = (over = {}) => ({
+  id: over.id ?? 'ev0',
+  title: over.title ?? 'An Event',
+  slug: over.slug ?? 'an-event',
+  volume: over.volume ?? 1000,
+  tags: over.tags ?? [],
+  markets: over.markets ?? [mkMarket()],
+})
+
+// --- Search ("knicks") -------------------------------------------------------
+// A single game exposing many sub-markets (the grouping case), tagged Sports.
+export const knicksGameEvent = mkEvent({
+  id: 'ev-knicks-game',
+  title: 'Pacers vs. Knicks',
+  slug: 'nba-ind-nyk-2025-05-21',
+  volume: 500000,
+  tags: [{ id: '1', label: 'Sports', slug: 'sports' }],
+  markets: [
+    mkMarket({ id: 'k1', question: 'Pacers vs. Knicks', conditionId: '0xk1', groupItemTitle: 'Moneyline', volume: 300000 }),
+    mkMarket({ id: 'k2', question: 'Spread: Knicks (-4.5)', conditionId: '0xk2', groupItemTitle: 'Knicks -4.5', volume: 90000 }),
+    mkMarket({ id: 'k3', question: 'Pacers vs Knicks: O/U 224.5', conditionId: '0xk3', groupItemTitle: 'O/U 224.5', volume: 60000 }),
+  ],
+})
+
+// A single-market crypto event (selects directly, no expand).
+export const knicksSingleEvent = mkEvent({
+  id: 'ev-knicks-single',
+  title: 'Knicks to win the title?',
+  slug: 'knicks-title',
+  volume: 120000,
+  tags: [{ id: '1', label: 'Sports', slug: 'sports' }],
+  markets: [mkMarket({ id: 'kt', question: 'Will the Knicks win the championship?', conditionId: '0xkt', volume: 120000 })],
+})
+
+export const searchKnicksPayload = {
+  events: [knicksGameEvent, knicksSingleEvent],
+  pagination: { hasMore: false },
+}
+
+// A query whose only matches are ineligible (all markets closed / no conditionId).
+export const searchIneligiblePayload = {
+  events: [
+    mkEvent({
+      id: 'ev-ineligible',
+      title: 'Resolved thing',
+      tags: [{ id: '1', label: 'Sports', slug: 'sports' }],
+      markets: [
+        mkMarket({ id: 'x1', conditionId: '0xclosed', closed: true }),
+        mkMarket({ id: 'x2', conditionId: null }),
+      ],
+    }),
+  ],
+  pagination: { hasMore: false },
+}
+
+// --- Browse (/events) --------------------------------------------------------
+// Single-market events render the market question (not the event title), so the
+// markets carry the distinctive text the tests assert on.
+export const topEventsDefault = [
+  mkEvent({ id: 'ev-top1', title: 'Top Politics Event', volume: 9000000, tags: [{ id: '2', label: 'Politics', slug: 'politics' }], markets: [mkMarket({ id: 'p1', question: 'Will the incumbent be re-elected?', conditionId: '0xp1', volume: 9000000 })] }),
+  mkEvent({ id: 'ev-top2', title: 'Top Crypto Event', volume: 8000000, tags: [{ id: '21', label: 'Crypto', slug: 'crypto' }], markets: [mkMarket({ id: 'e1', question: 'Will ETH flip BTC?', conditionId: '0xe1', volume: 8000000 })] }),
+]
+
+export const sportsEvents = [
+  mkEvent({ id: 'ev-sport1', title: 'World Cup Winner', volume: 2000000, tags: [{ id: '1', label: 'Sports', slug: 'sports' }], markets: [
+    mkMarket({ id: 's1', question: 'Will Spain win?', conditionId: '0xs1', groupItemTitle: 'Spain', volume: 900000 }),
+    mkMarket({ id: 's2', question: 'Will Brazil win?', conditionId: '0xs2', groupItemTitle: 'Brazil', volume: 800000 }),
+  ] }),
+]
+
+export const cryptoEvents = [
+  mkEvent({ id: 'ev-crypto1', title: 'BTC above 100k?', volume: 1500000, tags: [{ id: '21', label: 'Crypto', slug: 'crypto' }], markets: [
+    mkMarket({ id: 'c1', question: 'Will BTC be above $100k?', conditionId: '0xc1', volume: 1500000 }),
+  ] }),
+]
+
+export { mkEvent, mkMarket }

--- a/frontend/src/test/helpers/mockGammaFetch.js
+++ b/frontend/src/test/helpers/mockGammaFetch.js
@@ -1,0 +1,35 @@
+import { vi } from 'vitest'
+
+/**
+ * Install a URL-aware `fetch` mock for Gamma API tests.
+ *
+ * @param {Array<{ match: (url: string) => boolean, json?: any, ok?: boolean, status?: number, error?: Error }>} routes
+ *   Ordered routes; the first whose `match(url)` is true wins. `error` rejects
+ *   the call (e.g. to simulate a network failure / abort).
+ * @returns the vi.fn so tests can assert on requested URLs.
+ *
+ * This is test-only code; URL matching here drives fixtures, not real requests.
+ */
+export function installGammaFetch(routes = []) {
+  const fn = vi.fn(async (url, options = {}) => {
+    const route = routes.find((r) => r.match(String(url)))
+    if (route?.error) throw route.error
+    if (options?.signal?.aborted) {
+      const err = new Error('aborted')
+      err.name = 'AbortError'
+      throw err
+    }
+    return {
+      ok: route?.ok ?? true,
+      status: route?.status ?? 200,
+      json: async () => route?.json ?? {},
+      text: async () => JSON.stringify(route?.json ?? {}),
+    }
+  })
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+/** Convenience matchers. */
+export const urlHas = (needle) => (url) => url.includes(needle)
+export const urlHasAll = (...needles) => (url) => needles.every((n) => url.includes(n))

--- a/frontend/src/test/usePolymarketSearch.test.js
+++ b/frontend/src/test/usePolymarketSearch.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { usePolymarketSearch } from '../hooks/usePolymarketSearch'
+import { installGammaFetch, urlHas } from './helpers/mockGammaFetch'
+import {
+  searchKnicksPayload,
+  searchIneligiblePayload,
+} from './fixtures/polymarket'
+
+describe('usePolymarketSearch', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('searches via /public-search?q= (never /markets?search=) and groups results by event', async () => {
+    const fetchMock = installGammaFetch([
+      { match: urlHas('/public-search'), json: searchKnicksPayload },
+    ])
+
+    const { result } = renderHook(() => usePolymarketSearch({ limit: 10 }))
+    await act(async () => {
+      await result.current.runSearch('knicks')
+    })
+
+    const requestedUrl = String(fetchMock.mock.calls[0][0])
+    expect(requestedUrl).toContain('/public-search')
+    expect(requestedUrl).toContain('q=knicks')
+    expect(requestedUrl).toContain('limit_per_type=10')
+    expect(requestedUrl).not.toContain('/markets')
+    expect(requestedUrl).not.toContain('search=knicks')
+
+    // Two events: a multi-sub-market game (grouped) and a single-market event.
+    expect(result.current.results).toHaveLength(2)
+    const game = result.current.results.find((e) => e.id === 'ev-knicks-game')
+    expect(game.markets).toHaveLength(3)
+    expect(game.markets[0].label).toBe('Moneyline')
+    const single = result.current.results.find((e) => e.id === 'ev-knicks-single')
+    expect(single.markets).toHaveLength(1)
+  })
+
+  it('drops events whose markets are all ineligible (closed / no conditionId)', async () => {
+    installGammaFetch([{ match: urlHas('/public-search'), json: searchIneligiblePayload }])
+
+    const { result } = renderHook(() => usePolymarketSearch({ limit: 10 }))
+    await act(async () => {
+      await result.current.runSearch('whatever')
+    })
+
+    expect(result.current.results).toEqual([])
+  })
+
+  it('fires no request and clears for a blank query', async () => {
+    const fetchMock = installGammaFetch([{ match: urlHas('/public-search'), json: searchKnicksPayload }])
+
+    const { result } = renderHook(() => usePolymarketSearch({ limit: 10 }))
+    await act(async () => {
+      await result.current.runSearch('   ')
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result.current.results).toEqual([])
+  })
+
+  it('constrains results to the selected categories (OR by tag id)', async () => {
+    installGammaFetch([{ match: urlHas('/public-search'), json: searchKnicksPayload }])
+
+    // Both fixture events are tagged Sports (id 1).
+    const sports = renderHook(() => usePolymarketSearch({ limit: 10, categories: ['sports'] }))
+    await act(async () => {
+      await sports.result.current.runSearch('knicks')
+    })
+    expect(sports.result.current.results).toHaveLength(2)
+
+    const crypto = renderHook(() => usePolymarketSearch({ limit: 10, categories: ['crypto'] }))
+    await act(async () => {
+      await crypto.result.current.runSearch('knicks')
+    })
+    expect(crypto.result.current.results).toHaveLength(0)
+  })
+
+  it('surfaces an error and clears results on a non-2xx response', async () => {
+    installGammaFetch([{ match: urlHas('/public-search'), ok: false, status: 503, json: {} }])
+
+    const { result } = renderHook(() => usePolymarketSearch({ limit: 10 }))
+    await act(async () => {
+      await result.current.runSearch('knicks')
+    })
+
+    expect(result.current.error).toContain('503')
+    expect(result.current.results).toEqual([])
+  })
+
+  it('swallows AbortError without setting an error', async () => {
+    const abortErr = new Error('aborted')
+    abortErr.name = 'AbortError'
+    installGammaFetch([{ match: urlHas('/public-search'), error: abortErr }])
+
+    const { result } = renderHook(() => usePolymarketSearch({ limit: 10 }))
+    await act(async () => {
+      await result.current.runSearch('knicks')
+    })
+
+    expect(result.current.error).toBeNull()
+    expect(result.current.results).toEqual([])
+  })
+
+  it('aborts the in-flight request when a newer search supersedes it', async () => {
+    installGammaFetch([{ match: urlHas('/public-search'), json: searchKnicksPayload }])
+    const abortSpy = vi.spyOn(AbortController.prototype, 'abort')
+
+    const { result } = renderHook(() => usePolymarketSearch({ limit: 10 }))
+    await act(async () => {
+      await result.current.runSearch('knick')
+      await result.current.runSearch('knicks')
+    })
+
+    // The second search must have aborted the first request's controller.
+    expect(abortSpy).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/test/usePolymarketTopMarkets.test.js
+++ b/frontend/src/test/usePolymarketTopMarkets.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { usePolymarketTopMarkets } from '../hooks/usePolymarketSearch'
+import { installGammaFetch, urlHasAll, urlHas } from './helpers/mockGammaFetch'
+import { topEventsDefault, sportsEvents, cryptoEvents } from './fixtures/polymarket'
+
+describe('usePolymarketTopMarkets', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('browses /events ordered by volume with no tag_id when no category selected', async () => {
+    const fetchMock = installGammaFetch([
+      { match: urlHas('/events'), json: topEventsDefault },
+    ])
+
+    const { result } = renderHook(() => usePolymarketTopMarkets({ limit: 12 }))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const url = String(fetchMock.mock.calls[0][0])
+    expect(url).toContain('/events')
+    expect(url).toContain('order=volume')
+    expect(url).toContain('ascending=false')
+    expect(url).not.toContain('tag_id')
+    expect(url).not.toContain('/markets')
+    expect(url).not.toContain('tag_slug')
+    expect(result.current.results).toHaveLength(2)
+  })
+
+  it('filters by numeric tag_id for a single category (sports => tag_id=1)', async () => {
+    const fetchMock = installGammaFetch([
+      { match: urlHasAll('/events', 'tag_id=1'), json: sportsEvents },
+    ])
+
+    const { result } = renderHook(() => usePolymarketTopMarkets({ categories: ['sports'], limit: 12 }))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(String(fetchMock.mock.calls[0][0])).toContain('tag_id=1')
+    expect(result.current.results[0].id).toBe('ev-sport1')
+  })
+
+  it('fans out one request per category and merges/de-dupes by event id (OR)', async () => {
+    const fetchMock = installGammaFetch([
+      { match: urlHasAll('/events', 'tag_id=1'), json: sportsEvents },
+      { match: urlHasAll('/events', 'tag_id=21'), json: cryptoEvents },
+    ])
+
+    const { result } = renderHook(() =>
+      usePolymarketTopMarkets({ categories: ['sports', 'crypto'], limit: 12 }),
+    )
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // One request per selected category.
+    const taggedCalls = fetchMock.mock.calls.filter(([u]) => String(u).includes('tag_id='))
+    expect(taggedCalls).toHaveLength(2)
+
+    const ids = result.current.results.map((e) => e.id).sort()
+    expect(ids).toEqual(['ev-crypto1', 'ev-sport1'])
+  })
+})

--- a/specs/013-polymarket-search-filter/checklists/requirements.md
+++ b/specs/013-polymarket-search-filter/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Polymarket Search & Category Filter
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- Validation passed on first iteration. The spec deliberately keeps the upstream
+  query mechanism (correct Polymarket endpoint/parameters) as an implementation
+  concern for `/speckit-plan`, while requiring correct observable behavior via
+  FR-001/FR-002/FR-013. Specific provider/API names appear only in the
+  Assumptions section as context for the breakage, not as requirements.

--- a/specs/013-polymarket-search-filter/contracts/gamma-api.md
+++ b/specs/013-polymarket-search-filter/contracts/gamma-api.md
@@ -6,8 +6,9 @@ The picker depends on these Gamma endpoints. Base URL comes from
 `Accept: application/json`, use `AbortController`, and tolerate transient
 failure (surface an error + retry, never a stale list).
 
-Rate limit: the `/public-search` family is ~350 requests / 10s — debounce and
-abort superseded requests.
+Both search and browse return **events with nested markets**, normalized into
+`NormalizedEvent` (see data-model.md). Rate limit: the `/public-search` family is
+~350 requests / 10s — debounce and abort superseded requests.
 
 ---
 
@@ -25,47 +26,49 @@ abort superseded requests.
 Example: `GET /public-search?q=knicks&limit_per_type=10`
 
 **Response (200)**: `{ "events": Event[], "pagination": {…} }`
-- `Event` includes `tags: Tag[]` and `markets: Market[]`.
-- `Market` includes `conditionId`, `question`, `active`, `closed`, `volume`,
-  `endDate`, `outcomes`, `outcomePrices`, `slug`, `image`/`icon`.
+- `Event`: `id`, `title`, `slug`, `tags: Tag[]`, `markets: Market[]`, `image`/`icon`.
+- `Market`: `conditionId`, `question`, `groupItemTitle`, `active`, `closed`,
+  `volume`, `endDate`, `outcomes`, `outcomePrices`, `slug`, `image`/`icon`.
 
 **Consumer rules**:
-- Flatten `events[].markets[]`, normalize, and keep only surfaceable markets
-  (`conditionId` present, `active === true`, `closed !== true`).
-- When categories are active, first keep only events whose `tags[].id` intersects
-  the selected `tagId`s, then flatten (Decision 4).
-- Preserve upstream order as relevance.
+- Normalize each event → `NormalizedEvent` keeping only surfaceable child markets
+  (`conditionId` present, `active === true`, `closed !== true`); drop events with
+  zero eligible children.
+- When categories are active, keep only events whose `tags[].id` intersects the
+  selected `tag_id`s (OR) before surfacing (Decision 6).
+- Preserve upstream event order as relevance.
 
 **Errors**: non-2xx → throw `Polymarket Gamma API returned <status>`; empty `q`
-→ caller must not send the request (treat blank as browse mode).
+→ caller must not send the request (blank = browse mode).
 
 ---
 
-## 2. Category browse — `GET /markets`
+## 2. Category / top browse — `GET /events`
 
-**Purpose**: list active, condition-bearing markets, optionally by category,
-ordered by volume (replaces the broken `tag_slug=`).
+**Purpose**: list active events (with nested markets), optionally by category,
+ordered by volume (replaces the broken `/markets?tag_slug=`).
 
 **Request params**:
 | param       | value |
 |-------------|-------|
-| `tag_id`    | numeric category id (omit for default top markets) |
+| `tag_id`    | numeric category id (omit for default top events) |
 | `active`    | `true` |
 | `closed`    | `false` |
 | `order`     | `volume` |
 | `ascending` | `false` |
 | `limit`     | e.g. `12` |
 
-Example: `GET /markets?tag_id=1&active=true&closed=false&order=volume&ascending=false&limit=12`
+Example: `GET /events?tag_id=1&active=true&closed=false&order=volume&ascending=false&limit=12`
 
-**Response (200)**: `Market[]` (or `{ data: Market[] }`) — normalize the same way;
-each has `conditionId`, `question`, `active`, `closed`, `volume`, `endDate`, …
+**Response (200)**: `Event[]` (or `{ data: Event[] }`) — same `Event`/`Market`
+shape as §1; events carry `tags`, `volume`/`volume24hr`, nested `markets[]`.
 
 **Consumer rules**:
-- Single category → one request. Multiple categories → one request per `tag_id`
-  in parallel, merge + de-dupe by `conditionId`, re-sort by volume, cap at
-  `limit` (Decision 5).
-- Apply the same surfaceable filter as search.
+- No category → one request (default top events).
+- One category → one request with `tag_id`.
+- Multiple categories → one request per `tag_id` in parallel, merge + de-dupe by
+  **event `id`**, re-sort by volume, cap at `limit` (Decision 5, OR semantics).
+- Apply the same per-market surfaceable filter and drop empty events as §1.
 
 ---
 
@@ -76,7 +79,7 @@ each has `conditionId`, `question`, `active`, `closed`, `volume`, `endDate`, …
 Example: `GET /tags/slug/pop-culture` → `{ "id": "596", "label": "Culture",
 "slug": "pop-culture", … }`
 
-**Verified seed mapping** (fallback if resolution is skipped/fails):
+**Verified seed mapping** (fallback / hermetic-test seed):
 
 | slug          | tag_id |
 |---------------|--------|
@@ -87,29 +90,32 @@ Example: `GET /tags/slug/pop-culture` → `{ "id": "596", "label": "Culture",
 | `business`    | `107`  |
 | `tech`        | `1401` |
 
-**Consumer rules**: resolve once, memoize in module scope; prefer the seed map
-to avoid a network round-trip (and to keep tests hermetic). A slug with no
-resolvable id applies no filter for that slug and yields an empty state rather
-than the default list.
+**Consumer rules**: prefer the seed map; resolve via `/tags/slug` only if
+unseeded; memoize in module scope. A slug with no resolvable id applies no filter
+for that slug.
 
 ---
 
 ## Contract test obligations
 
-Each obligation below is asserted in Vitest by mocking `fetch` (`vi.stubGlobal`)
-and inspecting the requested URL + handling the canned response:
+Asserted in Vitest by mocking `fetch` (`vi.stubGlobal`) and inspecting the
+requested URL + handling the canned response:
 
 - **C1**: search issues `GET …/public-search?q=<encoded query>&limit_per_type=…`
   (never `/markets?search=`).
-- **C2**: browse with a category issues `GET …/markets?...&tag_id=<numeric id>…`
-  using the verified mapping (never `tag_slug=`).
-- **C3**: only surfaceable markets (conditionId + active + !closed) appear;
-  closed/condition-less items in the payload are dropped.
-- **C4**: combined query+category keeps only markets from events tagged with a
-  selected `tag_id`.
-- **C5**: multi-category browse merges results from each `tag_id` request and
-  de-dupes by `conditionId`.
+- **C2**: browse issues `GET …/events?...` and, with a category, includes
+  `tag_id=<numeric id>` from the verified mapping (never `tag_slug=`, never
+  `/markets`).
+- **C3**: events are normalized with only surfaceable child markets
+  (conditionId + active + !closed); events with zero eligible children are
+  dropped.
+- **C4**: combined query+category keeps only events whose `tags` include a
+  selected `tag_id` (OR across selected categories).
+- **C5**: multi-category browse fans out one request per `tag_id` and merges +
+  de-dupes events by `id`.
 - **C6**: a superseded in-flight request is aborted and never overwrites newer
   results.
 - **C7**: non-2xx and network failure surface an error string; aborts are
   swallowed silently.
+- **C8**: a multi-market event normalizes to one `NormalizedEvent` with N
+  children (grouping), and a single-market event to one child.

--- a/specs/013-polymarket-search-filter/contracts/gamma-api.md
+++ b/specs/013-polymarket-search-filter/contracts/gamma-api.md
@@ -1,0 +1,115 @@
+# External Contract: Polymarket Gamma API (consumed)
+
+The picker depends on these Gamma endpoints. Base URL comes from
+`config/networks.js` (`network.polymarket.gammaApiUrl`, default
+`https://gamma-api.polymarket.com`). Unauthenticated. All requests send
+`Accept: application/json`, use `AbortController`, and tolerate transient
+failure (surface an error + retry, never a stale list).
+
+Rate limit: the `/public-search` family is ~350 requests / 10s — debounce and
+abort superseded requests.
+
+---
+
+## 1. Keyword search — `GET /public-search`
+
+**Purpose**: relevance-ranked free-text search (replaces the broken
+`/markets?search=`).
+
+**Request params**:
+| param            | type   | value |
+|------------------|--------|-------|
+| `q`              | string | the trimmed user query (**required**; `query=` is rejected) |
+| `limit_per_type` | int    | result cap per type (e.g. `10`) |
+
+Example: `GET /public-search?q=knicks&limit_per_type=10`
+
+**Response (200)**: `{ "events": Event[], "pagination": {…} }`
+- `Event` includes `tags: Tag[]` and `markets: Market[]`.
+- `Market` includes `conditionId`, `question`, `active`, `closed`, `volume`,
+  `endDate`, `outcomes`, `outcomePrices`, `slug`, `image`/`icon`.
+
+**Consumer rules**:
+- Flatten `events[].markets[]`, normalize, and keep only surfaceable markets
+  (`conditionId` present, `active === true`, `closed !== true`).
+- When categories are active, first keep only events whose `tags[].id` intersects
+  the selected `tagId`s, then flatten (Decision 4).
+- Preserve upstream order as relevance.
+
+**Errors**: non-2xx → throw `Polymarket Gamma API returned <status>`; empty `q`
+→ caller must not send the request (treat blank as browse mode).
+
+---
+
+## 2. Category browse — `GET /markets`
+
+**Purpose**: list active, condition-bearing markets, optionally by category,
+ordered by volume (replaces the broken `tag_slug=`).
+
+**Request params**:
+| param       | value |
+|-------------|-------|
+| `tag_id`    | numeric category id (omit for default top markets) |
+| `active`    | `true` |
+| `closed`    | `false` |
+| `order`     | `volume` |
+| `ascending` | `false` |
+| `limit`     | e.g. `12` |
+
+Example: `GET /markets?tag_id=1&active=true&closed=false&order=volume&ascending=false&limit=12`
+
+**Response (200)**: `Market[]` (or `{ data: Market[] }`) — normalize the same way;
+each has `conditionId`, `question`, `active`, `closed`, `volume`, `endDate`, …
+
+**Consumer rules**:
+- Single category → one request. Multiple categories → one request per `tag_id`
+  in parallel, merge + de-dupe by `conditionId`, re-sort by volume, cap at
+  `limit` (Decision 5).
+- Apply the same surfaceable filter as search.
+
+---
+
+## 3. Category resolution — `GET /tags/slug/{slug}`
+
+**Purpose**: map a chip slug to its numeric `tag_id`.
+
+Example: `GET /tags/slug/pop-culture` → `{ "id": "596", "label": "Culture",
+"slug": "pop-culture", … }`
+
+**Verified seed mapping** (fallback if resolution is skipped/fails):
+
+| slug          | tag_id |
+|---------------|--------|
+| `politics`    | `2`    |
+| `sports`      | `1`    |
+| `crypto`      | `21`   |
+| `pop-culture` | `596`  |
+| `business`    | `107`  |
+| `tech`        | `1401` |
+
+**Consumer rules**: resolve once, memoize in module scope; prefer the seed map
+to avoid a network round-trip (and to keep tests hermetic). A slug with no
+resolvable id applies no filter for that slug and yields an empty state rather
+than the default list.
+
+---
+
+## Contract test obligations
+
+Each obligation below is asserted in Vitest by mocking `fetch` (`vi.stubGlobal`)
+and inspecting the requested URL + handling the canned response:
+
+- **C1**: search issues `GET …/public-search?q=<encoded query>&limit_per_type=…`
+  (never `/markets?search=`).
+- **C2**: browse with a category issues `GET …/markets?...&tag_id=<numeric id>…`
+  using the verified mapping (never `tag_slug=`).
+- **C3**: only surfaceable markets (conditionId + active + !closed) appear;
+  closed/condition-less items in the payload are dropped.
+- **C4**: combined query+category keeps only markets from events tagged with a
+  selected `tag_id`.
+- **C5**: multi-category browse merges results from each `tag_id` request and
+  de-dupes by `conditionId`.
+- **C6**: a superseded in-flight request is aborted and never overwrites newer
+  results.
+- **C7**: non-2xx and network failure surface an error string; aborts are
+  swallowed silently.

--- a/specs/013-polymarket-search-filter/contracts/polymarket-hooks.md
+++ b/specs/013-polymarket-search-filter/contracts/polymarket-hooks.md
@@ -1,63 +1,64 @@
 # Internal Contract: Picker Hooks & Component
 
-The UI contracts for the data hooks and the `PolymarketBrowser` component. These
-define the surface that tests target and that the two call sites
-(`FriendMarketsModal` inline, `Dashboard` feed) rely on. Backward compatibility
-with existing call-site props is required (FR-015).
+UI contracts for the data hooks and the `PolymarketBrowser` component — the
+surface tests target and that the two call sites (`FriendMarketsModal` inline,
+`Dashboard` feed) rely on. Backward compatibility with existing call-site props
+is required (FR-015). Both hooks now return **`NormalizedEvent[]`** (events with
+nested eligible markets) — see data-model.md.
 
 ---
 
 ## Hook: `usePolymarketSearch({ limit, categories })`
 
-Searches markets by free text, optionally constrained to categories.
+Searches events by free text, optionally constrained to categories.
 
 **Inputs**:
-- `limit?: number` — max results (default as today).
+- `limit?: number` — max events.
 - `categories?: string[]` — selected category **slugs**; when non-empty, results
-  are constrained to events tagged with those categories (Decision 4). *(New
-  input — additive; omitting it preserves global search.)*
+  are constrained to events tagged with those categories, OR semantics
+  (Decision 6). *(Additive input; omitting it preserves global search.)*
 
-**Returns** (unchanged keys; behavior corrected):
-- `results: NormalizedMarket[]` — surfaceable, relevance-ordered.
+**Returns**:
+- `results: NormalizedEvent[]` — surfaceable, relevance-ordered events.
 - `isLoading: boolean`, `error: string|null`, `lastQuery: string`.
 - `search(query): void` — debounced entry point.
-- `runSearch(query): Promise<void>` — immediate (used by retry/tests).
+- `runSearch(query): Promise<void>` — immediate (retry/tests).
 - `clear(): void`.
 
 **Behavioral contract**:
-- Uses `GET /public-search?q=…` (contract C1); blank/whitespace query → clears
-  results, fires no request.
-- Applies the surfaceable filter (C3) and, when `categories` non-empty, the tag
-  intersection (C4).
-- Single in-flight `AbortController`; superseded requests are aborted and
-  discarded (C6). Errors set `error` and clear `results`; aborts are silent (C7).
+- Uses `GET /public-search?q=…` (C1); blank/whitespace query → clears results,
+  fires no request.
+- Normalizes to events with only surfaceable children, drops empty events (C3,
+  C8); when `categories` non-empty, applies the tag intersection (C4).
+- Single in-flight `AbortController`; superseded requests aborted and discarded
+  (C6). Errors set `error` and clear `results`; aborts silent (C7).
 
 ---
 
 ## Hook: `usePolymarketTopMarkets({ categories, limit })`
 
-Browse top markets, optionally by category.
+Browse top events, optionally by category. (Name retained for call-site
+compatibility; now returns events.)
 
-**Inputs**:
-- `categories?: string[]` — category **slugs**.
-- `limit?: number`.
+**Inputs**: `categories?: string[]` (slugs), `limit?: number`.
 
-**Returns**: `{ results, isLoading, error, refresh }` (unchanged).
+**Returns**: `{ results: NormalizedEvent[], isLoading, error, refresh }`.
 
 **Behavioral contract**:
-- No categories → `GET /markets?…order=volume&ascending=false` (top markets).
-- One category → `GET /markets?tag_id=<numeric>…` (C2).
-- Multiple categories → parallel per-`tag_id` requests merged + de-duped by
-  `conditionId`, re-sorted by volume, capped at `limit` (C5).
-- Surfaceable filter applied (C3); abort on unmount/refresh.
+- No categories → `GET /events?…order=volume&ascending=false` (top events).
+- One category → `GET /events?tag_id=<numeric>…` (C2).
+- Multiple categories → parallel per-`tag_id` requests merged + de-duped by event
+  `id`, re-sorted by volume, capped at `limit` (C5, OR).
+- Per-market surfaceable filter + drop empty events (C3); abort on
+  unmount/refresh.
 
 ---
 
 ## Helper: `resolveCategoryTagId(slug): string`
 
-Maps a chip slug to a numeric `tag_id` using the verified seed map, memoized;
-falls back to `GET /tags/slug/{slug}` only if unseeded. Pure/synchronous for
-seeded slugs so tests need no network.
+Maps a chip slug to a numeric `tag_id` via the verified seed map (memoized);
+falls back to `GET /tags/slug/{slug}` only if unseeded. Synchronous for seeded
+slugs so tests need no network.
 
 ---
 
@@ -67,34 +68,49 @@ seeded slugs so tests need no network.
 selectedConditionId, className }` — same signature as today.
 
 **Behavioral contract (the fixes)**:
-- Passes `activeCategories` into **both** `usePolymarketTopMarkets` and
-  `usePolymarketSearch` (today only the former).
-- Toggling a category **does not clear** the query (remove the
-  `if (trimmedQuery) setQuery('')` line); query is preserved (FR-004).
+- Passes `activeCategories` into **both** hooks (today only the browse hook).
+- **Multi-select OR** chips: toggling adds/removes a slug; `Clear` resets;
+  toggling does **not** clear the query (remove `if (trimmedQuery) setQuery('')`)
+  (FR-002, FR-004).
+- With categories active, typing constrains search to them by default (FR-003).
 - Exactly **one** debounce drives search (~300–350ms); the hook-level second
-  debounce is removed (FR-009). No double-fire.
-- Mode selection: `trimmedQuery` non-empty → search results; else → browse.
+  debounce is removed (FR-009).
+- Mode: `trimmedQuery` non-empty → search; else → browse.
+- **Event-grouped rendering** (FR-017, Decision 10): one row per
+  `NormalizedEvent`. An event with >1 eligible market renders an expand toggle
+  (`aria-expanded`); expanding lists child markets (label = `market.label`,
+  i.e. `groupItemTitle`) each selectable. An event with exactly one market
+  selects that market directly on row click (no expand). `expandedEventIds`
+  tracks open rows.
 - Renders exactly one of: loading (skeletons, `aria-busy`), error
   (`role="alert"` + Retry), empty (distinct copy for search-empty vs
-  category-empty vs no-markets), or the results list (FR-011/012).
-- Results keyed by `conditionId`; selecting calls `onSelectMarket(market)`
-  (FR-014). `selectedConditionId` still marks the active card.
-- Accessibility preserved: labeled search input, `role="group"` filter set,
-  `aria-pressed` chips, `role="alert"` error, `aria-busy` loading; a vitest-axe
+  category-empty vs no-markets), or the event list (FR-011/012).
+- Events keyed by `id`; child markets keyed by `conditionId`. Selecting a child
+  calls `onSelectMarket(market)` (FR-014); `selectedConditionId` highlights the
+  matching child.
+- Accessibility preserved/extended: labeled search input, `role="group"` filter
+  set, `aria-pressed` chips, expand toggle with `aria-expanded`, keyboard-
+  navigable sub-markets, `role="alert"` error, `aria-busy` loading; vitest-axe
   assertion guards it.
 
 ---
 
 ## Component test obligations (Vitest + @testing-library/react)
 
-- **T1 (US1)**: typing a term shows only relevant markets; an obviously relevant
-  market is near the top; mock asserts `/public-search?q=` was called.
-- **T2 (US2)**: selecting a category narrows results; selecting a different
-  category changes the set; mock asserts distinct `tag_id` requests.
+- **T1 (US1)**: typing a term shows only relevant events; an obviously relevant
+  event is near the top; mock asserts `/public-search?q=` was called.
+- **T2 (US2)**: selecting a category narrows results; selecting a second category
+  shows the union (OR); mock asserts a `tag_id` request per selected category.
 - **T3 (US3)**: with a query active, toggling a category preserves the typed
-  query and constrains results; removing the category broadens back to the query.
-- **T4 (US4)**: loading, empty (search vs category), and error states each render
+  query and constrains results; removing the category broadens back; selecting a
+  category first then typing also constrains (default).
+- **T4 (US4)**: loading, empty (search vs category), and error states render
   distinctly; Retry re-issues the correct request; no stale list on error.
 - **T5**: superseded request never overwrites newer results (race).
-- **T6**: only surfaceable markets render (closed/condition-less dropped).
-- **T7 (a11y)**: vitest-axe finds no violations in the picker's main states.
+- **T6**: only surfaceable child markets render; events with no eligible children
+  are dropped.
+- **T7 (US1/FR-017)**: a multi-sub-market event renders as one expandable row;
+  expanding reveals children; selecting a child emits its `conditionId`. A
+  single-market event selects directly without an expand step.
+- **T8 (a11y)**: vitest-axe finds no violations across the picker's main states
+  (collapsed list, expanded event, empty, error).

--- a/specs/013-polymarket-search-filter/contracts/polymarket-hooks.md
+++ b/specs/013-polymarket-search-filter/contracts/polymarket-hooks.md
@@ -1,0 +1,100 @@
+# Internal Contract: Picker Hooks & Component
+
+The UI contracts for the data hooks and the `PolymarketBrowser` component. These
+define the surface that tests target and that the two call sites
+(`FriendMarketsModal` inline, `Dashboard` feed) rely on. Backward compatibility
+with existing call-site props is required (FR-015).
+
+---
+
+## Hook: `usePolymarketSearch({ limit, categories })`
+
+Searches markets by free text, optionally constrained to categories.
+
+**Inputs**:
+- `limit?: number` — max results (default as today).
+- `categories?: string[]` — selected category **slugs**; when non-empty, results
+  are constrained to events tagged with those categories (Decision 4). *(New
+  input — additive; omitting it preserves global search.)*
+
+**Returns** (unchanged keys; behavior corrected):
+- `results: NormalizedMarket[]` — surfaceable, relevance-ordered.
+- `isLoading: boolean`, `error: string|null`, `lastQuery: string`.
+- `search(query): void` — debounced entry point.
+- `runSearch(query): Promise<void>` — immediate (used by retry/tests).
+- `clear(): void`.
+
+**Behavioral contract**:
+- Uses `GET /public-search?q=…` (contract C1); blank/whitespace query → clears
+  results, fires no request.
+- Applies the surfaceable filter (C3) and, when `categories` non-empty, the tag
+  intersection (C4).
+- Single in-flight `AbortController`; superseded requests are aborted and
+  discarded (C6). Errors set `error` and clear `results`; aborts are silent (C7).
+
+---
+
+## Hook: `usePolymarketTopMarkets({ categories, limit })`
+
+Browse top markets, optionally by category.
+
+**Inputs**:
+- `categories?: string[]` — category **slugs**.
+- `limit?: number`.
+
+**Returns**: `{ results, isLoading, error, refresh }` (unchanged).
+
+**Behavioral contract**:
+- No categories → `GET /markets?…order=volume&ascending=false` (top markets).
+- One category → `GET /markets?tag_id=<numeric>…` (C2).
+- Multiple categories → parallel per-`tag_id` requests merged + de-duped by
+  `conditionId`, re-sorted by volume, capped at `limit` (C5).
+- Surfaceable filter applied (C3); abort on unmount/refresh.
+
+---
+
+## Helper: `resolveCategoryTagId(slug): string`
+
+Maps a chip slug to a numeric `tag_id` using the verified seed map, memoized;
+falls back to `GET /tags/slug/{slug}` only if unseeded. Pure/synchronous for
+seeded slugs so tests need no network.
+
+---
+
+## Component: `PolymarketBrowser` (props unchanged)
+
+`{ onSelectMarket, variant, defaultCategories, limit, showFilters,
+selectedConditionId, className }` — same signature as today.
+
+**Behavioral contract (the fixes)**:
+- Passes `activeCategories` into **both** `usePolymarketTopMarkets` and
+  `usePolymarketSearch` (today only the former).
+- Toggling a category **does not clear** the query (remove the
+  `if (trimmedQuery) setQuery('')` line); query is preserved (FR-004).
+- Exactly **one** debounce drives search (~300–350ms); the hook-level second
+  debounce is removed (FR-009). No double-fire.
+- Mode selection: `trimmedQuery` non-empty → search results; else → browse.
+- Renders exactly one of: loading (skeletons, `aria-busy`), error
+  (`role="alert"` + Retry), empty (distinct copy for search-empty vs
+  category-empty vs no-markets), or the results list (FR-011/012).
+- Results keyed by `conditionId`; selecting calls `onSelectMarket(market)`
+  (FR-014). `selectedConditionId` still marks the active card.
+- Accessibility preserved: labeled search input, `role="group"` filter set,
+  `aria-pressed` chips, `role="alert"` error, `aria-busy` loading; a vitest-axe
+  assertion guards it.
+
+---
+
+## Component test obligations (Vitest + @testing-library/react)
+
+- **T1 (US1)**: typing a term shows only relevant markets; an obviously relevant
+  market is near the top; mock asserts `/public-search?q=` was called.
+- **T2 (US2)**: selecting a category narrows results; selecting a different
+  category changes the set; mock asserts distinct `tag_id` requests.
+- **T3 (US3)**: with a query active, toggling a category preserves the typed
+  query and constrains results; removing the category broadens back to the query.
+- **T4 (US4)**: loading, empty (search vs category), and error states each render
+  distinctly; Retry re-issues the correct request; no stale list on error.
+- **T5**: superseded request never overwrites newer results (race).
+- **T6**: only surfaceable markets render (closed/condition-less dropped).
+- **T7 (a11y)**: vitest-axe finds no violations in the picker's main states.

--- a/specs/013-polymarket-search-filter/data-model.md
+++ b/specs/013-polymarket-search-filter/data-model.md
@@ -1,0 +1,101 @@
+# Phase 1 Data Model: Polymarket Search & Category Filter
+
+This feature has no persistent storage. The "data model" is the set of in-memory
+shapes that flow through the picker: the normalized market, the category
+definition, and the derived picker state. Field names below match the existing
+`normaliseGammaMarket` output so changes stay minimal.
+
+## Entity: NormalizedMarket
+
+A single Polymarket market eligible to back a wager. Produced by
+`normaliseGammaMarket` from a Gamma market object (whether obtained via
+`/public-search` event flattening or `/markets` browse).
+
+| Field         | Type            | Source (Gamma)                         | Notes |
+|---------------|-----------------|----------------------------------------|-------|
+| `id`          | string\|null    | `id` / `marketId`                      | display key fallback |
+| `slug`        | string\|null    | `slug`                                 | |
+| `question`    | string          | `question` / `title` / `name`          | shown on card; matched by search |
+| `description` | string          | `description`                          | |
+| `category`    | string\|array\|null | `category` / `categories` / event `tags` | display tag |
+| `conditionId` | string (bytes32)\|null | `conditionId` / `condition_id`    | **required** to link; used as list key |
+| `endDate`     | string\|null    | `endDate` / `end_date_iso`             | |
+| `volume`      | number\|null    | `volume`                               | browse sort key; shown as "vol" |
+| `liquidity`   | number\|null    | `liquidity`                            | |
+| `active`      | boolean         | `active` (default true)                | eligibility |
+| `closed`      | boolean         | `closed` (default false)               | eligibility |
+| `image`       | string\|null    | `image` / `icon`                       | |
+| `outcomes`    | `{name,price}[]`| parsed `outcomes`/`outcomePrices`      | |
+
+**Validation / eligibility rule** (Decision 6): a NormalizedMarket is
+**surfaceable** iff `conditionId != null` AND `active === true` AND
+`closed !== true`. Non-surfaceable markets are dropped before ranking/display.
+
+**Identity**: `conditionId` is the stable identity used for de-duplication
+(multi-category merge) and as the React list `key`.
+
+## Entity: CategoryFilter
+
+A user-selectable topic chip. Static definitions plus a resolved upstream ID.
+
+| Field    | Type   | Notes |
+|----------|--------|-------|
+| `slug`   | string | stable key, e.g. `pop-culture` |
+| `label`  | string | user-facing, e.g. `Pop Culture` |
+| `tagId`  | string\|number | numeric Gamma tag id (resolved/seeded) |
+
+**Seed mapping** (verified, Decision 3): politics→2, sports→1, crypto→21,
+pop-culture→596, business→107, tech→1401.
+
+**Resolution rule**: `tagId` is taken from the seed map; if absent it is fetched
+once via `GET /tags/slug/{slug}` and memoized in module scope. A category with no
+resolvable `tagId` is treated as "no filter applied" for that slug (and surfaced
+as empty rather than silently returning the default list).
+
+## Entity: PickerState (derived, in-component)
+
+The observable state of the picker, derived from inputs. Drives which request is
+issued and which view is shown.
+
+| Field             | Type            | Derivation |
+|-------------------|-----------------|-----------|
+| `query`          | string          | controlled input; `trimmedQuery = query.trim()` |
+| `activeCategories`| string[] (slugs)| user toggles, falling back to prop/saved prefs until touched |
+| `mode`           | `'search'`\|`'browse'` | `trimmedQuery.length > 0 ? 'search' : 'browse'` |
+| `results`        | NormalizedMarket[] | surfaceable + ranked (see below) |
+| `status`         | `'idle'`\|`'loading'`\|`'empty'`\|`'error'`\|`'ready'` | one at a time |
+| `error`          | string\|null    | last request error message |
+
+**State transitions (request selection)**:
+
+```
+mode = browse, categories = []        → GET /markets?…order=volume (top markets)
+mode = browse, categories = [a,b]     → parallel GET /markets?tag_id=<a|b>…, merge by conditionId
+mode = search, categories = []        → GET /public-search?q=…, flatten markets
+mode = search, categories = [a,b]     → GET /public-search?q=…, keep events whose tags ∈ {a,b}, flatten markets
+```
+
+**Query/filter interaction rules** (FR-003/004/005):
+- Toggling a category MUST NOT clear `query` (removes the current
+  `if (trimmedQuery) setQuery('')` behavior).
+- Clearing `query` returns to the active category's browse view (or default
+  top markets if none selected).
+- Clearing categories returns to default top markets while preserving `query`.
+
+**Ranking rule** (FR-008, Decision 8):
+- browse: sort surfaceable markets by `volume` desc.
+- search: preserve upstream relevance order; optional saved-pref/history boost as
+  a tie-breaker only, never reordering above relevance.
+
+**Concurrency rule** (FR-009/010, Decision 7): a single debounce (~300–350ms)
+and a single in-flight `AbortController`; results from a superseded request are
+discarded (never written to `results`).
+
+## Relationships
+
+- A `CategoryFilter.tagId` selects `NormalizedMarket`s via the upstream tag, OR
+  (in search mode) constrains which events' markets are surfaced by
+  `event.tags ∋ tagId`.
+- `PickerState.results` is a filtered+ranked list of `NormalizedMarket`.
+- Selecting a `NormalizedMarket` emits it via `onSelectMarket(market)`; only its
+  `conditionId` (and metadata) feed the unchanged linked-market form downstream.

--- a/specs/013-polymarket-search-filter/data-model.md
+++ b/specs/013-polymarket-search-filter/data-model.md
@@ -1,101 +1,125 @@
 # Phase 1 Data Model: Polymarket Search & Category Filter
 
 This feature has no persistent storage. The "data model" is the set of in-memory
-shapes that flow through the picker: the normalized market, the category
-definition, and the derived picker state. Field names below match the existing
-`normaliseGammaMarket` output so changes stay minimal.
+shapes that flow through the picker: the normalized **event** (grouping its
+markets), the normalized **market** (sub-market), the category definition, and
+the derived picker state. Field names match the existing `normaliseGammaMarket`
+output where possible to keep changes minimal.
 
-## Entity: NormalizedMarket
+## Entity: NormalizedEvent
 
-A single Polymarket market eligible to back a wager. Produced by
-`normaliseGammaMarket` from a Gamma market object (whether obtained via
-`/public-search` event flattening or `/markets` browse).
+A real-world happening (game/question) grouping one or more eligible markets.
+One row in the picker. Produced from a Gamma `Event` (from `/public-search` or
+`/events`).
 
-| Field         | Type            | Source (Gamma)                         | Notes |
+| Field      | Type                | Source (Gamma event)        | Notes |
+|------------|---------------------|-----------------------------|-------|
+| `id`       | string              | `id`                        | grouping/dedup identity; React key |
+| `title`    | string              | `title`                     | row heading |
+| `slug`     | string\|null        | `slug`                      | |
+| `tagIds`   | string[]            | `tags[].id`                 | category membership (search constraint) |
+| `category` | string\|null        | first `tags[].label`        | display chip |
+| `volume`   | number\|null        | `volume`                    | browse sort key |
+| `image`    | string\|null        | `image`/`icon`              | |
+| `markets`  | NormalizedMarket[]  | eligible `markets[]`        | ≥1 required to surface |
+
+**Validation / surface rule** (Decision 7, 10): an event is **surfaceable** iff
+it has ≥1 surfaceable `NormalizedMarket`. Non-surfaceable events are dropped.
+
+**Identity**: `id` (used for multi-category merge dedup and as the React key).
+
+## Entity: NormalizedMarket (sub-market)
+
+A single market under an event — what the user actually links a wager to.
+Produced by `normaliseGammaMarket` (reused).
+
+| Field         | Type            | Source (Gamma market)                  | Notes |
 |---------------|-----------------|----------------------------------------|-------|
-| `id`          | string\|null    | `id` / `marketId`                      | display key fallback |
+| `id`          | string\|null    | `id` / `marketId`                      | |
 | `slug`        | string\|null    | `slug`                                 | |
-| `question`    | string          | `question` / `title` / `name`          | shown on card; matched by search |
+| `question`    | string          | `question` / `title` / `name`          | sub-market label |
+| `label`       | string          | `groupItemTitle` \|\| `question`       | short label when expanded (e.g. "Spain") |
 | `description` | string          | `description`                          | |
-| `category`    | string\|array\|null | `category` / `categories` / event `tags` | display tag |
-| `conditionId` | string (bytes32)\|null | `conditionId` / `condition_id`    | **required** to link; used as list key |
+| `conditionId` | string (bytes32)\|null | `conditionId` / `condition_id`    | **required** to link |
 | `endDate`     | string\|null    | `endDate` / `end_date_iso`             | |
-| `volume`      | number\|null    | `volume`                               | browse sort key; shown as "vol" |
+| `volume`      | number\|null    | `volume`                               | sub-market sort key; shown as "vol" |
 | `liquidity`   | number\|null    | `liquidity`                            | |
 | `active`      | boolean         | `active` (default true)                | eligibility |
 | `closed`      | boolean         | `closed` (default false)               | eligibility |
 | `image`       | string\|null    | `image` / `icon`                       | |
 | `outcomes`    | `{name,price}[]`| parsed `outcomes`/`outcomePrices`      | |
 
-**Validation / eligibility rule** (Decision 6): a NormalizedMarket is
-**surfaceable** iff `conditionId != null` AND `active === true` AND
-`closed !== true`. Non-surfaceable markets are dropped before ranking/display.
-
-**Identity**: `conditionId` is the stable identity used for de-duplication
-(multi-category merge) and as the React list `key`.
+**Surface rule** (Decision 7): surfaceable iff `conditionId != null` AND
+`active === true` AND `closed !== true`. Filtered before its event is assembled.
 
 ## Entity: CategoryFilter
 
-A user-selectable topic chip. Static definitions plus a resolved upstream ID.
+A user-selectable topic chip with a resolved upstream ID.
 
-| Field    | Type   | Notes |
-|----------|--------|-------|
-| `slug`   | string | stable key, e.g. `pop-culture` |
-| `label`  | string | user-facing, e.g. `Pop Culture` |
-| `tagId`  | string\|number | numeric Gamma tag id (resolved/seeded) |
+| Field   | Type           | Notes |
+|---------|----------------|-------|
+| `slug`  | string         | stable key, e.g. `pop-culture` |
+| `label` | string         | user-facing, e.g. `Pop Culture` |
+| `tagId` | string\|number | numeric Gamma tag id (seeded/resolved) |
 
 **Seed mapping** (verified, Decision 3): politics→2, sports→1, crypto→21,
 pop-culture→596, business→107, tech→1401.
 
-**Resolution rule**: `tagId` is taken from the seed map; if absent it is fetched
-once via `GET /tags/slug/{slug}` and memoized in module scope. A category with no
-resolvable `tagId` is treated as "no filter applied" for that slug (and surfaced
-as empty rather than silently returning the default list).
+**Resolution rule**: from the seed map; otherwise fetched once via
+`GET /tags/slug/{slug}` and memoized. Categories are **multi-selectable**;
+selected categories combine with **OR** (Decision 4).
 
 ## Entity: PickerState (derived, in-component)
 
-The observable state of the picker, derived from inputs. Drives which request is
-issued and which view is shown.
-
-| Field             | Type            | Derivation |
-|-------------------|-----------------|-----------|
-| `query`          | string          | controlled input; `trimmedQuery = query.trim()` |
-| `activeCategories`| string[] (slugs)| user toggles, falling back to prop/saved prefs until touched |
+| Field             | Type                | Derivation |
+|-------------------|---------------------|-----------|
+| `query`          | string              | controlled input; `trimmedQuery = query.trim()` |
+| `activeCategories`| string[] (slugs)    | user toggles (multi-select), falling back to prop/saved prefs until touched |
 | `mode`           | `'search'`\|`'browse'` | `trimmedQuery.length > 0 ? 'search' : 'browse'` |
-| `results`        | NormalizedMarket[] | surfaceable + ranked (see below) |
+| `expandedEventIds`| Set<string>        | which event rows are expanded |
+| `results`        | NormalizedEvent[]   | surfaceable + ranked |
 | `status`         | `'idle'`\|`'loading'`\|`'empty'`\|`'error'`\|`'ready'` | one at a time |
-| `error`          | string\|null    | last request error message |
+| `error`          | string\|null        | last request error message |
 
-**State transitions (request selection)**:
+**Request selection (state transitions)**:
 
 ```
-mode = browse, categories = []        → GET /markets?…order=volume (top markets)
-mode = browse, categories = [a,b]     → parallel GET /markets?tag_id=<a|b>…, merge by conditionId
-mode = search, categories = []        → GET /public-search?q=…, flatten markets
-mode = search, categories = [a,b]     → GET /public-search?q=…, keep events whose tags ∈ {a,b}, flatten markets
+mode=browse, categories=[]        → GET /events?active=true&closed=false&order=volume&ascending=false (top events)
+mode=browse, categories=[a,b]     → parallel GET /events?tag_id=<a|b>…, merge events by id (OR)
+mode=search, categories=[]        → GET /public-search?q=… (events, global)
+mode=search, categories=[a,b]     → GET /public-search?q=…, keep events whose tagIds ∩ {a,b} ≠ ∅ (OR)
 ```
 
-**Query/filter interaction rules** (FR-003/004/005):
-- Toggling a category MUST NOT clear `query` (removes the current
-  `if (trimmedQuery) setQuery('')` behavior).
-- Clearing `query` returns to the active category's browse view (or default
-  top markets if none selected).
-- Clearing categories returns to default top markets while preserving `query`.
+**Query/filter interaction rules** (FR-002/003/004/005):
+- Categories are multi-select; toggling adds/removes a slug (OR semantics).
+- Toggling a category MUST NOT clear `query` (remove the existing
+  `if (trimmedQuery) setQuery('')`).
+- With categories active, typing a query constrains the search to those
+  categories by default (FR-003).
+- Clearing `query` → active categories' browse view (or top events if none).
+- Clearing categories → top events, query preserved.
 
-**Ranking rule** (FR-008, Decision 8):
-- browse: sort surfaceable markets by `volume` desc.
-- search: preserve upstream relevance order; optional saved-pref/history boost as
-  a tie-breaker only, never reordering above relevance.
+**Grouping / expand rules** (FR-017, Decision 10):
+- Render one row per `NormalizedEvent`.
+- Event with >1 market → expandable; toggling adds/removes its `id` in
+  `expandedEventIds`; expanded list shows child markets (label = market.label).
+- Event with exactly 1 market → selecting the row selects that market (no
+  expand affordance).
+- Selecting any child market → `onSelectMarket(market)`; `selectedConditionId`
+  highlights the matching child.
 
-**Concurrency rule** (FR-009/010, Decision 7): a single debounce (~300–350ms)
-and a single in-flight `AbortController`; results from a superseded request are
-discarded (never written to `results`).
+**Ranking** (FR-008, Decision 9): browse → events by volume desc; search →
+upstream relevance order (optional pref/history tie-break only). Children sorted
+by volume desc.
+
+**Concurrency** (FR-009/010, Decision 8): one debounce (~300–350ms), one
+in-flight `AbortController`; superseded results discarded.
 
 ## Relationships
 
-- A `CategoryFilter.tagId` selects `NormalizedMarket`s via the upstream tag, OR
-  (in search mode) constrains which events' markets are surfaced by
-  `event.tags ∋ tagId`.
-- `PickerState.results` is a filtered+ranked list of `NormalizedMarket`.
-- Selecting a `NormalizedMarket` emits it via `onSelectMarket(market)`; only its
-  `conditionId` (and metadata) feed the unchanged linked-market form downstream.
+- `NormalizedEvent` 1→N `NormalizedMarket` (only eligible children).
+- `CategoryFilter.tagId` selects events via the upstream tag (browse) or
+  constrains search events by `tagIds` membership (search).
+- `PickerState.results` is a filtered+ranked list of `NormalizedEvent`.
+- Selecting a child `NormalizedMarket` emits it via `onSelectMarket(market)`;
+  only its `conditionId` (+ metadata) feeds the unchanged linked-market form.

--- a/specs/013-polymarket-search-filter/plan.md
+++ b/specs/013-polymarket-search-filter/plan.md
@@ -1,0 +1,139 @@
+# Implementation Plan: Polymarket Search & Category Filter
+
+**Branch**: `claude/polymarket-search-filter-z0tu7n` | **Date**: 2026-06-13 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/013-polymarket-search-filter/spec.md`
+
+## Summary
+
+The "Linked Polymarket Event" picker's search and category filters are broken
+because the integration calls the Gamma API with parameters it ignores:
+free-text search is sent to `/markets?search=` (unsupported — the endpoint
+returns a default set regardless), and category filtering uses `tag_slug=`
+(unsupported — also ignored). The fix re-points the data layer at the correct
+Gamma endpoints — `/public-search?q=<term>` for relevance-ranked search and
+`/markets?tag_id=<numeric id>` for category browse — maps the six user-facing
+category labels to their real numeric tag IDs, threads the active category into
+search so users can search within a category, preserves the typed query when
+toggling filters, collapses the double debounce into one, and adds the missing
+Vitest coverage. Scope is the frontend picker (`PolymarketBrowser`) and its data
+hooks (`usePolymarketSearch.js`); no contract, on-chain, or new-oracle changes.
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES2022), React 18 function components + hooks
+
+**Primary Dependencies**: React, Vite 7, wagmi 3 (`useChainId`); data via the
+public Polymarket Gamma REST API (`https://gamma-api.polymarket.com`, no auth)
+reached with the browser `fetch` + `AbortController`
+
+**Storage**: None server-side. Client-only state (React `useState`/`useMemo`);
+existing user preferences (saved categories) via `useUserPreferences`; an
+in-memory (module-scoped) cache for the category-slug→tag_id map
+
+**Testing**: Vitest 4 + @testing-library/react + jsdom; accessibility via
+vitest-axe; `fetch` mocked with `vi.stubGlobal` (no MSW in this repo). Setup at
+`frontend/src/test/setup.js`
+
+**Target Platform**: Modern evergreen browsers (mobile + desktop web app served
+at fairwins.app/app)
+
+**Project Type**: Web application — frontend feature within an existing
+React + Vite app (`frontend/`)
+
+**Performance Goals**: Results update within ~1s of the user pausing typing
+(single debounce ≈ 300–350ms + network); no flicker from out-of-order responses;
+no perceptible jank on the picker's result list
+
+**Constraints**: Gamma API is unauthenticated and rate-limited (the
+`/public-search` family is ~350 req / 10s); requests MUST be debounced and
+aborted on supersession. Only active, non-closed, condition-bearing markets may
+be shown (eligible to back a wager). WCAG 2.1 AA per constitution Principle V.
+Network config (Gamma base URL) comes from `config/networks.js`, never hardcoded
+in components
+
+**Scale/Scope**: Two call sites (wager-creation modal `inline` variant and
+dashboard `feed` variant); one component + one hooks module changed; ~10–12
+results per query; six category chips
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Security-First Smart Contracts**: N/A — no `contracts/` changes. No
+  on-chain, fund-custody, access-control, or oracle-resolution code is touched.
+  The selected `conditionId` continues to flow into the existing, unchanged
+  linked-market form. ✅ PASS
+- **II. Test-First & Comprehensive Coverage**: This feature is currently
+  untested. The plan mandates Vitest unit tests for the data hooks (correct
+  endpoints/params, normalization, eligibility filtering, abort/supersession,
+  error states) and component tests for the picker (relevant results, category
+  narrowing, combined query+category, query-preserved-on-toggle, empty/loading/
+  error states). Tests are written alongside the behavior and must pass in CI.
+  ✅ PASS (enforced by FR-016 and Phase 1 contracts)
+- **III. Honest State, No Mocks in Shipped Paths**: The fix replaces a silently
+  wrong integration with one that reflects real upstream data. No mock/stub data
+  in production paths; mocks live only in Vitest. Only genuinely
+  active/tradeable/unresolved markets are surfaced (no implied finality). Gamma
+  base URL stays network-scoped via `config/networks.js`. ✅ PASS
+- **IV. Fail Loudly in CI**: No `continue-on-error` added; new tests and lint run
+  in the existing frontend CI jobs and must pass. ✅ PASS
+- **V. Accessible, Consistent Frontend**: Existing ARIA roles on the picker
+  (search input label, `role="group"` filters, `aria-pressed` chips,
+  `role="alert"` errors, `aria-busy` loading) are preserved and extended to new
+  states; a vitest-axe check is added. ESLint must stay clean. Same behavior
+  across both call sites (FR-015). ✅ PASS
+
+**Result**: PASS — no violations, Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/013-polymarket-search-filter/
+├── plan.md              # This file (/speckit-plan command output)
+├── research.md          # Phase 0 output — Gamma API decisions
+├── data-model.md        # Phase 1 output — picker/market entities & state
+├── quickstart.md        # Phase 1 output — manual + automated validation guide
+├── contracts/
+│   ├── gamma-api.md     # External: Gamma endpoints/params this feature relies on
+│   └── polymarket-hooks.md  # Internal: hook + component interface contracts
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit-specify)
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/
+├── src/
+│   ├── components/
+│   │   └── fairwins/
+│   │       ├── PolymarketBrowser.jsx      # MODIFY — query/filter wiring, debounce,
+│   │       │                              #   pass category into search, preserve query
+│   │       ├── PolymarketBrowser.css      # (unchanged unless new state needs styling)
+│   │       ├── FriendMarketsModal.jsx     # call site (inline) — no API change expected
+│   │       └── Dashboard.jsx              # call site (feed) — no API change expected
+│   ├── hooks/
+│   │   └── usePolymarketSearch.js         # MODIFY — /public-search?q, tag_id mapping,
+│   │                                      #   eligibility filter, category-aware search,
+│   │                                      #   slug→tag_id resolver/cache
+│   ├── config/
+│   │   └── networks.js                    # READ — Gamma base URL (already present)
+│   └── test/
+│       ├── usePolymarketSearch.test.js    # NEW — hook unit tests
+│       ├── usePolymarketTopMarkets.test.js# NEW — browse hook unit tests
+│       └── PolymarketBrowser.test.jsx     # NEW — component search/filter tests
+```
+
+**Structure Decision**: Existing web-app layout under `frontend/src`. The change
+is localized to one component and one hooks module, with new sibling test files
+under `frontend/src/test/` (the repo's established Vitest location). No new
+directories, packages, or services are introduced (YAGNI per Principle/Workflow
+§4).
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally empty.

--- a/specs/013-polymarket-search-filter/plan.md
+++ b/specs/013-polymarket-search-filter/plan.md
@@ -12,12 +12,18 @@ free-text search is sent to `/markets?search=` (unsupported — the endpoint
 returns a default set regardless), and category filtering uses `tag_slug=`
 (unsupported — also ignored). The fix re-points the data layer at the correct
 Gamma endpoints — `/public-search?q=<term>` for relevance-ranked search and
-`/markets?tag_id=<numeric id>` for category browse — maps the six user-facing
-category labels to their real numeric tag IDs, threads the active category into
-search so users can search within a category, preserves the typed query when
-toggling filters, collapses the double debounce into one, and adds the missing
-Vitest coverage. Scope is the frontend picker (`PolymarketBrowser`) and its data
-hooks (`usePolymarketSearch.js`); no contract, on-chain, or new-oracle changes.
+`/events?tag_id=<numeric id>` for category browse (both return **events with
+nested markets**) — and presents results **grouped by event**: a game or
+question with many sub-markets (moneyline, spreads, over/unders) is one
+expandable row the user expands to pick a specific sub-market, instead of
+flooding the list (per clarification 2026-06-13). It maps the six user-facing
+category labels to their real numeric tag IDs, makes the category chips
+multi-select with OR semantics, threads the active category into search (an
+active category constrains the search by default), preserves the typed query
+when toggling filters, collapses the double debounce into one, and adds the
+missing Vitest coverage. Scope is the frontend picker (`PolymarketBrowser`) and
+its data hooks (`usePolymarketSearch.js`); no contract, on-chain, or new-oracle
+changes.
 
 ## Technical Context
 
@@ -111,15 +117,18 @@ frontend/
 ├── src/
 │   ├── components/
 │   │   └── fairwins/
-│   │       ├── PolymarketBrowser.jsx      # MODIFY — query/filter wiring, debounce,
-│   │       │                              #   pass category into search, preserve query
-│   │       ├── PolymarketBrowser.css      # (unchanged unless new state needs styling)
+│   │       ├── PolymarketBrowser.jsx      # MODIFY — event-grouped rows w/ expand state,
+│   │       │                              #   multi-select OR chips, query/filter wiring,
+│   │       │                              #   single debounce, pass category into search,
+│   │       │                              #   preserve query on toggle
+│   │       ├── PolymarketBrowser.css      # MODIFY — expandable event row + sub-market list
 │   │       ├── FriendMarketsModal.jsx     # call site (inline) — no API change expected
 │   │       └── Dashboard.jsx              # call site (feed) — no API change expected
 │   ├── hooks/
-│   │   └── usePolymarketSearch.js         # MODIFY — /public-search?q, tag_id mapping,
-│   │                                      #   eligibility filter, category-aware search,
-│   │                                      #   slug→tag_id resolver/cache
+│   │   └── usePolymarketSearch.js         # MODIFY — /public-search?q (search) +
+│   │                                      #   /events?tag_id (browse), event grouping,
+│   │                                      #   eligibility filter, category-constrained
+│   │                                      #   search, multi-tag merge, slug→tag_id cache
 │   ├── config/
 │   │   └── networks.js                    # READ — Gamma base URL (already present)
 │   └── test/

--- a/specs/013-polymarket-search-filter/quickstart.md
+++ b/specs/013-polymarket-search-filter/quickstart.md
@@ -1,0 +1,79 @@
+# Quickstart & Validation: Polymarket Search & Category Filter
+
+How to run and validate the feature end-to-end. Details live in
+[research.md](./research.md), [data-model.md](./data-model.md), and
+[contracts/](./contracts/); this file is the run/verify guide.
+
+## Prerequisites
+
+- Node + repo deps installed (`npm install` at repo root and in `frontend/` per
+  project setup).
+- A chain with Polymarket sidebets enabled (the picker self-gates on
+  `capabilities.polymarketSidebets`; it renders `null` otherwise).
+- Network access to `https://gamma-api.polymarket.com` (no auth/key needed).
+
+## Run the app
+
+```bash
+npm run frontend        # Vite dev server (from repo root)
+```
+
+Open the app, start creating a wager, and open the **Linked Polymarket Event**
+picker (inline variant). The dashboard **Top from Polymarket** feed exercises the
+browse (feed) variant.
+
+## Manual validation (maps to user stories)
+
+1. **Search relevance (US1)** — type `knicks`. **Expect**: only Knicks-related
+   markets (e.g. "Pacers vs. Knicks", spreads, over/unders); no album/GTA-VI
+   noise. Clearing the box returns to the top-markets list.
+2. **Category narrowing (US2)** — with no query, tap **Sports**. **Expect**: the
+   list changes to sports markets. Tap **Crypto**. **Expect**: a different,
+   crypto set (not the previous list). Tap **Clear**. **Expect**: default top
+   markets return.
+3. **Search within category (US3)** — type `lakers`, then toggle **Sports**.
+   **Expect**: the typed query is **preserved** (not wiped) and results reflect
+   both. Remove **Sports** → results broaden to the query alone.
+4. **Responsive + trustworthy (US4)** — type quickly; results update within ~1s
+   of pausing, no flicker/out-of-order. Simulate a failure (offline / block the
+   Gamma host in devtools) → an error with a **Retry** that re-issues the
+   request; never a stale list. A no-match query shows a distinct empty state.
+5. **Eligibility** — every listed market is active/unresolved and selectable;
+   selecting one links it to the wager (the downstream linked-market form
+   receives the `conditionId`).
+
+## Quick API sanity (optional, no app needed)
+
+```bash
+# Search must be relevant (uses q=, not search=)
+curl -s "https://gamma-api.polymarket.com/public-search?q=knicks&limit_per_type=5"
+
+# Category browse by numeric tag_id (Sports=1)
+curl -s "https://gamma-api.polymarket.com/markets?tag_id=1&active=true&closed=false&order=volume&ascending=false&limit=5"
+
+# Slug → tag_id mapping
+curl -s "https://gamma-api.polymarket.com/tags/slug/pop-culture"
+```
+
+## Automated tests
+
+```bash
+npm run test:frontend                                   # full frontend suite
+npx vitest run src/test/usePolymarketSearch.test.js \
+               src/test/usePolymarketTopMarkets.test.js \
+               src/test/PolymarketBrowser.test.jsx      # this feature
+```
+
+`fetch` is mocked via `vi.stubGlobal` (no MSW). The suite must cover contract
+obligations **C1–C7** ([gamma-api.md](./contracts/gamma-api.md)) and component
+obligations **T1–T7** ([polymarket-hooks.md](./contracts/polymarket-hooks.md)),
+including the regression fixture where searching `knicks` against the old code
+path would have returned GTA-VI markets.
+
+## Done / acceptance
+
+- Manual steps 1–5 pass; success criteria SC-001…SC-008 in
+  [spec.md](./spec.md) hold.
+- New Vitest files pass; `npm run lint` (frontend) clean; vitest-axe clean.
+- No `contracts/` (Solidity) or deployment changes; behavior identical across
+  both picker call sites.

--- a/specs/013-polymarket-search-filter/quickstart.md
+++ b/specs/013-polymarket-search-filter/quickstart.md
@@ -24,16 +24,19 @@ browse (feed) variant.
 
 ## Manual validation (maps to user stories)
 
-1. **Search relevance (US1)** — type `knicks`. **Expect**: only Knicks-related
-   markets (e.g. "Pacers vs. Knicks", spreads, over/unders); no album/GTA-VI
-   noise. Clearing the box returns to the top-markets list.
-2. **Category narrowing (US2)** — with no query, tap **Sports**. **Expect**: the
-   list changes to sports markets. Tap **Crypto**. **Expect**: a different,
-   crypto set (not the previous list). Tap **Clear**. **Expect**: default top
-   markets return.
+1. **Search relevance + grouping (US1/FR-017)** — type `knicks`. **Expect**:
+   only Knicks-related results; no album/GTA-VI noise. A game with many
+   sub-markets (moneyline/spreads/over-unders) appears as **one expandable event
+   row** — expand it to see and select an individual sub-market. Clearing the box
+   returns to the top-events list.
+2. **Category narrowing, multi-select OR (US2)** — with no query, tap **Sports**.
+   **Expect**: the list changes to sports events. Also tap **Crypto**.
+   **Expect**: the union of sports OR crypto events. Tap **Clear**. **Expect**:
+   default top events return.
 3. **Search within category (US3)** — type `lakers`, then toggle **Sports**.
    **Expect**: the typed query is **preserved** (not wiped) and results reflect
-   both. Remove **Sports** → results broaden to the query alone.
+   both. Selecting **Sports** first and then typing also constrains to Sports.
+   Remove **Sports** → results broaden to the query alone.
 4. **Responsive + trustworthy (US4)** — type quickly; results update within ~1s
    of pausing, no flicker/out-of-order. Simulate a failure (offline / block the
    Gamma host in devtools) → an error with a **Retry** that re-issues the
@@ -45,11 +48,11 @@ browse (feed) variant.
 ## Quick API sanity (optional, no app needed)
 
 ```bash
-# Search must be relevant (uses q=, not search=)
+# Search must be relevant (uses q=, not search=); returns events w/ nested markets
 curl -s "https://gamma-api.polymarket.com/public-search?q=knicks&limit_per_type=5"
 
-# Category browse by numeric tag_id (Sports=1)
-curl -s "https://gamma-api.polymarket.com/markets?tag_id=1&active=true&closed=false&order=volume&ascending=false&limit=5"
+# Category browse by numeric tag_id (Sports=1); events with nested markets
+curl -s "https://gamma-api.polymarket.com/events?tag_id=1&active=true&closed=false&order=volume&ascending=false&limit=5"
 
 # Slug → tag_id mapping
 curl -s "https://gamma-api.polymarket.com/tags/slug/pop-culture"
@@ -65,14 +68,14 @@ npx vitest run src/test/usePolymarketSearch.test.js \
 ```
 
 `fetch` is mocked via `vi.stubGlobal` (no MSW). The suite must cover contract
-obligations **C1–C7** ([gamma-api.md](./contracts/gamma-api.md)) and component
-obligations **T1–T7** ([polymarket-hooks.md](./contracts/polymarket-hooks.md)),
+obligations **C1–C8** ([gamma-api.md](./contracts/gamma-api.md)) and component
+obligations **T1–T8** ([polymarket-hooks.md](./contracts/polymarket-hooks.md)),
 including the regression fixture where searching `knicks` against the old code
-path would have returned GTA-VI markets.
+path would have returned GTA-VI markets, and the event-grouping/expand case.
 
 ## Done / acceptance
 
-- Manual steps 1–5 pass; success criteria SC-001…SC-008 in
+- Manual steps 1–5 pass; success criteria SC-001…SC-009 in
   [spec.md](./spec.md) hold.
 - New Vitest files pass; `npm run lint` (frontend) clean; vitest-axe clean.
 - No `contracts/` (Solidity) or deployment changes; behavior identical across

--- a/specs/013-polymarket-search-filter/research.md
+++ b/specs/013-polymarket-search-filter/research.md
@@ -4,12 +4,14 @@ All findings below were verified against the live Gamma API
 (`https://gamma-api.polymarket.com`, unauthenticated) on 2026-06-13, in addition
 to Polymarket's developer documentation. They resolve every "NEEDS
 CLARIFICATION" implied by the spec's Assumptions (the correct upstream query
-mechanism).
+mechanism) and incorporate the 2026-06-13 spec clarifications (event grouping,
+multi-select OR categories, search constrained to the active category).
 
-## Decision 1 — Free-text search uses `/public-search?q=`, not `/markets?search=`
+## Decision 1 — Free-text search uses `/public-search?q=`, returned as events
 
 **Decision**: Perform keyword search against
-`GET /public-search?q=<term>&limit_per_type=<N>`.
+`GET /public-search?q=<term>&limit_per_type=<N>` and consume the **events** it
+returns (each with nested markets).
 
 **Evidence**:
 - `GET /markets?search=knicks` (current code) ignores the `search` param and
@@ -20,50 +22,51 @@ mechanism).
   …) — relevance-ranked and correct.
 - The param name is **`q`** (a request with `query=` returned
   `validation error … query argument "q": empty`).
-
-**Response shape**: `{ "events": [ … ], "pagination": { … } }`. Each event
-carries a `tags` array (category membership) and a nested `markets` array. Each
-market object includes the fields the picker needs: `conditionId`, `question`,
-`active`, `closed`, `volume`, `endDate`, `outcomes`, `outcomePrices`, `slug`,
-`image`/`icon`. Markets to surface are obtained by **flattening
-`event.markets`** across returned events.
+- Response shape is `{ "events": Event[], "pagination": {…} }`. Each `Event`
+  carries `tags: Tag[]` and a nested `markets: Market[]`; each `Market` includes
+  `conditionId`, `question`, `active`, `closed`, `volume`, `endDate`, `outcomes`,
+  `outcomePrices`, `slug`, `image`/`icon`, `groupItemTitle`.
 
 **Rationale**: It is the only endpoint that honors free-text relevance search,
-and it returns the same market fields already consumed by `normaliseGammaMarket`,
-so normalization is reusable.
+and it returns events-with-nested-markets — exactly the grouping the picker now
+needs (Decision 10).
 
 **Alternatives considered**:
 - `/markets?search=` — rejected: param unsupported (the bug).
 - Client-side substring filtering over a generic `/markets` pull — rejected:
-  cannot reproduce upstream relevance ranking, would miss markets outside the
-  fetched page, and wastes the rate budget.
+  cannot reproduce upstream relevance ranking, misses markets outside the page,
+  and wastes the rate budget.
 
-## Decision 2 — Category filtering uses numeric `tag_id`, not `tag_slug`
+## Decision 2 — Category browse uses `/events?tag_id=` (events with nested markets)
 
-**Decision**: Browse markets via
-`GET /markets?tag_id=<numeric>&active=true&closed=false&order=volume&ascending=false&limit=<N>`.
+**Decision**: Browse via
+`GET /events?tag_id=<numeric>&active=true&closed=false&order=volume&ascending=false&limit=<N>`,
+and the default (no category) top list via the same endpoint without `tag_id`.
 
 **Evidence**:
 - The current `tag_slug=` param is unsupported and silently ignored — selecting
   "Business" vs "Pop Culture" returned the identical default list (the bug).
-- `GET /markets?tag_id=2&active=true&closed=false&order=volume&ascending=false`
-  returned real markets with `conditionId`s, confirming `/markets` accepts
-  `tag_id`.
+- `GET /events?tag_id=1&active=true&closed=false&order=volume&ascending=false`
+  returned a list of events (e.g. "World Cup Winner") each with event-level
+  `tags`, `volume`/`volume24hr`, and a nested `markets[]` (e.g. "Will Spain win
+  the 2026 FIFA World Cup?" with its own `conditionId`, `volume`,
+  `groupItemTitle`). `order=volume` is honored on `/events`.
 
-**Rationale**: `tag_id` is the documented, working filter parameter for both
-`/markets` and `/events`; `/markets` returns flat, condition-bearing markets that
-map directly to the picker's needs.
+**Rationale**: Switching browse from `/markets` to `/events` makes browse return
+the **same event-grouped shape** as search, so one normalizer and one grouped
+render path serve both modes (consistency, less code). `/markets` returns flat
+markets with no parent-event handle, which would make grouping browse results
+impossible without extra calls.
 
 **Alternatives considered**:
-- `/events?tag_id=…` then flatten — viable and equivalent; `/markets` chosen for
-  a flatter response and to preserve the existing browse code path. (Either is
-  acceptable at implementation time; the contract documents `/markets`.)
+- `/markets?tag_id=…` (the previous plan) — rejected now that results must be
+  grouped by event: flat markets cannot be regrouped reliably client-side.
 
 ## Decision 3 — Map the six category labels to real numeric tag IDs via `/tags/slug/{slug}`
 
 **Decision**: Resolve each user-facing category slug to its numeric `tag_id`
-using `GET /tags/slug/{slug}`, cached in module scope (slugs/IDs are stable).
-Verified mapping:
+using `GET /tags/slug/{slug}`, seeded with the verified values below and memoized
+in module scope (slugs/IDs are stable).
 
 | Chip label   | slug          | tag_id |
 |--------------|---------------|--------|
@@ -74,95 +77,119 @@ Verified mapping:
 | Business     | `business`    | `107`  |
 | Tech         | `tech`        | `1401` |
 
-**Evidence**: each `GET /tags/slug/<slug>` returned a `Tag` object with the IDs
-above (e.g. `pop-culture` → `{ id: "596", label: "Culture", slug: "pop-culture" }`).
+**Evidence**: each `GET /tags/slug/<slug>` returned a `Tag` with the IDs above
+(e.g. `pop-culture` → `{ id: "596", label: "Culture", slug: "pop-culture" }`).
 
-**Rationale**: A resolver keeps the chip definitions human-readable while sending
-the API the numeric IDs it requires. Resolving via `/tags/slug` (rather than
-hardcoding) self-heals if an ID ever changes; the verified IDs above serve as a
-safe fallback/seed and let tests assert exact request URLs without a network
-round-trip.
+**Rationale**: A resolver keeps chip definitions human-readable while sending the
+numeric IDs the API requires; the verified seed map keeps tests hermetic and
+avoids a network round-trip.
 
-**Alternatives considered**:
-- Hardcode IDs only — acceptable but brittle if Polymarket renumbers; keep them
-  as a seed/fallback alongside the resolver.
-- Pull the full `/tags` list and match — rejected: the default list is paginated
-  to 100 granular tags and does not surface the top-level categories;
-  `/tags/slug/{slug}` is the direct lookup.
+**Alternatives considered**: hardcode-only (brittle) or scan full `/tags`
+(paginated to 100 granular tags; top-level categories not surfaced) — both
+rejected in favor of seed + `/tags/slug` fallback.
 
-## Decision 4 — "Search within a category" filters search results by tag membership
+## Decision 4 — Multi-select categories with OR semantics
 
-**Decision**: When both a query and one or more categories are active, call
-`/public-search?q=…`, then keep only events whose `tags` include a selected
-`tag_id`, and surface those events' markets. (OR semantics across multiple
-selected categories.)
+**Decision**: Category chips are multi-select. Selected categories are combined
+with OR: a result qualifies if it belongs to **any** selected category
+(clarification 2026-06-13).
 
-**Rationale**: `/public-search` results include per-event `tags`, so the
-category constraint can be applied client-side on a small result set —
-deterministic, no extra request, and robust regardless of whether the search
-endpoint accepts a server-side tag filter. Categories live at the **event**
-level, which is the correct granularity for these markets.
+**Implementation**: browse issues one `/events?tag_id=<id>…` request per selected
+category in parallel, then merges and de-duplicates events by event `id`,
+re-sorts by volume, and caps at `limit` (Decision 5). With a single category it
+degenerates to one request; with none it is the default top-events query.
 
-**Alternatives considered**:
-- A server-side tag param on `/public-search` — not relied upon (undocumented/
-  unverified); client-side filter of the returned `tags` is simpler and certain.
+**Rationale**: Matches the existing component and the saved-preferences array
+(`polymarketCategories`), and is the more powerful UX. OR is the intuitive
+meaning of "show me Sports or Crypto."
 
-## Decision 5 — Multi-category browse = parallel `tag_id` requests merged by `conditionId`
+## Decision 5 — Multi-category merge by event id
 
-**Decision**: For browse mode with N selected categories, issue one
-`/markets?tag_id=<id>…` request per category in parallel, then merge and
-de-duplicate by `conditionId`, re-sort by volume, and cap at `limit`.
+**Decision**: For N selected categories, fan out N parallel requests and merge by
+event `id` (dedupe), re-rank by volume, cap at `limit`.
 
-**Rationale**: Guarantees correct OR semantics across categories without
-depending on undocumented repeated-param behavior. N is at most 6 and requests
-are abortable; the rate budget (~350/10s) easily covers it. With a single
-selected category it degenerates to one request.
+**Rationale**: Guarantees correct OR semantics without relying on undocumented
+repeated-`tag_id` behavior. N ≤ 6, requests are abortable, and the rate budget
+(~350/10s) easily covers it.
 
-**Alternatives considered**:
-- Repeated `tag_id=` params in one URL — behavior across Gamma versions is
-  unverified; rejected for determinism.
+## Decision 6 — Search constrained to active categories by default
 
-## Decision 6 — Eligibility filter: active, not closed, condition-bearing
+**Decision**: When one or more categories are selected and a query is present,
+call `/public-search?q=…`, then keep only events whose `tags[].id` intersects the
+selected `tag_id`s (OR across selected categories), and surface those events
+(clarification 2026-06-13). With no category selected, search is global.
 
-**Decision**: After normalization, surface only markets where `active === true`,
-`closed !== true`, and `conditionId` is present (FR-006, FR-007). Apply this
-uniformly to both search and browse results. (`/public-search` can return closed
-markets even for live queries — observed `closed: true` items — so the
-client-side guard is required, not just the `active/closed` query params.)
+**Rationale**: `/public-search` events carry `tags`, so the category constraint
+is a deterministic client-side filter on a small result set — no extra request,
+and it honors the visible active chip (FR-003).
 
-**Rationale**: Only such markets can back a new wager; this prevents selecting an
-unusable/resolved market.
+**Alternatives considered**: a server-side tag param on `/public-search` —
+unverified/undocumented; client-side `tags` filter is simpler and certain.
 
-## Decision 7 — Single debounce; abort/supersession safety
+## Decision 7 — Eligibility filter: active, not closed, condition-bearing (per sub-market)
+
+**Decision**: Within each event, keep only markets where `active === true`,
+`closed !== true`, and `conditionId` is present (FR-006, FR-007). An **event is
+surfaced only if it has ≥1 eligible market**; events with zero eligible markets
+are dropped entirely.
+
+**Rationale**: Only such markets can back a new wager (`/public-search` and
+`/events` can include closed markets even for live queries, so the client-side
+guard is required). Dropping empty events prevents dead expandable rows.
+
+## Decision 8 — Single debounce; abort/supersession safety
 
 **Decision**: Drive search from one debounce (~300–350ms) instead of the current
-two stacked timers (component 350ms + hook 400ms ≈ 750ms). Keep a single
-`AbortController` per in-flight request and ignore results once superseded so a
-slow earlier response can never overwrite a newer query/filter (FR-009, FR-010).
+two stacked timers (≈750ms). Keep a single `AbortController` per in-flight
+request and discard superseded results so a slow earlier response can never
+overwrite a newer query/filter (FR-009, FR-010).
 
-**Rationale**: Removes perceived lag and the out-of-order overwrite class of bug
+**Rationale**: Removes perceived lag and the out-of-order overwrite bug class
 while respecting the rate limit.
 
-**Alternatives considered**:
-- Keep both debounces — rejected (sluggish, redundant).
+## Decision 9 — Ranking & personalization
 
-## Decision 8 — Ranking & personalization
+**Decision**: Browse orders **events** by volume (desc). Search preserves the
+upstream relevance order of events; existing saved-preference/history "boosts"
+apply only as a minor tie-breaker and MUST NOT reorder above relevance (spec
+Assumptions). Within an expanded event, sub-markets are ordered by volume desc.
+Eligibility filtering happens before ranking.
 
-**Decision**: Browse mode orders by volume (desc). Search mode preserves the
-upstream relevance order; existing saved-preference / history "boosts" may apply
-only as a minor tie-breaker and MUST NOT reorder above relevance (spec
-Assumptions). Eligibility filtering happens before ranking.
+**Rationale**: Honors FR-008 (relevance for search, popularity for browse) and
+keeps the existing personalization nicety non-destructively.
 
-**Rationale**: Honors FR-008 (relevance for search, popularity for browse) while
-retaining the existing personalization nicety in a non-destructive way.
+## Decision 10 — Event grouping & expandable rows
 
-## Decision 9 — Testing approach (no new deps)
+**Decision**: Normalize both search and browse responses into a list of
+**NormalizedEvent** objects, each holding its eligible **NormalizedMarket**
+children. The picker renders one row per event; an event with >1 eligible market
+is expandable to reveal and select a child sub-market (using `groupItemTitle` as
+the child label where present). An event with exactly one eligible market is
+shown directly and selecting the row selects that market (no redundant expand)
+— clarification 2026-06-13, FR-017.
+
+**Rationale**: A single game can expose 60+ sub-markets (verified: World Cup
+event had 60 markets); flattening floods the list and buries the matchup.
+Grouping makes "find the matchup" fast while still letting the user pick the
+exact sub-market that backs the wager. The data already arrives grouped from both
+endpoints (Decisions 1, 2), so grouping is normalization, not extra fetching.
+
+**Selection contract**: selecting any (sub-)market emits the existing
+`onSelectMarket(market)` with that market's `conditionId` — the downstream
+linked-market form is unchanged (FR-014).
+
+**Accessibility**: the expand control is a real toggle button with
+`aria-expanded`; the sub-market list is keyboard-navigable; existing input/group/
+chip/alert/busy roles are preserved (Constitution V, vitest-axe).
+
+## Decision 11 — Testing approach (no new deps)
 
 **Decision**: Use the repo's existing stack — Vitest 4, @testing-library/react,
 jsdom, vitest-axe — and mock `fetch` via `vi.stubGlobal('fetch', …)` returning
-canned Gamma payloads (the bug's "knicks→GTA VI" case, a per-category fixture,
-a closed/ineligible market, an error, and an abort/supersession scenario). No
-MSW or other new dependency is introduced.
+canned Gamma payloads: the bug's "knicks→GTA VI" regression case, an event with
+many sub-markets (grouping/expand), a per-category `/events?tag_id` fixture, a
+multi-category merge case, a closed/ineligible sub-market, a query+category
+constraint case, an error, and an abort/supersession scenario. No MSW.
 
 **Rationale**: Matches established patterns (`ipfsService.test.js`,
 `usePriceConversion.test.js`), keeps CI fast, and satisfies Principle II.
@@ -173,4 +200,4 @@ MSW or other new dependency is introduced.
 - [Fetching Markets guide](https://docs.polymarket.com/developers/gamma-markets-api/fetch-markets-guide)
 - [Polymarket agent-skills: market-data](https://github.com/Polymarket/agent-skills/blob/main/market-data.md)
 - [AgentBets: Polymarket Gamma API guide (2026)](https://agentbets.ai/guides/polymarket-gamma-api-guide/)
-- Live API verification: `/public-search?q=`, `/markets?tag_id=`, `/tags/slug/{slug}` (2026-06-13)
+- Live API verification: `/public-search?q=`, `/events?tag_id=`, `/tags/slug/{slug}` (2026-06-13)

--- a/specs/013-polymarket-search-filter/research.md
+++ b/specs/013-polymarket-search-filter/research.md
@@ -1,0 +1,176 @@
+# Phase 0 Research: Polymarket Search & Category Filter
+
+All findings below were verified against the live Gamma API
+(`https://gamma-api.polymarket.com`, unauthenticated) on 2026-06-13, in addition
+to Polymarket's developer documentation. They resolve every "NEEDS
+CLARIFICATION" implied by the spec's Assumptions (the correct upstream query
+mechanism).
+
+## Decision 1 — Free-text search uses `/public-search?q=`, not `/markets?search=`
+
+**Decision**: Perform keyword search against
+`GET /public-search?q=<term>&limit_per_type=<N>`.
+
+**Evidence**:
+- `GET /markets?search=knicks` (current code) ignores the `search` param and
+  returns a default/volume-ordered set — this is the exact production bug
+  (searching "knicks" returned album/GTA-VI markets).
+- `GET /public-search?q=knicks&limit_per_type=5` returned only Knicks markets
+  ("Pacers vs. Knicks", "Spread: Knicks (-4.5)", "Pacers vs Knicks: O/U 224.5",
+  …) — relevance-ranked and correct.
+- The param name is **`q`** (a request with `query=` returned
+  `validation error … query argument "q": empty`).
+
+**Response shape**: `{ "events": [ … ], "pagination": { … } }`. Each event
+carries a `tags` array (category membership) and a nested `markets` array. Each
+market object includes the fields the picker needs: `conditionId`, `question`,
+`active`, `closed`, `volume`, `endDate`, `outcomes`, `outcomePrices`, `slug`,
+`image`/`icon`. Markets to surface are obtained by **flattening
+`event.markets`** across returned events.
+
+**Rationale**: It is the only endpoint that honors free-text relevance search,
+and it returns the same market fields already consumed by `normaliseGammaMarket`,
+so normalization is reusable.
+
+**Alternatives considered**:
+- `/markets?search=` — rejected: param unsupported (the bug).
+- Client-side substring filtering over a generic `/markets` pull — rejected:
+  cannot reproduce upstream relevance ranking, would miss markets outside the
+  fetched page, and wastes the rate budget.
+
+## Decision 2 — Category filtering uses numeric `tag_id`, not `tag_slug`
+
+**Decision**: Browse markets via
+`GET /markets?tag_id=<numeric>&active=true&closed=false&order=volume&ascending=false&limit=<N>`.
+
+**Evidence**:
+- The current `tag_slug=` param is unsupported and silently ignored — selecting
+  "Business" vs "Pop Culture" returned the identical default list (the bug).
+- `GET /markets?tag_id=2&active=true&closed=false&order=volume&ascending=false`
+  returned real markets with `conditionId`s, confirming `/markets` accepts
+  `tag_id`.
+
+**Rationale**: `tag_id` is the documented, working filter parameter for both
+`/markets` and `/events`; `/markets` returns flat, condition-bearing markets that
+map directly to the picker's needs.
+
+**Alternatives considered**:
+- `/events?tag_id=…` then flatten — viable and equivalent; `/markets` chosen for
+  a flatter response and to preserve the existing browse code path. (Either is
+  acceptable at implementation time; the contract documents `/markets`.)
+
+## Decision 3 — Map the six category labels to real numeric tag IDs via `/tags/slug/{slug}`
+
+**Decision**: Resolve each user-facing category slug to its numeric `tag_id`
+using `GET /tags/slug/{slug}`, cached in module scope (slugs/IDs are stable).
+Verified mapping:
+
+| Chip label   | slug          | tag_id |
+|--------------|---------------|--------|
+| Politics     | `politics`    | `2`    |
+| Sports       | `sports`      | `1`    |
+| Crypto       | `crypto`      | `21`   |
+| Pop Culture  | `pop-culture` | `596`  |
+| Business     | `business`    | `107`  |
+| Tech         | `tech`        | `1401` |
+
+**Evidence**: each `GET /tags/slug/<slug>` returned a `Tag` object with the IDs
+above (e.g. `pop-culture` → `{ id: "596", label: "Culture", slug: "pop-culture" }`).
+
+**Rationale**: A resolver keeps the chip definitions human-readable while sending
+the API the numeric IDs it requires. Resolving via `/tags/slug` (rather than
+hardcoding) self-heals if an ID ever changes; the verified IDs above serve as a
+safe fallback/seed and let tests assert exact request URLs without a network
+round-trip.
+
+**Alternatives considered**:
+- Hardcode IDs only — acceptable but brittle if Polymarket renumbers; keep them
+  as a seed/fallback alongside the resolver.
+- Pull the full `/tags` list and match — rejected: the default list is paginated
+  to 100 granular tags and does not surface the top-level categories;
+  `/tags/slug/{slug}` is the direct lookup.
+
+## Decision 4 — "Search within a category" filters search results by tag membership
+
+**Decision**: When both a query and one or more categories are active, call
+`/public-search?q=…`, then keep only events whose `tags` include a selected
+`tag_id`, and surface those events' markets. (OR semantics across multiple
+selected categories.)
+
+**Rationale**: `/public-search` results include per-event `tags`, so the
+category constraint can be applied client-side on a small result set —
+deterministic, no extra request, and robust regardless of whether the search
+endpoint accepts a server-side tag filter. Categories live at the **event**
+level, which is the correct granularity for these markets.
+
+**Alternatives considered**:
+- A server-side tag param on `/public-search` — not relied upon (undocumented/
+  unverified); client-side filter of the returned `tags` is simpler and certain.
+
+## Decision 5 — Multi-category browse = parallel `tag_id` requests merged by `conditionId`
+
+**Decision**: For browse mode with N selected categories, issue one
+`/markets?tag_id=<id>…` request per category in parallel, then merge and
+de-duplicate by `conditionId`, re-sort by volume, and cap at `limit`.
+
+**Rationale**: Guarantees correct OR semantics across categories without
+depending on undocumented repeated-param behavior. N is at most 6 and requests
+are abortable; the rate budget (~350/10s) easily covers it. With a single
+selected category it degenerates to one request.
+
+**Alternatives considered**:
+- Repeated `tag_id=` params in one URL — behavior across Gamma versions is
+  unverified; rejected for determinism.
+
+## Decision 6 — Eligibility filter: active, not closed, condition-bearing
+
+**Decision**: After normalization, surface only markets where `active === true`,
+`closed !== true`, and `conditionId` is present (FR-006, FR-007). Apply this
+uniformly to both search and browse results. (`/public-search` can return closed
+markets even for live queries — observed `closed: true` items — so the
+client-side guard is required, not just the `active/closed` query params.)
+
+**Rationale**: Only such markets can back a new wager; this prevents selecting an
+unusable/resolved market.
+
+## Decision 7 — Single debounce; abort/supersession safety
+
+**Decision**: Drive search from one debounce (~300–350ms) instead of the current
+two stacked timers (component 350ms + hook 400ms ≈ 750ms). Keep a single
+`AbortController` per in-flight request and ignore results once superseded so a
+slow earlier response can never overwrite a newer query/filter (FR-009, FR-010).
+
+**Rationale**: Removes perceived lag and the out-of-order overwrite class of bug
+while respecting the rate limit.
+
+**Alternatives considered**:
+- Keep both debounces — rejected (sluggish, redundant).
+
+## Decision 8 — Ranking & personalization
+
+**Decision**: Browse mode orders by volume (desc). Search mode preserves the
+upstream relevance order; existing saved-preference / history "boosts" may apply
+only as a minor tie-breaker and MUST NOT reorder above relevance (spec
+Assumptions). Eligibility filtering happens before ranking.
+
+**Rationale**: Honors FR-008 (relevance for search, popularity for browse) while
+retaining the existing personalization nicety in a non-destructive way.
+
+## Decision 9 — Testing approach (no new deps)
+
+**Decision**: Use the repo's existing stack — Vitest 4, @testing-library/react,
+jsdom, vitest-axe — and mock `fetch` via `vi.stubGlobal('fetch', …)` returning
+canned Gamma payloads (the bug's "knicks→GTA VI" case, a per-category fixture,
+a closed/ineligible market, an error, and an abort/supersession scenario). No
+MSW or other new dependency is introduced.
+
+**Rationale**: Matches established patterns (`ipfsService.test.js`,
+`usePriceConversion.test.js`), keeps CI fast, and satisfies Principle II.
+
+## Sources
+
+- [Gamma Markets API overview](https://docs.polymarket.com/developers/gamma-markets-api/overview)
+- [Fetching Markets guide](https://docs.polymarket.com/developers/gamma-markets-api/fetch-markets-guide)
+- [Polymarket agent-skills: market-data](https://github.com/Polymarket/agent-skills/blob/main/market-data.md)
+- [AgentBets: Polymarket Gamma API guide (2026)](https://agentbets.ai/guides/polymarket-gamma-api-guide/)
+- Live API verification: `/public-search?q=`, `/markets?tag_id=`, `/tags/slug/{slug}` (2026-06-13)

--- a/specs/013-polymarket-search-filter/spec.md
+++ b/specs/013-polymarket-search-filter/spec.md
@@ -1,0 +1,276 @@
+# Feature Specification: Polymarket Search & Category Filter
+
+**Feature Branch**: `claude/polymarket-search-filter-z0tu7n`
+
+**Created**: 2026-06-13
+
+**Status**: Draft
+
+**Input**: User description: "the search and filter of polymarket is currently not functioning for users. investigate the implementation and then run /speckit-specify to specify a proper implementation of the search functionality so users will be able to quickly find the matchups they need."
+
+## User Scenarios & Testing *(mandatory)*
+
+The "Linked Polymarket Event" picker lets a user attach a wager to a real
+Polymarket market so the wager settles automatically when that market resolves.
+The picker appears in the wager-creation flow and in the dashboard feed. Today
+its two ways of finding a market — typing a search query and tapping a category
+filter — both fail: searches return irrelevant markets and category taps never
+change the list. The journeys below restore the picker's core promise: a user
+can quickly find the specific matchup they want to wager on.
+
+### User Story 1 - Find a specific market by searching (Priority: P1)
+
+A user knows the matchup they want (e.g. a New York Knicks game) and types a
+term into the search box. They expect to see markets whose questions actually
+relate to what they typed, ranked so the most relevant appears first, and to
+pick one to attach to their wager.
+
+**Why this priority**: Search is the primary way users locate a known matchup.
+It is currently broken in the most visible way — typing "knicks" returns
+album-release and GTA VI markets — which blocks the core task of linking a
+wager. Without this, the picker is unusable for anyone with a specific event in
+mind.
+
+**Independent Test**: Type a distinctive term (e.g. "knicks") and confirm every
+returned market's question is plausibly related to that term, that an obviously
+relevant market appears near the top, and that selecting a result attaches it to
+the wager.
+
+**Acceptance Scenarios**:
+
+1. **Given** the picker is open with no query, **When** the user types a term
+   that matches live markets, **Then** the list updates to show only markets
+   whose question text relates to that term, most-relevant first.
+2. **Given** a search term that matches no live markets, **When** results
+   return, **Then** the user sees a clear "no matching markets" empty state
+   rather than an unrelated or stale list.
+3. **Given** search results are shown, **When** the user clears the search box,
+   **Then** the picker returns to the default browse list of top markets.
+4. **Given** the user selects a market from the search results, **When** they
+   continue, **Then** that market is linked to the wager and used for automatic
+   settlement.
+
+---
+
+### User Story 2 - Narrow the list by category (Priority: P1)
+
+A user without a specific market in mind wants to browse a topic — Sports,
+Politics, Crypto, Pop Culture, Business, or Tech. They tap a category and expect
+the list to narrow to markets in that category.
+
+**Why this priority**: Category browsing is the primary discovery path for users
+exploring what they can wager on. It is currently fully broken — selecting
+"Business" and "Pop Culture" both return the identical default political list —
+so the filters are decorative. Restoring them is equally critical to search.
+
+**Independent Test**: Tap a category and confirm the result set visibly changes
+to markets belonging to that category, and that tapping a different category
+produces a different, category-appropriate set.
+
+**Acceptance Scenarios**:
+
+1. **Given** the default browse list is shown, **When** the user selects a
+   category, **Then** the list updates to show only markets in that category.
+2. **Given** a category is selected, **When** the user selects a different
+   category, **Then** the list updates to the newly selected category's markets
+   (not the previous category's or the default set).
+3. **Given** one or more categories are selected, **When** the user clears the
+   selection, **Then** the list returns to the default top-markets browse view.
+4. **Given** a selected category has no eligible live markets, **When** results
+   return, **Then** the user sees a clear empty state for that category.
+
+---
+
+### User Story 3 - Search within a category (Priority: P2)
+
+A user combines both tools: they pick a category and also type a query to search
+within it (e.g. Sports + "lakers"), and they can adjust the category without
+losing what they typed.
+
+**Why this priority**: Combining the two tools is how users refine large result
+sets, but it depends on Stories 1 and 2 working first. A key sub-frustration
+today is that toggling a category wipes the typed query, forcing a re-type.
+
+**Independent Test**: Type a query, then toggle a category, and confirm the
+query is preserved and results reflect both the query and the category;
+confirm removing the category broadens results back to the query alone.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has typed a search query, **When** they select a category,
+   **Then** the typed query is preserved and results reflect both the query and
+   the category.
+2. **Given** a query and a category are both active, **When** the user removes
+   the category, **Then** the query remains and results broaden to all
+   categories matching the query.
+3. **Given** a query and a category are both active, **When** the user clears the
+   query, **Then** the category remains active and the list shows that
+   category's browse view.
+
+---
+
+### User Story 4 - Trustworthy, responsive results (Priority: P2)
+
+While searching or filtering, the user always understands the picker's state:
+results feel responsive, loading and empty states are clear, failures are
+recoverable, and every listed market is one they can actually wager on.
+
+**Why this priority**: Trust in the picker depends on it never showing stale,
+ineligible, or silently-failed results. This hardens the experience around
+Stories 1–3 but is not itself the primary discovery path.
+
+**Independent Test**: Exercise rapid typing, an induced network failure, and an
+empty result set, and confirm the picker shows responsive updates, a retry
+affordance on failure, and only eligible markets — never a stale list presented
+as current.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is typing quickly, **When** characters change, **Then**
+   results update responsively without flicker from superseded requests, and the
+   list reflects the latest query.
+2. **Given** a results request fails, **When** the error occurs, **Then** the
+   user sees a clear error message and a way to retry, not a blank or stale
+   list.
+3. **Given** results are loading, **When** the request is in flight, **Then** the
+   user sees a loading indicator distinct from the empty state.
+4. **Given** any market is listed, **When** it is displayed, **Then** it is an
+   active, tradeable, unresolved market eligible for wager linking, with the
+   information needed to choose it (question, and a useful signal such as
+   volume).
+
+---
+
+### Edge Cases
+
+- **Whitespace / very short queries**: Leading/trailing whitespace is ignored;
+  the system defines a minimum effective query length and does not fire noisy
+  requests for a single stray character.
+- **Rapid query changes (race conditions)**: A slow earlier request must never
+  overwrite results for a newer query; only the latest query's results are shown.
+- **Special characters / emoji in query**: Unusual input must not break the
+  picker; it returns a normal result or a normal empty state.
+- **No results**: Both empty search results and empty category results show a
+  clear, distinct empty state rather than the previous list.
+- **Upstream unavailable / rate-limited / timeout**: A recoverable error state
+  with retry is shown; the picker never presents stale results as current.
+- **Markets missing required data**: Markets lacking the data needed to link or
+  display them are excluded so the user never selects an unusable market.
+- **Resolved / closed / inactive markets**: Never shown, since they cannot back a
+  new wager.
+- **Category with zero eligible markets**: Distinct empty state, with selection
+  still adjustable.
+- **Query that matches a category name**: Treated as a text search over markets,
+  not as an implicit category switch (categories change only via the filters).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The picker MUST return search results whose market questions are
+  relevant to the user's query, ordered most-relevant first. Searching a
+  distinctive term MUST NOT return markets unrelated to that term.
+- **FR-002**: The picker MUST narrow results to the selected category when a
+  category filter is active, and selecting different categories MUST produce
+  correspondingly different result sets.
+- **FR-003**: The picker MUST support applying a search query and a category
+  filter simultaneously, returning markets that satisfy both.
+- **FR-004**: Changing the category selection MUST preserve any text the user has
+  already typed in the search box.
+- **FR-005**: Clearing the search query MUST return to the active category's
+  browse view (or the default top-markets view when no category is selected);
+  clearing the category selection MUST return to the default top-markets view
+  while preserving any active query.
+- **FR-006**: The picker MUST display only markets that are active, tradeable,
+  and unresolved (eligible to back a new wager); resolved, closed, or inactive
+  markets MUST be excluded.
+- **FR-007**: The picker MUST exclude markets that lack the data required to link
+  a wager or to render a usable result card, so a user cannot select an unusable
+  market.
+- **FR-008**: In browse mode (no query), results MUST be ordered by a useful
+  popularity signal (e.g. trading volume, highest first); in search mode, results
+  MUST be ordered by relevance to the query.
+- **FR-009**: The picker MUST update results responsively as the user types,
+  consolidating rapid keystrokes so the upstream is not queried on every
+  character, while keeping perceived latency low.
+- **FR-010**: The picker MUST ensure that results from a superseded request never
+  replace results for a newer query or filter selection.
+- **FR-011**: The picker MUST present distinct, clear states for loading,
+  empty/no-results, and error conditions, and MUST NOT present stale results as
+  current.
+- **FR-012**: On a failed results request, the picker MUST offer the user a way
+  to retry.
+- **FR-013**: The category filter set offered to users MUST map to real,
+  supported upstream categories so that every offered category returns its
+  corresponding markets.
+- **FR-014**: Selecting a market from any result (search or browse) MUST link
+  that market to the wager such that the wager settles automatically when the
+  market resolves, preserving the existing selection behavior.
+- **FR-015**: Search and filter behavior MUST be consistent everywhere the picker
+  appears (wager-creation flow and dashboard feed).
+- **FR-016**: The search and filter behavior MUST be covered by automated tests,
+  including relevant-results, category-narrowing, combined query+category,
+  query-preservation-on-toggle, empty/error states, and superseded-request
+  handling.
+
+### Key Entities *(include if feature involves data)*
+
+- **Market (matchup)**: A single Polymarket prediction market the user can link
+  a wager to. Relevant attributes for this feature: a human-readable question/
+  title, category/topic association, a popularity signal (e.g. trading volume),
+  resolution/active status, and the identifiers required to link it for automatic
+  settlement.
+- **Search query**: The free-text term the user types to find markets by their
+  question text.
+- **Category filter**: A user-selectable topic (e.g. Sports, Politics, Crypto,
+  Pop Culture, Business, Tech) that constrains results to markets in that topic.
+- **Result set / picker state**: The current list shown to the user plus its
+  state (browsing vs. searching, selected categories, loading/empty/error),
+  driven by the combination of active query and active category filters.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For a distinctive search term that has matching live markets, 100%
+  of returned results have questions relevant to the term, and a clearly relevant
+  market appears within the top results.
+- **SC-002**: Selecting each offered category returns a result set composed of
+  markets in that category, and selecting two different categories yields
+  measurably different result sets (no longer the identical default list).
+- **SC-003**: Users can locate and select a specific known matchup in under 15
+  seconds from opening the picker.
+- **SC-004**: Results update within roughly one second of the user pausing
+  typing, with no flicker from out-of-order responses.
+- **SC-005**: 100% of listed markets are eligible to back a new wager (active,
+  tradeable, unresolved, and complete enough to link).
+- **SC-006**: Empty, loading, and error states are each distinctly presented;
+  a failed request always offers a retry and never displays a stale list as
+  current.
+- **SC-007**: The same search and filter behavior holds in every place the picker
+  appears.
+- **SC-008**: Automated tests cover the search, filter, combined, state, and
+  race-condition behaviors and pass in CI.
+
+## Assumptions
+
+- The upstream prediction-market data source (Polymarket's public market data)
+  remains the single source of markets; no new oracle or data provider is
+  introduced by this feature.
+- The current breakage stems from the integration requesting markets in a way the
+  upstream does not honor (free-text search and category parameters that are
+  ignored). Choosing the correct upstream query mechanism is an implementation
+  concern for the plan; this spec only requires that the resulting behavior be
+  correct.
+- The user-facing category set (Sports, Politics, Crypto, Pop Culture, Business,
+  Tech) is retained, but each category must be mapped to a real upstream topic so
+  it actually filters. Adjusting category labels to match available upstream
+  topics is acceptable if needed to make filtering work.
+- Scope is limited to the frontend search/filter experience and the layer that
+  fetches market data for the picker. On-chain settlement logic and adding new
+  oracle sources are out of scope.
+- Personalization signals already used to rank browse results (saved category
+  preferences, history) may be retained as a ranking refinement but MUST NOT
+  override query relevance in search mode.
+- "Active, tradeable, unresolved" is defined by the upstream market status fields
+  already available for each market.

--- a/specs/013-polymarket-search-filter/spec.md
+++ b/specs/013-polymarket-search-filter/spec.md
@@ -32,23 +32,27 @@ wager. Without this, the picker is unusable for anyone with a specific event in
 mind.
 
 **Independent Test**: Type a distinctive term (e.g. "knicks") and confirm every
-returned market's question is plausibly related to that term, that an obviously
-relevant market appears near the top, and that selecting a result attaches it to
-the wager.
+returned result is plausibly related to that term, that an obviously relevant
+event appears near the top, that an event with many sub-markets appears as one
+expandable row, and that selecting a sub-market attaches it to the wager.
 
 **Acceptance Scenarios**:
 
 1. **Given** the picker is open with no query, **When** the user types a term
-   that matches live markets, **Then** the list updates to show only markets
-   whose question text relates to that term, most-relevant first.
+   that matches live markets, **Then** the list updates to show only events
+   whose markets relate to that term, most-relevant first.
 2. **Given** a search term that matches no live markets, **When** results
    return, **Then** the user sees a clear "no matching markets" empty state
    rather than an unrelated or stale list.
 3. **Given** search results are shown, **When** the user clears the search box,
    **Then** the picker returns to the default browse list of top markets.
-4. **Given** the user selects a market from the search results, **When** they
-   continue, **Then** that market is linked to the wager and used for automatic
-   settlement.
+4. **Given** an event that has many sub-markets (e.g. a game's moneyline,
+   spreads, and over/unders), **When** it appears in results, **Then** it is
+   shown as a single event row that the user can expand to reveal and select an
+   individual sub-market.
+5. **Given** the user selects a (sub-)market from the results, **When** they
+   continue, **Then** that specific market is linked to the wager and used for
+   automatic settlement.
 
 ---
 
@@ -71,9 +75,10 @@ produces a different, category-appropriate set.
 
 1. **Given** the default browse list is shown, **When** the user selects a
    category, **Then** the list updates to show only markets in that category.
-2. **Given** a category is selected, **When** the user selects a different
-   category, **Then** the list updates to the newly selected category's markets
-   (not the previous category's or the default set).
+2. **Given** one category is selected, **When** the user selects an additional
+   category, **Then** the list updates to the union of markets across all
+   selected categories (OR semantics), and deselecting a category narrows the
+   list back to the remaining selected categories.
 3. **Given** one or more categories are selected, **When** the user clears the
    selection, **Then** the list returns to the default top-markets browse view.
 4. **Given** a selected category has no eligible live markets, **When** results
@@ -106,6 +111,9 @@ confirm removing the category broadens results back to the query alone.
 3. **Given** a query and a category are both active, **When** the user clears the
    query, **Then** the category remains active and the list shows that
    category's browse view.
+4. **Given** one or more categories are already selected, **When** the user then
+   types a query, **Then** the search is constrained to the selected categories
+   by default (results must match both the query and a selected category).
 
 ---
 
@@ -162,6 +170,25 @@ as current.
   still adjustable.
 - **Query that matches a category name**: Treated as a text search over markets,
   not as an implicit category switch (categories change only via the filters).
+- **Event with a single market**: An event that has only one market is shown
+  directly (no redundant expand affordance for a single child).
+- **Expanded event whose sub-markets become ineligible**: Only eligible
+  sub-markets are listed under an event; an event with no eligible sub-markets is
+  not shown at all.
+
+## Clarifications
+
+### Session 2026-06-13
+
+- Q: How should the picker present an event that returns many sub-markets (e.g.
+  "knicks" → a game's moneyline + several spreads + several over/unders)? → A:
+  Group them under a single expandable event row; the user expands to select an
+  individual sub-market (not one top-level row per sub-market).
+- Q: Should category chips be multi-select or single-select? → A: Multi-select
+  with OR semantics (results belong to any selected category).
+- Q: When a category is already selected and the user types a query, should
+  search be constrained to that category by default? → A: Yes — constrain the
+  search to the selected categories by default.
 
 ## Requirements *(mandatory)*
 
@@ -171,10 +198,13 @@ as current.
   relevant to the user's query, ordered most-relevant first. Searching a
   distinctive term MUST NOT return markets unrelated to that term.
 - **FR-002**: The picker MUST narrow results to the selected category when a
-  category filter is active, and selecting different categories MUST produce
-  correspondingly different result sets.
-- **FR-003**: The picker MUST support applying a search query and a category
-  filter simultaneously, returning markets that satisfy both.
+  category filter is active. Category filters MUST be multi-selectable, combined
+  with OR semantics (results belong to ANY selected category), and selecting
+  different categories MUST produce correspondingly different result sets.
+- **FR-003**: The picker MUST support applying a search query and category
+  filters simultaneously, returning only results that satisfy both. When one or
+  more categories are already selected and the user types a query, the search
+  MUST be constrained to the selected categories by default.
 - **FR-004**: Changing the category selection MUST preserve any text the user has
   already typed in the search box.
 - **FR-005**: Clearing the search query MUST return to the active category's
@@ -203,30 +233,43 @@ as current.
 - **FR-013**: The category filter set offered to users MUST map to real,
   supported upstream categories so that every offered category returns its
   corresponding markets.
-- **FR-014**: Selecting a market from any result (search or browse) MUST link
-  that market to the wager such that the wager settles automatically when the
-  market resolves, preserving the existing selection behavior.
+- **FR-014**: Selecting a (sub-)market from any result (search or browse) MUST
+  link that specific market to the wager such that the wager settles
+  automatically when the market resolves, preserving the existing selection
+  behavior.
+- **FR-017**: When an event exposes multiple related markets (e.g. a game's
+  moneyline, spreads, and over/unders), the picker MUST group them under a single
+  event entry that the user can expand to reveal and select an individual
+  sub-market, rather than listing every sub-market as a separate top-level
+  result. An event with a single market is shown without a redundant expand step.
 - **FR-015**: Search and filter behavior MUST be consistent everywhere the picker
   appears (wager-creation flow and dashboard feed).
 - **FR-016**: The search and filter behavior MUST be covered by automated tests,
-  including relevant-results, category-narrowing, combined query+category,
-  query-preservation-on-toggle, empty/error states, and superseded-request
-  handling.
+  including relevant-results, multi-category OR narrowing, combined
+  query+category (default constraint), query-preservation-on-toggle,
+  event grouping/expand and sub-market selection, empty/error states, and
+  superseded-request handling.
 
 ### Key Entities *(include if feature involves data)*
 
-- **Market (matchup)**: A single Polymarket prediction market the user can link
-  a wager to. Relevant attributes for this feature: a human-readable question/
-  title, category/topic association, a popularity signal (e.g. trading volume),
-  resolution/active status, and the identifiers required to link it for automatic
-  settlement.
-- **Search query**: The free-text term the user types to find markets by their
-  question text.
+- **Event (grouped matchup)**: A real-world happening (e.g. a specific game or
+  question) that groups one or more related markets. Shown as a single
+  expandable row in the picker. Relevant attributes: a human-readable title, its
+  category/topic association(s), and its set of eligible child markets. An event
+  is surfaced only if it has at least one eligible child market.
+- **Market (sub-market)**: A single Polymarket prediction market under an event
+  that the user actually links a wager to. Relevant attributes: a human-readable
+  question/title, a popularity signal (e.g. trading volume), resolution/active
+  status, and the identifiers required to link it for automatic settlement.
+- **Search query**: The free-text term the user types to find events/markets by
+  their text.
 - **Category filter**: A user-selectable topic (e.g. Sports, Politics, Crypto,
-  Pop Culture, Business, Tech) that constrains results to markets in that topic.
-- **Result set / picker state**: The current list shown to the user plus its
-  state (browsing vs. searching, selected categories, loading/empty/error),
-  driven by the combination of active query and active category filters.
+  Pop Culture, Business, Tech). Multiple may be selected at once; selected
+  categories constrain results with OR semantics.
+- **Result set / picker state**: The current list of events (with their
+  expandable sub-markets) shown to the user plus its state (browsing vs.
+  searching, selected categories, expanded events, loading/empty/error), driven
+  by the combination of active query and active category filters.
 
 ## Success Criteria *(mandatory)*
 
@@ -251,6 +294,9 @@ as current.
   appears.
 - **SC-008**: Automated tests cover the search, filter, combined, state, and
   race-condition behaviors and pass in CI.
+- **SC-009**: An event with many related sub-markets (e.g. a single game's
+  moneyline/spreads/over-unders) occupies a single result row that expands to its
+  sub-markets, rather than flooding the list with one row per sub-market.
 
 ## Assumptions
 

--- a/specs/013-polymarket-search-filter/tasks.md
+++ b/specs/013-polymarket-search-filter/tasks.md
@@ -36,9 +36,9 @@ Web app — frontend feature. Source under `frontend/src/`, tests under
 
 **Purpose**: Test fixtures/helpers the rest of the work depends on
 
-- [ ] T001 [P] Create Gamma API test fixtures in `frontend/src/test/fixtures/polymarket.js`: a `/public-search?q=knicks` payload (events with a multi-sub-market game event + the GTA-VI regression items), `/events?tag_id=<id>` payloads for ≥2 categories, an event containing a closed/condition-less (ineligible) market, a single-market event, and an error case.
-- [ ] T002 [P] Add a `fetch` mock helper (URL-aware, returns fixtures via `vi.stubGlobal`) in `frontend/src/test/helpers/mockGammaFetch.js`, following the existing pattern in `frontend/src/test/ipfsService.test.js`.
-- [ ] T003 [P] Confirm the Gamma base URL is sourced from `frontend/src/config/networks.js` (`network.polymarket.gammaApiUrl`) and note the verified category seed map (politics=2, sports=1, crypto=21, pop-culture=596, business=107, tech=1401) for use in T005.
+- [X] T001 [P] Create Gamma API test fixtures in `frontend/src/test/fixtures/polymarket.js`: a `/public-search?q=knicks` payload (events with a multi-sub-market game event + the GTA-VI regression items), `/events?tag_id=<id>` payloads for ≥2 categories, an event containing a closed/condition-less (ineligible) market, a single-market event, and an error case.
+- [X] T002 [P] Add a `fetch` mock helper (URL-aware, returns fixtures via `vi.stubGlobal`) in `frontend/src/test/helpers/mockGammaFetch.js`, following the existing pattern in `frontend/src/test/ipfsService.test.js`.
+- [X] T003 [P] Confirm the Gamma base URL is sourced from `frontend/src/config/networks.js` (`network.polymarket.gammaApiUrl`) and note the verified category seed map (politics=2, sports=1, crypto=21, pop-culture=596, business=107, tech=1401) for use in T005.
 
 ---
 
@@ -49,9 +49,9 @@ Web app — frontend feature. Source under `frontend/src/`, tests under
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T004 Add `normaliseGammaEvent(event)` in `frontend/src/hooks/usePolymarketSearch.js` that reuses `normaliseGammaMarket` for children, sets each child `label = groupItemTitle || question`, keeps only eligible children (`conditionId` present, `active === true`, `closed !== true`), captures event `id/title/slug/volume/tagIds`, and returns `null` when the event has zero eligible children. (data-model: NormalizedEvent/NormalizedMarket; Decisions 7, 10)
-- [ ] T005 Add `resolveCategoryTagId(slug)` in `frontend/src/hooks/usePolymarketSearch.js` backed by the verified seed map, memoized in module scope, with a `GET /tags/slug/{slug}` fallback for unseeded slugs. (Decision 3)
-- [ ] T006 Add a single-flight request helper (one `AbortController`, discard superseded responses, swallow `AbortError`, surface non-2xx as `Polymarket Gamma API returned <status>`) in `frontend/src/hooks/usePolymarketSearch.js`, to be used by both hooks. (Decision 8; C6/C7)
+- [X] T004 Add `normaliseGammaEvent(event)` in `frontend/src/hooks/usePolymarketSearch.js` that reuses `normaliseGammaMarket` for children, sets each child `label = groupItemTitle || question`, keeps only eligible children (`conditionId` present, `active === true`, `closed !== true`), captures event `id/title/slug/volume/tagIds`, and returns `null` when the event has zero eligible children. (data-model: NormalizedEvent/NormalizedMarket; Decisions 7, 10)
+- [X] T005 Add `resolveCategoryTagId(slug)` in `frontend/src/hooks/usePolymarketSearch.js` backed by the verified seed map, memoized in module scope, with a `GET /tags/slug/{slug}` fallback for unseeded slugs. (Decision 3)
+- [X] T006 Add a single-flight request helper (one `AbortController`, discard superseded responses, swallow `AbortError`, surface non-2xx as `Polymarket Gamma API returned <status>`) in `frontend/src/hooks/usePolymarketSearch.js`, to be used by both hooks. (Decision 8; C6/C7)
 
 **Checkpoint**: Normalization, tag resolution, and fetch safety are ready.
 
@@ -68,15 +68,15 @@ sub-market, and a single-market event selects directly.
 
 ### Tests for User Story 1 ⚠️ (write first, must fail)
 
-- [ ] T007 [P] [US1] Hook tests in `frontend/src/test/usePolymarketSearch.test.js`: search calls `…/public-search?q=<encoded>&limit_per_type=…` (never `/markets?search=`), normalizes to events with eligible children, drops ineligible/empty events, and the `knicks` fixture yields only relevant events. (C1, C3, C8; regression)
-- [ ] T008 [P] [US1] Component tests in `frontend/src/test/PolymarketBrowser.test.jsx`: typing shows grouped event rows; a multi-sub-market event renders one expandable row that reveals children on expand; selecting a child calls `onSelectMarket` with its `conditionId`; a single-market event selects directly without expanding. (T1, T7)
+- [X] T007 [P] [US1] Hook tests in `frontend/src/test/usePolymarketSearch.test.js`: search calls `…/public-search?q=<encoded>&limit_per_type=…` (never `/markets?search=`), normalizes to events with eligible children, drops ineligible/empty events, and the `knicks` fixture yields only relevant events. (C1, C3, C8; regression)
+- [X] T008 [P] [US1] Component tests in `frontend/src/test/PolymarketBrowser.test.jsx`: typing shows grouped event rows; a multi-sub-market event renders one expandable row that reveals children on expand; selecting a child calls `onSelectMarket` with its `conditionId`; a single-market event selects directly without expanding. (T1, T7)
 
 ### Implementation for User Story 1
 
-- [ ] T009 [US1] Rewrite `usePolymarketSearch({ limit })` in `frontend/src/hooks/usePolymarketSearch.js` to fetch `GET /public-search?q=<query>&limit_per_type=<limit>` via the T006 helper, map results through `normaliseGammaEvent`, return `NormalizedEvent[]`, and clear on blank/whitespace query. (C1; Decision 1)
-- [ ] T010 [US1] Implement event-grouped rendering in `frontend/src/components/fairwins/PolymarketBrowser.jsx`: one row per `NormalizedEvent` keyed by `id`; events with >1 child get an expand toggle (`aria-expanded`) backed by an `expandedEventIds` set; expanded child list keyed by `conditionId` with `label`; single-child events select on row click; selection calls `onSelectMarket(market)` and honors `selectedConditionId`. (FR-017; Decision 10)
-- [ ] T011 [US1] Add expandable-event-row and sub-market-list styles (collapsed/expanded, selected child) in `frontend/src/components/fairwins/PolymarketBrowser.css`.
-- [ ] T012 [US1] Wire the search input through a single debounce to `usePolymarketSearch` in `frontend/src/components/fairwins/PolymarketBrowser.jsx`, removing the component-level pre-debounce so search no longer double-fires. (depends on T010)
+- [X] T009 [US1] Rewrite `usePolymarketSearch({ limit })` in `frontend/src/hooks/usePolymarketSearch.js` to fetch `GET /public-search?q=<query>&limit_per_type=<limit>` via the T006 helper, map results through `normaliseGammaEvent`, return `NormalizedEvent[]`, and clear on blank/whitespace query. (C1; Decision 1)
+- [X] T010 [US1] Implement event-grouped rendering in `frontend/src/components/fairwins/PolymarketBrowser.jsx`: one row per `NormalizedEvent` keyed by `id`; events with >1 child get an expand toggle (`aria-expanded`) backed by an `expandedEventIds` set; expanded child list keyed by `conditionId` with `label`; single-child events select on row click; selection calls `onSelectMarket(market)` and honors `selectedConditionId`. (FR-017; Decision 10)
+- [X] T011 [US1] Add expandable-event-row and sub-market-list styles (collapsed/expanded, selected child) in `frontend/src/components/fairwins/PolymarketBrowser.css`.
+- [X] T012 [US1] Wire the search input through a single debounce to `usePolymarketSearch` in `frontend/src/components/fairwins/PolymarketBrowser.jsx`, removing the component-level pre-debounce so search no longer double-fires. (depends on T010)
 
 **Checkpoint**: Search returns relevant, grouped, expandable, selectable results — MVP usable.
 
@@ -92,13 +92,13 @@ the union of sports OR crypto events; Clear → default top events.
 
 ### Tests for User Story 2 ⚠️ (write first, must fail)
 
-- [ ] T013 [P] [US2] Hook tests in `frontend/src/test/usePolymarketTopMarkets.test.js`: no category → `GET /events?…order=volume&ascending=false`; one category → includes `tag_id=<seed id>` (never `tag_slug`, never `/markets`); multiple categories → one request per `tag_id`, results merged/de-duped by event `id`. (C2, C5)
-- [ ] T014 [P] [US2] Component tests in `frontend/src/test/PolymarketBrowser.test.jsx`: selecting a category narrows results; selecting a second shows the union; chips are multi-select (`aria-pressed`); Clear restores default top events; category-empty shows its distinct empty state. (T2)
+- [X] T013 [P] [US2] Hook tests in `frontend/src/test/usePolymarketTopMarkets.test.js`: no category → `GET /events?…order=volume&ascending=false`; one category → includes `tag_id=<seed id>` (never `tag_slug`, never `/markets`); multiple categories → one request per `tag_id`, results merged/de-duped by event `id`. (C2, C5)
+- [X] T014 [P] [US2] Component tests in `frontend/src/test/PolymarketBrowser.test.jsx`: selecting a category narrows results; selecting a second shows the union; chips are multi-select (`aria-pressed`); Clear restores default top events; category-empty shows its distinct empty state. (T2)
 
 ### Implementation for User Story 2
 
-- [ ] T015 [US2] Rewrite `usePolymarketTopMarkets({ categories, limit })` in `frontend/src/hooks/usePolymarketSearch.js` to fetch `GET /events?…&order=volume&ascending=false` (default) and `GET /events?tag_id=<resolveCategoryTagId(slug)>…` per selected category in parallel, merge/de-dupe by event `id`, re-sort by volume, cap at `limit`, and normalize via `normaliseGammaEvent`. (C2, C5; Decisions 2, 4, 5)
-- [ ] T016 [US2] Make the category chips multi-select in `frontend/src/components/fairwins/PolymarketBrowser.jsx` (toggle add/remove slug, Clear-all) and route browse mode through the shared grouped event render from T010. (FR-002)
+- [X] T015 [US2] Rewrite `usePolymarketTopMarkets({ categories, limit })` in `frontend/src/hooks/usePolymarketSearch.js` to fetch `GET /events?…&order=volume&ascending=false` (default) and `GET /events?tag_id=<resolveCategoryTagId(slug)>…` per selected category in parallel, merge/de-dupe by event `id`, re-sort by volume, cap at `limit`, and normalize via `normaliseGammaEvent`. (C2, C5; Decisions 2, 4, 5)
+- [X] T016 [US2] Make the category chips multi-select in `frontend/src/components/fairwins/PolymarketBrowser.jsx` (toggle add/remove slug, Clear-all) and route browse mode through the shared grouped event render from T010. (FR-002)
 
 **Checkpoint**: Browse-by-category works with OR multi-select; US1 still works.
 
@@ -115,13 +115,13 @@ broadens to query alone.
 
 ### Tests for User Story 3 ⚠️ (write first, must fail)
 
-- [ ] T017 [P] [US3] Hook test in `frontend/src/test/usePolymarketSearch.test.js`: `usePolymarketSearch({ categories })` keeps only events whose `tagIds` intersect the selected `tag_id`s (OR across categories). (C4)
-- [ ] T018 [P] [US3] Component tests in `frontend/src/test/PolymarketBrowser.test.jsx`: toggling a category preserves the query; query+category constrains results; selecting a category before typing also constrains (default); removing the category broadens results. (T3)
+- [X] T017 [P] [US3] Hook test in `frontend/src/test/usePolymarketSearch.test.js`: `usePolymarketSearch({ categories })` keeps only events whose `tagIds` intersect the selected `tag_id`s (OR across categories). (C4)
+- [X] T018 [P] [US3] Component tests in `frontend/src/test/PolymarketBrowser.test.jsx`: toggling a category preserves the query; query+category constrains results; selecting a category before typing also constrains (default); removing the category broadens results. (T3)
 
 ### Implementation for User Story 3
 
-- [ ] T019 [US3] Add a `categories` input to `usePolymarketSearch` in `frontend/src/hooks/usePolymarketSearch.js` and filter the normalized events by `tagIds ∩ resolved selected tag_ids` (OR) before returning. (C4; Decision 6)
-- [ ] T020 [US3] In `frontend/src/components/fairwins/PolymarketBrowser.jsx`, pass `activeCategories` into `usePolymarketSearch`, and remove the `if (trimmedQuery) setQuery('')` branch in `toggleCategory` so the query persists across category toggles. (FR-003, FR-004)
+- [X] T019 [US3] Add a `categories` input to `usePolymarketSearch` in `frontend/src/hooks/usePolymarketSearch.js` and filter the normalized events by `tagIds ∩ resolved selected tag_ids` (OR) before returning. (C4; Decision 6)
+- [X] T020 [US3] In `frontend/src/components/fairwins/PolymarketBrowser.jsx`, pass `activeCategories` into `usePolymarketSearch`, and remove the `if (trimmedQuery) setQuery('')` branch in `toggleCategory` so the query persists across category toggles. (FR-003, FR-004)
 
 **Checkpoint**: Query and category compose correctly; US1/US2 still work.
 
@@ -138,14 +138,14 @@ distinct; every listed market is eligible; axe finds no violations.
 
 ### Tests for User Story 4 ⚠️ (write first, must fail)
 
-- [ ] T021 [P] [US4] Hook tests in `frontend/src/test/usePolymarketSearch.test.js`: a superseded in-flight request is aborted and never overwrites newer results; non-2xx/network failure sets an error string and clears results; `AbortError` is swallowed. (C6, C7, T5)
-- [ ] T022 [P] [US4] Component tests in `frontend/src/test/PolymarketBrowser.test.jsx`: distinct loading (skeleton/`aria-busy`), empty (search vs category vs no-markets), and error (`role="alert"` + Retry) states; Retry re-issues the correct request for the active mode; ineligible markets never render. (T4, T6)
-- [ ] T023 [US4] Accessibility test in `frontend/src/test/PolymarketBrowser.test.jsx` using `vitest-axe`: no violations in collapsed list, expanded event, empty, and error states. (T8) — same file as T022, so runs after it.
+- [X] T021 [P] [US4] Hook tests in `frontend/src/test/usePolymarketSearch.test.js`: a superseded in-flight request is aborted and never overwrites newer results; non-2xx/network failure sets an error string and clears results; `AbortError` is swallowed. (C6, C7, T5)
+- [X] T022 [P] [US4] Component tests in `frontend/src/test/PolymarketBrowser.test.jsx`: distinct loading (skeleton/`aria-busy`), empty (search vs category vs no-markets), and error (`role="alert"` + Retry) states; Retry re-issues the correct request for the active mode; ineligible markets never render. (T4, T6)
+- [X] T023 [US4] Accessibility test in `frontend/src/test/PolymarketBrowser.test.jsx` using `vitest-axe`: no violations in collapsed list, expanded event, empty, and error states. (T8) — same file as T022, so runs after it.
 
 ### Implementation for User Story 4
 
-- [ ] T024 [US4] Consolidate to a single debounce (~300–350ms) and confirm both hooks use the T006 single-flight/supersession helper in `frontend/src/hooks/usePolymarketSearch.js`; remove the now-redundant second debounce. (FR-009, FR-010; Decision 8)
-- [ ] T025 [US4] Finalize the picker's state UI in `frontend/src/components/fairwins/PolymarketBrowser.jsx`: mutually-exclusive loading/empty/error/list rendering, mode-aware Retry handler, distinct empty copy, and preserved/added ARIA (`aria-expanded` on the expand toggle, keyboard-navigable sub-markets, `role="alert"`, `aria-busy`). (FR-011, FR-012; Constitution V)
+- [X] T024 [US4] Consolidate to a single debounce (~300–350ms) and confirm both hooks use the T006 single-flight/supersession helper in `frontend/src/hooks/usePolymarketSearch.js`; remove the now-redundant second debounce. (FR-009, FR-010; Decision 8)
+- [X] T025 [US4] Finalize the picker's state UI in `frontend/src/components/fairwins/PolymarketBrowser.jsx`: mutually-exclusive loading/empty/error/list rendering, mode-aware Retry handler, distinct empty copy, and preserved/added ARIA (`aria-expanded` on the expand toggle, keyboard-navigable sub-markets, `role="alert"`, `aria-busy`). (FR-011, FR-012; Constitution V)
 
 **Checkpoint**: All four stories function independently and the picker is trustworthy.
 
@@ -153,10 +153,10 @@ distinct; every listed market is eligible; axe finds no violations.
 
 ## Phase 7: Polish & Cross-Cutting Concerns
 
-- [ ] T026 [P] Verify both call sites consume grouped events correctly — `FriendMarketsModal.jsx` (inline) and `Dashboard.jsx` (feed) — and update the PolymarketBrowser stub/assertions in `frontend/src/test/FriendMarketsModal.test.jsx` if the grouped shape changed expectations. (FR-015)
-- [ ] T027 [P] Remove dead code (old `search=`/`tag_slug` params, double-debounce remnants) and refresh JSDoc in `frontend/src/hooks/usePolymarketSearch.js`.
-- [ ] T028 Run `npm run lint` and `npm run test:frontend` from `frontend/`; fix any lint/test failures (no `continue-on-error`; Constitution IV).
-- [ ] T029 Execute the manual validation in `specs/013-polymarket-search-filter/quickstart.md` (search+grouping, multi-select OR, search-within-category, states) and confirm SC-001…SC-009.
+- [X] T026 [P] Verify both call sites consume grouped events correctly — `FriendMarketsModal.jsx` (inline) and `Dashboard.jsx` (feed) — and update the PolymarketBrowser stub/assertions in `frontend/src/test/FriendMarketsModal.test.jsx` if the grouped shape changed expectations. (FR-015)
+- [X] T027 [P] Remove dead code (old `search=`/`tag_slug` params, double-debounce remnants) and refresh JSDoc in `frontend/src/hooks/usePolymarketSearch.js`.
+- [X] T028 Run `npm run lint` and `npm run test:frontend` from `frontend/`; fix any lint/test failures (no `continue-on-error`; Constitution IV).
+- [X] T029 Execute the manual validation in `specs/013-polymarket-search-filter/quickstart.md` (search+grouping, multi-select OR, search-within-category, states) and confirm SC-001…SC-009.
 
 ---
 

--- a/specs/013-polymarket-search-filter/tasks.md
+++ b/specs/013-polymarket-search-filter/tasks.md
@@ -1,0 +1,246 @@
+---
+
+description: "Task list for Polymarket Search & Category Filter"
+---
+
+# Tasks: Polymarket Search & Category Filter
+
+**Input**: Design documents from `/specs/013-polymarket-search-filter/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: INCLUDED — required by Constitution Principle II (Test-First, NON-NEGOTIABLE)
+and spec FR-016. Tests for each story are written first and must fail before the
+story's implementation.
+
+**Organization**: Grouped by user story. Note this feature touches a small,
+shared surface — `frontend/src/hooks/usePolymarketSearch.js` and
+`frontend/src/components/fairwins/PolymarketBrowser.jsx` — so several
+implementation tasks within a phase edit the same file and run sequentially.
+Test files differ per layer, so hook-test vs component-test tasks parallelize.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different file, no dependency on an incomplete task)
+- **[Story]**: US1–US4 (from spec.md)
+- Exact file paths are included in each task
+
+## Path Conventions
+
+Web app — frontend feature. Source under `frontend/src/`, tests under
+`frontend/src/test/` (the repo's established Vitest location).
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Test fixtures/helpers the rest of the work depends on
+
+- [ ] T001 [P] Create Gamma API test fixtures in `frontend/src/test/fixtures/polymarket.js`: a `/public-search?q=knicks` payload (events with a multi-sub-market game event + the GTA-VI regression items), `/events?tag_id=<id>` payloads for ≥2 categories, an event containing a closed/condition-less (ineligible) market, a single-market event, and an error case.
+- [ ] T002 [P] Add a `fetch` mock helper (URL-aware, returns fixtures via `vi.stubGlobal`) in `frontend/src/test/helpers/mockGammaFetch.js`, following the existing pattern in `frontend/src/test/ipfsService.test.js`.
+- [ ] T003 [P] Confirm the Gamma base URL is sourced from `frontend/src/config/networks.js` (`network.polymarket.gammaApiUrl`) and note the verified category seed map (politics=2, sports=1, crypto=21, pop-culture=596, business=107, tech=1401) for use in T005.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared data-layer building blocks used by every story. All live in
+`frontend/src/hooks/usePolymarketSearch.js`, so they run sequentially.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T004 Add `normaliseGammaEvent(event)` in `frontend/src/hooks/usePolymarketSearch.js` that reuses `normaliseGammaMarket` for children, sets each child `label = groupItemTitle || question`, keeps only eligible children (`conditionId` present, `active === true`, `closed !== true`), captures event `id/title/slug/volume/tagIds`, and returns `null` when the event has zero eligible children. (data-model: NormalizedEvent/NormalizedMarket; Decisions 7, 10)
+- [ ] T005 Add `resolveCategoryTagId(slug)` in `frontend/src/hooks/usePolymarketSearch.js` backed by the verified seed map, memoized in module scope, with a `GET /tags/slug/{slug}` fallback for unseeded slugs. (Decision 3)
+- [ ] T006 Add a single-flight request helper (one `AbortController`, discard superseded responses, swallow `AbortError`, surface non-2xx as `Polymarket Gamma API returned <status>`) in `frontend/src/hooks/usePolymarketSearch.js`, to be used by both hooks. (Decision 8; C6/C7)
+
+**Checkpoint**: Normalization, tag resolution, and fetch safety are ready.
+
+---
+
+## Phase 3: User Story 1 - Find a specific market by searching (Priority: P1) 🎯 MVP
+
+**Goal**: Typing a term returns relevant markets, grouped by event, where a game
+with many sub-markets is one expandable row; selecting a (sub-)market links it.
+
+**Independent Test**: Type `knicks`; results are Knicks-related (no GTA-VI noise),
+a multi-sub-market game shows as one expandable row, expanding lets you select a
+sub-market, and a single-market event selects directly.
+
+### Tests for User Story 1 ⚠️ (write first, must fail)
+
+- [ ] T007 [P] [US1] Hook tests in `frontend/src/test/usePolymarketSearch.test.js`: search calls `…/public-search?q=<encoded>&limit_per_type=…` (never `/markets?search=`), normalizes to events with eligible children, drops ineligible/empty events, and the `knicks` fixture yields only relevant events. (C1, C3, C8; regression)
+- [ ] T008 [P] [US1] Component tests in `frontend/src/test/PolymarketBrowser.test.jsx`: typing shows grouped event rows; a multi-sub-market event renders one expandable row that reveals children on expand; selecting a child calls `onSelectMarket` with its `conditionId`; a single-market event selects directly without expanding. (T1, T7)
+
+### Implementation for User Story 1
+
+- [ ] T009 [US1] Rewrite `usePolymarketSearch({ limit })` in `frontend/src/hooks/usePolymarketSearch.js` to fetch `GET /public-search?q=<query>&limit_per_type=<limit>` via the T006 helper, map results through `normaliseGammaEvent`, return `NormalizedEvent[]`, and clear on blank/whitespace query. (C1; Decision 1)
+- [ ] T010 [US1] Implement event-grouped rendering in `frontend/src/components/fairwins/PolymarketBrowser.jsx`: one row per `NormalizedEvent` keyed by `id`; events with >1 child get an expand toggle (`aria-expanded`) backed by an `expandedEventIds` set; expanded child list keyed by `conditionId` with `label`; single-child events select on row click; selection calls `onSelectMarket(market)` and honors `selectedConditionId`. (FR-017; Decision 10)
+- [ ] T011 [US1] Add expandable-event-row and sub-market-list styles (collapsed/expanded, selected child) in `frontend/src/components/fairwins/PolymarketBrowser.css`.
+- [ ] T012 [US1] Wire the search input through a single debounce to `usePolymarketSearch` in `frontend/src/components/fairwins/PolymarketBrowser.jsx`, removing the component-level pre-debounce so search no longer double-fires. (depends on T010)
+
+**Checkpoint**: Search returns relevant, grouped, expandable, selectable results — MVP usable.
+
+---
+
+## Phase 4: User Story 2 - Narrow the list by category (Priority: P1)
+
+**Goal**: Multi-selectable category chips actually filter browse results (OR
+semantics), reusing the grouped event rendering.
+
+**Independent Test**: With no query, tap Sports → sports events; also tap Crypto →
+the union of sports OR crypto events; Clear → default top events.
+
+### Tests for User Story 2 ⚠️ (write first, must fail)
+
+- [ ] T013 [P] [US2] Hook tests in `frontend/src/test/usePolymarketTopMarkets.test.js`: no category → `GET /events?…order=volume&ascending=false`; one category → includes `tag_id=<seed id>` (never `tag_slug`, never `/markets`); multiple categories → one request per `tag_id`, results merged/de-duped by event `id`. (C2, C5)
+- [ ] T014 [P] [US2] Component tests in `frontend/src/test/PolymarketBrowser.test.jsx`: selecting a category narrows results; selecting a second shows the union; chips are multi-select (`aria-pressed`); Clear restores default top events; category-empty shows its distinct empty state. (T2)
+
+### Implementation for User Story 2
+
+- [ ] T015 [US2] Rewrite `usePolymarketTopMarkets({ categories, limit })` in `frontend/src/hooks/usePolymarketSearch.js` to fetch `GET /events?…&order=volume&ascending=false` (default) and `GET /events?tag_id=<resolveCategoryTagId(slug)>…` per selected category in parallel, merge/de-dupe by event `id`, re-sort by volume, cap at `limit`, and normalize via `normaliseGammaEvent`. (C2, C5; Decisions 2, 4, 5)
+- [ ] T016 [US2] Make the category chips multi-select in `frontend/src/components/fairwins/PolymarketBrowser.jsx` (toggle add/remove slug, Clear-all) and route browse mode through the shared grouped event render from T010. (FR-002)
+
+**Checkpoint**: Browse-by-category works with OR multi-select; US1 still works.
+
+---
+
+## Phase 5: User Story 3 - Search within a category (Priority: P2)
+
+**Goal**: Combine query + category; the active category constrains search by
+default; toggling a category never wipes the typed query.
+
+**Independent Test**: Type `lakers`, toggle Sports → query preserved and results
+reflect both; select Sports first then type → constrained; remove Sports →
+broadens to query alone.
+
+### Tests for User Story 3 ⚠️ (write first, must fail)
+
+- [ ] T017 [P] [US3] Hook test in `frontend/src/test/usePolymarketSearch.test.js`: `usePolymarketSearch({ categories })` keeps only events whose `tagIds` intersect the selected `tag_id`s (OR across categories). (C4)
+- [ ] T018 [P] [US3] Component tests in `frontend/src/test/PolymarketBrowser.test.jsx`: toggling a category preserves the query; query+category constrains results; selecting a category before typing also constrains (default); removing the category broadens results. (T3)
+
+### Implementation for User Story 3
+
+- [ ] T019 [US3] Add a `categories` input to `usePolymarketSearch` in `frontend/src/hooks/usePolymarketSearch.js` and filter the normalized events by `tagIds ∩ resolved selected tag_ids` (OR) before returning. (C4; Decision 6)
+- [ ] T020 [US3] In `frontend/src/components/fairwins/PolymarketBrowser.jsx`, pass `activeCategories` into `usePolymarketSearch`, and remove the `if (trimmedQuery) setQuery('')` branch in `toggleCategory` so the query persists across category toggles. (FR-003, FR-004)
+
+**Checkpoint**: Query and category compose correctly; US1/US2 still work.
+
+---
+
+## Phase 6: User Story 4 - Trustworthy, responsive results (Priority: P2)
+
+**Goal**: Single debounce, abort/supersession safety, distinct loading/empty/
+error states with retry, only eligible markets, and accessibility.
+
+**Independent Test**: Rapid typing updates without out-of-order overwrites; an
+induced failure shows an error + working Retry (no stale list); empty/loading are
+distinct; every listed market is eligible; axe finds no violations.
+
+### Tests for User Story 4 ⚠️ (write first, must fail)
+
+- [ ] T021 [P] [US4] Hook tests in `frontend/src/test/usePolymarketSearch.test.js`: a superseded in-flight request is aborted and never overwrites newer results; non-2xx/network failure sets an error string and clears results; `AbortError` is swallowed. (C6, C7, T5)
+- [ ] T022 [P] [US4] Component tests in `frontend/src/test/PolymarketBrowser.test.jsx`: distinct loading (skeleton/`aria-busy`), empty (search vs category vs no-markets), and error (`role="alert"` + Retry) states; Retry re-issues the correct request for the active mode; ineligible markets never render. (T4, T6)
+- [ ] T023 [US4] Accessibility test in `frontend/src/test/PolymarketBrowser.test.jsx` using `vitest-axe`: no violations in collapsed list, expanded event, empty, and error states. (T8) — same file as T022, so runs after it.
+
+### Implementation for User Story 4
+
+- [ ] T024 [US4] Consolidate to a single debounce (~300–350ms) and confirm both hooks use the T006 single-flight/supersession helper in `frontend/src/hooks/usePolymarketSearch.js`; remove the now-redundant second debounce. (FR-009, FR-010; Decision 8)
+- [ ] T025 [US4] Finalize the picker's state UI in `frontend/src/components/fairwins/PolymarketBrowser.jsx`: mutually-exclusive loading/empty/error/list rendering, mode-aware Retry handler, distinct empty copy, and preserved/added ARIA (`aria-expanded` on the expand toggle, keyboard-navigable sub-markets, `role="alert"`, `aria-busy`). (FR-011, FR-012; Constitution V)
+
+**Checkpoint**: All four stories function independently and the picker is trustworthy.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [ ] T026 [P] Verify both call sites consume grouped events correctly — `FriendMarketsModal.jsx` (inline) and `Dashboard.jsx` (feed) — and update the PolymarketBrowser stub/assertions in `frontend/src/test/FriendMarketsModal.test.jsx` if the grouped shape changed expectations. (FR-015)
+- [ ] T027 [P] Remove dead code (old `search=`/`tag_slug` params, double-debounce remnants) and refresh JSDoc in `frontend/src/hooks/usePolymarketSearch.js`.
+- [ ] T028 Run `npm run lint` and `npm run test:frontend` from `frontend/`; fix any lint/test failures (no `continue-on-error`; Constitution IV).
+- [ ] T029 Execute the manual validation in `specs/013-polymarket-search-filter/quickstart.md` (search+grouping, multi-select OR, search-within-category, states) and confirm SC-001…SC-009.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies — start immediately.
+- **Foundational (Phase 2)**: depends on Setup — BLOCKS all user stories.
+- **User Stories (Phase 3–6)**: all depend on Foundational.
+  - US1 (P1) is the MVP and introduces the shared grouped render (T010) that US2
+    reuses, so **US2 depends on T010**. US3 and US4 also build on US1's hook/UI.
+  - Practical order: US1 → US2 → US3 → US4 (priority order). They are
+    independently *testable*, but because they edit two shared files, parallel
+    development across stories needs coordination.
+- **Polish (Phase 7)**: after the desired stories are complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: after Foundational. No dependency on other stories.
+- **US2 (P1)**: after Foundational; reuses US1's grouped render (T010).
+- **US3 (P2)**: after Foundational; extends US1's search hook + chips.
+- **US4 (P2)**: after Foundational; hardens US1/US2/US3 behavior.
+
+### Within Each User Story
+
+- Write the story's tests first and confirm they fail, then implement.
+- In the hook file: normalization/resolver/fetch helper (Phase 2) before hook
+  bodies; hook bodies before the component wiring that consumes them.
+
+### Parallel Opportunities
+
+- Setup: T001, T002, T003 all `[P]`.
+- Per story, the hook-test task and the component-test task target different
+  files and are `[P]` with each other (e.g. T007 ∥ T008; T013 ∥ T014;
+  T017 ∥ T018; T021 ∥ T022).
+- T023 shares `PolymarketBrowser.test.jsx` with T022 → not parallel with it.
+- Implementation tasks editing the same file (hook file T004–T006, T009, T015,
+  T019, T024; component file T010, T012, T016, T020, T025) are sequential within
+  that file. The CSS task (T011) is `[P]` against hook/component edits.
+- Polish: T026 and T027 are `[P]` (different files); T028/T029 run last.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Write the two test layers in parallel (different files), confirm they FAIL:
+Task: "T007 Hook tests in frontend/src/test/usePolymarketSearch.test.js"
+Task: "T008 Component tests in frontend/src/test/PolymarketBrowser.test.jsx"
+
+# Then implement sequentially within shared files (T009 hook → T010/T012 component),
+# with the CSS task in parallel:
+Task: "T011 Expandable event-row styles in frontend/src/components/fairwins/PolymarketBrowser.css"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1: Setup → 2. Phase 2: Foundational → 3. Phase 3: US1.
+4. **STOP and VALIDATE**: search returns relevant, grouped, expandable,
+   selectable results (the headline bug — "knicks → GTA VI" — is fixed).
+5. Demo/ship the MVP.
+
+### Incremental Delivery
+
+1. Setup + Foundational → foundation ready.
+2. US1 → relevant grouped search (MVP).
+3. US2 → working multi-select category browse.
+4. US3 → search-within-category.
+5. US4 → responsiveness, states, a11y hardening.
+6. Polish → call-site verification, cleanup, lint/test, quickstart.
+
+---
+
+## Notes
+
+- `[P]` = different files, no dependency on an incomplete task.
+- `[Story]` maps each task to a user story for traceability.
+- Contract obligations C1–C8 ([contracts/gamma-api.md]) and component obligations
+  T1–T8 ([contracts/polymarket-hooks.md]) are covered across the test tasks.
+- This is frontend-only — no `contracts/` (Solidity), on-chain, or oracle changes;
+  no security-review gate is triggered.
+- Commit after each task or logical group; keep CI green (Constitution IV).


### PR DESCRIPTION
## Summary

The "Linked Polymarket Event" picker's search and category filtering are broken for users. This PR adds a Spec Kit specification (`specs/013-polymarket-search-filter/spec.md`) defining a proper implementation, following the investigation requested in the task. **Spec only — no implementation yet.**

## Investigation findings (current behavior)

Confirmed via user screenshots of `fairwins.app/app`:

- **Search returns irrelevant results.** Searching `knicks` returned "New Rihanna Album before GTA VI?", "New Playboi Carti Album before GTA VI?", "Will Jesus Christ return before GTA VI?", "Trump out as President before GTA VI?" — none related to the Knicks.
- **Category filters do nothing.** Selecting *Business* and *Pop Culture* both returned the identical default political list (Russian LDPR election, US AI safety bill, Spencer Pratt, Esteban Bullrich). The chip highlights but the result set never changes.

Code-level root causes (`frontend/src/components/fairwins/PolymarketBrowser.jsx`, `frontend/src/hooks/usePolymarketSearch.js`):

- Gamma API `search` and `tag_slug` params appear not to be honored by the `/markets` endpoint — search and category requests return a default set regardless of input.
- Category filters are never passed to the search hook (search is always global).
- Toggling a category clears the typed query.
- Double debounce (350ms component + 400ms hook) ≈ 750ms perceived lag.
- Only `conditionId` is validated; no relevance/completeness checks.
- No test coverage for search or filter behavior.

## What the spec defines

Four prioritized, independently testable user journeys:

1. **P1 — Find a specific market by searching** (relevant, relevance-ranked results)
2. **P1 — Narrow the list by category** (each category actually filters)
3. **P2 — Search within a category** (combine both; preserve the typed query when toggling)
4. **P2 — Trustworthy, responsive results** (single debounce, distinct loading/empty/error states with retry, only eligible markets, no out-of-order overwrites)

Plus 16 functional requirements, measurable + technology-agnostic success criteria, edge cases (race conditions, empty/error states, ineligible markets), and an Assumptions section.

## Scope

Frontend search/filter UX and the market-data fetch layer only. On-chain settlement and adding new oracle sources are out of scope. The correct upstream query mechanism (right Polymarket endpoint/params) is deliberately left to `/speckit-plan`; the spec requires correct observable behavior.

## Quality

Spec validated against the requirements checklist (`specs/013-polymarket-search-filter/checklists/requirements.md`) — passed on first iteration, no open `[NEEDS CLARIFICATION]` markers.

## Next step

`/speckit-plan` to design the implementation against the chosen stack (must pass the constitution check, including test-first coverage per Principle II).

https://claude.ai/code/session_01QSDpd5YzAS2oG5Mxck6cNL

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSDpd5YzAS2oG5Mxck6cNL)_