### PR TITLE
chore(deploy): redeploy v2 contracts on Polygon Amoy to mainnet parity

### DIFF
--- a/deployments/amoy-chain80002-v2.json
+++ b/deployments/amoy-chain80002-v2.json
@@ -7,17 +7,19 @@
   "wmatic": "0x0ae690AAD8663aaB12a671A6A0d74242332de85f",
   "polymarketCTF": "0x95F40ea10E6C51892783c4E7721Ada1425917e22",
   "contracts": {
-    "polymarketAdapter": "0x423d2Ca885d67E46062CFF732Eff952f4F736136",
-    "membershipManager": "0xFaEbF662aa591fF95e97306b413522efC958540f",
-    "wagerRegistry": "0x66c7fa8cB1642Fc5e94Fa92928f1d6333c8d657f",
-    "keyRegistry": "0xb314c4Ee52D9D89bf7FEE66a43aBeAc7D047a5Cb",
+    "polymarketAdapter": "0x98fe63209f5BffcCe905bF8779a1F06576A2C313",
+    "membershipManager": "0x101C3eC35fa48A500c2dFA9026f1d42F1431Abe8",
+    "wagerRegistry": "0x916841aEe4832a2e9DD42470fa05a7329486e75a",
+    "keyRegistry": "0xcEFdeBba8E040c035c690ca9057cF22E73247c24",
+    "sanctionsGuard": "0xdF41355dD5E47FCA4eE2F2205af4C70Dab8C13B3",
     "chainlinkDataFeedAdapter": "0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23",
     "chainlinkFunctionsAdapter": "0x074fC18C1E322a7537b53B8B2Bf0762629E3b532",
     "umaAdapter": "0xcEa9b4A01CcD3aA6545ea834a268C69e7eEfee88"
   },
   "mocks": {
-    "mockPolymarketCTF": "0x95F40ea10E6C51892783c4E7721Ada1425917e22"
+    "mockPolymarketCTF": "0x95F40ea10E6C51892783c4E7721Ada1425917e22",
+    "mockSanctionsOracle": "0xa5F0bB3a63C55721078be5ee80653E9cB0927D9E"
   },
   "saltPrefix": "FairWins-P2P-v2.0-",
