### PR TITLE
Relocate network selector to a My Account tab and simplify the wallet menu

### DIFF
--- a/frontend/src/components/wallet/NetworkSettings.css
+++ b/frontend/src/components/wallet/NetworkSettings.css
@@ -1,0 +1,139 @@
+/* NetworkSettings — My Account → Network tab */
+
+.network-settings .section h3 {
+  margin: 0 0 16px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.network-card-list {
+  list-style: none;
+  margin: 16px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.network-card {
+  padding: 16px;
+  background: var(--color-surface-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.network-card.active {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 1px var(--color-primary);
+}
+
+.network-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.network-card-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.network-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.network-kind {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+
+.network-kind.mainnet {
+  color: var(--color-success, #15803d);
+  background: rgba(34, 197, 94, 0.14);
+}
+
+.network-kind.testnet {
+  color: var(--color-warning, #b45309);
+  background: rgba(245, 158, 11, 0.16);
+}
+
+.network-active-badge {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-primary);
+  padding: 6px 12px;
+  border: 1px solid var(--color-primary);
+  border-radius: 6px;
+  white-space: nowrap;
+}
+
+.network-switch-btn {
+  font-size: 13px;
+  font-weight: 600;
+  color: white;
+  background: var(--brand-primary, var(--color-primary));
+  border: none;
+  border-radius: 6px;
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+  white-space: nowrap;
+}
+
+.network-switch-btn:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.network-switch-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.network-feature-tags {
+  list-style: none;
+  margin: 14px 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.network-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  cursor: default;
+}
+
+.network-tag.available {
+  color: var(--color-success, #15803d);
+  background: rgba(34, 197, 94, 0.12);
+  border-color: rgba(34, 197, 94, 0.3);
+}
+
+.network-tag.unavailable {
+  color: var(--color-text-secondary);
+  background: var(--color-surface);
+  border-color: var(--color-border);
+  opacity: 0.75;
+}
+
+.network-tag-icon {
+  font-weight: 700;
+}

--- a/frontend/src/components/wallet/NetworkSettings.jsx
+++ b/frontend/src/components/wallet/NetworkSettings.jsx
@@ -1,0 +1,94 @@
+import { useChainId, useSwitchChain } from 'wagmi'
+import { getSelectableNetworks } from '../../config/networks'
+import { getNetworkFeatures } from '../../config/networkCapabilities'
+import './NetworkSettings.css'
+
+/**
+ * NetworkSettings
+ *
+ * The relocated network selector that lives on the My Account → Network tab.
+ * Lists every user-switchable network as a card and surfaces capability tags
+ * (Sanctions Guard, oracles, swaps, …) so members can make an informed switch
+ * before moving to another chain. Switching goes through wagmi.switchChain, so
+ * the connected wallet prompts the user to confirm the chain change.
+ */
+function NetworkSettings() {
+  const chainId = useChainId()
+  const { switchChain, isPending, variables, error } = useSwitchChain()
+  const networks = getSelectableNetworks()
+  const pendingChainId = isPending ? variables?.chainId : null
+
+  return (
+    <div className="network-settings" role="tabpanel">
+      <div className="section">
+        <h3>Network</h3>
+        <p className="section-description">
+          Choose which network FairWins connects to. Tags show which protocol
+          features are deployed on each network so you can switch with
+          confidence — switching prompts your wallet to confirm.
+        </p>
+
+        {error && (
+          <div className="key-error" role="alert">
+            {error.shortMessage || error.message || 'Failed to switch network.'}
+          </div>
+        )}
+
+        <ul className="network-card-list">
+          {networks.map((net) => {
+            const isActive = net.chainId === chainId
+            const features = getNetworkFeatures(net.chainId)
+            const switching = pendingChainId === net.chainId
+            return (
+              <li
+                key={net.chainId}
+                className={`network-card ${isActive ? 'active' : ''}`}
+              >
+                <div className="network-card-header">
+                  <div className="network-card-title">
+                    <span className="network-name">{net.name}</span>
+                    <span
+                      className={`network-kind ${net.isTestnet ? 'testnet' : 'mainnet'}`}
+                    >
+                      {net.isTestnet ? 'Testnet' : 'Mainnet'}
+                    </span>
+                  </div>
+                  {isActive ? (
+                    <span className="network-active-badge">Connected</span>
+                  ) : (
+                    <button
+                      type="button"
+                      className="network-switch-btn"
+                      onClick={() => switchChain({ chainId: net.chainId })}
+                      disabled={isPending}
+                      aria-label={`Switch to ${net.name}`}
+                    >
+                      {switching ? 'Switching…' : 'Switch'}
+                    </button>
+                  )}
+                </div>
+
+                <ul className="network-feature-tags">
+                  {features.map((feature) => (
+                    <li
+                      key={feature.key}
+                      className={`network-tag ${feature.deployed ? 'available' : 'unavailable'}`}
+                      title={`${feature.description} ${feature.deployed ? '(Deployed)' : '(Not deployed)'}`}
+                    >
+                      <span className="network-tag-icon" aria-hidden="true">
+                        {feature.deployed ? '✓' : '—'}
+                      </span>
+                      <span className="network-tag-label">{feature.label}</span>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            )
+          })}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export default NetworkSettings

--- a/frontend/src/components/wallet/WalletButton.jsx
+++ b/frontend/src/components/wallet/WalletButton.jsx
@@ -5,7 +5,6 @@ import { useDex } from '../../hooks/useDex'
 import { useNetworkMode } from '../../hooks/useNetworkMode'
 import { useWalletRoles } from '../../hooks'
 import { useRoleDetails } from '../../hooks/useRoleDetails'
-import { useTheme } from '../../hooks/useTheme'
 import { useModal } from '../../hooks/useUI'
 import { ROLES, ROLE_INFO } from '../../contexts/RoleContext'
 import { DEX_ADDRESSES, TOKENS } from '../../constants/dex'
@@ -41,14 +40,13 @@ function WalletButton({ className = '' }) {
   const navigate = useNavigate()
   const { showModal } = useModal()
   const { balances, loading: balanceLoading } = useDex()
-  const { isTestnet, network, switchMode: switchNetworkMode, isSwitching: isNetworkSwitching } = useNetworkMode()
+  const { isTestnet, network } = useNetworkMode()
   const { hasRole, rolesLoading, refreshRoles } = useWalletRoles()
   const {
     roleDetails,
     loading: roleDetailsLoading,
     refresh: refreshRoleDetails
   } = useRoleDetails()
-  const { toggleMode, isDark } = useTheme()
   const dropdownRef = useRef(null)
   const buttonRef = useRef(null)
   const [connectorStatus, setConnectorStatus] = useState({})
@@ -392,39 +390,6 @@ function WalletButton({ className = '' }) {
                   </div>
                 </div>
               )}
-
-              {/* Network Toggle */}
-              <div className="dropdown-section">
-                <div className="toggle-row">
-                  <span className="toggle-label">
-                    {isTestnet ? 'Amoy Testnet' : 'Polygon Mainnet'}
-                  </span>
-                  <button
-                    onClick={() => switchNetworkMode('toggle')}
-                    className="toggle-btn"
-                    disabled={isNetworkSwitching}
-                    aria-label={`Switch to ${isTestnet ? 'Polygon Mainnet' : 'Amoy Testnet'}`}
-                  >
-                    {isNetworkSwitching ? 'Switching...' : isTestnet ? 'Mainnet' : 'Testnet'}
-                  </button>
-                </div>
-              </div>
-
-              {/* Theme Toggle */}
-              <div className="dropdown-section">
-                <div className="toggle-row">
-                  <span className="toggle-label">
-                    {isDark ? '🌙 Dark Theme' : '☀️ Light Theme'}
-                  </span>
-                  <button
-                    onClick={toggleMode}
-                    className="toggle-btn"
-                    aria-label={`Switch to ${isDark ? 'light' : 'dark'} theme`}
-                  >
-                    {isDark ? 'Light Mode' : 'Dark Mode'}
-                  </button>
-                </div>
-              </div>
 
               {/* Navigation Actions */}
               <div className="dropdown-actions">

--- a/frontend/src/config/networkCapabilities.js
+++ b/frontend/src/config/networkCapabilities.js
@@ -1,0 +1,89 @@
+/**
+ * Per-chain protocol capability descriptors.
+ *
+ * Powers the informational tags on the My Account → Network tab so members can
+ * see which FairWins features are actually live on a given network before they
+ * switch. `deployed(chainId)` resolves against the per-chain deployment record
+ * (contracts.js) and the per-chain capability flags (networks.js) — it does not
+ * hit the chain, so it is cheap to call during render.
+ */
+
+import { getContractAddressForChain } from './contracts'
+import { getNetwork } from './networks'
+
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/
+
+const isDeployed = (addr) => typeof addr === 'string' && ADDRESS_RE.test(addr)
+
+const hasContract = (chainId, name) =>
+  isDeployed(getContractAddressForChain(name, chainId))
+
+export const NETWORK_FEATURES = [
+  {
+    key: 'wagers',
+    label: 'P2P Wagers',
+    description: 'Create and settle peer-to-peer wagers.',
+    deployed: (chainId) => hasContract(chainId, 'wagerRegistry'),
+  },
+  {
+    key: 'membership',
+    label: 'Memberships',
+    description: 'On-chain membership tiers and access roles.',
+    deployed: (chainId) => hasContract(chainId, 'membershipManager'),
+  },
+  {
+    key: 'encryptedWagers',
+    label: 'Encrypted Wagers',
+    description: 'Private wagers backed by the on-chain key registry.',
+    deployed: (chainId) => hasContract(chainId, 'keyRegistry'),
+  },
+  {
+    key: 'sanctionsGuard',
+    label: 'Sanctions Guard',
+    description: 'OFAC sanctions screening enforced on participation.',
+    deployed: (chainId) => hasContract(chainId, 'sanctionsGuard'),
+  },
+  {
+    key: 'polymarketOracle',
+    label: 'Polymarket Oracle',
+    description: 'Settle wagers by reference to Polymarket markets.',
+    deployed: (chainId) => hasContract(chainId, 'polymarketAdapter'),
+  },
+  {
+    key: 'chainlinkOracle',
+    label: 'Chainlink Oracle',
+    description: 'Resolve via Chainlink Data Feeds / Functions.',
+    deployed: (chainId) =>
+      hasContract(chainId, 'chainlinkDataFeedAdapter') ||
+      hasContract(chainId, 'chainlinkFunctionsAdapter'),
+  },
+  {
+    key: 'umaOracle',
+    label: 'UMA Oracle',
+    description: 'Resolve via the UMA Optimistic Oracle.',
+    deployed: (chainId) => hasContract(chainId, 'umaAdapter'),
+  },
+  {
+    key: 'swap',
+    label: 'Token Swap',
+    description: 'In-app token swaps via Uniswap V3.',
+    deployed: (chainId) => Boolean(getNetwork(chainId)?.capabilities?.dex),
+  },
+]
+
+/**
+ * Resolve every capability tag for a chain, flattening `deployed` to a boolean.
+ *
+ * @param {number} chainId
+ * @returns {{ key: string, label: string, description: string, deployed: boolean }[]}
+ */
+export function getNetworkFeatures(chainId) {
+  return NETWORK_FEATURES.map(({ key, label, description, deployed }) => ({
+    key,
+    label,
+    description,
+    deployed: deployed(chainId),
+  }))
+}
+
+export default getNetworkFeatures

--- a/frontend/src/config/networks.js
+++ b/frontend/src/config/networks.js
@@ -37,6 +37,8 @@ const NETWORKS = {
     name: 'Polygon Amoy',
     isTestnet: true,
     isPrimary: false,
+    // Surfaced in the My Account → Network tab as a user-switchable network.
+    selectable: true,
     nativeCurrency: { decimals: 18, name: 'MATIC', symbol: 'MATIC' },
     rpcUrl: import.meta.env?.VITE_RPC_URL_AMOY || 'https://rpc-amoy.polygon.technology',
     explorer: { name: 'Polygonscan', baseUrl: 'https://amoy.polygonscan.com' },
@@ -88,6 +90,8 @@ const NETWORKS = {
     name: 'Polygon',
     isTestnet: false,
     isPrimary: true,
+    // Surfaced in the My Account → Network tab as a user-switchable network.
+    selectable: true,
     nativeCurrency: { decimals: 18, name: 'MATIC', symbol: 'MATIC' },
     rpcUrl: import.meta.env?.VITE_RPC_URL_POLYGON || 'https://polygon-bor-rpc.publicnode.com',
     explorer: { name: 'Polygonscan', baseUrl: 'https://polygonscan.com' },
@@ -126,6 +130,8 @@ const NETWORKS = {
     name: 'Hardhat',
     isTestnet: true,
     isPrimary: false,
+    // Local dev only — not offered in the user-facing network switcher.
+    selectable: false,
     nativeCurrency: { decimals: 18, name: 'Ether', symbol: 'ETH' },
     rpcUrl: 'http://127.0.0.1:8545',
     explorer: { name: 'Local', baseUrl: '' },
@@ -161,6 +167,18 @@ export function isSupportedChainId(chainId) {
 
 export function listSupportedChainIds() {
   return Object.keys(NETWORKS).map((id) => parseInt(id, 10))
+}
+
+/**
+ * Networks offered in the user-facing network switcher (My Account → Network).
+ * Mainnets first, then testnets, so the production default surfaces at the top.
+ * Future chains opt in by setting `selectable: true` on their NETWORKS entry.
+ */
+export function getSelectableNetworks() {
+  return listSupportedChainIds()
+    .map((id) => NETWORKS[id])
+    .filter((net) => net?.selectable)
+    .sort((a, b) => Number(a.isTestnet) - Number(b.isTestnet))
 }
 
 /**

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -8,6 +8,7 @@ import { useModal } from '../hooks/useUI'
 import { ROLES, ROLE_INFO } from '../contexts/RoleContext'
 import { hasRegisteredKey, ensureKeyRegistered } from '../utils/keyRegistryService'
 import SwapPanel from '../components/fairwins/SwapPanel'
+import NetworkSettings from '../components/wallet/NetworkSettings'
 import PremiumPurchaseModal from '../components/ui/PremiumPurchaseModal'
 import AddressQRModal from '../components/ui/AddressQRModal'
 import BlockiesAvatar from '../components/ui/BlockiesAvatar'
@@ -248,6 +249,7 @@ function WalletPage() {
               <div className="tabs" role="tablist">
                 <button role="tab" aria-selected={activeTab === 'account'} className={`tab ${activeTab === 'account' ? 'active' : ''}`} onClick={() => setActiveTab('account')}>Account</button>
                 <button role="tab" aria-selected={activeTab === 'membership'} className={`tab ${activeTab === 'membership' ? 'active' : ''}`} onClick={() => setActiveTab('membership')}>Membership</button>
+                <button role="tab" aria-selected={activeTab === 'network'} className={`tab ${activeTab === 'network' ? 'active' : ''}`} onClick={() => setActiveTab('network')}>Network</button>
                 <button role="tab" aria-selected={activeTab === 'security'} className={`tab ${activeTab === 'security' ? 'active' : ''}`} onClick={() => setActiveTab('security')}>Security</button>
                 <button role="tab" aria-selected={activeTab === 'preferences'} className={`tab ${activeTab === 'preferences' ? 'active' : ''}`} onClick={() => setActiveTab('preferences')}>Preferences</button>
                 <button role="tab" aria-selected={activeTab === 'swap'} className={`tab ${activeTab === 'swap' ? 'active' : ''}`} onClick={() => setActiveTab('swap')}>Swap</button>
@@ -328,6 +330,12 @@ function WalletPage() {
                         </div>
                       )}
                     </div>
+                  </div>
+                )}
+
+                {activeTab === 'network' && (
+                  <div className="network-section" role="tabpanel">
+                    <NetworkSettings />
                   </div>
                 )}
 

--- a/frontend/src/test/NetworkSettings.test.jsx
+++ b/frontend/src/test/NetworkSettings.test.jsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { useChainId, useSwitchChain } from 'wagmi'
+import NetworkSettings from '../components/wallet/NetworkSettings'
+
+// The relocated network selector (My Account → Network tab). wagmi hooks are
+// mocked globally in test/setup.js; we override per-test for chain state.
+
+describe('NetworkSettings — relocated network selector', () => {
+  const switchChain = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useChainId.mockReturnValue(61) // unsupported chain → every network offers "Switch"
+    useSwitchChain.mockReturnValue({
+      switchChain,
+      isPending: false,
+      variables: undefined,
+      error: null,
+    })
+  })
+
+  it('lists the user-switchable networks', () => {
+    render(<NetworkSettings />)
+    expect(screen.getByText('Polygon')).toBeInTheDocument()
+    expect(screen.getByText('Polygon Amoy')).toBeInTheDocument()
+  })
+
+  it('shows capability tags so members can make an informed switch', () => {
+    render(<NetworkSettings />)
+    // Each card renders the full capability set; assert the compliance + oracle tags.
+    expect(screen.getAllByText('Sanctions Guard').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Polymarket Oracle').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('UMA Oracle').length).toBeGreaterThan(0)
+  })
+
+  it('marks Token Swap available on mainnet but not on the testnet', () => {
+    render(<NetworkSettings />)
+    const polygonCard = screen.getByText('Polygon').closest('.network-card')
+    const amoyCard = screen.getByText('Polygon Amoy').closest('.network-card')
+
+    const polygonSwap = within(polygonCard).getByText('Token Swap').closest('.network-tag')
+    const amoySwap = within(amoyCard).getByText('Token Swap').closest('.network-tag')
+
+    expect(polygonSwap).toHaveClass('available')
+    expect(amoySwap).toHaveClass('unavailable')
+  })
+
+  it('marks the connected network instead of offering a switch button', () => {
+    useChainId.mockReturnValue(137)
+    render(<NetworkSettings />)
+    const polygonCard = screen.getByText('Polygon').closest('.network-card')
+    expect(within(polygonCard).getByText('Connected')).toBeInTheDocument()
+    expect(within(polygonCard).queryByRole('button', { name: /Switch to Polygon/ })).toBeNull()
+  })
+
+  it('switches chains through wagmi when a switch button is clicked', () => {
+    render(<NetworkSettings />)
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to Polygon Amoy' }))
+    expect(switchChain).toHaveBeenCalledWith({ chainId: 80002 })
+  })
+})


### PR DESCRIPTION
## Summary

Simplifies the member wallet dropdown and moves the network selector into a dedicated **Network** tab inside the **My Account** view, in preparation for deploying to additional networks. Each network now shows clear capability tags (Sanctions Guard, oracles, swaps, etc.) so members can make an informed switch.

Addresses the request to (1) simplify the member wallet view, (2) relocate the network selector to its own tab in My Account, and (3) show clear tags for what is deployed on each network. Per follow-up, the theme switcher was also removed from the wallet menu since it already lives in the main header.

## What changed

**Wallet dropdown (`WalletButton.jsx`) — simplified**
- Removed the inline **Testnet/Mainnet** network toggle (relocated, see below).
- Removed the **Light/Dark theme** toggle — theme already lives in the main header.
- The dropdown now shows account info, roles, and navigation actions only. The current network name still appears in the header for quick reference.

**New Network tab (`My Account` → `Network`)**
- `components/wallet/NetworkSettings.{jsx,css}` — lists every user-switchable network as a card with a Connected/Switch control (switching goes through `wagmi.switchChain`, so the wallet confirms the change).
- Each card renders **capability tags** resolved from the per-chain deployment record + capability flags:
  - P2P Wagers, Memberships, Encrypted Wagers
  - **Sanctions Guard** (compliance)
  - **Polymarket / Chainlink / UMA** oracles
  - **Token Swap** (Uniswap V3)
- Available capabilities show a green ✓; not-yet-deployed ones are muted with a `—`, e.g. Token Swap is shown unavailable on Amoy where there is no DEX deployment.

**Supporting config**
- `config/networks.js` — added a `selectable` flag per network and `getSelectableNetworks()` (mainnets first). Future chains opt in by setting `selectable: true`.
- `config/networkCapabilities.js` — single source of truth mapping capability tags to per-chain deployment/capability lookups.

## Testing

- `frontend/src/test/NetworkSettings.test.jsx` — new coverage for network listing, capability tags, the mainnet-vs-testnet Token Swap difference, the Connected state, and switching via wagmi.
- Full frontend suite green: **1231 passed**. ESLint clean on changed files (one pre-existing warning in untouched code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSegANQqjF58HB6wSYgKob)_