### PR TITLE
test(coverage): measure access/upgradeable/integration suites in contract coverage

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,9 +1,12 @@
 module.exports = {
   skipFiles: [
-    'mocks/',
-    'ProposalRegistryFuzzTest.sol',
-    'WelfareMetricRegistryFuzzTest.sol',
-    'DAOFactory.sol', // Skip due to constructor gas limits under coverage instrumentation
+    'mocks/', // test-only mock contracts (never deployed)
+    // NOTE: contracts/test/* (Medusa/Echidna fuzz harnesses + mock oracles) are test-only
+    // and show as ~0% in the per-file report, but they are intentionally NOT added to
+    // skipFiles: skipping that whole directory corrupts solidity-coverage's source-map
+    // attribution for the production contracts those harnesses import (collapsing
+    // WagerRegistry coverage to ~5%). Read the per-file production rows (access/, oracles/,
+    // privacy/, upgradeable/, wagers/) rather than the blended "All files" total.
   ],
   mocha: {
     timeout: 180000, // 3 minutes for coverage (instrumented code is slower)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:fork": "hardhat test test/fork/*.test.js",
     "test:all": "hardhat test test/**/*.test.js",
     "test:gas": "REPORT_GAS=true hardhat test",
-    "test:coverage": "hardhat coverage --testfiles '{test/!(BatchOperations|DAOFactory).test.js,test/oracles/*.test.js,test/integration/!(factory)/**/*.test.js}'",
+    "test:coverage": "hardhat coverage --testfiles '{test/*.test.js,test/access/*.test.js,test/upgradeable/*.test.js,test/oracles/*.test.js,test/integration/**/*.test.js}'",
     "deploy:local": "hardhat run scripts/deploy/deploy.js --network localhost",
     "deploy:mordor": "hardhat run scripts/deploy/deploy.js --network mordor",
     "deploy:deterministic": "hardhat run scripts/deploy/deploy-deterministic.js",


### PR DESCRIPTION
## Smart-contract test & security review

Audited the latest CI on `main` (run on `1b721df`) for the three goals — high coverage, passing tests, no open vulnerabilities — and fixed a coverage-**measurement** gap found along the way.

### ✅ Passing tests
- `npm test`: **304 passing, 5 pending, 0 failing** (reproduced locally; matches the green `Test Pipeline` + `Security Testing & Analysis` runs on `main`).
- `npm run check:storage-layout` (the UUPS upgrade-safety gate): **pass**.

### 📊 Coverage — the fix in this PR
The `test:coverage` testfiles glob only matched `test/*.test.js`, `test/oracles/*`, and `test/integration/<subdir>/**`. It **excluded** `test/access/**`, `test/upgradeable/**`, and top-level `test/integration/*.test.js` — so the spec-026 voucher and spec-027 upgradeable suites never contributed to coverage, even though those contracts are fully exercised by their own tests. The report therefore showed:

| Contract | Before (reported) | After (real) |
|---|---|---|
| `VoucherBatchMinter.sol` | 0% | **100%** |
| `MembershipVoucher.sol` | 0% | **76.47%** |
| `MembershipManager.sol` | 80.19% | **94.34%** |
| `access/` (dir) | 59.89% | **92.31%** |
| `upgradeable/UUPSManaged.sol` (branch) | 25% | **75%** |
| `wagers/WagerRegistry.sol` | 95.42% | **96.95%** |

Other production rows: `oracles/` 85%, `privacy/KeyRegistry.sol` 100%, all `interfaces/` 100%. The widened glob runs the full 304-test set under instrumentation (fork tests stay out — they need a live RPC).

Also removed three **stale** `.solcover.js` `skipFiles` entries (`DAOFactory`, `ProposalRegistryFuzzTest`, `WelfareMetricRegistryFuzzTest` — none of those contracts exist anymore) and documented why `contracts/test/*` is left instrumented rather than directory-skipped (skipping the whole dir corrupts solidity-coverage's source-map attribution and collapses `WagerRegistry` to ~5%).

> Note: the blended **"All files"** total (~64%) is still pulled down by `contracts/test/*` (Medusa/Echidna fuzz harnesses + mock oracles) being instrumented as if production. Read the per-file production rows, not the blended total.

### 🔒 Vulnerabilities — no action needed
- **Slither** (latest `main` artifact): **0 High/Critical**, 22 Medium, 25 Low, 12 Informational. The Mediums are the standard false-positive categories — `reentrancy-no-eth` on `nonReentrant`-guarded, CEI-ordered functions (`cancelOpen`/`batchExpireOpen`/`declineWager`); `incorrect-equality` on a safe enum compare (`tier == Tier.None`); a deliberately-minimal `IVoucherMint` interface; and `unused-return` on intentionally-ignored returns.
- **`npm audit --omit=dev`: 0 vulnerabilities.** The 158 advisories from a full `npm audit` are all devDependencies (Hardhat / ens / viem / ws tooling) that don't ship in deployed contracts or the frontend bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fr7roFnHwPBdMuaRVt2ujS)_