### PR TITLE
Spec: Multi-stablecoin support (028)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/026-membership-vouchers"
+  "feature_directory": "specs/028-multi-stablecoin-support"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,5 +72,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/027-upgradeable-membership/plan.md
+at specs/028-multi-stablecoin-support/plan.md
 <!-- SPECKIT END -->

--- a/specs/028-multi-stablecoin-support/checklists/requirements.md
+++ b/specs/028-multi-stablecoin-support/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Multi-Stablecoin Support
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-22
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- One open scope decision (membership payments in non-USDC) is captured in the spec's
+  **Clarifications** section with an assumed default; it is surfaced to the user for
+  confirmation but does not block planning under the assumed default.
+- The on-chain stake-token allow-list and runtime decimals handling already exist, so
+  the spec deliberately treats the supported-list curation as a governance/compliance
+  decision rather than prescribing implementation.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.

--- a/specs/028-multi-stablecoin-support/contracts/allowlist-seeding.op.md
+++ b/specs/028-multi-stablecoin-support/contracts/allowlist-seeding.op.md
@@ -1,0 +1,46 @@
+# Contract: Allow-list Seeding Operation
+
+How curated stablecoins are admitted to the on-chain `WagerRegistry` allow-list. **Reuses existing contract entrypoints — no Solidity change.**
+
+## Existing on-chain interface (unchanged)
+
+```solidity
+function setTokenAllowed(address token, bool allowed) external onlyRole(DEFAULT_ADMIN_ROLE);
+function isAllowedToken(address token) external view returns (bool);
+event TokenAllowed(address indexed token, bool allowed);
+```
+
+`createWager` / `createOpenWager` revert with `NotAllowedToken()` if `token` is not allow-listed.
+
+## Fresh deployments — `scripts/deploy/`
+
+- Add curated mainnet addresses to `constants.js` `TOKENS[<network>]` (e.g. `USDT`, `EURC`).
+- Include them in `initialize(...)` `initialTokens` so a new `WagerRegistry` is seeded at deploy.
+- Deploy continues to read each token's `decimals()` on-chain (existing behavior); abort on unverified/zero addresses (mirrors `requireRealStablecoin`).
+
+## Existing deployments — `scripts/ops/seed-stablecoins.js` (new)
+
+Idempotent admin op (floppy-keystore / admin signer per key-management rules):
+
+```
+for each curated token on the target network:
+  if !isAllowedToken(token):
+     read symbol()/decimals() on-chain  → log + sanity-check (standard ERC-20, expected decimals)
+     setTokenAllowed(token, true)         → emits TokenAllowed
+  else: skip (already allowed)
+```
+
+## Operational contract
+
+| ID | Requirement |
+|----|-------------|
+| O-1 | Op is idempotent: re-running adds nothing already allow-listed. (safe re-run) |
+| O-2 | Op verifies each address on-chain (symbol/decimals) before allowing; aborts on mismatch or non-contract address. (Constitution III) |
+| O-3 | Only `DEFAULT_ADMIN_ROLE` can seed; signer comes from the keystore flow; no private keys in logs. (key-management) |
+| O-4 | Curated rationale (issuer, peg, GENIUS basis) is recorded in config/docs alongside the address. (FR-017) |
+| O-5 | Mainnet seeding of a coin requires compliance/legal sign-off recorded before the tx. (FR-002, R3) |
+| O-6 | Removing a coin (`setTokenAllowed(token,false)`) stops new wagers in it but leaves existing wagers settleable. (FR-016) |
+
+## Sync to frontend
+
+After seeding, the curated config (`networks.js` `stablecoins`) is the frontend's enumeration source; `npm run sync:frontend-contracts` continues to sync the default `paymentToken`. A config test asserts every curated frontend entry is intended to be allow-listed on its network (config/on-chain parity is an operational check, not a runtime call).

--- a/specs/028-multi-stablecoin-support/contracts/member-preferences.schema.md
+++ b/specs/028-multi-stablecoin-support/contracts/member-preferences.schema.md
@@ -1,0 +1,45 @@
+# Contract: Member Stablecoin Preferences (UserPreferencesContext)
+
+Extends the existing `UserPreferencesContext` (client-side, per-wallet localStorage via `userStorage`). No backend, no on-chain change.
+
+## Stored keys (per wallet address)
+
+| localStorage key | Type | Default when absent |
+|------------------|------|---------------------|
+| `stablecoin_default` | string (symbol or checksummed address) | none ⇒ effective USDC |
+| `stablecoin_visibility` | `Record<tokenKey, boolean>` | `{}` ⇒ all supported visible |
+
+## Context API additions
+
+```
+preferences.stablecoinDefault          // raw stored value (may be null)
+preferences.stablecoinVisibility        // raw stored map (may be {})
+
+setDefaultStablecoin(tokenKey)          // FR-008; persists + updates state
+setStablecoinVisibility(tokenKey, bool) // FR-007; persists; enforces INV-2
+```
+
+Plus a selector hook layered on config + prefs:
+
+```
+useVisibleStablecoins()  -> { list, defaultCoin, isVisible(key), effectiveDefault }
+```
+
+## Behavioral contract
+
+| ID | Given | When | Then |
+|----|-------|------|------|
+| P-1 | no stored prefs | app loads | default = USDC, all supported coins visible (FR-009, SC-004) |
+| P-2 | member sets default = EURC | starting a new wager | selector pre-selects EURC (FR-008, US2-3) |
+| P-3 | member hides USDT | opening any stablecoin selector | USDT not offered to that member (FR-007, US2-2) |
+| P-4 | member hides their current default | toggle visibility off | must pick a replacement default, else default reverts to USDC; default coin is never left hidden-and-selected with no fallback (FR-009, US2-5) |
+| P-5 | stored default not on active network | network switch | effective default = USDC; stored value preserved for when they switch back (FR-014, edge) |
+| P-6 | stored default references a removed coin | app loads | effective default = USDC (FR-009, edge) |
+| P-7 | wallet B connects | after wallet A had prefs | wallet B sees its own prefs/defaults, not A's (FR-010, INV-3) |
+| P-8 | coin hidden by member | counterparty created a wager in it | member can still accept/claim/refund it (FR-011, US3-3) — visibility never gates actions |
+
+## Validation
+
+- `tokenKey` is normalized (prefer checksummed address; symbol accepted and resolved via `findStablecoin`).
+- Writes are guarded by a connected `account` (mirrors existing `savePreference`).
+- Setting visibility/default for a coin not in the active network's supported set is a no-op (defensive).

