### PR TITLE
fix(wagers): My Wagers open-challenge display — stake decimals + "Open Challenge" label

### DIFF
--- a/frontend/src/components/fairwins/marketHelpers.js
+++ b/frontend/src/components/fairwins/marketHelpers.js
@@ -2,6 +2,8 @@
 // MyMarketsModal, and ShareWagerModal so the same display logic and
 // acceptance-URL format apply everywhere.
 
+import { isOpenChallengeMarket } from './wagerCardHelpers'
+
 export const formatUSD = (amount, symbol) => {
   const num = parseFloat(amount) || 0
   const isStablecoin = symbol === 'USDC' || symbol === 'USDT' || symbol === 'DAI'
@@ -40,6 +42,8 @@ export const getMarketDescription = (market) => {
   }
 
   const stakeInfo = market.stakeAmount ? `${market.stakeAmount} ${market.stakeTokenSymbol || 'MATIC'}` : ''
+  // Open challenges (feature 024) have no bound opponent and code-gated terms — label them honestly.
+  if (isOpenChallengeMarket(market)) return `Open Challenge${stakeInfo ? ` - ${stakeInfo}` : ''}`
   return `Private Bet${stakeInfo ? ` - ${stakeInfo}` : ''}`
 }
 

--- a/frontend/src/components/fairwins/wagerCardHelpers.js
+++ b/frontend/src/components/fairwins/wagerCardHelpers.js
@@ -8,6 +8,20 @@ import { WagerStatus as MarketStatus } from '../../constants/wagerDefaults'
  * pure functions of their inputs — no React, no side effects.
  */
 
+const ZERO_ADDRESS_RE = /^0x0{40}$/i
+
+/**
+ * True if and only if a wager is an open challenge (feature 024): created with no named opponent.
+ * Named-opponent wagers always have a non-zero opponent at creation, so an absent/zero opponent uniquely
+ * identifies an open challenge (until a taker accepts, after which the opponent is bound and this returns false).
+ */
+export function isOpenChallengeMarket(market) {
+  if (!market) return false
+  // Match the literal zero address that toWagerShape / the subgraph write for an unaccepted open challenge.
+  // Don't treat a merely-missing opponent field as open — that would mislabel wagers from other data paths.
+  return typeof market.opponent === 'string' && ZERO_ADDRESS_RE.test(market.opponent)
+}
+
 /**
  * Display title for a wager, handling encrypted/private placeholders.
  */
@@ -34,6 +48,9 @@ export function getMarketDisplayTitle(market) {
     }
     // If encrypted/private, show stake and time info
     const stakeInfo = market.stakeAmount ? `${market.stakeAmount} ${market.stakeTokenSymbol || 'ETC'}` : ''
+    // Open challenges (feature 024) have no bound opponent — named wagers always do at creation — and their
+    // code-gated terms aren't decryptable here, so label them honestly as "Open Challenge" not "Private Bet".
+    if (isOpenChallengeMarket(market)) return `Open Challenge${stakeInfo ? ` - ${stakeInfo}` : ''}`
     return `Private Bet${stakeInfo ? ` - ${stakeInfo}` : ''}`
   }
 

--- a/frontend/src/test/openChallengeLabel.test.js
+++ b/frontend/src/test/openChallengeLabel.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { isOpenChallengeMarket, getMarketDisplayTitle } from '../components/fairwins/wagerCardHelpers'
+import { getMarketDescription } from '../components/fairwins/marketHelpers'
+
+// Feature 024: an open challenge (no bound opponent, code-gated terms) must read as "Open Challenge"
+// in the My Wagers views, not the generic "Private Bet" used for encrypted named-opponent wagers.
+
+const ZERO = '0x0000000000000000000000000000000000000000'
+const NAMED = '0x2222222222222222222222222222222222222222'
+
+// An encrypted friend wager whose terms can't be shown → falls through to the stake/label fallback.
+function encryptedWager(overrides = {}) {
+  return {
+    marketType: 'friend',
+    description: 'Encrypted Wager',
+    stakeAmount: '10',
+    stakeTokenSymbol: 'USDC',
+    ...overrides,
+  }
+}
+
+describe('isOpenChallengeMarket', () => {
+  it('is true for a zero-address opponent (unaccepted open challenge)', () => {
+    expect(isOpenChallengeMarket({ opponent: ZERO })).toBe(true)
+  })
+  it('is false for a named opponent', () => {
+    expect(isOpenChallengeMarket({ opponent: NAMED })).toBe(false)
+  })
+  it('is false when the opponent field is missing/null (avoid mislabeling other data paths)', () => {
+    expect(isOpenChallengeMarket({})).toBe(false)
+    expect(isOpenChallengeMarket({ opponent: null })).toBe(false)
+    expect(isOpenChallengeMarket(null)).toBe(false)
+  })
+})
+
+describe('open-challenge title labels', () => {
+  it('getMarketDisplayTitle labels an unaccepted open challenge "Open Challenge - <stake>"', () => {
+    expect(getMarketDisplayTitle(encryptedWager({ opponent: ZERO }))).toBe('Open Challenge - 10 USDC')
+  })
+  it('getMarketDisplayTitle keeps "Private Bet - <stake>" for an encrypted named-opponent wager', () => {
+    expect(getMarketDisplayTitle(encryptedWager({ opponent: NAMED }))).toBe('Private Bet - 10 USDC')
+  })
+  it('getMarketDescription labels an open challenge "Open Challenge - <stake>"', () => {
+    expect(getMarketDescription({ description: 'Encrypted Wager', opponent: ZERO, stakeAmount: '10', stakeTokenSymbol: 'USDC' }))
+      .toBe('Open Challenge - 10 USDC')
+  })
+  it('getMarketDescription keeps "Private Bet" for an encrypted named-opponent wager', () => {
+    expect(getMarketDescription({ description: 'Encrypted Wager', opponent: NAMED, stakeAmount: '10', stakeTokenSymbol: 'USDC' }))
+      .toBe('Private Bet - 10 USDC')
+  })
+})

