### PR TITLE
Fix report enumeration falling back to legacy FriendGroupMarketFactory

### DIFF
--- a/frontend/src/data/reports/reportDataSource.js
+++ b/frontend/src/data/reports/reportDataSource.js
@@ -3,19 +3,21 @@
  * (spec 016-wager-tax-report; contracts/report-builder.md; research.md D1/D2).
  *
  * Implements the `dataSource` interface reportBuilder expects:
- *   enumerateWagers({account}) → wager[]      (via WagerRepository / subgraph)
- *   getWagerEvents(wagerId)    → events[]      (escrow contract logs)
+ *   enumerateWagers({account}) → wager[]      (escrow contract logs, by user)
+ *   getWagerEvents(wagerId)    → events[]      (escrow contract logs, by wager)
  *   getBlock(blockNumber)      → { timestamp } (RPC)
  *   getTransactionReceipt(tx)  → receipt       (RPC, for txHash + gas fee)
  *
- * The subgraph cannot supply transaction hashes or gas fees, so the per-wager
- * value-moving events are read from chain logs and enriched from receipts.
+ * Self-contained: enumeration scans the escrow contract for events indexed by
+ * the user's address, so the report does NOT depend on the subgraph or the
+ * legacy EventsSource (which is hardwired to the retired FriendGroupMarketFactory
+ * and threw "FriendGroupMarketFactory address not configured" on v2 networks).
  *
  * Two contract generations are supported, resolved from synced config per chain
  * (Constitution V — never hardcoded):
- *   - v2 WagerRegistry (Polygon/Amoy/Hardhat): WagerCreated / WagerAccepted /
+ *   - v2 WagerRegistry (Polygon/Amoy/Mordor/Hardhat): WagerCreated / WagerAccepted /
  *     PayoutClaimed / WagerRefunded / WagerCancelled / WagerDrawn
- *   - v1 FriendGroupMarketFactory (legacy Mordor): MarketCreatedPending /
+ *   - v1 FriendGroupMarketFactory (legacy): MarketCreatedPending /
  *     ParticipantAccepted / WinningsClaimed / StakeRefunded
  */
 
@@ -23,13 +25,33 @@ import { ethers } from 'ethers'
 import { getContractAddressForChain, NETWORK_CONFIG, DEPLOYMENT_BLOCKS } from '../../config/contracts'
 import { WAGER_REGISTRY_ABI } from '../../abis/WagerRegistry'
 import { FRIEND_GROUP_MARKET_FACTORY_ABI } from '../../abis/FriendGroupMarketFactory'
-import { getDefaultWagerRepository } from '../wagers/WagerRepository'
 
 const SCAN_CHUNK = 10_000
 
