### PR TITLE
feat(notifications): source draw proposals from the subgraph (remove the last eth_getLogs)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,7 +22,7 @@ steps:
       # for production traffic, publish to the decentralized net + proxy the keyed
       # gateway URL via nginx (see the VITE_PINATA_JWT pattern).
       - '--build-arg'
-      - 'VITE_SUBGRAPH_URL=https://api.studio.thegraph.com/query/1755381/fairwins-amoy/v0.1.0'
+      - 'VITE_SUBGRAPH_URL=https://api.studio.thegraph.com/query/1755381/fairwins-amoy/v0.2.0'
       - '--build-arg'
       - 'VITE_WAGER_SOURCE=subgraph'
       - '-t'

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -28,8 +28,8 @@ VITE_NETWORK_ID=137
 # report, which reads each transfer's txHash from the index and fetches only one
 # transaction receipt per transfer (for the gas fee). Set the URL matching the
 # selected chain; one subgraph is deployed per network:
-#   Polygon (137):   https://api.studio.thegraph.com/query/1755381/fairwins-polygon/v0.1.0
-#   Amoy (80002):    https://api.studio.thegraph.com/query/1755381/fairwins-amoy/v0.1.0
+#   Polygon (137):   https://api.studio.thegraph.com/query/1755381/fairwins-polygon/v0.2.0
+#   Amoy (80002):    https://api.studio.thegraph.com/query/1755381/fairwins-amoy/v0.2.0
 #   Mordor (63):     <indexer-url-if-available; else leave unset to use the RPC fallback>
 # (Above are the Studio dev query endpoints from the v0.1.0 deploy; rate-limited.
 #  For production, publish to the decentralized network and use the gateway URL.)

