### PR TITLE
feat(clearpath): Standard DAOs & External DAO Connectors (spec 030)

### DIFF
--- a/.openzeppelin/unknown-63.json
+++ b/.openzeppelin/unknown-63.json
@@ -20,6 +20,11 @@
       "address": "0x5bdf74Ce98D41bf35192c20B25ACd561C75CFe62",
       "txHash": "0xe8c99f33f0c2f10fbf95784316f82937e8a62f42c8e543cdab3822effee6036f",
       "kind": "uups"
+    },
+    {
+      "address": "0xcEE0fb2e1407f0A0d19Bcf4Fee2726A3005FA3C0",
+      "txHash": "0x790d26b8d17e407b167690a6af56a409951c3fd9425c695ba2736388b69bf58f",
+      "kind": "uups"
     }
   ],
   "impls": {
@@ -1658,6 +1663,254 @@
               "slot": "0"
             }
           ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)26_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:62",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "d0e3184529490d1de6805d95115df24fd02d72a029db2ea5e609d3aea7c0d229": {
+      "address": "0x28270cB71E87D2D6C662e61CFE6eD02d05d43B7A",
+      "txHash": "0x6b26304d658db6ed6d1520589e9566a31a69623981fcc5f5b0c5b5a464894a43",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSManaged",
+            "src": "contracts/upgradeable/UUPSManaged.sol:46"
+          },
+          {
+            "label": "membershipManager",
+            "offset": 0,
+            "slot": "50",
+            "type": "t_contract(IMembershipManager)2841",
+            "contract": "ExternalDAORegistry",
+            "src": "contracts/clearpath/ExternalDAORegistry.sol:33"
+          },
+          {
+            "label": "externalCount",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_uint256",
+            "contract": "ExternalDAORegistry",
+            "src": "contracts/clearpath/ExternalDAORegistry.sol:34"
+          },
+          {
+            "label": "_entries",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_mapping(t_uint256,t_struct(Entry)2262_storage)",
+            "contract": "ExternalDAORegistry",
+            "src": "contracts/clearpath/ExternalDAORegistry.sol:35"
+          },
+          {
+            "label": "_idByDao",
+            "offset": 0,
+            "slot": "53",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ExternalDAORegistry",
+            "src": "contracts/clearpath/ExternalDAORegistry.sol:36"
+          },
+          {
+            "label": "_byRegistrant",
+            "offset": 0,
+            "slot": "54",
+            "type": "t_mapping(t_address,t_array(t_uint256)dyn_storage)",
+            "contract": "ExternalDAORegistry",
+            "src": "contracts/clearpath/ExternalDAORegistry.sol:37"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "55",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "ExternalDAORegistry",
+            "src": "contracts/clearpath/ExternalDAORegistry.sol:39"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)26_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)36_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)26_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)147_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)26_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IMembershipManager)2841": {
+            "label": "contract IMembershipManager",
+            "numberOfBytes": "20"
+          },
+          "t_enum(Framework)2610": {
+            "label": "enum IExternalDAORegistry.Framework",
+            "members": [
+              "OZGovernor"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_array(t_uint256)dyn_storage)": {
+            "label": "mapping(address => uint256[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Entry)2262_storage)": {
+            "label": "mapping(uint256 => struct ExternalDAORegistry.Entry)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Entry)2262_storage": {
+            "label": "struct ExternalDAORegistry.Entry",
+            "members": [
+              {
+                "label": "dao",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "framework",
+                "type": "t_enum(Framework)2610",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "registrant",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "registeredAt",
+                "type": "t_uint64",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "label",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
           "erc7201:openzeppelin.storage.AccessControl": [
             {
               "contract": "AccessControlUpgradeable",

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/028-token-mint"
+  "feature_directory": "specs/030-clearpath-standard-daos"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,5 +72,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/028-token-mint/plan.md
+at specs/030-clearpath-standard-daos/plan.md
 <!-- SPECKIT END -->

--- a/contracts/clearpath/ExternalDAORegistry.sol
+++ b/contracts/clearpath/ExternalDAORegistry.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {UUPSManaged} from "../upgradeable/UUPSManaged.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
+import {IExternalDAORegistry} from "./interfaces/IExternalDAORegistry.sol";
+import {IMembershipManager} from "../interfaces/IMembershipManager.sol";
+
+/// @title ExternalDAORegistry (ClearPath spec 030, pillar B)
+/// @notice Network-scoped on-chain registry of DAOs deployed by other platforms (Olympia + any OpenZeppelin
+///         Governor DAO). A member registers an existing governance contract by address; the registry validates
+///         it is a recognized governance contract (ERC-165 `IGovernor` probe + defensive `IGovernor` view
+///         calls), records it for shared discovery / subgraph indexing, and emits `ExternalDAORegistered`.
+///         Registration is gated by a MembershipManager tier (>= Silver). The registry holds NO authority over
+///         the registered DAO — ClearPath only reads it and constructs user-signed actions against the DAO's own
+///         contract (invariant INV-4). Imports only the `IGovernor` interface (no OZ Governor implementation),
+///         so it is paris-safe and deployable on ETC/Mordor.
+/// @dev    UUPS (UUPSManaged); append-only storage with a trailing `__gap`; registered in
+///         `npm run check:storage-layout`.
+contract ExternalDAORegistry is IExternalDAORegistry, UUPSManaged {
+    bytes32 public constant DAO_MEMBER_ROLE = keccak256("DAO_MEMBER_ROLE");
+
+    struct Entry {
+        address dao;
+        Framework framework;
+        address registrant;
+        uint64 registeredAt;
+        string label;
+    }
+
+    // ---- Append-only storage (never insert/reorder/remove above __gap) ----
+    IMembershipManager public membershipManager;
+    uint256 public externalCount;
+    mapping(uint256 => Entry) private _entries;
+    mapping(address => uint256) private _idByDao; // 0 = not registered (ids start at 1)
+    mapping(address => uint256[]) private _byRegistrant;
+
+    uint256[45] private __gap;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        // UUPSManaged constructor already calls _disableInitializers().
+    }
+
+    function initialize(address admin, address membershipManager_) external initializer {
+        if (admin == address(0) || membershipManager_ == address(0)) revert ZeroAddress();
+        __UUPSManaged_init(admin);
+        membershipManager = IMembershipManager(membershipManager_);
+    }
+
+    /// @notice Admin may rotate the membership integration (append-only, UUPS-gated).
+    function setMembershipManager(address manager) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (manager == address(0)) revert ZeroAddress();
+        membershipManager = IMembershipManager(manager);
+    }
+
+    /// @inheritdoc IExternalDAORegistry
+    function registerExternalDAO(address dao, Framework framework, string calldata label)
+        external
+        returns (uint256 id)
+    {
+        if (dao == address(0)) revert ZeroAddress();
+        if (_idByDao[dao] != 0) revert AlreadyRegistered();
+        // Tier gate (>= Silver). Registration is read-only metadata: it does NOT consume a creation quota and is
+        // not a value-moving action, so no sanctions screen and no recordCreate (INV: registry confers no power).
+        if (
+            uint8(membershipManager.getActiveTier(msg.sender, DAO_MEMBER_ROLE)) <
+            uint8(IMembershipManager.Tier.Silver)
+        ) revert InsufficientMembershipTier();
+        if (!_isGovernor(dao)) revert NotAGovernor(dao);
+
+        id = ++externalCount;
+        _entries[id] = Entry({
+            dao: dao,
+            framework: framework,
+            registrant: msg.sender,
+            registeredAt: uint64(block.timestamp),
+            label: label
+        });
+        _idByDao[dao] = id;
+        _byRegistrant[msg.sender].push(id);
+        emit ExternalDAORegistered(id, dao, framework, msg.sender, label);
+    }
+
+    function getExternalDAO(uint256 id)
+        external
+        view
+        returns (address dao, Framework framework, string memory label, address registrant, uint64 registeredAt)
+    {
+        Entry storage e = _entries[id];
+        return (e.dao, e.framework, e.label, e.registrant, e.registeredAt);
+    }
+
+    function isRegistered(address dao) external view returns (bool) {
+        return _idByDao[dao] != 0;
+    }
+
+    function getExternalDAOsByRegistrant(address who) external view returns (uint256[] memory) {
+        return _byRegistrant[who];
+    }
+
+    /// @dev Validate that `dao` is a recognized governance contract. Primary: ERC-165 `supportsInterface` for the
+    ///      `IGovernor` interfaceId. Fallback (some governors don't implement ERC-165 cleanly): probe two
+    ///      `IGovernor` views. Returns false for EOAs and non-governance contracts.
+    function _isGovernor(address dao) internal view returns (bool) {
+        if (dao.code.length == 0) return false; // EOA
+        try IERC165(dao).supportsInterface(type(IGovernor).interfaceId) returns (bool ok) {
+            if (ok) return true;
+        } catch {}
+        // Defensive fallback: a real Governor answers these views; a random contract reverts.
+        try IGovernor(dao).COUNTING_MODE() returns (string memory mode) {
+            if (bytes(mode).length == 0) return false;
+            try IGovernor(dao).votingPeriod() returns (uint256) {
+                return true;
+            } catch {
+                return false;
+            }
+        } catch {
+            return false;
+        }
+    }
+}

--- a/contracts/clearpath/interfaces/IExternalDAORegistry.sol
+++ b/contracts/clearpath/interfaces/IExternalDAORegistry.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title IExternalDAORegistry
+/// @notice A lightweight, network-scoped on-chain registry of DAOs deployed by OTHER platforms (ClearPath
+///         spec 030, pillar B). A member registers an existing governance contract by address; ClearPath then
+///         tracks it (read-only) and lets the member take user-signed governance actions via a per-framework
+///         connector. The registry confers ClearPath NO authority over the registered DAO — it is metadata for
+///         shared discovery + subgraph indexing. Registration is gated by a MembershipManager tier.
+interface IExternalDAORegistry {
+    /// @notice External governance frameworks ClearPath can connect to. Extensible (Aragon/Moloch/Safe later).
+    enum Framework {
+        OZGovernor // 0 — OpenZeppelin Governor (Olympia + any IGovernor DAO)
+    }
+
+    event ExternalDAORegistered(
+        uint256 indexed id,
+        address indexed dao,
+        Framework framework,
+        address indexed registrant,
+        string label
+    );
+
+    /// @notice Register an existing external governance contract. Validates `dao` is a recognized governance
+    ///         contract (ERC-165 IGovernor probe + defensive IGovernor view calls) before adding. Tier-gated.
+    ///         Confers NO authority over `dao`.
+    function registerExternalDAO(address dao, Framework framework, string calldata label) external returns (uint256 id);
+
+    function getExternalDAO(uint256 id)
+        external
+        view
+        returns (address dao, Framework framework, string memory label, address registrant, uint64 registeredAt);
+
+    function externalCount() external view returns (uint256);
+    function isRegistered(address dao) external view returns (bool);
+    function getExternalDAOsByRegistrant(address who) external view returns (uint256[] memory);
+
+    // --- errors ---
+    error ZeroAddress();
+    error AlreadyRegistered();
+    error NotAGovernor(address dao);
+    error MembershipDenied();
+    error InsufficientMembershipTier();
+}

--- a/contracts/mocks/clearpath/MockGovernorLike.sol
+++ b/contracts/mocks/clearpath/MockGovernorLike.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
+
+/// @dev TEST-ONLY. A minimal stand-in for an OZ Governor used to exercise `ExternalDAORegistry._isGovernor`
+///      WITHOUT importing the real OZ Governor implementation (which pulls in the Cancun `mcopy` opcode and is
+///      not paris-compilable). Toggles ERC-165 support to exercise both validation paths (primary ERC-165 probe
+///      and the defensive IGovernor-view fallback).
+contract MockGovernorLike is IERC165 {
+    bool public immutable supports165;
+
+    constructor(bool supports165_) {
+        supports165 = supports165_;
+    }
+
+    function supportsInterface(bytes4 interfaceId) external view returns (bool) {
+        if (!supports165) return false;
+        return interfaceId == type(IGovernor).interfaceId || interfaceId == type(IERC165).interfaceId;
+    }
+
+    function COUNTING_MODE() external pure returns (string memory) {
+        return "support=bravo&quorum=for,abstain";
+    }
+
+    function votingPeriod() external pure returns (uint256) {
+        return 50400;
+    }
+}
+
+/// @dev TEST-ONLY. A contract with code that is NOT a governor (no IERC165/IGovernor surface) — must be rejected.
+contract MockNonGovernor {
+    uint256 public value;
+
+    function setValue(uint256 v) external {
+        value = v;
+    }
+}

--- a/contracts/mocks/clearpath/MockMembershipTier.sol
+++ b/contracts/mocks/clearpath/MockMembershipTier.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @dev TEST-ONLY. Minimal MembershipManager stand-in exposing just the `getActiveTier` view that
+///      `ExternalDAORegistry` consults for tier gating. Tier values mirror `IMembershipManager.Tier`
+///      (0 None, 1 Bronze, 2 Silver, 3 Gold, 4 Platinum).
+contract MockMembershipTier {
+    mapping(address => uint8) private _tier;
+
+    function setTier(address user, uint8 tier) external {
+        _tier[user] = tier;
+    }
+
+    function getActiveTier(address user, bytes32) external view returns (uint8) {
+        return _tier[user];
+    }
+}

--- a/deployments/mordor-chain63-v2.json
+++ b/deployments/mordor-chain63-v2.json
@@ -22,7 +22,9 @@
     "restrictedERC20Impl": "0x0dD67E2af8Ad301a3B5308c2AD41CCb2220b0444",
     "openERC20V2Impl": "0x92169007926fBc8Ac90cdD311dD3C2557158C395",
     "openERC721V2Impl": "0xEeaBC05214FF0C42cbA42b365aB400b7ca4311cE",
-    "restrictedERC20V2Impl": "0x664d87bed13ea4D50Cd3da8e0aC5A8D70A302A0B"
+    "restrictedERC20V2Impl": "0x664d87bed13ea4D50Cd3da8e0aC5A8D70A302A0B",
+    "externalDAORegistry": "0xcEE0fb2e1407f0A0d19Bcf4Fee2726A3005FA3C0",
+    "externalDAORegistryImpl": "0x28270cB71E87D2D6C662e61CFE6eD02d05d43B7A"
   },
   "mocks": {
     "mockSanctionsOracle": "0xa5F0bB3a63C55721078be5ee80653E9cB0927D9E"
@@ -49,7 +51,8 @@
     "restrictedERC20Impl": [],
     "openERC20V2Impl": [],
     "openERC721V2Impl": [],
-    "restrictedERC20V2Impl": []
+    "restrictedERC20V2Impl": [],
+    "externalDAORegistryImpl": []
   },
   "saltPrefix": "FairWins-P2P-v2.0-",
   "timestamp": "2026-06-21T03:31:32.666Z",
@@ -61,5 +64,6 @@
   },
   "tokenMintDeployedAt": "2026-06-23T20:29:36.569Z",
   "tokenV2UpgradedAt": "2026-06-23T23:13:49.946Z",
-  "tokenV2TemplatesSyncedAt": "2026-06-23T23:32:04.921Z"
+  "tokenV2TemplatesSyncedAt": "2026-06-23T23:32:04.921Z",
+  "clearpathDeployedAt": "2026-06-24T13:16:39.566Z"
 }

--- a/frontend/src/abis/externalDAORegistry.js
+++ b/frontend/src/abis/externalDAORegistry.js
@@ -34,6 +34,33 @@ export const VOTING_TOKEN_READ_ABI = [
   'function symbol() view returns (string)',
 ]
 
+/** Minimal ERC-20 balance read (for treasury USDC balances). */
+export const ERC20_BALANCE_ABI = [
+  'function balanceOf(address account) view returns (uint256)',
+  'function decimals() view returns (uint8)',
+  'function symbol() view returns (string)',
+]
+
+/** Per-proposal reads for the live (subgraph-less) indexer. */
+export const GOVERNOR_PROPOSAL_ABI = [
+  'function proposalVotes(uint256 proposalId) view returns (uint256 againstVotes, uint256 forVotes, uint256 abstainVotes)',
+  'function proposalSnapshot(uint256 proposalId) view returns (uint256)',
+  'function proposalDeadline(uint256 proposalId) view returns (uint256)',
+  'event ProposalCreated(uint256 proposalId, address proposer, address[] targets, uint256[] values, string[] signatures, bytes[] calldatas, uint256 voteStart, uint256 voteEnd, string description)',
+]
+
+/** User-signed management actions (US5) — constructed for the user to sign against the DAO's own contract. */
+export const GOVERNOR_WRITE_ABI = [
+  'function castVote(uint256 proposalId, uint8 support) returns (uint256)',
+  'function castVoteWithReason(uint256 proposalId, uint8 support, string reason) returns (uint256)',
+  'function queue(address[] targets, uint256[] values, bytes[] calldatas, bytes32 descriptionHash) returns (uint256)',
+  'function execute(address[] targets, uint256[] values, bytes[] calldatas, bytes32 descriptionHash) payable returns (uint256)',
+  'function propose(address[] targets, uint256[] values, bytes[] calldatas, string description) returns (uint256)',
+]
+
+/** Vote support values (GovernorCountingSimple: 0 Against, 1 For, 2 Abstain). */
+export const VOTE_SUPPORT = { Against: 0, For: 1, Abstain: 2 }
+
 /** Frameworks the registry recognizes (matches the on-chain enum order). */
 export const DAO_FRAMEWORK = { OZGovernor: 0 }
 export const DAO_FRAMEWORK_LABEL = { 0: 'OpenZeppelin Governor' }

--- a/frontend/src/abis/externalDAORegistry.js
+++ b/frontend/src/abis/externalDAORegistry.js
@@ -1,0 +1,51 @@
+// Spec 030 — ClearPath external-DAO registry + the standard IGovernor read surface.
+// Hand-maintained (the repo does not auto-generate frontend ABIs; sync only does addresses). Refresh from the
+// compiled artifact after contract changes.
+
+/** ExternalDAORegistry (UUPS) — register/track DAOs deployed by other platforms (Olympia + any OZ Governor). */
+export const EXTERNAL_DAO_REGISTRY_ABI = [
+  'function registerExternalDAO(address dao, uint8 framework, string label) returns (uint256 id)',
+  'function getExternalDAO(uint256 id) view returns (address dao, uint8 framework, string label, address registrant, uint64 registeredAt)',
+  'function externalCount() view returns (uint256)',
+  'function isRegistered(address dao) view returns (bool)',
+  'function getExternalDAOsByRegistrant(address who) view returns (uint256[])',
+  'function DAO_MEMBER_ROLE() view returns (bytes32)',
+]
+
+/** Standard OZ IGovernor read surface — works for native ClearPath DAOs and external Governor DAOs alike. */
+export const GOVERNOR_READ_ABI = [
+  'function name() view returns (string)',
+  'function token() view returns (address)',
+  'function timelock() view returns (address)',
+  'function votingDelay() view returns (uint256)',
+  'function votingPeriod() view returns (uint256)',
+  'function proposalThreshold() view returns (uint256)',
+  'function COUNTING_MODE() view returns (string)',
+  'function CLOCK_MODE() view returns (string)',
+  'function clock() view returns (uint48)',
+  'function quorum(uint256 timepoint) view returns (uint256)',
+  'function state(uint256 proposalId) view returns (uint8)',
+  'function supportsInterface(bytes4 interfaceId) view returns (bool)',
+]
+
+/** Minimal ERC-20/721 metadata read for a Governor's voting token. */
+export const VOTING_TOKEN_READ_ABI = [
+  'function name() view returns (string)',
+  'function symbol() view returns (string)',
+]
+
+/** Frameworks the registry recognizes (matches the on-chain enum order). */
+export const DAO_FRAMEWORK = { OZGovernor: 0 }
+export const DAO_FRAMEWORK_LABEL = { 0: 'OpenZeppelin Governor' }
+
+/** OZ IGovernor.ProposalState enum (for rendering proposal status when available). */
+export const PROPOSAL_STATE_LABEL = {
+  0: 'Pending',
+  1: 'Active',
+  2: 'Canceled',
+  3: 'Defeated',
+  4: 'Succeeded',
+  5: 'Queued',
+  6: 'Expired',
+  7: 'Executed',
+}

--- a/frontend/src/components/clearpath/ClearPathPanel.jsx
+++ b/frontend/src/components/clearpath/ClearPathPanel.jsx
@@ -19,7 +19,7 @@ const TABS = [
 const short = (a) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '')
 
 export default function ClearPathPanel() {
-  const { isSupported, chainId, reader, listExternalDAOs, registerExternalDAO } = useClearPath()
+  const { isSupported, chainId, reader, signer, usdcAddress, listExternalDAOs, registerExternalDAO } = useClearPath()
   const [tab, setTab] = useState('daos')
   const [loading, setLoading] = useState(true)
   const [daos, setDaos] = useState([])
@@ -66,7 +66,7 @@ export default function ClearPathPanel() {
   if (selected) {
     return (
       <div className="clearpath">
-        <ExternalDaoView record={selected} reader={reader} chainId={chainId} onBack={() => setSelected(null)} />
+        <ExternalDaoView record={selected} reader={reader} signer={signer} chainId={chainId} usdcAddress={usdcAddress} onBack={() => setSelected(null)} />
       </div>
     )
   }

--- a/frontend/src/components/clearpath/ClearPathPanel.jsx
+++ b/frontend/src/components/clearpath/ClearPathPanel.jsx
@@ -1,0 +1,127 @@
+import { useCallback, useEffect, useState } from 'react'
+import './clearpath.css'
+import { getNetwork } from '../../config/networks'
+import { DAO_FRAMEWORK_LABEL } from '../../abis/externalDAORegistry'
+import { useClearPath } from './useClearPath'
+import RegisterExternalDao from './RegisterExternalDao'
+import ExternalDaoView from './ExternalDaoView'
+
+// Spec 030 — ClearPath module (external-DAO pillar), embedded as the My Account "ClearPath" tab. Lists DAOs
+// deployed by other platforms registered in the on-chain ExternalDAORegistry (read live over RPC — works on
+// subgraph-less Mordor, where Olympia lives), lets a member register a new one, and opens a per-DAO tracking
+// view. Network-scoped; self-disables truthfully where ClearPath isn't deployed (FR-016). Real on-chain only.
+
+const TABS = [
+  { id: 'daos', label: 'External DAOs' },
+  { id: 'register', label: 'Register' },
+]
+
+const short = (a) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '')
+
+export default function ClearPathPanel() {
+  const { isSupported, chainId, reader, listExternalDAOs, registerExternalDAO } = useClearPath()
+  const [tab, setTab] = useState('daos')
+  const [loading, setLoading] = useState(true)
+  const [daos, setDaos] = useState([])
+  const [error, setError] = useState(null)
+  const [selected, setSelected] = useState(null)
+  const net = getNetwork(chainId)
+
+  // Loads the registry over RPC. Does NOT setState synchronously (the first statement when supported is the
+  // async read) so it is safe to call from the effect; the Refresh button flips `loading` itself.
+  const load = useCallback(async () => {
+    if (!isSupported) return
+    try {
+      const list = await listExternalDAOs()
+      setDaos(list)
+      setError(null)
+    } catch (e) {
+      setError(e?.shortMessage || e?.message || 'Could not load DAOs.')
+      setDaos([])
+    } finally {
+      setLoading(false)
+    }
+  }, [isSupported, listExternalDAOs])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const refresh = () => {
+    setLoading(true)
+    load()
+  }
+
+  if (!isSupported) {
+    return (
+      <div className="clearpath">
+        <div className="cp-disabled" role="status">
+          ClearPath isn’t deployed on {net?.name || 'this network'}. Switch to a supported network (e.g. Ethereum
+          Classic Mordor) to track and manage DAOs.
+        </div>
+      </div>
+    )
+  }
+
+  if (selected) {
+    return (
+      <div className="clearpath">
+        <ExternalDaoView record={selected} reader={reader} chainId={chainId} onBack={() => setSelected(null)} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="clearpath">
+      <p className="cp-intro">
+        ClearPath — track and manage DAOs across platforms on {net?.name || 'this network'}. Add an existing DAO
+        (e.g. an OpenZeppelin Governor like Olympia) and inspect its live governance + treasury. Native ClearPath
+        DAOs are coming next.
+      </p>
+
+      <div className="cp-tabs" role="tablist">
+        {TABS.map((t) => (
+          <button key={t.id} type="button" role="tab" aria-selected={tab === t.id} className={`cp-tab ${tab === t.id ? 'active' : ''}`} onClick={() => setTab(t.id)}>
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'daos' && (
+        <div role="tabpanel">
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.75rem' }}>
+            <span className="cp-row-sub">DAOs registered on {net?.name || 'this network'}</span>
+            <button type="button" className="cp-btn" onClick={refresh} disabled={loading}>{loading ? 'Loading…' : 'Refresh'}</button>
+          </div>
+          {error && <div className="cp-error" role="alert">{error}</div>}
+          {!loading && daos.length === 0 && !error && (
+            <p className="cp-empty">No external DAOs registered yet. Use “Register” to add one.</p>
+          )}
+          {daos.map((d) => (
+            <div key={d.id} className="cp-row" role="button" tabIndex={0}
+              onClick={() => setSelected(d)} onKeyDown={(e) => { if (e.key === 'Enter') setSelected(d) }}>
+              <div style={{ minWidth: 0 }}>
+                <div className="cp-row-name">{d.label || 'External DAO'}</div>
+                <div className="cp-row-sub">{short(d.dao)}</div>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem' }}>
+                <span className="cp-badge cp-badge-ext">{DAO_FRAMEWORK_LABEL[d.framework] || 'Unknown'}</span>
+                <span aria-hidden="true" style={{ color: 'var(--cp-text-3)' }}>›</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {tab === 'register' && (
+        <div role="tabpanel">
+          <RegisterExternalDao
+            reader={reader}
+            register={registerExternalDAO}
+            onRegistered={() => { setTab('daos'); load() }}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/clearpath/CpAddressField.jsx
+++ b/frontend/src/components/clearpath/CpAddressField.jsx
@@ -1,0 +1,64 @@
+import { useState } from 'react'
+import AddressBookButton from '../ui/AddressBookButton'
+import QRScanner from '../ui/QRScanner'
+import { extractAddressFromScan } from '../../lib/addressBook/scanAddress'
+
+// Spec 030 (US3/US5) — a ClearPath address input wired to the app's address book + QR scanner, so any
+// recipient / target / token / governor address can be picked from saved contacts or scanned from a QR code
+// (the same affordances used on the wager-create form). Keeps the ClearPath `cp-*` styling. `onChange`
+// receives the raw address string (not an event), to drop cleanly into both `setState` and action-patch wiring.
+export default function CpAddressField({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder = '0x…',
+  disabled = false,
+  hint,
+}) {
+  const [scanOpen, setScanOpen] = useState(false)
+
+  // QR payloads can be a raw 0x, an EIP-681 `ethereum:` URI, or a share URL — extract the address from any.
+  const handleScan = (decodedText) => {
+    const addr = extractAddressFromScan(decodedText)
+    if (addr) onChange(addr)
+    setScanOpen(false)
+  }
+
+  return (
+    <div className="cp-field">
+      {label && (
+        <label className="cp-label" htmlFor={id}>
+          {label}
+        </label>
+      )}
+      <div className="cp-addr-row">
+        <input
+          id={id}
+          className="cp-input cp-mono"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          disabled={disabled}
+          autoComplete="off"
+          spellCheck="false"
+        />
+        <AddressBookButton disabled={disabled} onSelect={(entry) => onChange(entry.address)} />
+        <button
+          type="button"
+          className="cp-icon-btn"
+          onClick={() => setScanOpen(true)}
+          disabled={disabled}
+          title="Scan QR code"
+          aria-label="Scan QR code"
+        >
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M3 3h8v8H3V3zm2 2v4h4V5H5zm8-2h8v8h-8V3zm2 2v4h4V5h-4zM3 13h8v8H3v-8zm2 2v4h4v-4H5zm10-2h2v2h-2v-2zm4 0h2v2h-2v-2zm-4 4h2v2h-2v-2zm2 2h2v2h-2v-2zm2-2h2v2h-2v-2zm0 4h2v2h-2v-2z" />
+          </svg>
+        </button>
+      </div>
+      {hint && <span className="cp-row-sub">{hint}</span>}
+      <QRScanner isOpen={scanOpen} onClose={() => setScanOpen(false)} onScanSuccess={handleScan} />
+    </div>
+  )
+}

--- a/frontend/src/components/clearpath/ExternalDaoView.jsx
+++ b/frontend/src/components/clearpath/ExternalDaoView.jsx
@@ -12,6 +12,30 @@ function short(a) {
   return a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '—'
 }
 
+// Humanize the standard IGovernor COUNTING_MODE() string, e.g.
+// "support=bravo&quorum=for,abstain" → "For / Against / Abstain · quorum counts For + Abstain".
+function humanizeCounting(mode) {
+  if (!mode) return '—'
+  const support = /support=([^&]+)/.exec(mode)?.[1]
+  const quorum = /quorum=([^&]+)/.exec(mode)?.[1]
+  const cap = (w) => (w ? w.charAt(0).toUpperCase() + w.slice(1) : w)
+  const options = support === 'bravo' ? 'For / Against / Abstain' : support === 'basic' ? 'For / Against' : support || 'custom'
+  const q = quorum ? ` · quorum counts ${quorum.split(',').map(cap).join(' + ')}` : ''
+  return options + q
+}
+
+// Humanize the EIP-6372 CLOCK_MODE() string → a plain clock label + the unit for delays/periods.
+function humanizeClock(mode) {
+  if (!mode || /blocknumber/.test(mode)) return 'Block number'
+  if (/timestamp/.test(mode)) return 'Timestamp'
+  return mode
+}
+function clockUnit(mode) {
+  if (!mode || /blocknumber/.test(mode)) return 'blocks'
+  if (/timestamp/.test(mode)) return 'seconds'
+  return ''
+}
+
 export default function ExternalDaoView({ record, reader, chainId, onBack }) {
   const [state, setState] = useState({ key: null, summary: null, error: null })
   const net = getNetwork(chainId)
@@ -59,11 +83,11 @@ export default function ExternalDaoView({ record, reader, chainId, onBack }) {
             <h4 style={{ marginBottom: '0.5rem' }}>Governance</h4>
             <div className="cp-kv"><span className="k">On-chain name</span><span>{s.name || '—'}</span></div>
             <div className="cp-kv"><span className="k">Voting token</span><span>{s.tokenName ? `${s.tokenName}${s.tokenSymbol ? ` (${s.tokenSymbol})` : ''}` : short(s.tokenAddr)}</span></div>
-            <div className="cp-kv"><span className="k">Voting delay</span><span className="cp-mono">{s.votingDelay ?? '—'}</span></div>
-            <div className="cp-kv"><span className="k">Voting period</span><span className="cp-mono">{s.votingPeriod ?? '—'}</span></div>
+            <div className="cp-kv"><span className="k">Voting delay</span><span className="cp-mono">{s.votingDelay != null ? `${s.votingDelay} ${clockUnit(s.clockMode)}`.trim() : '—'}</span></div>
+            <div className="cp-kv"><span className="k">Voting period</span><span className="cp-mono">{s.votingPeriod != null ? `${s.votingPeriod} ${clockUnit(s.clockMode)}`.trim() : '—'}</span></div>
             <div className="cp-kv"><span className="k">Proposal threshold</span><span className="cp-mono">{s.proposalThreshold ?? '—'}</span></div>
-            <div className="cp-kv"><span className="k">Counting</span><span className="cp-mono" style={{ fontSize: '0.7rem' }}>{s.countingMode || '—'}</span></div>
-            <div className="cp-kv"><span className="k">Clock</span><span className="cp-mono" style={{ fontSize: '0.7rem' }}>{s.clockMode || 'blocks'}</span></div>
+            <div className="cp-kv"><span className="k">Voting</span><span title={s.countingMode || ''}>{humanizeCounting(s.countingMode)}</span></div>
+            <div className="cp-kv"><span className="k">Clock</span><span title={s.clockMode || ''}>{humanizeClock(s.clockMode)}</span></div>
           </div>
 
           <div className="cp-card">

--- a/frontend/src/components/clearpath/ExternalDaoView.jsx
+++ b/frontend/src/components/clearpath/ExternalDaoView.jsx
@@ -20,6 +20,12 @@ import ProposalBuilder from './ProposalBuilder'
 // authorized by the DAO's own rules, the member can vote / queue / execute / propose — user-signed; ClearPath
 // holds no authority. No mock data.
 
+// Upper bound on awaiting a confirmation. A tx that broadcasts but is then silently dropped from the mempool
+// (never mined, never replaced) would otherwise leave tx.wait() pending forever — orphaning the persistent
+// in-flight toast AND the busy lock (the finally never runs). 120s is far longer than a normal confirmation on
+// the live ClearPath networks (Mordor ~15s blocks), so it only ever trips on a genuinely stuck/dropped tx.
+const CONFIRM_TIMEOUT_MS = 120000
+
 function short(a) {
   return a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '—'
 }
@@ -91,8 +97,13 @@ export default function ExternalDaoView({ record, reader, signer, chainId, usdcA
   }, [reader, record.dao])
   useEffect(() => { loadProposals() }, [loadProposals])
 
-  // Returns true ONLY when the tx actually confirmed, so callers can gate success-only UI (e.g. the proposal
-  // builder must not reset/close on a reverted propose — that would imply a success the chain didn't give).
+  // Surfaces the whole on-chain activity to the app notification system so the user stays aware end-to-end:
+  // a persistent "confirm in your wallet" prompt during signing, a persistent "awaiting confirmation" toast
+  // while the tx mines (block times on subgraph-less chains like Mordor exceed the 5s default auto-dismiss, so
+  // a non-sticky toast would vanish mid-flight), then a terminal confirmed (with the tx hash for traceability)
+  // or failed toast. Each REPLACES the previous in the single-slot toast. Returns true ONLY when the tx actually
+  // confirmed, so callers can gate success-only UI (e.g. the proposal builder must not reset/close on a reverted
+  // propose — that would imply a success the chain didn't give).
   async function run(label, makeTx) {
     if (!signer) {
       showNotification('Connect a wallet to act on this DAO.', 'warning')
@@ -100,14 +111,21 @@ export default function ExternalDaoView({ record, reader, signer, chainId, usdcA
     }
     setBusy(true)
     try {
+      showNotification(`${label}: confirm in your wallet…`, 'info', 0)
       const tx = await makeTx()
-      showNotification(`${label} submitted — awaiting confirmation…`, 'info')
-      await tx.wait()
-      showNotification(`${label} confirmed.`, 'success')
+      showNotification(`${label} submitted — awaiting confirmation…`, 'info', 0)
+      await tx.wait(1, CONFIRM_TIMEOUT_MS)
+      showNotification(`${label} confirmed${tx?.hash ? ` · tx ${short(tx.hash)}` : ''}.`, 'success')
       await loadProposals()
       return true
     } catch (e) {
-      showNotification(e?.shortMessage || e?.reason || e?.message || `${label} failed.`, 'error')
+      // A timeout is NOT a confirmed revert — the tx may still mine. Surface that honestly (and dismissably)
+      // rather than claiming failure; busy is released by finally so the user can Refresh once it lands.
+      if (e?.code === 'TIMEOUT') {
+        showNotification(`${label} is taking longer than expected — it may still confirm. Check your wallet or the explorer, then Refresh.`, 'warning', 0)
+      } else {
+        showNotification(e?.shortMessage || e?.reason || e?.message || `${label} failed.`, 'error')
+      }
       return false
     } finally {
       setBusy(false)

--- a/frontend/src/components/clearpath/ExternalDaoView.jsx
+++ b/frontend/src/components/clearpath/ExternalDaoView.jsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react'
+import { ethers } from 'ethers'
+import { getNetwork } from '../../config/networks'
+import { DAO_FRAMEWORK_LABEL } from '../../abis/externalDAORegistry'
+import { readGovernorSummary } from './governorConnector'
+
+// Spec 030 (US3) — tracking view for a registered external DAO (e.g. Olympia). Reads the DAO's LIVE state via
+// the standard IGovernor connector (real on-chain, no mock data). Proposal enumeration needs indexing; on
+// subgraph-less networks (Mordor) that section disables truthfully with a block-explorer deep link (FR-020).
+
+function short(a) {
+  return a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '—'
+}
+
+export default function ExternalDaoView({ record, reader, chainId, onBack }) {
+  const [state, setState] = useState({ key: null, summary: null, error: null })
+  const net = getNetwork(chainId)
+  const explorerBase = (net?.explorer?.baseUrl || '').replace(/\/$/, '')
+  const loading = state.key !== record.dao
+
+  useEffect(() => {
+    let cancelled = false
+    readGovernorSummary(reader, record.dao)
+      .then((summary) => {
+        if (!cancelled) setState({ key: record.dao, summary, error: null })
+      })
+      .catch((e) => {
+        if (!cancelled) setState({ key: record.dao, summary: null, error: e?.message || 'Could not read the DAO.' })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [reader, record.dao])
+
+  const s = state.summary
+
+  return (
+    <div>
+      <button type="button" className="cp-btn-link" onClick={onBack}>‹ Back</button>
+
+      <div className="cp-card" style={{ marginTop: '0.6rem' }}>
+        <div style={{ display: 'flex', gap: '0.6rem', alignItems: 'center', flexWrap: 'wrap' }}>
+          <h2>{record.label || s?.name || 'External DAO'}</h2>
+          <span className="cp-badge cp-badge-ext">External · {DAO_FRAMEWORK_LABEL[record.framework] || 'Unknown'}</span>
+        </div>
+        <div className="cp-row-sub" style={{ marginTop: '0.3rem' }}>{record.dao}</div>
+        <p className="cp-intro" style={{ marginTop: '0.6rem' }}>
+          Tracked on {net?.name || 'this network'}. ClearPath holds no authority over this DAO — it reads its
+          on-chain state and (where your wallet is authorized by the DAO's own rules) lets you act on it.
+        </p>
+      </div>
+
+      {loading && <div className="cp-notice" role="status">Reading live DAO state…</div>}
+      {state.error && <div className="cp-error" role="alert">{state.error}</div>}
+
+      {s && (
+        <div className="cp-grid-2">
+          <div className="cp-card">
+            <h4 style={{ marginBottom: '0.5rem' }}>Governance</h4>
+            <div className="cp-kv"><span className="k">On-chain name</span><span>{s.name || '—'}</span></div>
+            <div className="cp-kv"><span className="k">Voting token</span><span>{s.tokenName ? `${s.tokenName}${s.tokenSymbol ? ` (${s.tokenSymbol})` : ''}` : short(s.tokenAddr)}</span></div>
+            <div className="cp-kv"><span className="k">Voting delay</span><span className="cp-mono">{s.votingDelay ?? '—'}</span></div>
+            <div className="cp-kv"><span className="k">Voting period</span><span className="cp-mono">{s.votingPeriod ?? '—'}</span></div>
+            <div className="cp-kv"><span className="k">Proposal threshold</span><span className="cp-mono">{s.proposalThreshold ?? '—'}</span></div>
+            <div className="cp-kv"><span className="k">Counting</span><span className="cp-mono" style={{ fontSize: '0.7rem' }}>{s.countingMode || '—'}</span></div>
+            <div className="cp-kv"><span className="k">Clock</span><span className="cp-mono" style={{ fontSize: '0.7rem' }}>{s.clockMode || 'blocks'}</span></div>
+          </div>
+
+          <div className="cp-card">
+            <h4 style={{ marginBottom: '0.5rem' }}>Treasury</h4>
+            <div className="cp-kv"><span className="k">Timelock / treasury</span><code className="cp-mono">{short(s.timelock)}</code></div>
+            <div className="cp-kv"><span className="k">Native balance</span><span className="cp-mono">{s.treasuryNative != null ? `${ethers.formatEther(s.treasuryNative)} ${net?.nativeCurrency?.symbol || ''}` : '—'}</span></div>
+            {explorerBase && (
+              <div className="cp-row-actions" style={{ marginTop: '0.6rem' }}>
+                <a className="cp-btn" href={`${explorerBase}/address/${record.dao}`} target="_blank" rel="noreferrer">Governor on explorer ↗</a>
+                {s.timelock && <a className="cp-btn" href={`${explorerBase}/address/${s.timelock}`} target="_blank" rel="noreferrer">Treasury ↗</a>}
+              </div>
+            )}
+          </div>
+
+          <div className="cp-card">
+            <h4 style={{ marginBottom: '0.5rem' }}>Proposals</h4>
+            <p className="cp-intro" style={{ margin: 0 }}>
+              Proposal history requires event indexing, which is not available on {net?.name || 'this network'}.
+              View this DAO's proposals on {net?.explorer?.name || 'the block explorer'} or its own app.
+            </p>
+            {explorerBase && (
+              <div className="cp-row-actions" style={{ marginTop: '0.6rem' }}>
+                <a className="cp-btn" href={`${explorerBase}/address/${record.dao}`} target="_blank" rel="noreferrer">View on {net?.explorer?.name || 'explorer'} ↗</a>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/clearpath/ExternalDaoView.jsx
+++ b/frontend/src/components/clearpath/ExternalDaoView.jsx
@@ -1,19 +1,28 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { ethers } from 'ethers'
 import { getNetwork } from '../../config/networks'
-import { DAO_FRAMEWORK_LABEL } from '../../abis/externalDAORegistry'
-import { readGovernorSummary } from './governorConnector'
+import { useNotification } from '../../hooks/useUI'
+import { DAO_FRAMEWORK_LABEL, PROPOSAL_STATE_LABEL, VOTE_SUPPORT } from '../../abis/externalDAORegistry'
+import {
+  readGovernorSummary,
+  readTreasuries,
+  extraTreasuries,
+  fetchGovernorProposals,
+  castVote,
+  queueProposal,
+  executeProposal,
+  proposeAction,
+} from './governorConnector'
 
-// Spec 030 (US3) — tracking view for a registered external DAO (e.g. Olympia). Reads the DAO's LIVE state via
-// the standard IGovernor connector (real on-chain, no mock data). Proposal enumeration needs indexing; on
-// subgraph-less networks (Mordor) that section disables truthfully with a block-explorer deep link (FR-020).
+// Spec 030 (US3 + US5) — tracking + management view for a registered external DAO (e.g. Olympia). Reads the
+// DAO's LIVE state via the standard IGovernor connector, its treasuries (timelock + known vaults) native+USDC,
+// and its proposals via a bounded on-chain log scan (the subgraph-less fallback). Where the connected wallet is
+// authorized by the DAO's own rules, the member can vote / queue / execute / propose — user-signed; ClearPath
+// holds no authority. No mock data.
 
 function short(a) {
   return a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '—'
 }
-
-// Humanize the standard IGovernor COUNTING_MODE() string, e.g.
-// "support=bravo&quorum=for,abstain" → "For / Against / Abstain · quorum counts For + Abstain".
 function humanizeCounting(mode) {
   if (!mode) return '—'
   const support = /support=([^&]+)/.exec(mode)?.[1]
@@ -23,8 +32,6 @@ function humanizeCounting(mode) {
   const q = quorum ? ` · quorum counts ${quorum.split(',').map(cap).join(' + ')}` : ''
   return options + q
 }
-
-// Humanize the EIP-6372 CLOCK_MODE() string → a plain clock label + the unit for delays/periods.
 function humanizeClock(mode) {
   if (!mode || /blocknumber/.test(mode)) return 'Block number'
   if (/timestamp/.test(mode)) return 'Timestamp'
@@ -35,28 +42,70 @@ function clockUnit(mode) {
   if (/timestamp/.test(mode)) return 'seconds'
   return ''
 }
+function fmtUsdc(bal, decimals) {
+  if (bal == null) return '—'
+  try { return ethers.formatUnits(bal, decimals) } catch { return '—' }
+}
 
-export default function ExternalDaoView({ record, reader, chainId, onBack }) {
-  const [state, setState] = useState({ key: null, summary: null, error: null })
+export default function ExternalDaoView({ record, reader, signer, chainId, usdcAddress, onBack }) {
+  const { showNotification } = useNotification()
   const net = getNetwork(chainId)
   const explorerBase = (net?.explorer?.baseUrl || '').replace(/\/$/, '')
-  const loading = state.key !== record.dao
 
+  const [sum, setSum] = useState({ key: null, summary: null, error: null })
+  const sumLoading = sum.key !== record.dao
+  const [treasuries, setTreasuries] = useState([])
+  const [props, setProps] = useState({ key: null, ok: true, proposals: [], scannedFrom: null, partial: false, error: null })
+  const propsLoading = props.key !== record.dao
+  const [busy, setBusy] = useState(false)
+  const s = sum.summary
+
+  // Summary + treasuries (timelock + known extra vaults), native + USDC.
   useEffect(() => {
     let cancelled = false
+    setTreasuries([])
     readGovernorSummary(reader, record.dao)
-      .then((summary) => {
-        if (!cancelled) setState({ key: record.dao, summary, error: null })
+      .then(async (summary) => {
+        if (cancelled) return
+        setSum({ key: record.dao, summary, error: null })
+        const vaults = []
+        if (summary?.timelock && ethers.isAddress(summary.timelock) && summary.timelock !== ethers.ZeroAddress) {
+          vaults.push({ label: 'Timelock', address: summary.timelock })
+        }
+        vaults.push(...extraTreasuries(chainId, record.dao))
+        if (vaults.length) {
+          try {
+            const t = await readTreasuries(reader, vaults, usdcAddress)
+            if (!cancelled) setTreasuries(t)
+          } catch { /* treasury balances are best-effort */ }
+        }
       })
-      .catch((e) => {
-        if (!cancelled) setState({ key: record.dao, summary: null, error: e?.message || 'Could not read the DAO.' })
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [reader, record.dao])
+      .catch((e) => { if (!cancelled) setSum({ key: record.dao, summary: null, error: e?.message || 'Could not read the DAO.' }) })
+    return () => { cancelled = true }
+  }, [reader, record.dao, chainId, usdcAddress])
 
-  const s = state.summary
+  // Proposals via the bounded live indexer (subgraph-less fallback).
+  const loadProposals = useCallback(async () => {
+    const res = await fetchGovernorProposals(reader, record.dao)
+    setProps({ key: record.dao, ...res })
+  }, [reader, record.dao])
+  useEffect(() => { loadProposals() }, [loadProposals])
+
+  async function run(label, makeTx) {
+    if (!signer) return showNotification('Connect a wallet to act on this DAO.', 'warning')
+    setBusy(true)
+    try {
+      const tx = await makeTx()
+      showNotification(`${label} submitted — awaiting confirmation…`, 'info')
+      await tx.wait()
+      showNotification(`${label} confirmed.`, 'success')
+      await loadProposals()
+    } catch (e) {
+      showNotification(e?.shortMessage || e?.reason || e?.message || `${label} failed.`, 'error')
+    } finally {
+      setBusy(false)
+    }
+  }
 
   return (
     <div>
@@ -70,12 +119,12 @@ export default function ExternalDaoView({ record, reader, chainId, onBack }) {
         <div className="cp-row-sub" style={{ marginTop: '0.3rem' }}>{record.dao}</div>
         <p className="cp-intro" style={{ marginTop: '0.6rem' }}>
           Tracked on {net?.name || 'this network'}. ClearPath holds no authority over this DAO — it reads its
-          on-chain state and (where your wallet is authorized by the DAO's own rules) lets you act on it.
+          on-chain state and (where your wallet is authorized by the DAO's own rules) lets you act on it, signed by you.
         </p>
       </div>
 
-      {loading && <div className="cp-notice" role="status">Reading live DAO state…</div>}
-      {state.error && <div className="cp-error" role="alert">{state.error}</div>}
+      {sumLoading && <div className="cp-notice" role="status">Reading live DAO state…</div>}
+      {sum.error && <div className="cp-error" role="alert">{sum.error}</div>}
 
       {s && (
         <div className="cp-grid-2">
@@ -92,30 +141,115 @@ export default function ExternalDaoView({ record, reader, chainId, onBack }) {
 
           <div className="cp-card">
             <h4 style={{ marginBottom: '0.5rem' }}>Treasury</h4>
-            <div className="cp-kv"><span className="k">Timelock / treasury</span><code className="cp-mono">{short(s.timelock)}</code></div>
-            <div className="cp-kv"><span className="k">Native balance</span><span className="cp-mono">{s.treasuryNative != null ? `${ethers.formatEther(s.treasuryNative)} ${net?.nativeCurrency?.symbol || ''}` : '—'}</span></div>
-            {explorerBase && (
-              <div className="cp-row-actions" style={{ marginTop: '0.6rem' }}>
-                <a className="cp-btn" href={`${explorerBase}/address/${record.dao}`} target="_blank" rel="noreferrer">Governor on explorer ↗</a>
-                {s.timelock && <a className="cp-btn" href={`${explorerBase}/address/${s.timelock}`} target="_blank" rel="noreferrer">Treasury ↗</a>}
+            {treasuries.length === 0 && <p className="cp-row-sub">Reading balances…</p>}
+            {treasuries.map((t) => (
+              <div key={t.address} className="cp-section" style={{ marginBottom: '0.5rem' }}>
+                <div className="cp-kv"><span className="k">{t.label}</span><code className="cp-mono">{short(t.address)}</code></div>
+                <div className="cp-kv"><span className="k">Native</span><span className="cp-mono">{t.native != null ? `${ethers.formatEther(t.native)} ${net?.nativeCurrency?.symbol || ''}` : '—'}</span></div>
+                <div className="cp-kv"><span className="k">{t.usdcSymbol || 'USDC'}</span><span className="cp-mono">{fmtUsdc(t.usdc, t.usdcDecimals)}</span></div>
+                {explorerBase && <a className="cp-btn-link" href={`${explorerBase}/address/${t.address}`} target="_blank" rel="noreferrer">View ↗</a>}
               </div>
-            )}
-          </div>
-
-          <div className="cp-card">
-            <h4 style={{ marginBottom: '0.5rem' }}>Proposals</h4>
-            <p className="cp-intro" style={{ margin: 0 }}>
-              Proposal history requires event indexing, which is not available on {net?.name || 'this network'}.
-              View this DAO's proposals on {net?.explorer?.name || 'the block explorer'} or its own app.
-            </p>
-            {explorerBase && (
-              <div className="cp-row-actions" style={{ marginTop: '0.6rem' }}>
-                <a className="cp-btn" href={`${explorerBase}/address/${record.dao}`} target="_blank" rel="noreferrer">View on {net?.explorer?.name || 'explorer'} ↗</a>
-              </div>
-            )}
+            ))}
           </div>
         </div>
       )}
+
+      <div className="cp-card">
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '0.5rem' }}>
+          <h4>Proposals</h4>
+          <button type="button" className="cp-btn" onClick={loadProposals} disabled={propsLoading || busy}>Refresh</button>
+        </div>
+        <p className="cp-intro" style={{ marginTop: '0.4rem' }}>
+          Live on-chain scan (no subgraph on {net?.name || 'this network'}). Actions are signed by your wallet and
+          gated by the DAO's own rules.
+        </p>
+
+        {propsLoading && <div className="cp-notice" role="status">Indexing proposals on-chain…</div>}
+        {!propsLoading && !props.ok && (
+          <div className="cp-error" role="alert">Couldn’t load proposals from this RPC: {props.error}</div>
+        )}
+        {!propsLoading && props.ok && props.proposals.length === 0 && (
+          <p className="cp-empty">No proposals found in the scanned range (from block {props.scannedFrom}).</p>
+        )}
+        {!propsLoading && props.ok && props.partial && props.proposals.length > 0 && (
+          <p className="cp-row-sub">Showing the most recent proposals; older ones may exist beyond the scanned range.</p>
+        )}
+
+        {props.proposals.map((p) => (
+          <div key={p.id} className="cp-card" style={{ background: 'var(--cp-canvas)' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.6rem', alignItems: 'center', flexWrap: 'wrap' }}>
+              <span className="cp-row-name">{p.description ? p.description.slice(0, 80) : `Proposal ${short(p.id)}`}</span>
+              <span className="cp-badge">{PROPOSAL_STATE_LABEL[p.state] ?? 'Unknown'}</span>
+            </div>
+            <div className="cp-row-sub" style={{ marginTop: '0.3rem' }}>#{p.id.length > 12 ? short(p.id) : p.id} · by {short(p.proposer)}</div>
+            {p.votes && (
+              <div className="cp-row-sub" style={{ marginTop: '0.3rem' }}>
+                For {p.votes.for} · Against {p.votes.against} · Abstain {p.votes.abstain}
+              </div>
+            )}
+            <div className="cp-row-actions" style={{ marginTop: '0.6rem' }}>
+              {p.state === 1 && (
+                <>
+                  <button type="button" className="cp-btn cp-btn-primary" disabled={busy} onClick={() => run('Vote For', () => castVote(signer, record.dao, p.id, VOTE_SUPPORT.For))}>Vote For</button>
+                  <button type="button" className="cp-btn" disabled={busy} onClick={() => run('Vote Against', () => castVote(signer, record.dao, p.id, VOTE_SUPPORT.Against))}>Against</button>
+                  <button type="button" className="cp-btn" disabled={busy} onClick={() => run('Vote Abstain', () => castVote(signer, record.dao, p.id, VOTE_SUPPORT.Abstain))}>Abstain</button>
+                </>
+              )}
+              {p.state === 4 && <button type="button" className="cp-btn cp-btn-primary" disabled={busy} onClick={() => run('Queue', () => queueProposal(signer, record.dao, p))}>Queue</button>}
+              {p.state === 5 && <button type="button" className="cp-btn cp-btn-primary" disabled={busy} onClick={() => run('Execute', () => executeProposal(signer, record.dao, p))}>Execute</button>}
+              {explorerBase && <a className="cp-btn-link" href={`${explorerBase}/address/${record.dao}`} target="_blank" rel="noreferrer">Details ↗</a>}
+            </div>
+          </div>
+        ))}
+
+        <ProposeForm record={record} signer={signer} run={run} busy={busy} />
+      </div>
+    </div>
+  )
+}
+
+// Minimal "new proposal" form (US5) — a single treasury/parameter action the member signs. Advanced; the DAO's
+// own rules (e.g. proposal threshold / membership) gate acceptance on-chain.
+function ProposeForm({ record, signer, run, busy }) {
+  const [open, setOpen] = useState(false)
+  const [target, setTarget] = useState('')
+  const [value, setValue] = useState('0')
+  const [calldata, setCalldata] = useState('0x')
+  const [description, setDescription] = useState('')
+
+  if (!open) {
+    return (
+      <div style={{ marginTop: '0.8rem' }}>
+        <button type="button" className="cp-btn-link" onClick={() => setOpen(true)}>+ New proposal</button>
+      </div>
+    )
+  }
+
+  const valid =
+    ethers.isAddress(target.trim()) && description.trim().length > 0 && /^0x([0-9a-fA-F]{2})*$/.test(calldata.trim())
+
+  function submit() {
+    run('Propose', () =>
+      proposeAction(signer, record.dao, {
+        targets: [target.trim()],
+        values: [ethers.parseEther(String(value || '0'))],
+        calldatas: [calldata.trim()],
+        description: description.trim(),
+      })
+    ).then(() => { setOpen(false); setTarget(''); setValue('0'); setCalldata('0x'); setDescription('') })
+  }
+
+  return (
+    <div className="cp-card" style={{ marginTop: '0.8rem', background: 'var(--cp-canvas)' }}>
+      <h4 style={{ marginBottom: '0.5rem' }}>New proposal</h4>
+      <div className="cp-field"><label className="cp-label">Target contract</label><input className="cp-input cp-mono" value={target} onChange={(e) => setTarget(e.target.value)} placeholder="0x…" /></div>
+      <div className="cp-field"><label className="cp-label">Value (native)</label><input className="cp-input cp-mono" value={value} onChange={(e) => setValue(e.target.value)} placeholder="0" /></div>
+      <div className="cp-field"><label className="cp-label">Calldata</label><input className="cp-input cp-mono" value={calldata} onChange={(e) => setCalldata(e.target.value)} placeholder="0x" /></div>
+      <div className="cp-field"><label className="cp-label">Description</label><input className="cp-input" value={description} onChange={(e) => setDescription(e.target.value)} placeholder="What this proposal does" /></div>
+      <div className="cp-row-actions">
+        <button type="button" className="cp-btn cp-btn-primary" disabled={!valid || busy} onClick={submit}>Submit proposal</button>
+        <button type="button" className="cp-btn" onClick={() => setOpen(false)}>Cancel</button>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/clearpath/ExternalDaoView.jsx
+++ b/frontend/src/components/clearpath/ExternalDaoView.jsx
@@ -91,8 +91,13 @@ export default function ExternalDaoView({ record, reader, signer, chainId, usdcA
   }, [reader, record.dao])
   useEffect(() => { loadProposals() }, [loadProposals])
 
+  // Returns true ONLY when the tx actually confirmed, so callers can gate success-only UI (e.g. the proposal
+  // builder must not reset/close on a reverted propose — that would imply a success the chain didn't give).
   async function run(label, makeTx) {
-    if (!signer) return showNotification('Connect a wallet to act on this DAO.', 'warning')
+    if (!signer) {
+      showNotification('Connect a wallet to act on this DAO.', 'warning')
+      return false
+    }
     setBusy(true)
     try {
       const tx = await makeTx()
@@ -100,8 +105,10 @@ export default function ExternalDaoView({ record, reader, signer, chainId, usdcA
       await tx.wait()
       showNotification(`${label} confirmed.`, 'success')
       await loadProposals()
+      return true
     } catch (e) {
       showNotification(e?.shortMessage || e?.reason || e?.message || `${label} failed.`, 'error')
+      return false
     } finally {
       setBusy(false)
     }
@@ -209,6 +216,7 @@ export default function ExternalDaoView({ record, reader, signer, chainId, usdcA
           usdcAddress={usdcAddress}
           nativeSymbol={net?.nativeCurrency?.symbol}
           treasuries={treasuries}
+          proposals={props.proposals}
           run={run}
           busy={busy}
           onSubmitted={loadProposals}

--- a/frontend/src/components/clearpath/ExternalDaoView.jsx
+++ b/frontend/src/components/clearpath/ExternalDaoView.jsx
@@ -11,8 +11,8 @@ import {
   castVote,
   queueProposal,
   executeProposal,
-  proposeAction,
 } from './governorConnector'
+import ProposalBuilder from './ProposalBuilder'
 
 // Spec 030 (US3 + US5) — tracking + management view for a registered external DAO (e.g. Olympia). Reads the
 // DAO's LIVE state via the standard IGovernor connector, its treasuries (timelock + known vaults) native+USDC,
@@ -202,53 +202,17 @@ export default function ExternalDaoView({ record, reader, signer, chainId, usdcA
           </div>
         ))}
 
-        <ProposeForm record={record} signer={signer} run={run} busy={busy} />
-      </div>
-    </div>
-  )
-}
-
-// Minimal "new proposal" form (US5) — a single treasury/parameter action the member signs. Advanced; the DAO's
-// own rules (e.g. proposal threshold / membership) gate acceptance on-chain.
-function ProposeForm({ record, signer, run, busy }) {
-  const [open, setOpen] = useState(false)
-  const [target, setTarget] = useState('')
-  const [value, setValue] = useState('0')
-  const [calldata, setCalldata] = useState('0x')
-  const [description, setDescription] = useState('')
-
-  if (!open) {
-    return (
-      <div style={{ marginTop: '0.8rem' }}>
-        <button type="button" className="cp-btn-link" onClick={() => setOpen(true)}>+ New proposal</button>
-      </div>
-    )
-  }
-
-  const valid =
-    ethers.isAddress(target.trim()) && description.trim().length > 0 && /^0x([0-9a-fA-F]{2})*$/.test(calldata.trim())
-
-  function submit() {
-    run('Propose', () =>
-      proposeAction(signer, record.dao, {
-        targets: [target.trim()],
-        values: [ethers.parseEther(String(value || '0'))],
-        calldatas: [calldata.trim()],
-        description: description.trim(),
-      })
-    ).then(() => { setOpen(false); setTarget(''); setValue('0'); setCalldata('0x'); setDescription('') })
-  }
-
-  return (
-    <div className="cp-card" style={{ marginTop: '0.8rem', background: 'var(--cp-canvas)' }}>
-      <h4 style={{ marginBottom: '0.5rem' }}>New proposal</h4>
-      <div className="cp-field"><label className="cp-label">Target contract</label><input className="cp-input cp-mono" value={target} onChange={(e) => setTarget(e.target.value)} placeholder="0x…" /></div>
-      <div className="cp-field"><label className="cp-label">Value (native)</label><input className="cp-input cp-mono" value={value} onChange={(e) => setValue(e.target.value)} placeholder="0" /></div>
-      <div className="cp-field"><label className="cp-label">Calldata</label><input className="cp-input cp-mono" value={calldata} onChange={(e) => setCalldata(e.target.value)} placeholder="0x" /></div>
-      <div className="cp-field"><label className="cp-label">Description</label><input className="cp-input" value={description} onChange={(e) => setDescription(e.target.value)} placeholder="What this proposal does" /></div>
-      <div className="cp-row-actions">
-        <button type="button" className="cp-btn cp-btn-primary" disabled={!valid || busy} onClick={submit}>Submit proposal</button>
-        <button type="button" className="cp-btn" onClick={() => setOpen(false)}>Cancel</button>
+        <ProposalBuilder
+          record={record}
+          signer={signer}
+          reader={reader}
+          usdcAddress={usdcAddress}
+          nativeSymbol={net?.nativeCurrency?.symbol}
+          treasuries={treasuries}
+          run={run}
+          busy={busy}
+          onSubmitted={loadProposals}
+        />
       </div>
     </div>
   )

--- a/frontend/src/components/clearpath/ProposalBuilder.jsx
+++ b/frontend/src/components/clearpath/ProposalBuilder.jsx
@@ -3,6 +3,7 @@ import { ethers } from 'ethers'
 import { ERC20_BALANCE_ABI } from '../../abis/externalDAORegistry'
 import { proposeAction } from './governorConnector'
 import { ACTION_TYPE, newAction, assemble, predictProposalId } from './proposalEncoding'
+import CpAddressField from './CpAddressField'
 
 // Spec 030 (US5, FR-023/024/025) — rich Governor proposal builder. Compose a proposal from named action types
 // (send native / send token / custom call), multiple actions, asset-aware human amounts — no hand-written
@@ -211,7 +212,7 @@ function ActionCard({ index, action, diag, meta, usdcAddress, nativeSymbol, canR
 
       {a.type === ACTION_TYPE.NATIVE && (
         <>
-          <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-nto`}>Recipient</label><input id={`f-${a.id}-nto`} className="cp-input cp-mono" value={a.nativeTo} onChange={(e) => onChange({ nativeTo: e.target.value })} placeholder="0x…" /></div>
+          <CpAddressField id={`f-${a.id}-nto`} label="Recipient" value={a.nativeTo} onChange={(v) => onChange({ nativeTo: v })} />
           <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-namt`}>Amount<span className="cp-suffix">{nativeSymbol}</span></label><input id={`f-${a.id}-namt`} className="cp-input cp-mono" value={a.nativeAmount} onChange={(e) => onChange({ nativeAmount: e.target.value })} placeholder="0.0" /></div>
         </>
       )}
@@ -225,8 +226,8 @@ function ActionCard({ index, action, diag, meta, usdcAddress, nativeSymbol, canR
               <option value="other">Other ERC-20…</option>
             </select>
           </div>
-          {!useDefaultUsdc && <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-taddr`}>Token address</label><input id={`f-${a.id}-taddr`} className="cp-input cp-mono" value={a.tokenAddress} onChange={(e) => onChange({ tokenAddress: e.target.value })} placeholder="0x…" /></div>}
-          <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-tto`}>Recipient</label><input id={`f-${a.id}-tto`} className="cp-input cp-mono" value={a.tokenTo} onChange={(e) => onChange({ tokenTo: e.target.value })} placeholder="0x…" /></div>
+          {!useDefaultUsdc && <CpAddressField id={`f-${a.id}-taddr`} label="Token address" value={a.tokenAddress} onChange={(v) => onChange({ tokenAddress: v })} hint="The ERC-20 contract to transfer (not the recipient)." />}
+          <CpAddressField id={`f-${a.id}-tto`} label="Recipient" value={a.tokenTo} onChange={(v) => onChange({ tokenTo: v })} />
           <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-tamt`}>Amount<span className="cp-suffix">{tokenSym}</span></label><input id={`f-${a.id}-tamt`} className="cp-input cp-mono" value={a.tokenAmount} onChange={(e) => onChange({ tokenAmount: e.target.value })} placeholder="0.0" /></div>
         </>
       )}
@@ -234,7 +235,7 @@ function ActionCard({ index, action, diag, meta, usdcAddress, nativeSymbol, canR
       {a.type === ACTION_TYPE.CUSTOM && (
         <>
           <p className="cp-row-sub">Advanced — encode the call yourself.</p>
-          <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-ctgt`}>Target contract</label><input id={`f-${a.id}-ctgt`} className="cp-input cp-mono" value={a.customTarget} onChange={(e) => onChange({ customTarget: e.target.value })} placeholder="0x…" /></div>
+          <CpAddressField id={`f-${a.id}-ctgt`} label="Target contract" value={a.customTarget} onChange={(v) => onChange({ customTarget: v })} />
           <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-cval`}>Value<span className="cp-suffix">{nativeSymbol}</span></label><input id={`f-${a.id}-cval`} className="cp-input cp-mono" value={a.customValue} onChange={(e) => onChange({ customValue: e.target.value })} placeholder="0" /></div>
           <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-ccd`}>Calldata</label><input id={`f-${a.id}-ccd`} className="cp-input cp-mono" value={a.customCalldata} onChange={(e) => onChange({ customCalldata: e.target.value })} placeholder="0x" /></div>
         </>

--- a/frontend/src/components/clearpath/ProposalBuilder.jsx
+++ b/frontend/src/components/clearpath/ProposalBuilder.jsx
@@ -1,0 +1,262 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { ethers } from 'ethers'
+import { ERC20_BALANCE_ABI } from '../../abis/externalDAORegistry'
+import { proposeAction } from './governorConnector'
+import { ACTION_TYPE, newAction, assemble, predictProposalId } from './proposalEncoding'
+
+// Spec 030 (US5, FR-023/024/025) — rich Governor proposal builder. Compose a proposal from named action types
+// (send native / send token / custom call), multiple actions, asset-aware human amounts — no hand-written
+// calldata for the common cases. Live preview of each encoded call + the exact arrays submitted. Pre-sign
+// guards: non-blocking over-treasury warning; duplicate-proposal detection; the DAO's own revert surfaced.
+
+const ERC20_TRANSFER_IFACE = new ethers.Interface(['function transfer(address to, uint256 amount)'])
+const short = (a) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '—')
+
+export default function ProposalBuilder({ record, signer, reader, usdcAddress, nativeSymbol, treasuries, run, busy, onSubmitted }) {
+  const [open, setOpen] = useState(false)
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [actions, setActions] = useState([newAction(ACTION_TYPE.TOKEN)])
+  const [tokenMeta, setTokenMeta] = useState({}) // addr(lc) → { decimals, symbol } | { unreadable:true }
+  const [showPayload, setShowPayload] = useState(false)
+
+  // Resolve token decimals/symbol: USDC from the treasury read (no extra RPC); other ERC-20s read live.
+  const metaFn = useCallback(
+    (addr) => {
+      const lc = String(addr).toLowerCase()
+      if (tokenMeta[lc]) return tokenMeta[lc].unreadable ? null : tokenMeta[lc]
+      if (usdcAddress && lc === usdcAddress.toLowerCase() && treasuries[0]) {
+        return { decimals: treasuries[0].usdcDecimals ?? 6, symbol: treasuries[0].usdcSymbol ?? 'USDC' }
+      }
+      return null
+    },
+    [tokenMeta, usdcAddress, treasuries]
+  )
+
+  useEffect(() => {
+    if (!reader) return undefined
+    let cancelled = false
+    const needed = [
+      ...new Set(
+        actions
+          .filter((a) => a.type === ACTION_TYPE.TOKEN)
+          .map((a) => (a.tokenAddress.trim() || usdcAddress || '').toLowerCase())
+          .filter(
+            (addr) =>
+              ethers.isAddress(addr) &&
+              !tokenMeta[addr] &&
+              !(usdcAddress && addr === usdcAddress.toLowerCase() && treasuries[0])
+          )
+      ),
+    ]
+    if (!needed.length) return undefined
+    ;(async () => {
+      const updates = {}
+      for (const addr of needed) {
+        try {
+          const c = new ethers.Contract(addr, ERC20_BALANCE_ABI, reader)
+          const [dec, sym] = await Promise.all([c.decimals(), c.symbol().catch(() => 'TOKEN')])
+          updates[addr] = { decimals: Number(dec), symbol: sym }
+        } catch {
+          updates[addr] = { unreadable: true }
+        }
+      }
+      if (!cancelled) setTokenMeta((m) => ({ ...m, ...updates }))
+    })()
+    return () => { cancelled = true }
+  }, [actions, usdcAddress, reader, tokenMeta, treasuries])
+
+  const A = useMemo(
+    () => assemble({ title, body, actions, usdcAddress, meta: metaFn }),
+    [title, body, actions, usdcAddress, metaFn]
+  )
+  const anyPending = A.perAction.some((p) => p.pending)
+  const valid = A.ok && !anyPending
+
+  // Pre-sign guards: over-treasury (warn, allow) + duplicate proposal (warn, block-by-choice).
+  const timelock = treasuries.find((t) => t.label === 'Timelock') || treasuries[0]
+  let nativeTotal = 0n
+  let usdcTotal = 0n
+  for (const p of A.perAction) {
+    if (!p.encoded) continue
+    nativeTotal += p.encoded.value
+    if (usdcAddress && p.encoded.target.toLowerCase() === usdcAddress.toLowerCase()) {
+      try { const [, amt] = ERC20_TRANSFER_IFACE.decodeFunctionData('transfer', p.encoded.calldata); usdcTotal += amt } catch { /* not a transfer */ }
+    }
+  }
+  const overNative = valid && timelock?.native != null && nativeTotal > timelock.native
+  const overUsdc = valid && timelock?.usdc != null && usdcTotal > timelock.usdc
+  const dupId = valid ? predictProposalId(A.targets, A.values, A.calldatas, A.descriptionHash) : null
+
+  function setAction(id, patch) {
+    setActions((arr) => arr.map((a) => (a.id === id ? { ...a, ...patch } : a)))
+  }
+  function addAction() {
+    setActions((arr) => [...arr, newAction(ACTION_TYPE.TOKEN)])
+  }
+  function removeAction(id) {
+    setActions((arr) => (arr.length <= 1 ? arr : arr.filter((a) => a.id !== id)))
+  }
+  function reset() {
+    setTitle(''); setBody(''); setActions([newAction(ACTION_TYPE.TOKEN)]); setShowPayload(false)
+  }
+  function submit() {
+    run('Propose', () =>
+      proposeAction(signer, record.dao, { targets: A.targets, values: A.values, calldatas: A.calldatas, description: A.description })
+    ).then(() => { reset(); setOpen(false); onSubmitted?.() })
+  }
+
+  if (!open) {
+    return (
+      <div style={{ marginTop: '0.8rem' }}>
+        <button type="button" className="cp-btn-link" onClick={() => setOpen(true)}>+ New proposal</button>
+      </div>
+    )
+  }
+
+  return (
+    <section className="cp-card" style={{ marginTop: '0.8rem', background: 'var(--cp-canvas)' }} aria-label="New proposal">
+      <h4 style={{ marginBottom: '0.6rem' }}>New proposal</h4>
+
+      <div className="cp-field">
+        <label className="cp-label" htmlFor="cp-prop-title">Title</label>
+        <input id="cp-prop-title" className="cp-input" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Fund core development" />
+      </div>
+      <div className="cp-field">
+        <label className="cp-label" htmlFor="cp-prop-body">Description (Markdown)</label>
+        <textarea id="cp-prop-body" className="cp-input cp-textarea" rows={4} value={body} onChange={(e) => setBody(e.target.value)} placeholder="What this proposal does and why." />
+      </div>
+
+      <div className="cp-action-head">
+        <h4 style={{ margin: 0 }}>Actions</h4>
+        <span className="cp-badge">{actions.length} action{actions.length === 1 ? '' : 's'}</span>
+        <button type="button" className="cp-btn" onClick={addAction}>+ Add action</button>
+      </div>
+
+      {actions.map((a, i) => (
+        <ActionCard
+          key={a.id}
+          index={i}
+          action={a}
+          diag={A.perAction[i]}
+          meta={metaFn}
+          usdcAddress={usdcAddress}
+          nativeSymbol={nativeSymbol}
+          canRemove={actions.length > 1}
+          onChange={(patch) => setAction(a.id, patch)}
+          onRemove={() => removeAction(a.id)}
+        />
+      ))}
+
+      {/* Summary + guards */}
+      <div className="cp-card" role="region" aria-label="Proposal summary" style={{ marginTop: '0.6rem' }}>
+        <div className="cp-kv"><span className="k">Actions</span><span>{actions.length}</span></div>
+        <div className="cp-kv"><span className="k">Total native value</span><span className="cp-mono">{ethers.formatEther(nativeTotal)} {nativeSymbol || ''}</span></div>
+        {overNative && <div className="cp-warn" role="status">Sends more {nativeSymbol} than the treasury holds. The proposal can still be created; execution will revert if not funded by then.</div>}
+        {overUsdc && <div className="cp-warn" role="status">Sends more {timelock?.usdcSymbol || 'USDC'} than the treasury holds. The proposal can still be created; execution will revert if not funded.</div>}
+        {!valid && <p className="cp-row-sub">{anyPending ? 'Reading token details…' : 'Add a title/description and at least one valid action to submit.'}</p>}
+
+        <details className="cp-section" open={showPayload} onToggle={(e) => setShowPayload(e.target.open)}>
+          <summary className="cp-btn-link" style={{ cursor: 'pointer' }}>Exact payload to submit</summary>
+          <div className="cp-preview cp-mono" style={{ marginTop: '0.4rem', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+            {`targets:   ${JSON.stringify(A.targets)}
+values:    ${JSON.stringify(A.values.map((v) => v.toString()))}
+calldatas: ${JSON.stringify(A.calldatas)}
+descriptionHash: ${A.descriptionHash}
+${dupId ? `proposalId: ${dupId}` : ''}`}
+          </div>
+        </details>
+
+        <div className="cp-row-actions" style={{ marginTop: '0.6rem' }}>
+          {signer ? (
+            <button type="button" className="cp-btn cp-btn-primary" disabled={!valid || busy} aria-disabled={!valid || busy} onClick={submit}>Submit proposal</button>
+          ) : (
+            <span className="cp-notice">Connect a wallet to propose.</span>
+          )}
+          <button type="button" className="cp-btn" onClick={() => { reset(); setOpen(false) }}>Cancel</button>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+const TYPE_OPTIONS = [
+  { v: ACTION_TYPE.TOKEN, label: 'Send USDC / token' },
+  { v: ACTION_TYPE.NATIVE, label: 'Send native coin' },
+  { v: ACTION_TYPE.CUSTOM, label: 'Custom call (advanced)' },
+]
+
+function ActionCard({ index, action, diag, meta, usdcAddress, nativeSymbol, canRemove, onChange, onRemove }) {
+  const a = action
+  const useDefaultUsdc = a.tokenMode !== 'other'
+  const tokenAddr = useDefaultUsdc ? (usdcAddress || '') : a.tokenAddress.trim()
+  const tokenMeta = a.type === ACTION_TYPE.TOKEN && tokenAddr ? meta(tokenAddr) : null
+  const tokenSym = tokenMeta?.symbol || (useDefaultUsdc ? 'USDC' : 'token')
+
+  return (
+    <div className="cp-card" style={{ background: 'var(--cp-surface)' }}>
+      <div className="cp-action-head">
+        <span className="cp-badge">#{index + 1}</span>
+        <label className="cp-label" htmlFor={`cp-act-type-${a.id}`} style={{ position: 'absolute', left: '-9999px' }}>Action {index + 1} type</label>
+        <select id={`cp-act-type-${a.id}`} className="cp-input cp-select" value={a.type} onChange={(e) => onChange({ type: e.target.value })} style={{ maxWidth: '14rem' }}>
+          {TYPE_OPTIONS.map((o) => <option key={o.v} value={o.v}>{o.label}</option>)}
+        </select>
+        {canRemove && <button type="button" className="cp-btn" aria-label={`Remove action ${index + 1}`} onClick={onRemove}>✕</button>}
+      </div>
+
+      {a.type === ACTION_TYPE.NATIVE && (
+        <>
+          <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-nto`}>Recipient</label><input id={`f-${a.id}-nto`} className="cp-input cp-mono" value={a.nativeTo} onChange={(e) => onChange({ nativeTo: e.target.value })} placeholder="0x…" /></div>
+          <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-namt`}>Amount<span className="cp-suffix">{nativeSymbol}</span></label><input id={`f-${a.id}-namt`} className="cp-input cp-mono" value={a.nativeAmount} onChange={(e) => onChange({ nativeAmount: e.target.value })} placeholder="0.0" /></div>
+        </>
+      )}
+
+      {a.type === ACTION_TYPE.TOKEN && (
+        <>
+          <div className="cp-field">
+            <label className="cp-label" htmlFor={`f-${a.id}-tsel`}>Token</label>
+            <select id={`f-${a.id}-tsel`} className="cp-input cp-select" value={useDefaultUsdc ? 'usdc' : 'other'} onChange={(e) => onChange(e.target.value === 'usdc' ? { tokenMode: 'usdc', tokenAddress: '' } : { tokenMode: 'other' })}>
+              <option value="usdc">USDC (treasury default)</option>
+              <option value="other">Other ERC-20…</option>
+            </select>
+          </div>
+          {!useDefaultUsdc && <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-taddr`}>Token address</label><input id={`f-${a.id}-taddr`} className="cp-input cp-mono" value={a.tokenAddress} onChange={(e) => onChange({ tokenAddress: e.target.value })} placeholder="0x…" /></div>}
+          <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-tto`}>Recipient</label><input id={`f-${a.id}-tto`} className="cp-input cp-mono" value={a.tokenTo} onChange={(e) => onChange({ tokenTo: e.target.value })} placeholder="0x…" /></div>
+          <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-tamt`}>Amount<span className="cp-suffix">{tokenSym}</span></label><input id={`f-${a.id}-tamt`} className="cp-input cp-mono" value={a.tokenAmount} onChange={(e) => onChange({ tokenAmount: e.target.value })} placeholder="0.0" /></div>
+        </>
+      )}
+
+      {a.type === ACTION_TYPE.CUSTOM && (
+        <>
+          <p className="cp-row-sub">Advanced — encode the call yourself.</p>
+          <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-ctgt`}>Target contract</label><input id={`f-${a.id}-ctgt`} className="cp-input cp-mono" value={a.customTarget} onChange={(e) => onChange({ customTarget: e.target.value })} placeholder="0x…" /></div>
+          <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-cval`}>Value<span className="cp-suffix">{nativeSymbol}</span></label><input id={`f-${a.id}-cval`} className="cp-input cp-mono" value={a.customValue} onChange={(e) => onChange({ customValue: e.target.value })} placeholder="0" /></div>
+          <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-ccd`}>Calldata</label><input id={`f-${a.id}-ccd`} className="cp-input cp-mono" value={a.customCalldata} onChange={(e) => onChange({ customCalldata: e.target.value })} placeholder="0x" /></div>
+        </>
+      )}
+
+      <div className="cp-preview" aria-live="polite">
+        {diag?.error && <span className="cp-error" role="alert">{diag.error}</span>}
+        {diag?.pending && <span>{diag.message}</span>}
+        {diag?.encoded && <ActionPreview type={a.type} enc={diag.encoded} nativeSymbol={nativeSymbol} tokenSym={tokenSym} />}
+      </div>
+    </div>
+  )
+}
+
+function ActionPreview({ type, enc, nativeSymbol, tokenSym }) {
+  if (type === ACTION_TYPE.NATIVE) {
+    return <span>Send {ethers.formatEther(enc.value)} {nativeSymbol} → {short(enc.target)}</span>
+  }
+  if (type === ACTION_TYPE.TOKEN) {
+    let to = '—'
+    let amt = ''
+    try {
+      const [t, a] = ERC20_TRANSFER_IFACE.decodeFunctionData('transfer', enc.calldata)
+      to = short(t)
+      amt = a.toString()
+    } catch { /* */ }
+    return <span>Transfer {tokenSym} (raw {amt}) → {to} · via {short(enc.target)}</span>
+  }
+  return <span>Call {short(enc.target)} · value {ethers.formatEther(enc.value)} {nativeSymbol} · calldata {enc.calldata.length > 12 ? `${enc.calldata.slice(0, 12)}…` : enc.calldata}</span>
+}

--- a/frontend/src/components/clearpath/ProposalBuilder.jsx
+++ b/frontend/src/components/clearpath/ProposalBuilder.jsx
@@ -12,7 +12,7 @@ import { ACTION_TYPE, newAction, assemble, predictProposalId } from './proposalE
 const ERC20_TRANSFER_IFACE = new ethers.Interface(['function transfer(address to, uint256 amount)'])
 const short = (a) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '—')
 
-export default function ProposalBuilder({ record, signer, reader, usdcAddress, nativeSymbol, treasuries, run, busy, onSubmitted }) {
+export default function ProposalBuilder({ record, signer, reader, usdcAddress, nativeSymbol, treasuries = [], proposals = [], run, busy, onSubmitted }) {
   const [open, setOpen] = useState(false)
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
@@ -24,9 +24,10 @@ export default function ProposalBuilder({ record, signer, reader, usdcAddress, n
   const metaFn = useCallback(
     (addr) => {
       const lc = String(addr).toLowerCase()
-      if (tokenMeta[lc]) return tokenMeta[lc].unreadable ? null : tokenMeta[lc]
-      if (usdcAddress && lc === usdcAddress.toLowerCase() && treasuries[0]) {
-        return { decimals: treasuries[0].usdcDecimals ?? 6, symbol: treasuries[0].usdcSymbol ?? 'USDC' }
+      if (tokenMeta[lc]) return tokenMeta[lc] // { decimals, symbol } OR { unreadable:true } → encoder shows a real error
+      if (usdcAddress && lc === usdcAddress.toLowerCase()) {
+        const u = treasuries.find((t) => t.usdcDecimals != null) // any vault carries the USDC meta (stamped identically)
+        if (u) return { decimals: u.usdcDecimals, symbol: u.usdcSymbol || 'USDC' }
       }
       return null
     },
@@ -73,7 +74,7 @@ export default function ProposalBuilder({ record, signer, reader, usdcAddress, n
   const anyPending = A.perAction.some((p) => p.pending)
   const valid = A.ok && !anyPending
 
-  // Pre-sign guards: over-treasury (warn, allow) + duplicate proposal (warn, block-by-choice).
+  // Pre-sign guards: over-treasury (warn, allow) + duplicate proposal (block submit — it would revert).
   const timelock = treasuries.find((t) => t.label === 'Timelock') || treasuries[0]
   let nativeTotal = 0n
   let usdcTotal = 0n
@@ -87,6 +88,8 @@ export default function ProposalBuilder({ record, signer, reader, usdcAddress, n
   const overNative = valid && timelock?.native != null && nativeTotal > timelock.native
   const overUsdc = valid && timelock?.usdc != null && usdcTotal > timelock.usdc
   const dupId = valid ? predictProposalId(A.targets, A.values, A.calldatas, A.descriptionHash) : null
+  // FR-025 duplicate pre-check: an identical action set + description hashes to the same id as a live proposal.
+  const isDuplicate = !!dupId && proposals.some((p) => p.id === dupId)
 
   function setAction(id, patch) {
     setActions((arr) => arr.map((a) => (a.id === id ? { ...a, ...patch } : a)))
@@ -101,9 +104,10 @@ export default function ProposalBuilder({ record, signer, reader, usdcAddress, n
     setTitle(''); setBody(''); setActions([newAction(ACTION_TYPE.TOKEN)]); setShowPayload(false)
   }
   function submit() {
+    // Only reset/close/reload on a CONFIRMED tx — a reverted propose must not look like success (US5 #9).
     run('Propose', () =>
       proposeAction(signer, record.dao, { targets: A.targets, values: A.values, calldatas: A.calldatas, description: A.description })
-    ).then(() => { reset(); setOpen(false); onSubmitted?.() })
+    ).then((ok) => { if (ok) { reset(); setOpen(false); onSubmitted?.() } })
   }
 
   if (!open) {
@@ -154,6 +158,7 @@ export default function ProposalBuilder({ record, signer, reader, usdcAddress, n
         <div className="cp-kv"><span className="k">Total native value</span><span className="cp-mono">{ethers.formatEther(nativeTotal)} {nativeSymbol || ''}</span></div>
         {overNative && <div className="cp-warn" role="status">Sends more {nativeSymbol} than the treasury holds. The proposal can still be created; execution will revert if not funded by then.</div>}
         {overUsdc && <div className="cp-warn" role="status">Sends more {timelock?.usdcSymbol || 'USDC'} than the treasury holds. The proposal can still be created; execution will revert if not funded.</div>}
+        {isDuplicate && <div className="cp-error" role="alert">This exact proposal already exists (id {dupId.length > 14 ? `${dupId.slice(0, 8)}…${dupId.slice(-4)}` : dupId}). Submitting it would revert — change an action or the description.</div>}
         {!valid && <p className="cp-row-sub">{anyPending ? 'Reading token details…' : 'Add a title/description and at least one valid action to submit.'}</p>}
 
         <details className="cp-section" open={showPayload} onToggle={(e) => setShowPayload(e.target.open)}>
@@ -169,7 +174,7 @@ ${dupId ? `proposalId: ${dupId}` : ''}`}
 
         <div className="cp-row-actions" style={{ marginTop: '0.6rem' }}>
           {signer ? (
-            <button type="button" className="cp-btn cp-btn-primary" disabled={!valid || busy} aria-disabled={!valid || busy} onClick={submit}>Submit proposal</button>
+            <button type="button" className="cp-btn cp-btn-primary" disabled={!valid || busy || isDuplicate} aria-disabled={!valid || busy || isDuplicate} onClick={submit}>Submit proposal</button>
           ) : (
             <span className="cp-notice">Connect a wallet to propose.</span>
           )}
@@ -197,7 +202,7 @@ function ActionCard({ index, action, diag, meta, usdcAddress, nativeSymbol, canR
     <div className="cp-card" style={{ background: 'var(--cp-surface)' }}>
       <div className="cp-action-head">
         <span className="cp-badge">#{index + 1}</span>
-        <label className="cp-label" htmlFor={`cp-act-type-${a.id}`} style={{ position: 'absolute', left: '-9999px' }}>Action {index + 1} type</label>
+        <label className="sr-only" htmlFor={`cp-act-type-${a.id}`}>Action {index + 1} type</label>
         <select id={`cp-act-type-${a.id}`} className="cp-input cp-select" value={a.type} onChange={(e) => onChange({ type: e.target.value })} style={{ maxWidth: '14rem' }}>
           {TYPE_OPTIONS.map((o) => <option key={o.v} value={o.v}>{o.label}</option>)}
         </select>

--- a/frontend/src/components/clearpath/RegisterExternalDao.jsx
+++ b/frontend/src/components/clearpath/RegisterExternalDao.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { ethers } from 'ethers'
 import { DAO_FRAMEWORK } from '../../abis/externalDAORegistry'
 import { validateGovernor } from './governorConnector'
+import CpAddressField from './CpAddressField'
 
 // Spec 030 (US3) — register an existing DAO deployed by another platform. Validates client-side (a fast mirror
 // of the on-chain ERC-165/IGovernor check) before the real register tx; the contract is the source of truth.
@@ -43,10 +44,7 @@ export default function RegisterExternalDao({ reader, register, onRegistered }) 
         Track and (where authorized) act on a DAO deployed by another platform — e.g. an OpenZeppelin Governor DAO
         like Olympia. ClearPath takes no custody or authority; you sign every action. Requires a Silver+ membership.
       </p>
-      <div className="cp-field">
-        <label className="cp-label" htmlFor="cp-dao-addr">Governor address</label>
-        <input id="cp-dao-addr" className="cp-input cp-mono" value={addr} onChange={(e) => setAddr(e.target.value)} placeholder="0x…" />
-      </div>
+      <CpAddressField id="cp-dao-addr" label="Governor address" value={addr} onChange={setAddr} disabled={busy} />
       <div className="cp-field">
         <label className="cp-label" htmlFor="cp-dao-label">Label (optional)</label>
         <input id="cp-dao-label" className="cp-input" value={label} onChange={(e) => setLabel(e.target.value)} placeholder="Olympia DAO" />

--- a/frontend/src/components/clearpath/RegisterExternalDao.jsx
+++ b/frontend/src/components/clearpath/RegisterExternalDao.jsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+import { ethers } from 'ethers'
+import { DAO_FRAMEWORK } from '../../abis/externalDAORegistry'
+import { validateGovernor } from './governorConnector'
+
+// Spec 030 (US3) — register an existing DAO deployed by another platform. Validates client-side (a fast mirror
+// of the on-chain ERC-165/IGovernor check) before the real register tx; the contract is the source of truth.
+
+export default function RegisterExternalDao({ reader, register, onRegistered }) {
+  const [addr, setAddr] = useState('')
+  const [label, setLabel] = useState('')
+  const [check, setCheck] = useState(null) // { ok, name, reason }
+  const [busy, setBusy] = useState(false)
+
+  async function doValidate() {
+    setCheck(null)
+    const result = await validateGovernor(reader, addr.trim())
+    setCheck(result)
+    if (result.ok && !label) setLabel(result.name || '')
+  }
+
+  async function doRegister() {
+    setBusy(true)
+    try {
+      await register({ dao: addr.trim(), framework: DAO_FRAMEWORK.OZGovernor, label: label.trim() })
+      setAddr('')
+      setLabel('')
+      setCheck(null)
+      onRegistered?.()
+    } catch {
+      /* notification already surfaced by the hook */
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const valid = check?.ok === true
+
+  return (
+    <div className="cp-card">
+      <h4 style={{ marginBottom: '0.6rem' }}>Register an external DAO</h4>
+      <p className="cp-intro">
+        Track and (where authorized) act on a DAO deployed by another platform — e.g. an OpenZeppelin Governor DAO
+        like Olympia. ClearPath takes no custody or authority; you sign every action. Requires a Silver+ membership.
+      </p>
+      <div className="cp-field">
+        <label className="cp-label" htmlFor="cp-dao-addr">Governor address</label>
+        <input id="cp-dao-addr" className="cp-input cp-mono" value={addr} onChange={(e) => setAddr(e.target.value)} placeholder="0x…" />
+      </div>
+      <div className="cp-field">
+        <label className="cp-label" htmlFor="cp-dao-label">Label (optional)</label>
+        <input id="cp-dao-label" className="cp-input" value={label} onChange={(e) => setLabel(e.target.value)} placeholder="Olympia DAO" />
+      </div>
+      <div className="cp-row-actions">
+        <button type="button" className="cp-btn" disabled={!ethers.isAddress(addr.trim())} onClick={doValidate}>Validate</button>
+        <button type="button" className="cp-btn cp-btn-primary" disabled={!valid || busy} onClick={doRegister}>
+          {busy ? 'Registering…' : 'Register DAO'}
+        </button>
+      </div>
+      {check && (
+        check.ok
+          ? <p className="cp-ok" role="status" style={{ marginTop: '0.6rem' }}>✓ Recognized governance contract{check.name ? `: ${check.name}` : ''}</p>
+          : <div className="cp-error" role="alert">{check.reason}</div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/clearpath/__tests__/ClearPathPanel.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ClearPathPanel.test.jsx
@@ -17,11 +17,19 @@ const cp = {
   registerExternalDAO: vi.fn(),
 }
 vi.mock('../useClearPath', () => ({ useClearPath: () => cp }))
+vi.mock('../../../hooks/useUI', () => ({ useNotification: () => ({ showNotification: vi.fn() }) }))
 
-const conn = { validateGovernor: vi.fn(), readGovernorSummary: vi.fn() }
+const conn = { validateGovernor: vi.fn(), readGovernorSummary: vi.fn(), fetchGovernorProposals: vi.fn(), readTreasuries: vi.fn() }
 vi.mock('../governorConnector', () => ({
   validateGovernor: (...a) => conn.validateGovernor(...a),
   readGovernorSummary: (...a) => conn.readGovernorSummary(...a),
+  readTreasuries: (...a) => conn.readTreasuries(...a),
+  extraTreasuries: () => [{ label: 'Olympia Treasury', address: '0x035b2e3c189B772e52F4C3DA6c45c84A3bB871bf' }],
+  fetchGovernorProposals: (...a) => conn.fetchGovernorProposals(...a),
+  castVote: vi.fn(),
+  queueProposal: vi.fn(),
+  executeProposal: vi.fn(),
+  proposeAction: vi.fn(),
 }))
 
 vi.mock('../../../config/networks', () => ({
@@ -40,6 +48,8 @@ describe('ClearPathPanel (spec 030 / US3)', () => {
     vi.clearAllMocks()
     cp.isSupported = true
     cp.listExternalDAOs.mockResolvedValue([olympiaRecord])
+    conn.fetchGovernorProposals.mockResolvedValue({ ok: true, proposals: [], scannedFrom: 16000000, scannedTo: 16500000, partial: false })
+    conn.readTreasuries.mockResolvedValue([])
   })
 
   it('self-disables truthfully on an unsupported network', async () => {
@@ -68,13 +78,39 @@ describe('ClearPathPanel (spec 030 / US3)', () => {
       countingMode: 'support=bravo&quorum=for,abstain',
       clockMode: 'mode=blocknumber&from=default',
     })
+    conn.readTreasuries.mockResolvedValue([
+      { label: 'Timelock', address: '0x0000000000000000000000000000000000000222', native: 0n, usdc: 1500000n, usdcSymbol: 'cUSD', usdcDecimals: 6 },
+      { label: 'Olympia Treasury', address: '0x035b2e3c189B772e52F4C3DA6c45c84A3bB871bf', native: 2147152000000000000n, usdc: 0n, usdcSymbol: 'cUSD', usdcDecimals: 6 },
+    ])
     const user = userEvent.setup()
     render(<ClearPathPanel />)
     await user.click(await screen.findByText('Olympia DAO'))
     expect(await screen.findByText('OlympiaGovernor')).toBeInTheDocument()
     expect(screen.getByText(/Olympia Member \(OLYM\)/)).toBeInTheDocument()
-    // proposals truthfully disabled (no indexing on this network)
-    expect(screen.getByText(/Proposal history requires event indexing/i)).toBeInTheDocument()
+    // treasury enrichment: the OlympiaTreasury vault + USDC balance render
+    expect(await screen.findByText('Olympia Treasury')).toBeInTheDocument()
+    expect(screen.getByText('1.5')).toBeInTheDocument() // 1500000 cUSD @ 6 decimals
+    // live indexer: empty range shows a truthful state (not a fabricated list)
+    expect(await screen.findByText(/No proposals found in the scanned range/i)).toBeInTheDocument()
+  })
+
+  it('renders a live proposal with vote actions when one is in range', async () => {
+    conn.fetchGovernorProposals.mockResolvedValue({
+      ok: true,
+      partial: false,
+      scannedFrom: 16000000,
+      scannedTo: 16500000,
+      proposals: [
+        { id: '42', proposer: '0xB85dbc899472756470EF4033b9637ff8fa2FD23D', description: 'Fund core dev', targets: [], values: [], calldatas: [], descriptionHash: '0x', voteStart: '1', voteEnd: '2', state: 1, votes: { for: '3', against: '1', abstain: '0' } },
+      ],
+    })
+    const user = userEvent.setup()
+    render(<ClearPathPanel />)
+    await user.click(await screen.findByText('Olympia DAO'))
+    expect(await screen.findByText('Fund core dev')).toBeInTheDocument()
+    expect(screen.getByText('Active')).toBeInTheDocument()
+    // US5: an Active proposal offers vote actions
+    expect(screen.getByRole('button', { name: /vote for/i })).toBeInTheDocument()
   })
 
   it('validates then registers a new external DAO', async () => {

--- a/frontend/src/components/clearpath/__tests__/ClearPathPanel.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ClearPathPanel.test.jsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ClearPathPanel from '../ClearPathPanel'
+
+// Spec 030 (US3) — the ClearPath panel: lists external DAOs from the on-chain registry, opens a live tracking
+// view (Olympia), registers a new DAO, and self-disables truthfully on unsupported networks. No mock data in
+// the product — the tests mock the hook/connector to drive the components deterministically.
+
+const cp = {
+  isSupported: true,
+  chainId: 63,
+  reader: {},
+  account: '0xabc',
+  isConnected: true,
+  listExternalDAOs: vi.fn(),
+  registerExternalDAO: vi.fn(),
+}
+vi.mock('../useClearPath', () => ({ useClearPath: () => cp }))
+
+const conn = { validateGovernor: vi.fn(), readGovernorSummary: vi.fn() }
+vi.mock('../governorConnector', () => ({
+  validateGovernor: (...a) => conn.validateGovernor(...a),
+  readGovernorSummary: (...a) => conn.readGovernorSummary(...a),
+}))
+
+vi.mock('../../../config/networks', () => ({
+  getNetwork: () => ({
+    name: 'Ethereum Classic Mordor',
+    explorer: { name: 'Blockscout', baseUrl: 'https://etc-mordor.blockscout.com' },
+    nativeCurrency: { symbol: 'ETC' },
+  }),
+}))
+
+const OLYMPIA = '0xB85dbc899472756470EF4033b9637ff8fa2FD23D'
+const olympiaRecord = { id: 1, dao: OLYMPIA, framework: 0, label: 'Olympia DAO', registrant: '0xabc', registeredAt: 1700000000 }
+
+describe('ClearPathPanel (spec 030 / US3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cp.isSupported = true
+    cp.listExternalDAOs.mockResolvedValue([olympiaRecord])
+  })
+
+  it('self-disables truthfully on an unsupported network', async () => {
+    cp.isSupported = false
+    render(<ClearPathPanel />)
+    expect(screen.getByText(/ClearPath isn’t deployed/i)).toBeInTheDocument()
+  })
+
+  it('lists external DAOs from the on-chain registry', async () => {
+    render(<ClearPathPanel />)
+    expect(await screen.findByText('Olympia DAO')).toBeInTheDocument()
+    expect(screen.getByText('OpenZeppelin Governor')).toBeInTheDocument()
+  })
+
+  it('opens a live tracking view for a registered DAO', async () => {
+    conn.readGovernorSummary.mockResolvedValue({
+      name: 'OlympiaGovernor',
+      tokenAddr: '0x0000000000000000000000000000000000000111',
+      tokenName: 'Olympia Member',
+      tokenSymbol: 'OLYM',
+      timelock: '0x0000000000000000000000000000000000000222',
+      treasuryNative: 0n,
+      votingDelay: '1',
+      votingPeriod: '100',
+      proposalThreshold: '0',
+      countingMode: 'support=bravo&quorum=for,abstain',
+      clockMode: 'mode=blocknumber&from=default',
+    })
+    const user = userEvent.setup()
+    render(<ClearPathPanel />)
+    await user.click(await screen.findByText('Olympia DAO'))
+    expect(await screen.findByText('OlympiaGovernor')).toBeInTheDocument()
+    expect(screen.getByText(/Olympia Member \(OLYM\)/)).toBeInTheDocument()
+    // proposals truthfully disabled (no indexing on this network)
+    expect(screen.getByText(/Proposal history requires event indexing/i)).toBeInTheDocument()
+  })
+
+  it('validates then registers a new external DAO', async () => {
+    conn.validateGovernor.mockResolvedValue({ ok: true, name: 'OlympiaGovernor', reason: '' })
+    cp.registerExternalDAO.mockResolvedValue({})
+    const user = userEvent.setup()
+    render(<ClearPathPanel />)
+    await user.click(screen.getByRole('tab', { name: /register/i }))
+    await user.type(screen.getByLabelText(/governor address/i), OLYMPIA)
+    await user.click(screen.getByRole('button', { name: /^validate$/i }))
+    expect(await screen.findByText(/Recognized governance contract/i)).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /register dao/i }))
+    await waitFor(() =>
+      expect(cp.registerExternalDAO).toHaveBeenCalledWith(
+        expect.objectContaining({ dao: OLYMPIA, framework: 0 })
+      )
+    )
+  })
+})

--- a/frontend/src/components/clearpath/__tests__/ClearPathPanel.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ClearPathPanel.test.jsx
@@ -40,6 +40,11 @@ vi.mock('../../../config/networks', () => ({
   }),
 }))
 
+// CpAddressField (governor/recipient inputs) pulls in AddressBookButton → useWallet, which throws without a
+// WalletProvider. Stub the wallet-scoped hooks so register + tracking views render the real fields in tests.
+vi.mock('../../../hooks/useAddressBook', () => ({ useAddressBook: () => ({ search: () => [] }) }))
+vi.mock('../../../hooks/useAddressScreening', () => ({ useAddressScreening: () => ({ getStatus: () => 'clear', screen: vi.fn() }) }))
+
 const OLYMPIA = '0xB85dbc899472756470EF4033b9637ff8fa2FD23D'
 const olympiaRecord = { id: 1, dao: OLYMPIA, framework: 0, label: 'Olympia DAO', registrant: '0xabc', registeredAt: 1700000000 }
 

--- a/frontend/src/components/clearpath/__tests__/CpAddressField.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/CpAddressField.test.jsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'vitest-axe'
+import CpAddressField from '../CpAddressField'
+
+// Spec 030 (US3/US5, FR-024) — the ClearPath address field wires the app's address book + QR scanner to any
+// address entry. Stub the heavy app components (which need the wallet provider / camera) so this stays a
+// focused wiring test: book pick → onChange(address); QR scan → extract → onChange(address); typing → onChange.
+
+const A_BOOK = '0x00000000000000000000000000000000000000a1'
+const A_SCAN = '0x00000000000000000000000000000000000000b2'
+
+vi.mock('../../ui/AddressBookButton', () => ({
+  default: ({ onSelect, disabled }) => (
+    <button type="button" disabled={disabled} onClick={() => onSelect({ address: A_BOOK })}>
+      book-pick
+    </button>
+  ),
+}))
+vi.mock('../../ui/QRScanner', () => ({
+  default: ({ isOpen, onScanSuccess }) =>
+    isOpen ? (
+      // emit an EIP-681 URI to prove the extractor pulls the bare address out
+      <button type="button" onClick={() => onScanSuccess(`ethereum:${A_SCAN}`)}>
+        scan-emit
+      </button>
+    ) : null,
+}))
+
+describe('CpAddressField (spec 030)', () => {
+  it('typing forwards the raw string to onChange', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<CpAddressField id="f1" label="Recipient" value="" onChange={onChange} />)
+    await user.type(screen.getByLabelText('Recipient'), '0x')
+    expect(onChange).toHaveBeenCalledWith('0')
+    expect(onChange).toHaveBeenCalledWith('x')
+  })
+
+  it('picking from the address book fills the field with the contact address', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<CpAddressField id="f1" label="Recipient" value="" onChange={onChange} />)
+    await user.click(screen.getByText('book-pick'))
+    expect(onChange).toHaveBeenCalledWith(A_BOOK)
+  })
+
+  it('scanning a QR code extracts the address from the payload and fills the field', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<CpAddressField id="f1" label="Recipient" value="" onChange={onChange} />)
+    // scanner is closed until the scan button is pressed
+    expect(screen.queryByText('scan-emit')).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /scan qr code/i }))
+    await user.click(screen.getByText('scan-emit'))
+    expect(onChange).toHaveBeenCalledWith(A_SCAN)
+  })
+
+  it('disables the input and affordances when disabled', () => {
+    render(<CpAddressField id="f1" label="Recipient" value="" onChange={() => {}} disabled />)
+    expect(screen.getByLabelText('Recipient')).toBeDisabled()
+    expect(screen.getByText('book-pick')).toBeDisabled()
+    expect(screen.getByRole('button', { name: /scan qr code/i })).toBeDisabled()
+  })
+
+  it('has no axe violations', async () => {
+    const { container } = render(<CpAddressField id="f1" label="Recipient" value="" onChange={() => {}} />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/components/clearpath/__tests__/ExternalDaoView.notifications.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ExternalDaoView.notifications.test.jsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ExternalDaoView from '../ExternalDaoView'
+
+// Spec 030 (US5) — every on-chain WRITE in the tracking view routes through run(label, makeTx), which must keep
+// the user aware of the activity via the app notification system: a persistent "confirm in your wallet" prompt,
+// a persistent "awaiting confirmation" toast while it mines, then a terminal confirmed (with tx hash) / failed
+// toast — and a no-wallet warning. These assert that contract end-to-end.
+
+const h = vi.hoisted(() => ({
+  showNotification: vi.fn(),
+  castVote: vi.fn(),
+  readGovernorSummary: vi.fn(),
+  readTreasuries: vi.fn(),
+  fetchGovernorProposals: vi.fn(),
+}))
+
+vi.mock('../../../hooks/useUI', () => ({ useNotification: () => ({ showNotification: h.showNotification }) }))
+vi.mock('../governorConnector', () => ({
+  readGovernorSummary: (...a) => h.readGovernorSummary(...a),
+  readTreasuries: (...a) => h.readTreasuries(...a),
+  extraTreasuries: () => [],
+  fetchGovernorProposals: (...a) => h.fetchGovernorProposals(...a),
+  castVote: (...a) => h.castVote(...a),
+  queueProposal: vi.fn(),
+  executeProposal: vi.fn(),
+  proposeAction: vi.fn(),
+}))
+vi.mock('../../../config/networks', () => ({
+  getNetwork: () => ({ name: 'Ethereum Classic Mordor', explorer: { baseUrl: 'https://etc-mordor.blockscout.com' }, nativeCurrency: { symbol: 'ETC' } }),
+}))
+// ProposalBuilder → CpAddressField → AddressBookButton → useWallet would throw without a provider.
+vi.mock('../../../hooks/useAddressBook', () => ({ useAddressBook: () => ({ search: () => [] }) }))
+vi.mock('../../../hooks/useAddressScreening', () => ({ useAddressScreening: () => ({ getStatus: () => 'clear', screen: vi.fn() }) }))
+
+const record = { id: 1, dao: '0xB85dbc899472756470EF4033b9637ff8fa2FD23D', framework: 0, label: 'Olympia DAO' }
+const HASH = '0xabcdef0000000000000000000000000000000000000000000000000000001234' // short() → 0xabcd…1234
+
+function renderView(signer) {
+  return render(
+    <ExternalDaoView record={record} reader={{}} signer={signer} chainId={63} usdcAddress="0x00000000000000000000000000000000000000dc" onBack={() => {}} />
+  )
+}
+
+describe('ExternalDaoView notifications (spec 030 / US5)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    h.readGovernorSummary.mockResolvedValue({
+      name: 'OlympiaGovernor', tokenAddr: '0x0000000000000000000000000000000000000111', tokenName: 'Olympia Member',
+      tokenSymbol: 'OLYM', timelock: '0x0000000000000000000000000000000000000222', treasuryNative: 0n,
+      votingDelay: '1', votingPeriod: '100', proposalThreshold: '0', countingMode: 'support=bravo', clockMode: 'mode=blocknumber',
+    })
+    h.readTreasuries.mockResolvedValue([])
+    h.fetchGovernorProposals.mockResolvedValue({
+      ok: true, partial: false, scannedFrom: 1, scannedTo: 2,
+      proposals: [{ id: '7', proposer: '0x00000000000000000000000000000000000000Aa', description: 'Fund dev', targets: [], values: [], calldatas: [], descriptionHash: '0x', voteStart: '1', voteEnd: '2', state: 1, votes: { for: '0', against: '0', abstain: '0' } }],
+    })
+  })
+
+  it('surfaces confirm → submitted (persistent) → confirmed (with tx hash) for a vote', async () => {
+    h.castVote.mockReturnValue({ hash: HASH, wait: vi.fn().mockResolvedValue({ status: 1 }) })
+    const user = userEvent.setup()
+    renderView({})
+    await user.click(await screen.findByRole('button', { name: /vote for/i }))
+    await waitFor(() => expect(h.castVote).toHaveBeenCalled())
+    // in-flight toasts are sticky (duration 0) so they survive slow block times
+    expect(h.showNotification).toHaveBeenCalledWith('Vote For: confirm in your wallet…', 'info', 0)
+    expect(h.showNotification).toHaveBeenCalledWith('Vote For submitted — awaiting confirmation…', 'info', 0)
+    await waitFor(() =>
+      expect(h.showNotification).toHaveBeenCalledWith(expect.stringContaining('Vote For confirmed · tx 0xabcd…1234'), 'success')
+    )
+  })
+
+  it('warns (does not send) when no wallet is connected', async () => {
+    const user = userEvent.setup()
+    renderView(null)
+    await user.click(await screen.findByRole('button', { name: /vote for/i }))
+    expect(h.showNotification).toHaveBeenCalledWith('Connect a wallet to act on this DAO.', 'warning')
+    expect(h.castVote).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a revert / rejection as an error toast', async () => {
+    h.castVote.mockReturnValue({ hash: HASH, wait: vi.fn().mockRejectedValue(new Error('execution reverted')) })
+    const user = userEvent.setup()
+    renderView({})
+    await user.click(await screen.findByRole('button', { name: /vote for/i }))
+    await waitFor(() => expect(h.showNotification).toHaveBeenCalledWith('execution reverted', 'error'))
+  })
+
+  it('treats a confirmation timeout as "may still confirm" (warning) and releases the busy lock', async () => {
+    // A broadcast-but-dropped tx: wait() rejects with ethers v6 TIMEOUT — must NOT look like a failure or a
+    // success, and must release busy so the controls are usable again (regression guard for the review finding).
+    const timeoutErr = Object.assign(new Error('wait for transaction timeout'), { code: 'TIMEOUT' })
+    h.castVote.mockReturnValue({ hash: HASH, wait: vi.fn().mockRejectedValue(timeoutErr) })
+    const user = userEvent.setup()
+    renderView({})
+    await user.click(await screen.findByRole('button', { name: /vote for/i }))
+    await waitFor(() =>
+      expect(h.showNotification).toHaveBeenCalledWith(expect.stringContaining('taking longer than expected'), 'warning', 0)
+    )
+    await waitFor(() => expect(screen.getByRole('button', { name: /vote for/i })).not.toBeDisabled())
+    expect(h.showNotification).not.toHaveBeenCalledWith(expect.stringContaining('confirmed'), 'success')
+    expect(h.showNotification).not.toHaveBeenCalledWith(expect.stringContaining('failed'), 'error')
+  })
+})

--- a/frontend/src/components/clearpath/__tests__/ProposalBuilder.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ProposalBuilder.test.jsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { axe } from 'vitest-axe'
 import { ethers } from 'ethers'
 import ProposalBuilder from '../ProposalBuilder'
+import { ACTION_TYPE, newAction, assemble, predictProposalId } from '../proposalEncoding'
 
 // Spec 030 (US5, FR-023/024) — the rich proposal builder: compose a Governor proposal without hand-writing
 // calldata, multi-action, asset-aware, with validation + the correct submitted payload.
@@ -87,6 +88,24 @@ describe('ProposalBuilder (spec 030 / US5)', () => {
     expect(screen.getByText('1 action')).toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: /\+ add action/i }))
     expect(screen.getByText('2 actions')).toBeInTheDocument()
+  })
+
+  it('detects a duplicate proposal and blocks submit (FR-025)', async () => {
+    // Compute the id the builder will derive for a 100-USDC transfer to TO titled "Fund dev"…
+    const A = assemble({
+      title: 'Fund dev', body: '',
+      actions: [{ ...newAction(ACTION_TYPE.TOKEN), tokenTo: TO, tokenAmount: '100' }],
+      usdcAddress: USDC, meta: () => ({ decimals: 6, symbol: 'cUSD' }),
+    })
+    const dupId = predictProposalId(A.targets, A.values, A.calldatas, A.descriptionHash)
+    const user = userEvent.setup()
+    renderBuilder({ proposals: [{ id: dupId }] }) // …and feed it as an already-existing proposal
+    await user.click(screen.getByRole('button', { name: /\+ new proposal/i }))
+    await user.type(screen.getByLabelText(/^title$/i), 'Fund dev')
+    await user.type(screen.getByLabelText(/recipient/i), TO)
+    await user.type(screen.getByLabelText(/amount/i), '100')
+    expect(await screen.findByText(/this exact proposal already exists/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /submit proposal/i })).toBeDisabled()
   })
 
   it('warns (non-blocking) when an action exceeds the treasury balance', async () => {

--- a/frontend/src/components/clearpath/__tests__/ProposalBuilder.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ProposalBuilder.test.jsx
@@ -12,6 +12,11 @@ import { ACTION_TYPE, newAction, assemble, predictProposalId } from '../proposal
 const proposeAction = vi.fn()
 vi.mock('../governorConnector', () => ({ proposeAction: (...a) => proposeAction(...a) }))
 
+// CpAddressField (recipient/target inputs) pulls in AddressBookButton → useWallet, which throws without a
+// WalletProvider. Stub the wallet-scoped hooks so the builder renders with the real fields in tests.
+vi.mock('../../../hooks/useAddressBook', () => ({ useAddressBook: () => ({ search: () => [] }) }))
+vi.mock('../../../hooks/useAddressScreening', () => ({ useAddressScreening: () => ({ getStatus: () => 'clear', screen: vi.fn() }) }))
+
 const USDC = '0x00000000000000000000000000000000000000dc'
 const TO = '0x00000000000000000000000000000000000000a1'
 const TRANSFER = new ethers.Interface(['function transfer(address to, uint256 amount)'])
@@ -106,6 +111,16 @@ describe('ProposalBuilder (spec 030 / US5)', () => {
     await user.type(screen.getByLabelText(/amount/i), '100')
     expect(await screen.findByText(/this exact proposal already exists/i)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /submit proposal/i })).toBeDisabled()
+  })
+
+  it('exposes address-book + QR-scan affordances on the recipient field', async () => {
+    const user = userEvent.setup()
+    renderBuilder()
+    await user.click(screen.getByRole('button', { name: /\+ new proposal/i }))
+    // default action is "Send USDC / token" → its recipient is a CpAddressField
+    expect(screen.getByLabelText(/recipient/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /choose from address book/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /scan qr code/i })).toBeInTheDocument()
   })
 
   it('warns (non-blocking) when an action exceeds the treasury balance', async () => {

--- a/frontend/src/components/clearpath/__tests__/ProposalBuilder.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ProposalBuilder.test.jsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'vitest-axe'
+import { ethers } from 'ethers'
+import ProposalBuilder from '../ProposalBuilder'
+
+// Spec 030 (US5, FR-023/024) — the rich proposal builder: compose a Governor proposal without hand-writing
+// calldata, multi-action, asset-aware, with validation + the correct submitted payload.
+
+const proposeAction = vi.fn()
+vi.mock('../governorConnector', () => ({ proposeAction: (...a) => proposeAction(...a) }))
+
+const USDC = '0x00000000000000000000000000000000000000dc'
+const TO = '0x00000000000000000000000000000000000000a1'
+const TRANSFER = new ethers.Interface(['function transfer(address to, uint256 amount)'])
+
+const treasuries = [
+  { label: 'Timelock', address: '0x0000000000000000000000000000000000000222', native: ethers.parseEther('100'), usdc: 1000000000n, usdcSymbol: 'cUSD', usdcDecimals: 6 },
+]
+
+function renderBuilder(extra = {}) {
+  const run = vi.fn((label, makeTx) => makeTx())
+  const onSubmitted = vi.fn()
+  render(
+    <ProposalBuilder
+      record={{ dao: '0x00000000000000000000000000000000000000d0' }}
+      signer={{}}
+      reader={null}
+      usdcAddress={USDC}
+      nativeSymbol="ETC"
+      treasuries={treasuries}
+      run={run}
+      busy={false}
+      onSubmitted={onSubmitted}
+      {...extra}
+    />
+  )
+  return { run, onSubmitted }
+}
+
+describe('ProposalBuilder (spec 030 / US5)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('composes and submits a USDC transfer without hand-written calldata', async () => {
+    proposeAction.mockResolvedValue({})
+    const user = userEvent.setup()
+    renderBuilder()
+    await user.click(screen.getByRole('button', { name: /\+ new proposal/i }))
+    await user.type(screen.getByLabelText(/^title$/i), 'Fund dev')
+    // default action type is "Send USDC / token"
+    await user.type(screen.getByLabelText(/recipient/i), TO)
+    await user.type(screen.getByLabelText(/amount/i), '100')
+    const submit = screen.getByRole('button', { name: /submit proposal/i })
+    await waitFor(() => expect(submit).toBeEnabled())
+    await user.click(submit)
+    await waitFor(() => expect(proposeAction).toHaveBeenCalled())
+    const [, , payload] = proposeAction.mock.calls[0]
+    expect(payload.targets).toEqual([USDC])
+    expect(payload.values).toEqual([0n]) // ERC-20 transfer carries no native value
+    expect(payload.description).toBe('# Fund dev')
+    const [to, amount] = TRANSFER.decodeFunctionData('transfer', payload.calldatas[0])
+    expect(to.toLowerCase()).toBe(TO)
+    expect(amount).toBe(ethers.parseUnits('100', 6))
+  })
+
+  it('blocks submit until a title and a valid action are present', async () => {
+    const user = userEvent.setup()
+    renderBuilder()
+    await user.click(screen.getByRole('button', { name: /\+ new proposal/i }))
+    // no title, no recipient/amount → submit disabled
+    expect(screen.getByRole('button', { name: /submit proposal/i })).toBeDisabled()
+  })
+
+  it('the expanded builder has no axe violations', async () => {
+    const user = userEvent.setup()
+    renderBuilder()
+    await user.click(screen.getByRole('button', { name: /\+ new proposal/i }))
+    const { container } = { container: document.body }
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('supports multiple actions in one proposal', async () => {
+    const user = userEvent.setup()
+    renderBuilder()
+    await user.click(screen.getByRole('button', { name: /\+ new proposal/i }))
+    expect(screen.getByText('1 action')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /\+ add action/i }))
+    expect(screen.getByText('2 actions')).toBeInTheDocument()
+  })
+
+  it('warns (non-blocking) when an action exceeds the treasury balance', async () => {
+    const user = userEvent.setup()
+    renderBuilder()
+    await user.click(screen.getByRole('button', { name: /\+ new proposal/i }))
+    await user.type(screen.getByLabelText(/^title$/i), 'Big spend')
+    await user.type(screen.getByLabelText(/recipient/i), TO)
+    await user.type(screen.getByLabelText(/amount/i), '999999') // > 1000 cUSD held
+    expect(await screen.findByText(/more cUSD than the treasury holds/i)).toBeInTheDocument()
+    // still submittable (execution, not proposal, would revert)
+    await waitFor(() => expect(screen.getByRole('button', { name: /submit proposal/i })).toBeEnabled())
+  })
+})

--- a/frontend/src/components/clearpath/__tests__/proposalEncoding.test.js
+++ b/frontend/src/components/clearpath/__tests__/proposalEncoding.test.js
@@ -51,6 +51,15 @@ describe('proposalEncoding', () => {
     try { encodeAction(a, { usdcAddress: USDC, meta: () => null }) } catch (e) { expect(e.pending).toBe(true) }
   })
 
+  it('reports an unreadable token as a real error, not a perpetual pending', () => {
+    const a = { ...newAction(ACTION_TYPE.TOKEN), tokenMode: 'other', tokenAddress: '0x00000000000000000000000000000000000000ee', tokenTo: TO, tokenAmount: '5' }
+    let thrown
+    try { encodeAction(a, { usdcAddress: USDC, meta: () => ({ unreadable: true }) }) } catch (e) { thrown = e }
+    expect(thrown).toBeTruthy()
+    expect(thrown.pending).toBeFalsy() // NOT a fake "still loading" state
+    expect(thrown.message).toMatch(/could not read this token/i)
+  })
+
   it('validates a custom call and rejects malformed hex', () => {
     const ok = { ...newAction(ACTION_TYPE.CUSTOM), customTarget: TO, customValue: '0', customCalldata: '0xabcd' }
     expect(encodeAction(ok, { usdcAddress: USDC, meta: usdcMeta }).calldata).toBe('0xabcd')

--- a/frontend/src/components/clearpath/__tests__/proposalEncoding.test.js
+++ b/frontend/src/components/clearpath/__tests__/proposalEncoding.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { ethers } from 'ethers'
+import {
+  ACTION_TYPE,
+  newAction,
+  buildDescription,
+  descriptionHash,
+  encodeAction,
+  assemble,
+  predictProposalId,
+} from '../proposalEncoding'
+
+// Spec 030 (FR-023/FR-025) — proposal encoding correctness: the riskiest part of the builder (a mis-encoded
+// action executes the wrong thing). Pure unit tests.
+
+const USDC = '0x00000000000000000000000000000000000000dc'
+const TO = '0x00000000000000000000000000000000000000a1'
+const usdcMeta = (addr) => (addr.toLowerCase() === USDC ? { decimals: 6, symbol: 'USDC' } : null)
+const TRANSFER = new ethers.Interface(['function transfer(address to, uint256 amount)'])
+
+describe('proposalEncoding', () => {
+  it('builds the description string and a matching keccak hash', () => {
+    expect(buildDescription('Title', 'Body')).toBe('# Title\n\nBody')
+    expect(buildDescription('Title', '')).toBe('# Title')
+    expect(buildDescription('', 'Body')).toBe('Body')
+    const d = '# Title\n\nBody'
+    expect(descriptionHash(d)).toBe(ethers.id(d))
+  })
+
+  it('encodes a native send (value + empty calldata)', () => {
+    const a = { ...newAction(ACTION_TYPE.NATIVE), nativeTo: TO, nativeAmount: '1.5' }
+    const enc = encodeAction(a, { usdcAddress: USDC, meta: usdcMeta })
+    expect(enc.target).toBe(TO)
+    expect(enc.value).toBe(ethers.parseEther('1.5'))
+    expect(enc.calldata).toBe('0x')
+  })
+
+  it('encodes an ERC-20 transfer with value 0 and decimals-scaled amount', () => {
+    const a = { ...newAction(ACTION_TYPE.TOKEN), tokenAddress: '', tokenTo: TO, tokenAmount: '100' }
+    const enc = encodeAction(a, { usdcAddress: USDC, meta: usdcMeta })
+    expect(enc.target).toBe(USDC) // default token = USDC
+    expect(enc.value).toBe(0n) // INVARIANT: no native value on a token transfer
+    const [to, amount] = TRANSFER.decodeFunctionData('transfer', enc.calldata)
+    expect(to.toLowerCase()).toBe(TO) // decodeFunctionData returns a checksummed address
+    expect(amount).toBe(ethers.parseUnits('100', 6)) // 6-decimals, not 18
+  })
+
+  it('marks a token action pending while its decimals are unknown', () => {
+    const a = { ...newAction(ACTION_TYPE.TOKEN), tokenMode: 'other', tokenAddress: '0x00000000000000000000000000000000000000ee', tokenTo: TO, tokenAmount: '5' }
+    expect(() => encodeAction(a, { usdcAddress: USDC, meta: () => null })).toThrowError(/decimals/i)
+    try { encodeAction(a, { usdcAddress: USDC, meta: () => null }) } catch (e) { expect(e.pending).toBe(true) }
+  })
+
+  it('validates a custom call and rejects malformed hex', () => {
+    const ok = { ...newAction(ACTION_TYPE.CUSTOM), customTarget: TO, customValue: '0', customCalldata: '0xabcd' }
+    expect(encodeAction(ok, { usdcAddress: USDC, meta: usdcMeta }).calldata).toBe('0xabcd')
+    const bad = { ...ok, customCalldata: '0xabc' } // odd length
+    expect(() => encodeAction(bad, { usdcAddress: USDC, meta: usdcMeta })).toThrowError(/hex/i)
+  })
+
+  it('rejects invalid addresses', () => {
+    const a = { ...newAction(ACTION_TYPE.NATIVE), nativeTo: 'nope', nativeAmount: '1' }
+    expect(() => encodeAction(a, { usdcAddress: USDC, meta: usdcMeta })).toThrowError(/address/i)
+  })
+
+  it('assembles a multi-action proposal with equal-length arrays', () => {
+    const actions = [
+      { ...newAction(ACTION_TYPE.NATIVE), nativeTo: TO, nativeAmount: '1' },
+      { ...newAction(ACTION_TYPE.TOKEN), tokenTo: TO, tokenAmount: '50' },
+    ]
+    const A = assemble({ title: 'Two payouts', body: '', actions, usdcAddress: USDC, meta: usdcMeta })
+    expect(A.ok).toBe(true)
+    expect(A.targets).toHaveLength(2)
+    expect(A.values).toHaveLength(2)
+    expect(A.calldatas).toHaveLength(2)
+    expect(A.targets.length === A.values.length && A.values.length === A.calldatas.length).toBe(true)
+    expect(A.descriptionHash).toBe(ethers.id('# Two payouts'))
+  })
+
+  it('blocks empty description or zero actions', () => {
+    expect(assemble({ title: '', body: '', actions: [{ ...newAction(ACTION_TYPE.NATIVE), nativeTo: TO, nativeAmount: '1' }], usdcAddress: USDC, meta: usdcMeta }).ok).toBe(false)
+    expect(assemble({ title: 'X', body: '', actions: [], usdcAddress: USDC, meta: usdcMeta }).ok).toBe(false)
+  })
+
+  it('predicts a stable proposalId that changes with the description', () => {
+    const t = [TO]; const v = [0n]; const c = ['0x']
+    const id1 = predictProposalId(t, v, c, ethers.id('# A'))
+    const id2 = predictProposalId(t, v, c, ethers.id('# A'))
+    const id3 = predictProposalId(t, v, c, ethers.id('# B'))
+    expect(id1).toBe(id2)
+    expect(id1).not.toBe(id3)
+  })
+})

--- a/frontend/src/components/clearpath/__tests__/useClearPath.test.js
+++ b/frontend/src/components/clearpath/__tests__/useClearPath.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useClearPath } from '../useClearPath'
+
+// Spec 030 (US3) — registerExternalDAO is a real on-chain write; it must keep the user aware via the app
+// notification system: a persistent "confirm in your wallet" + "awaiting confirmation" toast, then a confirmed
+// (with tx hash) / failed toast. Asserts that contract directly on the hook.
+
+const REGISTRY = '0xb85dbc899472756470ef4033b9637ff8fa2fd23d' // lowercase → ethers.isAddress passes (no checksum)
+const HASH = '0xabcdef0000000000000000000000000000000000000000000000000000001234'
+
+const h = vi.hoisted(() => ({ showNotification: vi.fn(), registerExternalDAO: vi.fn() }))
+
+vi.mock('../../../hooks/useUI', () => ({ useNotification: () => ({ showNotification: h.showNotification }) }))
+vi.mock('../../../hooks/useWalletManagement', () => ({
+  useWallet: () => ({ account: '0xacc', signer: {}, provider: {}, chainId: 63, isConnected: true }),
+}))
+vi.mock('../../../config/contracts', () => ({ getContractAddressForChain: () => REGISTRY }))
+// Keep ethers.isAddress real; stub only Contract so the write goes to our fake. Contract is invoked with `new`,
+// so the mock implementation must be a real (constructable) function, not an arrow.
+vi.mock('ethers', async (importOriginal) => {
+  const actual = await importOriginal()
+  function FakeContract() {
+    return { registerExternalDAO: (...a) => h.registerExternalDAO(...a) }
+  }
+  return { ...actual, ethers: { ...actual.ethers, Contract: vi.fn(FakeContract) } }
+})
+
+describe('useClearPath.registerExternalDAO notifications (spec 030 / US3)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('fires confirm → submitted (persistent) → confirmed (with tx hash)', async () => {
+    h.registerExternalDAO.mockResolvedValue({ hash: HASH, wait: vi.fn().mockResolvedValue({}) })
+    const { result } = renderHook(() => useClearPath())
+    expect(result.current.isSupported).toBe(true)
+    await act(async () => {
+      await result.current.registerExternalDAO({ dao: REGISTRY, framework: 0, label: 'Olympia' })
+    })
+    expect(h.showNotification).toHaveBeenCalledWith('Register DAO: confirm in your wallet…', 'info', 0)
+    expect(h.showNotification).toHaveBeenCalledWith('Register DAO submitted — awaiting confirmation…', 'info', 0)
+    expect(h.showNotification).toHaveBeenCalledWith(expect.stringContaining('Registered Olympia. · tx 0xabcd…1234'), 'success')
+  })
+
+  it('surfaces a failure as an error toast and rethrows', async () => {
+    h.registerExternalDAO.mockRejectedValue(new Error('boom'))
+    const { result } = renderHook(() => useClearPath())
+    await act(async () => {
+      await expect(
+        result.current.registerExternalDAO({ dao: REGISTRY, framework: 0, label: 'X' })
+      ).rejects.toThrow('boom')
+    })
+    expect(h.showNotification).toHaveBeenCalledWith('boom', 'error')
+  })
+
+  it('treats a confirmation timeout as a "may still confirm" warning (not a failure) and rethrows', async () => {
+    const timeoutErr = Object.assign(new Error('wait for transaction timeout'), { code: 'TIMEOUT' })
+    h.registerExternalDAO.mockResolvedValue({ hash: HASH, wait: vi.fn().mockRejectedValue(timeoutErr) })
+    const { result } = renderHook(() => useClearPath())
+    await act(async () => {
+      await expect(
+        result.current.registerExternalDAO({ dao: REGISTRY, framework: 0, label: 'Olympia' })
+      ).rejects.toThrow('wait for transaction timeout')
+    })
+    expect(h.showNotification).toHaveBeenCalledWith(expect.stringContaining('taking longer than expected'), 'warning', 0)
+    expect(h.showNotification).not.toHaveBeenCalledWith(expect.stringContaining('Registered'), 'success')
+  })
+})

--- a/frontend/src/components/clearpath/clearpath.css
+++ b/frontend/src/components/clearpath/clearpath.css
@@ -72,5 +72,7 @@
 .clearpath .cp-error { color: var(--semantic-loss, #c0492f); background: color-mix(in srgb, var(--semantic-loss, #c0492f) 10%, transparent); padding: 0.6rem 0.8rem; border-radius: var(--cp-radius); margin: 0.6rem 0; font-size: 0.85rem; }
 .clearpath .cp-notice { color: var(--cp-text-2); background: var(--cp-canvas); padding: 0.6rem 0.8rem; border-radius: var(--cp-radius); margin: 0.6rem 0; font-size: 0.85rem; }
 .clearpath .cp-ok { color: var(--semantic-win, #2e7d32); font-size: 0.85rem; }
+.clearpath .cp-section { border-top: 1px solid var(--cp-border); padding-top: 0.5rem; }
+.clearpath .cp-section:first-child { border-top: none; padding-top: 0; }
 .clearpath .cp-disabled { color: var(--cp-text-2); text-align: center; padding: 2rem; }
 .clearpath .cp-empty { color: var(--cp-text-3); text-align: center; padding: 1.5rem; }

--- a/frontend/src/components/clearpath/clearpath.css
+++ b/frontend/src/components/clearpath/clearpath.css
@@ -72,6 +72,12 @@
 .clearpath .cp-error { color: var(--semantic-loss, #c0492f); background: color-mix(in srgb, var(--semantic-loss, #c0492f) 10%, transparent); padding: 0.6rem 0.8rem; border-radius: var(--cp-radius); margin: 0.6rem 0; font-size: 0.85rem; }
 .clearpath .cp-notice { color: var(--cp-text-2); background: var(--cp-canvas); padding: 0.6rem 0.8rem; border-radius: var(--cp-radius); margin: 0.6rem 0; font-size: 0.85rem; }
 .clearpath .cp-ok { color: var(--semantic-win, #2e7d32); font-size: 0.85rem; }
+.clearpath .cp-textarea { resize: vertical; min-height: 4.5rem; font-family: inherit; }
+.clearpath .cp-select { appearance: auto; }
+.clearpath .cp-suffix { color: var(--cp-text-3); font-size: 0.8rem; margin-left: 0.4rem; }
+.clearpath .cp-preview { margin-top: 0.5rem; padding: 0.5rem 0.7rem; border-radius: var(--cp-radius); background: var(--cp-canvas); font-size: 0.82rem; color: var(--cp-text-2); }
+.clearpath .cp-warn { color: var(--semantic-warning, #b8860b); background: color-mix(in srgb, var(--semantic-warning, #b8860b) 12%, transparent); padding: 0.6rem 0.8rem; border-radius: var(--cp-radius); margin: 0.5rem 0; font-size: 0.85rem; }
+.clearpath .cp-action-head { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.6rem; flex-wrap: wrap; }
 .clearpath .cp-section { border-top: 1px solid var(--cp-border); padding-top: 0.5rem; }
 .clearpath .cp-section:first-child { border-top: none; padding-top: 0; }
 .clearpath .cp-disabled { color: var(--cp-text-2); text-align: center; padding: 2rem; }

--- a/frontend/src/components/clearpath/clearpath.css
+++ b/frontend/src/components/clearpath/clearpath.css
@@ -82,3 +82,28 @@
 .clearpath .cp-section:first-child { border-top: none; padding-top: 0; }
 .clearpath .cp-disabled { color: var(--cp-text-2); text-align: center; padding: 2rem; }
 .clearpath .cp-empty { color: var(--cp-text-3); text-align: center; padding: 1.5rem; }
+
+/* Address field with address-book + QR-scan affordances (CpAddressField).
+   `.fm-scan-btn` is the shared icon-button box from the wager form (FriendMarketsModal.css), which the reused
+   AddressBookButton hardcodes; that stylesheet isn't loaded in the ClearPath surface, so mirror the sizing here
+   (scoped under .clearpath) so the address-book button and the scan button render as matched square icons. */
+.clearpath .cp-addr-row { display: flex; gap: 0.5rem; align-items: stretch; }
+.clearpath .cp-addr-row > .cp-input { flex: 1; min-width: 0; }
+.clearpath .cp-addr-row .ab-book-btn-wrap { display: inline-flex; align-self: stretch; }
+.clearpath .fm-scan-btn,
+.clearpath .cp-icon-btn {
+  display: flex; align-items: center; justify-content: center; align-self: stretch;
+  width: 42px; min-width: 42px; box-sizing: border-box;
+  background: var(--cp-canvas); border: 1px solid var(--cp-border); border-radius: var(--cp-radius);
+  color: var(--cp-text-2); cursor: pointer; transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+.clearpath .cp-addr-row .ab-book-btn-wrap .fm-scan-btn { height: 100%; }
+.clearpath .fm-scan-btn svg,
+.clearpath .cp-icon-btn svg { width: 20px; height: 20px; flex: none; }
+.clearpath .fm-scan-btn:hover:not(:disabled),
+.clearpath .cp-icon-btn:hover:not(:disabled) {
+  border-color: var(--cp-accent); color: var(--cp-accent);
+  background: color-mix(in srgb, var(--cp-accent) 10%, transparent);
+}
+.clearpath .fm-scan-btn:disabled,
+.clearpath .cp-icon-btn:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/frontend/src/components/clearpath/clearpath.css
+++ b/frontend/src/components/clearpath/clearpath.css
@@ -1,0 +1,76 @@
+/*
+ * Spec 030 — ClearPath module styling. Scoped under `.clearpath`; mapped onto the app theme variables
+ * (frontend/src/theme.css) so light/dark both work — no hardcoded palette.
+ */
+.clearpath {
+  --cp-accent: var(--brand-primary);
+  --cp-surface: var(--surface-color);
+  --cp-canvas: var(--bg-primary);
+  --cp-text: var(--text-primary);
+  --cp-text-2: var(--text-secondary);
+  --cp-text-3: var(--text-muted);
+  --cp-border: var(--border-color);
+  --cp-radius: var(--radius-md, 8px);
+  --cp-radius-lg: var(--radius-lg, 12px);
+  --cp-mono: ui-monospace, 'SFMono-Regular', Menlo, monospace;
+  color: var(--cp-text);
+}
+
+.clearpath h2, .clearpath h3, .clearpath h4 { margin: 0; font-weight: 600; }
+.clearpath .cp-mono, .clearpath code { font-family: var(--cp-mono); font-size: 0.82rem; }
+.clearpath .cp-intro { color: var(--cp-text-2); margin: 0 0 0.9rem; }
+
+.clearpath .cp-tabs { display: flex; gap: 0.4rem; margin-bottom: 1rem; flex-wrap: wrap; }
+.clearpath .cp-tab {
+  padding: 0.4rem 0.9rem; border-radius: 999px; border: 1px solid var(--cp-border);
+  background: var(--cp-surface); color: var(--cp-text-2); cursor: pointer; font-weight: 600; font-size: 0.85rem;
+}
+.clearpath .cp-tab:hover { border-color: var(--cp-accent); }
+.clearpath .cp-tab.active { background: var(--cp-accent); color: #fff; border-color: var(--cp-accent); }
+
+.clearpath .cp-card {
+  border: 1px solid var(--cp-border); border-radius: var(--cp-radius-lg);
+  background: var(--cp-surface); padding: 1rem; margin-bottom: 1rem;
+}
+.clearpath .cp-grid-2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
+
+.clearpath .cp-kv { display: flex; justify-content: space-between; gap: 1rem; padding: 0.35rem 0; border-bottom: 1px solid var(--cp-border); }
+.clearpath .cp-kv:last-child { border-bottom: none; }
+.clearpath .cp-kv .k { color: var(--cp-text-3); font-size: 0.8rem; }
+
+.clearpath .cp-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 0.75rem;
+  padding: 0.7rem 0.9rem; border: 1px solid var(--cp-border); border-radius: var(--cp-radius);
+  background: var(--cp-surface); cursor: pointer; margin-bottom: 0.5rem;
+}
+.clearpath .cp-row:hover { border-color: var(--cp-accent); }
+.clearpath .cp-row-name { font-weight: 600; }
+.clearpath .cp-row-sub { color: var(--cp-text-3); font-family: var(--cp-mono); font-size: 0.74rem; }
+
+.clearpath .cp-badge {
+  font-size: 0.68rem; font-weight: 700; border-radius: 5px; padding: 0.15rem 0.5rem;
+  color: var(--cp-accent); background: color-mix(in srgb, var(--cp-accent) 14%, transparent);
+}
+.clearpath .cp-badge-ext { color: var(--text-secondary); background: color-mix(in srgb, var(--text-secondary) 14%, transparent); }
+
+.clearpath .cp-field { margin-bottom: 0.7rem; display: flex; flex-direction: column; gap: 0.3rem; }
+.clearpath .cp-label { font-size: 0.8rem; color: var(--cp-text-2); }
+.clearpath .cp-input {
+  padding: 0.55rem 0.7rem; border: 1px solid var(--cp-border); border-radius: var(--cp-radius);
+  background: var(--cp-canvas); color: var(--cp-text); font-size: 0.9rem; width: 100%; box-sizing: border-box;
+}
+.clearpath .cp-btn {
+  padding: 0.5rem 0.9rem; border-radius: var(--cp-radius); border: 1px solid var(--cp-border);
+  background: var(--cp-surface); color: var(--cp-text); cursor: pointer; font-weight: 600; font-size: 0.85rem;
+}
+.clearpath .cp-btn:hover:not(:disabled) { border-color: var(--cp-accent); }
+.clearpath .cp-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.clearpath .cp-btn-primary { background: var(--cp-accent); border-color: var(--cp-accent); color: #fff; }
+.clearpath .cp-btn-link { background: none; border: none; color: var(--cp-accent); cursor: pointer; padding: 0; font-weight: 600; }
+.clearpath .cp-row-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+
+.clearpath .cp-error { color: var(--semantic-loss, #c0492f); background: color-mix(in srgb, var(--semantic-loss, #c0492f) 10%, transparent); padding: 0.6rem 0.8rem; border-radius: var(--cp-radius); margin: 0.6rem 0; font-size: 0.85rem; }
+.clearpath .cp-notice { color: var(--cp-text-2); background: var(--cp-canvas); padding: 0.6rem 0.8rem; border-radius: var(--cp-radius); margin: 0.6rem 0; font-size: 0.85rem; }
+.clearpath .cp-ok { color: var(--semantic-win, #2e7d32); font-size: 0.85rem; }
+.clearpath .cp-disabled { color: var(--cp-text-2); text-align: center; padding: 2rem; }
+.clearpath .cp-empty { color: var(--cp-text-3); text-align: center; padding: 1.5rem; }

--- a/frontend/src/components/clearpath/governorConnector.js
+++ b/frontend/src/components/clearpath/governorConnector.js
@@ -1,5 +1,31 @@
 import { ethers } from 'ethers'
-import { GOVERNOR_READ_ABI, VOTING_TOKEN_READ_ABI } from '../../abis/externalDAORegistry'
+import {
+  GOVERNOR_READ_ABI,
+  VOTING_TOKEN_READ_ABI,
+  ERC20_BALANCE_ABI,
+  GOVERNOR_PROPOSAL_ABI,
+  GOVERNOR_WRITE_ABI,
+} from '../../abis/externalDAORegistry'
+
+/**
+ * Per-DAO extra treasury vaults that are NOT the OZ timelock. Some platforms (Olympia) hold funds in a separate
+ * vault contract; the generic Governor connector can't infer it, so known vaults are overlaid here by
+ * (chainId → governor-address-lowercased). Keep this small + verified — never guess an address.
+ */
+const EXTRA_TREASURIES = {
+  63: {
+    // Olympia DAO on Mordor — OlympiaTreasury (basefee vault), separate from the Governor's TimelockController.
+    '0xb85dbc899472756470ef4033b9637ff8fa2fd23d': [
+      { label: 'Olympia Treasury', address: '0x035b2e3c189B772e52F4C3DA6c45c84A3bB871bf' },
+    ],
+  },
+}
+
+/** Known extra (non-timelock) treasury vaults for a DAO, or [] if none. */
+export function extraTreasuries(chainId, governorAddr) {
+  const byChain = EXTRA_TREASURIES[Number(chainId)] || {}
+  return byChain[String(governorAddr).toLowerCase()] || []
+}
 
 // Spec 030 (US3/US5) — the ClearPath connector for OpenZeppelin Governor DAOs. Reads any external (or native)
 // Governor via the standard IGovernor ABI, so the same surface serves Olympia and any Governor-based DAO. All
@@ -78,4 +104,127 @@ export async function readGovernorSummary(reader, address) {
     countingMode,
     clockMode,
   }
+}
+
+/**
+ * Read native + USDC balances for a DAO's treasury vault(s) — the Governor's timelock plus any known extra vault
+ * (e.g. OlympiaTreasury). Real on-chain reads; each balance degrades to null independently.
+ */
+export async function readTreasuries(reader, vaults, usdcAddr) {
+  const safe = async (p) => { try { return await p } catch { return null } }
+  let usdcDecimals = 6
+  let usdcSymbol = 'USDC'
+  let usdc = null
+  if (usdcAddr && ethers.isAddress(usdcAddr)) {
+    usdc = new ethers.Contract(usdcAddr, ERC20_BALANCE_ABI, reader)
+    const d = await safe(usdc.decimals())
+    if (d != null) usdcDecimals = Number(d)
+    const s = await safe(usdc.symbol())
+    if (s) usdcSymbol = s
+  }
+  return Promise.all(
+    vaults.map(async (v) => {
+      const native = await safe(reader.getBalance(v.address))
+      const usdcBal = usdc ? await safe(usdc.balanceOf(v.address)) : null
+      return {
+        label: v.label,
+        address: v.address,
+        native,
+        usdc: usdcBal,
+        usdcSymbol,
+        usdcDecimals,
+      }
+    })
+  )
+}
+
+const PROPOSAL_CREATED_TOPIC = ethers.id(
+  'ProposalCreated(uint256,address,address[],uint256[],string[],bytes[],uint256,uint256,string)'
+)
+const PROPOSAL_IFACE = new ethers.Interface(GOVERNOR_PROPOSAL_ABI)
+
+/**
+ * Limited LIVE on-chain indexing for chains without a subgraph (Mordor/ETC): a bounded, chunked `eth_getLogs`
+ * scan of the Governor's `ProposalCreated` events, newest-first, enriched with live `state` + `proposalVotes`.
+ * Resilient: if the RPC rejects a chunk it stops and returns what it has (marked `partial`) rather than failing
+ * wholesale; only a first-chunk failure yields `{ ok: false }`. Never fabricates — returns exactly what chain has.
+ */
+export async function fetchGovernorProposals(reader, governor, { lookbackBlocks = 500000, chunk = 50000, max = 50 } = {}) {
+  if (!reader) return { ok: false, error: 'No provider.', proposals: [] }
+  let current
+  try {
+    current = await reader.getBlockNumber()
+  } catch (e) {
+    return { ok: false, error: e?.message || 'Could not read block number.', proposals: [] }
+  }
+  const floor = Math.max(0, current - lookbackBlocks)
+  const govRead = new ethers.Contract(governor, [...GOVERNOR_READ_ABI, ...GOVERNOR_PROPOSAL_ABI], reader)
+  const raw = []
+  let scannedFrom = current
+  let partial = false
+  let firstChunk = true
+  for (let to = current; to >= floor; to -= chunk) {
+    const from = Math.max(floor, to - chunk + 1)
+    try {
+      const logs = await reader.getLogs({ address: governor, topics: [PROPOSAL_CREATED_TOPIC], fromBlock: from, toBlock: to })
+      raw.push(...logs)
+      scannedFrom = from
+      firstChunk = false
+    } catch (e) {
+      if (firstChunk) return { ok: false, error: e?.shortMessage || e?.message || 'RPC rejected getLogs.', proposals: [] }
+      partial = true
+      break
+    }
+    if (raw.length >= max) { partial = true; break }
+  }
+
+  // newest first, enrich with live state + votes
+  raw.reverse()
+  const proposals = []
+  for (const log of raw.slice(0, max)) {
+    let parsed
+    try { parsed = PROPOSAL_IFACE.parseLog(log) } catch { continue }
+    const a = parsed.args
+    const id = a.proposalId
+    const state = await (async () => { try { return Number(await govRead.state(id)) } catch { return null } })()
+    const votes = await (async () => {
+      try {
+        const [against, forV, abstain] = await govRead.proposalVotes(id)
+        return { against: against.toString(), for: forV.toString(), abstain: abstain.toString() }
+      } catch { return null }
+    })()
+    proposals.push({
+      id: id.toString(),
+      proposer: a.proposer,
+      description: a.description,
+      targets: a.targets,
+      values: a.values.map((v) => v.toString()),
+      calldatas: a.calldatas,
+      descriptionHash: ethers.id(a.description),
+      voteStart: a.voteStart.toString(),
+      voteEnd: a.voteEnd.toString(),
+      state,
+      votes,
+    })
+  }
+  return { ok: true, proposals, scannedFrom, scannedTo: current, partial }
+}
+
+// --- US5: user-signed management actions (the member signs; the external DAO's own rules gate authorization) ---
+
+function writeContract(signer, governor) {
+  return new ethers.Contract(governor, GOVERNOR_WRITE_ABI, signer)
+}
+
+export function castVote(signer, governor, proposalId, support) {
+  return writeContract(signer, governor).castVote(proposalId, support)
+}
+export function queueProposal(signer, governor, p) {
+  return writeContract(signer, governor).queue(p.targets, p.values, p.calldatas, p.descriptionHash)
+}
+export function executeProposal(signer, governor, p) {
+  return writeContract(signer, governor).execute(p.targets, p.values, p.calldatas, p.descriptionHash)
+}
+export function proposeAction(signer, governor, { targets, values, calldatas, description }) {
+  return writeContract(signer, governor).propose(targets, values, calldatas, description)
 }

--- a/frontend/src/components/clearpath/governorConnector.js
+++ b/frontend/src/components/clearpath/governorConnector.js
@@ -1,0 +1,81 @@
+import { ethers } from 'ethers'
+import { GOVERNOR_READ_ABI, VOTING_TOKEN_READ_ABI } from '../../abis/externalDAORegistry'
+
+// Spec 030 (US3/US5) — the ClearPath connector for OpenZeppelin Governor DAOs. Reads any external (or native)
+// Governor via the standard IGovernor ABI, so the same surface serves Olympia and any Governor-based DAO. All
+// reads are real on-chain calls; nothing is fabricated. ClearPath holds no authority — management actions (a
+// later step) are constructed here for the user to sign against the DAO's own contract.
+
+/**
+ * Pre-validate (client-side) that `address` looks like a Governor — mirrors the on-chain `_isGovernor` check the
+ * registry enforces, so the UI can give fast feedback before the user pays for a register tx. The contract is
+ * the source of truth. Returns `{ ok, name, reason }`.
+ */
+export async function validateGovernor(reader, address) {
+  if (!reader) return { ok: false, reason: 'No provider available.' }
+  if (!ethers.isAddress(address)) return { ok: false, reason: 'Not a valid address.' }
+  const code = await reader.getCode(address)
+  if (!code || code === '0x') return { ok: false, reason: 'No contract at this address (looks like a wallet).' }
+  const gov = new ethers.Contract(address, GOVERNOR_READ_ABI, reader)
+  // A real Governor answers these standard views; a random contract reverts.
+  try {
+    const mode = await gov.COUNTING_MODE()
+    await gov.votingPeriod()
+    let name = ''
+    try { name = await gov.name() } catch { name = '' }
+    if (!mode || mode.length === 0) return { ok: false, reason: 'Not a recognized governance contract.' }
+    return { ok: true, name, reason: '' }
+  } catch {
+    return { ok: false, reason: 'Not a recognized governance contract (no IGovernor interface).' }
+  }
+}
+
+/**
+ * Read a Governor's live summary for the tracking view. Each field is read independently and degrades to null on
+ * a missing/optional method (e.g. a Governor without a timelock), so a non-standard Governor still renders
+ * truthfully rather than failing wholesale.
+ */
+export async function readGovernorSummary(reader, address) {
+  const gov = new ethers.Contract(address, GOVERNOR_READ_ABI, reader)
+  const safe = async (p) => { try { return await p } catch { return null } }
+
+  const [name, tokenAddr, timelock, votingDelay, votingPeriod, proposalThreshold, countingMode, clockMode] =
+    await Promise.all([
+      safe(gov.name()),
+      safe(gov.token()),
+      safe(gov.timelock()),
+      safe(gov.votingDelay()),
+      safe(gov.votingPeriod()),
+      safe(gov.proposalThreshold()),
+      safe(gov.COUNTING_MODE()),
+      safe(gov.CLOCK_MODE()),
+    ])
+
+  let tokenName = null
+  let tokenSymbol = null
+  if (tokenAddr && ethers.isAddress(tokenAddr) && tokenAddr !== ethers.ZeroAddress) {
+    const t = new ethers.Contract(tokenAddr, VOTING_TOKEN_READ_ABI, reader)
+    tokenName = await safe(t.name())
+    tokenSymbol = await safe(t.symbol())
+  }
+
+  // Treasury = the timelock's native balance (the OZ Governor pattern: the timelock holds + executes funds).
+  let treasuryNative = null
+  if (timelock && ethers.isAddress(timelock) && timelock !== ethers.ZeroAddress) {
+    treasuryNative = await safe(reader.getBalance(timelock))
+  }
+
+  return {
+    name,
+    tokenAddr,
+    tokenName,
+    tokenSymbol,
+    timelock,
+    treasuryNative,
+    votingDelay: votingDelay != null ? votingDelay.toString() : null,
+    votingPeriod: votingPeriod != null ? votingPeriod.toString() : null,
+    proposalThreshold: proposalThreshold != null ? proposalThreshold.toString() : null,
+    countingMode,
+    clockMode,
+  }
+}

--- a/frontend/src/components/clearpath/proposalEncoding.js
+++ b/frontend/src/components/clearpath/proposalEncoding.js
@@ -73,6 +73,7 @@ export function encodeAction(a, { usdcAddress, meta }) {
     requireAddress(token, 'Token')
     requireAddress(a.tokenTo, 'Recipient')
     const m = meta ? meta(token) : null
+    if (m && m.unreadable) throw new Error('Could not read this token (decimals/symbol). Check the address.')
     if (!m) {
       const e = new Error('Reading token decimals…')
       e.pending = true
@@ -121,8 +122,7 @@ export function assemble({ title, body, actions, usdcAddress, meta }) {
 
 /**
  * Predict the OZ Governor proposalId for a payload (same hashing the contract uses) — for the duplicate
- * pre-check. hashProposal = keccak256(abi.encode(targets, values, keccak256(calldatas...), descriptionHash))...
- * OZ uses keccak256(abi.encode(targets, values, calldatas, descriptionHash)).
+ * pre-check. OZ: proposalId = uint256(keccak256(abi.encode(targets, values, calldatas, descriptionHash))).
  */
 export function predictProposalId(targets, values, calldatas, descHash) {
   const coder = ethers.AbiCoder.defaultAbiCoder()

--- a/frontend/src/components/clearpath/proposalEncoding.js
+++ b/frontend/src/components/clearpath/proposalEncoding.js
@@ -1,0 +1,134 @@
+import { ethers } from 'ethers'
+
+// Spec 030 (US5, FR-023/024/025) — pure encoding/validation for the ClearPath proposal builder. Turns
+// human-entered actions (send native / send token / custom call) into the exact OZ IGovernor.propose() payload
+// (parallel targets/values/calldatas + description), with field-level errors. No React, no chain calls — unit
+// testable. Governor correctness invariants live here: value=0 for ERC-20, description reused byte-for-byte,
+// description hash = keccak256(utf8), arrays equal length.
+
+export const ACTION_TYPE = { NATIVE: 'native', TOKEN: 'token', CUSTOM: 'custom' }
+
+const ERC20_TRANSFER_IFACE = new ethers.Interface(['function transfer(address to, uint256 amount)'])
+
+let _seq = 0
+/** A fresh blank action. `id` is a React key only — never submitted. */
+export function newAction(type = ACTION_TYPE.TOKEN) {
+  _seq += 1
+  return {
+    id: `a${_seq}`,
+    type,
+    nativeTo: '',
+    nativeAmount: '',
+    tokenMode: 'usdc', // 'usdc' (treasury default) | 'other' (arbitrary ERC-20 at tokenAddress)
+    tokenAddress: '',
+    tokenTo: '',
+    tokenAmount: '',
+    customTarget: '',
+    customValue: '',
+    customCalldata: '0x',
+  }
+}
+
+/** Merge a title + markdown body into the single Governor description string. */
+export function buildDescription(title, body) {
+  const t = (title || '').trim()
+  const b = (body || '').trim()
+  if (!t) return b
+  return b ? `# ${t}\n\n${b}` : `# ${t}`
+}
+
+/** keccak256(utf8(description)) — exactly what queue/execute recompute. */
+export function descriptionHash(description) {
+  return ethers.id(description)
+}
+
+function parseHuman(v, decimals, label) {
+  const s = (v ?? '').toString().trim() || '0'
+  let out
+  try {
+    out = ethers.parseUnits(s, decimals)
+  } catch {
+    const e = new Error(`${label} is not a valid number.`)
+    throw e
+  }
+  if (out < 0n) throw new Error(`${label} must not be negative.`)
+  return out
+}
+function requireAddress(v, label) {
+  if (!ethers.isAddress((v || '').trim())) throw new Error(`${label} is not a valid address.`)
+}
+
+/**
+ * Encode ONE action → { target, value (bigint), calldata }. Throws an Error with a human message on invalid
+ * input; sets `err.pending = true` when a token's decimals haven't loaded yet (caller treats as not-ready).
+ * @param meta (tokenAddr) => { decimals, symbol } | null
+ */
+export function encodeAction(a, { usdcAddress, meta }) {
+  if (a.type === ACTION_TYPE.NATIVE) {
+    requireAddress(a.nativeTo, 'Recipient')
+    return { target: a.nativeTo.trim(), value: parseHuman(a.nativeAmount, 18, 'Amount'), calldata: '0x' }
+  }
+  if (a.type === ACTION_TYPE.TOKEN) {
+    const token = a.tokenMode === 'other' ? (a.tokenAddress || '').trim() : (usdcAddress || '')
+    requireAddress(token, 'Token')
+    requireAddress(a.tokenTo, 'Recipient')
+    const m = meta ? meta(token) : null
+    if (!m) {
+      const e = new Error('Reading token decimals…')
+      e.pending = true
+      throw e
+    }
+    const amount = parseHuman(a.tokenAmount, m.decimals, 'Amount')
+    return {
+      target: token,
+      value: 0n, // ERC-20 transfer carries NO native value (invariant FR-025)
+      calldata: ERC20_TRANSFER_IFACE.encodeFunctionData('transfer', [a.tokenTo.trim(), amount]),
+    }
+  }
+  // custom call (advanced)
+  requireAddress(a.customTarget, 'Target')
+  const cd = (a.customCalldata || '0x').trim()
+  if (!/^0x([0-9a-fA-F]{2})*$/.test(cd)) throw new Error('Calldata must be valid hex (0x, even length).')
+  return { target: a.customTarget.trim(), value: parseHuman(a.customValue, 18, 'Value'), calldata: cd }
+}
+
+/**
+ * Assemble the whole proposal. Returns the submit payload + per-action diagnostics so the UI can render inline
+ * state without re-encoding. `ok` is true only when the description is non-empty, there is ≥1 action, and every
+ * action encodes cleanly (no errors, none pending).
+ */
+export function assemble({ title, body, actions, usdcAddress, meta }) {
+  const description = buildDescription(title, body)
+  const targets = []
+  const values = []
+  const calldatas = []
+  const perAction = []
+  let ok = description.trim().length > 0 && Array.isArray(actions) && actions.length > 0
+  for (const a of actions || []) {
+    try {
+      const enc = encodeAction(a, { usdcAddress, meta })
+      perAction.push({ encoded: enc })
+      targets.push(enc.target)
+      values.push(enc.value)
+      calldatas.push(enc.calldata)
+    } catch (e) {
+      perAction.push(e.pending ? { pending: true, message: e.message } : { error: e.message })
+      ok = false
+    }
+  }
+  return { ok, targets, values, calldatas, description, descriptionHash: descriptionHash(description), perAction }
+}
+
+/**
+ * Predict the OZ Governor proposalId for a payload (same hashing the contract uses) — for the duplicate
+ * pre-check. hashProposal = keccak256(abi.encode(targets, values, keccak256(calldatas...), descriptionHash))...
+ * OZ uses keccak256(abi.encode(targets, values, calldatas, descriptionHash)).
+ */
+export function predictProposalId(targets, values, calldatas, descHash) {
+  const coder = ethers.AbiCoder.defaultAbiCoder()
+  const encoded = coder.encode(
+    ['address[]', 'uint256[]', 'bytes[]', 'bytes32'],
+    [targets, values, calldatas, descHash]
+  )
+  return BigInt(ethers.keccak256(encoded)).toString()
+}

--- a/frontend/src/components/clearpath/useClearPath.js
+++ b/frontend/src/components/clearpath/useClearPath.js
@@ -5,6 +5,10 @@ import { useNotification } from '../../hooks/useUI'
 import { getContractAddressForChain } from '../../config/contracts'
 import { EXTERNAL_DAO_REGISTRY_ABI } from '../../abis/externalDAORegistry'
 
+// Upper bound on awaiting a confirmation — a broadcast-but-dropped tx must not hang wait() forever (it would
+// orphan the persistent in-flight toast). 120s is well beyond a normal confirmation on the live networks.
+const CONFIRM_TIMEOUT_MS = 120000
+
 /**
  * Spec 030 — ClearPath hook (external-DAO pillar). Resolves the per-chain ExternalDAORegistry, exposes whether
  * the feature is available on the active network (FR-016/FR-020: truthful self-disable when absent), reads the
@@ -58,13 +62,22 @@ export function useClearPath() {
       }
       const reg = new ethers.Contract(registryAddress, EXTERNAL_DAO_REGISTRY_ABI, signer)
       try {
+        // Persistent (duration 0) wallet + mining toasts so the user stays aware across the whole on-chain
+        // activity; each is replaced by the next, ending in a confirmed (with tx hash) / failed toast.
+        showNotification('Register DAO: confirm in your wallet…', 'info', 0)
         const tx = await reg.registerExternalDAO(dao, framework, label)
-        showNotification('Register DAO submitted — awaiting confirmation…', 'info')
-        const receipt = await tx.wait()
-        showNotification(`Registered ${label || 'DAO'}.`, 'success')
+        showNotification('Register DAO submitted — awaiting confirmation…', 'info', 0)
+        const receipt = await tx.wait(1, CONFIRM_TIMEOUT_MS)
+        const ref = tx?.hash ? ` · tx ${tx.hash.slice(0, 6)}…${tx.hash.slice(-4)}` : ''
+        showNotification(`Registered ${label || 'DAO'}.${ref}`, 'success')
         return receipt
       } catch (e) {
-        showNotification(e?.shortMessage || e?.reason || e?.message || 'Register failed.', 'error')
+        // Timeout ≠ confirmed failure — the register may still mine; say so honestly rather than "failed".
+        if (e?.code === 'TIMEOUT') {
+          showNotification('Register DAO is taking longer than expected — it may still confirm. Check your wallet or the explorer, then Refresh.', 'warning', 0)
+        } else {
+          showNotification(e?.shortMessage || e?.reason || e?.message || 'Register failed.', 'error')
+        }
         throw e
       }
     },

--- a/frontend/src/components/clearpath/useClearPath.js
+++ b/frontend/src/components/clearpath/useClearPath.js
@@ -16,6 +16,7 @@ export function useClearPath() {
   const { showNotification } = useNotification()
 
   const registryAddress = getContractAddressForChain('externalDAORegistry', chainId)
+  const usdcAddress = getContractAddressForChain('paymentToken', chainId) // per-network USDC for treasury balances
   const isSupported = ethers.isAddress(registryAddress || '')
   const reader = provider || signer?.provider || null
 
@@ -73,6 +74,7 @@ export function useClearPath() {
   return {
     isSupported,
     registryAddress,
+    usdcAddress,
     chainId,
     account,
     isConnected,

--- a/frontend/src/components/clearpath/useClearPath.js
+++ b/frontend/src/components/clearpath/useClearPath.js
@@ -1,0 +1,84 @@
+import { useCallback } from 'react'
+import { ethers } from 'ethers'
+import { useWallet } from '../../hooks/useWalletManagement'
+import { useNotification } from '../../hooks/useUI'
+import { getContractAddressForChain } from '../../config/contracts'
+import { EXTERNAL_DAO_REGISTRY_ABI } from '../../abis/externalDAORegistry'
+
+/**
+ * Spec 030 — ClearPath hook (external-DAO pillar). Resolves the per-chain ExternalDAORegistry, exposes whether
+ * the feature is available on the active network (FR-016/FR-020: truthful self-disable when absent), reads the
+ * live registry over RPC (works on subgraph-less Mordor where Olympia lives), and wraps the register write as a
+ * real on-chain tx with honest pending/confirmed/failed state surfaced through the app notification system.
+ */
+export function useClearPath() {
+  const { account, signer, provider, chainId, isConnected } = useWallet()
+  const { showNotification } = useNotification()
+
+  const registryAddress = getContractAddressForChain('externalDAORegistry', chainId)
+  const isSupported = ethers.isAddress(registryAddress || '')
+  const reader = provider || signer?.provider || null
+
+  const registryReader = useCallback(() => {
+    if (!isSupported || !reader) return null
+    return new ethers.Contract(registryAddress, EXTERNAL_DAO_REGISTRY_ABI, reader)
+  }, [isSupported, registryAddress, reader])
+
+  /** Read every external DAO registered on the active network (network-scoped, real on-chain). */
+  const listExternalDAOs = useCallback(async () => {
+    const reg = registryReader()
+    if (!reg) return []
+    const n = Number(await reg.externalCount())
+    const out = []
+    for (let id = n; id >= 1; id--) {
+      const [dao, framework, label, registrant, registeredAt] = await reg.getExternalDAO(id)
+      out.push({
+        id,
+        dao,
+        framework: Number(framework),
+        label,
+        registrant,
+        registeredAt: Number(registeredAt),
+      })
+    }
+    return out
+  }, [registryReader])
+
+  /** Register an external DAO. Real on-chain tx; honest state + notifications. Returns the receipt. */
+  const registerExternalDAO = useCallback(
+    async ({ dao, framework = 0, label = '' }) => {
+      if (!isSupported) {
+        showNotification('ClearPath is not available on this network.', 'warning')
+        throw new Error('unsupported network')
+      }
+      if (!signer) {
+        showNotification('Connect a wallet to register a DAO.', 'warning')
+        throw new Error('no signer')
+      }
+      const reg = new ethers.Contract(registryAddress, EXTERNAL_DAO_REGISTRY_ABI, signer)
+      try {
+        const tx = await reg.registerExternalDAO(dao, framework, label)
+        showNotification('Register DAO submitted — awaiting confirmation…', 'info')
+        const receipt = await tx.wait()
+        showNotification(`Registered ${label || 'DAO'}.`, 'success')
+        return receipt
+      } catch (e) {
+        showNotification(e?.shortMessage || e?.reason || e?.message || 'Register failed.', 'error')
+        throw e
+      }
+    },
+    [isSupported, signer, registryAddress, showNotification]
+  )
+
+  return {
+    isSupported,
+    registryAddress,
+    chainId,
+    account,
+    isConnected,
+    reader,
+    signer,
+    listExternalDAOs,
+    registerExternalDAO,
+  }
+}

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -35,6 +35,7 @@ const MORDOR_CONTRACTS = {
   membershipVoucher: '0xf514e0e342A898E4681bf51590B672aEC5620401',
   voucherBatchMinter: '0xc26F02da923263e2c9CFB722006e0B8Da2F952B2',
   tokenFactory: '0x5bdf74Ce98D41bf35192c20B25ACd561C75CFe62',
+  externalDAORegistry: '0xcEE0fb2e1407f0A0d19Bcf4Fee2726A3005FA3C0',
 }
 
 // Local Hardhat sandbox (chainId 1337) — populated by deploy.js + sync.

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -9,6 +9,7 @@ import { ROLES, ROLE_INFO } from '../contexts/RoleContext'
 import { hasRegisteredKey, ensureKeyRegistered } from '../utils/keyRegistryService'
 import SwapPanel from '../components/fairwins/SwapPanel'
 import TokensPanel from '../components/tokens/TokensPanel'
+import ClearPathPanel from '../components/clearpath/ClearPathPanel'
 import AccountDashboard from '../components/account/AccountDashboard'
 import AddressBookPanel from '../components/account/AddressBookPanel'
 import NetworkSettings from '../components/wallet/NetworkSettings'
@@ -29,6 +30,7 @@ const WALLET_TABS = [
   { id: 'preferences', label: 'Preferences' },
   { id: 'reports', label: 'Reporting' },
   { id: 'tokens', label: 'Tokens' },
+  { id: 'clearpath', label: 'ClearPath' },
   { id: 'swap', label: 'Swap' },
 ]
 
@@ -453,6 +455,11 @@ function WalletPage() {
                 {activeTab === 'tokens' && (
                   <div className="tokens-section" role="tabpanel">
                     <TokensPanel />
+                  </div>
+                )}
+                {activeTab === 'clearpath' && (
+                  <div className="clearpath-section" role="tabpanel">
+                    <ClearPathPanel />
                   </div>
                 )}
                 {activeTab === 'swap' && (

--- a/frontend/src/test/clearpath.accessibility.test.jsx
+++ b/frontend/src/test/clearpath.accessibility.test.jsx
@@ -16,6 +16,7 @@ const cp = {
   registerExternalDAO: vi.fn(),
 }
 vi.mock('../components/clearpath/useClearPath', () => ({ useClearPath: () => cp }))
+vi.mock('../hooks/useUI', () => ({ useNotification: () => ({ showNotification: vi.fn() }) }))
 vi.mock('../components/clearpath/governorConnector', () => ({
   validateGovernor: vi.fn(),
   readGovernorSummary: vi.fn().mockResolvedValue({
@@ -24,6 +25,13 @@ vi.mock('../components/clearpath/governorConnector', () => ({
     treasuryNative: 0n, votingDelay: '1', votingPeriod: '100', proposalThreshold: '0',
     countingMode: 'support=bravo', clockMode: 'mode=blocknumber',
   }),
+  extraTreasuries: () => [],
+  readTreasuries: vi.fn().mockResolvedValue([]),
+  fetchGovernorProposals: vi.fn().mockResolvedValue({ ok: true, proposals: [], scannedFrom: 0, scannedTo: 1, partial: false }),
+  castVote: vi.fn(),
+  queueProposal: vi.fn(),
+  executeProposal: vi.fn(),
+  proposeAction: vi.fn(),
 }))
 vi.mock('../config/networks', () => ({
   getNetwork: () => ({ name: 'Ethereum Classic Mordor', explorer: { name: 'Blockscout', baseUrl: 'https://etc-mordor.blockscout.com' }, nativeCurrency: { symbol: 'ETC' } }),

--- a/frontend/src/test/clearpath.accessibility.test.jsx
+++ b/frontend/src/test/clearpath.accessibility.test.jsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import ClearPathPanel from '../components/clearpath/ClearPathPanel'
+
+// Spec 030 (T057) — axe accessibility (WCAG 2.1 AA) over the ClearPath module surfaces. Picked up by the gating
+// CI step `npm test -- --run accessibility.test`.
+
+const cp = {
+  isSupported: true,
+  chainId: 63,
+  reader: {},
+  account: '0xabc',
+  isConnected: true,
+  listExternalDAOs: vi.fn(),
+  registerExternalDAO: vi.fn(),
+}
+vi.mock('../components/clearpath/useClearPath', () => ({ useClearPath: () => cp }))
+vi.mock('../components/clearpath/governorConnector', () => ({
+  validateGovernor: vi.fn(),
+  readGovernorSummary: vi.fn().mockResolvedValue({
+    name: 'OlympiaGovernor', tokenAddr: '0x0000000000000000000000000000000000000111',
+    tokenName: 'Olympia Member', tokenSymbol: 'OLYM', timelock: '0x0000000000000000000000000000000000000222',
+    treasuryNative: 0n, votingDelay: '1', votingPeriod: '100', proposalThreshold: '0',
+    countingMode: 'support=bravo', clockMode: 'mode=blocknumber',
+  }),
+}))
+vi.mock('../config/networks', () => ({
+  getNetwork: () => ({ name: 'Ethereum Classic Mordor', explorer: { name: 'Blockscout', baseUrl: 'https://etc-mordor.blockscout.com' }, nativeCurrency: { symbol: 'ETC' } }),
+}))
+
+describe('ClearPath accessibility (WCAG 2.1 AA)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cp.isSupported = true
+    cp.listExternalDAOs.mockResolvedValue([
+      { id: 1, dao: '0xB85dbc899472756470EF4033b9637ff8fa2FD23D', framework: 0, label: 'Olympia DAO', registrant: '0xabc', registeredAt: 1700000000 },
+    ])
+  })
+
+  it('the DAO list has no axe violations', async () => {
+    const { container } = render(<ClearPathPanel />)
+    await screen.findByText('Olympia DAO')
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('the disabled (unsupported network) state has no axe violations', async () => {
+    cp.isSupported = false
+    const { container } = render(<ClearPathPanel />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/clearpath.accessibility.test.jsx
+++ b/frontend/src/test/clearpath.accessibility.test.jsx
@@ -36,6 +36,10 @@ vi.mock('../components/clearpath/governorConnector', () => ({
 vi.mock('../config/networks', () => ({
   getNetwork: () => ({ name: 'Ethereum Classic Mordor', explorer: { name: 'Blockscout', baseUrl: 'https://etc-mordor.blockscout.com' }, nativeCurrency: { symbol: 'ETC' } }),
 }))
+// CpAddressField → AddressBookButton → useWallet would throw without a WalletProvider if a register/tracking
+// view mounts; stub the wallet-scoped hooks so the address fields render under axe.
+vi.mock('../hooks/useAddressBook', () => ({ useAddressBook: () => ({ search: () => [] }) }))
+vi.mock('../hooks/useAddressScreening', () => ({ useAddressScreening: () => ({ getStatus: () => 'clear', screen: vi.fn() }) }))
 
 describe('ClearPath accessibility (WCAG 2.1 AA)', () => {
   beforeEach(() => {

--- a/scripts/deploy/check-storage-layout.js
+++ b/scripts/deploy/check-storage-layout.js
@@ -21,6 +21,7 @@ const UPGRADEABLE_CONTRACTS = [
   { name: "WagerRegistry", deploymentsKey: "wagerRegistry" },
   { name: "MembershipManager", deploymentsKey: "membershipManager" }, // spec 027 — second adopter of UUPSManaged
   { name: "TokenFactory", deploymentsKey: "tokenFactory" }, // spec 028 — token-issuance authority/registry
+  { name: "ExternalDAORegistry", deploymentsKey: "externalDAORegistry" }, // spec 030 — ClearPath external-DAO registry
 ];
 
 function loadDeployedImpl(deploymentsKey) {

--- a/scripts/deploy/deploy-clearpath.js
+++ b/scripts/deploy/deploy-clearpath.js
@@ -1,0 +1,85 @@
+/**
+ * Targeted spec-030 deploy: add the ClearPath ExternalDAORegistry to an ALREADY-deployed network WITHOUT
+ * touching existing core contracts. Reuses the network's recorded MembershipManager and APPENDS the new
+ * addresses to its `deployments/<net>-chain<id>-v2.json` record (never overwrites).
+ *
+ * This deploys ONLY the external-DAO registry (pillar B of spec 030). Native standard DAOs are deferred:
+ * OZ 5.4.0 GovernorUpgradeable pulls in the Cancun `mcopy` opcode (via SignatureChecker -> Bytes.sol) and is
+ * not deployable on pre-Cancun ETC/Mordor (see memory `oz-governor-mcopy-mordor`). The registry imports only the
+ * IGovernor INTERFACE, so it is paris-safe and deploys on Mordor + Amoy.
+ *
+ *   GAS_PRICE_WEI=100000000000 npx hardhat run scripts/deploy/deploy-clearpath.js --network mordor
+ *   npx hardhat run scripts/deploy/deploy-clearpath.js --network amoy
+ *
+ * Then: npm run sync:frontend-contracts  (frontend picks up the externalDAORegistry address).
+ */
+const hre = require("hardhat");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+
+const { saveDeployment, getDeploymentFilename } = require("./lib/helpers");
+const { deployProxy } = require("./lib/upgradeable");
+
+async function main() {
+  const network = await ethers.provider.getNetwork();
+  const networkName = hre.network.name;
+  const chainId = Number(network.chainId);
+  const [deployer] = await ethers.getSigners();
+  const balance = await ethers.provider.getBalance(deployer.address);
+
+  console.log("=".repeat(60));
+  console.log("ClearPath (spec 030) — ExternalDAORegistry targeted deploy");
+  console.log("=".repeat(60));
+  console.log(`Network:  ${networkName} (chainId ${chainId})`);
+  console.log(`Deployer: ${deployer.address}`);
+  console.log(`Balance:  ${ethers.formatEther(balance)}`);
+
+  const filename = getDeploymentFilename(network, "v2");
+  const filepath = path.join(process.cwd(), "deployments", filename);
+  if (!fs.existsSync(filepath)) {
+    throw new Error(`No existing deployment record at deployments/${filename}. Run the core deploy first.`);
+  }
+  const record = JSON.parse(fs.readFileSync(filepath, "utf8"));
+  const contracts = record.contracts || (record.contracts = {});
+
+  const membershipManager = contracts.membershipManager;
+  if (!membershipManager || !ethers.isAddress(membershipManager)) {
+    throw new Error(`No membershipManager in deployments/${filename}; cannot wire ClearPath tier gating.`);
+  }
+  console.log(`Reusing MembershipManager: ${membershipManager}`);
+
+  if (contracts.externalDAORegistry) {
+    console.log(`\n⚠️  externalDAORegistry already recorded (${contracts.externalDAORegistry}). To change logic,`);
+    console.log(`   run an in-place upgrade (lib/upgradeable.js upgradeProxy), not this script. Aborting.`);
+    return;
+  }
+
+  console.log("\nDeploying ExternalDAORegistry behind a UUPS proxy...");
+  const proxy = await deployProxy({
+    name: "ExternalDAORegistry",
+    initArgs: [deployer.address, membershipManager],
+  });
+
+  // APPEND to the record (preserve everything already there).
+  contracts.externalDAORegistry = proxy.proxy;
+  contracts.externalDAORegistryImpl = proxy.implementation;
+  record.constructorArgs = record.constructorArgs || {};
+  record.constructorArgs.externalDAORegistryImpl = [];
+  record.clearpathDeployedAt = new Date().toISOString();
+  saveDeployment(filename, record);
+
+  console.log("\n" + "=".repeat(60));
+  console.log("Appended to deployments/" + filename);
+  console.log("=".repeat(60));
+  console.log(`  externalDAORegistry     ${contracts.externalDAORegistry}`);
+  console.log(`  externalDAORegistryImpl ${contracts.externalDAORegistryImpl}`);
+  console.log(`\nNext: npm run sync:frontend-contracts (frontend reads the address)`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/scripts/ops/seed-clearpath-olympia.js
+++ b/scripts/ops/seed-clearpath-olympia.js
@@ -1,0 +1,65 @@
+/**
+ * Spec 030 — seed the ClearPath ExternalDAORegistry with the real Olympia DAO so the feature has LIVE data.
+ * Idempotent. Two steps, both as the deployer (which holds ROLE_MANAGER_ROLE on the MembershipManager):
+ *   1. grant the deployer DAO_MEMBER_ROLE @ Silver (so it passes the registry's tier gate)
+ *   2. register the live OlympiaGovernor as an external OZ-Governor DAO
+ *
+ *   GAS_PRICE_WEI=100000000000 npx hardhat run scripts/ops/seed-clearpath-olympia.js --network mordor
+ */
+const hre = require("hardhat");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+const { getDeploymentFilename } = require("../deploy/lib/helpers");
+
+// OlympiaGovernor — verified live on Mordor (name() == "OlympiaGovernor", answers IGovernor views).
+const OLYMPIA_GOVERNOR_MORDOR = "0xB85dbc899472756470EF4033b9637ff8fa2FD23D";
+const Tier = { None: 0, Bronze: 1, Silver: 2, Gold: 3, Platinum: 4 };
+
+async function main() {
+  const network = await ethers.provider.getNetwork();
+  const [deployer] = await ethers.getSigners();
+  const filename = getDeploymentFilename(network, "v2");
+  const record = JSON.parse(fs.readFileSync(path.join(process.cwd(), "deployments", filename), "utf8"));
+  const c = record.contracts || {};
+  if (!c.externalDAORegistry) throw new Error("externalDAORegistry not deployed on this network");
+
+  console.log(`Network ${hre.network.name} (${network.chainId}) · deployer ${deployer.address}`);
+  const membership = await ethers.getContractAt("MembershipManager", c.membershipManager);
+  const registry = await ethers.getContractAt("ExternalDAORegistry", c.externalDAORegistry);
+  const role = await registry.DAO_MEMBER_ROLE();
+
+  // 1) Ensure the deployer has >= Silver for DAO_MEMBER_ROLE.
+  const tier = Number(await membership.getActiveTier(deployer.address, role));
+  if (tier < Tier.Silver) {
+    const roleMgr = await membership.ROLE_MANAGER_ROLE();
+    if (!(await membership.hasRole(roleMgr, deployer.address))) {
+      throw new Error("deployer lacks ROLE_MANAGER_ROLE on MembershipManager — cannot grant the tier");
+    }
+    console.log("Granting deployer DAO_MEMBER_ROLE @ Silver (365d)...");
+    const tx = await membership.grantMembership(deployer.address, role, Tier.Silver, 365);
+    await tx.wait();
+    console.log("  ✓ granted");
+  } else {
+    console.log(`Deployer already has tier ${tier} for DAO_MEMBER_ROLE`);
+  }
+
+  // 2) Register Olympia (idempotent).
+  if (await registry.isRegistered(OLYMPIA_GOVERNOR_MORDOR)) {
+    console.log("Olympia already registered.");
+  } else {
+    console.log(`Registering OlympiaGovernor ${OLYMPIA_GOVERNOR_MORDOR}...`);
+    const tx = await registry.registerExternalDAO(OLYMPIA_GOVERNOR_MORDOR, 0 /* OZGovernor */, "Olympia DAO");
+    await tx.wait();
+    console.log("  ✓ registered");
+  }
+
+  console.log(`externalCount now: ${(await registry.externalCount()).toString()}`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/scripts/utils/sync-frontend-contracts.js
+++ b/scripts/utils/sync-frontend-contracts.js
@@ -188,6 +188,7 @@ function main() {
         keyRegistry: deployed.keyRegistry,
         sanctionsGuard: deployed.sanctionsGuard,
         tokenFactory: deployed.tokenFactory, // spec 028 — token issuance (only present where deployed)
+        externalDAORegistry: deployed.externalDAORegistry, // spec 030 — ClearPath external-DAO registry
         polymarketAdapter: deployed.polymarketAdapter,
         chainlinkDataFeedAdapter: deployed.chainlinkDataFeedAdapter,
         chainlinkFunctionsAdapter: deployed.chainlinkFunctionsAdapter,

--- a/specs/030-clearpath-standard-daos/checklists/requirements.md
+++ b/specs/030-clearpath-standard-daos/checklists/requirements.md
@@ -1,0 +1,49 @@
+# Specification Quality Checklist: ClearPath Standard DAOs & External DAO Connectors
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- **Scope split (2026-06-24):** This spec is the **standard-DAO foundation** for the
+  ClearPath module — native traditional-governance DAOs + the external-DAO
+  registry/connectors (Olympia first). The **futarchy** governance mode lives in
+  spec 029 and is layered on top afterward. Decided with the user: scope = native
+  standard DAOs + external tracking; structure = new spec 030, 029 stays futarchy.
+- **Platform-integration references** (MembershipManager, SanctionsGuard, UUPSManaged,
+  USDC, subgraph, OpenZeppelin Governor/Votes, the IGovernor interface, Olympia's
+  contracts) appear in the Assumptions and cross-cutting FRs as *reuse-existing /
+  interoperate-with* requirements and recorded defaults — not prescribed internal
+  implementation. This mirrors spec 028's accepted convention. Concrete contract
+  design is deferred to `plan.md`.
+- **Worth pressure-testing in `/speckit-clarify` before planning:** the native voting
+  source default (membership-NFT vs token-weighted); whether the external registry is
+  on-chain vs frontend-only; the validation method for "recognized governance
+  contract" (ERC-165 / IGovernor probe); and confirming OZ Governor builds on OZ
+  5.4.0 / `paris` for ETC/Mordor.

--- a/specs/030-clearpath-standard-daos/checklists/requirements.md
+++ b/specs/030-clearpath-standard-daos/checklists/requirements.md
@@ -42,8 +42,13 @@
   interoperate-with* requirements and recorded defaults — not prescribed internal
   implementation. This mirrors spec 028's accepted convention. Concrete contract
   design is deferred to `plan.md`.
-- **Worth pressure-testing in `/speckit-clarify` before planning:** the native voting
-  source default (membership-NFT vs token-weighted); whether the external registry is
-  on-chain vs frontend-only; the validation method for "recognized governance
-  contract" (ERC-165 / IGovernor probe); and confirming OZ Governor builds on OZ
-  5.4.0 / `paris` for ETC/Mordor.
+- **`/speckit-clarify` session 2026-06-24 (complete)** resolved: native voting source =
+  **both selectable, default membership-NFT**; external registry = **on-chain,
+  network-scoped**; first external deliverable = **includes signed management actions**
+  (not read-only first). Recorded in the spec's `## Clarifications` and integrated into
+  FR-001 / FR-005 + Assumptions.
+- **Deferred to planning (technical, not a user decision):** confirm OZ Governor +
+  Timelock build/deploy on OZ 5.4.0 / EVM `paris` for ETC/Mordor (Olympia runs OZ
+  Governor v5.1 there, so it is expected to work — verify in research); and the exact
+  "recognized governance contract" validation probe (ERC-165 / IGovernor function
+  probe). Membership tier defaults mirror spec 028.

--- a/specs/030-clearpath-standard-daos/checklists/requirements.md
+++ b/specs/030-clearpath-standard-daos/checklists/requirements.md
@@ -52,3 +52,11 @@
   Governor v5.1 there, so it is expected to work — verify in research); and the exact
   "recognized governance contract" validation probe (ERC-165 / IGovernor function
   probe). Membership tier defaults mirror spec 028.
+- **Expansion — as-built alignment (2026-06-24):** the spec was expanded **in place**
+  (no new spec dir) to match the build: external-first sequencing (native US1/US4/US6
+  deferred — the OZ-5.4.0 `mcopy` blocker, resolved during implementation, not a code
+  regression), limited live on-chain indexing (FR-021), treasury+USDC enrichment
+  (FR-022), and the **rich proposal builder** (FR-023/FR-024) with Governor correctness
+  invariants (FR-025) + new acceptance scenarios (US5 #5–9), edge cases, and SC-013/014.
+  No new contract — the builder composes the existing `IGovernor.propose()`. All items
+  re-validated: still passing (16/16).

--- a/specs/030-clearpath-standard-daos/contracts/contracts.md
+++ b/specs/030-clearpath-standard-daos/contracts/contracts.md
@@ -1,0 +1,78 @@
+# Phase 1 Interface Contracts: ClearPath Standard DAOs (on-chain)
+
+Interface sketches. State/authority contracts inherit `UUPSManaged` (append-only +
+`__gap`, one-time `initialize`, `UPGRADER_ROLE`-gated upgrades), CEI + fail-closed
+sanctions on value moves. Native DAOs are assembled from **audited OZ Governor +
+Timelock + Votes** (not re-implemented). Signatures are the contract; bodies are the
+implementation phase.
+
+## IClearPathDAOFactory
+
+```solidity
+interface IClearPathDAOFactory {
+    enum VotingKind { MembershipNFT, ERC20Token }
+    event DAOCreated(uint256 indexed id, address indexed governor, address indexed creator, address timelock, address votingSource, VotingKind kind, string name);
+
+    struct GovParams { uint48 votingDelay; uint32 votingPeriod; uint256 proposalThreshold; uint8 quorumFraction; uint64 timelockDelay; }
+
+    // Tier (≥ Silver) + sanctions gated. Deploys beacon clones (Governor + Timelock + voting source), wires roles,
+    // funds nothing (treasury starts empty), records the row, emits DAOCreated.
+    function createDAO(
+        string calldata name, string calldata purpose,
+        VotingKind kind, address erc20VotesTokenOrZero,   // zero ⇒ deploy a soulbound MembershipNFT
+        GovParams calldata params
+    ) external returns (uint256 id, address governor, address timelock);
+
+    function getDAO(uint256 id) external view returns (/* DAO row */);
+    function daoCount() external view returns (uint256);
+    function getDAOsByCreator(address who) external view returns (uint256[] memory);
+}
+```
+
+## IExternalDAORegistry
+
+```solidity
+interface IExternalDAORegistry {
+    enum Framework { OZGovernor }   // Olympia = OZGovernor; extensible (Aragon/Moloch/Safe later)
+    event ExternalDAORegistered(uint256 indexed id, address indexed dao, Framework framework, address indexed registrant, string label);
+
+    // Tier-gated. Validates the address is a recognized governance contract (ERC-165 IGovernor probe +
+    // defensive IGovernor view staticcalls) before adding. Confers NO authority over `dao`.
+    function registerExternalDAO(address dao, Framework framework, string calldata label) external returns (uint256 id);
+
+    function getExternalDAO(uint256 id) external view returns (address dao, Framework framework, string memory label, address registrant);
+    function externalCount() external view returns (uint256);
+    function isRegistered(address dao) external view returns (bool);
+}
+```
+
+## Native governance (reused OZ, configured — not re-implemented)
+
+- `StandardGovernor` = `GovernorUpgradeable` + `GovernorSettingsUpgradeable` +
+  `GovernorCountingSimpleUpgradeable` + `GovernorVotesUpgradeable` +
+  `GovernorVotesQuorumFractionUpgradeable` + `GovernorTimelockControlUpgradeable`
+  (OZ 5.4.0, paris-safe). Standard `IGovernor` surface: `propose`, `castVote[WithReason]`,
+  `state`, `proposalVotes`, `proposalDeadline`, `proposalSnapshot`, `quorum`, `queue`,
+  `execute`, `cancel`.
+- `DAOTimelock` = `TimelockControllerUpgradeable` — executor + USDC treasury holder.
+- `MembershipNFT` = `ERC721VotesUpgradeable` soulbound (transfers disabled except
+  mint/burn by the DAO admin); or an `ERC20Votes` token (spec-028 factory) for token voting.
+
+## External connector (off-chain, frontend) — `governorConnector`
+
+Reads any external Governor via the standard `IGovernor` ABI + the voting token +
+timelock/treasury balance; constructs **user-signed** `propose`/`castVote`/`queue`/
+`execute` calls. No on-chain ClearPath contract participates in external actions.
+Olympia labeled connector resolves its addresses from github.com/olympiadao
+deployment records per network (Mordor / ETC mainnet) — verified, never hardcoded blind.
+
+## Cross-cutting (every state-changing ClearPath entrypoint)
+
+- `nonReentrant`; CEI; `SafeERC20` for USDC.
+- `_screen(account)` → `sanctionsGuard.checkBlocked(account)` as the first check on
+  value-moving actions (fail-closed; `address(0)` guard disables for oracle-less nets);
+  disbursement recipient screened at execution.
+- Membership tier gate via `MembershipManager.checkCanCreate` + `getActiveTier ≥ Silver`
+  + `recordCreate`.
+- Append-only storage + `__gap`; `check:storage-layout` gated. Events above are the
+  subgraph's source of truth (FR-020).

--- a/specs/030-clearpath-standard-daos/contracts/ui-contract.md
+++ b/specs/030-clearpath-standard-daos/contracts/ui-contract.md
@@ -1,0 +1,62 @@
+# Phase 1 UI Contract: ClearPath Standard DAOs (Account Center module)
+
+The frontend contract, mirroring the spec-028 Token Mint module. Real Web3 only;
+honest tx state; theme-aware; truthful subgraph-less fallback; the same IGovernor UI
+serves native + external DAOs.
+
+## Placement & gating
+
+- New tab `{ id: 'clearpath', label: 'ClearPath' }` in `WALLET_TABS`
+  (`frontend/src/pages/WalletPage.jsx`) → `<ClearPathPanel/>` (My Account → Account
+  Center), in the slot the `tokens` tab uses.
+- `useClearPath()` (mirrors `useTokenFactory`): resolves the per-chain factory +
+  registry via `getContractAddressForChain('clearPathDAOFactory' | 'externalDAORegistry', chainId)`;
+  `isSupported` self-disables truthfully where undeployed (FR-016); exposes the
+  member's tier to gate Create / Register before signing.
+
+## Information architecture (ClearPathPanel)
+
+- **My DAOs** — summary strip + the member's native + tracked external DAOs (labeled
+  by type/framework).
+- **Create** — `CreateDaoWizard`: name, purpose, voting source (membership-NFT default
+  or governance token), USDC treasury, governance params → summary → one real create tx.
+- **Explorer** — native + registered external DAOs on the active network; a
+  **Register external DAO** action (`RegisterExternalDao`: paste address → validate →
+  add).
+- **`DaoDetailView`** (native) — sub-tabs: Overview · Proposals · Treasury · Members ·
+  Roles · Activity · Contract. **`ExternalDaoView`** — Overview · Proposals · Treasury ·
+  Members · Activity (read), plus management actions where authorized + a deep-link to
+  the external app.
+- **`ProposalView`** — propose / vote / queue / execute (native AND external, via the
+  shared `governorConnector`), showing the live IGovernor proposal state + tallies.
+
+## Notification & state contract (FR-014 — spec-028 parity)
+
+- Every user action (create DAO, register external, join, propose, vote, queue,
+  execute, role grant/revoke, ownership transfer) → `showNotification(message, type)`
+  from `useNotification`: submitted (info) → confirmed (success) / failed (error);
+  tier/sanctions blocks → warning/error before signing; an external action the foreign
+  DAO rejects surfaces that DAO's reason (no implied success).
+- Passive loads (lists, detail reads, tallies) → inline `role="alert"`/`role="status"`,
+  not toasts. No phantom rows: an entry appears only after its tx confirms.
+
+## Data sources (FR-020)
+
+- `clearpathSubgraph.js`: `fetchDAOs`, `fetchExternalDAOs`, `fetchProposals`,
+  `fetchVotes`, `fetchMembers`, `fetchActivity` via `getSubgraphUrl(chainId)`; returns
+  `{ available:false }` on subgraph-less networks (Mordor/ETC) → truthful "unavailable"
+  or bounded on-chain reads (incl. direct IGovernor reads for a tracked external DAO).
+  Never fabricates rows.
+
+## Theming & accessibility (FR-019)
+
+- `clearpath.css` scoped under `.clearpath`, mapped onto `theme.css` light/dark
+  variables (the `tokens.css` approach). WCAG 2.1 AA: real table semantics, correct
+  tablist/radiogroup, link-vs-button semantics, disabled-state signalling. Covered by
+  `frontend/src/test/clearpath.accessibility.test.jsx` (vitest-axe, gating CI step).
+
+## ABIs
+
+- Hand-maintained `frontend/src/abis/clearPathDAOFactory.js`, `externalDAORegistry.js`,
+  and the standard `IGovernor` ABI (shared by native + external); subgraph JSON ABIs
+  under `frontend/src/abis/*.json`. Refresh from artifacts after contract changes.

--- a/specs/030-clearpath-standard-daos/data-model.md
+++ b/specs/030-clearpath-standard-daos/data-model.md
@@ -1,0 +1,92 @@
+# Phase 1 Data Model: ClearPath Standard DAOs & External DAO Connectors
+
+Entities, the (standard OZ Governor) proposal state machine, and invariants.
+Maps to spec Key Entities + FR-001…FR-020.
+
+## On-chain entities
+
+### Native DAO (registry row in `ClearPathDAOFactory`)
+| Field | Type | Notes |
+|---|---|---|
+| `id` | uint256 | network-scoped registry id |
+| `governor` | address | beacon-clone OZ Governor |
+| `timelock` | address | TimelockController = executor + USDC treasury holder |
+| `votingSource` | address | ERC721Votes membership NFT (default) or ERC20Votes token |
+| `votingKind` | uint8 | 0 = NFT-membership, 1 = ERC20-token |
+| `name`, `purpose` | string | validated non-empty |
+| `creator` | address | initial admin |
+| `createdAt` | uint64 | |
+
+### Governance params (set at creation via GovernorSettings)
+`votingDelay` (blocks/seconds per OZ clock), `votingPeriod`, `proposalThreshold`,
+`quorumFraction` (%), `timelockDelay` (s).
+
+### Native DAO roles
+Timelock `PROPOSER_ROLE` / `EXECUTOR_ROLE` / `CANCELLER_ROLE` (OZ TimelockController),
+wired so the Governor is proposer/canceller and execution is permissionless
+(EXECUTOR = address(0)) or restricted per config. A DAO admin (`DEFAULT_ADMIN_ROLE`
+on the membership NFT / a ClearPath admin role) manages membership + params.
+
+### Proposal (OZ Governor — read via IGovernor)
+`proposalId` (uint256, derived from targets/values/calldatas/descriptionHash),
+`proposer`, `targets[]`/`values[]`/`calldatas[]`, `voteStart`/`voteEnd`,
+`state` (enum), `forVotes`/`againstVotes`/`abstainVotes`, `eta` (queued).
+
+### Vote
+`(proposalId, voter) → support (0/1/2), weight, reason` (from `VoteCast`).
+
+### External DAO (`ExternalDAORegistry`)
+| Field | Type | Notes |
+|---|---|---|
+| `id` | uint256 | network-scoped |
+| `dao` | address | the external governor |
+| `framework` | uint8/enum | OZ_GOVERNOR (Olympia) … extensible |
+| `label` | string | optional |
+| `registeredBy` | address | registrant (no authority conferred) |
+| `registeredAt` | uint64 | |
+
+### Indexed (subgraph) — `DAO`, `Proposal`, `Vote`, `Member`, `ExternalDAO`,
+`GovernanceActivity` (type/actor/from/to/amount/detail/timestamp/txHash).
+
+## Proposal state machine (OZ Governor — standard)
+
+```
+Pending → Active → (Succeeded | Defeated | Canceled)
+Succeeded → Queued → Executed        (Expired if not executed in window)
+```
+
+| Transition | Trigger | Auth | Notes |
+|---|---|---|---|
+| create → Pending | `propose(targets,values,calldatas,desc)` | proposer (≥ threshold) + tier + sanctions | snapshot at `voteStart` |
+| Pending → Active | time (`votingDelay` elapsed) | — | voting opens |
+| Active → Succeeded/Defeated | time (`votingPeriod` elapsed) | — | quorum + majority decide |
+| Succeeded → Queued | `queue(...)` | permissionless | timelock `eta` set |
+| Queued → Executed | `execute(...)` | permissionless after `timelockDelay` | treasury action runs once; recipient sanctions-screened |
+| any active → Canceled | `cancel(...)` | proposer/canceller per rules | |
+
+External DAOs expose the **same** lifecycle via IGovernor; ClearPath reads `state`
+and constructs the matching user-signed action.
+
+## Invariants (tested — SC-004)
+
+- **INV-1 (treasury via governance only)**: the native DAO's USDC (in the timelock)
+  moves only through an `Executed` proposal; no admin withdrawal path.
+- **INV-2 (no overdraw / single execution)**: a queued action exceeding the treasury
+  balance reverts on execute; OZ Governor guarantees a proposal executes at most once.
+- **INV-3 (sanctions non-bypassable)**: create-DAO, fund-treasury, execute-disbursement
+  and disbursement recipients are `checkBlocked`-screened (fail-closed); read-only
+  tracking is not gated.
+- **INV-4 (no external authority)**: `ExternalDAORegistry` confers ClearPath no role,
+  key, or call-authority over a registered DAO; every external action is user-signed
+  and gated by the external DAO's own rules.
+- **INV-5 (network scope)**: native + external registries are per-network; cross-network
+  external registration is rejected.
+
+## Validation rules
+
+- Non-empty name/purpose; valid voting source; `quorumFraction ≤ 100`; sane
+  delays/periods.
+- External register: ERC-165 `supportsInterface(IGovernor)` (+ defensive IGovernor
+  view staticcalls); reject EOAs / non-Governor / wrong-network / duplicate.
+- Tier ≥ Silver + `checkCanCreate` to create a native DAO or register an external DAO.
+- Sanctions `checkBlocked` on every value-moving entrypoint + disbursement recipient.

--- a/specs/030-clearpath-standard-daos/plan.md
+++ b/specs/030-clearpath-standard-daos/plan.md
@@ -1,0 +1,124 @@
+# Implementation Plan: ClearPath Standard DAOs & External DAO Connectors
+
+**Branch**: `feat/clearpath-standard-daos-030` | **Date**: 2026-06-24 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/030-clearpath-standard-daos/spec.md`
+
+## Summary
+
+ClearPath's standard-DAO foundation: members **launch native traditional-governance
+DAOs** (OpenZeppelin Governor + TimelockController + a Votes voting source — a
+governance token `ERC20Votes` or a membership NFT `ERC721Votes`, default membership-
+NFT — with a USDC treasury held by the timelock) and **register/track/manage DAOs
+deployed by other platforms** via an on-chain network-scoped `ExternalDAORegistry`
+and per-framework connectors. The first connector targets **Olympia DAO** (OZ
+Governor on ETC/Mordor) and is built against the standard **IGovernor** interface so
+it generalizes to any Governor-based DAO — and so the **same governance UI serves
+native and external DAOs**. Signed management actions (propose/vote/queue/execute)
+are in scope from the start; ClearPath holds **no authority** over external DAOs
+(the member signs every action with their own wallet).
+
+Embedded as a My Account (Account Center) tab (the spec-028 pattern), gated by
+`MembershipManager` tiers, every action through the app notification system,
+`SanctionsGuard` non-bypassable on value-moving actions, theme-aware/accessible,
+within the no-backend footprint, real on-chain state only. New UUPS contracts on
+OZ 5.4.0 / Solidity ^0.8.24 / EVM `paris`, deployed to Mordor (63) + Amoy (80002)
+first. The futarchy governance mode (spec 029) layers on this foundation later.
+
+## Technical Context
+
+**Language/Version**: Solidity ^0.8.24 (EVM `paris`); JavaScript/JSX (React 18 + Vite); AssemblyScript (subgraph).
+
+**Primary Dependencies**: OpenZeppelin Contracts (Upgradeable) **5.4.0** — confirmed to ship `GovernorUpgradeable`, `TimelockControllerUpgradeable`, `Governor{CountingSimple,Settings,Votes,VotesQuorumFraction,TimelockControl}Upgradeable`, `ERC20VotesUpgradeable`, `ERC721VotesUpgradeable`, with **no Cancun opcodes** (paris-safe). Existing platform contracts (`UUPSManaged`, `MembershipManager`, `SanctionsGuard`). No new third-party dependency (unlike spec 029's LMSR `@prb/math`).
+
+**Storage**: On-chain (UUPS proxies + beacon clones, append-only + `__gap`); The Graph subgraph for enumeration; no app database.
+
+**Testing**: Hardhat (`test/clearpath/`, `test/integration/clearpath/`, `test/upgradeable/`); subgraph Matchstick; frontend Vitest + `vitest-axe`.
+
+**Target Platform**: EVM — Mordor (63) + Amoy (80002) first, Polygon (137) later. Olympia (the first external connector) is live on Mordor + ETC mainnet.
+
+**Project Type**: Web (contracts + React frontend + subgraph) — extends the monorepo.
+
+**Performance Goals**: DAO creation end-to-end < 3 min (SC-001); standard Governor gas; honest tx state.
+
+**Constraints**: OZ 5.4.0 / paris (ETC/Mordor); no-backend; sanctions non-bypassable + fail-closed on value moves; append-only upgradeable storage (CI-gated); WCAG 2.1 AA; network-scoped + truthful subgraph-less fallback; ClearPath holds no authority over external DAOs.
+
+**Scale/Scope**: Multiple native + external DAOs per network; standard Governor proposal volumes; the standard-DAO foundation delivered across phases A–F.
+
+## Constitution Check
+
+*GATE: must pass before Phase 0 and re-check after Phase 1.*
+
+- **I. Security-First (NON-NEGOTIABLE)** — PASS. New contracts inherit `UUPSManaged` (CEI, `_disableInitializers`, one-time `initialize`, non-brickable upgrade gate, append-only storage + `__gap`, `check:storage-layout`), reuse the fail-closed `SanctionsGuard` (non-bypassable on value moves), and build native governance on **audited OpenZeppelin Governor + Timelock** rather than bespoke code — materially lower risk than spec 029 (no new math primitive). External-DAO interaction is read + **user-signed** actions through the external DAO's own access control; ClearPath custodies nothing. Slither/Medusa must report no new high/critical.
+- **II. Test-First & Coverage (NON-NEGOTIABLE)** — PASS. Each phase ships unit + integration + upgrade-lifecycle + Matchstick + Vitest, covering authorized/unauthorized paths, treasury safety (SC-004), and the external connector (read + a signed action) against a real Governor DAO.
+- **III. Honest State, No Mocks** — PASS. Real on-chain tx, honest pending/confirmed/failed; network-scoped; subgraph-less views fall back to on-chain reads or disable truthfully (never fabricate DAOs/proposals/members). External DAOs clearly labeled as externally deployed; "manage" never implies authority ClearPath lacks.
+- **IV. Fail Loudly in CI** — PASS. New test/lint/build/security/storage/subgraph gates fail the pipeline; no `continue-on-error` on gates.
+- **V. Accessible Frontend** — PASS. ClearPath UI on `theme.css` light/dark variables (the `tokens.css` approach), WCAG 2.1 AA, gating axe tests.
+- **Additional constraints** — PASS. No secrets (floppy keystore); `contracts-archive/` reference-only; no-backend preserved; `governance.md` updated.
+
+**Result:** PASS. No constitution deviation requiring justification (contrast spec 029's LMSR). Complexity Tracking notes the minor patterns below.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/030-clearpath-standard-daos/
+├── plan.md · research.md · data-model.md · quickstart.md
+├── contracts/{contracts.md, ui-contract.md}
+├── checklists/requirements.md
+└── tasks.md   # /speckit-tasks — not created here
+```
+
+### Source Code (repository root)
+
+```text
+contracts/clearpath/                        # NEW — all state/authority contracts inherit UUPSManaged (append-only + __gap)
+├── ClearPathDAOFactory.sol                 # creates native DAOs (Governor+Timelock+Votes+USDC treasury); registry; tier+sanctions gate
+├── governance/StandardGovernor.sol         # OZ Governor (CountingSimple+Settings+Votes+QuorumFraction+TimelockControl) — beacon impl
+├── governance/DAOTimelock.sol              # OZ TimelockController = executor + USDC treasury holder — beacon impl
+├── voting/MembershipNFT.sol                # ERC721Votes soulbound membership (default voting source) — beacon impl
+│                                            # token voting reuses spec-028 ERC20Votes token factory
+├── external/ExternalDAORegistry.sol        # UUPS: network-scoped register/validate (ERC-165 IGovernor probe); no authority over externals
+└── interfaces/                             # IClearPathDAOFactory, IExternalDAORegistry (+ reuse OZ IGovernor)
+# Reused as-is: contracts/upgradeable/UUPSManaged.sol, contracts/access/{MembershipManager,SanctionsGuard}.sol, per-network USDC
+
+test/clearpath/ · test/integration/clearpath/ · test/upgradeable/ClearPath*.upgrade.test.js
+scripts/deploy/deploy-clearpath.js          # UUPS proxies + beacons via lib/upgradeable.js; wires SanctionsGuard+MembershipManager+USDC
+
+subgraph/                                   # DAO/Proposal/Vote/Member/ExternalDAO/Activity entities
+├── schema.graphql (append) · subgraph.yaml (ClearPathDAOFactory + ExternalDAORegistry datasources + Governor template)
+├── src/mappings/clearpath*.ts · tests/clearpath.test.ts (Matchstick)
+
+frontend/src/
+├── pages/WalletPage.jsx                    # add { id: 'clearpath', label: 'ClearPath' } to WALLET_TABS + panel
+└── components/clearpath/
+    ├── ClearPathPanel.jsx (My DAOs / Create / Explorer) · useClearPath.js (gating, reads, writes w/ honest state)
+    ├── CreateDaoWizard.jsx · DaoDetailView.jsx (Overview/Proposals/Treasury/Members/Roles/Activity/Contract)
+    ├── ProposalView.jsx (propose/vote/queue/execute) · RegisterExternalDao.jsx · ExternalDaoView.jsx
+    ├── connectors/ (governorConnector.js — IGovernor read+act; olympia label/addresses) · clearpathSubgraph.js
+    └── clearpath.css (mapped onto theme.css variables)
+
+docs/developer-guide/clearpath-dao.md (NEW) · docs/system-overview/governance.md (UPDATE "no DAO")
+```
+
+**Structure Decision**: Extend the monorepo. Native DAOs are assembled from **audited OZ Governor + Timelock + Votes** sub-contracts deployed per-DAO as **beacon clones** (one upgradeable impl per type, all upgrade together; the timelock is the executor + USDC treasury — the standard OZ pattern). A single `ClearPathDAOFactory` (UUPS) creates them + keeps the native registry; a separate `ExternalDAORegistry` (UUPS) holds the network-scoped external-DAO list. The frontend embeds a **ClearPath My Account tab** (spec-028 pattern); a single `governorConnector` serves both native and external Governor DAOs via the standard IGovernor ABI. Subgraph indexes both factories + a per-DAO Governor template.
+
+## Complexity Tracking
+
+| Pattern | Why Needed | Simpler Alternative Rejected Because |
+|---------|------------|--------------------------------------|
+| **Beacon-clone DAO sub-contracts** (Governor/Timelock/MembershipNFT) | Each native DAO needs isolated governance + treasury while all upgrade together; cheap deploys. | Independent UUPS proxies per DAO = far costlier deploy/upgrade; a single shared Governor can't isolate per-DAO membership/treasury. Storage-gate the beacon impls. |
+| **External-DAO interaction with no on-chain authority** | "Manage" must not give ClearPath custody/keys over a foreign DAO. | An on-chain adapter holding delegated authority would be a custody + security liability; instead the frontend connector builds calls the **user signs** against the external DAO's own contract. |
+| **On-chain `ExternalDAORegistry`** | Shared, indexable, no-backend-persistent discovery of registered external DAOs. | A frontend-only watchlist isn't shareable/indexable and can't persist within the no-backend footprint. |
+
+*No constitution-level deviation* — native governance is audited OZ Governor (contrast spec 029's new LMSR primitive).
+
+## Phasing (incremental delivery, by spec priority)
+
+- **Phase A — native DAO + treasury + membership (P1, US1):** `ClearPathDAOFactory` + beacon Governor/Timelock/MembershipNFT (+ token-voting via the spec-028 ERC20Votes factory), USDC treasury, tier+sanctions gating; deploy Mordor+Amoy; subgraph `DAO` entity; ClearPath tab + Create + My DAOs.
+- **Phase B — external registry + tracking + Explorer (P1, US2/US3):** `ExternalDAORegistry` (register + ERC-165/IGovernor validate), the `governorConnector` read path, unified My DAOs/Explorer (native + external labeled), Olympia tracked on Mordor.
+- **Phase C — proposal lifecycle + external management (P2, US4/US5):** native propose→vote→queue→execute UI; external signed actions (propose/vote/queue/execute) via the connector where authorized; deep-link fallback for unsupported frameworks.
+- **Phase D — roles, params & ownership (P2, US6):** native DAO role grants/revokes, parameter config, ownership transfer/renounce.
+- **Phase E — activity & contract surface (P3, US7/US8):** subgraph-sourced activity history + the contract surface, with truthful subgraph-less disable.
+- **Phase F — polish & cross-cutting:** `docs/developer-guide/clearpath-dao.md` + update `governance.md`; Slither/Medusa + axe/Lighthouse; quickstart A–E validation on local + Mordor (incl. tracking real Olympia); CI green.

--- a/specs/030-clearpath-standard-daos/quickstart.md
+++ b/specs/030-clearpath-standard-daos/quickstart.md
@@ -1,0 +1,84 @@
+# Quickstart & Validation: ClearPath Standard DAOs & External DAO Connectors
+
+End-to-end validation against real on-chain state (no mock data). Run on local
+Hardhat (1337), Amoy (80002), or Mordor (63). On Mordor (no subgraph) lists fall
+back to on-chain reads or disable truthfully. See `contracts/` + `data-model.md`.
+
+## Prerequisites
+
+- `npm install` (no new third-party dep — native governance is OZ 5.4.0 Governor,
+  already installed). `npm run compile` succeeds.
+- A funded deployer; the existing `SanctionsGuard`, `MembershipManager`, and a USDC
+  token deployed/recorded for the target network (read, not redeployed).
+
+## 1. Deploy (factory + beacons + external registry)
+
+```bash
+npm run deploy:clearpath -- --network <local|amoy|mordor>   # UUPS proxies + beacons via lib/upgradeable.js;
+                                                            # wires SanctionsGuard + MembershipManager + USDC;
+                                                            # configures DAO_MEMBER_ROLE tier; records proxies+impls
+npm run check:storage-layout        # ClearPath contracts registered; passes (baseline)
+npm run sync:frontend-contracts     # frontend picks up addresses/ABIs
+```
+**Expect**: `deployments/<network>.json` gains `clearPathDAOFactory`(+Impl),
+`externalDAORegistry`(+Impl), and the Governor/Timelock/MembershipNFT beacon+impl refs.
+
+## Validation — A–E
+
+### A. Launch a native standard DAO (US1, P1)
+1. As a member ≥ the required tier, `createDAO(name, purpose, MembershipNFT, 0, params)`
+   → one `DAOCreated`; a deployed Governor + Timelock (USDC treasury) + soulbound
+   membership NFT; the DAO in My DAOs.
+2. Pick the token-voting option → the DAO uses an ERC20Votes token instead.
+3. **Negative**: a sub-tier or sanctioned wallet → rejected before signing + on-chain.
+
+### B. Discover, register & track an external DAO — Olympia (US2/US3, P1)
+1. In Explorer → **Register external DAO**, paste Olympia's governor address on Mordor
+   → validated (ERC-165 IGovernor) and added with framework=OZGovernor; appears in My
+   DAOs / Explorer labeled "external".
+2. Open it → its real treasury balance, proposals + vote tallies + states, and
+   membership match Olympia's on-chain state. Registering an EOA / non-Governor →
+   rejected with a truthful reason.
+3. Switch networks → only the active network's DAOs show; unsupported network → tab
+   disabled truthfully. Subgraph-less (Mordor) → on-chain reads / truthful "unavailable".
+
+### C. Proposal lifecycle — native + external (US4/US5, P2)
+1. Native: `propose` a USDC treasury disbursement → vote to quorum + success → `queue`
+   → after the timelock `execute` → recipient funded on-chain, exactly once; a defeated
+   proposal performs no action.
+2. External (Olympia), as a wallet holding its membership NFT: `castVote` on an open
+   proposal through ClearPath → the vote records on Olympia's own contract (user-signed);
+   a wallet without authority → rejected by Olympia's rules, reason surfaced.
+3. **Sanctions**: a ClearPath-mediated value move with a sanctioned actor/recipient →
+   blocked. **Unsupported framework** → read-only + truthful deep-link, no broken action.
+
+### D. Admin: roles, params, ownership (US6, P2)
+1. Grant the proposer role to a second wallet → only it (and admins) can propose;
+   revoke → blocked. Update params → applied to new proposals. Transfer/renounce
+   ownership → authority moves; unauthorized callers rejected on-chain.
+
+### E. Activity + contract surface + theme (US7/US8)
+1. After actions, the activity feed shows created/registered/proposed/voted/executed
+   events (subgraph) with actor/tx/time; Mordor → truthful disable.
+2. Contract sub-tab shows real governor/timelock/token addresses + framework + explorer
+   links; copy address/ABI work; external DAOs labeled "externally deployed".
+3. Toggle dark mode → restyles via theme variables; axe passes.
+
+## Invariants + gates
+
+- **INV-1..5** (data-model.md): treasury moves only via executed proposals; no overdraw /
+  single execution; sanctions non-bypassable on value moves; ClearPath holds no
+  authority over external DAOs; network-scoped.
+
+```bash
+npm test                       # unit + integration for factory/governor/timelock/registry + upgrade lifecycle
+npm run check:storage-layout   # append-only storage (gating)
+npm run test:frontend          # Vitest for the ClearPath module (incl. axe)
+cd subgraph && npm run codegen && npm run build   # + Matchstick via Docker
+# CI additionally runs Slither (proxy/clone/AccessControl/Governor) + Medusa: no new high/critical
+```
+
+**Done when**: every A–E scenario passes against real on-chain state (incl. tracking a
+real Olympia DAO + a user-signed external vote), treasury safety + sanctions hold, no
+phantom/mock rows, subgraph-less fallback is truthful, and the suite + security gates
+are green.

--- a/specs/030-clearpath-standard-daos/research.md
+++ b/specs/030-clearpath-standard-daos/research.md
@@ -1,0 +1,123 @@
+# Phase 0 Research: ClearPath Standard DAOs & External DAO Connectors
+
+Decisions for spec 030. Grounded in the repo + the Olympia research + the
+`/speckit-clarify` outcomes (both voting sources default NFT · on-chain external
+registry · signed management from the start).
+
+## D1 — Native governance basis: OpenZeppelin Governor + Timelock (paris-safe)
+
+- **Decision**: Build native standard DAOs from **OZ 5.4.0 `GovernorUpgradeable`**
+  composed with `GovernorSettingsUpgradeable`, `GovernorCountingSimpleUpgradeable`,
+  `GovernorVotesUpgradeable`, `GovernorVotesQuorumFractionUpgradeable`, and
+  `GovernorTimelockControlUpgradeable`; the **`TimelockControllerUpgradeable` is the
+  executor and the USDC treasury holder** (canonical OZ pattern). No bespoke voting.
+- **Rationale**: Audited, standard, and — verified locally — **OZ 5.4.0 ships the
+  full governance suite with no Cancun opcodes** (paris-safe), so it deploys on
+  ETC/Mordor. Olympia already runs OZ Governor v5.1 on Mordor + ETC mainnet,
+  confirming feasibility. Using the same Governor as Olympia means one IGovernor UI
+  serves native + external DAOs.
+- **Alternatives**: bespoke voting (rejected — audit risk, reinvention);
+  Moloch-style shares (deferred — futarchy spec 029 uses Moloch treasury; standard
+  DAOs follow the Governor norm + interoperate with external Governor DAOs).
+
+## D2 — Voting source: ERC20Votes or ERC721Votes (default NFT)
+
+- **Decision**: Selectable at creation — **`ERC721Votes` soulbound membership NFT**
+  (1 member = 1 vote, the default, mirrors Olympia) or **`ERC20Votes` governance
+  token** (token-weighted; reuse the spec-028 token factory's ERC20Votes path where
+  possible). Both satisfy `GovernorVotes`' `IVotes` interface.
+- **Rationale**: Covers community (1p1v) and token-economic DAOs with one Governor;
+  NFT default is the simplest, Olympia-aligned option (clarified 2026-06-24).
+
+## D3 — Per-DAO deployment: beacon clones
+
+- **Decision**: `ClearPathDAOFactory` (UUPS, `UUPSManaged`) deploys each native DAO's
+  Governor + Timelock + voting source as **beacon-proxy clones** of one upgradeable
+  impl per type (all clones upgrade together; storage-gate the impls). Factory keeps a
+  network-scoped native-DAO registry + emits `DAOCreated`. Tier (≥ Silver) +
+  sanctions gated, following `WagerRegistry`/spec-028.
+- **Fallback**: if `check:storage-layout` can't cover beacon impls, deploy the OZ
+  Governor/Timelock as minimal non-upgradeable per-DAO instances (they're audited OZ
+  and rarely need patching) and keep only the factory + registry upgradeable.
+
+## D4 — External DAO registry (on-chain, network-scoped)
+
+- **Decision**: `ExternalDAORegistry` (UUPS, `UUPSManaged`) records
+  `register(address, framework, label)` per network, **validates** the address is a
+  recognized governance contract before adding, emits `ExternalDAORegistered` for
+  discovery + subgraph indexing, and holds **no authority** over the external DAO.
+  Tier-gated registration; duplicates rejected.
+- **Validation (D4a)**: probe the target with **ERC-165 `supportsInterface`** for the
+  OZ `IGovernor` interfaceId, plus a defensive staticcall to a couple of IGovernor
+  view functions (`COUNTING_MODE()`, `votingPeriod()`); reject EOAs / non-Governor
+  contracts / wrong-network addresses with a truthful reason.
+- **Rationale**: Shared, indexable, no-backend-persistent discovery (clarified
+  2026-06-24); ERC-165 is the standard capability probe OZ Governor supports.
+
+## D5 — External connector: IGovernor read + user-signed act (Olympia first)
+
+- **Decision**: A single frontend `governorConnector` reads external DAO state via the
+  standard **`IGovernor`** ABI (`state`, `proposalVotes`, `proposalDeadline`,
+  `proposalSnapshot`, `quorum`, plus the voting token + timelock/treasury balance) and
+  constructs **user-signed** actions (`propose`, `castVote`/`castVoteWithReason`,
+  `queue`, `execute`). Olympia is the first labeled connector (its OlympiaGovernor =
+  OZ Governor, soulbound `OlympiaMemberNFT`, `OlympiaTreasury` vault on ETC/Mordor;
+  `OlympiaGovernor` ≈ `0xB85dbc89…`, `OlympiaTreasury` ≈ `0x035b2e3c…`). Because the
+  connector targets IGovernor, it covers Olympia AND any Governor DAO; unsupported
+  frameworks get a truthful deep-link, not a broken action.
+- **Rationale**: No custody/authority; reuse the exact same UI for native + external
+  (both are Governor). Authorization is enforced by the external DAO's own rules; the
+  user signs.
+
+## D6 — Treasury asset & sanctions
+
+- **Decision**: Native treasury = the platform **USDC** per network (held by the
+  DAO's TimelockController). Sanctions: store `ISanctionsGuard`, `checkBlocked` in the
+  Checks phase of every ClearPath-mediated value-moving action (create DAO, fund
+  treasury, execute disbursement) and screen the disbursement recipient; read-only
+  tracking is not gated. ClearPath-mediated external value moves are screened; the
+  external DAO's own SanctionsOracle (Olympia has one) also applies.
+- **Rationale**: FR-015; consistent with wagers + spec 028/029.
+
+## D7 — Membership gating
+
+- **Decision**: Gate native-DAO creation + external-DAO registration by a
+  `MembershipManager` tier (≥ Silver) via `checkCanCreate(sender, DAO_MEMBER_ROLE)` +
+  `getActiveTier` + `recordCreate`, following `WagerRegistry`. Define
+  `keccak256("DAO_MEMBER_ROLE")`; admin authorizes the factory/registry as callers.
+- **Rationale**: FR-013 — reuse existing membership, no parallel system.
+
+## D8 — Frontend Account Center integration
+
+- **Decision**: Add `{ id: 'clearpath', label: 'ClearPath' }` to `WALLET_TABS`
+  (`frontend/src/pages/WalletPage.jsx`) rendering `<ClearPathPanel/>` in the same
+  slot as the spec-028 `tokens` tab. `useClearPath` mirrors `useTokenFactory`
+  (per-chain factory via `getContractAddressForChain`, `isSupported` self-disable,
+  honest tx state). Every action → `useNotification`/`showNotification`; passive
+  loads → inline `role="alert"`. `clearpath.css` mapped onto `theme.css` light/dark.
+- **Rationale**: Strict spec-028 parity (FR-012/014/019).
+
+## D9 — Subgraph & deploy
+
+- **Decision**: `ClearPathDAOFactory` datasource (`DAOCreated` → `DAO`) +
+  `ExternalDAORegistry` datasource (`ExternalDAORegistered` → `ExternalDAO`) + a
+  per-DAO **Governor data-source template** (the spec-028 `TokenInstance` pattern)
+  indexing `ProposalCreated`/`VoteCast`/`ProposalQueued`/`ProposalExecuted` →
+  `Proposal`/`Vote`/`Member`/`GovernanceActivity`. Matchstick tests. Truthful
+  subgraph-less fallback (Mordor) to bounded on-chain reads or a disabled view.
+  Deploy via `scripts/deploy/deploy-clearpath.js` (UUPS proxies + beacons through
+  `lib/upgradeable.js`), Mordor + Amoy first; `check:storage-layout` +
+  `sync:frontend-contracts`; verify via `scripts/deploy/verify.js`.
+
+## Residual risks
+
+- Beacon-proxy storage-gate coverage (fallback D3).
+- ERC-165 false negatives for non-standard Governors (some DAOs don't implement
+  ERC-165) — allow a manual framework override + truthful "unverified type" label.
+- External DAO on a different chain than the active network — registry is
+  network-scoped; reject cross-network registration.
+- Olympia address/chain mapping (Mordor vs ETC-mainnet) — resolve from
+  github.com/olympiadao deployment records at implementation; never hardcode without
+  verification.
+- Keeper liveness for native `queue`/`execute` — permissionless (anyone can call
+  after timelock), frontend triggers; consistent with no-backend.

--- a/specs/030-clearpath-standard-daos/spec.md
+++ b/specs/030-clearpath-standard-daos/spec.md
@@ -47,6 +47,14 @@ non-bypassably on value-moving actions, is **theme-aware** (light/dark) and
 accessible, runs entirely within the platform's **no-backend** footprint, and shows
 **real on-chain state only** — never mock data.
 
+## Clarifications
+
+### Session 2026-06-24
+
+- Q: For native standard DAOs, what determines voting power? → A: **Both, selectable at creation** — a governance token (`ERC20Votes`, may reuse the spec-028 token factory) or a membership NFT (1 member = 1 vote); the **default presented option is membership-NFT** (mirrors Olympia).
+- Q: How are registered external DAOs stored / discovered? → A: A lightweight **on-chain, network-scoped `ExternalDAORegistry`** records `(address, framework, label)` for shared discovery + subgraph indexing (fits the no-backend footprint); ClearPath still holds **no authority** over the external DAO.
+- Q: What's in the first external-DAO deliverable — track-only or also management? → A: **Include signed native management actions** (create proposal / vote / queue / execute via the connector, user-signed) **from the start**, alongside read-only tracking — not deferred to a later phase.
+
 ## User Scenarios & Testing *(mandatory)*
 
 ### User Story 1 - Launch a standard DAO (Priority: P1)
@@ -314,10 +322,11 @@ explorer; copy an address/ABI and confirm correctness.
 **Native standard DAOs (US1/US4)**
 
 - **FR-001**: The system MUST allow an authorized member to create a native standard
-  DAO specifying at least name, purpose, voting-weight source (governance token or
-  membership NFT), a USDC treasury, and governance parameters (voting delay, voting
-  period, quorum, timelock delay), deploying the governance + treasury contracts
-  on-chain.
+  DAO specifying at least name, purpose, a **voting-weight source selectable at
+  creation — a governance token (`ERC20Votes`) or a membership NFT (1 member = 1
+  vote), defaulting to membership-NFT** — a USDC treasury, and governance parameters
+  (voting delay, voting period, quorum, timelock delay), deploying the governance +
+  treasury contracts on-chain.
 - **FR-002**: A native DAO MUST support a standard proposal lifecycle — submit a
   proposal (a USDC treasury action or a parameter change), vote during the voting
   period, and (after the timelock) queue and execute a passed proposal — with vote
@@ -332,9 +341,11 @@ explorer; copy an address/ABI and confirm correctness.
 **External DAO registry & connectors (US3/US5)**
 
 - **FR-005**: The system MUST allow a member to register an existing external DAO by
-  (network, address, framework/type) with an optional label, MUST validate that the
-  address is a recognized governance contract (e.g. responds to the standard
-  IGovernor interface) before adding, and MUST reject unrecognized/invalid addresses.
+  (network, address, framework/type) with an optional label into a lightweight
+  **on-chain, network-scoped registry** (shared discovery + subgraph-indexable), MUST
+  validate that the address is a recognized governance contract (e.g. responds to the
+  standard IGovernor interface) before adding, and MUST reject unrecognized/invalid
+  addresses. The registry grants ClearPath **no authority** over the external DAO.
 - **FR-006**: The system MUST track a registered external DAO **read-only** — its
   treasury balance, proposals + vote tallies + proposal states, and membership —
   sourced from the external DAO's on-chain state/indexing, strictly network-scoped
@@ -493,7 +504,9 @@ explorer; copy an address/ABI and confirm correctness.
   DAO's own access control; ClearPath holds no keys, roles, or custody, and offers a
   deep-link to the external app as a fallback. A lightweight on-chain registry records
   registered external DAOs (network-scoped, for shared discovery + indexing) but
-  grants ClearPath no power over them.
+  grants ClearPath no power over them. **Signed management actions are in scope for
+  this spec from the start** (clarified 2026-06-24) — not deferred to a later phase —
+  alongside read-only tracking.
 - **Reuse of platform infrastructure**: Integrates with the existing
   `MembershipManager` (authorization) and `SanctionsGuard` (screening) and reuses the
   per-network **USDC** as the native treasury asset, `UUPSManaged`,

--- a/specs/030-clearpath-standard-daos/spec.md
+++ b/specs/030-clearpath-standard-daos/spec.md
@@ -1,0 +1,521 @@
+# Feature Specification: ClearPath Standard DAOs & External DAO Connectors
+
+**Feature Branch**: `feat/clearpath-standard-daos-030`
+
+**Created**: 2026-06-24
+
+**Status**: Draft
+
+**Input**: User description: "ClearPath Standard DAOs — the foundation of the ClearPath module, shipped before the futarchy spec (029). Two pillars: (A) members launch native standard (traditional-governance) DAOs — token- or NFT-membership voting, a USDC treasury, propose→vote→timelock→execute, roles/ownership — using OpenZeppelin Governor + Timelock; (B) members register, track, and manage DAOs deployed by other platforms, with an Olympia DAO connector first (OZ Governor on Ethereum Classic), designed against the standard IGovernor interface so it generalizes. Embedded as its own My Account (Account Center) tab, wired into membership, notifications, and sanctions, on new UUPS contracts (OZ 5.4.0) for Mordor + Amoy. No futarchy in this spec."
+
+## Overview
+
+ClearPath is the platform's DAO governance module, embedded as its own tab in the
+My Account (Account Center) pages. This spec delivers the **standard
+(traditional-governance) DAO foundation** and the ability to **connect to DAOs from
+other platforms** — so members get a working DAO home immediately. The advanced
+**futarchy** governance mode (LMSR conditional markets + welfare-metric resolution)
+is a follow-on (spec 029) layered on top of this foundation.
+
+Two pillars:
+
+- **Native standard DAOs** — a member launches a traditional-governance DAO with
+  voting weight from a governance **token** or a **membership NFT**, a **USDC
+  treasury**, and a standard proposal lifecycle (propose → vote → timelock/queue →
+  execute), plus scoped roles, parameter configuration, and ownership
+  transfer/renounce. ClearPath uses **standard, audited governance (OpenZeppelin
+  Governor + TimelockController)** rather than a bespoke scheme.
+- **External DAO registry + connectors** — a member registers an existing DAO
+  deployed elsewhere by its address, ClearPath validates it is a recognized
+  governance contract, and then **tracks** its real treasury, proposals, vote
+  tallies, and membership, and lets the member take **native governance actions**
+  (propose / vote / queue / execute) where the external DAO's own rules authorize
+  their wallet. The first connector targets **Olympia DAO** on Ethereum Classic (an
+  OpenZeppelin Governor + soulbound-NFT-membership treasury DAO); because it is
+  built against the standard **IGovernor** interface, it generalizes to any
+  Governor-based DAO. ClearPath takes **no custody or authority** over external
+  DAOs — it is a registry, dashboard, and action-router.
+
+Because ClearPath's own standard DAOs are themselves OZ Governor, **the same
+governance UI serves both native and external DAOs**, and they appear together in
+the member's "My DAOs" list, clearly labeled by type/framework and network-scoped.
+
+Like Token Mint (spec 028), ClearPath lives as **its own tab in the My Account
+(Account Center)** pages, is gated by **MembershipManager** tiers, surfaces every
+action through the **app-level notification system**, enforces **SanctionsGuard**
+non-bypassably on value-moving actions, is **theme-aware** (light/dark) and
+accessible, runs entirely within the platform's **no-backend** footprint, and shows
+**real on-chain state only** — never mock data.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Launch a standard DAO (Priority: P1)
+
+An authorized member creates a native standard DAO, choosing its name, purpose,
+voting-weight source (a governance token or a membership NFT), a USDC treasury, and
+governance parameters (voting delay/period, quorum, timelock). The transaction is
+submitted on-chain and, once confirmed, the DAO appears in the member's "My DAOs"
+list with its real deployed governor + treasury.
+
+**Why this priority**: The smallest end-to-end slice that proves the full create →
+deploy → list → govern loop against real on-chain state, and the foundation the
+proposal lifecycle (US4) and futarchy (spec 029) build on. The MVP.
+
+**Independent Test**: Connect an authorized wallet, create a token-voted standard
+DAO, confirm the transaction, and verify the deployed governor + timelock + treasury
+exist on-chain and appear in My DAOs — no mock data anywhere.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authorized member, **When** they submit a valid DAO creation (name,
+   purpose, voting source, treasury, params), **Then** a governor + timelock + USDC
+   treasury are deployed on-chain and the confirmed DAO address is shown.
+2. **Given** a creation form, **When** the member picks token-weighted vs
+   NFT-membership voting, **Then** the deployed DAO uses exactly that voting source.
+3. **Given** a pending creation, **When** it is unconfirmed, **Then** the UI shows
+   it pending and does not present the DAO as finalized until the chain confirms.
+4. **Given** a wallet below the required membership tier or a sanctioned wallet,
+   **When** it attempts to create a DAO, **Then** the action is blocked with a
+   surfaced reason (before signing and on-chain).
+
+---
+
+### User Story 2 - Discover, inspect & join DAOs (Priority: P1)
+
+From the My Account → **ClearPath** tab, a member browses DAOs on the active
+network (native + external, clearly labeled), opens a DAO's detail view (purpose,
+treasury, proposals, members, roles), and joins or follows a DAO they are eligible
+for.
+
+**Why this priority**: Establishes the Account Center module home and makes launched
+and registered DAOs visible/usable; paired with US1/US3 it yields the complete
+"create or add a DAO, find it, engage" loop.
+
+**Independent Test**: After a DAO is created/registered, open the ClearPath tab,
+find it in the explorer, open its detail view and confirm the displayed
+treasury/members/proposals match real on-chain values, then join/follow it.
+
+**Acceptance Scenarios**:
+
+1. **Given** DAOs exist on the active network, **When** a member opens the ClearPath
+   explorer, **Then** each DAO shows name, type/framework (native vs external),
+   member/holder count, treasury balance, and active-proposal count from chain/index.
+2. **Given** a DAO detail view, **When** a member opens it, **Then** treasury,
+   members, proposals, and roles are shown truthfully from chain.
+3. **Given** an eligible member, **When** they join/follow a DAO, **Then** it appears
+   in their "My DAOs" list (native + external unified, labeled).
+4. **Given** the active network, **When** DAOs are listed, **Then** only that
+   network's DAOs appear and data never leaks across networks; on a network without
+   ClearPath deployed, the feature is disabled with a truthful message.
+
+---
+
+### User Story 3 - Register & track an external DAO (Priority: P1)
+
+A member registers an existing DAO deployed by another platform (e.g. **Olympia
+DAO**) by its address; ClearPath validates it is a recognized governance contract,
+adds it to the registry with an optional label, and tracks its real treasury,
+proposals + vote tallies + states, and membership — read-only.
+
+**Why this priority**: The user emphasized that adding and tracking DAOs from other
+platforms is important; this is independently valuable (a multi-DAO dashboard) even
+before native creation, and it shares the unified My DAOs surface with US1/US2.
+
+**Independent Test**: Register a real external DAO (Olympia on Mordor) by address,
+confirm it is validated and added, and confirm its treasury balance, proposals, and
+membership shown match the external DAO's real on-chain state — with a truthful
+"unavailable" state if the data source is unreachable, never fabricated rows.
+
+**Acceptance Scenarios**:
+
+1. **Given** the address of a recognized external governance contract, **When** a
+   member registers it, **Then** it is validated, added to the network-scoped
+   registry with its framework/type and label, and appears in My DAOs / Explorer.
+2. **Given** an address that is not a recognized governance contract, **When** a
+   member tries to register it, **Then** registration is rejected with a truthful
+   reason and nothing is added.
+3. **Given** a registered external DAO, **When** its detail view is opened, **Then**
+   its treasury, proposals + vote tallies + states, and membership are shown
+   truthfully from the external DAO's on-chain state/index.
+4. **Given** a network without indexing for the external DAO, **When** its data is
+   requested, **Then** ClearPath falls back to on-chain reads or shows a truthful
+   "unavailable on this network" state — never fabricated data.
+
+---
+
+### User Story 4 - Run a proposal on a native DAO (Priority: P2)
+
+A member of a native standard DAO submits a proposal (a USDC treasury action or a
+parameter change), other members vote during the voting period, and after the
+timelock the passed proposal is queued and executed.
+
+**Why this priority**: Proposals are the unit of governance; this completes the
+native standard-DAO lifecycle on top of US1, and is the standard counterpart the
+futarchy spec later swaps the decision mechanism into.
+
+**Independent Test**: Submit a treasury-funding proposal, cast enough votes to reach
+quorum and succeed, advance past the timelock, queue and execute it, and confirm the
+recipient is funded on-chain; separately, a defeated proposal performs no action.
+
+**Acceptance Scenarios**:
+
+1. **Given** an eligible member, **When** they submit a valid proposal, **Then** it
+   is recorded with a voting schedule and its state progresses (pending → active).
+2. **Given** an active proposal, **When** members cast votes, **Then** tallies
+   update on-chain and the proposal succeeds iff quorum + majority are met.
+3. **Given** a succeeded proposal, **When** the timelock elapses and it is queued
+   and executed, **Then** the treasury action executes on-chain (recipient funded /
+   parameter changed) exactly once.
+4. **Given** a defeated or expired proposal, **When** execution is attempted, **Then**
+   it is rejected and no treasury action occurs.
+
+---
+
+### User Story 5 - Manage an external DAO (Priority: P2)
+
+For a registered external DAO, where the connected wallet is authorized by the
+external DAO's own rules, the member takes native governance actions — create a
+proposal, cast a vote, queue, execute — constructed by the connector and signed by
+the member; ClearPath holds no authority of its own.
+
+**Why this priority**: "Connect with and manage" the external DAO is the second half
+of the external-DAO ask; it depends on registration/tracking (US3) and reuses the
+same IGovernor surface as native DAOs (US4).
+
+**Independent Test**: On a registered Olympia DAO, as a wallet holding its
+membership NFT, cast a vote on an open proposal through ClearPath and confirm the
+vote is recorded on the external DAO; as a wallet without authority, confirm the
+action is rejected by the external DAO's own rules.
+
+**Acceptance Scenarios**:
+
+1. **Given** a registered external DAO and an authorized wallet, **When** the member
+   casts a vote / creates a proposal / queues / executes through ClearPath, **Then**
+   the action is executed on the external DAO's own contract, signed by the member.
+2. **Given** a wallet not authorized by the external DAO's rules, **When** it
+   attempts such an action, **Then** the external DAO rejects it and the reason is
+   surfaced.
+3. **Given** an external action that moves value through a ClearPath-mediated path,
+   **When** the actor or recipient is sanctioned, **Then** sanctions screening blocks
+   it.
+4. **Given** a framework ClearPath has no connector for, **When** management is
+   requested, **Then** ClearPath tracks read-only and offers a truthful deep-link to
+   the external app rather than a broken action.
+
+---
+
+### User Story 6 - Administer a DAO: roles, parameters & ownership (Priority: P2)
+
+A native-DAO administrator grants/revokes scoped roles (e.g. proposer, treasurer,
+canceller), configures governance parameters, and transfers or renounces
+administrative ownership.
+
+**Why this priority**: Delegated least-privilege administration and safe hand-off
+are required for real organizations operating a DAO.
+
+**Independent Test**: Grant the proposer role to a second wallet and confirm only it
+(and admins) can propose; revoke it and confirm proposing is blocked; transfer
+ownership and confirm the prior admin loses authority.
+
+**Acceptance Scenarios**:
+
+1. **Given** a DAO, **When** an admin grants a role, **Then** that address can
+   perform exactly the actions the role authorizes and nothing more (on-chain).
+2. **Given** a role holder, **When** an admin revokes the role, **Then** the address
+   can no longer perform that action.
+3. **Given** governance parameters, **When** an admin updates them (within the rules),
+   **Then** subsequent proposals use the updated parameters.
+4. **Given** ownership transfer/renounce, **When** an admin assigns a new owner or
+   renounces, **Then** authority moves accordingly (renounce irreversible, behind a
+   clear warning) and unauthorized callers are rejected on-chain.
+
+---
+
+### User Story 7 - Review activity & event history (Priority: P3)
+
+Any user reviewing a DAO (native or external) sees its on-chain governance history —
+DAO created/registered, member joined, proposal created, votes, queued, executed —
+with type, actor, transaction, and time, filterable by category.
+
+**Why this priority**: An auditable governance trail builds trust but is read-only
+and depends on event indexing.
+
+**Independent Test**: Create and execute a proposal, then open the activity history
+and confirm both events appear with the correct actor, transaction, and time, and
+that category filters narrow the list.
+
+**Acceptance Scenarios**:
+
+1. **Given** a DAO with on-chain actions, **When** the activity view is opened,
+   **Then** each event shows type, detail, actor, transaction, and time from indexed
+   on-chain data.
+2. **Given** the activity view, **When** the user filters by category, **Then** only
+   matching events are shown.
+3. **Given** a network without indexing, **When** the activity view is opened, **Then**
+   it falls back to on-chain reads or is disabled with a truthful message — never
+   fabricated events.
+
+---
+
+### User Story 8 - Inspect the contract surface (Priority: P3)
+
+Any user can view a DAO's contract surface: its governor/treasury/voting-token
+addresses, framework/type, per-network deployment, and (for native DAOs) metadata;
+and can copy addresses or the governor ABI, with explorer deep links.
+
+**Why this priority**: Transparency about the underlying contracts supports trust and
+integration, and is read-only.
+
+**Independent Test**: Open a DAO's contract view and confirm the displayed
+governor/treasury addresses and framework match the real deployment/registry and
+explorer; copy an address/ABI and confirm correctness.
+
+**Acceptance Scenarios**:
+
+1. **Given** a native or external DAO, **When** the contract view is opened, **Then**
+   its governor/treasury/token addresses, framework, and explorer links reflect the
+   real on-chain/registry state.
+2. **Given** the contract view, **When** the user copies an address or ABI, **Then**
+   the copied value matches the deployed contract.
+3. **Given** an external DAO, **When** the view is shown, **Then** it is clearly
+   labeled as externally deployed (ClearPath holds no authority over it).
+
+---
+
+### Edge Cases
+
+- **Invalid DAO/proposal metadata**: empty name/purpose, invalid voting source,
+  a funding amount exceeding the treasury, or an invalid recipient are rejected
+  before submission.
+- **Invalid external address**: registering an EOA, a non-governance contract, or a
+  contract on the wrong network is rejected with a truthful reason; nothing is added.
+- **Transaction failure / rejection**: a reverted or user-rejected create, register,
+  propose, vote, queue, or execute leaves no phantom DAO/proposal in any list.
+- **Membership revoked mid-session**: a member whose tier drops below the requirement
+  can no longer create/register, reflected on next action.
+- **Sanctioned actors**: a sanctioned wallet cannot create a DAO, fund a treasury,
+  execute a disbursement, or be a disbursement recipient, in every ClearPath-mediated
+  flow.
+- **External DAO not authorizing the wallet**: a management action the external DAO's
+  rules forbid is rejected by the external DAO; ClearPath surfaces the reason and
+  does not imply success.
+- **Unsupported external framework**: ClearPath tracks read-only and deep-links to
+  the external app rather than offering a broken action.
+- **Treasury underfunded for an executed action**: execution that would exceed the
+  treasury balance is rejected; an executed proposal cannot overdraw the vault.
+- **Network without support / subgraph-less**: the feature self-disables truthfully,
+  and tracking falls back to on-chain reads or a truthful "unavailable" state — never
+  fabricated rows.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Native standard DAOs (US1/US4)**
+
+- **FR-001**: The system MUST allow an authorized member to create a native standard
+  DAO specifying at least name, purpose, voting-weight source (governance token or
+  membership NFT), a USDC treasury, and governance parameters (voting delay, voting
+  period, quorum, timelock delay), deploying the governance + treasury contracts
+  on-chain.
+- **FR-002**: A native DAO MUST support a standard proposal lifecycle — submit a
+  proposal (a USDC treasury action or a parameter change), vote during the voting
+  period, and (after the timelock) queue and execute a passed proposal — with vote
+  tallies and proposal state read truthfully from chain.
+- **FR-003**: A native DAO's treasury MUST be disbursable only by an executed
+  proposal, MUST reject an action that would overdraw it, and MUST execute a passed
+  proposal's action **exactly once**.
+- **FR-004**: DAO and proposal creation MUST execute as real on-chain transactions
+  and MUST NOT present a DAO/proposal as finalized before the chain confirms it. No
+  mock-only flow may ship in production paths.
+
+**External DAO registry & connectors (US3/US5)**
+
+- **FR-005**: The system MUST allow a member to register an existing external DAO by
+  (network, address, framework/type) with an optional label, MUST validate that the
+  address is a recognized governance contract (e.g. responds to the standard
+  IGovernor interface) before adding, and MUST reject unrecognized/invalid addresses.
+- **FR-006**: The system MUST track a registered external DAO **read-only** — its
+  treasury balance, proposals + vote tallies + proposal states, and membership —
+  sourced from the external DAO's on-chain state/indexing, strictly network-scoped
+  and truthful.
+- **FR-007**: Where the connected wallet is authorized by the external DAO's **own**
+  rules, the system MUST allow native governance actions (create proposal, cast
+  vote, queue, execute) constructed through a per-framework connector and signed by
+  the member; the system MUST take no custody or authority of its own over external
+  DAOs and MUST surface the external DAO's rejection reason when an action is not
+  authorized.
+- **FR-008**: The system MUST ship an **Olympia** connector first, designed against
+  the standard IGovernor interface so it generalizes to other Governor-based DAOs;
+  for frameworks without a connector, the system MUST track read-only and offer a
+  truthful deep-link rather than a broken action.
+
+**Unified discovery & administration (US2/US6/US7/US8)**
+
+- **FR-009**: The system MUST present native and external DAOs together in a member's
+  DAO list and an active-network explorer, each clearly labeled by type/framework and
+  network-scoped, and MUST let an eligible member join/follow a DAO.
+- **FR-010**: A native DAO MUST be administered through scoped, least-privilege roles
+  (e.g. proposer, treasurer, canceller, admin); the system MUST allow an admin to
+  grant/revoke roles and configure governance parameters, with every role-gated
+  action enforced on-chain, and MUST allow ownership transfer and irreversible
+  renounce (behind a clear warning).
+- **FR-011**: The system MUST present a per-DAO activity/event history (type, detail,
+  actor, transaction, time) with category filtering, and a contract surface
+  (governor/treasury/token addresses, framework, per-network deployment, explorer
+  links, copy address/ABI), sourced from real on-chain/indexed/registry state.
+
+**Platform integration & cross-cutting (parity with spec 028)**
+
+- **FR-012**: ClearPath MUST be presented as **its own section/tab within the My
+  Account (Account Center)** pages — not a standalone sub-app and not a top-level app
+  navigation tab — consistent with the Token Mint module (spec 028). This spec
+  establishes the ClearPath module home.
+- **FR-013**: Authorization MUST integrate with the platform's **existing
+  membership/access-control system** (MembershipManager tiers/roles) to gate creating
+  a native DAO, registering an external DAO, and privileged actions — not a parallel
+  permission system.
+- **FR-014**: Every user-initiated action (create DAO, register external DAO, join,
+  propose, vote, queue, execute, role grant/revoke, ownership transfer) MUST surface
+  through the **app-level notification system** with honest submitted/confirmed/failed
+  state; passive background data loads MUST use accessible inline status/alerts rather
+  than toasts.
+- **FR-015**: The platform's **sanctions screening** MUST be enforced non-bypassably
+  and fail-closed on every ClearPath-mediated value-moving action (create a DAO, fund
+  a treasury, execute a disbursement) and on disbursement recipients, using the same
+  sanctions system as the rest of the platform; read-only tracking of external DAOs
+  is not gated.
+- **FR-016**: ClearPath data MUST be **scoped to the active network** and MUST NOT
+  leak across networks; on networks where the feature is not deployed it MUST be
+  disabled with a truthful explanation.
+- **FR-017**: The feature MUST surface honest transaction state and MUST NOT leave
+  phantom DAOs, proposals, or registry entries in any list when a transaction does
+  not confirm.
+- **FR-018**: The contracts that hold authority/state over the ClearPath system
+  (factory, registry, native governance/treasury) MUST follow the project's
+  **upgradeable-contract pattern** where they hold state or authority, preserving
+  state across logic upgrades, with append-only storage validated by the
+  storage-layout gate.
+- **FR-019**: The ClearPath UI MUST be **theme-aware** (respecting the app's
+  light/dark theme variables) and MUST meet WCAG 2.1 AA, following the token module's
+  theming approach.
+- **FR-020**: The feature MUST operate within the platform's **no-backend footprint**
+  (no app server added); DAO/proposal/member/activity enumeration (native and
+  external) MUST use subgraph indexing with an on-chain RPC fallback or a **truthful
+  disable** on subgraph-less networks (Mordor/ETC) — it MUST NOT display fabricated
+  DAOs, proposals, members, or events.
+
+### Key Entities *(include if feature involves data)*
+
+- **Standard DAO (native)**: A traditional-governance DAO created through the
+  feature. Attributes: name, purpose, voting source (governance token or membership
+  NFT), governor + timelock + treasury addresses, governance parameters, network,
+  creator/admins.
+- **Voting Source**: A governance token (token-weighted) or a membership NFT
+  (membership-weighted) that determines voting power for a native DAO.
+- **Treasury / Vault**: A native DAO's USDC funds, disbursable only by an executed
+  proposal.
+- **Proposal**: A funded action (treasury action = amount + recipient, or a
+  parameter change) with a standard state lifecycle (pending → active →
+  succeeded/defeated → queued → executed/expired) and a voting schedule.
+- **Vote**: A member's cast vote on a proposal, weighted by the voting source.
+- **Administrative Role**: A scoped authority over a native DAO (e.g. proposer,
+  treasurer, canceller, admin), least-privilege, tracked with grant time.
+- **External DAO**: A registry entry for a DAO deployed by another platform —
+  network, address, framework/type, label, and discovered governor/treasury/token
+  references; tracked read-only, managed via the user's own authority.
+- **DAO Connector / Adapter**: A per-framework read+act interface (Olympia / OZ
+  Governor first) ClearPath uses to read an external DAO's state and construct native
+  actions for the user to sign.
+- **DAO Registry / List**: The per-network record of native DAOs created and external
+  DAOs registered through the feature, used for discovery and a member's DAO list.
+- **Governance Activity Event**: An indexed on-chain event (created/registered,
+  joined, proposed, voted, queued, executed) powering the activity history.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An authorized member can create a native standard DAO and see it
+  confirmed with its real on-chain governor + treasury, end-to-end, in under 3
+  minutes on a supported network.
+- **SC-002**: 100% of DAOs/proposals/registry entries shown as created/registered in
+  the UI correspond to confirmed on-chain state — zero phantom or mock entries appear.
+- **SC-003**: A member can register a real external DAO (e.g. Olympia on Mordor) and
+  see its actual treasury, proposals, and membership from chain in 100% of supported
+  cases; an unrecognized address is rejected, and an unreadable data source yields a
+  truthful "unavailable" state — never fabricated rows.
+- **SC-004**: Treasury safety holds for native DAOs: only an executed proposal
+  disburses funds, the treasury can never overdraw, and a passed proposal executes
+  exactly once — verified by tests.
+- **SC-005**: No sanctioned address can create a DAO, fund a treasury, execute a
+  disbursement, or be a disbursement recipient, in any ClearPath-mediated flow.
+- **SC-006**: Authorization holds: only members with the required tier/role can
+  create/register/administer, and unauthorized callers are rejected on-chain (not only
+  in the UI), verified for both authorized and unauthorized paths.
+- **SC-007**: An external management action taken through ClearPath succeeds only when
+  the external DAO's own rules authorize the wallet, is signed by the member, and
+  leaves ClearPath with no authority over the external DAO — verified against a real
+  Governor DAO.
+- **SC-008**: ClearPath data never crosses network boundaries: switching networks
+  shows only that network's DAOs in 100% of cases, and unsupported networks disable
+  the feature with a clear message.
+- **SC-009**: Every user-initiated ClearPath action is a real on-chain transaction
+  with honest pending/confirmed/failed state surfaced through the app notification
+  system — verified by tests covering success and failure paths.
+- **SC-010**: DAO/proposal/member/activity data shown matches real on-chain/indexed
+  state (no fabricated rows); on networks without indexing the affected view falls
+  back to on-chain reads or disables truthfully in 100% of cases.
+- **SC-011**: The ClearPath UI renders correctly in light and dark themes and passes
+  automated accessibility (axe) checks with no violations.
+- **SC-012**: The full automated test suite (contract unit + integration +
+  upgrade-lifecycle, subgraph Matchstick, frontend Vitest incl. axe) passes in CI,
+  and security static analysis/fuzzing report no new high/critical findings.
+
+## Assumptions
+
+- **Governance basis**: Native standard DAOs use **OpenZeppelin Governor +
+  TimelockController** with OZ Votes-based voting power — a governance token
+  (`ERC20Votes`, which may reuse the spec-028 token factory) or a membership NFT
+  (`ERC721Votes`/soulbound), selectable at creation. The default presented option is
+  membership-NFT (1 member = 1 vote), mirroring Olympia; token-weighted is the
+  alternative. OZ Governor on OZ 5.4.0 / EVM `paris` (ETC/Mordor-compatible) is
+  assumed deployable — to be confirmed in planning (OZ ≥ 5.5 needs Cancun `mcopy`).
+- **External connector**: The Olympia connector targets the standard OZ **IGovernor**
+  interface (`propose`, `castVote`, `state`, `proposalVotes`, `queue`, `execute`) plus
+  reading the treasury balance and membership token, so it generalizes to any
+  Governor-based DAO. Olympia is OZ Governor v5.1.0 (soulbound NFT = 1 vote) +
+  TimelockController + OlympiaTreasury + OlympiaExecutor + SanctionsOracle, deployed on
+  ETC mainnet + Mordor (demo_v0.2; github.com/olympiadao). Additional frameworks
+  (Aragon/Moloch/Safe) are later connectors.
+- **No authority over external DAOs**: "Manage" means ClearPath constructs native
+  governance actions the member **signs** with their own wallet, gated by the external
+  DAO's own access control; ClearPath holds no keys, roles, or custody, and offers a
+  deep-link to the external app as a fallback. A lightweight on-chain registry records
+  registered external DAOs (network-scoped, for shared discovery + indexing) but
+  grants ClearPath no power over them.
+- **Reuse of platform infrastructure**: Integrates with the existing
+  `MembershipManager` (authorization) and `SanctionsGuard` (screening) and reuses the
+  per-network **USDC** as the native treasury asset, `UUPSManaged`,
+  `lib/upgradeable.js`, `check:storage-layout`, `sync:frontend-contracts`, the
+  subgraph data-source-template pattern, and the app notification/theme systems.
+- **On-chain stack & networks**: New upgradeable contracts target OpenZeppelin 5.4.0
+  / Solidity ^0.8.24 / EVM `paris`, inherit `UUPSManaged`, use a one-time
+  `initialize`, keep storage append-only with a trailing gap (storage-layout gated),
+  and deploy to **Mordor (63) + Amoy (80002)** first (Polygon later).
+- **Account Center placement**: ClearPath is embedded as a tab in the My Account
+  (Account Center) pages exactly like the spec-028 Tokens tab — not a standalone app
+  and not a top-level nav item; the old dual-app architecture is not revived.
+- **Archived designs are reference only**: `contracts-archive/core/DAOFactory.sol` and
+  `docs/archived/` inform the design but are **not** imported or deployed; new active
+  contracts are written against current standards. `docs/system-overview/
+  governance.md` (which currently states "no DAO") is updated to reflect ClearPath as
+  an opt-in module.
+- **Sequencing**: This standard-DAO foundation ships first; the **futarchy** governance
+  mode (spec 029 — LMSR conditional markets + welfare-metric resolution) is the
+  follow-on layered on top. Native standard DAOs being OZ Governor means the same
+  governance UI serves native and external DAOs.
+- **Indexing dependency**: Discovery, proposal/member lists, and activity history
+  depend on subgraph indexing; on subgraph-less networks (Mordor/ETC) they fall back
+  to on-chain reads where feasible or disable truthfully — never fabricated
+  (Constitution III).

--- a/specs/030-clearpath-standard-daos/spec.md
+++ b/specs/030-clearpath-standard-daos/spec.md
@@ -55,9 +55,18 @@ accessible, runs entirely within the platform's **no-backend** footprint, and sh
 - Q: How are registered external DAOs stored / discovered? → A: A lightweight **on-chain, network-scoped `ExternalDAORegistry`** records `(address, framework, label)` for shared discovery + subgraph indexing (fits the no-backend footprint); ClearPath still holds **no authority** over the external DAO.
 - Q: What's in the first external-DAO deliverable — track-only or also management? → A: **Include signed native management actions** (create proposal / vote / queue / execute via the connector, user-signed) **from the start**, alongside read-only tracking — not deferred to a later phase.
 
+### Session 2026-06-24 (expansion — as-built alignment)
+
+- External-first sequencing: OpenZeppelin 5.4.0 `GovernorUpgradeable` transitively uses the Cancun `mcopy` opcode (via `SignatureChecker` → `Bytes.sol`), so **native OZ-Governor DAOs cannot compile/deploy on pre-Cancun ETC/Mordor**. Per the user's decision, the **external-DAO connector ships first** (Mordor + Amoy); **native ClearPath DAOs (US1, US4, US6) are DEFERRED** pending a governance-base choice (OZ Governor on Cancun chains / a custom paris-safe governor / vendor OZ 5.1). The external connector is unaffected — the on-chain `ExternalDAORegistry` imports only the `IGovernor` *interface*, so it is paris-safe; reads/actions go through the `IGovernor` ABI.
+- Subgraph-less networks get **limited live on-chain indexing** (a bounded, chunked `eth_getLogs` scan of `ProposalCreated`, enriched with live `state()`/`proposalVotes()`) — the concrete realization of the truthful-fallback requirement, with truthful empty / partial / error states (never fabricated).
+- Treasury tracking surfaces the Governor's **timelock AND known extra vaults** (e.g. the real OlympiaTreasury on Mordor) with **native + per-network USDC** balances.
+- The proposal builder is a **rich, no-calldata-required** composer (named action types, multiple actions, asset-aware amounts, encoded-call preview, pre-sign guards) over the existing `IGovernor.propose()` — **no new contract**.
+
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1 - Launch a standard DAO (Priority: P1)
+### User Story 1 - Launch a standard DAO (Priority: P1) — ⏸️ DEFERRED (native)
+
+> **Deferred (2026-06-24):** native OZ-Governor DAOs can't run on pre-Cancun ETC/Mordor (the `mcopy` blocker). Implement after the external-DAO pillar, once the governance base is chosen. Requirements retained below unchanged.
 
 An authorized member creates a native standard DAO, choosing its name, purpose,
 voting-weight source (a governance token or a membership NFT), a USDC treasury, and
@@ -151,7 +160,7 @@ membership shown match the external DAO's real on-chain state — with a truthfu
 
 ---
 
-### User Story 4 - Run a proposal on a native DAO (Priority: P2)
+### User Story 4 - Run a proposal on a native DAO (Priority: P2) — ⏸️ DEFERRED (native)
 
 A member of a native standard DAO submits a proposal (a USDC treasury action or a
 parameter change), other members vote during the voting period, and after the
@@ -210,9 +219,32 @@ action is rejected by the external DAO's own rules.
    requested, **Then** ClearPath tracks read-only and offers a truthful deep-link to
    the external app rather than a broken action.
 
+**Rich proposal builder (expanded)** — the create-proposal surface MUST let a member
+compose a proposal without hand-writing calldata:
+
+5. **Given** the proposal builder, **When** a member adds a "Send native" or "Send
+   USDC/ERC-20" action with a recipient and a human amount, **Then** the system
+   encodes the correct on-chain call (native: value + empty calldata; token: a
+   `transfer` call with `value` 0 and the amount scaled by the token's decimals) — the
+   member never types hex.
+6. **Given** the builder, **When** a member adds multiple actions, **Then** they are
+   submitted as one proposal with parallel `targets`/`values`/`calldatas` arrays of
+   equal length, and the builder shows a live preview of each encoded call plus the
+   exact `targets`/`values`/`calldatas`/`description` (and `descriptionHash`) that will
+   be submitted.
+7. **Given** an action that would send more than the treasury holds, **When** the
+   member reviews it, **Then** a **non-blocking** warning is shown (the proposal can
+   still be created; execution would revert if unfunded) — it does not fake success.
+8. **Given** invalid input (bad address, unparseable amount, malformed custom
+   calldata, empty title/description, or zero actions), **When** the member tries to
+   submit, **Then** submit is blocked with a truthful field-level reason.
+9. **Given** the connected wallet is not authorized by the DAO's own rules (e.g. below
+   the proposer threshold), **When** the member submits, **Then** the DAO's revert
+   reason is surfaced — ClearPath does not imply success.
+
 ---
 
-### User Story 6 - Administer a DAO: roles, parameters & ownership (Priority: P2)
+### User Story 6 - Administer a DAO: roles, parameters & ownership (Priority: P2) — ⏸️ DEFERRED (native)
 
 A native-DAO administrator grants/revokes scoped roles (e.g. proposer, treasurer,
 canceller), configures governance parameters, and transfers or renounces
@@ -314,6 +346,16 @@ explorer; copy an address/ABI and confirm correctness.
 - **Network without support / subgraph-less**: the feature self-disables truthfully,
   and tracking falls back to on-chain reads or a truthful "unavailable" state — never
   fabricated rows.
+- **Duplicate proposal**: composing an action set + description identical to an
+  existing proposal yields the same proposal id; the builder detects this and warns
+  ("this exact proposal already exists") instead of paying gas for a guaranteed revert.
+- **ERC-20 transfer with a native value**: the builder forces `value` = 0 for token
+  transfers so native coin is never stranded in the executor.
+- **Description edited after submit**: changing the description string changes its hash
+  and thus the proposal id; the stored exact string is reused for queue/execute so the
+  ids line up (a near-identical description is a *different* proposal).
+- **Proposer below threshold / votes not yet snapshotted**: surfaced pre-sign where the
+  threshold is readable; otherwise the DAO's own revert reason is surfaced.
 
 ## Requirements *(mandatory)*
 
@@ -416,6 +458,38 @@ explorer; copy an address/ABI and confirm correctness.
   disable** on subgraph-less networks (Mordor/ETC) — it MUST NOT display fabricated
   DAOs, proposals, members, or events.
 
+**Live indexing, treasury & proposal builder (expansion)**
+
+- **FR-021**: On subgraph-less networks the system MUST provide **limited live
+  on-chain indexing** of a Governor's proposals — a bounded, chunked scan of
+  `ProposalCreated` events enriched with live proposal `state` and vote tallies — and
+  MUST present truthful empty / partial (RPC-limited) / error states; it MUST NOT
+  fabricate proposals.
+- **FR-022**: The system MUST present a tracked DAO's treasury holdings across its
+  Governor **timelock and any known extra vault** (e.g. OlympiaTreasury), showing
+  **native and per-network USDC** balances read from chain.
+- **FR-023**: The proposal builder MUST let a member compose a Governor proposal
+  **without hand-writing calldata**: named action types (send native, send a
+  USDC/ERC-20 token by address, and a custom-call escape hatch), **multiple actions in
+  one proposal**, **asset-aware human amounts** (scaled by the token's decimals), and a
+  **live preview** of each encoded call plus the exact `targets`/`values`/`calldatas`/
+  `description`/`descriptionHash` that will be submitted.
+- **FR-024**: The builder MUST apply **field-level validation** (valid addresses,
+  parseable amounts, well-formed custom calldata, non-empty description, at least one
+  action) and **pre-sign guards**: a **non-blocking** warning when an action exceeds
+  the treasury's balance (the proposal may still be created; execution would revert),
+  and surfacing the DAO's **own authorization/threshold revert** rather than implying
+  success.
+- **FR-025**: The system MUST preserve Governor proposal **correctness invariants**:
+  the **exact description string** is reused byte-for-byte across propose → queue →
+  execute (so `descriptionHash` matches and the proposal id resolves); ERC-20 transfer
+  actions carry **`value` = 0** (the amount is in calldata; the executing
+  timelock/treasury holds the funds, not the proposer); `targets`/`values`/`calldatas`
+  arrays are equal length and non-empty; and a **duplicate proposal** (identical
+  targets/values/calldatas/descriptionHash) is detected and surfaced truthfully
+  ("this exact proposal already exists") rather than reverting blindly. Proposal
+  building is pure client-side ABI encoding (paris-safe; no Cancun dependency).
+
 ### Key Entities *(include if feature involves data)*
 
 - **Standard DAO (native)**: A traditional-governance DAO created through the
@@ -482,6 +556,13 @@ explorer; copy an address/ABI and confirm correctness.
 - **SC-012**: The full automated test suite (contract unit + integration +
   upgrade-lifecycle, subgraph Matchstick, frontend Vitest incl. axe) passes in CI,
   and security static analysis/fuzzing report no new high/critical findings.
+- **SC-013**: A member can compose a multi-action Governor proposal (e.g. send native +
+  send USDC) entirely through the builder **without writing any calldata**, and the
+  encoded `targets`/`values`/`calldatas` exactly match the chosen actions (token amounts
+  scaled by the correct decimals; ERC-20 `value` = 0) — verified by tests.
+- **SC-014**: On a subgraph-less network, the live indexer shows a DAO's real proposals
+  (with live state + tallies) or a truthful empty/partial/error state — never fabricated
+  rows — verified against a real Governor DAO.
 
 ## Assumptions
 
@@ -532,3 +613,16 @@ explorer; copy an address/ABI and confirm correctness.
   depend on subgraph indexing; on subgraph-less networks (Mordor/ETC) they fall back
   to on-chain reads where feasible or disable truthfully — never fabricated
   (Constitution III).
+- **External-first sequencing (clarified 2026-06-24)**: native OZ-Governor DAOs are
+  blocked on pre-Cancun ETC/Mordor by the OZ-5.4.0 `mcopy` dependency, so US1/US4/US6
+  are **deferred**; the external-DAO pillar (US2/US3/US5) ships first on Mordor + Amoy.
+  Revisit native DAOs with one of: OZ Governor on Cancun chains, a custom paris-safe
+  governor, or a vendored OZ 5.1 Governor.
+- **Live indexing**: the subgraph-less proposal fallback is a **bounded, chunked
+  `eth_getLogs` scan** of `ProposalCreated` enriched with live `state`/`proposalVotes`;
+  it is best-effort (truthful partial/error states) and not a full historical index.
+- **Proposal builder**: it is a **pure client-side ABI-encoding layer** over the
+  existing `IGovernor.propose()` — **no new contract**. It composes named action types
+  (send native / send token / custom) into the parallel arrays; token decimals are read
+  live; the description string is treated as opaque bytes and reused verbatim for
+  queue/execute so the proposal id resolves.

--- a/specs/030-clearpath-standard-daos/tasks.md
+++ b/specs/030-clearpath-standard-daos/tasks.md
@@ -107,7 +107,7 @@ own rules authorize the wallet; ClearPath holds no authority; deep-link fallback
 **Independent test**: On a registered Olympia DAO, as a member-NFT holder, cast a vote through ClearPath (recorded
 on Olympia); an unauthorized wallet is rejected by Olympia's rules.
 
-- [ ] T046 [US5] Extend `ExternalDaoView.jsx` + `governorConnector.js` — user-signed `propose`/`castVote`/`queue`/`execute` against the external DAO; surface the external DAO's rejection reason; deep-link to the external app for unsupported frameworks
+- [X] T046 [US5] Extend `ExternalDaoView.jsx` + `governorConnector.js` — user-signed `propose`/`castVote`/`queue`/`execute` against the external DAO; surface the external DAO's rejection reason; deep-link to the external app for unsupported frameworks
 - [ ] T047 [US5] Sanctions on ClearPath-mediated external value moves (where applicable) + clear "externally deployed, ClearPath holds no authority" labeling (INV-4)
 - [ ] T048 [P] [US5] Integration test `test/integration/clearpath/external-governor.test.js` — deploy a real OZ Governor (stand-in for Olympia), register it, cast a user-signed vote (authorized) and confirm it records on that governor; unauthorized wallet rejected by the governor; ClearPath holds no role on it
 - [ ] T049 [P] [US5] Vitest `__tests__/ExternalDaoView.test.jsx` — management actions via mocked connector (authorized/rejected), deep-link fallback, no implied success

--- a/specs/030-clearpath-standard-daos/tasks.md
+++ b/specs/030-clearpath-standard-daos/tasks.md
@@ -1,0 +1,163 @@
+# Tasks: ClearPath Standard DAOs & External DAO Connectors
+
+**Feature**: spec 030 | **Branch**: `feat/clearpath-standard-daos-030`
+**Spec**: [spec.md](./spec.md) · **Plan**: [plan.md](./plan.md) · **Data model**: [data-model.md](./data-model.md) · **Contracts**: [contracts/](./contracts/)
+
+Tests are REQUIRED (Constitution II): contract unit + integration + upgrade-lifecycle, subgraph Matchstick,
+frontend Vitest incl. axe — covering authorized AND unauthorized paths, treasury-safety invariants INV-1..5,
+and the external connector (read + a user-signed action) against a real Governor DAO. New contracts on
+OpenZeppelin 5.4.0 only (paris-safe); treasury asset = platform USDC per network; ClearPath holds NO authority
+over external DAOs (manage = user-signed actions). `[P]` = parallelizable (different files, no incomplete deps).
+
+Phase ↔ plan mapping: Setup/Foundational → scaffolding · US1 → plan A · US2/US3 → plan B · US4/US5 → plan C ·
+US6 → plan D · US7/US8 → plan E · Polish → plan F.
+
+## Phase 1: Setup
+
+- [ ] T001 Create the contract package skeleton `contracts/clearpath/` with subdirs `governance/`, `voting/`, `external/`, `interfaces/` and a short `contracts/clearpath/README.md` (purpose + "archive is reference-only")
+- [ ] T002 [P] Create the frontend module skeleton `frontend/src/components/clearpath/` (empty `clearpath.css` scoped under `.clearpath`, mapped onto `theme.css` variables) and `frontend/src/abis/` placeholders (`clearPathDAOFactory.js`, `externalDAORegistry.js`, `iGovernor.js`)
+- [ ] T003 [P] Confirm OZ 5.4.0 governance availability + paris-safety: add a compile smoke contract `contracts/clearpath/governance/_GovImports.sol` importing `GovernorUpgradeable`/`TimelockControllerUpgradeable`/`ERC721VotesUpgradeable`/`ERC20VotesUpgradeable`; `npm run compile` green (delete after)
+
+## Phase 2: Foundational (blocking prerequisites)
+
+- [ ] T004 Add `contracts/clearpath/interfaces/IClearPathDAOFactory.sol` and `IExternalDAORegistry.sol` per `contracts/contracts.md` (events, structs, enums: `VotingKind`, `Framework`)
+- [ ] T005 Add `DAO_MEMBER_ROLE = keccak256("DAO_MEMBER_ROLE")` gating helper usage notes; confirm `IMembershipManager.checkCanCreate/getActiveTier/recordCreate` + `ISanctionsGuard.checkBlocked` signatures wired (no new contract; reference `WagerRegistry` pattern)
+- [ ] T006 [P] Extend `scripts/deploy/lib/upgradeable.js` usage in a new `scripts/deploy/deploy-clearpath.js` skeleton (resolve SanctionsGuard + MembershipManager + USDC from `deployments/<net>.json`; no deploy yet)
+- [ ] T007 [P] Add the ClearPath tab scaffold: register `{ id: 'clearpath', label: 'ClearPath' }` in `frontend/src/pages/WalletPage.jsx` `WALLET_TABS` + render a placeholder `<ClearPathPanel/>`; create `frontend/src/components/clearpath/ClearPathPanel.jsx` (self-disables via `useClearPath` when unsupported)
+- [ ] T008 [P] Add `frontend/src/components/clearpath/useClearPath.js` skeleton: per-chain factory/registry resolution via `getContractAddressForChain`, `isSupported`, honest tx-state wrapper, `useNotification` wiring (mirror `useTokenFactory`)
+- [ ] T009 [P] Add subgraph base: append `DAO`, `ExternalDAO`, `Proposal`, `Vote`, `Member`, `GovernanceActivity` entities to `subgraph/schema.graphql` (no datasources yet)
+
+## Phase 3: User Story 1 — Launch a native standard DAO (Priority: P1) 🎯 MVP
+
+**Goal**: An authorized member creates a native OZ-Governor DAO (membership-NFT or token voting) with a USDC
+treasury; it appears in My DAOs with its real on-chain governor + treasury.
+**Independent test**: Create a token-voted DAO, confirm the deployed governor/timelock/treasury exist on-chain
+and appear in My DAOs — no mock data.
+
+- [ ] T010 [P] [US1] `contracts/clearpath/voting/MembershipNFT.sol` — `ERC721VotesUpgradeable` soulbound (transfers blocked except admin mint/burn), beacon-clone-ready, `__gap`
+- [ ] T011 [P] [US1] `contracts/clearpath/governance/DAOTimelock.sol` — `TimelockControllerUpgradeable` wrapper (executor + USDC treasury holder), beacon-clone-ready
+- [ ] T012 [US1] `contracts/clearpath/governance/StandardGovernor.sol` — `GovernorUpgradeable` + `GovernorSettings` + `GovernorCountingSimple` + `GovernorVotes` + `GovernorVotesQuorumFraction` + `GovernorTimelockControl` (OZ 5.4.0), beacon-clone-ready, `__gap`
+- [ ] T013 [US1] `contracts/clearpath/ClearPathDAOFactory.sol` — UUPS (`UUPSManaged`), `createDAO` deploys beacon clones (governor/timelock/voting source), wires Timelock roles (governor = proposer/canceller, permissionless executor), tier (≥ Silver) + sanctions gated, network-scoped registry, `DAOCreated` event, append-only storage + `__gap`
+- [ ] T014 [US1] Register `ClearPathDAOFactory` (+ beacon impls) in `npm run check:storage-layout` config
+- [ ] T015 [P] [US1] Unit tests `test/clearpath/ClearPathDAOFactory.test.js` — create DAO (both voting kinds), tier gate (authorized + unauthorized), sanctions gate, registry rows, `DAOCreated`; treasury starts empty
+- [ ] T016 [P] [US1] Unit tests `test/clearpath/StandardGovernor.test.js` + `MembershipNFT.test.js` — governor wiring (voting source, quorum, timelock), soulbound transfer-block
+- [ ] T017 [P] [US1] Upgrade-lifecycle test `test/upgradeable/ClearPathDAOFactory.upgrade.test.js` — UUPS upgrade preserves registry; only `UPGRADER_ROLE` upgrades
+- [ ] T018 [US1] Flesh out `scripts/deploy/deploy-clearpath.js` — deploy factory (UUPS) + beacons via `lib/upgradeable.js`, wire SanctionsGuard/MembershipManager/USDC, configure `DAO_MEMBER_ROLE` tier + authorize factory as MembershipManager caller; record proxies+impls in `deployments/`
+- [ ] T019 [US1] Deploy to Mordor (63) + Amoy (80002); `npm run check:storage-layout` + `npm run sync:frontend-contracts`; verify via `scripts/deploy/verify.js`
+- [ ] T020 [US1] Subgraph: `ClearPathDAOFactory` datasource in `subgraph/subgraph.yaml` + `src/mappings/clearpathFactory.ts` (`DAOCreated` → `DAO`); networks.json entry; codegen + build
+- [ ] T021 [P] [US1] Matchstick `subgraph/tests/clearpath.test.ts` — `DAOCreated` indexes a `DAO` with governor/timelock/voting kind
+- [ ] T022 [US1] Frontend `frontend/src/abis/clearPathDAOFactory.js` (create + reads) + extend `useClearPath.js` with `createDAO` (honest pending/confirmed/failed) + `listMyDAOs`
+- [ ] T023 [US1] `frontend/src/components/clearpath/CreateDaoWizard.jsx` — name/purpose, voting source (membership-NFT default / token), USDC treasury, governance params, deployment summary, real create tx + `showNotification`
+- [ ] T024 [US1] `frontend/src/components/clearpath/ClearPathPanel.jsx` — My Tokens-style "My DAOs" + Create tabs; summary strip; self-disable on unsupported networks (FR-016)
+- [ ] T025 [P] [US1] Vitest `frontend/src/components/clearpath/__tests__/CreateDaoWizard.test.jsx` — create flow (both voting kinds), tier/sanctions block, honest state, no phantom rows
+
+## Phase 4: User Story 2 — Discover, inspect & join DAOs (Priority: P1)
+
+**Goal**: Browse native + external DAOs on the active network, open a detail view, join/follow.
+**Independent test**: After creating a DAO, find it in Explorer, open detail (treasury/members match chain), join.
+
+- [ ] T026 [US2] Extend `useClearPath.js` — `listAllDAOs` (native + external, network-scoped), `getDAO` live reads (treasury balance via USDC, member/holder count), `joinDAO`/follow
+- [ ] T027 [US2] `frontend/src/components/clearpath/DaoDetailView.jsx` — Overview/Members/Treasury sub-tabs (capability-gated), real on-chain reads, inline `role="alert"` on load failure
+- [ ] T028 [US2] Extend `ClearPathPanel.jsx` — Explorer tab (network-scoped) + unified My DAOs (native + external labeled by type)
+- [ ] T029 [US2] Subgraph: index `Member` (join) + DAO list reads; extend `clearpathFactory.ts`; codegen + build
+- [ ] T030 [P] [US2] Vitest `__tests__/DaoDetailView.test.jsx` + `ClearPathPanel.test.jsx` — explorer lists from chain/index, join flow, network-scope, truthful disable
+
+## Phase 5: User Story 3 — Register & track an external DAO (Priority: P1)
+
+**Goal**: Register an existing Governor DAO (Olympia) by address, validate it, track its real state read-only.
+**Independent test**: Register Olympia on Mordor; treasury/proposals/membership shown match its on-chain state;
+an EOA/non-Governor address is rejected; unreadable source → truthful "unavailable".
+
+- [ ] T031 [US3] `contracts/clearpath/external/ExternalDAORegistry.sol` — UUPS (`UUPSManaged`), `registerExternalDAO(dao, framework, label)` with ERC-165 `IGovernor` validation (+ defensive `COUNTING_MODE()`/`votingPeriod()` staticcalls), network-scoped, tier-gated, `ExternalDAORegistered`, duplicates rejected, NO authority over `dao`, `__gap`
+- [ ] T032 [US3] Register `ExternalDAORegistry` in `check:storage-layout`; add to `deploy-clearpath.js`; deploy Mordor + Amoy; sync
+- [ ] T033 [P] [US3] Unit tests `test/clearpath/ExternalDAORegistry.test.js` — register valid Governor, reject EOA / non-Governor / duplicate / cross-network; tier gate; confers no authority (INV-4)
+- [ ] T034 [US3] Subgraph: `ExternalDAORegistry` datasource + `src/mappings/externalRegistry.ts` (`ExternalDAORegistered` → `ExternalDAO`); codegen + build
+- [ ] T035 [P] [US3] Matchstick: extend `clearpath.test.ts` — `ExternalDAORegistered` indexes an `ExternalDAO`
+- [ ] T036 [US3] `frontend/src/components/clearpath/connectors/governorConnector.js` — IGovernor read path (`state`, `proposalVotes`, `proposalDeadline`, `quorum`, voting token, timelock/treasury balance) + Olympia labeled addresses resolved per network (Mordor/ETC), verified not hardcoded blind
+- [ ] T037 [US3] `frontend/src/components/clearpath/RegisterExternalDao.jsx` (validate + register tx + `showNotification`) + `ExternalDaoView.jsx` (read-only tracking: treasury/proposals/members) + `clearpathSubgraph.js` (`fetchExternalDAOs`, truthful `{available:false}` fallback)
+- [ ] T038 [P] [US3] Vitest `__tests__/RegisterExternalDao.test.jsx` + `ExternalDaoView.test.jsx` — validation reject paths, tracked reads from mocked connector/subgraph, truthful disable (no fabricated rows)
+
+## Phase 6: User Story 4 — Run a proposal on a native DAO (Priority: P2)
+
+**Goal**: Propose a USDC treasury action, vote, queue after timelock, execute; treasury safety holds.
+**Independent test**: Propose → reach quorum/success → queue → execute → recipient funded once; defeated → no action.
+
+- [ ] T039 [US4] Extend `useClearPath.js` + `governorConnector.js` — `propose`, `castVote[WithReason]`, `queue`, `execute`, proposal `state`/tallies reads (shared native + external via IGovernor)
+- [ ] T040 [US4] `frontend/src/components/clearpath/ProposalView.jsx` — submit proposal (USDC disbursement / param change), vote, queue, execute; live state + tallies; `showNotification`; recipient sanctions note
+- [ ] T041 [US4] Extend `DaoDetailView.jsx` — Proposals sub-tab (list + open ProposalView)
+- [ ] T042 [US4] Subgraph: per-DAO `Governor` data-source template (the spec-028 `TokenInstance` pattern), spawned on `DAOCreated`; `src/mappings/governor.ts` (`ProposalCreated`/`VoteCast`/`ProposalQueued`/`ProposalExecuted` → `Proposal`/`Vote`/`GovernanceActivity`); codegen + build
+- [ ] T043 [P] [US4] Integration test `test/integration/clearpath/native-proposal.test.js` — full lifecycle on a real deployed native DAO: propose→vote→quorum→queue→execute funds recipient exactly once (INV-2); defeated → no action; over-treasury execute reverts (INV-1); sanctioned recipient blocked (INV-3); unauthorized propose rejected
+- [ ] T044 [P] [US4] Matchstick: extend `clearpath.test.ts` — proposal/vote/execute events index `Proposal`/`Vote`/`GovernanceActivity`
+- [ ] T045 [P] [US4] Vitest `__tests__/ProposalView.test.jsx` — propose/vote/queue/execute honest state, tallies, unauthorized + truthful disable
+
+## Phase 7: User Story 5 — Manage an external DAO (Priority: P2)
+
+**Goal**: Take user-signed governance actions (propose/vote/queue/execute) on a registered external DAO where its
+own rules authorize the wallet; ClearPath holds no authority; deep-link fallback for unsupported frameworks.
+**Independent test**: On a registered Olympia DAO, as a member-NFT holder, cast a vote through ClearPath (recorded
+on Olympia); an unauthorized wallet is rejected by Olympia's rules.
+
+- [ ] T046 [US5] Extend `ExternalDaoView.jsx` + `governorConnector.js` — user-signed `propose`/`castVote`/`queue`/`execute` against the external DAO; surface the external DAO's rejection reason; deep-link to the external app for unsupported frameworks
+- [ ] T047 [US5] Sanctions on ClearPath-mediated external value moves (where applicable) + clear "externally deployed, ClearPath holds no authority" labeling (INV-4)
+- [ ] T048 [P] [US5] Integration test `test/integration/clearpath/external-governor.test.js` — deploy a real OZ Governor (stand-in for Olympia), register it, cast a user-signed vote (authorized) and confirm it records on that governor; unauthorized wallet rejected by the governor; ClearPath holds no role on it
+- [ ] T049 [P] [US5] Vitest `__tests__/ExternalDaoView.test.jsx` — management actions via mocked connector (authorized/rejected), deep-link fallback, no implied success
+
+## Phase 8: User Story 6 — Administer a DAO: roles, parameters & ownership (Priority: P2)
+
+**Goal**: Grant/revoke scoped roles, configure params, transfer/renounce ownership — least privilege, on-chain.
+**Independent test**: Grant proposer to a 2nd wallet (only it+admin can propose), revoke (blocked), transfer ownership.
+
+- [ ] T050 [US6] Extend `ClearPathDAOFactory`/governor wiring + `useClearPath.js` for role grant/revoke (Timelock/membership roles), param updates (GovernorSettings), ownership transfer/renounce
+- [ ] T051 [US6] `frontend/src/components/clearpath/RolesPanel.jsx` (in `DaoDetailView` Roles sub-tab) — role table, grant/revoke, params, transfer/renounce (renounce behind confirm); `showNotification`
+- [ ] T052 [P] [US6] Tests: `test/clearpath/dao-admin.test.js` (role gating authorized+unauthorized on-chain; param updates apply to new proposals; ownership moves) + Vitest `__tests__/RolesPanel.test.jsx`
+
+## Phase 9: User Story 7 — Activity & event history (Priority: P3)
+
+**Goal**: Per-DAO governance history (native + external), filterable, subgraph-sourced, truthful disable.
+
+- [ ] T053 [US7] `frontend/src/components/clearpath/ActivityPanel.jsx` (in `DaoDetailView`) — event feed (type/actor/tx/time) + category filter (radiogroup); `clearpathSubgraph.js` `fetchActivity`; truthful subgraph-less disable
+- [ ] T054 [P] [US7] Vitest `__tests__/ActivityPanel.test.jsx` — feed renders from mocked subgraph, filter, truthful disable (no fabricated rows)
+
+## Phase 10: User Story 8 — Inspect the contract surface (Priority: P3)
+
+**Goal**: Governor/treasury/token addresses, framework, per-network deployment, explorer links, copy address/ABI;
+external DAOs labeled "externally deployed".
+
+- [ ] T055 [US8] `frontend/src/components/clearpath/ContractPanel.jsx` (in `DaoDetailView`) — metadata + explorer deep links (explorer-aware) + copy address/ABI via shared `useClipboard` + `showNotification`; external label
+- [ ] T056 [P] [US8] Vitest `__tests__/ContractPanel.test.jsx` — addresses/framework render truthfully, copy fires notification, external labeled, no implied authority
+
+## Phase 11: Polish & cross-cutting
+
+- [ ] T057 [P] `frontend/src/test/clearpath.accessibility.test.jsx` — vitest-axe over ClearPath surfaces (CreateDaoWizard, DaoDetailView, ProposalView, ExternalDaoView, ContractPanel) — no violations; named to hit the gating CI a11y step
+- [ ] T058 [P] `docs/developer-guide/clearpath-dao.md` (NEW) — native standard DAOs (OZ Governor/Timelock/Votes), external registry + connectors (Olympia/IGovernor), Account Center IA, no-authority posture, deploy/sync; note futarchy (spec 029) is the follow-on
+- [ ] T059 [P] Update `docs/system-overview/governance.md` — "no DAO" → ClearPath as an opt-in module (native standard DAOs + external tracking)
+- [ ] T060 Run Slither (proxy/clone/AccessControl/Governor detectors) + Medusa across `contracts/clearpath/`; axe/Lighthouse over the portal; resolve/justify — no new high/critical; record in `specs/030-clearpath-standard-daos/security-analysis.md`
+- [ ] T061 Execute `quickstart.md` A–E on local + Mordor (incl. registering & tracking a REAL Olympia DAO and a user-signed external vote); record `validation-results.md`
+- [ ] T062 Confirm `npm test`, `npm run test:frontend`, `npm run check:storage-layout`, and subgraph codegen+build+matchstick are green with no `continue-on-error` on test/lint/build/security gates (Principle IV)
+
+## Dependencies
+
+- Setup (T001–T003) → Foundational (T004–T009) → user stories.
+- **US1 (T010–T025)** is the MVP and precedes all others (the factory + native DAO + tab).
+- **US2 (T026–T030)** depends on US1 (DAOs to list) — establishes the unified explorer.
+- **US3 (T031–T038)** depends on Foundational + the explorer (US2) for the unified list; the registry/connector are otherwise independent of US1's factory.
+- **US4 (T039–T045)** depends on US1 (native DAO to propose on).
+- **US5 (T046–T049)** depends on US3 (a registered external DAO) + the shared `governorConnector` (US3/US4).
+- **US6 (T050–T052)** depends on US1.
+- **US7 (T053–T054)** + **US8 (T055–T056)** depend on US1/US3 (data to show); read-only.
+- Polish (T057–T062) last.
+
+## Parallel execution examples
+
+- Setup: T002, T003 in parallel with T001 done.
+- US1 contracts: T010, T011 [P] (different files) before T012 (governor composes them) before T013 (factory).
+- US1 tests: T015, T016, T017 [P] after their contracts compile.
+- Cross-story [P]: Vitest tasks (T025/T030/T038/T045/T049/T052/T054/T056) are independent once their component exists.
+
+## Implementation strategy
+
+- **MVP = US1** (Phase 3): a member can create a native standard DAO with a USDC treasury and see it on-chain in
+  the ClearPath tab — the smallest valuable, independently shippable slice (plan Phase A).
+- Then **US2 + US3** (plan B) to land discovery + the external-DAO registry/tracking (Olympia) — the other P1 basics.
+- Then **US4 + US5** (plan C) proposals + external management, **US6** (D) admin, **US7/US8** (E) activity/contract
+  surface, **Polish** (F). Each phase ships with its tests + deploy/sync and is independently demoable.

--- a/specs/030-clearpath-standard-daos/tasks.md
+++ b/specs/030-clearpath-standard-daos/tasks.md
@@ -12,6 +12,16 @@ over external DAOs (manage = user-signed actions). `[P]` = parallelizable (diffe
 Phase ↔ plan mapping: Setup/Foundational → scaffolding · US1 → plan A · US2/US3 → plan B · US4/US5 → plan C ·
 US6 → plan D · US7/US8 → plan E · Polish → plan F.
 
+> **PIVOT (2026-06-24) — external-first; native DAOs deferred.** Implementing US1 surfaced a hard blocker:
+> OZ 5.4.0 `GovernorUpgradeable` → `SignatureChecker` → `Bytes.sol` uses the Cancun `mcopy` opcode, so native
+> OZ-Governor DAOs **cannot compile/deploy on pre-Cancun ETC/Mordor** (see memory `oz-governor-mcopy-mordor`).
+> Per the user's decision, the **external-DAO connector ships first** (US3/US5 — `ExternalDAORegistry` is
+> paris-safe: it imports only the `IGovernor` interface, no implementation; tracks Olympia + any Governor DAO on
+> Mordor + Amoy). **Native DAO tasks (US1/US4/US6 — T010–T025, T039–T045, T050–T052) are DEFERRED** pending a
+> governance-base choice (OZ Governor on Cancun chains / a custom paris-safe governor / vendor OZ 5.1). The
+> drafted native OZ-Governor contracts were removed; their design remains in this spec's plan/contracts. New
+> implementation order: **US3 (register/track) → US5 (manage) → US2 (unified discovery) → US7/US8 → polish.**
+
 ## Phase 1: Setup
 
 - [ ] T001 Create the contract package skeleton `contracts/clearpath/` with subdirs `governance/`, `voting/`, `external/`, `interfaces/` and a short `contracts/clearpath/README.md` (purpose + "archive is reference-only")
@@ -68,9 +78,9 @@ and appear in My DAOs — no mock data.
 **Independent test**: Register Olympia on Mordor; treasury/proposals/membership shown match its on-chain state;
 an EOA/non-Governor address is rejected; unreadable source → truthful "unavailable".
 
-- [ ] T031 [US3] `contracts/clearpath/external/ExternalDAORegistry.sol` — UUPS (`UUPSManaged`), `registerExternalDAO(dao, framework, label)` with ERC-165 `IGovernor` validation (+ defensive `COUNTING_MODE()`/`votingPeriod()` staticcalls), network-scoped, tier-gated, `ExternalDAORegistered`, duplicates rejected, NO authority over `dao`, `__gap`
+- [X] T031 [US3] `contracts/clearpath/external/ExternalDAORegistry.sol` — UUPS (`UUPSManaged`), `registerExternalDAO(dao, framework, label)` with ERC-165 `IGovernor` validation (+ defensive `COUNTING_MODE()`/`votingPeriod()` staticcalls), network-scoped, tier-gated, `ExternalDAORegistered`, duplicates rejected, NO authority over `dao`, `__gap`
 - [ ] T032 [US3] Register `ExternalDAORegistry` in `check:storage-layout`; add to `deploy-clearpath.js`; deploy Mordor + Amoy; sync
-- [ ] T033 [P] [US3] Unit tests `test/clearpath/ExternalDAORegistry.test.js` — register valid Governor, reject EOA / non-Governor / duplicate / cross-network; tier gate; confers no authority (INV-4)
+- [X] T033 [P] [US3] Unit tests `test/clearpath/ExternalDAORegistry.test.js` — register valid Governor, reject EOA / non-Governor / duplicate / cross-network; tier gate; confers no authority (INV-4)
 - [ ] T034 [US3] Subgraph: `ExternalDAORegistry` datasource + `src/mappings/externalRegistry.ts` (`ExternalDAORegistered` → `ExternalDAO`); codegen + build
 - [ ] T035 [P] [US3] Matchstick: extend `clearpath.test.ts` — `ExternalDAORegistered` indexes an `ExternalDAO`
 - [ ] T036 [US3] `frontend/src/components/clearpath/connectors/governorConnector.js` — IGovernor read path (`state`, `proposalVotes`, `proposalDeadline`, `quorum`, voting token, timelock/treasury balance) + Olympia labeled addresses resolved per network (Mordor/ETC), verified not hardcoded blind

--- a/specs/030-clearpath-standard-daos/tasks.md
+++ b/specs/030-clearpath-standard-daos/tasks.md
@@ -25,7 +25,7 @@ US6 → plan D · US7/US8 → plan E · Polish → plan F.
 ## Phase 1: Setup
 
 - [ ] T001 Create the contract package skeleton `contracts/clearpath/` with subdirs `governance/`, `voting/`, `external/`, `interfaces/` and a short `contracts/clearpath/README.md` (purpose + "archive is reference-only")
-- [ ] T002 [P] Create the frontend module skeleton `frontend/src/components/clearpath/` (empty `clearpath.css` scoped under `.clearpath`, mapped onto `theme.css` variables) and `frontend/src/abis/` placeholders (`clearPathDAOFactory.js`, `externalDAORegistry.js`, `iGovernor.js`)
+- [X] T002 [P] Create the frontend module skeleton `frontend/src/components/clearpath/` (empty `clearpath.css` scoped under `.clearpath`, mapped onto `theme.css` variables) and `frontend/src/abis/` placeholders (`clearPathDAOFactory.js`, `externalDAORegistry.js`, `iGovernor.js`)
 - [ ] T003 [P] Confirm OZ 5.4.0 governance availability + paris-safety: add a compile smoke contract `contracts/clearpath/governance/_GovImports.sol` importing `GovernorUpgradeable`/`TimelockControllerUpgradeable`/`ERC721VotesUpgradeable`/`ERC20VotesUpgradeable`; `npm run compile` green (delete after)
 
 ## Phase 2: Foundational (blocking prerequisites)
@@ -33,8 +33,8 @@ US6 → plan D · US7/US8 → plan E · Polish → plan F.
 - [ ] T004 Add `contracts/clearpath/interfaces/IClearPathDAOFactory.sol` and `IExternalDAORegistry.sol` per `contracts/contracts.md` (events, structs, enums: `VotingKind`, `Framework`)
 - [ ] T005 Add `DAO_MEMBER_ROLE = keccak256("DAO_MEMBER_ROLE")` gating helper usage notes; confirm `IMembershipManager.checkCanCreate/getActiveTier/recordCreate` + `ISanctionsGuard.checkBlocked` signatures wired (no new contract; reference `WagerRegistry` pattern)
 - [ ] T006 [P] Extend `scripts/deploy/lib/upgradeable.js` usage in a new `scripts/deploy/deploy-clearpath.js` skeleton (resolve SanctionsGuard + MembershipManager + USDC from `deployments/<net>.json`; no deploy yet)
-- [ ] T007 [P] Add the ClearPath tab scaffold: register `{ id: 'clearpath', label: 'ClearPath' }` in `frontend/src/pages/WalletPage.jsx` `WALLET_TABS` + render a placeholder `<ClearPathPanel/>`; create `frontend/src/components/clearpath/ClearPathPanel.jsx` (self-disables via `useClearPath` when unsupported)
-- [ ] T008 [P] Add `frontend/src/components/clearpath/useClearPath.js` skeleton: per-chain factory/registry resolution via `getContractAddressForChain`, `isSupported`, honest tx-state wrapper, `useNotification` wiring (mirror `useTokenFactory`)
+- [X] T007 [P] Add the ClearPath tab scaffold: register `{ id: 'clearpath', label: 'ClearPath' }` in `frontend/src/pages/WalletPage.jsx` `WALLET_TABS` + render a placeholder `<ClearPathPanel/>`; create `frontend/src/components/clearpath/ClearPathPanel.jsx` (self-disables via `useClearPath` when unsupported)
+- [X] T008 [P] Add `frontend/src/components/clearpath/useClearPath.js` skeleton: per-chain factory/registry resolution via `getContractAddressForChain`, `isSupported`, honest tx-state wrapper, `useNotification` wiring (mirror `useTokenFactory`)
 - [ ] T009 [P] Add subgraph base: append `DAO`, `ExternalDAO`, `Proposal`, `Vote`, `Member`, `GovernanceActivity` entities to `subgraph/schema.graphql` (no datasources yet)
 
 ## Phase 3: User Story 1 — Launch a native standard DAO (Priority: P1) 🎯 MVP
@@ -83,9 +83,9 @@ an EOA/non-Governor address is rejected; unreadable source → truthful "unavail
 - [X] T033 [P] [US3] Unit tests `test/clearpath/ExternalDAORegistry.test.js` — register valid Governor, reject EOA / non-Governor / duplicate / cross-network; tier gate; confers no authority (INV-4)
 - [ ] T034 [US3] Subgraph: `ExternalDAORegistry` datasource + `src/mappings/externalRegistry.ts` (`ExternalDAORegistered` → `ExternalDAO`); codegen + build
 - [ ] T035 [P] [US3] Matchstick: extend `clearpath.test.ts` — `ExternalDAORegistered` indexes an `ExternalDAO`
-- [ ] T036 [US3] `frontend/src/components/clearpath/connectors/governorConnector.js` — IGovernor read path (`state`, `proposalVotes`, `proposalDeadline`, `quorum`, voting token, timelock/treasury balance) + Olympia labeled addresses resolved per network (Mordor/ETC), verified not hardcoded blind
-- [ ] T037 [US3] `frontend/src/components/clearpath/RegisterExternalDao.jsx` (validate + register tx + `showNotification`) + `ExternalDaoView.jsx` (read-only tracking: treasury/proposals/members) + `clearpathSubgraph.js` (`fetchExternalDAOs`, truthful `{available:false}` fallback)
-- [ ] T038 [P] [US3] Vitest `__tests__/RegisterExternalDao.test.jsx` + `ExternalDaoView.test.jsx` — validation reject paths, tracked reads from mocked connector/subgraph, truthful disable (no fabricated rows)
+- [X] T036 [US3] `frontend/src/components/clearpath/connectors/governorConnector.js` — IGovernor read path (`state`, `proposalVotes`, `proposalDeadline`, `quorum`, voting token, timelock/treasury balance) + Olympia labeled addresses resolved per network (Mordor/ETC), verified not hardcoded blind
+- [X] T037 [US3] `frontend/src/components/clearpath/RegisterExternalDao.jsx` (validate + register tx + `showNotification`) + `ExternalDaoView.jsx` (read-only tracking: treasury/proposals/members) + `clearpathSubgraph.js` (`fetchExternalDAOs`, truthful `{available:false}` fallback)
+- [X] T038 [P] [US3] Vitest `__tests__/RegisterExternalDao.test.jsx` + `ExternalDaoView.test.jsx` — validation reject paths, tracked reads from mocked connector/subgraph, truthful disable (no fabricated rows)
 
 ## Phase 6: User Story 4 — Run a proposal on a native DAO (Priority: P2)
 
@@ -138,7 +138,7 @@ external DAOs labeled "externally deployed".
 
 ## Phase 11: Polish & cross-cutting
 
-- [ ] T057 [P] `frontend/src/test/clearpath.accessibility.test.jsx` — vitest-axe over ClearPath surfaces (CreateDaoWizard, DaoDetailView, ProposalView, ExternalDaoView, ContractPanel) — no violations; named to hit the gating CI a11y step
+- [X] T057 [P] `frontend/src/test/clearpath.accessibility.test.jsx` — vitest-axe over ClearPath surfaces (CreateDaoWizard, DaoDetailView, ProposalView, ExternalDaoView, ContractPanel) — no violations; named to hit the gating CI a11y step
 - [ ] T058 [P] `docs/developer-guide/clearpath-dao.md` (NEW) — native standard DAOs (OZ Governor/Timelock/Votes), external registry + connectors (Olympia/IGovernor), Account Center IA, no-authority posture, deploy/sync; note futarchy (spec 029) is the follow-on
 - [ ] T059 [P] Update `docs/system-overview/governance.md` — "no DAO" → ClearPath as an opt-in module (native standard DAOs + external tracking)
 - [ ] T060 Run Slither (proxy/clone/AccessControl/Governor detectors) + Medusa across `contracts/clearpath/`; axe/Lighthouse over the portal; resolve/justify — no new high/critical; record in `specs/030-clearpath-standard-daos/security-analysis.md`

--- a/test/clearpath/ExternalDAORegistry.test.js
+++ b/test/clearpath/ExternalDAORegistry.test.js
@@ -1,0 +1,106 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+// Spec 030 (US3) — ExternalDAORegistry: register/validate/track DAOs deployed by other platforms (Olympia + any
+// OZ Governor). Tier-gated; ERC-165 IGovernor validation (primary) + IGovernor-view fallback; rejects
+// EOAs / non-governors / duplicates / sub-tier; confers no authority (INV-4 — registry stores metadata only).
+
+const Tier = { None: 0, Bronze: 1, Silver: 2, Gold: 3, Platinum: 4 };
+
+async function deployRegistry(admin, membership) {
+  const Impl = await ethers.getContractFactory("ExternalDAORegistry");
+  const impl = await Impl.deploy();
+  await impl.waitForDeployment();
+  const initData = Impl.interface.encodeFunctionData("initialize", [admin, membership]);
+  const Proxy = await ethers.getContractFactory("ERC1967Proxy");
+  const proxy = await Proxy.deploy(await impl.getAddress(), initData);
+  await proxy.waitForDeployment();
+  return Impl.attach(await proxy.getAddress());
+}
+
+describe("ExternalDAORegistry (spec 030 / US3)", () => {
+  let owner, member, outsider, membership, registry;
+
+  beforeEach(async () => {
+    [owner, member, outsider] = await ethers.getSigners();
+    const Mock = await ethers.getContractFactory("MockMembershipTier");
+    membership = await Mock.deploy();
+    await membership.waitForDeployment();
+    await membership.setTier(member.address, Tier.Silver); // eligible
+    await membership.setTier(outsider.address, Tier.Bronze); // sub-tier
+    registry = await deployRegistry(owner.address, await membership.getAddress());
+  });
+
+  async function deployGovernor(supports165) {
+    const G = await ethers.getContractFactory("MockGovernorLike");
+    const g = await G.deploy(supports165);
+    await g.waitForDeployment();
+    return g;
+  }
+
+  it("registers a Governor validated via ERC-165 and records it (no authority conferred)", async () => {
+    const gov = await deployGovernor(true);
+    const govAddr = await gov.getAddress();
+    await expect(registry.connect(member).registerExternalDAO(govAddr, 0, "Olympia"))
+      .to.emit(registry, "ExternalDAORegistered")
+      .withArgs(1n, govAddr, 0, member.address, "Olympia");
+    expect(await registry.externalCount()).to.equal(1n);
+    expect(await registry.isRegistered(govAddr)).to.equal(true);
+    const [dao, framework, label, registrant] = await registry.getExternalDAO(1);
+    expect(dao).to.equal(govAddr);
+    expect(framework).to.equal(0);
+    expect(label).to.equal("Olympia");
+    expect(registrant).to.equal(member.address);
+    expect(await registry.getExternalDAOsByRegistrant(member.address)).to.deep.equal([1n]);
+  });
+
+  it("registers a Governor that lacks ERC-165 via the IGovernor-view fallback", async () => {
+    const gov = await deployGovernor(false);
+    await expect(registry.connect(member).registerExternalDAO(await gov.getAddress(), 0, "NoERC165"))
+      .to.emit(registry, "ExternalDAORegistered");
+    expect(await registry.externalCount()).to.equal(1n);
+  });
+
+  it("rejects an EOA (no code)", async () => {
+    await expect(
+      registry.connect(member).registerExternalDAO(outsider.address, 0, "eoa")
+    ).to.be.revertedWithCustomError(registry, "NotAGovernor");
+  });
+
+  it("rejects a non-governor contract", async () => {
+    const NG = await ethers.getContractFactory("MockNonGovernor");
+    const ng = await NG.deploy();
+    await ng.waitForDeployment();
+    await expect(
+      registry.connect(member).registerExternalDAO(await ng.getAddress(), 0, "x")
+    ).to.be.revertedWithCustomError(registry, "NotAGovernor");
+  });
+
+  it("rejects the zero address and duplicates", async () => {
+    await expect(
+      registry.connect(member).registerExternalDAO(ethers.ZeroAddress, 0, "z")
+    ).to.be.revertedWithCustomError(registry, "ZeroAddress");
+    const gov = await deployGovernor(true);
+    await registry.connect(member).registerExternalDAO(await gov.getAddress(), 0, "first");
+    await expect(
+      registry.connect(member).registerExternalDAO(await gov.getAddress(), 0, "again")
+    ).to.be.revertedWithCustomError(registry, "AlreadyRegistered");
+  });
+
+  it("enforces the membership tier gate (>= Silver)", async () => {
+    const gov = await deployGovernor(true);
+    await expect(
+      registry.connect(outsider).registerExternalDAO(await gov.getAddress(), 0, "x")
+    ).to.be.revertedWithCustomError(registry, "InsufficientMembershipTier");
+  });
+
+  it("only UPGRADER_ROLE can upgrade the registry", async () => {
+    const Impl2 = await ethers.getContractFactory("ExternalDAORegistry");
+    const impl2 = await Impl2.deploy();
+    await impl2.waitForDeployment();
+    await expect(
+      registry.connect(member).upgradeToAndCall(await impl2.getAddress(), "0x")
+    ).to.be.reverted; // not UPGRADER_ROLE
+    await expect(registry.connect(owner).upgradeToAndCall(await impl2.getAddress(), "0x")).to.not.be.reverted;
+  });
+});


### PR DESCRIPTION
## Spec 030 — ClearPath Standard DAOs & External DAO Connectors

Reintroduces the **ClearPath** module as a My Account → **ClearPath** tab: track and (where the DAO's own rules authorize the signer) manage DAOs deployed by other platforms — starting with the live **Olympia DAO** on Mordor. ClearPath holds **no custody or authority**; every action is user-signed.

### Pivot: external-first (OZ Governor mcopy blocker)
Native OZ-`Governor` DAOs can't compile/deploy on pre-Cancun ETC/Mordor (OZ 5.4 `GovernorUpgradeable`→`SignatureChecker`→`Bytes.sol` uses `mcopy`). So this ships the **external-DAO connector first** (the registry imports only the `IGovernor` interface → paris-safe). Native ClearPath DAOs + futarchy (spec 029) remain deferred.

### Contracts
- **`ExternalDAORegistry`** (UUPS, `UUPSManaged`) — `registerExternalDAO(dao, framework, label)`, Silver+ gated via `MembershipManager`, validates the target is a real Governor (ERC-165 `IGovernor` probe + `COUNTING_MODE()`/`votingPeriod()` fallback), rejects EOA/non-governor/duplicate/zero. Append-only storage + `__gap`. **Deployed + seeded on Mordor** (Olympia registered).

### Frontend (live data, no mocks — Constitution III)
- **External DAO list** read live from the on-chain registry (works on subgraph-less Mordor).
- **Register** flow with client-side Governor pre-validation.
- **Tracking view**: humanized governance (counting/clock/units), treasuries (timelock + OlympiaTreasury) native + USDC, and proposals via a **bounded live on-chain indexer** (chunked `eth_getLogs`, the subgraph-less fallback; honest ok/partial/error).
- **US5 management** (user-signed): vote / queue / execute, plus a **rich proposal builder** (no hand-written calldata, multi-action, asset-aware, live preview, duplicate pre-check, over-treasury warning).
- **Address book + QR scanner** wired onto every ClearPath address field (recipient / token / target / governor), matching the wager-create affordances.
- **Notification system**: every on-chain write surfaces confirm→submitted(persistent)→confirmed(+tx hash)/failed toasts; bounded `tx.wait` so a dropped tx can't orphan the toast/busy lock; reads stay inline. (App-wide notification *feed/bell* generalization deferred to its own spec.)

### Tests / quality
- 36/36 ClearPath frontend tests; contract suite + storage-layout gate; vitest-axe a11y; lint clean.
- Built with the speckit flow; each major step adversarially reviewed via multi-agent workflows.

### Notes
- Amoy deploy pending (insufficient POL at deploy time); Mordor is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)