### PR TITLE
spec: membership purchase progress indicator (022)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/021-address-book"
+  "feature_directory": "specs/022-membership-purchase-progress"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,5 +57,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/021-address-book/plan.md
+at specs/022-membership-purchase-progress/plan.md
 <!-- SPECKIT END -->

--- a/frontend/src/components/ui/PremiumPurchaseModal.css
+++ b/frontend/src/components/ui/PremiumPurchaseModal.css
@@ -1644,3 +1644,175 @@
     display: none;
   }
 }
+
+/* ===========================
+   Purchase Progress (spec 022)
+   Dedicated processing view: per-wallet-interaction step indicator.
+   =========================== */
+
+.ppm-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ppm-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.ppm-progress-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.ppm-progress-position {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary, #718096);
+}
+
+.ppm-progress-bar {
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--bg-primary, #f8fafc);
+  overflow: hidden;
+}
+
+.ppm-progress-bar-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--brand-primary, #36B37E);
+  transition: width 0.3s ease;
+}
+
+.ppm-progress-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ppm-progress-step {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.75rem;
+  border: 1px solid var(--border-color, #e2e8f0);
+  border-radius: 10px;
+  background: var(--bg-secondary, #ffffff);
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.ppm-progress-step--active,
+.ppm-progress-step--confirming {
+  border-color: var(--brand-primary, #36B37E);
+  background: rgba(54, 179, 126, 0.06);
+}
+
+.ppm-progress-step--completed {
+  opacity: 0.85;
+}
+
+.ppm-progress-step--failed {
+  border-color: var(--error-color, #e53e3e);
+  background: rgba(229, 62, 62, 0.06);
+}
+
+.ppm-progress-step-icon {
+  flex: 0 0 1.75rem;
+  width: 1.75rem;
+  height: 1.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--bg-primary, #f8fafc);
+  color: var(--text-tertiary, #a0aec0);
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.ppm-progress-step--completed .ppm-progress-step-icon {
+  background: var(--success-color, #48bb78);
+  color: #fff;
+}
+
+.ppm-progress-step--failed .ppm-progress-step-icon {
+  background: var(--error-color, #e53e3e);
+  color: #fff;
+}
+
+.ppm-progress-step-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.ppm-progress-step-label {
+  font-weight: 600;
+  color: var(--text-primary, #2d3748);
+}
+
+.ppm-progress-step-kind {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+  color: var(--text-tertiary, #a0aec0);
+}
+
+.ppm-progress-step-kind--signature {
+  color: var(--brand-primary, #36B37E);
+}
+
+.ppm-progress-step-detail {
+  font-size: 0.82rem;
+  color: var(--text-secondary, #718096);
+}
+
+.ppm-progress-step-status {
+  font-size: 0.8rem;
+  color: var(--brand-primary, #36B37E);
+}
+
+.ppm-progress-step-error {
+  font-size: 0.82rem;
+  color: var(--error-color, #e53e3e);
+}
+
+.ppm-progress-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+/* Dark theme */
+:root.theme-dark .ppm-progress-step {
+  background: var(--bg-secondary, #1a202c);
+  border-color: var(--border-color, #2d3748);
+}
+
+:root.theme-dark .ppm-progress-bar,
+:root.theme-dark .ppm-progress-step-icon {
+  background: var(--bg-primary, #171923);
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .ppm-progress-bar-fill {
+    transition: none;
+  }
+}

--- a/frontend/src/components/ui/PremiumPurchaseModal.jsx
+++ b/frontend/src/components/ui/PremiumPurchaseModal.jsx
@@ -5,12 +5,13 @@ import { useNotification } from '../../hooks/useUI'
 import { useTierPrices } from '../../hooks/useTierPrices'
 import { useEncryption } from '../../hooks/useEncryption'
 import { recordRolePurchase } from '../../utils/roleStorage'
-import { purchaseRoleWithStablecoin, getUserTierOnChain } from '../../utils/blockchainService'
-import { ensureKeyRegistered } from '../../utils/keyRegistryService'
+import { getUserTierOnChain } from '../../utils/blockchainService'
 import { getCurrentDocument } from '../../utils/legalDocs'
 import { ACCOUNT_MODERATION_PATH } from '../../constants/legalLinks'
 import MembershipAttestation from '../compliance/MembershipAttestation'
 import { getTransactionUrl } from '../../config/blockExplorer'
+import { usePurchaseFlow } from '../../hooks/usePurchaseFlow'
+import PurchaseProgressView from './PurchaseProgressView'
 import './PremiumPurchaseModal.css'
 
 /**
@@ -91,6 +92,7 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
   const { showNotification } = useNotification()
   const { getPrice, getLimits } = useTierPrices()
   const { ensureInitialized } = useEncryption()
+  const flow = usePurchaseFlow()
 
   const isUpgradeFlow = action === 'upgrade'
   const isExtendFlow = action === 'extend'
@@ -98,11 +100,15 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
   const [currentStep, setCurrentStep] = useState(0)
   const [selectedTier, setSelectedTier] = useState('BRONZE')
   const [acknowledged, setAcknowledged] = useState(false)
-  const [isPurchasing, setIsPurchasing] = useState(false)
+  const [showProcessing, setShowProcessing] = useState(false)
   const [purchaseResult, setPurchaseResult] = useState(null)
   const [errors, setErrors] = useState({})
   const [keyRegStatus, setKeyRegStatus] = useState(null) // null | 'registering' | 'success' | 'skipped' | 'failed'
   const [keyRegError, setKeyRegError] = useState(null)
+
+  // While any wallet interaction is in flight the modal must not be dismissed
+  // (FR-012) and the step/footer controls are locked.
+  const isBusy = flow.status === 'running'
 
   const [userCurrentTier, setUserCurrentTier] = useState(0)
   const [isLoadingTier, setIsLoadingTier] = useState(false)
@@ -180,12 +186,14 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
     }
     if (!validateStep(1)) return
 
-    setIsPurchasing(true)
-    try {
-      const tierValue = selectedTierInfo.id
-      const tierName = selectedTierInfo.name
-      showNotification(`Please confirm the transaction in your wallet (${tierName} tier, ${selectedPrice} USDC)`, 'info', 10000)
+    const tierValue = selectedTierInfo.id
+    const tierName = selectedTierInfo.name
+    showNotification(`Confirm the wallet prompts to complete your ${tierName} membership (${selectedPrice} USDC)`, 'info', 10000)
 
+    // Switch to the dedicated Processing view (spec 022) — the step indicator
+    // surfaces each wallet interaction in turn.
+    setShowProcessing(true)
+    try {
       // Get a fresh signer
       const { ethers } = await import('ethers')
       const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' })
@@ -195,46 +203,56 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
 
       // Spec 007 (FR-039): record the accepted in-force Terms version hash on-chain.
       const acceptedTermsHash = getCurrentDocument('terms')?.hash || null
-      const receipt = await purchaseRoleWithStablecoin(signer, ROLE_KEY, selectedPrice, tierValue, action, acceptedTermsHash)
-      grantRole(ROLE_KEY)
-      recordRolePurchase(account, ROLE_KEY, {
-        price: selectedPrice,
-        currency: 'USDC',
-        tier: selectedTier,
-        tierValue,
-        txHash: receipt.hash,
-        purchasedBy: account,
-      }, chainId)
-      setPurchaseResult({ success: true, tier: tierName, txHash: receipt.hash })
-      try { await loadRoles() } catch (e) { console.warn('refresh roles failed:', e) }
-      showNotification(`${tierName} membership activated.`, 'success', 7000)
 
-      // Auto-register encryption key after successful payment
-      setKeyRegStatus('registering')
-      try {
-        const keys = await ensureInitialized()
-        if (keys?.publicKey) {
-          const wasNew = await ensureKeyRegistered(signer, account, keys.publicKey)
-          setKeyRegStatus(wasNew ? 'success' : 'skipped')
-        } else {
-          setKeyRegStatus('failed')
-          setKeyRegError('Could not derive encryption keys')
-        }
-      } catch (keyErr) {
-        console.warn('[PremiumPurchaseModal] key registration failed (non-fatal):', keyErr.message)
-        setKeyRegStatus('failed')
-        setKeyRegError(keyErr.message)
-      }
-
-      setCurrentStep(2)
+      await flow.start({
+        signer,
+        account,
+        roleName: ROLE_KEY,
+        priceUSD: selectedPrice,
+        tier: tierValue,
+        action,
+        termsHash: acceptedTermsHash,
+        ensureInitialized,
+        // Membership is active the moment payment confirms — run side effects then,
+        // before the (non-blocking) key steps.
+        onPaid: async (receipt) => {
+          grantRole(ROLE_KEY)
+          recordRolePurchase(account, ROLE_KEY, {
+            price: selectedPrice,
+            currency: 'USDC',
+            tier: selectedTier,
+            tierValue,
+            txHash: receipt.hash,
+            purchasedBy: account,
+          }, chainId)
+          try { await loadRoles() } catch (e) { console.warn('refresh roles failed:', e) }
+          showNotification(`${tierName} membership activated.`, 'success', 7000)
+        },
+      })
     } catch (err) {
-      console.error('[PremiumPurchaseModal] purchase failed:', err)
+      // Failure to even acquire a signer (before the flow starts). In-flow failures
+      // are handled by the progress view's Retry / Continue actions.
+      console.error('[PremiumPurchaseModal] purchase setup failed:', err)
       setPurchaseResult({ success: false, error: err.message })
       showNotification('Purchase failed: ' + err.message, 'error', 7000)
-    } finally {
-      setIsPurchasing(false)
+      setShowProcessing(false)
+      setCurrentStep(2)
     }
   }
+
+  // React to the flow reaching a terminal success (all steps done, or the member
+  // chose "Continue anyway" past a non-blocking key step).
+  useEffect(() => {
+    if (flow.status !== 'succeeded') return
+    setPurchaseResult({ success: true, tier: selectedTierInfo?.name, txHash: flow.purchaseReceipt?.hash })
+    setKeyRegStatus(flow.keyRegOutcome) // 'success' | 'skipped' | 'failed'
+    if (flow.keyRegOutcome === 'failed') {
+      setKeyRegError('Key registration was not completed')
+    }
+    setShowProcessing(false)
+    setCurrentStep(2)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [flow.status])
 
   const resetForm = useCallback(() => {
     setCurrentStep(0)
@@ -242,17 +260,18 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
     setAcknowledged(false)
     setPurchaseResult(null)
     setErrors({})
-    setIsPurchasing(false)
+    setShowProcessing(false)
     setKeyRegStatus(null)
     setKeyRegError(null)
-  }, [])
+    flow.reset()
+  }, [flow])
 
   const handleClose = useCallback(() => {
-    if (!isPurchasing) {
+    if (!isBusy) {
       resetForm()
       onClose?.()
     }
-  }, [isPurchasing, resetForm, onClose])
+  }, [isBusy, resetForm, onClose])
 
   if (!isOpen) return null
 
@@ -281,7 +300,7 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
           <button
             className="ppm-close-btn"
             onClick={handleClose}
-            disabled={isPurchasing}
+            disabled={isBusy}
             aria-label="Close modal"
           >
             <span aria-hidden="true">&times;</span>
@@ -297,7 +316,7 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
                 key={step.id}
                 className={`ppm-step ${isActive ? 'active' : ''} ${isCompleted ? 'completed' : ''}`}
                 onClick={() => handleStepClick(index)}
-                disabled={isPurchasing || index > currentStep}
+                disabled={isBusy || index > currentStep}
                 aria-current={isActive ? 'step' : undefined}
               >
                 <span className="ppm-step-icon" aria-hidden="true">
@@ -310,8 +329,32 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
         </nav>
 
         <div className="ppm-content">
+          {/* Processing view (spec 022): dedicated per-wallet-interaction progress,
+              shown between Review and Complete. */}
+          {showProcessing && (
+            <div className="ppm-panel" role="tabpanel">
+              <section className="ppm-section">
+                <h3 className="ppm-section-title">
+                  <span aria-hidden="true">⏳</span> Completing your purchase
+                </h3>
+                <PurchaseProgressView
+                  steps={flow.steps}
+                  activeIndex={flow.activeIndex}
+                  activeStep={flow.activeStep}
+                  status={flow.status}
+                  completedCount={flow.completedCount}
+                  total={flow.total}
+                  progressFraction={flow.progressFraction}
+                  canContinueAnyway={flow.canContinueAnyway}
+                  onRetry={flow.retry}
+                  onContinueAnyway={flow.continueAnyway}
+                />
+              </section>
+            </div>
+          )}
+
           {/* Step 1: Tier */}
-          {currentStep === 0 && (
+          {!showProcessing && currentStep === 0 && (
             <div className="ppm-panel" role="tabpanel">
               <section className="ppm-section">
                 <div className="ppm-section-header">
@@ -379,7 +422,7 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
                             value={tierKey}
                             checked={isSelected}
                             onChange={() => setSelectedTier(tierKey)}
-                            disabled={isPurchasing}
+                            disabled={isBusy}
                             className="ppm-tier-radio"
                           />
                           <div className="ppm-tier-content">
@@ -404,7 +447,7 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
           )}
 
           {/* Step 2: Review */}
-          {currentStep === 1 && (
+          {!showProcessing && currentStep === 1 && (
             <div className="ppm-panel" role="tabpanel">
               <section className="ppm-section">
                 <h3 className="ppm-section-title">
@@ -574,40 +617,38 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
 
         <footer className="ppm-footer">
           <div className="ppm-footer-left">
-            {currentStep > 0 && currentStep < 2 && (
-              <button type="button" className="ppm-btn-secondary" onClick={handleBack} disabled={isPurchasing}>
+            {!showProcessing && currentStep > 0 && currentStep < 2 && (
+              <button type="button" className="ppm-btn-secondary" onClick={handleBack} disabled={isBusy}>
                 Back
               </button>
             )}
           </div>
           <div className="ppm-footer-right">
-            {currentStep < 2 && (
-              <button type="button" className="ppm-btn-secondary" onClick={handleClose} disabled={isPurchasing}>
+            {/* During the Processing view, recovery actions live in the progress
+                view itself (Retry / Continue anyway), so the form footer is hidden. */}
+            {!showProcessing && currentStep < 2 && (
+              <button type="button" className="ppm-btn-secondary" onClick={handleClose} disabled={isBusy}>
                 Cancel
               </button>
             )}
-            {currentStep === 0 && (
+            {!showProcessing && currentStep === 0 && (
               <button
                 type="button"
                 className="ppm-btn-primary"
                 onClick={handleNext}
-                disabled={isPurchasing || availableTiers.length === 0}
+                disabled={isBusy || availableTiers.length === 0}
               >
                 Continue
               </button>
             )}
-            {currentStep === 1 && (
+            {!showProcessing && currentStep === 1 && (
               <button
                 type="button"
                 className="ppm-btn-primary ppm-btn-purchase"
                 onClick={handlePurchase}
-                disabled={isPurchasing || !isConnected || !isCorrectNetwork || !acknowledged}
+                disabled={isBusy || !isConnected || !isCorrectNetwork || !acknowledged}
               >
-                {isPurchasing ? (
-                  <><span className="ppm-spinner" aria-hidden="true" /> Processing...</>
-                ) : (
-                  <>Confirm Purchase (${selectedPrice.toFixed(2)} USDC)</>
-                )}
+                Confirm Purchase (${selectedPrice.toFixed(2)} USDC)
               </button>
             )}
             {currentStep === 2 && (

--- a/frontend/src/components/ui/PurchaseProgressView.jsx
+++ b/frontend/src/components/ui/PurchaseProgressView.jsx
@@ -1,0 +1,122 @@
+/**
+ * Spec 022 — Membership Purchase Progress Indicator.
+ *
+ * Presentational, stateless render of the purchase step sequence. Receives state
+ * from `usePurchaseFlow` and reports user intent via callbacks. Owns no
+ * orchestration. See specs/022-membership-purchase-progress/contracts/.
+ */
+
+const KIND_LABEL = {
+  transaction: 'Transaction — confirm in your wallet (costs gas)',
+  signature: 'Signature — sign a message (no funds move, no gas)',
+}
+
+const STATE_ICON = {
+  pending: '○',
+  active: '●',
+  confirming: '●',
+  completed: '✓',
+  failed: '✕',
+}
+
+function announce(activeStep) {
+  if (!activeStep) return ''
+  const stateWord =
+    activeStep.state === 'confirming' ? 'confirming on-chain'
+      : activeStep.state === 'active' ? 'waiting for your wallet'
+        : activeStep.state === 'failed' ? 'failed'
+          : activeStep.state
+  return `Step: ${activeStep.label}. ${activeStep.kind}. ${stateWord}.`
+}
+
+function PurchaseProgressView({
+  steps = [],
+  activeIndex = null,
+  status = 'idle',
+  completedCount = 0,
+  total = 0,
+  progressFraction = 0,
+  activeStep = null,
+  canContinueAnyway = false,
+  onRetry,
+  onContinueAnyway,
+}) {
+  const positionLabel = total > 0 ? `Step ${Math.min(completedCount + 1, total)} of ${total}` : ''
+
+  return (
+    <div className="ppm-progress" role="group" aria-label="Purchase progress">
+      {/* Live announcement for assistive tech (FR-013) */}
+      <div className="ppm-sr-only" role="status" aria-live="polite">
+        {announce(activeStep)}
+      </div>
+
+      <div className="ppm-progress-header">
+        <span className="ppm-progress-position">{positionLabel}</span>
+        <div
+          className="ppm-progress-bar"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={total}
+          aria-valuenow={completedCount}
+          aria-label="Overall purchase progress"
+        >
+          <div
+            className="ppm-progress-bar-fill"
+            style={{ width: `${Math.round(progressFraction * 100)}%` }}
+          />
+        </div>
+      </div>
+
+      <ol className="ppm-progress-steps">
+        {steps.map((step, index) => {
+          const isActive = index === activeIndex && (step.state === 'active' || step.state === 'confirming')
+          const accessibleName = `${step.label}. ${KIND_LABEL[step.kind]}. ${step.state}.`
+          return (
+            <li
+              key={step.id}
+              className={`ppm-progress-step ppm-progress-step--${step.state}`}
+              aria-current={isActive ? 'step' : undefined}
+              aria-label={accessibleName}
+            >
+              <span className="ppm-progress-step-icon" aria-hidden="true">
+                {(step.state === 'active' || step.state === 'confirming')
+                  ? <span className="ppm-spinner" />
+                  : STATE_ICON[step.state]}
+              </span>
+              <span className="ppm-progress-step-body">
+                <span className="ppm-progress-step-label">{step.label}</span>
+                <span className={`ppm-progress-step-kind ppm-progress-step-kind--${step.kind}`}>
+                  {step.kind === 'signature' ? 'Signature · no gas' : 'Transaction · in wallet'}
+                </span>
+                {step.detail && (
+                  <span className="ppm-progress-step-detail">{step.detail}</span>
+                )}
+                {step.state === 'confirming' && (
+                  <span className="ppm-progress-step-status" role="status">Waiting for confirmation…</span>
+                )}
+                {step.state === 'failed' && step.failureReason && (
+                  <span className="ppm-progress-step-error">{step.failureReason}</span>
+                )}
+              </span>
+            </li>
+          )
+        })}
+      </ol>
+
+      {status === 'failed' && (
+        <div className="ppm-progress-actions">
+          <button type="button" className="ppm-btn-primary" onClick={onRetry}>
+            Retry
+          </button>
+          {canContinueAnyway && (
+            <button type="button" className="ppm-btn-secondary" onClick={onContinueAnyway}>
+              Continue anyway
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default PurchaseProgressView

--- a/frontend/src/hooks/usePurchaseFlow.js
+++ b/frontend/src/hooks/usePurchaseFlow.js
@@ -1,0 +1,205 @@
+import { useState, useRef, useCallback, useMemo } from 'react'
+import { purchaseRoleWithStablecoin, checkApprovalNeeded } from '../utils/blockchainService'
+import { ensureKeyRegistered } from '../utils/keyRegistryService'
+
+/**
+ * Spec 022 — Membership Purchase Progress Indicator.
+ *
+ * Step state machine that drives the dedicated "Processing" view of
+ * PremiumPurchaseModal. It surfaces the real wallet interactions of a membership
+ * purchase as discrete, labeled steps with live state, and supports safe recovery:
+ *
+ *   approve (optional) -> pay -> sign -> register
+ *
+ * - The approve step is OMITTED when the member already has sufficient allowance
+ *   (FR-009), determined by a read-only pre-flight (`checkApprovalNeeded`).
+ * - approve/pay are surfaced via the `onProgress` callback of
+ *   `purchaseRoleWithStablecoin`; sign/register are orchestrated here.
+ * - sign/register are non-blocking: the membership is already active once `pay`
+ *   confirms, so a key-step failure offers Retry AND Continue anyway (FR-010).
+ * - Retry resumes from the failed step without re-running the payment (FR-008).
+ *
+ * This hook changes NO purchase mechanics (FR-001a); it only observes and
+ * sequences the existing calls.
+ */
+
+const STEP_DEFS = {
+  approve: { id: 'approve', label: 'Approve USDC spending', detail: 'Authorize the membership contract to collect your USDC — no funds move yet.', kind: 'transaction', blocking: true },
+  pay: { id: 'pay', label: 'Pay for membership', detail: 'Send your USDC and receive the membership.', kind: 'transaction', blocking: true },
+  sign: { id: 'sign', label: 'Sign to set up private wagers', detail: 'Sign a message to derive your encryption key — no funds move, no gas.', kind: 'signature', blocking: false },
+  register: { id: 'register', label: 'Register your encryption key', detail: 'Publish your encryption key so others can send you private wagers.', kind: 'transaction', blocking: false },
+}
+
+const makeStep = (id) => ({ ...STEP_DEFS[id], state: 'pending', failureReason: null, txHash: null })
+
+/**
+ * @param {object} [deps] - injectable for tests; defaults to the real services.
+ */
+export function usePurchaseFlow(deps = {}) {
+  const purchaseFn = deps.purchaseRoleWithStablecoin || purchaseRoleWithStablecoin
+  const approvalCheckFn = deps.checkApprovalNeeded || checkApprovalNeeded
+  const registerKeyFn = deps.ensureKeyRegistered || ensureKeyRegistered
+
+  const [steps, setSteps] = useState([])
+  const [status, setStatus] = useState('idle') // idle | running | succeeded | failed
+  const [keyRegOutcome, setKeyRegOutcome] = useState(null) // null | success | skipped | failed
+
+  const paramsRef = useRef(null)
+  const receiptRef = useRef(null)
+  const publicKeyRef = useRef(null)
+
+  const updateStep = useCallback((id, patch) => {
+    setSteps((prev) => prev.map((s) => (s.id === id ? { ...s, ...patch } : s)))
+  }, [])
+
+  // Map approve/pay events from the service onto step state.
+  const handleProgress = useCallback((evt) => {
+    const { step, phase, txHash } = evt || {}
+    if (!step || phase === 'skipped') return
+    if (phase === 'start') updateStep(step, { state: 'active', failureReason: null })
+    else if (phase === 'sent') updateStep(step, { state: 'confirming', txHash })
+    else if (phase === 'confirmed') updateStep(step, { state: 'completed', txHash })
+  }, [updateStep])
+
+  // Mark the in-flight (or next pending) step as failed and attribute the reason.
+  const markFailed = useCallback((reason) => {
+    setSteps((prev) => {
+      let idx = prev.findIndex((s) => s.state === 'active' || s.state === 'confirming')
+      if (idx === -1) idx = prev.findIndex((s) => s.state === 'pending')
+      if (idx === -1) return prev
+      return prev.map((s, i) => (i === idx ? { ...s, state: 'failed', failureReason: reason } : s))
+    })
+  }, [])
+
+  /**
+   * Run the flow from a given segment: 'purchase' (approve+pay), 'sign', or
+   * 'register'. Used for both the initial run and resume-after-failure.
+   */
+  const runSegments = useCallback(async (fromSegment) => {
+    const p = paramsRef.current
+    if (!p) return
+    setStatus('running')
+    try {
+      if (fromSegment === 'purchase') {
+        const receipt = await purchaseFn(
+          p.signer, p.roleName, p.priceUSD, p.tier, p.action, p.termsHash, handleProgress,
+        )
+        receiptRef.current = receipt
+        // Defensively ensure approve (if present) + pay show completed.
+        setSteps((prev) => prev.map((s) =>
+          (s.id === 'approve' || s.id === 'pay') && s.state !== 'completed'
+            ? { ...s, state: 'completed' }
+            : s,
+        ))
+        // Membership is now active — fire side effects exactly once.
+        try { await p.onPaid?.(receipt) } catch (e) { console.warn('[usePurchaseFlow] onPaid failed:', e?.message) }
+      }
+
+      if (fromSegment === 'purchase' || fromSegment === 'sign') {
+        updateStep('sign', { state: 'active', failureReason: null })
+        const keys = await p.ensureInitialized()
+        if (!keys?.publicKey) throw new Error('Could not derive encryption keys')
+        publicKeyRef.current = keys.publicKey
+        updateStep('sign', { state: 'completed' })
+      }
+
+      // register
+      updateStep('register', { state: 'active', failureReason: null })
+      const wasNew = await registerKeyFn(p.signer, p.account, publicKeyRef.current)
+      updateStep('register', { state: 'completed' })
+      setKeyRegOutcome(wasNew ? 'success' : 'skipped')
+      setStatus('succeeded')
+    } catch (err) {
+      markFailed(err?.message || 'Step failed')
+      setStatus('failed')
+    }
+  }, [purchaseFn, registerKeyFn, handleProgress, updateStep, markFailed])
+
+  /**
+   * Begin a fresh purchase flow. Builds the step list (omitting approval when not
+   * needed) and runs it end to end.
+   */
+  const start = useCallback(async (params) => {
+    paramsRef.current = params
+    receiptRef.current = null
+    publicKeyRef.current = null
+    setKeyRegOutcome(null)
+    setStatus('running')
+
+    const approvalNeeded = await approvalCheckFn(
+      params.signer, params.roleName, params.priceUSD, params.tier, params.action,
+    )
+    const ids = approvalNeeded ? ['approve', 'pay', 'sign', 'register'] : ['pay', 'sign', 'register']
+    setSteps(ids.map(makeStep))
+
+    await runSegments('purchase')
+  }, [approvalCheckFn, runSegments])
+
+  /** Resume from the first failed step without repeating completed paid steps. */
+  const retry = useCallback(async () => {
+    const failedIdx = steps.findIndex((s) => s.state === 'failed')
+    if (failedIdx === -1) return
+    const failedId = steps[failedIdx].id
+    // Reset the failed step and everything after it back to pending.
+    setSteps((prev) => prev.map((s, i) =>
+      i >= failedIdx ? { ...s, state: 'pending', failureReason: null } : s,
+    ))
+    const segment = (failedId === 'approve' || failedId === 'pay')
+      ? 'purchase'
+      : (failedId === 'sign' ? 'sign' : 'register')
+    await runSegments(segment)
+  }, [steps, runSegments])
+
+  /**
+   * Accept a non-blocking key-step failure and finish as success. Valid only when
+   * the outstanding failure is a non-blocking (sign/register) step (FR-010).
+   */
+  const continueAnyway = useCallback(() => {
+    const failed = steps.find((s) => s.state === 'failed')
+    if (!failed || failed.blocking) return
+    setKeyRegOutcome('failed')
+    setStatus('succeeded')
+  }, [steps])
+
+  const reset = useCallback(() => {
+    paramsRef.current = null
+    receiptRef.current = null
+    publicKeyRef.current = null
+    setSteps([])
+    setStatus('idle')
+    setKeyRegOutcome(null)
+  }, [])
+
+  // Derived selectors (data-model.md).
+  const total = steps.length
+  const completedCount = useMemo(() => steps.filter((s) => s.state === 'completed').length, [steps])
+  const activeIndex = useMemo(() => {
+    const i = steps.findIndex((s) => s.state === 'active' || s.state === 'confirming' || s.state === 'failed')
+    return i === -1 ? null : i
+  }, [steps])
+  const progressFraction = total > 0 ? completedCount / total : 0
+  const activeStep = activeIndex == null ? null : steps[activeIndex]
+  const canContinueAnyway = useMemo(
+    () => status === 'failed' && steps.some((s) => s.state === 'failed' && !s.blocking),
+    [status, steps],
+  )
+
+  return {
+    steps,
+    status,
+    total,
+    completedCount,
+    activeIndex,
+    activeStep,
+    progressFraction,
+    keyRegOutcome,
+    canContinueAnyway,
+    purchaseReceipt: receiptRef.current,
+    start,
+    retry,
+    continueAnyway,
+    reset,
+  }
+}
+
+export default usePurchaseFlow

--- a/frontend/src/test/PurchaseProgressView.test.jsx
+++ b/frontend/src/test/PurchaseProgressView.test.jsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'vitest-axe'
+import PurchaseProgressView from '../components/ui/PurchaseProgressView'
+
+const step = (id, kind, state, extra = {}) => ({
+  id,
+  label: { approve: 'Approve USDC spending', pay: 'Pay for membership', sign: 'Sign to set up private wagers', register: 'Register your encryption key' }[id],
+  detail: 'detail text',
+  kind,
+  blocking: id === 'approve' || id === 'pay',
+  state,
+  failureReason: null,
+  txHash: null,
+  ...extra,
+})
+
+const runningProps = (over = {}) => ({
+  steps: [
+    step('pay', 'transaction', 'completed'),
+    step('sign', 'signature', 'active'),
+    step('register', 'transaction', 'pending'),
+  ],
+  activeIndex: 1,
+  activeStep: step('sign', 'signature', 'active'),
+  status: 'running',
+  completedCount: 1,
+  total: 3,
+  progressFraction: 1 / 3,
+  canContinueAnyway: false,
+  onRetry: vi.fn(),
+  onContinueAnyway: vi.fn(),
+  ...over,
+})
+
+describe('PurchaseProgressView — labels & kind (US1)', () => {
+  it('renders each step label (FR-002)', () => {
+    render(<PurchaseProgressView {...runningProps()} />)
+    expect(screen.getByText('Pay for membership')).toBeInTheDocument()
+    expect(screen.getByText('Sign to set up private wagers')).toBeInTheDocument()
+    expect(screen.getByText('Register your encryption key')).toBeInTheDocument()
+  })
+
+  it('distinguishes signature steps from transaction steps (FR-003)', () => {
+    render(<PurchaseProgressView {...runningProps()} />)
+    // signature indicator present for the sign step, transaction indicator for others
+    expect(screen.getByText(/Signature · no gas/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/Transaction · in wallet/i).length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('announces the active step via a live region (FR-013)', () => {
+    render(<PurchaseProgressView {...runningProps()} />)
+    const status = screen.getByRole('status')
+    expect(status.textContent).toMatch(/Sign to set up private wagers/i)
+  })
+})
+
+describe('PurchaseProgressView — progress position & states (US2)', () => {
+  it('shows overall position "step N of M" (FR-005)', () => {
+    render(<PurchaseProgressView {...runningProps()} />)
+    expect(screen.getByText(/Step 2 of 3/i)).toBeInTheDocument()
+  })
+
+  it('exposes a progressbar reflecting completed count', () => {
+    render(<PurchaseProgressView {...runningProps()} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '1')
+    expect(bar).toHaveAttribute('aria-valuemax', '3')
+  })
+
+  it('marks the active step with aria-current (FR-004)', () => {
+    render(<PurchaseProgressView {...runningProps()} />)
+    const current = document.querySelector('[aria-current="step"]')
+    expect(current).toBeTruthy()
+    expect(current.textContent).toMatch(/Sign to set up private wagers/i)
+  })
+})
+
+describe('PurchaseProgressView — failure & recovery (US3)', () => {
+  const failedBlocking = () => runningProps({
+    steps: [step('pay', 'transaction', 'failed', { failureReason: 'Transaction rejected by user' }), step('sign', 'signature', 'pending'), step('register', 'transaction', 'pending')],
+    status: 'failed',
+    activeIndex: 0,
+    activeStep: step('pay', 'transaction', 'failed', { failureReason: 'Transaction rejected by user' }),
+    canContinueAnyway: false,
+  })
+
+  const failedKey = () => runningProps({
+    steps: [step('pay', 'transaction', 'completed'), step('sign', 'signature', 'completed'), step('register', 'transaction', 'failed', { failureReason: 'register boom' })],
+    status: 'failed',
+    activeIndex: 2,
+    completedCount: 2,
+    activeStep: step('register', 'transaction', 'failed', { failureReason: 'register boom' }),
+    canContinueAnyway: true,
+  })
+
+  it('shows the failure reason and a Retry action (FR-007)', () => {
+    render(<PurchaseProgressView {...failedBlocking()} />)
+    expect(screen.getByText('Transaction rejected by user')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument()
+  })
+
+  it('does NOT offer Continue anyway for a blocking failure', () => {
+    render(<PurchaseProgressView {...failedBlocking()} />)
+    expect(screen.queryByRole('button', { name: /continue anyway/i })).not.toBeInTheDocument()
+  })
+
+  it('offers Continue anyway only for a non-blocking key-step failure (FR-010)', async () => {
+    const props = failedKey()
+    render(<PurchaseProgressView {...props} />)
+    const cont = screen.getByRole('button', { name: /continue anyway/i })
+    await userEvent.click(cont)
+    expect(props.onContinueAnyway).toHaveBeenCalled()
+  })
+
+  it('fires onRetry when Retry is clicked', async () => {
+    const props = failedKey()
+    render(<PurchaseProgressView {...props} />)
+    await userEvent.click(screen.getByRole('button', { name: /retry/i }))
+    expect(props.onRetry).toHaveBeenCalled()
+  })
+})
+
+describe('PurchaseProgressView — accessibility (FR-013, constitution V)', () => {
+  it('has no axe violations while running', async () => {
+    const { container } = render(<PurchaseProgressView {...runningProps()} />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('has no axe violations in a failed state', async () => {
+    const { container } = render(<PurchaseProgressView {...runningProps({
+      steps: [step('pay', 'transaction', 'completed'), step('register', 'transaction', 'failed', { failureReason: 'boom' })],
+      status: 'failed', activeIndex: 1, total: 2, completedCount: 1, canContinueAnyway: true,
+      activeStep: step('register', 'transaction', 'failed', { failureReason: 'boom' }),
+    })} />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/blockchainService.purchase.test.js
+++ b/frontend/src/test/blockchainService.purchase.test.js
@@ -57,6 +57,38 @@ describe('purchaseRoleWithStablecoin — chain-aware contract resolution', () =>
   })
 })
 
+describe('purchaseRoleWithStablecoin — onProgress callback (spec 022)', () => {
+  beforeEach(() => resolverMock.mockReset())
+
+  // The approve/pay event SEQUENCE is exercised end-to-end via usePurchaseFlow,
+  // which drives a mocked purchaseRoleWithStablecoin. Here we guard the additive
+  // 7th `onProgress` parameter: it must not change the existing control flow, and a
+  // throwing callback must never abort the purchase.
+
+  it('accepts an onProgress arg without altering the no-contract error path (regression)', async () => {
+    resolverMock.mockReturnValue(POLYGON_MM)
+    const signer = makeSigner({ chainId: 80002, code: '0x' })
+    const onProgress = vi.fn()
+
+    await expect(
+      purchaseRoleWithStablecoin(signer, 'WAGER_PARTICIPANT', 2, 1, 'purchase', null, onProgress)
+    ).rejects.toThrow(/switch your wallet to Polygon/i)
+  })
+
+  it('behaves identically whether or not onProgress is provided', async () => {
+    resolverMock.mockReturnValue(POLYGON_MM)
+    const signer = makeSigner({ chainId: 80002, code: '0x' })
+
+    const withCb = purchaseRoleWithStablecoin(signer, 'WAGER_PARTICIPANT', 2, 1, 'purchase', null, () => { throw new Error('cb boom') })
+    const without = purchaseRoleWithStablecoin(signer, 'WAGER_PARTICIPANT', 2, 1, 'purchase', null)
+
+    // A throwing callback does not surface as the rejection reason; both paths
+    // reject with the same actionable contract error.
+    await expect(withCb).rejects.toThrow(/switch your wallet to Polygon/i)
+    await expect(without).rejects.toThrow(/switch your wallet to Polygon/i)
+  })
+})
+
 describe('getUserTierOnChain — chain-aware tier read', () => {
   beforeEach(() => resolverMock.mockReset())
   // The test env sets VITE_SKIP_BLOCKCHAIN_CALLS=true (vite.config.js) which

--- a/frontend/src/test/chainResolutionGuard.test.js
+++ b/frontend/src/test/chainResolutionGuard.test.js
@@ -37,7 +37,10 @@ const ALLOW = {
   // resolver fallbacks (hasRoleOnChain / getUserTierOnChain / fetchFriendMarketsForUser),
   // the generic getContract() helper, and legacy v1 reads (tierRegistry /
   // roleManager / paymentProcessor / registerZKKey) not deployed on v2.
-  'utils/blockchainService.js': { addr: 11, prov: 2 },
+  // +1 (spec 022): checkApprovalNeeded's legacy-path paymentProcessor pre-flight,
+  // mirroring purchaseRoleWithStablecoin's own legacy fallback (MM path is
+  // chain-aware via getContractAddressForChain).
+  'utils/blockchainService.js': { addr: 12, prov: 2 },
   // catch-branch fallbacks in getKeyRegistryContract + registerEncryptionKey
   'utils/keyRegistryService.js': { addr: 4, prov: 0 },
   // catch-branch fallback in screenAddress

--- a/frontend/src/test/usePurchaseFlow.test.js
+++ b/frontend/src/test/usePurchaseFlow.test.js
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+// Mock the services the hook depends on so we drive the wallet sequence
+// deterministically without any chain calls (spec 022).
+vi.mock('../utils/blockchainService', () => ({
+  purchaseRoleWithStablecoin: vi.fn(),
+  checkApprovalNeeded: vi.fn(),
+}))
+vi.mock('../utils/keyRegistryService', () => ({
+  ensureKeyRegistered: vi.fn(),
+}))
+
+import { usePurchaseFlow } from '../hooks/usePurchaseFlow'
+import { purchaseRoleWithStablecoin, checkApprovalNeeded } from '../utils/blockchainService'
+import { ensureKeyRegistered } from '../utils/keyRegistryService'
+
+const baseParams = (overrides = {}) => ({
+  signer: { getAddress: async () => '0xabc' },
+  account: '0xabc',
+  roleName: 'WAGER_PARTICIPANT',
+  priceUSD: 2,
+  tier: 1,
+  action: 'purchase',
+  termsHash: null,
+  ensureInitialized: vi.fn(async () => ({ publicKey: new Uint8Array([1, 2, 3]) })),
+  onPaid: vi.fn(async () => {}),
+  ...overrides,
+})
+
+describe('usePurchaseFlow — step list construction (FR-009)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    purchaseRoleWithStablecoin.mockResolvedValue({ hash: '0xpay' })
+    ensureKeyRegistered.mockResolvedValue(true)
+  })
+
+  it('includes the approve step when allowance is insufficient', async () => {
+    checkApprovalNeeded.mockResolvedValue(true)
+    const { result } = renderHook(() => usePurchaseFlow())
+
+    await act(async () => { await result.current.start(baseParams()) })
+
+    const ids = result.current.steps.map((s) => s.id)
+    expect(ids).toEqual(['approve', 'pay', 'sign', 'register'])
+    expect(result.current.total).toBe(4)
+  })
+
+  it('OMITS the approve step entirely when allowance already covers the price', async () => {
+    checkApprovalNeeded.mockResolvedValue(false)
+    const { result } = renderHook(() => usePurchaseFlow())
+
+    await act(async () => { await result.current.start(baseParams()) })
+
+    const ids = result.current.steps.map((s) => s.id)
+    expect(ids).toEqual(['pay', 'sign', 'register'])
+    expect(result.current.total).toBe(3)
+  })
+
+  it('marks signature vs transaction kinds correctly', async () => {
+    checkApprovalNeeded.mockResolvedValue(true)
+    const { result } = renderHook(() => usePurchaseFlow())
+    await act(async () => { await result.current.start(baseParams()) })
+
+    const byId = Object.fromEntries(result.current.steps.map((s) => [s.id, s]))
+    expect(byId.approve.kind).toBe('transaction')
+    expect(byId.pay.kind).toBe('transaction')
+    expect(byId.sign.kind).toBe('signature')
+    expect(byId.register.kind).toBe('transaction')
+    expect(byId.sign.blocking).toBe(false)
+    expect(byId.pay.blocking).toBe(true)
+  })
+})
+
+describe('usePurchaseFlow — happy path & progress (US2)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    checkApprovalNeeded.mockResolvedValue(false)
+    ensureKeyRegistered.mockResolvedValue(true)
+  })
+
+  it('drives approve/pay step state from onProgress events and completes', async () => {
+    purchaseRoleWithStablecoin.mockImplementation(async (...args) => {
+      const onProgress = args[6]
+      onProgress({ step: 'pay', phase: 'start' })
+      onProgress({ step: 'pay', phase: 'sent', txHash: '0xp' })
+      onProgress({ step: 'pay', phase: 'confirmed', txHash: '0xp' })
+      return { hash: '0xp' }
+    })
+    const params = baseParams()
+    const { result } = renderHook(() => usePurchaseFlow())
+
+    await act(async () => { await result.current.start(params) })
+
+    expect(result.current.status).toBe('succeeded')
+    expect(result.current.steps.every((s) => s.state === 'completed')).toBe(true)
+    expect(result.current.completedCount).toBe(3)
+    expect(result.current.progressFraction).toBe(1)
+    expect(result.current.keyRegOutcome).toBe('success')
+    expect(params.onPaid).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports skipped key registration as "skipped"', async () => {
+    purchaseRoleWithStablecoin.mockResolvedValue({ hash: '0xp' })
+    ensureKeyRegistered.mockResolvedValue(false)
+    const { result } = renderHook(() => usePurchaseFlow())
+    await act(async () => { await result.current.start(baseParams()) })
+    expect(result.current.keyRegOutcome).toBe('skipped')
+  })
+})
+
+describe('usePurchaseFlow — failure attribution & recovery (US3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    checkApprovalNeeded.mockResolvedValue(false)
+  })
+
+  it('attributes a payment rejection to the pay step with a reason (FR-007)', async () => {
+    purchaseRoleWithStablecoin.mockImplementation(async (...args) => {
+      const onProgress = args[6]
+      onProgress({ step: 'pay', phase: 'start' })
+      throw new Error('Transaction rejected by user')
+    })
+    const { result } = renderHook(() => usePurchaseFlow())
+
+    await act(async () => { await result.current.start(baseParams()) })
+
+    expect(result.current.status).toBe('failed')
+    const pay = result.current.steps.find((s) => s.id === 'pay')
+    expect(pay.state).toBe('failed')
+    expect(pay.failureReason).toMatch(/rejected/i)
+    // Non-blocking continue must NOT be offered for a blocking pay failure.
+    expect(result.current.canContinueAnyway).toBe(false)
+  })
+
+  it('retry after a key-registration failure does NOT re-run payment (FR-008)', async () => {
+    purchaseRoleWithStablecoin.mockResolvedValue({ hash: '0xp' })
+    const ensureInitialized = vi.fn(async () => ({ publicKey: new Uint8Array([9]) }))
+    ensureKeyRegistered
+      .mockRejectedValueOnce(new Error('register boom'))
+      .mockResolvedValueOnce(true)
+
+    const { result } = renderHook(() => usePurchaseFlow())
+    await act(async () => { await result.current.start(baseParams({ ensureInitialized })) })
+
+    expect(result.current.status).toBe('failed')
+    const reg = result.current.steps.find((s) => s.id === 'register')
+    expect(reg.state).toBe('failed')
+    expect(result.current.canContinueAnyway).toBe(true) // register is non-blocking
+
+    await act(async () => { await result.current.retry() })
+
+    expect(result.current.status).toBe('succeeded')
+    // Payment ran exactly once across the initial attempt + retry.
+    expect(purchaseRoleWithStablecoin).toHaveBeenCalledTimes(1)
+    // The encryption signature was not re-requested (sign already completed).
+    expect(ensureInitialized).toHaveBeenCalledTimes(1)
+    expect(ensureKeyRegistered).toHaveBeenCalledTimes(2)
+  })
+
+  it('continueAnyway finalizes a non-blocking key failure as success (FR-010)', async () => {
+    purchaseRoleWithStablecoin.mockResolvedValue({ hash: '0xp' })
+    ensureKeyRegistered.mockRejectedValue(new Error('register boom'))
+    const { result } = renderHook(() => usePurchaseFlow())
+
+    await act(async () => { await result.current.start(baseParams()) })
+    expect(result.current.status).toBe('failed')
+
+    await act(async () => { result.current.continueAnyway() })
+
+    await waitFor(() => expect(result.current.status).toBe('succeeded'))
+    expect(result.current.keyRegOutcome).toBe('failed')
+  })
+})

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -1103,9 +1103,17 @@ const PAYMENT_PROCESSOR_ABI = [
  * @param {string} action - 'purchase' (default), 'upgrade', or 'extend'
  * @returns {Promise<Object>} Transaction receipt with roleGranted status
  */
-export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tier = MembershipTier.BRONZE, action = 'purchase', termsHash = null) {
+export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tier = MembershipTier.BRONZE, action = 'purchase', termsHash = null, onProgress = null) {
   if (!signer) {
     throw new Error('Wallet not connected')
+  }
+
+  // Spec 022: best-effort progress emission so the purchase modal can surface the
+  // approve/pay sub-steps. MUST NOT change control flow or on-chain calls — a
+  // throwing callback is swallowed.
+  const emit = (step, phase, extra = {}) => {
+    if (typeof onProgress !== 'function') return
+    try { onProgress({ step, phase, ...extra }) } catch (e) { /* non-fatal */ void e }
   }
 
   // Resolve the MembershipManager for the wallet's CURRENT chain, not the
@@ -1165,8 +1173,13 @@ export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tie
 
       const allowance = await paymentToken.allowance(userAddress, mmAddress)
       if (allowance < price) {
+        emit('approve', 'start')
         const approveTx = await paymentToken.approve(mmAddress, price)
+        emit('approve', 'sent', { txHash: approveTx.hash })
         await approveTx.wait()
+        emit('approve', 'confirmed', { txHash: approveTx.hash })
+      } else {
+        emit('approve', 'skipped')
       }
 
       // Spec 007 (FR-039): when an accepted T&C version hash is supplied, use the
@@ -1177,6 +1190,7 @@ export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tie
         : null
       const hasTerms = normTerms !== null && /^0x[0-9a-fA-F]{64}$/.test(normTerms)
       let tx
+      emit('pay', 'start')
       if (action === 'upgrade') {
         tx = hasTerms
           ? await mm.upgradeTierWithTerms(roleHash, validTier, normTerms)
@@ -1188,7 +1202,9 @@ export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tie
           ? await mm.purchaseTierWithTerms(roleHash, validTier, normTerms)
           : await mm.purchaseTier(roleHash, validTier)
       }
+      emit('pay', 'sent', { txHash: tx.hash })
       const receipt = await tx.wait()
+      emit('pay', 'confirmed', { txHash: receipt.hash })
       return {
         hash: receipt.hash,
         blockNumber: receipt.blockNumber,
@@ -1264,6 +1280,7 @@ export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tie
     const allowance = BigInt(allowanceRaw.toString())
 
     if (allowance < amount) {
+      emit('approve', 'start')
       console.log('Approving the stablecoin for PaymentProcessor...', {
         spender: paymentProcessorAddress,
         amount: amountWei.toString(),
@@ -1286,8 +1303,10 @@ export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tie
         const approveTx = await stableContract.approve(paymentProcessorAddress, amountWei, {
           gasLimit: gasLimit
         })
+        emit('approve', 'sent', { txHash: approveTx.hash })
         console.log('Approve transaction sent:', approveTx.hash)
         await approveTx.wait()
+        emit('approve', 'confirmed', { txHash: approveTx.hash })
         console.log('Stablecoin approved successfully')
       } catch (approveError) {
         console.error('Approve failed:', approveError)
@@ -1302,6 +1321,7 @@ export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tie
         throw new Error(`Failed to approve the stablecoin. Please ensure you have enough native token for gas and try again. Details: ${approveError.message || 'Unknown error'}`)
       }
     } else {
+      emit('approve', 'skipped')
       console.log('Stablecoin already approved for PaymentProcessor, allowance:', ethers.formatUnits(allowance, 6))
     }
 
@@ -1319,13 +1339,16 @@ export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tie
       amount: amountWei.toString()
     })
 
+    emit('pay', 'start')
     const purchaseTx = await paymentProcessor.purchaseTierWithToken(
       roleHash,
       validTier,
       stableAddress,
       amountWei
     )
+    emit('pay', 'sent', { txHash: purchaseTx.hash })
     const receipt = await purchaseTx.wait()
+    emit('pay', 'confirmed', { txHash: receipt.hash })
 
     console.log('Role purchased successfully:', receipt)
 
@@ -1353,6 +1376,67 @@ export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tie
     } else {
       throw new Error(error.message || 'Transaction failed')
     }
+  }
+}
+
+/**
+ * Spec 022: read-only pre-flight to decide whether the membership purchase will
+ * require a separate ERC-20 approval prompt. Lets the progress indicator build the
+ * exact step list up front and OMIT the approval step entirely when the member
+ * already has sufficient allowance (FR-009). No wallet prompt is issued.
+ *
+ * Mirrors the contract/price resolution used by `purchaseRoleWithStablecoin`.
+ * On any error it conservatively returns `true` (assume approval needed) so the
+ * indicator never hides a prompt that does appear.
+ *
+ * @returns {Promise<boolean>} true if an approval transaction will be requested
+ */
+export async function checkApprovalNeeded(signer, roleName, priceUSD, tier = MembershipTier.BRONZE, action = 'purchase') {
+  if (!signer) return true
+  try {
+    let walletChainId = null
+    try {
+      walletChainId = Number((await signer.provider.getNetwork()).chainId)
+    } catch { /* fall back to build-time chain */ }
+
+    const mmAddress = getContractAddressForChain('membershipManager', walletChainId)
+    if (mmAddress) {
+      const code = await signer.provider.getCode(mmAddress)
+      if (!code || code === '0x') return true
+      const roleHash = getRoleHash(roleName)
+      if (!roleHash) return true
+      const validTier = [1, 2, 3, 4].includes(tier) ? tier : MembershipTier.BRONZE
+      const mm = new ethers.Contract(mmAddress, MEMBERSHIP_MANAGER_ABI, signer)
+      const paymentTokenAddr = await mm.paymentToken()
+      if (!paymentTokenAddr || paymentTokenAddr === ethers.ZeroAddress) return true
+      const paymentToken = new ethers.Contract(paymentTokenAddr, ERC20_ABI, signer)
+      const userAddress = await signer.getAddress()
+
+      let price
+      if (action === 'upgrade') {
+        const membership = await mm.getMembership(userAddress, roleHash)
+        const currentCfg = await mm.getTierConfig(roleHash, membership.tier)
+        const newCfg = await mm.getTierConfig(roleHash, validTier)
+        price = newCfg.priceUSDC - currentCfg.priceUSDC
+      } else {
+        const tierCfg = await mm.getTierConfig(roleHash, validTier)
+        price = tierCfg.priceUSDC
+      }
+      const allowance = await paymentToken.allowance(userAddress, mmAddress)
+      return allowance < price
+    }
+
+    // Legacy PaymentProcessor path
+    const paymentProcessorAddress = getContractAddress('paymentProcessor')
+    if (!paymentProcessorAddress) return true
+    const stableContract = new ethers.Contract(DEX_ADDRESSES.STABLECOIN, ERC20_ABI, signer)
+    const userAddress = await signer.getAddress()
+    const amountWei = ethers.parseUnits(String(priceUSD), 6)
+    const allowance = await stableContract.allowance(userAddress, paymentProcessorAddress)
+    return BigInt(allowance.toString()) < BigInt(amountWei.toString())
+  } catch (e) {
+    console.warn('[checkApprovalNeeded] pre-flight failed, assuming approval needed:', e?.message)
+    return true
   }
 }
 

--- a/specs/022-membership-purchase-progress/checklists/requirements.md
+++ b/specs/022-membership-purchase-progress/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Membership Purchase Progress Indicator
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- The phrase "4 transactions and signing a message" from the request is treated as
+  the member's perceived sequence; the spec keeps the indicator adaptive to the
+  real interactions (e.g. approval skipped when allowance already sufficient) and
+  documents this in Assumptions rather than hard-coding a count.
+- Spec references the existing purchase flow (approval → payment → key signature →
+  key registration) at the behavioral level only; no contract names, components, or
+  function signatures appear in the spec, satisfying the "no implementation details"
+  criterion.

--- a/specs/022-membership-purchase-progress/contracts/on-progress-callback.md
+++ b/specs/022-membership-purchase-progress/contracts/on-progress-callback.md
@@ -1,0 +1,53 @@
+# Contract: `onProgress` callback for `purchaseRoleWithStablecoin`
+
+Additive, **optional** parameter so the modal can surface the approve/pay
+sub-steps. Existing callers that omit it are unaffected (FR-001a — no mechanics
+change).
+
+## Signature (additive)
+
+```
+purchaseRoleWithStablecoin(
+  signer, roleName, priceUSD, tier, action, termsHash,
+  onProgress?           // NEW: optional (event) => void
+)
+```
+
+> Implementation note: prefer appending as a trailing optional argument or an
+> options object to avoid breaking the positional signature used by current
+> callers and `blockchainService.purchase.test.js`.
+
+## Event shape
+
+```
+{
+  step:  'approve' | 'pay',
+  phase: 'start' | 'sent' | 'confirmed' | 'skipped',
+  txHash?: string        // present on 'sent' / 'confirmed' for transaction steps
+}
+```
+
+## Emission rules
+
+| Situation | Events emitted (in order) |
+|-----------|---------------------------|
+| Approval needed (`allowance < price`) | `{approve,start}` → `{approve,sent,txHash}` → `{approve,confirmed,txHash}` |
+| Approval not needed | `{approve,skipped}` (or no approve event at all — the modal omits the step from its pre-flight list either way) |
+| Payment | `{pay,start}` → `{pay,sent,txHash}` → `{pay,confirmed,txHash}` |
+
+## Guarantees
+
+- Callback invocation is best-effort and MUST NOT change control flow, on-chain
+  calls, arguments, or their order. Errors thrown by `onProgress` MUST NOT abort the
+  purchase (wrap in a try/catch).
+- No new wallet prompt is introduced by emitting events.
+- `sign` and `register` steps are **not** emitted here — they are orchestrated and
+  tracked by the modal/`usePurchaseFlow` (R3), since they occur after the service
+  call returns.
+
+## Test expectations (`blockchainService.purchase.test.js`)
+
+- With sufficient allowance: no `approve,start`/`sent`/`confirmed` sequence (only
+  `pay` events, optionally a single `approve,skipped`).
+- With insufficient allowance: full `approve` sequence precedes `pay`.
+- Omitting `onProgress` entirely: behavior identical to today (regression guard).

--- a/specs/022-membership-purchase-progress/contracts/purchase-progress-view.md
+++ b/specs/022-membership-purchase-progress/contracts/purchase-progress-view.md
@@ -1,0 +1,46 @@
+# Contract: `PurchaseProgressView` component
+
+Presentational, stateless render of the purchase step sequence. Owns no
+orchestration — it receives state from `usePurchaseFlow` and reports user intent
+via callbacks.
+
+## Props
+
+| Prop | Type | Required | Notes |
+|------|------|----------|-------|
+| `steps` | `PurchaseStep[]` | yes | Ordered steps (approval already omitted when not needed) |
+| `activeIndex` | number \| null | yes | Drives the active highlight + live announcement |
+| `status` | `'idle' \| 'running' \| 'succeeded' \| 'failed'` | yes | Overall flow status |
+| `onRetry` | `() => void` | yes | Invoked by the per-failure "Retry" action |
+| `onContinueAnyway` | `() => void` | yes | Shown only when the active failure is a non-blocking key step |
+
+## Rendering contract
+
+- Renders an ordered, semantic list of steps; each item shows: label, a
+  transaction-vs-signature indicator (FR-003), and a visual state for
+  `pending` / `active` / `confirming` / `completed` / `failed` (FR-004).
+- Shows overall progress position — "step N of M" and/or a proportional bar driven
+  by `completedCount / total` (FR-005).
+- For an `active`/`confirming` step, shows a waiting/in-progress affordance so the
+  app does not appear frozen (FR-006); reuse the existing `ppm-spinner`.
+- For a `failed` step, shows the `failureReason` and a "Retry" action (FR-007); if
+  that step is a non-blocking key step, also shows "Continue anyway" (FR-010).
+
+## Accessibility contract (constitution V, FR-013)
+
+- Each step has an accessible name combining label + kind + state
+  (e.g. "Pay for membership, transaction, in progress").
+- An `aria-live="polite"` region announces the active step and state changes;
+  `role="status"` on the waiting/confirming affordance.
+- "Retry" / "Continue anyway" are real buttons with discernible names; focus is
+  managed sensibly when they appear.
+- Zero `vitest-axe` violations.
+
+## Test expectations (`PurchaseProgressView.test.jsx`)
+
+- Given mixed step states, the correct visual + accessible state renders for each.
+- Transaction vs signature indicator differs between `kind` values.
+- "Continue anyway" appears only for non-blocking key-step failures, not for
+  approve/pay failures.
+- `onRetry` / `onContinueAnyway` fire on the respective controls.
+- axe: no violations across idle/running/failed snapshots.

--- a/specs/022-membership-purchase-progress/data-model.md
+++ b/specs/022-membership-purchase-progress/data-model.md
@@ -1,0 +1,74 @@
+# Phase 1 Data Model: Membership Purchase Progress Indicator
+
+This feature introduces **no persisted or on-chain data**. The model below
+describes transient, in-component UI state owned by `usePurchaseFlow` and consumed
+by `PurchaseProgressView`. Field names are indicative; exact shapes are finalized in
+implementation.
+
+## Entity: PurchaseStep
+
+One required wallet interaction in the purchase sequence.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | enum: `approve` \| `pay` \| `sign` \| `register` | Stable identifier used for retry targeting |
+| `label` | string | Plain-language name shown to the member (e.g. "Approve USDC spending", "Pay for membership", "Sign to set up private wagers", "Register your encryption key") |
+| `kind` | enum: `transaction` \| `signature` | Drives the "confirm in wallet (costs gas)" vs "sign a message (no funds move)" distinction — FR-003 |
+| `state` | enum: `pending` \| `active` \| `confirming` \| `completed` \| `failed` | `active` = wallet prompt awaiting member; `confirming` = tx awaiting mining — FR-004, FR-006 |
+| `blocking` | boolean | `true` for `approve`/`pay`; `false` for `sign`/`register` (membership already active) — FR-010 |
+| `failureReason` | string \| null | Plain-language reason when `state === 'failed'` — FR-007 |
+| `txHash` | string \| null | Set for `transaction` steps once sent; used for an optional explorer link |
+
+### State transitions (per step)
+
+```text
+pending ──> active ──> confirming ──> completed        (transaction steps)
+pending ──> active ──────────────────> completed        (signature steps)
+   any active/confirming ──> failed                      (rejection or error)
+   failed ──> active                                     (Retry; no re-payment for prior steps)
+```
+
+### Validation / invariants
+
+- `kind = signature` ⇒ step never enters `confirming` and never carries gas cost.
+- `id = approve` is present **only when** the pre-flight allowance read shows
+  `allowance < price` (otherwise omitted entirely) — FR-009.
+- At most one step is `active` or `confirming` at a time.
+- A `failed` non-blocking step (`sign`/`register`) MUST NOT block reaching the
+  completion confirmation; "Continue anyway" finalizes the flow as success — FR-010.
+
+## Entity: PurchaseProgress
+
+Overall state of the in-flight purchase (the `usePurchaseFlow` return value).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `steps` | `PurchaseStep[]` | Ordered list for the chosen action, built up front (approval omitted when not needed) — FR-001, FR-005, FR-009 |
+| `activeIndex` | number \| null | Index of the current `active`/`confirming` step; `null` before start or after completion |
+| `total` | number | `steps.length`; used for "step N of M" / proportional bar — FR-005 |
+| `status` | enum: `idle` \| `running` \| `succeeded` \| `failed` | Overall flow status |
+| `purchaseReceipt` | object \| null | Captured once `pay` confirms; enables resume of key steps without re-payment — FR-008 |
+| `keyRegOutcome` | enum: `null` \| `success` \| `skipped` \| `failed` | Mirrors existing key-registration result for the Complete screen |
+
+### Derived selectors
+
+- `completedCount` = count of `state === 'completed'` steps.
+- `progressFraction` = `completedCount / total` (for the proportional bar).
+- `activeStep` = `steps[activeIndex]` (for the live region announcement).
+
+### Action interface (exposed by `usePurchaseFlow`)
+
+| Action | Behavior |
+|--------|----------|
+| `start()` | Pre-flight allowance read → build `steps` → run sequentially, updating step state from `onProgress` + key-flow awaits |
+| `retry()` | Resume from the first `failed` step; for `sign`/`register` failures, re-run only the key step (never the purchase) — FR-008 |
+| `continueAnyway()` | Valid only when the sole remaining failure is a non-blocking key step; sets `status = 'succeeded'`, records `keyRegOutcome = 'failed'`, advances to Complete with the "register later" notice — FR-010 |
+
+## Mapping to existing code
+
+| Model element | Source today | Change |
+|---------------|--------------|--------|
+| `approve` / `pay` step events | inside `purchaseRoleWithStablecoin` | emit via new optional `onProgress` callback (R1) |
+| `sign` step | `ensureInitialized()` in modal | becomes its own tracked step (R3) |
+| `register` step | `ensureKeyRegistered()` in modal | becomes its own tracked step (R3) |
+| `keyRegOutcome` | existing `keyRegStatus` state | reused for the Complete screen messaging |

--- a/specs/022-membership-purchase-progress/plan.md
+++ b/specs/022-membership-purchase-progress/plan.md
@@ -1,0 +1,129 @@
+# Implementation Plan: Membership Purchase Progress Indicator
+
+**Branch**: `022-membership-purchase-progress` | **Date**: 2026-06-19 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/022-membership-purchase-progress/spec.md`
+
+## Summary
+
+When a member confirms a Wager Participant purchase, the modal today collapses a
+sequence of distinct wallet interactions — optional USDC approval, payment,
+encryption-key signature, and key registration — into a single "Processing…"
+spinner. Members cannot tell which wallet prompt they are approving, how far along
+they are, or what failed when a prompt is rejected.
+
+This feature adds a **dedicated "Processing" view** between the existing Review and
+Complete phases of `PremiumPurchaseModal`. The view renders the ordered wallet
+interactions as discrete, labeled steps with live state (pending / active /
+completed / failed), an overall progress position, and per-step recovery actions.
+
+The approach is **presentation-only** (FR-001a): no contract, pricing, or
+purchase-mechanics changes. The existing purchase logic in
+`purchaseRoleWithStablecoin` plus the modal's key-registration flow are
+**refactored to emit step progress** (via an optional `onProgress` callback and a
+modal-side step state machine) without altering the on-chain calls or their order.
+A pre-flight read of the member's stablecoin allowance lets the indicator build the
+exact step list up front so the approval step is **omitted entirely** when it is
+not needed.
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES2022), React 18 function components + hooks
+
+**Primary Dependencies**: React, Vite, `ethers` v6 (already used by
+`blockchainService.js` / `keyRegistryService.js`); no new runtime dependencies
+
+**Storage**: N/A (transient in-component UI state only; existing `roleStorage`
+record-keeping is unchanged)
+
+**Testing**: Vitest + `@testing-library/react` + `@testing-library/user-event`;
+`vitest-axe` for accessibility assertions; existing Cypress e2e for membership
+flows (`frontend/cypress/e2e/full/20-expired-membership.cy.js` family)
+
+**Target Platform**: Modern browsers (the FairWins React + Vite frontend)
+
+**Project Type**: Web application — frontend only (`frontend/`)
+
+**Performance Goals**: Indicator state transitions are perceived as immediate
+(<100 ms) on each wallet event; no added blocking work on the purchase path
+
+**Constraints**: WCAG 2.1 AA (constitution V); honest on-chain state — no implied
+finality, pending-confirmation states surfaced truthfully (constitution III);
+network-scoped (no testnet/mainnet leakage); no `continue-on-error` on lint/test
+
+**Scale/Scope**: One modal (`PremiumPurchaseModal.jsx`) plus its CSS, one service
+function (`purchaseRoleWithStablecoin`), and the modal's key-registration flow.
+Net new: one presentational progress component, one step state model/hook, and
+their tests. Estimated ~3 source files touched + 2–3 new files.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Applicability | Status |
+|-----------|---------------|--------|
+| I. Security-First Smart Contracts (NON-NEGOTIABLE) | No `contracts/` changes; presentation-only (FR-001a). No new on-chain calls, no change to call order/args. | ✅ N/A — confirmed no contract edits |
+| II. Test-First & Comprehensive Coverage (NON-NEGOTIABLE) | Frontend logic: Vitest unit/integration tests for the new progress component, the step state machine, the `onProgress` emissions, and retry/continue-anyway paths, written alongside the code. Update `blockchainService.purchase.test.js` for the callback. | ✅ Planned |
+| III. Honest State, No Mocks in Shipped Paths | Indicator must reflect real wallet/allowance state: omit approval via real allowance read, show pending-confirmation truthfully, never imply finality before a tx is mined. No mock data. | ✅ Planned |
+| IV. Fail Loudly in CI | No `continue-on-error`; lint + Vitest must pass. | ✅ Planned |
+| V. Accessible, Consistent Frontend | New UI meets WCAG 2.1 AA: `aria-live` announcements on step/state change, accessible names per step, focus handling on retry actions; axe assertions via `vitest-axe`. Contract addresses/ABIs continue to come from generated config (unchanged). | ✅ Planned |
+
+**Additional constraints**: No new core technology introduced (constitution
+"Additional Constraints"). No keys/secrets touched. Net result: **PASS, no
+violations** — Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/022-membership-purchase-progress/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output (UI state model)
+├── quickstart.md        # Phase 1 output (validation guide)
+├── contracts/           # Phase 1 output (component props + onProgress contract)
+│   ├── purchase-progress-view.md
+│   └── on-progress-callback.md
+└── checklists/
+    └── requirements.md  # Existing spec-quality checklist
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/
+├── components/ui/
+│   ├── PremiumPurchaseModal.jsx      # MODIFIED: add Processing phase; drive step
+│   │                                 #   state machine; render PurchaseProgressView
+│   ├── PremiumPurchaseModal.css      # MODIFIED: styles for the processing view +
+│   │                                 #   step states (reuse ppm-step* tokens)
+│   └── PurchaseProgressView.jsx      # NEW: presentational ordered-step indicator
+│                                     #   (states, progress position, retry/continue)
+├── hooks/
+│   └── usePurchaseFlow.js            # NEW: step state machine — builds step list,
+│                                     #   runs/resumes steps, exposes states+actions
+└── utils/
+    └── blockchainService.js          # MODIFIED: purchaseRoleWithStablecoin gains an
+                                      #   optional onProgress callback (approve/pay
+                                      #   sub-steps); no change to on-chain calls
+
+frontend/src/test/
+├── PurchaseProgressView.test.jsx     # NEW: rendering, states, a11y (axe), actions
+├── usePurchaseFlow.test.js           # NEW: step-list build, resume-without-repay,
+│                                     #   omit-approval, non-blocking key failure
+└── blockchainService.purchase.test.js# MODIFIED: assert onProgress emissions +
+                                      #   approval-skipped omission
+```
+
+**Structure Decision**: Web application, frontend only. The work lives entirely
+under `frontend/src`. UI is split into a **presentational** `PurchaseProgressView`
+(pure render of step state, easily axe-/snapshot-tested) and a **`usePurchaseFlow`
+hook** that owns the orchestration/state machine, keeping `PremiumPurchaseModal`
+thin and the new logic independently testable. The service change is a minimal,
+additive `onProgress` callback so the modal can surface the approve/pay sub-steps
+that are otherwise buried inside `purchaseRoleWithStablecoin`.
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally empty.

--- a/specs/022-membership-purchase-progress/quickstart.md
+++ b/specs/022-membership-purchase-progress/quickstart.md
@@ -1,0 +1,74 @@
+# Quickstart & Validation: Membership Purchase Progress Indicator
+
+A run/validation guide proving the feature end-to-end. Implementation details live
+in `tasks.md` and the code; this file is how you confirm it works.
+
+## Prerequisites
+
+- Repo installed: `npm install` (root) and `cd frontend && npm install`.
+- For automated tests: no chain needed (wallet/service calls are mocked in Vitest).
+- For manual validation: a wallet (e.g. MetaMask) on a supported network with test
+  USDC, per the existing local dev flow (`specs/006-local-dev-environment`).
+
+## Automated validation
+
+Run from `frontend/`:
+
+```bash
+npm run test:run -- src/test/PurchaseProgressView.test.jsx \
+                    src/test/usePurchaseFlow.test.js \
+                    src/test/blockchainService.purchase.test.js
+```
+
+Expected: all pass, including the accessibility (axe) assertions. Then run the full
+suite and lint to satisfy constitution IV:
+
+```bash
+npm run test:run
+npm run lint
+```
+
+### Scenarios the automated tests must cover
+
+| Scenario | Maps to | Expected outcome |
+|----------|---------|------------------|
+| Fresh purchase, no prior allowance | US1, US2, FR-001/003/004/005 | Step list = approve → pay → sign → register; each step's label, kind, and state render and advance; "step N of M" increments |
+| Purchase with sufficient allowance | FR-009 | Approve step **omitted**; list = pay → sign → register; total reflects 3 steps |
+| Reject the payment prompt | US3, FR-007 | `pay` marked failed with a reason; earlier steps stay completed; Retry offered; retry does not re-approve |
+| Payment succeeds, key registration fails | US3, FR-008/010 | `register` marked failed; **Retry** re-runs only key registration (no re-payment); **Continue anyway** advances to Complete with membership active + "register later" notice |
+| Signature step vs transaction step | FR-003 | `sign` shows signature indicator (no gas); `approve`/`pay`/`register` show transaction indicator |
+| Accessibility | FR-013, constitution V | aria-live announces active step/state; zero axe violations |
+
+## Manual validation (happy path)
+
+1. `cd frontend && npm run dev`; open the app and connect a wallet on a supported
+   network with test USDC and **no existing membership**.
+2. Open **Get Wager Access**, choose a tier, proceed through **Review**, and click
+   **Confirm Purchase**.
+3. Observe the **Processing view** appears between Review and Complete showing the
+   ordered steps. As each wallet prompt opens, confirm the highlighted step matches
+   it ("Approve…", then "Pay…", then "Sign…", then "Register…") and the progress
+   position advances.
+4. Approve each prompt; confirm all steps reach completed and the modal advances to
+   the existing **Complete** screen with the transaction link and key-registration
+   status.
+
+## Manual validation (recovery)
+
+1. Repeat steps 1–2 above.
+2. When the **encryption-key signature/registration** prompt appears, **reject** it.
+3. Confirm the Processing view marks that step **failed** with a reason, the
+   already-paid steps remain completed, and both **Retry** and **Continue anyway**
+   are offered.
+4. Click **Continue anyway**; confirm the modal advances to Complete, the membership
+   is shown active, and the "register key later in Security settings" notice is
+   present. (Alternatively click **Retry** and confirm no second payment prompt
+   appears.)
+
+## Definition of done (validation)
+
+- All scenarios in the table pass in CI (Vitest + axe), lint clean.
+- Manual happy-path and recovery walkthroughs behave as described.
+- No change to pricing, contracts called, or the order/number of underlying wallet
+  interactions (FR-001a) — confirmed by the unchanged `purchaseRoleWithStablecoin`
+  on-chain calls and the regression test that runs it without `onProgress`.

--- a/specs/022-membership-purchase-progress/research.md
+++ b/specs/022-membership-purchase-progress/research.md
@@ -1,0 +1,137 @@
+# Phase 0 Research: Membership Purchase Progress Indicator
+
+All open questions from the spec were resolved during `/speckit-clarify`
+(presentation-only scope; dedicated Processing view; omit approval when not needed;
+non-blocking key failure offers Retry + Continue anyway). This document records the
+design decisions that turn those clarifications into an implementable approach. No
+external/library research was required — no new dependencies are introduced.
+
+## R1. Surfacing the approve/pay sub-steps without changing mechanics
+
+**Decision**: Add an optional `onProgress(event)` callback parameter to
+`purchaseRoleWithStablecoin(...)`. It fires at the existing decision points the
+function already reaches: `approve:start` / `approve:sent` / `approve:confirmed`
+(only when an approval is actually needed), and `pay:start` / `pay:sent` /
+`pay:confirmed`. The on-chain calls, their arguments, and their order are
+unchanged; the callback only reports what the function is already doing.
+
+**Rationale**: The approve and pay interactions are currently invisible because
+they happen inside the service function while the modal shows one spinner. A
+callback is the smallest, non-breaking change (the parameter is optional; existing
+callers are unaffected) and keeps the orchestration in the modal layer where the UI
+state lives. It satisfies FR-001a (no mechanics change) and constitution III
+(honest state — events reflect the real tx lifecycle).
+
+**Alternatives considered**:
+- *Move approve/pay orchestration into the modal* — rejected: duplicates contract
+  resolution/allowance logic already centralized in the service, higher regression
+  risk, violates simplicity (YAGNI).
+- *Poll provider/tx state from the modal* — rejected: racy, no clean mapping to
+  "which prompt is open", more code than a callback.
+- *Emit via a shared event bus* — rejected: over-engineered for one call site.
+
+## R2. Building the exact step list up front (omit approval when not needed)
+
+**Decision**: Before starting the flow, perform a **read-only pre-flight**: read
+the member's stablecoin `allowance` (and reuse the existing balance read) for the
+resolved spender. If `allowance >= price`, the approval step is excluded from the
+step list entirely; otherwise it is included as the first step. The pay, sign, and
+register steps are always present for a fresh purchase. The same `onProgress`
+events confirm/repair the list at runtime if state changed between pre-flight and
+execution (defensive — if the wallet unexpectedly prompts for approval, the step is
+re-inserted; if not needed, no step lingers pending).
+
+**Rationale**: FR-009 + the clarification require omission (not a "skipped/greyed"
+step) when approval is unneeded. Knowing the list before any prompt lets the
+overall progress count ("step N of M") be correct from the first render. The
+pre-flight is a cheap read with no wallet prompt, consistent with the existing
+in-service allowance check.
+
+**Alternatives considered**:
+- *Always show approval, mark it skipped* — rejected: contradicts the clarified
+  decision to omit.
+- *Discover steps lazily as prompts occur* — rejected: makes "M" (total) unknown
+  until late, undermining the progress goal (US2).
+
+## R3. Mapping the encryption-key flow to two distinct steps
+
+**Decision**: Split the modal's current single `keyRegStatus === 'registering'`
+phase into two ordered steps:
+1. **Sign** — `ensureInitialized()` triggers `signer.signMessage(...)` to derive
+   the encryption key (a *signature*, not a transaction; no gas).
+2. **Register** — `ensureKeyRegistered(...)` sends the `registerKey` /
+   `registerKeyWithEligibility` *transaction* on-chain.
+
+Each step reports its own active/confirmed/failed state. Both are flagged
+`blocking: false`.
+
+**Rationale**: US1 requires distinguishing a signature from a transaction; these
+two interactions are genuinely different wallet prompts and currently hidden under
+one label. Splitting them gives accurate per-prompt labeling and lets failure
+attribution (US3) name the right step.
+
+**Alternatives considered**:
+- *Keep them as one "encryption setup" step* — rejected: fails US1 (a signature and
+  a transaction look different in the wallet; collapsing them re-creates the
+  confusion this feature exists to remove).
+
+## R4. Resumable retry without re-payment
+
+**Decision**: The `usePurchaseFlow` hook is a small state machine that records the
+**result of each completed step** (notably the purchase receipt once `pay` is
+confirmed). Retry re-runs only from the failed step forward:
+- Approve/pay failure → re-invoke `purchaseRoleWithStablecoin`. Because the service
+  re-checks allowance internally, a previously-succeeded approval is naturally
+  skipped, so retry never re-approves or double-pays.
+- Sign/register failure (payment already confirmed) → retry calls **only**
+  `ensureInitialized` / `ensureKeyRegistered`; it does **not** call the purchase
+  function again. This guarantees FR-008 (no duplicate payment).
+
+For non-blocking key steps, the view also exposes **Continue anyway**, which
+finalizes the flow as success (membership active) and advances to Complete with the
+existing "register key later in Security settings" notice.
+
+**Rationale**: Multi-step on-chain flows are frequently interrupted; safe,
+position-aware resume is the core of US3 and prevents the worst failure mode
+(paying twice). Keying retry on recorded step results makes the guarantee explicit
+rather than relying on idempotency by luck.
+
+**Alternatives considered**:
+- *Restart the whole flow on any failure* — rejected: risks double-payment and
+  re-prompting for already-completed steps; violates FR-008.
+- *Persist progress across modal close/reopen* — rejected as out of scope: the
+  clarified behavior treats key steps as non-blocking with "do it later" recovery
+  from Security settings; in-session resume is sufficient.
+
+## R5. Processing view placement and the top-level nav
+
+**Decision**: Introduce an internal modal phase `processing` shown after the member
+confirms on Review and before Complete. While processing, the modal content area
+renders `<PurchaseProgressView>`; the existing top three-phase stepper (Choose Tier
+→ Review → Complete) is retained and unchanged in count, with Review shown complete
+and Complete pending until the flow finishes. The modal continues to disable
+close/dismiss while any wallet interaction is in progress (FR-012, existing
+`isPurchasing` guard).
+
+**Rationale**: Matches the clarified "dedicated Processing view between Review and
+Complete; top nav stays three phases." Reuses the existing `ppm-step*` visual
+tokens and the `isPurchasing` dismissal guard, minimizing new surface area.
+
+**Alternatives considered**: Expanding the top nav to inline every wallet step, or
+nesting steps inside the Review panel — both rejected during clarification.
+
+## R6. Accessibility of a live step indicator
+
+**Decision**: Render the step list as a semantic list with each step exposing an
+accessible name (label + kind + state, e.g. "Pay for membership, transaction, in
+progress"). Use an `aria-live="polite"` region to announce the active step and
+state transitions, and `role="status"` for the waiting/confirming state. Respect
+the existing reduced-motion handling already present in `PremiumPurchaseModal.css`.
+Validate with `vitest-axe` (zero violations) and assert announced text in tests.
+
+**Rationale**: Constitution V (WCAG 2.1 AA) and FR-013 require the indicator be
+perceivable to assistive tech, including announcing progress changes. `vitest-axe`
+is already a project dependency, so this is testable in CI.
+
+**Alternatives considered**: Visual-only indicator — rejected: violates FR-013 and
+constitution V.

--- a/specs/022-membership-purchase-progress/spec.md
+++ b/specs/022-membership-purchase-progress/spec.md
@@ -24,6 +24,28 @@ This feature adds a visual, step-by-step progress indicator to the purchase moda
 so the member always knows what they are being asked to approve, where they are in
 the sequence, and how much is left.
 
+## Clarifications
+
+### Session 2026-06-19
+
+- Q: Should this feature only add the progress indicator, or also reduce the number
+  of wallet prompts (e.g. EIP-2612 permit)? → A: Progress indicator only — the
+  purchase mechanics (approve → pay → sign → register) are unchanged; this feature
+  is presentation only.
+- Q: How is the per-wallet-interaction progress laid out relative to the existing
+  3-step nav (Choose Tier → Review → Complete)? → A: A dedicated "Processing" view
+  shown after the member confirms — a distinct phase between Review and Complete
+  that lists the ordered wallet steps with per-step state. The top-level nav stays
+  at three phases.
+- Q: When the member already has sufficient USDC allowance (no approval prompt),
+  how should the approval step appear? → A: Omit it entirely — the indicator shows
+  only the steps that will actually prompt the wallet this time, so the step count
+  varies per purchase.
+- Q: If a non-blocking encryption-key step (signature or registration) fails, what
+  should the processing view do? → A: Mark it failed and offer BOTH an inline
+  "Retry" (resumes the key step, no re-payment) and a "Continue anyway" that
+  advances to Complete with a "register key later in Security settings" notice.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - See which wallet action I am approving (Priority: P1)
@@ -118,9 +140,11 @@ without repeating already-completed payments.
    or key registration) failed, **When** the member retries, **Then** the flow
    resumes at the failed step and does not re-request payment.
 3. **Given** the encryption-key signing or registration step fails, **When** the
-   member chooses to continue, **Then** the membership is still recognized as
-   active (the key step is non-blocking) and the member is told they can complete
-   key registration later from Security settings.
+   processing view marks it failed, **Then** the member is offered both an inline
+   "Retry" of that step (no re-payment) and a "Continue anyway" action; choosing
+   "Continue anyway" advances to Complete with the membership recognized as active
+   (the key step is non-blocking) and a notice that key registration can be
+   completed later from Security settings.
 
 ---
 
@@ -128,9 +152,9 @@ without repeating already-completed payments.
 
 - **Approval already granted**: If the member has already approved sufficient
   stablecoin allowance, the approval step is not requested by the wallet. The
-  indicator must reflect this honestly — either present the step as already
-  complete or omit it — and not leave a permanently "pending" step that never
-  activates.
+  indicator MUST omit the approval step entirely in that case, showing only the
+  steps that will actually prompt the wallet this time, and never leave a
+  permanently "pending" step that never activates.
 - **Extend flow**: The extend action does not change tier price and may not
   require a fresh approval; the indicator must show only the steps actually
   required for that action and keep the count accurate.
@@ -154,7 +178,13 @@ without repeating already-completed payments.
 - **FR-001**: The purchase modal MUST display a visual indicator of the ordered
   sequence of wallet interactions required to complete the purchase (approve
   spending, pay for membership, sign for encryption-key setup, register encryption
-  key), shown once the member confirms the purchase.
+  key), shown in a dedicated "Processing" view presented after the member confirms
+  the purchase. This view is a distinct phase between Review and Complete; the
+  top-level modal nav remains three phases (Choose Tier → Review → Complete).
+- **FR-001a**: This feature is presentation only. It MUST NOT change the purchase
+  mechanics, pricing, the contracts called, or the order/number of underlying
+  wallet interactions; it only changes how that existing sequence is surfaced to
+  the member.
 - **FR-002**: For the currently-active interaction, the indicator MUST show a
   human-readable label describing what the member is approving.
 - **FR-003**: The indicator MUST distinguish a transaction (moves funds or changes
@@ -175,11 +205,15 @@ without repeating already-completed payments.
   already-completed paid steps (no duplicate payment).
 - **FR-009**: The displayed steps MUST match the wallet interactions actually
   required for the chosen action (purchase, upgrade, or extend) and the current
-  approval state, including correctly handling the case where stablecoin approval
-  is already granted.
+  approval state. When stablecoin approval is already granted, the approval step
+  MUST be omitted entirely so the indicator shows only steps that will prompt the
+  wallet this time.
 - **FR-010**: The encryption-key signing and registration steps MUST be presented
-  as part of the sequence but treated as non-blocking — if they fail, the member is
-  informed the membership is active and key setup can be completed later.
+  as part of the sequence but treated as non-blocking. If one fails, the indicator
+  MUST mark it failed and offer both an inline "Retry" of that step (without
+  re-requesting payment) and a "Continue anyway" action that advances to the
+  completion confirmation with the membership recognized as active and a notice
+  that key setup can be completed later from Security settings.
 - **FR-011**: On successful completion of all required steps, the indicator MUST
   show all steps as done and lead into the existing purchase-complete confirmation.
 - **FR-012**: The modal MUST continue to prevent accidental dismissal while any
@@ -235,5 +269,6 @@ without repeating already-completed payments.
   grant occur in a single transaction on some networks). The indicator reflects the
   real interactions for the member's situation rather than a fixed count.
 - The existing three-phase modal framing (Choose Tier → Review → Complete) is
-  retained; this feature enriches the transition between Review and Complete — the
-  phase where the wallet interactions occur — with per-interaction progress.
+  retained; this feature adds a dedicated "Processing" view between Review and
+  Complete — the phase where the wallet interactions occur — that surfaces
+  per-interaction progress. The top-level three-phase nav is unchanged.

--- a/specs/022-membership-purchase-progress/spec.md
+++ b/specs/022-membership-purchase-progress/spec.md
@@ -1,0 +1,239 @@
+# Feature Specification: Membership Purchase Progress Indicator
+
+**Feature Branch**: `022-membership-purchase-progress`
+
+**Created**: 2026-06-19
+
+**Status**: Draft
+
+**Input**: User description: "when purchasing a membership the user is prompted to send 4 transactions and signing a message. the user needs needs 1) know what step of the process they are on, what transaction they are sending, and the progress in the flow. add a visual indicator of the steps and progress to the modal in order to keep the user engaged and informed"
+
+## Context
+
+When a member buys, upgrades, or extends Wager Participant access, confirming the
+purchase triggers a sequence of separate wallet interactions: approving the
+stablecoin spend, paying for the membership tier, signing a message to derive an
+encryption key, and registering that key. Today the modal collapses all of these
+into a single "Processing…" spinner. The member sees multiple wallet pop-ups
+appear with no on-screen explanation of which one they are approving, why, how
+many remain, or whether something failed partway through. This causes confusion,
+abandoned purchases, and wallet prompts that get dismissed because they look
+unexpected.
+
+This feature adds a visual, step-by-step progress indicator to the purchase modal
+so the member always knows what they are being asked to approve, where they are in
+the sequence, and how much is left.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - See which wallet action I am approving (Priority: P1)
+
+As a member completing a purchase, when each wallet pop-up appears I can see, on
+the modal, a label that tells me exactly what that pop-up is for (e.g. "Approve
+USDC spending", "Pay for membership", "Sign to set up private wagers", "Register
+your encryption key") and whether it is a payment/transaction or a message
+signature.
+
+**Why this priority**: This is the core need. Members are most likely to abandon
+or reject a wallet prompt when they cannot tell what they are approving. Naming
+the active action directly addresses the request and the abandonment risk.
+
+**Independent Test**: Start a purchase and advance through each wallet
+interaction; confirm the modal shows a distinct, human-readable label for the
+currently-requested action and indicates whether it is a transaction or a
+signature, matching the pop-up the wallet is showing.
+
+**Acceptance Scenarios**:
+
+1. **Given** a member has confirmed their purchase and the wallet is requesting
+   the stablecoin approval, **When** the approval pop-up appears, **Then** the
+   modal highlights an "Approve spending" step and indicates it is a transaction
+   to confirm in the wallet.
+2. **Given** the approval has completed and the wallet is requesting the payment,
+   **When** the payment pop-up appears, **Then** the modal highlights the "Pay for
+   membership" step as active.
+3. **Given** the payment has completed and the wallet is requesting a message
+   signature for encryption-key setup, **When** the signature pop-up appears,
+   **Then** the modal highlights the signing step and clearly indicates it is a
+   message to sign (no funds move) rather than a transaction.
+4. **Given** the signature is complete and the key-registration transaction is
+   requested, **When** that pop-up appears, **Then** the modal highlights the
+   "Register encryption key" step as active.
+
+---
+
+### User Story 2 - Track overall progress through the flow (Priority: P1)
+
+As a member, I can see how many steps the purchase involves, which steps are
+already done, which step is active, and which are still to come, so I know how far
+along I am and that progress is being made.
+
+**Why this priority**: Knowing "step 2 of 4" and seeing completed steps keeps the
+member engaged and reassured during the unavoidable wallet round-trips, directly
+satisfying the "progress in the flow" requirement.
+
+**Independent Test**: Run a full purchase and confirm that at each stage the
+indicator shows completed steps as done, the current step as active, and remaining
+steps as pending, with an overall position (e.g. a count or filled progress bar)
+that advances as steps complete.
+
+**Acceptance Scenarios**:
+
+1. **Given** the purchase sequence has started, **When** the modal renders the
+   progress indicator, **Then** it shows the full ordered list of steps the member
+   will be asked to complete, with a clear overall position indicator.
+2. **Given** a step completes successfully, **When** the next step becomes active,
+   **Then** the completed step is visibly marked as done and the overall progress
+   advances.
+3. **Given** a wallet interaction is awaiting the member's confirmation, **When**
+   the member looks at the modal, **Then** the active step shows a waiting/in-progress
+   state distinct from completed and pending steps.
+4. **Given** every step has completed, **When** the flow finishes, **Then** all
+   steps are marked done and the member sees the existing completion confirmation.
+
+---
+
+### User Story 3 - Understand and recover when a step fails or is rejected (Priority: P2)
+
+As a member, if I reject a wallet prompt or a step fails, I can see which step
+failed and why, and the steps I already completed are not lost, so I can retry
+from where I stopped instead of starting over or paying twice.
+
+**Why this priority**: Multi-step on-chain flows are frequently interrupted
+(rejected prompt, insufficient gas, network hiccup). Clear failure attribution and
+safe recovery prevent duplicate payments and support tickets, but the happy-path
+visibility (US1, US2) delivers the primary value first.
+
+**Independent Test**: Reject the wallet prompt at a non-first step (e.g. the key
+signature) and confirm the modal marks that step as failed with a reason, keeps
+the earlier completed steps marked done, and offers a way to retry the failed step
+without repeating already-completed payments.
+
+**Acceptance Scenarios**:
+
+1. **Given** the member rejects a wallet prompt for the active step, **When** the
+   rejection is detected, **Then** that step is marked as failed with a plain-language
+   reason and a way to retry it.
+2. **Given** the membership payment already succeeded but a later step (signature
+   or key registration) failed, **When** the member retries, **Then** the flow
+   resumes at the failed step and does not re-request payment.
+3. **Given** the encryption-key signing or registration step fails, **When** the
+   member chooses to continue, **Then** the membership is still recognized as
+   active (the key step is non-blocking) and the member is told they can complete
+   key registration later from Security settings.
+
+---
+
+### Edge Cases
+
+- **Approval already granted**: If the member has already approved sufficient
+  stablecoin allowance, the approval step is not requested by the wallet. The
+  indicator must reflect this honestly — either present the step as already
+  complete or omit it — and not leave a permanently "pending" step that never
+  activates.
+- **Extend flow**: The extend action does not change tier price and may not
+  require a fresh approval; the indicator must show only the steps actually
+  required for that action and keep the count accurate.
+- **Member closes or navigates away mid-flow**: While any wallet interaction is in
+  progress, the modal must remain in a state that prevents accidental dismissal of
+  the in-progress purchase (consistent with current behavior that disables close
+  during processing).
+- **Wallet disconnects or network switches mid-flow**: The active step must surface
+  the resulting error rather than appearing to hang on a waiting state forever.
+- **Step takes a long time to confirm on-chain**: While waiting for a transaction
+  to be mined, the active step must indicate that confirmation is pending so the
+  member does not think the app has frozen.
+- **Single combined transaction path**: On networks where payment grants the role
+  in one transaction, the indicator must still represent the real number of wallet
+  interactions for that path rather than showing steps that never occur.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The purchase modal MUST display a visual indicator of the ordered
+  sequence of wallet interactions required to complete the purchase (approve
+  spending, pay for membership, sign for encryption-key setup, register encryption
+  key), shown once the member confirms the purchase.
+- **FR-002**: For the currently-active interaction, the indicator MUST show a
+  human-readable label describing what the member is approving.
+- **FR-003**: The indicator MUST distinguish a transaction (moves funds or changes
+  on-chain state, costs gas) from a message signature (no funds move, no gas), so
+  the member knows what kind of wallet prompt to expect.
+- **FR-004**: The indicator MUST visually differentiate, at a minimum, three step
+  states: completed, active/in-progress, and pending/upcoming.
+- **FR-005**: The indicator MUST show overall progress position (for example, "step
+  N of M" and/or a proportional progress bar) and advance it as each step
+  completes.
+- **FR-006**: When the wallet is awaiting the member's confirmation or an on-chain
+  transaction is awaiting mining, the active step MUST show a waiting/in-progress
+  state so the member understands the app is not frozen.
+- **FR-007**: When a step fails or the member rejects a wallet prompt, the
+  indicator MUST mark that specific step as failed and present a plain-language
+  reason.
+- **FR-008**: After a failure, the member MUST be able to retry without redoing
+  already-completed paid steps (no duplicate payment).
+- **FR-009**: The displayed steps MUST match the wallet interactions actually
+  required for the chosen action (purchase, upgrade, or extend) and the current
+  approval state, including correctly handling the case where stablecoin approval
+  is already granted.
+- **FR-010**: The encryption-key signing and registration steps MUST be presented
+  as part of the sequence but treated as non-blocking — if they fail, the member is
+  informed the membership is active and key setup can be completed later.
+- **FR-011**: On successful completion of all required steps, the indicator MUST
+  show all steps as done and lead into the existing purchase-complete confirmation.
+- **FR-012**: The modal MUST continue to prevent accidental dismissal while any
+  wallet interaction is in progress.
+- **FR-013**: The progress indicator MUST be perceivable to assistive technologies,
+  announcing the active step, its state, and progress changes.
+
+### Key Entities *(include if feature involves data)*
+
+- **Purchase Step**: One required wallet interaction in the purchase sequence.
+  Attributes: order/position, display label, kind (transaction vs signature),
+  state (pending, active, completed, failed), optional failure reason, and whether
+  it is blocking or non-blocking for membership activation.
+- **Purchase Progress**: The overall state of the in-flight purchase. Attributes:
+  the ordered list of steps for the chosen action, the index of the active step,
+  total count, and whether the overall flow is in progress, complete, or failed.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: At every point during the purchase, a member can correctly identify
+  which wallet action they are being asked to approve by reading only the modal.
+- **SC-002**: A member can state how many steps remain and which steps are already
+  done at any point in the flow, without external help.
+- **SC-003**: When a wallet prompt is rejected or a step fails, a member can
+  identify which step failed and successfully retry without making a duplicate
+  payment.
+- **SC-004**: The rate of purchases abandoned during the wallet-interaction phase
+  decreases relative to the pre-feature baseline.
+- **SC-005**: Support requests asking "which transaction am I signing?" or "did my
+  purchase go through?" during membership purchase decrease relative to the
+  pre-feature baseline.
+- **SC-006**: In usability testing, at least 90% of members complete a multi-step
+  purchase on the first attempt without expressing confusion about which prompt
+  they are approving.
+
+## Assumptions
+
+- The set and order of wallet interactions follow the current purchase flow:
+  optional stablecoin approval, membership payment, encryption-key signature, and
+  encryption-key registration. The indicator adapts to skip interactions that are
+  not required for a given action or approval state.
+- The encryption-key signature and registration steps remain non-blocking for
+  membership activation, consistent with current behavior where key registration
+  failure is logged as non-fatal and surfaced as a recoverable warning.
+- The feature changes only how progress is presented in the purchase modal; it does
+  not change pricing, the contracts called, the order of operations, or the
+  underlying purchase logic.
+- "4 transactions and signing a message" in the request describes the member's
+  perceived sequence of wallet pop-ups; the actual number can vary (for example,
+  approval is skipped when allowance is already sufficient, or payment and role
+  grant occur in a single transaction on some networks). The indicator reflects the
+  real interactions for the member's situation rather than a fixed count.
+- The existing three-phase modal framing (Choose Tier → Review → Complete) is
+  retained; this feature enriches the transition between Review and Complete — the
+  phase where the wallet interactions occur — with per-interaction progress.

--- a/specs/022-membership-purchase-progress/tasks.md
+++ b/specs/022-membership-purchase-progress/tasks.md
@@ -1,0 +1,203 @@
+---
+
+description: "Task list for Membership Purchase Progress Indicator"
+---
+
+# Tasks: Membership Purchase Progress Indicator
+
+**Input**: Design documents from `/specs/022-membership-purchase-progress/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: INCLUDED — constitution II (Test-First & Comprehensive Coverage) is
+NON-NEGOTIABLE. Within each phase, write the listed tests first and confirm they
+FAIL before implementing.
+
+**Organization**: Tasks are grouped by user story. US1 and US2 are both Priority P1;
+US3 is P2.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: US1 / US2 / US3 (Setup, Foundational, Polish carry no story label)
+- All paths are repo-relative from the project root.
+
+## Path Conventions
+
+Web app, frontend only — all source under `frontend/src/`, tests under
+`frontend/src/test/` (Vitest + @testing-library/react + vitest-axe), per plan.md.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create new file scaffolding and confirm test tooling.
+
+- [ ] T001 [P] Create stub hook `frontend/src/hooks/usePurchaseFlow.js` exporting an empty `usePurchaseFlow()` returning the `PurchaseProgress` shape from data-model.md (placeholder values)
+- [ ] T002 [P] Create stub component `frontend/src/components/ui/PurchaseProgressView.jsx` accepting the props from `contracts/purchase-progress-view.md` and rendering an empty ordered list
+- [ ] T003 Confirm `vitest-axe` matcher is registered in the frontend Vitest setup (locate the existing setup file referenced by `frontend/vite.config.*`/`vitest` config); add the `toHaveNoViolations` matcher import if missing
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build the shared step state machine, the service progress callback, the
+presentational view scaffold, and the modal Processing-phase wiring that ALL user
+stories build on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T004 Write failing tests for the `onProgress` callback in `frontend/src/test/blockchainService.purchase.test.js`: emits `approve` start/sent/confirmed then `pay` events when allowance < price; emits NO `approve` start/sent/confirmed (only `pay`) when allowance ≥ price; behaves identically to today when `onProgress` is omitted (regression)
+- [ ] T005 Implement the optional `onProgress` callback in `purchaseRoleWithStablecoin` in `frontend/src/utils/blockchainService.js` per `contracts/on-progress-callback.md` — wrap emissions in try/catch, change NO on-chain calls/args/order (FR-001a), add it as a trailing optional arg/options to preserve existing callers
+- [ ] T006 Write failing tests for `usePurchaseFlow` step-list construction in `frontend/src/test/usePurchaseFlow.test.js`: builds ordered steps `[approve?, pay, sign, register]`; omits `approve` entirely when the pre-flight allowance read shows allowance ≥ price (FR-009); sets correct `kind`/`blocking` per step (data-model.md)
+- [ ] T007 Implement `usePurchaseFlow` step-list builder in `frontend/src/hooks/usePurchaseFlow.js`: pre-flight read of allowance (read-only, no wallet prompt) + price, build `PurchaseStep[]`/`PurchaseProgress` state per data-model.md (depends on T006)
+- [ ] T008 Implement the `usePurchaseFlow` sequential runner in `frontend/src/hooks/usePurchaseFlow.js`: `start()` calls `purchaseRoleWithStablecoin` with `onProgress` mapping `approve`/`pay` events → step state, then runs `sign` (via `ensureInitialized`) and `register` (via `ensureKeyRegistered`) as discrete steps; track `activeIndex`, `status`, and `purchaseReceipt` (depends on T007; same file as T007 — sequential)
+- [ ] T009 Implement `PurchaseProgressView` base render in `frontend/src/components/ui/PurchaseProgressView.jsx`: ordered semantic list of steps driven by props, applying state classes; reuse existing `ppm-step*` visual tokens (depends on T002)
+- [ ] T010 Wire the Processing phase into `frontend/src/components/ui/PremiumPurchaseModal.jsx`: replace the single inline "Processing…" path in `handlePurchase` with `usePurchaseFlow`; render `<PurchaseProgressView>` as a dedicated view between Review and Complete; keep the 3-phase top nav and the `isPurchasing` dismissal guard (FR-012); on success advance to the existing Complete step (depends on T008, T009)
+- [ ] T011 [P] Add Processing-view and step-state styles in `frontend/src/components/ui/PremiumPurchaseModal.css` (active/confirming/completed/failed states; reuse existing tokens; respect existing reduced-motion block)
+
+**Checkpoint**: Foundation ready — the modal shows a multi-step Processing view driven by real wallet events. User stories can now layer specific behaviors.
+
+---
+
+## Phase 3: User Story 1 - See which wallet action I am approving (Priority: P1) 🎯 MVP
+
+**Goal**: Each wallet interaction shows a plain-language label and a clear
+transaction-vs-signature indicator matching the open wallet prompt.
+
+**Independent Test**: Run a purchase; as each prompt opens, the active step's label
+matches it and signature steps are visibly distinguished from transaction steps.
+
+- [ ] T012 [US1] Write failing tests in `frontend/src/test/PurchaseProgressView.test.jsx`: each step renders its human-readable label (FR-002); `kind: 'signature'` steps show a "sign a message / no funds move" indicator while `transaction` steps show a "confirm in wallet / costs gas" indicator (FR-003)
+- [ ] T013 [US1] Define per-step label + `kind` metadata (`approve`/`pay`/`sign`/`register` → label + `transaction`|`signature`) in the step builder in `frontend/src/hooks/usePurchaseFlow.js`
+- [ ] T014 [US1] Render the per-step label and transaction-vs-signature indicator with an accessible name in `frontend/src/components/ui/PurchaseProgressView.jsx` (depends on T013)
+- [ ] T015 [US1] Add an `aria-live="polite"` region announcing the active step label + kind in `frontend/src/components/ui/PurchaseProgressView.jsx` (same file as T014 — sequential)
+
+**Checkpoint**: Members can read, on the modal, exactly which wallet action each prompt is and whether it is a transaction or a signature.
+
+---
+
+## Phase 4: User Story 2 - Track overall progress through the flow (Priority: P1)
+
+**Goal**: Show how many steps there are, which are done/active/pending, and an
+overall position that advances as steps complete.
+
+**Independent Test**: During a purchase, completed steps show done, the active step
+shows in-progress, pending steps show upcoming, and "step N of M" / a progress bar
+advances; an already-approved purchase correctly counts one fewer step.
+
+- [ ] T016 [US2] Write failing tests in `frontend/src/test/usePurchaseFlow.test.js` and `frontend/src/test/PurchaseProgressView.test.jsx`: derived `completedCount`/`progressFraction`/`total` advance as steps complete (FR-005); distinct `pending`/`active`/`confirming`/`completed` states render (FR-004, FR-006); omitted approval reduces `total` (FR-009)
+- [ ] T017 [US2] Add derived selectors (`completedCount`, `progressFraction`, `activeStep`, `total`) to `frontend/src/hooks/usePurchaseFlow.js`
+- [ ] T018 [US2] Render the overall progress position ("step N of M" and/or proportional bar) and distinct visuals for pending/active/confirming/completed in `frontend/src/components/ui/PurchaseProgressView.jsx` (depends on T017)
+- [ ] T019 [US2] Add the waiting/confirming affordance (reuse `ppm-spinner`, `role="status"`) for a step awaiting wallet confirmation or tx mining in `frontend/src/components/ui/PurchaseProgressView.jsx` (same file as T018 — sequential)
+
+**Checkpoint**: Members can see overall progress and per-step state advance in real time.
+
+---
+
+## Phase 5: User Story 3 - Understand and recover when a step fails (Priority: P2)
+
+**Goal**: A failed/rejected step is attributed with a reason; completed paid steps
+are preserved; retry resumes without re-payment; non-blocking key failures also
+offer "Continue anyway".
+
+**Independent Test**: Reject a non-first prompt — that step shows failed with a
+reason, earlier steps stay done, and retrying resumes without re-charging; rejecting
+a key step offers both Retry and Continue anyway.
+
+- [ ] T020 [US3] Write failing tests in `frontend/src/test/usePurchaseFlow.test.js`: a rejected step → `state: 'failed'` + `failureReason` (FR-007); `retry()` after a `pay`-success/`register`-fail resumes ONLY the key step and never re-invokes the purchase (FR-008); `continueAnyway()` is valid only for a non-blocking key-step failure and finalizes `status: 'succeeded'` with `keyRegOutcome: 'failed'` (FR-010)
+- [ ] T021 [US3] Implement per-step failure capture (`state: 'failed'`, `failureReason`) and `retry()` resume logic in `frontend/src/hooks/usePurchaseFlow.js`: approve/pay retry re-invokes the purchase (internal allowance check skips a done approval — no double-pay); sign/register retry re-runs only that key step using the captured `purchaseReceipt`
+- [ ] T022 [US3] Implement `continueAnyway()` in `frontend/src/hooks/usePurchaseFlow.js` — finalize as success for a non-blocking key-step failure, recording `keyRegOutcome: 'failed'` (same file as T021 — sequential)
+- [ ] T023 [US3] Render the failed state with `failureReason` + a "Retry" action, and a "Continue anyway" action shown ONLY for non-blocking key-step failures, in `frontend/src/components/ui/PurchaseProgressView.jsx` (FR-007, FR-010)
+- [ ] T024 [US3] Ensure the Complete screen shows membership active + the existing "register key later in Security settings" notice when reached via `continueAnyway` in `frontend/src/components/ui/PremiumPurchaseModal.jsx`
+
+**Checkpoint**: All three user stories are independently functional; failures are attributable and recoverable without duplicate payment.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Accessibility, theming, and full validation across all stories.
+
+- [ ] T025 [P] Add/confirm `vitest-axe` zero-violation assertions across idle/running/failed render states in `frontend/src/test/PurchaseProgressView.test.jsx` (FR-013, constitution V)
+- [ ] T026 [P] Add dark-theme (`:root.theme-dark`) and reduced-motion coverage for the Processing-view styles in `frontend/src/components/ui/PremiumPurchaseModal.css`
+- [ ] T027 Run `npm run lint` and `npm run test:run` in `frontend/` and resolve any failures (constitution IV — no `continue-on-error`)
+- [ ] T028 Execute the `specs/022-membership-purchase-progress/quickstart.md` manual walkthroughs (happy path + recovery) and confirm behavior
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately.
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS all user stories.
+- **User Stories (Phases 3–5)**: All depend on Foundational. US1 and US2 (both P1)
+  are the MVP core; US3 (P2) builds on the same hook/view.
+- **Polish (Phase 6)**: Depends on the desired user stories being complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: After Foundational. Independently testable (labels + kind).
+- **US2 (P1)**: After Foundational. Independently testable (progress + states).
+  Touches the same hook/view as US1 but no behavioral dependency on it.
+- **US3 (P2)**: After Foundational. Independently testable (failure + recovery).
+
+### Within Each User Story / Phase
+
+- Write the listed tests FIRST and confirm they FAIL before implementing.
+- Hook/state changes before view rendering that consumes them.
+- Tasks editing the same file run sequentially (noted inline); only different-file
+  tasks are marked `[P]`.
+
+### Parallel Opportunities
+
+- T001, T002 (Setup) — different files, parallel.
+- T011 (CSS) parallel with the JS foundational tasks once the markup contract is set.
+- T025 (test file) and T026 (CSS) in Polish — different files, parallel.
+- Note: most foundational/US tasks touch the shared `usePurchaseFlow.js`,
+  `PurchaseProgressView.jsx`, or `PremiumPurchaseModal.jsx`, so they are largely
+  sequential within those files.
+
+---
+
+## Parallel Example: Phase 1 Setup
+
+```bash
+# Different files — run together:
+Task: "Create stub hook frontend/src/hooks/usePurchaseFlow.js"
+Task: "Create stub component frontend/src/components/ui/PurchaseProgressView.jsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 + US2 — both P1)
+
+1. Phase 1: Setup
+2. Phase 2: Foundational (CRITICAL — blocks all stories)
+3. Phase 3: US1 (labeled steps + transaction/signature) → validate
+4. Phase 4: US2 (overall progress + states) → validate
+5. **STOP and VALIDATE**: members can identify every prompt and see progress — the
+   primary value (SC-001, SC-002). Deploy/demo if ready.
+
+### Incremental Delivery
+
+1. Setup + Foundational → multi-step Processing view live.
+2. US1 → labeled, kind-differentiated steps → demo.
+3. US2 → progress position + live state → demo.
+4. US3 → failure attribution + safe retry / continue-anyway → demo.
+5. Polish → a11y/theming/full validation.
+
+---
+
+## Notes
+
+- [P] = different files, no incomplete dependencies.
+- This feature is presentation-only (FR-001a): NO contract, pricing, or
+  purchase-mechanics changes; the only service edit is the additive `onProgress`
+  callback. The no-callback regression test (T004) guards this.
+- Verify each phase's tests FAIL before implementing (constitution II).
+- Commit after each task or logical group; keep CI green (constitution IV).
+- Stop at any checkpoint to validate a story independently.

--- a/specs/022-membership-purchase-progress/tasks.md
+++ b/specs/022-membership-purchase-progress/tasks.md
@@ -33,9 +33,9 @@ Web app, frontend only — all source under `frontend/src/`, tests under
 
 **Purpose**: Create new file scaffolding and confirm test tooling.
 
-- [ ] T001 [P] Create stub hook `frontend/src/hooks/usePurchaseFlow.js` exporting an empty `usePurchaseFlow()` returning the `PurchaseProgress` shape from data-model.md (placeholder values)
-- [ ] T002 [P] Create stub component `frontend/src/components/ui/PurchaseProgressView.jsx` accepting the props from `contracts/purchase-progress-view.md` and rendering an empty ordered list
-- [ ] T003 Confirm `vitest-axe` matcher is registered in the frontend Vitest setup (locate the existing setup file referenced by `frontend/vite.config.*`/`vitest` config); add the `toHaveNoViolations` matcher import if missing
+- [X] T001 [P] Create stub hook `frontend/src/hooks/usePurchaseFlow.js` exporting an empty `usePurchaseFlow()` returning the `PurchaseProgress` shape from data-model.md (placeholder values)
+- [X] T002 [P] Create stub component `frontend/src/components/ui/PurchaseProgressView.jsx` accepting the props from `contracts/purchase-progress-view.md` and rendering an empty ordered list
+- [X] T003 Confirm `vitest-axe` matcher is registered in the frontend Vitest setup (locate the existing setup file referenced by `frontend/vite.config.*`/`vitest` config); add the `toHaveNoViolations` matcher import if missing
 
 ---
 
@@ -47,14 +47,14 @@ stories build on.
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T004 Write failing tests for the `onProgress` callback in `frontend/src/test/blockchainService.purchase.test.js`: emits `approve` start/sent/confirmed then `pay` events when allowance < price; emits NO `approve` start/sent/confirmed (only `pay`) when allowance ≥ price; behaves identically to today when `onProgress` is omitted (regression)
-- [ ] T005 Implement the optional `onProgress` callback in `purchaseRoleWithStablecoin` in `frontend/src/utils/blockchainService.js` per `contracts/on-progress-callback.md` — wrap emissions in try/catch, change NO on-chain calls/args/order (FR-001a), add it as a trailing optional arg/options to preserve existing callers
-- [ ] T006 Write failing tests for `usePurchaseFlow` step-list construction in `frontend/src/test/usePurchaseFlow.test.js`: builds ordered steps `[approve?, pay, sign, register]`; omits `approve` entirely when the pre-flight allowance read shows allowance ≥ price (FR-009); sets correct `kind`/`blocking` per step (data-model.md)
-- [ ] T007 Implement `usePurchaseFlow` step-list builder in `frontend/src/hooks/usePurchaseFlow.js`: pre-flight read of allowance (read-only, no wallet prompt) + price, build `PurchaseStep[]`/`PurchaseProgress` state per data-model.md (depends on T006)
-- [ ] T008 Implement the `usePurchaseFlow` sequential runner in `frontend/src/hooks/usePurchaseFlow.js`: `start()` calls `purchaseRoleWithStablecoin` with `onProgress` mapping `approve`/`pay` events → step state, then runs `sign` (via `ensureInitialized`) and `register` (via `ensureKeyRegistered`) as discrete steps; track `activeIndex`, `status`, and `purchaseReceipt` (depends on T007; same file as T007 — sequential)
-- [ ] T009 Implement `PurchaseProgressView` base render in `frontend/src/components/ui/PurchaseProgressView.jsx`: ordered semantic list of steps driven by props, applying state classes; reuse existing `ppm-step*` visual tokens (depends on T002)
-- [ ] T010 Wire the Processing phase into `frontend/src/components/ui/PremiumPurchaseModal.jsx`: replace the single inline "Processing…" path in `handlePurchase` with `usePurchaseFlow`; render `<PurchaseProgressView>` as a dedicated view between Review and Complete; keep the 3-phase top nav and the `isPurchasing` dismissal guard (FR-012); on success advance to the existing Complete step (depends on T008, T009)
-- [ ] T011 [P] Add Processing-view and step-state styles in `frontend/src/components/ui/PremiumPurchaseModal.css` (active/confirming/completed/failed states; reuse existing tokens; respect existing reduced-motion block)
+- [X] T004 Write failing tests for the `onProgress` callback in `frontend/src/test/blockchainService.purchase.test.js`: emits `approve` start/sent/confirmed then `pay` events when allowance < price; emits NO `approve` start/sent/confirmed (only `pay`) when allowance ≥ price; behaves identically to today when `onProgress` is omitted (regression)
+- [X] T005 Implement the optional `onProgress` callback in `purchaseRoleWithStablecoin` in `frontend/src/utils/blockchainService.js` per `contracts/on-progress-callback.md` — wrap emissions in try/catch, change NO on-chain calls/args/order (FR-001a), add it as a trailing optional arg/options to preserve existing callers
+- [X] T006 Write failing tests for `usePurchaseFlow` step-list construction in `frontend/src/test/usePurchaseFlow.test.js`: builds ordered steps `[approve?, pay, sign, register]`; omits `approve` entirely when the pre-flight allowance read shows allowance ≥ price (FR-009); sets correct `kind`/`blocking` per step (data-model.md)
+- [X] T007 Implement `usePurchaseFlow` step-list builder in `frontend/src/hooks/usePurchaseFlow.js`: pre-flight read of allowance (read-only, no wallet prompt) + price, build `PurchaseStep[]`/`PurchaseProgress` state per data-model.md (depends on T006)
+- [X] T008 Implement the `usePurchaseFlow` sequential runner in `frontend/src/hooks/usePurchaseFlow.js`: `start()` calls `purchaseRoleWithStablecoin` with `onProgress` mapping `approve`/`pay` events → step state, then runs `sign` (via `ensureInitialized`) and `register` (via `ensureKeyRegistered`) as discrete steps; track `activeIndex`, `status`, and `purchaseReceipt` (depends on T007; same file as T007 — sequential)
+- [X] T009 Implement `PurchaseProgressView` base render in `frontend/src/components/ui/PurchaseProgressView.jsx`: ordered semantic list of steps driven by props, applying state classes; reuse existing `ppm-step*` visual tokens (depends on T002)
+- [X] T010 Wire the Processing phase into `frontend/src/components/ui/PremiumPurchaseModal.jsx`: replace the single inline "Processing…" path in `handlePurchase` with `usePurchaseFlow`; render `<PurchaseProgressView>` as a dedicated view between Review and Complete; keep the 3-phase top nav and the `isPurchasing` dismissal guard (FR-012); on success advance to the existing Complete step (depends on T008, T009)
+- [X] T011 [P] Add Processing-view and step-state styles in `frontend/src/components/ui/PremiumPurchaseModal.css` (active/confirming/completed/failed states; reuse existing tokens; respect existing reduced-motion block)
 
 **Checkpoint**: Foundation ready — the modal shows a multi-step Processing view driven by real wallet events. User stories can now layer specific behaviors.
 
@@ -68,10 +68,10 @@ transaction-vs-signature indicator matching the open wallet prompt.
 **Independent Test**: Run a purchase; as each prompt opens, the active step's label
 matches it and signature steps are visibly distinguished from transaction steps.
 
-- [ ] T012 [US1] Write failing tests in `frontend/src/test/PurchaseProgressView.test.jsx`: each step renders its human-readable label (FR-002); `kind: 'signature'` steps show a "sign a message / no funds move" indicator while `transaction` steps show a "confirm in wallet / costs gas" indicator (FR-003)
-- [ ] T013 [US1] Define per-step label + `kind` metadata (`approve`/`pay`/`sign`/`register` → label + `transaction`|`signature`) in the step builder in `frontend/src/hooks/usePurchaseFlow.js`
-- [ ] T014 [US1] Render the per-step label and transaction-vs-signature indicator with an accessible name in `frontend/src/components/ui/PurchaseProgressView.jsx` (depends on T013)
-- [ ] T015 [US1] Add an `aria-live="polite"` region announcing the active step label + kind in `frontend/src/components/ui/PurchaseProgressView.jsx` (same file as T014 — sequential)
+- [X] T012 [US1] Write failing tests in `frontend/src/test/PurchaseProgressView.test.jsx`: each step renders its human-readable label (FR-002); `kind: 'signature'` steps show a "sign a message / no funds move" indicator while `transaction` steps show a "confirm in wallet / costs gas" indicator (FR-003)
+- [X] T013 [US1] Define per-step label + `kind` metadata (`approve`/`pay`/`sign`/`register` → label + `transaction`|`signature`) in the step builder in `frontend/src/hooks/usePurchaseFlow.js`
+- [X] T014 [US1] Render the per-step label and transaction-vs-signature indicator with an accessible name in `frontend/src/components/ui/PurchaseProgressView.jsx` (depends on T013)
+- [X] T015 [US1] Add an `aria-live="polite"` region announcing the active step label + kind in `frontend/src/components/ui/PurchaseProgressView.jsx` (same file as T014 — sequential)
 
 **Checkpoint**: Members can read, on the modal, exactly which wallet action each prompt is and whether it is a transaction or a signature.
 
@@ -86,10 +86,10 @@ overall position that advances as steps complete.
 shows in-progress, pending steps show upcoming, and "step N of M" / a progress bar
 advances; an already-approved purchase correctly counts one fewer step.
 
-- [ ] T016 [US2] Write failing tests in `frontend/src/test/usePurchaseFlow.test.js` and `frontend/src/test/PurchaseProgressView.test.jsx`: derived `completedCount`/`progressFraction`/`total` advance as steps complete (FR-005); distinct `pending`/`active`/`confirming`/`completed` states render (FR-004, FR-006); omitted approval reduces `total` (FR-009)
-- [ ] T017 [US2] Add derived selectors (`completedCount`, `progressFraction`, `activeStep`, `total`) to `frontend/src/hooks/usePurchaseFlow.js`
-- [ ] T018 [US2] Render the overall progress position ("step N of M" and/or proportional bar) and distinct visuals for pending/active/confirming/completed in `frontend/src/components/ui/PurchaseProgressView.jsx` (depends on T017)
-- [ ] T019 [US2] Add the waiting/confirming affordance (reuse `ppm-spinner`, `role="status"`) for a step awaiting wallet confirmation or tx mining in `frontend/src/components/ui/PurchaseProgressView.jsx` (same file as T018 — sequential)
+- [X] T016 [US2] Write failing tests in `frontend/src/test/usePurchaseFlow.test.js` and `frontend/src/test/PurchaseProgressView.test.jsx`: derived `completedCount`/`progressFraction`/`total` advance as steps complete (FR-005); distinct `pending`/`active`/`confirming`/`completed` states render (FR-004, FR-006); omitted approval reduces `total` (FR-009)
+- [X] T017 [US2] Add derived selectors (`completedCount`, `progressFraction`, `activeStep`, `total`) to `frontend/src/hooks/usePurchaseFlow.js`
+- [X] T018 [US2] Render the overall progress position ("step N of M" and/or proportional bar) and distinct visuals for pending/active/confirming/completed in `frontend/src/components/ui/PurchaseProgressView.jsx` (depends on T017)
+- [X] T019 [US2] Add the waiting/confirming affordance (reuse `ppm-spinner`, `role="status"`) for a step awaiting wallet confirmation or tx mining in `frontend/src/components/ui/PurchaseProgressView.jsx` (same file as T018 — sequential)
 
 **Checkpoint**: Members can see overall progress and per-step state advance in real time.
 
@@ -105,11 +105,11 @@ offer "Continue anyway".
 reason, earlier steps stay done, and retrying resumes without re-charging; rejecting
 a key step offers both Retry and Continue anyway.
 
-- [ ] T020 [US3] Write failing tests in `frontend/src/test/usePurchaseFlow.test.js`: a rejected step → `state: 'failed'` + `failureReason` (FR-007); `retry()` after a `pay`-success/`register`-fail resumes ONLY the key step and never re-invokes the purchase (FR-008); `continueAnyway()` is valid only for a non-blocking key-step failure and finalizes `status: 'succeeded'` with `keyRegOutcome: 'failed'` (FR-010)
-- [ ] T021 [US3] Implement per-step failure capture (`state: 'failed'`, `failureReason`) and `retry()` resume logic in `frontend/src/hooks/usePurchaseFlow.js`: approve/pay retry re-invokes the purchase (internal allowance check skips a done approval — no double-pay); sign/register retry re-runs only that key step using the captured `purchaseReceipt`
-- [ ] T022 [US3] Implement `continueAnyway()` in `frontend/src/hooks/usePurchaseFlow.js` — finalize as success for a non-blocking key-step failure, recording `keyRegOutcome: 'failed'` (same file as T021 — sequential)
-- [ ] T023 [US3] Render the failed state with `failureReason` + a "Retry" action, and a "Continue anyway" action shown ONLY for non-blocking key-step failures, in `frontend/src/components/ui/PurchaseProgressView.jsx` (FR-007, FR-010)
-- [ ] T024 [US3] Ensure the Complete screen shows membership active + the existing "register key later in Security settings" notice when reached via `continueAnyway` in `frontend/src/components/ui/PremiumPurchaseModal.jsx`
+- [X] T020 [US3] Write failing tests in `frontend/src/test/usePurchaseFlow.test.js`: a rejected step → `state: 'failed'` + `failureReason` (FR-007); `retry()` after a `pay`-success/`register`-fail resumes ONLY the key step and never re-invokes the purchase (FR-008); `continueAnyway()` is valid only for a non-blocking key-step failure and finalizes `status: 'succeeded'` with `keyRegOutcome: 'failed'` (FR-010)
+- [X] T021 [US3] Implement per-step failure capture (`state: 'failed'`, `failureReason`) and `retry()` resume logic in `frontend/src/hooks/usePurchaseFlow.js`: approve/pay retry re-invokes the purchase (internal allowance check skips a done approval — no double-pay); sign/register retry re-runs only that key step using the captured `purchaseReceipt`
+- [X] T022 [US3] Implement `continueAnyway()` in `frontend/src/hooks/usePurchaseFlow.js` — finalize as success for a non-blocking key-step failure, recording `keyRegOutcome: 'failed'` (same file as T021 — sequential)
+- [X] T023 [US3] Render the failed state with `failureReason` + a "Retry" action, and a "Continue anyway" action shown ONLY for non-blocking key-step failures, in `frontend/src/components/ui/PurchaseProgressView.jsx` (FR-007, FR-010)
+- [X] T024 [US3] Ensure the Complete screen shows membership active + the existing "register key later in Security settings" notice when reached via `continueAnyway` in `frontend/src/components/ui/PremiumPurchaseModal.jsx`
 
 **Checkpoint**: All three user stories are independently functional; failures are attributable and recoverable without duplicate payment.
 
@@ -119,9 +119,9 @@ a key step offers both Retry and Continue anyway.
 
 **Purpose**: Accessibility, theming, and full validation across all stories.
 
-- [ ] T025 [P] Add/confirm `vitest-axe` zero-violation assertions across idle/running/failed render states in `frontend/src/test/PurchaseProgressView.test.jsx` (FR-013, constitution V)
-- [ ] T026 [P] Add dark-theme (`:root.theme-dark`) and reduced-motion coverage for the Processing-view styles in `frontend/src/components/ui/PremiumPurchaseModal.css`
-- [ ] T027 Run `npm run lint` and `npm run test:run` in `frontend/` and resolve any failures (constitution IV — no `continue-on-error`)
+- [X] T025 [P] Add/confirm `vitest-axe` zero-violation assertions across idle/running/failed render states in `frontend/src/test/PurchaseProgressView.test.jsx` (FR-013, constitution V)
+- [X] T026 [P] Add dark-theme (`:root.theme-dark`) and reduced-motion coverage for the Processing-view styles in `frontend/src/components/ui/PremiumPurchaseModal.css`
+- [X] T027 Run `npm run lint` and `npm run test:run` in `frontend/` and resolve any failures (constitution IV — no `continue-on-error`)
 - [ ] T028 Execute the `specs/022-membership-purchase-progress/quickstart.md` manual walkthroughs (happy path + recovery) and confirm behavior
 
 ---


### PR DESCRIPTION
## Summary

Adds the Spec Kit specification for a **step-by-step progress indicator** in the membership purchase modal (`specs/022-membership-purchase-progress/`).

### Problem

When a member buys/upgrades/extends Wager Participant access, confirming the purchase triggers a sequence of distinct wallet interactions that the current modal collapses into a single "Processing…" spinner:

1. **Approve** USDC spending (skipped if allowance already sufficient)
2. **Pay** for the membership tier
3. **Sign** a message to derive the encryption key
4. **Register** the encryption key on-chain

Multiple wallet pop-ups appear with no on-screen explanation of which one is active, why, how many remain, or whether something failed — causing confusion, abandoned purchases, and rejected prompts.

### What this spec defines

- **US1 (P1)** — name the active wallet action and whether it's a transaction or a signature
- **US2 (P1)** — show overall progress (completed / active / pending steps, "step N of M")
- **US3 (P2)** — attribute failures to a step and recover/retry without duplicate payment
- 13 functional requirements, edge cases (approval-already-granted, extend flow, mid-flow disconnect, combined-tx path), and measurable, technology-agnostic success criteria
- Requirements quality checklist (all items passing)

### Scope

Presentation-only: no changes to pricing, contracts called, order of operations, or purchase logic. The indicator adapts to the real wallet interactions for the member's situation rather than hard-coding a count.

### Next steps

Ready for `/speckit-clarify` (optional) or `/speckit-plan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAhmu1c2Ki8CC5Wgn37abc

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAhmu1c2Ki8CC5Wgn37abc)_