### PR TITLE
Serve wager reads over RPC on networks without a subgraph (ETC Mordor)

### DIFF
--- a/docs/developer-guide/networks-without-subgraph.md
+++ b/docs/developer-guide/networks-without-subgraph.md
@@ -1,0 +1,103 @@
+# Reading data on networks without a subgraph
+
+Not every network FairWins deploys to has a hosted Graph indexer. **Ethereum
+Classic / Mordor (chain 63)** is the motivating case: no Graph provider supports
+it, so the app cannot read wagers from a subgraph and must read directly from
+the chain over RPC.
+
+This document describes the strategy the frontend uses to serve those networks
+transparently, so adding another un-indexed chain in the future is a config
+change rather than a code change.
+
+## Strategy: per-chain data-source selection
+
+The "does this chain have an indexer?" decision is **per-network metadata**, not
+a global flag. Each network in [`frontend/src/config/networks.js`](../../frontend/src/config/networks.js)
+declares a `subgraphUrl`:
+
+| Chain | `subgraphUrl` | Wager reads served by |
+| --- | --- | --- |
+| Polygon (137) | Studio endpoint (default/env) | `SubgraphSource` (The Graph) |
+| Polygon Amoy (80002) | Studio endpoint (default/env) | `SubgraphSource` (The Graph) |
+| Ethereum Classic Mordor (63) | `null` | `RegistrySource` (RPC) |
+| Hardhat (1337) | `null` | `RegistrySource` (RPC) |
+
+Two helpers expose this:
+
+```js
+import { getSubgraphUrl, hasSubgraph } from '../config/networks'
+
+getSubgraphUrl(63) // → null  (Mordor has no subgraph)
+hasSubgraph(137)   // → true
+```
+
+Resolution is **strictly per-chain**: a subgraph URL configured for one network
+can never be queried while the wallet is on another (so a Polygon endpoint is
+never hit while connected to Mordor).
+
+## The data sources
+
+The UI never talks to a source directly — it goes through
+[`WagerRepository`](../../frontend/src/data/wagers/WagerRepository.js), which is
+bound to a chain id and picks the source for that chain:
+
+- **`SubgraphSource`** — GraphQL against the chain's `subgraphUrl`. Used when
+  `hasSubgraph(chainId)` is true. If the endpoint errors or is unreachable, it
+  **falls back to `RegistrySource`** (not the retired events source).
+- **`RegistrySource`** — direct RPC reads of the v2 `WagerRegistry` using its
+  purpose-built pagination views (`getUserWagerCount`, `getUserWagerIds`,
+  `getUserWagers`, `getWager`). No `eth_getLogs` block-range scanning, so it
+  works on public RPCs (Amoy, Mordor) that reject wide log ranges. This is the
+  default for any chain without a subgraph.
+- **`EventsSource`** — *legacy*. Reads the retired `FriendGroupMarketFactory`
+  and is no longer wired into the automatic fallback path. Retained only behind
+  an explicit `VITE_WAGER_SOURCE=events` override.
+
+Both live sources emit the same mapped `Wager` shape, so the list, detail, and
+report views are agnostic to which one produced a page.
+
+```
+useMyWagers / useAccountStats / reportDataSource
+        │  (chainId)
+        ▼
+   WagerRepository(chainId)
+        │
+  hasSubgraph(chainId) ? SubgraphSource ─(on error)─▶ RegistrySource (RPC)
+                       : RegistrySource (RPC)
+```
+
+## Threading the chain id
+
+Reads are keyed on the wallet's connected chain so a user on testnet never sees
+mainnet wagers (or vice versa):
+
+- `useMyWagers` reads the active chain from `wagmi`'s `useChainId()` (override
+  with the `chainId` option) and builds a per-chain repository.
+- `useAccountStats` and `reportDataSource` pass their `chainId` to
+  `getDefaultWagerRepository(chainId)`.
+
+## Reporting
+
+The tax/activity report (`reportDataSource`) prefers the indexed
+`listTransfers` path where a subgraph exists. On a chain without one it returns
+`null` from `listTransfers` and enumerates wagers via the RPC repository
+(`enumerateWagers`), then does a **bounded** on-chain event scan per wager. No
+hard dependency on the subgraph remains.
+
+## Membership / roles
+
+Role reads (`hasRoleOnChain`) and the Quick Start membership banner have always
+read from the `MembershipManager` over RPC and are already chain-aware, so they
+work on un-indexed networks. The banner is additionally gated on
+`blockchainSynced` so it only renders once the wallet's roles are confirmed
+on-chain — it won't linger for a member while the RPC read resolves.
+
+## Adding another un-indexed network
+
+1. Add the network to `networks.js` with `subgraphUrl: null` (or a
+   `VITE_SUBGRAPH_URL_<NET>` override if you stand up your own indexer later).
+2. Ensure `wagerRegistry` (and `membershipManager`) addresses are recorded for
+   the chain in `contracts.js` / `deployments/`.
+
+No source code changes are required — `WagerRepository` will route the chain to
+`RegistrySource` automatically.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -23,22 +23,27 @@ VITE_NETWORK_ID=137
 # VITE_RPC_URL=
 
 # --- Indexing subgraph (Spec 017: v2 WagerRegistry + WagerTransfer) ---
-# The Graph endpoint for the ACTIVE network (VITE_NETWORK_ID). Powers the "my
-# wagers" list, landing-page stats, and — critically — the RPC-light tax/activity
-# report, which reads each transfer's txHash from the index and fetches only one
-# transaction receipt per transfer (for the gas fee). Set the URL matching the
-# selected chain; one subgraph is deployed per network:
-#   Polygon (137):   https://api.studio.thegraph.com/query/1755381/fairwins-polygon/v0.2.0
-#   Amoy (80002):    https://api.studio.thegraph.com/query/1755381/fairwins-amoy/v0.2.0
-#   Mordor (63):     <indexer-url-if-available; else leave unset to use the RPC fallback>
-# (Above are the Studio dev query endpoints from the v0.1.0 deploy; rate-limited.
-#  For production, publish to the decentralized network and use the gateway URL.)
-# When unset/unreachable, the report falls back to a bounded chain scan and the
-# wager list falls back to direct RPC reads.
+# Subgraph endpoints are now resolved PER-CHAIN in src/config/networks.js, so a
+# network without an indexer (e.g. Ethereum Classic Mordor) transparently reads
+# wagers directly from the WagerRegistry over RPC (RegistrySource) — no global
+# flag required. Defaults ship for the indexed networks; override per-chain only
+# if you run your own indexer:
+#   VITE_SUBGRAPH_URL_POLYGON  (137)   default: studio fairwins-polygon
+#   VITE_SUBGRAPH_URL_AMOY     (80002) default: studio fairwins-amoy
+#   VITE_SUBGRAPH_URL_MORDOR   (63)    default: none → RPC reads (no subgraph)
+# (Studio dev query endpoints are rate-limited; for production publish to the
+#  decentralized network and use the gateway URL.)
+# VITE_SUBGRAPH_URL_POLYGON=
+# VITE_SUBGRAPH_URL_AMOY=
+# VITE_SUBGRAPH_URL_MORDOR=
+#
+# Legacy single-endpoint override. Applies ONLY to the build-time active chain
+# (VITE_NETWORK_ID) and never leaks to other networks at runtime. Prefer the
+# per-chain vars above.
 # VITE_SUBGRAPH_URL=