--- a/frontend/src/test/wagerStakeDisplay.test.js
+++ b/frontend/src/test/wagerStakeDisplay.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { ethers } from 'ethers'
+import { toWagerShape } from '../utils/blockchainService'
+import { getContractAddressForChain } from '../config/contracts'
+
+// Regression for the My Wagers "Private Bet - 0.000000000001 tokens" bug: toWagerShape derived the stake
+// token's decimals/symbol from the build-time chain (137) instead of the CONNECTED chain, so a USDC wager on
+// Mordor (63) fell back to 18 decimals + 'tokens'. It must resolve the token against the connected chain.
+
+const MORDOR = 63
+const usdc = getContractAddressForChain('paymentToken', MORDOR) // synced Mordor USDC (6 decimals)
+
+function wager(overrides = {}) {
+  return {
+    creator: '0x1111111111111111111111111111111111111111',
+    opponent: ethers.ZeroAddress,
+    arbitrator: ethers.ZeroAddress,
+    token: usdc,
+    creatorStake: 1_000_000n, // 1 USDC at 6 decimals
+    opponentStake: 1_000_000n,
+    acceptDeadline: 0n,
+    resolveDeadline: 0n,
+    resolutionType: 0,
+    status: 1,
+    winner: ethers.ZeroAddress,
+    paid: false,
+    metadataUri: '',
+    polymarketConditionId: ethers.ZeroHash,
+    creatorIsYes: false,
+    metadataHash: ethers.ZeroHash,
+    ...overrides,
+  }
+}
+
+describe('toWagerShape — chain-aware stake token (My Wagers display)', () => {
+  it('formats a USDC stake on the connected chain (Mordor 63) with 6 decimals + USDC symbol', () => {
+    const w = toWagerShape('1', wager(), MORDOR)
+    expect(w.stakeAmount).toBe('1.0')
+    expect(w.creatorStake).toBe('1.0')
+    expect(w.stakeTokenSymbol).toBe('USDC')
+    // The bug rendered this as 1e6 / 1e18:
+    expect(w.stakeAmount).not.toBe('0.000000000001')
+  })
+
+  it('reproduces the old bug when the token does not match the (default-chain) config', () => {
+    // A token unknown to the resolved chain config → 18 decimals + 'tokens' (the pre-fix behavior). This
+    // documents WHY the connected chain must be used — with the right chain the USDC case above is correct.
+    const w = toWagerShape('2', wager({ token: '0x000000000000000000000000000000000000dEaD' }), MORDOR)
+    expect(w.stakeTokenSymbol).toBe('tokens')
+    expect(w.stakeAmount).toBe('0.000000000001')
+  })
+})

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -403,11 +403,25 @@ function processMarketResult(marketId, marketResult, acceptanceStatus, acceptanc
 // (spec 012 T002 — Draw previously fell through to 'unknown').
 export const WAGER_STATUS_NAMES = ['none', 'pending', 'active', 'resolved', 'cancelled', 'refunded', 'draw']
 
-function toWagerShape(id, w) {
+// Exported for regression testing (chain-aware stake-token decimals/symbol — a USDC wager on a non-default
+// chain must not render as "0.000000000001 tokens").
+export function toWagerShape(id, w, chainId) {
   const tokenAddr = w.token
-  const paymentToken = (DEPLOYED_CONTRACTS?.paymentToken || '').toLowerCase()
-  const isUSDC = tokenAddr && tokenAddr.toLowerCase() === paymentToken
+  // Resolve the stake token against the CONNECTED chain's config — not the build-time DEPLOYED_CONTRACTS
+  // (default chain 137). Otherwise a USDC wager on e.g. Mordor (63) fails the address match → defaults to
+  // 18 decimals + 'tokens', rendering "0.000000000001 tokens" instead of the real USDC amount.
+  const resolveToken = (name) =>
+    chainId != null ? getContractAddressForChain(name, chainId) : (DEPLOYED_CONTRACTS?.[name] || '')
+  const tl = tokenAddr ? tokenAddr.toLowerCase() : ''
+  const paymentToken = (resolveToken('paymentToken') || '').toLowerCase()
+  const wmatic = (resolveToken('wmatic') || '').toLowerCase()
+  const isUSDC = !!tl && tl === paymentToken
+  const isWrapped = !!tl && tl === wmatic
   const decimals = isUSDC ? 6 : 18
+  // USDC → "USDC"; the wrapped-native stake token's symbol differs by chain (WETC on ETC/Mordor 61/63,
+  // else WMATIC); anything else falls back to "tokens".
+  const isEtcChain = chainId != null && (Number(chainId) === 63 || Number(chainId) === 61)
+  const stakeTokenSymbol = isUSDC ? 'USDC' : (isWrapped ? (isEtcChain ? 'WETC' : 'WMATIC') : 'tokens')
 
   const metadataUri = w.metadataUri || ''
   const ipfsRef = parseEncryptedIpfsReference(metadataUri)
@@ -444,7 +458,7 @@ function toWagerShape(id, w) {
     stakeAmount: ethers.formatUnits(w.opponentStake, decimals),
     stakeToken: tokenAddr,
     stakeTokenAddress: tokenAddr,
-    stakeTokenSymbol: isUSDC ? 'USDC' : 'tokens',
+    stakeTokenSymbol,
     resolutionType: Number(w.resolutionType),
     status: WAGER_STATUS_NAMES[Number(w.status)] || 'unknown',
     winner: (w.winner && w.winner !== ethers.ZeroAddress) ? w.winner : null,
@@ -469,7 +483,7 @@ function toWagerShape(id, w) {
   }
 }
 
-async function fetchWagersForUserV2(userAddress, provider, registryAddress) {
+async function fetchWagersForUserV2(userAddress, provider, registryAddress, chainId) {
   const registry = new ethers.Contract(registryAddress, WAGER_REGISTRY_ABI, provider)
 
   // O(N_user) read via the contract's per-user EnumerableSet.UintSet index.
@@ -487,7 +501,7 @@ async function fetchWagersForUserV2(userAddress, provider, registryAddress) {
       registry.getUserWagers(userAddress, offset, limit),
     ])
     for (let i = 0; i < ids.length; i++) {
-      wagers.push(toWagerShape(String(ids[i]), structs[i]))
+      wagers.push(toWagerShape(String(ids[i]), structs[i], chainId))
     }
   }
   return wagers
@@ -514,7 +528,7 @@ export async function fetchFriendMarketsForUser(userAddress, chainId) {
     // v2 path: WagerRegistry event scan
     const registryAddress = resolve('wagerRegistry')
     if (registryAddress) {
-      return await fetchWagersForUserV2(userAddress, provider, registryAddress)
+      return await fetchWagersForUserV2(userAddress, provider, registryAddress, chainId)
     }
 
     const friendFactoryAddress = resolve('friendGroupMarketFactory')


### PR DESCRIPTION
## Summary

Two fixes to how **open-challenge** wagers (feature 024) render on the **My Wagers** views, both surfaced while testing on **Mordor (63)**.

### 1. Stake shown as "0.000000000001 tokens" on non-default chains

`blockchainService.toWagerShape` derived the stake token's decimals/symbol by matching the wager's token against `DEPLOYED_CONTRACTS.paymentToken` — the **build-time/default chain (137)** config. On the connected chain (e.g. Mordor 63) the USDC address didn't match, so it fell back to **18 decimals + "tokens"** → a 1 USDC stake (1e6 base units) printed as `1e6 / 1e18 = 0.000000000001`.

**Fix:** resolve the token against the **connected chain** — thread `chainId` through `fetchWagersForUserV2 → toWagerShape`, match vs `getContractAddressForChain('paymentToken'/'wmatic', chainId)`. USDC → 6 + `USDC`; wrapped-native → 18 + `WETC` (ETC 61/63) / `WMATIC`; else 18 + `tokens`. Pre-existing multi-chain bug, not specific to open challenges.

### 2. Open challenges labeled "Private Bet"

The title fallback rendered every undecryptable wager as "Private Bet". An open challenge has no bound opponent and code-gated terms the viewer usually can't decrypt, so it always hit that fallback — confusing the creator viewing their own challenge.

**Fix:** new `isOpenChallengeMarket` (zero-address opponent ⇒ unaccepted open challenge; named wagers always have a non-zero opponent, and once taken the opponent is bound so it reverts to the normal title). Both `getMarketDisplayTitle` and `getMarketDescription` now return **"Open Challenge - <stake>"**, keeping "Private Bet" for encrypted named-opponent wagers. Matches the literal zero address only, so other data paths aren't mislabeled.

## Tests
- `wagerStakeDisplay.test.js` — USDC on Mordor → `1.0 USDC` (not `0.000000000001 tokens`).
- `openChallengeLabel.test.js` — open challenge → "Open Challenge - …"; named-opponent → "Private Bet - …"; missing opponent not mislabeled.
- Existing WagerCard/WagerTable/wagerStatusNames display tests stay green; lint clean.

> Follow-up to #722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)