### PR TITLE
docs: align docs with UUPS proxies + open challenges + vouchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ outcome is determined by battle-tested oracles.
 
 - **1v1 even-money or Make an Offer odds** — equal stakes, or asymmetric stakes
   at a creator-set multiplier where the settler puts up the majority stake
+- **Open challenges** — post a wager with no named opponent, gated by a
+  four-word claim code; whoever you share the code with can take the other side
+  (Silver+ to create, any active tier to take)
 - **QR / deep-link sharing** — the opponent scans a code and accepts in-app
 - **Mutual draws** — both parties (or the arbitrator) can settle a push; each
   side gets its own stake back
@@ -55,16 +58,22 @@ outcome is determined by battle-tested oracles.
 
 ### Roles, tiers, and operator powers
 
-Wager creation requires a paid **Wager Participant** membership on
-`MembershipManager`. The four-tier ladder is anchored at **$2 Bronze** in
-USDC:
+Wager participation requires a paid **Wager Participant** membership on
+`MembershipManager` (the default tier is **None** — no participation). The
+four-tier ladder is anchored at **$2 Bronze** in USDC:
 
 | Tier | Price | Wagers / month | Open wagers at once |
 |------|-------|----------------|---------------------|
+| None     | —    | 0         | 0         |
 | Bronze   | $2   | 15        | 5         |
 | Silver   | $8   | 30        | 10        |
 | Gold     | $25  | 100       | 30        |
 | Platinum | $100 | Unlimited | Unlimited |
+
+A membership can be **bought directly** (soulbound) or acquired by **redeeming
+a `MembershipVoucher`** — a transferable ERC-721 bought with USDC at a tier's
+price that can be gifted or resold, then redeemed (burned) for the soulbound
+membership.
 
 The operator team retains a narrow set of on-chain powers, each bound to a
 distinct OpenZeppelin AccessControl role:
@@ -76,8 +85,10 @@ distinct OpenZeppelin AccessControl role:
   for full disclosure.
 - `ROLE_MANAGER_ROLE` — grant / revoke memberships outside the purchase
   flow (support, gifts, dispute resolution).
+- `UPGRADER_ROLE` — authorize UUPS implementation upgrades on the proxies
+  (logic swaps at stable addresses; no other privilege).
 - `DEFAULT_ADMIN_ROLE` — tier config, treasury, and authority to grant the
-  three roles above.
+  roles above.
 
 See [Roles and Tiers](docs/system-overview/roles-and-tiers.md) for the full
 privilege matrix. No role can move escrowed stakes.
@@ -97,19 +108,23 @@ privilege matrix. No role can move escrowed stakes.
 │ tiers, limits │ │ Chainalysis  │  │ Polymarket · Chainlink  │
 └───────────────┘ └──────────────┘  │ DataFeed · Functions ·  │
                                     │ UMA OOv3                │
-┌───────────────┐                   └─────────────────────────┘
-│ KeyRegistry   │   public keys for end-to-end
-│ (privacy)     │   encrypted wager terms (IPFS)
-└───────────────┘
+┌───────────────┐  ┌──────────────┐ └─────────────────────────┘
+│ KeyRegistry   │  │ Membership   │  public keys (privacy) +
+│ (privacy)     │  │ Voucher      │  transferable ERC-721 voucher
+└───────────────┘  └──────────────┘  redeemed via MembershipManager
 ```
 
-Core contracts are UUPS-upgradeable behind stable proxy addresses — logic is
-swappable in place while escrowed state is preserved (see
-[ADR 004](docs/adr/004-upgradeable-registry-uups.md)).
+`WagerRegistry` and `MembershipManager` are UUPS-upgradeable behind stable
+proxy addresses — logic is swappable in place while escrowed state is
+preserved (see [ADR 004](docs/adr/004-upgradeable-registry-uups.md)). The
+`MembershipVoucher` ERC-721 is the deliberate exception: a tradable bearer
+asset is kept immutable.
 
 Frontend: React + Vite SPA (no backend) served by nginx on Cloud Run behind
-Cloudflare. Deployed addresses are recorded in [`deployments/`](deployments/)
-— Polygon mainnet (137) and Polygon Amoy testnet (80002). Full picture:
+Cloudflare. Deployed addresses are recorded in [`deployments/`](deployments/).
+The testnets — Polygon Amoy (80002) and Mordor/ETC (63) — run the
+feature-complete upgradeable set; Polygon mainnet (137) is still the pre-UUPS
+set pending migration. Full picture:
 [Architecture guide](docs/developer-guide/architecture.md).
 
 ## Quick Start
@@ -184,8 +199,9 @@ contract MyOracleAdapter is IOracleAdapter {
 
 | Contract | Location | Description |
 |----------|----------|-------------|
-| `WagerRegistry` | `contracts/wagers/` | Wager lifecycle + stake escrow |
-| `MembershipManager` | `contracts/access/` | Tiered memberships, rate limits |
+| `WagerRegistry` | `contracts/wagers/` | Wager lifecycle + stake escrow, incl. open challenges (UUPS proxy) |
+| `MembershipManager` | `contracts/access/` | Tiered memberships, rate limits, voucher redemption (UUPS proxy) |
+| `MembershipVoucher` | `contracts/access/` | Transferable ERC-721 voucher → soulbound membership (immutable) |
 | `SanctionsGuard` | `contracts/access/` | Chainalysis screening + deny list |
 | `KeyRegistry` | `contracts/privacy/` | Encryption public keys |
 | `PolymarketOracleAdapter` | `contracts/oracles/` | Polymarket CTF outcomes |

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -62,8 +62,9 @@ The active contracts live under `contracts/` (everything in
 
 | Contract | Directory | Responsibility |
 |----------|-----------|----------------|
-| `WagerRegistry` | `contracts/wagers/` | Wager lifecycle + stake escrow: create, accept, resolve, draw, claim, refund |
-| `MembershipManager` | `contracts/access/` | Tiered, time-bound memberships (USDC); monthly & concurrent creation limits |
+| `WagerRegistry` | `contracts/wagers/` | Wager lifecycle + stake escrow: create, accept, resolve, draw, claim, refund — including **open challenges** (code-gated, no named opponent). **UUPS proxy** (spec 025) |
+| `MembershipManager` | `contracts/access/` | Tiered, time-bound memberships (USDC); monthly & concurrent creation limits; **voucher redemption**. **UUPS proxy** (spec 027) |
+| `MembershipVoucher` | `contracts/access/` | Transferable ERC-721 bearer claim on a membership — bought with USDC, redeemed (burned) for a soulbound membership (spec 026). **Immutable** by design |
 | `SanctionsGuard` | `contracts/access/` | Non-bypassable screening against the Chainalysis oracle + operator deny list |
 | `KeyRegistry` | `contracts/privacy/` | Public encryption keys for end-to-end encrypted wager terms |
 | `PolymarketOracleAdapter` | `contracts/oracles/` | Reads outcomes from Polymarket's Conditional Token Framework |
@@ -76,6 +77,15 @@ All four oracle adapters implement the same `IOracleAdapter` interface
 resolves any oracle-typed wager through a uniform `autoResolveFromOracle` /
 `autoResolveFromPolymarket` path. See [Smart Contracts](smart-contracts.md)
 for per-contract detail and the lifecycle state machine.
+
+The two value-bearing core contracts are **UUPS upgradeable proxies**: their
+logic is swapped in place (state and addresses preserved) so features ship
+without stranding wagers or memberships. New upgradeable contracts inherit
+`contracts/upgradeable/UUPSManaged.sol`; storage stays append-only behind a
+`__gap` and `npm run check:storage-layout` gates every upgrade. See
+[Upgradeable Contracts](upgradeable-contracts.md) and
+[ADR-004](../adr/004-upgradeable-registry-uups.md). `MembershipVoucher` is the
+deliberate exception — a tradable bearer asset is kept immutable.
 
 ## Frontend layer
 
@@ -97,7 +107,7 @@ for per-contract detail and the lifecycle state machine.
 flowchart LR
     subgraph Reads
         RPC[Polygon JSON-RPC] -->|getWager / getUserWagers / events| Ctx[FriendMarketsContext cache]
-        SUB[Subgraph<br/>optional, legacy v1] -.fallback only.-> Ctx
+        SUB[Subgraph<br/>v2 WagerRegistry] -.draw proposals, transfers.-> Ctx
         Ctx --> UI[Dashboard / My Wagers]
     end
     subgraph Writes
@@ -106,9 +116,11 @@ flowchart LR
 ```
 
 - **Reads** go straight to the chain with ethers.js (`getWager`,
-  `getUserWagers`, event scans). The Graph subgraph under `subgraph/` indexes
-  the *legacy v1* `FriendGroupMarketFactory`, not `WagerRegistry`, so the live
-  app does not depend on it.
+  `getUserWagers`, event scans) for the wager lists. The Graph subgraph under
+  `subgraph/` now indexes the **v2 `WagerRegistry`** (spec 017, including a
+  per-transfer record) and sources specific features such as draw proposals;
+  the wager grid still reads direct-from-chain, so a subgraph outage degrades
+  gracefully. The legacy v1 `FriendGroupMarketFactory` is no longer indexed.
 - **Writes** are wallet transactions. In-flight transactions are tracked in
   localStorage so a page reload can resume a half-finished creation flow.
 - **Encrypted terms** never touch a server: the SPA encrypts client-side,
@@ -154,16 +166,19 @@ application backend.
 
 ## Networks and deployments
 
-| Network | Chain ID | Purpose | Record |
-|---------|----------|---------|--------|
-| Polygon mainnet | 137 | Production | `deployments/polygon-chain137-v2.json` |
-| Polygon Amoy | 80002 | Testnet | `deployments/amoy-chain80002-v2.json` |
-| Hardhat | 1337 | Local development | generated locally |
-| Mordor (ETC) | 63 | Testnet (Ethereum Classic, v2 core-only) | `deployments/mordor-chain63-v2.json` |
+| Network | Chain ID | Purpose | Contract set | Record |
+|---------|----------|---------|--------------|--------|
+| Polygon mainnet | 137 | Production | **Pre-UUPS** (plain contracts, no voucher; migration pending) | `deployments/polygon-chain137-v2.json` |
+| Polygon Amoy | 80002 | Testnet | Feature-complete (UUPS + voucher + open challenges) | `deployments/amoy-chain80002-v2.json` |
+| Hardhat | 1337 | Local development | Feature-complete | generated locally |
+| Mordor (ETC) | 63 | Testnet (Ethereum Classic, core-only) | Feature-complete, no oracle adapters | `deployments/mordor-chain63-v2.json` |
 
