### PR TITLE
Surface action-needed tag on collapsed wager cards

### DIFF
--- a/frontend/src/components/fairwins/WagerCard.jsx
+++ b/frontend/src/components/fairwins/WagerCard.jsx
@@ -95,7 +95,14 @@ export default function WagerCard({
         </div>
         <div className="wc-header-side">
           <span className={`wc-status ${vm.statusClass}`}>{vm.statusText}</span>
-          {vm.actionNeeded && !vm.actionBadgeRedundant && (
+          {/* Action-needed tag. While the card is collapsed this tag is the only
+              signal that the wager needs attention — its action buttons live in
+              the expanded body, and on phones the grid never auto-expands, so a
+              claimable/refundable wager would otherwise look inert (the user
+              can't tell which rows need them without opening each one). Once the
+              card is open the matching button is visible, so the tag is dropped
+              for the kinds that render a button to avoid the duplicate. */}
+          {vm.actionNeeded && (!isOpen || !vm.actionBadgeRedundant) && (
             <Badge variant={vm.actionNeeded === 'claim' ? 'success' : 'warning'} className="wc-action-needed">
               {ACTION_NEEDED_LABELS[vm.actionNeeded] ?? vm.actionNeeded}
             </Badge>

--- a/frontend/src/test/WagerCard.test.jsx
+++ b/frontend/src/test/WagerCard.test.jsx
@@ -3,9 +3,13 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import WagerCardGrid from '../components/fairwins/WagerCardGrid'
 
-// The activity watcher is optional; stub it so the grid renders without a provider.
+// The activity watcher is optional; stub it so the grid renders without a
+// provider. Tests assign activityRef.current per scenario to drive the
+// action-needed tags; the mock reads it lazily so the same object is returned
+// on every render.
+const activityRef = vi.hoisted(() => ({ current: { actionNeededByWagerId: {} } }))
 vi.mock('../hooks/useWagerActivity', () => ({
-  useWagerActivityOptional: () => ({ actionNeededByWagerId: {} }),
+  useWagerActivityOptional: () => activityRef.current,
 }))
 
 const ME = '0x1234567890123456789012345678901234567890'
@@ -34,7 +38,10 @@ const activeWager = (over = {}) => ({
 })
 
 describe('WagerCard (via WagerCardGrid)', () => {
-  beforeEach(() => vi.clearAllMocks())
+  beforeEach(() => {
+    vi.clearAllMocks()
+    activityRef.current = { actionNeededByWagerId: {} }
+  })
 
   it('renders a collapsed card with stake, token, title and status pill', () => {
     render(<WagerCardGrid {...baseProps} markets={[activeWager()]} />)
@@ -126,6 +133,25 @@ describe('WagerCard (via WagerCardGrid)', () => {
     const claimBtn = screen.getByRole('button', { name: /^claim$/i })
     await user.click(claimBtn)
     expect(onClaim).toHaveBeenCalledTimes(1)
+  })
+
+  it('flags a claimable wager with a Claim tag while collapsed, then shows the button when expanded', async () => {
+    const user = userEvent.setup()
+    activityRef.current = { actionNeededByWagerId: { '42': 'claim' } }
+    const won = activeWager({ id: '42', description: 'Won Wager', status: 'resolved', computedStatus: 'resolved', winner: ME, paid: false })
+    render(<WagerCardGrid {...baseProps} onClaim={vi.fn()} showOutcome markets={[won]} />)
+
+    const card = screen.getByText('Won Wager').closest('.wc-card')
+    // Collapsed: the Claim button lives in the body, so the tag is the visible cue.
+    expect(screen.queryByRole('button', { name: /^claim$/i })).not.toBeInTheDocument()
+    const tag = card.querySelector('.wc-action-needed')
+    expect(tag).toBeInTheDocument()
+    expect(tag).toHaveTextContent(/claim/i)
+
+    // Expanding reveals the real Claim button and drops the now-redundant tag.
+    await user.click(screen.getByText('Won Wager'))
+    expect(screen.getByRole('button', { name: /^claim$/i })).toBeInTheDocument()
+    expect(card.querySelector('.wc-action-needed')).toBeNull()
   })
 
   it('does not show a Claim action to the losing side', async () => {

--- a/frontend/src/test/actionNeededBadges.test.jsx
+++ b/frontend/src/test/actionNeededBadges.test.jsx
@@ -284,11 +284,14 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
       expect(document.querySelectorAll('.wc-action-needed')).toHaveLength(0)
     })
 
-    // Every action kind now has a matching button in the Actions column, so the
-    // duplicate status badge is suppressed across the board.
+    // While collapsed, the action-needed tag is the ONLY signal that a card
+    // needs attention (its action button lives in the expanded body, and the
+    // phone grid never auto-expands). Once expanded the matching button shows,
+    // so the now-redundant tag is dropped.
     it.each(['accept', 'claim', 'resolve', 'refund', 'respondDraw'])(
-      'does not render a redundant status badge for "%s"',
+      'tags the collapsed card for "%s", then drops the redundant tag once expanded',
       async (kind) => {
+        const user = userEvent.setup()
         activityRef.current = baseActivity({
           actionNeededByWagerId: { '1': kind }
         })
@@ -297,6 +300,11 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
           render(modalUi([wagerOne()]))
         })
 
+        // Collapsed: the tag flags the wager without the user opening it.
+        expect(document.querySelectorAll('.wc-action-needed')).toHaveLength(1)
+
+        // Expanding reveals the matching button → the duplicate tag drops.
+        await user.click(screen.getByText('Wager One'))
         expect(document.querySelectorAll('.wc-action-needed')).toHaveLength(0)
       }
     )


### PR DESCRIPTION
## Problem

On smaller displays the **My Wagers** list renders the expandable card grid (`WagerCardGrid` / `WagerCard`). A wager's contextual action buttons — **Claim**, **Refund**, **Respond to Draw**, etc. — live *only* inside the expanded card body. To find which wagers need them, the user has to expand each card one at a time.

As reported: a "Won" wager has a **Claim** action available, but the collapsed card shows no hint of it — you only discover the button after tapping to expand.

| Collapsed (before) | Expanded |
|---|---|
| `10.0 USDC · Won · Resolved` — no action cue | reveals a green **Claim** button |

## Root cause

The card header already renders an action-needed tag, but it was gated on `!actionBadgeRedundant`. That flag is `true` for every kind that has a matching button (`accept`/`claim`/`resolve`/`refund`/`respondDraw`). The "redundant" assumption holds for the **table** view (button always visible in the Actions column) and for an **expanded** card — but it's wrong for a **collapsed** card, where the button is hidden. So the only attention signal was suppressed exactly when it was needed.

## Fix

`WagerCard.jsx` — keep showing the action-needed tag while the card is collapsed, regardless of redundancy. Once the card is expanded the real button becomes visible, so the now-duplicate tag is still dropped:

```js
vm.actionNeeded && (!isOpen || !vm.actionBadgeRedundant)
```

This is presentation-only — no new network calls, no view-model changes, and the table view is untouched (it never rendered this tag).

## Tests

- Updated the parametrized badge test in `actionNeededBadges.test.jsx`: collapsed cards now show the tag for each action kind, and the tag drops once expanded.
- Added a realistic claimable-wager case to `WagerCard.test.jsx`: a resolved wager the viewer won (unpaid) shows a **Claim** tag while collapsed, then the actual Claim button when expanded.
- `WagerCard`, `actionNeededBadges`, and `WagerTable` suites pass (28 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LG1ArzdptqQfe5TK95HT9g)_