### PR TITLE
fix(encryption): stop double sign prompt and false "keys not initialized" on wager creation

### DIFF
--- a/frontend/src/hooks/useEncryption.js
+++ b/frontend/src/hooks/useEncryption.js
@@ -17,13 +17,12 @@ import {
   publicKeyFromSignature,
   encryptMarketMetadata,
   decryptMarketMetadata,
-  createEncryptedMarket,
   addParticipantToMarket,
   addRecipient,
   // X-Wing (v2.0) functions
   deriveXWingKeyPairFromSignature,
   xwingPublicKeyFromSignature,
-  createEncryptedMarketXWing,
+  encryptMarketMetadataXWing,
   // Unified functions
   decryptEnvelopeUnified,
   addParticipantUnified,
@@ -41,6 +40,7 @@ import {
   ensureKeyRegistered,
   clearKeyCache
 } from '../utils/keyRegistryService.js'
+import { CURRENT_ENCRYPTION_VERSION } from '../utils/crypto/constants.js'
 
 // Cache signatures in session storage (now stores JSON with version info)
 const SIGNATURE_CACHE_KEY = 'fairwins_encryption_signature'
@@ -195,6 +195,7 @@ export function useEncryption() {
           console.log('[useEncryption] Reused cached session signature (no wallet popup)')
           return {
             signature: cached.signature,
+            version: cached.version,
             publicKey: x25519Keys.publicKey,
             xwingPublicKey: xwingKeys.publicKey
           }
@@ -238,6 +239,7 @@ export function useEncryption() {
 
         return {
           signature: x25519Result.signature,
+          version: signingVersion,
           publicKey: x25519Result.publicKey,
           xwingPublicKey: xwingKeys.publicKey
         }
@@ -262,6 +264,7 @@ export function useEncryption() {
     if (keyPairs.x25519?.privateKey && keyPairs.xwing?.secretKey) {
       return {
         signature,
+        version: cachedVersion ?? CURRENT_ENCRYPTION_VERSION,
         publicKey: keyPairs.x25519.publicKey,
         xwingPublicKey: keyPairs.xwing.publicKey
       }
@@ -284,6 +287,7 @@ export function useEncryption() {
       console.log('[useEncryption] Derived dual keypairs from cached signature (no wallet popup)')
       return {
         signature,
+        version: cachedVersion ?? CURRENT_ENCRYPTION_VERSION,
         publicKey: x25519Keys.publicKey,
         xwingPublicKey: xwingKeys.publicKey
       }
@@ -291,7 +295,7 @@ export function useEncryption() {
 
     // No cached signature - need to prompt user to sign
     return initializeKeys()
-  }, [signature, keyPairs, initializeKeys])
+  }, [signature, cachedVersion, keyPairs, initializeKeys])
 
   /**
    * Create encrypted market metadata
@@ -310,14 +314,24 @@ export function useEncryption() {
       throw new Error('Wallet not connected')
     }
 
-    await ensureInitialized()
+    // Obtain the creator's key-derivation signature ONCE (prompts at most a single
+    // wallet popup, or none if a session signature is cached). The envelope is then
+    // built synchronously from that signature via the encryptMarketMetadata* helpers.
+    //
+    // Previously this called createEncryptedMarket{,XWing}(metadata, signer, ...),
+    // which re-derived the keypair by signing the message a SECOND time — the source
+    // of the duplicate "sign the rules" prompt on every wager creation.
+    const { signature: creatorSignature, version } = await ensureInitialized()
+    const signingVersion = version || CURRENT_ENCRYPTION_VERSION
+
+    const recipients = [{ address: account, signature: creatorSignature }]
 
     // Use X-Wing (post-quantum) by default for new markets
-    if (algorithm === 'xwing') {
-      return createEncryptedMarketXWing(metadata, signer, account, termsVersion)
-    } else {
-      return createEncryptedMarket(metadata, signer, account, termsVersion)
-    }
+    const envelope = algorithm === 'xwing'
+      ? encryptMarketMetadataXWing(metadata, recipients, signingVersion, termsVersion)
+      : encryptMarketMetadata(metadata, recipients, signingVersion, termsVersion)
+
+    return { envelope, creatorSignature, signingVersion }
   }, [signer, account, ensureInitialized])
 
   /**
@@ -484,7 +498,22 @@ export function useEncryption() {
    * @returns {Object} Updated envelope with the new recipient
    */
   const addRecipientByPublicKey = useCallback((envelope, recipientAddress, recipientPublicKey) => {
-    if (!account || !keyPairs.x25519?.privateKey) {
+    if (!account) {
+      throw new Error('Wallet not connected')
+    }
+    // Prefer the in-state private key, but fall back to deriving it from the cached
+    // session signature. setKeyPairs() from a just-completed initializeKeys() hasn't
+    // flushed into this render's closure yet, so reading keyPairs alone can spuriously
+    // report "Encryption keys not initialized" when this is called right after
+    // createEncrypted() within the same handler tick (the user-visible bug).
+    let x25519PrivateKey = keyPairs.x25519?.privateKey
+    if (!x25519PrivateKey) {
+      const cached = getCachedSignatureData(account)
+      if (cached?.signature) {
+        x25519PrivateKey = deriveKeyPairFromSignature(cached.signature).privateKey
+      }
+    }
+    if (!x25519PrivateKey) {
       throw new Error('Encryption keys not initialized')
     }
     if (isXWingEnvelope(envelope)) {
@@ -496,7 +525,7 @@ export function useEncryption() {
         'Create the envelope with { algorithm: "x25519" } when the recipient comes from KeyRegistry.'
       )
     }
-    return addRecipient(envelope, account, keyPairs.x25519.privateKey, {
+    return addRecipient(envelope, account, x25519PrivateKey, {
       address: recipientAddress,
       publicKey: recipientPublicKey
     })

--- a/frontend/src/test/useEncryption.test.jsx
+++ b/frontend/src/test/useEncryption.test.jsx
@@ -1,0 +1,135 @@
+/**
+ * Regression tests for the two wager-encryption bugs surfaced during private
+ * wager creation:
+ *
+ *  1. Double "sign the rules" prompt — createEncrypted used to sign the key
+ *     derivation message twice (once in ensureInitialized, once again inside
+ *     createEncryptedMarket{,XWing}). It must now sign at most once.
+ *
+ *  2. "Encryption keys not initialized" — addRecipientByPublicKey read the
+ *     X25519 private key straight from React state, which is still null within
+ *     the same handler tick that just initialized the keys. It must fall back
+ *     to deriving the key from the cached session signature.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+import { useEncryption } from '../hooks/useEncryption'
+import {
+  encryptMarketMetadata,
+  publicKeyFromSignature,
+  getRecipients
+} from '../utils/crypto/envelopeEncryption.js'
+
+const ACCOUNT = '0x1111111111111111111111111111111111111111'
+const OPPONENT = '0x2222222222222222222222222222222222222222'
+const FIXED_SIGNATURE = '0x' + 'a'.repeat(130)
+const SIGNATURE_CACHE_KEY = 'fairwins_encryption_signature'
+
+// signMessage spy shared across the mocked wallet so the test can assert how
+// many times the user was prompted to sign.
+const signMessage = vi.fn(async () => FIXED_SIGNATURE)
+
+vi.mock('../hooks/useWalletManagement', () => ({
+  useWallet: () => ({
+    account: ACCOUNT,
+    isConnected: true,
+    signer: {
+      signMessage,
+      getAddress: async () => ACCOUNT,
+      provider: { getNetwork: async () => ({ chainId: 80002n }) }
+    }
+  })
+}))
+
+// Avoid real on-chain key registration during initializeKeys().
+vi.mock('../utils/keyRegistryService.js', () => ({
+  lookupPublicKey: vi.fn(async () => null),
+  hasRegisteredKey: vi.fn(async () => false),
+  ensureKeyRegistered: vi.fn(async () => false),
+  clearKeyCache: vi.fn()
+}))
+
+function cacheSignature(account, signature, version = 2) {
+  sessionStorage.setItem(
+    `${SIGNATURE_CACHE_KEY}_${account.toLowerCase()}`,
+    JSON.stringify({ signature, version })
+  )
+}
+
+const metadata = { name: 'Test wager', description: 'Heads or tails for 10 USDC' }
+
+describe('useEncryption — wager creation bug fixes', () => {
+  beforeEach(() => {
+    signMessage.mockClear()
+    sessionStorage.clear()
+  })
+
+  it('Fix #1: createEncrypted prompts for a signature only once (no double sign)', async () => {
+    const { result } = renderHook(() => useEncryption())
+
+    let created
+    await act(async () => {
+      created = await result.current.createEncrypted(metadata, { algorithm: 'x25519' })
+    })
+
+    expect(signMessage).toHaveBeenCalledTimes(1)
+    expect(created.envelope).toBeTruthy()
+    // Creator is the sole recipient of a freshly-created envelope.
+    expect(getRecipients(created.envelope)).toEqual([ACCOUNT.toLowerCase()])
+  })
+
+  it('Fix #1: createEncrypted does not re-prompt when a session signature is cached', async () => {
+    cacheSignature(ACCOUNT, FIXED_SIGNATURE)
+    const { result } = renderHook(() => useEncryption())
+
+    await act(async () => {
+      await result.current.createEncrypted(metadata, { algorithm: 'x25519' })
+    })
+
+    // Keys derive from the cached signature — the user is never prompted.
+    expect(signMessage).not.toHaveBeenCalled()
+  })
+
+  it('Fix #2: addRecipientByPublicKey works from the cached signature when keyPairs state is empty', () => {
+    // Render with no cache so the mount effect leaves keyPairs null...
+    const { result } = renderHook(() => useEncryption())
+    expect(result.current.isInitialized).toBe(false)
+
+    // ...then a session signature appears (mirrors initializeKeys() having just
+    // cached the signature but React state not yet reflecting it in this tick).
+    cacheSignature(ACCOUNT, FIXED_SIGNATURE)
+
+    const envelope = encryptMarketMetadata(
+      metadata,
+      [{ address: ACCOUNT, signature: FIXED_SIGNATURE }],
+      2
+    )
+    const opponentKey = publicKeyFromSignature('0x' + 'b'.repeat(130))
+
+    let updated
+    expect(() => {
+      updated = result.current.addRecipientByPublicKey(envelope, OPPONENT, opponentKey)
+    }).not.toThrow()
+
+    expect(getRecipients(updated)).toEqual(
+      expect.arrayContaining([ACCOUNT.toLowerCase(), OPPONENT.toLowerCase()])
+    )
+  })
+
+  it('addRecipientByPublicKey still throws when there is no key material at all', () => {
+    const { result } = renderHook(() => useEncryption())
+
+    const envelope = encryptMarketMetadata(
+      metadata,
+      [{ address: ACCOUNT, signature: FIXED_SIGNATURE }],
+      2
+    )
+    const opponentKey = publicKeyFromSignature('0x' + 'b'.repeat(130))
+
+    // No cached signature, no in-state keys → genuine "not initialized".
+    expect(() =>
+      result.current.addRecipientByPublicKey(envelope, OPPONENT, opponentKey)
+    ).toThrow(/not initialized/i)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes two bugs in the private-wager creation flow that users hit when creating an encrypted ("Private Wager") wager: being prompted to **sign the rules twice**, and then always seeing **"Encryption keys not initialized."** Both live in `frontend/src/hooks/useEncryption.js`.

> Note: the third reported symptom — **"Transaction will fail: require(false)"** — is a *separate, on-chain* issue (an undecodable revert from the `createWager`/`createWagerWithTerms` static-call preflight, most likely the terms-overload being called against a deployed registry that predates it). That is being investigated separately and is **not** addressed here.

## Bug #1 — duplicate "sign the rules" prompt
`createEncrypted()` called `ensureInitialized()` (which signs the key-derivation message) **and then** `createEncryptedMarket{,XWing}()`, which re-derived the keypair by signing the **same** message a second time.

Now `createEncrypted()` derives the keypair once via `ensureInitialized()` and builds the envelope synchronously from that signature using `encryptMarketMetadata{,XWing}`. `ensureInitialized()`/`initializeKeys()` also return the signing `version` so the envelope still records the correct version. The user is prompted **at most once** (zero times when a session signature is cached).

## Bug #2 — spurious "Encryption keys not initialized"
`addRecipientByPublicKey()` read the X25519 private key from React state (`keyPairs`), which is still `null` within the same handler tick that just initialized the keys (`setKeyPairs` hasn't flushed to this render's closure). The modal calls it immediately after `createEncrypted()`, so it threw on the first attempt every time.

It now falls back to deriving the key from the cached session signature (`getCachedSignatureData` + `deriveKeyPairFromSignature`) and only throws when there is genuinely no key material.

## Tests
New `frontend/src/test/useEncryption.test.jsx` covers:
- `createEncrypted` prompts for a signature exactly once
- no re-prompt when a session signature is cached
- `addRecipientByPublicKey` succeeds from the cached signature when `keyPairs` state is empty (the stale-state path)
- it still throws when no key material exists at all

All existing crypto + modal suites pass (`crypto/*`, `FriendMarketsModal`, `MyMarketsModal`, `MarketAcceptanceModal`, `WalletPage`); lint clean.

https://claude.ai/code/session_012KJafGtCGuvFNEKGq93Fpn

---
_Generated by [Claude Code](https://claude.ai/code/session_012KJafGtCGuvFNEKGq93Fpn)_