### PR TITLE
docs: remove archived futarchy drift from governance & security

### DIFF
--- a/docs/system-overview/governance.md
+++ b/docs/system-overview/governance.md
@@ -1,6 +1,10 @@
 # Governance
 
-Governance structure and progressive decentralization roadmap for FairWins.
+How FairWins is operated today, and the direction of travel toward reducing
+that operator authority over time. FairWins is a peer-to-peer wager protocol —
+there is **no on-chain token governance, no DAO, and no proposal/voting
+process**. "Governance" here means the small set of bounded operator roles and
+how they are custodied.
 
 ## On-chain operator roles
 
@@ -17,6 +21,10 @@ authority. For the full privilege matrix see
 | `ROLE_MANAGER_ROLE` | Grant / revoke `WAGER_PARTICIPANT` memberships outside the purchase flow | Ops multisig |
 | `UPGRADER_ROLE` | Authorize UUPS implementation upgrades on `WagerRegistry` / `MembershipManager` (logic swaps at stable addresses; state preserved) | Air-gapped floppy-keystore admin |
 
+**No role can move escrowed stakes or redirect a payout.** Escrow is held by
+`WagerRegistry` and only ever flows to a wager's own participants via the
+resolution and refund paths.
+
 ### The right to pause
 
 `GUARDIAN_ROLE` holders can pause `WagerRegistry`, halting wager creation and
@@ -32,249 +40,61 @@ refund wagers until unfrozen. Every freeze emits `AccountFrozen(user,
 moderator, reason)`; every unfreeze emits `AccountUnfrozen(user, moderator)`.
 The full disclosure is in [Account Moderation Policy](account-moderation.md).
 
