### PR TITLE
feat(landing): replace "Built on X" badge with a "Deployed on" networks section

### DIFF
--- a/frontend/src/components/LandingPage.jsx
+++ b/frontend/src/components/LandingPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import Header from './Header'
 import LiveStats from './fairwins/LiveStats'
+import DeployedNetworks from './fairwins/DeployedNetworks'
 import Footer from './Footer'
 import { useChainTokens } from '../hooks/useChainTokens'
 import './LandingPage.css'
@@ -9,7 +10,7 @@ import './LandingPage.css'
 function LandingPage() {
   const navigate = useNavigate()
   const [visibleSections, setVisibleSections] = useState(new Set())
-  const { native: nativeSymbol, networkName } = useChainTokens()
+  const { native: nativeSymbol } = useChainTokens()
 
   const handleGetStarted = () => {
     navigate('/app')
@@ -50,10 +51,7 @@ function LandingPage() {
         </div>
 
         <div className="hero-content">
-          <div className="hero-badge">
-            <span className="hero-badge-dot" />
-            Built on {networkName || 'Polygon'}
-          </div>
+          <DeployedNetworks />
 
           <h1 className="hero-headline">
             Your Wager.<br />

--- a/frontend/src/components/fairwins/DeployedNetworks.css
+++ b/frontend/src/components/fairwins/DeployedNetworks.css
@@ -1,0 +1,78 @@
+.deployed-networks {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.deployed-networks-label {
+  color: #7BDCB5;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.deployed-networks-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.deployed-network-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.4rem 0.85rem;
+  background: rgba(45, 122, 79, 0.15);
+  border: 1px solid rgba(45, 122, 79, 0.3);
+  border-radius: 999px;
+  color: #d6f5e6;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-decoration: none;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+a.deployed-network-chip:hover {
+  background: rgba(45, 122, 79, 0.28);
+  border-color: rgba(54, 179, 126, 0.6);
+  transform: translateY(-1px);
+}
+
+.deployed-network-dot {
+  width: 7px;
+  height: 7px;
+  background: #36B37E;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.deployed-network-name {
+  white-space: nowrap;
+}
+
+.deployed-network-tag {
+  padding: 0.05rem 0.4rem;
+  background: rgba(76, 154, 255, 0.18);
+  border-radius: 999px;
+  color: #9ec5ff;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  a.deployed-network-chip:hover {
+    transform: none;
+  }
+}

--- a/frontend/src/components/fairwins/DeployedNetworks.jsx
+++ b/frontend/src/components/fairwins/DeployedNetworks.jsx
@@ -1,0 +1,42 @@
+import { getDeployedNetworks } from '../../config/contracts'
+import './DeployedNetworks.css'
+
+/**
+ * "Deployed on" cluster for the landing hero. Replaces the old single
+ * "Built on <network>" badge: as FairWins ships to more chains this lists
+ * every network with a live wagerRegistry deployment (see getDeployedNetworks).
+ *
+ * Each chip links to the deployed escrow contract on that chain's explorer
+ * when one is known; otherwise it renders as a static pill.
+ */
+function DeployedNetworks() {
+  const networks = getDeployedNetworks()
+  if (networks.length === 0) return null
+
+  return (
+    <div className="deployed-networks" aria-label="Networks FairWins is deployed on">
+      <span className="deployed-networks-label">Deployed on</span>
+      <ul className="deployed-networks-list">
+        {networks.map((net) => {
+          const Tag = net.contractUrl ? 'a' : 'span'
+          const linkProps = net.contractUrl
+            ? { href: net.contractUrl, target: '_blank', rel: 'noopener noreferrer' }
+            : {}
+          return (
+            <li key={net.chainId}>
+              <Tag className="deployed-network-chip" {...linkProps}>
+                <span className="deployed-network-dot" aria-hidden="true" />
+                <span className="deployed-network-name">{net.name}</span>
+                {net.isTestnet && (
+                  <span className="deployed-network-tag">Testnet</span>
+                )}
+              </Tag>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+export default DeployedNetworks

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -8,6 +8,12 @@
  * Last updated: 2026-05-09 (Amoy network added for Polymarket integration)
  */
 
+// Network metadata (names, explorers, native currency) lives in networks.js,
+// the single source of truth. We import it here to pair on-chain deployments
+// with their display info for getDeployedNetworks(). Safe from import cycles:
+// networks.js intentionally does NOT import from this file.
+import { NETWORKS } from './networks'
+
 // Mordor (Ethereum Classic testnet, chainId 63) — v2 P2P betting deployment.
 // CORE ONLY: no oracle adapters (ETC has no Polymarket/Chainlink/UMA), so those
 // keys are intentionally absent and their capability tags read "unavailable".
@@ -173,6 +179,51 @@ export function getContractAddressForChain(contractName, chainId) {
   if (chainId == null) return getContractAddress(contractName)
   const chainContracts = NETWORK_CONTRACTS[chainId]
   return chainContracts ? chainContracts[contractName] : undefined
+}
+
+// Local-only sandboxes — never surfaced as public "deployed" networks.
+const LOCAL_ONLY_CHAIN_IDS = new Set([1337])
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/
+
+/**
+ * Networks the app has been publicly deployed to — derived from
+ * NETWORK_CONTRACTS entries that carry a live `wagerRegistry` (v2 escrow)
+ * address, paired with their display metadata from networks.js. Local-only
+ * sandboxes (Hardhat 1337) are excluded. Mainnets surface before testnets so
+ * the production network reads first.
+ *
+ * This is the source for the landing page's "Deployed on" section, so it grows
+ * automatically as new chains gain a wagerRegistry deployment — no UI edits.
+ *
+ * @returns {Array<{chainId:number,name:string,isTestnet:boolean,nativeSymbol:string,explorerUrl:string,contractUrl:string}>}
+ */
+export function getDeployedNetworks() {
+  return Object.entries(NETWORK_CONTRACTS)
+    .map(([id, contracts]) => ({ chainId: parseInt(id, 10), contracts }))
+    .filter(
+      ({ chainId, contracts }) =>
+        !LOCAL_ONLY_CHAIN_IDS.has(chainId) &&
+        ADDRESS_RE.test(contracts?.wagerRegistry || '')
+    )
+    .map(({ chainId, contracts }) => {
+      const net = NETWORKS[chainId]
+      const explorerUrl = net?.explorer?.baseUrl || ''
+      return {
+        chainId,
+        name: net?.name || `Chain ${chainId}`,
+        isTestnet: Boolean(net?.isTestnet),
+        nativeSymbol: net?.nativeCurrency?.symbol || '',
+        explorerUrl,
+        // Link straight to the deployed escrow contract when an explorer exists.
+        contractUrl: explorerUrl
+          ? `${explorerUrl.replace(/\/$/, '')}/address/${contracts.wagerRegistry}`
+          : '',
+      }
+    })
+    .sort(
+      (a, b) =>
+        Number(a.isTestnet) - Number(b.isTestnet) || a.name.localeCompare(b.name)
+    )
 }
 
 /**

--- a/frontend/src/test/DeployedNetworks.test.jsx
+++ b/frontend/src/test/DeployedNetworks.test.jsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { getDeployedNetworks } from '../config/contracts'
+import DeployedNetworks from '../components/fairwins/DeployedNetworks'
+
+describe('getDeployedNetworks()', () => {
+  it('lists every chain with a live wagerRegistry, excluding local Hardhat', () => {
+    const nets = getDeployedNetworks()
+    const ids = nets.map((n) => n.chainId)
+
+    // Public deployments (Polygon, Amoy, Mordor) are present...
+    expect(ids).toEqual(expect.arrayContaining([137, 80002, 63]))
+    // ...and the local-only Hardhat sandbox (1337) is not.
+    expect(ids).not.toContain(1337)
+  })
+
+  it('orders mainnets before testnets', () => {
+    const nets = getDeployedNetworks()
+    const firstTestnetIdx = nets.findIndex((n) => n.isTestnet)
+    const lastMainnetIdx = nets.map((n) => n.isTestnet).lastIndexOf(false)
+    if (firstTestnetIdx !== -1 && lastMainnetIdx !== -1) {
+      expect(lastMainnetIdx).toBeLessThan(firstTestnetIdx)
+    }
+  })
+
+  it('links each chip to the deployed escrow on the chain explorer', () => {
+    const polygon = getDeployedNetworks().find((n) => n.chainId === 137)
+    expect(polygon.contractUrl).toMatch(/^https:\/\/polygonscan\.com\/address\/0x/)
+  })
+})
+
+describe('<DeployedNetworks />', () => {
+  it('renders a "Deployed on" label and a chip per deployed network', () => {
+    render(<DeployedNetworks />)
+    expect(screen.getByText('Deployed on')).toBeInTheDocument()
+
+    const list = screen.getByLabelText(/deployed on/i)
+    const expected = getDeployedNetworks()
+    expected.forEach((net) => {
+      expect(within(list).getByText(net.name)).toBeInTheDocument()
+    })
+  })
+
+  it('flags testnets with a Testnet tag', () => {
+    render(<DeployedNetworks />)
+    const testnetCount = getDeployedNetworks().filter((n) => n.isTestnet).length
+    expect(screen.getAllByText('Testnet')).toHaveLength(testnetCount)
+  })
+})


### PR DESCRIPTION
## Why

The landing hero showed a single-network badge — "Built on Ethereum Classic Mordor" (it renders whichever network the build is pinned to). Now that FairWins ships to multiple chains, pinning the hero to one network is misleading. This swaps it for a **"Deployed on"** section that lists every network the app has a live deployment on.

## What changed

- **`getDeployedNetworks()`** in `frontend/src/config/contracts.js` — derives the public deployment list from `NETWORK_CONTRACTS` entries that carry a valid `wagerRegistry` (v2 escrow) address, paired with display metadata (name, explorer, native currency) from `networks.js`. It:
  - excludes the local-only Hardhat sandbox (1337),
  - orders mainnets before testnets,
  - links each chip to the deployed escrow contract on that chain's block explorer.
- **`DeployedNetworks` component** (`components/fairwins/DeployedNetworks.jsx` + CSS) — renders the network chips in the hero spot where the old badge sat, tagging testnets with a small "Testnet" pill.
- **`LandingPage.jsx`** — renders `<DeployedNetworks />` in place of the badge and drops the now-unused `networkName`.
- **Tests** (`test/DeployedNetworks.test.jsx`) cover the helper (membership, ordering, explorer links) and the component (label, one chip per network, testnet tags).

Current result: **Polygon**, **Polygon Amoy** (Testnet), **Ethereum Classic Mordor** (Testnet). New chains surface automatically once they gain a `wagerRegistry` deployment — no further UI edits.

## Verification

- `npx vitest run` — new `DeployedNetworks` tests (5) + existing `LandingPage.oracle` (2) + `contractsConfig` (23) all pass
- `eslint` clean on changed files
- `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fabhcqgn928HdgM3Ak1yTr)_