-// Value-moving events per contract generation.
-const V2_EVENTS = ['WagerCreated', 'WagerAccepted', 'PayoutClaimed', 'WagerRefunded', 'WagerCancelled', 'WagerDrawn']
-const V1_EVENTS = ['MarketCreatedPending', 'ParticipantAccepted', 'WinningsClaimed', 'StakeRefunded']
+// Value-moving events + the user-indexed enumeration filters per generation.
+// Each enumeration entry is [eventName, ...topicArgs] where `null` is a wildcard
+// and `'@user'` is replaced with the report subject's address.
+const GENERATIONS = {
+  v2: {
+    abi: WAGER_REGISTRY_ABI,
+    valueEvents: ['WagerCreated', 'WagerAccepted', 'PayoutClaimed', 'WagerRefunded', 'WagerCancelled', 'WagerDrawn'],
+    enumeration: [
+      ['WagerCreated', null, '@user'], // creator
+      ['WagerCreated', null, null, '@user'], // opponent
+      ['WagerAccepted', null, '@user'], // accepted by user
+      ['PayoutClaimed', null, '@user'], // winner
+    ],
+  },
+  v1: {
+    abi: FRIEND_GROUP_MARKET_FACTORY_ABI,
+    valueEvents: ['MarketCreatedPending', 'ParticipantAccepted', 'WinningsClaimed', 'StakeRefunded'],
+    enumeration: [
+      ['MarketCreatedPending', null, '@user'], // creator
+      ['ParticipantAccepted', null, '@user'], // participant
+      ['WinningsClaimed', null, '@user'], // winner
+    ],
+  },
+}
 
 function getProvider(opts = {}) {
   return opts.provider || new ethers.JsonRpcProvider(NETWORK_CONFIG.rpcUrl)
@@ -37,33 +59,23 @@ function getProvider(opts = {}) {
 
 /**
  * Resolve the escrow contract for a chain: prefer the v2 WagerRegistry; fall
- * back to the legacy v1 FriendGroupMarketFactory. Returns the address, ABI,
- * the value-event list, and the deployment start block.
+ * back to the legacy v1 FriendGroupMarketFactory. Returns the address, ABI, the
+ * value-event list, the user-indexed enumeration filters, and the start block.
  */
 export function resolveEscrow(chainId) {
   const registry = getContractAddressForChain('wagerRegistry', chainId)
   if (registry) {
-    return {
-      address: registry,
-      abi: WAGER_REGISTRY_ABI,
-      valueEvents: V2_EVENTS,
-      deployBlock: DEPLOYMENT_BLOCKS.wagerRegistry || 0,
-    }
+    return { address: registry, ...GENERATIONS.v2, deployBlock: DEPLOYMENT_BLOCKS.wagerRegistry || 0 }
   }
   const factory = getContractAddressForChain('friendGroupMarketFactory', chainId)
   if (factory) {
-    return {
-      address: factory,
-      abi: FRIEND_GROUP_MARKET_FACTORY_ABI,
-      valueEvents: V1_EVENTS,
-      deployBlock: DEPLOYMENT_BLOCKS.friendGroupMarketFactory || 0,
-    }
+    return { address: factory, ...GENERATIONS.v1, deployBlock: DEPLOYMENT_BLOCKS.friendGroupMarketFactory || 0 }
   }
   throw new Error('No wager escrow contract is configured for this network.')
 }
 
 /** Normalize an ethers EventLog into the report's { name, args, txHash, block } shape. */
-function normalizeEvent(ev) {
+export function normalizeEvent(ev) {
   const a = ev.args || {}
   const id = a.wagerId ?? a.friendMarketId
   const big = (v) => (v != null ? v.toString() : undefined)
@@ -88,17 +100,33 @@ function normalizeEvent(ev) {
   }
 }
 
+/** Run a topic-filtered queryFilter across the block range in bounded chunks. */
+async function scan(contract, provider, filter, fromBlock, latest, label) {
+  const out = []
+  let from = fromBlock || 0
+  while (from <= latest) {
+    const to = Math.min(from + SCAN_CHUNK - 1, latest)
+    try {
+      const logs = await contract.queryFilter(filter, from, to)
+      out.push(...logs)
+    } catch (err) {
+      console.warn(`[reportDataSource] ${label} scan ${from}-${to} failed:`, err?.message)
+    }
+    from = to + 1
+  }
+  return out
+}
+
 /**
  * Build the on-chain report data source for the active network.
  *
  * @param {object} [opts]
  * @param {number} [opts.chainId] - active chain id (for chain-scoped address resolution)
- * @param {object} [opts.repository] - WagerRepository (defaults to shared instance)
  * @param {object} [opts.provider] - ethers provider (defaults to NETWORK_CONFIG rpc)
+ * @param {object} [opts.contract] - escrow contract override (testing)
  * @returns {object} dataSource
  */
 export function createReportDataSource(opts = {}) {
-  const repository = opts.repository || getDefaultWagerRepository()
   const provider = getProvider(opts)
   const chainId = opts.chainId
   let escrow = null
@@ -106,7 +134,7 @@ export function createReportDataSource(opts = {}) {
   const ensure = () => {
     if (!contract) {
       escrow = resolveEscrow(chainId)
-      contract = new ethers.Contract(escrow.address, escrow.abi, provider)
+      contract = opts.contract || new ethers.Contract(escrow.address, escrow.abi, provider)
     }
     return contract
   }
@@ -114,26 +142,29 @@ export function createReportDataSource(opts = {}) {
   return {
     async enumerateWagers({ account }) {
       if (!account) return []
-      const all = []
-      let cursor = null
-      for (let page = 0; page < 200; page++) {
-        const res = await repository.listMyWagers({
-          userAddress: account,
-          cursor,
-          pageSize: 100,
-          filter: { includeExpired: true },
-        })
-        all.push(...(res.items || []))
-        if (!res.hasMore || !res.nextCursor) break
-        cursor = res.nextCursor
+      if (import.meta.env?.VITE_SKIP_BLOCKCHAIN_CALLS === 'true') return []
+      const c = ensure()
+      const latest = await provider.getBlockNumber()
+      // wagerId → wager context, built from the indexed enumeration logs.
+      const byId = new Map()
+      for (const [name, ...topics] of escrow.enumeration) {
+        const args = topics.map((t) => (t === '@user' ? account : t))
+        const filter = c.filters[name](...args)
+        const logs = await scan(c, provider, filter, escrow.deployBlock, latest, name)
+        for (const ev of logs) {
+          const n = normalizeEvent(ev)
+          const id = n.args.wagerId
+          if (id == null) continue
+          const existing = byId.get(id) || { id, participants: [account] }
+          // Capture creator + stake token from the creation event when present.
+          if (n.name === 'WagerCreated' || n.name === 'MarketCreatedPending') {
+            existing.creator = n.args.creator || existing.creator
+            existing.stakeTokenAddress = n.args.token || existing.stakeTokenAddress
+          }
+          byId.set(id, existing)
+        }
       }
-      return all.map((w) => ({
-        id: String(w.id),
-        creator: w.creator,
-        participants: w.participants || [],
-        stakeTokenAddress: w.stakeTokenAddress,
-        stakeAmount: w.stakeAmount,
-      }))
+      return [...byId.values()]
     },
 
     async getWagerEvents(wagerId) {
@@ -143,17 +174,8 @@ export function createReportDataSource(opts = {}) {
       const out = []
       for (const name of escrow.valueEvents) {
         const filter = c.filters[name](wagerId)
-        let from = escrow.deployBlock || 0
-        while (from <= latest) {
-          const to = Math.min(from + SCAN_CHUNK - 1, latest)
-          try {
-            const logs = await c.queryFilter(filter, from, to)
-            for (const ev of logs) out.push(normalizeEvent(ev))
-          } catch (err) {
-            console.warn(`[reportDataSource] ${name} scan ${from}-${to} failed:`, err?.message)
-          }
-          from = to + 1
-        }
+        const logs = await scan(c, provider, filter, escrow.deployBlock, latest, name)
+        for (const ev of logs) out.push(normalizeEvent(ev))
       }
       return out.sort((a, b) => a.blockNumber - b.blockNumber)
     },

--- a/frontend/src/test/reports/reportDataSource.test.js
+++ b/frontend/src/test/reports/reportDataSource.test.js
@@ -1,6 +1,10 @@
-import { describe, it, expect } from 'vitest'
-import { resolveEscrow } from '../../data/reports/reportDataSource'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createReportDataSource, resolveEscrow } from '../../data/reports/reportDataSource'
 import { WAGER_REGISTRY_ABI } from '../../abis/WagerRegistry'
+
+const USER = '0x1111111111111111111111111111111111111111'
+const OTHER = '0x2222222222222222222222222222222222222222'
+const TOKEN = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'
 
 // Regression: the deployment registers the escrow as `wagerRegistry`, NOT
 // `friendGroupMarketFactory`. Asking for the factory key produced
@@ -22,5 +26,61 @@ describe('resolveEscrow (address-config bug fix)', () => {
 
   it('throws a clear error when no escrow is configured for the chain', () => {
     expect(() => resolveEscrow(999999)).toThrow(/no wager escrow contract is configured/i)
+  })
+})
+
+// Regression: enumeration must read the wagerRegistry contract directly and
+// NEVER fall back to the legacy EventsSource (which threw
+// "FriendGroupMarketFactory address not configured").
+describe('createReportDataSource.enumerateWagers (self-contained chain scan)', () => {
+  // The test env pins VITE_SKIP_BLOCKCHAIN_CALLS='true'; turn it off so the scan runs.
+  beforeEach(() => vi.stubEnv('VITE_SKIP_BLOCKCHAIN_CALLS', 'false'))
+  afterEach(() => vi.unstubAllEnvs())
+
+  function fakeContract(logsByEvent) {
+    return {
+      filters: new Proxy({}, {
+        get: (_t, name) => (...args) => ({ name: String(name), args }),
+      }),
+      // Return logs only on the first chunk (from===0) to avoid duplicates.
+      queryFilter: async (filter, from) => {
+        if (from !== 0) return []
+        const all = logsByEvent[filter.name] || []
+        // crude topic match: the indexed user arg must equal a log party
+        return all.filter((log) => filter.args.includes(log._match))
+      },
+    }
+  }
+
+  it('collects the user\'s wagers from indexed registry logs (no repository)', async () => {
+    const logsByEvent = {
+      WagerCreated: [
+        { _match: USER, fragment: { name: 'WagerCreated' }, transactionHash: '0xa1', blockNumber: 100,
+          args: { wagerId: 1n, creator: USER, opponent: OTHER, token: TOKEN } },
+      ],
+      WagerAccepted: [
+        { _match: USER, fragment: { name: 'WagerAccepted' }, transactionHash: '0xb2', blockNumber: 130,
+          args: { wagerId: 2n, opponent: USER } },
+      ],
+      PayoutClaimed: [],
+    }
+    const ds = createReportDataSource({
+      chainId: 137,
+      provider: { getBlockNumber: async () => 5000 },
+      contract: fakeContract(logsByEvent),
+    })
+    const wagers = await ds.enumerateWagers({ account: USER })
+    const ids = wagers.map((w) => w.id).sort()
+    expect(ids).toEqual(['1', '2'])
+    const w1 = wagers.find((w) => w.id === '1')
+    expect(w1.creator).toBe(USER)
+    expect(w1.stakeTokenAddress).toBe(TOKEN)
+    // user is recorded as a party so buildReport's isParty filter keeps it
+    expect(wagers.find((w) => w.id === '2').participants).toContain(USER)
+  })
+
+  it('returns [] without an account', async () => {
+    const ds = createReportDataSource({ chainId: 137, provider: { getBlockNumber: async () => 1 }, contract: fakeContract({}) })
+    expect(await ds.enumerateWagers({ account: null })).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

The reporting page still showed **`FriendGroupMarketFactory address not configured`** when clicking *Generate report*, even after #700.

### Root cause

That exact string comes from the **legacy `EventsSource`** (`getFactoryContract`), not from the report's contract-reading path that #700 fixed. The report's **enumeration** step (`reportDataSource.enumerateWagers`) delegated to `WagerRepository.listMyWagers()`, which — when `VITE_SUBGRAPH_URL` is unset or the subgraph is unreachable — **falls back to `EventsSource`**. `EventsSource` is hardwired to the retired `FriendGroupMarketFactory`, so on the v2 `wagerRegistry` networks it throws before any wagers are read.

### Fix

Make the report **fully self-contained** — enumerate the user's wagers by scanning the resolved escrow contract directly for events **indexed by the user's address**:
- v2 `WagerRegistry`: `WagerCreated` (creator & opponent), `WagerAccepted`, `PayoutClaimed`
- v1 factory (legacy fallback): `MarketCreatedPending`, `ParticipantAccepted`, `WinningsClaimed`

Each wager's context (creator, stake token) is built from its creation log. The report no longer depends on `WagerRepository`, `EventsSource`, or the subgraph at all.

## Testing
- New injected-contract test proves enumeration reads the registry directly (and the no-account short-circuit).
- **1328 frontend tests pass**; ESLint clean.

## Note
Still worth a **live-network manual pass** (connect a wallet with wagers on a `wagerRegistry` deployment, generate a report) to confirm end-to-end — this environment can't reach a live chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198Kum4cPs11ufUarv3gjqF

---
_Generated by [Claude Code](https://claude.ai/code/session_0198Kum4cPs11ufUarv3gjqF)_