-Contracts deploy deterministically via the Safe Singleton Factory with a
-versioned salt prefix (`FairWins-P2P-v2.0-`) — see
-[Singleton Deployment Patterns](singleton-deployment-patterns.md).
+The original v2 set deployed deterministically via the Safe Singleton Factory
+with a versioned salt prefix (`FairWins-P2P-v2.0-`) — see
+[Singleton Deployment Patterns](singleton-deployment-patterns.md). The
+upgradeable contracts now live behind proxies; logic changes ship as in-place
+upgrades. The testnets (Amoy, Mordor) are feature-complete; Polygon mainnet
+still runs the pre-UUPS set pending the upgradeable migration.
 
 ### Mordor (Ethereum Classic testnet)
 
@@ -185,7 +200,8 @@ deployment record and operational links (explorer, faucet, Classic USD, ETCswap)
 - **Checks-effects-interactions** throughout; payouts are pull-based.
 - **Role separation**: `DEFAULT_ADMIN_ROLE` (config), `GUARDIAN_ROLE`
   (pause), `ACCOUNT_MODERATOR_ROLE` (freeze accounts), `ROLE_MANAGER_ROLE`
-  (memberships). No role can move escrowed stakes.
+  (memberships), `UPGRADER_ROLE` (authorizes UUPS upgrades). No role can move
+  escrowed stakes.
 - **Sanctions screening** on every create/accept via `SanctionsGuard`.
 - **CI security gates**: Slither, Medusa fuzzing, and the full Hardhat suite
   must pass — see [Security Testing](../security/index.md).

--- a/docs/developer-guide/frontend.md
+++ b/docs/developer-guide/frontend.md
@@ -59,7 +59,7 @@ cd frontend && npm install && npm run dev
 ## Contract configuration
 
 Addresses come from `src/config/contracts.js`, keyed by chain ID (137 Polygon
-mainnet, 80002 Amoy, 1337 Hardhat, 63 legacy Mordor). The file is **generated**
+mainnet, 80002 Amoy, 1337 Hardhat, 63 Mordor/ETC). The file is **generated**
 from `deployments/` records:
 
 ```bash
@@ -85,12 +85,32 @@ is preceded by the same guards the contracts enforce:
 In-flight transactions are persisted to localStorage so a reload can resume
 the flow.
 
+### Writing: open challenges and voucher redemption
+
+Two feature flows mirror the same approve-then-call pattern but resolve the
+contract chain-aware (`getContractAddressForChain(name, chainId)`):
+
+- **Open challenges (024)** — `hooks/useOpenChallengeCreate.js` and
+  `hooks/useOpenChallengeAccept.js`, surfaced by
+  `components/fairwins/OpenChallengeModal.jsx`. Create generates a four-word
+  code client-side (`utils/claimCode/`), derives the on-chain `claimAuthority`,
+  seals the terms under a code-keyed envelope, and calls `createOpenWager`.
+  Take = `discover(code)` (read-only lookup + decrypt) then `accept(code,
+  wagerId)`, which **approves the stake, signs an EIP-712 acceptance, then
+  calls `acceptOpenWager`** — the approval step is mandatory (escrows the
+  matching stake) and is reported through a step checklist.
+- **Membership vouchers (026)** — `MembershipVoucher.mint` (USDC approval to
+  the voucher contract) and `MembershipManager.redeemVoucher`; the voucher is a
+  standard ERC-721, so transfer/gift uses normal wallet flows. ABIs:
+  `abis/MembershipVoucher.js` + the voucher functions on `abis/MembershipManager.js`.
+
 ### Reading: the wager cache
 
 `FriendMarketsContext` is the single source of truth for the user's wagers,
 cached per chain. It pulls from `data/wagers/EventsSource.js` (direct RPC event
-scans + `getUserWagers` pagination); `SubgraphSource.js` exists but the
-deployed subgraph indexes the legacy v1 factory, so RPC is the primary path.
+scans + `getUserWagers` pagination). `SubgraphSource.js` reads the **v2
+`WagerRegistry`** subgraph (spec 017) for features like draw proposals, but the
+wager grid stays direct-from-chain so a subgraph outage degrades gracefully.
 
 ### Encryption
 

--- a/docs/developer-guide/setup.md
+++ b/docs/developer-guide/setup.md
@@ -61,19 +61,22 @@ npx hardhat compile
 
 ```
 prediction-dao-research/
-├── contracts/              # Solidity smart contracts
-│   ├── FutarchyGovernor.sol
-│   ├── WelfareMetricRegistry.sol
-│   ├── ProposalRegistry.sol
-│   ├── ConditionalMarketFactory.sol
-│   ├── PrivacyCoordinator.sol
-│   ├── OracleResolver.sol
-│   └── RagequitModule.sol
-├── test/                   # Contract tests (Mocha/Chai)
-│   ├── WelfareMetricRegistry.test.js
-│   └── ProposalRegistry.test.js
+├── contracts/              # Active Solidity smart contracts
+│   ├── wagers/
+│   │   └── WagerRegistry.sol            # escrow + open challenges (UUPS proxy)
+│   ├── access/
+│   │   ├── MembershipManager.sol        # tiers + voucher redemption (UUPS proxy)
+│   │   ├── MembershipVoucher.sol        # transferable ERC-721 voucher (immutable)
+│   │   └── SanctionsGuard.sol           # compliance screening
+│   ├── privacy/
+│   │   └── KeyRegistry.sol              # encryption public keys
+│   ├── oracles/                         # Polymarket / Chainlink (×2) / UMA adapters
+│   └── upgradeable/
+│       └── UUPSManaged.sol              # shared UUPS + AccessControl base
+│   # (contracts-archive/ holds superseded research — reference-only)
+├── test/                   # Hardhat tests: unit (*.test.js), integration/, fork/, oracles/, upgradeable/
 ├── scripts/                # Deployment and utility scripts
-│   └── deploy.js
+│   └── deploy/             # deploy + lib/upgradeable.js (deployProxy/upgradeProxy)
 ├── frontend/              # React frontend application
 │   ├── src/
 │   │   ├── components/   # React components

--- a/docs/developer-guide/smart-contracts.md
+++ b/docs/developer-guide/smart-contracts.md
@@ -8,8 +8,9 @@ markets, friend-group factories — and is reference-only.)
 
 ```mermaid
 graph TD
-    WR[WagerRegistry<br/><i>wagers/</i>]
-    MM[MembershipManager<br/><i>access/</i>]
+    WR[WagerRegistry<br/><i>wagers/ · UUPS proxy</i>]
+    MM[MembershipManager<br/><i>access/ · UUPS proxy</i>]
+    MV[MembershipVoucher<br/><i>access/ · immutable ERC-721</i>]
     SG[SanctionsGuard<br/><i>access/</i>]
     KR[KeyRegistry<br/><i>privacy/</i>]
     PA[PolymarketOracleAdapter]
@@ -21,6 +22,8 @@ graph TD
     WR -->|checkBlocked| SG
     WR -->|getOutcome via IOracleAdapter| PA & CDF & CFN & UMAA
     MM -->|checkBlocked| SG
+    MM -->|redeemVoucher burns + grants| MV
+    MV -->|price / treasury config| MM
     SG -->|isSanctioned| CHA[Chainalysis oracle]
     PA --> PM[Polymarket CTF]
     CDF --> FEED[Chainlink price feeds]
@@ -29,12 +32,21 @@ graph TD
     KR -.read by frontend for<br/>envelope encryption.-> WR
 ```
 
-Four admin roles (OpenZeppelin `AccessControl`) span the suite:
+Admin roles (OpenZeppelin `AccessControl`) span the suite:
 `DEFAULT_ADMIN_ROLE` (configuration), `GUARDIAN_ROLE` (pause),
 `ACCOUNT_MODERATOR_ROLE` (per-account freeze), `ROLE_MANAGER_ROLE`
-(membership grants); plus the paid user role `WAGER_PARTICIPANT_ROLE`.
-See [Roles and Tiers](../system-overview/roles-and-tiers.md) and the
-[Account Moderation Policy](../system-overview/account-moderation.md).
+(membership grants), and `UPGRADER_ROLE` (authorizes UUPS implementation
+upgrades on `WagerRegistry` / `MembershipManager`); plus the paid user role
+`WAGER_PARTICIPANT_ROLE`. See [Roles and Tiers](../system-overview/roles-and-tiers.md)
+and the [Account Moderation Policy](../system-overview/account-moderation.md).
+
+> **Upgradeability.** `WagerRegistry` (spec 025) and `MembershipManager`
+> (spec 027) are **UUPS proxies** — they inherit
+> [`UUPSManaged`](upgradeable-contracts.md), live at stable addresses, and have
+> their logic upgraded in place (state preserved). `MembershipVoucher`
+> (spec 026) is deliberately **immutable**. See
+> [ADR-004](../adr/004-upgradeable-registry-uups.md) and the
+> [contract-upgrade runbook](../runbooks/contract-upgrades.md).
 
 ## WagerRegistry (`contracts/wagers/WagerRegistry.sol`)
 
