### PR TITLE
Address Book iteration 2: QR scan, inline picker button, screening info + docs

### DIFF
--- a/docs/user-guide/address-book.md
+++ b/docs/user-guide/address-book.md
@@ -1,0 +1,92 @@
+# Address Book & Screening
+
+The **Address Book** lets you save the people you wager with under friendly
+names so you never have to paste a long `0x…` address again. It also screens
+saved and entered addresses against sanctions/compliance lists and warns you
+before you transact.
+
+Your address book is stored **only on your device** (in your browser), scoped to
+the connected wallet. FairWins never uploads your contacts to a server.
+
+## Where to find it
+
+- **My Account → Address Book** — the full manager, where you add, edit, delete,
+  search, import, and export contacts.
+- **Anywhere you enter an address** (for example, the opponent or arbitrator field
+  when creating a wager) — an **address-book icon button** sits next to the QR
+  scan button. Tap it to search and pick a saved contact.
+
+## Managing contacts
+
+Each contact has:
+
+- a **nickname** (e.g. "Alex");
+- one or more **addresses** — a friend may use several wallets, so you can group
+  them all under one name;
+- a **network** for each address (defaults to the network you are on); and
+- optional **notes**.
+
+A single address is identified by the pair *(address, network)*, so the same
+address can be saved for more than one network, and the book warns you if you try
+to save a duplicate.
+
+### Adding an address by QR code
+
+When adding or editing a contact, each address row has a **QR scan button**.
+Tap it to open your camera and scan a wallet QR code (a raw address, an
+`ethereum:` URI, or a FairWins share link). The scanned address fills that row
+automatically.
+
+## How screening works
+
+Every saved or entered address is checked against the on-chain
+sanctions/compliance oracle. Results appear as small tags:
+
+| Tag | Meaning |
+|-----|---------|
+| *(no tag)* | The address screened **clear** on this network. |
+| **Restricted** | The address is flagged by sanctions screening. |
+| **Unscreened** | The address could not be checked (see "Fails closed" below). |
+
+Four principles govern screening:
+
+1. **Advisory only.** The tags in the app are a convenience pre-check. They do
+   **not** block anything by themselves.
+2. **The on-chain guard enforces.** FairWins' smart contracts independently
+   screen every participant when a wager is created or accepted. A restricted
+   address is blocked on-chain **even if the app shows no warning** — the contract
+   is the source of truth, not the UI.
+3. **Fails closed.** If an address cannot be screened — for example the guard is
+   not configured on the current network, or the check fails — it is shown as
+   **Unscreened**, never as clear. Treat "Unscreened" as "unknown, proceed with
+   caution."
+4. **Network-scoped.** A screening result applies only to the network it was
+   checked on. The same address may screen differently on a different network, so
+   the network is always part of the result.
+
+Results are cached briefly during your session to avoid repeated on-chain reads,
+then re-checked the next time you open the book or pick an address.
+
+## Portability: encrypted export & import
+
+You can move your address book between devices:
+
+- **Export** produces an encrypted file. The encryption key is derived from a
+  signature from your wallet, so the file contains **no readable** names,
+  addresses, or notes.
+- **Import** on another device (or after clearing your browser) restores your
+  contacts — but only with the **same wallet** that created the export, since the
+  decryption key comes from that wallet's signature. There is no separate
+  passphrase to remember.
+- Importing **merges** additively: new addresses are added, existing ones are
+  kept (no duplicates), and where a nickname or note differs you are asked which
+  to keep. Nothing is silently deleted.
+
+If you import a file created by a different wallet, or a corrupted file, the
+import fails safely and your existing book is left unchanged.
+
+## Privacy notes
+
+- Contacts live in your browser's local storage, keyed to your wallet address.
+  Clearing your browser data removes them — export a backup first.
+- Different wallets on the same device have separate, isolated address books.

--- a/frontend/src/components/account/AddressBookPanel.css
+++ b/frontend/src/components/account/AddressBookPanel.css
@@ -4,6 +4,49 @@
   gap: 1rem;
 }
 
