### PR TITLE
fix(frontend): render icon-only buttons (close, refresh, QR) hidden by border-box padding

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -65,3 +65,13 @@ button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
+
+/* Icon-only buttons: the global `padding: 0.6em 1.2em` above, combined with
+   `box-sizing: border-box`, subtracts ~38px of horizontal padding from
+   fixed-size icon buttons (e.g. 32-36px close/refresh/QR controls). That
+   collapses the content box to zero width and squeezes the SVG out of view,
+   leaving an empty square. Reset padding when the button's only element child
+   is an <svg> so text buttons keep their default padding. */
+button:has(> svg:only-child) {
+  padding: 0;
+}


### PR DESCRIPTION
## Problem

SVG icons in several icon-only buttons rendered as **empty squares** in both light and dark themes, on mobile and desktop:

- the **X** close button on panels/modals
- the **refresh** button on the *My Wagers* panel
- the mini **QR** action button (and the settle-option / address-QR buttons)

## Root cause

Two global rules combine to squeeze these icons to zero width:

- `frontend/src/App.css` — `* { box-sizing: border-box; }`
- `frontend/src/index.css` — `button { padding: 0.6em 1.2em; }` (Vite scaffold default)

The broken controls are all **fixed-size, icon-only** buttons (e.g. `.mm-close-btn` 36×36, `.mm-refresh-btn` 32×32) that set `width`/`height` but no padding of their own, so they inherit the global `0.6em 1.2em`. Under `border-box`, the horizontal `1.2em` (~19px per side, ~38px total) is **subtracted** from the 32–36px width, collapsing the content box to 0 width. The centered SVG is squeezed to nothing, leaving an empty square — independent of theme or device, exactly as reported.

## Fix

Reset padding to `0` for buttons whose only element child is an `<svg>`:

```css
button:has(> svg:only-child) {
  padding: 0;
}
```

This fixes every icon-only button app-wide in a single rule while leaving text buttons' default padding untouched (e.g. unclassed `<button>Switch Network</button>` controls that rely on the global padding). `:has()` is supported across the modern Chromium/Brave/Safari/Firefox targets the app runs on.

## Testing

CSS-only change; the layout collapse is not exercised by jsdom/Vitest. Verified by inspecting the cascade against the affected button classes (`.mm-close-btn`, `.mm-refresh-btn`) — both are icon-only and now keep a non-zero content box.

https://claude.ai/code/session_012ZY4p7Nw638dsnsDKboYQr

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZY4p7Nw638dsnsDKboYQr)_