### PR TITLE
chore(deploy): Amoy (80002) — UUPS WagerRegistry + 024 open challenges

### DIFF
--- a/.openzeppelin/unknown-80002.json
+++ b/.openzeppelin/unknown-80002.json
@@ -1,0 +1,584 @@
+{
+  "manifestVersion": "3.2",
+  "proxies": [
+    {
+      "address": "0x72ECAD23D369BFD0C22221a303faD1fE4b480d11",
+      "txHash": "0x9cfffddd3958addf87d7a9333aef843d3da5606d7f7c5584477f957c418980ba",
+      "kind": "uups"
+    }
+  ],
+  "impls": {
+    "655b1400039002ec82ab9ae1bb2ab2de9313af08b27578ae216c0d3abedbbb5f": {
+      "address": "0xa2176F5Fea39888cD1697Be4651415490C78905d",
+      "txHash": "0xff901a36cfe705fc65b829b8f501ceab02cbca8659fbda3b891f50ded05699cd",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSManaged",
+            "src": "contracts/upgradeable/UUPSManaged.sol:46"
+          },
+          {
+            "label": "membershipManager",
+            "offset": 0,
+            "slot": "50",
+            "type": "t_contract(IMembershipManager)13808",
+            "contract": "WagerRegistry",
+            "src": "contracts/wagers/WagerRegistry.sol:47"
+          },
+          {
+            "label": "polymarketAdapter",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_contract(IOracleAdapter)14452",
+            "contract": "WagerRegistry",
+            "src": "contracts/wagers/WagerRegistry.sol:48"
+          },
+          {
+            "label": "sanctionsGuard",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_contract(ISanctionsGuard)13874",
+            "contract": "WagerRegistry",
+            "src": "contracts/wagers/WagerRegistry.sol:52"
+          },
+          {
+            "label": "oracleAdapters",
+            "offset": 0,
+            "slot": "53",
+            "type": "t_mapping(t_enum(ResolutionType)13886,t_contract(IOracleAdapter)14452)",
+            "contract": "WagerRegistry",
+            "src": "contracts/wagers/WagerRegistry.sol:56"
+          },
+          {
+            "label": "_allowedTokens",
+            "offset": 0,
+            "slot": "54",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "WagerRegistry",
+            "src": "contracts/wagers/WagerRegistry.sol:58"
+          },
+          {
+            "label": "_wagers",
+            "offset": 0,
+            "slot": "55",
+            "type": "t_mapping(t_uint256,t_struct(Wager)13929_storage)",
+            "contract": "WagerRegistry",
+            "src": "contracts/wagers/WagerRegistry.sol:59"
+          },
+          {
+            "label": "_frozen",
+            "offset": 0,
+            "slot": "56",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "WagerRegistry",
+            "src": "contracts/wagers/WagerRegistry.sol:60"
+          },
+          {
+            "label": "wagerTermsVersionHash",
+            "offset": 0,
+            "slot": "57",
+            "type": "t_mapping(t_uint256,t_bytes32)",
+            "contract": "WagerRegistry",
+            "src": "contracts/wagers/WagerRegistry.sol:65"
+          },
+          {
+            "label": "_nextWagerId",
+            "offset": 0,
+            "slot": "58",
+            "type": "t_uint256",
+            "contract": "WagerRegistry",
+            "src": "contracts/wagers/WagerRegistry.sol:68"
+          },
+          {
+            "label": "_drawConsent",
+            "offset": 0,
+            "slot": "59",
+            "type": "t_mapping(t_uint256,t_uint8)",
+            "contract": "WagerRegistry",
+            "src": "contracts/wagers/WagerRegistry.sol:76"
+          },
+          {
+            "label": "_userWagerIds",
+            "offset": 0,
+            "slot": "60",
+            "type": "t_mapping(t_address,t_struct(UintSet)11394_storage)",
+            "contract": "WagerRegistry",
+            "src": "contracts/wagers/WagerRegistry.sol:84"
+          },
+          {
+            "label": "claimAuthority",
+            "offset": 0,
+            "slot": "61",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "WagerRegistry",
+            "src": "contracts/wagers/WagerRegistry.sol:89"
+          },
+          {
+            "label": "openWagerIdByClaim",
+            "offset": 0,
+            "slot": "62",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "WagerRegistry",
+            "src": "contracts/wagers/WagerRegistry.sol:92"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "63",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "WagerRegistry",
+            "src": "contracts/wagers/WagerRegistry.sol:96"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)26_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)36_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)26_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(EIP712Storage)425_storage": {
+            "label": "struct EIP712Upgradeable.EIP712Storage",
+            "members": [
+              {
+                "label": "_hashedName",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_hashedVersion",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "_version",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(InitializableStorage)147_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)298_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)362_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)26_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_contract(IMembershipManager)13808": {
+            "label": "contract IMembershipManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IOracleAdapter)14452": {
+            "label": "contract IOracleAdapter",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ISanctionsGuard)13874": {
+            "label": "contract ISanctionsGuard",
+            "numberOfBytes": "20"
+          },
+          "t_enum(ResolutionType)13886": {
+            "label": "enum IWagerRegistry.ResolutionType",
+            "members": [
+              "Either",
+              "Creator",
+              "Opponent",
+              "ThirdParty",
+              "Polymarket",
+              "ChainlinkDataFeed",
+              "ChainlinkFunctions",
+              "UMA"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(Status)13894": {
+            "label": "enum IWagerRegistry.Status",
+            "members": [
+              "None",
+              "Open",
+              "Active",
+              "Resolved",
+              "Cancelled",
+              "Refunded",
+              "Draw"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_struct(UintSet)11394_storage)": {
+            "label": "mapping(address => struct EnumerableSet.UintSet)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_enum(ResolutionType)13886,t_contract(IOracleAdapter)14452)": {
+            "label": "mapping(enum IWagerRegistry.ResolutionType => contract IOracleAdapter)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_bytes32)": {
+            "label": "mapping(uint256 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Wager)13929_storage)": {
+            "label": "mapping(uint256 => struct IWagerRegistry.Wager)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint8)": {
+            "label": "mapping(uint256 => uint8)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Set)10702_storage": {
+            "label": "struct EnumerableSet.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_positions",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(UintSet)11394_storage": {
+            "label": "struct EnumerableSet.UintSet",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)10702_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Wager)13929_storage": {
+            "label": "struct IWagerRegistry.Wager",
+            "members": [
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "opponent",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "arbitrator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "creatorStake",
+                "type": "t_uint128",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "opponentStake",
+                "type": "t_uint128",
+                "offset": 16,
+                "slot": "4"
+              },
+              {
+                "label": "acceptDeadline",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "resolveDeadline",
+                "type": "t_uint64",
+                "offset": 8,
+                "slot": "5"
+              },
+              {
+                "label": "resolutionType",
+                "type": "t_enum(ResolutionType)13886",
+                "offset": 16,
+                "slot": "5"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(Status)13894",
+                "offset": 17,
+                "slot": "5"
+              },
+              {
+                "label": "paid",
+                "type": "t_bool",
+                "offset": 18,
+                "slot": "5"
+              },
+              {
+                "label": "creatorIsYes",
+                "type": "t_bool",
+                "offset": 19,
+                "slot": "5"
+              },
+              {
+                "label": "winner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "metadataHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "polymarketConditionId",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "metadataUri",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "9"
+              }
+            ],
+            "numberOfBytes": "320"
+          },
+          "t_uint128": {
+            "label": "uint128",
+            "numberOfBytes": "16"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.EIP712": [
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedName",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:38",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedVersion",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:40",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_name",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:42",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_version",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:43",
+              "offset": 0,
+              "slot": "3"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:43",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)26_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:62",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/deployments/amoy-chain80002-v2.json
+++ b/deployments/amoy-chain80002-v2.json
@@ -9,7 +9,8 @@
   "contracts": {
     "polymarketAdapter": "0x98fe63209f5BffcCe905bF8779a1F06576A2C313",
     "membershipManager": "0x101C3eC35fa48A500c2dFA9026f1d42F1431Abe8",
-    "wagerRegistry": "0x916841aEe4832a2e9DD42470fa05a7329486e75a",
+    "wagerRegistry": "0x72ECAD23D369BFD0C22221a303faD1fE4b480d11",
+    "wagerRegistryImpl": "0xa2176F5Fea39888cD1697Be4651415490C78905d",
     "keyRegistry": "0xcEFdeBba8E040c035c690ca9057cF22E73247c24",
     "sanctionsGuard": "0xdF41355dD5E47FCA4eE2F2205af4C70Dab8C13B3",
     "chainlinkDataFeedAdapter": "0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23",
@@ -20,9 +21,36 @@
     "mockPolymarketCTF": "0x95F40ea10E6C51892783c4E7721Ada1425917e22",
     "mockSanctionsOracle": "0xa5F0bB3a63C55721078be5ee80653E9cB0927D9E"
   },
+  "constructorArgs": {
+    "membershipManager": [
+      "0x52502d049571C7893447b86c4d8B38e6184bF6e1",
+      "0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582",
+      "0x52502d049571C7893447b86c4d8B38e6184bF6e1"
+    ],
+    "wagerRegistryImpl": [],
+    "sanctionsGuard": [
+      "0x52502d049571C7893447b86c4d8B38e6184bF6e1",
+      "0xa5F0bB3a63C55721078be5ee80653E9cB0927D9E"
+    ],
+    "keyRegistry": [],
+    "polymarketAdapter": [
+      "0x52502d049571C7893447b86c4d8B38e6184bF6e1",
+      "0x95F40ea10E6C51892783c4E7721Ada1425917e22"
+    ],
+    "chainlinkDataFeedAdapter": [
+      "0x52502d049571C7893447b86c4d8B38e6184bF6e1"
+    ],
+    "chainlinkFunctionsAdapter": [
+      "0x52502d049571C7893447b86c4d8B38e6184bF6e1",
+      "0xC22a79eBA640940ABB6dF0f7982cc119578E11De"
+    ],
+    "umaAdapter": [
+      "0x52502d049571C7893447b86c4d8B38e6184bF6e1",
+      "0xd8866E76441df243fc98B892362Fc6264dC3ca80"
+    ],
+    "mockSanctionsOracle": [],
+    "mockPolymarketCTF": []
+  },
   "saltPrefix": "FairWins-P2P-v2.0-",
-  "timestamp": "2026-06-15T02:23:55.220Z",
-  "deployBlocks": {
-    "wagerRegistry": 40172425
-  }
+  "timestamp": "2026-06-21T02:51:29.600Z"
 }

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -48,7 +48,7 @@ const AMOY_CONTRACTS = {
   deployer: '0x52502d049571C7893447b86c4d8B38e6184bF6e1',
   treasury: '0x52502d049571C7893447b86c4d8B38e6184bF6e1',
   // v2 core (populated by `npm run sync:frontend-contracts -- --network amoy --chainId 80002`)
-  wagerRegistry: '0x916841aEe4832a2e9DD42470fa05a7329486e75a',
+  wagerRegistry: '0x72ECAD23D369BFD0C22221a303faD1fE4b480d11',
   membershipManager: '0x101C3eC35fa48A500c2dFA9026f1d42F1431Abe8',
   keyRegistry: '0xcEFdeBba8E040c035c690ca9057cF22E73247c24',
   sanctionsGuard: '0xdF41355dD5E47FCA4eE2F2205af4C70Dab8C13B3',


### PR DESCRIPTION
## Summary

Deployed the current `main` contract set to **Polygon Amoy (80002)** at the 25 gwei floor, bringing the testnet to parity with `main`: the **UUPS WagerRegistry proxy** + feature **024 open-challenge wagers**. Enables live testing of the open-challenge create/take flow on Amoy.

## Amoy addresses (recorded)

| contract | address |
|---|---|
| `wagerRegistry` (UUPS proxy) | `0x72ECAD23D369BFD0C22221a303faD1fE4b480d11` |
| `wagerRegistryImpl` | `0xa2176F5Fea39888cD1697Be4651415490C78905d` |
| `membershipManager` | `0x101C3eC35fa48A500c2dFA9026f1d42F1431Abe8` |
| `USDC` (mock) | `0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582` |

## Files

- `deployments/amoy-chain80002-v2.json` — deploy record (source of truth).
- `frontend/src/config/contracts.js` — synced Amoy addresses.
- `.openzeppelin/unknown-80002.json` — OZ proxy manifest (required for future in-place upgrades; mirrors the tracked Mordor `unknown-63.json`).

## Post-deploy

- Silver `WAGER_PARTICIPANT` granted to the test wallet `0x5250…6e1` (tx `0x04eed569…`), so it can create open challenges (Silver+ gate).
- Source verification on the Amoy explorer is still pending a valid `ETHERSCAN_API_KEY` (known-invalid on all chains per prior notes) — non-blocking for functional testing.

> Follow-up to #722 / #728. #726 (vouchers + UUPS MembershipManager) will ship its additional contracts in a later deploy once its conflicts are resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)