### PR TITLE
Fix report RPC flood: enumerate via subgraph, bound per-wager log scans

### DIFF
--- a/frontend/src/data/reports/reportDataSource.js
+++ b/frontend/src/data/reports/reportDataSource.js
@@ -2,21 +2,21 @@
  * On-chain data source adapter for the wager tax/activity report
  * (spec 016-wager-tax-report; contracts/report-builder.md; research.md D1/D2).
  *
- * Implements the `dataSource` interface reportBuilder expects:
- *   enumerateWagers({account}) → wager[]      (escrow contract logs, by user)
- *   getWagerEvents(wagerId)    → events[]      (escrow contract logs, by wager)
- *   getBlock(blockNumber)      → { timestamp } (RPC)
- *   getTransactionReceipt(tx)  → receipt       (RPC, for txHash + gas fee)
+ * Strategy (chosen for scalability on public RPCs):
+ *   - ENUMERATION via the subgraph (WagerRepository). Scanning the chain for a
+ *     user's wagers from the deployment block is not viable on a public RPC
+ *     (the node rejects wide `eth_getLogs` ranges → request floods / rate
+ *     limits). The subgraph is the indexed, scalable path. When it is not
+ *     configured we fail with a clear, actionable error rather than brute-force
+ *     scanning from genesis.
+ *   - PER-WAGER details (txHash + gas fee — which the subgraph cannot supply)
+ *     are read from chain logs, but bounded to a TIGHT block window around each
+ *     wager's `createdAt` (from the subgraph) with adaptive, shrink-on-limit
+ *     chunking and a request budget. No genesis scans.
  *
- * Self-contained: enumeration scans the escrow contract for events indexed by
- * the user's address, so the report does NOT depend on the subgraph or the
- * legacy EventsSource (which is hardwired to the retired FriendGroupMarketFactory
- * and threw "FriendGroupMarketFactory address not configured" on v2 networks).
- *
- * Two contract generations are supported, resolved from synced config per chain
- * (Constitution V — never hardcoded):
- *   - v2 WagerRegistry (Polygon/Amoy/Mordor/Hardhat): WagerCreated / WagerAccepted /
- *     PayoutClaimed / WagerRefunded / WagerCancelled / WagerDrawn
+ * Contract generations (resolved from synced config, never hardcoded):
+ *   - v2 WagerRegistry: WagerCreated / WagerAccepted / PayoutClaimed /
+ *     WagerRefunded / WagerCancelled / WagerDrawn
  *   - v1 FriendGroupMarketFactory (legacy): MarketCreatedPending /
  *     ParticipantAccepted / WinningsClaimed / StakeRefunded
  */
@@ -25,52 +25,40 @@ import { ethers } from 'ethers'
 import { getContractAddressForChain, NETWORK_CONFIG, DEPLOYMENT_BLOCKS } from '../../config/contracts'
 import { WAGER_REGISTRY_ABI } from '../../abis/WagerRegistry'
 import { FRIEND_GROUP_MARKET_FACTORY_ABI } from '../../abis/FriendGroupMarketFactory'
+import { getDefaultWagerRepository } from '../wagers/WagerRepository'
 
-const SCAN_CHUNK = 10_000
+const INITIAL_CHUNK = 5000
+const MIN_CHUNK = 200
+// Per-getWagerEvents request budget — bounds work for any single wager.
+const SCAN_BUDGET = 60
+// Approx block time (seconds) per chain, for timestamp → block estimation.
+const BLOCK_TIME_SEC = { 137: 2, 80002: 2, 63: 13, 1337: 1 }
+// Margin (seconds) before a wager's createdAt to start its event window.
+const PRE_WINDOW_SEC = 3600
 