--- a/specs/028-multi-stablecoin-support/contracts/stablecoin-registry.config.md
+++ b/specs/028-multi-stablecoin-support/contracts/stablecoin-registry.config.md
@@ -1,0 +1,46 @@
+# Contract: Supported-Stablecoin Config & Helpers
+
+Front-end config contract for the curated, network-scoped supported-stablecoin set. No new Solidity. Source of truth for **presentation/enumeration**; the on-chain `WagerRegistry` allow-list remains the **enforcement** layer.
+
+## Config shape — `frontend/src/config/networks.js`
+
+Each network entry keeps its existing `stablecoin` (default) and gains a `stablecoins` array:
+
+```js
+// chain 137 (Polygon) — illustrative; addresses verified on-chain at seed time
+stablecoin: { address: '0x3c49…', symbol: 'USDC', name: 'USD Coin', decimals: 6 }, // unchanged default
+stablecoins: [
+  { address: '0x3c49…', symbol: 'USDC', name: 'USD Coin', decimals: 6, peg: 'USD',
+    isDefault: true,  issuer: 'Circle', complianceBasis: 'GENIUS: permitted US issuer', standardErc20: true },
+  { address: '0xc2132…', symbol: 'USDT', name: 'Tether USD', decimals: 6, peg: 'USD',
+    isDefault: false, issuer: 'Tether', complianceBasis: 'GENIUS: pending issuer sign-off', standardErc20: true },
+  { address: '0x…EURC', symbol: 'EURC', name: 'Euro Coin', decimals: 6, peg: 'EUR',
+    isDefault: false, issuer: 'Circle', complianceBasis: 'GENIUS: comparable-regime non-USD', standardErc20: true },
+],
+```
+
+- Testnets (Amoy 80002, Mordor 63) keep their single existing stablecoin as both `stablecoin` and the sole `stablecoins` entry unless additional test tokens are configured. Hardhat (1337) stays `null`.
+- `VITE_*` env overrides continue to apply to addresses.
+
+## Helper API — `frontend/src/config/stablecoins.js` (new)
+
+| Function | Returns | Contract |
+|----------|---------|----------|
+| `getSupportedStablecoins(chainId)` | `StablecoinConfig[]` | All curated coins for the network (empty if none). Never throws. |
+| `getDefaultStablecoin(chainId)` | `StablecoinConfig \| null` | The `isDefault` entry (USDC); falls back to the network's `stablecoin`. |
+| `findStablecoin(chainId, key)` | `StablecoinConfig \| null` | Look up by address (checksum-insensitive) or symbol. |
+| `isCuratedStablecoin(chainId, address)` | `boolean` | Whether an address is in the curated set for the network. |
+
+## Invariants (asserted by config test)
+
+- IC-1: Each network with a `stablecoins` array has **exactly one** `isDefault: true`, and it is USDC on chains that have USDC. (FR-001)
+- IC-2: Every entry has `standardErc20 === true`. (FR-002b)
+- IC-3: `stablecoin` (legacy default object) deep-equals the `isDefault` entry's `{address, symbol, name, decimals}`. (SC-004 backward-compat)
+- IC-4: Addresses are unique per network and checksummed.
+- IC-5: No address appears for a network on which it is not deployed (network-scoping). (FR-014)
+
+## Consumers
+
+- `useChainTokens()` — unchanged return (default stable).
+- `useSupportedStablecoins()` / `useVisibleStablecoins()` (new hooks) — wrap the helpers + member visibility prefs.
+- `StablecoinSelector`, `StablecoinPreferences`, `TokenAmount`.

--- a/specs/028-multi-stablecoin-support/data-model.md
+++ b/specs/028-multi-stablecoin-support/data-model.md
@@ -1,0 +1,80 @@
+# Phase 1 Data Model: Multi-Stablecoin Support
+
+No new database or on-chain schema is introduced. The model below describes the config-level, preference-level, and existing on-chain entities the feature relies on. New/changed fields are marked **(new)**.
+
+## Entity: Supported Stablecoin (curated config)
+
+Per-network curated entry, defined in `frontend/src/config/networks.js` under each network's `stablecoins: [...]` array and mirrored in deploy `TOKENS`.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `address` | string (checksummed ERC-20 address) | Verified on-chain at deploy/seed time. |
+| `symbol` | string | e.g. `USDC`, `USDT`, `EURC`. Display + report ticker. |
+| `name` | string | e.g. `USD Coin`, `Tether USD`, `Euro Coin`. |
+| `decimals` | number | Read on-chain to confirm; never assumed 6. |
+| `peg` **(new)** | string | Peg currency code: `USD`, `EUR`, … Drives per-currency grouping; prevents non-USD-as-USD. |
+| `isDefault` **(new)** | boolean | Exactly one per network is `true` (USDC). Platform default. |
+| `issuer` **(new)** | string | Issuing entity (e.g. `Circle`). For audit/FR-017. |
+| `complianceBasis` **(new)** | string | GENIUS-Act rationale (permitted/registered issuer; comparable-regime for non-USD). For audit/FR-017. |
+| `standardErc20` **(new)** | boolean (must be `true`) | Asserts non-rebasing, non-fee-on-transfer (FR-002b). Curation gate. |
+
+**Validation rules**
+- Each network's `stablecoins` array contains exactly one `isDefault: true` entry, and it MUST be USDC for the first release (FR-001).
+- Every entry MUST have `standardErc20: true` (FR-002b); entries failing this are not added.
+- `address` MUST be unique within a network and MUST be on the on-chain `WagerRegistry` allow-list before being offered for new wagers (kept in sync by the seeding op, R5).
+- The set is network-scoped: a coin listed for chain A is never offered on chain B (FR-014).
+
+**Backward compatibility**: the existing single `stablecoin` object per network is retained and MUST equal the `isDefault` entry, so all current `useChainTokens()` consumers keep working unchanged (SC-004).
+
+## Entity: Member Stablecoin Preferences (client-side, per wallet)
+
+Stored in localStorage via `userStorage`, keyed by wallet address. Surfaced through `UserPreferencesContext`.
+
+| Key | Type | Default | Notes |
+|-----|------|---------|-------|
+| `stablecoin_default` **(new)** | string (token symbol or address) | USDC for active network | The member's pre-selected stablecoin for new wagers (FR-008). |
+| `stablecoin_visibility` **(new)** | object `{ [tokenKey]: boolean }` | all supported visible | `false` hides the coin from the member's own selectors (FR-007). Absent key ⇒ visible. |
+
+**Derived/effective values** (computed in context, not stored)
+- `effectiveDefault(chainId)`: stored default if it is a supported, visible coin on `chainId`; else USDC (FR-009, FR-014).
+- `visibleStablecoins(chainId)`: supported set on `chainId` minus coins marked hidden; the effective default is always forced visible (a member cannot hide their only/default coin into oblivion — FR-009).
+
+**Invariants**
+- INV-1: There is always exactly one effective default (USDC fallback). (FR-009)
+- INV-2: Hiding the current default requires choosing a replacement default or reverts the default to USDC. (US2 scenario 5)
+- INV-3: Preferences are scoped per wallet; switching wallets loads that wallet's prefs (or defaults). (FR-010)
+- INV-4: Visibility never affects acting on a counterparty's wager — only the member's own selection surfaces. (FR-011)
+
+**State transitions (default selection)**
+```
+unset ──set default X──▶ X
+  X  ──hide X──▶ (requires replacement Y) ──▶ Y    | if none chosen ──▶ USDC
+  X  ──default coin removed from supported set──▶ USDC
+  X  ──switch to network without X──▶ USDC (effective; stored value preserved)
+```
+
+## Entity: Wager — denomination aspect (existing, on-chain)
+
+No schema change. The relevant existing fields:
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `token` | `WagerRegistry` per-wager struct + `WagerCreated` event + subgraph | The single ERC-20 the wager is denominated in; set at creation; used for escrow, payout, refund, draw. |
+| stake/payout amounts | on-chain raw units | Rendered at `token`'s decimals (FR-005, FR-012). |
+
+**Rules (already enforced on-chain)**
+- A wager has exactly one `token` (FR-004); both parties stake that token.
+- `token` MUST be on `_allowedTokens` at create time, else `NotAllowedToken` revert (FR-015).
+- Removing a token from the allow-list later does not affect existing wagers' settlement (FR-016) — the per-wager `token` and balances are immutable.
+
+## Entity: Token Metadata (reports) — extended
+
+`frontend/src/data/reports/tokenMeta.js` resolves `{ ticker, decimals }` per token address; reports group by `tokenTicker` (`reportBuilder.js` `byTicker`).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `ticker` | string | existing |
+| `decimals` | number | existing |
+| `peg` **(new)** | string | `USD`/`EUR`/… ensures non-USD amounts are grouped separately and never summed into a USD total (FR-013a). |
+
+**Rule**: report totals are computed strictly per `ticker`/`peg`; no cross-peg `usdValue` aggregation for non-USD coins.

