### PR TITLE
Fix: winner unable to claim payout from My Wagers

### DIFF
--- a/frontend/src/components/fairwins/MyMarketsModal.css
+++ b/frontend/src/components/fairwins/MyMarketsModal.css
@@ -635,6 +635,45 @@
   background: rgba(229, 83, 61, 0.22);
 }
 
+.mm-action-btn.mm-action-claim {
+  background: linear-gradient(135deg, #36B37E 0%, #2F9E6E 100%);
+  color: white;
+}
+
+.mm-action-btn.mm-action-claim:hover:not(:disabled) {
+  background: linear-gradient(135deg, #3DC48B 0%, #36B37E 100%);
+}
+
+.mm-action-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Inline claim failure shown beside the row's Claim button. */
+.mm-action-error {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 0.7rem;
+  color: #E5533D;
+}
+
+/* Winner's "Claim Winnings" call-to-action in the detail view. */
+.mm-claim-section {
+  margin-bottom: 1rem;
+}
+
+.mm-btn-claim {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.mm-claim-hint {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  opacity: 0.7;
+}
+
 /* Expired offer treatment */
 .mm-status-badge.status-expired {
   background: rgba(229, 83, 61, 0.15);

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -26,6 +26,24 @@ const ACTION_NEEDED_LABELS = {
 }
 
 /**
+ * True when `account` is the declared winner of a resolved wager whose payout
+ * has not yet been pulled — i.e. the viewer can call claimPayout to collect.
+ *
+ * WagerRegistry escrows both stakes and pays the winner on a *pull* basis
+ * (claimPayout), so a resolved wager sits here until the winner claims. The
+ * list row and the detail view both gate the "Claim" action on this so the
+ * green action badge has a real button behind it (previously the badge looked
+ * clickable but only opened the detail card — nothing claimed the funds).
+ */
+function isWinnerUnpaid(market, account) {
+  if (!market || !account) return false
+  if (String(market.status).toLowerCase() !== 'resolved') return false
+  if (market.paid) return false
+  return market.winner != null &&
+    market.winner.toLowerCase() === account.toLowerCase()
+}
+
+/**
  * MyMarketsModal Component
  *
  * A comprehensive modal for users to manage their wagers:
@@ -55,7 +73,7 @@ function MyMarketsModal({
   // Active network metadata, used to scope/label the wagers shown so it's
   // clear they belong to the selected network (testnet vs mainnet).
   const activeNetwork = useMemo(() => (chainId ? getNetwork(chainId) : null), [chainId])
-  const { dismissedIds, dismissMarket, dismissMarkets } = useFriendMarkets()
+  const { dismissedIds, dismissMarket, dismissMarkets, refresh: refreshFriendMarkets } = useFriendMarkets()
 
   const { markets: marketsWithEnvelopes, fetchEnvelope } = useLazyIpfsEnvelope(friendMarkets)
   const { markets: decryptableMarkets, decryptMarket, isMarketDecrypting } = useLazyMarketDecryption(marketsWithEnvelopes)
@@ -583,6 +601,64 @@ function MyMarketsModal({
     dismissMarkets(markets.map(m => m.id))
   }, [dismissMarkets])
 
+  // Winner pulls their payout. The contract escrows both stakes and pays the
+  // winner via claimPayout (pull, not push), so resolving a wager isn't the
+  // end of the flow — the winner still has to claim. This is the action behind
+  // the green "Claim" badge in the list and the "Claim Winnings" button in the
+  // detail view. claimingId/claimError are keyed by wager id so a single
+  // in-flight claim and its error map back to the right row.
+  const [claimingId, setClaimingId] = useState(null)
+  const [claimError, setClaimError] = useState(null)
+
+  const handleClaimPayout = useCallback(async (market) => {
+    if (!signer) return
+    const id = String(market.id)
+
+    if (!isCorrectNetwork) {
+      try {
+        await switchNetwork()
+      } catch {
+        setClaimError({ id, message: 'Please switch to the correct network.' })
+        return
+      }
+    }
+
+    setClaimingId(id)
+    setClaimError(null)
+
+    try {
+      const registry = new ethers.Contract(
+        getContractAddressForChain('wagerRegistry', chainId),
+        WAGER_REGISTRY_ABI,
+        signer
+      )
+      const tx = await registry.claimPayout(market.wagerId ?? market.id)
+      await tx.wait()
+      // Pull fresh on-chain data so the claimed wager flips to paid (which
+      // hides the Claim affordances) and clear its unread activity.
+      markWagerRead?.(id)
+      await refreshFriendMarkets?.()
+    } catch (err) {
+      const reason = err?.reason || err?.shortMessage || err?.data?.message || err?.message || ''
+      const lower = reason.toLowerCase()
+      let message
+      if (err?.code === 'ACTION_REJECTED' || err?.code === 4001 || lower.includes('user rejected')) {
+        message = 'Transaction was cancelled in your wallet.'
+      } else if (lower.includes('alreadypaid') || lower.includes('already paid') || lower.includes('already claimed')) {
+        message = 'This payout has already been claimed.'
+      } else if (lower.includes('notwinner') || lower.includes('not winner')) {
+        message = 'Only the winning side can claim this payout.'
+      } else if (lower.includes('notresolved') || lower.includes('not resolved')) {
+        message = 'This wager has not been resolved yet.'
+      } else {
+        message = 'Failed to claim winnings. Please try again.'
+      }
+      setClaimError({ id, message })
+    } finally {
+      setClaimingId(null)
+    }
+  }, [signer, isCorrectNetwork, switchNetwork, chainId, markWagerRead, refreshFriendMarkets])
+
   if (!isOpen) return null
 
   return (
@@ -764,6 +840,9 @@ function MyMarketsModal({
                       signer={signer}
                       isCorrectNetwork={isCorrectNetwork}
                       switchNetwork={switchNetwork}
+                      onClaimPayout={handleClaimPayout}
+                      claimingId={claimingId}
+                      claimError={claimError}
                       onRefunded={() => {
                         setSelectedMarketId(null)
                         fetchMarketsData?.()
@@ -794,6 +873,9 @@ function MyMarketsModal({
                       statusFilter={statusFilter}
                       showResolveCountdown
                       onResolve={handleOpenResolution}
+                      onClaim={handleClaimPayout}
+                      claimingId={claimingId}
+                      claimError={claimError}
                     />
                   )}
                 </div>
@@ -924,6 +1006,9 @@ function MyMarketsModal({
                       isHistoryView
                       onDecrypt={handleDecryptMarket}
                       isDecrypting={isMarketDecrypting(selectedMarket?.id)}
+                      onClaimPayout={handleClaimPayout}
+                      claimingId={claimingId}
+                      claimError={claimError}
                     />
                   ) : categorizedMarkets.history.length === 0 ? (
                     <div className="mm-empty-state">
@@ -940,6 +1025,10 @@ function MyMarketsModal({
                       getStatusLabel={getStatusLabel}
                       getTimeRemaining={getTimeRemaining}
                       showOutcome
+                      account={account}
+                      onClaim={handleClaimPayout}
+                      claimingId={claimingId}
+                      claimError={claimError}
                     />
                   )}
                 </div>
@@ -1032,6 +1121,9 @@ function MarketsTable({
   onAccept,
   onClearExpired,
   onClearAllExpired,
+  onClaim,
+  claimingId,
+  claimError,
   statusFilter,
   account,
   showResolveCountdown = false
@@ -1065,8 +1157,15 @@ function MarketsTable({
     return getTimeRemaining(endTime)
   }
 
+  // A resolved wager whose winner is the viewer and hasn't pulled their payout
+  // yet gets a real Claim button in the actions column (fixes the bug where the
+  // green "Claim" badge only opened the detail card instead of claiming).
+  const canClaim = (market) =>
+    typeof onClaim === 'function' && isWinnerUnpaid(market, account)
+  const hasClaimableRow = markets.some(canClaim)
+
   const tableHasActionsColumn =
-    showActions || canAccept || showResolveCountdown ||
+    showActions || canAccept || showResolveCountdown || hasClaimableRow ||
     (typeof onClearExpired === 'function' && expiredMarkets.length > 0)
 
   return (
@@ -1184,6 +1283,21 @@ function MarketsTable({
                       >
                         {isCreator ? 'Reclaim & Clear' : 'Clear'}
                       </button>
+                    )}
+                    {canClaim(market) && (
+                      <>
+                        <button
+                          className="mm-action-btn mm-action-claim"
+                          onClick={(e) => { e.stopPropagation(); onClaim(market) }}
+                          disabled={claimingId === String(market.id)}
+                          title="Claim your winnings"
+                        >
+                          {claimingId === String(market.id) ? 'Claiming…' : 'Claim'}
+                        </button>
+                        {claimError?.id === String(market.id) && (
+                          <span className="mm-action-error" role="alert">{claimError.message}</span>
+                        )}
+                      </>
                     )}
                   </td>
                 )}
@@ -1339,9 +1453,16 @@ function MarketDetailView({
   isCorrectNetwork,
   switchNetwork,
   onWithdraw,
-  onRefunded
+  onRefunded,
+  onClaimPayout,
+  claimingId,
+  claimError
 }) {
   const isCreator = market.creator?.toLowerCase() === account?.toLowerCase()
+  // Winner can pull their escrowed payout while the wager is resolved-unpaid.
+  const showClaimButton =
+    typeof onClaimPayout === 'function' && isWinnerUnpaid(market, account)
+  const isClaiming = claimingId === String(market.id)
   const position = userPositions?.find(p => String(p.marketId) === String(market.id))
   // For un-accepted offers, the relevant deadline is the *acceptance*
   // deadline, not the trading/resolve window — the latter is what made
@@ -1662,6 +1783,37 @@ function MarketDetailView({
 
       {/* Actions */}
       <div className="mm-detail-actions">
+        {showClaimButton && (
+          <div className="mm-claim-section">
+            <button
+              type="button"
+              className="mm-btn-primary mm-btn-claim"
+              onClick={() => onClaimPayout(market)}
+              disabled={isClaiming}
+            >
+              {isClaiming ? (
+                <>
+                  <span className="mm-spinner-small"></span>
+                  Claiming Winnings...
+                </>
+              ) : (
+                <>
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                    <path d="M12 1v22"/>
+                    <path d="M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6"/>
+                  </svg>
+                  Claim Winnings
+                </>
+              )}
+            </button>
+            <p className="mm-claim-hint">
+              You won this wager. Claim to transfer the combined stakes to your wallet.
+            </p>
+            {claimError?.id === String(market.id) && (
+              <p className="mm-withdraw-error" role="alert">{claimError.message}</p>
+            )}
+          </div>
+        )}
         {isCreatorView && isCreator && (market.computedStatus || market.status) === MarketStatus.PENDING_ACCEPTANCE && !withdrawSuccess && (
           <div className="mm-withdraw-section">
             <button

--- a/frontend/src/test/MyMarketsModal.test.jsx
+++ b/frontend/src/test/MyMarketsModal.test.jsx
@@ -804,6 +804,102 @@ describe('MyMarketsModal', () => {
     })
   })
 
+  describe('Claim winnings (winner pull payout)', () => {
+    const me = '0x1234567890123456789012345678901234567890'
+    const other = '0xABCDEF1234567890ABCDEF1234567890ABCDEF12'
+
+    const resolvedWon = (overrides = {}) => ({
+      id: '42', description: 'Won Wager', creator: me, opponent: other,
+      participants: [me, other], status: 'resolved', marketType: 'friend',
+      winner: me, paid: false,
+      endDate: new Date(Date.now() - 3_600_000).toISOString(),
+      ...overrides
+    })
+
+    const openHistory = async (user) => {
+      const historyTab = screen.getByRole('tab', { name: /history/i })
+      await user.click(historyTab)
+    }
+
+    it('shows a real Claim button for the winner of a resolved, unpaid wager', async () => {
+      const user = userEvent.setup()
+      await act(async () => {
+        renderWithProviders(
+          <MyMarketsModal isOpen onClose={mockOnClose} friendMarkets={[resolvedWon()]} />
+        )
+      })
+      await openHistory(user)
+
+      await waitFor(() => expect(screen.getByText('Won Wager')).toBeInTheDocument())
+      expect(screen.getByRole('button', { name: /^claim$/i })).toBeInTheDocument()
+    })
+
+    it('claims in place instead of opening the detail card (regression: claim opened the card)', async () => {
+      const user = userEvent.setup()
+      await act(async () => {
+        renderWithProviders(
+          <MyMarketsModal isOpen onClose={mockOnClose} friendMarkets={[resolvedWon()]} />
+        )
+      })
+      await openHistory(user)
+
+      const claimBtn = await screen.findByRole('button', { name: /^claim$/i })
+      await act(async () => {
+        await user.click(claimBtn)
+      })
+
+      // The click must NOT navigate into the detail view — that was the bug.
+      expect(screen.queryByText('Back to list')).not.toBeInTheDocument()
+      // Still on the list (the row title is rendered in the table, not the detail header).
+      expect(screen.getByText('Won Wager')).toBeInTheDocument()
+    })
+
+    it('shows the Claim Winnings button in the detail view when the row is opened', async () => {
+      const user = userEvent.setup()
+      await act(async () => {
+        renderWithProviders(
+          <MyMarketsModal isOpen onClose={mockOnClose} friendMarkets={[resolvedWon()]} />
+        )
+      })
+      await openHistory(user)
+
+      // Open the detail by clicking the row title (not the Claim button).
+      const titleCell = await screen.findByText('Won Wager')
+      await user.click(titleCell)
+
+      expect(await screen.findByText('Back to list')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /claim winnings/i })).toBeInTheDocument()
+    })
+
+    it('does not show a Claim button to the losing side', async () => {
+      const user = userEvent.setup()
+      await act(async () => {
+        renderWithProviders(
+          <MyMarketsModal isOpen onClose={mockOnClose}
+            friendMarkets={[resolvedWon({ winner: other })]} />
+        )
+      })
+      await openHistory(user)
+
+      await waitFor(() => expect(screen.getByText('Won Wager')).toBeInTheDocument())
+      expect(screen.queryByRole('button', { name: /^claim$/i })).not.toBeInTheDocument()
+    })
+
+    it('does not show a Claim button once the payout has been paid', async () => {
+      const user = userEvent.setup()
+      await act(async () => {
+        renderWithProviders(
+          <MyMarketsModal isOpen onClose={mockOnClose}
+            friendMarkets={[resolvedWon({ paid: true })]} />
+        )
+      })
+      await openHistory(user)
+
+      await waitFor(() => expect(screen.getByText('Won Wager')).toBeInTheDocument())
+      expect(screen.queryByRole('button', { name: /^claim$/i })).not.toBeInTheDocument()
+    })
+  })
+
   describe('Accessibility', () => {
     it('should have proper tab roles', async () => {
       await act(async () => {


### PR DESCRIPTION
## The bug

On a **resolved** wager, the winning side saw a green **"Claim"** indicator in the *My Wagers* list, but clicking it opened the wager detail card instead of claiming funds (see reported screenshots).

### Root cause

The green "Claim" element was **not a button** — it was the action-needed `Badge` (a passive label) rendered in the Status column of the row. The row itself has `onClick={() => onSelect(market)}`, so clicking the badge (or anywhere on the row) bubbled up and navigated into the detail card.

Worse: **nothing in the UI ever called `WagerRegistry.claimPayout`.** The contract escrows both stakes and pays the winner on a *pull* basis, so a resolved wager sits in a "claimable" state until the winner claims. But:
- The list row's actions column only had Accept / Resolve / Clear buttons.
- The detail view only had Withdraw, Resolve, and **Claim *Refund*** (the expired-no-resolution path) — no "Claim Winnings".
- Resolved wagers are categorized into the **History** tab, whose table has no actions column and whose detail view wasn't even wired with the signer/network context.

Net result: a winner literally could not claim their escrowed winnings from the UI.

## The fix

Add a real winner pull-payout flow in `MyMarketsModal`:

- **`handleClaimPayout`** — calls `WagerRegistry.claimPayout(wagerId)`, then refreshes on-chain data so the wager flips to `paid` (which removes the claim affordances). Mirrors the existing `handleClearExpired`/`claimRefund` pattern, with mapped error messages (user-rejected, already paid, not winner, not resolved).
- **Row Claim button** — a real `<button>` in the actions column (with `e.stopPropagation()`) for the resolved-unpaid winner, so clicking **Claim** claims instead of opening the card. The History table now renders an actions column when a claimable row is present.
- **"Claim Winnings" button** in the detail view for the same state, so the card path also works (the row still navigates there, and the winner can claim from it).
- **`isWinnerUnpaid(market, account)`** helper gates both affordances on `status === 'resolved'`, `winner === viewer`, and `!paid`.

The existing action-needed "Claim" badge is left intact (it's the activity-watcher indicator); the new button is what actually performs the claim.

## Tests

Added 5 tests to `MyMarketsModal.test.jsx`:
- winner sees a real Claim button on a resolved/unpaid wager,
- clicking Claim claims in place and does **not** open the detail card (the regression),
- the detail view shows "Claim Winnings" when the row is opened,
- no Claim button for the losing side,
- no Claim button once `paid`.

Full frontend suite green: **1222 tests passed**, ESLint clean.

https://claude.ai/code/session_01T4Nrm5ivskP7C2Yh6KB4vR

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4Nrm5ivskP7C2Yh6KB4vR)_