### PR TITLE
Use the site-green brand accent for all quick actions

### DIFF
--- a/frontend/src/components/fairwins/Dashboard.css
+++ b/frontend/src/components/fairwins/Dashboard.css
@@ -197,10 +197,10 @@
 
 /* The quick-actions surface is a 3-column grid. Group headers span the full
    row (grid-column: 1 / -1) so the six tiles read as two labeled intent
-   clusters: "Create a wager" and "Track & share". Each tile drives its own
-   accent from the --qa-accent / --qa-accent-rgb custom properties set inline
-   per card, so one color source feeds the rail, icon chip, hover glow and
-   arrow. */
+   clusters: "Start a wager" and "Track & share". Every tile shares the single
+   site-green brand accent (--qa-accent / --qa-accent-rgb, set on
+   .quick-action-card) which feeds the rail, icon chip, hover glow and arrow;
+   tiles are told apart by icon, tag and label rather than color. */
 .quick-actions-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -234,10 +234,6 @@
   color: var(--brand-primary, #00b894);
 }
 
-.qa-group-header--track .qa-group-eyebrow {
-  color: #06B6D4;
-}
-
 .qa-group-sub {
   font-size: 0.8rem;
   color: var(--text-secondary);
@@ -246,6 +242,10 @@
 /* --- Action tile --- */
 
 .quick-action-card {
+  /* Single site-green brand accent shared by every tile (hex + rgb channels
+     kept in sync so the rgba() tints match the solid color). */
+  --qa-accent: var(--brand-primary, #36B37E);
+  --qa-accent-rgb: var(--brand-primary-rgb, 54, 179, 126);
   position: relative;
   display: grid;
   grid-template-columns: auto 1fr auto;
@@ -273,7 +273,7 @@
     var(--surface-color);
 }
 
-/* Left accent rail — the per-tile color signature. */
+/* Left accent rail — the site-green brand signature on every tile. */
 .qa-rail {
   position: absolute;
   left: 0;

--- a/frontend/src/components/fairwins/Dashboard.jsx
+++ b/frontend/src/components/fairwins/Dashboard.jsx
@@ -40,13 +40,13 @@ const QA_ARROW = (
 )
 
 function QuickActionCard({ action, onAction }) {
-  // Each card carries its own accent (hex + "r,g,b" string) so the CSS can
-  // tint the icon chip, accent rail, hover glow and arrow from one source of
-  // truth without a class explosion.
+  // Every card uses the single site-green brand accent (set on
+  // .quick-action-card in CSS). Tiles are differentiated by icon, tag, and
+  // label — not color. The `qa-{category}` class only drives the subtle
+  // primary-group emphasis on the creation tiles.
   return (
     <button
       className={`quick-action-card qa-${action.category}`}
-      style={{ '--qa-accent': action.accent, '--qa-accent-rgb': action.accentRgb }}
       onClick={() => onAction(action.id)}
       aria-label={action.ariaLabel || action.title}
     >
@@ -81,13 +81,12 @@ function QuickActions({ onAction, actionNeededCount = 0 }) {
 
   // The six actions split into two intents the user actually has: starting a
   // wager (three settlement styles) vs. tracking/handing one off. Grouping +
-  // per-card accent colors make that split legible at a glance.
+  // labels/tags/icons make that split legible — all tiles share the site-green
+  // brand accent (no per-tile colors).
   const createActions = [
     {
       id: 'create-1v1-friends',
       category: 'create',
-      accent: '#36B37E',
-      accentRgb: '54, 179, 126',
       tag: 'People settle',
       icon: (
         <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -103,8 +102,6 @@ function QuickActions({ onAction, actionNeededCount = 0 }) {
     {
       id: 'create-1v1-oracle',
       category: 'create',
-      accent: '#3B82F6',
-      accentRgb: '59, 130, 246',
       tag: 'Oracle settles',
       icon: (
         <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -121,8 +118,6 @@ function QuickActions({ onAction, actionNeededCount = 0 }) {
     {
       id: 'create-bookmaker',
       category: 'create',
-      accent: '#8B5CF6',
-      accentRgb: '139, 92, 246',
       tag: 'Set the odds',
       icon: (
         <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -139,8 +134,6 @@ function QuickActions({ onAction, actionNeededCount = 0 }) {
     {
       id: 'my-wagers',
       category: 'track',
-      accent: '#06B6D4',
-      accentRgb: '6, 182, 212',
       tag: 'Track',
       icon: (
         <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -162,8 +155,6 @@ function QuickActions({ onAction, actionNeededCount = 0 }) {
     {
       id: 'scan-qr',
       category: 'qr',
-      accent: '#F59E0B',
-      accentRgb: '245, 158, 11',
       tag: 'Scan',
       icon: (
         <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -179,8 +170,6 @@ function QuickActions({ onAction, actionNeededCount = 0 }) {
     {
       id: 'share-account',
       category: 'qr',
-      accent: '#EC4899',
-      accentRgb: '236, 72, 153',
       tag: 'Share',
       // QR grid with an outward arrow — keeps the QR vocabulary of the
       // adjacent Scan card while staying visually distinct from it.

--- a/specs/014-quick-action-dashboard/spec.md
+++ b/specs/014-quick-action-dashboard/spec.md
@@ -12,7 +12,8 @@
 
 ### Session 2026-06-14
 
-- Q: How many visible, labeled action groups should the dashboard show? → A: Two groups — "Start a wager" (the three creation tiles) and "Track & share" (My Wagers plus the two QR actions); the QR pair stays distinguishable through its own per-action accent color and iconography rather than a separate heading.
+- Q: How many visible, labeled action groups should the dashboard show? → A: Two groups — "Start a wager" (the three creation tiles) and "Track & share" (My Wagers plus the two QR actions); the QR pair stays distinguishable through iconography rather than a separate heading.
+- Q: Should each action have its own accent color? → A: No — all quick-action tiles use the single site-green brand accent. Actions are differentiated by icon, role tag, and label, not by color. (Supersedes the earlier per-action color treatment.)
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -160,9 +161,9 @@ from each other, and that *Share Account* keeps its descriptive accessible name.
   outbound cue) without requiring a separate group heading.
 - **FR-002**: The three wager-creation actions MUST be presented as the primary,
   most visually prominent group.
-- **FR-003**: Each quick action MUST have a distinct visual identity (color and
-  icon) so it is individually recognizable, replacing the current uniform
-  single-color treatment.
+- **FR-003**: Each quick action MUST be individually recognizable through its
+  icon, role tag, and label. All tiles MUST share the single site-green brand
+  accent — actions are not differentiated by color.
 - **FR-004**: The system MUST preserve the existing action labels exactly:
   "Friends Decide (1v1)", "Oracle Settles (1v1)", "Bookmaker", "My Wagers",
   "Scan QR Code", "Share Account".


### PR DESCRIPTION
## Summary

Follow-up to #683. The redesigned quick-action tiles used distinct per-action accent colors (green / blue / violet / cyan / amber / pink), which read as **rainbow-colored**. This switches every tile to the **single site-green brand accent**.

## What changed

- Removed the per-card `accent` / `accentRgb` data and the inline `style` that set `--qa-accent` / `--qa-accent-rgb` per tile (`Dashboard.jsx`).
- Defaulted `--qa-accent` / `--qa-accent-rgb` to the brand token (`--brand-primary` / `--brand-primary-rgb`) on `.quick-action-card`, so the rail, icon chip, hover glow, focus ring, tag, and arrow are all site green (`Dashboard.css`).
- Removed the cyan (`#06B6D4`) "Track & share" eyebrow override — both group labels are now brand green.
- Tiles remain individually recognizable by **icon, role tag, and label** (not color), and the two-group structure ("Start a wager" / "Track & share") is unchanged.

## Spec

Updated `specs/014-quick-action-dashboard/spec.md` — `FR-003` and a Clarifications entry now record the single-accent decision (supersedes the earlier per-action color treatment).

## Testing

- `npx vitest run` — **1206/1206 pass**.
- ESLint clean on `Dashboard.jsx`.
- No test asserted accent hex values; group-label and card-count assertions (`DSH-01`) are unaffected.

https://claude.ai/code/session_01QEvEN3KM3yS4gghdvn6nBr

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEvEN3KM3yS4gghdvn6nBr)_