-  "timestamp": "2026-05-24T02:29:26.974Z"
+  "timestamp": "2026-06-15T02:23:55.220Z"
 }

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -49,11 +49,11 @@ const AMOY_CONTRACTS = {
   deployer: '0x52502d049571C7893447b86c4d8B38e6184bF6e1',
   treasury: '0x52502d049571C7893447b86c4d8B38e6184bF6e1',
   // v2 core (populated by `npm run sync:frontend-contracts -- --network amoy --chainId 80002`)
-  wagerRegistry: '0x95cC567EF97f21bdd135844652aD8792fa8ba266',
-  membershipManager: '0xFaEbF662aa591fF95e97306b413522efC958540f',
-  keyRegistry: '0xb314c4Ee52D9D89bf7FEE66a43aBeAc7D047a5Cb',
-  sanctionsGuard: '',
-  polymarketAdapter: '0x423d2Ca885d67E46062CFF732Eff952f4F736136',
+  wagerRegistry: '0x916841aEe4832a2e9DD42470fa05a7329486e75a',
+  membershipManager: '0x101C3eC35fa48A500c2dFA9026f1d42F1431Abe8',
+  keyRegistry: '0xcEFdeBba8E040c035c690ca9057cF22E73247c24',
+  sanctionsGuard: '0xdF41355dD5E47FCA4eE2F2205af4C70Dab8C13B3',
+  polymarketAdapter: '0x98fe63209f5BffcCe905bF8779a1F06576A2C313',
   // Stake / payment tokens (Circle USDC + Wrapped MATIC on Amoy)
   paymentToken: '0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582',
   wmatic: '0x0ae690AAD8663aaB12a671A6A0d74242332de85f',

--- a/scripts/debug/probe-amoy-gasfloor.js
+++ b/scripts/debug/probe-amoy-gasfloor.js
@@ -1,0 +1,54 @@
+/**
+ * probe-amoy-gasfloor.js — find the minimum gas price Amoy will mine.
+ * Sends a 0-value self-tx at the requested gwei; if it doesn't confirm in ~40s,
+ * replaces it at the same nonce with 30 gwei so no nonce is left stuck.
+ *
+ *   node scripts/debug/probe-amoy-gasfloor.js <gwei>
+ */
+require("dotenv").config();
+const { ethers } = require("ethers");
+
+const RPC = process.env.AMOY_RPC_URL || "https://rpc-amoy.polygon.technology";
+const GWEI = process.argv[2] || "5";
+
+async function waitMined(provider, hash, ms) {
+  const start = Date.now();
+  while (Date.now() - start < ms) {
+    const rc = await provider.getTransactionReceipt(hash);
+    if (rc) return rc;
+    await new Promise((r) => setTimeout(r, 3000));
+  }
+  return null;
+}
+
+(async () => {
+  const provider = new ethers.JsonRpcProvider(RPC);
+  let pk = process.env.PRIVATE_KEY;
+  if (!pk) throw new Error("PRIVATE_KEY not in env");
+  if (!pk.startsWith("0x")) pk = "0x" + pk;
+  const w = new ethers.Wallet(pk, provider);
+
+  const nonce = await provider.getTransactionCount(w.address, "latest");
+  const gasPrice = ethers.parseUnits(GWEI, "gwei");
+  console.log(`Probing ${GWEI} gwei from ${w.address} (nonce ${nonce})...`);
+
+  const tx = await w.sendTransaction({ to: w.address, value: 0, gasPrice, gasLimit: 21000, nonce });
+  console.log(`  sent ${tx.hash}`);
+  const rc = await waitMined(provider, tx.hash, 40000);
+  if (rc) {
+    console.log(`  ✓ MINED at ${GWEI} gwei in block ${rc.blockNumber} — floor <= ${GWEI} gwei`);
+    process.exit(0);
+  }
+
+  console.log(`  … not mined in 40s at ${GWEI} gwei; replacing at 30 gwei (same nonce) to clear...`);
+  const repl = await w.sendTransaction({ to: w.address, value: 0, gasPrice: ethers.parseUnits("30", "gwei"), gasLimit: 21000, nonce });
+  console.log(`  replacement ${repl.hash}`);
+  const rc2 = await waitMined(provider, repl.hash, 40000);
+  console.log(rc2 ? `  ✓ replacement mined (block ${rc2.blockNumber}); floor is ABOVE ${GWEI} gwei` : `  ⚠️ replacement also pending — check network`);
+  process.exit(rc2 ? 2 : 1);
+})().catch((e) => {
+  console.error("ERR", e.shortMessage || e.message);
+  if (e.info) console.error("  info:", JSON.stringify(e.info));
+  if (e.error) console.error("  error:", JSON.stringify(e.error));
+  process.exit(1);
+});

--- a/scripts/debug/validate-amoy-deployment.js
+++ b/scripts/debug/validate-amoy-deployment.js
@@ -1,0 +1,120 @@
+/**
+ * validate-amoy-deployment.js  (READ-ONLY, network-aware)
+ *
+ * Computes the deterministic CREATE2 addresses for the CURRENT compiled
+ * contracts — exactly as scripts/deploy/deploy.js would for the active network
+ * — and checks on-chain which ones are actually deployed. Compares predicted vs
+ * the deployment record vs the frontend config. Sends NO transactions.
+ *
+ *   npx hardhat run scripts/debug/validate-amoy-deployment.js --network amoy
+ *   npx hardhat run scripts/debug/validate-amoy-deployment.js --network polygon   (method cross-check)
+ */
+const hre = require("hardhat");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+const {
+  SALT_PREFIXES,
+  SINGLETON_FACTORY_ADDRESS,
+  TOKENS,
+  POLYMARKET_CTF,
+  CHAINLINK_FUNCTIONS_ROUTER,
+  UMA_OOV3,
+} = require("../deploy/lib/constants");
+
+const DEPLOYER = "0x52502d049571C7893447b86c4d8B38e6184bF6e1";
+// Mirrors the inline map in deploy.js (real Chainalysis oracle on mainnet only).
+const CHAINALYSIS_ORACLE = { 137: "0x40C57923924B5c5c5455c48D93317139ADDaC8fb" };
+const V2 = SALT_PREFIXES.V2;
+const salt = (suffix) => ethers.id(V2 + suffix);
+
+async function predict(name, args, saltSuffix) {
+  const f = await ethers.getContractFactory(name);
+  const tx = await f.getDeployTransaction(...args);
+  const initCodeHash = ethers.keccak256(tx.data);
+  return ethers.getCreate2Address(SINGLETON_FACTORY_ADDRESS, salt(saltSuffix), initCodeHash);
+}
+async function codeLen(addr) {
+  if (!addr || addr === "(absent)") return 0;
+  const code = await ethers.provider.getCode(addr);
+  return code === "0x" ? 0 : (code.length - 2) / 2;
+}
+
+async function main() {
+  const net = await ethers.provider.getNetwork();
+  const chainId = Number(net.chainId);
+  const networkName = hre.network.name;
+  console.log(`\nNetwork: ${networkName} (chainId ${chainId})`);
+
+  const recordPath = path.join(__dirname, "..", "..", "deployments", `${networkName}-chain${chainId}-v2.json`);
+  const record = fs.existsSync(recordPath)
+    ? JSON.parse(fs.readFileSync(recordPath, "utf8"))
+    : { contracts: {}, mocks: {}, treasury: DEPLOYER };
+
+  const usdc = TOKENS[networkName].USC;
+  const wmatic = TOKENS[networkName].WMATIC;
+  // Use the treasury that was actually passed at deploy time (it's a ctor arg of
+  // MembershipManager, so it affects the CREATE2 address). Falls back to deployer.
+  const treasury = record.treasury || DEPLOYER;
+  console.log(`treasury (ctor arg): ${treasury}`);
+  console.log(`usdc=${usdc}  wmatic=${wmatic}`);
+
+  // Resolve Polymarket CTF the way deploy.js does: configured real CTF, else a
+  // deterministic MockPolymarketCTF.
+  let polymarketCTF = POLYMARKET_CTF[networkName];
+  if (!polymarketCTF) {
+    polymarketCTF = await predict("MockPolymarketCTF", [], "MockPolymarketCTF");
+    console.log(`polymarketCTF (mock): ${polymarketCTF}`);
+  } else {
+    console.log(`polymarketCTF (real): ${polymarketCTF}`);
+  }
+
+  // Resolve sanctions oracle: real Chainalysis on mainnet, else mock.
+  let sanctionsOracle = CHAINALYSIS_ORACLE[chainId];
+  if (!sanctionsOracle) {
+    sanctionsOracle = await predict("MockSanctionsOracle", [], "MockSanctionsOracle");
+    console.log(`sanctionsOracle (mock): ${sanctionsOracle}`);
+  } else {
+    console.log(`sanctionsOracle (real): ${sanctionsOracle}`);
+  }
+
+  // ---- predict in dependency order (mirrors deploy.js) ----
+  const adapter = await predict("PolymarketOracleAdapter", [DEPLOYER, polymarketCTF], "PolymarketOracleAdapter");
+  const mgr = await predict("MembershipManager", [DEPLOYER, usdc, treasury], "MembershipManager");
+  const reg = await predict("WagerRegistry", [DEPLOYER, mgr, adapter, [usdc, wmatic]], "WagerRegistry-userindex");
+  const guard = await predict("SanctionsGuard", [DEPLOYER, sanctionsOracle], "SanctionsGuard");
+  const cl = await predict("ChainlinkDataFeedOracleAdapter", [DEPLOYER], "ChainlinkDataFeedOracleAdapter");
+  const fn = await predict("ChainlinkFunctionsOracleAdapter", [DEPLOYER, CHAINLINK_FUNCTIONS_ROUTER[networkName]], "ChainlinkFunctionsOracleAdapter");
+  const uma = await predict("UMAOptimisticOracleV3Adapter", [DEPLOYER, UMA_OOV3[networkName]], "UMAOptimisticOracleV3Adapter");
+  const key = await predict("KeyRegistry", [], "KeyRegistry");
+
+  const predicted = {
+    polymarketAdapter: adapter,
+    membershipManager: mgr,
+    wagerRegistry: reg,
+    sanctionsGuard: guard,
+    chainlinkDataFeedAdapter: cl,
+    chainlinkFunctionsAdapter: fn,
+    umaAdapter: uma,
+    keyRegistry: key,
+  };
+
+  console.log("\n" + "=".repeat(118));
+  console.log("contract".padEnd(26), "predicted (current bytecode)".padEnd(44), "on-chain   record          match");
+  console.log("=".repeat(118));
+  let allMatch = true;
+  for (const [k, addr] of Object.entries(predicted)) {
+    const len = await codeLen(addr);
+    const rec = (record.contracts && record.contracts[k]) || "(absent)";
+    const matchRec = rec.toLowerCase() === addr.toLowerCase();
+    if (!matchRec) allMatch = false;
+    const status = len > 0 ? `LIVE ${String(len).padStart(5)}b` : "MISSING    ";
+    console.log(`${k.padEnd(26)} ${addr}  ${status} ${matchRec ? "✓ rec-match" : "✗ rec-DIFF"}`);
+  }
+  console.log("=".repeat(118));
+  console.log(allMatch
+    ? "RESULT: every predicted address matches the deployment record → prediction method is SOUND."
+    : "RESULT: some predicted addresses differ from the record (see ✗ rows above).");
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/debug/verify-amoy-wiring.js
+++ b/scripts/debug/verify-amoy-wiring.js
@@ -1,0 +1,40 @@
+/**
+ * verify-amoy-wiring.js (READ-ONLY) — confirm the freshly deployed Amoy v2 set
+ * is wired correctly: registry -> mgr/adapter/guard/oracles, mgr -> guard +
+ * authorized caller.
+ *   npx hardhat run scripts/debug/verify-amoy-wiring.js --network amoy
+ */
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+
+const RT = { Polymarket: 4, ChainlinkDataFeed: 5, ChainlinkFunctions: 6, UMA: 7 };
+
+async function main() {
+  const rec = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "..", "deployments", "amoy-chain80002-v2.json"), "utf8"));
+  const c = rec.contracts;
+  const reg = await ethers.getContractAt("WagerRegistry", c.wagerRegistry);
+  const mgr = await ethers.getContractAt("MembershipManager", c.membershipManager);
+
+  const eq = (a, b) => String(a).toLowerCase() === String(b).toLowerCase();
+  const line = (label, got, want) => console.log(`  ${eq(got, want) ? "✓" : "✗"} ${label}: ${got}${eq(got, want) ? "" : `  (expected ${want})`}`);
+
+  console.log("WagerRegistry wiring:");
+  line("membershipManager", await reg.membershipManager(), c.membershipManager);
+  line("sanctionsGuard", await reg.sanctionsGuard(), c.sanctionsGuard);
+  line("oracle[Polymarket]", await reg.oracleAdapters(RT.Polymarket), c.polymarketAdapter);
+  line("oracle[ChainlinkDataFeed]", await reg.oracleAdapters(RT.ChainlinkDataFeed), c.chainlinkDataFeedAdapter);
+  line("oracle[ChainlinkFunctions]", await reg.oracleAdapters(RT.ChainlinkFunctions), c.chainlinkFunctionsAdapter);
+  line("oracle[UMA]", await reg.oracleAdapters(RT.UMA), c.umaAdapter);
+
+  console.log("MembershipManager wiring:");
+  line("sanctionsGuard", await mgr.sanctionsGuard(), c.sanctionsGuard);
+  console.log(`  ${(await mgr.authorizedCallers(c.wagerRegistry)) ? "✓" : "✗"} authorizedCallers[wagerRegistry] = ${await mgr.authorizedCallers(c.wagerRegistry)}`);
+
+  // Token allowlist on the registry
+  console.log("WagerRegistry stake-token allowlist:");
+  console.log(`  ${(await reg.isAllowedToken(rec.paymentToken)) ? "✓" : "✗"} USDC ${rec.paymentToken}`);
+  console.log(`  ${(await reg.isAllowedToken(rec.wmatic)) ? "✓" : "✗"} WMATIC ${rec.wmatic}`);
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e.shortMessage || e.message); process.exit(1); });

