### PR TITLE
Fix My Wagers decrypt flow and redesign the wager list row

### DIFF
--- a/frontend/src/components/fairwins/MyMarketsModal.css
+++ b/frontend/src/components/fairwins/MyMarketsModal.css
@@ -1903,6 +1903,97 @@
   }
 }
 
+/* Narrow screens: the 4-column wager table can't fit the Actions column, so it
+   used to push the buttons off-screen behind a horizontal scroll (you couldn't
+   see what action a row needed). Below 640px we drop the table layout and render
+   each row as a self-contained card: title, then time + status on one line, then
+   the action buttons wrapping onto their own full-width line — everything visible
+   without any sideways scrolling. */
+@media (max-width: 640px) {
+  .mm-table-container {
+    overflow-x: visible;
+  }
+
+  .mm-table,
+  .mm-table tbody,
+  .mm-table tr,
+  .mm-table td {
+    display: block;
+    width: 100%;
+  }
+
+  /* Hide the header row without removing it from the accessibility tree. */
+  .mm-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .mm-table-row {
+    border: 1px solid var(--border-color, #23303D);
+    border-radius: 12px;
+    margin-bottom: 0.75rem;
+    padding: 0.875rem;
+    background: var(--bg-primary, #0E141B);
+  }
+
+  .mm-table-row:last-child {
+    margin-bottom: 0;
+  }
+
+  .mm-table td {
+    padding: 0;
+    border-bottom: none;
+  }
+
+  /* Title gets the full width and can wrap (no ellipsis truncation in a card). */
+  .mm-table-market {
+    max-width: none;
+    min-width: 0;
+    margin-bottom: 0.5rem;
+  }
+
+  .mm-table-market-title > span {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+  }
+
+  /* Time + status sit together above the actions. */
+  .mm-table-time {
+    display: inline-block;
+    margin: 0 0 0.5rem 0;
+    margin-right: 0.75rem;
+  }
+
+  /* Actions get their own full-width line and wrap instead of overflowing. */
+  .mm-table-actions {
+    white-space: normal;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+  }
+
+  .mm-table-actions .mm-action-btn {
+    margin-right: 0;
+    flex: 1 1 auto;
+    justify-content: center;
+    min-height: 40px;
+  }
+
+  /* Keep the unread accent bar aligned to the card's rounded corner. */
+  .mm-table-row.mm-unread::before {
+    border-radius: 2px 0 0 2px;
+  }
+}
+
 /* Reduced Motion */
 @media (prefers-reduced-motion: reduce) {
   .my-markets-modal-backdrop,

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -116,14 +116,21 @@ function MyMarketsModal({
   const [showAcceptanceModal, setShowAcceptanceModal] = useState(false)
   const [acceptanceMarket, setAcceptanceMarket] = useState(null)
 
-  // Filter state
-  const [marketTypeFilter, setMarketTypeFilter] = useState('all') // 'all', 'friend'
+  // Sort + filter state. The old "Type" filter was dropped: every wager in this
+  // view is a friend wager, so it only ever had one meaningful option. Its slot
+  // is reused for a Sort control over fields we already hold (recency, end time,
+  // stake size).
+  const [sortKey, setSortKey] = useState('newest') // 'newest' | 'endingSoon' | 'stakeHighToLow'
   const [statusFilter, setStatusFilter] = useState('all')
 
   const handleDecryptMarket = useCallback(async (marketId) => {
     try {
-      await fetchEnvelope(marketId)
-      await decryptMarket(marketId)
+      // Pass the just-fetched envelope straight into decryptMarket. The merged
+      // copy on the markets prop only lands on the next render, so handing the
+      // envelope over directly lets a single click run fetch → decrypt in one
+      // pass instead of the old fetch-then-(re-click)-to-decrypt flow.
+      const envelope = await fetchEnvelope(marketId)
+      await decryptMarket(marketId, envelope)
     } catch (err) {
       console.error('[MyMarketsModal] Decryption failed:', err)
     }
@@ -160,7 +167,7 @@ function MyMarketsModal({
       setActiveTab('participating')
       setSelectedMarketId(null)
       setShowResolutionModal(false)
-      setMarketTypeFilter('all')
+      setSortKey('newest')
       setStatusFilter('all')
     }
   }, [isOpen])
@@ -310,11 +317,6 @@ function MyMarketsModal({
       const status = getMarketStatus(market)
       const marketWithStatus = { ...market, computedStatus: status }
 
-      // Apply type filter
-      if (marketTypeFilter !== 'all' && market.marketType !== marketTypeFilter) {
-        return
-      }
-
       // Apply status filter. The default ("all") view also hides expired
       // offers so they don't clutter the list — pick "Expired" explicitly
       // to see them.
@@ -351,18 +353,43 @@ function MyMarketsModal({
       }
     })
 
-    // Sort each list newest-first. Wager `id` is sequential on-chain (higher =
-    // newer) and always present; createdAt is preferred when available.
+    // Sort each list by the user-selected key. Wager `id` is sequential on-chain
+    // (higher = newer) and always present, so it is the stable tiebreaker for
+    // every comparator.
+    const endMs = (m) => {
+      if (m.tradingEndTime != null) {
+        return typeof m.tradingEndTime === 'bigint'
+          ? Number(m.tradingEndTime) * 1000
+          : Number(m.tradingEndTime)
+      }
+      return m.endDate ? new Date(m.endDate).getTime() : 0
+    }
+    const stakeOf = (m) => parseFloat(m.stakeAmount) || 0
     const byNewest = (a, b) =>
       (Number(b.createdAt) || 0) - (Number(a.createdAt) || 0) ||
       (Number(b.id) || 0) - (Number(a.id) || 0)
-    participating.sort(byNewest)
-    created.sort(byNewest)
-    arbitrating.sort(byNewest)
-    history.sort(byNewest)
+    // Soonest-ending first; wagers with no end time sort to the bottom.
+    const byEndingSoon = (a, b) => {
+      const ae = endMs(a)
+      const be = endMs(b)
+      if (!ae && !be) return byNewest(a, b)
+      if (!ae) return 1
+      if (!be) return -1
+      return ae - be || byNewest(a, b)
+    }
+    const byStake = (a, b) => stakeOf(b) - stakeOf(a) || byNewest(a, b)
+    const comparator =
+      sortKey === 'endingSoon' ? byEndingSoon
+        : sortKey === 'stakeHighToLow' ? byStake
+          : byNewest
+
+    participating.sort(comparator)
+    created.sort(comparator)
+    arbitrating.sort(comparator)
+    history.sort(comparator)
 
     return { participating, created, arbitrating, history }
-  }, [markets, decryptableMarkets, userPositions, account, marketTypeFilter, statusFilter, dismissedIds, chainId])
+  }, [markets, decryptableMarkets, userPositions, account, sortKey, statusFilter, dismissedIds, chainId])
 
   // Derive the selected market from the live categorized lists so the detail
   // view reflects fresh data (e.g., decryptedMetadata) after decryption
@@ -864,19 +891,22 @@ function MyMarketsModal({
         {/* Filter Bar */}
         <div className="mm-filter-bar">
           <div className="mm-filter-group">
-            <label>Type:</label>
+            <label htmlFor="mm-sort-select">Sort:</label>
             <select
-              value={marketTypeFilter}
-              onChange={(e) => setMarketTypeFilter(e.target.value)}
+              id="mm-sort-select"
+              value={sortKey}
+              onChange={(e) => setSortKey(e.target.value)}
               className="mm-filter-select"
             >
-              <option value="all">All Wagers</option>
-              <option value="friend">Friend Wagers</option>
+              <option value="newest">Newest</option>
+              <option value="endingSoon">Ending soonest</option>
+              <option value="stakeHighToLow">Highest stake</option>
             </select>
           </div>
           <div className="mm-filter-group">
-            <label>Status:</label>
+            <label htmlFor="mm-status-select">Status:</label>
             <select
+              id="mm-status-select"
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value)}
               className="mm-filter-select"

--- a/frontend/src/hooks/useEncryption.js
+++ b/frontend/src/hooks/useEncryption.js
@@ -365,20 +365,37 @@ export function useEncryption() {
     // Get the envelope's signing version
     const envelopeVersion = getEnvelopeSigningVersion(envelope)
 
-    // Check if cached signature version matches envelope's signing version
+    // Obtain the key-derivation signature, prompting the wallet at most once.
+    // We capture the RETURNED signature here rather than reading the keyPairs
+    // state below, because initializeKeys/ensureInitialized call setKeyPairs()
+    // and React has not flushed that update into this closure yet. Reading the
+    // stale (null) keyPairs is exactly what made decryption fall through to the
+    // signer-based path and prompt the user to sign a SECOND time — the decrypt
+    // double-signature bug. With the signature in hand we derive the keys
+    // synchronously, so a single signature unlocks the wager (click → sign → see).
+    let init
     if (cachedVersion !== null && cachedVersion !== envelopeVersion) {
       console.log(`[useEncryption] Version mismatch: cached v${cachedVersion}, envelope v${envelopeVersion}. Re-signing...`)
       // Clear the stale cache and directly call initializeKeys to force fresh signature
-      // Note: We call initializeKeys directly instead of updating state and calling ensureInitialized
-      // because state updates are async and ensureInitialized would see stale values
       clearSignatureCache(account)
-      await initializeKeys()
+      init = await initializeKeys()
     } else {
       // Ensure we have keys (may prompt user once if no cached signature)
-      await ensureInitialized()
+      init = await ensureInitialized()
     }
 
-    // Use unified decrypt with both key types
+    // Derive both private keys from the freshly-obtained signature and decrypt
+    // in the same pass — no dependence on the not-yet-flushed keyPairs state.
+    if (init?.signature) {
+      const x25519Keys = deriveKeyPairFromSignature(init.signature)
+      const xwingKeys = deriveXWingKeyPairFromSignature(init.signature)
+      return decryptEnvelopeUnified(envelope, account, {
+        x25519PrivateKey: x25519Keys.privateKey,
+        xwingSecretKey: xwingKeys.secretKey
+      })
+    }
+
+    // Fallback: use in-state keys if they already happen to be populated.
     if (keyPairs.x25519?.privateKey && keyPairs.xwing?.secretKey) {
       return decryptEnvelopeUnified(envelope, account, {
         x25519PrivateKey: keyPairs.x25519.privateKey,
@@ -386,7 +403,8 @@ export function useEncryption() {
       })
     }
 
-    // Fallback to signer-based decryption for v1.0 only (shouldn't happen after ensureInitialized)
+    // Last-resort signer-based decryption for v1.0 only (shouldn't happen after
+    // ensureInitialized returns a signature).
     if (!signer) {
       throw new Error('No signer available')
     }
@@ -826,11 +844,11 @@ export function useLazyMarketDecryption(markets) {
   }, [markets, decryptionCache, decryptingIds, decryptionErrors, account, isEncrypted, canUserDecrypt])
 
   // Function to decrypt a single market on demand
-  const decryptMarket = useCallback(async (marketId) => {
+  const decryptMarket = useCallback(async (marketId, envelopeOverride = null) => {
     const marketIdStr = String(marketId)
     const market = markets?.find(m => String(m.id) === marketIdStr)
 
-    if (!market) {
+    if (!market && !envelopeOverride) {
       throw new Error('Market not found')
     }
 
@@ -840,9 +858,17 @@ export function useLazyMarketDecryption(markets) {
       return cached.metadata
     }
 
+    // Prefer an envelope handed straight to us by the caller (typically the
+    // value fetchEnvelope just resolved). The markets prop only merges that
+    // envelope into market.metadata on the NEXT render, so the market captured
+    // in this closure can still carry the un-encrypted placeholder. Without the
+    // override the first "Decrypt" click saw "not encrypted" and silently
+    // no-opped, which is why decryption used to take two clicks.
+    const envelope = envelopeOverride ?? market?.metadata
+
     // Not encrypted?
-    if (!isEncrypted(market.metadata)) {
-      return market.metadata
+    if (!isEncrypted(envelope)) {
+      return envelope
     }
 
     // Note: We don't hard-block based on canUserDecrypt here.
@@ -868,7 +894,7 @@ export function useLazyMarketDecryption(markets) {
 
     try {
       // This may prompt for signature if not yet initialized
-      const decrypted = await decryptMetadata(market.metadata)
+      const decrypted = await decryptMetadata(envelope)
 
       // Cache the result
       setDecryptionCache(prev => {

--- a/frontend/src/test/MyMarketsModal.test.jsx
+++ b/frontend/src/test/MyMarketsModal.test.jsx
@@ -303,7 +303,7 @@ describe('MyMarketsModal', () => {
   })
 
   describe('Filter Bar', () => {
-    it('should display type filter dropdown', async () => {
+    it('should display sort dropdown in place of the old type filter', async () => {
       await act(async () => {
         renderWithProviders(
           <MyMarketsModal isOpen={true} onClose={mockOnClose} />
@@ -311,10 +311,29 @@ describe('MyMarketsModal', () => {
       })
 
       await waitFor(() => {
-        const typeSelect = screen.getByText('Type:').nextElementSibling
-        expect(typeSelect).toBeInTheDocument()
-        expect(typeSelect.tagName).toBe('SELECT')
+        const sortSelect = screen.getByText('Sort:').nextElementSibling
+        expect(sortSelect).toBeInTheDocument()
+        expect(sortSelect.tagName).toBe('SELECT')
       })
+
+      // The redundant friend-only "Type" filter is gone.
+      expect(screen.queryByText('Type:')).not.toBeInTheDocument()
+    })
+
+    it('offers recency, end-time and stake sort options', async () => {
+      await act(async () => {
+        renderWithProviders(
+          <MyMarketsModal isOpen={true} onClose={mockOnClose} />
+        )
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText('Sort:')).toBeInTheDocument()
+      })
+
+      const sortSelect = screen.getByText('Sort:').nextElementSibling
+      const optionValues = Array.from(sortSelect.options).map((o) => o.value)
+      expect(optionValues).toEqual(['newest', 'endingSoon', 'stakeHighToLow'])
     })
 
     it('should display refresh button', async () => {

--- a/frontend/src/test/useEncryption.test.jsx
+++ b/frontend/src/test/useEncryption.test.jsx
@@ -133,3 +133,52 @@ describe('useEncryption — wager creation bug fixes', () => {
     ).toThrow(/not initialized/i)
   })
 })
+
+describe('useEncryption — decrypt flow (My Wagers decrypt bug)', () => {
+  beforeEach(() => {
+    signMessage.mockClear()
+    sessionStorage.clear()
+  })
+
+  it('decryptMetadata prompts for a signature exactly once (no decrypt double-sign)', async () => {
+    // Envelope is addressed to the connected account, signed with the same
+    // signature the mocked wallet returns, so the derived key can unwrap it.
+    const envelope = encryptMarketMetadata(
+      metadata,
+      [{ address: ACCOUNT, signature: FIXED_SIGNATURE }],
+      2
+    )
+
+    const { result } = renderHook(() => useEncryption())
+
+    let decrypted
+    await act(async () => {
+      decrypted = await result.current.decryptMetadata(envelope)
+    })
+
+    // Regression: the old code read the not-yet-flushed keyPairs state, fell
+    // through to signer-based decryption, and prompted a SECOND signature.
+    expect(signMessage).toHaveBeenCalledTimes(1)
+    expect(decrypted).toMatchObject(metadata)
+  })
+
+  it('decryptMetadata does not prompt at all when a session signature is cached', async () => {
+    cacheSignature(ACCOUNT, FIXED_SIGNATURE)
+    const envelope = encryptMarketMetadata(
+      metadata,
+      [{ address: ACCOUNT, signature: FIXED_SIGNATURE }],
+      2
+    )
+
+    const { result } = renderHook(() => useEncryption())
+
+    let decrypted
+    await act(async () => {
+      decrypted = await result.current.decryptMetadata(envelope)
+    })
+
+    // Keys derive from the cached signature — viewing is click → see.
+    expect(signMessage).not.toHaveBeenCalled()
+    expect(decrypted).toMatchObject(metadata)
+  })
+})


### PR DESCRIPTION
Addresses the UX and decryption-bug notes from testing the **My Wagers** area.

## Decryption bug — restore `click → sign (cache) → see`

The reported flow was: click decrypt → a lock appears but nothing else → click again → sign → prompted to sign **again** → finally see the terms. Two root causes, both stale-closure timing issues:

1. **Double signature.** `decryptMetadata` called `ensureInitialized()`/`initializeKeys()` (which sign and `setKeyPairs(...)`), then read `keyPairs` from the same closure. React hasn't flushed that state yet, so the read saw `null` and fell through to the signer-based `decryptMarketMetadata`, prompting a **second** signature. It now derives the keys directly from the signature those functions return, so one signature unlocks the wager.
2. **First click no-ops (the "lock appears, nothing happens" step).** `handleDecryptMarket` ran `fetchEnvelope` then `decryptMarket`, but `decryptMarket` closed over the pre-fetch `markets` list — the envelope isn't merged into `market.metadata` until the next render, so `isEncrypted()` was false and it silently returned. `decryptMarket` now accepts an `envelopeOverride` and `handleDecryptMarket` passes the just-fetched envelope straight in.

Net result: a single click fetches, prompts one signature (cached for the session), and reveals the terms.

## My Wagers list UX

- **Dropped the "Type" filter.** Every wager here is a friend wager, so `All Wagers / Friend Wagers` had no real effect. Its slot now holds a **Sort** control — `Newest`, `Ending soonest`, `Highest stake` — over fields already available on each wager.
- **Action buttons no longer scroll off-screen.** Below 640px the 4-column table (Wager / Time Left / Status / Actions) used to overflow horizontally, hiding the action a row needs behind a side-scroll. It now renders each row as a self-contained card with the action buttons wrapping onto their own full-width line — everything visible, no horizontal scrolling. The header row is hidden but kept in the accessibility tree.

## Tests

- New regression tests in `useEncryption.test.jsx`: `decryptMetadata` prompts for a signature exactly once, and not at all when a session signature is cached.
- Updated `MyMarketsModal.test.jsx`: the old "Type" dropdown assertion is replaced with Sort-control coverage (presence + option set).
- Full suite for the touched areas passes (`useEncryption`, `MyMarketsModal`, `actionNeededBadges`, `feedNavigation`, `useIpfs`); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YFxMijuSwHKyN61JRLm9i

---
_Generated by [Claude Code](https://claude.ai/code/session_013YFxMijuSwHKyN61JRLm9i)_