### PR TITLE
Voucher testing feedback: gift/transfer UX + neutral eligibility wording

### DIFF
--- a/frontend/src/components/compliance/EntryGate.jsx
+++ b/frontend/src/components/compliance/EntryGate.jsx
@@ -83,7 +83,7 @@ export default function EntryGate() {
         <p>By selecting <strong>Enter</strong>, you confirm that:</p>
         <ul>
           <li>You are at least 21 years old.</li>
-          <li>You are not a U.S. person and are not accessing FairWins from the United States or any restricted jurisdiction listed in our Terms.</li>
+          <li>You are not accessing FairWins from any restricted jurisdiction listed in our Terms.</li>
           <li>You are not subject to sanctions and do not appear on any government restricted-party list.</li>
           <li>Accessing peer-to-peer wagering is lawful where you are located, and you accept full responsibility for compliance with your local laws.</li>
           <li>

--- a/frontend/src/components/compliance/MembershipAttestation.jsx
+++ b/frontend/src/components/compliance/MembershipAttestation.jsx
@@ -11,7 +11,7 @@ import { useState, useEffect } from 'react'
 
 const ATTESTATIONS = [
   { id: 'age', label: 'I am at least 21 years of age.' },
-  { id: 'jurisdiction', label: 'I am not a U.S. person and am not located, resident, or established in the United States or any Restricted Jurisdiction defined in the Terms.' },
+  { id: 'jurisdiction', label: 'I am not located, resident, or established in any Restricted Jurisdiction defined in the Terms.' },
   { id: 'sanctions', label: 'I am not, and do not act on behalf of, any person subject to sanctions or named on any restricted-party list (including the OFAC SDN list).' },
   { id: 'norecourse', label: 'I understand FairWins is not a registered exchange, broker, or regulated gambling operator, that there is no regulator or authority to which I can appeal a dispute, and that wager outcomes are settled by smart contract and the published dispute-resolution mechanism.' },
   { id: 'risk', label: 'I understand I may lose the entire amount of any wager, that I bear sole responsibility for my own tax reporting, and that I have sole control of my wallet and private keys.' },

--- a/frontend/src/hooks/useVouchers.js
+++ b/frontend/src/hooks/useVouchers.js
@@ -25,7 +25,7 @@ import { ERC20_ABI } from '../abis/ERC20'
  */
 export function useVouchers() {
   const { account, signer, provider, chainId } = useWallet()
-  const [status, setStatus] = useState('idle') // idle | minting | redeeming | listing | success | error
+  const [status, setStatus] = useState('idle') // idle | minting | redeeming | transferring | listing | success | error
   const [error, setError] = useState(null)
   const [lastTxHash, setLastTxHash] = useState(null)
 
@@ -121,6 +121,40 @@ export function useVouchers() {
     [signer, account, voucherAvailable, batchMintAvailable, voucherAddress, managerAddress, batchMinterAddress, paymentTokenAddress]
   )
 
+  /**
+   * Transfer a voucher you hold to another address (e.g. a fresh wallet, or the person you're gifting
+   * it to). Uses ERC-721 `safeTransferFrom` so the destination is checked for receiver support. The
+   * recipient can then redeem it into their own soulbound membership.
+   */
+  const transferVoucher = useCallback(
+    async (tokenId, to) => {
+      if (!signer) throw new Error('Connect a wallet to transfer a voucher.')
+      if (!voucherAvailable) throw new Error('Membership vouchers are not available on this network yet.')
+      const dest = (to || '').trim()
+      if (!ethers.isAddress(dest)) throw new Error('Enter a valid recipient address.')
+      if (account && dest.toLowerCase() === account.toLowerCase()) {
+        throw new Error('That voucher is already in this wallet.')
+      }
+      setStatus('transferring')
+      setError(null)
+      setLastTxHash(null)
+      try {
+        const voucher = new ethers.Contract(voucherAddress, MEMBERSHIP_VOUCHER_ABI, signer)
+        // The voucher overloads safeTransferFrom; pick the 3-arg (no data) form explicitly.
+        const tx = await voucher['safeTransferFrom(address,address,uint256)'](account, dest, tokenId)
+        setLastTxHash(tx.hash)
+        await tx.wait()
+        setStatus('success')
+        return { tokenId, to: dest, txHash: tx.hash }
+      } catch (e) {
+        setStatus('error')
+        setError(e?.shortMessage || e?.message || 'Transfer failed.')
+        throw e
+      }
+    },
+    [signer, account, voucherAvailable, voucherAddress]
+  )
+
   /** Redeem voucher `tokenId` into a soulbound membership for the connected wallet. `termsHash` may be 0x0. */
   const redeemVoucher = useCallback(
     async (tokenId, termsHash) => {
@@ -196,6 +230,7 @@ export function useVouchers() {
     voucherAddress,
     mintVouchers,
     redeemVoucher,
+    transferVoucher,
     listMyVouchers,
     reset,
   }

--- a/frontend/src/legal/terms.md
+++ b/frontend/src/legal/terms.md
@@ -10,7 +10,7 @@ Before you agree, understand the following in plain language. The full terms bel
 - **FairWins is software, not a bookmaker.** You wager directly against other people. FairWins is never the other side of your bet, never sets odds, never holds your money, and never takes a cut of any wager.
 - **Your membership fee buys access only.** It is not a bet, not a deposit, and not refundable.
 - **You can lose everything you wager.** There is no insurance and no regulator you can appeal to.
-- **You must qualify to use FairWins.** You must be at least 21, not a U.S. person, not located in a restricted jurisdiction, and not subject to sanctions.
+- **You must qualify to use FairWins.** You must be at least 21, not located in a restricted jurisdiction, and not subject to sanctions.
 - **You control your own wallet.** If you lose your keys, no one — including FairWins — can recover your funds or your account.
 - **Disputes with FairWins go to arbitration, individually.** You give up the right to a court trial and to class actions against us.
 
@@ -43,7 +43,6 @@ If any provision of a more specific step (membership attestation, signed message
 - **"Public Wager"** — a Wager broadcast for acceptance by any address.
 - **"Smart Contract"** — the FairWins protocol contracts deployed on the Polygon network.
 - **"Resolution Mechanism"** — the on-chain process, including any oracle and dispute procedure, by which the outcome of a Wager is determined and settled, as described in the Service documentation.
-- **"U.S. Person"** — any individual resident in the United States; any entity organized under U.S. law or with its principal place of business in the United States; and any person acting on behalf of any of the foregoing.
 - **"Restricted Jurisdiction"** — any jurisdiction listed in **Schedule A**, as amended from time to time.
 - **"Restricted Party"** — any person subject to sanctions administered by OFAC or any other applicable authority, or named on any government restricted-party or denied-persons list.
 
@@ -64,11 +63,10 @@ If any provision of a more specific step (membership attestation, signed message
 You may use the Service only if you meet **all** of the following at all times. By using the Service you represent and warrant that:
 
 - (a) you are at least **21 years of age** and of legal capacity to enter a binding contract;
-- (b) you are **not a U.S. Person** and are not located, resident, incorporated, or established in the United States;
-- (c) you are not located, resident, incorporated, or established in any **Restricted Jurisdiction**;
-- (d) you are **not a Restricted Party** and do not act on behalf of any Restricted Party;
-- (e) your access to and use of peer-to-peer wagering software is **lawful in the jurisdiction from which you access it**, and you bear sole responsibility for that determination; and
-- (f) you have **sole and exclusive control** of the wallet and private keys you use with the Service.
+- (b) you are not located, resident, incorporated, or established in any **Restricted Jurisdiction**;
+- (c) you are **not a Restricted Party** and do not act on behalf of any Restricted Party;
+- (d) your access to and use of peer-to-peer wagering software is **lawful in the jurisdiction from which you access it**, and you bear sole responsibility for that determination; and
+- (e) you have **sole and exclusive control** of the wallet and private keys you use with the Service.
 
 These representations are renewed each time you access the Service, purchase or renew a Membership Pass, sign a Service message, or enter a Wager.
 
@@ -218,7 +216,6 @@ Questions about these Terms: Howdy@fairwins.app.
 
 The Service is not available to persons located, resident, incorporated, or established in:
 
-- The **United States** of America and its territories;
 - **Cuba, Iran, North Korea, Syria**, and the **Crimea, Donetsk, and Luhansk** regions;
 - Any jurisdiction subject to comprehensive sanctions by OFAC or other applicable authority; and
 - Any jurisdiction in which peer-to-peer wagering, prediction markets, or the Service is unlawful, including without limitation.

--- a/frontend/src/pages/VouchersPage.jsx
+++ b/frontend/src/pages/VouchersPage.jsx
@@ -7,6 +7,11 @@ import { useTierPrices } from '../hooks/useTierPrices'
 import { TIER_NAMES, TIER_COLORS } from '../hooks/useRoleDetails'
 import { MEMBERSHIP_VOUCHERS_TERMS_PATH } from '../constants/legalLinks'
 import Button from '../components/ui/Button'
+import AddressInput from '../components/ui/AddressInput'
+import AddressBookButton from '../components/ui/AddressBookButton'
+import QRScanner from '../components/ui/QRScanner'
+import MembershipAttestation from '../components/compliance/MembershipAttestation'
+import { extractAddressFromScan } from '../lib/addressBook/scanAddress'
 import './vouchers.css'
 
 const TIER_ORDER = ['BRONZE', 'SILVER', 'GOLD', 'PLATINUM']
@@ -23,7 +28,7 @@ export default function VouchersPage() {
   const { getPrice, ROLE_HASHES, TIER_IDS } = useTierPrices()
   const {
     status, error, lastTxHash, voucherAvailable, batchMintAvailable,
-    mintVouchers, redeemVoucher, listMyVouchers,
+    mintVouchers, redeemVoucher, transferVoucher, listMyVouchers,
   } = useVouchers()
   const { hash } = useLocation()
 
@@ -38,6 +43,7 @@ export default function VouchersPage() {
   const [selectedTier, setSelectedTier] = useState('BRONZE')
   const [quantity, setQuantity] = useState(1)
   const [recipient, setRecipient] = useState('')
+  const [recipientResolved, setRecipientResolved] = useState('')
   const [minted, setMinted] = useState(null)
 
   const [myVouchers, setMyVouchers] = useState([])
@@ -46,8 +52,18 @@ export default function VouchersPage() {
   const [acceptedTerms, setAcceptedTerms] = useState(false)
   const [redeemed, setRedeemed] = useState(false)
 
+  // Transfer-a-voucher state (sends the selected held voucher to another wallet).
+  const [transferTo, setTransferTo] = useState('')
+  const [transferToResolved, setTransferToResolved] = useState('')
+  const [transferred, setTransferred] = useState(null)
+
+  // Shared QR scanner for the gift + transfer address fields. `qrTarget` says
+  // which field a successful scan should populate.
+  const [qrScannerOpen, setQrScannerOpen] = useState(false)
+  const [qrTarget, setQrTarget] = useState(null) // 'gift' | 'transfer'
+
   const role = ROLE_HASHES.WAGER_PARTICIPANT
-  const busy = status === 'minting' || status === 'redeeming'
+  const busy = status === 'minting' || status === 'redeeming' || status === 'transferring'
 
   // Deep links from the "Get Wager Access" modal (#vch-buy-h / #vch-redeem-h) scroll to the section.
   useEffect(() => {
@@ -79,8 +95,17 @@ export default function VouchersPage() {
 
   if (!isConnected) return <Navigate to="/" replace />
 
+  // Resolve the gift recipient: prefer the ENS-resolved address, else accept a
+  // directly-typed hex address. Empty when neither is valid yet.
+  const giftAddr = recipientResolved || (ethers.isAddress(recipient.trim()) ? recipient.trim() : '')
   const giftMode = recipient.trim().length > 0
-  const recipientValid = !giftMode || ethers.isAddress(recipient.trim())
+  const recipientValid = !giftMode || ethers.isAddress(giftAddr)
+
+  // Transfer recipient (same ENS-or-hex resolution as the gift field).
+  const transferAddr = transferToResolved || (ethers.isAddress(transferTo.trim()) ? transferTo.trim() : '')
+  const transferEntered = transferTo.trim().length > 0
+  const transferValid = ethers.isAddress(transferAddr) && transferAddr.toLowerCase() !== (account || '').toLowerCase()
+
   const qtyNum = Math.min(MAX_QUANTITY, Math.max(1, Math.floor(Number(quantity) || 1)))
   const unitPrice = getPrice('WAGER_PARTICIPANT', selectedTier)
   const totalPrice = unitPrice * qtyNum
@@ -88,13 +113,49 @@ export default function VouchersPage() {
   const needsHelper = qtyNum > 1 || giftMode
   const buyBlocked = needsHelper && !batchMintAvailable
 
+  function openQrScanner(target) {
+    setQrTarget(target)
+    setQrScannerOpen(true)
+  }
+
+  function handleQrScanSuccess(decodedText) {
+    const addr = extractAddressFromScan(decodedText)
+    if (addr) {
+      if (qrTarget === 'gift') {
+        setRecipient(addr)
+        setRecipientResolved(addr)
+      } else if (qrTarget === 'transfer') {
+        setTransferTo(addr)
+        setTransferToResolved(addr)
+      }
+    }
+    setQrScannerOpen(false)
+    setQrTarget(null)
+  }
+
   async function onBuy() {
     setMinted(null)
     try {
-      const res = await mintVouchers(role, TIER_IDS[selectedTier], qtyNum, recipient)
+      // Pass the resolved 0x address (ENS-resolved or directly typed) so the hook's
+      // address check passes for gifts entered as an ENS name.
+      const res = await mintVouchers(role, TIER_IDS[selectedTier], qtyNum, giftAddr || recipient)
       setMinted(res)
       // Holdings only change if you bought for yourself.
       if (!res.gift) refreshVouchers()
+    } catch {
+      /* error surfaced via hook state */
+    }
+  }
+
+  async function onTransfer() {
+    setTransferred(null)
+    if (!selectedVoucherId) return
+    try {
+      const res = await transferVoucher(selectedVoucherId, transferAddr || transferTo)
+      setTransferred(res)
+      setTransferTo('')
+      setTransferToResolved('')
+      refreshVouchers()
     } catch {
       /* error surfaced via hook state */
     }
@@ -185,19 +246,45 @@ export default function VouchersPage() {
               disabled={!voucherAvailable || busy}
             />
           </label>
-          <label className="vch-field vch-field-grow">
-            <span>Gift to address <em>(optional)</em></span>
-            <input
-              className={`vch-input ${giftMode && !recipientValid ? 'vch-input-error' : ''}`}
-              type="text"
-              spellCheck="false"
-              autoComplete="off"
-              placeholder="0x… — leave blank to buy for yourself"
-              value={recipient}
-              onChange={(e) => setRecipient(e.target.value)}
+        </div>
+
+        {/* Gift recipient on its own single line, with address-book + QR like the
+            wager opponent field (voucher testing feedback). Leave blank to buy
+            for yourself. */}
+        <div className="vch-field">
+          <label htmlFor="vch-gift-to">Gift to address <em>(optional)</em></label>
+          <div className="fm-input-with-action">
+            <div className="fm-address-input-wrap">
+              <AddressInput
+                id="vch-gift-to"
+                value={recipient}
+                onChange={(e) => setRecipient(e.target.value)}
+                onResolvedChange={(addr) => setRecipientResolved(addr || '')}
+                placeholder="0x… or ENS — leave blank to buy for yourself"
+                disabled={!voucherAvailable || busy}
+                error={giftMode && !recipientValid}
+              />
+            </div>
+            <AddressBookButton
               disabled={!voucherAvailable || busy}
+              onSelect={(entry) => {
+                setRecipient(entry.address)
+                setRecipientResolved(entry.address)
+              }}
             />
-          </label>
+            <button
+              type="button"
+              className="fm-scan-btn"
+              onClick={() => openQrScanner('gift')}
+              disabled={!voucherAvailable || busy}
+              title="Scan QR code"
+              aria-label="Scan recipient QR code"
+            >
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M3 3h8v8H3V3zm2 2v4h4V5H5zm8-2h8v8h-8V3zm2 2v4h4V5h-4zM3 13h8v8H3v-8zm2 2v4h4v-4H5zm10-2h2v2h-2v-2zm4 0h2v2h-2v-2zm-4 4h2v2h-2v-2zm2 2h2v2h-2v-2zm2-2h2v2h-2v-2zm0 4h2v2h-2v-2z"/>
+              </svg>
+            </button>
+          </div>
         </div>
         {giftMode && !recipientValid && (
           <p className="vch-warn" role="status">That doesn’t look like a valid wallet address.</p>
@@ -288,19 +375,81 @@ export default function VouchersPage() {
           </fieldset>
         )}
 
-        <label className="vch-terms">
-          <input
-            type="checkbox"
-            checked={acceptedTerms}
-            onChange={(e) => setAcceptedTerms(e.target.checked)}
-            disabled={!voucherAvailable || busy || myVouchers.length === 0}
-          />
-          I accept the{' '}
+        {/* Transfer the selected voucher to someone else instead of redeeming it.
+            No membership is granted by transferring — the recipient redeems it
+            themselves. Same address entry / address book / QR as the gift field. */}
+        {myVouchers.length > 0 && (
+          <div className="vch-transfer">
+            <span className="vch-subhead">Transfer this voucher to someone else</span>
+            <p className="vch-help">
+              Send the selected voucher to another wallet — they can redeem it for their own membership.
+              Transferring doesn’t grant a membership here.
+            </p>
+            <div className="fm-input-with-action">
+              <div className="fm-address-input-wrap">
+                <AddressInput
+                  id="vch-transfer-to"
+                  value={transferTo}
+                  onChange={(e) => setTransferTo(e.target.value)}
+                  onResolvedChange={(addr) => setTransferToResolved(addr || '')}
+                  placeholder="0x… or ENS — who should receive it"
+                  disabled={!voucherAvailable || busy}
+                  error={transferEntered && !transferValid}
+                />
+              </div>
+              <AddressBookButton
+                disabled={!voucherAvailable || busy}
+                onSelect={(entry) => {
+                  setTransferTo(entry.address)
+                  setTransferToResolved(entry.address)
+                }}
+              />
+              <button
+                type="button"
+                className="fm-scan-btn"
+                onClick={() => openQrScanner('transfer')}
+                disabled={!voucherAvailable || busy}
+                title="Scan QR code"
+                aria-label="Scan recipient QR code"
+              >
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path d="M3 3h8v8H3V3zm2 2v4h4V5H5zm8-2h8v8h-8V3zm2 2v4h4V5h-4zM3 13h8v8H3v-8zm2 2v4h4v-4H5zm10-2h2v2h-2v-2zm4 0h2v2h-2v-2zm-4 4h2v2h-2v-2zm2 2h2v2h-2v-2zm2-2h2v2h-2v-2zm0 4h2v2h-2v-2z"/>
+                </svg>
+              </button>
+            </div>
+            {transferEntered && !transferValid && (
+              <p className="vch-warn" role="status">
+                Enter a valid wallet address that isn’t this one.
+              </p>
+            )}
+            <Button
+              variant="secondary"
+              onClick={onTransfer}
+              loading={status === 'transferring'}
+              disabled={!voucherAvailable || !selectedVoucherId || !transferValid || busy}
+            >
+              {selectedVoucherId ? `Transfer voucher #${selectedVoucherId}` : 'Transfer voucher'}
+            </Button>
+            {transferred && (
+              <p className="vch-success" role="status">
+                Sent voucher #{transferred.tokenId} to {transferred.to.slice(0, 6)}…{transferred.to.slice(-4)}.
+              </p>
+            )}
+          </div>
+        )}
+
+        <div className="vch-divider" role="separator" aria-hidden="true" />
+
+        {/* Terms acceptance for redemption uses the SAME attestation block as the
+            membership purchase flow (voucher testing feedback), so a redeemer
+            confirms the identical eligibility statements. */}
+        <MembershipAttestation onChange={setAcceptedTerms} />
+        <p className="vch-fineprint">
+          Redeeming is also governed by the{' '}
           <a href={MEMBERSHIP_VOUCHERS_TERMS_PATH} target="_blank" rel="noopener noreferrer">
-            Terms &amp; Conditions
-          </a>{' '}
-          (including the membership voucher terms) and confirm I’m eligible.
-        </label>
+            membership voucher terms
+          </a>.
+        </p>
 
         <Button
           variant="primary"
@@ -316,6 +465,12 @@ export default function VouchersPage() {
           </p>
         )}
       </section>
+
+      <QRScanner
+        isOpen={qrScannerOpen}
+        onClose={() => { setQrScannerOpen(false); setQrTarget(null) }}
+        onScanSuccess={handleQrScanSuccess}
+      />
     </div>
   )
 }

--- a/frontend/src/pages/vouchers.css
+++ b/frontend/src/pages/vouchers.css
@@ -185,6 +185,35 @@
   border-color: #c77d11;
 }
 
+/* Gift / transfer address fields take the full row (single line) with the
+   address-book + QR buttons sitting next to the input. */
+.vch-field label {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.3rem;
+  display: block;
+}
+
+/* Transfer-a-voucher block inside the redeem card */
+.vch-transfer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 0.85rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md, 8px);
+  background: var(--bg-primary);
+}
+.vch-subhead {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.vch-divider {
+  border-top: 1px solid var(--border-color);
+  margin: 0.5rem 0;
+}
+
 /* Held-voucher list for redemption */
 .vch-myvouchers-head {
   display: flex;

--- a/frontend/src/test/MembershipAttestation.test.jsx
+++ b/frontend/src/test/MembershipAttestation.test.jsx
@@ -43,7 +43,7 @@ describe('MembershipAttestation (T043)', () => {
   it('covers the required eligibility/risk attestations (FR-037)', () => {
     render(<MembershipAttestation onChange={() => {}} />)
     expect(screen.getByText(/at least 21 years/i)).toBeInTheDocument()
-    expect(screen.getByText(/not a U\.S\. person/i)).toBeInTheDocument()
+    expect(screen.getByText(/not located, resident, or established in any Restricted Jurisdiction/i)).toBeInTheDocument()
     expect(screen.getByText(/OFAC SDN/i)).toBeInTheDocument()
     expect(screen.getByText(/no regulator or authority/i)).toBeInTheDocument()
     expect(screen.getByText(/VPN, proxy/i)).toBeInTheDocument()

--- a/frontend/src/test/VouchersPage.test.jsx
+++ b/frontend/src/test/VouchersPage.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 
 // Mock the data hooks so we can render VouchersPage deterministically (spec 026).
@@ -37,6 +37,7 @@ const baseVouchers = {
   batchMintAvailable: true,
   mintVouchers: vi.fn(),
   redeemVoucher: vi.fn(),
+  transferVoucher: vi.fn().mockResolvedValue({ tokenId: '7', to: '0x2222222222222222222222222222222222222222', txHash: '0xabc' }),
   listMyVouchers: vi.fn().mockResolvedValue([]),
   reset: vi.fn(),
 }
@@ -94,6 +95,48 @@ describe('VouchersPage (spec 026)', () => {
     // Default state (qty 1, self) is fine; the block only appears once the order needs the helper.
     // Render asserts the buy section is present; the warning is exercised in interaction tests elsewhere.
     expect(screen.getByRole('heading', { name: /Buy a voucher/i })).toBeInTheDocument()
+  })
+
+  it('gives the gift field its own line with an address book and QR scan button', async () => {
+    useVouchers.mockReturnValue({ ...baseVouchers, listMyVouchers: vi.fn().mockResolvedValue([]) })
+    renderPage()
+    // The gift recipient is an AddressInput (id wired) rather than the old plain input.
+    expect(document.getElementById('vch-gift-to')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Choose from address book/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Scan recipient QR code/i })).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText(/don’t have any vouchers to redeem/i)).toBeInTheDocument())
+  })
+
+  it('uses the same membership attestation block for redemption as for purchase', async () => {
+    useVouchers.mockReturnValue({ ...baseVouchers, listMyVouchers: vi.fn().mockResolvedValue([]) })
+    renderPage()
+    // The shared MembershipAttestation renders its discrete, individually-ticked eligibility checkboxes.
+    expect(screen.getByText(/Membership confirmation/i)).toBeInTheDocument()
+    expect(screen.getAllByRole('checkbox').length).toBeGreaterThanOrEqual(5)
+    await waitFor(() => expect(screen.getByText(/don’t have any vouchers to redeem/i)).toBeInTheDocument())
+  })
+
+  it('transfers a held voucher to another address via the transfer button', async () => {
+    const transferVoucher = vi.fn().mockResolvedValue({
+      tokenId: '7', to: '0x2222222222222222222222222222222222222222', txHash: '0xabc',
+    })
+    const listMyVouchers = vi.fn().mockResolvedValue([
+      { tokenId: '7', tier: 1, durationDays: 30, role: '0xrole' },
+    ])
+    useVouchers.mockReturnValue({ ...baseVouchers, transferVoucher, listMyVouchers })
+    renderPage()
+    await waitFor(() => expect(screen.getByText('#7')).toBeInTheDocument())
+
+    // Select the voucher, type a recipient, and transfer.
+    fireEvent.click(screen.getByRole('radio', { name: /membership|#7/i }))
+    fireEvent.change(document.getElementById('vch-transfer-to'), {
+      target: { value: '0x2222222222222222222222222222222222222222' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /Transfer voucher/i }))
+
+    await waitFor(() =>
+      expect(transferVoucher).toHaveBeenCalledWith('7', '0x2222222222222222222222222222222222222222'),
+    )
   })
 
   it('shows an honest "not available on this network" notice when the voucher is undeployed', () => {

--- a/frontend/src/test/keygenEligibility.test.js
+++ b/frontend/src/test/keygenEligibility.test.js
@@ -12,7 +12,7 @@ describe('key-gen eligibility disclosure (T048)', () => {
   it('states the standing eligibility facts', () => {
     const text = ELIGIBILITY_DISCLOSURE.facts.join(' ')
     expect(text).toMatch(/21 years/i)
-    expect(text).toMatch(/not a U\.S\. person/i)
+    expect(text).toMatch(/not located in a Restricted Jurisdiction/i)
     expect(text).toMatch(/sanctioned/i)
     expect(text).toMatch(/sole control of this wallet/i)
   })

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -187,6 +187,10 @@ vi.mock('wagmi', () => ({
   useSwitchChain: vi.fn(() => ({
     switchChain: vi.fn()
   })),
+  // ENS resolution hooks (used by AddressInput). Default to "no resolution" so
+  // address fields render without a WagmiProvider/QueryClient in unit tests.
+  useEnsAddress: vi.fn(() => ({ data: undefined, isLoading: false, isError: false, error: null })),
+  useEnsName: vi.fn(() => ({ data: undefined, isLoading: false, isError: false, error: null })),
   useWalletClient: vi.fn(() => ({
     data: {
       account: { address: '0x1234567890123456789012345678901234567890' },

--- a/frontend/src/utils/crypto/constants.js
+++ b/frontend/src/utils/crypto/constants.js
@@ -242,7 +242,7 @@ export const ELIGIBILITY_DISCLOSURE = {
   title: 'FairWins — Account Key Generation',
   facts: [
     'I am at least 21 years old.',
-    'I am not a U.S. person and am not located in a Restricted Jurisdiction.',
+    'I am not located in a Restricted Jurisdiction.',
     'I am not a sanctioned or restricted party.',
     'I have sole control of this wallet and its private keys, and I meet and continue to meet the eligibility requirements of the FairWins Terms & Conditions.',
   ],


### PR DESCRIPTION
Addresses the four items from voucher (spec 026) testing feedback.

## Changes

### 1. Gift-to-address is a single line with address book + QR
The gift recipient on the **Buy a voucher** card is now its own full-width line using the ENS-aware `AddressInput`, an `AddressBookButton`, and a QR scan button — the same pattern as the wager opponent field — instead of a bare text input squeezed next to the quantity box. Gifts entered as an ENS name are resolved before minting.

### 2. Transfer a voucher
The **Redeem a voucher** card gains a *Transfer this voucher to someone else* block: pick a held voucher, enter a recipient (address entry / address book / QR), and send it via ERC-721 `safeTransferFrom`. The recipient can then redeem it themselves. Backed by a new `transferVoucher()` in `useVouchers`.

### 3. Redemption terms == purchase terms
Redemption now renders the same `MembershipAttestation` block used by the membership purchase flow, so a redeemer confirms the identical eligibility statements. The voucher-specific terms deep link is retained as a note.

### 4. Neutral eligibility wording (do not exclude the US)
Removed the "not a U.S. person / not in the United States" affirmations from the user-agreement surfaces, so the platform can service the US in a compliant manner:
- `MembershipAttestation`, `EntryGate`, and the key-generation eligibility disclosure
- `terms.md`: eligibility section, the `U.S. Person` definition, and Schedule A

Sanctions and restricted-jurisdiction language is **retained**; the US is neither excluded nor explicitly endorsed. The key-derivation signing message is untouched (the disclosure facts are display-only), so existing encryption keys remain reproducible. The privacy policy's data-processing-location mention is left as-is (not an exclusion).

> ⚠️ These are user-facing legal-text changes and should get a legal review before release.

## Tests
- Shared test `setup.js` now mocks the wagmi ENS hooks so `AddressInput` renders in unit tests.
- New `VouchersPage` coverage: gift book/QR controls, the shared attestation block, and voucher transfer.
- Updated `MembershipAttestation` / key-gen eligibility assertions for the reworded text.
- Full frontend suite green: **1587 tests / 157 files passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEiYds3KeTTJuVYi5p2W44

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEiYds3KeTTJuVYi5p2W44)_