-## Current Governance Structure
-
-### Guardian Multisig
-
-**Composition**: 5-of-7 multisig
-
-**Powers**:
-- Holds `GUARDIAN_ROLE` and `DEFAULT_ADMIN_ROLE` during the guarded launch
-- Initial parameter tuning (tier prices, allowlisted tokens)
-- Temporary intervention if critical issues
-
-**Members**: TBD during launch phase
-
-### Futarchy Process
-
-All non-emergency decisions go through futarchy:
-
-1. Community votes on welfare metrics
-2. Proposals submitted with bonds
-3. Prediction markets determine outcomes
-4. Execute if markets indicate approval
-
-## Progressive Decentralization
-
-### Phase 1: Guarded Launch (Year 1)
-
-**Guardian Powers**:
-- Full emergency pause authority
-- Can update certain parameters
-- Monitor system closely
-
-**Rationale**: New system needs close oversight
-
-**Spending Limits**:
-- 50,000 MATIC per proposal
-- 100,000 MATIC daily aggregate
-
-### Phase 2: Increased Threshold (Year 2)
-
-**Changes**:
-- Guardian threshold: 5-of-7 → 6-of-7
-- Longer timelock periods
-- Higher spending limits
-- More community oversight
-
-**Rationale**: Require broader consensus for intervention
-
-### Phase 3: Reduced Authority (Year 3)
-
-**Changes**:
-- Guardians can only pause, not modify
-- Community can override guardian pause
-- Significantly higher spending limits
-- Automated monitoring reduces need for intervention
-
-**Rationale**: System proven stable, reduce central control
-
-### Phase 4: Full Decentralization (Year 4+)
-
-**Changes**:
-- Guardian multisig disbanded
-- All decisions via futarchy
-- Meta-governance: system governs itself
-- No special privileges for anyone
-
-**Rationale**: System mature enough for full autonomy
-
-## Governance Parameters
-
-### Adjustable Parameters
-
-Parameters that can be changed via governance:
-
-**Economic**:
-- Bond amounts (proposal, oracle, challenge)
-- Spending limits
-- LMSR liquidity parameter
-- Fee structure
-
-**Timing**:
-- Review period duration
-- Trading period range
-- Challenge period
-- Timelock duration
-
-**Welfare Metrics**:
-- Add new metrics
-- Adjust metric weights
-- Change calculation methods
-- Update data sources
-
-### Parameter Change Process
-
-1. Submit proposal for parameter change
-2. Goes through full futarchy process
-3. Market determines if change improves welfare
-4. If approved, parameter updated after timelock
-
-## Welfare Metric Governance
-
-### Current Metrics
-
-1. **Treasury Value** (Primary) - Weight: 40%
-2. **Network Activity** (Secondary) - Weight: 30%
-3. **Hash Rate Security** (Tertiary) - Weight: 20%
-4. **Developer Activity** (Quaternary) - Weight: 10%
-
-### Changing Metrics
-
-**Adding New Metrics**:
-
-1. Propose new metric definition
-2. Specify calculation methodology
-3. Provide data sources
-4. Markets decide if addition improves governance
-
-**Adjusting Weights**:
-
-1. Propose new weight distribution
-2. Justify based on protocol priorities
-3. Markets evaluate impact on decision quality
-
-## Meta-Governance
-
-### System Governs Itself
-
-Once fully decentralized, protocol upgrades go through futarchy:
-
-**Upgrade Process**:
-
-1. Propose contract upgrade
-2. Specify changes and rationale
-3. Select welfare metric (typically treasury value)
-4. Market decides if upgrade improves protocol
-5. If approved, UUPS proxy updated
-
-**Benefits**:
-
-- No external control
-- Economically optimal decisions
-- Continuous improvement
-- Self-correcting system
-
-## Emergency Procedures
-
-### When Guardians Can Pause
-
-**Valid Reasons**:
-- Critical smart contract vulnerability
-- Oracle manipulation detected
-- Market manipulation detected
-- Significant unexpected behavior
-
-**Invalid Reasons**:
-- Disagreement with community decisions
-- Political pressure
-- Personal interests
-
-### Pause Process
-
-1. Guardian multisig detects issue
-2. Threshold of guardians agree (5-of-7)
-3. Emergency pause activated
-4. Public announcement with explanation
-5. Investigation and fix
-6. Community review
-7. Unpause via futarchy vote
-
-### Overriding Guardian Pause
-
-After Year 3, community can override:
-
-1. Token holders vote
-2. Requires supermajority (67%)
-3. Unpause if approved
-4. Guardian action logged for accountability
-
-## Governance Participation
-
-### Who Can Participate
-
-**Submit Proposals**: Anyone with 50 MATIC bond
-
-**Trade on Markets**: Anyone with MATIC for gas + position collateral
-
-**Report Oracle Values**: Anyone with 100 MATIC bond
-
-**Challenge Reports**: Anyone with 150 MATIC bond
-
-**Vote on Metrics**: Token holders (if applicable)
-
-### Incentives
-
-**Aligned Incentives**:
-- Traders profit from accurate predictions
-- Proposers bond returned if legitimate
-- Oracles build reputation
-- Token value increases with good governance
-
-**Penalties**:
-- Spam proposals lose bond
-- False oracle reports lose bond
-- Frivolous challenges lose bond
-
-## Governance Analytics
-
-### Key Metrics to Track
-
-**Participation**:
-- Number of proposals per month
-- Trading volume per market
-- Number of unique traders
-- Oracle accuracy rate
-
-**Outcomes**:
-- Proposal approval rate
-- Average welfare metric improvement
-- Challenge frequency
-- Ragequit utilization
-
-**Health**:
-- Market liquidity
-- Price volatility
-- Time to resolution
-- Bond forfeiture rate
-
-## Future Governance Features
-
-### Potential Additions
-
-**Delegation**: Delegate trading/voting power
-
-**Reputation**: Track historical accuracy
-
-**Quadratic Mechanisms**: QF or QV for certain decisions
-
-**Prediction Markets for Metrics**: Markets decide metric weights
-
-**Multi-chain**: Cross-chain governance coordination
+## Operator custody
+
+During the guarded launch the admin roles are held by a **project multisig**,
+which also tunes the only on-chain parameters that exist — tier prices, the
+allowlisted stake tokens, and the treasury address. `UPGRADER_ROLE` is held
+separately, on an **air-gapped floppy keystore**, so day-to-day configuration
+and the authority to replace contract logic are never the same key.
+
+This separation is the point: a guardian can stop the protocol but cannot seize
+an account; a moderator can freeze an account but cannot pause the protocol or
+move treasury funds; a role manager can hand out memberships but cannot touch
+admin roles; an upgrader can ship new logic behind a proxy but holds no other
+privilege and cannot grant itself one.
+
+## Emergency pause
+
+`GUARDIAN_ROLE` is for incident response, not policy. Legitimate grounds are a
+credible exploit report, a discovered vulnerability, or an oracle/adapter
+compromise — **not** disagreement with how people are using the protocol. The
+process is:
+
+1. The guardian multisig detects or receives a credible report.
+2. A threshold of signers agree and activate the pause.
+3. A public notice explains what was paused and why.
+4. The issue is investigated and fixed (a fix ships as a UUPS upgrade — see the
+   [Contract upgrades runbook](../runbooks/contract-upgrades.md)).
+5. The same role calls `unpause()` to restore creation/acceptance.
+
+Because pause does not gate settlement or refunds, escrowed wagers continue to
+resolve and remain refundable even while creation/acceptance is halted.
+
+## Decentralization direction
+
+FairWins launches operator-guarded and aims to reduce that authority as the
+system proves out. The roles are already bounded (no role can move user funds),
+and the intended path is to move `DEFAULT_ADMIN_ROLE` and `UPGRADER_ROLE`
+behind a **timelock and/or a broader multisig** before scaling on mainnet, so
+upgrades and parameter changes carry a public delay window. There is no token,
+and no plan to gate the protocol behind one.
+
+## Historical note
+
+This repository began as *prediction-dao-research*, an exploration of
+**futarchy-based DAO governance** (the "ClearPath" design: welfare-metric
+oracles, conditional-token prediction markets, proposal bonds, and
+ragequit). That governance design is **not deployed and not maintained** — it
+is preserved for reference under
+[`docs/archived/`](https://github.com/chippr-robotics/prediction-dao-research/tree/main/docs/archived)
+and `contracts-archive/`. The live product is the peer-to-peer wager system
+these docs describe; its only "governance" is the bounded operator roles above.
 
 ## For More Details
 
 - [Introduction](introduction.md)
 - [How It Works](how-it-works.md)
 - [Security Model](security.md)
+- [Account Moderation Policy](account-moderation.md)
 - [Contributing Guidelines](../developer-guide/contributing.md)

--- a/docs/system-overview/security.md
+++ b/docs/system-overview/security.md
@@ -85,297 +85,90 @@ for the operational procedure.
 
 ## Threat model
 
-## Philosophy of Security
-
-Security in a decentralized wager protocol requires more than technical safeguards. It demands a thoughtful blend of cryptographic protection, economic incentives, and transparency. FairWins approaches security through layers that work together to create a resilient environment where honest participation becomes the rational choice.
-
-Think of the security model as a series of concentric circles. At the core lies the smart contract code itself, written carefully and audited thoroughly. Around that sits a layer of cryptographic privacy tools that shield individual positions while keeping aggregate data transparent. Further out, economic mechanisms create skin-in-the-game that discourages manipulation. Finally, time delays and governance checks provide humans with the breathing room needed to catch problems before they cause harm.
-
-## Understanding the Threats
-
-Before diving into defenses, let's talk about what we're defending against. Prediction markets face unique challenges because they sit at the intersection of money and information. Several threat categories matter here:
-
-**Market manipulation** occurs when someone tries to move prices artificially rather than letting them reflect genuine beliefs. Imagine a large trader buying huge amounts of PASS tokens not because they believe a proposal will work, but to create the illusion of support.
-
-**Oracle manipulation** targets the system's connection to reality. Since markets resolve based on welfare metric values reported by oracles, a dishonest reporter might submit false data to benefit their position. The challenge is ensuring oracles tell the truth even when lying could be profitable.
-
-**Vote buying and collusion** threaten the core premise that market prices aggregate genuine knowledge. If participants can be bribed or coordinate to manipulate outcomes, the system loses its predictive power. This becomes especially problematic in governance contexts where decisions affect real resources.
-
-**Smart contract exploits** represent technical vulnerabilities in the code itself. Unlike traditional systems where bugs can be patched quickly, blockchain code is immutable once deployed. A single overlooked vulnerability could compromise the entire system.
-
-**Front-running** exploits the public nature of blockchain transactions. When someone sees your trade in the mempool before it executes, they might rush to front-run you by submitting a transaction with higher gas fees, profiting from the price movement your trade will cause.
-
-Some threats fall outside our scope. We don't defend against nation-state level attacks on the underlying blockchain, physical coercion of participants, or complete network compromise. These require different approaches at the infrastructure layer.
-
-## How User Data Stays Private
-
-Privacy in a public blockchain context seems paradoxical at first. Every transaction gets recorded permanently and publicly. Yet participants in prediction markets need privacy to prevent coordination, vote buying, and social pressure from corrupting their honest assessments.
-
-The platform solves this through two complementary systems borrowed from cutting-edge research: Nightmarket for position encryption and MACI for anti-collusion.
-
-### Position Encryption with Nightmarket
-
-When you trade on a prediction market, your exact position size and direction remain hidden even though the trade gets recorded on-chain. Here's how that works in practice.
-
-Imagine you want to buy 100 PASS tokens for a proposal. Instead of broadcasting "Alice buys 100 PASS tokens," your wallet creates a cryptographic commitment. This commitment acts like a sealed envelope that proves you made a valid trade without revealing the details inside.
-
-The commitment uses a Poseidon hash, which is specially designed to work efficiently with zero-knowledge proofs. Your wallet generates a proof that demonstrates several things simultaneously: you have sufficient balance, you're not double-spending, and your trade falls within valid parameters. All of this happens without revealing your identity, position size, or trading direction.
-
-These encrypted positions get submitted to the PrivacyCoordinator contract, which batches them together with other trades in the same epoch. An epoch lasts one hour, and all positions within that epoch get processed together. This batching prevents timing analysis where observers might correlate the timing of your on-chain transaction with price movements to infer your position.
-
-From the public perspective, the blockchain shows aggregate data: total trading volume, the overall price movement, the number of positions submitted. Individual positions remain private, viewable only by you through your private keys.
-
-### Key Changes to Prevent Vote Buying
-
-The MACI (Minimal Anti-Collusion Infrastructure) component addresses a more subtle problem. Even with encrypted positions, someone might try to bribe you by saying "show me your private key after you vote for my preferred outcome, and I'll pay you."
-
-MACI makes this unenforceable through key-change messages. When you register with the system, you submit a public key. All your encrypted positions use this key. But at any time, you can submit a key-change message (encrypted with your old key so only you can create it) that establishes a new public key.
-
-This key change invalidates all your previous positions. So if someone bribes you to vote a certain way, you can accept their payment, vote as you actually believe, then change your key. The briber cannot verify whether you kept your promise because your key change makes your original encrypted positions unverifiable.
-
-The beauty of this approach is that it makes vote buying economically irrational for the briber. They have no way to enforce the agreement, so rational actors won't pay for unverifiable votes.
-
-### Preventing Front-Running
-
-Traditional exchanges suffer from front-running because pending transactions sit visibly in the mempool. Bots monitor the mempool and submit competing transactions with higher gas fees to execute first, profiting from the price movement they know is coming.
-
-The batch processing approach naturally prevents this. Your encrypted position goes into a batch with dozens of others, and the batch gets processed atomically. No one can see your specific trade to front-run it. They only see the aggregate effect after the epoch closes.
-
-## Economic Security Through Bonds
-
-The platform uses financial stakes to align incentives with honest behavior. This bond system creates a situation where honesty becomes the most profitable strategy.
-
-When you submit a proposal, you post a 50  bond. This bond gets returned if your proposal goes through the process in good faith, even if it ultimately gets rejected by the markets. But if you submit spam or clearly malicious proposals, the bond gets slashed.
-
-This creates a simple calculation: is the potential gain from spamming the system worth losing 50 MATIC? For genuine proposers, the bond represents a recoverable deposit. For spammers, it becomes an expensive barrier.
-
-Oracle reporters face a similar dynamic but with higher stakes. Reporting welfare metric values requires a 100  bond. If the community accepts your report, you get the bond back. If someone successfully challenges your report as inaccurate, you lose the bond.
-
-The interesting part comes with challenges. To challenge an oracle report, you must post a 150  bond that exceeds the reporter's stake. This asymmetry serves a purpose. Challenging should be accessible enough that false reports get caught, but expensive enough that frivolous challenges don't clog the system.
-
-If your challenge succeeds, you get your bond back plus a portion of the slashed reporter bond as a reward. If your challenge fails because the original report was accurate, you lose your bond. This creates a two-sided incentive: reporters want to tell the truth to keep their bond, and challengers want to only challenge when they have strong evidence.
-
-### Access Controls and Timelock Protection
-
-The system includes a guardian multisig that can trigger an emergency pause. This represents a pragmatic balance between security and decentralization during the early phases.
-
-Initially, the guardian multisig requires 5 signatures out of 7 total guardians. These guardians have limited powers: they can pause the system in response to a discovered vulnerability, but they cannot modify proposals, steal funds, or change outcomes.
-
-Every proposal includes a 2-day timelock before execution. This delay serves multiple purposes. First, it gives the community time to review the proposal one last time and notice any issues. Second, it opens a window for the ragequit mechanism, allowing dissenting token holders to exit with their proportional share of the treasury if they strongly disagree with an approved proposal.
-
-Spending limits add another layer of defense. No single proposal can request more than 50,000. and the daily aggregate across all proposals caps at 100,000. These limits prevent a compromised system or malicious proposal from draining the entire treasury at once.
-
-### Progressive Decentralization Over Time
-
-Security doesn't mean keeping control centralized forever. The guardian powers decrease on a fixed schedule, eventually disappearing entirely as the system proves its resilience.
-
-In year one, guardians have full emergency pause authority. They can respond quickly to threats while the system is new and more vulnerable. During year two, the multisig threshold increases to 6-of-7, making emergency actions require broader consensus among guardians.
-
-By year three, guardian authority shrinks to pause-only powers. They lose the ability to make parameter changes or upgrades, even in emergencies. By year four and beyond, the guardian multisig dissolves completely, leaving the system fully under community control through the futarchy mechanism itself.
-
-This timeline balances security with the eventual goal of decentralization. New systems carry higher risks that justify more centralized safeguards. As the system matures and proves robust, those safeguards can fade away safely.
-
-## Oracle Security and Truth
-
-Oracles connect prediction markets to reality. When a proposal's trading period ends, an oracle determines the actual welfare metric values under both the PASS and FAIL scenarios. This connection to ground truth makes oracle security critical.
-
-The platform uses a multi-stage process designed to encourage accurate reporting while making manipulation expensive and risky.
-
-### Designated Reporting Phase
-
-Anyone can become the designated reporter by being first to submit a report with the required 100  bond. This report includes welfare metric values for both scenarios (what would happen if the proposal passes, what would happen if it fails) along with evidence supporting those values.
-
-The evidence typically takes the form of an IPFS hash pointing to a detailed document showing methodology, data sources, calculations, and timestamps. This transparency allows the community to verify the reporter's work.
-
-For three days, the report sits in a settlement window. During this time, the community can examine the evidence and decide whether it looks accurate.
-
-### Challenge Period
-
-Following settlement, a two-day challenge period begins. If someone believes the report is inaccurate, they can challenge it by posting a 150  bond and providing counter-evidence.
-
-The higher bond requirement for challenges prevents cheap griefing while ensuring serious challenges can proceed. If you genuinely believe a report is false and you have strong evidence, risking 150  to correct it and potentially earn rewards makes sense. If you're just hoping to delay things or cause trouble, the high cost deters you.
-
-### Escalation and Final Resolution
-
-If a challenge appears, the dispute escalates to UMA, a decentralized truth oracle that uses token holder voting to resolve disagreements. UMA voters examine both sides' evidence and vote on which is more accurate.
-
-This escalation mechanism provides a final arbiter while keeping most resolutions simple. The vast majority of reports should be straightforward and uncontested, with escalation happening only when genuine disagreement exists.
-
-Bonds get distributed based on the outcome. If the original report stands, the challenger loses their bond, and the reporter keeps theirs. If the challenge succeeds, the reporter loses their bond, the challenger gets theirs back plus a reward, and the market resolves using the corrected values.
-
-### Time-Weighted Average Pricing
-
-For metrics like treasury value, the system uses time-weighted average price (TWAP) oracles rather than spot prices. TWAP calculates the average price over a period, making manipulation much more expensive.
-
-A manipulator would need to maintain an artificial price for the entire averaging period, not just manipulate a single moment. This dramatically increases the cost of manipulation while providing more stable, representative values for governance decisions.
-
-## Smart Contract Security Practices
-
-The smart contract code itself represents the foundation of security. Several practices minimize the risk of vulnerabilities.
-
-### Established Patterns and Audited Libraries
-
-Wherever possible, the contracts use OpenZeppelin libraries. These libraries have been audited extensively and battle-tested across thousands of projects. Rather than reinventing core functionality like access control or token handling, building on OpenZeppelin reduces the surface area for bugs.
-
-### Reentrancy Guards
-
-All functions that involve external calls or value transfers include reentrancy guards. These guards prevent the classic attack where a malicious contract calls back into your contract during execution, potentially executing critical functions multiple times in an unexpected way.
-
-### Integer Overflow Protection
-
-Solidity 0.8 and later includes built-in overflow checking, automatically reverting transactions that would overflow or underflow. This eliminates an entire class of vulnerabilities that plagued earlier contracts.
-
-### Comprehensive Access Control
-
-Every sensitive function checks that the caller has appropriate permissions. Only the FutarchyGovernor can activate proposals. Only registered reporters can submit oracle values. Only the system itself can resolve markets and distribute rewards.
-
-### Audit Requirements and Bug Bounties
-
-Before any mainnet deployment, the platform requires a minimum of two independent security audits from reputable firms. These audits involve expert security researchers examining the code line-by-line, looking for vulnerabilities, testing edge cases, and verifying that the implementation matches the specification.
-
-Following audits, a bug bounty program with 100,000 USD in  reserves rewards security researchers who find and responsibly disclose vulnerabilities. This ongoing incentive helps catch issues even after deployment.
-
-Formal verification of critical functions uses mathematical proofs to guarantee certain properties hold under all possible conditions. While formal verification can't catch every bug, it provides extremely high confidence in core invariants like "the total bond pool always equals the sum of individual bonds."
-
-## Real-World Security Scenarios
-
-Understanding security mechanisms in theory helps, but seeing them work through concrete examples makes the picture clearer.
-
-### Scenario: Attempted Market Manipulation
-
-Consider a wealthy trader, Alice, who wants to manipulate a proposal's market to make it look more popular than it deserves. She starts buying large amounts of PASS tokens, trying to push the price up and create the illusion of community support.
-
-The LMSR market maker handles this gracefully. As Alice buys more PASS tokens, the price increases, but with bounded impact. The logarithmic cost function means each additional token costs more than the last, making manipulation increasingly expensive. Alice might be able to move the price somewhat, but she cannot push it arbitrarily high without spending astronomical amounts.
-
-Meanwhile, other traders see the artificially high price and recognize an opportunity. If they believe Alice's assessment is wrong, they can sell PASS tokens or buy FAIL tokens at what they consider favorable prices. The market self-corrects as rational traders take the other side of Alice's position.
-
-The privacy mechanisms prevent Alice from targeting or bribing specific traders. She cannot see who holds large positions that could counteract hers. She cannot offer targeted bribes because she cannot verify whether someone actually changed their position after accepting payment.
-
-Finally, the multi-day trading period (7-21 days) means Alice would need to maintain her manipulation for an extended period while other traders have time to respond. This makes manipulation not just expensive but unsustainable.
-
-### Scenario: False Oracle Report
-
-Bob becomes a designated reporter and submits welfare metric values. He posts the required 100  bond and provides an IPFS hash to his evidence. But Bob has made a critical error in his calculations, or perhaps he is deliberately trying to manipulate the outcome.
-
-During the three-day settlement window, community member Carol reviews Bob's evidence. She notices the error and gathers correct data showing the actual welfare metric values differ significantly from Bob's report.
-
-Carol decides to challenge the report. She posts a 150  bond and submits her counter-evidence with corrected calculations. The dispute escalates to UMA's oracle system.
-
-UMA token holders examine both sides' evidence. Carol's evidence includes raw data, correct methodology, and independently verifiable calculations. Bob's evidence contains the error. UMA voters recognize Carol's submission as accurate and vote accordingly.
-
-As a result, Bob loses his 100  bond (slashed for false reporting), Carol gets her 150  back plus a portion of Bob's slashed bond as a reward, and the market resolves using the correct values Carol provided.
-
-This outcome accomplishes several things. Bob faced real financial consequences for his error or attempted manipulation. Carol got compensated for doing the work to correct the record. Future reporters see that accuracy matters and sloppy or malicious reporting carries costs. The market participants ultimately get the correct resolution despite Bob's initial false report.
-
-### Scenario: Attempted Vote Buying
-
-David holds governance tokens and sees a proposal coming up for vote. Eve, who stands to benefit significantly if the proposal passes, approaches David with an offer. "Vote for this proposal," she says, "show me your encrypted private key after voting so I can verify you did it, and I'll pay you 1 ETH."
-
-David accepts the offer and registers a public key with the system. He submits encrypted positions buying PASS tokens, using Eve's payment to fund the purchase. Eve monitors the blockchain and sees encrypted positions being submitted during the right timeframe.
-
-After the epoch closes, David sends Eve what appears to be his private key. Eve thinks she can verify his vote. But David has been clever. Before sending the key, he submitted a key-change message using his actual key. This message, encrypted so only he could create it, established a new public key and invalidated all his previous positions.
-
-The "private key" David sent to Eve is actually a decoy. Even if Eve tries to decrypt his positions with it, she gets garbage data or positions that no longer matter because they were invalidated by his key change. David then uses his real key to submit new positions reflecting his actual beliefs about the proposal.
-
-Eve realizes she has no way to verify whether David kept his promise. She cannot distinguish between David changing his vote after accepting payment or David never voting for her proposal in the first place. This uncertainty makes vote buying economically irrational for future buyers like Eve. They're paying for promises they cannot verify.
-
-### Scenario: Smart Contract Vulnerability Discovered
-
-Frank, a security researcher, finds a potential vulnerability in the market making contract. Instead of exploiting it, he responsibly discloses it to the team through the security email.
-
-The guardian multisig receives the report and evaluates the severity. This looks like a real issue that could allow manipulation under specific conditions. The guardians trigger an emergency pause, freezing proposal submissions and trading while preserving all existing positions and bonds.
-
-The development team creates a fix and deploys it using the UUPS proxy upgrade mechanism. The fix goes through expedited review by the auditors who examined the original code. Once verified, the upgrade transaction gets queued with appropriate timelock.
-
-After the timelock period passes without issues, the upgrade executes. The guardians unpause the system. Frank receives a bug bounty reward for his responsible disclosure. The team publishes a post-mortem explaining what happened, how it was fixed, and what steps are being taken to prevent similar issues.
-
-This incident actually strengthens trust in the system. The vulnerability got caught and fixed before any exploitation. The response was transparent and professional. Frank's reward incentivizes other researchers to look for issues rather than exploit them.
-
-## Monitoring and Response
-
-Security is not a one-time achievement but an ongoing process requiring constant vigilance.
-
-### What Gets Monitored
-
-The system tracks several key metrics that could indicate security issues:
-
-Unusual trading volumes might suggest manipulation attempts or system gaming. Rapid price movements inconsistent with genuine information could indicate front-running or coordination. Failed transactions clustered together might reveal someone probing for vulnerabilities.
-
-Bond forfeiture rates provide insight into the health of the incentive system. If many proposers or reporters lose their bonds, either the system is working correctly to punish bad behavior, or the bond amounts might need adjustment.
-
-Challenge rates on oracle reports indicate whether the reporting system functions properly. Too few challenges might mean reports are accurate, or it might mean the challenge bond is too high. Too many challenges might indicate widespread disputes about data or attempts to grief reporters.
-
-### Incident Response
-
-When something goes wrong, the response follows a structured process rather than chaotic improvisation.
-
-Detection happens through automated monitoring and community reports. The monitoring system alerts guardians when metrics cross certain thresholds. Community members can also report suspicious activity or discovered vulnerabilities.
-
-Assessment involves the guardians evaluating severity and determining the appropriate response. Is this a critical issue requiring immediate pause? A medium issue that needs addressing but not emergency action? Or a false alarm that requires no response?
-
-Response actions depend on severity. Critical issues trigger the emergency pause while the team investigates and develops a fix. Medium issues might get addressed through the normal upgrade process. Minor issues get documented and queued for the next regular maintenance.
-
-Resolution includes implementing the fix, testing it thoroughly, deploying through appropriate channels (expedited for emergencies, normal governance process for non-critical issues), and verifying the fix resolves the issue.
-
-Finally, post-mortem reports document what happened, what the root cause was, how it was fixed, and what steps prevent similar issues in the future. This transparency builds trust and helps the entire ecosystem learn from incidents.
-
-## Best Practices for Users
-
-Security tools only work when users employ them correctly. Here are practical recommendations for different types of participants.
-
-### For Everyone
-
-Hardware wallets provide the strongest protection for significant holdings. While convenient, browser extension wallets remain more vulnerable to phishing and malware. For amounts worth protecting, hardware wallets offer reasonable cost-benefit tradeoffs.
-
-Verify contract addresses before interacting with them. Phishing sites often look identical to legitimate ones but interact with malicious contracts. Double-checking the address against official sources takes seconds and prevents most scams.
-
-Never share private keys, seed phrases, or password-encrypted key files. Legitimate services never ask for these. Anyone requesting them is trying to steal your funds.
-
-Watch for phishing attempts in email, social media, and chat. Attackers often impersonate team members, create fake support channels, or promote scam versions of legitimate sites. Verify through official channels before trusting communications from unfamiliar sources.
-
-### For Traders
-
-Start with small positions while you learn the system. Experimenting with amounts you can afford to lose lets you understand the mechanics without risking serious capital. Scale up as you gain confidence and understanding.
-
-Use key changes if anything feels suspicious. If someone approaches you about coordinating trades, if you suspect vote buying attempts, or if you just want additional privacy, submitting a key-change message takes moments and invalidates any previous commitments.
-
-Monitor your positions regularly through the interface. While positions remain private, you can see your own holdings and verify that trades executed as expected.
-
-Report anomalies you observe. If you notice unusual behavior, suspicious patterns, or potential vulnerabilities, reporting helps protect the entire community.
-
-### For Proposers
-
-Provide accurate, complete information in your proposals. Misleading the community might seem advantageous short-term, but it risks your bond and your reputation while harming trust in the system.
-
-Respond to questions and concerns during the review period. Engagement shows good faith and helps the community make informed assessments. Going silent often raises suspicions.
-
-Avoid promising unrealistic outcomes. Markets work best when participants make honest predictions about effects, not when proposers oversell benefits or hide costs.
-
-Engage honestly with the community throughout the process. The goal is not just getting your proposal approved but building trust and demonstrating competence that benefits future endeavors.
-
-## Looking Toward Mainnet
-
-Current deployments are research code on testnet. Before mainnet launch, several additional security measures become critical.
-
-Two independent security audits from reputable firms provide professional review of the codebase. Different auditors catch different issues, and multiple perspectives improve coverage.
-
-The bug bounty program with 100,000 USD in  reserves rewards ongoing security research. This incentive helps discover vulnerabilities before attackers can exploit them.
-
-Formal verification of critical functions provides mathematical proofs that certain properties always hold. While expensive and time-consuming, formal verification offers the highest confidence for core components.
-
-A 30-day community review period after audits complete gives the entire ecosystem time to examine findings, test fixes, and raise concerns before launch.
-
-Extended testnet deployment under conditions mimicking mainnet helps discover issues that only appear under real-world usage patterns. The testnet phase should include stress testing, attempts at manipulation, and exploration of edge cases.
+FairWins is a peer-to-peer wager layer, so its threats are about **settlement
+and escrow integrity between two parties** — not the manipulation risks of an
+order book or a prediction market. The main ones, and how the protocol handles
+them:
+
+| Threat | Mitigation |
+|--------|------------|
+| The loser refuses to pay | Both stakes are escrowed in `WagerRegistry` at acceptance; the contract pays the winner directly. No counterparty action is needed to get paid. |
+| The parties disagree on the outcome | The settler is fixed **at creation** (you, your opponent, a named arbitrator, or an oracle). A draw requires mutual consent (or the arbitrator's ruling) and returns each side's own stake. |
+| An oracle never reports, or reports an invalid/tied result | After the resolve deadline anyone can trigger a refund — both stakes return to their owners. Tied/invalid oracle outcomes settle as a draw. Funds are never stranded. |
+| Funds get stuck in a half-finished flow | Every state has an exit: un-accepted offers refund after the acceptance deadline (and `batchExpireOpen` sweeps stale ones); active wagers refund after the resolve deadline. Payouts are pull-based and idempotent. |
+| Sanctioned or restricted use | `SanctionsGuard` screens both parties on create and accept against the Chainalysis oracle plus an operator deny list, and is **fail-closed** — an unreachable oracle means *not allowed*. |
+| Operator overreach | Powers are split across bounded roles (above); none can move escrowed stakes, redirect a payout, or forge a result. |
+| Smart-contract exploit | Checks-effects-interactions, audited OpenZeppelin primitives, reentrancy guards, pull payments, and a CI security pipeline (below). A guardian can pause new activity while a fix ships as a UUPS upgrade. |
+| Front-running / MEV | Stakes are fixed amounts with no order book and no price to move, so the usual trade-ordering MEV does not apply. Wager terms can be end-to-end encrypted so the mempool reveals only a hash. |
+
+Out of scope: attacks on the underlying chain, physical coercion, and
+compromise of a user's own wallet or keys. Those are addressed at the
+infrastructure and user-operational-security layers.
+
+## Smart-contract security practices
+
+- **Audited libraries.** The contracts build on OpenZeppelin primitives
+  (`AccessControl`, `Pausable`, `ReentrancyGuard`, `SafeERC20`, and the UUPS
+  proxy machinery) rather than re-implementing core functionality.
+- **Checks-effects-interactions and pull payments.** State is updated before
+  external calls, and winners *claim* their pot (`claimPayout`) rather than
+  receiving a push transfer — eliminating reentrancy and forced-send footguns.
+- **Reentrancy guards** on the value-moving functions, as defence in depth.
+- **Overflow safety.** Solidity 0.8+ reverts on overflow/underflow by default.
+- **Comprehensive access control.** Every privileged function is gated by an
+  explicit role; the sensitive `MembershipManager` hooks only accept calls from
+  the authorised `WagerRegistry`.
+- **CI security pipeline.** Every change must pass the unit / integration /
+  fork test suites, **Slither** static analysis, and **Medusa** fuzzing — these
+  gates are not allowed `continue-on-error`. See
+  [Security Testing](../security/index.md) and the binding standards in
+  `.specify/memory/constitution.md`.
+- **Upgrade safety.** Storage-layout compatibility is validated
+  (`npm run check:storage-layout`) before any UUPS upgrade, so a
+  state-corrupting layout fails in CI rather than on-chain.
+
+## Private wager terms
+
+The on-chain record (addresses, stakes, token, deadlines, status) is public,
+like all blockchain data. The **terms** of a wager can be end-to-end encrypted
+client-side: the chain stores only a keccak hash and an IPFS pointer, and only
+the participants (plus the arbitrator, if any) hold keys to decrypt the
+content. Envelopes use the X-Wing hybrid KEM (X25519 + ML-KEM-768), with public
+keys published in the on-chain `KeyRegistry`. Full detail:
+[Privacy Mechanisms](privacy.md).
+
+(The earlier research design for *position* privacy — Poseidon commitments,
+zero-knowledge proofs, and MACI-style anti-collusion — belonged to the archived
+futarchy/governance system and is **not** part of the deployed wager protocol.)
+
+## Best practices for users
+
+- **Use a hardware wallet** for meaningful balances; browser-extension wallets
+  are more exposed to phishing and malware.
+- **Verify contract addresses** against the records in
+  [`deployments/`](https://github.com/chippr-robotics/prediction-dao-research/tree/main/deployments)
+  before interacting — phishing sites mimic the UI but point at malicious
+  contracts.
+- **Never share** private keys, seed phrases, or keystore files. No legitimate
+  FairWins flow ever asks for them.
+- **Watch for impersonation** in email, social media, and chat; confirm through
+  official channels before trusting unfamiliar communications.
+
+## Security testing and disclosure
+
+The contract suite runs the security pipeline above on every change, and all
+deployed addresses are recorded in the repository's `deployments/` directory so
+you can verify exactly what you are interacting with. Hardening continues as the
+protocol scales on mainnet — including moving admin and upgrade authority behind
+a timelock/multisig (see [Governance](governance.md#decentralization-direction)).
+
+For security concerns requiring confidential disclosure, email
+**security@fairwins.app** with a detailed description and reproduction steps.
 
 ## For More Details
 
-The [Privacy Mechanisms](privacy.md) documentation covers cryptographic implementations in depth.
-
-The [Introduction](introduction.md) provides system overview context.
-
-The [How It Works](how-it-works.md) guide explains operational details.
-
-The [Governance](governance.md) documentation describes the decentralization roadmap.
-
-For security concerns requiring confidential disclosure, email security@example.com with detailed description and reproduction steps. Responsible disclosure earns bug bounty eligibility and credit for improving the system's security.
-
+- [Privacy Mechanisms](privacy.md) — envelope encryption for wager terms.
+- [Introduction](introduction.md) — system overview context.
+- [How It Works](how-it-works.md) — the wager lifecycle and exit paths.
+- [Governance](governance.md) — operator roles and the decentralization direction.
+- [Account Moderation Policy](account-moderation.md) — the freeze power in full.


### PR DESCRIPTION
## Why

`docs/system-overview/governance.md` and `security.md` still documented the **archived futarchy / ClearPath DAO** design — welfare-metric oracles, PASS/FAIL conditional-token prediction markets, LMSR, MATIC proposal/oracle/challenge bonds, ragequit, Nightmarket position encryption, MACI anti-collusion, and a multi-year *"all decisions via futarchy"* roadmap. None of those contracts are deployed (they live in `contracts-archive/` only), so the pages contradicted the actual peer-to-peer wager protocol. This is the cleanup deferred from #735.

## governance.md

- **Kept** the accurate operator-roles section (the 5-role table, pause, freeze).
- **Replaced** the futarchy roadmap with an honest account: operator custody (project multisig + air-gapped `UPGRADER_ROLE`), an emergency-pause process, a real decentralization direction (move admin/upgrade authority behind a timelock/multisig — **no token, no on-chain voting**), and a historical note pointing at `docs/archived/`.

## security.md

- **Kept** the accurate *Operator powers* and *Contract upgradeability* (UUPS) sections.
- **Replaced** the futarchy threat model, Nightmarket/MACI privacy, bond economics, oracle-reporting flow, and PASS/FAIL manipulation scenarios with:
  - a **P2P-wager threat model** (settlement/escrow integrity, oracle-never-reports → refund, sanctions, operator overreach, exploits, MEV),
  - accurate **smart-contract security practices** (OZ libs, checks-effects-interactions, pull payments, reentrancy guards, Slither/Medusa CI gates, storage-layout gate),
  - an **envelope-encryption** pointer to `privacy.md` (with an explicit note that the Poseidon/MACI position-privacy design is archived),
  - trimmed **user best practices**,
  - the **correct disclosure address** `security@fairwins.app` (was the placeholder `security@example.com`).

## Verification

- Inbound anchor links preserved (`security.md#operator-powers` from account-moderation.md; `governance.md#decentralization-direction`).
- No broken internal links/anchors.
- The only remaining "futarchy" mentions are the explicit *archived / not deployed* historical notes.
- Net: **−531 / +144** lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)