### PR TITLE
fix(account-stats): correct declined-wager P&L and wire real USDC wallet balance

### DIFF
--- a/frontend/src/hooks/useAccountStats.js
+++ b/frontend/src/hooks/useAccountStats.js
@@ -13,6 +13,7 @@
  * Updates are polling-based — no websockets. See research.md R5.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Contract, formatUnits } from 'ethers'
 import { useWallet } from './useWalletManagement'
 import usePriceConversion from './usePriceConversion'
 import { useChainTokens } from './useChainTokens'
@@ -29,8 +30,27 @@ import {
 
 const POLL_MS = 60_000
 
+const ERC20_BALANCE_ABI = ['function balanceOf(address) view returns (uint256)']
+
 function emptyFreshness() {
   return { lastUpdated: null, status: 'refreshing' }
+}
+
+/**
+ * Read the connected wallet's stablecoin balance in human units. The wallet
+ * context only tracks the native balance, so the dashboard's "Wallet Balance"
+ * tile would otherwise omit the user's USDC — the very token wagers are staked
+ * in. Best-effort: a read failure returns null and leaves the tile unchanged.
+ */
+async function fetchStableBalance({ provider, address, stableAddress, stableDecimals }) {
+  if (!provider || !address || !stableAddress) return null
+  try {
+    const token = new Contract(stableAddress, ERC20_BALANCE_ABI, provider)
+    const raw = await token.balanceOf(address)
+    return Number(formatUnits(raw, stableDecimals ?? 6))
+  } catch {
+    return null
+  }
 }
 
 async function loadAllWagers(repository, account) {
@@ -52,12 +72,13 @@ async function loadAllWagers(repository, account) {
 
 export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
   const wallet = useWallet() || {}
-  const { address, chainId, isConnected, balances, refreshBalances } = wallet
+  const { address, chainId, isConnected, balances, refreshBalances, provider } = wallet
   const { convertToUsd } = usePriceConversion()
   const tokens = useChainTokens()
 
   const [range, setRange] = useState(initialRange)
   const [wagers, setWagers] = useState([])
+  const [stableBalance, setStableBalance] = useState(null)
   const [valuedTransfers, setValuedTransfers] = useState([])
   const [tokenMetaByAddress, setTokenMetaByAddress] = useState({})
   const [isLoading, setIsLoading] = useState(false)
@@ -76,6 +97,7 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
     if (!isConnected || !address) {
       setWagers([])
       setValuedTransfers([])
+      setStableBalance(null)
       setIsLoading(false)
       return
     }
@@ -91,9 +113,15 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
     try {
       const repository = getDefaultWagerRepository()
       const ds = createReportDataSource({ chainId })
-      const [loadedWagers, rawTransfers] = await Promise.all([
+      const [loadedWagers, rawTransfers, stable] = await Promise.all([
         loadAllWagers(repository, address),
         ds.listTransfers({ account: address }),
+        fetchStableBalance({
+          provider,
+          address,
+          stableAddress: tokens.stableAddress,
+          stableDecimals: tokens.stableDecimals,
+        }),
       ])
       if (reqId !== reqIdRef.current) return
 
@@ -101,6 +129,7 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
       if (reqId !== reqIdRef.current) return
 
       setWagers(loadedWagers)
+      if (stable != null) setStableBalance(stable)
       setValuedTransfers(transfers)
       setTokenMetaByAddress(meta)
       setIsSupportedNetwork(true)
@@ -124,7 +153,7 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
     } finally {
       if (reqId === reqIdRef.current) setIsLoading(false)
     }
-  }, [isConnected, address, chainId])
+  }, [isConnected, address, chainId, provider, tokens.stableAddress, tokens.stableDecimals])
 
   // Reload on connect / account / network change.
   useEffect(() => {
@@ -157,14 +186,15 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
       usd += nUsd
       rows.push({ symbol: tokens.native || 'NATIVE', amount: nativeAmt, usdValue: nUsd })
     }
-    // Stablecoin balance (par $1) when the wallet context exposes it.
-    const stableAmt = Number(balances?.stable ?? balances?.tokens?.[tokens.stableAddress]) || 0
+    // Stablecoin balance (par $1) read directly from the token contract — the
+    // wallet context only tracks native, so this is the wager-staking balance.
+    const stableAmt = Number(stableBalance) || 0
     if (stableAmt > 0) {
       usd += stableAmt
       rows.push({ symbol: tokens.stable || 'STABLE', amount: stableAmt, usdValue: stableAmt })
     }
     return { walletBalanceUsd: usd, walletBalances: rows }
-  }, [balances, convertToUsd, tokens.native, tokens.stable, tokens.stableAddress])
+  }, [balances, convertToUsd, stableBalance, tokens.native, tokens.stable])
 
   // ---- Derived view models ----
   const wagerStatusById = useMemo(() => {

--- a/subgraph/src/mappings/wagerRegistry.ts
+++ b/subgraph/src/mappings/wagerRegistry.ts
@@ -187,6 +187,12 @@ export function handleWagerDeclined(event: WagerDeclined): void {
   if (wager == null) return
   wager.status = 'declined'
   wager.save()
+
+  // Declining an open wager refunds the creator their stake on-chain
+  // (WagerRegistry.declineWager → token.safeTransfer(creator, creatorStake)).
+  // Only the creator ever deposited, so record one refund row — without it the
+  // creator's deposit looks like an unrecovered loss in P&L/activity reporting.
+  recordTransfer(event, id, wager.creator, REFUND, wager.token, wager.creatorStake, event.address, wager.creator)
 }
 
 export function handleDrawProposed(event: DrawProposed): void {

--- a/subgraph/tests/wagerRegistry.test.ts
+++ b/subgraph/tests/wagerRegistry.test.ts
@@ -245,6 +245,12 @@ describe('US2: WagerTransfer records', () => {
     // One deposit row from creation so far.
     assert.entityCount('WagerTransfer', 1)
     let event = declined(16)
+    // The decline happens in a different transaction than creation; give it a
+    // distinct hash so the refund row doesn't share the deposit's transfer id
+    // (newMockEvent reuses one default txHash/logIndex across mock events).
+    event.transaction.hash = Bytes.fromHexString(
+      '0x00000000000000000000000000000000000000000000000000000000deadbeef',
+    )
     handleWagerDeclined(event)
     // Decline refunds the creator their stake — a second (refund) row.
     assert.entityCount('WagerTransfer', 2)

--- a/subgraph/tests/wagerRegistry.test.ts
+++ b/subgraph/tests/wagerRegistry.test.ts
@@ -239,4 +239,20 @@ describe('US2: WagerTransfer records', () => {
     assert.fieldEquals('WagerTransfer', id, 'direction', 'refund')
     assert.fieldEquals('WagerTransfer', id, 'amount', '1000')
   })
+
+  test('WagerDeclined emits one refund row (creator only) for the returned stake', () => {
+    handleWagerCreated(created(16))
+    // One deposit row from creation so far.
+    assert.entityCount('WagerTransfer', 1)
+    let event = declined(16)
+    handleWagerDeclined(event)
+    // Decline refunds the creator their stake — a second (refund) row.
+    assert.entityCount('WagerTransfer', 2)
+    let id = transferId(event, CREATOR)
+    assert.fieldEquals('WagerTransfer', id, 'direction', 'refund')
+    assert.fieldEquals('WagerTransfer', id, 'party', CREATOR.toHexString())
+    assert.fieldEquals('WagerTransfer', id, 'amount', '1000')
+    assert.fieldEquals('WagerTransfer', id, 'from', event.address.toHexString())
+    assert.fieldEquals('WagerTransfer', id, 'to', CREATOR.toHexString())
+  })
 })


### PR DESCRIPTION
## Problem

The new **My Account** stats dashboard (spec 020) showed figures that don't match the wallet's true on-chain values — most visibly a **Net P&L of −$15** driven by a large "Deposit" in Recent Activity with **no matching Refund**, and a **Wallet Balance of $0**.

Root-causing against the contracts and subgraph turned up two genuine "not wired to real data" bugs.

## Fixes

### 1. Declined wagers recorded a phantom loss (subgraph)

On-chain, `WagerRegistry.declineWager()` refunds the creator their full stake — `token.safeTransfer(creator, creatorStake)` — exactly like `cancelOpen()`. But the subgraph's `handleWagerDeclined` only set `status = 'declined'` and **never recorded the refund `WagerTransfer`**. `handleWagerCancelled` *does* record its refund.

Consequence on the dashboard, which derives realized P&L purely from the transfer stream:
- the creator's deposit looked unrecovered → **realized Net P&L understated by the declined stake**
- the refund never appeared in **Recent Activity**

This exactly explains the screenshots: a declined ~$15 stake shows a $15 deposit with no offsetting refund, pinning Net P&L at −$15. `handleWagerDeclined` now records the creator's refund (mirroring `handleWagerCancelled`), so a declined wager nets to $0 in realized P&L and the refund shows in the feed.

> Note: the live hosted subgraph must be redeployed and re-synced for the corrected history to reach production.

### 2. Wallet Balance omitted USDC (frontend)

The wallet context only tracks the **native** balance. The dashboard read `balances.stable` / `balances.tokens[stableAddress]`, which are never populated (and `getTokenBalance` mis-formats USDC at 18 decimals instead of 6). So the user's USDC — the token wagers are actually staked in — never counted, leaving Wallet Balance at $0.

`useAccountStats` now reads the stablecoin balance directly from the token contract with the correct decimals, alongside the other feeds, so it refreshes on poll and manual refresh.

## Testing

- `subgraph`: added a matchstick test asserting `WagerDeclined` emits one creator refund row (amount/party/from/to). `graph build` compiles the mapping to WASM successfully. (The `graph test` binary download is blocked by the sandbox network policy, so the suite couldn't be executed here.)
- `frontend`: `vitest run` for `src/test/account` + `src/test/reports` — **138 passing**; ESLint clean on the changed hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHvH27vD3j81CNeWPJkD3z

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHvH27vD3j81CNeWPJkD3z)_