@@ -45,7 +57,9 @@ The core contract: escrow plus a state machine over every wager.
 ```mermaid
 stateDiagram-v2
     [*] --> Open: createWager / createWagerWithTerms
+    [*] --> Open: createOpenWager (open challenge, no named opponent)
     Open --> Active: acceptWager
+    Open --> Active: acceptOpenWager (claim-code signature)
     Open --> Refunded: cancelOpen / declineWager /<br/>claimRefund / batchExpireOpen<br/>(after acceptDeadline)
     Active --> Resolved: declareWinner /<br/>autoResolveFromPolymarket /<br/>autoResolveFromOracle
     Active --> Draw: declareDraw (both parties<br/>or arbitrator)
@@ -61,7 +75,9 @@ stateDiagram-v2
 |----------|--------|--------|
 | `createWager(opponent, arbitrator, token, creatorStake, opponentStake, acceptDeadline, resolveDeadline, resolutionType, conditionId, creatorIsYes, metadataHash, metadataUri)` | Creator | Escrows creator stake, emits `WagerCreated` |
 | `createWagerWithTerms(...)` | Creator | Same, additionally binds the current terms-version hash |
+| `createOpenWager(claimAuthority, arbitrator, token, stake, …)` | Creator (Silver+) | **Open challenge** — no named opponent; escrows creator stake, emits `OpenWagerCreated` |
 | `acceptWager(wagerId)` | Named opponent | Escrows opponent stake, activates wager, emits `WagerAccepted` |
+| `acceptOpenWager(wagerId, signature)` | Any active member | Takes an open challenge with the code key's EIP-712 signature; escrows the matching stake, emits `WagerAccepted` |
 | `declineWager(wagerId)` / `cancelOpen(wagerId)` | Opponent / creator | Refunds creator, closes the offer |
 | `declareWinner(wagerId, winner)` | Authorized declarer (per resolution type) | Resolves the wager, emits `WagerResolved` |
 | `declareDraw(wagerId)` / `revokeDraw(wagerId)` | Participants or arbitrator | Two-party consent (bitmask) settles a draw, emits `DrawProposed` → `WagerDrawn` |
@@ -105,18 +121,61 @@ oracle outcomes settle as a draw.
 - Guardian pause halts new activity; account freezes (`AccountFrozen`) block a
   specific address. Neither affects escrowed funds or refund paths.
 
+### Open challenges (feature 024)
+
+An **open challenge** is a wager posted with no named opponent, gated by a
+four-word claim code. The code is generated client-side and never leaves the
+browser; it derives (a) an on-chain `claimAuthority` address recorded at
+creation and (b) a symmetric key that encrypts the terms. The same code does
+triple duty for a taker: discover the wager (`openWagerIdForClaim(authority)`),
+decrypt its terms, and sign an EIP-712 acceptance **bound to the taker's
+address** (so a passive observer of the code cannot replay someone else's
+signature). Mechanics:
+
+- **`createOpenWager(...)`** — requires Silver+ membership; stakes are equal by
+  construction (`creatorStake == opponentStake == stake`); resolution type may
+  be `Either`, `ThirdParty`, or an oracle (single-party `Creator`/`Opponent`
+  self-resolution is disallowed because the opponent is unknown at creation).
+- **`acceptOpenWager(wagerId, signature)`** — any active membership tier may
+  take it; the taker must first **approve their stake to the registry**, then
+  accept (it escrows the matching stake via `transferFrom`). Decline is blocked
+  — only the creator can withdraw an un-taken challenge.
+- Views: `openWagerIdForClaim(authority)` (0 = no live challenge) and
+  `isOpenChallenge(wagerId)`.
+
 ## MembershipManager (`contracts/access/MembershipManager.sol`)
 
-Time-bound, USDC-priced membership tiers that gate wager participation.
+Time-bound, USDC-priced membership tiers that gate wager participation. A
+**UUPS upgradeable proxy** (spec 027) inheriting `UUPSManaged`; voucher
+redemption (spec 026) shipped as its first in-place upgrade.
 
 - **Tiers**: `None`, `Bronze`, `Silver`, `Gold`, `Platinum` — each with a
   monthly creation allowance and a max-concurrent-wagers cap.
 - `purchaseTier()` / `purchaseTierWithTerms()` (records the accepted-terms
   hash on-chain), `upgradeTier()`, `extendMembership()`.
+- `redeemVoucher(voucherId, acceptedTermsHash)` — burns a `MembershipVoucher`
+  and writes the soulbound `(role, tier)` membership it carries (screens the
+  redeemer); `setVoucher(address)` wires the voucher contract (admin).
 - `checkCanCreate(user, role)` view + `recordCreate` / `recordClose` hooks
   called by `WagerRegistry`.
 - `grantMembership()` / `revokeMembership()` for `ROLE_MANAGER_ROLE`.
 - Fees flow to the treasury address fixed at deployment.
+
+## MembershipVoucher (`contracts/access/MembershipVoucher.sol`)
+
+A transferable **ERC-721 bearer claim** on a `(role, tier)` membership
+(spec 026) — the giftable/resellable on-ramp to membership.
+
+- `mint(role, tier)` — pays that tier's USDC price to the treasury and mints a
+  voucher (the minter is **not** sanctions-screened — screening happens at
+  redemption). It confers **no** membership while held.
+- Held, gifted, or resold as a standard ERC-721; redeemed via
+  `MembershipManager.redeemVoucher`, which burns it and grants a soulbound
+  membership.
+- **Immutable by design** (not upgradeable): a tradable bearer asset's rules
+  must not change after purchase. Carries a best-effort EIP-2981 royalty
+  (default 2.5%, 5% hard cap); the mutable redemption logic lives in the
+  upgradeable `MembershipManager`.
 
 ## SanctionsGuard (`contracts/access/SanctionsGuard.sol`)
 
@@ -176,9 +235,46 @@ sequenceDiagram
 
 ## Deployed addresses
 
-`deployments/` is the source of truth. Current v2 deployments:
+`deployments/*-v2.json` is the source of truth. For the UUPS contracts the
+table lists the **proxy** address (the stable address you integrate against);
+each record also stores the current implementation under `…Impl`.
 
-=== "Polygon Mainnet (137)"
+**Feature-complete networks** (UUPS registry + UUPS membership + voucher +
+open challenges): Polygon Amoy (80002) and Mordor / Ethereum Classic (63).
+Polygon mainnet (137) is still the **pre-UUPS** set (plain contracts, no
+voucher) pending the upgradeable migration.
+
+=== "Polygon Amoy (80002) — feature-complete"
+
+    | Contract | Address |
+    |----------|---------|
+    | WagerRegistry (proxy) | `0xA429CdaD3E1497e33BEA7D6FE7d6913fE880241b` |
+    | MembershipManager (proxy) | `0x89158f2E044C73c687dA12B7FA42b94F9A6D8465` |
+    | MembershipVoucher | `0x33C8Ccacf6442Cf4238f01419e38C781cB859769` |
+    | SanctionsGuard | `0xdF41355dD5E47FCA4eE2F2205af4C70Dab8C13B3` |
+    | KeyRegistry | `0xcEFdeBba8E040c035c690ca9057cF22E73247c24` |
+    | PolymarketOracleAdapter | `0x98fe63209f5BffcCe905bF8779a1F06576A2C313` |
+    | ChainlinkDataFeedOracleAdapter | `0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23` |
+    | ChainlinkFunctionsOracleAdapter | `0x074fC18C1E322a7537b53B8B2Bf0762629E3b532` |
+    | UMAOptimisticOracleV3Adapter | `0xcEa9b4A01CcD3aA6545ea834a268C69e7eEfee88` |
+    | Stake token (test USDC) | `0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582` |
+
+=== "Mordor / ETC (63) — feature-complete, core-only"
+
+    Core-only: no oracle adapters are deployed on Ethereum Classic (Spec 015).
+
+    | Contract | Address |
+    |----------|---------|
+    | WagerRegistry (proxy) | `0x3ccB144d8aa838e8d4D695867cC72e548117830C` |
+    | MembershipManager (proxy) | `0x68bCBA1055DAbe11b98Bb8425A16e648Ad65d541` |
+    | MembershipVoucher | `0xf514e0e342A898E4681bf51590B672aEC5620401` |
+    | SanctionsGuard | `0xdF41355dD5E47FCA4eE2F2205af4C70Dab8C13B3` |
+    | KeyRegistry | `0xcEFdeBba8E040c035c690ca9057cF22E73247c24` |
+    | Stake token (Classic USD) | `0xDE093684c796204224BC081f937aa059D903c52a` |
+
+=== "Polygon Mainnet (137) — pre-UUPS"
+
+    Plain (non-proxy) contracts, no voucher; UUPS migration pending.
 
     | Contract | Address |
     |----------|---------|
@@ -192,23 +288,13 @@ sequenceDiagram
     | UMAOptimisticOracleV3Adapter | `0x8224433d099Af6cd30540A78421aBFd6e044E949` |
     | Stake token (USDC) | `0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359` |
 
-=== "Polygon Amoy (80002)"
-
-    | Contract | Address |
-    |----------|---------|
-    | WagerRegistry | `0x66c7fa8cB1642Fc5e94Fa92928f1d6333c8d657f` |
-    | MembershipManager | `0xFaEbF662aa591fF95e97306b413522efC958540f` |
-    | KeyRegistry | `0xb314c4Ee52D9D89bf7FEE66a43aBeAc7D047a5Cb` |
-    | PolymarketOracleAdapter | `0x423d2Ca885d67E46062CFF732Eff952f4F736136` |
-    | ChainlinkDataFeedOracleAdapter | `0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23` |
-    | ChainlinkFunctionsOracleAdapter | `0x074fC18C1E322a7537b53B8B2Bf0762629E3b532` |
-    | UMAOptimisticOracleV3Adapter | `0xcEa9b4A01CcD3aA6545ea834a268C69e7eEfee88` |
-    | Stake token (test USDC) | `0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582` |
-
-Deployment uses the Safe Singleton Factory with salt prefix
+The original v2 deploy used the Safe Singleton Factory with salt prefix
 `FairWins-P2P-v2.0-` for deterministic cross-chain addresses — see
-[Singleton Deployment Patterns](singleton-deployment-patterns.md). After any
-deploy, run `npm run sync:frontend-contracts` to regenerate
+[Singleton Deployment Patterns](singleton-deployment-patterns.md). The
+upgradeable contracts now ship as proxies; logic changes go out as in-place
+upgrades, never a redeploy (see the
+[contract-upgrade runbook](../runbooks/contract-upgrades.md)). After any
+deploy or upgrade, run `npm run sync:frontend-contracts` to regenerate
 `frontend/src/config/contracts.js`.
 
 ## Development workflow

--- a/docs/developer-guide/upgradeable-contracts.md
+++ b/docs/developer-guide/upgradeable-contracts.md
@@ -2,8 +2,8 @@
 
 This guide shows how to make a value-bearing contract upgradeable by reusing the shared primitives built in
 spec 025 — **without reimplementing** the proxy, authorization, storage-safety, or deploy machinery
-(the PR #724 ask). `WagerRegistry` is the reference adopter; `MembershipManager` (and then the voucher
-feature) is the next.
+(the PR #724 ask). `WagerRegistry` is the reference adopter (spec 025); `MembershipManager` (spec 027) is the
+second, with voucher redemption (spec 026) shipped as its first in-place upgrade — both are now live.
 
 Background: [ADR-004](../adr/004-upgradeable-registry-uups.md). Operations:
 [runbooks/contract-upgrades.md](../runbooks/contract-upgrades.md).
@@ -83,10 +83,14 @@ function (state that defaults to 0 needs none).
    `deployProxy` and registered in the storage-layout check (`{ name: "MembershipManager", deploymentsKey:
    "membershipManager" }`). Behavior-neutral cutover (memberships are 30-day time-bound, so the legacy
    coexistence window drains in ~a month); `WagerRegistry` is repointed via `setMembershipManager(proxy)`.
-2. **Voucher redemption** (new feature): ships as the membership proxy's **first in-place upgrade** — append
-   the voucher state, add the redemption functions, `upgradeProxy({ name: "MembershipManager", proxyAddress })`.
-   No membership redeploy, no state migration, no broad role grant — exactly mirroring how feature 024 lands
-   on the WagerRegistry proxy.
+2. **Voucher redemption** (spec 026 — ✅ implemented): two parts. The tradable asset is a **separate,
+   immutable** `MembershipVoucher` (`contracts/access/MembershipVoucher.sol`) — an ERC-721 bearer claim that is
+   intentionally **not** upgradeable (a bearer asset's rules must not change after purchase, and it minimizes
+   the attack surface on a USDC-taking contract). Only the **mutable redemption logic** (screening, Terms,
+   grant) is added to the membership proxy as its **first in-place upgrade** — append the voucher pointer +
+   `redeemVoucher`/`setVoucher`, then `upgradeProxy({ name: "MembershipManager", proxyAddress })`. No membership
+   redeploy, no state migration, no broad role grant — exactly mirroring how feature 024 lands on the
+   WagerRegistry proxy. (So: don't make the voucher upgradeable; do ship its redemption logic as an upgrade.)
 
 ## Don'ts
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -121,11 +121,17 @@ In the create UI these settlers appear as **Me**, **Them**, **A Friend**, and
 
 | Contract | Role |
 |----------|------|
-| `WagerRegistry` | Wager lifecycle and stake escrow (create, accept, resolve, claim, refund) |
-| `MembershipManager` | Tiered memberships (Bronze → Platinum) with creation rate limits |
+| `WagerRegistry` | Wager lifecycle and stake escrow (create, accept, resolve, claim, refund), including open challenges. **UUPS proxy** — upgradeable at a stable address (spec 025) |
+| `MembershipManager` | Tiered memberships (Bronze → Platinum) with creation rate limits and voucher redemption. **UUPS proxy** (spec 027) |
+| `MembershipVoucher` | Transferable ERC-721 bearer claim on a membership; bought with USDC, redeemed (burned) for a soulbound membership (spec 026). **Immutable** by design |
 | `SanctionsGuard` | Non-bypassable sanctions screening (Chainalysis oracle + deny list) |
 | `KeyRegistry` | Public encryption keys for private wager terms |
 | Oracle adapters | `PolymarketOracleAdapter`, `ChainlinkDataFeedOracleAdapter`, `ChainlinkFunctionsOracleAdapter`, `UMAOptimisticOracleV3Adapter` |
+
+The two value-bearing core contracts (`WagerRegistry`, `MembershipManager`)
+are **UUPS upgradeable proxies** — logic is swapped in place while state and
+addresses are preserved — so features ship without stranding wagers or
+memberships (see [ADR-004](adr/004-upgradeable-registry-uups.md)).
 
 The earlier futarchy/DAO-governance research (ClearPath, friend-group market
 factories, conditional-token markets) has been superseded by this P2P design;

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -47,6 +47,36 @@ await (await membership.purchaseTierWithTerms(ROLE, 1, acceptedTermsHash)).wait(
 usage against the tier's `Limits` — `createWager` reverts once either limit
 is hit.
 
+### Membership vouchers (feature 026)
+
+A `MembershipVoucher` is a transferable ERC-721 bearer claim — buy it with
+USDC, then hold, gift, or resell it. It confers **no** membership until it is
+**redeemed** (which burns it and writes a soulbound membership to the
+redeemer). Mint is on the voucher contract; redeem is on the manager.
+
+```javascript
+const voucher = new ethers.Contract(MEMBERSHIP_VOUCHER_ADDRESS, MembershipVoucherABI, signer);
+
+// Buy a voucher for a tier (USDC approval to the voucher contract first).
+const cfg = await membership.getTierConfig(ROLE, 2 /* Silver */);
+await (await usdc.approve(MEMBERSHIP_VOUCHER_ADDRESS, cfg.priceUSDC)).wait();
+const mintTx = await voucher.mint(ROLE, 2);
+const mintRc = await mintTx.wait();
+const tokenId = mintRc.logs
+    .map(l => { try { return voucher.interface.parseLog(l); } catch { return null; } })
+    .find(e => e?.name === "VoucherMinted").args.id;
+
+// Gift / resell: it's a standard ERC-721.
+await voucher.transferFrom(myAddress, recipientAddress, tokenId);
+
+// Redeem (the holder): burns the voucher, grants the (role, tier) it carries.
+await (await membership.redeemVoucher(tokenId, acceptedTermsHash)).wait();
+```
+
+Redemption screens the redeemer through `SanctionsGuard` (the minter is not
+screened — screening happens at redeem time). `MembershipVoucher` is immutable
+and carries a best-effort EIP-2981 royalty (default 2.5%, 5% cap).
+
 ## Creating a wager
 
 ```javascript
