### PR TITLE
docs(specs): validate + close shipped tasks across 024/025/026/027

### DIFF
--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -107,14 +107,29 @@ Each script saves a JSON file to `deployments/`:
 - `<network>-chain<chainId>-markets-deployment.json`
 - `<network>-chain<chainId>-registries-deployment.json`
 
-## Upgradeable WagerRegistry (UUPS proxy)
+## Upgradeable contracts (UUPS proxies)
 
-`WagerRegistry` deploys as a **UUPS proxy** (via `scripts/deploy/lib/upgradeable.js`).
-The deployment artifact records two addresses: `wagerRegistry` (the stable
-**proxy** address that the frontend and subgraph consume) and
-`wagerRegistryImpl` (the current logic implementation, which changes on every
-upgrade). If a prior non-upgradeable registry coexists, it is recorded as
+Two contracts deploy as **UUPS proxies** (via `scripts/deploy/lib/upgradeable.js`):
+`WagerRegistry` (spec 025) and `MembershipManager` (spec 027). Each records a
+stable **proxy** address (consumed by the frontend and subgraph) plus a current
+**implementation** address (changes on every upgrade):
+
+| Contract | Proxy key | Implementation key |
+|----------|-----------|--------------------|
+| WagerRegistry | `wagerRegistry` | `wagerRegistryImpl` |
+| MembershipManager | `membershipManager` | `membershipManagerImpl` |
+
+If a prior non-upgradeable registry coexists, it is recorded as
 `wagerRegistryLegacy` (settle-only).
+
+**Registry → membership repoint (cutover).** `WagerRegistry` resolves
+membership against the `MembershipManager` **proxy**. On a fresh full deploy the
+registry is initialized pointing at the proxy directly; when migrating a network
+whose registry pointed at a non-proxy membership authority, repoint it with
+`WagerRegistry.setMembershipManager(<membershipManager proxy>)` at cutover (and
+withdraw any accrued fees from the legacy authority via its admin path). The
+voucher rail (spec 026) ships as the **first in-place upgrade** of the
+`membershipManager` proxy — never a redeploy.
 
 **Pre-flight gate.** Before deploying or upgrading, run:
 

--- a/specs/024-open-challenge-wagers/tasks.md
+++ b/specs/024-open-challenge-wagers/tasks.md
@@ -35,9 +35,9 @@ The Graph indexer in `subgraph/`, deploy/sync utilities in `scripts/`.
 
 **Purpose**: Scaffolding and dependency confirmation. No behavior change. Builds on the existing repo.
 
-- [ ] T001 Create the claim-code module and test directories: `frontend/src/utils/claimCode/` and
+- [X] T001 Create the claim-code module and test directories: `frontend/src/utils/claimCode/` and
   `frontend/src/test/claimCode/` (empty placeholders are fine; files land in Phase 2).
-- [ ] T002 [P] Verify no new dependencies are needed (plan.md "No new dependencies"): confirm
+- [X] T002 [P] Verify no new dependencies are needed (plan.md "No new dependencies"): confirm
   `@openzeppelin/contracts` exposes `utils/cryptography/EIP712.sol` and `utils/cryptography/ECDSA.sol`,
   and that `frontend/package.json` already pins `ethers` (v6, bundled `LangEn`), `@noble/ciphers`, and
   `@noble/hashes`. Record the resolved versions in `specs/024-open-challenge-wagers/research.md` if any
@@ -240,17 +240,17 @@ cannot be reused by an observer, and a four-word brute force is impractical with
 
 ### Tests for User Story 2 (write first, must fail) ⚠️
 
-- [ ] T028 [P] [US2] Write FAILING signature/anti-front-run unit tests in
+- [X] T028 [P] [US2] Write FAILING signature/anti-front-run unit tests in
   `test/WagerRegistry.openChallenge.test.js`: a wrong-key signature → `BadClaimSignature`; a signature
   bound to a *different* `taker` or `wagerId` (replay/front-run attempt) → `BadClaimSignature`; a
   malleable-`s` signature is rejected by `ECDSA.recover`; an unset claim slot can never be satisfied by a
   forged accept. (FR-011/SC-006, research.md R1)
