### PR TITLE
Fix My Wagers UX: tab icons, redundant badges, outcome column, close button

### DIFF
--- a/frontend/src/components/fairwins/MyMarketsModal.css
+++ b/frontend/src/components/fairwins/MyMarketsModal.css
@@ -578,6 +578,11 @@
   color: #E5533D;
 }
 
+/* Neutral outcome (draw, refunded, settled-by-other) — no win/loss colour. */
+.mm-outcome.neutral {
+  color: var(--text-secondary, #AAB6C2);
+}
+
 /* Action Buttons in Table */
 .mm-action-btn {
   display: inline-flex;

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -25,6 +25,12 @@ const ACTION_NEEDED_LABELS = {
   respondDraw: 'Respond to draw'
 }
 
+// 'claim' and 'resolve' already have a real action button in the row's Actions
+// column, so a duplicate status-column badge for them is just noise (and the
+// badge looked clickable but wasn't). Suppress those two; the remaining action
+// kinds have no inline button yet, so their badge stays as the only affordance.
+const ACTION_BADGES_WITH_BUTTON = new Set(['claim', 'resolve'])
+
 /**
  * True when `account` is the declared winner of a resolved wager whose payout
  * has not yet been pulled — i.e. the viewer can call claimPayout to collect.
@@ -694,8 +700,12 @@ function MyMarketsModal({
             onClick={onClose}
             aria-label="Close modal"
           >
-            <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
-              <path d="M15 5L5 15M5 5L15 15" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+            {/* Two separate <line>s with the stroke on the <svg> (matching the
+                tab icons that render reliably). The previous single multi-moveto
+                <path> rendered blank on mobile, leaving an empty square. */}
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
             </svg>
           </button>
         </header>
@@ -707,9 +717,14 @@ function MyMarketsModal({
             onClick={() => { setActiveTab('participating'); setSelectedMarketId(null) }}
             role="tab"
             aria-selected={activeTab === 'participating'}
+            aria-label="Participating — wagers others sent you (inbound)"
+            title="Participating — wagers others sent you (inbound)"
           >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M22 12h-4l-3 9L9 3l-3 9H2"/>
+            {/* Inbound: a wager that came TO you — arrow pointing down into a tray. */}
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="7 10 12 15 17 10" />
+              <line x1="12" y1="3" x2="12" y2="15" />
             </svg>
             <span>Participating</span>
           </button>
@@ -718,11 +733,14 @@ function MyMarketsModal({
             onClick={() => { setActiveTab('created'); setSelectedMarketId(null) }}
             role="tab"
             aria-selected={activeTab === 'created'}
+            aria-label="Created — wagers you sent out (outbound)"
+            title="Created — wagers you sent out (outbound)"
           >
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-              <path d="M12 2L2 7l10 5 10-5-10-5z"/>
-              <path d="M2 17l10 5 10-5"/>
-              <path d="M2 12l10 5 10-5"/>
+            {/* Outbound: a wager you sent OUT — arrow pointing up out of a tray. */}
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="17 8 12 3 7 8" />
+              <line x1="12" y1="3" x2="12" y2="15" />
             </svg>
             <span>Created</span>
           </button>
@@ -732,6 +750,8 @@ function MyMarketsModal({
               onClick={() => { setActiveTab('arbitrating'); setSelectedMarketId(null) }}
               role="tab"
               aria-selected={activeTab === 'arbitrating'}
+              aria-label="Arbitrating — wagers you resolve as the neutral arbitrator"
+              title="Arbitrating — wagers you resolve as the neutral arbitrator"
             >
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                 <path d="M12 3v18M5 7h14M5 7l-3 6a4 4 0 008 0L5 7zM19 7l-3 6a4 4 0 008 0l-5-6z"/>
@@ -744,6 +764,8 @@ function MyMarketsModal({
             onClick={() => { setActiveTab('history'); setSelectedMarketId(null) }}
             role="tab"
             aria-selected={activeTab === 'history'}
+            aria-label="History — resolved and settled wagers"
+            title="History — resolved and settled wagers"
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <circle cx="12" cy="12" r="10"/>
@@ -1106,6 +1128,49 @@ function getMarketDisplayTitle(market) {
   return market.proposalTitle || market.description || `Market #${market.id}`
 }
 
+/**
+ * Human-readable outcome for a terminal wager row in the History tab.
+ *
+ * The raw `market.outcome` field is almost never populated for peer wagers (it
+ * only exists for some oracle markets), which is why the Outcome column showed
+ * "N/A" for every resolved bet. We derive a meaningful result from the wager's
+ * terminal status and on-chain winner instead:
+ *   - resolved + you won              → "Won"   (green)
+ *   - resolved + you staked and lost  → "Lost"  (red)
+ *   - resolved + you only arbitrated  → winner's short address (neutral)
+ *   - draw / refunded / cancelled / … → that status (neutral)
+ */
+function getRowOutcome(market, account) {
+  const status = market.computedStatus
+  if (status === MarketStatus.DRAW) return { label: 'Draw', tone: 'neutral' }
+  if (status === MarketStatus.REFUNDED) return { label: 'Refunded', tone: 'neutral' }
+  if (status === MarketStatus.CANCELLED) return { label: 'Cancelled', tone: 'neutral' }
+  if (status === MarketStatus.DECLINED) return { label: 'Declined', tone: 'neutral' }
+  if (status === MarketStatus.ORACLE_TIMED_OUT) return { label: 'Timed Out', tone: 'neutral' }
+
+  if (status === MarketStatus.RESOLVED) {
+    const userAddr = account?.toLowerCase()
+    const winner = market.winner?.toLowerCase?.()
+    if (userAddr && winner) {
+      if (winner === userAddr) return { label: 'Won', tone: 'positive' }
+      const isCreator = market.creator?.toLowerCase() === userAddr
+      const isParticipant = market.participants?.some(p => p?.toLowerCase() === userAddr)
+      if (isCreator || isParticipant) return { label: 'Lost', tone: 'negative' }
+    }
+    if (market.winner) {
+      return { label: `${market.winner.slice(0, 6)}…${market.winner.slice(-4)}`, tone: 'neutral' }
+    }
+    return { label: 'Resolved', tone: 'neutral' }
+  }
+
+  // Non-terminal or unknown: fall back to any explicit outcome the data carries.
+  if (market.outcome) {
+    const positive = market.outcome === 'Pass' || market.outcome === 'Yes' || market.outcome === 'Won'
+    return { label: market.outcome, tone: positive ? 'positive' : 'negative' }
+  }
+  return { label: 'N/A', tone: 'neutral' }
+}
+
 function MarketsTable({
   markets,
   onSelect,
@@ -1190,6 +1255,7 @@ function MarketsTable({
             const showClearBtn = isExpired && typeof onClearExpired === 'function'
             const displayTitle = getMarketDisplayTitle(market)
             const actionNeeded = actionNeededByWagerId?.[String(market.id)] ?? null
+            const rowOutcome = showOutcome ? getRowOutcome(market, account) : null
 
             return (
               <tr
@@ -1226,8 +1292,8 @@ function MarketsTable({
                 </td>
                 <td className="mm-table-time">
                   {showOutcome ? (
-                    <span className={`mm-outcome ${market.outcome === 'Pass' || market.outcome === 'Yes' ? 'positive' : 'negative'}`}>
-                      {market.outcome || 'N/A'}
+                    <span className={`mm-outcome ${rowOutcome.tone}`}>
+                      {rowOutcome.label}
                     </span>
                   ) : isExpired ? (
                     <span className="mm-time-expired">Expired</span>
@@ -1239,7 +1305,7 @@ function MarketsTable({
                   <span className={`mm-status-badge ${getStatusClass(market.computedStatus)}`}>
                     {showUnderConsideration ? 'Under Consideration' : getStatusLabel(market.computedStatus)}
                   </span>
-                  {actionNeeded && (
+                  {actionNeeded && !ACTION_BADGES_WITH_BUTTON.has(actionNeeded) && (
                     <Badge
                       variant={actionNeeded === 'claim' ? 'success' : 'warning'}
                       className="mm-action-needed-badge"

--- a/frontend/src/test/actionNeededBadges.test.jsx
+++ b/frontend/src/test/actionNeededBadges.test.jsx
@@ -245,7 +245,7 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
   describe('MyMarketsModal wager cards', () => {
     it('shows an action badge on exactly the wager that needs action', async () => {
       activityRef.current = baseActivity({
-        actionNeededByWagerId: { '1': 'claim', '2': null }
+        actionNeededByWagerId: { '1': 'accept', '2': null }
       })
       const markets = [wagerOne(), wagerTwo()]
 
@@ -254,18 +254,16 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
       })
 
       const row1 = screen.getByText('Wager One').closest('tr')
-      expect(within(row1).getByText('Claim')).toBeInTheDocument()
+      expect(within(row1).getByText('Accept')).toBeInTheDocument()
 
       // Wager 2 (action kind null) has no badge — exactly one in the document.
       expect(document.querySelectorAll('.mm-action-needed-badge')).toHaveLength(1)
       const row2 = screen.getByText('Wager Two').closest('tr')
-      expect(within(row2).queryByText('Claim')).not.toBeInTheDocument()
+      expect(within(row2).queryByText('Accept')).not.toBeInTheDocument()
     })
 
     it.each([
       ['accept', 'Accept'],
-      ['resolve', 'Resolve'],
-      ['claim', 'Claim'],
       ['refund', 'Refund'],
       ['respondDraw', 'Respond to draw']
     ])('labels a "%s" action badge "%s"', async (kind, label) => {
@@ -281,9 +279,26 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
       expect(within(row).getByText(label)).toBeInTheDocument()
     })
 
+    // 'claim' and 'resolve' have a real action button in the row's Actions
+    // column, so the duplicate status badge is intentionally suppressed.
+    it.each(['claim', 'resolve'])(
+      'does not render a redundant status badge for "%s"',
+      async (kind) => {
+        activityRef.current = baseActivity({
+          actionNeededByWagerId: { '1': kind }
+        })
+
+        await act(async () => {
+          render(modalUi([wagerOne()]))
+        })
+
+        expect(document.querySelectorAll('.mm-action-needed-badge')).toHaveLength(0)
+      }
+    )
+
     it('removes the badge when the action is no longer needed', async () => {
       activityRef.current = baseActivity({
-        actionNeededByWagerId: { '1': 'claim', '2': null }
+        actionNeededByWagerId: { '1': 'accept', '2': null }
       })
       const markets = [wagerOne(), wagerTwo()]
 
@@ -292,7 +307,7 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
         view = render(modalUi(markets))
       })
 
-      expect(screen.getByText('Claim')).toBeInTheDocument()
+      expect(screen.getByText('Accept')).toBeInTheDocument()
 
       activityRef.current = baseActivity({
         actionNeededByWagerId: { '1': null, '2': null }
@@ -301,7 +316,7 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
         view.rerender(modalUi(markets))
       })
 
-      expect(screen.queryByText('Claim')).not.toBeInTheDocument()
+      expect(screen.queryByText('Accept')).not.toBeInTheDocument()
       expect(document.querySelectorAll('.mm-action-needed-badge')).toHaveLength(0)
     })
 


### PR DESCRIPTION
Addresses four UX issues reported on the **My Wagers** modal (screenshots in dark and light mode).

## Changes

### 1. Clearer tab icons (inbound / outbound source)
The Participating and Created tabs used ambiguous icons (a pulse line and stacked layers) that didn't convey where the data comes from — especially on mobile, where the text labels are hidden.

- **Participating** now uses an **inbound** (download-into-tray) icon — wagers others sent *to* you.
- **Created** now uses an **outbound** (upload-out-of-tray) icon — wagers you sent *out*.
- Added `aria-label` + `title` to every tab (Participating, Created, Arbitrating, History) so the meaning survives the mobile icon-only layout for screen readers and on hover.

### 2. Removed redundant "Claim" / "Resolve" status badges
These action-needed pills duplicated the real action buttons now present in the Actions column (and the badge *looked* clickable but wasn't). They're now suppressed; other action kinds without an inline button (Accept, Refund, Respond to draw) keep their badge.

### 3. Outcome column no longer shows "N/A"
The raw `outcome` field is almost never populated for peer wagers, so the History "Outcome" column read **N/A** for every resolved bet. It now derives a meaningful result from the wager's terminal status and on-chain `winner`:

- resolved + you won → **Won** (green)
- resolved + you staked and lost → **Lost** (red)
- resolved + you only arbitrated → winner's short address (neutral)
- draw / refunded / cancelled / timed-out → that status (neutral)

### 4. Close (X) button renders reliably
The close button showed as an empty rounded square in **both** themes (confirmed by the reporter). The old SVG was a single multi-`moveto` `<path>` that rendered blank on mobile. Rewrote it as two `<line>`s with the stroke on the `<svg>` element — the same pattern the tab icons (which always render) use.

## Testing
- Updated `actionNeededBadges.test.jsx` to reflect the suppressed claim/resolve badges (and added cases asserting they render no badge).
- `actionNeededBadges.test.jsx` (12), `MyMarketsModal.test.jsx` (39), `feedNavigation.test.jsx` + `Dashboard.test.jsx` (22) all pass.
- ESLint clean on changed files.

https://claude.ai/code/session_012D6UNDKFafVez1yJPJZ1ka

---
_Generated by [Claude Code](https://claude.ai/code/session_012D6UNDKFafVez1yJPJZ1ka)_