-// Value-moving events + the user-indexed enumeration filters per generation.
-// Each enumeration entry is [eventName, ...topicArgs] where `null` is a wildcard
-// and `'@user'` is replaced with the report subject's address.
-const GENERATIONS = {
-  v2: {
-    abi: WAGER_REGISTRY_ABI,
-    valueEvents: ['WagerCreated', 'WagerAccepted', 'PayoutClaimed', 'WagerRefunded', 'WagerCancelled', 'WagerDrawn'],
-    enumeration: [
-      ['WagerCreated', null, '@user'], // creator
-      ['WagerCreated', null, null, '@user'], // opponent
-      ['WagerAccepted', null, '@user'], // accepted by user
-      ['PayoutClaimed', null, '@user'], // winner
-    ],
-  },
-  v1: {
-    abi: FRIEND_GROUP_MARKET_FACTORY_ABI,
-    valueEvents: ['MarketCreatedPending', 'ParticipantAccepted', 'WinningsClaimed', 'StakeRefunded'],
-    enumeration: [
-      ['MarketCreatedPending', null, '@user'], // creator
-      ['ParticipantAccepted', null, '@user'], // participant
-      ['WinningsClaimed', null, '@user'], // winner
-    ],
-  },
+const V2 = {
+  abi: WAGER_REGISTRY_ABI,
+  valueEvents: ['WagerCreated', 'WagerAccepted', 'PayoutClaimed', 'WagerRefunded', 'WagerCancelled', 'WagerDrawn'],
+}
+const V1 = {
+  abi: FRIEND_GROUP_MARKET_FACTORY_ABI,
+  valueEvents: ['MarketCreatedPending', 'ParticipantAccepted', 'WinningsClaimed', 'StakeRefunded'],
+}
+
+function subgraphConfigured() {
+  return Boolean(import.meta.env?.VITE_SUBGRAPH_URL)
 }
 
 function getProvider(opts = {}) {
   return opts.provider || new ethers.JsonRpcProvider(NETWORK_CONFIG.rpcUrl)
 }
 
-/**
- * Resolve the escrow contract for a chain: prefer the v2 WagerRegistry; fall
- * back to the legacy v1 FriendGroupMarketFactory. Returns the address, ABI, the
- * value-event list, the user-indexed enumeration filters, and the start block.
- */
+/** Resolve the escrow contract (prefer v2 WagerRegistry, fall back to v1 factory). */
 export function resolveEscrow(chainId) {
   const registry = getContractAddressForChain('wagerRegistry', chainId)
-  if (registry) {
-    return { address: registry, ...GENERATIONS.v2, deployBlock: DEPLOYMENT_BLOCKS.wagerRegistry || 0 }
-  }
+  if (registry) return { address: registry, ...V2, deployBlock: DEPLOYMENT_BLOCKS.wagerRegistry || 0 }
   const factory = getContractAddressForChain('friendGroupMarketFactory', chainId)
-  if (factory) {
-    return { address: factory, ...GENERATIONS.v1, deployBlock: DEPLOYMENT_BLOCKS.friendGroupMarketFactory || 0 }
-  }
+  if (factory) return { address: factory, ...V1, deployBlock: DEPLOYMENT_BLOCKS.friendGroupMarketFactory || 0 }
   throw new Error('No wager escrow contract is configured for this network.')
 }
 
@@ -100,19 +88,44 @@ export function normalizeEvent(ev) {
   }
 }
 
