### PR TITLE
feat(018): My Wagers views & privacy feedback (table view, hide terms, view toggle)

### DIFF
--- a/frontend/cypress/e2e/fast/13-dashboard.cy.js
+++ b/frontend/cypress/e2e/fast/13-dashboard.cy.js
@@ -147,13 +147,13 @@ describe('Dashboard', () => {
     cy.get('.quick-action-card').contains('My Wagers').click()
     cy.get('[role="dialog"], .my-markets-modal', { timeout: 5000 }).should('be.visible')
 
-    // If there are wager rows, clicking one should show the detail view.
+    // The full detail view is reached from the table view (spec 018): switch to
+    // the table, then click a row.
+    cy.contains('button', /^Table$/).click()
     cy.get('.mm-panel, [role="tabpanel"]').then(($panel) => {
-      const cards = $panel.find('.wc-card .wc-header')
-      if (cards.length > 0) {
-        // Expand the first card, then open the full detail via "View details".
-        cy.wrap(cards.first()).click()
-        cy.contains('.wc-card button', 'View details').click()
+      const rows = $panel.find('.mm-table-row, tr[role="button"]')
+      if (rows.length > 0) {
+        cy.wrap(rows.first()).click()
         // Detail view should show the back button and market info.
         cy.get('.mm-detail, .mm-back-btn').should('be.visible')
         cy.get('.mm-detail-header, .mm-detail-title-row').should('be.visible')

--- a/frontend/src/components/fairwins/MyMarketsModal.css
+++ b/frontend/src/components/fairwins/MyMarketsModal.css
@@ -269,9 +269,43 @@
   border-color: #4C9AFF;
 }
 
-/* Density toggle (spec 017) — sits to the right of the filter controls. */
-.mm-density-toggle {
+/* View switch (spec 018) — leads the right-aligned toolbar cluster
+   (view toggle → density → refresh). */
+.mm-view-toggle {
   margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  background: var(--bg-secondary, #141C24);
+  border: 1px solid var(--border-color, #23303D);
+  border-radius: 8px;
+}
+
+.mm-view-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.6rem;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--text-secondary, #AAB6C2);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.mm-view-btn:hover { color: var(--text-primary, #E6EDF3); }
+
+.mm-view-btn.active {
+  background: rgba(76, 154, 255, 0.12);
+  color: #4C9AFF;
+}
+
+/* Density toggle (spec 017) — sits between the view switch and refresh. */
+.mm-density-toggle {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -5,14 +5,14 @@ import { useLazyMarketDecryption } from '../../hooks/useEncryption'
 import { useLazyIpfsEnvelope } from '../../hooks/useIpfs'
 import { useWagerActivityOptional } from '../../hooks/useWagerActivity'
 import { useFriendMarkets } from '../../contexts/FriendMarketsContext.js'
-import { WagerStatus as MarketStatus, DisputeStatus, WAGER_DEFAULTS, MyWagersDensity, MY_WAGERS_DENSITY_KEY } from '../../constants/wagerDefaults'
+import { WagerStatus as MarketStatus, DisputeStatus, WAGER_DEFAULTS, MyWagersDensity, MY_WAGERS_DENSITY_KEY, MyWagersView, MY_WAGERS_VIEW_KEY } from '../../constants/wagerDefaults'
 import { getContractAddressForChain } from '../../config/contracts'
 import { getNetwork } from '../../config/networks'
 import { WAGER_REGISTRY_ABI } from '../../abis/WagerRegistry'
 import { getFeeOverrides } from '../../utils/feeOverrides'
 import { getTransactionUrl } from '../../config/blockExplorer'
 import MarketAcceptanceModal from './MarketAcceptanceModal'
-import WagerCardGrid from './WagerCardGrid'
+import WagerList from './WagerList'
 import ResolveButtonWithCountdown from './ResolveButtonWithCountdown'
 import { getMarketDisplayTitle, isWinnerUnpaid } from './wagerCardHelpers'
 import './MyMarketsModal.css'
@@ -107,6 +107,20 @@ function MyMarketsModal({
       try { sessionStorage.setItem(MY_WAGERS_DENSITY_KEY, next) } catch { /* storage unavailable */ }
       return next
     })
+  }, [])
+
+  // View mode (spec 018): grid cards vs compact table. Session-scoped, default grid.
+  const [viewMode, setViewMode] = useState(() => {
+    try {
+      const saved = sessionStorage.getItem(MY_WAGERS_VIEW_KEY)
+      return saved === MyWagersView.TABLE ? MyWagersView.TABLE : MyWagersView.GRID
+    } catch {
+      return MyWagersView.GRID
+    }
+  })
+  const selectView = useCallback((mode) => {
+    setViewMode(mode)
+    try { sessionStorage.setItem(MY_WAGERS_VIEW_KEY, mode) } catch { /* storage unavailable */ }
   }, [])
 
   // Transient confirmation toast (spec 017 FR-015) shown after a successful
@@ -930,20 +944,50 @@ function MyMarketsModal({
               <option value={MarketStatus.EXPIRED}>Expired</option>
             </select>
           </div>
-          <button
-            type="button"
-            className="mm-density-toggle"
-            onClick={toggleDensity}
-            title={density === MyWagersDensity.COMFORTABLE ? 'Switch to compact view' : 'Switch to comfortable view'}
-            aria-pressed={density === MyWagersDensity.COMFORTABLE}
-          >
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
-              {density === MyWagersDensity.COMFORTABLE
-                ? <path d="M3 5h18M3 12h18M3 19h18" />
-                : <path d="M3 5h18M3 10h18M3 15h18M3 20h18" />}
-            </svg>
-            {density === MyWagersDensity.COMFORTABLE ? 'Comfortable' : 'Compact'}
-          </button>
+          {/* View switch (spec 018) — inline with density + refresh */}
+          <div className="mm-view-toggle" role="group" aria-label="Wager view">
+            <button
+              type="button"
+              className={`mm-view-btn ${viewMode === MyWagersView.GRID ? 'active' : ''}`}
+              onClick={() => selectView(MyWagersView.GRID)}
+              aria-pressed={viewMode === MyWagersView.GRID}
+              title="Grid view"
+            >
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/>
+                <rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/>
+              </svg>
+              Grid
+            </button>
+            <button
+              type="button"
+              className={`mm-view-btn ${viewMode === MyWagersView.TABLE ? 'active' : ''}`}
+              onClick={() => selectView(MyWagersView.TABLE)}
+              aria-pressed={viewMode === MyWagersView.TABLE}
+              title="Table view"
+            >
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
+              </svg>
+              Table
+            </button>
+          </div>
+          {viewMode === MyWagersView.GRID && (
+            <button
+              type="button"
+              className="mm-density-toggle"
+              onClick={toggleDensity}
+              title={density === MyWagersDensity.COMFORTABLE ? 'Switch to compact view' : 'Switch to comfortable view'}
+              aria-pressed={density === MyWagersDensity.COMFORTABLE}
+            >
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+                {density === MyWagersDensity.COMFORTABLE
+                  ? <path d="M3 5h18M3 12h18M3 19h18" />
+                  : <path d="M3 5h18M3 10h18M3 15h18M3 20h18" />}
+              </svg>
+              {density === MyWagersDensity.COMFORTABLE ? 'Comfortable' : 'Compact'}
+            </button>
+          )}
           <button
             className="mm-refresh-btn"
             onClick={fetchMarketsData}
@@ -1018,7 +1062,8 @@ function MyMarketsModal({
                       <p className="mm-hint">Create or accept a wager to see them here.</p>
                     </div>
                   ) : (
-                    <WagerCardGrid
+                    <WagerList
+                      viewMode={viewMode}
                       density={density}
                       onDecrypt={handleDecryptMarket}
                       isDecrypting={isMarketDecrypting}
@@ -1089,7 +1134,8 @@ function MyMarketsModal({
                       <p className="mm-hint">Use the quick actions on the dashboard to create your first wager.</p>
                     </div>
                   ) : (
-                    <WagerCardGrid
+                    <WagerList
+                      viewMode={viewMode}
                       density={density}
                       onDecrypt={handleDecryptMarket}
                       isDecrypting={isMarketDecrypting}
@@ -1147,7 +1193,8 @@ function MyMarketsModal({
                       <p className="mm-hint">When someone names you as the neutral resolver, those wagers appear here.</p>
                     </div>
                   ) : (
-                    <WagerCardGrid
+                    <WagerList
+                      viewMode={viewMode}
                       density={density}
                       onDecrypt={handleDecryptMarket}
                       isDecrypting={isMarketDecrypting}
@@ -1197,7 +1244,8 @@ function MyMarketsModal({
                       <p>Your resolved wagers will appear here.</p>
                     </div>
                   ) : (
-                    <WagerCardGrid
+                    <WagerList
+                      viewMode={viewMode}
                       density={density}
                       onDecrypt={handleDecryptMarket}
                       isDecrypting={isMarketDecrypting}

--- a/frontend/src/components/fairwins/WagerCard.css
+++ b/frontend/src/components/fairwins/WagerCard.css
@@ -207,6 +207,40 @@
   margin-bottom: 14px;
 }
 
+.wc-terms-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+/* Hide/show toggle for decrypted private-bet terms (spec 018 FR-002) */
+.wc-terms-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.5rem;
+  background: transparent;
+  border: 1px solid var(--border-color, #23303D);
+  border-radius: 6px;
+  color: var(--text-secondary, #AAB6C2);
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.wc-terms-toggle:hover {
+  border-color: #4C9AFF;
+  color: #4C9AFF;
+}
+
+.wc-terms-concealed {
+  letter-spacing: 0.15em;
+  color: var(--text-muted, #7A8590);
+  user-select: none;
+}
+
 .wc-terms-label,
 .wc-meta-label {
   font-size: 0.65rem;
@@ -298,6 +332,22 @@
   margin-top: 14px;
   display: flex;
   justify-content: center;
+}
+
+/* Table view (spec 018) — compact action buttons inside table rows. */
+.wc-action-sm {
+  flex: 0 0 auto;
+  padding: 0.3rem 0.6rem;
+  font-size: 0.75rem;
+  border-radius: 8px;
+  margin-right: 0.375rem;
+}
+
+.wc-action-sm:last-child { margin-right: 0; }
+
+.wc-table-amount {
+  white-space: nowrap;
+  color: var(--text-primary, #E6EDF3);
 }
 
 @media (max-width: 600px) {

--- a/frontend/src/components/fairwins/WagerCard.jsx
+++ b/frontend/src/components/fairwins/WagerCard.jsx
@@ -19,24 +19,26 @@ const VARIANT_CLASS = {
 }
 
 /**
- * WagerCard (spec 017)
+ * WagerCard (spec 017, updated spec 018)
  *
  * A single wager rendered as an expandable card. Collapsed: stake, title, status
  * pill, chevron (+ opponent/time preview in comfortable density). Expanded: terms
- * (or an inline decrypt affordance for encrypted wagers), a 2-column metadata
- * grid, contextual action buttons, and a "View details" link to the full detail
- * view. Pure presentation — all side effects flow through the passed callbacks.
+ * (with a hide/show control for decrypted private wagers, or an inline decrypt
+ * affordance for encrypted ones), a 2-column metadata grid, and contextual
+ * action buttons. The expanded card IS the detail surface (spec 018 FR-001 — the
+ * separate "View details" button was removed). Pure presentation.
  */
 export default function WagerCard({
   market,
   vm,
   isOpen,
   onToggle,
-  onSelect,
   onDecrypt,
   onResolve,
   account,
   showResolveCountdown = false,
+  termsHidden = false,
+  onToggleHideTerms,
 }) {
   const headingId = `wc-${vm.id}-title`
   const panelId = `wc-${vm.id}-panel`
@@ -47,6 +49,8 @@ export default function WagerCard({
       onToggle()
     }
   }
+
+  const concealTerms = vm.canHideTerms && termsHidden
 
   return (
     <div className={`wc-card${isOpen ? ' wc-open' : ''}${vm.isExpired ? ' wc-expired' : ''}`}>
@@ -138,8 +142,39 @@ export default function WagerCard({
           )}
           {(vm.encState === 'revealed' || vm.encState === 'plain') && vm.terms && (
             <div className="wc-terms">
-              <div className="wc-terms-label">Wager terms</div>
-              <div className="wc-terms-text">{vm.terms}</div>
+              <div className="wc-terms-head">
+                <div className="wc-terms-label">Wager terms</div>
+                {vm.canHideTerms && (
+                  <button
+                    type="button"
+                    className="wc-terms-toggle"
+                    onClick={(e) => { e.stopPropagation(); onToggleHideTerms?.() }}
+                    aria-pressed={concealTerms}
+                    title={concealTerms ? 'Show wager terms' : 'Hide wager terms'}
+                  >
+                    {concealTerms ? (
+                      <>
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                          <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z"/><circle cx="12" cy="12" r="3"/>
+                        </svg>
+                        Show
+                      </>
+                    ) : (
+                      <>
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                          <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/>
+                        </svg>
+                        Hide
+                      </>
+                    )}
+                  </button>
+                )}
+              </div>
+              {concealTerms ? (
+                <div className="wc-terms-text wc-terms-concealed" aria-hidden="true">•••• •••••• ••••</div>
+              ) : (
+                <div className="wc-terms-text">{vm.terms}</div>
+              )}
             </div>
           )}
 
@@ -154,30 +189,25 @@ export default function WagerCard({
           </div>
 
           {/* Actions */}
-          <div className="wc-actions">
-            {showResolveCountdown && !vm.isExpired && (
-              <ResolveButtonWithCountdown market={market} onResolve={onResolve} account={account} />
-            )}
-            {vm.actions.map((a) => (
-              <button
-                key={a.key}
-                type="button"
-                className={`wc-action ${VARIANT_CLASS[a.variant] || 'wc-action-ghost'}`}
-                onClick={(e) => { e.stopPropagation(); a.onClick() }}
-                disabled={a.disabled}
-                title={a.title}
-              >
-                {a.label}
-              </button>
-            ))}
-            <button
-              type="button"
-              className="wc-action wc-action-ghost wc-action-details"
-              onClick={(e) => { e.stopPropagation(); onSelect() }}
-            >
-              View details
-            </button>
-          </div>
+          {(vm.actions.length > 0 || (showResolveCountdown && !vm.isExpired)) && (
+            <div className="wc-actions">
+              {showResolveCountdown && !vm.isExpired && (
+                <ResolveButtonWithCountdown market={market} onResolve={onResolve} account={account} />
+              )}
+              {vm.actions.map((a) => (
+                <button
+                  key={a.key}
+                  type="button"
+                  className={`wc-action ${VARIANT_CLASS[a.variant] || 'wc-action-ghost'}`}
+                  onClick={(e) => { e.stopPropagation(); a.onClick() }}
+                  disabled={a.disabled}
+                  title={a.title}
+                >
+                  {a.label}
+                </button>
+              ))}
+            </div>
+          )}
 
           {/* Per-card action errors */}
           {vm.actions.filter(a => a.error).map((a) => (

--- a/frontend/src/components/fairwins/WagerCardGrid.jsx
+++ b/frontend/src/components/fairwins/WagerCardGrid.jsx
@@ -1,34 +1,19 @@
 import { useMemo, useState } from 'react'
 import { WagerStatus as MarketStatus } from '../../constants/wagerDefaults'
 import { useWagerActivityOptional } from '../../hooks/useWagerActivity'
-import { getMarketDisplayTitle, getRowOutcome, isWinnerUnpaid, formatShortAddress } from './wagerCardHelpers'
+import { buildWagerVm } from './wagerVm'
 import WagerCard from './WagerCard'
 
-// Action kinds whose card already renders a matching button, so the duplicate
-// status-row badge is just noise (mirrors the old MarketsTable behavior).
-const ACTION_BADGES_WITH_BUTTON = new Set(['accept', 'claim', 'resolve'])
-
-// Stable avatar tint for the comfortable-density preview line (from the mockup).
-const AVATAR_PALETTE = ['#fca5a5', '#fdba74', '#86efac', '#93c5fd', '#c4b5fd', '#f9a8d4', '#67e8f9']
-function avatarColor(seed) {
-  const s = String(seed || '')
-  let n = 0
-  for (const ch of s) n += ch.charCodeAt(0)
-  return AVATAR_PALETTE[n % AVATAR_PALETTE.length]
-}
-
 /**
- * WagerCardGrid (spec 017)
+ * WagerCardGrid (spec 017, updated spec 018)
  *
- * Responsive, expandable card grid for My Wagers. Drop-in replacement for the
- * former MarketsTable — accepts the same prop contract plus `density`,
- * `onDecrypt`, and `isDecrypting`. Owns the single-open accordion state and the
- * clear-all-expired affordance. Adds no network calls; every side effect flows
- * through the passed callbacks.
+ * Responsive, expandable card grid for My Wagers. Owns the single-open accordion
+ * state, the per-card "hide decrypted terms" state (FR-002), and the
+ * clear-all-expired affordance. Shares its view model with the table view via
+ * buildWagerVm. Adds no network calls; every side effect flows through callbacks.
  */
 export default function WagerCardGrid({
   markets,
-  onSelect,
   getStatusClass,
   getStatusLabel,
   getTimeRemaining,
@@ -61,6 +46,9 @@ export default function WagerCardGrid({
 
   // Single-open accordion: at most one expanded card at a time (FR-007).
   const [openId, setOpenId] = useState(null)
+  // Per-card re-hidden decrypted terms (spec 018 FR-002). Default visible after
+  // decryption; the user opts to conceal. View-only — does not re-encrypt.
+  const [hiddenTermIds, setHiddenTermIds] = useState(() => new Set())
 
   const expiredMarkets = useMemo(
     () => markets.filter(m => m.computedStatus === MarketStatus.EXPIRED),
@@ -71,138 +59,22 @@ export default function WagerCardGrid({
     expiredMarkets.length > 0 &&
     typeof onClearAllExpired === 'function'
 
-  const me = account?.toLowerCase()
-
-  // Pick the right countdown source: pending/expired offers use the *acceptance*
-  // deadline, everything else the trading/resolve end.
-  const rowTimeLeft = (market) => {
-    const isPending =
-      market.computedStatus === MarketStatus.PENDING_ACCEPTANCE ||
-      market.computedStatus === MarketStatus.EXPIRED
-    const endTime = isPending && market.acceptanceDeadline
-      ? market.acceptanceDeadline
-      : (market.tradingEndTime || market.endDate)
-    if (market.computedStatus === MarketStatus.EXPIRED) return 'Expired'
-    return getTimeRemaining(endTime)
+  const ctx = {
+    account, isDecrypting, getStatusClass, getStatusLabel, getTimeRemaining, formatDate,
+    showActions, showOutcome, showResolveCountdown,
+    canResolve, canAccept, isCreatorOfPending,
+    onResolve, onAccept, onClearExpired, onClaim, onRefund,
+    claimingId, claimError, refundingId, refundError,
+    actionNeededByWagerId,
   }
 
-  const buildVm = (market) => {
-    const idStr = String(market.id)
-    const isExpired = market.computedStatus === MarketStatus.EXPIRED
-    const isCreator = market.creator?.toLowerCase?.() === me
-    const displayTitle = getMarketDisplayTitle(market)
-    const timeLeft = rowTimeLeft(market)
-    const outcome = showOutcome ? getRowOutcome(market, account) : null
-    const actionNeeded = actionNeededByWagerId?.[idStr] ?? null
-
-    // Encryption display state.
-    const encState = !market.isEncrypted
-      ? 'plain'
-      : market.decryptedMetadata
-        ? 'revealed'
-        : (isDecrypting && isDecrypting(market.id))
-          ? 'decrypting'
-          : (market.decryptionError || market.ipfsEnvelopeError)
-            ? 'unavailable'
-            : 'locked'
-
-    const termsRaw = market.decryptedMetadata?.terms || market.decryptedMetadata?.description || ''
-    const terms = termsRaw && termsRaw !== displayTitle ? termsRaw : ''
-
-    // Counterparty / creator labels (on-chain public; display only).
-    const others = [market.creator, ...(market.participants || [])]
-      .filter(a => a && a.toLowerCase?.() !== me)
-    const opponent = others.length ? formatShortAddress(others[0]) : '—'
-    const creatorLabel = market.creator?.toLowerCase?.() === me ? 'You' : formatShortAddress(market.creator)
-    const endRaw = market.tradingEndTime || market.endDate
-
-    const meta = [
-      showOutcome && outcome
-        ? { label: 'Outcome', value: outcome.label, tone: outcome.tone }
-        : { label: 'Opponent', value: opponent },
-      { label: showOutcome ? 'Settled' : 'Ends', value: showOutcome ? formatDate(endRaw) : timeLeft },
-      { label: 'Wager ID', value: `#${market.id}` },
-      { label: 'Creator', value: creatorLabel },
-    ]
-
-    // Action visibility — identical rules to the former MarketsTable.
-    const showClearBtn = isExpired && typeof onClearExpired === 'function'
-    const showAcceptBtn = !isExpired && canAccept?.(market)
-    const showUnderConsideration = !isExpired && isCreatorOfPending?.(market)
-    const showResolveBtn = showActions && canResolve?.(market)
-    const canClaimRow = typeof onClaim === 'function' && isWinnerUnpaid(market, account)
-    const showRefundBtn = actionNeeded === 'refund' && !showClearBtn && typeof onRefund === 'function'
-    const showDrawBtn = actionNeeded === 'respondDraw' && typeof onResolve === 'function'
-
-    const actionBadgeRedundant =
-      ACTION_BADGES_WITH_BUTTON.has(actionNeeded) ||
-      (actionNeeded === 'refund' && (showClearBtn || showRefundBtn)) ||
-      showDrawBtn
-
-    const actions = []
-    if (showAcceptBtn) {
-      actions.push({ key: 'accept', label: 'View Offer', variant: 'primary', onClick: () => onAccept(market), title: 'View offer details' })
-    }
-    if (showResolveBtn && !showResolveCountdown) {
-      actions.push({ key: 'resolve', label: 'Resolve', variant: 'primary', onClick: () => onResolve(market), title: 'Resolve wager' })
-    }
-    if (showClearBtn) {
-      actions.push({
-        key: 'clear',
-        label: isCreator ? 'Reclaim & Clear' : 'Clear',
-        variant: 'ghost',
-        onClick: () => onClearExpired(market),
-        title: isCreator ? 'Reclaim stake and clear' : 'Clear from list',
-      })
-    }
-    if (canClaimRow) {
-      actions.push({
-        key: 'claim',
-        label: claimingId === idStr ? 'Claiming…' : 'Claim',
-        variant: 'success',
-        onClick: () => onClaim(market),
-        disabled: claimingId === idStr,
-        error: claimError?.id === idStr ? claimError.message : null,
-        title: 'Claim your winnings',
-      })
-    }
-    if (showRefundBtn) {
-      actions.push({
-        key: 'refund',
-        label: refundingId === idStr ? 'Refunding…' : 'Refund',
-        variant: 'warning',
-        onClick: () => onRefund(market),
-        disabled: refundingId === idStr,
-        error: refundError?.id === idStr ? refundError.message : null,
-        title: 'Reclaim your stake — the resolution window has passed',
-      })
-    }
-    if (showDrawBtn) {
-      actions.push({ key: 'draw', label: 'Respond to Draw', variant: 'primary', onClick: () => onResolve(market), title: 'Your counterparty proposed a draw — review and respond' })
-    }
-
-    return {
-      id: idStr,
-      stake: market.stakeAmount ?? '—',
-      tokenSymbol: market.stakeTokenSymbol || 'ETC',
-      displayTitle,
-      isPrivate: Boolean(market.isPrivate),
-      statusClass: getStatusClass(market.computedStatus),
-      statusText: showUnderConsideration ? 'Under Consideration' : getStatusLabel(market.computedStatus),
-      isExpired,
-      timeLeft,
-      outcome,
-      encState,
-      terms,
-      meta,
-      actions,
-      actionNeeded,
-      actionBadgeRedundant,
-      // comfortable-density preview line
-      showPreview: density === 'comfortable' && openId !== idStr && opponent !== '—',
-      opponent,
-      avatarColor: avatarColor(others[0] || idStr),
-    }
+  const toggleHideTerms = (id) => {
+    setHiddenTermIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
   }
 
   return (
@@ -210,7 +82,9 @@ export default function WagerCardGrid({
       <div className="wc-grid" role="list">
         {markets.map((market) => {
           const idStr = String(market.id)
-          const vm = buildVm(market)
+          const vm = buildWagerVm(market, ctx)
+          // Grid-only display flags.
+          vm.showPreview = density === 'comfortable' && openId !== idStr && vm.opponent !== '—'
           return (
             <div role="listitem" key={`${market.marketType}-${market.id}`} className="wc-grid-item">
               <WagerCard
@@ -224,11 +98,12 @@ export default function WagerCardGrid({
                   // (spec 012 FR-004 carried forward to the inline card view).
                   if (willOpen) onView?.(market)
                 }}
-                onSelect={() => onSelect(market)}
                 onDecrypt={onDecrypt}
                 onResolve={onResolve}
                 account={account}
                 showResolveCountdown={showResolveCountdown}
+                termsHidden={hiddenTermIds.has(idStr)}
+                onToggleHideTerms={() => toggleHideTerms(idStr)}
               />
             </div>
           )

--- a/frontend/src/components/fairwins/WagerList.jsx
+++ b/frontend/src/components/fairwins/WagerList.jsx
@@ -1,0 +1,16 @@
+import { MyWagersView } from '../../constants/wagerDefaults'
+import WagerCardGrid from './WagerCardGrid'
+import WagerTable from './WagerTable'
+
+/**
+ * WagerList (spec 018)
+ *
+ * Thin switch between the grid (expandable cards) and table (compact rows) views
+ * of My Wagers. Forwards the shared prop contract to whichever view is active so
+ * MyMarketsModal's call sites stay simple.
+ */
+export default function WagerList({ viewMode = MyWagersView.GRID, ...props }) {
+  return viewMode === MyWagersView.TABLE
+    ? <WagerTable {...props} />
+    : <WagerCardGrid {...props} />
+}

--- a/frontend/src/components/fairwins/WagerTable.jsx
+++ b/frontend/src/components/fairwins/WagerTable.jsx
@@ -1,0 +1,158 @@
+import { useMemo } from 'react'
+import { WagerStatus as MarketStatus } from '../../constants/wagerDefaults'
+import { useWagerActivityOptional } from '../../hooks/useWagerActivity'
+import { buildWagerVm } from './wagerVm'
+import ResolveButtonWithCountdown from './ResolveButtonWithCountdown'
+
+const VARIANT_CLASS = {
+  primary: 'wc-action-primary',
+  success: 'wc-action-success',
+  danger: 'wc-action-danger',
+  warning: 'wc-action-warning',
+  ghost: 'wc-action-ghost',
+}
+
+/**
+ * WagerTable (spec 018 FR-003/004)
+ *
+ * Compact, minimal table view for My Wagers — Wager / Amount / Date / State /
+ * Actions. Clicking a row (outside an action control) opens the wager's full
+ * detail view via onSelect. Shares its view model and action wiring with the
+ * card grid through buildWagerVm, so behavior is identical across views.
+ */
+export default function WagerTable({
+  markets,
+  onSelect,
+  onView,
+  getStatusClass,
+  getStatusLabel,
+  getTimeRemaining,
+  formatDate,
+  showActions = false,
+  showOutcome = false,
+  canResolve,
+  canAccept,
+  isCreatorOfPending,
+  onResolve,
+  onAccept,
+  onClearExpired,
+  onClearAllExpired,
+  onClaim,
+  claimingId,
+  claimError,
+  onRefund,
+  refundingId,
+  refundError,
+  statusFilter,
+  account,
+  showResolveCountdown = false,
+}) {
+  const activity = useWagerActivityOptional()
+  const actionNeededByWagerId = activity?.actionNeededByWagerId
+
+  const expiredMarkets = useMemo(
+    () => markets.filter(m => m.computedStatus === MarketStatus.EXPIRED),
+    [markets]
+  )
+  const showClearAll =
+    statusFilter === MarketStatus.EXPIRED &&
+    expiredMarkets.length > 0 &&
+    typeof onClearAllExpired === 'function'
+
+  const ctx = {
+    account, getStatusClass, getStatusLabel, getTimeRemaining, formatDate,
+    showActions, showOutcome, showResolveCountdown,
+    canResolve, canAccept, isCreatorOfPending,
+    onResolve, onAccept, onClearExpired, onClaim, onRefund,
+    claimingId, claimError, refundingId, refundError,
+    actionNeededByWagerId,
+  }
+
+  const rows = markets.map(m => ({ market: m, vm: buildWagerVm(m, ctx) }))
+  const hasActionsColumn =
+    showResolveCountdown ||
+    rows.some(({ vm }) => vm.actions.length > 0)
+
+  const openRow = (market) => {
+    onView?.(market)
+    onSelect(market)
+  }
+
+  return (
+    <div className="wc-table-container mm-table-container">
+      <table className="mm-table" role="table">
+        <thead>
+          <tr>
+            <th>Wager</th>
+            <th>Amount</th>
+            <th>{showOutcome ? 'Settled' : 'Date'}</th>
+            <th>State</th>
+            {hasActionsColumn && <th>Actions</th>}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(({ market, vm }) => (
+            <tr
+              key={`${market.marketType}-${market.id}`}
+              className={`mm-table-row${vm.isExpired ? ' mm-table-row-expired' : ''}`}
+              role="button"
+              tabIndex={0}
+              onClick={() => openRow(market)}
+              onKeyDown={(e) => { if (e.key === 'Enter') openRow(market) }}
+            >
+              <td className="mm-table-market">
+                <span className="mm-table-market-title">
+                  <span>{vm.displayTitle}</span>
+                </span>
+              </td>
+              <td className="wc-table-amount">
+                <strong>{vm.stake}</strong> {vm.tokenSymbol}
+                {vm.outcome && (
+                  <span className={`wc-outcome ${vm.outcome.tone}`} style={{ marginLeft: 6 }}>{vm.outcome.label}</span>
+                )}
+              </td>
+              <td className="mm-table-time">{vm.meta[1]?.value}</td>
+              <td>
+                <span className={`mm-status-badge ${vm.statusClass}`}>{vm.statusText}</span>
+              </td>
+              {hasActionsColumn && (
+                <td className="mm-table-actions" onClick={(e) => e.stopPropagation()}>
+                  {showResolveCountdown && !vm.isExpired && (
+                    <ResolveButtonWithCountdown market={market} onResolve={onResolve} account={account} />
+                  )}
+                  {vm.actions.map((a) => (
+                    <button
+                      key={a.key}
+                      type="button"
+                      className={`wc-action wc-action-sm ${VARIANT_CLASS[a.variant] || 'wc-action-ghost'}`}
+                      onClick={(e) => { e.stopPropagation(); a.onClick() }}
+                      disabled={a.disabled}
+                      title={a.title}
+                    >
+                      {a.label}
+                    </button>
+                  ))}
+                  {vm.actions.filter(a => a.error).map((a) => (
+                    <span className="wc-action-error" role="alert" key={`${a.key}-err`}>{a.error}</span>
+                  ))}
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {showClearAll && (
+        <div className="wc-grid-footer">
+          <button
+            type="button"
+            className="mm-btn-secondary mm-btn-small"
+            onClick={() => onClearAllExpired(expiredMarkets)}
+            title="Hide all expired offers from this list"
+          >
+            Clear all expired ({expiredMarkets.length})
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/fairwins/wagerVm.js
+++ b/frontend/src/components/fairwins/wagerVm.js
@@ -1,0 +1,187 @@
+import { WagerStatus as MarketStatus } from '../../constants/wagerDefaults'
+import { getMarketDisplayTitle, getRowOutcome, isWinnerUnpaid, formatShortAddress } from './wagerCardHelpers'
+
+// Action kinds whose row already renders a matching button, so the duplicate
+// status badge is just noise (mirrors the former MarketsTable behavior).
+const ACTION_BADGES_WITH_BUTTON = new Set(['accept', 'claim', 'resolve'])
+
+// Stable avatar tint for the comfortable-density preview line (from the mockup).
+const AVATAR_PALETTE = ['#fca5a5', '#fdba74', '#86efac', '#93c5fd', '#c4b5fd', '#f9a8d4', '#67e8f9']
+export function avatarColor(seed) {
+  const s = String(seed || '')
+  let n = 0
+  for (const ch of s) n += ch.charCodeAt(0)
+  return AVATAR_PALETTE[n % AVATAR_PALETTE.length]
+}
+
+/**
+ * Pick the right countdown source: pending/expired offers use the *acceptance*
+ * deadline, everything else the trading/resolve end.
+ */
+export function rowTimeLeft(market, getTimeRemaining) {
+  const isPending =
+    market.computedStatus === MarketStatus.PENDING_ACCEPTANCE ||
+    market.computedStatus === MarketStatus.EXPIRED
+  const endTime = isPending && market.acceptanceDeadline
+    ? market.acceptanceDeadline
+    : (market.tradingEndTime || market.endDate)
+  if (market.computedStatus === MarketStatus.EXPIRED) return 'Expired'
+  return getTimeRemaining(endTime)
+}
+
+/**
+ * Build the shared, presentation-only view model for one wager (spec 017/018).
+ *
+ * Used by both the grid (WagerCardGrid/WagerCard) and the table (WagerTable) so
+ * status, metadata, encryption state, and contextual actions stay identical
+ * across views. Pure: all side effects flow through the callbacks in `ctx`.
+ *
+ * @param {object} market
+ * @param {object} ctx - formatters, predicates, action callbacks, in-flight
+ *   state, the activity-watcher map, and `isDecrypting`.
+ */
+export function buildWagerVm(market, ctx) {
+  const {
+    account,
+    isDecrypting,
+    getStatusClass,
+    getStatusLabel,
+    getTimeRemaining,
+    formatDate,
+    showActions = false,
+    showOutcome = false,
+    showResolveCountdown = false,
+    canResolve,
+    canAccept,
+    isCreatorOfPending,
+    onResolve,
+    onAccept,
+    onClearExpired,
+    onClaim,
+    onRefund,
+    claimingId,
+    claimError,
+    refundingId,
+    refundError,
+    actionNeededByWagerId,
+  } = ctx
+
+  const me = account?.toLowerCase()
+  const idStr = String(market.id)
+  const isExpired = market.computedStatus === MarketStatus.EXPIRED
+  const isCreator = market.creator?.toLowerCase?.() === me
+  const displayTitle = getMarketDisplayTitle(market)
+  const timeLeft = rowTimeLeft(market, getTimeRemaining)
+  const outcome = showOutcome ? getRowOutcome(market, account) : null
+  const actionNeeded = actionNeededByWagerId?.[idStr] ?? null
+
+  // Encryption display state.
+  const encState = !market.isEncrypted
+    ? 'plain'
+    : market.decryptedMetadata
+      ? 'revealed'
+      : (isDecrypting && isDecrypting(market.id))
+        ? 'decrypting'
+        : (market.decryptionError || market.ipfsEnvelopeError)
+          ? 'unavailable'
+          : 'locked'
+
+  const termsRaw = market.decryptedMetadata?.terms || market.decryptedMetadata?.description || ''
+  const terms = termsRaw && termsRaw !== displayTitle ? termsRaw : ''
+  // Only encrypted wagers that have been decrypted can be re-hidden (FR-002).
+  const canHideTerms = Boolean(market.isEncrypted) && encState === 'revealed' && Boolean(terms)
+
+  // Counterparty / creator labels (on-chain public; display only).
+  const others = [market.creator, ...(market.participants || [])]
+    .filter(a => a && a.toLowerCase?.() !== me)
+  const opponent = others.length ? formatShortAddress(others[0]) : '—'
+  const creatorLabel = market.creator?.toLowerCase?.() === me ? 'You' : formatShortAddress(market.creator)
+  const endRaw = market.tradingEndTime || market.endDate
+
+  const meta = [
+    showOutcome && outcome
+      ? { label: 'Outcome', value: outcome.label, tone: outcome.tone }
+      : { label: 'Opponent', value: opponent },
+    { label: showOutcome ? 'Settled' : 'Ends', value: showOutcome ? formatDate(endRaw) : timeLeft },
+    { label: 'Wager ID', value: `#${market.id}` },
+    { label: 'Creator', value: creatorLabel },
+  ]
+
+  // Action visibility — identical rules to the former MarketsTable.
+  const showClearBtn = isExpired && typeof onClearExpired === 'function'
+  const showAcceptBtn = !isExpired && canAccept?.(market)
+  const showUnderConsideration = !isExpired && isCreatorOfPending?.(market)
+  const showResolveBtn = showActions && canResolve?.(market)
+  const canClaimRow = typeof onClaim === 'function' && isWinnerUnpaid(market, account)
+  const showRefundBtn = actionNeeded === 'refund' && !showClearBtn && typeof onRefund === 'function'
+  const showDrawBtn = actionNeeded === 'respondDraw' && typeof onResolve === 'function'
+
+  const actionBadgeRedundant =
+    ACTION_BADGES_WITH_BUTTON.has(actionNeeded) ||
+    (actionNeeded === 'refund' && (showClearBtn || showRefundBtn)) ||
+    showDrawBtn
+
+  const actions = []
+  if (showAcceptBtn) {
+    actions.push({ key: 'accept', label: 'View Offer', variant: 'primary', onClick: () => onAccept(market), title: 'View offer details' })
+  }
+  if (showResolveBtn && !showResolveCountdown) {
+    actions.push({ key: 'resolve', label: 'Resolve', variant: 'primary', onClick: () => onResolve(market), title: 'Resolve wager' })
+  }
+  if (showClearBtn) {
+    actions.push({
+      key: 'clear',
+      label: isCreator ? 'Reclaim & Clear' : 'Clear',
+      variant: 'ghost',
+      onClick: () => onClearExpired(market),
+      title: isCreator ? 'Reclaim stake and clear' : 'Clear from list',
+    })
+  }
+  if (canClaimRow) {
+    actions.push({
+      key: 'claim',
+      label: claimingId === idStr ? 'Claiming…' : 'Claim',
+      variant: 'success',
+      onClick: () => onClaim(market),
+      disabled: claimingId === idStr,
+      error: claimError?.id === idStr ? claimError.message : null,
+      title: 'Claim your winnings',
+    })
+  }
+  if (showRefundBtn) {
+    actions.push({
+      key: 'refund',
+      label: refundingId === idStr ? 'Refunding…' : 'Refund',
+      variant: 'warning',
+      onClick: () => onRefund(market),
+      disabled: refundingId === idStr,
+      error: refundError?.id === idStr ? refundError.message : null,
+      title: 'Reclaim your stake — the resolution window has passed',
+    })
+  }
+  if (showDrawBtn) {
+    actions.push({ key: 'draw', label: 'Respond to Draw', variant: 'primary', onClick: () => onResolve(market), title: 'Your counterparty proposed a draw — review and respond' })
+  }
+
+  return {
+    id: idStr,
+    stake: market.stakeAmount ?? '—',
+    tokenSymbol: market.stakeTokenSymbol || 'ETC',
+    displayTitle,
+    isPrivate: Boolean(market.isPrivate),
+    statusClass: getStatusClass(market.computedStatus),
+    statusText: showUnderConsideration ? 'Under Consideration' : getStatusLabel(market.computedStatus),
+    isExpired,
+    timeLeft,
+    outcome,
+    encState,
+    terms,
+    canHideTerms,
+    meta,
+    actions,
+    actionNeeded,
+    actionBadgeRedundant,
+    opponent,
+    avatarColor: avatarColor(others[0] || idStr),
+  }
+}

--- a/frontend/src/constants/wagerDefaults.js
+++ b/frontend/src/constants/wagerDefaults.js
@@ -209,6 +209,15 @@ export const MyWagersDensity = {
 
 export const MY_WAGERS_DENSITY_KEY = 'fairwins.myWagers.density'
 
+// ── My Wagers view mode (spec 018) ──────────────────────────────────
+// Grid = expandable cards (default); Table = compact rows. Session-scoped.
+export const MyWagersView = {
+  GRID: 'grid',
+  TABLE: 'table',
+}
+
+export const MY_WAGERS_VIEW_KEY = 'fairwins.myWagers.view'
+
 // Terminal statuses — wagers in these states are considered "history"
 export const TERMINAL_STATUSES = new Set([
   'resolved',

--- a/frontend/src/test/MyMarketsModal.test.jsx
+++ b/frontend/src/test/MyMarketsModal.test.jsx
@@ -146,6 +146,8 @@ describe('MyMarketsModal', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // Reset session-scoped UI prefs (view/density) so test order can't leak them.
+    try { sessionStorage.clear() } catch { /* no-op */ }
     // Mock window.ethereum to avoid provider creation errors
     global.window.ethereum = undefined
     useWallet.mockReturnValue({
@@ -883,7 +885,7 @@ describe('MyMarketsModal', () => {
       expect(screen.getByText('Won Wager')).toBeInTheDocument()
     })
 
-    it('shows the Claim Winnings button in the detail view when the row is opened', async () => {
+    it('shows the Claim Winnings button in the detail view opened from the table view', async () => {
       const user = userEvent.setup()
       await act(async () => {
         renderWithProviders(
@@ -892,9 +894,10 @@ describe('MyMarketsModal', () => {
       })
       await openHistory(user)
 
-      // Expand the card, then open the full detail via "View details".
+      // The full detail is reached from the table view (spec 018): switch to the
+      // table, then click the row.
+      await user.click(screen.getByRole('button', { name: /^table$/i }))
       await user.click(await screen.findByText('Won Wager'))
-      await user.click(await screen.findByRole('button', { name: /view details/i }))
 
       expect(await screen.findByText('Back to list')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /claim winnings/i })).toBeInTheDocument()
@@ -958,6 +961,39 @@ describe('MyMarketsModal', () => {
         const tabpanel = screen.queryByRole('tabpanel')
         expect(tabpanel).toBeInTheDocument()
       })
+    })
+  })
+
+  describe('View toggle (spec 018)', () => {
+    const me = '0x1234567890123456789012345678901234567890'
+    const toggleWager = {
+      id: 'v1', description: 'Toggle Wager', creator: '0xABCDEF1234567890ABCDEF1234567890ABCDEF12',
+      participants: [me], status: 'active', marketType: 'friend',
+      tradingEndTime: BigInt(Math.floor(Date.now() / 1000) + 86400),
+    }
+
+    it('switches between grid and table and hides the density toggle in table view', async () => {
+      const user = userEvent.setup()
+      await act(async () => {
+        renderWithProviders(
+          <MyMarketsModal isOpen onClose={mockOnClose} friendMarkets={[toggleWager]} />
+        )
+      })
+
+      await waitFor(() => expect(screen.getByText('Toggle Wager')).toBeInTheDocument())
+
+      // Grid is the default: the density toggle is shown, no table yet.
+      expect(screen.getByRole('button', { name: /compact/i })).toBeInTheDocument()
+      expect(screen.queryByRole('table')).not.toBeInTheDocument()
+
+      // Switch to table view → a table renders and density is hidden.
+      await user.click(screen.getByRole('button', { name: /^table$/i }))
+      expect(screen.getByRole('table')).toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /compact/i })).not.toBeInTheDocument()
+
+      // Switch back to grid → table is gone.
+      await user.click(screen.getByRole('button', { name: /^grid$/i }))
+      expect(screen.queryByRole('table')).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/test/WagerCard.test.jsx
+++ b/frontend/src/test/WagerCard.test.jsx
@@ -46,7 +46,7 @@ describe('WagerCard (via WagerCardGrid)', () => {
     expect(screen.queryByText('Wager ID')).not.toBeInTheDocument()
   })
 
-  it('expands in place on click, revealing metadata and View details', async () => {
+  it('expands in place on click, revealing metadata (no redundant View details)', async () => {
     const user = userEvent.setup()
     render(<WagerCardGrid {...baseProps} markets={[activeWager()]} />)
     const header = screen.getByText('Lakers ML vs Mike').closest('[role="button"]')
@@ -55,7 +55,8 @@ describe('WagerCard (via WagerCardGrid)', () => {
     expect(header).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByText('Wager ID')).toBeInTheDocument()
     expect(screen.getByText('#1')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /view details/i })).toBeInTheDocument()
+    // spec 018 FR-001: the expanded card IS the detail — no "View details" button.
+    expect(screen.queryByRole('button', { name: /view details/i })).not.toBeInTheDocument()
   })
 
   it('keeps at most one card expanded (accordion)', async () => {
@@ -71,14 +72,28 @@ describe('WagerCard (via WagerCardGrid)', () => {
     expect(a).toHaveAttribute('aria-expanded', 'false')
   })
 
-  it('View details calls onSelect with the wager', async () => {
+  it('lets the user hide and re-show decrypted private terms (spec 018 FR-002)', async () => {
     const user = userEvent.setup()
-    const onSelect = vi.fn()
-    render(<WagerCardGrid {...baseProps} onSelect={onSelect} markets={[activeWager()]} />)
+    const m = activeWager({ isEncrypted: true, decryptedMetadata: { terms: 'Lakers win outright' } })
+    render(<WagerCardGrid {...baseProps} isDecrypting={() => false} markets={[m]} />)
     await user.click(screen.getByText('Lakers ML vs Mike'))
-    await user.click(screen.getByRole('button', { name: /view details/i }))
-    expect(onSelect).toHaveBeenCalledTimes(1)
-    expect(onSelect.mock.calls[0][0].id).toBe('1')
+    // Decrypted terms are visible…
+    expect(screen.getByText('Lakers win outright')).toBeInTheDocument()
+    // …hide them…
+    await user.click(screen.getByRole('button', { name: /^hide$/i }))
+    expect(screen.queryByText('Lakers win outright')).not.toBeInTheDocument()
+    // …and show them again (no re-decryption).
+    await user.click(screen.getByRole('button', { name: /^show$/i }))
+    expect(screen.getByText('Lakers win outright')).toBeInTheDocument()
+  })
+
+  it('offers no hide control for a plain (non-encrypted) wager', async () => {
+    const user = userEvent.setup()
+    const m = activeWager({ decryptedMetadata: { terms: 'Open terms' } })
+    render(<WagerCardGrid {...baseProps} markets={[m]} />)
+    await user.click(screen.getByText('Lakers ML vs Mike'))
+    expect(screen.getByText('Open terms')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^hide$/i })).not.toBeInTheDocument()
   })
 
   it('shows an inline decrypt affordance for an encrypted, undecrypted wager', async () => {

--- a/frontend/src/test/WagerTable.test.jsx
+++ b/frontend/src/test/WagerTable.test.jsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import WagerTable from '../components/fairwins/WagerTable'
+
+vi.mock('../hooks/useWagerActivity', () => ({
+  useWagerActivityOptional: () => ({ actionNeededByWagerId: {} }),
+}))
+
+const ME = '0x1234567890123456789012345678901234567890'
+const OTHER = '0xABCDEF1234567890ABCDEF1234567890ABCDEF12'
+
+const baseProps = {
+  account: ME,
+  getStatusClass: () => 'status-active',
+  getStatusLabel: (s) => (s === 'resolved' ? 'Resolved' : 'Active'),
+  getTimeRemaining: () => '2d',
+  formatDate: () => 'Jun 1, 2026',
+  onSelect: vi.fn(),
+  onView: vi.fn(),
+  onResolve: vi.fn(),
+  onAccept: vi.fn(),
+  onClaim: vi.fn(),
+  onRefund: vi.fn(),
+  onClearExpired: vi.fn(),
+}
+
+const wager = (over = {}) => ({
+  id: '1', marketType: 'friend', description: 'Lakers ML vs Mike',
+  creator: ME, participants: [ME, OTHER], status: 'active', computedStatus: 'active',
+  stakeAmount: '15.0', stakeTokenSymbol: 'USDC', ...over,
+})
+
+describe('WagerTable (spec 018)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders compact rows with wager, amount, date and state columns', () => {
+    render(<WagerTable {...baseProps} markets={[wager()]} />)
+    expect(screen.getByRole('columnheader', { name: 'Wager' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Amount' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Date' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'State' })).toBeInTheDocument()
+    expect(screen.getByText('Lakers ML vs Mike')).toBeInTheDocument()
+    expect(screen.getByText('15.0')).toBeInTheDocument()
+    expect(screen.getByText('Active')).toBeInTheDocument()
+  })
+
+  it('opens the detail view when a row is clicked', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    const onView = vi.fn()
+    render(<WagerTable {...baseProps} onSelect={onSelect} onView={onView} markets={[wager()]} />)
+    await user.click(screen.getByText('Lakers ML vs Mike').closest('tr'))
+    expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(onSelect.mock.calls[0][0].id).toBe('1')
+    expect(onView).toHaveBeenCalledWith(expect.objectContaining({ id: '1' }))
+  })
+
+  it('runs the row action without opening the detail view', async () => {
+    const user = userEvent.setup()
+    const onClaim = vi.fn()
+    const onSelect = vi.fn()
+    const won = wager({ id: '7', status: 'resolved', computedStatus: 'resolved', winner: ME, paid: false })
+    render(<WagerTable {...baseProps} onSelect={onSelect} onClaim={onClaim} showOutcome markets={[won]} />)
+    const row = screen.getByText('Lakers ML vs Mike').closest('tr')
+    await user.click(within(row).getByRole('button', { name: /^claim$/i }))
+    expect(onClaim).toHaveBeenCalledTimes(1)
+    // Clicking the action must not bubble to the row's detail navigation.
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/test/feedNavigation.test.jsx
+++ b/frontend/src/test/feedNavigation.test.jsx
@@ -239,12 +239,6 @@ describe('Feed → wager navigation (spec 012 T018, FR-004/FR-016)', () => {
       fireEvent.click(row)
     })
     expect(activityRef.current.markWagerRead).toHaveBeenCalledWith('42')
-
-    // The full detail view is still reachable via "View details".
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /view details/i }))
-    })
-    expect(await screen.findByRole('button', { name: /back to list/i })).toBeInTheDocument()
   })
 
   it('renders per-tab count badges on the pill tabs (spec 017 FR-016)', async () => {

--- a/specs/018-wager-views-feedback/spec.md
+++ b/specs/018-wager-views-feedback/spec.md
@@ -1,0 +1,78 @@
+# Feature Specification: My Wagers — Views & Privacy Feedback
+
+**Feature Branch**: `claude/wager-views-feedback`
+**Created**: 2026-06-18
+**Status**: Draft
+**Predecessor**: builds on spec 017 (My Wagers card grid), now merged.
+
+**Input**: Post-merge review feedback on the card grid:
+1. The card's "View details" button is redundant — the expanded card already
+   shows the same information as the detail view.
+2. Users must be able to re-hide a private bet's decrypted description to avoid
+   shoulder-surfing exposure after decrypting it.
+3. Provide a table/list view option alongside the grid: minimal columns
+   (wager, amount, date, state, actions); clicking a wager opens its full details.
+4. The view-switch control must sit inline with the refresh and density buttons.
+
+## User Scenarios & Testing
+
+### US1 - Remove the redundant "View details" (P2)
+The expanded grid card is the detail surface; the separate "View details" button
+is removed. The full `MarketDetailView` is still reachable from the table view.
+
+**Acceptance**: Expanding a grid card shows terms/metadata/actions with no
+"View details" button.
+
+### US2 - Re-hide decrypted private terms (P1)
+After decrypting an encrypted ("private") wager, the card shows the terms with a
+control to hide them again; hiding re-conceals the terms text (view-only — the
+data stays decrypted in memory) and offers a "Show terms" control to reveal.
+
+**Acceptance**: Decrypt a private wager → terms visible + "Hide" control →
+clicking hides the terms and shows "Show terms" → clicking reveals them again.
+Hiding is per-card and does not re-trigger decryption.
+
+### US3 - Table view (P1)
+A table/list view presents wagers in compact rows — wager, amount, date, state,
+actions — mirroring the pre-redesign table. Clicking a row (not an action) opens
+the wager's full detail view. All inline actions behave as in the grid.
+
+**Acceptance**: Switch to table view → wagers render as rows with those columns →
+clicking a row opens the detail view → action buttons run the existing flows.
+
+### US4 - View toggle placement (P2)
+A Grid/Table toggle sits in the toolbar inline with the density and refresh
+controls. The chosen view is remembered for the session. The density toggle is
+only shown in grid view (it has no effect on the table).
+
+**Acceptance**: The Grid/Table toggle renders next to refresh/density; switching
+persists for the session.
+
+## Requirements
+
+- **FR-001**: The grid card MUST NOT render a "View details" button; the expanded
+  card is the detail surface for grid view.
+- **FR-002**: For an encrypted wager whose terms have been decrypted, the card
+  MUST provide a control to hide the terms again and to re-show them, without
+  re-running decryption. Hiding is per-card and view-only.
+- **FR-003**: The view MUST offer a table view with columns wager, amount, date,
+  state, and actions; a row click (outside an action control) MUST open the
+  wager's full detail view (`MarketDetailView`).
+- **FR-004**: The table view MUST surface the same contextual actions as the grid
+  (accept/resolve/claim/refund/reclaim/respond-to-draw) wired to the existing
+  handlers, with no change to on-chain semantics.
+- **FR-005**: A Grid/Table view toggle MUST be placed inline with the refresh and
+  density controls; the selected view MUST persist for the session.
+- **FR-006**: The density toggle MUST only be shown in grid view.
+- **FR-007**: All preserved My Wagers behavior (tabs, filters, sort, empty states,
+  network scoping, expired handling, decryption flow) MUST continue to work in
+  both views.
+
+## Assumptions
+- Default view is grid (current behavior); view + density persist via
+  sessionStorage, matching spec 017's density approach.
+- "Private bets" = encrypted wagers; the hide/show control only appears once such
+  a wager is decrypted (plain wagers have nothing to hide).
+- Table view reaches details via row click (replacing the grid's removed
+  "View details"); the grid reaches details via inline expansion.
+- Frontend-only; no contract/ABI/subgraph changes.


### PR DESCRIPTION
## Summary

Implements the four post-merge feedback items on the My Wagers card grid (spec 017, #702). **Frontend-only — no contract/ABI/subgraph changes.**

| # | Feedback | Change |
|---|----------|--------|
| 1 | "View details" button is redundant — the expanded card shows the same info | Removed the button from the grid card; the expanded card **is** the detail surface. The full detail view is now reached from the table view. |
| 2 | Users need to re-hide a private bet's description after decrypting | Added a per-card **Hide / Show** toggle for decrypted private (encrypted) terms — view-only re-conceal, no re-decryption. Plain wagers have no toggle (nothing to hide). |
| 3 | Need a table view alongside the grid | New compact **table view** (Wager / Amount / Date / State / Actions); clicking a row opens the wager's full detail view. Grid & table share one view-model builder (`wagerVm.js`) so status/metadata/actions stay identical. |
| 4 | View-switch buttons should be inline with refresh + view buttons | Added a **Grid / Table** segmented toggle inline with the density and refresh controls; selection persists for the session. Density toggle now only shows in grid view. |

## Implementation notes

- `wagerVm.js` — extracted the shared per-wager view model (status, metadata, encryption state, contextual actions) so `WagerCardGrid` and the new `WagerTable` can't drift.
- `WagerList.jsx` — thin grid/table switch the modal renders at its four call sites.
- Detail navigation: grid = inline expansion (no detail nav); table = row-click → `MarketDetailView`. Both reuse the existing on-chain action handlers — no semantics change.
- Session prefs: `fairwins.myWagers.view` (default grid) joins the existing density key.

## Verification

- **Vitest: 1346/1346 pass** — added `WagerTable.test.jsx`, grid view-toggle + hide/show-terms tests; migrated the affected `WagerCard`/`MyMarketsModal`/`feedNavigation` tests off the removed "View details".
- **ESLint: clean.**
- **Scope check:** no `contracts/`, ABI, or subgraph files touched.
- Cypress **fast lane** (`13-dashboard`) updated so the detail-view check uses the table view. Full-tier Cypress selectors remain aligned but need a live-env verification run (no Hardhat/wallet in CI sandbox).

Spec for traceability: `specs/018-wager-views-feedback/spec.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyzbjKGZZuUFzgFM4v3Yto

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyzbjKGZZuUFzgFM4v3Yto)_