-- [ ] T029 [P] [US2] Write FAILING accept-gauntlet unit tests in `test/WagerRegistry.openChallenge.test.js`:
+- [X] T029 [P] [US2] Write FAILING accept-gauntlet unit tests in `test/WagerRegistry.openChallenge.test.js`:
   creator self-accept → `SelfWager`; named arbitrator accepting a ThirdParty open challenge →
   `ArbitratorCannotTake`; non-member taker → `MembershipDenied`; sanctioned taker / sanctioned creator →
   sanctions revert; frozen taker → revert; **a Bronze (lowest active tier) taker with the code SUCCEEDS** —
   participation has no tier floor (FR-005a/FR-013). (FR-013/014/015, SC-007)
-- [ ] T030 [P] [US2] Write FAILING create-guard unit tests in `test/WagerRegistry.openChallenge.test.js`:
+- [X] T030 [P] [US2] Write FAILING create-guard unit tests in `test/WagerRegistry.openChallenge.test.js`:
   `Creator` or `Opponent` resolution type → `OpenResolutionTypeNotAllowed`; zero `claimAuthority` →
   `ZeroClaimAuthority`; a second open wager reusing an already-`Open` authority → `ClaimAuthorityInUse`;
   (equal stakes are enforced by the single-`stake` param — assert `creatorStake == opponentStake`); a
@@ -263,13 +263,13 @@ cannot be reused by an observer, and a four-word brute force is impractical with
 
 ### Implementation for User Story 2
 
-- [ ] T032 [US2] Confirm and, if needed, tighten the US1 contract checks so every assertion in T028–T030
+- [X] T032 [US2] Confirm and, if needed, tighten the US1 contract checks so every assertion in T028–T030
   passes in `contracts/wagers/WagerRegistry.sol` (the CEI gauntlet from T016/T017 should already cover
   these; add any missing revert/branch). No new public surface.
 - [X] T033 [US2] Add the non-member buy-membership prompt to
   `frontend/src/components/fairwins/TakeChallengeModal.jsx`: when the taker lacks active membership, block
   acceptance and route to the existing membership-purchase flow (no open-challenge exemption). (FR-013)
-- [ ] T033a [US2] Ensure no "decline" affordance is shown for open challenges in the wager-management UI
+- [X] T033a [US2] Ensure no "decline" affordance is shown for open challenges in the wager-management UI
   (e.g. `frontend/src/components/fairwins/` wager views): an open challenge only ever exposes the creator's
   cancel/withdraw action while Open — never a decline button — mirroring the contract guard. (FR-023/FR-025)
 - [X] T034 [US2] Add the honest-state notices to
@@ -287,7 +287,7 @@ cannot be reused by an observer, and a four-word brute force is impractical with
   and show an upgrade prompt (mirrors the contract `InsufficientMembershipTier`). The take/accept flow is
   unaffected — any active tier may participate. Add a Vitest case asserting the option is hidden/disabled
   below Silver and enabled at Silver+. (FR-005a, SC honest-state)
-- [ ] T036 [US2] Ensure discovery indistinguishability in the frontend: open challenges are never listed or
+- [X] T036 [US2] Ensure discovery indistinguishability in the frontend: open challenges are never listed or
   rendered identifiably without the code (no public list endpoint reveals which entry is which); a holder
   reaches the wager only via `openWagerIdForClaim`. Verify in `frontend/src/hooks/useOpenChallengeAccept.js`
   and any wager-listing view. (FR-008)
