### PR TITLE
Only show future (wagerable) Polymarket markets in the picker

### DIFF
--- a/frontend/src/hooks/usePolymarketSearch.js
+++ b/frontend/src/hooks/usePolymarketSearch.js
@@ -104,9 +104,23 @@ export function normaliseGammaMarket(m) {
   }
 }
 
-/** A market may back a wager only if it is active, unresolved, and has a condition id. */
+/**
+ * A market's resolution must be in the future to be wagerable. Markets with a
+ * missing or unparseable end date are treated as ineligible — we can't confirm
+ * they're still open, and the wager form needs a settlement date.
+ */
+function endsInFuture(endDate) {
+  if (!endDate) return false
+  const t = Date.parse(endDate)
+  return Number.isFinite(t) && t > Date.now()
+}
+
+/**
+ * A market may back a wager only if it is active, unresolved, has a condition id,
+ * and ends in the future (so users can't pick an event that has already passed).
+ */
 function isEligibleMarket(m) {
-  return Boolean(m.conditionId) && m.active === true && m.closed !== true
+  return Boolean(m.conditionId) && m.active === true && m.closed !== true && endsInFuture(m.endDate)
 }
 
 /**

--- a/frontend/src/test/usePolymarketSearch.test.js
+++ b/frontend/src/test/usePolymarketSearch.test.js
@@ -5,6 +5,8 @@ import { installGammaFetch, urlHas } from './helpers/mockGammaFetch'
 import {
   searchKnicksPayload,
   searchIneligiblePayload,
+  mkEvent,
+  mkMarket,
 } from './fixtures/polymarket'
 
 describe('usePolymarketSearch', () => {
@@ -48,6 +50,40 @@ describe('usePolymarketSearch', () => {
     })
 
     expect(result.current.results).toEqual([])
+  })
+
+  it('drops markets that have already ended (only future events are wagerable)', async () => {
+    const payload = {
+      events: [
+        mkEvent({
+          id: 'ev-past',
+          title: 'Already finished',
+          tags: [{ id: '1', label: 'Sports', slug: 'sports' }],
+          markets: [mkMarket({ id: 'past', conditionId: '0xpast', endDate: '2020-01-01T00:00:00Z' })],
+        }),
+        mkEvent({
+          id: 'ev-future',
+          title: 'Upcoming game',
+          tags: [{ id: '1', label: 'Sports', slug: 'sports' }],
+          markets: [
+            mkMarket({ id: 'fut', conditionId: '0xfut', question: 'Future market?', endDate: '2030-01-01T00:00:00Z' }),
+            mkMarket({ id: 'fin', conditionId: '0xfin', question: 'Finished market?', endDate: '2019-06-01T00:00:00Z' }),
+          ],
+        }),
+      ],
+      pagination: { hasMore: false },
+    }
+    installGammaFetch([{ match: urlHas('/public-search'), json: payload }])
+
+    const { result } = renderHook(() => usePolymarketSearch({ limit: 10 }))
+    await act(async () => {
+      await result.current.runSearch('anything')
+    })
+
+    // The all-past event is dropped; the future event keeps only its future market.
+    expect(result.current.results).toHaveLength(1)
+    expect(result.current.results[0].id).toBe('ev-future')
+    expect(result.current.results[0].markets.map((m) => m.conditionId)).toEqual(['0xfut'])
   })
 
   it('fires no request and clears for a blank query', async () => {

--- a/specs/013-polymarket-search-filter/contracts/gamma-api.md
+++ b/specs/013-polymarket-search-filter/contracts/gamma-api.md
@@ -32,8 +32,8 @@ Example: `GET /public-search?q=knicks&limit_per_type=10`
 
 **Consumer rules**:
 - Normalize each event → `NormalizedEvent` keeping only surfaceable child markets
-  (`conditionId` present, `active === true`, `closed !== true`); drop events with
-  zero eligible children.
+  (`conditionId` present, `active === true`, `closed !== true`, and a future,
+  parseable `endDate`); drop events with zero eligible children.
 - When categories are active, keep only events whose `tags[].id` intersects the
   selected `tag_id`s (OR) before surfacing (Decision 6).
 - Preserve upstream event order as relevance.
@@ -107,8 +107,8 @@ requested URL + handling the canned response:
   `tag_id=<numeric id>` from the verified mapping (never `tag_slug=`, never
   `/markets`).
 - **C3**: events are normalized with only surfaceable child markets
-  (conditionId + active + !closed); events with zero eligible children are
-  dropped.
+  (conditionId + active + !closed + future endDate); events with zero eligible
+  children — including all-past-dated events — are dropped.
 - **C4**: combined query+category keeps only events whose `tags` include a
   selected `tag_id` (OR across selected categories).
 - **C5**: multi-category browse fans out one request per `tag_id` and merges +

--- a/specs/013-polymarket-search-filter/data-model.md
+++ b/specs/013-polymarket-search-filter/data-model.md
@@ -50,7 +50,9 @@ Produced by `normaliseGammaMarket` (reused).
 | `outcomes`    | `{name,price}[]`| parsed `outcomes`/`outcomePrices`      | |
 
 **Surface rule** (Decision 7): surfaceable iff `conditionId != null` AND
-`active === true` AND `closed !== true`. Filtered before its event is assembled.
+`active === true` AND `closed !== true` AND `endDate` is present, parseable, and
+in the future (`Date.parse(endDate) > Date.now()`). Filtered before its event is
+assembled.
 
 ## Entity: CategoryFilter
 

--- a/specs/013-polymarket-search-filter/research.md
+++ b/specs/013-polymarket-search-filter/research.md
@@ -129,9 +129,9 @@ unverified/undocumented; client-side `tags` filter is simpler and certain.
 ## Decision 7 — Eligibility filter: active, not closed, condition-bearing (per sub-market)
 
 **Decision**: Within each event, keep only markets where `active === true`,
-`closed !== true`, and `conditionId` is present (FR-006, FR-007). An **event is
-surfaced only if it has ≥1 eligible market**; events with zero eligible markets
-are dropped entirely.
+`closed !== true`, `conditionId` is present, AND the end date is present,
+parseable, and in the future (FR-006, FR-007). An **event is surfaced only if it
+has ≥1 eligible market**; events with zero eligible markets are dropped entirely.
 
 **Rationale**: Only such markets can back a new wager (`/public-search` and
 `/events` can include closed markets even for live queries, so the client-side

--- a/specs/013-polymarket-search-filter/spec.md
+++ b/specs/013-polymarket-search-filter/spec.md
@@ -164,8 +164,9 @@ as current.
   with retry is shown; the picker never presents stale results as current.
 - **Markets missing required data**: Markets lacking the data needed to link or
   display them are excluded so the user never selects an unusable market.
-- **Resolved / closed / inactive markets**: Never shown, since they cannot back a
-  new wager.
+- **Resolved / closed / inactive / already-ended markets**: Never shown, since
+  they cannot back a new wager. A market whose end date is in the past (or
+  missing/unparseable) is excluded even if the upstream still flags it active.
 - **Category with zero eligible markets**: Distinct empty state, with selection
   still adjustable.
 - **Query that matches a category name**: Treated as a text search over markets,
@@ -212,8 +213,9 @@ as current.
   clearing the category selection MUST return to the default top-markets view
   while preserving any active query.
 - **FR-006**: The picker MUST display only markets that are active, tradeable,
-  and unresolved (eligible to back a new wager); resolved, closed, or inactive
-  markets MUST be excluded.
+  unresolved, AND end in the future (eligible to back a new wager); resolved,
+  closed, inactive, or already-ended markets MUST be excluded. A market whose
+  resolution/end date is missing or unparseable MUST be treated as ineligible.
 - **FR-007**: The picker MUST exclude markets that lack the data required to link
   a wager or to render a usable result card, so a user cannot select an unusable
   market.
@@ -286,7 +288,7 @@ as current.
 - **SC-004**: Results update within roughly one second of the user pausing
   typing, with no flicker from out-of-order responses.
 - **SC-005**: 100% of listed markets are eligible to back a new wager (active,
-  tradeable, unresolved, and complete enough to link).
+  tradeable, unresolved, ending in the future, and complete enough to link).
 - **SC-006**: Empty, loading, and error states are each distinctly presented;
   a failed request always offers a retry and never displays a stale list as
   current.


### PR DESCRIPTION
## Summary

Follow-up to #652. The picker filtered to active / unresolved / condition-bearing markets but did **not** check the end date, so a market that's still flagged `active` with an `endDate` already in the past could appear — and users can't create a wager on an event that has already happened.

This adds a **future-end-date** requirement to market eligibility.

## Change

`frontend/src/hooks/usePolymarketSearch.js`:
- A market is eligible only if it is active, unresolved, condition-bearing, **and** its `endDate` is present, parseable, and in the future (`Date.parse(endDate) > Date.now()`).
- Markets with a past, missing, or unparseable end date are dropped. As before, an event with no remaining eligible markets is dropped entirely, so an all-past-dated event disappears from results.

Applies to both search (`/public-search`) and browse (`/events`) since they share the normalizer.

## Tests

- New hook test: an all-past event is dropped; a mixed event keeps only its future market.
- Full Polymarket suite green (18 tests); lint clean (0 errors).

## Docs

Synced the eligibility definition across the feature spec/contracts: FR-006, SC-005, the data-model surface rule, research Decision 7, and contract obligation C3.

## Scope

Frontend-only; no contract, on-chain, or new-oracle changes.

https://claude.ai/code/session_01QSDpd5YzAS2oG5Mxck6cNL

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSDpd5YzAS2oG5Mxck6cNL)_