### PR TITLE
chore: enable frontend-design plugin; gitignore .playwright-mcp artifacts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "frontend-design@claude-plugins-official": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,7 @@ medusa-corpus/
 
 # MkDocs
 site/
+
+# Playwright MCP session artifacts (console logs, page snapshots, downloaded
+# browser extensions like the MetaMask .crx) — transient, can be tens of MB.
+.playwright-mcp/


### PR DESCRIPTION
Two small housekeeping changes that were sitting untracked in the working tree.

## `.claude/settings.json`
Enables the `frontend-design` plugin. `.claude/` is already partly tracked in this repo (the skills), so this belongs in-tree.

## `.gitignore` → ignore `.playwright-mcp/`
Playwright MCP writes session artifacts here — console logs, page-snapshot YAML, and **downloaded browser extensions** (the MetaMask `.crx` alone is ~27 MB). These are transient run output, not source. Ignoring the directory keeps it from showing up as untracked noise and, more importantly, keeps a 27 MB binary out of git history (which can't be cleanly removed later).

No artifacts are committed — only the ignore rule + the settings file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)