-# Use the subgraph as the primary wager source (else direct RPC). Recommended when
-# VITE_SUBGRAPH_URL is set.
-# VITE_WAGER_SOURCE=subgraph
+# Force a specific wager data source for debugging: subgraph | registry | events.
+# Leave unset to auto-select per chain (subgraph where indexed, RPC otherwise).
+# VITE_WAGER_SOURCE=
 #
 # The Graph Studio DEPLOY KEY is a secret used only by `graph auth` when deploying
 # the subgraph — it is NOT a frontend var and MUST live in your local .env only,

--- a/frontend/src/components/fairwins/Dashboard.jsx
+++ b/frontend/src/components/fairwins/Dashboard.jsx
@@ -450,7 +450,7 @@ function Dashboard() {
   const { isConnected, account } = useWallet()
   const { connectWallet } = useWalletConnection()
   const { preferences: _preferences } = useUserPreferences()
-  const { hasRole } = useWalletRoles()
+  const { hasRole, blockchainSynced } = useWalletRoles()
   const { showModal, hideModal } = useModal()
   const navigate = useNavigate()
   const location = useLocation()
@@ -625,8 +625,11 @@ function Dashboard() {
         </div>
       </header>
 
-      {/* Membership CTA Banner */}
-      {isConnected && !bannerDismissed && !hasRole(ROLES.WAGER_PARTICIPANT) && (
+      {/* Membership CTA Banner — only shown once the wallet's roles have been
+          confirmed on-chain (blockchainSynced) so it doesn't linger for members
+          on networks where the role read is still resolving (e.g. the RPC-only
+          Mordor network, which has no subgraph). */}
+      {isConnected && blockchainSynced && !bannerDismissed && !hasRole(ROLES.WAGER_PARTICIPANT) && (
         <div className="dashboard-cta-banner">
           <div className="cta-banner-content">
             <strong>Get access to create and accept peer-to-peer wagers</strong>

--- a/frontend/src/config/networks.js
+++ b/frontend/src/config/networks.js
@@ -42,6 +42,13 @@ const NETWORKS = {
     nativeCurrency: { decimals: 18, name: 'MATIC', symbol: 'MATIC' },
     rpcUrl: import.meta.env?.VITE_RPC_URL_AMOY || 'https://rpc-amoy.polygon.technology',
     explorer: { name: 'Polygonscan', baseUrl: 'https://amoy.polygonscan.com' },
+    // The Graph endpoint that indexes this chain's WagerRegistry. When present,
+    // the wager list/reports read from the subgraph; when null (see Mordor),
+    // the app falls back to direct RPC reads via RegistrySource. Override with
+    // VITE_SUBGRAPH_URL_AMOY.
+    subgraphUrl:
+      import.meta.env?.VITE_SUBGRAPH_URL_AMOY ||
+      'https://api.studio.thegraph.com/query/1755381/fairwins-amoy/v0.2.0',
     // USDC on Amoy. Defaults to the Circle faucet USDC deployed alongside
     // our contracts (same as paymentToken in contracts.js). Override via
     // VITE_AMOY_USDC if a different token is needed.
@@ -95,6 +102,11 @@ const NETWORKS = {
     nativeCurrency: { decimals: 18, name: 'Ethereum Classic', symbol: 'ETC' },
     rpcUrl: import.meta.env?.VITE_RPC_URL_MORDOR || 'https://rpc.mordor.etccooperative.org',
     explorer: { name: 'Blockscout', baseUrl: 'https://etc-mordor.blockscout.com' },
+    // No hosted Graph indexer supports Ethereum Classic / Mordor, so there is no
+    // subgraph for this chain. The app reads wagers directly from the
+    // WagerRegistry over RPC (RegistrySource). Set VITE_SUBGRAPH_URL_MORDOR only
+    // if a self-hosted indexer (Goldsky/Ponder/Envio) is stood up later.
+    subgraphUrl: import.meta.env?.VITE_SUBGRAPH_URL_MORDOR || null,
     // Classic USD (USC) — Ethereum Classic's fiat-backed stablecoin (Brale-issued),
     // reused as-is (never a mock). Verify the canonical Mordor address + decimals
     // on-chain before relying on it (Spec 015, T001). Override via VITE_MORDOR_USC.
@@ -150,6 +162,11 @@ const NETWORKS = {
     nativeCurrency: { decimals: 18, name: 'MATIC', symbol: 'MATIC' },
     rpcUrl: import.meta.env?.VITE_RPC_URL_POLYGON || 'https://polygon-bor-rpc.publicnode.com',
     explorer: { name: 'Polygonscan', baseUrl: 'https://polygonscan.com' },
+    // The Graph endpoint indexing the production WagerRegistry on Polygon.
+    // Override with VITE_SUBGRAPH_URL_POLYGON.
+    subgraphUrl:
+      import.meta.env?.VITE_SUBGRAPH_URL_POLYGON ||
+      'https://api.studio.thegraph.com/query/1755381/fairwins-polygon/v0.2.0',
     // Native USDC on Polygon (Circle-issued, USDC.e is the bridged variant
     // and is not used here). Decimals=6.
     stablecoin: {
@@ -190,6 +207,8 @@ const NETWORKS = {
     nativeCurrency: { decimals: 18, name: 'Ether', symbol: 'ETH' },
     rpcUrl: 'http://127.0.0.1:8545',
     explorer: { name: 'Local', baseUrl: '' },
+    // Local dev has no subgraph — reads go straight to the local node over RPC.
+    subgraphUrl: null,
     stablecoin: null,
     dex: null,
     contracts: {},
@@ -211,6 +230,29 @@ export function getNetwork(chainId) {
 
 export function isDexAvailable(chainId) {
   return Boolean(getNetwork(chainId)?.dex)
+}
+
+/**
+ * The Graph endpoint that indexes `chainId`, or null when no subgraph is
+ * deployed for that network. This is the single source of truth for the
+ * "does this chain have an indexer?" decision used to route wager reads
+ * between the subgraph and direct RPC (RegistrySource).
+ *
+ * Resolution is strictly per-chain so a subgraph URL configured for one
+ * network can never leak to another (e.g. a Polygon endpoint must not be
+ * queried while the wallet is on Mordor).
+ */
+export function getSubgraphUrl(chainId) {
+  const net = chainId != null ? NETWORKS[chainId] : null
+  return net?.subgraphUrl || null
+}
+
+/**
+ * Whether `chainId` is indexed by a subgraph. Networks that return false
+ * (e.g. Ethereum Classic Mordor) must be served from RPC reads instead.
+ */
+export function hasSubgraph(chainId) {
+  return Boolean(getSubgraphUrl(chainId))
 }
 
 /**

--- a/frontend/src/data/reports/reportDataSource.js
+++ b/frontend/src/data/reports/reportDataSource.js
@@ -26,6 +26,7 @@ import { getContractAddressForChain, NETWORK_CONFIG, DEPLOYMENT_BLOCKS } from '.
 import { WAGER_REGISTRY_ABI } from '../../abis/WagerRegistry'
 import { FRIEND_GROUP_MARKET_FACTORY_ABI } from '../../abis/FriendGroupMarketFactory'
 import { getDefaultWagerRepository } from '../wagers/WagerRepository'
+import { getSubgraphUrl, hasSubgraph } from '../../config/networks'
 
 const INITIAL_CHUNK = 5000
 const MIN_CHUNK = 200
@@ -45,8 +46,11 @@ const V1 = {
   valueEvents: ['MarketCreatedPending', 'ParticipantAccepted', 'WinningsClaimed', 'StakeRefunded'],
 }
 
-function subgraphConfigured() {
-  return Boolean(import.meta.env?.VITE_SUBGRAPH_URL)
+// Whether the given chain is indexed by a subgraph. Resolved per-chain so a
+// network without an indexer (e.g. Mordor) transparently uses the RPC-backed
+// repository path instead.
+function subgraphConfigured(chainId) {
+  return hasSubgraph(chainId)
 }
 
 // GraphQL: a party's value movements, time-ordered, straight from the index
@@ -74,8 +78,8 @@ const WAGER_TRANSFERS_QUERY = `
   }
 `
 
-async function postSubgraph(query, variables) {
-  const url = import.meta.env?.VITE_SUBGRAPH_URL
+async function postSubgraph(url, query, variables) {
+  if (!url) throw new Error('No subgraph endpoint configured for this chain')
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -197,7 +201,8 @@ async function scanAdaptive(contract, filter, fromBlock, toBlock, label, budget)
 export function createReportDataSource(opts = {}) {
   const provider = getProvider(opts)
   const chainId = opts.chainId
-  const repository = opts.repository || getDefaultWagerRepository()
+  const repository = opts.repository || getDefaultWagerRepository(chainId)
+  const subgraphUrl = getSubgraphUrl(chainId)
   // wagerId → createdAt (unix seconds), captured during enumeration for windowing.
   const createdAtById = new Map()
 
@@ -234,12 +239,12 @@ export function createReportDataSource(opts = {}) {
      */
     async listTransfers({ account }) {
       if (!account) return []
-      if (!subgraphConfigured()) return null
+      if (!subgraphConfigured(chainId)) return null
       const party = String(account).toLowerCase()
       const all = []
       const pageSize = 1000
       for (let skip = 0; skip < 100_000; skip += pageSize) {
-        const data = await postSubgraph(WAGER_TRANSFERS_QUERY, { party, first: pageSize, skip })
+        const data = await postSubgraph(subgraphUrl, WAGER_TRANSFERS_QUERY, { party, first: pageSize, skip })
         const rows = data?.wagerTransfers || []
         all.push(...rows.map(transferToPreItem))
         if (rows.length < pageSize) break
@@ -249,11 +254,9 @@ export function createReportDataSource(opts = {}) {
 
     async enumerateWagers({ account }) {
       if (!account) return []
-      if (!subgraphConfigured()) {
-        throw new Error(
-          'Wager reporting requires the indexing subgraph (VITE_SUBGRAPH_URL) to be configured for this network.',
-        )
-      }
+      // No subgraph throw here: the repository enumerates v2 wagers over RPC
+      // (RegistrySource) on networks without an indexer, so reporting still
+      // works — just with on-chain event windowing instead of indexed rows.
       const all = []
       let cursor = null
       for (let page = 0; page < 200; page++) {
@@ -263,10 +266,11 @@ export function createReportDataSource(opts = {}) {
           pageSize: 100,
           filter: { includeExpired: true },
         })
-        // Guard against the repository's legacy EventsSource fallback (it targets
-        // the retired factory and cannot serve v2 reporting).
-        if (String(res.source || '').includes('fallback') || res.source === 'events') {
-          throw new Error('The reporting subgraph is unreachable right now. Please try again shortly.')
+        // Only the retired EventsSource (legacy FriendGroupMarketFactory) cannot
+        // serve v2 reporting. The 'registry' source and the 'subgraph-fallback'
+        // (which now resolves to RegistrySource over RPC) are both valid.
+        if (res.source === 'events') {
+          throw new Error('Wager reporting is temporarily unavailable for this network.')
         }
         all.push(...(res.items || []))
         if (!res.hasMore || !res.nextCursor) break

--- a/frontend/src/data/wagers/RegistrySource.js
+++ b/frontend/src/data/wagers/RegistrySource.js
@@ -1,0 +1,194 @@
+/**
+ * RegistrySource — WagerSource implementation backed by direct RPC reads of
+ * the v2 `WagerRegistry`.
+ *
+ * This is the data path for networks that have NO subgraph (e.g. Ethereum
+ * Classic Mordor, local Hardhat). It replaces the legacy `EventsSource`, which
+ * read the deprecated `FriendGroupMarketFactory` and is not deployed on those
+ * networks.
+ *
+ * It uses the registry's purpose-built pagination views — `getUserWagerCount`,
+ * `getUserWagerIds`, `getUserWagers`, `getWager` — so there is no `eth_getLogs`
+ * block-range scanning. Public RPCs that reject wide `eth_getLogs` windows
+ * (Amoy, Mordor) are handled the same way `blockchainService.fetchWagersForUserV2`
+ * already does for the Quick Start dashboard.
+ *
+ * The mapped shape mirrors `SubgraphSource.toWager` so the UI is agnostic to
+ * which source produced a page. The chain id is threaded through every call so
+ * a wallet on testnet never reads mainnet wagers (or vice versa).
+ */
+
+import { ethers } from 'ethers'
+import { getContractAddressForChain } from '../../config/contracts'
+import { getNetwork, getCurrentChainId } from '../../config/networks'
+import { WAGER_REGISTRY_ABI } from '../../abis/WagerRegistry'
+import { upsertCache } from './cacheStore'
+import { applyFilters, paginate } from './sortFilter'
+import { WagerSortKey } from '../../constants/wagerDefaults'
+
+// IWagerRegistry.Status enum order (contracts/interfaces/IWagerRegistry.sol):
+//   None, Open, Active, Resolved, Cancelled, Refunded, Draw
+// Mapped to the lowercase string statuses the subgraph emits and the UI's
+// sort/filter helpers understand. `None` should not occur for a real wager;
+// it is treated as `open` defensively.
+const STATUS_BY_ENUM = [
+  'open', // None
+  'open', // Open
+  'active', // Active
+  'resolved', // Resolved
+  'cancelled', // Cancelled
+  'refunded', // Refunded
+  'drawn', // Draw
+]
+
+// Cap the number of wagers pulled per user in a single read so a pathological
+// account can't stall the UI. Pagination/sort happens client-side over this
+// bounded set, exactly like the events-backed source did.
+const MAX_USER_WAGERS = 500
+const PAGE = 100
+
+function resolveChainId(chainId) {
+  return chainId != null ? chainId : getCurrentChainId()
+}
+
+function getProvider(chainId) {
+  const net = getNetwork(chainId)
+  return new ethers.JsonRpcProvider(net?.rpcUrl)
+}
+
+function getRegistry(chainId, provider) {
+  const address = getContractAddressForChain('wagerRegistry', chainId)
+  if (!address) {
+    throw new Error(`wagerRegistry not deployed on chain ${chainId}`)
+  }
+  return new ethers.Contract(address, WAGER_REGISTRY_ABI, provider)
+}
+
+function toWager(id, raw) {
+  const metadataUri = raw.metadataUri || ''
+  const isIpfs = Boolean(metadataUri && String(metadataUri).startsWith('ipfs://'))
+  const ipfsCid = isIpfs ? String(metadataUri).slice('ipfs://'.length) : null
+
+  const opponent = raw.opponent && raw.opponent !== ethers.ZeroAddress ? raw.opponent : null
+  const winner = raw.winner && raw.winner !== ethers.ZeroAddress ? raw.winner : null
+  const status = STATUS_BY_ENUM[Number(raw.status)] || 'open'
+
+  // v2 carries explicit accept/resolve deadlines on-chain (the subgraph does
+  // not), so RegistrySource can populate timing directly — no rehydration
+  // round-trip is needed for the deadlines. Description/decryption still loads
+  // lazily from the metadata reference.
+  const resolveDeadlineMs = Number(raw.resolveDeadline || 0) * 1000
+
+  return {
+    id: String(id),
+    // v2 WagerRegistry is always 1v1.
+    marketType: 'oneVsOne',
+    status,
+    resolutionType: Number(raw.resolutionType ?? 0),
+    creator: raw.creator,
+    opponent,
+    participants: [raw.creator, opponent].filter(Boolean).map((p) => String(p).toLowerCase()),
+    arbitrator:
+      raw.arbitrator && raw.arbitrator !== ethers.ZeroAddress ? raw.arbitrator : null,
+    // Raw integer token units, matching SubgraphSource (formatting happens in
+    // the card using the token's decimals).
+    stakeAmount: String(raw.creatorStake ?? 0),
+    creatorStake: String(raw.creatorStake ?? 0),
+    opponentStake: String(raw.opponentStake ?? 0),
+    stakeTokenAddress: raw.token,
+    stakeTokenSymbol: null,
+    // No creation timestamp is stored on-chain; the detail view rehydrates the
+    // human-readable created date when needed.
+    createdAt: 0,
+    acceptDeadline: Number(raw.acceptDeadline || 0) * 1000,
+    resolveDeadline: resolveDeadlineMs,
+    // endTime drives the list's expiry gate; leave it unset (0) to match
+    // SubgraphSource so a past resolve deadline never silently hides a wager.
+    // The deadlines above remain available to the detail view.
+    endTime: 0,
+    resolvedAt: null,
+    winner,
+    metadataUri: metadataUri || null,
+    metadataHash: raw.metadataHash || null,
+    ipfsCid,
+    needsIpfsFetch: isIpfs,
+    description: '',
+    isEncrypted: false,
+    // Description/metadata is fetched lazily; the deadlines above are already
+    // authoritative, so this only drives the description hydration.
+    needsRehydration: true,
+  }
+}
+
+async function fetchAllForUser(contract, userAddress) {
+  const total = Number(await contract.getUserWagerCount(userAddress))
+  if (!total) return []
+  const count = Math.min(total, MAX_USER_WAGERS)
+
+  const wagers = []
+  for (let offset = 0; offset < count; offset += PAGE) {
+    const limit = Math.min(PAGE, count - offset)
+    const [ids, structs] = await Promise.all([
+      contract.getUserWagerIds(userAddress, offset, limit),
+      contract.getUserWagers(userAddress, offset, limit),
+    ])
+    for (let i = 0; i < ids.length; i++) {
+      wagers.push(toWager(String(ids[i]), structs[i]))
+    }
+  }
+  return wagers
+}
+
+export async function syncIndex(_userAddress) {
+  // The registry exposes per-user pagination directly, so there is no client
+  // watermark to maintain. Return an empty index for interface parity.
+  return { marketIds: [], lastBlock: 0 }
+}
+
+export async function listPage({
+  userAddress,
+  cursor,
+  pageSize = 25,
+  sortKey = WagerSortKey.CREATED,
+  filter,
+  chainId,
+}) {
+  if (!userAddress) {
+    return { items: [], nextCursor: null, hasMore: false, totalKnown: 0, source: 'registry' }
+  }
+  if (import.meta.env.VITE_SKIP_BLOCKCHAIN_CALLS === 'true') {
+    return { items: [], nextCursor: null, hasMore: false, totalKnown: 0, source: 'registry' }
+  }
+
+  const cid = resolveChainId(chainId)
+  const provider = getProvider(cid)
+  const contract = getRegistry(cid, provider)
+
+  const all = await fetchAllForUser(contract, userAddress)
+  if (all.length) upsertCache(userAddress, all)
+
+  const filtered = applyFilters(all, { ownerAddress: userAddress, ...filter })
+  const page = paginate(filtered, { cursor, pageSize, sortKey })
+  return { ...page, source: 'registry' }
+}
+
+export async function getById(id, userAddress, opts = {}) {
+  if (!id) return null
+  if (import.meta.env.VITE_SKIP_BLOCKCHAIN_CALLS === 'true') return null
+
+  const cid = resolveChainId(opts.chainId)
+  const provider = getProvider(cid)
+  const contract = getRegistry(cid, provider)
+
+  try {
+    const raw = await contract.getWager(id)
+    // An unset wager returns a zero-address creator.
+    if (!raw?.creator || raw.creator === ethers.ZeroAddress) return null
+    const wager = toWager(String(id), raw)
+    if (userAddress) upsertCache(userAddress, [wager])
+    return wager
+  } catch (err) {
+    console.warn(`[RegistrySource] getById ${id} failed:`, err?.message)
+    return null
+  }
+}

--- a/frontend/src/data/wagers/SubgraphSource.js
+++ b/frontend/src/data/wagers/SubgraphSource.js
@@ -7,14 +7,28 @@
  * is the only data fetched; encrypted envelopes round-trip as raw strings
  * and are decrypted client-side via useLazyMarketDecryption.
  *
- * Falls back to EventsSource if the subgraph endpoint is unreachable.
+ * The endpoint is resolved per-chain from networks.js. When a chain has no
+ * subgraph, or the endpoint is unreachable, reads fall back to RegistrySource
+ * (direct RPC reads of the v2 WagerRegistry) rather than the deprecated
+ * FriendGroupMarketFactory-backed EventsSource.
  */
 
 import { WagerSortKey } from '../../constants/wagerDefaults'
 import { upsertCache } from './cacheStore'
-import * as EventsSource from './EventsSource'
+import * as RegistrySource from './RegistrySource'
+import { getSubgraphUrl, getCurrentChainId } from '../../config/networks'
 
-const SUBGRAPH_URL = import.meta.env?.VITE_SUBGRAPH_URL || ''
+// Legacy single-endpoint override. Honored only for the build-time active
+// chain so it can never leak to a different network at runtime; per-chain
+// `subgraphUrl` in networks.js is the preferred configuration.
+const LEGACY_SUBGRAPH_URL = import.meta.env?.VITE_SUBGRAPH_URL || ''
+
+function resolveSubgraphUrl(chainId) {
+  const perChain = getSubgraphUrl(chainId)
+  if (perChain) return perChain
+  if (chainId == null || chainId === getCurrentChainId()) return LEGACY_SUBGRAPH_URL
+  return ''
+}
 
 // v2 WagerRegistry has no on-chain trading/resolution deadlines in its events,
 // so "ends" sort falls back to createdAt; the detail view hydrates timing from
@@ -59,9 +73,9 @@ const PAGE_QUERY = `
   }
 `
 
-async function postGraphQL(query, variables) {
-  if (!SUBGRAPH_URL) throw new Error('VITE_SUBGRAPH_URL is not set')
-  const res = await fetch(SUBGRAPH_URL, {
+async function postGraphQL(url, query, variables) {
+  if (!url) throw new Error('No subgraph endpoint configured for this chain')
+  const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ query, variables }),
@@ -119,15 +133,22 @@ export async function listPage({
   pageSize = 25,
   sortKey = WagerSortKey.CREATED,
   filter,
+  chainId,
 }) {
   if (!userAddress) {
     return { items: [], nextCursor: null, hasMore: false, totalKnown: 0, source: 'subgraph' }
   }
-  if (!SUBGRAPH_URL) {
-    return EventsSource.listPage({ userAddress, cursor, pageSize, sortKey, filter }).then(r => ({
-      ...r,
-      source: 'subgraph-fallback',
-    }))
+  const subgraphUrl = resolveSubgraphUrl(chainId)
+  if (!subgraphUrl) {
+    const fallback = await RegistrySource.listPage({
+      userAddress,
+      cursor,
+      pageSize,
+      sortKey,
+      filter,
+      chainId,
+    })
+    return { ...fallback, source: 'subgraph-fallback' }
   }
   if (import.meta.env.VITE_SKIP_BLOCKCHAIN_CALLS === 'true') {
     return { items: [], nextCursor: null, hasMore: false, totalKnown: 0, source: 'subgraph' }
@@ -142,7 +163,7 @@ export async function listPage({
   }
 
   try {
-    const data = await postGraphQL(PAGE_QUERY, variables)
+    const data = await postGraphQL(subgraphUrl, PAGE_QUERY, variables)
     const items = (data?.wagers || []).slice(0, pageSize).map(toWager)
     const hasMore = (data?.wagers || []).length > pageSize
     const nextCursor = hasMore && items.length
@@ -151,17 +172,26 @@ export async function listPage({
     if (items.length) upsertCache(userAddress, items)
     return { items, nextCursor, hasMore, totalKnown: items.length, source: 'subgraph' }
   } catch (err) {
-    console.warn('[SubgraphSource] falling back to EventsSource:', err?.message)
-    const fallback = await EventsSource.listPage({ userAddress, cursor, pageSize, sortKey, filter })
+    console.warn('[SubgraphSource] falling back to RegistrySource (RPC):', err?.message)
+    const fallback = await RegistrySource.listPage({
+      userAddress,
+      cursor,
+      pageSize,
+      sortKey,
+      filter,
+      chainId,
+    })
     return { ...fallback, source: 'subgraph-fallback' }
   }
 }
 
-export async function getById(id, userAddress) {
+export async function getById(id, userAddress, opts = {}) {
   if (!id || !userAddress) return null
-  if (!SUBGRAPH_URL) return EventsSource.getById(id, userAddress)
+  const subgraphUrl = resolveSubgraphUrl(opts.chainId)
+  if (!subgraphUrl) return RegistrySource.getById(id, userAddress, opts)
   try {
     const data = await postGraphQL(
+      subgraphUrl,
       `query($id: ID!) { wager(id: $id) { id status resolutionType creator opponent token creatorStake opponentStake winner createdAt resolvedAt metadataUri metadataHash } }`,
       { id: String(id) }
     )
@@ -169,7 +199,7 @@ export async function getById(id, userAddress) {
     if (wager) upsertCache(userAddress, [wager])
     return wager
   } catch (err) {
-    console.warn('[SubgraphSource] getById fallback:', err?.message)
-    return EventsSource.getById(id, userAddress)
+    console.warn('[SubgraphSource] getById fallback to RPC:', err?.message)
+    return RegistrySource.getById(id, userAddress, opts)
   }
 }

--- a/frontend/src/data/wagers/WagerRepository.js
+++ b/frontend/src/data/wagers/WagerRepository.js
@@ -3,35 +3,51 @@
  * sources. Swapping `SubgraphSource` for an Envio/Ponder/Goldsky source
  * later is a one-line change at the call site; no UI changes required.
  *
+ * Source selection is per-chain: networks indexed by a subgraph
+ * (`hasSubgraph(chainId)`) read from `SubgraphSource`; networks without one
+ * (e.g. Ethereum Classic Mordor) read directly from the on-chain
+ * `WagerRegistry` via `RegistrySource`. The repository is bound to a chain id
+ * so a wallet on testnet never reads mainnet wagers (or vice versa).
+ *
  * Sources implement the WagerSource interface:
- *   syncIndex(userAddress): Promise<{ marketIds, lastBlock }>
- *   listPage({ userAddress, cursor, pageSize, sortKey, filter }):
+ *   syncIndex(userAddress, opts): Promise<{ marketIds, lastBlock }>
+ *   listPage({ userAddress, cursor, pageSize, sortKey, filter, chainId }):
  *     Promise<{ items, nextCursor, hasMore, totalKnown, source }>
- *   getById(id, userAddress): Promise<Wager|null>
+ *   getById(id, userAddress, opts): Promise<Wager|null>
  */
 
 import * as EventsSource from './EventsSource'
 import * as SubgraphSource from './SubgraphSource'
+import * as RegistrySource from './RegistrySource'
 import { WagerSortKey } from '../../constants/wagerDefaults'
+import { hasSubgraph } from '../../config/networks'
 
 const SOURCE_REGISTRY = {
   events: EventsSource,
   subgraph: SubgraphSource,
+  registry: RegistrySource,
 }
 
-function resolveSourceKey(explicit) {
+function resolveSourceKey(explicit, chainId) {
+  // An explicit per-call override or the global VITE_WAGER_SOURCE escape hatch
+  // always wins (useful for debugging a specific source).
   if (explicit && SOURCE_REGISTRY[explicit]) return explicit
   const envSource = import.meta.env?.VITE_WAGER_SOURCE
   if (envSource && SOURCE_REGISTRY[envSource]) return envSource
+  // Chain-aware default: indexed chains use the subgraph; everything else
+  // (Mordor, Hardhat, any future un-indexed deployment) reads over RPC.
+  if (chainId != null) return hasSubgraph(chainId) ? 'subgraph' : 'registry'
   return 'subgraph'
 }
 
 export function createWagerRepository(opts = {}) {
-  const sourceKey = resolveSourceKey(opts.source)
+  const chainId = opts.chainId ?? null
+  const sourceKey = resolveSourceKey(opts.source, chainId)
   const source = SOURCE_REGISTRY[sourceKey]
 
   return {
     sourceKey,
+    chainId,
 
     async listMyWagers({
       userAddress,
@@ -49,24 +65,30 @@ export function createWagerRepository(opts = {}) {
         pageSize,
         sortKey,
         filter,
+        chainId,
       })
     },
 
     async getWagerById(id, userAddress) {
       if (!id || !userAddress) return null
-      return source.getById(String(id), String(userAddress).toLowerCase())
+      return source.getById(String(id), String(userAddress).toLowerCase(), { chainId })
     },
 
     async syncIndex(userAddress) {
       if (!userAddress) return { marketIds: [], lastBlock: 0 }
-      return source.syncIndex(String(userAddress).toLowerCase())
+      return source.syncIndex(String(userAddress).toLowerCase(), { chainId })
     },
   }
 }
 
-let defaultInstance = null
+// Repositories are cheap and stateless, so memoize one per chain id to keep a
+// stable identity across renders (hooks depend on it).
+const instancesByChain = new Map()
 
-export function getDefaultWagerRepository() {
-  if (!defaultInstance) defaultInstance = createWagerRepository()
-  return defaultInstance
+export function getDefaultWagerRepository(chainId = null) {
+  const key = chainId == null ? 'default' : String(chainId)
+  if (!instancesByChain.has(key)) {
+    instancesByChain.set(key, createWagerRepository({ chainId }))
+  }
+  return instancesByChain.get(key)
 }

--- a/frontend/src/hooks/useAccountStats.js
+++ b/frontend/src/hooks/useAccountStats.js
@@ -131,7 +131,7 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
       activity: { ...f.activity, status: 'refreshing' },
     }))
     try {
-      const repository = getDefaultWagerRepository()
+      const repository = getDefaultWagerRepository(chainId)
       const [loadedWagers, stable] = await Promise.all([
         loadAllWagers(repository, address),
         fetchStableBalance({

--- a/frontend/src/hooks/useMyWagers.js
+++ b/frontend/src/hooks/useMyWagers.js
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useChainId } from 'wagmi'
 import { getDefaultWagerRepository } from '../data/wagers/WagerRepository'
 import { WagerSortKey } from '../constants/wagerDefaults'
 
@@ -30,11 +31,19 @@ export function useMyWagers({
   filter = {},
   pageSize = DEFAULT_PAGE_SIZE,
   repository,
+  // Active chain — defaults to the wallet's connected chain so the data source
+  // (subgraph vs. RPC) is selected per network. Pass explicitly to override.
+  chainId,
   // Back-compat for callers that used the older naming
   initialSort,
   initialFilter,
 } = {}) {
-  const repo = useMemo(() => repository || getDefaultWagerRepository(), [repository])
+  const wagmiChainId = useChainId()
+  const activeChainId = chainId ?? wagmiChainId
+  const repo = useMemo(
+    () => repository || getDefaultWagerRepository(activeChainId),
+    [repository, activeChainId]
+  )
   const effectiveSort = sort ?? initialSort ?? WagerSortKey.CREATED
   const effectiveFilter = useMemo(
     () => filter ?? initialFilter ?? {},

--- a/frontend/src/test/RegistrySource.test.js
+++ b/frontend/src/test/RegistrySource.test.js
@@ -1,0 +1,117 @@
+/**
+ * RegistrySource — direct RPC reads of the v2 WagerRegistry for networks that
+ * have no subgraph (e.g. Ethereum Classic Mordor). Verifies the registry's
+ * pagination views are used (no eth_getLogs), the v2 struct maps to the shared
+ * Wager shape, and the status enum is decoded to the UI's string statuses.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const USER = '0x1111111111111111111111111111111111111111'
+const OPP = '0x2222222222222222222222222222222222222222'
+const ZERO = '0x0000000000000000000000000000000000000000'
+
+// A fake WagerRegistry contract whose pagination views return canned structs.
+const makeStruct = (over = {}) => ({
+  creator: USER,
+  opponent: OPP,
+  arbitrator: ZERO,
+  token: '0xtok',
+  creatorStake: 100n,
+  opponentStake: 150n,
+  acceptDeadline: 1700000000n,
+  resolveDeadline: 1700100000n,
+  resolutionType: 2,
+  status: 2, // Active
+  paid: false,
+  creatorIsYes: true,
+  winner: ZERO,
+  metadataHash: '0xhash',
+  metadataUri: 'ipfs://cid1',
+  ...over,
+})
+
+const contractMock = {
+  getUserWagerCount: vi.fn(async () => 2n),
+  getUserWagerIds: vi.fn(async () => [1n, 2n]),
+  getUserWagers: vi.fn(async () => [makeStruct(), makeStruct({ status: 3, winner: USER })]),
+  getWager: vi.fn(async () => makeStruct()),
+}
+
+vi.mock('ethers', async (orig) => {
+  const actual = await orig()
+  return {
+    ...actual,
+    ethers: {
+      ...actual.ethers,
+      JsonRpcProvider: class {},
+      Contract: class {
+        constructor() {
+          return contractMock
+        }
+      },
+      ZeroAddress: ZERO,
+    },
+  }
+})
+
+vi.mock('../config/contracts', () => ({
+  getContractAddressForChain: vi.fn(() => '0x3ccB144d8aa838e8d4D695867cC72e548117830C'),
+}))
+
+vi.mock('../data/wagers/cacheStore', () => ({ upsertCache: vi.fn() }))
+
+describe('RegistrySource (RPC reads for un-indexed networks)', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_SKIP_BLOCKCHAIN_CALLS', 'false')
+    contractMock.getUserWagerCount.mockClear()
+    contractMock.getUserWagerIds.mockClear()
+    contractMock.getUserWagers.mockClear()
+  })
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('lists a user\'s wagers via getUserWagerCount/Ids/Wagers (no log scan)', async () => {
+    const mod = await import('../data/wagers/RegistrySource')
+    const res = await mod.listPage({ userAddress: USER, pageSize: 10, chainId: 63, filter: { includeExpired: true } })
+
+    expect(contractMock.getUserWagerCount).toHaveBeenCalledWith(USER)
+    expect(contractMock.getUserWagerIds).toHaveBeenCalled()
+    expect(contractMock.getUserWagers).toHaveBeenCalled()
+    expect(res.source).toBe('registry')
+    expect(res.items).toHaveLength(2)
+
+    const ids = res.items.map((w) => w.id).sort()
+    expect(ids).toEqual(['1', '2'])
+  })
+
+  it('maps the v2 struct to the shared Wager shape and decodes the status enum', async () => {
+    const mod = await import('../data/wagers/RegistrySource')
+    const res = await mod.listPage({ userAddress: USER, pageSize: 10, chainId: 63, filter: { includeExpired: true } })
+    const byId = Object.fromEntries(res.items.map((w) => [w.id, w]))
+
+    expect(byId['1'].status).toBe('active') // enum 2 → 'active'
+    expect(byId['2'].status).toBe('resolved') // enum 3 → 'resolved'
+    expect(byId['1'].marketType).toBe('oneVsOne')
+    expect(byId['1'].participants).toEqual([USER.toLowerCase(), OPP.toLowerCase()])
+    expect(byId['1'].stakeTokenAddress).toBe('0xtok')
+    expect(byId['1'].stakeAmount).toBe('100')
+    expect(byId['1'].opponentStake).toBe('150')
+    expect(byId['1'].ipfsCid).toBe('cid1')
+    expect(byId['1'].needsIpfsFetch).toBe(true)
+  })
+
+  it('getById reads a single wager via getWager', async () => {
+    const mod = await import('../data/wagers/RegistrySource')
+    const w = await mod.getById('1', USER, { chainId: 63 })
+    expect(contractMock.getWager).toHaveBeenCalledWith('1')
+    expect(w.id).toBe('1')
+    expect(w.status).toBe('active')
+  })
+
+  it('returns empty when blockchain calls are skipped', async () => {
+    vi.stubEnv('VITE_SKIP_BLOCKCHAIN_CALLS', 'true')
+    const mod = await import('../data/wagers/RegistrySource')
+    const res = await mod.listPage({ userAddress: USER, pageSize: 10, chainId: 63, filter: { includeExpired: true } })
+    expect(res.items).toEqual([])
+    expect(contractMock.getUserWagerCount).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/test/SubgraphSource.v2.test.js
+++ b/frontend/src/test/SubgraphSource.v2.test.js
@@ -2,18 +2,18 @@
  * Spec 017 / FR-018: the "my wagers" SubgraphSource is migrated to the v2 Wager
  * schema (creator/opponent/token/creatorStake/opponentStake/status/createdAt),
  * mapping participants ⇐ [creator, opponent] and stakeToken ⇐ token. A GraphQL
- * field error degrades to the EventsSource (RPC) fallback rather than surfacing
- * broken data (constitution II + III).
+ * field error degrades to the RegistrySource (RPC) fallback rather than
+ * surfacing broken data (constitution II + III).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 const USER = '0x1111111111111111111111111111111111111111'
 const OPP = '0x2222222222222222222222222222222222222222'
 
-// EventsSource is the RPC fallback; mock it so the fallback path is observable
-// without a provider.
-vi.mock('../data/wagers/EventsSource', () => ({
-  listPage: vi.fn(async () => ({ items: [], nextCursor: null, hasMore: false, totalKnown: 0, source: 'events' })),
+// RegistrySource is the RPC fallback (direct v2 WagerRegistry reads); mock it so
+// the fallback path is observable without a provider.
+vi.mock('../data/wagers/RegistrySource', () => ({
+  listPage: vi.fn(async () => ({ items: [], nextCursor: null, hasMore: false, totalKnown: 0, source: 'registry' })),
   getById: vi.fn(async () => null),
 }))
 // cacheStore.upsertCache touches localStorage indirectly; keep it inert.
@@ -65,7 +65,7 @@ describe('SubgraphSource v2 migration (FR-018)', () => {
     expect(w.needsRehydration).toBe(true) // R5: chain fills timing + description
   })
 
-  it('falls back to EventsSource when the subgraph returns a GraphQL field error', async () => {
+  it('falls back to RegistrySource (RPC) when the subgraph returns a GraphQL field error', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({
       ok: true,
       json: async () => ({ errors: [{ message: "Type `Wager` has no field `marketType`" }] }),

--- a/frontend/src/test/reports/reportDataSource.test.js
+++ b/frontend/src/test/reports/reportDataSource.test.js
@@ -31,10 +31,22 @@ describe('createReportDataSource.enumerateWagers (subgraph-based, no genesis sca
     }
   }
 
-  it('requires the subgraph and throws a clear error when it is not configured', async () => {
-    vi.stubEnv('VITE_SUBGRAPH_URL', '')
-    const ds = createReportDataSource({ chainId: 80002, provider: { getBlockNumber: async () => 1 }, repository: fakeRepo([]) })
-    await expect(ds.enumerateWagers({ account: USER })).rejects.toThrow(/requires the indexing subgraph/i)
+  it('enumerates over RPC (no throw) on a chain without a subgraph (e.g. Mordor)', async () => {
+    // Chain 63 (Mordor) has no subgraph, so the repository serves v2 wagers from
+    // RegistrySource (source: 'registry'). Reporting must still work.
+    const repo = fakeRepo([
+      {
+        source: 'registry',
+        hasMore: false,
+        nextCursor: null,
+        items: [
+          { id: '1', creator: USER, participants: [USER], stakeTokenAddress: '0xtok', stakeAmount: '100', createdAt: 0 },
+        ],
+      },
+    ])
+    const ds = createReportDataSource({ chainId: 63, provider: { getBlockNumber: async () => 1 }, repository: repo })
+    const wagers = await ds.enumerateWagers({ account: USER })
+    expect(wagers.map((w) => w.id)).toEqual(['1'])
   })
 
   it('enumerates the user\'s wagers from the subgraph repository (never scans logs)', async () => {
@@ -56,11 +68,29 @@ describe('createReportDataSource.enumerateWagers (subgraph-based, no genesis sca
     expect(repo.listMyWagers).toHaveBeenCalledWith(expect.objectContaining({ userAddress: USER, filter: { includeExpired: true } }))
   })
 
-  it('fails clearly if the repository falls back to the legacy events source', async () => {
-    vi.stubEnv('VITE_SUBGRAPH_URL', 'http://subgraph.example')
-    const repo = fakeRepo([{ source: 'subgraph-fallback', hasMore: false, nextCursor: null, items: [] }])
+  it('accepts the subgraph-fallback (RPC) source as valid v2 data', async () => {
+    // When the subgraph is unreachable on an indexed chain the repository now
+    // falls back to RegistrySource (RPC), tagged 'subgraph-fallback'. That is
+    // valid v2 data, so enumeration succeeds rather than erroring.
+    const repo = fakeRepo([
+      {
+        source: 'subgraph-fallback',
+        hasMore: false,
+        nextCursor: null,
+        items: [
+          { id: '9', creator: USER, participants: [USER], stakeTokenAddress: '0xtok', stakeAmount: '5', createdAt: 0 },
+        ],
+      },
+    ])
     const ds = createReportDataSource({ chainId: 80002, provider: { getBlockNumber: async () => 1 }, repository: repo })
-    await expect(ds.enumerateWagers({ account: USER })).rejects.toThrow(/subgraph is unreachable/i)
+    const wagers = await ds.enumerateWagers({ account: USER })
+    expect(wagers.map((w) => w.id)).toEqual(['9'])
+  })
+
+  it('still rejects the retired legacy events source (cannot serve v2 reporting)', async () => {
+    const repo = fakeRepo([{ source: 'events', hasMore: false, nextCursor: null, items: [] }])
+    const ds = createReportDataSource({ chainId: 80002, provider: { getBlockNumber: async () => 1 }, repository: repo })
+    await expect(ds.enumerateWagers({ account: USER })).rejects.toThrow(/temporarily unavailable/i)
   })
 
   it('returns [] without an account', async () => {
@@ -76,9 +106,10 @@ describe('createReportDataSource.listTransfers (subgraph WagerTransfer, no log s
     vi.unstubAllGlobals()
   })
 
-  it('returns null when no subgraph is configured (signals bounded-scan fallback)', async () => {
-    vi.stubEnv('VITE_SUBGRAPH_URL', '')
-    const ds = createReportDataSource({ chainId: 80002, provider: { getBlockNumber: async () => 1 } })
+  it('returns null on a chain without a subgraph (signals RPC/bounded-scan fallback)', async () => {
+    // Chain 63 (Mordor) has no subgraph endpoint, so the indexed transfer query
+    // is skipped and the caller falls back to enumerate + bounded scan.
+    const ds = createReportDataSource({ chainId: 63, provider: { getBlockNumber: async () => 1 } })
     expect(await ds.listTransfers({ account: USER })).toBeNull()
   })
 


### PR DESCRIPTION
## Problem

ETC **Mordor (chain 63)** has no hosted Graph indexer. When that network is selected the app could not load wagers and the Quick Start membership banner did not clear:

- **Wager reads** went subgraph-first. With no subgraph for Mordor, the only fallback (`EventsSource`) read the **retired `FriendGroupMarketFactory`**, which isn't deployed on Mordor — so it threw and no wagers loaded. Worse, subgraph configuration was a single **global** env var (`VITE_SUBGRAPH_URL`), so a Polygon endpoint would be queried while connected to Mordor.
- **Reports** hard-failed on chains without a subgraph (`enumerateWagers` threw).
- **Membership banner** could linger while/after the on-chain role read resolved.

## Strategy: per-chain data-source selection

"Does this chain have an indexer?" is now **per-network metadata**, not a global flag.

| Chain | `subgraphUrl` | Wager reads |
| --- | --- | --- |
| Polygon (137) | Studio endpoint | `SubgraphSource` (The Graph) |
| Polygon Amoy (80002) | Studio endpoint | `SubgraphSource` (The Graph) |
| **ETC Mordor (63)** | **`null`** | **`RegistrySource` (RPC)** |
| Hardhat (1337) | `null` | `RegistrySource` (RPC) |

### Changes
- **`config/networks.js`** — each network declares `subgraphUrl`; new `getSubgraphUrl(chainId)` / `hasSubgraph(chainId)` helpers resolve support **strictly per-chain** so an endpoint never leaks across networks.
- **`RegistrySource.js`** (new) — a `WagerSource` that reads the v2 `WagerRegistry` directly over RPC using its pagination views (`getUserWagerCount` / `getUserWagerIds` / `getUserWagers` / `getWager`). No `eth_getLogs` scanning, so it works on public RPCs that reject wide log ranges. Emits the same mapped `Wager` shape as the subgraph source.
- **`WagerRepository.js`** — bound to a `chainId`; selects subgraph vs. RPC via `hasSubgraph(chainId)` and threads `chainId` to every source call. Memoized per chain.
- **`SubgraphSource.js`** — resolves its endpoint per-chain and falls back to `RegistrySource` (RPC) instead of the legacy events source.
- **`reportDataSource.js`** — per-chain subgraph gate; enumerates via the RPC repository on un-indexed chains instead of throwing.
- **`useMyWagers` / `useAccountStats`** — build a per-chain repository so testnet/mainnet reads stay isolated (`useMyWagers` defaults to wagmi's `useChainId()`).
- **Membership banner** (`Dashboard.jsx`) — gated on `blockchainSynced` so it only renders once roles are confirmed on-chain and clears for members instead of lingering during the RPC read.

The legacy `EventsSource` is retained only behind an explicit `VITE_WAGER_SOURCE=events` override.

## Tests
- New `RegistrySource.test.js` (pagination usage, struct→shape mapping, status-enum decode, skip guard).
- Updated `SubgraphSource.v2.test.js` and `reports/reportDataSource.test.js` to the per-chain semantics.
- Full suite green: **154 files / 1573 tests pass**; lint clean (one pre-existing unrelated warning).

## Docs
`docs/developer-guide/networks-without-subgraph.md` explains the strategy and how to add another un-indexed network (config-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTB9uCzafh6vozrHuh8LFp)_