### PR TITLE
fix(landing): default landing header to dark mode

### DIFF
--- a/frontend/src/components/Header.css
+++ b/frontend/src/components/Header.css
@@ -10,6 +10,17 @@
   transition: background 0.3s ease, border-color 0.3s ease;
 }
 
+/* Landing page header defaults to a dark appearance so it blends with the
+   dark hero section instead of contrasting against it. Overriding the theme
+   variables the header consumes keeps nav links, the hamburger and the mobile
+   nav consistently dark regardless of the active light/dark theme. */
+.landing-page .site-header {
+  --bg-secondary: #0a0f1a;
+  --text-primary: #E6EDF3;
+  --border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+}
+
 .header-container {
   max-width: 1400px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary

On the landing page, the sticky header rendered with the active light theme's white surface (`--bg-secondary: #FFFFFF`), which contrasted sharply against the dark hero section (`#0a0f1a`) directly below it — the first thing visitors see on load.

This scopes a dark appearance to the **landing-page header only**, so it blends with the hero instead of standing out, as requested.

## Change

- Add a `.landing-page .site-header` override in `Header.css` that redefines the theme variables the header consumes (`--bg-secondary`, `--text-primary`, `--border-color`) with dark values, plus a slightly stronger shadow.
- Because the override targets the CSS variables, the nav links, hamburger icon, and mobile nav all pick up the dark styling consistently — no per-element changes needed.
- Scope is limited to the landing page; the in-app header and global light/dark theming are untouched.

## Testing

- `npx vitest run src/test/LandingPage.oracle.test.jsx` — passes (2/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGxw4SehEJdZDvDBN3PBBV)_