### PR TITLE
Fix Account dashboard participant data wiring

### DIFF
--- a/frontend/src/components/account/ActivityBreakdowns.jsx
+++ b/frontend/src/components/account/ActivityBreakdowns.jsx
@@ -54,7 +54,7 @@ function ActivityBreakdowns({ breakdowns }) {
         </ul>
       </Group>
 
-      <Group title="By oracle">
+      <Group title="By resolution">
         <ul className="account-breakdown-list">
           {b.byOracle.map((o) => (
             <li key={o.resolutionType}>

--- a/frontend/src/hooks/useAccountStats.js
+++ b/frontend/src/hooks/useAccountStats.js
@@ -18,12 +18,13 @@ import { useWallet } from './useWalletManagement'
 import usePriceConversion from './usePriceConversion'
 import { useChainTokens } from './useChainTokens'
 import { getDefaultWagerRepository } from '../data/wagers/WagerRepository'
-import { createReportDataSource } from '../data/reports/reportDataSource'
+import { getContractAddressForChain } from '../config/contracts'
 import {
   computeSummary,
   computePnlSeries,
   computeBreakdowns,
   enrichTransfers,
+  deriveTransfersFromWagers,
   isSettledStatus,
   DEFAULT_RANGE,
 } from '../lib/account'
@@ -101,6 +102,25 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
       setIsLoading(false)
       return
     }
+    // Network support is decided by a configured escrow for the active chain —
+    // the same resolution the wager list and report use. Without one, the
+    // dashboard's data is meaningless, so surface the "unsupported" state rather
+    // than spinning forever.
+    const escrowConfigured = Boolean(
+      getContractAddressForChain('wagerRegistry', chainId) ||
+      getContractAddressForChain('friendGroupMarketFactory', chainId),
+    )
+    if (!escrowConfigured) {
+      setIsSupportedNetwork(false)
+      setWagers([])
+      setValuedTransfers([])
+      setTokenMetaByAddress({})
+      setIsLoading(false)
+      const settled = { lastUpdated: Date.now(), status: 'fresh' }
+      setFreshness({ summary: settled, series: settled, balances: settled, activity: settled })
+      return
+    }
+
     const reqId = ++reqIdRef.current
     setIsLoading(true)
     setError(null)
@@ -112,10 +132,8 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
     }))
     try {
       const repository = getDefaultWagerRepository()
-      const ds = createReportDataSource({ chainId })
-      const [loadedWagers, rawTransfers, stable] = await Promise.all([
+      const [loadedWagers, stable] = await Promise.all([
         loadAllWagers(repository, address),
-        ds.listTransfers({ account: address }),
         fetchStableBalance({
           provider,
           address,
@@ -125,7 +143,11 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
       ])
       if (reqId !== reqIdRef.current) return
 
-      const { transfers, tokenMetaByAddress: meta } = await enrichTransfers(rawTransfers || [], { chainId })
+      // Derive the member's value movements from the SAME authoritative wagers
+      // that power My Wagers — not the separate WagerTransfer entity — so totals,
+      // P&L, breakdowns, and activity are always consistent with the wager list.
+      const rawTransfers = deriveTransfersFromWagers({ wagers: loadedWagers, address })
+      const { transfers, tokenMetaByAddress: meta } = await enrichTransfers(rawTransfers, { chainId })
       if (reqId !== reqIdRef.current) return
 
       setWagers(loadedWagers)

--- a/frontend/src/lib/account/breakdowns.js
+++ b/frontend/src/lib/account/breakdowns.js
@@ -8,15 +8,15 @@
  *   Σ byToken.ownStakeUsd === AccountSummary.totalWageredUsd
  */
 import { isActiveStatus, normalizeStatus } from './status'
+import { ResolutionTypeNames } from '../../constants/wagerDefaults'
 
-// resolutionType (subgraph Int) → human label. Indexes match the adapter
-// registry order; unknown values fall back to a generic label.
-export const ORACLE_LABELS = Object.freeze({
-  0: 'Manual',
-  1: 'Polymarket',
-  2: 'Chainlink',
-  3: 'UMA',
-})
+// resolutionType (on-chain enum) → human label, sourced from the single source
+// of truth (constants/wagerDefaults → contracts/interfaces/IWagerRegistry.sol).
+// The previous hand-maintained map was wrong (0:Manual, 1:Polymarket, 2:Chainlink,
+// 3:UMA): it mislabeled peer/manual resolution (Either/Creator/Opponent/
+// ThirdParty) as oracles and showed real Polymarket (4) as "Type 4". Unknown
+// values still fall back to a generic label.
+export const ORACLE_LABELS = ResolutionTypeNames
 
 export function oracleLabel(resolutionType) {
   const n = Number(resolutionType)

--- a/frontend/src/lib/account/deriveTransfers.js
+++ b/frontend/src/lib/account/deriveTransfers.js
@@ -1,0 +1,106 @@
+/**
+ * deriveTransfersFromWagers — synthesize the member's value movements
+ * (deposit / payout / refund) directly from the authoritative wager records
+ * that power "My Wagers", instead of the separate `WagerTransfer` subgraph
+ * entity (`reportDataSource.listTransfers`).
+ *
+ * Why: the Account dashboard previously read money flows from a DIFFERENT data
+ * path than the wager list and the notification feed. When that entity is only
+ * partially indexed the activity feed shows a confusing, incomplete subset of
+ * events. Deriving from the same `wagers` array the rest of the app trusts makes
+ * the dashboard's totals, P&L, breakdowns, and activity exactly consistent with
+ * My Wagers — every time, regardless of WagerTransfer indexing gaps.
+ *
+ * The amounts are exact, not estimated: payout = creatorStake + opponentStake
+ * (WagerRegistry transfers the full pot to the winner with no fee), and each
+ * party's refund/draw return is their own stake — mirroring the on-chain
+ * lifecycle the subgraph mappings record.
+ *
+ * Output shape matches `transferDerivation.deriveTransfers` pre-items so the
+ * result feeds straight into `enrichTransfers` (token meta + USD valuation).
+ * Pure — no I/O. `txHash` is intentionally empty: these are derived from wager
+ * state, not a single log, so there is no one transaction to link.
+ */
+import { normalizeStatus, sameAddress } from './status'
+
+/** Statuses in which the opponent has accepted and therefore staked. */
+const OPPONENT_HAS_DEPOSITED = new Set([
+  'active',
+  'draw_proposed',
+  'resolved',
+  'refunded',
+  'drawn',
+])
+
+/** Settled statuses where both parties get their own stake back. */
+const MUTUAL_REFUND_STATUSES = new Set(['refunded', 'drawn'])
+
+/** Settled statuses where only the creator ever deposited, so only they refund. */
+const CREATOR_ONLY_REFUND_STATUSES = new Set(['cancelled', 'declined'])
+
+function toBigInt(value) {
+  try {
+    return BigInt(value ?? 0)
+  } catch {
+    return 0n
+  }
+}
+
+/**
+ * @param {object} params
+ * @param {Array}  params.wagers  - rich wagers (creator, opponent, winner, stakes, status, timestamps)
+ * @param {string} params.address - the member's wallet address
+ * @returns {Array} unenriched transfer pre-items { wagerId, direction, tokenAddress, amountRaw, txHash, timestamp }
+ */
+export function deriveTransfersFromWagers({ wagers = [], address } = {}) {
+  if (!address) return []
+  const items = []
+
+  for (const w of wagers) {
+    const isCreator = sameAddress(w.creator, address)
+    const isOpponent = sameAddress(w.opponent, address)
+    if (!isCreator && !isOpponent) continue
+
+    const token = w.stakeTokenAddress || w.token || null
+    const status = normalizeStatus(w.status)
+    const creatorStake = toBigInt(w.creatorStake ?? w.stakeAmount)
+    const opponentStake = toBigInt(w.opponentStake ?? w.stakeAmount)
+    const ownStake = isCreator ? creatorStake : opponentStake
+
+    // Timestamps: the creator stakes at creation; we have no separate acceptance
+    // time for the opponent, so we attribute their deposit to createdAt too.
+    // Settlement uses resolvedAt when present, else createdAt (refund/cancel/
+    // decline events don't set resolvedAt in the index).
+    const createdAt = Number(w.createdAt) || 0
+    const settledAt = Number(w.resolvedAt) || createdAt
+
+    const push = (direction, amount, timestamp) => {
+      if (amount <= 0n) return
+      items.push({
+        wagerId: String(w.id),
+        direction,
+        tokenAddress: token,
+        amountRaw: amount.toString(),
+        txHash: '',
+        timestamp,
+      })
+    }
+
+    // ---- Deposits: the member's own stake into escrow ----
+    if (isCreator) push('deposit', creatorStake, createdAt)
+    if (isOpponent && OPPONENT_HAS_DEPOSITED.has(status)) push('deposit', opponentStake, createdAt)
+
+    // ---- Settlement: value returned to the member ----
+    if (status === 'resolved' && sameAddress(w.winner, address)) {
+      push('payout', creatorStake + opponentStake, settledAt)
+    } else if (MUTUAL_REFUND_STATUSES.has(status)) {
+      push('refund', ownStake, settledAt)
+    } else if (CREATOR_ONLY_REFUND_STATUSES.has(status) && isCreator) {
+      push('refund', creatorStake, settledAt)
+    }
+  }
+
+  return items
+}
+
+export default deriveTransfersFromWagers

--- a/frontend/src/lib/account/index.js
+++ b/frontend/src/lib/account/index.js
@@ -3,6 +3,7 @@ export { computeSummary } from './computeSummary'
 export { computePnlSeries, RANGES, DEFAULT_RANGE, BUCKET_THRESHOLD } from './computePnlSeries'
 export { computeBreakdowns, oracleLabel, ORACLE_LABELS } from './breakdowns'
 export { enrichTransfers } from './enrichTransfers'
+export { deriveTransfersFromWagers } from './deriveTransfers'
 export {
   ACTIVE_STATUSES,
   classifyOutcome,

--- a/frontend/src/test/account/breakdowns.test.js
+++ b/frontend/src/test/account/breakdowns.test.js
@@ -6,10 +6,10 @@ const ME = '0xMe'
 
 describe('computeBreakdowns (spec 020 — US4, FR-009)', () => {
   const wagers = [
-    { id: '1', status: 'resolved', winner: ME, resolutionType: 1 },
-    { id: '2', status: 'active', resolutionType: 1 },
-    { id: '3', status: 'active', resolutionType: 2 },
-    { id: '4', status: 'refunded', resolutionType: 3 },
+    { id: '1', status: 'resolved', winner: ME, resolutionType: 1 }, // Creator (peer)
+    { id: '2', status: 'active', resolutionType: 1 }, // Creator (peer)
+    { id: '3', status: 'active', resolutionType: 2 }, // Opponent (peer)
+    { id: '4', status: 'refunded', resolutionType: 4 }, // Polymarket (oracle)
   ]
   const transfers = [
     { wagerId: '1', direction: 'deposit', tokenAddress: '0xUSDC', ticker: 'USDC', usdValue: 100 },
@@ -33,16 +33,23 @@ describe('computeBreakdowns (spec 020 — US4, FR-009)', () => {
     expect(byToken[0].symbol).toBe('USDC') // largest stake first
   })
 
-  it('byOracle labels resolution types', () => {
+  it('byOracle labels resolution types from the on-chain enum (peer vs oracle)', () => {
     const { byOracle } = computeBreakdowns({ wagers, transfers })
     const labels = byOracle.map((o) => o.label)
+    // Peer/manual resolution must NOT be mislabeled as an oracle.
+    expect(labels).toContain('Creator')
+    expect(labels).toContain('Opponent')
+    // Real oracle types keep their names.
     expect(labels).toContain('Polymarket')
-    expect(labels).toContain('Chainlink')
-    expect(labels).toContain('UMA')
+    expect(labels).not.toContain('UMA') // no UMA wager in this fixture
   })
 
-  it('oracleLabel falls back for unknown types', () => {
-    expect(oracleLabel(1)).toBe('Polymarket')
+  it('oracleLabel maps the contract enum and falls back for unknown types', () => {
+    expect(oracleLabel(0)).toBe('Either')
+    expect(oracleLabel(1)).toBe('Creator')
+    expect(oracleLabel(3)).toBe('Third Party')
+    expect(oracleLabel(4)).toBe('Polymarket')
+    expect(oracleLabel(7)).toBe('UMA Optimistic Oracle')
     expect(oracleLabel(99)).toBe('Type 99')
   })
 })

--- a/frontend/src/test/account/deriveTransfers.test.js
+++ b/frontend/src/test/account/deriveTransfers.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { deriveTransfersFromWagers } from '../../lib/account/deriveTransfers'
+
+const ME = '0x00000000000000000000000000000000000000Me'.toLowerCase()
+const OPP = '0x00000000000000000000000000000000000000Op'.toLowerCase()
+const USDC = '0xUsdc'
+
+// 1 USDC in base units (6 decimals) keeps the fixtures readable.
+const U = (n) => String(BigInt(n) * 1_000_000n)
+
+const base = {
+  token: USDC,
+  creatorStake: U(10),
+  opponentStake: U(10),
+  createdAt: 1000,
+  resolvedAt: 2000,
+}
+
+describe('deriveTransfersFromWagers (Account dashboard money flows)', () => {
+  it('returns nothing without an address', () => {
+    expect(deriveTransfersFromWagers({ wagers: [{ id: '1', creator: ME }], address: null })).toEqual([])
+  })
+
+  it('skips wagers the member is not a party to', () => {
+    const wagers = [{ id: '1', creator: OPP, opponent: '0xother', status: 'active', ...base }]
+    expect(deriveTransfersFromWagers({ wagers, address: ME })).toEqual([])
+  })
+
+  it('creator deposit is recorded at creation even while open (not yet accepted)', () => {
+    const wagers = [{ id: '1', creator: ME, opponent: OPP, status: 'open', ...base, stakeTokenAddress: USDC }]
+    const out = deriveTransfersFromWagers({ wagers, address: ME })
+    expect(out).toEqual([
+      { wagerId: '1', direction: 'deposit', tokenAddress: USDC, amountRaw: U(10), txHash: '', timestamp: 1000 },
+    ])
+  })
+
+  it('opponent only deposits once the wager is accepted (active+), never while open', () => {
+    const open = [{ id: '1', creator: OPP, opponent: ME, status: 'open', ...base, stakeTokenAddress: USDC }]
+    expect(deriveTransfersFromWagers({ wagers: open, address: ME })).toEqual([])
+
+    const active = [{ id: '1', creator: OPP, opponent: ME, status: 'active', ...base, stakeTokenAddress: USDC }]
+    const out = deriveTransfersFromWagers({ wagers: active, address: ME })
+    expect(out).toEqual([
+      { wagerId: '1', direction: 'deposit', tokenAddress: USDC, amountRaw: U(10), txHash: '', timestamp: 1000 },
+    ])
+  })
+
+  it('winner gets a payout of the full pot (creatorStake + opponentStake), no fee', () => {
+    const wagers = [{ id: '1', creator: ME, opponent: OPP, winner: ME, status: 'resolved', ...base, stakeTokenAddress: USDC }]
+    const out = deriveTransfersFromWagers({ wagers, address: ME })
+    expect(out).toEqual([
+      { wagerId: '1', direction: 'deposit', tokenAddress: USDC, amountRaw: U(10), txHash: '', timestamp: 1000 },
+      { wagerId: '1', direction: 'payout', tokenAddress: USDC, amountRaw: U(20), txHash: '', timestamp: 2000 },
+    ])
+  })
+
+  it('loser records only their deposit (a realized loss)', () => {
+    const wagers = [{ id: '1', creator: ME, opponent: OPP, winner: OPP, status: 'resolved', ...base, stakeTokenAddress: USDC }]
+    const out = deriveTransfersFromWagers({ wagers, address: ME })
+    expect(out.map((t) => t.direction)).toEqual(['deposit'])
+  })
+
+  it('refunded / drawn return each party their own stake', () => {
+    for (const status of ['refunded', 'drawn']) {
+      const wagers = [{ id: '1', creator: ME, opponent: OPP, status, ...base, stakeTokenAddress: USDC }]
+      const out = deriveTransfersFromWagers({ wagers, address: ME })
+      expect(out.map((t) => t.direction)).toEqual(['deposit', 'refund'])
+      expect(out[1].amountRaw).toBe(U(10))
+    }
+  })
+
+  it('cancelled / declined refund only the creator (opponent never deposited)', () => {
+    for (const status of ['cancelled', 'declined']) {
+      const asCreator = deriveTransfersFromWagers({
+        wagers: [{ id: '1', creator: ME, opponent: OPP, status, ...base, stakeTokenAddress: USDC }],
+        address: ME,
+      })
+      expect(asCreator.map((t) => t.direction)).toEqual(['deposit', 'refund'])
+
+      const asOpponent = deriveTransfersFromWagers({
+        wagers: [{ id: '1', creator: OPP, opponent: ME, status, ...base, stakeTokenAddress: USDC }],
+        address: ME,
+      })
+      expect(asOpponent).toEqual([]) // opponent never staked, so no deposit and no refund
+    }
+  })
+
+  it('uses createdAt for settlement when resolvedAt is absent', () => {
+    const wagers = [{ id: '1', creator: ME, opponent: OPP, status: 'refunded', token: USDC, creatorStake: U(5), opponentStake: U(5), createdAt: 1500, resolvedAt: null }]
+    const out = deriveTransfersFromWagers({ wagers, address: ME })
+    expect(out.every((t) => t.timestamp === 1500)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Problem

The Account dashboard retrieved participant data from a **different, less reliable path** than "My Wagers" and the notification feed, which are correct. This produced the two issues in the screenshots:

- **"By oracle" claimed oracles were used when they weren't.** Testing accounts resolved wagers peer-to-peer, yet the breakdown showed Polymarket / Manual / UMA — and a real Polymarket wager showed "Type 4".
- **"Recent activity" showed a random/partial subset** of events, inconsistent with the wager history.

## Root causes & fixes

### 1. Wrong resolution-type → label mapping
`lib/account/breakdowns.js` hard-coded `ORACLE_LABELS` as `{0:Manual, 1:Polymarket, 2:Chainlink, 3:UMA}`, which does **not** match the on-chain enum:

```
ResolutionType { Either:0, Creator:1, Opponent:2, ThirdParty:3,
                 Polymarket:4, ChainlinkDataFeed:5, ChainlinkFunctions:6, UMA:7 }
```

So peer/manual resolution (0–3) was mislabeled as oracles, and real oracle types (4–7) fell through to "Type N". Labels now come from the single source of truth (`constants/wagerDefaults` → `IWagerRegistry.sol`). The section is retitled **"By resolution"** since peer types aren't oracles.

### 2. Activity/P&L derived from a separate, partially-indexed entity
The dashboard read money movements from the `WagerTransfer` subgraph entity (`reportDataSource.listTransfers`) — a different path from the `wagers` entity that powers My Wagers and the notification feed. When that entity is incompletely indexed, the activity feed shows a confusing subset.

It now derives deposit / payout / refund flows **directly from the same authoritative wagers** the rest of the app trusts, so totals, P&L, breakdowns, and activity are always consistent with the wager list. Amounts are exact, not estimated: payout = `creatorStake + opponentStake` (WagerRegistry sends the full pot to the winner, no fee), and each party's refund/draw return is their own stake — mirroring the subgraph lifecycle mappings.

## Changes
- `lib/account/deriveTransfers.js` — new pure `deriveTransfersFromWagers` helper (+ tests)
- `lib/account/breakdowns.js` — labels from the canonical enum
- `hooks/useAccountStats.js` — derive transfers from wagers; explicit configured-escrow network-support check (replaces error-string sniffing)
- `components/account/ActivityBreakdowns.jsx` — "By oracle" → "By resolution"
- `test/account/breakdowns.test.js` — corrected to the real enum

## Testing
Full frontend suite green: **1476 passed** (140 files), including the new `deriveTransfers.test.js` (9 cases) and updated breakdown labels. Lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tszPuokvxby3dWc9NUSmc

---
_Generated by [Claude Code](https://claude.ai/code/session_019tszPuokvxby3dWc9NUSmc)_