+.ab-panel-head-titles {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+/* Address input + inline QR scan button inside the contact edit modal. */
+.ab-input-with-scan {
+  display: flex;
+  align-items: stretch;
+  gap: 0.4rem;
+}
+
+.ab-input-with-scan input {
+  flex: 1;
+  min-width: 0;
+}
+
+.ab-scan-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  min-width: 42px;
+  border: 1px solid var(--border-color, #cbd5e1);
+  border-radius: 0.375rem;
+  background: var(--btn-bg, #f8fafc);
+  color: inherit;
+  cursor: pointer;
+}
+
+.ab-scan-btn svg {
+  width: 20px;
+  height: 20px;
+  flex: none;
+}
+
+.ab-scan-btn:hover,
+.ab-scan-btn:focus-visible {
+  border-color: var(--accent, #2563eb);
+  color: var(--accent, #2563eb);
+}
+
 .ab-panel-head {
   display: flex;
   align-items: center;

--- a/frontend/src/components/account/AddressBookPanel.jsx
+++ b/frontend/src/components/account/AddressBookPanel.jsx
@@ -15,6 +15,7 @@ import { addressKey, listEntries } from '../../lib/addressBook/addressBookStore'
 import ContactCard from './ContactCard'
 import ContactEditModal from './ContactEditModal'
 import AddressBookImportExport from './AddressBookImportExport'
+import ScreeningInfoButton from '../ui/ScreeningInfoButton'
 import './AddressBookPanel.css'
 
 function networkName(chainId) {
@@ -99,7 +100,10 @@ export default function AddressBookPanel({ address }) {
   return (
     <div className="ab-panel">
       <div className="ab-panel-head">
-        <h3>Address Book</h3>
+        <div className="ab-panel-head-titles">
+          <h3>Address Book</h3>
+          <ScreeningInfoButton />
+        </div>
         <div className="ab-panel-head-actions">
           <AddressBookImportExport />
           <button

--- a/frontend/src/components/account/ContactEditModal.jsx
+++ b/frontend/src/components/account/ContactEditModal.jsx
@@ -6,8 +6,10 @@
  * addresses before save (FR-005) and warns on duplicates (edge case).
  */
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useCallback } from 'react'
 import { isValidAddress } from '../../lib/addressBook/addressBookStore'
+import { extractAddressFromScan } from '../../lib/addressBook/scanAddress'
+import QRScanner from '../ui/QRScanner'
 
 function emptyRow(defaultChainId) {
   return { address: '', chainId: defaultChainId, notes: '' }
@@ -29,6 +31,18 @@ export default function ContactEditModal({
       : [emptyRow(defaultChainId)],
   )
   const [error, setError] = useState('')
+  const [scanRow, setScanRow] = useState(null)
+
+  // Fill the scanned row with the address extracted from the QR payload.
+  const handleScanSuccess = useCallback((decodedText) => {
+    const addr = extractAddressFromScan(decodedText)
+    setScanRow((idx) => {
+      if (addr && idx != null) {
+        setRows((prev) => prev.map((r, i) => (i === idx ? { ...r, address: addr } : r)))
+      }
+      return null
+    })
+  }, [])
 
   const setRow = (i, patch) =>
     setRows((prev) => prev.map((r, idx) => (idx === i ? { ...r, ...patch } : r)))
@@ -105,15 +119,28 @@ export default function ContactEditModal({
             <div className="ab-address-edit-row" key={i}>
               <div className="ab-field">
                 <label htmlFor={`ab-addr-${i}`}>Address *</label>
-                <input
-                  id={`ab-addr-${i}`}
-                  type="text"
-                  value={row.address}
-                  onChange={(e) => setRow(i, { address: e.target.value })}
-                  placeholder="0x…"
-                  autoComplete="off"
-                  spellCheck="false"
-                />
+                <div className="ab-input-with-scan">
+                  <input
+                    id={`ab-addr-${i}`}
+                    type="text"
+                    value={row.address}
+                    onChange={(e) => setRow(i, { address: e.target.value })}
+                    placeholder="0x…"
+                    autoComplete="off"
+                    spellCheck="false"
+                  />
+                  <button
+                    type="button"
+                    className="ab-scan-btn"
+                    onClick={() => setScanRow(i)}
+                    title="Scan QR code"
+                    aria-label={`Scan a QR code for address ${i + 1}`}
+                  >
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                      <path d="M3 3h8v8H3V3zm2 2v4h4V5H5zm8-2h8v8h-8V3zm2 2v4h4V5h-4zM3 13h8v8H3v-8zm2 2v4h4v-4H5zm10-2h2v2h-2v-2zm4 0h2v2h-2v-2zm-4 4h2v2h-2v-2zm2 2h2v2h-2v-2zm2-2h2v2h-2v-2zm0 4h2v2h-2v-2z" />
+                    </svg>
+                  </button>
+                </div>
                 {duplicateWarnings[i] && (
                   <span className="ab-warn" role="status">
                     {duplicateWarnings[i]}
@@ -177,6 +204,12 @@ export default function ContactEditModal({
           </button>
         </div>
       </div>
+
+      <QRScanner
+        isOpen={scanRow !== null}
+        onClose={() => setScanRow(null)}
+        onScanSuccess={handleScanSuccess}
+      />
     </div>
   )
 }

--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -13,6 +13,8 @@ import { ResolutionType, isOracleModelExposed } from '../../constants/wagerDefau
 import QRScanner from '../ui/QRScanner'
 import WagerQRCode from '../ui/WagerQRCode'
 import AddressInput from '../ui/AddressInput'
+import AddressBookButton from '../ui/AddressBookButton'
+import AddressScreenNotice from '../ui/AddressScreenNotice'
 import SaveAddressToast from '../ui/SaveAddressToast'
 import { isEnsName } from '../../utils/validation'
 import { getCurrentDocument } from '../../utils/legalDocs'
@@ -1452,10 +1454,16 @@ function FriendMarketsModal({
                               disabled={submitting}
                               error={!!errors.opponent}
                               errorMessage={errors.opponent}
-                              enableAddressBook
-                              chainId={chainId}
                             />
                           </div>
+                          <AddressBookButton
+                            chainId={chainId}
+                            disabled={submitting}
+                            onSelect={(entry) => {
+                              handleFormChange('opponent', entry.address)
+                              handleFormChange('opponentResolved', entry.address)
+                            }}
+                          />
                           <button
                             type="button"
                             className="fm-scan-btn"
@@ -1469,6 +1477,10 @@ function FriendMarketsModal({
                             </svg>
                           </button>
                         </div>
+                        <AddressScreenNotice
+                          address={formData.opponentResolved || formData.opponent}
+                          chainId={chainId}
+                        />
                       </div>
                     )}
 
@@ -1581,16 +1593,30 @@ function FriendMarketsModal({
                         <label htmlFor="fm-arbitrator">
                           Arbitrator Address <span className="fm-required">*</span>
                         </label>
-                        <AddressInput
-                          id="fm-arbitrator"
-                          value={formData.arbitrator}
-                          onChange={(e) => handleFormChange('arbitrator', e.target.value)}
-                          onResolvedChange={(addr) => handleFormChange('arbitratorResolved', addr || '')}
-                          placeholder="0x... or ENS name — the neutral resolver"
-                          disabled={submitting}
-                          error={!!errors.arbitrator}
-                          errorMessage={errors.arbitrator}
-                          enableAddressBook
+                        <div className="fm-input-with-action">
+                          <div className="fm-address-input-wrap">
+                            <AddressInput
+                              id="fm-arbitrator"
+                              value={formData.arbitrator}
+                              onChange={(e) => handleFormChange('arbitrator', e.target.value)}
+                              onResolvedChange={(addr) => handleFormChange('arbitratorResolved', addr || '')}
+                              placeholder="0x... or ENS name — the neutral resolver"
+                              disabled={submitting}
+                              error={!!errors.arbitrator}
+                              errorMessage={errors.arbitrator}
+                            />
+                          </div>
+                          <AddressBookButton
+                            chainId={chainId}
+                            disabled={submitting}
+                            onSelect={(entry) => {
+                              handleFormChange('arbitrator', entry.address)
+                              handleFormChange('arbitratorResolved', entry.address)
+                            }}
+                          />
+                        </div>
+                        <AddressScreenNotice
+                          address={formData.arbitratorResolved || formData.arbitrator}
                           chainId={chainId}
                         />
                         <span className="fm-hint">

--- a/frontend/src/components/ui/AddressBookButton.jsx
+++ b/frontend/src/components/ui/AddressBookButton.jsx
@@ -1,0 +1,108 @@
+/**
+ * AddressBookButton (Spec 021 iteration 2) — a compact icon button that opens a
+ * searchable popover of the member's saved addresses. Designed to sit inline
+ * next to the QR-scan button on the wager-create form (it reuses the same
+ * sizing class), so picking a saved contact is one tap away.
+ */
+
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react'
+import { useAddressBook } from '../../hooks/useAddressBook'
+import { useAddressScreening } from '../../hooks/useAddressScreening'
+import { getNetwork } from '../../config/networks'
+import AddressBookPicker from './AddressBookPicker'
+import ScreeningInfoButton from './ScreeningInfoButton'
+import './AddressBookField.css'
+
+const netName = (id) => getNetwork(id)?.name || `Chain ${id}`
+
+export default function AddressBookButton({ onSelect, disabled = false }) {
+  const { search } = useAddressBook()
+  const { getStatus, screen } = useAddressScreening()
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const wrapRef = useRef(null)
+
+  const entries = useMemo(() => search(query), [search, query])
+
+  // Screen the visible results when the popover opens.
+  useEffect(() => {
+    if (open && entries.length) screen(entries)
+  }, [open, entries, screen])
+
+  // Close on outside click / Escape.
+  useEffect(() => {
+    if (!open) return undefined
+    const onDocClick = (e) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target)) setOpen(false)
+    }
+    const onKey = (e) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDocClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const handleSelect = useCallback(
+    (entry) => {
+      onSelect?.(entry)
+      setOpen(false)
+      setQuery('')
+    },
+    [onSelect],
+  )
+
+  return (
+    <span className="ab-book-btn-wrap" ref={wrapRef}>
+      <button
+        type="button"
+        className="fm-scan-btn ab-book-btn"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label="Choose from address book"
+        title="Address book"
+        disabled={disabled}
+        onClick={() => setOpen((o) => !o)}
+      >
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+          <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+          <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
+          <circle cx="12" cy="9" r="2" />
+          <path d="M9 14a3 3 0 0 1 6 0" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="ab-book-popover" role="dialog" aria-label="Address book">
+          <div className="ab-book-popover-head">
+            <input
+              type="search"
+              className="ab-book-search"
+              placeholder="Search saved addresses"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              aria-label="Search saved addresses"
+              autoFocus
+            />
+            <ScreeningInfoButton />
+          </div>
+          {entries.length ? (
+            <AddressBookPicker
+              entries={entries}
+              getStatus={getStatus}
+              networkName={netName}
+              onSelect={handleSelect}
+            />
+          ) : (
+            <p className="ab-picker-empty" role="note">
+              {query ? 'No saved contacts match.' : 'No saved contacts yet.'}
+            </p>
+          )}
+        </div>
+      )}
+    </span>
+  )
+}

--- a/frontend/src/components/ui/AddressBookField.css
+++ b/frontend/src/components/ui/AddressBookField.css
@@ -59,4 +59,56 @@
   margin: 0;
   font-size: 0.82rem;
   color: var(--text-muted, #64748b);
+  padding: 0.5rem 0.6rem;
+}
+
+/* Inline address-book icon button (sits next to the QR scan button). */
+.ab-book-btn-wrap {
+  position: relative;
+  display: inline-flex;
+  align-self: flex-start;
+}
+
+.ab-book-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 1100;
+  width: min(320px, 80vw);
+  background: var(--card-bg, #fff);
+  color: inherit;
+  border: 1px solid var(--border-color, #cbd5e1);
+  border-radius: 0.5rem;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
+  padding: 0.5rem;
+}
+
+.ab-book-popover-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.4rem;
+}
+
+.ab-book-search {
+  flex: 1;
+  min-width: 0;
+  padding: 0.4rem 0.55rem;
+  border: 1px solid var(--border-color, #cbd5e1);
+  border-radius: 0.375rem;
+  font: inherit;
+}
+
+/* Inline screening notice under an address field. */
+.ab-screen-notice {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.4rem;
+  font-size: 0.82rem;
+}
+
+.ab-screen-notice-text {
+  color: var(--text-muted, #475569);
 }

--- a/frontend/src/components/ui/AddressScreenNotice.jsx
+++ b/frontend/src/components/ui/AddressScreenNotice.jsx
@@ -1,0 +1,38 @@
+/**
+ * AddressScreenNotice (Spec 021 iteration 2) — inline advisory screening notice
+ * for a single address (e.g. the opponent entered on the wager-create form).
+ * Shows a RestrictionTag plus short text when the address screens as restricted
+ * or unscreened; renders nothing when clear/empty.
+ */
+
+import { useEffect } from 'react'
+import { useAddressScreening } from '../../hooks/useAddressScreening'
+import { isValidAddress } from '../../lib/addressBook/addressBookStore'
+import RestrictionTag from '../account/RestrictionTag'
+import ScreeningInfoButton from './ScreeningInfoButton'
+
+const MESSAGES = {
+  restricted: 'This address is flagged by sanctions screening. Creating a wager with it will be blocked on-chain.',
+  uncertain: 'This address could not be screened on this network. Proceed with caution.',
+}
+
+export default function AddressScreenNotice({ address, chainId }) {
+  const { getStatus, screen } = useAddressScreening()
+  const valid = address && isValidAddress(address)
+
+  useEffect(() => {
+    if (valid) screen([{ address, chainId }])
+  }, [valid, address, chainId, screen])
+
+  if (!valid) return null
+  const status = getStatus(address, chainId)
+  if (status !== 'restricted' && status !== 'uncertain') return null
+
+  return (
+    <div className="ab-screen-notice" role="status">
+      <RestrictionTag status={status} />
+      <span className="ab-screen-notice-text">{MESSAGES[status]}</span>
+      <ScreeningInfoButton />
+    </div>
+  )
+}

--- a/frontend/src/components/ui/ScreeningInfo.css
+++ b/frontend/src/components/ui/ScreeningInfo.css
@@ -1,0 +1,58 @@
+.ab-info-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.ab-info-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid var(--border-color, #cbd5e1);
+  border-radius: 50%;
+  background: transparent;
+  color: var(--text-secondary, #64748b);
+  cursor: pointer;
+}
+
+.ab-info-btn:hover,
+.ab-info-btn:focus-visible {
+  color: var(--accent, #2563eb);
+  border-color: var(--accent, #2563eb);
+}
+
+.ab-info-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 1100;
+  width: min(320px, 80vw);
+  background: var(--card-bg, #fff);
+  color: inherit;
+  border: 1px solid var(--border-color, #cbd5e1);
+  border-radius: 0.5rem;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
+  padding: 0.75rem 0.9rem;
+  text-align: left;
+}
+
+.ab-info-popover h4 {
+  margin: 0 0 0.5rem;
+  font-size: 0.9rem;
+}
+
+.ab-info-popover ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.82rem;
+}
+
+.ab-info-doc {
+  margin: 0.6rem 0 0;
+  font-size: 0.82rem;
+}

--- a/frontend/src/components/ui/ScreeningInfoButton.jsx
+++ b/frontend/src/components/ui/ScreeningInfoButton.jsx
@@ -1,0 +1,87 @@
+/**
+ * ScreeningInfoButton (Spec 021 iteration 2) — an info (ⓘ) button that explains
+ * how address screening works: it is an advisory pre-check, the on-chain guard
+ * is the real enforcement, results fail closed, and they are network-scoped.
+ * Links to the detailed user-guide doc.
+ */
+
+import { useState, useRef, useEffect } from 'react'
+import './ScreeningInfo.css'
+
+export default function ScreeningInfoButton({ className = '' }) {
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef(null)
+
+  useEffect(() => {
+    if (!open) return undefined
+    const onDocClick = (e) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target)) setOpen(false)
+    }
+    const onKey = (e) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDocClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDocClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  return (
+    <span className={`ab-info-wrap ${className}`} ref={wrapRef}>
+      <button
+        type="button"
+        className="ab-info-btn"
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        aria-label="How address screening works"
+        title="How screening works"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+          <circle cx="12" cy="12" r="10" />
+          <line x1="12" y1="16" x2="12" y2="12" />
+          <line x1="12" y1="8" x2="12.01" y2="8" />
+        </svg>
+      </button>
+
+      {open && (
+        <div className="ab-info-popover" role="dialog" aria-label="How address screening works">
+          <h4>How address screening works</h4>
+          <ul>
+            <li>
+              <strong>Advisory only.</strong> The warning tags are a convenience pre-check. They
+              do <em>not</em> block anything by themselves.
+            </li>
+            <li>
+              <strong>On-chain guard enforces.</strong> The smart contracts independently screen
+              every participant, so a restricted address is blocked on-chain even if the app shows
+              no warning.
+            </li>
+            <li>
+              <strong>Fails closed.</strong> If an address can&apos;t be screened (the guard isn&apos;t
+              configured on the network, or the check fails), it shows as
+              <em> Unscreened</em> — never as clear.
+            </li>
+            <li>
+              <strong>Network-scoped.</strong> A result applies only to the network it was checked
+              on; the same address may screen differently on another network.
+            </li>
+          </ul>
+          <p className="ab-info-doc">
+            See the{' '}
+            <a
+              href="https://chippr-robotics.github.io/prediction-dao-research/user-guide/address-book/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Address Book &amp; screening guide
+            </a>{' '}
+            for full details.
+          </p>
+        </div>
+      )}
+    </span>
+  )
+}

--- a/frontend/src/lib/addressBook/scanAddress.js
+++ b/frontend/src/lib/addressBook/scanAddress.js
@@ -1,0 +1,14 @@
+/**
+ * Extract an EVM address from scanned QR content (Spec 021 iteration 2).
+ *
+ * Handles raw addresses, EIP-681 `ethereum:0x…` URIs, and URLs that carry the
+ * address in their path or query (e.g. a FairWins share link). Returns a 0x
+ * address string, or null when none is present.
+ */
+export function extractAddressFromScan(decodedText) {
+  if (typeof decodedText !== 'string') return null
+  const match = decodedText.match(/0x[a-fA-F0-9]{40}/)
+  return match ? match[0] : null
+}
+
+export default extractAddressFromScan

--- a/frontend/src/test/addressBook/AddressBookButton.test.jsx
+++ b/frontend/src/test/addressBook/AddressBookButton.test.jsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'vitest-axe'
+
+const A1 = '0x1111111111111111111111111111111111111111'
+
+let entries = []
+let statusMap = {}
+const screenFn = vi.fn()
+vi.mock('../../hooks/useAddressBook', () => ({
+  useAddressBook: () => ({ search: () => entries }),
+}))
+vi.mock('../../hooks/useAddressScreening', () => ({
+  useAddressScreening: () => ({
+    getStatus: (addr) => statusMap[addr?.toLowerCase()] || 'clear',
+    screen: screenFn,
+  }),
+}))
+
+import AddressBookButton from '../../components/ui/AddressBookButton'
+
+describe('AddressBookButton (iteration 2)', () => {
+  beforeEach(() => {
+    entries = [{ contactId: 'c1', nickname: 'Alex', address: A1, chainId: 137 }]
+    statusMap = {}
+    screenFn.mockReset()
+  })
+
+  it('opens a popover and selects a saved contact', async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+    render(<AddressBookButton chainId={137} onSelect={onSelect} />)
+    await user.click(screen.getByRole('button', { name: 'Choose from address book' }))
+    await user.click(screen.getByText('Alex'))
+    expect(onSelect).toHaveBeenCalledWith(entries[0])
+  })
+
+  it('filters results via the search box', async () => {
+    const user = userEvent.setup()
+    render(<AddressBookButton chainId={137} onSelect={() => {}} />)
+    await user.click(screen.getByRole('button', { name: 'Choose from address book' }))
+    expect(screen.getByLabelText('Search saved addresses')).toBeInTheDocument()
+    expect(screen.getByText('Alex')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when there are no saved contacts', async () => {
+    entries = []
+    const user = userEvent.setup()
+    render(<AddressBookButton chainId={137} onSelect={() => {}} />)
+    await user.click(screen.getByRole('button', { name: 'Choose from address book' }))
+    expect(screen.getByText('No saved contacts yet.')).toBeInTheDocument()
+  })
+
+  it('reuses the QR button sizing class for matched dimensions', () => {
+    render(<AddressBookButton chainId={137} onSelect={() => {}} />)
+    expect(screen.getByRole('button', { name: 'Choose from address book' })).toHaveClass('fm-scan-btn')
+  })
+
+  it('has no accessibility violations when open', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<AddressBookButton chainId={137} onSelect={() => {}} />)
+    await user.click(screen.getByRole('button', { name: 'Choose from address book' }))
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/addressBook/AddressScreenNotice.test.jsx
+++ b/frontend/src/test/addressBook/AddressScreenNotice.test.jsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+
+const A1 = '0x1111111111111111111111111111111111111111'
+
+let statusMap = {}
+vi.mock('../../hooks/useAddressScreening', () => ({
+  useAddressScreening: () => ({
+    getStatus: (addr) => statusMap[addr?.toLowerCase()] || 'clear',
+    screen: vi.fn(),
+  }),
+}))
+
+import AddressScreenNotice from '../../components/ui/AddressScreenNotice'
+
+describe('AddressScreenNotice (iteration 2)', () => {
+  beforeEach(() => {
+    statusMap = {}
+  })
+
+  it('warns when the address is restricted', () => {
+    statusMap[A1.toLowerCase()] = 'restricted'
+    render(<AddressScreenNotice address={A1} chainId={137} />)
+    expect(screen.getByText('Restricted')).toBeInTheDocument()
+    expect(screen.getByText(/blocked on-chain/i)).toBeInTheDocument()
+  })
+
+  it('warns (uncertain) when the address cannot be screened', () => {
+    statusMap[A1.toLowerCase()] = 'uncertain'
+    render(<AddressScreenNotice address={A1} chainId={137} />)
+    expect(screen.getByText('Unscreened')).toBeInTheDocument()
+  })
+
+  it('renders nothing for a clear address', () => {
+    const { container } = render(<AddressScreenNotice address={A1} chainId={137} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing for an empty/invalid address', () => {
+    const { container } = render(<AddressScreenNotice address="" chainId={137} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('has no accessibility violations', async () => {
+    statusMap[A1.toLowerCase()] = 'restricted'
+    const { container } = render(<AddressScreenNotice address={A1} chainId={137} />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/addressBook/ContactEditModal.test.jsx
+++ b/frontend/src/test/addressBook/ContactEditModal.test.jsx
@@ -2,6 +2,18 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { axe } from 'vitest-axe'
+
+// Stub the camera-driven scanner: when open, expose a button that fires a scan.
+const SCANNED = '0x52908400098527886E0F7030069857D2E4169EE7'
+vi.mock('../../components/ui/QRScanner', () => ({
+  default: ({ isOpen, onScanSuccess }) =>
+    isOpen ? (
+      <button type="button" onClick={() => onScanSuccess(`ethereum:${SCANNED}`)}>
+        mock-scan
+      </button>
+    ) : null,
+}))
+
 import ContactEditModal from '../../components/account/ContactEditModal'
 
 const NETWORKS = [
@@ -60,6 +72,14 @@ describe('ContactEditModal', () => {
     setup({ findDuplicate })
     await user.type(screen.getByLabelText('Address *'), VALID)
     expect(await screen.findByText(/Already saved under "Bob"/)).toBeInTheDocument()
+  })
+
+  it('fills an address row from a scanned QR code (iteration 2)', async () => {
+    const user = userEvent.setup()
+    setup()
+    await user.click(screen.getByRole('button', { name: 'Scan a QR code for address 1' }))
+    await user.click(screen.getByRole('button', { name: 'mock-scan' }))
+    expect(screen.getByLabelText('Address *')).toHaveValue(SCANNED)
   })
 
   it('has no accessibility violations', async () => {

--- a/frontend/src/test/addressBook/ScreeningInfoButton.test.jsx
+++ b/frontend/src/test/addressBook/ScreeningInfoButton.test.jsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'vitest-axe'
+import ScreeningInfoButton from '../../components/ui/ScreeningInfoButton'
+
+describe('ScreeningInfoButton (iteration 2)', () => {
+  it('toggles an explanation of how screening works', async () => {
+    const user = userEvent.setup()
+    render(<ScreeningInfoButton />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'How address screening works' }))
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeInTheDocument()
+    expect(dialog).toHaveTextContent(/Advisory only/i)
+    expect(dialog).toHaveTextContent(/on-chain guard/i)
+    expect(dialog).toHaveTextContent(/Fails closed/i)
+    expect(dialog).toHaveTextContent(/Network-scoped/i)
+  })
+
+  it('links to the address-book guide', async () => {
+    const user = userEvent.setup()
+    render(<ScreeningInfoButton />)
+    await user.click(screen.getByRole('button', { name: 'How address screening works' }))
+    const link = screen.getByRole('link', { name: /Address Book.*screening guide/i })
+    expect(link).toHaveAttribute('href', expect.stringContaining('address-book'))
+  })
+
+  it('has no accessibility violations when open', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<ScreeningInfoButton />)
+    await user.click(screen.getByRole('button', { name: 'How address screening works' }))
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/addressBook/scanAddress.test.js
+++ b/frontend/src/test/addressBook/scanAddress.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { extractAddressFromScan } from '../../lib/addressBook/scanAddress'
+
+const ADDR = '0x52908400098527886E0F7030069857D2E4169EE7'
+
+describe('extractAddressFromScan', () => {
+  it('returns a raw address as-is', () => {
+    expect(extractAddressFromScan(ADDR)).toBe(ADDR)
+  })
+
+  it('extracts from an EIP-681 ethereum: URI', () => {
+    expect(extractAddressFromScan(`ethereum:${ADDR}@137`)).toBe(ADDR)
+  })
+
+  it('extracts from a share URL path or query', () => {
+    expect(extractAddressFromScan(`https://fairwins.app/u/${ADDR}`)).toBe(ADDR)
+    expect(extractAddressFromScan(`https://fairwins.app/?address=${ADDR}`)).toBe(ADDR)
+  })
+
+  it('returns null when no address is present', () => {
+    expect(extractAddressFromScan('not an address')).toBeNull()
+    expect(extractAddressFromScan('')).toBeNull()
+    expect(extractAddressFromScan(null)).toBeNull()
+  })
+
+  it('ignores too-short hex strings', () => {
+    expect(extractAddressFromScan('0x1234')).toBeNull()
+  })
+})

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
     - Accepting a Wager: user-guide/accept-wager.md
     - Resolving a Wager: user-guide/resolve-wager.md
     - Private Wager Encryption: user-guide/private-market-encryption.md
+    - Address Book & Screening: user-guide/address-book.md
     - FAQ: user-guide/faq.md
   - Developer Guide:
     - Setup: developer-guide/setup.md


### PR DESCRIPTION
## Summary

Follow-up improvements to the merged Address Book feature (#715), addressing three requests. Frontend + docs only — **no contract, subgraph, or backend changes**.

### 1. QR scanning in the address entry modal
Each address row in the contact edit modal gets a QR scan button (matching the wager-create scanner). It reuses the existing `QRScanner` and a new shared `extractAddressFromScan` parser (handles raw addresses, `ethereum:` URIs, and share URLs). The scanned address fills that row.

### 2. Inline address-book icon button on wager creation
The address-book picker on the **opponent** and **arbitrator** fields is now a compact **icon button inline next to the QR button**, reusing the exact `fm-scan-btn` sizing class (42×44) so they match. It opens a searchable popover of saved contacts (`AddressBookButton`), replacing the previous full-width block addon. The restriction warning for the entered address moved to an inline `AddressScreenNotice` below the field.

### 3. Screening info button + documentation
A new info (ⓘ) button (`ScreeningInfoButton`) explains how screening works — **advisory only**, **on-chain guard enforces**, **fails closed**, **network-scoped** — shown in the Address Book panel header, the picker popover, and the inline notice. It links to a new detailed guide: `docs/user-guide/address-book.md` (added to the MkDocs nav).

## New components / modules
- `components/ui/AddressBookButton.jsx` — inline icon picker
- `components/ui/AddressScreenNotice.jsx` — inline restriction notice
- `components/ui/ScreeningInfoButton.jsx` — screening explainer popover
- `lib/addressBook/scanAddress.js` — QR payload → address parser
- `docs/user-guide/address-book.md` — user guide

## Validation
- New Vitest unit/component/`vitest-axe` tests for all of the above (address-book suite: 72 tests).
- **Full frontend suite: 1465/1465 passing** (incl. all `FriendMarketsModal` tests — no regressions).
- **ESLint clean.**
- WCAG 2.1 AA: tags/notices use icon + text; popovers are keyboard/escape/outside-click dismissible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rde8joG1pivDQK5Nhnd4FF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rde8joG1pivDQK5Nhnd4FF)_