### PR TITLE
fix(frontend): flag estimated tier prices when MembershipManager is unreachable (#752)

### DIFF
--- a/frontend/src/components/ui/PremiumPurchaseModal.css
+++ b/frontend/src/components/ui/PremiumPurchaseModal.css
@@ -635,6 +635,15 @@
   line-height: 1.4;
 }
 
+/* Shown when tier prices fall back to hardcoded estimates (MembershipManager
+   unreachable / per-tier read failed) so the amount may not match on-chain. */
+.ppm-price-estimate {
+  font-size: 0.8125rem;
+  color: #c77d11;
+  margin-top: 0.5rem;
+  line-height: 1.4;
+}
+
 .ppm-error {
   color: #e53e3e;
   font-size: 0.8125rem;

--- a/frontend/src/components/ui/PremiumPurchaseModal.jsx
+++ b/frontend/src/components/ui/PremiumPurchaseModal.jsx
@@ -92,7 +92,7 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
   const { grantRole, loadRoles } = useRoles()
   const { account, isConnected, isCorrectNetwork, switchNetwork, chainId } = useWeb3()
   const { showNotification } = useNotification()
-  const { getPrice, getLimits } = useTierPrices()
+  const { getPrice, getLimits, usingFallbackPrices } = useTierPrices()
   const { ensureInitialized } = useEncryption()
   const flow = usePurchaseFlow()
   const navigate = useNavigate()
@@ -541,6 +541,13 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
                       <span>Total</span>
                       <span>${selectedPrice.toFixed(2)} USDC</span>
                     </div>
+                    {usingFallbackPrices && (
+                      <p className="ppm-price-estimate" role="status">
+                        ⚠ Estimated price — live pricing couldn’t be loaded from the
+                        membership contract, so this is a fallback estimate. Confirm
+                        the exact amount in your wallet before approving.
+                      </p>
+                    )}
                   </div>
 
                   <TierLimits tierName={selectedTier} chainLimits={chainLimits} />

--- a/frontend/src/hooks/useTierPrices.js
+++ b/frontend/src/hooks/useTierPrices.js
@@ -42,6 +42,12 @@ export function useTierPrices() {
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState(null)
   const [lastUpdated, setLastUpdated] = useState(null)
+  // True whenever the displayed prices include the hardcoded FALLBACK_PRICES
+  // (no MembershipManager on this chain, or a per-tier read failed) rather than
+  // being fully sourced on-chain. Starts true (initial state IS the fallback)
+  // and is flipped to false only after a clean on-chain fetch. Lets the UI warn
+  // that prices for a real-money product may be estimates / out of sync.
+  const [usingFallbackPrices, setUsingFallbackPrices] = useState(true)
 
   // Resolve the MembershipManager + provider for the wallet's connected chain so
   // tier prices/limits reflect the network the user is actually on, not the
@@ -62,6 +68,7 @@ export function useTierPrices() {
       // whatever was fetched for a previously-connected network.
       setTierPrices(FALLBACK_PRICES)
       setTierLimits({})
+      setUsingFallbackPrices(true)
       setError('MembershipManager not deployed')
       setIsLoading(false)
       return
@@ -71,6 +78,7 @@ export function useTierPrices() {
     try {
       const prices = { BRONZE: {}, SILVER: {}, GOLD: {}, PLATINUM: {} }
       const limits = { BRONZE: {}, SILVER: {}, GOLD: {}, PLATINUM: {} }
+      let usedFallback = false
       for (const [roleKey, roleHash] of Object.entries(ROLE_HASHES)) {
         for (const [tierName, tierId] of Object.entries(TIER_IDS)) {
           try {
@@ -84,11 +92,13 @@ export function useTierPrices() {
             }
           } catch {
             prices[tierName][roleKey] = FALLBACK_PRICES[tierName]?.[roleKey] ?? 0
+            usedFallback = true
           }
         }
       }
       setTierPrices(prices)
       setTierLimits(limits)
+      setUsingFallbackPrices(usedFallback)
       setLastUpdated(new Date())
     } catch (err) {
       console.error('Error fetching tier prices:', err)
@@ -126,6 +136,7 @@ export function useTierPrices() {
     isLoading,
     error,
     lastUpdated,
+    usingFallbackPrices,
     fetchPrices,
     getPrice,
     getTotalPrice,

--- a/frontend/src/pages/VouchersPage.jsx
+++ b/frontend/src/pages/VouchersPage.jsx
@@ -25,7 +25,7 @@ const MAX_QUANTITY = 50
  */
 export default function VouchersPage() {
   const { account, isConnected } = useWallet()
-  const { getPrice, ROLE_HASHES, TIER_IDS } = useTierPrices()
+  const { getPrice, ROLE_HASHES, TIER_IDS, usingFallbackPrices } = useTierPrices()
   const {
     status, error, lastTxHash, voucherAvailable, batchMintAvailable,
     mintVouchers, redeemVoucher, transferVoucher, listMyVouchers,
@@ -231,6 +231,14 @@ export default function VouchersPage() {
             )
           })}
         </fieldset>
+
+        {usingFallbackPrices && (
+          <p className="vch-warn" role="status">
+            ⚠ Estimated pricing — live tier prices couldn’t be loaded, so these are
+            fallback estimates and may differ from the on-chain price. Confirm the
+            exact amount in your wallet.
+          </p>
+        )}
 
         <div className="vch-buy-row">
           <label className="vch-field">

--- a/frontend/src/test/useTierPrices.chain.test.js
+++ b/frontend/src/test/useTierPrices.chain.test.js
@@ -28,4 +28,14 @@ describe('useTierPrices — chain-aware resolution', () => {
       expect(resolver).toHaveBeenCalledWith('membershipManager', 80002)
     )
   })
+
+  it('flags usingFallbackPrices when no MembershipManager is deployed (#752)', async () => {
+    const { result } = renderHook(() => useTierPrices())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    // No contract on this chain → prices are the hardcoded fallback ladder, and
+    // the hook must say so rather than presenting them as authoritative.
+    expect(result.current.usingFallbackPrices).toBe(true)
+    expect(result.current.error).toBe('MembershipManager not deployed')
+    expect(result.current.getPrice('WAGER_PARTICIPANT', 'BRONZE')).toBe(2)
+  })
 })


### PR DESCRIPTION
## Summary
Fixes #752. `useTierPrices` silently presented a hardcoded fallback ladder ($2/$8/$25/$100) as if it were authoritative whenever the `MembershipManager` was undeployed/unreachable or a per-tier `getTierConfig` read threw. For a real-money product, the membership-purchase and voucher UIs could therefore show stale/drifted prices with no indication they were estimates.

## Change
- **`useTierPrices`**: new `usingFallbackPrices` flag. Starts `true` (initial state *is* the fallback ladder) and flips to `false` only after a clean on-chain fetch. Set `true` when there's no `MembershipManager` on the chain or any tier read falls back. A transient refresh failure keeps the last-known on-chain values and leaves the flag at its prior value (so genuine on-chain prices aren't mislabeled).
- **`PremiumPurchaseModal`**: amber "Estimated price — confirm in your wallet" note under the order total when `usingFallbackPrices` is set (new `.ppm-price-estimate` style).
- **`VouchersPage`**: equivalent note under the tier selector (reuses the existing `.vch-warn` style).

The notes render **only** when prices are actually fallbacks, so normal on-chain operation is visually unchanged.

## Verification
- New hook test asserts `usingFallbackPrices === true` when no `MembershipManager` is deployed; existing chain-resolution test still passes.
- `vitest`: useTierPrices (2) + VouchersPage/voucher suites (14) pass.
- `eslint` clean on all changed files.

_Identified by a TODO/stub audit of the repo._

🤖 Generated with [Claude Code](https://claude.com/claude-code)