### PR TITLE
fix(frontend): wager details on acceptance screen, accept-by time sync, readable notification bell

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -585,10 +585,15 @@ function FriendMarketsModal({
     setFormData(prev => {
       const updated = { ...prev, oracleConditionId: market.conditionId }
       // Lock the wager's end time to the linked market so the side bet can't
-      // resolve before (or long after) Polymarket does.
+      // resolve before (or long after) Polymarket does. Re-derive the accept-by
+      // deadline from the new end time so the timeline tiles ("Accept by") show
+      // the right time immediately — otherwise they keep the stale default until
+      // submit re-runs validateForm. (The initialPolymarketMarket path already
+      // does this; this is the in-modal picker equivalent.)
       const linkedEnd = toDateTimeLocal(market.endDate)
       if (linkedEnd) {
         updated.endDateTime = linkedEnd
+        updated.acceptanceDeadline = getMidpointAcceptanceDeadline(linkedEnd)
       }
       const sideSynced = prev.creatorSide !== '' && (
         prev.description === '' || prev.description === lastAutoDescriptionRef.current

--- a/frontend/src/components/fairwins/MarketAcceptanceModal.jsx
+++ b/frontend/src/components/fairwins/MarketAcceptanceModal.jsx
@@ -97,6 +97,16 @@ function MarketAcceptanceModal({
   const [isDecrypting, setIsDecrypting] = useState(false)
   const [decryptionError, setDecryptionError] = useState(null)
 
+  // If the opener already decrypted the wager (e.g. the My Wagers list, which
+  // runs lazy decryption), use that plaintext directly so the acceptance screen
+  // shows the real terms — and the user isn't asked to sign again just to read
+  // what they're already looking at one screen back.
+  useEffect(() => {
+    if (marketData?.decryptedDescription) {
+      setDecryptedDescription(marketData.decryptedDescription)
+    }
+  }, [marketData?.decryptedDescription])
+
   // Determine user's role
   const isArbitrator = marketData?.arbitrator?.toLowerCase() === account?.toLowerCase()
   const isParticipant = marketData?.participants?.some(

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -533,10 +533,39 @@ function MyMarketsModal({
 
   // Handle opening acceptance modal
   const handleOpenAcceptance = (market) => {
+    // The wager's plaintext title once decryption (lazy hook) has run. We pass
+    // this through so the acceptance modal can show what the wager is actually
+    // about instead of the "Encrypted Wager" placeholder — the user already
+    // decrypted it here in My Wagers, so re-prompting for a signature on the
+    // acceptance screen would be redundant.
+    const decryptedDescription =
+      market.decryptedMetadata?.description ||
+      market.decryptedMetadata?.name ||
+      market.decryptedMetadata?.question ||
+      null
+
+    // The on-chain encrypted envelope, as a JSON string the modal can parse if
+    // it still needs to decrypt itself (metadataCipher is the parsed object).
+    const rawDescription = typeof market.metadataCipher === 'string'
+      ? market.metadataCipher
+      : market.metadataCipher
+        ? JSON.stringify(market.metadataCipher)
+        : undefined
+
     // Transform market data to match what MarketAcceptanceModal expects
     const marketData = {
       id: market.id,
       description: market.description || market.proposalTitle,
+      // Encryption context — without these the modal falls back to the literal
+      // "Encrypted Wager" string and gives the user no way to see the terms.
+      isEncrypted: Boolean(market.isEncrypted),
+      decryptedDescription,
+      rawDescription,
+      ipfsCid: market.ipfsCid || null,
+      resolutionType: market.resolutionType,
+      // Surface the wager's resolution/end date on the acceptance screen so the
+      // counterparty can see when it settles (e.g. a linked Polymarket's date).
+      estimatedMarketEndDate: market.endTime || (market.endDate ? new Date(market.endDate).getTime() : null),
       creator: market.creator,
       participants: market.participants || [],
       arbitrator: market.arbitrator || null,

--- a/frontend/src/components/notifications/NotificationBell.css
+++ b/frontend/src/components/notifications/NotificationBell.css
@@ -25,6 +25,24 @@
   background: var(--surface-color, var(--bg-secondary));
 }
 
+/* Keep the bell glyph readable on every header surface/theme — the icon
+   inherits the button's `color`, so pin it to the primary text token. */
+.notification-bell-icon {
+  color: var(--text-primary);
+}
+
+/* With unread activity the bell needs to read clearly against the header.
+   Tint the button with the brand color and brighten the glyph so it stands
+   out instead of fading into the surface behind it. */
+.notification-bell.has-unread {
+  background: color-mix(in srgb, var(--brand-primary) 18%, var(--bg-secondary));
+  border-color: var(--brand-primary);
+}
+
+.notification-bell.has-unread .notification-bell-icon {
+  color: var(--brand-primary);
+}
+
 .notification-bell:focus-visible {
   outline: 2px solid var(--brand-primary);
   outline-offset: 2px;

--- a/frontend/src/components/notifications/NotificationBell.jsx
+++ b/frontend/src/components/notifications/NotificationBell.jsx
@@ -22,7 +22,7 @@ function NotificationBell() {
     <div className="notification-bell-wrap">
       <button
         type="button"
-        className="notification-bell"
+        className={`notification-bell${unreadCount > 0 ? ' has-unread' : ''}`}
         aria-label={`Notifications, ${unreadCount} unread`}
         aria-haspopup="dialog"
         aria-expanded={open}

--- a/frontend/src/test/MarketAcceptanceModal.test.jsx
+++ b/frontend/src/test/MarketAcceptanceModal.test.jsx
@@ -182,6 +182,19 @@ describe('MarketAcceptanceModal', () => {
       expect(screen.getByText('Private Wager')).toBeInTheDocument()
     })
 
+    it('should show pre-decrypted terms without re-prompting when opener supplies them', () => {
+      const marketData = createMockMarketData({
+        isEncrypted: true,
+        decryptedDescription: "I'm betting Yes: Will England win Group L?",
+      })
+      render(<MarketAcceptanceModal {...defaultProps} marketData={marketData} />)
+
+      // The real terms are shown (not the "Encrypted Wager" placeholder) and
+      // no signature/decrypt prompt is needed.
+      expect(screen.getByText("I'm betting Yes: Will England win Group L?")).toBeInTheDocument()
+      expect(screen.queryByText('Decrypt Wager Details')).not.toBeInTheDocument()
+    })
+
     it('should show decrypt prompt for encrypted markets when user can decrypt', () => {
       useEncryption.mockReturnValue({
         decryptMetadata: vi.fn(),


### PR DESCRIPTION
## Summary

Fixes several issues raised from the offer-acceptance flow and header (reported with mobile screenshots of an oracle-linked "Will England win Group L" wager).

### 1. No way to see wager details from the acceptance screen
When opening the **Review Offer** modal from *My Wagers*, the wager showed only the `Encrypted Wager` placeholder with no terms and no way to read them. Root cause: `MyMarketsModal.handleOpenAcceptance` built a minimal `marketData` that dropped all encryption/decryption context, so `MarketAcceptanceModal` fell back to the literal placeholder string.

- `handleOpenAcceptance` now passes through the already-decrypted description (the user just decrypted it one screen back), the encrypted envelope / `ipfsCid` as a fallback decrypt path, the resolution type, and the resolution end date.
- `MarketAcceptanceModal` seeds its `decryptedDescription` state from `marketData.decryptedDescription`, so the real terms render with the **Private Wager** badge — without asking the user to sign again to read what they were already looking at.

### 2. Polymarket date/time correctness
Verified the wager end is locked to Polymarket's `endDate` (the market's **resolution** timestamp, which includes Polymarket's buffer on live events). This is the correct field — it guarantees the side bet can't settle before Polymarket resolves. For "Will England win Group L", that resolution is after the full group stage, which is why it sits well past the individual match. No code change needed; the acceptance screen now also surfaces this resolution date (via change #1) so it's transparent to the counterparty.

### 3. Accept-by time not displayed correctly until "Create Wager"
Linking a Polymarket market in the creation modal updated `endDateTime` but not the derived `acceptanceDeadline`, so the timeline tiles ("Accept by") showed a stale time until clicking **Create Wager** re-ran validation. `handleSelectPolymarketMarket` now recomputes `acceptanceDeadline` from the linked end date immediately (matching the existing `initialPolymarketMarket` path).

### 4. Notification bell unreadable with notifications
The header bell faded into the surface when it had unread activity. The glyph is now pinned to the primary text color, and the `has-unread` state gets a brand-tinted background, brand border, and brand-colored icon so it reads clearly.

## Testing
- `MarketAcceptanceModal`, `NotificationBell`, `FriendMarketsModal`, `MyMarketsModal` suites pass (148 tests, including a new test asserting pre-decrypted terms render without a re-prompt).
- ESLint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Tfn3cEKRW7ReppFVjkfCZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017Tfn3cEKRW7ReppFVjkfCZ)_