### PR TITLE
Redesign end-date input as compact chips with timeline

### DIFF
--- a/frontend/cypress/e2e/fast/22-accessibility.cy.js
+++ b/frontend/cypress/e2e/fast/22-accessibility.cy.js
@@ -320,8 +320,9 @@ describe('Accessibility', () => {
       .should('have.attr', 'max')
       .and('not.be.empty')
 
-    // The acceptance deadline should be displayed in locale format.
-    cy.get('.fm-readonly-value', { timeout: 3000 })
+    // The derived timeline tiles (Accept by / Ends / Resolve by) should
+    // render with a real clock value, not the em-dash placeholder.
+    cy.get('.fm-stat-tile.is-accept .fm-stat-time', { timeout: 3000 })
       .should('be.visible')
       .invoke('text')
       .should('not.be.empty')

--- a/frontend/cypress/e2e/full/04-wager-creation-tx.cy.js
+++ b/frontend/cypress/e2e/full/04-wager-creation-tx.cy.js
@@ -331,11 +331,12 @@ describe('Wager Creation with Real Transactions', () => {
       encrypted: false,
     })
 
-    // Verify the acceptance deadline field is displayed (deterministic, not editable)
+    // Verify the derived acceptance deadline is displayed (deterministic, not
+    // editable) via the glanceable "Accept by" timeline tile.
     cy.get('[role="dialog"]').within(() => {
-      cy.contains('Acceptance Deadline').should('be.visible')
-      cy.get('.fm-readonly-value').should('exist')
-      cy.get('.fm-readonly-value').invoke('text').should('not.be.empty').and('not.equal', '—')
+      cy.contains('Accept by').should('be.visible')
+      cy.get('.fm-stat-tile.is-accept .fm-stat-time').should('exist')
+      cy.get('.fm-stat-tile.is-accept .fm-stat-time').invoke('text').should('not.be.empty').and('not.equal', '—')
     })
 
     submitWagerForm()

--- a/frontend/src/components/fairwins/FriendMarketsModal.css
+++ b/frontend/src/components/fairwins/FriendMarketsModal.css
@@ -247,15 +247,6 @@
   cursor: not-allowed;
 }
 
-.fm-readonly-value {
-  padding: 0.625rem 0.875rem;
-  background: var(--bg-primary, #0E141B);
-  border: 1px solid var(--border-color, #23303D);
-  border-radius: 8px;
-  color: var(--text-muted, #7A8590);
-  font-size: 0.875rem;
-}
-
 .fm-hint {
   font-size: 0.75rem;
   color: var(--text-muted, #7A8590);
@@ -264,6 +255,130 @@
 .fm-error {
   font-size: 0.75rem;
   color: #E5533D;
+}
+
+/* ── End date + glanceable timeline (compact-chips redesign) ─────────
+   Replaces the tall stack of End Date / Acceptance Deadline / Resolution
+   Window read-only rows with a slim accent track + three stat tiles. */
+.fm-endtime {
+  --fm-accept: #E8910C;   /* amber  — accept-by */
+  --fm-active: #36B37E;   /* green  — ends (matches app accent) */
+  --fm-resolve: #8C7CF0;  /* purple — resolve-by */
+}
+
+.fm-endtime-summary {
+  font-size: 0.75rem;
+  color: var(--text-muted, #7A8590);
+}
+
+.fm-timeline-track {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  margin: 0.25rem 0;
+}
+
+.fm-timeline-node {
+  position: absolute;
+  top: 50%;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  border: 3px solid var(--bg-secondary, #161B22);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+}
+
+.fm-timeline-node.is-accept {
+  background: var(--fm-accept);
+}
+
+.fm-timeline-node.is-end {
+  width: 18px;
+  height: 18px;
+  background: var(--fm-active);
+}
+
+.fm-stat-tiles {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.fm-stat-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  padding: 0.5rem 0.625rem;
+  border-radius: 10px;
+  border: 1px solid var(--tile-border);
+  background: var(--tile-bg);
+}
+
+.fm-stat-tile.is-accept {
+  --tile-accent: var(--fm-accept);
+  --tile-bg: rgba(232, 145, 12, 0.08);
+  --tile-border: rgba(232, 145, 12, 0.28);
+}
+
+.fm-stat-tile.is-ends {
+  --tile-accent: var(--fm-active);
+  --tile-bg: rgba(54, 179, 126, 0.08);
+  --tile-border: rgba(54, 179, 126, 0.28);
+}
+
+.fm-stat-tile.is-resolve {
+  --tile-accent: var(--fm-resolve);
+  --tile-bg: rgba(140, 124, 240, 0.08);
+  --tile-border: rgba(140, 124, 240, 0.28);
+}
+
+.fm-stat-head {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--tile-accent);
+}
+
+.fm-stat-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--tile-accent);
+  flex-shrink: 0;
+}
+
+.fm-stat-time {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--text-primary, #E6EDF3);
+}
+
+.fm-stat-day {
+  font-size: 0.7rem;
+  color: var(--text-muted, #7A8590);
+}
+
+.fm-timeline-note {
+  display: flex;
+  gap: 0.375rem;
+  margin: 0.25rem 0 0;
+  padding: 0.5rem 0.625rem;
+  border-radius: 8px;
+  background: var(--bg-primary, #0E141B);
+  font-size: 0.72rem;
+  line-height: 1.4;
+  color: var(--text-muted, #7A8590);
+}
+
+.fm-timeline-note-icon {
+  color: var(--text-secondary, #9BA7B3);
+  flex-shrink: 0;
 }
 
 /* Stake Amount Input Wrapper - with $ prefix for USD */

--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -115,6 +115,32 @@ const RESOLUTION_TAB_ICONS = {
   [ResolutionType.UMA]: '🔮',
 }
 
+// ── End-date timeline formatters (compact-chips redesign) ───────────
+// The end-date region renders three glanceable stat tiles (Accept by /
+// Ends / Resolve by). Each shows a short clock + day, so the timeline reads
+// at a glance without the tall stack of labelled read-only rows it replaces.
+
+/** "2:05 PM" — short local clock for a stat tile. */
+const formatTileClock = (date) =>
+  date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+
+/** "Jun 17" — short local month + day for a stat tile. */
+const formatTileDay = (date) =>
+  date.toLocaleDateString([], { month: 'short', day: 'numeric' })
+
+/**
+ * Human duration between two dates as "1 day 0h" / "3h" — used for the
+ * "lasts …" summary so the wager length is legible before committing.
+ */
+const formatTimelineSpan = (from, to) => {
+  let minutes = Math.max(0, Math.round((to.getTime() - from.getTime()) / 60000))
+  const days = Math.floor(minutes / 1440)
+  minutes -= days * 1440
+  const hours = Math.floor(minutes / 60)
+  if (days > 0) return `${days} day${days > 1 ? 's' : ''} ${hours}h`
+  return `${hours}h`
+}
+
 /**
  * FriendMarketsModal
  *
@@ -1638,62 +1664,106 @@ function FriendMarketsModal({
                     })()}
 
                     {/*
-                      End date input. Hidden entirely when a Polymarket is
-                      linked — the wager's end time is locked to that market's
-                      own end time so the side bet can't settle before (or
-                      long after) the linked event.
+                      End date + glanceable timeline (compact-chips redesign).
+                      The datetime input keeps #fm-end-date with min/max; the
+                      acceptance deadline and resolution window that used to be
+                      separate read-only rows are now a slim accent track plus
+                      three stat tiles (Accept by / Ends / Resolve by) for the
+                      lowest vertical footprint.
+
+                      The editable input is hidden when a Polymarket is linked —
+                      the wager's end time is locked to that market's own end time
+                      so the side bet can't settle before (or long after) the
+                      linked event — but the derived timeline still renders.
                     */}
-                    {!(formData.resolutionType === ResolutionType.Polymarket && selectedPolymarketMarket) && (
-                      <div className="fm-form-group">
-                        <label htmlFor="fm-end-date">
-                          End Date &amp; Time <span className="fm-required">*</span>
-                        </label>
-                        <input
-                          id="fm-end-date"
-                          type="datetime-local"
-                          value={formData.endDateTime}
-                          onChange={(e) => handleFormChange('endDateTime', e.target.value)}
-                          min={toDateTimeLocal(new Date(Date.now() + WAGER_DEFAULTS.MIN_TRADING_PERIOD_SECONDS * 1000))}
-                          max={toDateTimeLocal(new Date(Date.now() + WAGER_DEFAULTS.MAX_TRADING_PERIOD_SECONDS * 1000))}
-                          disabled={submitting}
-                          className={`fm-datetime-input ${errors.endDateTime ? 'error' : ''}`}
-                        />
-                        <span className="fm-hint">When does this wager end? You can resolve it once this time passes. (min: 1 hour, max: 21 days)</span>
-                        {errors.endDateTime && <span className="fm-error">{errors.endDateTime}</span>}
-                      </div>
-                    )}
+                    <div className="fm-form-group fm-form-full fm-endtime">
+                      {!(formData.resolutionType === ResolutionType.Polymarket && selectedPolymarketMarket) && (
+                        <>
+                          <label htmlFor="fm-end-date">
+                            End Date &amp; Time <span className="fm-required">*</span>
+                          </label>
+                          <input
+                            id="fm-end-date"
+                            type="datetime-local"
+                            value={formData.endDateTime}
+                            onChange={(e) => handleFormChange('endDateTime', e.target.value)}
+                            min={toDateTimeLocal(new Date(Date.now() + WAGER_DEFAULTS.MIN_TRADING_PERIOD_SECONDS * 1000))}
+                            max={toDateTimeLocal(new Date(Date.now() + WAGER_DEFAULTS.MAX_TRADING_PERIOD_SECONDS * 1000))}
+                            disabled={submitting}
+                            className={`fm-datetime-input ${errors.endDateTime ? 'error' : ''}`}
+                          />
+                          {errors.endDateTime && <span className="fm-error">{errors.endDateTime}</span>}
+                        </>
+                      )}
 
-                    {/* Acceptance Deadline - deterministic, not user-editable */}
-                    <div className="fm-form-group">
-                      <label>Acceptance Deadline</label>
-                      <div className="fm-readonly-value">
-                        {formData.acceptanceDeadline
-                          ? new Date(formData.acceptanceDeadline).toLocaleString()
-                          : '—'}
-                      </div>
-                      <span className="fm-hint">Halfway between now and the end time — your opponent must accept before this.</span>
+                      {formData.endDateTime && !Number.isNaN(new Date(formData.endDateTime).getTime()) && (() => {
+                        const now = new Date()
+                        const end = new Date(formData.endDateTime)
+                        const accept = formData.acceptanceDeadline && !Number.isNaN(new Date(formData.acceptanceDeadline).getTime())
+                          ? new Date(formData.acceptanceDeadline)
+                          : null
+                        const windowMs = (WAGER_DEFAULTS.RESOLUTION_WINDOW_SECONDS || 48 * 3600) * 1000
+                        const resolveClose = new Date(end.getTime() + windowMs)
+
+                        // Position the accent track / markers proportionally along
+                        // now → resolveClose so the amber (accept) and green (end)
+                        // marks land where they actually fall in the timeline.
+                        const span = Math.max(1, resolveClose.getTime() - now.getTime())
+                        const clamp = (n) => Math.max(0, Math.min(100, n))
+                        const acceptPct = accept ? clamp(((accept.getTime() - now.getTime()) / span) * 100) : 0
+                        const endPct = clamp(((end.getTime() - now.getTime()) / span) * 100)
+                        const trackStyle = {
+                          background: `linear-gradient(to right,` +
+                            ` var(--fm-accept) 0%, var(--fm-accept) ${acceptPct}%,` +
+                            ` var(--fm-active) ${acceptPct}%, var(--fm-active) ${endPct}%,` +
+                            ` var(--fm-resolve) ${endPct}%, var(--fm-resolve) 100%)`
+                        }
+
+                        return (
+                          <>
+                            <span className="fm-endtime-summary">
+                              Resolves once this passes · lasts {formatTimelineSpan(now, end)} · min 1h, max 21d
+                            </span>
+
+                            <div className="fm-timeline-track" style={trackStyle} aria-hidden="true">
+                              {accept && (
+                                <span className="fm-timeline-node is-accept" style={{ left: `${acceptPct}%` }} />
+                              )}
+                              <span className="fm-timeline-node is-end" style={{ left: `${endPct}%` }} />
+                            </div>
+
+                            <div className="fm-stat-tiles">
+                              <div className="fm-stat-tile is-accept">
+                                <span className="fm-stat-head">
+                                  <span className="fm-stat-dot" aria-hidden="true" />Accept by
+                                </span>
+                                <span className="fm-stat-time">{accept ? formatTileClock(accept) : '—'}</span>
+                                <span className="fm-stat-day">{accept ? formatTileDay(accept) : ''}</span>
+                              </div>
+                              <div className="fm-stat-tile is-ends">
+                                <span className="fm-stat-head">
+                                  <span className="fm-stat-dot" aria-hidden="true" />Ends
+                                </span>
+                                <span className="fm-stat-time">{formatTileClock(end)}</span>
+                                <span className="fm-stat-day">{formatTileDay(end)}</span>
+                              </div>
+                              <div className="fm-stat-tile is-resolve">
+                                <span className="fm-stat-head">
+                                  <span className="fm-stat-dot" aria-hidden="true" />Resolve by
+                                </span>
+                                <span className="fm-stat-time">{formatTileClock(resolveClose)}</span>
+                                <span className="fm-stat-day">{formatTileDay(resolveClose)}</span>
+                              </div>
+                            </div>
+
+                            <p className="fm-timeline-note">
+                              <span className="fm-timeline-note-icon" aria-hidden="true">&#9432;</span>
+                              Opponent accepts before the amber mark; you settle in the 48h after it ends or stakes refund.
+                            </p>
+                          </>
+                        )
+                      })()}
                     </div>
-
-                    {/* Resolution window — derived from the end time so the full timeline is
-                        clear before the user commits (Bug #1). Resolve allowed in
-                        [end time, end time + 48h]; refundable after that. */}
-                    {formData.endDateTime && !Number.isNaN(new Date(formData.endDateTime).getTime()) && (() => {
-                      const end = new Date(formData.endDateTime)
-                      const windowMs = (WAGER_DEFAULTS.RESOLUTION_WINDOW_SECONDS || 48 * 3600) * 1000
-                      const resolveClose = new Date(end.getTime() + windowMs)
-                      return (
-                        <div className="fm-form-group">
-                          <label>Resolution Window</label>
-                          <div className="fm-readonly-value">
-                            {end.toLocaleString()} → {resolveClose.toLocaleString()}
-                          </div>
-                          <span className="fm-hint">
-                            You have 48 hours after the end time to resolve. If unresolved by{' '}
-                            {resolveClose.toLocaleString()}, both stakes can be refunded.
-                          </span>
-                        </div>
-                      )
-                    })()}
 
                     {/* Privacy / Encryption Toggle */}
                     <div className="fm-form-group fm-form-full">


### PR DESCRIPTION
## Summary

Redesigns the end-date region of the wager creation form (`FriendMarketsModal`) from a tall vertical stack of three labelled read-only rows (**End Date & Time**, **Acceptance Deadline**, **Resolution Window**) into a **compact, glanceable layout** with the lowest vertical footprint:

- the `datetime-local` input (unchanged behaviour),
- a single summary line — `Resolves once this passes · lasts 1 day 0h · min 1h, max 21d`,
- a **slim accent track** whose amber→green→purple gradient and two markers are positioned proportionally along `now → resolve-close`,
- **three stat tiles** — **Accept by** / **Ends** / **Resolve by** — each showing a short clock + day,
- a one-line footnote explaining the accept window and 48h settle/refund rule.

The derived values are identical to before (midpoint acceptance deadline, end time, end + 48h resolution close); only the presentation changed.

### Before → After

| Before | After |
|---|---|
| 3 stacked `label` + read-only value + hint blocks | datetime input + summary line + slim track + 3 stat tiles + note |

## Notes

- **Accessibility (WCAG 2.1 AA):** color is never the only cue — every tile pairs its accent color with an uppercase label and a dot. Decorative dots/markers/icon are `aria-hidden`.
- **E2E compatibility:** the `#fm-end-date` datetime input keeps its `min`/`max` constraints so existing wager-creation flows are unaffected.
- **Polymarket linking:** the editable input is still hidden when a market is linked (end time locked), but the derived timeline now renders so the schedule stays visible.
- Updated the fast (`22-accessibility`) and full (`04-wager-creation-tx`) Cypress assertions that targeted the removed `.fm-readonly-value` / "Acceptance Deadline" rows to point at the new `.fm-stat-tile` elements. Removed the now-unused `.fm-readonly-value` CSS rule.

## Testing

- `npx eslint` on the changed component — clean
- `npx vitest run src/test/FriendMarketsModal.test.jsx` — **54/54 passing**

https://claude.ai/code/session_01YFgnMg3wRosxrGWTeNKHAL

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFgnMg3wRosxrGWTeNKHAL)_