### PR TITLE
My Wagers: real Refund &amp; Respond-to-Draw buttons, replacing redundant action badges

### DIFF
--- a/frontend/src/components/fairwins/MyMarketsModal.css
+++ b/frontend/src/components/fairwins/MyMarketsModal.css
@@ -649,6 +649,28 @@
   background: linear-gradient(135deg, #3DC48B 0%, #36B37E 100%);
 }
 
+/* Refund — returning your own stake (not winnings), so a neutral blue rather
+   than the green Claim treatment. */
+.mm-action-btn.mm-action-refund {
+  background: linear-gradient(135deg, #4C9AFF 0%, #3A7FD5 100%);
+  color: white;
+}
+
+.mm-action-btn.mm-action-refund:hover:not(:disabled) {
+  background: linear-gradient(135deg, #5CA9FF 0%, #4C9AFF 100%);
+}
+
+/* Respond to Draw — a counterparty needs an answer, so an attention amber that
+   matches the resolve/dispute family. */
+.mm-action-btn.mm-action-draw {
+  background: linear-gradient(135deg, #F5A623 0%, #D99520 100%);
+  color: #0E141B;
+}
+
+.mm-action-btn.mm-action-draw:hover:not(:disabled) {
+  background: linear-gradient(135deg, #FFB834 0%, #F5A623 100%);
+}
+
 .mm-action-btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -1257,6 +1257,15 @@ function MarketsTable({
             const displayTitle = getMarketDisplayTitle(market)
             const actionNeeded = actionNeededByWagerId?.[String(market.id)] ?? null
             const rowOutcome = showOutcome ? getRowOutcome(market, account) : null
+            // Hide the action badge when this row already exposes a button for
+            // the same action: accept→"View Offer", claim→"Claim",
+            // resolve→"Resolve" (always have a button), plus refund→"Reclaim &
+            // Clear" but only in the expired-offer case that renders that button.
+            // The refundable case (active past the resolve deadline) has no grid
+            // button, and 'respondDraw' never does, so those keep their badge.
+            const actionBadgeRedundant =
+              ACTION_BADGES_WITH_BUTTON.has(actionNeeded) ||
+              (actionNeeded === 'refund' && showClearBtn)
 
             return (
               <tr
@@ -1306,7 +1315,7 @@ function MarketsTable({
                   <span className={`mm-status-badge ${getStatusClass(market.computedStatus)}`}>
                     {showUnderConsideration ? 'Under Consideration' : getStatusLabel(market.computedStatus)}
                   </span>
-                  {actionNeeded && !ACTION_BADGES_WITH_BUTTON.has(actionNeeded) && (
+                  {actionNeeded && !actionBadgeRedundant && (
                     <Badge
                       variant={actionNeeded === 'claim' ? 'success' : 'warning'}
                       className="mm-action-needed-badge"

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -25,11 +25,12 @@ const ACTION_NEEDED_LABELS = {
   respondDraw: 'Respond to draw'
 }
 
-// 'claim' and 'resolve' already have a real action button in the row's Actions
-// column, so a duplicate status-column badge for them is just noise (and the
-// badge looked clickable but wasn't). Suppress those two; the remaining action
-// kinds have no inline button yet, so their badge stays as the only affordance.
-const ACTION_BADGES_WITH_BUTTON = new Set(['claim', 'resolve'])
+// 'accept', 'claim' and 'resolve' already have a real action button in the
+// row's Actions column ("View Offer", "Claim", "Resolve"), so a duplicate
+// status-column badge for them is just noise (and the badge looked clickable
+// but wasn't). Suppress those; the remaining action kinds have no inline button
+// yet, so their badge stays as the only affordance.
+const ACTION_BADGES_WITH_BUTTON = new Set(['accept', 'claim', 'resolve'])
 
 /**
  * True when `account` is the declared winner of a resolved wager whose payout

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -25,11 +25,11 @@ const ACTION_NEEDED_LABELS = {
   respondDraw: 'Respond to draw'
 }
 
-// 'accept', 'claim' and 'resolve' already have a real action button in the
-// row's Actions column ("View Offer", "Claim", "Resolve"), so a duplicate
-// status-column badge for them is just noise (and the badge looked clickable
-// but wasn't). Suppress those; the remaining action kinds have no inline button
-// yet, so their badge stays as the only affordance.
+// Action kinds whose row always renders a matching button in the Actions
+// column ("View Offer", "Claim", "Resolve"), so a duplicate status-column badge
+// is just noise (and the badge looked clickable but wasn't). 'refund' and
+// 'respondDraw' also have buttons now, but only conditionally, so they're
+// handled per-row (see actionBadgeRedundant) rather than in this set.
 const ACTION_BADGES_WITH_BUTTON = new Set(['accept', 'claim', 'resolve'])
 
 /**
@@ -666,6 +666,62 @@ function MyMarketsModal({
     }
   }, [signer, isCorrectNetwork, switchNetwork, chainId, markWagerRead, refreshFriendMarkets])
 
+  // Participant reclaims their stake on a wager that ran past its resolution
+  // window without a winner being declared (the "refundable" state). Mirrors
+  // handleClaimPayout: a pull call (claimRefund) keyed by wager id so the
+  // in-flight spinner and any error map back to the right row. This backs the
+  // "Refund" list button (refundable case) — the expired pre-acceptance case is
+  // handled separately by handleClearExpired's "Reclaim & Clear".
+  const [refundingId, setRefundingId] = useState(null)
+  const [refundError, setRefundError] = useState(null)
+
+  const handleClaimRefund = useCallback(async (market) => {
+    if (!signer) return
+    const id = String(market.id)
+
+    if (!isCorrectNetwork) {
+      try {
+        await switchNetwork()
+      } catch {
+        setRefundError({ id, message: 'Please switch to the correct network.' })
+        return
+      }
+    }
+
+    setRefundingId(id)
+    setRefundError(null)
+
+    try {
+      const registry = new ethers.Contract(
+        getContractAddressForChain('wagerRegistry', chainId),
+        WAGER_REGISTRY_ABI,
+        signer
+      )
+      const tx = await registry.claimRefund(market.wagerId ?? market.id)
+      await tx.wait()
+      // Pull fresh on-chain data so the refunded wager leaves the list and clear
+      // its unread activity.
+      markWagerRead?.(id)
+      await refreshFriendMarkets?.()
+    } catch (err) {
+      const reason = err?.reason || err?.shortMessage || err?.data?.message || err?.message || ''
+      const lower = reason.toLowerCase()
+      let message
+      if (err?.code === 'ACTION_REJECTED' || err?.code === 4001 || lower.includes('user rejected')) {
+        message = 'Transaction was cancelled in your wallet.'
+      } else if (lower.includes('alreadyrefunded') || lower.includes('already refunded')) {
+        message = 'This wager has already been refunded.'
+      } else if (lower.includes('notrefundable') || lower.includes('not refundable')) {
+        message = 'Not refundable yet — the resolution window may still be open. Try resolving instead.'
+      } else {
+        message = 'Failed to claim refund. Please try again.'
+      }
+      setRefundError({ id, message })
+    } finally {
+      setRefundingId(null)
+    }
+  }, [signer, isCorrectNetwork, switchNetwork, chainId, markWagerRead, refreshFriendMarkets])
+
   if (!isOpen) return null
 
   return (
@@ -899,6 +955,9 @@ function MyMarketsModal({
                       onClaim={handleClaimPayout}
                       claimingId={claimingId}
                       claimError={claimError}
+                      onRefund={handleClaimRefund}
+                      refundingId={refundingId}
+                      refundError={refundError}
                     />
                   )}
                 </div>
@@ -959,6 +1018,9 @@ function MyMarketsModal({
                       onClearExpired={handleClearExpired}
                       onClearAllExpired={handleClearAllExpired}
                       statusFilter={statusFilter}
+                      onRefund={handleClaimRefund}
+                      refundingId={refundingId}
+                      refundError={refundError}
                     />
                   )}
                 </div>
@@ -1190,6 +1252,9 @@ function MarketsTable({
   onClaim,
   claimingId,
   claimError,
+  onRefund,
+  refundingId,
+  refundError,
   statusFilter,
   account,
   showResolveCountdown = false
@@ -1230,8 +1295,18 @@ function MarketsTable({
     typeof onClaim === 'function' && isWinnerUnpaid(market, account)
   const hasClaimableRow = markets.some(canClaim)
 
+  // Rows that need a Refund (refundable, not the expired-offer case) or a
+  // Respond-to-Draw button — both derived from the activity watcher's action
+  // kind, so the Actions column appears even in tabs that have no other button.
+  const actionKindOf = (market) => actionNeededByWagerId?.[String(market.id)] ?? null
+  const hasRefundRow = typeof onRefund === 'function' &&
+    markets.some(m => actionKindOf(m) === 'refund' && m.computedStatus !== MarketStatus.EXPIRED)
+  const hasDrawRow = typeof onResolve === 'function' &&
+    markets.some(m => actionKindOf(m) === 'respondDraw')
+
   const tableHasActionsColumn =
     showActions || canAccept || showResolveCountdown || hasClaimableRow ||
+    hasRefundRow || hasDrawRow ||
     (typeof onClearExpired === 'function' && expiredMarkets.length > 0)
 
   return (
@@ -1257,15 +1332,24 @@ function MarketsTable({
             const displayTitle = getMarketDisplayTitle(market)
             const actionNeeded = actionNeededByWagerId?.[String(market.id)] ?? null
             const rowOutcome = showOutcome ? getRowOutcome(market, account) : null
-            // Hide the action badge when this row already exposes a button for
-            // the same action: accept→"View Offer", claim→"Claim",
-            // resolve→"Resolve" (always have a button), plus refund→"Reclaim &
-            // Clear" but only in the expired-offer case that renders that button.
-            // The refundable case (active past the resolve deadline) has no grid
-            // button, and 'respondDraw' never does, so those keep their badge.
+            // Refundable case (active past the resolve window): a "Refund"
+            // button that pulls the stake back. The expired pre-acceptance case
+            // keeps its own "Reclaim & Clear" button (showClearBtn) instead.
+            const showRefundBtn =
+              actionNeeded === 'refund' && !showClearBtn && typeof onRefund === 'function'
+            // Counterparty proposed a draw: a "Respond to Draw" button that opens
+            // the resolution flow so this user can confirm (or decline) it.
+            const showDrawBtn =
+              actionNeeded === 'respondDraw' && typeof onResolve === 'function'
+            // Hide the action badge whenever this row already exposes a button for
+            // the same action — accept→"View Offer", claim→"Claim",
+            // resolve→"Resolve", refund→"Reclaim & Clear"/"Refund",
+            // respondDraw→"Respond to Draw". Falls back to the badge only when no
+            // matching button is rendered (e.g. outside the relevant tab).
             const actionBadgeRedundant =
               ACTION_BADGES_WITH_BUTTON.has(actionNeeded) ||
-              (actionNeeded === 'refund' && showClearBtn)
+              (actionNeeded === 'refund' && (showClearBtn || showRefundBtn)) ||
+              showDrawBtn
 
             return (
               <tr
@@ -1374,6 +1458,30 @@ function MarketsTable({
                           <span className="mm-action-error" role="alert">{claimError.message}</span>
                         )}
                       </>
+                    )}
+                    {showRefundBtn && (
+                      <>
+                        <button
+                          className="mm-action-btn mm-action-refund"
+                          onClick={(e) => { e.stopPropagation(); onRefund(market) }}
+                          disabled={refundingId === String(market.id)}
+                          title="Reclaim your stake — the resolution window has passed"
+                        >
+                          {refundingId === String(market.id) ? 'Refunding…' : 'Refund'}
+                        </button>
+                        {refundError?.id === String(market.id) && (
+                          <span className="mm-action-error" role="alert">{refundError.message}</span>
+                        )}
+                      </>
+                    )}
+                    {showDrawBtn && (
+                      <button
+                        className="mm-action-btn mm-action-draw"
+                        onClick={(e) => { e.stopPropagation(); onResolve(market) }}
+                        title="Your counterparty proposed a draw — review and respond"
+                      >
+                        Respond to Draw
+                      </button>
                     )}
                   </td>
                 )}

--- a/frontend/src/test/actionNeededBadges.test.jsx
+++ b/frontend/src/test/actionNeededBadges.test.jsx
@@ -244,7 +244,7 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
   })
 
   describe('MyMarketsModal wager cards', () => {
-    it('shows an action badge on exactly the wager that needs action', async () => {
+    it('shows a Refund button on exactly the wager that needs a refund', async () => {
       activityRef.current = baseActivity({
         actionNeededByWagerId: { '1': 'refund', '2': null }
       })
@@ -255,20 +255,17 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
       })
 
       const row1 = screen.getByText('Wager One').closest('tr')
-      expect(within(row1).getByText('Refund')).toBeInTheDocument()
+      expect(within(row1).getByRole('button', { name: /^refund$/i })).toBeInTheDocument()
+      // The button replaces the badge — no redundant status pill.
+      expect(document.querySelectorAll('.mm-action-needed-badge')).toHaveLength(0)
 
-      // Wager 2 (action kind null) has no badge — exactly one in the document.
-      expect(document.querySelectorAll('.mm-action-needed-badge')).toHaveLength(1)
       const row2 = screen.getByText('Wager Two').closest('tr')
-      expect(within(row2).queryByText('Refund')).not.toBeInTheDocument()
+      expect(within(row2).queryByRole('button', { name: /^refund$/i })).not.toBeInTheDocument()
     })
 
-    it.each([
-      ['refund', 'Refund'],
-      ['respondDraw', 'Respond to draw']
-    ])('labels a "%s" action badge "%s"', async (kind, label) => {
+    it('shows a Respond to Draw button when a draw is proposed', async () => {
       activityRef.current = baseActivity({
-        actionNeededByWagerId: { '1': kind }
+        actionNeededByWagerId: { '1': 'respondDraw' }
       })
 
       await act(async () => {
@@ -276,12 +273,13 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
       })
 
       const row = screen.getByText('Wager One').closest('tr')
-      expect(within(row).getByText(label)).toBeInTheDocument()
+      expect(within(row).getByRole('button', { name: /respond to draw/i })).toBeInTheDocument()
+      expect(document.querySelectorAll('.mm-action-needed-badge')).toHaveLength(0)
     })
 
-    // 'accept', 'claim' and 'resolve' have a real action button in the row's
-    // Actions column, so the duplicate status badge is intentionally suppressed.
-    it.each(['accept', 'claim', 'resolve'])(
+    // Every action kind now has a matching button in the Actions column, so the
+    // duplicate status badge is suppressed across the board.
+    it.each(['accept', 'claim', 'resolve', 'refund', 'respondDraw'])(
       'does not render a redundant status badge for "%s"',
       async (kind) => {
         activityRef.current = baseActivity({
@@ -296,7 +294,7 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
       }
     )
 
-    it('removes the badge when the action is no longer needed', async () => {
+    it('removes the Refund button when the action is no longer needed', async () => {
       activityRef.current = baseActivity({
         actionNeededByWagerId: { '1': 'refund', '2': null }
       })
@@ -307,7 +305,7 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
         view = render(modalUi(markets))
       })
 
-      expect(screen.getByText('Refund')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /^refund$/i })).toBeInTheDocument()
 
       activityRef.current = baseActivity({
         actionNeededByWagerId: { '1': null, '2': null }
@@ -316,7 +314,7 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
         view.rerender(modalUi(markets))
       })
 
-      expect(screen.queryByText('Refund')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /^refund$/i })).not.toBeInTheDocument()
       expect(document.querySelectorAll('.mm-action-needed-badge')).toHaveLength(0)
     })
 

--- a/frontend/src/test/actionNeededBadges.test.jsx
+++ b/frontend/src/test/actionNeededBadges.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, within, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import Dashboard from '../components/fairwins/Dashboard'
 import MyMarketsModal from '../components/fairwins/MyMarketsModal'
@@ -316,6 +317,40 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
       })
 
       expect(screen.queryByText('Refund')).not.toBeInTheDocument()
+      expect(document.querySelectorAll('.mm-action-needed-badge')).toHaveLength(0)
+    })
+
+    it('suppresses the "refund" badge when the row shows a Clear/Reclaim button', async () => {
+      const user = userEvent.setup()
+      // An expired pending offer → computedStatus EXPIRED → the row renders a
+      // Clear button, which makes the "refund" action badge redundant.
+      const expired = {
+        id: '7',
+        description: 'Expired Offer',
+        creator: OTHER,
+        participants: [ME],
+        status: 'pending_acceptance',
+        acceptanceDeadline: Date.now() - 60 * 60 * 1000,
+        endDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+        marketType: 'friend'
+      }
+      activityRef.current = baseActivity({
+        actionNeededByWagerId: { '7': 'refund' }
+      })
+
+      await act(async () => {
+        render(modalUi([expired]))
+      })
+
+      // Expired offers are hidden under the default "all" filter — switch to Expired.
+      const statusSelect = screen.getAllByRole('combobox')[1]
+      await act(async () => {
+        await user.selectOptions(statusSelect, 'expired')
+      })
+
+      expect(screen.getByText('Expired Offer')).toBeInTheDocument()
+      // The Clear button is present, so the refund badge is suppressed.
+      expect(screen.getByRole('button', { name: /^clear$/i })).toBeInTheDocument()
       expect(document.querySelectorAll('.mm-action-needed-badge')).toHaveLength(0)
     })
 

--- a/frontend/src/test/actionNeededBadges.test.jsx
+++ b/frontend/src/test/actionNeededBadges.test.jsx
@@ -245,7 +245,7 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
   describe('MyMarketsModal wager cards', () => {
     it('shows an action badge on exactly the wager that needs action', async () => {
       activityRef.current = baseActivity({
-        actionNeededByWagerId: { '1': 'accept', '2': null }
+        actionNeededByWagerId: { '1': 'refund', '2': null }
       })
       const markets = [wagerOne(), wagerTwo()]
 
@@ -254,16 +254,15 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
       })
 
       const row1 = screen.getByText('Wager One').closest('tr')
-      expect(within(row1).getByText('Accept')).toBeInTheDocument()
+      expect(within(row1).getByText('Refund')).toBeInTheDocument()
 
       // Wager 2 (action kind null) has no badge — exactly one in the document.
       expect(document.querySelectorAll('.mm-action-needed-badge')).toHaveLength(1)
       const row2 = screen.getByText('Wager Two').closest('tr')
-      expect(within(row2).queryByText('Accept')).not.toBeInTheDocument()
+      expect(within(row2).queryByText('Refund')).not.toBeInTheDocument()
     })
 
     it.each([
-      ['accept', 'Accept'],
       ['refund', 'Refund'],
       ['respondDraw', 'Respond to draw']
     ])('labels a "%s" action badge "%s"', async (kind, label) => {
@@ -279,9 +278,9 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
       expect(within(row).getByText(label)).toBeInTheDocument()
     })
 
-    // 'claim' and 'resolve' have a real action button in the row's Actions
-    // column, so the duplicate status badge is intentionally suppressed.
-    it.each(['claim', 'resolve'])(
+    // 'accept', 'claim' and 'resolve' have a real action button in the row's
+    // Actions column, so the duplicate status badge is intentionally suppressed.
+    it.each(['accept', 'claim', 'resolve'])(
       'does not render a redundant status badge for "%s"',
       async (kind) => {
         activityRef.current = baseActivity({
@@ -298,7 +297,7 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
 
     it('removes the badge when the action is no longer needed', async () => {
       activityRef.current = baseActivity({
-        actionNeededByWagerId: { '1': 'accept', '2': null }
+        actionNeededByWagerId: { '1': 'refund', '2': null }
       })
       const markets = [wagerOne(), wagerTwo()]
 
@@ -307,7 +306,7 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
         view = render(modalUi(markets))
       })
 
-      expect(screen.getByText('Accept')).toBeInTheDocument()
+      expect(screen.getByText('Refund')).toBeInTheDocument()
 
       activityRef.current = baseActivity({
         actionNeededByWagerId: { '1': null, '2': null }
@@ -316,7 +315,7 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
         view.rerender(modalUi(markets))
       })
 
-      expect(screen.queryByText('Accept')).not.toBeInTheDocument()
+      expect(screen.queryByText('Refund')).not.toBeInTheDocument()
       expect(document.querySelectorAll('.mm-action-needed-badge')).toHaveLength(0)
     })
 


### PR DESCRIPTION
Follow-up to #690. Brings **all** My Wagers action kinds in line with the same "row button instead of a status pill" pattern.

### Background
#690 turned the "Claim"/"Resolve" status badges into reliance on the real Actions-column buttons. This PR finishes the job for the remaining kinds: **accept**, **refund**, and **respondDraw** — adding the two buttons that didn't exist yet (Refund, Respond to Draw) and suppressing every badge that now has a matching button.

### New action buttons
- **Refund** — `handleClaimRefund` pulls the stake back via `claimRefund` for the *refundable* case (an active wager past its resolution window), keyed by wager id with an inline spinner/error, exactly like the Claim button. The *expired pre-acceptance* case keeps its existing "Reclaim & Clear" button.
- **Respond to Draw** — opens the resolution flow so the user can confirm or decline a counterparty's draw proposal (reuses the existing `declareDraw` path in `ResolutionModal`).
- Both are wired through the participating/created tabs and styled consistently with the other action buttons (blue Refund, amber Respond to Draw).

### Badge suppression (now complete)
| Action | Row button | Badge |
|---|---|---|
| `accept` | "View Offer" | hidden |
| `claim` | "Claim" | hidden |
| `resolve` | "Resolve" | hidden |
| `refund` | "Reclaim & Clear" (expired) / **"Refund"** (refundable) | hidden when its button shows |
| `respondDraw` | **"Respond to Draw"** | hidden when its button shows |

The badge remains only as a defensive fallback for the (now rare) case where no matching button renders.

### Testing
- `actionNeededBadges.test.jsx` — 14 tests: Refund/Respond-to-Draw buttons appear on the right rows, no badge for any kind, button removed when the action clears, plus the expired→Clear case.
- `MyMarketsModal.test.jsx` — 39 tests pass. ESLint clean.

https://claude.ai/code/session_012D6UNDKFafVez1yJPJZ1ka