### PR TITLE
Gate "either side submits outcome" to equal-stakes (non-leveraged) wagers

### DIFF
--- a/contracts/wagers/WagerRegistry.sol
+++ b/contracts/wagers/WagerRegistry.sol
@@ -15,8 +15,11 @@ import "../oracles/IOracleAdapter.sol";
 
 /// @title WagerRegistry
 /// @notice Peer-to-peer wager escrow. Each wager has a named creator and opponent,
-///         a stake in an allowlisted ERC20 (USDC or WMATIC), and one of five
-///         resolution types: Either / Creator / Opponent / ThirdParty / Polymarket.
+///         a stake in an allowlisted ERC20 (USDC or WMATIC), and a resolution type:
+///         Either / Creator / Opponent / ThirdParty / Polymarket (plus extensible
+///         oracle types). `Either` lets either party submit the outcome and is only
+///         permitted on equal-stakes (non-leveraged) wagers — asymmetric "Offer"
+///         stakes must use a single settler, an arbitrator, or an oracle.
 /// @dev    Role separation:
 ///           DEFAULT_ADMIN_ROLE       — config (membership manager, adapter, token allowlist)
 ///           GUARDIAN_ROLE            — emergency pause / unpause
@@ -99,6 +102,7 @@ contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausab
     error AcceptExpired();
     error ResolveExpired();
     error NotAuthorized();
+    error EitherRequiresEqualStakes();
     error WinnerNotParticipant();
     error NotWinner();
     error NotResolved();
@@ -279,6 +283,16 @@ contract WagerRegistry is IWagerRegistry, AccessControl, ReentrancyGuard, Pausab
         if (resolveDeadline <= acceptDeadline) revert BadDeadlines();
         if (acceptDeadline > block.timestamp + MAX_ACCEPT_WINDOW) revert BadDeadlines();
         if (resolveDeadline > block.timestamp + MAX_RESOLVE_WINDOW) revert BadDeadlines();
+
+        // "Either side submits the outcome" (ResolutionType.Either) is a mutual-trust
+        // resolution path — no oracle, no arbitrator, and whoever calls declareWinner
+        // first decides the result. That is only sound on a level peer-to-peer wager
+        // where both sides stake the same amount. On an asymmetric "Offer" (leveraged)
+        // wager the side risking less could self-declare and seize the larger
+        // counterparty stake, so restrict Either to equal-stakes (non-leveraged) bets.
+        if (resolutionType == ResolutionType.Either && creatorStake != opponentStake) {
+            revert EitherRequiresEqualStakes();
+        }
 
         if (resolutionType == ResolutionType.ThirdParty) {
             if (arbitrator == address(0)) revert ArbitratorRequired();

--- a/docs/system-overview/how-it-works.md
+++ b/docs/system-overview/how-it-works.md
@@ -67,7 +67,7 @@ How a wager resolves is fixed at creation time:
 
 | Resolution type | Who can settle | How |
 |----------------|----------------|-----|
-| `Either` | Creator or opponent | `declareWinner(wagerId, winner)` |
+| `Either` | Creator or opponent | `declareWinner(wagerId, winner)` — **equal-stakes wagers only** |
 | `Creator` | Creator only | `declareWinner(...)` |
 | `Opponent` | Opponent only | `declareWinner(...)` |
 | `ThirdParty` | Named arbitrator | `declareWinner(...)` |
@@ -77,10 +77,17 @@ How a wager resolves is fixed at creation time:
 | `UMA` | Anyone | `autoResolveFromOracle(wagerId)` reads the settled UMA Optimistic Oracle V3 assertion |
 
 The on-chain enum names are unchanged. In the create UI these are surfaced as
-**Me** (`Creator`), **Them** (`Opponent`), **A Friend** (`ThirdParty`), and
-**An Oracle** (`Polymarket` / Chainlink / UMA). `Either` is retained on-chain for
-pre-existing wagers but is no longer offered when creating new ones — every new
-wager names a single settler, which in an Offer also carries the majority stake.
+**Me** (`Creator`), **Them** (`Opponent`), **Either of Us** (`Either`),
+**A Friend** (`ThirdParty`), and **An Oracle** (`Polymarket` / Chainlink / UMA).
+
+`Either` lets either side submit the outcome — a mutual-trust path with no named
+settler. It is only sound on a level peer-to-peer wager where both sides stake the
+same amount, so the registry **restricts it to equal-stakes (non-leveraged) bets**
+(`EitherRequiresEqualStakes`). An asymmetric **Offer** (where the settler puts up
+the majority stake) must instead name a single settler, a third-party arbitrator,
+or an oracle — otherwise the smaller-staked side could self-declare and seize the
+pot. The create UI mirrors this: **Either of Us** is offered for even-money wagers
+and withheld from Offers.
 
 For oracle types, the creator declares at creation which side they take
 (`creatorIsYes`); when the adapter reports the outcome, the registry maps it to

--- a/frontend/src/abis/WagerRegistry.js
+++ b/frontend/src/abis/WagerRegistry.js
@@ -139,6 +139,11 @@ export const WAGER_REGISTRY_ABI = [
   },
   {
     "inputs": [],
+    "name": "EitherRequiresEqualStakes",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "NotCreator",
     "type": "error"
   },

--- a/frontend/src/abis/WagerRegistry.json
+++ b/frontend/src/abis/WagerRegistry.json
@@ -139,6 +139,11 @@
   },
   {
     "inputs": [],
+    "name": "EitherRequiresEqualStakes",
+    "type": "error"
+  },
+  {
+    "inputs": [],
     "name": "NotCreator",
     "type": "error"
   },

