### PR TITLE
feat(019): My Wagers automatic views, auto-refresh & full-width tabs

### DIFF
--- a/frontend/cypress/e2e/fast/13-dashboard.cy.js
+++ b/frontend/cypress/e2e/fast/13-dashboard.cy.js
@@ -147,9 +147,8 @@ describe('Dashboard', () => {
     cy.get('.quick-action-card').contains('My Wagers').click()
     cy.get('[role="dialog"], .my-markets-modal', { timeout: 5000 }).should('be.visible')
 
-    // The full detail view is reached from the table view (spec 018): switch to
-    // the table, then click a row.
-    cy.contains('button', /^Table$/).click()
+    // At the default 1280px viewport the table view renders automatically
+    // (spec 019); clicking a row opens the full detail view.
     cy.get('.mm-panel, [role="tabpanel"]').then(($panel) => {
       const rows = $panel.find('.mm-table-row, tr[role="button"]')
       if (rows.length > 0) {
@@ -176,7 +175,7 @@ describe('Dashboard', () => {
 
     // Check across all tabs that status badges exist and have the right classes.
     cy.get('.mm-panel, [role="tabpanel"]').then(($panel) => {
-      const badges = $panel.find('.wc-status')
+      const badges = $panel.find('.wc-status, .mm-status-badge')
       if (badges.length > 0) {
         // Every badge should have a status-* class.
         badges.each((_, el) => {
@@ -315,6 +314,8 @@ describe('Dashboard', () => {
   // DSH-13: Decrypt encrypted wager in list
   // ---------------------------------------------------------------------------
   it('[DSH-13] Decrypt encrypted wager in list', () => {
+    // Narrow viewport → compact card grid (spec 019), where decrypt is inline.
+    cy.viewport(390, 844)
     connectAndVisitDashboard()
 
     // Open My Wagers.
@@ -366,6 +367,8 @@ describe('Dashboard', () => {
    * matching the wallet-disconnected-from-node scenario in production caches.
    */
   function seedFriendMarketsAndOpen(markets) {
+    // Narrow viewport → compact card grid (spec 019); these checks expand cards.
+    cy.viewport(390, 844)
     connectAndVisitDashboard()
     cy.window().then((win) => {
       win.localStorage.setItem('friendMarkets', JSON.stringify(markets))

--- a/frontend/src/components/fairwins/MyMarketsModal.css
+++ b/frontend/src/components/fairwins/MyMarketsModal.css
@@ -159,9 +159,12 @@
 }
 
 .mm-tab {
-  flex: 0 0 auto;
+  /* Spec 019: tabs span the full width, sharing the row evenly. */
+  flex: 1 1 0;
+  min-width: 0;
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 0.5rem;
   padding: 0.55rem 0.875rem;
   margin-bottom: 0.75rem;

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -4,8 +4,9 @@ import { useWallet, useWeb3 } from '../../hooks'
 import { useLazyMarketDecryption } from '../../hooks/useEncryption'
 import { useLazyIpfsEnvelope } from '../../hooks/useIpfs'
 import { useWagerActivityOptional } from '../../hooks/useWagerActivity'
+import { useMediaQuery } from '../../hooks/useMediaQuery'
 import { useFriendMarkets } from '../../contexts/FriendMarketsContext.js'
-import { WagerStatus as MarketStatus, DisputeStatus, WAGER_DEFAULTS, MyWagersDensity, MY_WAGERS_DENSITY_KEY, MyWagersView, MY_WAGERS_VIEW_KEY } from '../../constants/wagerDefaults'
+import { WagerStatus as MarketStatus, DisputeStatus, WAGER_DEFAULTS, MyWagersDensity, MyWagersView } from '../../constants/wagerDefaults'
 import { getContractAddressForChain } from '../../config/contracts'
 import { getNetwork } from '../../config/networks'
 import { WAGER_REGISTRY_ABI } from '../../abis/WagerRegistry'
@@ -91,37 +92,11 @@ function MyMarketsModal({
   const [sortKey, setSortKey] = useState('newest') // 'newest' | 'endingSoon' | 'stakeHighToLow'
   const [statusFilter, setStatusFilter] = useState('all')
 
-  // Card-grid density (spec 017). Session-scoped: read once from sessionStorage,
-  // default compact; mirrored back on toggle so it survives reopening the modal.
-  const [density, setDensity] = useState(() => {
-    try {
-      const saved = sessionStorage.getItem(MY_WAGERS_DENSITY_KEY)
-      return saved === MyWagersDensity.COMFORTABLE ? MyWagersDensity.COMFORTABLE : MyWagersDensity.COMPACT
-    } catch {
-      return MyWagersDensity.COMPACT
-    }
-  })
-  const toggleDensity = useCallback(() => {
-    setDensity(prev => {
-      const next = prev === MyWagersDensity.COMFORTABLE ? MyWagersDensity.COMPACT : MyWagersDensity.COMFORTABLE
-      try { sessionStorage.setItem(MY_WAGERS_DENSITY_KEY, next) } catch { /* storage unavailable */ }
-      return next
-    })
-  }, [])
-
-  // View mode (spec 018): grid cards vs compact table. Session-scoped, default grid.
-  const [viewMode, setViewMode] = useState(() => {
-    try {
-      const saved = sessionStorage.getItem(MY_WAGERS_VIEW_KEY)
-      return saved === MyWagersView.TABLE ? MyWagersView.TABLE : MyWagersView.GRID
-    } catch {
-      return MyWagersView.GRID
-    }
-  })
-  const selectView = useCallback((mode) => {
-    setViewMode(mode)
-    try { sessionStorage.setItem(MY_WAGERS_VIEW_KEY, mode) } catch { /* storage unavailable */ }
-  }, [])
+  // Automatic view selection (spec 019): wide displays get the table, narrow
+  // displays get the compact card grid. No manual view/density toggle.
+  const isWideViewport = useMediaQuery('(min-width: 768px)')
+  const viewMode = isWideViewport ? MyWagersView.TABLE : MyWagersView.GRID
+  const density = MyWagersDensity.COMPACT
 
   // Transient confirmation toast (spec 017 FR-015) shown after a successful
   // on-chain action (claim/refund). Auto-dismisses.
@@ -134,6 +109,15 @@ function MyMarketsModal({
     const id = setTimeout(() => setToast(null), 2600)
     return () => clearTimeout(id)
   }, [toast])
+
+  // Auto-refresh (spec 019 FR-003/004): keep the list current while the modal is
+  // open so users don't need a manual refresh button. Pulls fresh on-chain data
+  // via the FriendMarkets context every 30s; stops on close/unmount.
+  useEffect(() => {
+    if (!isOpen || !account || typeof refreshFriendMarkets !== 'function') return
+    const id = setInterval(() => { refreshFriendMarkets() }, 30000)
+    return () => clearInterval(id)
+  }, [isOpen, account, refreshFriendMarkets])
 
   const handleDecryptMarket = useCallback(async (marketId) => {
     try {
@@ -944,62 +928,6 @@ function MyMarketsModal({
               <option value={MarketStatus.EXPIRED}>Expired</option>
             </select>
           </div>
-          {/* View switch (spec 018) — inline with density + refresh */}
-          <div className="mm-view-toggle" role="group" aria-label="Wager view">
-            <button
-              type="button"
-              className={`mm-view-btn ${viewMode === MyWagersView.GRID ? 'active' : ''}`}
-              onClick={() => selectView(MyWagersView.GRID)}
-              aria-pressed={viewMode === MyWagersView.GRID}
-              title="Grid view"
-            >
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/>
-                <rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/>
-              </svg>
-              Grid
-            </button>
-            <button
-              type="button"
-              className={`mm-view-btn ${viewMode === MyWagersView.TABLE ? 'active' : ''}`}
-              onClick={() => selectView(MyWagersView.TABLE)}
-              aria-pressed={viewMode === MyWagersView.TABLE}
-              title="Table view"
-            >
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
-              </svg>
-              Table
-            </button>
-          </div>
-          {viewMode === MyWagersView.GRID && (
-            <button
-              type="button"
-              className="mm-density-toggle"
-              onClick={toggleDensity}
-              title={density === MyWagersDensity.COMFORTABLE ? 'Switch to compact view' : 'Switch to comfortable view'}
-              aria-pressed={density === MyWagersDensity.COMFORTABLE}
-            >
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
-                {density === MyWagersDensity.COMFORTABLE
-                  ? <path d="M3 5h18M3 12h18M3 19h18" />
-                  : <path d="M3 5h18M3 10h18M3 15h18M3 20h18" />}
-              </svg>
-              {density === MyWagersDensity.COMFORTABLE ? 'Comfortable' : 'Compact'}
-            </button>
-          )}
-          <button
-            className="mm-refresh-btn"
-            onClick={fetchMarketsData}
-            disabled={loading}
-            title="Refresh wagers"
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className={loading ? 'spinning' : ''}>
-              <path d="M23 4v6h-6"/>
-              <path d="M1 20v-6h6"/>
-              <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"/>
-            </svg>
-          </button>
         </div>
 
         {/* Content Area */}

--- a/frontend/src/test/MyMarketsModal.test.jsx
+++ b/frontend/src/test/MyMarketsModal.test.jsx
@@ -144,10 +144,27 @@ describe('MyMarketsModal', () => {
     )
   }
 
+  // Spec 019: the view is chosen by viewport. Default the matchMedia mock to
+  // "narrow" (no min-width match) → grid; setWideViewport() forces the table.
+  const setWideViewport = (wide) => {
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: wide && /min-width/.test(query),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
-    // Reset session-scoped UI prefs (view/density) so test order can't leak them.
+    // Reset session-scoped UI prefs so test order can't leak them.
     try { sessionStorage.clear() } catch { /* no-op */ }
+    // Default to narrow viewport (grid) for every test unless it opts into wide.
+    setWideViewport(false)
     // Mock window.ethereum to avoid provider creation errors
     global.window.ethereum = undefined
     useWallet.mockReturnValue({
@@ -338,7 +355,7 @@ describe('MyMarketsModal', () => {
       expect(optionValues).toEqual(['newest', 'endingSoon', 'stakeHighToLow'])
     })
 
-    it('should display refresh button', async () => {
+    it('no longer shows a manual refresh button (auto-refresh, spec 019)', async () => {
       await act(async () => {
         renderWithProviders(
           <MyMarketsModal isOpen={true} onClose={mockOnClose} />
@@ -346,8 +363,9 @@ describe('MyMarketsModal', () => {
       })
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /refresh/i })).toBeInTheDocument()
+        expect(screen.getByText('Sort:')).toBeInTheDocument()
       })
+      expect(screen.queryByRole('button', { name: /refresh/i })).not.toBeInTheDocument()
     })
   })
 
@@ -885,8 +903,10 @@ describe('MyMarketsModal', () => {
       expect(screen.getByText('Won Wager')).toBeInTheDocument()
     })
 
-    it('shows the Claim Winnings button in the detail view opened from the table view', async () => {
+    it('shows the Claim Winnings button in the detail view opened from the table row', async () => {
       const user = userEvent.setup()
+      // Wide viewport → table view renders automatically (spec 019).
+      setWideViewport(true)
       await act(async () => {
         renderWithProviders(
           <MyMarketsModal isOpen onClose={mockOnClose} friendMarkets={[resolvedWon()]} />
@@ -894,9 +914,7 @@ describe('MyMarketsModal', () => {
       })
       await openHistory(user)
 
-      // The full detail is reached from the table view (spec 018): switch to the
-      // table, then click the row.
-      await user.click(screen.getByRole('button', { name: /^table$/i }))
+      // The full detail is reached by clicking a table row.
       await user.click(await screen.findByText('Won Wager'))
 
       expect(await screen.findByText('Back to list')).toBeInTheDocument()
@@ -964,36 +982,58 @@ describe('MyMarketsModal', () => {
     })
   })
 
-  describe('View toggle (spec 018)', () => {
+  describe('Automatic view by viewport (spec 019)', () => {
     const me = '0x1234567890123456789012345678901234567890'
-    const toggleWager = {
+    const aWager = {
       id: 'v1', description: 'Toggle Wager', creator: '0xABCDEF1234567890ABCDEF1234567890ABCDEF12',
       participants: [me], status: 'active', marketType: 'friend',
       tradingEndTime: BigInt(Math.floor(Date.now() / 1000) + 86400),
     }
 
-    it('switches between grid and table and hides the density toggle in table view', async () => {
-      const user = userEvent.setup()
+    it('renders the compact card grid on a narrow viewport (no table, no toggles)', async () => {
+      setWideViewport(false)
       await act(async () => {
         renderWithProviders(
-          <MyMarketsModal isOpen onClose={mockOnClose} friendMarkets={[toggleWager]} />
+          <MyMarketsModal isOpen onClose={mockOnClose} friendMarkets={[aWager]} />
         )
       })
-
       await waitFor(() => expect(screen.getByText('Toggle Wager')).toBeInTheDocument())
-
-      // Grid is the default: the density toggle is shown, no table yet.
-      expect(screen.getByRole('button', { name: /compact/i })).toBeInTheDocument()
       expect(screen.queryByRole('table')).not.toBeInTheDocument()
+      // No manual view/density/refresh controls remain.
+      expect(screen.queryByRole('button', { name: /^grid$/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /^table$/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /compact|comfortable/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /refresh/i })).not.toBeInTheDocument()
+    })
 
-      // Switch to table view → a table renders and density is hidden.
-      await user.click(screen.getByRole('button', { name: /^table$/i }))
+    it('renders the table on a wide viewport', async () => {
+      setWideViewport(true)
+      await act(async () => {
+        renderWithProviders(
+          <MyMarketsModal isOpen onClose={mockOnClose} friendMarkets={[aWager]} />
+        )
+      })
+      await waitFor(() => expect(screen.getByText('Toggle Wager')).toBeInTheDocument())
       expect(screen.getByRole('table')).toBeInTheDocument()
-      expect(screen.queryByRole('button', { name: /compact/i })).not.toBeInTheDocument()
+    })
 
-      // Switch back to grid → table is gone.
-      await user.click(screen.getByRole('button', { name: /^grid$/i }))
-      expect(screen.queryByRole('table')).not.toBeInTheDocument()
+    it('auto-refreshes the list on an interval while open (FR-003/004)', async () => {
+      vi.useFakeTimers()
+      const refresh = vi.fn()
+      try {
+        await act(async () => {
+          renderWithProviders(
+            <MyMarketsModal isOpen onClose={mockOnClose} />,
+            { friendMarketsContext: { ...defaultFriendMarketsContext, refresh } }
+          )
+        })
+        expect(refresh).not.toHaveBeenCalled()
+        // After the poll interval the list pulls fresh data on its own.
+        await act(async () => { vi.advanceTimersByTime(30000) })
+        expect(refresh).toHaveBeenCalled()
+      } finally {
+        vi.useRealTimers()
+      }
     })
   })
 })

--- a/specs/019-wager-auto-views/spec.md
+++ b/specs/019-wager-auto-views/spec.md
@@ -1,0 +1,61 @@
+# Feature Specification: My Wagers — Automatic Views & Simplification
+
+**Feature Branch**: `claude/wager-auto-views`
+**Created**: 2026-06-18
+**Status**: Draft
+**Predecessor**: builds on specs 017 & 018 (My Wagers card grid + table view), merged.
+
+**Input**: Iteration feedback to automate and simplify My Wagers:
+1. Small displays always use compact cards; wider displays use the table — chosen
+   automatically by viewport, removing the manual Grid/Table and density toggles.
+2. The list auto-refreshes, so the manual refresh button is removed.
+3. The tab strip spans the full width so the tabs are not cramped.
+
+## User Scenarios & Testing
+
+### US1 - Automatic view by viewport (P1)
+The view is chosen by screen width: narrow/mobile → compact card grid; wide
+desktop → table. No manual Grid/Table toggle and no density toggle.
+
+**Acceptance**: At a narrow width the grid (compact cards) renders; at a wide
+width the table renders; resizing across the breakpoint switches the view with no
+user control involved.
+
+### US2 - Auto-refresh (P2)
+The wager list refreshes itself on an interval while the modal is open, so the
+manual refresh button is removed.
+
+**Acceptance**: The refresh button is gone; the list re-fetches periodically while
+open and stops when closed.
+
+### US3 - Full-width tabs (P3)
+The tab strip (Participating / Created / Arbitrating / History) stretches across
+the available width so tabs are evenly spaced, not cramped to the left.
+
+**Acceptance**: Tabs fill the width with equal share; the active tab is still
+clearly indicated.
+
+## Requirements
+
+- **FR-001**: The view MUST be selected automatically from viewport width — below
+  the breakpoint the compact card grid; at/above it the table — with no manual
+  view or density toggle in the UI.
+- **FR-002**: On small displays the card grid MUST render in compact density.
+- **FR-003**: The wager list MUST auto-refresh on an interval while the modal is
+  open, and the manual refresh button MUST be removed.
+- **FR-004**: Auto-refresh MUST stop when the modal closes/unmounts.
+- **FR-005**: The tab strip MUST span the full toolbar width with tabs sharing the
+  space evenly.
+- **FR-006**: All preserved My Wagers behavior (tabs, filters, sort, empty states,
+  network scoping, expired handling, decryption flow, inline actions, hide/show
+  terms, row-click → detail in table) MUST continue to work.
+
+## Assumptions
+- Breakpoint: 768px (reuses the app's existing `useMediaQuery`/mobile breakpoint).
+  ≥768px → table; <768px → compact grid.
+- Auto-refresh interval: 30s (on-chain data; avoids hammering RPC), via the
+  existing FriendMarkets refresh; pauses with the modal closed.
+- Removing the manual toggles is intended simplification (per the annotated
+  feedback) — view is fully automatic; session-persisted view/density prefs from
+  spec 018 are dropped.
+- Frontend-only; no contract/ABI/subgraph changes.


### PR DESCRIPTION
## Summary

Automates and simplifies the My Wagers experience per the latest iteration feedback. **Frontend-only — no contract/ABI/subgraph changes.**

| # | Feedback | Change |
|---|----------|--------|
| 1 | Small displays should always use compact cards; wider displays the table | View is now selected **automatically by viewport** via `useMediaQuery('(min-width: 768px)')` — `<768px` → compact card grid, `≥768px` → table. The manual **Grid/Table** and **density** toggles are removed. |
| 2 | The table should auto-refresh so the user doesn't need the button | The list **auto-refreshes every 30s** while the modal is open (via the existing FriendMarkets refresh) and stops on close. The manual **refresh button is removed**. |
| 3 | The 3/4 tabs look cramped | The tab strip now **spans the full width** (`flex: 1`), with tabs evenly sharing the row. |

## Notes

- Breakpoint 768px reuses the app's existing responsive hook.
- The session-persisted view/density prefs from #706 are dropped — the view is fully automatic now (intended simplification per the annotated screenshot).
- `fetchMarketsData` (on open + after actions) and all inline actions, hide/show terms, and table row→detail behavior are unchanged.

## Verification

- **Vitest: 1357/1357 pass** — added tests for narrow→grid / wide→table auto-selection and the 30s auto-refresh interval; updated the toolbar tests for the removed controls.
- **ESLint: clean.** No `contracts/`, ABI, or subgraph files touched.
- Cypress **fast lane** (`13-dashboard`) made viewport-deterministic (narrow for card flows, default 1280px for the table detail flow). Full-tier Cypress still needs a live-env verification run (no Hardhat/wallet in CI sandbox).

Spec: `specs/019-wager-auto-views/spec.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyzbjKGZZuUFzgFM4v3Yto

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyzbjKGZZuUFzgFM4v3Yto)_