### PR TITLE
feat(subgraph): index oracle adapter conditions (#751)

### DIFF
--- a/frontend/src/abis/ChainlinkDataFeedOracleAdapter.json
+++ b/frontend/src/abis/ChainlinkDataFeedOracleAdapter.json
@@ -1,0 +1,590 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "admin",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AlreadyResolved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ConditionAlreadyRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ConditionNotRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DeadlineNotReached",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FeedNotAllowed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidComparisonOp",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidDeadline",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MarketAlreadyLinked",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "StaleFeedData",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "answer",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      }
+    ],
+    "name": "ConditionEvaluated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expectedResolutionTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "ConditionRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "confidence",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "resolvedAt",
+        "type": "uint256"
+      }
+    ],
+    "name": "ConditionResolved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "feed",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "allowed",
+        "type": "bool"
+      }
+    ],
+    "name": "FeedAllowed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "friendMarketId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "MarketLinked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "allowedFeeds",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "conditions",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "feed",
+        "type": "address"
+      },
+      {
+        "internalType": "int256",
+        "name": "threshold",
+        "type": "int256"
+      },
+      {
+        "internalType": "enum ChainlinkDataFeedOracleAdapter.Comparison",
+        "name": "op",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint64",
+        "name": "deadline",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "registered",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "evaluate",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getConditionMetadata",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expectedResolutionTime",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getConfiguredChainId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getOutcome",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "confidence",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "resolvedAt",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isAvailable",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isConditionResolved",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isConditionSupported",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "friendMarketId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "linkMarket",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "marketToCondition",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oracleType",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "feed",
+        "type": "address"
+      },
+      {
+        "internalType": "int256",
+        "name": "threshold",
+        "type": "int256"
+      },
+      {
+        "internalType": "enum ChainlinkDataFeedOracleAdapter.Comparison",
+        "name": "op",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint64",
+        "name": "deadline",
+        "type": "uint64"
+      }
+    ],
+    "name": "registerCondition",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "resolutionCache",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint64",
+        "name": "resolvedAt",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint96",
+        "name": "confidence",
+        "type": "uint96"
+      },
+      {
+        "internalType": "bool",
+        "name": "exists",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "feed",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "allowed",
+        "type": "bool"
+      }
+    ],
+    "name": "setFeedAllowed",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/frontend/src/abis/ChainlinkFunctionsOracleAdapter.json
+++ b/frontend/src/abis/ChainlinkFunctionsOracleAdapter.json
@@ -1,0 +1,660 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "admin",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_router",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AlreadyResolved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ConditionAlreadyRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ConditionNotRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidResponseLength",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MarketAlreadyLinked",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OnlyRouterCanFulfill",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "RequestAlreadyPending",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "RouterHasNoCode",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnknownRequestId",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expectedResolutionTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "ConditionRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "confidence",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "resolvedAt",
+        "type": "uint256"
+      }
+    ],
+    "name": "ConditionResolved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "friendMarketId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "MarketLinked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferRequested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "requestId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "err",
+        "type": "bytes"
+      }
+    ],
+    "name": "RequestFailed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RequestFulfilled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RequestSent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "requestId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ResolutionRequested",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "conditionToPendingRequest",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "conditions",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "sourceHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "encodedRequest",
+        "type": "bytes"
+      },
+      {
+        "internalType": "uint64",
+        "name": "subscriptionId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint32",
+        "name": "gasLimit",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "donId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "registered",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getConditionMetadata",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expectedResolutionTime",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getConfiguredChainId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getOutcome",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "confidence",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "resolvedAt",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "requestId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "response",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "err",
+        "type": "bytes"
+      }
+    ],
+    "name": "handleOracleFulfillment",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isAvailable",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isConditionResolved",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isConditionSupported",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "friendMarketId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "linkMarket",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "marketToCondition",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oracleType",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "encodedRequest",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "sourceHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint64",
+        "name": "subscriptionId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint32",
+        "name": "gasLimit",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "donId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "registerCondition",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "requestResolution",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "requestId",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "requestToCondition",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "resolutionCache",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint64",
+        "name": "resolvedAt",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint96",
+        "name": "confidence",
+        "type": "uint96"
+      },
+      {
+        "internalType": "bool",
+        "name": "exists",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "router",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/frontend/src/abis/UMAOptimisticOracleV3Adapter.json
+++ b/frontend/src/abis/UMAOptimisticOracleV3Adapter.json
@@ -1,0 +1,669 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "admin",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_oo",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AlreadyResolved",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AssertionAlreadyPending",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ConditionAlreadyRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ConditionNotRegistered",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LivenessTooShort",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MarketAlreadyLinked",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "OOHasNoCode",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ReentrancyGuardReentrantCall",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "SafeERC20FailedOperation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnauthorizedCallback",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UnknownAssertion",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assertionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "AssertionDisputed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "assertionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "asserter",
+        "type": "address"
+      }
+    ],
+    "name": "AssertionMade",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expectedResolutionTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "ConditionRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "confidence",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "resolvedAt",
+        "type": "uint256"
+      }
+    ],
+    "name": "ConditionResolved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "friendMarketId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "MarketLinked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "MIN_LIVENESS",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "asserter",
+        "type": "address"
+      }
+    ],
+    "name": "assertResolution",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "assertionId",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "assertionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "assertionDisputedCallback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "assertionId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bool",
+        "name": "assertedTruthfully",
+        "type": "bool"
+      }
+    ],
+    "name": "assertionResolvedCallback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "assertionToCondition",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "conditionToAssertion",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "conditions",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "claim",
+        "type": "bytes"
+      },
+      {
+        "internalType": "address",
+        "name": "bondCurrency",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bondAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint64",
+        "name": "liveness",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "registered",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getConditionMetadata",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "description",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expectedResolutionTime",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getConfiguredChainId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getOutcome",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "confidence",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "resolvedAt",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isAvailable",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isConditionResolved",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "isConditionSupported",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "friendMarketId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "linkMarket",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "marketToCondition",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oo",
+    "outputs": [
+      {
+        "internalType": "contract OptimisticOracleV3Interface",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oracleType",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "conditionId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "claim",
+        "type": "bytes"
+      },
+      {
+        "internalType": "address",
+        "name": "bondCurrency",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bondAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint64",
+        "name": "liveness",
+        "type": "uint64"
+      }
+    ],
+    "name": "registerCondition",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "resolutionCache",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "outcome",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint64",
+        "name": "resolvedAt",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint96",
+        "name": "confidence",
+        "type": "uint96"
+      },
+      {
+        "internalType": "bool",
+        "name": "exists",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/subgraph/README.md
+++ b/subgraph/README.md
@@ -36,11 +36,19 @@ a valid, fully-featured subgraph. `matic` carries `WagerRegistry` only until the
 voucher + redemption manager ship to mainnet, so `graph build --network matic`
 fails by design (`'MembershipVoucher' was not found in the 'matic' configuration`).
 
-| Network (manifest id) | chainId | WagerRegistry | MembershipVoucher | MembershipManager |
-|-----------------------|--------:|--------------:|------------------:|------------------:|
-| matic (Polygon mainnet) | 137 | 88118344 | — (deferred) | — (deferred) |
-| mordor | 63 | 16404317 | 16404315 | 16404308 |
-| polygon-amoy | 80002 | 40521027 | 40521024 | 40521018 |
+| Network (manifest id) | chainId | WagerRegistry | MembershipVoucher | MembershipManager | Oracle adapters¹ |
+|-----------------------|--------:|--------------:|------------------:|------------------:|-----------------:|
+| matic (Polygon mainnet) | 137 | 88118344 | — (deferred) | — (deferred) | — (deferred) |
+| mordor | 63 | 16404317 | 16404315 | 16404308 | n/a (no adapters) |
+| polygon-amoy | 80002 | 40521027 | 40521024 | 40521018 | 38841810 / 38841814 / 38841817 |
+
+¹ **Oracle adapters** (issue #751): `ChainlinkDataFeedOracleAdapter`,
+`ChainlinkFunctionsOracleAdapter`, `UMAOptimisticOracleV3Adapter`, indexed into
+`OracleCondition` + `OracleMarketLink`. They are deployed on Amoy + Polygon
+mainnet only — **Mordor has no oracle adapters** (oracle resolution is out of
+scope on ETC per spec 015), so `graph build --network mordor` does not carry
+these data sources. On `matic` they are deferred alongside the voucher/manager
+until the mainnet UUPS migration lands.
 
 ## Build, test, deploy
 
@@ -87,6 +95,14 @@ Set the resulting endpoint as `VITE_SUBGRAPH_URL` (per network) in the frontend
   gifts/resales via ERC-721 `Transfer`, and flipped to `redeemed` (or `burned`)
   when `MembershipManager.MembershipRedeemed` fires. On-chain/public by nature;
   no contract calls in the handlers.
+- **OracleCondition** (issue #751) — an outcome condition pre-registered with an
+  oracle adapter, keyed by `<adapterType>-<conditionId>`. Upserted on
+  `ConditionRegistered`, flipped to `resolved` (with `outcome`/`confidence`) on
+  `ConditionResolved`. Lets the create-wager flow list available conditions per
+  adapter without an `eth_getLogs` scan.
+- **OracleMarketLink** (immutable, issue #751) — one row per `MarketLinked`,
+  associating a `marketId` with an `OracleCondition`. The three adapter handlers
+  (`oracleAdapters.ts`) make no contract calls.
 
 See `schema.graphql` and `specs/017-subgraph-v2-wager-transfers/` for the full
 contract.

--- a/subgraph/networks.json
+++ b/subgraph/networks.json
@@ -31,6 +31,18 @@
     "MembershipManager": {
       "address": "0x89158f2E044C73c687dA12B7FA42b94F9A6D8465",
       "startBlock": 40521018
+    },
+    "ChainlinkDataFeedOracleAdapter": {
+      "address": "0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23",
+      "startBlock": 38841810
+    },
+    "ChainlinkFunctionsOracleAdapter": {
+      "address": "0x074fC18C1E322a7537b53B8B2Bf0762629E3b532",
+      "startBlock": 38841814
+    },
+    "UMAOptimisticOracleV3Adapter": {
+      "address": "0xcEa9b4A01CcD3aA6545ea834a268C69e7eEfee88",
+      "startBlock": 38841817
     }
   }
 }

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -120,3 +120,55 @@ type Voucher @entity(immutable: false) {
   redeemedAt: BigInt
   redeemTxHash: Bytes
 }
+
+"The oracle adapters wired into WagerRegistry v2 that can settle a wager (issue #751)."
+enum OracleAdapterType {
+  chainlinkDataFeed
+  chainlinkFunctions
+  uma
+}
+
+"""
+An outcome condition pre-registered with an oracle adapter (issue #751). Indexed
+from each adapter's ConditionRegistered / ConditionResolved events so the
+create-wager flow can list available conditions without an eth_getLogs scan.
+On-chain and public by nature; the mappings make no contract calls.
+"""
+type OracleCondition @entity(immutable: false) {
+  "<adapterType>-<conditionId> (a conditionId could in principle be reused across adapters)"
+  id: ID!
+  "the oracle adapter that holds this condition"
+  adapter: OracleAdapterType!
+  "adapter contract address"
+  adapterAddress: Bytes!
+  "the on-chain condition id (bytes32)"
+  conditionId: Bytes!
+  "human description: empty for Chainlink (not stored on-chain), the UMA claim for UMA"
+  description: String!
+  "expected resolution time (unix seconds); 0 when not tracked on-chain"
+  expectedResolutionTime: BigInt!
+  registeredAt: BigInt!
+  registeredTxHash: Bytes!
+  "true once a ConditionResolved event has been seen"
+  resolved: Boolean!
+  "settled outcome (null until resolved)"
+  outcome: Boolean
+  "confidence (basis points) reported at resolution (null until resolved)"
+  confidence: BigInt
+  resolvedAt: BigInt
+  "markets linked to this condition via linkMarket"
+  links: [OracleMarketLink!]! @derivedFrom(field: "condition")
+}
+
+"A link between a market id and an oracle condition (issue #751), one per MarketLinked event."
+type OracleMarketLink @entity(immutable: true) {
+  "txHash-logIndex (unique even when several links share one transaction)"
+  id: ID!
+  condition: OracleCondition!
+  "the market id passed to linkMarket (the adapter's friendMarketId param)"
+  marketId: BigInt!
+  conditionId: Bytes!
+  adapter: OracleAdapterType!
+  linkedAt: BigInt!
+  linkedTxHash: Bytes!
+}

--- a/subgraph/src/mappings/oracleAdapters.ts
+++ b/subgraph/src/mappings/oracleAdapters.ts
@@ -1,0 +1,154 @@
+import { Address, BigInt, Bytes, ethereum } from '@graphprotocol/graph-ts'
+import { OracleCondition, OracleMarketLink } from '../../generated/schema'
+
+// The three adapters emit identical ConditionRegistered / MarketLinked /
+// ConditionResolved signatures (declared on IOracleAdapter), but codegen emits a
+// separate typed module per data source, so we alias the imports and delegate to
+// shared helpers. Mappings make no contract calls — a handler can never revert.
+import {
+  ConditionRegistered as DataFeedConditionRegistered,
+  MarketLinked as DataFeedMarketLinked,
+  ConditionResolved as DataFeedConditionResolved,
+} from '../../generated/ChainlinkDataFeedOracleAdapter/ChainlinkDataFeedOracleAdapter'
+import {
+  ConditionRegistered as FunctionsConditionRegistered,
+  MarketLinked as FunctionsMarketLinked,
+  ConditionResolved as FunctionsConditionResolved,
+} from '../../generated/ChainlinkFunctionsOracleAdapter/ChainlinkFunctionsOracleAdapter'
+import {
+  ConditionRegistered as UmaConditionRegistered,
+  MarketLinked as UmaMarketLinked,
+  ConditionResolved as UmaConditionResolved,
+} from '../../generated/UMAOptimisticOracleV3Adapter/UMAOptimisticOracleV3Adapter'
+
+// Schema enum (OracleAdapterType) string values.
+const ADAPTER_DATAFEED = 'chainlinkDataFeed'
+const ADAPTER_FUNCTIONS = 'chainlinkFunctions'
+const ADAPTER_UMA = 'uma'
+
+// A conditionId could in principle be reused across adapters, so key by both.
+function conditionKey(adapter: string, conditionId: Bytes): string {
+  return adapter + '-' + conditionId.toHexString()
+}
+
+// Create a minimal condition row if we somehow see a link/resolve before the
+// registration (on-chain, registerCondition precedes both — but indexing must
+// never assume event ordering). Returns the loaded-or-created entity.
+function ensureCondition(
+  adapter: string,
+  adapterAddress: Address,
+  conditionId: Bytes,
+  event: ethereum.Event
+): OracleCondition {
+  const id = conditionKey(adapter, conditionId)
+  let c = OracleCondition.load(id)
+  if (c == null) {
+    c = new OracleCondition(id)
+    c.adapter = adapter
+    c.conditionId = conditionId
+    c.adapterAddress = adapterAddress
+    c.description = ''
+    c.expectedResolutionTime = BigInt.fromI32(0)
+    c.resolved = false
+    c.registeredAt = event.block.timestamp
+    c.registeredTxHash = event.transaction.hash
+    c.save()
+  }
+  return c
+}
+
+// ConditionRegistered → upsert (idempotent if the adapter ever re-registers).
+function registerCondition(
+  adapter: string,
+  adapterAddress: Address,
+  conditionId: Bytes,
+  description: string,
+  expectedResolutionTime: BigInt,
+  event: ethereum.Event
+): void {
+  const id = conditionKey(adapter, conditionId)
+  let c = OracleCondition.load(id)
+  if (c == null) {
+    c = new OracleCondition(id)
+    c.adapter = adapter
+    c.conditionId = conditionId
+    c.resolved = false
+    c.registeredAt = event.block.timestamp
+    c.registeredTxHash = event.transaction.hash
+  }
+  c.adapterAddress = adapterAddress
+  c.description = description
+  c.expectedResolutionTime = expectedResolutionTime
+  c.save()
+}
+
+// MarketLinked → one immutable OracleMarketLink per event.
+function linkMarket(
+  adapter: string,
+  adapterAddress: Address,
+  marketId: BigInt,
+  conditionId: Bytes,
+  event: ethereum.Event
+): void {
+  ensureCondition(adapter, adapterAddress, conditionId, event)
+  const id = event.transaction.hash.toHexString() + '-' + event.logIndex.toString()
+  const link = new OracleMarketLink(id)
+  link.condition = conditionKey(adapter, conditionId)
+  link.marketId = marketId
+  link.conditionId = conditionId
+  link.adapter = adapter
+  link.linkedAt = event.block.timestamp
+  link.linkedTxHash = event.transaction.hash
+  link.save()
+}
+
+// ConditionResolved → flip the condition to resolved with its outcome.
+function resolveCondition(
+  adapter: string,
+  adapterAddress: Address,
+  conditionId: Bytes,
+  outcome: boolean,
+  confidence: BigInt,
+  resolvedAt: BigInt,
+  event: ethereum.Event
+): void {
+  const c = ensureCondition(adapter, adapterAddress, conditionId, event)
+  c.resolved = true
+  c.outcome = outcome
+  c.confidence = confidence
+  c.resolvedAt = resolvedAt
+  c.save()
+}
+
+// ── Chainlink Data Feed ──────────────────────────────────────────────────────
+export function handleDataFeedConditionRegistered(event: DataFeedConditionRegistered): void {
+  registerCondition(ADAPTER_DATAFEED, event.address, event.params.conditionId, event.params.description, event.params.expectedResolutionTime, event)
+}
+export function handleDataFeedMarketLinked(event: DataFeedMarketLinked): void {
+  linkMarket(ADAPTER_DATAFEED, event.address, event.params.friendMarketId, event.params.conditionId, event)
+}
+export function handleDataFeedConditionResolved(event: DataFeedConditionResolved): void {
+  resolveCondition(ADAPTER_DATAFEED, event.address, event.params.conditionId, event.params.outcome, event.params.confidence, event.params.resolvedAt, event)
+}
+
+// ── Chainlink Functions ──────────────────────────────────────────────────────
+export function handleFunctionsConditionRegistered(event: FunctionsConditionRegistered): void {
+  registerCondition(ADAPTER_FUNCTIONS, event.address, event.params.conditionId, event.params.description, event.params.expectedResolutionTime, event)
+}
+export function handleFunctionsMarketLinked(event: FunctionsMarketLinked): void {
+  linkMarket(ADAPTER_FUNCTIONS, event.address, event.params.friendMarketId, event.params.conditionId, event)
+}
+export function handleFunctionsConditionResolved(event: FunctionsConditionResolved): void {
+  resolveCondition(ADAPTER_FUNCTIONS, event.address, event.params.conditionId, event.params.outcome, event.params.confidence, event.params.resolvedAt, event)
+}
+
+// ── UMA Optimistic Oracle V3 ─────────────────────────────────────────────────
+export function handleUmaConditionRegistered(event: UmaConditionRegistered): void {
+  registerCondition(ADAPTER_UMA, event.address, event.params.conditionId, event.params.description, event.params.expectedResolutionTime, event)
+}
+export function handleUmaMarketLinked(event: UmaMarketLinked): void {
+  linkMarket(ADAPTER_UMA, event.address, event.params.friendMarketId, event.params.conditionId, event)
+}
+export function handleUmaConditionResolved(event: UmaConditionResolved): void {
+  resolveCondition(ADAPTER_UMA, event.address, event.params.conditionId, event.params.outcome, event.params.confidence, event.params.resolvedAt, event)
+}

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -119,3 +119,92 @@ dataSources:
         - event: MembershipRedeemed(indexed address,indexed bytes32,uint8,indexed uint256,uint64)
           handler: handleMembershipRedeemed
       file: ./src/mappings/membershipVoucher.ts
+
+  # ---------------------------------------------------------------------------
+  # Oracle adapter conditions (issue #751). Indexes each adapter's
+  # ConditionRegistered / MarketLinked / ConditionResolved events into
+  # OracleCondition + OracleMarketLink so the create-wager flow can list
+  # registered conditions without an eth_getLogs scan. Schema + handlers
+  # (./src/mappings/oracleAdapters.ts) ship with the manifest; defaults target
+  # Amoy. The adapters are deployed on Amoy (80002) and Polygon mainnet (137)
+  # ONLY — Mordor has no oracle adapters (oracle resolution is out of scope on
+  # ETC per spec 015), so `graph build --network mordor` does not carry these
+  # data sources. Per-network address + startBlock live in networks.json.
+  # ---------------------------------------------------------------------------
+  - kind: ethereum
+    name: ChainlinkDataFeedOracleAdapter
+    network: polygon-amoy
+    source:
+      address: "0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23"
+      abi: ChainlinkDataFeedOracleAdapter
+      startBlock: 38841810
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - OracleCondition
+        - OracleMarketLink
+      abis:
+        - name: ChainlinkDataFeedOracleAdapter
+          file: ../frontend/src/abis/ChainlinkDataFeedOracleAdapter.json
+      eventHandlers:
+        - event: ConditionRegistered(indexed bytes32,string,uint256)
+          handler: handleDataFeedConditionRegistered
+        - event: MarketLinked(indexed uint256,indexed bytes32)
+          handler: handleDataFeedMarketLinked
+        - event: ConditionResolved(indexed bytes32,bool,uint256,uint256)
+          handler: handleDataFeedConditionResolved
+      file: ./src/mappings/oracleAdapters.ts
+
+  - kind: ethereum
+    name: ChainlinkFunctionsOracleAdapter
+    network: polygon-amoy
+    source:
+      address: "0x074fC18C1E322a7537b53B8B2Bf0762629E3b532"
+      abi: ChainlinkFunctionsOracleAdapter
+      startBlock: 38841814
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - OracleCondition
+        - OracleMarketLink
+      abis:
+        - name: ChainlinkFunctionsOracleAdapter
+          file: ../frontend/src/abis/ChainlinkFunctionsOracleAdapter.json
+      eventHandlers:
+        - event: ConditionRegistered(indexed bytes32,string,uint256)
+          handler: handleFunctionsConditionRegistered
+        - event: MarketLinked(indexed uint256,indexed bytes32)
+          handler: handleFunctionsMarketLinked
+        - event: ConditionResolved(indexed bytes32,bool,uint256,uint256)
+          handler: handleFunctionsConditionResolved
+      file: ./src/mappings/oracleAdapters.ts
+
+  - kind: ethereum
+    name: UMAOptimisticOracleV3Adapter
+    network: polygon-amoy
+    source:
+      address: "0xcEa9b4A01CcD3aA6545ea834a268C69e7eEfee88"
+      abi: UMAOptimisticOracleV3Adapter
+      startBlock: 38841817
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - OracleCondition
+        - OracleMarketLink
+      abis:
+        - name: UMAOptimisticOracleV3Adapter
+          file: ../frontend/src/abis/UMAOptimisticOracleV3Adapter.json
+      eventHandlers:
+        - event: ConditionRegistered(indexed bytes32,string,uint256)
+          handler: handleUmaConditionRegistered
+        - event: MarketLinked(indexed uint256,indexed bytes32)
+          handler: handleUmaMarketLinked
+        - event: ConditionResolved(indexed bytes32,bool,uint256,uint256)
+          handler: handleUmaConditionResolved
+      file: ./src/mappings/oracleAdapters.ts

--- a/subgraph/tests/oracleAdapters.test.ts
+++ b/subgraph/tests/oracleAdapters.test.ts
@@ -1,0 +1,81 @@
+import {
+  assert,
+  describe,
+  test,
+  clearStore,
+  afterEach,
+  newMockEvent,
+} from 'matchstick-as/assembly/index'
+import { BigInt, Bytes, ethereum } from '@graphprotocol/graph-ts'
+import {
+  ConditionRegistered,
+  MarketLinked,
+  ConditionResolved,
+} from '../generated/ChainlinkDataFeedOracleAdapter/ChainlinkDataFeedOracleAdapter'
+import {
+  handleDataFeedConditionRegistered,
+  handleDataFeedMarketLinked,
+  handleDataFeedConditionResolved,
+} from '../src/mappings/oracleAdapters'
+
+// 32-byte condition id used across the cases.
+const COND = Bytes.fromHexString('0x00000000000000000000000000000000000000000000000000000000000000aa')
+const ID = 'chainlinkDataFeed-' + COND.toHexString()
+
+function registered(desc: string, ert: i32): ConditionRegistered {
+  let event = changetype<ConditionRegistered>(newMockEvent())
+  event.parameters = new Array<ethereum.EventParam>()
+  event.parameters.push(new ethereum.EventParam('conditionId', ethereum.Value.fromFixedBytes(COND)))
+  event.parameters.push(new ethereum.EventParam('description', ethereum.Value.fromString(desc)))
+  event.parameters.push(new ethereum.EventParam('expectedResolutionTime', ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(ert))))
+  return event
+}
+
+function linked(marketId: i32): MarketLinked {
+  let event = changetype<MarketLinked>(newMockEvent())
+  event.parameters = new Array<ethereum.EventParam>()
+  event.parameters.push(new ethereum.EventParam('friendMarketId', ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(marketId))))
+  event.parameters.push(new ethereum.EventParam('conditionId', ethereum.Value.fromFixedBytes(COND)))
+  return event
+}
+
+function resolved(outcome: boolean, confidence: i32, resolvedAt: i32): ConditionResolved {
+  let event = changetype<ConditionResolved>(newMockEvent())
+  event.parameters = new Array<ethereum.EventParam>()
+  event.parameters.push(new ethereum.EventParam('conditionId', ethereum.Value.fromFixedBytes(COND)))
+  event.parameters.push(new ethereum.EventParam('outcome', ethereum.Value.fromBoolean(outcome)))
+  event.parameters.push(new ethereum.EventParam('confidence', ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(confidence))))
+  event.parameters.push(new ethereum.EventParam('resolvedAt', ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(resolvedAt))))
+  return event
+}
+
+describe('oracle adapter conditions (issue #751)', () => {
+  afterEach(() => {
+    clearStore()
+  })
+
+  test('ConditionRegistered creates an OracleCondition', () => {
+    handleDataFeedConditionRegistered(registered('', 1000))
+    assert.entityCount('OracleCondition', 1)
+    assert.fieldEquals('OracleCondition', ID, 'adapter', 'chainlinkDataFeed')
+    assert.fieldEquals('OracleCondition', ID, 'conditionId', COND.toHexString())
+    assert.fieldEquals('OracleCondition', ID, 'expectedResolutionTime', '1000')
+    assert.fieldEquals('OracleCondition', ID, 'resolved', 'false')
+  })
+
+  test('MarketLinked records a link and ensures the condition exists', () => {
+    handleDataFeedMarketLinked(linked(42))
+    assert.entityCount('OracleMarketLink', 1)
+    // The condition is ensured even though registration was not replayed here.
+    assert.entityCount('OracleCondition', 1)
+  })
+
+  test('ConditionResolved marks the condition resolved with its outcome', () => {
+    handleDataFeedConditionRegistered(registered('', 0))
+    handleDataFeedConditionResolved(resolved(true, 10000, 12345))
+    assert.fieldEquals('OracleCondition', ID, 'resolved', 'true')
+    assert.fieldEquals('OracleCondition', ID, 'outcome', 'true')
+    assert.fieldEquals('OracleCondition', ID, 'confidence', '10000')
+    assert.fieldEquals('OracleCondition', ID, 'resolvedAt', '12345')
+  })
+})


