### PR TITLE
fix(open-challenge): approve stake before accepting + show funding steps

### DIFF
--- a/frontend/src/components/fairwins/OpenChallengeModal.css
+++ b/frontend/src/components/fairwins/OpenChallengeModal.css
@@ -70,3 +70,58 @@
   border: 1px solid rgba(255, 184, 0, 0.35);
   color: #d99b00;
 }
+
+/* Take-a-challenge step checklist — shows the approve → sign → confirm sequence. */
+.oc-steps {
+  list-style: none;
+  counter-reset: oc-step;
+  margin: 0.5rem 0 0.75rem;
+  padding: 0;
+}
+
+.oc-step {
+  counter-increment: oc-step;
+  position: relative;
+  padding: 0.35rem 0 0.35rem 2rem;
+  font-size: 0.88rem;
+  line-height: 1.4;
+  color: var(--fm-text-muted, rgba(255, 255, 255, 0.6));
+}
+
+.oc-step::before {
+  content: counter(oc-step);
+  position: absolute;
+  left: 0;
+  top: 0.3rem;
+  width: 1.4rem;
+  height: 1.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.78rem;
+  font-weight: 600;
+  border-radius: 50%;
+  border: 1px solid var(--fm-border, rgba(255, 255, 255, 0.2));
+  color: inherit;
+}
+
+.oc-step--active {
+  color: var(--fm-accent, #2fbf71);
+  font-weight: 600;
+}
+
+.oc-step--active::before {
+  border-color: var(--fm-accent, #2fbf71);
+  color: var(--fm-accent, #2fbf71);
+}
+
+.oc-step--done {
+  color: var(--fm-text, rgba(255, 255, 255, 0.85));
+}
+
+.oc-step--done::before {
+  content: '\2713';
+  background: var(--fm-accent, #2fbf71);
+  border-color: var(--fm-accent, #2fbf71);
+  color: #0a0a0a;
+}

--- a/frontend/src/components/fairwins/OpenChallengeModal.jsx
+++ b/frontend/src/components/fairwins/OpenChallengeModal.jsx
@@ -222,6 +222,7 @@ function TakerPanel({ onClose, onBuyMembership, initialCode = '' }) {
   const [phase, setPhase] = useState('enter') // enter | found | accepted
   const [found, setFound] = useState(null)
   const [error, setError] = useState(null)
+  const [progress, setProgress] = useState(null)
   const [txHash, setTxHash] = useState(null)
 
   const codeValid = isValidCode(code)
@@ -241,11 +242,13 @@ function TakerPanel({ onClose, onBuyMembership, initialCode = '' }) {
   const handleAccept = useCallback(async () => {
     setError(null)
     try {
-      const { txHash: hash } = await accept(code, found.wagerId)
+      const { txHash: hash } = await accept(code, found.wagerId, (p) => setProgress(p))
       setTxHash(hash)
       setPhase('accepted')
     } catch (err) {
       setError(err.message)
+    } finally {
+      setProgress(null)
     }
   }, [accept, code, found])
 
@@ -291,11 +294,18 @@ function TakerPanel({ onClose, onBuyMembership, initialCode = '' }) {
           </>
         ) : (
           <>
-            <p className="fm-hint">Accepting binds you as the opponent and escrows your equal stake. Save your code to re-read the terms later.</p>
+            <p className="fm-hint">Accepting binds you as the opponent and escrows your equal stake. This takes a few steps:</p>
+            <ol className="oc-steps">
+              <li className={stepClass(progress?.step, 'approve')}>Approve the stake token (lets the wager contract escrow your stake)</li>
+              <li className={stepClass(progress?.step, 'sign')}>Sign to authorize acceptance with your code</li>
+              <li className={stepClass(progress?.step, 'accept')}>Confirm acceptance — your stake is escrowed</li>
+            </ol>
+            {progress && <p className="fm-hint" role="status">{progress.message}</p>}
             {error && <div className="fm-error-banner" role="alert">{error}</div>}
+            <p className="fm-hint">Save your code to re-read the terms later.</p>
             <div className="fm-success-actions">
-              <button type="button" className="fm-btn-primary" onClick={handleAccept} disabled={busy}>{busy ? 'Accepting…' : 'Accept challenge'}</button>
-              <button type="button" className="fm-btn-secondary" onClick={() => { setPhase('enter'); setFound(null) }}>Back</button>
+              <button type="button" className="fm-btn-primary" onClick={handleAccept} disabled={busy}>{busy ? (progress ? `${stepLabel(progress.step)}…` : 'Accepting…') : 'Accept challenge'}</button>
+              <button type="button" className="fm-btn-secondary" onClick={() => { setPhase('enter'); setFound(null); setProgress(null) }} disabled={busy}>Back</button>
             </div>
           </>
         )}
@@ -320,6 +330,24 @@ function TakerPanel({ onClose, onBuyMembership, initialCode = '' }) {
       </div>
     </form>
   )
+}
+
+// Full step order the accept flow walks through (the visible list omits the quick "check" read).
+const ACCEPT_STEP_ORDER = ['check', 'approve', 'sign', 'accept']
+const STEP_LABELS = { check: 'Checking', approve: 'Approving', sign: 'Signing', accept: 'Confirming' }
+
+/** Mark a list step done (a later step is active), active (current), or pending — for the take-flow checklist. */
+function stepClass(current, step) {
+  if (!current) return 'oc-step'
+  const ci = ACCEPT_STEP_ORDER.indexOf(current)
+  const si = ACCEPT_STEP_ORDER.indexOf(step)
+  if (ci > si) return 'oc-step oc-step--done'
+  if (ci === si) return 'oc-step oc-step--active'
+  return 'oc-step'
+}
+
+function stepLabel(step) {
+  return STEP_LABELS[step] || 'Accepting'
 }
 
 function formatTerms(terms) {

--- a/frontend/src/hooks/useOpenChallengeAccept.js
+++ b/frontend/src/hooks/useOpenChallengeAccept.js
@@ -10,6 +10,13 @@ import { decryptEnvelopeCode, isCodeEnvelope } from '../utils/crypto/envelopeEnc
 
 const WAGER_PARTICIPANT_ROLE = ethers.keccak256(ethers.toUtf8Bytes('WAGER_PARTICIPANT_ROLE'))
 const MEMBERSHIP_ABI = ['function hasActiveRole(address user, bytes32 role) view returns (bool)']
+const ERC20_ABI = [
+  'function balanceOf(address owner) view returns (uint256)',
+  'function allowance(address owner, address spender) view returns (uint256)',
+  'function approve(address spender, uint256 amount) returns (bool)',
+  'function decimals() view returns (uint8)',
+  'function symbol() view returns (string)',
+]
 
 /**
  * Take-a-challenge flow for open-challenge wagers (feature 024). The four-word code does triple duty:
@@ -84,10 +91,15 @@ export function useOpenChallengeAccept() {
   }, [provider, signer, account, chainId, resolveRegistry])
 
   /**
-   * Accept the open challenge: sign the code-derived EIP-712 message bound to this taker, then send
-   * acceptOpenWager. The signature is only valid for `account`, so an observer cannot reuse it (FR-011).
+   * Accept the open challenge. Taking the other side escrows your matching stake, so this runs the full
+   * funding flow and reports each step via onProgress({ step, message }):
+   *   1. check    — read the wager's token + stake and confirm your balance covers it
+   *   2. approve  — approve the registry to pull your stake (only when the current allowance is short)
+   *   3. sign     — sign the code-derived EIP-712 message bound to this taker (FR-011: not reusable)
+   *   4. accept   — send acceptOpenWager (a pre-flight staticCall surfaces a clear revert first)
+   * The skipped "ERC20: transfer amount exceeds allowance" failure came from sending step 4 without step 2.
    */
-  const accept = useCallback(async (code, wagerId) => {
+  const accept = useCallback(async (code, wagerId, onProgress = () => {}) => {
     setError(null)
     setBusy(true)
     try {
@@ -98,6 +110,40 @@ export function useOpenChallengeAccept() {
       const registry = new ethers.Contract(registryAddr, WAGER_REGISTRY_ABI, signer)
       const net = await signer.provider.getNetwork()
 
+      // 1. Read the authoritative stake the contract will pull (opponentStake == creatorStake for open
+      //    challenges) and make sure the taker can cover it before any wallet prompt.
+      onProgress({ step: 'check', message: 'Checking your balance and approval…' })
+      const w = await registry.getWager(wagerId)
+      const tokenAddr = w.token
+      const stake = w.opponentStake
+      if (!tokenAddr || tokenAddr === ethers.ZeroAddress) {
+        throw new Error('This challenge has no stake token configured.')
+      }
+      const token = new ethers.Contract(tokenAddr, ERC20_ABI, signer)
+      let decimals = 18
+      let symbol = 'tokens'
+      try { decimals = Number(await token.decimals()) } catch { /* default 18 */ }
+      try { symbol = await token.symbol() } catch { /* default tokens */ }
+
+      const balance = await token.balanceOf(account)
+      if (balance < stake) {
+        throw new Error(
+          `Insufficient ${symbol} balance to take this challenge. ` +
+          `You have ${ethers.formatUnits(balance, decimals)} but need ${ethers.formatUnits(stake, decimals)}.`
+        )
+      }
+
+      // 2. Approve the registry to escrow your stake (skip if already approved). This is the step whose
+      //    absence caused the allowance revert — it must land before the staticCall and send below.
+      const allowance = await token.allowance(account, registryAddr)
+      if (allowance < stake) {
+        onProgress({ step: 'approve', message: `Approve ${symbol} spending in your wallet…` })
+        const approveTx = await token.approve(registryAddr, ethers.MaxUint256)
+        await approveTx.wait()
+      }
+
+      // 3. Sign the code-derived acceptance (bound to this taker, single-use).
+      onProgress({ step: 'sign', message: 'Sign to authorize acceptance…' })
       const signature = await signOpenAccept(code, {
         wagerId,
         taker: account,
@@ -105,13 +151,14 @@ export function useOpenChallengeAccept() {
         verifyingContract: registryAddr,
       })
 
-      // Pre-flight to surface a clear revert reason before the wallet prompt.
+      // 4. Pre-flight to surface a clear revert reason before the final wallet prompt.
       try {
         await registry.acceptOpenWager.staticCall(wagerId, signature)
       } catch (sim) {
         throw new Error(translateAcceptRevert(sim.reason || sim.shortMessage || sim.message || ''))
       }
 
+      onProgress({ step: 'accept', message: 'Confirm acceptance in your wallet…' })
       const tx = await registry.acceptOpenWager(wagerId, signature)
       const receipt = await tx.wait()
       if (!receipt || receipt.status === 0) throw new Error('Acceptance reverted on-chain.')
@@ -137,6 +184,8 @@ export function translateAcceptRevert(reason) {
   if (r.includes('ArbitratorCannotTake')) return 'You are the named arbitrator for this challenge and cannot take it.'
   if (r.includes('MembershipDenied')) return 'An active membership is required to take a challenge. Purchase one and try again.'
   if (r.includes('AccountFrozen')) return 'This account is restricted from accepting wagers.'
+  if (r.includes('exceeds allowance')) return 'The stake approval did not go through. Approve the token and try again.'
+  if (r.includes('exceeds balance')) return 'Your token balance is too low to cover the stake.'
   return reason || 'Acceptance failed. Please try again.'
 }
 

--- a/frontend/src/test/claimCode/OpenChallengeModal.test.jsx
+++ b/frontend/src/test/claimCode/OpenChallengeModal.test.jsx
@@ -68,8 +68,12 @@ describe('OpenChallengeModal (tabbed Maker/Taker)', () => {
 
     await waitFor(() => expect(discover).toHaveBeenCalledWith('river tiger kite zoo'))
     expect(await screen.findByText(/Will it snow/)).toBeInTheDocument()
+    // The funding steps are shown up front so the taker knows acceptance is multi-step.
+    expect(screen.getByText(/Approve the stake token/i)).toBeInTheDocument()
+    expect(screen.getByText(/Sign to authorize acceptance/i)).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /accept challenge/i }))
-    await waitFor(() => expect(accept).toHaveBeenCalledWith('river tiger kite zoo', 4n))
+    // accept now receives an onProgress callback (step reporting) as its 3rd arg.
+    await waitFor(() => expect(accept).toHaveBeenCalledWith('river tiger kite zoo', 4n, expect.any(Function)))
     expect(await screen.findByText(/taken the challenge/i)).toBeInTheDocument()
   })
 

--- a/frontend/src/test/useOpenChallengeAccept.test.jsx
+++ b/frontend/src/test/useOpenChallengeAccept.test.jsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// Regression guard for the open-challenge take flow: accepting escrows the taker's matching stake, so
+// the hook MUST approve the registry to pull the stake BEFORE calling acceptOpenWager. Skipping the
+// approval is what produced "ERC20: transfer amount exceeds allowance" when taking a challenge.
+
+const TOKEN = '0x1111111111111111111111111111111111111111'
+const REGISTRY = '0x2222222222222222222222222222222222222222'
+const ACCOUNT = '0x3333333333333333333333333333333333333333'
+const STAKE = 10_000_000n // 10 USDC (6 decimals)
+
+const { state, calls } = vi.hoisted(() => ({
+  state: { allowance: 0n, balance: 100_000_000n },
+  calls: [],
+}))
+
+vi.mock('../hooks/useWeb3', () => ({
+  useWeb3: () => ({
+    account: ACCOUNT,
+    chainId: 63,
+    provider: { isFakeProvider: true },
+    signer: {
+      getAddress: () => Promise.resolve(ACCOUNT),
+      provider: { getNetwork: () => Promise.resolve({ chainId: 63n }) },
+    },
+  }),
+}))
+
+vi.mock('../config/contracts', () => ({
+  getContractAddressForChain: (name) => (name === 'wagerRegistry' ? REGISTRY : ''),
+  getContractAddress: (name) => (name === 'wagerRegistry' ? REGISTRY : ''),
+}))
+
+vi.mock('../utils/claimCode/wordlist.js', () => ({ isValidCode: () => true }))
+vi.mock('../utils/claimCode/deriveFromCode.js', () => ({
+  deriveFromCode: () => ({ claimAddress: '0xclaim', symKey: new Uint8Array(32) }),
+  signOpenAccept: () => Promise.resolve('0xsignature'),
+}))
+// discover-only deps — not exercised by accept(), but imported at module top.
+vi.mock('../utils/ipfsService', () => ({ fetchEncryptedEnvelope: vi.fn(), parseEncryptedIpfsReference: vi.fn() }))
+vi.mock('../utils/crypto/envelopeEncryption.js', () => ({ decryptEnvelopeCode: vi.fn(), isCodeEnvelope: vi.fn() }))
+
+vi.mock('ethers', async () => {
+  const real = await vi.importActual('ethers')
+  function FakeContract(address) {
+    if (address === REGISTRY) {
+      const acceptOpenWager = (...a) => {
+        calls.push('accept')
+        return Promise.resolve({ wait: () => Promise.resolve({ status: 1, hash: '0xtxhash' }) })
+      }
+      acceptOpenWager.staticCall = () => Promise.resolve()
+      return {
+        getWager: () => Promise.resolve({ token: TOKEN, opponentStake: STAKE }),
+        acceptOpenWager,
+      }
+    }
+    // token contract
+    return {
+      decimals: () => Promise.resolve(6),
+      symbol: () => Promise.resolve('USDC'),
+      balanceOf: () => Promise.resolve(state.balance),
+      allowance: () => Promise.resolve(state.allowance),
+      approve: (...a) => {
+        calls.push('approve')
+        return Promise.resolve({ wait: () => Promise.resolve({ status: 1 }) })
+      },
+    }
+  }
+  return {
+    ...real,
+    ethers: {
+      ...real.ethers,
+      Contract: FakeContract,
+    },
+  }
+})
+
+import { useOpenChallengeAccept } from '../hooks/useOpenChallengeAccept'
+
+describe('useOpenChallengeAccept.accept (funding flow)', () => {
+  beforeEach(() => {
+    calls.length = 0
+    state.allowance = 0n
+    state.balance = 100_000_000n
+  })
+
+  it('approves the registry BEFORE sending acceptOpenWager when allowance is short', async () => {
+    const { result } = renderHook(() => useOpenChallengeAccept())
+    const steps = []
+    let res
+    await act(async () => {
+      res = await result.current.accept('river tiger kite zoo', 4n, (p) => steps.push(p.step))
+    })
+    expect(res.txHash).toBe('0xtxhash')
+    // The order matters — approval must precede acceptance.
+    expect(calls).toEqual(['approve', 'accept'])
+    // Steps are surfaced for the UI checklist.
+    expect(steps).toEqual(expect.arrayContaining(['check', 'approve', 'sign', 'accept']))
+  })
+
+  it('skips approval when the existing allowance already covers the stake', async () => {
+    state.allowance = STAKE
+    const { result } = renderHook(() => useOpenChallengeAccept())
+    await act(async () => {
+      await result.current.accept('river tiger kite zoo', 4n)
+    })
+    expect(calls).toEqual(['accept'])
+  })
+
+  it('throws a friendly error (and never sends) when the balance is short', async () => {
+    state.balance = 1n
+    const { result } = renderHook(() => useOpenChallengeAccept())
+    await expect(
+      act(async () => {
+        await result.current.accept('river tiger kite zoo', 4n)
+      })
+    ).rejects.toThrow(/Insufficient USDC balance/i)
+    expect(calls).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem

Accepting an open challenge with a valid four-word phrase reverted with **`ERC20: transfer amount exceeds allowance`**.

Taking an open challenge escrows the taker's matching stake on-chain:
`acceptOpenWager` → `_settleAccept` → `IERC20(token).safeTransferFrom(msg.sender, registry, opponentStake)` (`contracts/wagers/WagerRegistry.sol:558,273`).

But `useOpenChallengeAccept.accept()` called `acceptOpenWager` **directly, with no ERC20 approval first** — so the transfer had no allowance to draw on. The sibling create flow (`useOpenChallengeCreate`) and the regular `MarketAcceptanceModal` both approve before depositing; the take flow was the only path missing it.

## Fix

`accept()` now runs the full funding flow and reports each step through an `onProgress({ step, message })` callback:

1. **check** — read the wager's token + `opponentStake`, confirm the taker's balance covers it (friendly error if not)
2. **approve** — approve the registry to pull the stake (skipped when the existing allowance already covers it)
3. **sign** — EIP-712 acceptance bound to the taker (unchanged; single-use)
4. **accept** — `acceptOpenWager` with a pre-flight `staticCall` to surface a clean revert reason

The **Taker** panel now shows the **approve → sign → confirm** checklist up front and highlights the active step, so the multi-prompt wallet sequence is expected rather than surprising. Added allowance/balance revert translations as a safety net.

## Tests

- New `useOpenChallengeAccept.test.jsx`: approval **precedes** acceptance; approval is **skipped** when allowance already covers the stake; short balance **throws** a friendly error and never sends.
- Updated `OpenChallengeModal.test.jsx`: `accept` now receives the `onProgress` callback (3rd arg) and the step checklist is rendered.
- Full frontend suite green: **148 files / 1544 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)