### PR TITLE
fix(frontend): sync membershipVoucher address to per-network config

### DIFF
--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -26,6 +26,7 @@ const MORDOR_CONTRACTS = {
   // Classic USD (USC) — real on-chain stablecoin (no mock); set by sync.
   paymentToken: '0xDE093684c796204224BC081f937aa059D903c52a',
   wmatic: '0x1953cab0E5bFa6D4a9BaD6E05fD46C1CC6527a5a',
+  membershipVoucher: '0xf514e0e342A898E4681bf51590B672aEC5620401',
 }
 
 // Local Hardhat sandbox (chainId 1337) — populated by deploy.js + sync.
@@ -59,6 +60,7 @@ const AMOY_CONTRACTS = {
   chainlinkDataFeedAdapter: '0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23',
   chainlinkFunctionsAdapter: '0x074fC18C1E322a7537b53B8B2Bf0762629E3b532',
   umaAdapter: '0xcEa9b4A01CcD3aA6545ea834a268C69e7eEfee88',
+  membershipVoucher: '0x33C8Ccacf6442Cf4238f01419e38C781cB859769',
 }
 
 // Polygon mainnet deployment (v2 — P2P betting architecture) — LIVE

--- a/frontend/src/test/contractsConfig.test.js
+++ b/frontend/src/test/contractsConfig.test.js
@@ -105,4 +105,20 @@ describe('contracts config', () => {
       )
     })
   })
+
+  describe('feature-complete testnets resolve the full contract set', () => {
+    // Specs 024/026/027: Amoy (80002) and Mordor (63) are deployed feature-complete
+    // (open challenges + vouchers + UUPS membership). Every slot the app needs to
+    // resolve MUST be a real address — guards against a deployed contract silently
+    // going unconfigured in the frontend (e.g. membershipVoucher was missing from
+    // the sync mapping, which disabled the voucher UI on both chains).
+    const ADDR = /^0x[0-9a-fA-F]{40}$/
+    for (const chainId of [63, 80002]) {
+      for (const name of ['wagerRegistry', 'membershipManager', 'membershipVoucher', 'paymentToken', 'sanctionsGuard']) {
+        it(`resolves ${name} on chain ${chainId}`, () => {
+          expect(getContractAddressForChain(name, chainId)).toMatch(ADDR)
+        })
+      }
+    }
+  })
 })

--- a/scripts/utils/sync-frontend-contracts.js
+++ b/scripts/utils/sync-frontend-contracts.js
@@ -183,6 +183,7 @@ function main() {
     ? {
         wagerRegistry: deployed.wagerRegistry,
         membershipManager: deployed.membershipManager,
+        membershipVoucher: deployed.membershipVoucher,
         keyRegistry: deployed.keyRegistry,
         sanctionsGuard: deployed.sanctionsGuard,
         polymarketAdapter: deployed.polymarketAdapter,


### PR DESCRIPTION
## Summary

Verifying that Amoy + Mordor contracts are properly configured in the frontend surfaced one real gap: the **`membershipVoucher` address was missing from `contracts.js`** for both chains. The deployments had it, but the sync script's v2 mapping never included the key — so `getContractAddressForChain('membershipVoucher', …)` returned `undefined` and the voucher UI showed *"not available on this network"* on both testnets.

## Fix
- Add `membershipVoucher` to the v2 mapping in `sync-frontend-contracts.js` (root cause — future syncs insert it automatically).
- Re-synced Amoy + Mordor → both blocks now carry the voucher (Amoy `0x33C8Cc…`, Mordor `0xf514e0…`).
- New `contractsConfig` regression guard: the feature-complete testnets (63, 80002) must resolve the full set (`wagerRegistry`/`membershipManager`/`membershipVoucher`/`paymentToken`/`sanctionsGuard`) to real addresses.

## Verification (both chains)
Automated cross-check of config vs deployment records: **all addresses match**; all three ABIs complete vs artifacts (WagerRegistry 61 fns / MembershipManager 42 / MembershipVoucher 26 — none missing). Config + sync + voucher tests green (28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)