### PR DESCRIPTION
## Summary
Addresses the deferred read-back work from #751 by indexing oracle-adapter conditions in the subgraph. The admin Oracle Adapters tab could register/link Chainlink/UMA conditions, but nothing could read them back — the adapters expose no on-chain enumeration (conditions live in a `mapping`) and the subgraph didn't index them.

## Change
Adds three data sources — `ChainlinkDataFeedOracleAdapter`, `ChainlinkFunctionsOracleAdapter`, `UMAOptimisticOracleV3Adapter` — indexing their shared `ConditionRegistered` / `MarketLinked` / `ConditionResolved` events into two new entities:

- **OracleCondition** (`<adapterType>-<conditionId>`): adapter, description, expectedResolutionTime, registered/resolved state + outcome/confidence.
- **OracleMarketLink** (immutable): one row per `MarketLinked`, `marketId` ↔ condition.

This lets the create-wager flow list available conditions per adapter without an `eth_getLogs` scan. Handlers (`oracleAdapters.ts`) make **no contract calls**, matching the no-revert invariant of the existing mappings.

## Scope / networks
- Adapters are deployed on **Amoy (80002)** and **Polygon mainnet (137)** only; **Mordor has none** (oracle resolution is out of scope on ETC per spec 015).
- Amoy `networks.json` carries the adapter addresses + creation blocks, resolved via archive-RPC binary search: **38841810 / 38841814 / 38841817**.
- On `matic` they're deferred alongside the voucher/manager until the mainnet UUPS migration lands. `graph build --network <mordor|matic>` therefore doesn't carry these data sources; the **default build + CI target Amoy** and are unaffected.

## Verification
- `graph codegen`, `graph build` (default), and `build:amoy` (via networks.json) all succeed.
- **Matchstick: 15/15 pass** (3 new oracle tests + 12 existing).
- Adapter JSON ABIs generated from `artifacts/`.

## Follow-up (not in this PR)
- Deploy to `fairwins-amoy` (this PR's author will run it).
- Wiring the indexed conditions into the create-wager picker + enabling the Chainlink/UMA models (`VITE_ORACLE_MODELS='all'`) remain tracked on #751.

_Part of the TODO/stub audit follow-up._

🤖 Generated with [Claude Code](https://claude.com/claude-code)