### PR TITLE
chore(frontend): point Amoy subgraph at fairwins-amoy v0.3.0 (gated on sync)

### DIFF
--- a/frontend/src/config/networks.js
+++ b/frontend/src/config/networks.js
@@ -48,7 +48,7 @@ const NETWORKS = {
     // VITE_SUBGRAPH_URL_AMOY.
     subgraphUrl:
       import.meta.env?.VITE_SUBGRAPH_URL_AMOY ||
-      'https://api.studio.thegraph.com/query/1755381/fairwins-amoy/v0.2.0',
+      'https://api.studio.thegraph.com/query/1755381/fairwins-amoy/v0.3.0',
     // USDC on Amoy. Defaults to the Circle faucet USDC deployed alongside
     // our contracts (same as paymentToken in contracts.js). Override via
     // VITE_AMOY_USDC if a different token is needed.


### PR DESCRIPTION
## Summary
Points the Amoy default `subgraphUrl` from `fairwins-amoy/v0.2.0` → **v0.3.0** (deployed in #758), which carries the oracle-adapter condition indexing (`OracleCondition` / `OracleMarketLink`). One-line config change; the `VITE_SUBGRAPH_URL_AMOY` override is unchanged.

## ⚠️ Do not merge until v0.3.0 is synced
v0.3.0 indexes from the adapter creation block **38841810** — at deploy time it was **~1.77M blocks behind** chain head. Pointing the live Amoy app at a lagging subgraph would show **stale wager / voucher / report data** until it catches up. Merge (and the resulting frontend deploy) should wait until v0.3.0 reaches head with no indexing errors.

Sync check:
```
curl -s "https://api.studio.thegraph.com/query/1755381/fairwins-amoy/v0.3.0" \
  -H 'content-type: application/json' \
  --data '{"query":"{ _meta { block { number } hasIndexingErrors } }"}'
```
Compare `_meta.block.number` to Amoy head; merge when the gap is small and `hasIndexingErrors:false`.

_Follow-up to #758 / #751._

🤖 Generated with [Claude Code](https://claude.com/claude-code)