--- a/scripts/debug/wait-for-amoy-funding.js
+++ b/scripts/debug/wait-for-amoy-funding.js
@@ -1,0 +1,41 @@
+/**
+ * wait-for-amoy-funding.js — poll the Amoy deployer balance until it can cover
+ * the v2 redeploy (~0.27 POL). Exits 0 when funded, 1 on timeout. Read-only.
+ */
+const ADDR = "0x52502d049571C7893447b86c4d8B38e6184bF6e1";
+const RPC = process.env.AMOY_RPC_URL || "https://rpc-amoy.polygon.technology";
+// Adapter + MembershipManager + tiers already deployed. Remaining = WagerRegistry
+// (gates at 0.1204 POL buffered) + SanctionsGuard/KeyRegistry/wiring. Need ~0.145.
+const THRESH = 145000000000000000n; // 0.145 POL
+const MAX_ITERS = 180; // 180 * 20s = 60 min
+const POLL_MS = 20000;
+
+async function balance() {
+  const r = await fetch(RPC, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "eth_getBalance", params: [ADDR, "latest"], id: 1 }),
+  });
+  const j = await r.json();
+  if (!j.result) throw new Error(JSON.stringify(j.error || j));
+  return BigInt(j.result);
+}
+
+(async () => {
+  for (let i = 0; i < MAX_ITERS; i++) {
+    try {
+      const b = await balance();
+      const pol = Number(b) / 1e18;
+      if (b >= THRESH) {
+        console.log(`FUNDED: ${pol.toFixed(4)} POL (>= 0.27). Ready to deploy.`);
+        process.exit(0);
+      }
+      console.log(`[${i}] balance ${pol.toFixed(4)} POL — below 0.27, waiting...`);
+    } catch (e) {
+      console.log(`[${i}] poll error: ${e.message}`);
+    }
+    await new Promise((r) => setTimeout(r, POLL_MS));
+  }
+  console.log("TIMEOUT: deployer still underfunded after 40 min.");
+  process.exit(1);
+})();