--- a/specs/028-multi-stablecoin-support/plan.md
+++ b/specs/028-multi-stablecoin-support/plan.md
@@ -1,0 +1,103 @@
+# Implementation Plan: Multi-Stablecoin Support
+
+**Branch**: `claude/multi-stablecoin-support-rq2baj` | **Date**: 2026-06-22 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/028-multi-stablecoin-support/spec.md`
+
+## Summary
+
+Let members stake and settle wagers in multiple curated stablecoins (USDC default, plus USDT and a euro-backed coin such as EURC on Polygon mainnet), and let members choose their default and visible stablecoins from the Preferences tab of the My Account view.
+
+**Key technical finding that shapes this plan**: the on-chain escrow (`WagerRegistry`) **already supports multiple ERC-20 stake tokens** via an admin-managed allow-list (`_allowedTokens`, `setTokenAllowed`, `isAllowedToken`, the `TokenAllowed` event, and a per-wager `token` field), and the wager-creation hook already accepts a caller-supplied stake token and reads its `decimals()`/`symbol()` at runtime. Therefore **no Solidity logic change and no contract upgrade are required**. The work is: (1) curate the supported stablecoins in config + seed them into the existing allow-list via the existing admin entrypoint; (2) add a per-network supported-stablecoins list to frontend config; (3) add member default/visible preferences (client-side per wallet); (4) surface a stablecoin selector in wager creation; (5) make all amount displays token-aware and strictly per-currency (no FX). This keeps the change small (YAGNI) and off the highest-risk contract surface.
+
+## Technical Context
+
+**Language/Version**: Solidity ^0.8.x (Hardhat) for contracts (no logic change this feature); JavaScript/JSX on React 18 + Vite for the frontend; Node scripts for deploy/ops.
+
+**Primary Dependencies**: ethers v6, wagmi/viem (chain + signer), The Graph subgraph (wager indexing, already token-aware), existing `WagerRegistry` v2 ABI.
+
+**Storage**: Member stablecoin preferences → browser localStorage, per wallet, via the existing `userStorage` utility and `UserPreferencesContext` (no backend, no on-chain storage). Supported-stablecoin curation → frontend `networks.js` config + deploy constants; on-chain allow-list state lives in the already-deployed `WagerRegistry`.
+
+**Testing**: Hardhat (`test/` unit + `test/integration/`) for multi-token wager flows against the existing allow-list; Vitest for frontend (preferences reducer, selector, token-aware display, report grouping); axe/Lighthouse for the new Preferences UI.
+
+**Target Platform**: Web app on Polygon mainnet (137, primary), Polygon Amoy (80002) and Mordor (63) testnets; supported set is strictly network-scoped.
+
+**Project Type**: Web application (React frontend + Solidity contracts + subgraph) — Option 2 structure.
+
+**Performance Goals**: No new latency budget; token metadata (symbol/decimals) is read once per token and cached, matching today's single-token behavior. Adding stablecoins must not add per-render RPC calls.
+
+**Constraints**: Curated set limited to standard, non-rebasing, non-fee-on-transfer ERC-20 stablecoins (FR-002b) so escrowed amount == staked amount. No FX/price source introduced (FR-013a); amounts are always per-stablecoin. USDC behavior for existing members must be unchanged with zero configuration (SC-004).
+
+**Scale/Scope**: First release adds 2 stablecoins beyond USDC on Polygon mainnet; curated list extensible by config/admin without code changes. Frontend touchpoints: Preferences tab, wager-creation selector, amount-display components, tax/P&L report grouping.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment | Status |
+|-----------|-----------|--------|
+| **I. Security-First Smart Contracts** | No change to `contracts/` logic. Multi-token escrow already exists and was shipped under the existing security review; this feature only **calls the existing `setTokenAllowed` admin entrypoint** to seed curated tokens and adds them to deploy `initialTokens`. No new reentrancy/custody surface. Curation rule (standard ERC-20 only) is the security control and is enforced by process + documented rationale (FR-002b/FR-017). No new Slither/Medusa surface. | PASS |
+| **II. Test-First & Coverage** | New Hardhat integration test proving create→accept→claim/refund/draw in a non-USDC allow-listed token (incl. a 18-decimal token) alongside existing allow-list unit tests; Vitest for preferences invariants, selector filtering, token-aware formatting, and per-ticker report grouping. Tests land with the behavior. | PASS |
+| **III. Honest State, No Mocks in Shipped Paths** | Real curated token addresses only (Circle/issuer-verified); no mock stablecoins in mainline. Amounts reflect real on-chain token + decimals; non-USD never shown as USD; supported set and preferences strictly network-scoped (degrade to USDC when a stored choice is absent on the active chain). | PASS |
+| **IV. Fail Loudly in CI** | No `continue-on-error` added. New tests gate the pipeline. | PASS |
+| **V. Accessible, Consistent Frontend** | New Preferences stablecoin manager + wager selector meet WCAG 2.1 AA (axe test), keyboard-operable, ESLint-clean; token addresses come from the generated sync artifacts / `networks.js`, never hand-copied into components. | PASS |
+| **Upgradeable-contracts guardrail** | `WagerRegistry` is a UUPS proxy, but this feature ships **no implementation change**, so no upgrade, no storage-layout change, no `__gap` concern. Explicitly NOT adding on-chain allow-list enumeration (would require an upgrade) — the frontend enumerates from curated config, consistent with existing config-driven address resolution. | PASS |
+
+**Result**: All gates PASS. No Complexity Tracking entries required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/028-multi-stablecoin-support/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (interface/UX contracts — no new Solidity)
+│   ├── stablecoin-registry.config.md
+│   ├── member-preferences.schema.md
+│   └── allowlist-seeding.op.md
+├── checklists/
+│   └── requirements.md  # from /speckit-specify
+└── tasks.md             # /speckit-tasks output (not created here)
+```
+
+### Source Code (repository root)
+
+```text
+contracts/
+└── wagers/WagerRegistry.sol        # NO CHANGE — already multi-token (allow-list + per-wager token)
+
+scripts/
+├── deploy/lib/constants.js         # TOKENS: add USDT + euro coin addresses per network
+├── deploy/deploy.js                # seed extra tokens into initialTokens for fresh deploys
+└── ops/seed-stablecoins.js         # NEW — admin op: setTokenAllowed for curated tokens on existing deployments
+
+frontend/src/
+├── config/
+│   ├── networks.js                 # add per-network `stablecoins` curated list (keep `stablecoin` as default)
+│   └── stablecoins.js              # NEW — helpers: getSupportedStablecoins(chainId), getDefaultStablecoin(chainId), findStablecoin(...)
+├── contexts/UserPreferencesContext.jsx  # add stablecoinDefault + stablecoinVisibility state/actions
+├── hooks/
+│   ├── useChainTokens.js           # keep (default stable); add useSupportedStablecoins() / useVisibleStablecoins()
+│   └── useFriendMarketCreation.js  # already accepts requestedToken — wire selector value through
+├── components/
+│   ├── account/StablecoinPreferences.jsx   # NEW — Preferences-tab manager (default + visibility)
+│   ├── wager/StablecoinSelector.jsx        # NEW — create-wager token picker (visible set, default pre-selected)
+│   └── ui/TokenAmount.jsx                   # NEW — render amount + symbol at token decimals (generalizes StableToken)
+├── pages/WalletPage.jsx            # mount StablecoinPreferences in the existing `preferences` tabpanel
+└── data/reports/
+    ├── tokenMeta.js                # add peg currency; keep per-token resolution
+    └── reportBuilder.js            # keep strict per-ticker grouping; do not sum non-USD into usdValue
+
+frontend/src/test/                  # Vitest: preferences, selector, TokenAmount, report grouping, networks config
+test/integration/                   # Hardhat: multi-token wager lifecycle (non-USDC, 18-decimal)
+```
+
+**Structure Decision**: Web-application layout (Option 2). The change is concentrated in frontend config/UI/preferences and deploy/ops scripts; `contracts/` is untouched. New frontend modules are small, composable units (`stablecoins.js` config helpers, `StablecoinPreferences`, `StablecoinSelector`, `TokenAmount`) that reuse existing patterns (`useChainTokens`, `UserPreferencesContext`, `userStorage`, `resolveTokenMeta`).
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally empty.