--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -44,11 +44,15 @@ const CUSTOM_TOKEN_OPTION = { id: 'CUSTOM', symbol: 'Custom', name: 'Custom Toke
 
 // Participant-resolved (people settle it) resolution types, in enum order.
 // Oracle-resolved types are computed per-chain at render time (adapter-gated).
-// "Either Party" (ResolutionType.Either) was retired: every wager now names a
-// single settler, which also drives who puts up the majority stake in an Offer.
 const PARTICIPANT_RESOLUTION_TYPES = [
   ResolutionType.Creator,
   ResolutionType.Opponent,
+  // "Either of us" (ResolutionType.Either) lets either side submit the outcome —
+  // a mutual-trust path with no named settler. The WagerRegistry only permits it
+  // on equal-stakes (non-leveraged) wagers, so it is offered for even-money bets
+  // and withheld from Offers (which carry asymmetric stakes). See
+  // `participantResolutionTypes` below, which gates it on the market type.
+  ResolutionType.Either,
   // ThirdParty re-enabled (Spec Kit 005): the WagerRegistry v3 per-user index now
   // records the arbitrator (so they can discover the wagers they oversee via
   // getUserWagers), and the creator encrypts the private terms for the arbitrator
@@ -56,12 +60,18 @@ const PARTICIPANT_RESOLUTION_TYPES = [
   ResolutionType.ThirdParty,
 ]
 
+// Even-money (equal-stakes) wagers may additionally let either side report the
+// result; Offers cannot (asymmetric stakes would let the smaller-staked side
+// self-declare and seize the pot — the contract reverts EitherRequiresEqualStakes).
+const EITHER_ALLOWED_MARKET_TYPES = new Set(['oneVsOne'])
+
 // Dropdown labels + helper text for every resolution type. Kept here so the
 // participant/oracle flows render from a single mapped source instead of a
 // hand-maintained option list.
 const RESOLUTION_TYPE_LABELS = {
   [ResolutionType.Creator]: 'Me (Creator)',
   [ResolutionType.Opponent]: 'Them (Opponent)',
+  [ResolutionType.Either]: 'Either of Us (equal stakes)',
   [ResolutionType.ThirdParty]: 'A Friend (Arbitrator)',
   [ResolutionType.Polymarket]: 'An Oracle (Polymarket)',
   [ResolutionType.ChainlinkDataFeed]: 'Chainlink Data Feed (price condition)',
@@ -71,6 +81,7 @@ const RESOLUTION_TYPE_LABELS = {
 const RESOLUTION_TYPE_HINTS = {
   [ResolutionType.Creator]: 'You settle the outcome — so you put up the majority stake (skin in the game)',
   [ResolutionType.Opponent]: 'Your opponent settles the outcome — so they put up the majority stake (skin in the game)',
+  [ResolutionType.Either]: 'Either side can submit the outcome (you both agree on a draw). Only available on even-money wagers where you each stake the same — best when you trust each other to report honestly',
   [ResolutionType.ThirdParty]: 'A neutral friend you name settles the wager (they can read the terms but cannot take a side)',
   [ResolutionType.Polymarket]: 'Settles automatically when the linked Polymarket market resolves',
   [ResolutionType.ChainlinkDataFeed]: 'Settles automatically once the price feed reading at the deadline passes the threshold',
@@ -98,6 +109,7 @@ const ORACLE_TAB_TYPES = [
 const RESOLUTION_TAB_LABELS = {
   [ResolutionType.Creator]: 'Me',
   [ResolutionType.Opponent]: 'Them',
+  [ResolutionType.Either]: 'Either',
   [ResolutionType.ThirdParty]: 'Friend',
   [ResolutionType.Polymarket]: 'Oracle',
   [ResolutionType.ChainlinkDataFeed]: 'Chainlink Data Feed',
@@ -111,6 +123,7 @@ const RESOLUTION_TAB_LABELS = {
 const RESOLUTION_TAB_ICONS = {
   [ResolutionType.Creator]: '👤',
   [ResolutionType.Opponent]: '👥',
+  [ResolutionType.Either]: '🤝',
   [ResolutionType.ThirdParty]: '⚖️',
   [ResolutionType.Polymarket]: '🔮',
   [ResolutionType.ChainlinkDataFeed]: '🔮',
@@ -168,6 +181,11 @@ function FriendMarketsModal({
   const { isConnected, account } = useWallet()
   const { signer, isCorrectNetwork, switchNetwork, chainId } = useWeb3()
 
+  // Declared up here (ahead of the resolution-option memos) because those memos
+  // gate the "Either of us" settler on the market type: it's only valid for
+  // even-money (equal-stakes) wagers, not Offers.
+  const [friendMarketType, setFriendMarketType] = useState(initialType || 'oneVsOne')
+
   // Per-chain capabilities — drives which resolution-type options the user
   // sees. Polymarket-pegged side bets only render on chains where the
   // Polymarket CTF is reachable (Polygon Amoy and Mainnet).
@@ -203,11 +221,21 @@ function FriendMarketsModal({
     ...(umaAdapter && isOracleModelExposed(ResolutionType.UMA) ? [ResolutionType.UMA] : []),
   ], [polymarketSidebetsEnabled, chainlinkDataFeedAdapter, chainlinkFunctionsAdapter, umaAdapter])
 
+  // Participant settlers offered for the current market type. "Either of us"
+  // (Either) is only sound on equal-stakes wagers, so it's dropped for Offers
+  // — keeping the UI in lockstep with the contract's EitherRequiresEqualStakes
+  // guard so the user never picks an option that would revert.
+  const participantResolutionTypes = useMemo(() => (
+    EITHER_ALLOWED_MARKET_TYPES.has(friendMarketType)
+      ? PARTICIPANT_RESOLUTION_TYPES
+      : PARTICIPANT_RESOLUTION_TYPES.filter((t) => t !== ResolutionType.Either)
+  ), [friendMarketType])
+
   const resolutionOptionTypes = useMemo(() => {
-    if (resolutionCategory === 'participant') return PARTICIPANT_RESOLUTION_TYPES
+    if (resolutionCategory === 'participant') return participantResolutionTypes
     if (resolutionCategory === 'oracle') return availableOracleResolutionTypes
-    return [...PARTICIPANT_RESOLUTION_TYPES, ...availableOracleResolutionTypes]
-  }, [resolutionCategory, availableOracleResolutionTypes])
+    return [...participantResolutionTypes, ...availableOracleResolutionTypes]
+  }, [resolutionCategory, participantResolutionTypes, availableOracleResolutionTypes])
 
   // Default resolution to pre-select when the modal opens, per category.
   const defaultResolutionType = useMemo(() => {
@@ -251,8 +279,8 @@ function FriendMarketsModal({
   // settlement choices first.
   const resolutionTabTypes = useMemo(() => {
     if (resolutionCategory === 'oracle') return ORACLE_TAB_TYPES
-    return [...PARTICIPANT_RESOLUTION_TYPES, ...ORACLE_TAB_TYPES]
-  }, [resolutionCategory])
+    return [...participantResolutionTypes, ...ORACLE_TAB_TYPES]
+  }, [resolutionCategory, participantResolutionTypes])
 
   // A tab is locked only for oracle types whose adapter/CTF isn't reachable.
   const isTabLocked = useCallback(
@@ -287,7 +315,6 @@ function FriendMarketsModal({
 
   // Creation flow state
   const [creationStep, setCreationStep] = useState('form') // 'form', 'success'
-  const [friendMarketType, setFriendMarketType] = useState(initialType || 'oneVsOne')
   const [createdMarket, setCreatedMarket] = useState(null)
 
   // Form data

--- a/frontend/src/constants/wagerDefaults.js
+++ b/frontend/src/constants/wagerDefaults.js
@@ -28,9 +28,11 @@ export const WAGER_DEFAULTS = {
   ODDS_MULTIPLIER: 200,
 
   /** Default resolution type: 1=Creator ("Me"), 2=Opponent ("Them"), 3=ThirdParty
-   *  ("Friend"), 4=Polymarket ("Oracle"). The legacy "Either Party" (0) option was
-   *  retired — every wager now names a single settler, which also drives who puts
-   *  up the majority stake in an Offer. */
+   *  ("Friend"), 4=Polymarket ("Oracle"). "Either of Us" (0) lets either side
+   *  submit the outcome and is offered only on even-money (equal-stakes) wagers —
+   *  the contract reverts EitherRequiresEqualStakes on asymmetric Offers — so it is
+   *  never the default (an Offer names a single settler, who carries the majority
+   *  stake). */
   RESOLUTION_TYPE: 1,
 
   /** Default trading / wager duration in days */

--- a/frontend/src/hooks/useFriendMarketCreation.js
+++ b/frontend/src/hooks/useFriendMarketCreation.js
@@ -297,6 +297,17 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
           'Either change the resolution type or clear the conditionId.'
         )
       }
+      // "Either side submits the outcome" is only allowed on a level peer-to-peer
+      // wager (equal stakes). An asymmetric Offer must use a single named resolver,
+      // a third party, or an oracle — never mutual-trust self-resolution. Mirror the
+      // contract's EitherRequiresEqualStakes guard so the user gets a clear message.
+      if (resolutionType === ResolutionType.Either && creatorStakeWei !== opponentStakeWei) {
+        throw new Error(
+          'Letting either side submit the outcome is only available on equal-stakes ' +
+          '(non-leveraged) peer-to-peer wagers. Use a single resolver, a third-party ' +
+          'arbitrator, or an oracle for an Offer with uneven stakes.'
+        )
+      }
 
       // Metadata (encrypted envelope → IPFS, or plaintext)
       let metadataReference
@@ -502,6 +513,7 @@ export function translateRevert(reason) {
   if (reason.includes('OracleAdapterNotSet')) return 'No oracle adapter is configured on-chain for this resolution type.'
   if (reason.includes('UnsupportedOracleResolutionType')) return 'This resolution type is not supported by the registry.'
   if (reason.includes('AdapterNotSet')) return 'Polymarket adapter not configured on-chain.'
+  if (reason.includes('EitherRequiresEqualStakes')) return 'Letting either side submit the outcome is only allowed on equal-stakes (non-leveraged) peer-to-peer wagers. For an Offer with uneven stakes, use a single resolver, a third-party arbitrator, or an oracle.'
   if (reason.includes('ArbitratorRequired')) return 'ThirdParty resolution requires an arbitrator.'
   if (reason.includes('ArbitratorDisallowed')) return 'Only ThirdParty resolution allows an arbitrator.'
   if (reason.includes('ZeroAddress')) return 'Invalid address (zero address not allowed).'

--- a/frontend/src/test/FriendMarketsModal.test.jsx
+++ b/frontend/src/test/FriendMarketsModal.test.jsx
@@ -378,20 +378,35 @@ describe('FriendMarketsModal', () => {
       expect(screen.queryByLabelText(/minimum participants/i)).not.toBeInTheDocument()
     })
 
-    it('participant category shows people-settled resolution options incl. Friend (no Either Party)', () => {
+    it('participant category (even-money) offers Me / Them / Either of Us / Friend', () => {
       renderWithProviders(
-        <FriendMarketsModal {...defaultProps} resolutionCategory="participant" />
+        <FriendMarketsModal {...defaultProps} initialType="oneVsOne" resolutionCategory="participant" />
       )
       const select = screen.getByLabelText(/who can resolve/i)
       const labels = Array.from(select.querySelectorAll('option')).map(o => o.textContent)
-      // "Either Party" was retired — every wager names a single settler. ThirdParty
-      // ("A Friend") is re-enabled (Spec Kit 005): the arbitrator is indexed for
-      // discovery and encrypted-for, so they can find and resolve the wager.
+      // "Either of Us" lets either side submit the outcome — re-enabled but only
+      // on even-money (equal-stakes) wagers, so it appears here. ThirdParty
+      // ("A Friend") is indexed for discovery and encrypted-for so the named
+      // arbitrator can find and resolve the wager (Spec Kit 005).
       expect(labels).toEqual([
         'Me (Creator)',
         'Them (Opponent)',
+        'Either of Us (equal stakes)',
         'A Friend (Arbitrator)',
       ])
+    })
+
+    it('Offer flow withholds the "Either of Us" settler (asymmetric stakes)', () => {
+      renderWithProviders(
+        <FriendMarketsModal {...defaultProps} initialType="offer" resolutionCategory="all" />
+      )
+      // The Offer flow renders settlers as a tab strip. "Either" is not sound on
+      // asymmetric stakes, so it must not appear (the contract would revert
+      // EitherRequiresEqualStakes).
+      expect(screen.queryByRole('tab', { name: /^either$/i })).not.toBeInTheDocument()
+      // The single-settler tabs are still present.
+      expect(screen.getByRole('tab', { name: /^me$/i })).toBeInTheDocument()
+      expect(screen.getByRole('tab', { name: /^them$/i })).toBeInTheDocument()
     })
 
     it('selecting Third Party reveals a required arbitrator address input', async () => {

--- a/frontend/src/test/useFriendMarketCreation.translateRevert.test.js
+++ b/frontend/src/test/useFriendMarketCreation.translateRevert.test.js
@@ -53,6 +53,11 @@ describe('useFriendMarketCreation: translateRevert', () => {
       .toMatch(/insufficient token balance/i)
   })
 
+  it('maps EitherRequiresEqualStakes to equal-stakes guidance', () => {
+    expect(translateRevert('execution reverted: EitherRequiresEqualStakes'))
+      .toMatch(/equal-stakes \(non-leveraged\)/i)
+  })
+
   it('falls back to a generic message for unknown reasons', () => {
     expect(translateRevert('out of gas: 0x1234'))
       .toMatch(/transaction will fail/i)

--- a/test/WagerRegistry.draw.test.js
+++ b/test/WagerRegistry.draw.test.js
@@ -206,7 +206,9 @@ describe("WagerRegistry — Draw resolution", function () {
   describe("fund correctness & finality", function () {
     it("unequal stakes: each party gets exactly their own stake back (sum == escrowed)", async () => {
       const fx = await loadFixture(deployFixture);
-      const id = await createActive(fx, { creatorStake: usdc(30), opponentStake: usdc(10) });
+      // Unequal "Offer" stakes can't use Either; Creator/Opponent types still
+      // settle a draw by mutual consent, so use Creator here.
+      const id = await createActive(fx, { resolutionType: Resolution.Creator, creatorStake: usdc(30), opponentStake: usdc(10) });
       const aBefore = await fx.usdcToken.balanceOf(fx.alice.address);
       const bBefore = await fx.usdcToken.balanceOf(fx.bob.address);
       await fx.reg.connect(fx.alice).declareDraw(id);

--- a/test/WagerRegistry.test.js
+++ b/test/WagerRegistry.test.js
@@ -224,6 +224,56 @@ describe("WagerRegistry", function () {
       await time.increase(31 * 24 * 3600);
       await expect(createDefault(reg, fx)).to.be.revertedWithCustomError(reg, "MembershipDenied");
     });
+
+    // "Either side submits the outcome" (ResolutionType.Either) is mutual-trust
+    // self-resolution: it is only allowed on a level peer-to-peer wager where both
+    // sides stake the same. Asymmetric/leveraged "Offer" stakes must use an oracle,
+    // a third-party arbitrator, or a single named resolver (Creator/Opponent).
+    describe("Either resolution requires equal (non-leveraged) stakes", () => {
+      it("allows Either when stakes are equal", async () => {
+        const fx = await loadFixture(deployFixture);
+        const id = await createDefault(fx.reg, fx, {
+          resolutionType: Resolution.Either,
+          creatorStake: usdc(25),
+          opponentStake: usdc(25),
+        });
+        const w = await fx.reg.getWager(id);
+        expect(w.resolutionType).to.equal(Resolution.Either);
+        expect(w.creatorStake).to.equal(w.opponentStake);
+      });
+
+      it("rejects Either when creator stakes more (leveraged)", async () => {
+        const fx = await loadFixture(deployFixture);
+        await expect(createDefault(fx.reg, fx, {
+          resolutionType: Resolution.Either,
+          creatorStake: usdc(30),
+          opponentStake: usdc(10),
+        })).to.be.revertedWithCustomError(fx.reg, "EitherRequiresEqualStakes");
+      });
+
+      it("rejects Either when opponent stakes more (leveraged)", async () => {
+        const fx = await loadFixture(deployFixture);
+        await expect(createDefault(fx.reg, fx, {
+          resolutionType: Resolution.Either,
+          creatorStake: usdc(10),
+          opponentStake: usdc(30),
+        })).to.be.revertedWithCustomError(fx.reg, "EitherRequiresEqualStakes");
+      });
+
+      it("still allows asymmetric stakes for non-Either resolution types", async () => {
+        const fx = await loadFixture(deployFixture);
+        // ThirdParty arbitration tolerates an asymmetric "Offer" wager.
+        const id = await createDefault(fx.reg, fx, {
+          resolutionType: Resolution.ThirdParty,
+          arbitrator: fx.charlie.address,
+          creatorStake: usdc(30),
+          opponentStake: usdc(10),
+        });
+        const w = await fx.reg.getWager(id);
+        expect(w.creatorStake).to.equal(usdc(30));
+        expect(w.opponentStake).to.equal(usdc(10));
+      });
+    });
   });
 
   describe("acceptWager", () => {
@@ -550,8 +600,11 @@ describe("WagerRegistry", function () {
     it("works end-to-end with WMATIC", async () => {
       const fx = await loadFixture(deployFixture);
       const { reg, wmatic, alice, bob } = fx;
+      // Asymmetric "Offer" stakes can't use Either self-resolution; use a single
+      // named resolver (Creator) instead.
       const id = await createDefault(reg, fx, {
         token: await wmatic.getAddress(),
+        resolutionType: Resolution.Creator,
         creatorStake: ethers.parseEther("1"),
         opponentStake: ethers.parseEther("2"),
       });


### PR DESCRIPTION
## What & why

Non-leveraged wagers needed an option to let **either side submit the outcome**, and that option must be available **only on peer-to-peer equal-stakes bets**.

`ResolutionType.Either` already lets either party settle via `declareWinner`, but the UI had retired it (every new wager named a single settler). This PR re-enables it, gated to equal-stakes wagers, and enforces the restriction on-chain.

### Why the restriction matters
`Either` is a mutual-trust path — no oracle, no arbitrator, and whoever calls `declareWinner` first decides the result. That's only sound when both sides stake the same. On an asymmetric **Offer** (leveraged) wager, the side risking less could self-declare and seize the larger counterparty stake. So `Either` + unequal stakes is now rejected at creation.

## Changes

**Contract (`WagerRegistry.sol`)**
- New `EitherRequiresEqualStakes` error; `_createWager` reverts when `resolutionType == Either && creatorStake != opponentStake`.
- Updated NatSpec.

**Frontend**
- `FriendMarketsModal`: surfaces **"Either of Us"** as a settler, offered only for even-money (`oneVsOne`) wagers and withheld from Offers (gated on market type, mirroring the contract).
- `useFriendMarketCreation`: defense-in-depth guard before submit + friendly `translateRevert` mapping.
- Added `EitherRequiresEqualStakes` to the `WagerRegistry` ABI (JS + regenerated JSON).
- Refreshed stale "Either was retired" comments.

**Docs**
- `how-it-works.md` documents the equal-stakes restriction and the re-enabled UI option.

## Tests
- **Contracts** (248 passing): `Either` requires equal stakes (both-direction rejection); non-`Either` types still allow asymmetric "Offer" stakes; updated two pre-existing asymmetric-stake tests that had relied on the default `Either` type (switched to `Creator`).
- **Frontend** (1467 passing): even-money flow lists "Either of Us"; Offer flow withholds it; `translateRevert` mapping. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016WQc9XatRe8qUvQRXK1bCt)_