-/** Run a topic-filtered queryFilter across the block range in bounded chunks. */
-async function scan(contract, provider, filter, fromBlock, latest, label) {
+/** Estimate a block number for a unix-second timestamp, clamped to [deployBlock, latest]. */
+function estimateBlock(targetSec, ctx) {
+  const delta = Math.max(0, Math.floor((ctx.latestSec - targetSec) / ctx.blockTimeSec))
+  return Math.min(ctx.latestBlock, Math.max(ctx.deployBlock || 0, ctx.latestBlock - delta))
+}
+
+/**
+ * queryFilter across a bounded block window with adaptive chunking: shrink the
+ * chunk on "range exceeds limit" style errors, grow it back on success, and
+ * stop with a clear error if the per-call request budget is exhausted.
+ */
+async function scanAdaptive(contract, filter, fromBlock, toBlock, label, budget) {
   const out = []
-  let from = fromBlock || 0
-  while (from <= latest) {
-    const to = Math.min(from + SCAN_CHUNK - 1, latest)
+  let from = fromBlock
+  let chunk = INITIAL_CHUNK
+  while (from <= toBlock) {
+    if (budget.used >= budget.max) {
+      throw new Error(
+        'This report period is too large to read from the network without the indexing subgraph. ' +
+        'Try a shorter period, or configure VITE_SUBGRAPH_URL for full coverage.',
+      )
+    }
+    const to = Math.min(from + chunk - 1, toBlock)
+    budget.used += 1
     try {
       const logs = await contract.queryFilter(filter, from, to)
       out.push(...logs)
+      from = to + 1
+      if (chunk < INITIAL_CHUNK) chunk = Math.min(INITIAL_CHUNK, chunk * 2)
     } catch (err) {
-      console.warn(`[reportDataSource] ${label} scan ${from}-${to} failed:`, err?.message)
+      const msg = err?.message || ''
+      if (/range|limit|exceed|too many|big/i.test(msg) && chunk > MIN_CHUNK) {
+        chunk = Math.max(MIN_CHUNK, Math.floor(chunk / 4))
+        continue
+      }
+      console.warn(`[reportDataSource] ${label} scan ${from}-${to} failed:`, msg)
+      from = to + 1
     }
-    from = to + 1
   }
   return out
 }
@@ -121,60 +134,94 @@ async function scan(contract, provider, filter, fromBlock, latest, label) {
  * Build the on-chain report data source for the active network.
  *
  * @param {object} [opts]
- * @param {number} [opts.chainId] - active chain id (for chain-scoped address resolution)
+ * @param {number} [opts.chainId] - active chain id
  * @param {object} [opts.provider] - ethers provider (defaults to NETWORK_CONFIG rpc)
  * @param {object} [opts.contract] - escrow contract override (testing)
+ * @param {object} [opts.repository] - WagerRepository override (testing)
  * @returns {object} dataSource
  */
 export function createReportDataSource(opts = {}) {
   const provider = getProvider(opts)
   const chainId = opts.chainId
+  const repository = opts.repository || getDefaultWagerRepository()
+  // wagerId → createdAt (unix seconds), captured during enumeration for windowing.
+  const createdAtById = new Map()
+
   let escrow = null
   let contract = null
-  const ensure = () => {
+  let chainCtx = null
+  const ensureContract = () => {
     if (!contract) {
       escrow = resolveEscrow(chainId)
       contract = opts.contract || new ethers.Contract(escrow.address, escrow.abi, provider)
     }
     return contract
   }
+  const ensureChainCtx = async () => {
+    if (!chainCtx) {
+      const latestBlock = await provider.getBlockNumber()
+      const block = await provider.getBlock(latestBlock)
+      chainCtx = {
+        latestBlock,
+        latestSec: Number(block?.timestamp ?? Math.floor(Date.now() / 1000)),
+        blockTimeSec: BLOCK_TIME_SEC[Number(chainId)] || 2,
+        deployBlock: escrow.deployBlock || 0,
+      }
+    }
+    return chainCtx
+  }
 
   return {
     async enumerateWagers({ account }) {
       if (!account) return []
-      if (import.meta.env?.VITE_SKIP_BLOCKCHAIN_CALLS === 'true') return []
-      const c = ensure()
-      const latest = await provider.getBlockNumber()
-      // wagerId → wager context, built from the indexed enumeration logs.
-      const byId = new Map()
-      for (const [name, ...topics] of escrow.enumeration) {
-        const args = topics.map((t) => (t === '@user' ? account : t))
-        const filter = c.filters[name](...args)
-        const logs = await scan(c, provider, filter, escrow.deployBlock, latest, name)
-        for (const ev of logs) {
-          const n = normalizeEvent(ev)
-          const id = n.args.wagerId
-          if (id == null) continue
-          const existing = byId.get(id) || { id, participants: [account] }
-          // Capture creator + stake token from the creation event when present.
-          if (n.name === 'WagerCreated' || n.name === 'MarketCreatedPending') {
-            existing.creator = n.args.creator || existing.creator
-            existing.stakeTokenAddress = n.args.token || existing.stakeTokenAddress
-          }
-          byId.set(id, existing)
-        }
+      if (!subgraphConfigured()) {
+        throw new Error(
+          'Wager reporting requires the indexing subgraph (VITE_SUBGRAPH_URL) to be configured for this network.',
+        )
       }
-      return [...byId.values()]
+      const all = []
+      let cursor = null
+      for (let page = 0; page < 200; page++) {
+        const res = await repository.listMyWagers({
+          userAddress: account,
+          cursor,
+          pageSize: 100,
+          filter: { includeExpired: true },
+        })
+        // Guard against the repository's legacy EventsSource fallback (it targets
+        // the retired factory and cannot serve v2 reporting).
+        if (String(res.source || '').includes('fallback') || res.source === 'events') {
+          throw new Error('The reporting subgraph is unreachable right now. Please try again shortly.')
+        }
+        all.push(...(res.items || []))
+        if (!res.hasMore || !res.nextCursor) break
+        cursor = res.nextCursor
+      }
+      for (const w of all) {
+        createdAtById.set(String(w.id), Math.floor((Number(w.createdAt) || 0) / 1000))
+      }
+      return all.map((w) => ({
+        id: String(w.id),
+        creator: w.creator,
+        participants: w.participants || [],
+        stakeTokenAddress: w.stakeTokenAddress,
+        stakeAmount: w.stakeAmount,
+      }))
     },
 
     async getWagerEvents(wagerId) {
       if (import.meta.env?.VITE_SKIP_BLOCKCHAIN_CALLS === 'true') return []
-      const c = ensure()
-      const latest = await provider.getBlockNumber()
+      const c = ensureContract()
+      const ctx = await ensureChainCtx()
+      const createdSec = createdAtById.get(String(wagerId)) || 0
+      // Tight window: from shortly before the wager was created to the chain head.
+      const fromBlock = createdSec > 0 ? estimateBlock(createdSec - PRE_WINDOW_SEC, ctx) : ctx.deployBlock
+      const toBlock = ctx.latestBlock
+      const budget = { used: 0, max: SCAN_BUDGET }
       const out = []
       for (const name of escrow.valueEvents) {
         const filter = c.filters[name](wagerId)
-        const logs = await scan(c, provider, filter, escrow.deployBlock, latest, name)
+        const logs = await scanAdaptive(c, filter, fromBlock, toBlock, name, budget)
         for (const ev of logs) out.push(normalizeEvent(ev))
       }
       return out.sort((a, b) => a.blockNumber - b.blockNumber)

--- a/frontend/src/test/reports/reportDataSource.test.js
+++ b/frontend/src/test/reports/reportDataSource.test.js
@@ -3,16 +3,8 @@ import { createReportDataSource, resolveEscrow } from '../../data/reports/report
 import { WAGER_REGISTRY_ABI } from '../../abis/WagerRegistry'
 
 const USER = '0x1111111111111111111111111111111111111111'
-const OTHER = '0x2222222222222222222222222222222222222222'
-const TOKEN = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'
 
-// Regression: the deployment registers the escrow as `wagerRegistry`, NOT
-// `friendGroupMarketFactory`. Asking for the factory key produced
-// "FriendGroupMarketFactory address not configured" on every live network.
-// resolveEscrow must resolve the configured wagerRegistry across all chains and
-// throw a clear error only when nothing is configured.
-
-describe('resolveEscrow (address-config bug fix)', () => {
+describe('resolveEscrow (contract resolution)', () => {
   for (const chainId of [137, 80002, 63, 1337]) {
     it(`resolves the v2 WagerRegistry on chain ${chainId} with the v2 ABI + events`, () => {
       const e = resolveEscrow(chainId)
@@ -29,58 +21,119 @@ describe('resolveEscrow (address-config bug fix)', () => {
   })
 })
 
-// Regression: enumeration must read the wagerRegistry contract directly and
-// NEVER fall back to the legacy EventsSource (which threw
-// "FriendGroupMarketFactory address not configured").
-describe('createReportDataSource.enumerateWagers (self-contained chain scan)', () => {
-  // The test env pins VITE_SKIP_BLOCKCHAIN_CALLS='true'; turn it off so the scan runs.
-  beforeEach(() => vi.stubEnv('VITE_SKIP_BLOCKCHAIN_CALLS', 'false'))
+describe('createReportDataSource.enumerateWagers (subgraph-based, no genesis scan)', () => {
   afterEach(() => vi.unstubAllEnvs())
 
-  function fakeContract(logsByEvent) {
+  function fakeRepo(pages) {
+    let call = 0
     return {
-      filters: new Proxy({}, {
-        get: (_t, name) => (...args) => ({ name: String(name), args }),
-      }),
-      // Return logs only on the first chunk (from===0) to avoid duplicates.
-      queryFilter: async (filter, from) => {
-        if (from !== 0) return []
-        const all = logsByEvent[filter.name] || []
-        // crude topic match: the indexed user arg must equal a log party
-        return all.filter((log) => filter.args.includes(log._match))
-      },
+      listMyWagers: vi.fn(async () => pages[Math.min(call++, pages.length - 1)]),
     }
   }
 
-  it('collects the user\'s wagers from indexed registry logs (no repository)', async () => {
-    const logsByEvent = {
-      WagerCreated: [
-        { _match: USER, fragment: { name: 'WagerCreated' }, transactionHash: '0xa1', blockNumber: 100,
-          args: { wagerId: 1n, creator: USER, opponent: OTHER, token: TOKEN } },
-      ],
-      WagerAccepted: [
-        { _match: USER, fragment: { name: 'WagerAccepted' }, transactionHash: '0xb2', blockNumber: 130,
-          args: { wagerId: 2n, opponent: USER } },
-      ],
-      PayoutClaimed: [],
-    }
-    const ds = createReportDataSource({
-      chainId: 137,
-      provider: { getBlockNumber: async () => 5000 },
-      contract: fakeContract(logsByEvent),
-    })
+  it('requires the subgraph and throws a clear error when it is not configured', async () => {
+    vi.stubEnv('VITE_SUBGRAPH_URL', '')
+    const ds = createReportDataSource({ chainId: 80002, provider: { getBlockNumber: async () => 1 }, repository: fakeRepo([]) })
+    await expect(ds.enumerateWagers({ account: USER })).rejects.toThrow(/requires the indexing subgraph/i)
+  })
+
+  it('enumerates the user\'s wagers from the subgraph repository (never scans logs)', async () => {
+    vi.stubEnv('VITE_SUBGRAPH_URL', 'http://subgraph.example')
+    const repo = fakeRepo([
+      {
+        source: 'subgraph',
+        hasMore: false,
+        nextCursor: null,
+        items: [
+          { id: '1', creator: USER, participants: [USER], stakeTokenAddress: '0xtok', stakeAmount: '100', createdAt: 1700000000000 },
+          { id: '2', creator: '0xother', participants: ['0xother', USER], stakeTokenAddress: '0xtok', stakeAmount: '50', createdAt: 1700001000000 },
+        ],
+      },
+    ])
+    const ds = createReportDataSource({ chainId: 80002, provider: { getBlockNumber: async () => 1 }, repository: repo })
     const wagers = await ds.enumerateWagers({ account: USER })
-    const ids = wagers.map((w) => w.id).sort()
-    expect(ids).toEqual(['1', '2'])
-    const w1 = wagers.find((w) => w.id === '1')
-    expect(w1.creator).toBe(USER)
-    expect(w1.stakeTokenAddress).toBe(TOKEN)
-    // user is recorded as a party so buildReport's isParty filter keeps it
-    expect(wagers.find((w) => w.id === '2').participants).toContain(USER)
+    expect(wagers.map((w) => w.id)).toEqual(['1', '2'])
+    expect(repo.listMyWagers).toHaveBeenCalledWith(expect.objectContaining({ userAddress: USER, filter: { includeExpired: true } }))
+  })
+
+  it('fails clearly if the repository falls back to the legacy events source', async () => {
+    vi.stubEnv('VITE_SUBGRAPH_URL', 'http://subgraph.example')
+    const repo = fakeRepo([{ source: 'subgraph-fallback', hasMore: false, nextCursor: null, items: [] }])
+    const ds = createReportDataSource({ chainId: 80002, provider: { getBlockNumber: async () => 1 }, repository: repo })
+    await expect(ds.enumerateWagers({ account: USER })).rejects.toThrow(/subgraph is unreachable/i)
   })
 
   it('returns [] without an account', async () => {
-    const ds = createReportDataSource({ chainId: 137, provider: { getBlockNumber: async () => 1 }, contract: fakeContract({}) })
+    vi.stubEnv('VITE_SUBGRAPH_URL', 'http://subgraph.example')
+    const ds = createReportDataSource({ chainId: 80002, provider: { getBlockNumber: async () => 1 }, repository: fakeRepo([]) })
     expect(await ds.enumerateWagers({ account: null })).toEqual([])
+  })
+})
+
+describe('createReportDataSource.getWagerEvents (bounded window, adaptive chunking)', () => {
+  beforeEach(() => vi.stubEnv('VITE_SKIP_BLOCKCHAIN_CALLS', 'false'))
+  afterEach(() => vi.unstubAllEnvs())
+
+  function fakeContract(onQuery) {
+    return {
+      filters: new Proxy({}, { get: (_t, name) => (...args) => ({ name: String(name), args }) }),
+      queryFilter: onQuery,
+    }
+  }
+
+  it('does not scan from genesis — starts near the wager createdAt and stays within budget', async () => {
+    vi.stubEnv('VITE_SUBGRAPH_URL', 'http://subgraph.example')
+    const calls = []
+    // latest block ~ 1,000,000; createdAt recent → window should be small.
+    const provider = {
+      getBlockNumber: async () => 1_000_000,
+      getBlock: async () => ({ timestamp: 2_000_000 }),
+    }
+    const contract = fakeContract(async (filter, from, to) => {
+      calls.push([from, to])
+      return []
+    })
+    const repo = {
+      listMyWagers: async () => ({
+        source: 'subgraph', hasMore: false, nextCursor: null,
+        // createdAt ~ now (latestSec 2,000,000) → window starts just below latest block
+        items: [{ id: '5', creator: '0x1111111111111111111111111111111111111111', participants: [], stakeTokenAddress: '0xtok', stakeAmount: '1', createdAt: 1_999_000_000 }],
+      }),
+    }
+    const ds = createReportDataSource({ chainId: 80002, provider, contract, repository: repo })
+    await ds.enumerateWagers({ account: '0x1111111111111111111111111111111111111111' })
+    await ds.getWagerEvents('5')
+
+    expect(calls.length).toBeGreaterThan(0)
+    const minFrom = Math.min(...calls.map((c) => c[0]))
+    // Must NOT start at genesis.
+    expect(minFrom).toBeGreaterThan(0)
+    // Bounded request count (budget).
+    expect(calls.length).toBeLessThanOrEqual(60)
+  })
+
+  it('shrinks the chunk when the RPC rejects the block range', async () => {
+    vi.stubEnv('VITE_SUBGRAPH_URL', 'http://subgraph.example')
+    const sizes = []
+    let firstBig = true
+    const provider = { getBlockNumber: async () => 10_000, getBlock: async () => ({ timestamp: 1000 }) }
+    const contract = fakeContract(async (filter, from, to) => {
+      sizes.push(to - from + 1)
+      if (firstBig && to - from + 1 > 1000) {
+        firstBig = false
+        const e = new Error('block range exceeds configured limit')
+        throw e
+      }
+      return []
+    })
+    const repo = {
+      listMyWagers: async () => ({ source: 'subgraph', hasMore: false, nextCursor: null,
+        items: [{ id: '9', creator: '0x1', participants: [], stakeTokenAddress: '0xt', stakeAmount: '1', createdAt: 0 }] }),
+    }
+    const ds = createReportDataSource({ chainId: 80002, provider, contract, repository: repo })
+    await ds.enumerateWagers({ account: '0xabc' })
+    await ds.getWagerEvents('9')
+    // After the rejection, a smaller chunk size must have been attempted.
+    expect(Math.min(...sizes)).toBeLessThan(5000)
   })
 })


### PR DESCRIPTION
## Summary

The report was hitting what looked like a **rate limit** on the live network. Root cause from the console: `enumerateWagers` was scanning `eth_getLogs` **from block `0x0` (genesis) to the chain head in 10,000-block chunks**, and the public Amoy RPC rejects every request with `block range exceeds configured limit` — a flood of failing requests, and no report.

Two problems:
1. **Genesis scan** — the chain-scan enumeration (added in #701) starts at the deployment block, which is `0` in config for Amoy, so it scans ~1.9M blocks.
2. **No indexer** — raw `eth_getLogs` over a public RPC can't span that range; this approach never scaled.

## Fix (per maintainer decision: use the subgraph)

- **Enumeration → subgraph.** `enumerateWagers` now uses `WagerRepository` (the indexed, scalable path the app is built around), guards against the legacy `EventsSource` fallback, and throws a **clear, actionable error** when `VITE_SUBGRAPH_URL` isn't configured — instead of brute-forcing from genesis.
- **Bounded on-chain detail reads.** `getWagerEvents` (needed for txHash + gas fee, which the subgraph can't supply) now scans only a **tight block window around each wager's `createdAt`** (from the subgraph), with **adaptive shrink-on-limit chunking** and a **per-wager request budget**. No genesis scans; respects the RPC's `getLogs` range limit; clear error if a window is still too large without an indexer.

## Testing
- New tests: subgraph-based enumeration, the no-subgraph error, the legacy-fallback guard, "does not scan from genesis / stays within budget", and "shrinks chunk on range rejection".
- **1332 frontend tests pass**; ESLint clean.

## Required follow-up (infra, not code)
This network needs **`VITE_SUBGRAPH_URL` set to a subgraph that indexes the v2 `wagerRegistry`**. Until then the report will show the clear "requires the indexing subgraph" message rather than working. For *fully* RPC-free reporting, the subgraph should also index each lifecycle event's **transaction hash** (then the client only needs `getTransactionReceipt` per transfer for the fee — no `getLogs` scans at all). Happy to spec that as a subgraph change next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198Kum4cPs11ufUarv3gjqF

---
_Generated by [Claude Code](https://claude.ai/code/session_0198Kum4cPs11ufUarv3gjqF)_