--- a/specs/028-multi-stablecoin-support/quickstart.md
+++ b/specs/028-multi-stablecoin-support/quickstart.md
@@ -1,0 +1,89 @@
+# Quickstart: Multi-Stablecoin Support — Validation Guide
+
+Runnable scenarios that prove the feature works end-to-end. Details live in [data-model.md](./data-model.md) and [contracts/](./contracts/); implementation steps belong in `tasks.md`.
+
+## Prerequisites
+
+- `npm install` at repo root and in `frontend/`.
+- Hardhat for contract/integration tests; Vitest for frontend.
+- No new deployment needed for tests — `WagerRegistry` already exposes the allow-list. Mainnet seeding uses the admin/keystore flow (out of scope for local validation).
+
+## 1. Contract / integration — multi-token wager lifecycle (US1, FR-004/005/015/016)
+
+```bash
+npm run compile
+npm test                     # unit: allow-list (setTokenAllowed/isAllowedToken/NotAllowedToken)
+npm run test -- test/integration   # or the integration script
+```
+
+**Expected**:
+- Allow-list two mock ERC-20s with **different decimals** (6 and 18). Create→accept→claim a wager in the 18-decimal token: escrowed == staked, winner paid the pooled stake in that token, amounts correct at 18 decimals.
+- Refund and draw paths settle in the wager's token.
+- Creating a wager in a **non-allow-listed** token reverts `NotAllowedToken`.
+- After `setTokenAllowed(token,false)`, an **existing** wager in that token still claims/refunds (FR-016); a **new** wager in it reverts.
+
+## 2. Frontend — supported config & helpers (FR-002/014, IC-1..IC-5)
+
+```bash
+npm run test:frontend -- stablecoins networks
+```
+
+**Expected**: `getSupportedStablecoins(137)` returns USDC+USDT+EURC; `getDefaultStablecoin(137)` is USDC; exactly one `isDefault`; every entry `standardErc20:true`; legacy `stablecoin` deep-equals the default entry; coins are network-scoped.
+
+## 3. Frontend — member preferences (US2, FR-007/008/009/010, P-1..P-8)
+
+```bash
+npm run test:frontend -- StablecoinPreferences UserPreferences
+```
+
+**Expected**:
+- No prefs ⇒ default USDC, all visible (P-1).
+- Set default EURC ⇒ persisted per wallet; reload reconnect same wallet ⇒ EURC default (P-2, INV-3).
+- Hide USDT ⇒ absent from this member's selectors (P-3).
+- Hide the current default ⇒ forced to pick a replacement or default reverts to USDC (P-4).
+- Stored default absent on active network ⇒ effective USDC (P-5); references removed coin ⇒ USDC (P-6).
+- Different wallet ⇒ its own prefs (P-7).
+
+## 4. Frontend — wager-creation selector (US1, FR-004/011/015)
+
+```bash
+npm run test:frontend -- StablecoinSelector useFriendMarketCreation
+```
+
+**Expected**: selector lists the member's **visible** supported coins, pre-selects their default; chosen address flows through `requestedToken` into creation; a hidden coin a counterparty used still lets the member accept (FR-011).
+
+## 5. Frontend — token-aware, per-currency display (US3, FR-012/013/013a, SC-002/007)
+
+```bash
+npm run test:frontend -- TokenAmount reportBuilder
+```
+
+**Expected**: every amount renders symbol + correct decimals; a list mixing USDC and EURC labels each; report totals group per ticker/peg and **never** sum EUR into a USD total; no FX/price call is made.
+
+## 6. Accessibility (Constitution V)
+
+```bash
+npm run test:frontend -- axe   # Preferences + selector
+```
+
+**Expected**: new Preferences stablecoin manager and selector pass axe, are keyboard-operable, ESLint-clean.
+
+## 7. Manual smoke (optional, testnet)
+
+```bash
+npm run frontend
+```
+
+1. My Account → Preferences → set EURC default, hide USDT → reload → choices persist.
+2. Create wager → selector pre-selects EURC → create in EURC → accept from a second wallet → claim. Amounts shown as EURC throughout; never as USD.
+
+## Done / acceptance mapping
+
+| Scenario | Spec refs |
+|----------|-----------|
+| 1 | US1; FR-004/005/015/016; SC-001/006/007/009 |
+| 2 | FR-002/002a/002b/014; SC-005/008 |
+| 3 | US2; FR-007/008/009/010; SC-003/004 |
+| 4 | US1; FR-004/011/015 |
+| 5 | US3; FR-012/013/013a; SC-002 |
+| 6 | Constitution V |