@@ -87,6 +117,43 @@ For oracle types, pass the registered condition ID and which side you're
 taking (`creatorIsYes`). For `ThirdParty`, pass a non-zero `arbitrator`.
 `createWagerWithTerms(...)` additionally binds the accepted terms-version
 hash on-chain.
+
+## Open challenges (feature 024)
+
+An open challenge is a wager posted with **no named opponent**, gated by a
+four-word claim code. The code derives an off-chain key whose address is the
+on-chain `claimAuthority`; the same code discovers the wager, decrypts its
+terms, and signs acceptance. **Silver+** membership is required to create one;
+**any active tier** may take it. Stakes are equal by construction.
+
+```javascript
+// Create — derive claimAuthority from the code off-chain, then post.
+// (See frontend/src/utils/claimCode/ for code generation + key derivation.)
+await (await usdc.approve(WAGER_REGISTRY_ADDRESS, stake)).wait();
+const tx = await registry.createOpenWager(
+    claimAuthority,             // address derived from the four-word code
+    ethers.ZeroAddress,         // arbitrator (required for ThirdParty)
+    USDC_ADDRESS, stake,
+    now + 48 * 3600,            // acceptDeadline
+    now + 9 * 86400,            // resolveDeadline
+    0,                          // ResolutionType.Either (or ThirdParty/oracle)
+    ethers.ZeroHash, true,
+    metadataHash, "ipfs://<cid>"
+);
+// wagerId from the OpenWagerCreated event.
+
+// Take — look the wager up by the code's authority, then accept with an
+// EIP-712 signature from the code key BOUND TO THE TAKER (not replayable).
+const wagerId = await registry.openWagerIdForClaim(claimAuthority); // 0 = no match
+const w = await registry.getWager(wagerId);
+await (await usdc.approve(WAGER_REGISTRY_ADDRESS, w.opponentStake)).wait();
+await (await registry.acceptOpenWager(wagerId, signature)).wait();
+```
+
+The taker MUST approve their stake before `acceptOpenWager` — it escrows the
+matching stake via `transferFrom`, so an un-approved call reverts with
+`ERC20: transfer amount exceeds allowance`. `isOpenChallenge(wagerId)`
+distinguishes an open challenge from a named-opponent wager.
 
 ## Accepting, declining, cancelling
 