### PR DESCRIPTION
## Summary

Polygon Amoy was running a **stale v2 deployment** (2026-05-24) that predated Spec 007's `SanctionsGuard` and the current core-contract bytecode. Polygon mainnet shipped the newer code on 2026-06-08, but Amoy was never caught up — so the testnet app pointed at older contracts and had no sanctions guard.

Detection method was validated by running the same deterministic CREATE2 prediction against **mainnet**, where **8/8 predicted addresses matched the deployment record and on-chain code** — confirming the Amoy gap was real, not a measurement error.

## What changed
- Redeployed the stale set on Amoy (deterministic, Safe Singleton Factory, at Amoy's enforced 25 gwei floor):

  | Contract | Address |
  |---|---|
  | PolymarketOracleAdapter | `0x98fe63209f5BffcCe905bF8779a1F06576A2C313` |
  | MembershipManager | `0x101C3eC35fa48A500c2dFA9026f1d42F1431Abe8` (+ 4 tiers) |
  | WagerRegistry | `0x916841aEe4832a2e9DD42470fa05a7329486e75a` |
  | SanctionsGuard | `0xdF41355dD5E47FCA4eE2F2205af4C70Dab8C13B3` (**was absent**) |
  | MockSanctionsOracle | `0xa5F0bB3a63C55721078be5ee80653E9cB0927D9E` (testnet only) |
  | KeyRegistry | `0xcEFdeBba8E040c035c690ca9057cF22E73247c24` |

  Chainlink ×2 / UMA / MockCTF were already current and reused.
- `deployments/amoy-chain80002-v2.json` updated; `frontend/src/config/contracts.js` `AMOY_CONTRACTS` synced (`sanctionsGuard` now populated).
- New read-only ops scripts under `scripts/debug/` to re-validate any network: predict-vs-record-vs-chain, on-chain wiring check, and an Amoy gas-floor probe.

## Validation
- ✅ 8/8 predicted = deployment record = live on-chain (Amoy)
- ✅ Wiring: registry → mgr / guard / polymarketAdapter / 3 oracle adapters; mgr → guard + authorizedCaller; USDC+WMATIC allowlisted
- ✅ Frontend config tests: 14/14 pass

## Notes
- Deterministic addresses depend on the admin/deployer `0x5250…6e1`; deploy used the floppy/admin key flow.
- No contract source changed — this is a deployment + config-sync PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)