--- a/specs/028-multi-stablecoin-support/research.md
+++ b/specs/028-multi-stablecoin-support/research.md
@@ -1,0 +1,64 @@
+# Phase 0 Research: Multi-Stablecoin Support
+
+All spec clarifications were resolved in `/speckit-clarify` (spec §Clarifications). This document records the technical decisions derived from the codebase survey and the clarified requirements. No open `NEEDS CLARIFICATION` remain.
+
+## R1. On-chain escrow already supports multiple stake tokens
+
+- **Decision**: Do **not** modify or upgrade `WagerRegistry`. Reuse its existing admin-managed token allow-list.
+- **Evidence**: `contracts/wagers/WagerRegistry.sol` has `mapping(address => bool) private _allowedTokens` (L58), `setTokenAllowed(address,bool)` gated by `DEFAULT_ADMIN_ROLE` (L278), `isAllowedToken(address)` (L869), `event TokenAllowed` (L102), per-wager `token` stored on the struct, and `if (!_allowedTokens[token]) revert NotAllowedToken()` guards on both `createWager` and `createOpenWager` (L369, L464). `initialize(...)` seeds `initialTokens` (L155-174).
+- **Rationale**: Smallest, lowest-risk change (Constitution I + Workflow §Simplicity). Avoids touching the highest-risk fund-custody surface and avoids a UUPS upgrade + storage-layout review.
+- **Alternatives considered**:
+  - *Add on-chain `getAllowedTokens()` enumeration* — rejected: requires a contract logic change + UUPS upgrade for a read the frontend can satisfy from curated config. Reintroduces the upgradeable-contract guardrail burden for no functional gain.
+  - *Per-token registry contract* — rejected: over-engineering; allow-list already exists.
+
+## R2. Frontend enumerates the supported set from curated config (not from chain)
+
+- **Decision**: Maintain the curated supported-stablecoin list in `frontend/src/config/networks.js` as a per-network `stablecoins` array, with the existing single `stablecoin` field retained as the network default (USDC). Add `frontend/src/config/stablecoins.js` helpers.
+- **Rationale**: Matches the existing config-driven address pattern (Constitution V: addresses come from config/sync artifacts, not hand-copied at call sites). Lets the frontend show symbol/name/decimals/peg without an enumeration call, and keeps the curated set auditable in one place (FR-017). The on-chain allow-list remains the enforcement layer; config is the presentation layer. The two are kept in sync by the seeding op (R5) and a config/test assertion.
+- **Alternatives considered**: Reading allow-list membership per candidate token via `isAllowedToken` — viable as a defensive check but insufficient for enumeration (no list on-chain) and adds RPC calls; deferred as optional hardening, not the source of truth.
+
+## R3. Curation criteria (which coins, and the safety rule)
+
+- **Decision**: First-release curated set on Polygon mainnet = **USDC (default), USDT, and one euro-backed coin (EURC)**. Each entry must be a **standard ERC-20**: non-rebasing, non-fee-on-transfer, fixed `decimals()`. Decimals are read/honored at runtime, not assumed to be 6.
+- **Rationale**: FR-002a/FR-002b and clarifications Q2/Q4. Fee-on-transfer/rebasing tokens break the escrow invariant (amount received ≠ amount sent); excluding them keeps the no-contract-change approach safe.
+- **GENIUS-Act gating (FR-002, FR-017)**: Only payment stablecoins from permitted/registered issuers (USD coins like USDC/USDT/PYUSD from regulated issuers; non-USD coins only from comparable, recognized regimes). Each admitted coin records a rationale (issuer, peg, GENIUS basis, Polygon availability) in config/docs. **Final issuer eligibility (esp. USDT and the specific euro coin) requires compliance/legal sign-off before mainnet seeding** — captured as a gating task, not a code blocker for testnet.
+- **Address sourcing**: verify each token address + `decimals()` on-chain at deploy/seed time (same discipline as existing `TOKENS`/Mordor USC note). Use native USDC on Polygon (`0x3c49…`), not bridged USDC.e.
+
+## R4. Member preferences: client-side, per wallet
+
+- **Decision**: Store `stablecoinDefault` (address or symbol) and `stablecoinVisibility` (map of token → shown/hidden) in localStorage via the existing `userStorage` + `UserPreferencesContext`, keyed by wallet address.
+- **Evidence/Pattern**: `UserPreferencesContext.jsx` already persists per-wallet keys (`recent_searches`, `default_slippage`, …) through `saveUserPreference(account, key, value)`. New keys: `stablecoin_default`, `stablecoin_visibility`.
+- **Invariants**: (a) absent prefs → default USDC, all supported visible (SC-004, FR-009); (b) exactly one valid default always (hiding the current default forces choosing a replacement or restores USDC — FR-009, US2 scenario 5); (c) a stored default not available on the active network falls back to USDC (FR-014, edge case).
+- **Rationale**: Q5 — no backend/contract change; consistent with existing storage. Per-device is acceptable for a display/selection preference.
+- **Alternatives considered**: On-chain or backend-synced prefs — rejected (heavier, new surface) per Q5; noted as possible later phase.
+
+## R5. Seeding the allow-list on existing deployments
+
+- **Decision**: Add `scripts/ops/seed-stablecoins.js` that, for a given network, calls `WagerRegistry.setTokenAllowed(token, true)` (admin/floppy-keystore signer) for each curated token not yet allow-listed (idempotent via `isAllowedToken`). For fresh deploys, add the curated addresses to `initialTokens` in `deploy.js`/`constants.js TOKENS`.
+- **Rationale**: Production `WagerRegistry` is already deployed; new coins are added by admin tx, not redeploy (Constitution: deployments are source of truth; no fresh redeploy). Keystore/admin flow per project key-management rules.
+- **Verification**: op logs each token symbol/decimals read on-chain and skips already-allowed tokens; a deployments/record or doc notes the curation rationale (FR-017).
+
+## R6. Token-aware, strictly per-currency display
+
+- **Decision**: Generalize `StableToken` into a `TokenAmount` component that renders an amount at the token's own decimals with its symbol; reuse `resolveTokenMeta` for symbol/decimals. Extend `tokenMeta` with a `peg` field (USD/EUR/…). Reports keep their existing **per-ticker grouping** (`reportBuilder.js` already builds `byTicker`); ensure overall/`usdValue` totals never fold non-USD pegs into a USD sum (FR-013/FR-013a).
+- **Evidence**: `reportBuilder.js` already groups per `tokenTicker` and resolves decimals per token (L34-41, L129-139). Wager-creation hook already reads `decimals()`/`symbol()` and uses `parseUnits/formatUnits` (no hardcoded 6) (`useFriendMarketCreation.js` L162-201).
+- **Rationale**: Multi-currency means amounts are not fungible; labeling + per-peg grouping prevents misleading sums (US3, SC-002). No FX source (Q3).
+- **Alternatives considered**: USD-equivalent conversion — rejected (Q3); would introduce a price-oracle dependency.
+
+## R7. Wager-creation selector wiring
+
+- **Decision**: Add a `StablecoinSelector` offering the member's **visible** supported set for the active network, pre-selecting their default; pass the chosen address through the existing `requestedToken`/`stakeTokenId` path into `useFriendMarketCreation`. The acceptor side reads the wager's `token` from chain/subgraph and stakes that same token (no per-acceptor choice).
+- **Evidence**: `useFriendMarketCreation.js` already resolves `stakeTokenAddress` from a requested token, defaulting to `paymentToken` (USDC) (L150-162), and surfaces a `NotAllowedToken` user message (L503).
+- **Rationale**: FR-004 (creator picks; acceptor matches), FR-011 (hidden filters only own choices, never blocks acting on a counterparty's wager).
+
+## Summary of decisions
+
+| # | Decision | Drives |
+|---|----------|--------|
+| R1 | No contract change; reuse existing allow-list | Constitution I, Simplicity |
+| R2 | Curated config is the enumeration source; chain is enforcement | FR-002, FR-017, V |
+| R3 | USDC+USDT+EURC, standard ERC-20 only, GENIUS-gated w/ sign-off | FR-002a/b, FR-017 |
+| R4 | Client-side per-wallet prefs w/ default invariant | FR-007/8/9/10/14 |
+| R5 | Admin seeding op + initialTokens for fresh deploys | FR-003, deployments policy |
+| R6 | TokenAmount + strict per-ticker, no FX | FR-005/12/13/13a |
+| R7 | Creator-selects/acceptor-matches via existing requestedToken | FR-004, FR-011, FR-015 |

--- a/specs/028-multi-stablecoin-support/spec.md
+++ b/specs/028-multi-stablecoin-support/spec.md
@@ -80,6 +80,8 @@ A member browses wagers and account views where amounts are shown in a mix of st
 
 - **FR-001**: The platform MUST support multiple stablecoins for wager staking and settlement, with USDC remaining the platform-wide default for any member who has not chosen otherwise.
 - **FR-002**: The set of stablecoins offered MUST be a curated allow-list limited to (a) major stablecoins deployed on the platform's supported networks (Polygon mainnet being the primary mainnet), and (b) stablecoins that would be permissible under the GENIUS Act, including non-US-dollar-backed stablecoins that meet that bar.
+- **FR-002a**: The first release MUST support at minimum USDC (default), USDT, and one euro-backed stablecoin (e.g., EURC) on Polygon mainnet; the curated set MUST remain extensible by curation without code changes to add further GENIUS-Act-permissible coins later.
+- **FR-002b**: The curated set MUST be limited to standard ERC-20 stablecoins that do not rebase and do not charge transfer fees, so the amount escrowed for a wager always equals the amount staked; rebasing or fee-on-transfer tokens MUST NOT be admitted.
 - **FR-003**: The supported-stablecoin list MUST be governed/curated by the platform (not arbitrarily extensible by ordinary members); only curated stablecoins may be used to create or accept wagers.
 - **FR-004**: A wager MUST be denominated in exactly one stablecoin, chosen at creation by the creator from the supported, member-visible set; the counterparty MUST stake the same stablecoin.
 - **FR-005**: Stake escrow, payouts, refunds, draws, and any settlement MUST occur in the wager's denominating stablecoin, with amounts honoring that stablecoin's decimal precision.
@@ -91,6 +93,7 @@ A member browses wagers and account views where amounts are shown in a mix of st
 - **FR-011**: A member's "hidden" preference MUST filter only the member's own selection surfaces; it MUST NOT prevent the member from accepting, claiming, or refunding a wager that a counterparty denominated in a hidden stablecoin.
 - **FR-012**: All monetary amounts shown anywhere in the app MUST be labeled with their stablecoin and rendered at that stablecoin's correct decimal precision.
 - **FR-013**: Aggregate or summary figures spanning multiple stablecoins MUST be presented per-stablecoin (grouped/labeled) and MUST NOT sum amounts across different stablecoins as if interchangeable.
+- **FR-013a**: Tax reports and P&L/account-stats views MUST report amounts strictly per-stablecoin and MUST NOT convert non-USD stablecoin amounts to USD or any common reference currency; no FX/price data source is introduced by this feature.
 - **FR-014**: The supported-stablecoin set MUST be network-scoped; only stablecoins available on the connected network are offered, and preferences degrade gracefully when a stored choice is unavailable on the active network.
 - **FR-015**: Attempting to create or accept a wager in a stablecoin outside the curated supported set MUST be rejected with a clear, member-facing explanation.
 - **FR-016**: Removing a stablecoin from the supported set MUST NOT block settlement of pre-existing wagers already denominated in it; such wagers remain claimable/refundable while the stablecoin is withdrawn from new-wager selectors.
@@ -113,6 +116,8 @@ A member browses wagers and account views where amounts are shown in a mix of st
 - **SC-005**: Every stablecoin offered for new wagers is justifiably on the curated list (GENIUS-Act-permissible and available on the active network), with zero stablecoins offered that fail either criterion.
 - **SC-006**: 100% of wagers denominated in a stablecoin that is later removed from the supported set remain claimable/refundable by their participants.
 - **SC-007**: Stablecoins with decimal precision other than six are entered, displayed, and settled at their correct precision in 100% of tested cases.
+- **SC-008**: The first release offers USDC, USDT, and a euro-backed stablecoin on Polygon mainnet, and a full create→accept→settle cycle succeeds in each of the three.
+- **SC-009**: For every supported stablecoin, the amount escrowed equals the amount staked (no fee-on-transfer/rebasing discrepancy) in 100% of tested cases.
 
 ## Assumptions
 
@@ -120,7 +125,7 @@ A member browses wagers and account views where amounts are shown in a mix of st
 - **The curated supported-stablecoin list is maintained by platform governance/admins**, surfaced to members as a read-only set; members curate only their personal visibility/default, not the platform list itself. The on-chain token allow-list already supports admin-controlled add/remove of stake tokens, and this feature builds on that mechanism.
 - **The wager creator selects the denomination** and the acceptor must match it; the platform does not attempt cross-stablecoin conversion or mixed-denomination wagers.
 - **Polygon mainnet is the primary target** for the expanded stablecoin set; testnets and other networks continue to use their network-appropriate stablecoin configuration, and the supported set is always network-scoped.
-- **"Major stablecoins deployed on Polygon mainnet"** is interpreted as the well-established, liquid stablecoins on Polygon (e.g., USDC as default, plus additional fiat-pegged tokens such as USDT and a euro-backed option), filtered by GENIUS-Act permissibility. The exact admitted list is a curation decision finalized during planning/implementation, not hard-coded by this spec.
+- **"Major stablecoins deployed on Polygon mainnet"** is interpreted as the well-established, liquid stablecoins on Polygon, filtered by GENIUS-Act permissibility. The confirmed first-release set is USDC (default) + USDT + one euro-backed stablecoin (e.g., EURC) — see Clarifications Q2 — with the curated list extensible thereafter without code changes. The exact euro-coin choice and any further additions are curation decisions finalized during planning, subject to compliance sign-off.
 - **GENIUS-Act permissibility** is the gating compliance criterion: only payment stablecoins from permitted/registered issuers (including non-USD stablecoins from comparable, recognized regimes) are admitted; algorithmic or non-compliant stablecoins are excluded. Final eligibility determinations require legal/compliance sign-off during planning.
 - **Member preferences persist locally per wallet** consistent with how existing member preferences are stored today; no new server-side account system is introduced by this feature.
 - **Existing USDC behavior is preserved** as the zero-configuration default so current members see no change unless they opt in.
@@ -131,9 +136,15 @@ A member browses wagers and account views where amounts are shown in a mix of st
 - Automatic conversion/swapping between stablecoins, or wagers with two different denominations.
 - Adding brand-new networks; this feature operates within the platform's already-supported networks.
 - A member-facing mechanism to add arbitrary tokens to the platform's supported list (curation stays with platform governance).
+- USD-equivalent valuation, FX conversion, or any cross-currency totals in reports/stats (amounts stay strictly per-stablecoin).
+- Cross-device/synced preferences (preferences stay client-side per wallet); rebasing or fee-on-transfer stablecoins.
 
 ## Clarifications
 
 ### Session 2026-06-22
 
 - **Q1 (Scope — membership payments)**: Should multi-stablecoin support extend to membership purchases (paying membership fees in a non-USDC stablecoin), or is it limited to wager staking/settlement plus member display preferences? → **A: Wagers + preferences only.** Membership fees stay USDC-only; `MembershipManager` keeps its single global payment token and is not changed by this feature.
+- **Q2 (Initial supported set)**: What stablecoins should the first release support beyond USDC? → **A: USDC (default) + USDT + one euro-backed stablecoin** (e.g., EURC) on Polygon mainnet. This proves both the USD-majors and the non-USD path in the first release; the set remains extensible via curation thereafter.
+- **Q3 (Non-USD reporting/valuation)**: How should non-USD stablecoin amounts appear in tax reports and P&L/account stats that currently assume USD? → **A: Strictly per-currency, no FX conversion.** Amounts are grouped/totaled per stablecoin and never converted to or summed as USD. No price/FX data-source dependency is introduced.
+- **Q4 (Token safety constraint)**: What constraint applies to which ERC-20 stablecoins may be curated? → **A: Standard ERC-20 only.** The curated set is limited to standard, non-rebasing, non-fee-on-transfer stablecoins so the amount escrowed always equals the amount staked.
+- **Q5 (Preference persistence)**: Where do a member's default/visible-stablecoin preferences live? → **A: Client-side, per wallet** (consistent with existing preference storage). Preferences are per-device and not synced across browsers/devices; no contract or backend storage change is introduced.

--- a/specs/028-multi-stablecoin-support/spec.md
+++ b/specs/028-multi-stablecoin-support/spec.md
@@ -1,0 +1,139 @@
+# Feature Specification: Multi-Stablecoin Support
+
+**Feature Branch**: `claude/multi-stablecoin-support-rq2baj`
+
+**Created**: 2026-06-22
+
+**Status**: Draft
+
+**Input**: User description: "we need the ability to support other stablecoins on the platform. usdc will still be the default choice. Members will need the ability to select and deselect their default and visible stablecoins in the preferences tab of the 'my account' view. We need to allow all major stablecoins which are deployed on polygon mainnet on the platfom. we should include non us dollar backed stable coins as well. we will only include stable coins which would be allowed under genius act."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Stake and settle wagers in a non-default stablecoin (Priority: P1)
+
+A member wants to create a wager denominated in a stablecoin other than USDC (for example, a euro-backed stablecoin or USDT). When creating a wager, they pick the stablecoin from the set of platform-supported, member-visible stablecoins, set the stake amount in that stablecoin, and invite an opponent. The opponent accepts by staking the same stablecoin, and the eventual payout, refund, or draw settlement happens in that same stablecoin.
+
+**Why this priority**: This is the core value of the feature — without the ability to actually escrow and settle a wager in another stablecoin, a token picker is cosmetic. It delivers a usable MVP on its own (USDC remains available as the default, plus at least one additional supported stablecoin).
+
+**Independent Test**: Create, accept, and resolve a wager denominated in a supported non-USDC stablecoin; confirm stakes are escrowed and the winner is paid out in that same stablecoin with the correct amounts (accounting for that token's decimals).
+
+**Acceptance Scenarios**:
+
+1. **Given** a member viewing the wager-creation flow, **When** they open the stablecoin selector, **Then** they see USDC plus every other platform-supported stablecoin they have marked visible, with USDC pre-selected as the default.
+2. **Given** a member has selected a supported euro-backed stablecoin and entered a stake, **When** they create the wager, **Then** the wager is denominated in that stablecoin and the stake amount is escrowed in that token.
+3. **Given** an opponent accepts a wager denominated in a non-USDC stablecoin, **When** they confirm, **Then** they stake the same stablecoin and the same amount, and the wager becomes active.
+4. **Given** a resolved non-USDC wager, **When** the winner claims, **Then** they receive the pooled stake in the wager's stablecoin, displayed with the correct symbol and decimal precision.
+5. **Given** a member attempts to use a stablecoin that is not on the platform's supported list, **When** they try to create or accept a wager with it, **Then** the action is rejected and the member is told only supported stablecoins are allowed.
+
+---
+
+### User Story 2 - Manage default and visible stablecoins in Preferences (Priority: P1)
+
+A member opens the Preferences tab in the "My Account" view. They see the list of all platform-supported stablecoins, each with a toggle for "visible" and a way to mark one as their personal default. They turn off stablecoins they never use (hiding them from selectors and amount displays) and pick which stablecoin is pre-selected when they start a new wager. Their choices persist across sessions and are remembered per wallet.
+
+**Why this priority**: The user explicitly requested this control. It is the primary interaction surface the feature adds for members and keeps the interface uncluttered for people who only ever use one or two stablecoins.
+
+**Independent Test**: In Preferences, mark a stablecoin as default and hide another; reload the app and reconnect the same wallet; confirm the wager creator pre-selects the chosen default and the hidden stablecoin no longer appears in selectors.
+
+**Acceptance Scenarios**:
+
+1. **Given** a member on the Preferences tab, **When** the tab loads, **Then** they see every platform-supported stablecoin with its symbol and name, a visibility toggle, and an indicator of which one is their default.
+2. **Given** a member toggles a stablecoin's visibility off, **When** they next open a stablecoin selector anywhere in the app, **Then** that stablecoin is not offered.
+3. **Given** a member sets a non-USDC stablecoin as their default, **When** they start a new wager, **Then** that stablecoin is pre-selected.
+4. **Given** a member has changed their preferences, **When** they return in a later session with the same wallet, **Then** their default and visibility choices are still applied.
+5. **Given** a member tries to deselect (hide) their current default stablecoin, **When** they do so, **Then** the system prevents leaving zero defaults — either USDC is restored as default or the member is required to choose another default first.
+6. **Given** a member has never set any preferences, **When** they use the app, **Then** USDC is the default and all platform-supported stablecoins are visible.
+
+---
+
+### User Story 3 - Discover and transact across the supported stablecoin set (Priority: P2)
+
+A member browses wagers and account views where amounts are shown in a mix of stablecoins. Each amount is clearly labeled with its stablecoin so values in different currencies are never silently added together or confused. When a member is invited to a wager denominated in a stablecoin they had hidden, the app still lets them act on that specific wager (the hidden preference filters their own choices, not wagers others created for them).
+
+**Why this priority**: Multiple stablecoins (including non-USD ones) mean amounts are no longer fungible at face value; the platform must present them unambiguously so members trust what they're staking and receiving. Important, but builds on P1.
+
+**Independent Test**: Display a list containing wagers and balances in two different stablecoins; confirm every amount is labeled with its stablecoin and that per-currency totals are not merged into a single misleading sum.
+
+**Acceptance Scenarios**:
+
+1. **Given** views that list wagers or balances in more than one stablecoin, **When** they render, **Then** every monetary amount shows its stablecoin symbol and correct decimal precision.
+2. **Given** aggregate figures (e.g., account stats, totals), **When** values span multiple stablecoins, **Then** they are grouped or labeled per stablecoin rather than summed across different currencies.
+3. **Given** a member was invited to (or is a counterparty on) a wager denominated in a stablecoin they have hidden in Preferences, **When** they view that wager, **Then** they can still accept, claim, or refund it in that stablecoin.
+
+---
+
+### Edge Cases
+
+- **Mismatched preferences between counterparties**: The wager creator chooses the denomination; the acceptor must stake that same stablecoin even if it is not their personal default or is hidden in their preferences.
+- **Hiding the default**: A member cannot end up with no default; the system enforces at least USDC (or a chosen replacement) as default.
+- **Stablecoin not available on the active network**: Supported stablecoins are network-scoped; a stablecoin not deployed on the connected network must not be offered there, and the selector must reflect the active network's available set only.
+- **Insufficient balance or allowance in the chosen stablecoin**: Creation/acceptance must fail clearly when the member lacks balance or approval for the selected stablecoin, naming the stablecoin involved.
+- **Differing decimals across stablecoins**: Amount entry, display, and settlement must respect each stablecoin's own decimal precision rather than assuming six decimals.
+- **A previously supported stablecoin is removed from the platform list**: Existing open/active wagers in that stablecoin must still be claimable/refundable; the stablecoin is simply no longer offered for new wagers and is removed from selectors.
+- **Non-USD value confusion**: A euro-pegged stablecoin amount must never be presented as if it were a US-dollar amount.
+- **Stale preferences referencing a removed stablecoin**: If a member's stored default points at a stablecoin the platform no longer supports, the app falls back to USDC as default.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The platform MUST support multiple stablecoins for wager staking and settlement, with USDC remaining the platform-wide default for any member who has not chosen otherwise.
+- **FR-002**: The set of stablecoins offered MUST be a curated allow-list limited to (a) major stablecoins deployed on the platform's supported networks (Polygon mainnet being the primary mainnet), and (b) stablecoins that would be permissible under the GENIUS Act, including non-US-dollar-backed stablecoins that meet that bar.
+- **FR-003**: The supported-stablecoin list MUST be governed/curated by the platform (not arbitrarily extensible by ordinary members); only curated stablecoins may be used to create or accept wagers.
+- **FR-004**: A wager MUST be denominated in exactly one stablecoin, chosen at creation by the creator from the supported, member-visible set; the counterparty MUST stake the same stablecoin.
+- **FR-005**: Stake escrow, payouts, refunds, draws, and any settlement MUST occur in the wager's denominating stablecoin, with amounts honoring that stablecoin's decimal precision.
+- **FR-006**: Members MUST be able to view, in the Preferences tab of the "My Account" view, the full list of platform-supported stablecoins (symbol and name) for the active network.
+- **FR-007**: Members MUST be able to mark each supported stablecoin as visible or hidden; hidden stablecoins MUST NOT appear in the member's own stablecoin selectors or default choices.
+- **FR-008**: Members MUST be able to designate one supported stablecoin as their personal default; that default MUST be pre-selected when they start a new wager.
+- **FR-009**: The system MUST guarantee a member always has exactly one valid default stablecoin, defaulting to USDC when none is chosen and preventing the member from removing their only default without selecting a replacement.
+- **FR-010**: Member stablecoin preferences (default and visibility) MUST persist across sessions and be scoped per wallet, so different wallets can have different preferences.
+- **FR-011**: A member's "hidden" preference MUST filter only the member's own selection surfaces; it MUST NOT prevent the member from accepting, claiming, or refunding a wager that a counterparty denominated in a hidden stablecoin.
+- **FR-012**: All monetary amounts shown anywhere in the app MUST be labeled with their stablecoin and rendered at that stablecoin's correct decimal precision.
+- **FR-013**: Aggregate or summary figures spanning multiple stablecoins MUST be presented per-stablecoin (grouped/labeled) and MUST NOT sum amounts across different stablecoins as if interchangeable.
+- **FR-014**: The supported-stablecoin set MUST be network-scoped; only stablecoins available on the connected network are offered, and preferences degrade gracefully when a stored choice is unavailable on the active network.
+- **FR-015**: Attempting to create or accept a wager in a stablecoin outside the curated supported set MUST be rejected with a clear, member-facing explanation.
+- **FR-016**: Removing a stablecoin from the supported set MUST NOT block settlement of pre-existing wagers already denominated in it; such wagers remain claimable/refundable while the stablecoin is withdrawn from new-wager selectors.
+- **FR-017**: The platform MUST record/maintain the rationale (GENIUS-Act eligibility and Polygon-mainnet availability) for each stablecoin admitted to the supported set, so the curated list is auditable.
+
+### Key Entities *(include if feature involves data)*
+
+- **Supported Stablecoin**: A curated, platform-approved stablecoin available for wagers. Attributes: symbol, display name, network(s) where available, decimal precision, peg currency (e.g., USD, EUR), and eligibility rationale (GENIUS-Act basis + availability). USDC is always a member of this set and is the platform default.
+- **Member Stablecoin Preferences**: Per-wallet settings capturing the member's chosen default stablecoin and the visibility (shown/hidden) state of each supported stablecoin. Defaults to "USDC as default, all visible" when unset.
+- **Wager (denomination aspect)**: An existing entity gaining/relying on a single denominating stablecoin attribute that fixes the token for staking, escrow, and settlement of that wager.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A member can create, have accepted, and settle a wager in a supported non-USDC stablecoin end-to-end, with correct amounts in that stablecoin, with no use of USDC at any step.
+- **SC-002**: 100% of monetary amounts displayed in the app are labeled with their stablecoin, and no view sums amounts across different stablecoins into a single combined total.
+- **SC-003**: A member can set a default stablecoin and hide unwanted stablecoins in under one minute, and those choices are correctly applied on the next session for the same wallet.
+- **SC-004**: For a member who never changes preferences, USDC is the default and the experience is unchanged from today (no added steps, no regressions for USDC-only usage).
+- **SC-005**: Every stablecoin offered for new wagers is justifiably on the curated list (GENIUS-Act-permissible and available on the active network), with zero stablecoins offered that fail either criterion.
+- **SC-006**: 100% of wagers denominated in a stablecoin that is later removed from the supported set remain claimable/refundable by their participants.
+- **SC-007**: Stablecoins with decimal precision other than six are entered, displayed, and settled at their correct precision in 100% of tested cases.
+
+## Assumptions
+
+- **Membership fees remain USDC-only for this feature.** The membership purchase flow today is tied to a single global payment token; extending membership pricing to multiple stablecoins is a separate, larger change and is treated as out of scope here. This feature targets wager staking/settlement and member display preferences. (Confirmed with stakeholder — see Clarifications.)
+- **The curated supported-stablecoin list is maintained by platform governance/admins**, surfaced to members as a read-only set; members curate only their personal visibility/default, not the platform list itself. The on-chain token allow-list already supports admin-controlled add/remove of stake tokens, and this feature builds on that mechanism.
+- **The wager creator selects the denomination** and the acceptor must match it; the platform does not attempt cross-stablecoin conversion or mixed-denomination wagers.
+- **Polygon mainnet is the primary target** for the expanded stablecoin set; testnets and other networks continue to use their network-appropriate stablecoin configuration, and the supported set is always network-scoped.
+- **"Major stablecoins deployed on Polygon mainnet"** is interpreted as the well-established, liquid stablecoins on Polygon (e.g., USDC as default, plus additional fiat-pegged tokens such as USDT and a euro-backed option), filtered by GENIUS-Act permissibility. The exact admitted list is a curation decision finalized during planning/implementation, not hard-coded by this spec.
+- **GENIUS-Act permissibility** is the gating compliance criterion: only payment stablecoins from permitted/registered issuers (including non-USD stablecoins from comparable, recognized regimes) are admitted; algorithmic or non-compliant stablecoins are excluded. Final eligibility determinations require legal/compliance sign-off during planning.
+- **Member preferences persist locally per wallet** consistent with how existing member preferences are stored today; no new server-side account system is introduced by this feature.
+- **Existing USDC behavior is preserved** as the zero-configuration default so current members see no change unless they opt in.
+
+## Out of Scope
+
+- Membership-tier pricing or membership purchases in non-USDC stablecoins.
+- Automatic conversion/swapping between stablecoins, or wagers with two different denominations.
+- Adding brand-new networks; this feature operates within the platform's already-supported networks.
+- A member-facing mechanism to add arbitrary tokens to the platform's supported list (curation stays with platform governance).
+
+## Clarifications
+
+### Session 2026-06-22
+
+- **Q1 (Scope — membership payments)**: Should multi-stablecoin support extend to membership purchases (paying membership fees in a non-USDC stablecoin), or is it limited to wager staking/settlement plus member display preferences? → **A: Wagers + preferences only.** Membership fees stay USDC-only; `MembershipManager` keeps its single global payment token and is not changed by this feature.


### PR DESCRIPTION
## Summary

Adds the feature specification for **multi-stablecoin support** (`specs/028-multi-stablecoin-support/`). Spec only — no code changes.

Members will be able to stake and settle wagers in any platform-supported stablecoin (USDC stays the default) and manage their **default and visible stablecoins** in the My Account → **Preferences** tab. The supported set is a curated, network-scoped allow-list limited to major stablecoins on Polygon mainnet that would be permissible under the GENIUS Act, including non-USD-backed coins.

## What's in this PR

- `spec.md` — 3 prioritized user stories, 17 functional requirements, success criteria, edge cases, assumptions, and resolved clarification.
- `checklists/requirements.md` — quality checklist (all items pass, zero `[NEEDS CLARIFICATION]`).
- Updates `.specify/feature.json` to point downstream Spec Kit commands at this feature.

## Key scope decisions

- **Confirmed with stakeholder**: scope is **wagers + display preferences only**. Membership fees stay USDC-only, so `MembershipManager` (single global payment token) is **not** changed by this feature.
- Wager creator picks the denomination; the counterparty must stake the same stablecoin. No cross-coin conversion or mixed-denomination wagers.
- Final admitted token list (GENIUS-Act eligibility + Polygon availability) is deferred to planning and needs legal/compliance sign-off.

## Codebase grounding (informs `/speckit-plan`)

- `WagerRegistry` already supports an admin-managed per-wager ERC20 **allow-list** (`setTokenAllowed`) and reads token decimals at runtime.
- Frontend already has a Preferences tab and per-wallet `UserPreferencesContext` (localStorage).

## Next steps

`/speckit-clarify` (optional, e.g. exact token list + curation role) → `/speckit-plan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JG6unrHGwAD5oDrbS56DUu)_