@@ -162,11 +229,13 @@ registry.on(registry.filters.WagerCreated(null, creatorAddress), (id, creator, o
 ```
 
 Lifecycle events, in order of a typical happy path:
-`WagerCreated` → `WagerAccepted` → `WagerResolved` → `PayoutClaimed`.
-Other exits: `WagerCancelled`, `WagerDeclined`, `WagerRefunded`,
-`DrawProposed`/`DrawRevoked`/`WagerDrawn`. Oracle links emit
-`PolymarketLinked` / `OracleConditionLinked` at creation. Moderation emits
-`AccountFrozen` / `AccountUnfrozen`.
+`WagerCreated` (or `OpenWagerCreated` for open challenges) → `WagerAccepted` →
+`WagerResolved` → `PayoutClaimed`. Other exits: `WagerCancelled`,
+`WagerDeclined`, `WagerRefunded`, `DrawProposed`/`DrawRevoked`/`WagerDrawn`.
+Oracle links emit `PolymarketLinked` / `OracleConditionLinked` at creation.
+Membership emits `VoucherSet` / `MembershipRedeemed` (vouchers) and
+`MembershipRevoked`; the voucher contract emits `VoucherMinted`. Moderation
+emits `AccountFrozen` / `AccountUnfrozen`.
 
 ## Encryption keys
 
@@ -193,6 +262,8 @@ the [Envelope Encryption Spec](../developer-guide/envelope-encryption-spec.md).
 | Membership-related revert on create | No active tier, or monthly/concurrent limit reached |
 | ERC-20 `transferFrom` failure | Missing/insufficient USDC approval or balance |
 | `acceptWager` revert | Wrong address (named opponent only), deadline passed, or not `Open` |
+| `acceptOpenWager` revert | Bad/old claim signature, not an open challenge, expired, or you're the creator/arbitrator |
+| `transfer amount exceeds allowance` on accept | Approve your stake to the registry before `acceptWager`/`acceptOpenWager` |
 | `declareWinner` revert | Caller not authorized for the wager's resolution type, or wager not `Active` |
 | `claimPayout` revert | Caller is not the winner, or already paid |
 | `claimRefund` revert | Relevant deadline hasn't passed yet |

--- a/docs/reference/contracts.md
+++ b/docs/reference/contracts.md
@@ -6,6 +6,13 @@ against. Source of truth: `contracts/interfaces/` and
 [`deployments/`](https://github.com/chippr-robotics/prediction-dao-research/tree/main/deployments)
 and are tabulated in the [Smart Contracts guide](../developer-guide/smart-contracts.md#deployed-addresses).
 
+> **Upgradeability.** `WagerRegistry` (spec 025) and `MembershipManager`
+> (spec 027) are **UUPS proxies at stable addresses** — the address you
+> integrate against never changes; logic is swapped in place and state is
+> preserved (see [ADR-004](../adr/004-upgradeable-registry-uups.md)).
+> `MembershipVoucher` (spec 026) is **immutable by design** — a tradable
+> bearer asset whose rules must not change after purchase.
+
 ## IWagerRegistry
 
 `contracts/interfaces/IWagerRegistry.sol` — the full wager lifecycle.
@@ -51,6 +58,29 @@ interface IWagerRegistry {
     ) external returns (uint256 wagerId);
 
     function acceptWager(uint256 wagerId) external;
+
+    // Open challenges (feature 024): a wager with NO named opponent, gated by a
+    // code-derived claim authority. The four-word claim code discovers the wager,
+    // decrypts its terms, and signs acceptance. Silver+ to create; any active tier
+    // may take. `acceptOpenWager`'s signature must be the code key's EIP-712 sig
+    // bound to the taker. Equal stakes (creatorStake == opponentStake == stake).
+    function createOpenWager(
+        address claimAuthority_,
+        address arbitrator,
+        address token,
+        uint128 stake,
+        uint64 acceptDeadline,
+        uint64 resolveDeadline,
+        ResolutionType resolutionType,
+        bytes32 oracleConditionId,
+        bool creatorIsYes,
+        bytes32 metadataHash,
+        string calldata metadataUri
+    ) external returns (uint256 wagerId);
+    function acceptOpenWager(uint256 wagerId, bytes calldata signature) external;
+    function openWagerIdForClaim(address authority) external view returns (uint256);
+    function isOpenChallenge(uint256 wagerId) external view returns (bool);
+
     function cancelOpen(uint256 wagerId) external;
     function declineWager(uint256 wagerId) external;
     function declareWinner(uint256 wagerId, address winner) external;
@@ -81,6 +111,8 @@ interface IWagerRegistry {
         address token, uint128 creatorStake, uint128 opponentStake,
         ResolutionType resolutionType, bytes32 metadataHash, string metadataUri);
     event WagerAccepted(uint256 indexed wagerId, address indexed opponent);
+    event OpenWagerCreated(uint256 indexed wagerId, address indexed creator, address indexed claimAuthority,
+        address token, uint128 stake, ResolutionType resolutionType, bytes32 metadataHash, string metadataUri);
     event WagerCancelled(uint256 indexed wagerId);
     event WagerDeclined(uint256 indexed wagerId, address indexed opponent);
     event WagerResolved(uint256 indexed wagerId, address indexed winner, address indexed by);
@@ -140,6 +172,13 @@ interface IMembershipManager {
     function grantMembership(address user, bytes32 role, Tier tier, uint32 durationDays) external;
     function revokeMembership(address user, bytes32 role) external;
 
+    // Voucher rail (feature 026): redeem a MembershipVoucher ERC-721 for a
+    // soulbound membership. `setVoucher` wires the voucher contract (admin);
+    // `redeemVoucher` burns the caller's voucher and grants the (role, tier) it
+    // carries. Added to the proxy as the membership's first in-place upgrade.
+    function setVoucher(address voucher) external;
+    function redeemVoucher(uint256 voucherId, bytes32 acceptedTermsHash) external;
+
     // Views
     function hasActiveRole(address user, bytes32 role) external view returns (bool);
     function getActiveTier(address user, bytes32 role) external view returns (Tier);
@@ -147,6 +186,9 @@ interface IMembershipManager {
     function getTierConfig(bytes32 role, Tier tier) external view returns (TierConfig memory);
 
     event MembershipRevoked(address indexed user, bytes32 indexed role, address indexed by);
+    event VoucherSet(address indexed voucher);
+    event MembershipRedeemed(address indexed user, bytes32 indexed role, Tier tier,
+        uint256 indexed voucherId, uint64 expiresAt);
 }
 ```
 
@@ -162,6 +204,43 @@ function extendMembership(bytes32 role) external;
 
 The role for wager participation is
 `keccak256("WAGER_PARTICIPANT_ROLE")`.
+
+## IMembershipVoucher
+
+`contracts/interfaces/IMembershipVoucher.sol` — the redemption surface
+`MembershipManager` calls on the voucher (feature 026). `MembershipVoucher`
+(`contracts/access/MembershipVoucher.sol`) is a **transferable ERC-721 bearer
+claim** on a `(role, tier)` membership: it is minted for USDC at the tier's
+price (paid to the treasury at mint) and **confers no membership while held** —
+it exists to be held, gifted, or resold. Redeeming it through
+`MembershipManager.redeemVoucher` burns it and writes a soulbound membership to
+the redeemer. It is **immutable** (not upgradeable) by design and carries a
+best-effort EIP-2981 royalty (default 2.5%, 5% hard cap).
+
+```solidity
+interface IMembershipVoucher {
+    struct VoucherInfo {
+        bytes32 role;
+        IMembershipManager.Tier tier;
+        uint32  durationDays;
+    }
+
+    function voucherInfo(uint256 tokenId) external view returns (VoucherInfo memory);
+    function burn(uint256 tokenId) external;            // MembershipManager (redeem) or token owner
+    function ownerOf(uint256 tokenId) external view returns (address);
+}
+```
+
+The implementation additionally exposes the buyer-facing mint and is a full
+ERC-721 + ERC-2981:
+
+```solidity
+function mint(bytes32 role, IMembershipManager.Tier tier) external returns (uint256 id);
+function membershipManager() external view returns (address);   // immutable redemption authority
+
+event VoucherMinted(uint256 indexed id, address indexed minter, bytes32 indexed role,
+    IMembershipManager.Tier tier, uint32 durationDays, uint128 priceUSDC);
+```
 
 ## ISanctionsGuard
 

--- a/docs/runbooks/contract-upgrades.md
+++ b/docs/runbooks/contract-upgrades.md
@@ -1,8 +1,16 @@
 # Runbook: Upgrading the contracts (UUPS proxies)
 
-How to deploy and upgrade the upgradeable contracts (`WagerRegistry`, and any contract that inherits
-`UUPSManaged`). Background: [ADR-004](../adr/004-upgradeable-registry-uups.md). Reuse guide for making a new
-contract upgradeable: [developer-guide/upgradeable-contracts.md](../developer-guide/upgradeable-contracts.md).
+How to deploy and upgrade the upgradeable contracts. Two contracts are UUPS proxies today —
+**`WagerRegistry`** (spec 025) and **`MembershipManager`** (spec 027) — plus any future contract that inherits
+`UUPSManaged`. This runbook is written with `WagerRegistry` in the examples; for `MembershipManager` substitute
+the contract name and its deployment keys (`membershipManager` proxy / `membershipManagerImpl`). Background:
+[ADR-004](../adr/004-upgradeable-registry-uups.md). Reuse guide for making a new contract upgradeable:
+[developer-guide/upgradeable-contracts.md](../developer-guide/upgradeable-contracts.md).
+
+> **Worked precedents.** Feature 024 (open challenges) shipped as an in-place upgrade of the `WagerRegistry`
+> proxy; voucher redemption (spec 026) shipped as the **first in-place upgrade** of the `MembershipManager`
+> proxy (the tradable `MembershipVoucher` ERC-721 is a separate, immutable contract — not upgraded). Both
+> followed the In-place upgrade steps below verbatim.
 
 > **Why this matters**: an upgrade replaces the code that custodies user funds. The proxy address never
 > changes and all state is preserved — but a bad storage layout or a lost upgrade key is catastrophic. Follow
@@ -109,4 +117,9 @@ The proxy address does NOT change; all state and funds are preserved.
   logic on an existing deployment, run an **upgrade**, never the deploy script.
 - **Lost `UPGRADER_ROLE` key** → the contract keeps working but can never be upgraded again. Protect the
   floppy keystore; consider moving `UPGRADER_ROLE` to a timelock/multisig before mainnet scale.
-- **Mordor/ETC** are legacy read-only and out of scope.
+- **Per-contract scope** → an upgrade targets one proxy. Upgrading `WagerRegistry` does not touch
+  `MembershipManager` (and vice-versa); run the pre-flight, `check:storage-layout`, and post-upgrade checks
+  separately for each, against its own `…Impl` record.
+- **Network state** → Amoy (80002) and Mordor/ETC (63) run the feature-complete upgradeable set (UUPS
+  registry + UUPS membership + voucher + open challenges). Polygon mainnet (137) is still the **pre-UUPS**
+  set; its first deploy is a cutover to proxies (carrying members over), not an in-place upgrade.

--- a/docs/system-overview/governance.md
+++ b/docs/system-overview/governance.md
@@ -4,7 +4,7 @@ Governance structure and progressive decentralization roadmap for FairWins.
 
 ## On-chain operator roles
 
-The protocol's privileged actions are split across four OpenZeppelin
+The protocol's privileged actions are split across five OpenZeppelin
 AccessControl roles, deliberately separated so no single key carries blanket
 authority. For the full privilege matrix see
 [Roles and Tiers](roles-and-tiers.md).
@@ -15,6 +15,7 @@ authority. For the full privilege matrix see
 | `GUARDIAN_ROLE` | Pause / unpause `WagerRegistry` in response to security incidents | Guardian Multisig + on-call signer(s) |
 | `ACCOUNT_MODERATOR_ROLE` | Per-account freeze / unfreeze on `WagerRegistry`. See [Account Moderation Policy](account-moderation.md). | Trust-and-safety multisig |
 | `ROLE_MANAGER_ROLE` | Grant / revoke `WAGER_PARTICIPANT` memberships outside the purchase flow | Ops multisig |
+| `UPGRADER_ROLE` | Authorize UUPS implementation upgrades on `WagerRegistry` / `MembershipManager` (logic swaps at stable addresses; state preserved) | Air-gapped floppy-keystore admin |
 
 ### The right to pause
 

--- a/docs/system-overview/how-it-works.md
+++ b/docs/system-overview/how-it-works.md
@@ -12,7 +12,9 @@ to payout, including every exit path.
 ```mermaid
 stateDiagram-v2
     [*] --> Open: createWager()<br/>creator stake escrowed
+    [*] --> Open: createOpenWager()<br/>open challenge — no named opponent
     Open --> Active: acceptWager()<br/>opponent stake escrowed
+    Open --> Active: acceptOpenWager()<br/>taken with a four-word code
     Open --> Refunded: cancelOpen() / declineWager() /<br/>acceptance deadline passes
     Active --> Resolved: declareWinner() or<br/>autoResolveFromPolymarket() /<br/>autoResolveFromOracle()
     Active --> Draw: declareDraw()<br/>(both parties consent,<br/>or arbitrator ruling)
@@ -60,6 +62,23 @@ If the opponent never accepts:
 
 The opponent can also explicitly `declineWager()`, which refunds the creator
 immediately.
+
+### Open challenges (no named opponent)
+
+A creator can instead post an **open challenge** with `createOpenWager()` —
+a wager with no opponent named up front, gated by a **four-word claim code**.
+The code is generated in the creator's browser and never leaves it; it both
+encrypts the terms and derives the on-chain *claim authority* recorded with the
+wager. The creator shares the code out-of-band (text, QR, or deep link), and
+**anyone who has it** can look the challenge up, read its terms, and take the
+other side by calling `acceptOpenWager()` with a one-time signature derived
+from the code and bound to their address. Stakes are equal by construction.
+
+Creating an open challenge requires a **Silver** membership or above; **any**
+active tier can take one. Because the opponent is unknown at creation, an open
+challenge must resolve via *Either side*, a named *third-party arbitrator*, or
+an *oracle* — not single-party self-resolution. The code is the only way to
+find, read, or take the challenge and **cannot be recovered if lost**.
 
 ## 3. Resolution (`Active → Resolved` / `Draw`)
 
@@ -148,13 +167,22 @@ sequenceDiagram
 
 ## Memberships and limits
 
-Wager participation requires an active membership purchased through
-`MembershipManager` (`purchaseTier()` / `purchaseTierWithTerms()`), priced in
-USDC. Each tier — Bronze, Silver, Gold, Platinum — sets a monthly creation
-allowance and a cap on concurrently open wagers. The registry calls
-`recordCreate` / `recordClose` hooks so the limits track actual usage. Admins
-can also grant or revoke memberships out of band. Full details:
-[Roles and Tiers](roles-and-tiers.md).
+Wager participation requires an active membership. The default starting tier is
+**None** (no participation); the paid tiers — Bronze, Silver, Gold, Platinum —
+each set a monthly creation allowance and a cap on concurrently open wagers.
+There are two ways to get one:
+
+- **Buy a tier directly** through `MembershipManager` (`purchaseTier()` /
+  `purchaseTierWithTerms()`), priced in USDC — the membership is **soulbound**
+  (non-transferable) and time-bound.
+- **Redeem a voucher.** A `MembershipVoucher` is a transferable ERC-721 bought
+  with USDC at a tier's price. It confers no membership while held — so it can
+  be **gifted or resold** — and is redeemed (`redeemVoucher`), which burns it
+  and writes the soulbound membership to the redeemer.
+
+The registry calls `recordCreate` / `recordClose` hooks so the limits track
+actual usage. Admins can also grant or revoke memberships out of band. Full
+details: [Roles and Tiers](roles-and-tiers.md).
 
 ## What keeps it honest
 

--- a/docs/system-overview/introduction.md
+++ b/docs/system-overview/introduction.md
@@ -10,7 +10,10 @@ the whole flow usable from a phone.
 It is deliberately **not** a prediction market. There is no order book, no
 liquidity pool, no market maker, and no token trading. Every wager is a private
 agreement between exactly two people (optionally with a named arbitrator), and
-the protocol's only job is to hold the stakes and pay the right person.
+the protocol's only job is to hold the stakes and pay the right person. You can
+name your opponent up front, or post an **open challenge** — a wager gated by a
+four-word code that whoever you share it with can take the other side of (see
+[How It Works](how-it-works.md#open-challenges-no-named-opponent)).
 
 > Before purchasing a membership, please read
 > [Roles and Tiers](roles-and-tiers.md) and the
@@ -89,14 +92,22 @@ flowchart LR
   See [Security Model](security.md) and [Account Moderation](account-moderation.md).
 - **Membership-gated creation.** Creating and accepting wagers requires an
   active membership tier (Bronze → Platinum, priced in USDC), which also rate
-  limits how many wagers an account can run concurrently. See
+  limits how many wagers an account can run concurrently. Memberships can be
+  bought directly (soulbound) or acquired by redeeming a transferable
+  **membership voucher** (a gift/resale-friendly ERC-721). See
   [Roles and Tiers](roles-and-tiers.md).
+- **Upgradeable, never redeployed.** The value-bearing core contracts
+  (`WagerRegistry`, `MembershipManager`) are UUPS proxies at stable addresses:
+  new features ship as in-place logic upgrades that preserve every wager,
+  membership, and balance — so an improvement never strands your funds. The
+  voucher token is the deliberate exception (immutable by design). See
+  [Upgradeable Contracts](../developer-guide/upgradeable-contracts.md).
 
 ## Where things live
 
 | Layer | Technology | Location |
 |-------|-----------|----------|
-| Contracts | Solidity (Hardhat) | `contracts/` — deployed on Polygon 137 & Amoy 80002 |
+| Contracts | Solidity (Hardhat) | `contracts/` — Polygon 137 (mainnet), Amoy 80002 & Mordor/ETC 63 (testnets). The testnets run the feature-complete upgradeable set; mainnet's UUPS migration is pending |
 | Frontend | React + Vite + wagmi/ethers | `frontend/` — served at [fairwins.app](https://fairwins.app) |
 | Encrypted metadata | IPFS (Pinata) | referenced from each wager's `metadataUri` |
 | Address book | JSON deployment records | `deployments/` (source of truth) |

--- a/docs/system-overview/roles-and-tiers.md
+++ b/docs/system-overview/roles-and-tiers.md
@@ -8,23 +8,37 @@ enforced via OpenZeppelin AccessControl.
 
 ### `WAGER_PARTICIPANT_ROLE`
 
-The one paid role. Required to call `WagerRegistry.createWager`. Sold by
-`MembershipManager` in USDC.
+The one paid role. Required to create or accept wagers. Sold by
+`MembershipManager` in USDC. The default state is the **None** tier — no
+membership, no participation.
 
-Four tiers, all valid for **30 days**, anchored at $2 Bronze:
+Four paid tiers, all valid for **30 days**, anchored at $2 Bronze:
 
 | Tier | Price (USDC) | Wagers / month | Open wagers at once |
 |------|--------------|----------------|---------------------|
+| None     | —    | 0         | 0         |
 | Bronze   | $2   | 15        | 5         |
 | Silver   | $8   | 30        | 10        |
 | Gold     | $25  | 100       | 30        |
 | Platinum | $100 | Unlimited | Unlimited |
 
 The two limits (`monthlyMarketCreation`, `maxConcurrentMarkets`) are the
-**only** on-chain restrictions. Stake size, resolution type (Either /
-Creator / Opponent / ThirdParty / Polymarket), and token choice (USDC or
-WMATIC) are not gated by tier — Bronze gets the same feature set as Platinum,
-just lower throughput.
+**only** throughput restrictions. Stake size, resolution type (Either /
+Creator / Opponent / ThirdParty / Polymarket / Chainlink / UMA), and token
+choice (USDC or WMATIC) are not gated by tier — Bronze gets the same feature
+set as Platinum, just lower throughput. One exception: creating an **open
+challenge** (`createOpenWager`, a code-gated wager with no named opponent)
+requires **Silver or above**, though *taking* one needs only any active tier.
+
+### Two ways to get a membership
+
+- **Buy a tier directly** — `purchaseTier` / `purchaseTierWithTerms` in USDC.
+  The resulting membership is **soulbound** (non-transferable) and time-bound.
+- **Redeem a voucher** — a `MembershipVoucher` is a transferable ERC-721 bought
+  with USDC at a tier's price (see spec 026). It confers no membership while
+  held, so it can be **gifted or resold**; redeeming it (`redeemVoucher`) burns
+  the voucher and writes the soulbound membership to the redeemer. The voucher
+  contract is immutable; redemption screens the redeemer through `SanctionsGuard`.
 
 Membership rolls in a 30-day window: the monthly counter resets the first
 time you create a wager after 30 days have elapsed since the last reset.

--- a/docs/user-guide/accept-wager.md
+++ b/docs/user-guide/accept-wager.md
@@ -1,7 +1,13 @@
 # Accepting a Wager
 
 This guide walks you through accepting a wager someone created for you on
-FairWins.
+FairWins — one created **for your specific address** and shared by QR or link.
+
+!!! tip "Taking an open challenge instead?"
+    If someone gave you a **four-word code** rather than a direct link, you're
+    taking an *open challenge* — a wager with no named opponent. The flow is
+    slightly different (enter the code → approve → sign → confirm). See
+    [Open Challenges](open-challenges.md#taking-an-open-challenge).
 
 ## Prerequisites
 
@@ -41,13 +47,16 @@ the wrong network, the app offers a one-click switch.
 
 ### 4. Accept (or decline)
 
-Click **Accept**. You'll be prompted for up to two transactions:
+Click **Accept**. Accepting **escrows your matching stake**, so you'll be
+prompted for up to two transactions:
 
-1. **Approve** — allow `WagerRegistry` to take your USDC stake
+1. **Approve** — allow `WagerRegistry` to take your USDC stake (skipped if you
+   already have enough allowance)
 2. **Accept** — the `acceptWager` call; your stake joins the creator's in escrow
 
 Acceptance also screens both addresses against the sanctions oracle and checks
-your membership tier.
+your membership tier. (Taking an *open challenge* by code adds a signing step
+between the two — see [Open Challenges](open-challenges.md#taking-an-open-challenge).)
 
 Not interested? **Decline** rejects the offer and releases the creator's stake
 back to them immediately.

--- a/docs/user-guide/create-wager.md
+++ b/docs/user-guide/create-wager.md
@@ -25,6 +25,7 @@ you're on the wrong network the app offers a one-click switch.
 | **Friends Decide (1v1)** | Even-money wager you and your opponent settle yourselves |
 | **Oracle Settles (1v1)** | Wager pegged to an external source (Polymarket, Chainlink, UMA) |
 | **Make an Offer** | Asymmetric stakes at odds you set — whoever settles puts up the majority stake (e.g. your 30 USDC vs. their 10) |
+| **Open Challenge** | A wager with **no named opponent**, gated by a four-word code anyone you share it with can take. Requires a **Silver** membership or above. See [Open Challenges](open-challenges.md) |
 
 ### 3. Fill in the wager details
 

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -18,13 +18,16 @@ a specific person who accepts your wager.
 
 ### Who is the counterparty?
 
-Always a specific person — usually someone you shared a QR code or link with.
-FairWins never takes the other side of a bet.
+Always a specific person — either someone you invited directly with a QR code
+or link, or, for an **open challenge**, whoever takes it using the four-word
+code you shared. FairWins never takes the other side of a bet.
 
 ### What does it cost?
 
 - A **membership tier** (Bronze → Platinum, priced in USDC) is required to
-  create and accept wagers, and sets your monthly/concurrent wager limits.
+  create and accept wagers, and sets your monthly/concurrent wager limits. You
+  can buy a tier directly or redeem a transferable
+  [membership voucher](membership-vouchers.md).
 - **Gas** on Polygon (paid in POL, typically a few cents per action).
 - There is no rake on the pot itself — the winner claims both stakes in full.
 
@@ -86,6 +89,51 @@ pays the winner directly when the wager resolves.
 You can cancel your own wager any time *before* it's accepted (and the invitee
 can decline it). After acceptance, there's no unilateral cancel — only
 resolution, mutual draw, or the deadline-based refund.
+
+### Can I post a wager without naming my opponent?
+
+Yes — that's an **open challenge**. You post the wager with no named opponent
+and get a **four-word code**; anyone you share the code with can take the other
+side. Creating one needs a **Silver** membership or above; taking one needs any
+active tier. Full guide: [Open Challenges](open-challenges.md).
+
+### What is the four-word code, and can I recover it?
+
+It's the key to your open challenge — it finds the challenge, decrypts its
+terms, and authorizes acceptance. It's generated in your browser and **cannot
+be recovered** if lost (we never store it). Save it as soon as it's shown, and
+share it only with people you want to be able to take the bet.
+
+### What does it take to accept an open challenge?
+
+Enter the four words, review the terms, then **approve** your stake token,
+**sign** to authorize acceptance, and **confirm** the transaction. Your matching
+stake is escrowed on confirmation. The app shows these as a checklist.
+
+## Memberships and vouchers
+
+### How do I get a membership?
+
+Two ways: buy a tier directly (it's soulbound to your wallet), or redeem a
+**membership voucher** someone bought or gave you. Both produce the same
+30-day, time-bound membership. See [Membership Vouchers](membership-vouchers.md).
+
+### What is a membership voucher?
+
+A transferable ERC-721 token you buy with USDC at a tier's price. Holding it
+gives you **no** membership — it's a bearer claim you can gift or resell, and
+whoever holds it can **redeem** it (which burns it) for the membership.
+
+### Can I buy a voucher as a gift?
+
+Yes. Buy the voucher, then send the NFT to the recipient's address; they redeem
+it for the membership. Because redemption is soulbound to the redeemer, let the
+recipient redeem it on the wallet they'll wager with.
+
+### Does holding a voucher let me create wagers?
+
+No — you must **redeem** it first. Redeeming burns the voucher and grants the
+soulbound membership that unlocks wagering.
 
 ## Privacy
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -65,7 +65,9 @@ Creating and accepting wagers requires an active membership tier:
    wagers per month and more running at the same time
 3. Approve the USDC payment and confirm the purchase transaction
 
-Memberships are time-bound and renewable. Details and current pricing:
+Memberships are time-bound and renewable. You can also receive one as a
+[membership voucher](membership-vouchers.md) — a transferable token someone buys
+and gifts you, which you redeem for the membership. Details and current pricing:
 [Roles and Tiers](../system-overview/roles-and-tiers.md).
 
 ## 5. (Optional) Register an encryption key

--- a/docs/user-guide/membership-vouchers.md
+++ b/docs/user-guide/membership-vouchers.md
@@ -1,0 +1,68 @@
+# Membership Vouchers
+
+A **membership voucher** is a prepaid, transferable claim on a FairWins
+membership. You buy it with USDC, and it can be **held, gifted, or resold** like
+any NFT. It only becomes a membership when someone **redeems** it.
+
+Think of it as a gift card: buying it doesn't sign *you* up — it creates a token
+that whoever holds it can turn into a membership.
+
+## Voucher vs. buying a membership directly
+
+| | Buy a tier directly | Buy a voucher |
+|---|---|---|
+| What you get | A membership on your own wallet | A transferable ERC-721 token |
+| Transferable? | No — memberships are **soulbound** | Yes — gift or resell it freely |
+| Gives membership immediately? | Yes | No — only once **redeemed** |
+| Good for | Joining yourself | Gifting, resale, buying ahead |
+
+Both cost the same USDC price for a given tier (Bronze, Silver, Gold,
+Platinum — see [Roles and Tiers](../system-overview/roles-and-tiers.md) for the
+current ladder).
+
+## Buying a voucher
+
+1. Go to **Account Center → Membership** and choose **Buy a voucher**.
+2. Pick the **tier**. The price is that tier's USDC price.
+3. Confirm the wallet prompts — **approve** USDC, then **mint**. The USDC goes
+   to the treasury and a voucher NFT lands in your wallet.
+
+Buying a voucher does **not** screen you against the sanctions list and does
+**not** give you a membership — screening and the membership grant happen at
+**redemption**.
+
+## Gifting or selling a voucher
+
+A voucher is a standard ERC-721, so you move it like any NFT:
+
+- **Gift** — send the voucher to a friend's address from your wallet (or any
+  NFT-aware wallet/marketplace).
+- **Resell** — list it on an NFT marketplace. A small creator royalty
+  (2.5% by default, capped at 5%) may apply on marketplace sales.
+
+While you hold it, the voucher confers **no** membership and grants **no**
+wager rights — it's purely a bearer claim waiting to be redeemed.
+
+## Redeeming a voucher
+
+Whoever holds the voucher redeems it to receive the membership:
+
+1. Go to **Account Center → Membership** and choose **Redeem a voucher**.
+2. Confirm the redemption. This **burns** the voucher and writes a
+   **soulbound, time-bound** membership (the tier the voucher carries) to your
+   wallet.
+
+Redemption screens the redeemer against the sanctions oracle, and — like a
+direct purchase — records your acceptance of the current Terms.
+
+!!! note "Redeem to a wallet you control"
+    The membership is soulbound to whoever redeems, so redeem from the wallet
+    you want to wager with. The voucher itself is transferable; the membership
+    it produces is not.
+
+## After redeeming
+
+You now have an active membership exactly as if you'd bought the tier directly —
+it's time-bound (30 days) and gates wager creation/acceptance and your monthly /
+concurrent limits. See [Getting Started](getting-started.md#4-get-a-membership)
+and [Roles and Tiers](../system-overview/roles-and-tiers.md).

--- a/docs/user-guide/open-challenges.md
+++ b/docs/user-guide/open-challenges.md
@@ -1,0 +1,91 @@
+# Open Challenges
+
+An **open challenge** is a wager you post with **no named opponent**. Instead of
+sending it to one specific address, you get a **four-word code** to share with
+whoever you like — and the first person to take it with that code becomes your
+opponent.
+
+It's the difference between *"hey Alice, 10 USDC says it rains tomorrow"* and
+*"10 USDC says it rains tomorrow — first taker gets the other side, here's the
+code."*
+
+## How it works at a glance
+
+1. You create an open challenge and the app gives you a **four-word code**
+   (e.g. `river tiger kite zoo`).
+2. You share that code however you like — text, DM, QR, a deep link.
+3. Anyone with the code can look up the challenge, read its terms, and **take
+   the other side** by staking the matching amount.
+4. Once taken, it's a normal wager — it resolves and pays out exactly like any
+   other.
+
+The code does three jobs: it **finds** the challenge, **decrypts** its private
+terms, and **authorizes** acceptance. It is generated in your browser and never
+sent to any server.
+
+!!! warning "Save your code — it cannot be recovered"
+    The four-word code is the **only** way to find, read, or take your
+    challenge. We don't store it and it can't be reset. If you lose it, no one
+    can take the challenge (you can still cancel it to get your stake back).
+    Anyone you give the code to can take the other side, so share it only with
+    the people you intend to.
+
+## Who can create and take one
+
+- **Creating** an open challenge requires a **Silver** membership or above.
+- **Taking** one requires **any** active membership tier (Bronze and up).
+
+## Creating an open challenge
+
+1. From the Dashboard choose **Open Challenge**.
+2. Enter the wager **description**, the **stake** (each side stakes the same
+   amount — equal stakes only), and **how it's resolved**:
+    - *Either side submits the outcome*, or
+    - *A named third-party arbitrator decides* (enter their address).
+
+    Single-party self-resolution (*Me* / *Them*) isn't offered for open
+    challenges, because the opponent is unknown when you post it.
+3. Confirm the wallet prompts — **approve** your stake, then **create**. Your
+   stake moves into escrow immediately.
+4. The app shows your **four-word code** plus a **QR code / link**. Save the
+   code now (see the warning above), then share it.
+
+## Taking an open challenge
+
+1. Open the app and choose **Take a challenge** (or open the link / scan the QR
+   someone sent you — the code is filled in for you).
+2. Enter the **four words** and select **Find challenge**. The app looks it up
+   and shows the (decrypted) terms.
+3. Select **Accept challenge**. Taking the other side escrows your matching
+   stake, so acceptance is a short, guided sequence:
+    1. **Approve** the stake token — lets the wager contract escrow your stake.
+    2. **Sign** to authorize acceptance with your code (a free signature, no gas).
+    3. **Confirm** the acceptance transaction — your stake joins the creator's
+       in escrow.
+
+    The app shows this as a checklist and highlights the active step.
+
+!!! note "Why three steps?"
+    The approval is a separate token transaction that lets the contract pull
+    your stake; the signature proves you hold the code and binds acceptance to
+    *your* wallet so no one can replay it. If you ever see
+    *"transfer amount exceeds allowance"*, the approval step didn't go
+    through — retry and approve the token.
+
+## After it's taken
+
+The wager is now **Active** and behaves like any other:
+
+- It resolves per the type you chose (either side, or the named arbitrator).
+- The winner claims the full pot; a draw returns each side's stake.
+- If it never resolves by the deadline, either party can claim a refund.
+
+See [Resolving a Wager](resolve-wager.md) for the settlement and refund paths.
+**Keep your code** even after acceptance — it's how you re-read the private
+terms later.
+
+## Cancelling an un-taken challenge
+
+If no one has taken your challenge yet, you can withdraw it from *My Wagers* and
+your stake is returned. Open challenges can't be *declined* by a taker — only
+you, the creator, can withdraw one before it's taken.

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -23,7 +23,8 @@ flowchart LR
 2. **Buy a membership** tier — this is what authorizes you to create and accept
    wagers, and sets how many you can run at once.
 3. **Create a wager**: terms, stake (USDC), deadlines, and a resolution method.
-4. **Share it** with your friend as a QR code or link.
+4. **Share it** with your friend as a QR code or link — or post an
+   [open challenge](open-challenges.md) that anyone with a four-word code can take.
 5. They **accept**, their stake locks, and the bet is on.
 6. When the event happens, the wager **resolves** — by one of you, an
    arbitrator, or an oracle — and the **winner claims** both stakes.
@@ -34,6 +35,9 @@ flowchart LR
   [User Journeys](user-journeys.md) to see the full flows.
 - **Making your first bet?** [Creating a Wager](create-wager.md), then
   [Accepting a Wager](accept-wager.md) for your friend's side.
+- **No opponent in mind?** [Open Challenges](open-challenges.md) — post a wager
+  anyone with the code can take.
+- **Gifting access?** [Membership Vouchers](membership-vouchers.md).
 - **Bet finished?** [Resolving a Wager](resolve-wager.md) covers declaring
   winners, draws, oracle settlement, and refunds.
 - **Care about privacy?** [Private Wager Encryption](private-market-encryption.md)

--- a/docs/user-guide/user-journeys.md
+++ b/docs/user-guide/user-journeys.md
@@ -110,13 +110,72 @@ The **Account Center** (My Account) is home base:
 | Tab | What it's for |
 |-----|---------------|
 | Account | Your address, connection status, disconnect |
-| Membership | Your current tier, limits, and tier purchase/renewal |
+| Membership | Your current tier and limits; buy/renew a tier, or buy/redeem a [membership voucher](membership-vouchers.md) |
 | Security | Registering your encryption key for private wagers |
 | Preferences | Polymarket category filters for oracle browsing |
 | Swap | Swapping tokens via Uniswap (e.g. POL → USDC) |
 
 A QR **scanner** is also available for accepting wagers in person — point it
 at a friend's share code and you land directly on the acceptance page.
+
+## Journey 7: An open challenge anyone can take
+
+When the creator doesn't have one specific opponent in mind, they post an
+**open challenge** — no named opponent, gated by a four-word code.
+
+```mermaid
+sequenceDiagram
+    actor A as Alex (creator, Silver+)
+    actor B as Bri (taker)
+    participant App as FairWins app
+    participant Chain as Polygon
+
+    A->>App: Dashboard → "Open Challenge"
+    A->>App: terms, 10 USDC stake, "Either" resolution
+    App->>Chain: approve USDC + createOpenWager
+    App-->>A: four-word code + QR  (save it!)
+    A-->>B: shares the code
+    B->>App: "Take a challenge" → enters code
+    App-->>B: shows decrypted terms
+    B->>App: Accept → approve + sign + confirm
+    App->>Chain: acceptOpenWager (matching stake escrowed)
+    Note over A,B: now a normal wager — resolves + pays out
+```
+
+1. **Alex creates an open challenge.** Requires a **Silver** membership or
+   above. Alex enters the terms, the (equal) stake, and a resolution method —
+   *Either side* or a *named arbitrator*. The app returns a **four-word code**
+   and a QR/link. **Alex saves the code** — it can't be recovered.
+2. **Alex shares the code** with one person or many — whoever gets it first can
+   take the other side.
+3. **Bri takes it.** Any active membership tier works. Bri chooses *Take a
+   challenge*, enters the four words, reads the decrypted terms, then
+   **approves** the stake, **signs** to authorize, and **confirms** — escrowing
+   the matching stake.
+4. From here it's identical to Journey 1: it resolves, draws, or refunds.
+
+Full guide: [Open Challenges](open-challenges.md).
+
+## Journey 8: Gifting a membership with a voucher
+
+A membership can be bought as a transferable token and given away.
+
+```mermaid
+flowchart LR
+    A["Account Center → Membership<br/>Buy a voucher (USDC)"] --> B[Voucher NFT lands<br/>in your wallet]
+    B --> C[Send the NFT to<br/>a friend's address]
+    C --> D["Friend: Redeem voucher<br/>(burns it)"]
+    D --> E[Friend gets a soulbound<br/>30-day membership]
+```
+
+1. **Buy a voucher** for a tier in Account Center → Membership (pays that tier's
+   USDC price). It arrives as an ERC-721 in your wallet and confers no
+   membership while held.
+2. **Gift or resell it** — send the NFT to whoever you like (or list it).
+3. **They redeem it.** Redemption burns the voucher and writes a soulbound,
+   time-bound membership to the redeemer's wallet, unlocking wagering for them.
+
+Full guide: [Membership Vouchers](membership-vouchers.md).
 
 ## What happens behind the scenes
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,8 @@ nav:
     - User Journeys: user-guide/user-journeys.md
     - Creating a Wager: user-guide/create-wager.md
     - Accepting a Wager: user-guide/accept-wager.md
+    - Open Challenges: user-guide/open-challenges.md
+    - Membership Vouchers: user-guide/membership-vouchers.md
     - Resolving a Wager: user-guide/resolve-wager.md
     - Private Wager Encryption: user-guide/private-market-encryption.md
     - Address Book & Screening: user-guide/address-book.md


### PR DESCRIPTION
## Why

The contracts shipped specs **024** (open challenges), **025** (UUPS `WagerRegistry`), **026** (membership vouchers), and **027** (UUPS `MembershipManager`), but the living docs still described a non-upgradeable registry with no vouchers and no open challenges. This brings every active doc in line with the deployed behavior.

I audited the doc tree (4 parallel reviewers) against ground truth from the contracts/interfaces and the `deployments/*-v2.json` records, then made targeted edits. `docs/archived/` and `docs/research/` are intentionally left as historical reference; the large pre-existing futarchy drift in `governance.md`/`security.md` is out of scope (only the in-scope `UPGRADER_ROLE` row was added).

## What changed

**Reference** — `contracts.md` (open-challenge fns/events, voucher rail, new `IMembershipVoucher` section, UUPS/immutable note), `api.md` (open-challenge + voucher examples incl. the mandatory stake approval; `OpenWagerCreated`; accept-allowance error rows), `index.md` (voucher in components table + UUPS note).

**Developer guide** — `smart-contracts.md` (UUPS + `UPGRADER_ROLE`, open challenges, `MembershipVoucher`, and **corrected deployed-address tables** — Amoy was stale, Mordor + voucher/proxy rows added, mainnet flagged pre-UUPS), `architecture.md` (voucher, UUPS, fixed the stale "subgraph indexes legacy v1" claim → now v2 `WagerRegistry`), `upgradeable-contracts.md` (voucher = separate immutable ERC-721 + redemption shipped as an in-place upgrade), `frontend.md` (open-challenge/voucher hooks; subgraph/Mordor fixes), `setup.md` (active contract tree), `runbooks/contract-upgrades.md` (applies to `MembershipManager`; Mordor no longer "legacy read-only").

**System overview + README** — open challenges, voucher acquisition path, **None** tier, `UPGRADER_ROLE`, the "upgradeable, never redeployed" principle, and deploy status (testnets feature-complete; mainnet pre-UUPS).

**User guide** — two new pages, **Open Challenges** and **Membership Vouchers** (wired into `mkdocs.yml` nav); updates to create/accept/faq/overview/getting-started/user-journeys for both flows, the *save-your-code* warning, and the explicit *approve → escrow* accept step.

## Verification

- No broken internal links or anchors across all changed docs (automated check).
- Every headline address in `smart-contracts.md` matches `deployments/*-v2.json`.
- Contract signatures (events, fns, struct fields) taken from `contracts/interfaces/` + `contracts/access/MembershipVoucher.sol`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)