--- a/frontend/src/contexts/WagerActivityContext.jsx
+++ b/frontend/src/contexts/WagerActivityContext.jsx
@@ -29,7 +29,7 @@ import {
 import { diffWagers } from '../data/notifications/diffEngine'
 import { deriveActionNeeded } from '../data/notifications/derivedState'
 import { computeDeadlineWarnings } from '../data/notifications/deadlineWarnings'
-import { scanDrawProposals } from '../data/notifications/drawProposalScan'
+import { fetchDrawProposals } from '../data/notifications/drawProposalScan'
 
 const MAX_TOASTS_PER_CYCLE = 3
 const TOAST_DURATION_MS = 6000
@@ -37,7 +37,7 @@ const TOAST_DURATION_MS = 6000
 export function WagerActivityProvider({
   children,
   fetchWagers = fetchFriendMarketsForUser,
-  scanProposals = scanDrawProposals,
+  scanProposals = fetchDrawProposals,
 }) {
   const { account: rawAccount, chainId } = useWallet()
   const { showNotification } = useNotification()
@@ -89,25 +89,27 @@ export function WagerActivityProvider({
       const base = storeRef.current
       const ids = wagers.map(w => String(w.id))
 
-      // Best-effort draw-proposal scan — pending consent is not readable from
-      // chain state, only observable as events. Failure never blocks the
-      // struct pipeline.
-      let scan = { proposals: [], toBlock: base.drawScanBlock }
+      // Best-effort draw-proposal read — the open-draw proposer is not in the
+      // WagerRegistry struct, so it comes from the subgraph (`drawProposer`).
+      // Failure never blocks the struct pipeline.
+      let scan = { proposals: [], ok: false }
       try {
-        scan = await scanProposals({ chainId, wagerIds: ids, fromBlock: base.drawScanBlock })
+        scan = await scanProposals({ chainId, wagerIds: ids })
       } catch {
-        scan = { proposals: [], toBlock: base.drawScanBlock }
+        scan = { proposals: [], ok: false }
       }
       if (scopeRef.current !== scope) return
 
-      // Latest event per wager wins (scan results are chronological).
-      const latestProposal = new Map()
-      for (const p of scan.proposals || []) latestProposal.set(String(p.wagerId), p)
-      const enriched = wagers.map(w => {
-        const p = latestProposal.get(String(w.id))
-        if (!p) return w
-        return { ...w, drawProposedBy: p.revoked ? null : p.proposer }
-      })
+      // A successful read is a COMPLETE snapshot of the requested wagers' draw
+      // state, so set drawProposedBy for every wager (proposer or null) — the
+      // diff then detects both a new proposal (null → proposer) and a revoke
+      // (proposer → null). On a failed read, retain prior state (leave
+      // drawProposedBy unset) rather than null everything and fabricate revokes.
+      const proposerByWagerId = new Map()
+      for (const p of scan.proposals || []) proposerByWagerId.set(String(p.wagerId), p.proposer)
+      const enriched = scan.ok
+        ? wagers.map(w => ({ ...w, drawProposedBy: proposerByWagerId.get(String(w.id)) ?? null }))
+        : wagers
 
       const { entries: changeEntries, nextSnapshots } = diffWagers({
         snapshots: base.snapshots,
@@ -124,16 +126,17 @@ export function WagerActivityProvider({
       const fresh = [...changeEntries, ...warnEntries]
 
       // Re-read the store AFTER all awaits: a markRead that landed while this
-      // poll was in flight must survive the save. snapshots/deadlineWarnings/
-      // drawScanBlock are poll-owned (polls never overlap), so the freshly
-      // computed values are authoritative; entries and their read flags come
-      // from the latest store.
+      // poll was in flight must survive the save. snapshots/deadlineWarnings are
+      // poll-owned (polls never overlap), so the freshly computed values are
+      // authoritative; entries and their read flags come from the latest store.
       const latest = storeRef.current
       let next = {
         ...latest,
         snapshots: nextSnapshots,
         deadlineWarnings: nextWarnRecords,
-        drawScanBlock: scan.toBlock ?? base.drawScanBlock,
+        // Draw state now comes from the subgraph each poll, not an incremental
+        // log scan — the watermark is retained (store-shape compat) but unused.
+        drawScanBlock: base.drawScanBlock,
         lastPolledAt: nowMs,
       }
       next = appendEntries(next, fresh)

--- a/frontend/src/data/notifications/drawProposalScan.js
+++ b/frontend/src/data/notifications/drawProposalScan.js
@@ -1,118 +1,74 @@
 /**
- * Best-effort DrawProposed / DrawRevoked event scan for wager notifications.
+ * Draw-proposal lookup for wager notifications — subgraph-sourced (spec 017).
  *
  * Draw proposals are the one participant-relevant signal the WagerRegistry
- * struct reads cannot surface (spec 012 watcher-api), so the poll loop runs
- * this incremental log scan against the registry:
+ * struct reads cannot surface. Previously this ran an incremental `eth_getLogs`
+ * scan of DrawProposed/DrawRevoked, which floods public RPCs and trips their
+ * `block range exceeds configured limit` cap. The v2 subgraph now indexes the
+ * proposer on the Wager itself (`drawProposer`, set while `status ==
+ * draw_proposed`, cleared on revoke), so we read current state in one bounded
+ * GraphQL query instead.
  *
- *   - `fromBlock` is the persisted watermark (`drawScanBlock`). A zero /
- *     missing watermark means "start tracking from the current tip" — no
- *     historical backfill (data-model.md).
- *   - The range fromBlock+1..tip is scanned in chunks of <= 9500 blocks
- *     (public RPCs commonly cap eth_getLogs at 10k blocks), at most 10
- *     chunks per call. When more blocks remain, `toBlock` is the last block
- *     actually scanned so the watermark advances incrementally.
- *   - Results are filtered to the caller's wagerIds (indexed-topic filter
- *     plus a post-filter for RPCs that ignore array topics) and ordered by
- *     (block, logIndex) so a later DrawRevoked supersedes an earlier
- *     DrawProposed for the same wager.
- *   - Best-effort contract: ANY failure (missing deployment, provider
- *     construction, RPC error) resolves { proposals: [], toBlock: fromBlock }
- *     — this never throws into the poll loop (FR-015).
+ * This returns a COMPLETE snapshot of the requested wagers' draw state, not a
+ * since-watermark event delta: the caller sets `drawProposedBy` to the proposer
+ * for every wager currently in `draw_proposed` and to `null` for the rest, so
+ * the diff engine detects both a new proposal (null → proposer) and a revoke
+ * (proposer → null). `ok` distinguishes a real "no proposals" answer from a
+ * failed read: on failure the caller must RETAIN prior state rather than null
+ * everything out (which would fabricate spurious revokes — constitution III).
+ *
+ * Best-effort: ANY failure (no endpoint, network, GraphQL error) resolves
+ * `{ proposals: [], ok: false }` and never throws into the poll loop (FR-015).
  */
 
-import { ethers } from 'ethers'
-import { getContractAddressForChain } from '../../config/contracts'
-import { getProvider } from '../../utils/blockchainService'
-import { WAGER_REGISTRY_ABI } from '../../abis/WagerRegistry'
-
-/** Blocks per eth_getLogs request (under common 10k public-RPC caps). */
-const CHUNK_BLOCKS = 9500
-
-/** Upper bound on chunks per call — keeps a single poll cycle bounded. */
-const MAX_CHUNKS_PER_CALL = 10
+// One bounded query — current draw-proposed wagers among the caller's ids.
+// `id_in` scopes to the user's wagers; `status` filters to open proposals.
+const QUERY = `
+  query DrawProposals($ids: [ID!]!) {
+    wagers(first: 1000, where: { id_in: $ids, status: draw_proposed }) {
+      id
+      drawProposer
+    }
+  }
+`
 
 /**
- * Scan the WagerRegistry for DrawProposed / DrawRevoked events on the given
- * wagers since the last watermark.
+ * Fetch the current open draw proposals for the given wagers from the subgraph.
  *
  * @param {object} params
- * @param {number} params.chainId - Active chain id (registry + RPC selector)
  * @param {string[]} params.wagerIds - Wager ids the user participates in
- * @param {number} [params.fromBlock] - Last scanned block (exclusive);
- *   0/missing = no backfill, start from the current tip
- * @returns {Promise<{proposals: {wagerId: string, proposer: string, revoked: boolean}[], toBlock: number}>}
- *   Events in chronological (block, logIndex) order; `revoked` is false for
- *   DrawProposed and true for DrawRevoked. Resolves — never rejects.
+ * @returns {Promise<{proposals: {wagerId: string, proposer: string}[], ok: boolean}>}
+ *   `proposals` lists every wager currently in `draw_proposed` with its
+ *   (lowercased) proposer. `ok` is true only when the read succeeded — the
+ *   caller retains prior draw state when `ok` is false. Resolves; never rejects.
  */
-export async function scanDrawProposals({ chainId, wagerIds, fromBlock }) {
-  const watermark = Number(fromBlock) || 0
+export async function fetchDrawProposals({ wagerIds }) {
+  const ids = (wagerIds || []).map(String)
+  // Nothing to ask about — a successful empty answer (lets the caller clear any
+  // stale proposals without a network round-trip).
+  if (ids.length === 0) return { proposals: [], ok: true }
+  const subgraphUrl = import.meta.env?.VITE_SUBGRAPH_URL || ''
+  if (!subgraphUrl) return { proposals: [], ok: false }
+
   try {
-    const address = getContractAddressForChain('wagerRegistry', chainId)
-    if (!address) {
-      throw new Error(`no wagerRegistry deployment for chain ${chainId}`)
-    }
-
-    const provider = getProvider(chainId)
-    const tip = await provider.getBlockNumber()
-
-    // Zero watermark: adopt the current tip without backfilling history —
-    // pre-existing proposals surface via state, not as "new" notifications.
-    if (watermark <= 0) return { proposals: [], toBlock: tip }
-
-    // No new blocks since the last scan.
-    if (watermark >= tip) return { proposals: [], toBlock: watermark }
-
-    const ids = (wagerIds || []).map(String)
-    // Nothing to match against — skip the log reads but still advance the
-    // watermark so a later first-wager scan doesn't backfill this gap.
-    if (ids.length === 0) return { proposals: [], toBlock: tip }
-
-    const contract = new ethers.Contract(address, WAGER_REGISTRY_ABI, provider)
-    const idTopics = ids.map(id => BigInt(id))
-    const proposedFilter = contract.filters.DrawProposed(idTopics)
-    const revokedFilter = contract.filters.DrawRevoked(idTopics)
-
-    const found = []
-    let from = watermark + 1
-    let scannedTo = watermark
-    for (let chunk = 0; chunk < MAX_CHUNKS_PER_CALL && from <= tip; chunk++) {
-      const to = Math.min(from + CHUNK_BLOCKS - 1, tip)
-      const [proposed, revoked] = await Promise.all([
-        contract.queryFilter(proposedFilter, from, to),
-        contract.queryFilter(revokedFilter, from, to),
-      ])
-      for (const ev of proposed) found.push({ ev, revoked: false })
-      for (const ev of revoked) found.push({ ev, revoked: true })
-      scannedTo = to
-      from = to + 1
-    }
-
-    // Chronological order so consumers can fold the stream left-to-right and
-    // let a later DrawRevoked supersede an earlier DrawProposed.
-    found.sort((a, b) => {
-      const byBlock = Number(a.ev.blockNumber ?? 0) - Number(b.ev.blockNumber ?? 0)
-      if (byBlock !== 0) return byBlock
-      return Number(a.ev.index ?? a.ev.logIndex ?? 0) - Number(b.ev.index ?? b.ev.logIndex ?? 0)
+    const res = await fetch(subgraphUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query: QUERY, variables: { ids } }),
     })
+    if (!res.ok) return { proposals: [], ok: false }
+    const json = await res.json()
+    if (json.errors || !json.data) return { proposals: [], ok: false }
 
-    const idSet = new Set(ids)
     const proposals = []
-    for (const { ev, revoked } of found) {
-      const wagerId = ev?.args?.wagerId != null ? ev.args.wagerId.toString() : null
-      // Post-filter: some RPCs ignore array-topic filters; never emit events
-      // for wagers the user is not part of.
-      if (!wagerId || !idSet.has(wagerId)) continue
-      proposals.push({
-        wagerId,
-        proposer: String(ev.args.proposer || '').toLowerCase(),
-        revoked,
-      })
+    for (const w of json.data.wagers || []) {
+      // A draw_proposed wager always has a proposer under v2 indexing; guard
+      // anyway so a null never becomes an empty-address "proposer".
+      if (!w || !w.drawProposer) continue
+      proposals.push({ wagerId: String(w.id), proposer: String(w.drawProposer).toLowerCase() })
     }
-
-    return { proposals, toBlock: scannedTo }
-  } catch (err) {
-    console.warn('[drawProposalScan] scan failed:', err?.message)
-    return { proposals: [], toBlock: watermark }
+    return { proposals, ok: true }
+  } catch {
+    return { proposals: [], ok: false }
   }
 }

--- a/frontend/src/test/WagerActivityContext.test.jsx
+++ b/frontend/src/test/WagerActivityContext.test.jsx
@@ -70,7 +70,7 @@ function OptionalProbe() {
   return <div data-testid="optional">{value === null ? 'null' : 'present'}</div>
 }
 
-const okScan = vi.fn(async ({ fromBlock }) => ({ proposals: [], toBlock: fromBlock || 100 }))
+const okScan = vi.fn(async () => ({ proposals: [], ok: true }))
 
 function renderProvider({ fetchWagers, scanProposals = okScan } = {}) {
   return render(
@@ -246,10 +246,10 @@ describe('catch-up + feed (T013)', () => {
     let releaseScan
     const gate = new Promise((res) => { releaseScan = res })
     const scanProposals = vi.fn()
-      .mockImplementationOnce(async ({ fromBlock }) => ({ proposals: [], toBlock: fromBlock }))
-      .mockImplementationOnce(async ({ fromBlock }) => {
+      .mockImplementationOnce(async () => ({ proposals: [], ok: true }))
+      .mockImplementationOnce(async () => {
         await gate
-        return { proposals: [], toBlock: fromBlock }
+        return { proposals: [], ok: true }
       })
     renderProvider({ fetchWagers, scanProposals })
     await flushPoll(0) // poll 1: catch-up creates the entry
@@ -378,13 +378,15 @@ describe('deadline warnings wiring (T029)', () => {
   })
 })
 
-describe('draw-proposal scan wiring (T022)', () => {
+describe('draw-proposal subgraph wiring (T022)', () => {
   it('emits draw-proposed entry and respondDraw action when counterparty proposes', async () => {
     const w = wager({ status: 'active' })
     const fetchWagers = vi.fn(async () => [w])
+    // Subgraph snapshot: first poll has no open draw; the next reports the
+    // opponent's open proposal on wager 1.
     const scanProposals = vi.fn()
-      .mockResolvedValueOnce({ proposals: [], toBlock: 50 })
-      .mockResolvedValue({ proposals: [{ wagerId: '1', proposer: OPPONENT, revoked: false }], toBlock: 80 })
+      .mockResolvedValueOnce({ proposals: [], ok: true })
+      .mockResolvedValue({ proposals: [{ wagerId: '1', proposer: OPPONENT }], ok: true })
     renderProvider({ fetchWagers, scanProposals })
     await flushPoll(0)
     expect(captured.entries.filter(e => e.type === 'draw-proposed')).toEqual([])
@@ -392,19 +394,50 @@ describe('draw-proposal scan wiring (T022)', () => {
     await flushPoll(30_000)
     expect(captured.entries.some(e => e.type === 'draw-proposed')).toBe(true)
     expect(captured.actionNeededByWagerId['1']).toBe('respondDraw')
-    // watermark advanced + persisted
-    expect(loadStore(ACCOUNT, CHAIN).drawScanBlock).toBe(80)
-    // scan got the known wager ids and prior watermark
+    // The lookup is scoped to the user's wager ids (no log-scan watermark).
     expect(scanProposals).toHaveBeenLastCalledWith(
-      expect.objectContaining({ chainId: CHAIN, wagerIds: ['1'], fromBlock: 50 })
+      expect.objectContaining({ chainId: CHAIN, wagerIds: ['1'] })
     )
+  })
+
+  it('detects a revoke when a previously-proposed wager drops out of the snapshot', async () => {
+    const fetchWagers = vi.fn(async () => [wager({ status: 'active' })])
+    // No open draw at first sight; a live poll introduces the opponent's
+    // proposal, then a later poll shows it withdrawn (gone from the snapshot).
+    const scanProposals = vi.fn()
+      .mockResolvedValueOnce({ proposals: [], ok: true })
+      .mockResolvedValueOnce({ proposals: [{ wagerId: '1', proposer: OPPONENT }], ok: true })
+      .mockResolvedValue({ proposals: [], ok: true })
+    renderProvider({ fetchWagers, scanProposals })
+    await flushPoll(0) // first sight: snapshot drawProposedBy = null, no entry
+    await flushPoll(30_000) // proposal appears (live): draw-proposed
+    expect(captured.entries.some(e => e.type === 'draw-proposed')).toBe(true)
+    expect(captured.actionNeededByWagerId['1']).toBe('respondDraw')
+    await flushPoll(30_000) // proposal gone: draw-revoked
+    expect(captured.entries.some(e => e.type === 'draw-revoked')).toBe(true)
+    expect(captured.actionNeededByWagerId['1']).toBeNull()
+  })
+
+  it('a failed subgraph read (ok:false) retains prior draw state — no false revoke', async () => {
+    const fetchWagers = vi.fn(async () => [wager({ status: 'active' })])
+    const scanProposals = vi.fn()
+      .mockResolvedValueOnce({ proposals: [], ok: true })
+      .mockResolvedValueOnce({ proposals: [{ wagerId: '1', proposer: OPPONENT }], ok: true })
+      .mockResolvedValue({ proposals: [], ok: false }) // subgraph unreachable
+    renderProvider({ fetchWagers, scanProposals })
+    await flushPoll(0) // first sight: drawProposedBy = null
+    await flushPoll(30_000) // proposal appears: draw-proposed
+    expect(captured.entries.some(e => e.type === 'draw-proposed')).toBe(true)
+    await flushPoll(30_000) // failed read: must NOT fabricate a revoke
+    expect(captured.entries.some(e => e.type === 'draw-revoked')).toBe(false)
+    expect(captured.actionNeededByWagerId['1']).toBe('respondDraw')
   })
 
   it('scan failure leaves the struct pipeline unaffected', async () => {
     const fetchWagers = vi.fn()
       .mockResolvedValueOnce([wager()])
       .mockResolvedValue([wager({ status: 'active' })])
-    const scanProposals = vi.fn(async ({ fromBlock }) => ({ proposals: [], toBlock: fromBlock || 0 }))
+    const scanProposals = vi.fn(async () => ({ proposals: [], ok: false }))
     renderProvider({ fetchWagers, scanProposals })
     await flushPoll(0)
     await flushPoll(30_000)

--- a/frontend/src/test/drawProposalScan.test.js
+++ b/frontend/src/test/drawProposalScan.test.js
@@ -1,280 +1,128 @@
 /**
- * Tests for data/notifications/drawProposalScan.js (spec 012, T020).
+ * Tests for data/notifications/drawProposalScan.js (spec 017 — subgraph read).
  *
- * Best-effort DrawProposed/DrawRevoked event scan per
- * specs/012-wager-notifications/contracts/watcher-api.md:
- *   - drawScanBlock = 0 means "start from the current tip" (no backfill)
- *   - chunked queryFilter (<= 9500 blocks/chunk, <= 10 chunks/call) with an
- *     incrementally advancing watermark
- *   - results filtered to the caller's wagerIds and ordered chronologically
- *   - ANY failure resolves { proposals: [], toBlock: fromBlock } — never throws
- *
- * The global setup.js ethers mock has no queryFilter, so ethers is re-mocked
- * locally with a controllable Contract (state shared via vi.hoisted — mock
- * factories cannot close over file-scope variables).
+ * The draw-proposal lookup no longer scans `eth_getLogs`; it reads the v2
+ * subgraph's `drawProposer` for the user's wagers currently in
+ * `status: draw_proposed`. Contract:
+ *   - returns a COMPLETE snapshot { proposals: [{wagerId, proposer}], ok }
+ *   - empty wagerIds → { proposals: [], ok: true } (no network call)
+ *   - missing VITE_SUBGRAPH_URL / HTTP error / GraphQL error / throw →
+ *     { proposals: [], ok: false } so the caller retains prior state
+ *   - proposer is lowercased; a null drawProposer row is dropped
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { fetchDrawProposals } from '../data/notifications/drawProposalScan'
 
-const h = vi.hoisted(() => {
-  const state = {
-    registryAddress: '0x00000000000000000000000000000000000000c4',
-    blockNumber: 1_000_000,
-    blockNumberError: null,
-    queryError: null,
-    proposedEvents: [],
-    revokedEvents: [],
-    queryCalls: [],
-  }
-  const provider = {
-    getBlockNumber: async () => {
-      if (state.blockNumberError) throw state.blockNumberError
-      return state.blockNumber
-    },
-  }
-  return { state, provider }
-})
+const SUBGRAPH = 'http://subgraph.example'
 
-vi.mock('ethers', () => {
-  class MockContract {
-    constructor(address, abi, provider) {
-      this.address = address
-      this.abi = abi
-      this.provider = provider
-      this.filters = {
-        DrawProposed: (...args) => ({ event: 'DrawProposed', topics: args }),
-        DrawRevoked: (...args) => ({ event: 'DrawRevoked', topics: args }),
-      }
-    }
-
-    async queryFilter(filter, fromBlock, toBlock) {
-      h.state.queryCalls.push({
-        event: filter.event,
-        fromBlock,
-        toBlock,
-        topics: filter.topics,
-      })
-      if (h.state.queryError) throw h.state.queryError
-      const source =
-        filter.event === 'DrawProposed' ? h.state.proposedEvents : h.state.revokedEvents
-      // Deliberately ignores topic filters: simulates an RPC that returns
-      // unfiltered logs so the module's post-filter by wagerId is exercised.
-      return source.filter(ev => ev.blockNumber >= fromBlock && ev.blockNumber <= toBlock)
-    }
-  }
-  return { ethers: { Contract: MockContract }, Contract: MockContract }
-})
-
-vi.mock('../config/contracts', () => ({
-  getContractAddressForChain: vi.fn(() => h.state.registryAddress),
-}))
-
-vi.mock('../utils/blockchainService', () => ({
-  getProvider: vi.fn(() => h.provider),
-}))
-
-import { scanDrawProposals } from '../data/notifications/drawProposalScan'
-import { getContractAddressForChain } from '../config/contracts'
-import { getProvider } from '../utils/blockchainService'
-
-const PROPOSER = '0x1111111111111111111111111111111111111111'
-
-/** ethers v6 EventLog shape (args.wagerId is a BigInt; `index` = log index). */
-function makeEvent(wagerId, blockNumber, { index = 0, proposer = PROPOSER } = {}) {
-  return { blockNumber, index, args: { wagerId: BigInt(wagerId), proposer } }
-}
-
-function callsFor(eventName) {
-  return h.state.queryCalls.filter(c => c.event === eventName)
+function mockFetchJson(payload, { ok = true, status = 200 } = {}) {
+  return vi.fn(async () => ({
+    ok,
+    status,
+    json: async () => payload,
+  }))
 }
 
 beforeEach(() => {
-  localStorage.clear()
-  h.state.registryAddress = '0x00000000000000000000000000000000000000c4'
-  h.state.blockNumber = 1_000_000
-  h.state.blockNumberError = null
-  h.state.queryError = null
-  h.state.proposedEvents = []
-  h.state.revokedEvents = []
-  h.state.queryCalls = []
-  vi.mocked(getContractAddressForChain).mockClear()
-  vi.mocked(getProvider).mockClear()
+  vi.stubEnv('VITE_SUBGRAPH_URL', SUBGRAPH)
+  vi.unstubAllGlobals?.()
 })
 
-describe('scanDrawProposals — zero watermark (no historical backfill)', () => {
-  it('returns no proposals and advances toBlock to the current tip when fromBlock is 0', async () => {
-    h.state.blockNumber = 123_456
-    h.state.proposedEvents = [makeEvent('1', 100)] // historical event must NOT surface
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})
 
-    const result = await scanDrawProposals({ chainId: 137, wagerIds: ['1', '2'], fromBlock: 0 })
-
-    expect(result).toEqual({ proposals: [], toBlock: 123_456 })
-    expect(h.state.queryCalls).toHaveLength(0)
+describe('fetchDrawProposals — input guards', () => {
+  it('returns a successful empty snapshot without a network call for empty wagerIds', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    const result = await fetchDrawProposals({ wagerIds: [] })
+    expect(result).toEqual({ proposals: [], ok: true })
+    expect(fetchSpy).not.toHaveBeenCalled()
   })
 
-  it('treats a missing fromBlock as a zero watermark', async () => {
-    h.state.blockNumber = 5_000
-
-    const result = await scanDrawProposals({ chainId: 137, wagerIds: ['1'] })
-
-    expect(result).toEqual({ proposals: [], toBlock: 5_000 })
-    expect(h.state.queryCalls).toHaveLength(0)
-  })
-
-  it('resolves the registry and provider for the requested chain', async () => {
-    await scanDrawProposals({ chainId: 80002, wagerIds: ['1'], fromBlock: 0 })
-
-    expect(getContractAddressForChain).toHaveBeenCalledWith('wagerRegistry', 80002)
-    expect(getProvider).toHaveBeenCalledWith(80002)
+  it('returns ok:false (retain prior state) when VITE_SUBGRAPH_URL is unset', async () => {
+    vi.stubEnv('VITE_SUBGRAPH_URL', '')
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    const result = await fetchDrawProposals({ wagerIds: ['1'] })
+    expect(result).toEqual({ proposals: [], ok: false })
+    expect(fetchSpy).not.toHaveBeenCalled()
   })
 })
 
-describe('scanDrawProposals — empty wagerIds', () => {
-  it('skips querying but still advances toBlock to the tip', async () => {
-    h.state.blockNumber = 5_000
+describe('fetchDrawProposals — successful read', () => {
+  it('maps draw_proposed wagers to {wagerId, proposer} with a lowercased proposer', async () => {
+    const fetchSpy = mockFetchJson({
+      data: {
+        wagers: [
+          { id: '7', drawProposer: '0xAbCdEF1111111111111111111111111111111111' },
+          { id: '9', drawProposer: '0x2222222222222222222222222222222222222222' },
+        ],
+      },
+    })
+    vi.stubGlobal('fetch', fetchSpy)
 
-    const result = await scanDrawProposals({ chainId: 137, wagerIds: [], fromBlock: 1_000 })
+    const result = await fetchDrawProposals({ wagerIds: ['7', '9', '11'] })
 
-    expect(result).toEqual({ proposals: [], toBlock: 5_000 })
-    expect(h.state.queryCalls).toHaveLength(0)
+    expect(result).toEqual({
+      ok: true,
+      proposals: [
+        { wagerId: '7', proposer: '0xabcdef1111111111111111111111111111111111' },
+        { wagerId: '9', proposer: '0x2222222222222222222222222222222222222222' },
+      ],
+    })
+    // The query is scoped to the caller's ids and the draw_proposed status.
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body)
+    expect(body.variables.ids).toEqual(['7', '9', '11'])
+    expect(body.query).toMatch(/status:\s*draw_proposed/)
+  })
+
+  it('returns an empty (but ok) snapshot when no wager is currently draw_proposed', async () => {
+    vi.stubGlobal('fetch', mockFetchJson({ data: { wagers: [] } }))
+    const result = await fetchDrawProposals({ wagerIds: ['7'] })
+    expect(result).toEqual({ proposals: [], ok: true })
+  })
+
+  it('drops a row whose drawProposer is null', async () => {
+    vi.stubGlobal('fetch', mockFetchJson({
+      data: { wagers: [{ id: '7', drawProposer: null }, { id: '8', drawProposer: '0x3333333333333333333333333333333333333333' }] },
+    }))
+    const result = await fetchDrawProposals({ wagerIds: ['7', '8'] })
+    expect(result).toEqual({
+      ok: true,
+      proposals: [{ wagerId: '8', proposer: '0x3333333333333333333333333333333333333333' }],
+    })
+  })
+
+  it('coerces numeric wagerIds to strings', async () => {
+    const fetchSpy = mockFetchJson({ data: { wagers: [] } })
+    vi.stubGlobal('fetch', fetchSpy)
+    await fetchDrawProposals({ wagerIds: [7, 9] })
+    expect(JSON.parse(fetchSpy.mock.calls[0][1].body).variables.ids).toEqual(['7', '9'])
   })
 })
 
-describe('scanDrawProposals — chunking and watermark', () => {
-  it('scans fromBlock+1 to tip in <= 9500-block chunks (25000-block span => 3 chunks)', async () => {
-    h.state.blockNumber = 26_000
-
-    const result = await scanDrawProposals({ chainId: 137, wagerIds: ['7'], fromBlock: 1_000 })
-
-    const expectedRanges = [
-      [1_001, 10_500],
-      [10_501, 20_000],
-      [20_001, 26_000],
-    ]
-    expect(callsFor('DrawProposed').map(c => [c.fromBlock, c.toBlock])).toEqual(expectedRanges)
-    expect(callsFor('DrawRevoked').map(c => [c.fromBlock, c.toBlock])).toEqual(expectedRanges)
-    expect(result.toBlock).toBe(26_000)
-    expect(result.proposals).toEqual([])
+describe('fetchDrawProposals — failure modes (never throws, ok:false)', () => {
+  it('ok:false on a non-2xx HTTP response', async () => {
+    vi.stubGlobal('fetch', mockFetchJson({}, { ok: false, status: 503 }))
+    expect(await fetchDrawProposals({ wagerIds: ['1'] })).toEqual({ proposals: [], ok: false })
   })
 
-  it('caps a call at 10 chunks and advances the watermark only over scanned blocks', async () => {
-    h.state.blockNumber = 115_000 // 114000-block span => 12 chunks remain
-    h.state.proposedEvents = [
-      makeEvent('7', 50_000), // inside the scanned window
-      makeEvent('7', 100_000), // beyond chunk 10 — picked up by a later call
-    ]
-
-    const result = await scanDrawProposals({ chainId: 137, wagerIds: ['7'], fromBlock: 1_000 })
-
-    expect(callsFor('DrawProposed')).toHaveLength(10)
-    expect(callsFor('DrawRevoked')).toHaveLength(10)
-    expect(callsFor('DrawProposed')[9].toBlock).toBe(96_000) // 1000 + 10 * 9500
-    expect(result.toBlock).toBe(96_000)
-    expect(result.proposals).toEqual([
-      { wagerId: '7', proposer: PROPOSER, revoked: false },
-    ])
+  it('ok:false on a GraphQL errors payload', async () => {
+    vi.stubGlobal('fetch', mockFetchJson({ errors: [{ message: 'bad field' }] }))
+    expect(await fetchDrawProposals({ wagerIds: ['1'] })).toEqual({ proposals: [], ok: false })
   })
 
-  it('keeps the watermark when there are no new blocks', async () => {
-    h.state.blockNumber = 5_000
-
-    const result = await scanDrawProposals({ chainId: 137, wagerIds: ['1'], fromBlock: 5_000 })
-
-    expect(result).toEqual({ proposals: [], toBlock: 5_000 })
-    expect(h.state.queryCalls).toHaveLength(0)
-  })
-})
-
-describe('scanDrawProposals — wagerId filtering', () => {
-  it('passes the wagerIds as a BigInt array-topic filter', async () => {
-    h.state.blockNumber = 2_000
-
-    await scanDrawProposals({ chainId: 137, wagerIds: ['1', '2'], fromBlock: 1_000 })
-
-    expect(callsFor('DrawProposed')[0].topics[0]).toEqual([1n, 2n])
-    expect(callsFor('DrawRevoked')[0].topics[0]).toEqual([1n, 2n])
+  it('ok:false when data is missing', async () => {
+    vi.stubGlobal('fetch', mockFetchJson({}))
+    expect(await fetchDrawProposals({ wagerIds: ['1'] })).toEqual({ proposals: [], ok: false })
   })
 
-  it('post-filters results to the requested wagerIds even when the RPC ignores topics', async () => {
-    h.state.blockNumber = 2_000
-    h.state.proposedEvents = [
-      makeEvent('1', 1_500),
-      makeEvent('99', 1_600), // not ours — must be dropped
-    ]
-
-    const result = await scanDrawProposals({ chainId: 137, wagerIds: ['1', '2'], fromBlock: 1_000 })
-
-    expect(result.proposals).toEqual([{ wagerId: '1', proposer: PROPOSER, revoked: false }])
-    expect(result.toBlock).toBe(2_000)
-  })
-
-  it('lowercases the proposer address', async () => {
-    h.state.blockNumber = 2_000
-    h.state.proposedEvents = [
-      makeEvent('1', 1_500, { proposer: '0xAbCdEF1111111111111111111111111111111111' }),
-    ]
-
-    const result = await scanDrawProposals({ chainId: 137, wagerIds: ['1'], fromBlock: 1_000 })
-
-    expect(result.proposals).toEqual([
-      { wagerId: '1', proposer: '0xabcdef1111111111111111111111111111111111', revoked: false },
-    ])
-  })
-})
-
-describe('scanDrawProposals — chronological ordering', () => {
-  it('orders events by (block, logIndex) so a later DrawRevoked supersedes the proposal', async () => {
-    h.state.blockNumber = 2_000
-    h.state.proposedEvents = [
-      makeEvent('5', 1_200, { index: 3 }),
-      makeEvent('5', 1_800, { index: 0 }),
-    ]
-    h.state.revokedEvents = [
-      makeEvent('5', 1_200, { index: 7 }), // same block as first proposal, later log
-    ]
-
-    const result = await scanDrawProposals({ chainId: 137, wagerIds: ['5'], fromBlock: 1_000 })
-
-    expect(result.proposals).toEqual([
-      { wagerId: '5', proposer: PROPOSER, revoked: false }, // block 1200, log 3
-      { wagerId: '5', proposer: PROPOSER, revoked: true }, // block 1200, log 7
-      { wagerId: '5', proposer: PROPOSER, revoked: false }, // block 1800, log 0
-    ])
-  })
-})
-
-describe('scanDrawProposals — failure modes (never throws)', () => {
-  it('resolves { proposals: [], toBlock: fromBlock } when queryFilter fails', async () => {
-    h.state.blockNumber = 26_000
-    h.state.queryError = new Error('block range limit exceeded')
-
-    const result = await scanDrawProposals({ chainId: 137, wagerIds: ['1'], fromBlock: 1_000 })
-
-    expect(result).toEqual({ proposals: [], toBlock: 1_000 })
-  })
-
-  it('resolves { proposals: [], toBlock: fromBlock } when the provider cannot fetch the tip', async () => {
-    h.state.blockNumberError = new Error('network down')
-
-    const result = await scanDrawProposals({ chainId: 137, wagerIds: ['1'], fromBlock: 1_000 })
-
-    expect(result).toEqual({ proposals: [], toBlock: 1_000 })
-  })
-
-  it('resolves { proposals: [], toBlock: fromBlock } when the chain has no registry deployment', async () => {
-    h.state.registryAddress = undefined
-
-    const result = await scanDrawProposals({ chainId: 63, wagerIds: ['1'], fromBlock: 1_000 })
-
-    expect(result).toEqual({ proposals: [], toBlock: 1_000 })
-    expect(h.state.queryCalls).toHaveLength(0)
-  })
-
-  it('falls back to a 0 watermark on failure when fromBlock is missing', async () => {
-    h.state.registryAddress = undefined
-
-    const result = await scanDrawProposals({ chainId: 63, wagerIds: ['1'] })
-
-    expect(result).toEqual({ proposals: [], toBlock: 0 })
+  it('ok:false when fetch rejects', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network down') }))
+    expect(await fetchDrawProposals({ wagerIds: ['1'] })).toEqual({ proposals: [], ok: false })
   })
 })

--- a/subgraph/README.md
+++ b/subgraph/README.md
@@ -66,7 +66,9 @@ Set the resulting endpoint as `VITE_SUBGRAPH_URL` (per network) in the frontend
 
 - **Wager** — identity, both parties, per-side stakes, lifecycle status, winner,
   createdAt/resolvedAt. Stakes are stored at creation so refund/accept transfers
-  derive amounts without contract reads.
+  derive amounts without contract reads. `drawProposer` carries the open-draw
+  proposer while `status == draw_proposed` (cleared on revoke), so the wager
+  watcher can surface draw proposals without an `eth_getLogs` scan.
 - **WagerTransfer** (immutable) — one row per value movement, keyed by
   `txHash-logIndex-party` (unique even when one log refunds two parties).
 

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -60,6 +60,9 @@ type Wager @entity(immutable: false) {
   status: WagerStatus!
   winner: Bytes
 
+  "address that proposed the open draw while status == draw_proposed; cleared on revoke. Lets the notifier surface the proposer (and the counterparty 'respond to draw' action) without an eth_getLogs scan."
+  drawProposer: Bytes
+
   createdAt: BigInt!
   resolvedAt: BigInt
 

--- a/subgraph/src/mappings/wagerRegistry.ts
+++ b/subgraph/src/mappings/wagerRegistry.ts
@@ -200,6 +200,9 @@ export function handleDrawProposed(event: DrawProposed): void {
   let wager = Wager.load(id)
   if (wager == null) return
   wager.status = 'draw_proposed'
+  // Record who proposed so the notifier can name the proposer and decide the
+  // counterparty's "respond to draw" action without an eth_getLogs scan.
+  wager.drawProposer = event.params.proposer
   wager.save()
 }
 
@@ -207,7 +210,8 @@ export function handleDrawRevoked(event: DrawRevoked): void {
   let id = event.params.wagerId.toString()
   let wager = Wager.load(id)
   if (wager == null) return
-  // Revoking a draw proposal returns the wager to active.
+  // Revoking a draw proposal returns the wager to active and clears the proposer.
   wager.status = 'active'
+  wager.drawProposer = null
   wager.save()
 }

--- a/subgraph/tests/wagerRegistry.test.ts
+++ b/subgraph/tests/wagerRegistry.test.ts
@@ -16,6 +16,8 @@ import {
   WagerCancelled,
   WagerResolved,
   WagerDeclined,
+  DrawProposed,
+  DrawRevoked,
 } from '../generated/WagerRegistry/WagerRegistry'
 import {
   handleWagerCreated,
@@ -26,6 +28,8 @@ import {
   handleWagerCancelled,
   handleWagerResolved,
   handleWagerDeclined,
+  handleDrawProposed,
+  handleDrawRevoked,
 } from '../src/mappings/wagerRegistry'
 
 const CREATOR = Address.fromString('0x1111111111111111111111111111111111111111')
@@ -119,6 +123,22 @@ function declined(wagerId: i32): WagerDeclined {
   return event
 }
 
+function drawProposed(wagerId: i32, proposer: Address): DrawProposed {
+  let event = changetype<DrawProposed>(newMockEvent())
+  event.parameters = new Array<ethereum.EventParam>()
+  event.parameters.push(new ethereum.EventParam('wagerId', ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(wagerId))))
+  event.parameters.push(new ethereum.EventParam('proposer', ethereum.Value.fromAddress(proposer)))
+  return event
+}
+
+function drawRevoked(wagerId: i32, proposer: Address): DrawRevoked {
+  let event = changetype<DrawRevoked>(newMockEvent())
+  event.parameters = new Array<ethereum.EventParam>()
+  event.parameters.push(new ethereum.EventParam('wagerId', ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(wagerId))))
+  event.parameters.push(new ethereum.EventParam('proposer', ethereum.Value.fromAddress(proposer)))
+  return event
+}
+
 // ---------------------------------------------------------------------------
 // US1 — Wager identity + lifecycle status
 // ---------------------------------------------------------------------------
@@ -163,6 +183,28 @@ describe('US1: Wager indexing', () => {
     handleWagerCreated(created(6))
     handleWagerDeclined(declined(6))
     assert.fieldEquals('Wager', '6', 'status', 'declined')
+  })
+
+  test('draw proposed records proposer + draw_proposed; revoke clears it and returns to active', () => {
+    handleWagerCreated(created(20))
+    handleWagerAccepted(accepted(20))
+    assert.fieldEquals('Wager', '20', 'status', 'active')
+
+    // Opponent proposes a draw: status flips and the proposer is recorded so the
+    // notifier can name them (and decide the creator's respond-draw action)
+    // without an eth_getLogs scan.
+    handleDrawProposed(drawProposed(20, OPPONENT))
+    assert.fieldEquals('Wager', '20', 'status', 'draw_proposed')
+    assert.fieldEquals('Wager', '20', 'drawProposer', OPPONENT.toHexString())
+
+    // Revoke returns the wager to active and clears the proposer (matchstick
+    // renders an unset nullable field as the string 'null').
+    handleDrawRevoked(drawRevoked(20, OPPONENT))
+    assert.fieldEquals('Wager', '20', 'status', 'active')
+    assert.fieldEquals('Wager', '20', 'drawProposer', 'null')
+
+    // No draw event ever produces a value movement (no WagerTransfer rows).
+    assert.entityCount('WagerTransfer', 2) // creator + opponent deposits only
   })
 })
 


### PR DESCRIPTION
Fixes the `[drawProposalScan] block range exceeds configured limit` flood seen on the Account page by replacing the wager watcher's incremental `eth_getLogs` scan with a subgraph read.

## Why the scan existed
The WagerRegistry struct read can't surface a draw's **proposer** — needed to (a) name the proposal in the toast and (b) decide the counterparty's `respondDraw` action. So the watcher fell back to scanning `DrawProposed`/`DrawRevoked` logs.

## Subgraph (redeployed v0.2.0 — `fairwins-amoy` + `fairwins-polygon`)
- Add `drawProposer: Bytes` to `Wager`. `handleDrawProposed` records `event.params.proposer`; `handleDrawRevoked` clears it (status already flips `draw_proposed` ↔ `active`).
- Matchstick test for set + clear (10/10 pass via the vendored Docker runner).

## Frontend
- **`drawProposalScan.js` → `fetchDrawProposals`**: one bounded GraphQL query for the user's wagers in `status: draw_proposed` with `drawProposer`. Returns a **complete snapshot** `{ proposals, ok }`. `ok:false` on any failure (no URL / HTTP / GraphQL / throw) so the caller **retains** prior state rather than fabricating revokes (constitution III — honest state). No chainId/RPC/watermark.
- **`WagerActivityContext`**: on `ok`, set `drawProposedBy` for *every* wager (proposer or `null`) so the existing diff detects both a new proposal (null→addr) **and a revoke** (addr→null) — a capability the old event scan needed explicit `revoked` rows for; on `!ok`, leave it unset (retain). `drawScanBlock` kept for store-shape compat, now unused.

## Account page
Already subgraph-backed: `useAccountStats` reads `listMyWagers` (SubgraphSource) + `listTransfers` (subgraph WagerTransfer); the only RPC is one ERC20 `balanceOf`. So this removes the **last** log scan behind the Account page.

## Config
`VITE_SUBGRAPH_URL` build-arg (`cloudbuild.yaml`) + `.env.example` bumped to **v0.2.0** (the deploy that adds `drawProposer`).

## Tests
- Subgraph: 10/10 matchstick.
- Frontend: `drawProposalScan` (subgraph fetch + graceful failure) and `WagerActivityContext` (propose, **revoke detection**, ok:false retain, struct-pipeline isolation) — plus diffEngine/derivedState/activityStore/account suites: **185 + 39 green**.

## Deploy ordering
v0.2.0 is **already live** on both Studio slugs, so the bumped URL resolves the moment this merges and Cloud Build ships.

Refs #707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)