@@ -307,14 +307,14 @@ the others revert, and the terms were readable to every code-holder. (spec US3 I
 
 ### Tests for User Story 3 (write first, must fail) ⚠️
 
-- [ ] T037 [P] [US3] Write a FAILING race/double-accept unit test in
+- [X] T037 [P] [US3] Write a FAILING race/double-accept unit test in
   `test/WagerRegistry.openChallenge.test.js`: two members submit valid code-derived signatures; exactly one
   binds as opponent, the second reverts `NotOpenChallenge` (status no longer `Open`), and no funds are
   taken from the loser. (SC-005, quickstart §1 "two members race")
 
 ### Implementation for User Story 3
 
-- [ ] T038 [US3] Add a public-challenge sharing affordance to
+- [X] T038 [US3] Add a public-challenge sharing affordance to
   `frontend/src/components/fairwins/FriendMarketsModal.jsx` (share-the-code openly / "anyone with the code
   can take" copy) and ensure the take flow handles a lost race gracefully ("already accepted" rather than a
   raw revert) in `frontend/src/components/fairwins/TakeChallengeModal.jsx`. (US3, FR-012/025)
@@ -339,7 +339,7 @@ this funds-bearing change can ship.
   `specs/024-open-challenge-wagers/research.md` that existing oracle fork coverage applies unchanged because
   post-accept behavior is identical to a named-opponent wager (FR-016). (Constitution II — fork tests where
   oracles are involved)
-- [ ] T041 Run the FULL existing contract suite (`npm test`) and confirm zero regressions in the
+- [X] T041 Run the FULL existing contract suite (`npm test`) and confirm zero regressions in the
   named-opponent create/accept/cancel/decline/resolve/draw/refund/claim flows. (FR-024, SC-008)
 - [ ] T042 [P] Run `npm run slither` and confirm no new high/critical findings on the changed paths;
   document EthTrust-SL ≥ L2 reasoning + the v1 residual-brute-force acceptance (FR-003a) in
@@ -368,13 +368,13 @@ frontend/subgraph repoint** (only the ABI gains the new fns/events). Until 025's
 024 cannot deploy there. Testnet (Amoy) first, mainnet (Polygon) after validation + sign-off. Mordor/ETC are
 legacy read-only and out of scope (spec Assumptions).
 
-- [ ] T047 Deploy 024 to **Amoy** (chainId 80002) as a **UUPS implementation upgrade** of the 025 proxy:
+- [X] T047 Deploy 024 to **Amoy** (chainId 80002) as a **UUPS implementation upgrade** of the 025 proxy:
   run the OZ storage-layout compatibility check, deploy the new `WagerRegistry` implementation, then
   `upgradeToAndCall` via the proxy admin role (floppy-keystore keys, 25 gwei floor) — the **proxy address
   does not change**. Update `deployments/amoy-chain80002-v2.json` with the new implementation address, run
   `npm run sync:frontend-contracts:amoy` (ABI gains the new fns/events; address unchanged) and
   `npm run verify:amoy`. (depends on 025 proxy live on Amoy)
-- [ ] T048 Deploy the v2 subgraph for Amoy with the new `OpenWagerCreated` handler (`fairwins-amoy`,
+- [X] T048 Deploy the v2 subgraph for Amoy with the new `OpenWagerCreated` handler (`fairwins-amoy`,
   Studio) and confirm it indexes open wagers with `opponent = null` / `status = open` and no indexing
   errors; smoke-test discovery against the Amoy deployment. (subgraph deploy flow, research.md R5)
 - [ ] T049 Validate on Amoy via quickstart §5 end-to-end (including the Silver+ create gate and the

--- a/specs/025-upgradeable-registry/tasks.md
+++ b/specs/025-upgradeable-registry/tasks.md
@@ -122,7 +122,7 @@ non-upgradeable registry plus correct fund accounting. (spec US1 Independent Tes
   registry — `wagerRegistry` (proxy), `wagerRegistryImpl`, `wagerRegistryLegacy` — in the deploy tooling, and
   run `npm run sync:frontend-contracts:*` so the frontend resolves the **proxy** as the stable address.
   (FR-014/FR-015; data-model.md "deployments record")
-- [ ] T014 [P] [US1] Coexistence config (no logic change): point `frontend/` and `subgraph/` at the proxy
+- [X] T014 [P] [US1] Coexistence config (no logic change): point `frontend/` and `subgraph/` at the proxy
   address and surface the legacy registry as **settle-only** (existing wagers claimable/resolvable there, not
   implied to have moved). (FR-007, Principle III)
 
@@ -259,7 +259,7 @@ later ships as the first in-place upgrade on each.
 > `hardhat run scripts/deploy/deploy.js` on the in-process network deploys the proxy + impl and records both.
 > Execute these on the operator workstation per `docs/runbooks/contract-upgrades.md`.
 
-- [ ] T032 Deploy the proxy (current logic) to **Amoy** (chainId 80002) via `npm run deploy:amoy` (floppy
+- [X] T032 Deploy the proxy (current logic) to **Amoy** (chainId 80002) via `npm run deploy:amoy` (floppy
   keystore, 25 gwei floor), `npm run verify:amoy`, `npm run sync:frontend-contracts:amoy`; confirm
   `deployments/amoy-chain80002-v2.json` records `wagerRegistry` (proxy) / `wagerRegistryImpl` /
   `wagerRegistryLegacy`. (plan.md Target Platform)

--- a/specs/026-membership-vouchers/tasks.md
+++ b/specs/026-membership-vouchers/tasks.md
@@ -160,7 +160,7 @@ reverts; minting is never screened. (spec US4)
 - [X] T016 [P] Subgraph: add a `Voucher` entity (`status: Held | Redeemed`) to `subgraph/schema.graphql` and index `VoucherMinted`, ERC-721 `Transfer`, and `MembershipRedeemed` in `subgraph/src/mappings/`. (FR-026)
 - [X] T017 [P] Frontend: mint flow (choose role+tier, approve+pay USDC) in `frontend/src/` consuming synced artifacts. (FR-001, Principle V)
 - [X] T018 [P] Frontend: redeem flow (connect redeeming wallet, accept Terms, screen, redeem-to-this-wallet) with an **honest privacy disclosure** banner (public mints/transfers; pseudonymity, not ZK) and royalty display. WCAG 2.1 AA. (FR-013/020, Principle III/V)
-- [ ] T019 Run `npm run sync:frontend-contracts:*` so the frontend resolves the voucher address/ABI from artifacts (never hand-copied). (FR-026, Principle V)
+- [X] T019 Run `npm run sync:frontend-contracts:*` so the frontend resolves the voucher address/ABI from artifacts (never hand-copied). (FR-026, Principle V)
 
 **Checkpoint**: Vouchers are indexed and mint/gift/redeem is usable with honest disclosure.
 
@@ -168,7 +168,7 @@ reverts; minting is never screened. (spec US4)
 
 ## Phase 8: Documentation
 
-- [ ] T020 [P] Add `docs/` coverage: how vouchers work (buy/gift/resell/redeem), the redeemer-only screening tradeoff (FR-014), the utility-not-investment framing, and the on-chain `tokenURI`/royalty. Update `CLAUDE.md` if the membership surface guidance needs the voucher rail noted.
+- [X] T020 [P] Add `docs/` coverage: how vouchers work (buy/gift/resell/redeem), the redeemer-only screening tradeoff (FR-014), the utility-not-investment framing, and the on-chain `tokenURI`/royalty. Update `CLAUDE.md` if the membership surface guidance needs the voucher rail noted.
 
 **Checkpoint**: Docs explain the voucher rail and its compliance posture.
 

--- a/specs/027-upgradeable-membership/tasks.md
+++ b/specs/027-upgradeable-membership/tasks.md
@@ -142,7 +142,7 @@ runbook/ADR/developer-guide are generic and already cite membership as the next 
 
 - [X] T017 [P] Update `docs/developer-guide/upgradeable-contracts.md` to mark `MembershipManager` as an adopter of `UUPSManaged` (it is already named as a next adopter), referencing this feature. (PR #724 reuse)
 - [X] T018 [P] Update `docs/system-overview/security.md` and `docs/system-overview/roles-and-tiers.md`: `MembershipManager` is now UUPS-upgradeable; document its `UPGRADER_ROLE`, the upgrade authorization model, `_disableInitializers`, and append-only storage. (FR-011/FR-012)
-- [ ] T019 [P] Update `scripts/deploy/README.md` and the `deployments/` schema notes to include the membership proxy/impl keys and the `WagerRegistry` repoint step at cutover. (FR-014/FR-016)
+- [X] T019 [P] Update `scripts/deploy/README.md` and the `deployments/` schema notes to include the membership proxy/impl keys and the `WagerRegistry` repoint step at cutover. (FR-014/FR-016)
 - [X] T020 Update `CLAUDE.md` Guardrails: `MembershipManager` is now a **UUPS proxy at a stable address** (logic swappable, state preserved); `deployments/` records `membershipManager` (proxy) + `membershipManagerImpl`; storage is append-only (run `check:storage-layout`). (keeps the agent guide accurate post-migration)
 
 **Checkpoint**: Docs reflect the membership migration; an operator/developer can act from them.
@@ -172,7 +172,7 @@ This is the cutover; feature 026 later ships as the first in-place upgrade on ea
 > keystore (`npm run floppy:mount`) and maintainer sign-off. Execute on the operator workstation per
 > `docs/runbooks/contract-upgrades.md`.
 
-- [ ] T026 Deploy the membership proxy (current logic) to **Amoy** (chainId 80002) via the floppy-keystore flow; repoint `WagerRegistry.setMembershipManager(proxy)`; `npm run verify:amoy`; `npm run sync:frontend-contracts:amoy`; confirm `deployments/amoy-chain80002-v2.json` records `membershipManager` (proxy) + `membershipManagerImpl`. (plan.md Target Platform; FR-009)
+- [X] T026 Deploy the membership proxy (current logic) to **Amoy** (chainId 80002) via the floppy-keystore flow; repoint `WagerRegistry.setMembershipManager(proxy)`; `npm run verify:amoy`; `npm run sync:frontend-contracts:amoy`; confirm `deployments/amoy-chain80002-v2.json` records `membershipManager` (proxy) + `membershipManagerImpl`. (plan.md Target Platform; FR-009)
 - [ ] T027 Validate on **Amoy**: full membership lifecycle parity through the proxy; wager gating works via the repointed registry; coexistence shown honestly; perform an additive upgrade dry-run and confirm state preserved + address unchanged (SC-006 proof). Get maintainer sign-off before mainnet. Block T028 on sign-off.
 - [ ] T028 After sign-off, deploy the membership proxy (current logic) to **Polygon** mainnet (chainId 137) via the floppy-keystore flow; repoint `WagerRegistry`; `npm run verify:polygon`; `npm run sync:frontend-contracts:polygon`; record proxy/impl in `deployments/polygon-chain137-v2.json`; withdraw accrued fees from the legacy authority via its admin path. Then feature 026 ships as the first in-place upgrade.
 


### PR DESCRIPTION
## What

Validated **task closure across the four feature specs** (open challenges 024, UUPS registry 025, vouchers 026, UUPS membership 027) by auditing every open checkbox against the actually-merged code, tests, and deployment records — then closed the ones that shipped but were never checked off, and documented exactly what remains genuinely open.

## Closed (18 shipped-but-unmarked tasks)

| Spec | Closed |
|---|---|
| 024 | T001, T002, T028, T029, T030, T032, T033a, T036, T037, T038, T041, T047, T048 |
| 025 | T014, T032 |
| 026 | T019, T020 |
| 027 | T026, **T019** (this PR also extends `scripts/deploy/README.md` with the membership proxy/impl keys + the `setMembershipManager` repoint-at-cutover step) |

Each was verified against a concrete artifact (contract symbol, test file, deployment-record field, frontend config, or docs page) — not assumed done because the feature shipped.

## Still open — genuinely pending (27 tasks, left unchecked on purpose)

- **Polygon mainnet deploys (6)** — `024 T049/T050, 025 T034, 026 T027, 027 T027/T028`. Blocked on the pending mainnet UUPS migration (no `*Impl` in `deployments/polygon-chain137-v2.json`).
- **Human security-agent review gates (4)** — `024 T045, 025 T029, 026 T023, 027 T023`. `.github/agents/` review; no in-repo sign-off artifact.
- **One-off verification runs (9)** — slither/coverage/a11y/manual-quickstart: `024 T042/T043/T044/T046, 025 T033, 026 T021/T024, 027 T021/T024`. CI runs these generically but there's no committed feature-scoped evidence.
- **Missing test/UI artifacts (8)** — `024 T015` (open-challenge integration test), `T025a` (post-accept readability), `T027` (subgraph matchstick for `handleOpenWagerCreated`), `T031`/`T039` (frontend defensive/public-mode tests), `T040` (Medusa open-path invariants), `T040a` (`test/fork/` oracle run); `027 T011` (legacy-membership coexistence surfacing — really a mainnet-cutover concern).

The feature set ships and is deployed feature-complete to **Amoy + Mordor**; the gaps above are hardening/evidence/mainnet, not core functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)