### PR TITLE
feat(swap): network-aware DEX provider — ETCswap on ETC, Uniswap elsewhere (spec 033)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/032-encrypted-data-sync"
+  "feature_directory": "specs/033-network-aware-swap"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,5 +72,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/032-encrypted-data-sync/plan.md
+at specs/033-network-aware-swap/plan.md
 <!-- SPECKIT END -->

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -64,6 +64,21 @@ VITE_NETWORK_ID=137
 # VITE_MORDOR_FAUCET=                                          # test-ETC faucet (T003)
 # VITE_MORDOR_ETCSWAP_URL=https://etcswap.org
 
+# --- Ethereum Classic mainnet (chainId 61) overrides (Spec 033) ---
+# All optional; networks.js ships on-chain-verified ETCswap V3 defaults so swaps
+# work out of the box. Set these only to point at a custom RPC/token or a
+# different ETCswap deployment. Like every chain, blanking a required address
+# (FACTORY + SWAP_ROUTER + QUOTER + WETC) turns the DEX/swap capability OFF — no
+# mock DEX. ETC mainnet enables ONLY the swap surface (it is wager-legacy).
+# VITE_RPC_URL_ETC=https://etc.rivet.link
+# VITE_ETC_USC=0xDE093684c796204224BC081f937aa059D903c52a       # Classic USD (USC), 6 decimals
+# VITE_ETC_ETCSWAP_FACTORY=0x2624E907BcC04f93C8f29d7C7149a8700Ceb8cDC
+# VITE_ETC_ETCSWAP_SWAP_ROUTER=0xEd88EDD995b00956097bF90d39C9341BBde324d1
+# VITE_ETC_ETCSWAP_QUOTER=0x4d8c163400CB87Cbe1bae76dBf36A09FED85d39B
+# VITE_ETC_ETCSWAP_POSITION_MANAGER=0x3CEDe6562D6626A04d7502CC35720901999AB699
+# VITE_ETC_WETC=0x1953cab0E5bFa6D4a9BaD6E05fD46C1CC6527a5a       # Wrapped ETC, 18 decimals
+# VITE_ETC_ETCSWAP_URL=https://v3.etcswap.org
+
 # Contract Addresses (update after deployment)
 # VITE_CONTRACT_ADDRESS=0x1234567890123456789012345678901234567890
 

--- a/frontend/src/components/fairwins/SwapPanel.jsx
+++ b/frontend/src/components/fairwins/SwapPanel.jsx
@@ -22,10 +22,17 @@ function SwapPanel() {
     setSlippage,
     addresses,
     isDexAvailable,
+    dexProvider,
+    network,
   } = useDex()
 
   const { isConnected, chainId } = useWallet()
   const { native: nativeSymbol, stable: stableSymbol } = useChainTokens()
+
+  // Network-aware DEX provider identity (ETC family → ETCswap; else Uniswap).
+  const providerName = dexProvider?.name || 'the DEX'
+  const providerUrl = dexProvider?.url || null
+  const networkName = network?.name || 'this network'
 
   const wnativeSymbol = nativeSymbol ? `W${nativeSymbol}` : 'WNATIVE'
   const labelFor = (key) => {
@@ -156,14 +163,13 @@ function SwapPanel() {
       <div className="swap-panel">
         <div className="swap-header">
           <h2>Swap</h2>
-          <p className="subtitle">DEX is not available on this network</p>
+          <p className="subtitle">Swaps are not available on {networkName}</p>
         </div>
         <div className="connect-message">
           <p>
-            Uniswap V3 is wired on Polygon Mainnet. Switch to Mainnet from the
-            Testnet/Mainnet toggle to swap, or supply community Uniswap V3
-            addresses via the <code>VITE_AMOY_UNISWAP_*</code> env vars to
-            enable swaps on Amoy.
+            {dexProvider
+              ? `${providerName} is not configured on ${networkName}. Switch to a network with a configured DEX, or supply the ${providerName} contract addresses for ${networkName} to enable in-app swaps.`
+              : `No DEX is configured on ${networkName}. Switch to a network with a configured DEX to enable in-app swaps.`}
           </p>
         </div>
       </div>
@@ -180,7 +186,7 @@ function SwapPanel() {
     <div className="swap-panel">
       <div className="swap-header">
         <h2>Swap</h2>
-        <p className="subtitle">Wrap, unwrap, and swap on the active chain</p>
+        <p className="subtitle">Wrap, unwrap, and swap via {providerName}</p>
       </div>
 
       <div className="mode-selector" role="tablist" aria-label="Swap mode">
@@ -360,8 +366,18 @@ function SwapPanel() {
             rel="noopener noreferrer"
             className="contract-link"
           >
-            Swap Router ↗
+            {providerName} Router ↗
           </a>
+          {providerUrl && (
+            <a
+              href={providerUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="contract-link"
+            >
+              Open {providerName} ↗
+            </a>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/wallet/NetworkSettings.jsx
+++ b/frontend/src/components/wallet/NetworkSettings.jsx
@@ -127,16 +127,16 @@ function NetworkSettings() {
                       </dd>
                     </div>
                   )}
-                  {net.capabilities?.dex && net.resources?.dexUrl && (
+                  {net.capabilities?.dex && net.dexProvider?.url && (
                     <div className="network-doc-row">
                       <dt>Swap</dt>
                       <dd>
                         <a
-                          href={net.resources.dexUrl}
+                          href={net.dexProvider.url}
                           target="_blank"
                           rel="noopener noreferrer"
                         >
-                          {`Swap into ${net.stablecoin?.symbol || 'tokens'}`}
+                          {`Open ${net.dexProvider.name} ↗`}
                         </a>
                       </dd>
                     </div>

--- a/frontend/src/config/networkCapabilities.js
+++ b/frontend/src/config/networkCapabilities.js
@@ -66,7 +66,7 @@ export const NETWORK_FEATURES = [
   {
     key: 'swap',
     label: 'Token Swap',
-    description: 'In-app token swaps via Uniswap V3.',
+    description: 'In-app token swaps via the network’s DEX (Uniswap or ETCswap).',
     deployed: (chainId) => Boolean(getNetwork(chainId)?.capabilities?.dex),
   },
 ]

--- a/frontend/src/config/networks.js
+++ b/frontend/src/config/networks.js
@@ -84,6 +84,11 @@ const NETWORKS = {
       // same Gamma instance for testnet listings.
       gammaApiUrl: import.meta.env?.VITE_POLYMARKET_GAMMA_URL || 'https://gamma-api.polymarket.com',
     },
+    // DEX provider identity — non-ETC networks route through Uniswap (Spec 033).
+    dexProvider: {
+      name: 'Uniswap',
+      url: 'https://app.uniswap.org/swap',
+    },
     get capabilities() {
       return {
         polymarketSidebets: true,
@@ -142,7 +147,70 @@ const NETWORKS = {
     // (or update the default) once confirmed; the card hides the row when empty.
     resources: {
       faucet: import.meta.env?.VITE_MORDOR_FAUCET || '',
-      dexUrl: import.meta.env?.VITE_MORDOR_ETCSWAP_URL || 'https://etcswap.org',
+    },
+    // DEX provider identity — the ETC family routes through ETCswap (Spec 033).
+    // Declared at the network level so the swap UI can name the provider even
+    // when `dex` is env-unconfigured (keeps the disabled-state message honest).
+    dexProvider: {
+      name: 'ETCswap',
+      url: import.meta.env?.VITE_MORDOR_ETCSWAP_URL || 'https://etcswap.org',
+    },
+    get capabilities() {
+      return {
+        polymarketSidebets: false,
+        dex: Boolean(this.dex),
+        friendMarkets: true,
+      }
+    },
+  },
+  61: {
+    chainId: 61,
+    name: 'Ethereum Classic',
+    isTestnet: false,
+    isPrimary: false,
+    // Surfaced in the My Account → Network tab as a user-switchable network.
+    selectable: true,
+    nativeCurrency: { decimals: 18, name: 'Ethereum Classic', symbol: 'ETC' },
+    rpcUrl: import.meta.env?.VITE_RPC_URL_ETC || 'https://etc.rivet.link',
+    explorer: { name: 'Blockscout', baseUrl: 'https://etc.blockscout.com' },
+    // No hosted Graph indexer supports Ethereum Classic, so wager reads go
+    // straight to the WagerRegistry over RPC (RegistrySource). ETC mainnet is
+    // wager-legacy (read-only); Spec 033 enables only the swap surface here.
+    subgraphUrl: import.meta.env?.VITE_SUBGRAPH_URL_ETC || null,
+    // Classic USD (USC) — the same Brale-issued token deployed at a deterministic
+    // address on ETC mainnet and Mordor; verified on etc.blockscout.com
+    // (Spec 033 research R2). Override via VITE_ETC_USC.
+    stablecoin: {
+      address: import.meta.env?.VITE_ETC_USC || '0xDE093684c796204224BC081f937aa059D903c52a',
+      symbol: 'USC',
+      name: 'Classic USD',
+      decimals: 6,
+    },
+    // ETCswap V3 (a Uniswap V3 deployment on Ethereum Classic). Addresses are the
+    // on-chain-verified canonical deployment (Spec 033 research R1); override via
+    // VITE_ETC_ETCSWAP_* + VITE_ETC_WETC. Gated like every chain: if an override
+    // blanks a required address the DEX flips off — no mock DEX.
+    dex: (() => {
+      const factory = import.meta.env?.VITE_ETC_ETCSWAP_FACTORY || '0x2624E907BcC04f93C8f29d7C7149a8700Ceb8cDC'
+      const router = import.meta.env?.VITE_ETC_ETCSWAP_SWAP_ROUTER || '0xEd88EDD995b00956097bF90d39C9341BBde324d1'
+      const quoter = import.meta.env?.VITE_ETC_ETCSWAP_QUOTER || '0x4d8c163400CB87Cbe1bae76dBf36A09FED85d39B'
+      const positionManager = import.meta.env?.VITE_ETC_ETCSWAP_POSITION_MANAGER || '0x3CEDe6562D6626A04d7502CC35720901999AB699'
+      const wnative = import.meta.env?.VITE_ETC_WETC || '0x1953cab0E5bFa6D4a9BaD6E05fD46C1CC6527a5a'
+      if (!factory || !router || !quoter || !wnative) return null
+      return {
+        factory,
+        swapRouter: router,
+        quoter,
+        positionManager: positionManager || null,
+        wnative,
+      }
+    })(),
+    contracts: {}, // ETC mainnet has no v2 wager deployment (wager-legacy)
+    polymarket: null, // no Polymarket on Ethereum Classic
+    // DEX provider identity — the ETC family routes through ETCswap (Spec 033).
+    dexProvider: {
+      name: 'ETCswap',
+      url: import.meta.env?.VITE_ETC_ETCSWAP_URL || 'https://v3.etcswap.org',
     },
     get capabilities() {
       return {
@@ -189,6 +257,11 @@ const NETWORKS = {
       ctf: import.meta.env?.VITE_POLYGON_POLYMARKET_CTF || '0x4D97DCd97eC945f40cF65F87097ACe5EA0476045',
       gammaApiUrl: import.meta.env?.VITE_POLYMARKET_GAMMA_URL || 'https://gamma-api.polymarket.com',
     },
+    // DEX provider identity — non-ETC networks route through Uniswap (Spec 033).
+    dexProvider: {
+      name: 'Uniswap',
+      url: 'https://app.uniswap.org/swap?chain=polygon',
+    },
     get capabilities() {
       return {
         polymarketSidebets: true,
@@ -230,6 +303,18 @@ export function getNetwork(chainId) {
 
 export function isDexAvailable(chainId) {
   return Boolean(getNetwork(chainId)?.dex)
+}
+
+/**
+ * The DEX provider descriptor (`{ name, url }`) for `chainId`, or null when the
+ * network has no DEX provider (e.g. local Hardhat). Declared per network so the
+ * mapping — ETC family (61, 63) → ETCswap; all others → Uniswap — is explicit
+ * and survives an unconfigured `dex`: the swap UI can still name the provider
+ * for honest disabled-state copy (Spec 033). Resolution is strictly per-chain so
+ * a provider identity never leaks across networks.
+ */
+export function getDexProvider(chainId) {
+  return getNetwork(chainId)?.dexProvider ?? null
 }
 
 /**

--- a/frontend/src/constants/dex.js
+++ b/frontend/src/constants/dex.js
@@ -1,10 +1,13 @@
 /**
- * Uniswap V3 DEX addresses and token metadata for the active chain.
+ * DEX addresses and token metadata for the active chain.
  *
- * Derives from frontend/src/config/networks.js. Polygon Mainnet has the
- * canonical V3 deployment; Polygon Amoy is wired via VITE_AMOY_UNISWAP_*
- * env vars when a community deployment is available. Consumers should gate
- * any DEX-aware UI on `isDexAvailable`.
+ * Derives from frontend/src/config/networks.js. The active chain's DEX is
+ * Uniswap V3 on Polygon-family chains and ETCswap (a Uniswap V3 deployment) on
+ * the Ethereum Classic family (Spec 033). Polygon Mainnet has the canonical
+ * Uniswap deployment; Polygon Amoy is wired via VITE_AMOY_UNISWAP_* env vars
+ * when a community deployment is available. Consumers should gate any DEX-aware
+ * UI on `isDexAvailable` and name the provider via the active network's
+ * `dexProvider` (see DexContext).
  */
 
 import { NETWORKS, getCurrentChainId, getNetwork } from '../config/networks'

--- a/frontend/src/contexts/DexContext.jsx
+++ b/frontend/src/contexts/DexContext.jsx
@@ -14,10 +14,11 @@ import logger from '../utils/logger'
 const ZERO = '0x0000000000000000000000000000000000000000'
 
 /**
- * Per-chain DEX wiring. Reads the active chain at runtime so the Testnet/
- * Mainnet toggle (wagmi.switchChain) transparently re-targets the right
- * Uniswap V3 deployment. Components that surface swap UI should branch on
- * `isDexAvailable` from the returned context.
+ * Per-chain DEX wiring. Reads the active chain at runtime so switching networks
+ * (wagmi.switchChain) transparently re-targets the right DEX deployment — Uniswap
+ * on Polygon-family chains, ETCswap on the Ethereum Classic family (Spec 033).
+ * Components that surface swap UI should branch on `isDexAvailable` and name the
+ * provider via `dexProvider` from the returned context.
  */
 export function DexProvider({ children }) {
   const { provider, signer, address, isConnected } = useWallet()
@@ -30,6 +31,11 @@ export function DexProvider({ children }) {
   const nativeConfig = network?.nativeCurrency || null
 
   const isDexAvailable = Boolean(dexConfig)
+
+  // Provider identity for the active chain (ETC family → ETCswap; else Uniswap).
+  // Independent of `dexConfig` so the swap UI can name the provider even when the
+  // DEX is unconfigured on this network (Spec 033).
+  const dexProvider = network?.dexProvider || null
 
   const addresses = useMemo(() => ({
     FACTORY: dexConfig?.factory || ZERO,
@@ -315,6 +321,7 @@ export function DexProvider({ children }) {
     tokens,
     addresses,
     isDexAvailable,
+    dexProvider,
     chainId,
     network,
   }

--- a/frontend/src/test/DexContext.test.jsx
+++ b/frontend/src/test/DexContext.test.jsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { useChainId } from 'wagmi'
+import { DexProvider } from '../contexts/DexContext.jsx'
+import { useDex } from '../hooks/useDex'
+
+// Spec 033 — DexContext must expose the active network's `dexProvider` so the
+// swap UI can name the provider. wagmi is mocked globally in test/setup.js; we
+// override useChainId per render. The wallet hook is stubbed (no provider) since
+// provider identity is derived purely from the active network.
+
+vi.mock('../hooks/useWalletManagement', () => ({
+  useWallet: () => ({ provider: null, signer: null, address: null, isConnected: false }),
+}))
+
+function ProviderProbe() {
+  const { dexProvider, isDexAvailable } = useDex()
+  return (
+    <div>
+      <span data-testid="provider">{dexProvider ? dexProvider.name : 'none'}</span>
+      <span data-testid="provider-url">{dexProvider?.url || ''}</span>
+      <span data-testid="dex-available">{String(isDexAvailable)}</span>
+    </div>
+  )
+}
+
+function renderAt(chainId) {
+  useChainId.mockReturnValue(chainId)
+  return render(
+    <DexProvider>
+      <ProviderProbe />
+    </DexProvider>
+  )
+}
+
+describe('DexContext — exposes network-aware dexProvider (Spec 033 FR-005/009)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('exposes ETCswap on Ethereum Classic mainnet (61)', () => {
+    renderAt(61)
+    expect(screen.getByTestId('provider')).toHaveTextContent('ETCswap')
+    expect(screen.getByTestId('provider-url')).toHaveTextContent('etcswap')
+  })
+
+  it('exposes ETCswap on Mordor (63)', () => {
+    renderAt(63)
+    expect(screen.getByTestId('provider')).toHaveTextContent('ETCswap')
+  })
+
+  it('exposes Uniswap on Polygon (137)', () => {
+    renderAt(137)
+    expect(screen.getByTestId('provider')).toHaveTextContent('Uniswap')
+    expect(screen.getByTestId('provider-url')).toHaveTextContent('uniswap.org')
+  })
+
+  it('exposes no provider on local Hardhat (1337)', () => {
+    renderAt(1337)
+    expect(screen.getByTestId('provider')).toHaveTextContent('none')
+  })
+})

--- a/frontend/src/test/NetworkSettings.test.jsx
+++ b/frontend/src/test/NetworkSettings.test.jsx
@@ -90,4 +90,27 @@ describe('NetworkSettings — relocated network selector', () => {
     expect(explorer).toHaveAttribute('rel', expect.stringContaining('noopener'))
     expect(within(card).getByText('Classic USD (USC)')).toBeInTheDocument()
   })
+
+  // Spec 033 — the Network tab DEX link comes from the per-network dexProvider.
+  it('lists Ethereum Classic (mainnet, chainId 61) as a selectable network', () => {
+    render(<NetworkSettings />)
+    const card = screen.getByText('Ethereum Classic').closest('.network-card')
+    expect(card).toBeInTheDocument()
+    expect(within(card).getByText('Mainnet')).toBeInTheDocument()
+  })
+
+  it('shows the ETCswap provider link on the Ethereum Classic card', () => {
+    render(<NetworkSettings />)
+    const card = screen.getByText('Ethereum Classic').closest('.network-card')
+    const link = within(card).getByRole('link', { name: /Open ETCswap/ })
+    expect(link).toHaveAttribute('href', 'https://v3.etcswap.org')
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+  })
+
+  it('shows the Uniswap provider link on the Polygon card', () => {
+    render(<NetworkSettings />)
+    const card = screen.getByText('Polygon').closest('.network-card')
+    const link = within(card).getByRole('link', { name: /Open Uniswap/ })
+    expect(link).toHaveAttribute('href', expect.stringContaining('app.uniswap.org'))
+  })
 })

--- a/frontend/src/test/SwapPanel.test.jsx
+++ b/frontend/src/test/SwapPanel.test.jsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// Spec 033 — SwapPanel must name/link the DEX provider that applies to the
+// active network (ETCswap on the ETC family, Uniswap elsewhere) and degrade
+// honestly when no DEX is configured. We mock the DEX/wallet/token hooks so the
+// component's provider-awareness is exercised in isolation.
+
+const { mockUseDex, mockUseWallet, mockUseChainTokens } = vi.hoisted(() => ({
+  mockUseDex: vi.fn(),
+  mockUseWallet: vi.fn(),
+  mockUseChainTokens: vi.fn(),
+}))
+
+vi.mock('../hooks/useDex', () => ({ useDex: mockUseDex }))
+vi.mock('../hooks', () => ({ useWallet: mockUseWallet }))
+vi.mock('../hooks/useChainTokens', () => ({ useChainTokens: mockUseChainTokens }))
+
+import SwapPanel from '../components/fairwins/SwapPanel'
+
+const ETC_ADDRESSES = {
+  WNATIVE: '0x1953cab0E5bFa6D4a9BaD6E05fD46C1CC6527a5a',
+  STABLECOIN: '0xDE093684c796204224BC081f937aa059D903c52a',
+  SWAP_ROUTER_02: '0xEd88EDD995b00956097bF90d39C9341BBde324d1',
+}
+const POLYGON_ADDRESSES = {
+  WNATIVE: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
+  STABLECOIN: '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+  SWAP_ROUTER_02: '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45',
+}
+
+function dexValue(overrides = {}) {
+  return {
+    balances: { native: '0', wnative: '0', stable: '0' },
+    loading: false,
+    quotingPrice: false,
+    wrapNative: vi.fn(),
+    unwrapNative: vi.fn(),
+    swap: vi.fn(),
+    getQuote: vi.fn(),
+    slippage: 50,
+    setSlippage: vi.fn(),
+    addresses: ETC_ADDRESSES,
+    isDexAvailable: true,
+    dexProvider: { name: 'ETCswap', url: 'https://v3.etcswap.org' },
+    network: { name: 'Ethereum Classic', chainId: 61 },
+    ...overrides,
+  }
+}
+
+const polygonDex = (overrides = {}) =>
+  dexValue({
+    addresses: POLYGON_ADDRESSES,
+    dexProvider: { name: 'Uniswap', url: 'https://app.uniswap.org/swap?chain=polygon' },
+    network: { name: 'Polygon', chainId: 137 },
+    ...overrides,
+  })
+
+describe('SwapPanel — network-aware DEX provider identity (Spec 033)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseWallet.mockReturnValue({ isConnected: true, chainId: 61 })
+    mockUseChainTokens.mockReturnValue({ native: 'ETC', stable: 'USC' })
+  })
+
+  it('US1: names ETCswap and links to it on an ETC-family chain', () => {
+    mockUseDex.mockReturnValue(dexValue())
+    render(<SwapPanel />)
+
+    expect(screen.getByText(/swap via ETCswap/)).toBeInTheDocument()
+    expect(screen.getByText('ETCswap Router ↗')).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: /Open ETCswap/ })
+    expect(link).toHaveAttribute('href', 'https://v3.etcswap.org')
+    // No Uniswap anywhere on an ETC chain (SC-003).
+    expect(screen.queryByText(/Uniswap/)).toBeNull()
+  })
+
+  it('US2: names Uniswap and links to it on a non-ETC chain', () => {
+    mockUseWallet.mockReturnValue({ isConnected: true, chainId: 137 })
+    mockUseChainTokens.mockReturnValue({ native: 'POL', stable: 'USDC' })
+    mockUseDex.mockReturnValue(polygonDex())
+    render(<SwapPanel />)
+
+    expect(screen.getByText(/swap via Uniswap/)).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: /Open Uniswap/ })
+    expect(link).toHaveAttribute('href', expect.stringContaining('app.uniswap.org'))
+    // No ETCswap on a non-ETC chain (SC-003).
+    expect(screen.queryByText(/ETCswap/)).toBeNull()
+  })
+
+  it('US3: disabled-state names the chain provider, never the wrong one (FR-006)', () => {
+    mockUseWallet.mockReturnValue({ isConnected: true, chainId: 63 })
+    mockUseChainTokens.mockReturnValue({ native: 'ETC', stable: 'USC' })
+    mockUseDex.mockReturnValue(
+      dexValue({
+        isDexAvailable: false,
+        dexProvider: { name: 'ETCswap', url: 'https://etcswap.org' },
+        network: { name: 'Ethereum Classic Mordor', chainId: 63 },
+      })
+    )
+    render(<SwapPanel />)
+
+    expect(
+      screen.getByText(/ETCswap is not configured on Ethereum Classic Mordor/)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/Uniswap/)).toBeNull()
+    expect(screen.queryByText(/Polygon/)).toBeNull()
+  })
+
+  it('US3: re-targets the provider when the chain changes (no stale text, FR-005)', () => {
+    mockUseDex.mockReturnValue(dexValue()) // ETC
+    const { rerender } = render(<SwapPanel />)
+    expect(screen.getByText(/swap via ETCswap/)).toBeInTheDocument()
+
+    // Switch to Polygon.
+    mockUseWallet.mockReturnValue({ isConnected: true, chainId: 137 })
+    mockUseChainTokens.mockReturnValue({ native: 'POL', stable: 'USDC' })
+    mockUseDex.mockReturnValue(polygonDex())
+    rerender(<SwapPanel />)
+
+    expect(screen.getByText(/swap via Uniswap/)).toBeInTheDocument()
+    expect(screen.queryByText(/ETCswap/)).toBeNull()
+  })
+})

--- a/frontend/src/test/networks.test.js
+++ b/frontend/src/test/networks.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getDexProvider,
+  getNetwork,
+  getSelectableNetworks,
+  isDexAvailable,
+  isSupportedChainId,
+} from '../config/networks'
+
+// Spec 033 — network-aware swap provider. The DEX provider is declared per
+// network so the mapping (ETC family → ETCswap; all others → Uniswap) is
+// explicit, pure, and survives an unconfigured `dex`.
+
+describe('getDexProvider — network → DEX provider mapping (Spec 033 FR-001/007)', () => {
+  it('returns null for chains without a DEX provider (Hardhat 1337)', () => {
+    expect(getDexProvider(1337)).toBeNull()
+  })
+
+  it('returns null for an unknown / unsupported chain id', () => {
+    // getNetwork falls back to the active network, which has no guarantee of a
+    // provider for a bogus id; the helper must not throw and must be a pure lookup.
+    expect(() => getDexProvider(999999)).not.toThrow()
+  })
+
+  it('maps ETC-family chains (61, 63) to ETCswap', () => {
+    expect(getDexProvider(61)?.name).toBe('ETCswap')
+    expect(getDexProvider(63)?.name).toBe('ETCswap')
+    expect(getDexProvider(61)?.url).toMatch(/etcswap/)
+    expect(getDexProvider(63)?.url).toMatch(/etcswap/)
+  })
+
+  it('maps non-ETC chains (137, 80002) to Uniswap', () => {
+    expect(getDexProvider(137)?.name).toBe('Uniswap')
+    expect(getDexProvider(80002)?.name).toBe('Uniswap')
+    expect(getDexProvider(137)?.url).toMatch(/uniswap\.org/)
+    expect(getDexProvider(80002)?.url).toMatch(/uniswap\.org/)
+  })
+
+  it('never returns a provider whose name mismatches the chain family (FR-002/009)', () => {
+    expect(getDexProvider(61)?.name).not.toBe('Uniswap')
+    expect(getDexProvider(63)?.name).not.toBe('Uniswap')
+    expect(getDexProvider(137)?.name).not.toBe('ETCswap')
+    expect(getDexProvider(80002)?.name).not.toBe('ETCswap')
+  })
+})
+
+describe('Ethereum Classic mainnet (chainId 61) (Spec 033 FR-011)', () => {
+  it('is a supported, selectable mainnet network', () => {
+    expect(isSupportedChainId(61)).toBe(true)
+    const net = getNetwork(61)
+    expect(net.chainId).toBe(61)
+    expect(net.name).toBe('Ethereum Classic')
+    expect(net.isTestnet).toBe(false)
+    expect(net.selectable).toBe(true)
+  })
+
+  it('appears in the user-facing selectable network list', () => {
+    const ids = getSelectableNetworks().map((n) => n.chainId)
+    expect(ids).toContain(61)
+  })
+
+  it('binds ETC mainnet to ETCswap with a configured DEX (verified defaults)', () => {
+    expect(isDexAvailable(61)).toBe(true)
+    expect(getDexProvider(61)?.name).toBe('ETCswap')
+  })
+
+  it('uses Classic USD (USC, 6 decimals) as the stablecoin', () => {
+    const net = getNetwork(61)
+    expect(net.stablecoin.symbol).toBe('USC')
+    expect(net.stablecoin.decimals).toBe(6)
+  })
+
+  it('uses the Ethereum Classic Blockscout explorer', () => {
+    expect(getNetwork(61).explorer.baseUrl).toBe('https://etc.blockscout.com')
+  })
+})

--- a/specs/033-network-aware-swap/checklists/requirements.md
+++ b/specs/033-network-aware-swap/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Network-Aware Swap Provider
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- **Resolved (2026-06-24)**: FR-011 clarification — the user chose to **add Ethereum Classic
+  mainnet (chainId 61)** as a user-selectable network bound to ETCswap as part of this feature
+  (broader scope: new network config, ETCswap addresses, ETC stablecoin/wrapped-native, explorer).
+  FR-011 and the ETC assumption were updated accordingly; no markers remain.
+- All items pass. The provider-mapping rule (FR-001), provider-identity requirements
+  (FR-002–FR-006), and honest-state gating (FR-010) are testable and technology-agnostic.

--- a/specs/033-network-aware-swap/contracts/dex-provider-interface.md
+++ b/specs/033-network-aware-swap/contracts/dex-provider-interface.md
@@ -1,0 +1,99 @@
+# Interface Contract: DEX Provider Resolution (frontend)
+
+This is a **frontend application contract** — the public config/context surface other modules and
+tests rely on. No HTTP/RPC API and no smart-contract ABI is introduced (the swap reuses the existing
+Uniswap-V3-compatible `SwapRouter02` / `QuoterV2` ABIs unchanged).
+
+---
+
+## C1. `dexProvider` descriptor (shape)
+
+```ts
+// Conceptual shape (the codebase is JS; this documents the contract)
+type DexProvider = {
+  name: string   // "ETCswap" | "Uniswap"  — user-facing, matches the active network
+  url: string    // absolute https:// URL to the provider web-app
+}
+```
+
+**Invariants**
+- Present on every supported network that can ever offer swaps; `null`/absent only for non-swap
+  chains (Hardhat `1337`).
+- `name` MUST match FR-001: ETC-family (`61`,`63`) → `"ETCswap"`; others (`137`,`80002`) → `"Uniswap"`.
+- Independent of `dex` availability (exists even when `dex === null`).
+
+---
+
+## C2. `getDexProvider(chainId)` — `frontend/src/config/networks.js`
+
+```ts
+function getDexProvider(chainId: number): DexProvider | null
+```
+
+| Input `chainId` | Output |
+|-----------------|--------|
+| `61` | `{ name: "ETCswap", url: "https://v3.etcswap.org" }` |
+| `63` | `{ name: "ETCswap", url: "https://etcswap.org" }` (or `v3.` per config) |
+| `137` | `{ name: "Uniswap", url: "https://app.uniswap.org/swap?chain=polygon" }` |
+| `80002` | `{ name: "Uniswap", url: "https://app.uniswap.org/swap" }` |
+| `1337` | `null` |
+| unknown | resolves via `getNetwork` fallback (same as existing helpers); `null` if no provider |
+
+**Contract guarantees**
+- Pure, synchronous, no side effects, no network I/O.
+- Never returns a provider whose `name` mismatches the requested chain (FR-002, FR-009).
+
+---
+
+## C3. `DexContext` value — added key
+
+The context returned by `useDex()` gains:
+
+```ts
+dexProvider: DexProvider | null   // = getNetwork(activeChainId)?.dexProvider ?? null
+```
+
+Existing keys (`isDexAvailable`, `chainId`, `network`, `addresses`, `tokens`, `getQuote`, `swap`,
+`wrapNative`, `unwrapNative`, `slippage`, `setSlippage`, `balances`, …) are unchanged.
+
+**Re-targeting guarantee (FR-005)**: when `useChainId()` changes, `network` and therefore
+`dexProvider` recompute, so all consumers re-render with the new provider and no stale values.
+
+---
+
+## C4. UI consumption contract (`SwapPanel`, `NetworkSettings`)
+
+`SwapPanel` MUST:
+- Use `dexProvider.name` in: panel subtitle, the disabled-state (`!isDexAvailable`) message, and the
+  router link label (`{name} Router ↗`).
+- Render a provider-app link `Open {dexProvider.name} ↗` → `dexProvider.url`
+  (`target="_blank" rel="noopener noreferrer"`), shown when `dexProvider` is present.
+- In the disabled-state, name the provider applicable to the **current** network and the current
+  `network.name`; MUST NOT reference a different network's provider (no hardcoded "Uniswap on Polygon").
+- Contain **zero** hardcoded "Uniswap"/"ETCswap" string literals in user-facing copy — all provider
+  text derives from `dexProvider`.
+
+`NetworkSettings` MUST:
+- Render the provider link from `dexProvider` (`href={dexProvider.url}`, label includes
+  `dexProvider.name`), gated on `capabilities.dex`, replacing the prior `resources.dexUrl` usage.
+
+**Accessibility**: links keep discernible text (the `↗` is decorative within the labeled link);
+external links retain `rel="noopener noreferrer"`. No new axe/Lighthouse violations.
+
+---
+
+## C5. Acceptance mapping
+
+| Spec requirement | Contract element |
+|------------------|------------------|
+| FR-001 mapping | C2 table |
+| FR-002 correct name everywhere | C4 (zero hardcoded literals) |
+| FR-003 provider link | C4 provider-app link → `dexProvider.url` |
+| FR-004 explorer/contract links | unchanged `getExplorerUrl(chainId, …)` (per-chain explorer) |
+| FR-005 re-target on switch | C3 re-targeting guarantee |
+| FR-006 honest disabled-state | C1 (independent of `dex`), C4 disabled-state rule |
+| FR-007 data-driven | C1 per-network declaration + C2 helper |
+| FR-008 mechanics unchanged | C3 (swap fns unchanged) |
+| FR-009 network-scoped | C2/C3 pure per-chain resolution |
+| FR-010 gated, no mock | `isDexAvailable = Boolean(dex)` unchanged; verified addresses only |
+| FR-011 ETC mainnet reachable | `networks[61]` entry (data-model) + C2 row `61` |

--- a/specs/033-network-aware-swap/data-model.md
+++ b/specs/033-network-aware-swap/data-model.md
@@ -1,0 +1,101 @@
+# Phase 1 Data Model: Network-Aware Swap Provider
+
+This feature adds **configuration shapes**, not persisted data. The "entities" are the in-memory
+config objects in `frontend/src/config/networks.js` and the context value exposed by `DexContext`.
+No database, no migration, no on-chain state change.
+
+---
+
+## Entity: DexProvider (new)
+
+A network-level descriptor of the DEX provider the swap routes through and presents.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | yes | User-facing provider name. Allowed values today: `"ETCswap"`, `"Uniswap"`. |
+| `url` | string (URL) | yes | Canonical provider web-app URL for the "open DEX" link. |
+
+**Placement**: declared at the **network level** (sibling of `dex`, not nested under it), so it is
+available even when `dex === null` (unconfigured DEX). See research R5.
+
+**Validation rules**:
+- `name` MUST be non-empty and MUST match the provider that actually applies to the network
+  (FR-001/FR-002): ETC-family → `"ETCswap"`; all others → `"Uniswap"`.
+- `url` MUST be an absolute `https://` URL.
+- A network MAY omit `dexProvider` (→ `null`) only when it never offers swaps (e.g. Hardhat `1337`).
+
+**Mapping rule (FR-001)** — encoded by per-network declaration, documented in a comment:
+- `61` (ETC mainnet) → ETCswap
+- `63` (Mordor) → ETCswap
+- `137` (Polygon) → Uniswap
+- `80002` (Amoy) → Uniswap
+- `1337` (Hardhat) → none
+
+---
+
+## Entity: Network DEX Binding (existing `networks.js` entry — extended)
+
+Each `NETWORKS[chainId]` object already binds a chain to its DEX deployment, stablecoin, wrapped
+native, explorer, and capabilities. This feature **adds** `dexProvider` and adds a full entry for
+chain `61`.
+
+Fields relevant to this feature (others unchanged):
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `chainId` | number | yes | e.g. `61`. |
+| `name` | string | yes | e.g. `"Ethereum Classic"`. |
+| `isTestnet` | boolean | yes | `61` → `false`. |
+| `selectable` | boolean | yes | `61` → `true` (surfaces in Network-tab selector). |
+| `nativeCurrency` | `{ decimals, name, symbol }` | yes | `61` → `{ 18, "Ethereum Classic", "ETC" }`. |
+| `rpcUrl` | string | yes | `61` → `VITE_RPC_URL_ETC \|\| "https://etc.rivet.link"`. |
+| `explorer` | `{ name, baseUrl }` | yes | `61` → `{ "Blockscout", "https://etc.blockscout.com" }`. |
+| `subgraphUrl` | string\|null | yes | `61` → `null` (no ETC indexer). |
+| `stablecoin` | `{ address, symbol, name, decimals }` | yes | `61` → USC `0xDE09…c52a`, `USC`, `Classic USD`, `6` (env `VITE_ETC_USC`). |
+| `dex` | `{ factory, swapRouter, quoter, positionManager, wnative } \| null` | yes | `61` → verified ETCswap V3 addresses (env `VITE_ETC_ETCSWAP_*`, `VITE_ETC_WETC`). |
+| **`dexProvider`** | `DexProvider \| null` | **new** | `61`/`63` → ETCswap; `137`/`80002` → Uniswap; `1337` → `null`. |
+| `resources` | `{ faucet? }` | optional | `resources.dexUrl` **removed** (consolidated into `dexProvider.url`, research R6); `faucet` retained where present. |
+| `capabilities` | getter `{ polymarketSidebets, dex, friendMarkets }` | yes | `61` → `polymarketSidebets:false`, `dex:Boolean(this.dex)`, `friendMarkets:true`. |
+
+**State / availability semantics** (unchanged invariants, restated):
+- `isDexAvailable(chainId) === Boolean(getNetwork(chainId)?.dex)`. Missing required DEX addresses →
+  `dex` is `null` → swap disabled (no mock). Honest-State.
+- `dexProvider` is **independent** of `dex` availability so disabled-state copy can still name the
+  provider (FR-006).
+
+---
+
+## Derived accessor: `getDexProvider(chainId)` (new helper in `networks.js`)
+
+| Aspect | Definition |
+|--------|------------|
+| Input | `chainId: number` |
+| Output | `DexProvider \| null` — the active network's `dexProvider`, or `null` if none/unknown |
+| Behavior | `getNetwork(chainId)?.dexProvider ?? null`; resolves the same fallback chain as `getNetwork` |
+| Scope guarantee | Pure per-chain lookup; identity never leaks across chains (FR-009) |
+
+---
+
+## Context exposure: `DexContext` value (extended)
+
+`DexProvider` (the React context, not the entity) already returns
+`{ ..., isDexAvailable, chainId, network }`. This feature adds:
+
+| Key | Type | Source |
+|-----|------|--------|
+| `dexProvider` | `DexProvider \| null` | `network?.dexProvider ?? null` (derived from active chain) |
+
+Consumers (`SwapPanel`) read `dexProvider.name` for all provider labels/messages and
+`dexProvider.url` for the provider-app link. `network.name` supplies the network name used in
+disabled-state copy.
+
+---
+
+## No-change surfaces (explicitly)
+
+- `wagmi.js` — chain `61` already defined and wired.
+- `blockExplorer.js` — chain `61 → etc.blockscout.com` already present.
+- `contracts.js` — unchanged; ETC mainnet has no project contracts (wager-legacy). Capability tags
+  other than "swap" correctly read as not-deployed on `61`.
+- Swap mechanics (`getQuote`/`swap`/`wrapNative`/`unwrapNative` in `DexContext`) — unchanged; both
+  providers are Uniswap-V3-compatible (FR-008).

--- a/specs/033-network-aware-swap/plan.md
+++ b/specs/033-network-aware-swap/plan.md
@@ -1,0 +1,122 @@
+# Implementation Plan: Network-Aware Swap Provider
+
+**Branch**: `033-network-aware-swap` | **Date**: 2026-06-24 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/033-network-aware-swap/spec.md`
+
+## Summary
+
+Make the in-app Swap surface name and link the **correct DEX provider** for the active
+network: Ethereum Classic networks (ETC mainnet `61`, Mordor `63`) default to **ETCswap**;
+all other networks (Polygon `137`, Amoy `80002`) default to **Uniswap**. Swap *routing*
+already targets the per-chain DEX deployment, but every user-facing label, message, and link
+is hardcoded "Uniswap V3" — misleading on Ethereum Classic.
+
+Technical approach: introduce a small, data-driven, **network-level `dexProvider` descriptor**
+(`{ name, url }`) in `frontend/src/config/networks.js`, declared on every supported network so
+it is available even when the chain has no configured DEX (for honest disabled-state copy).
+Expose it through `DexContext`, and consume it in `SwapPanel` (labels, disabled-state message,
+provider link) and `NetworkSettings` (provider link), replacing hardcoded "Uniswap" strings.
+Add Ethereum Classic mainnet (`61`) to `networks.js` bound to ETCswap, using the on-chain
+verified ETCswap V3 addresses (see [research.md](./research.md)) as env-overridable defaults.
+Frontend-only; no backend, no smart-contract changes; reuses the existing Uniswap-V3-compatible
+swap/quote/wrap logic unchanged.
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES modules), React 18, Node 20 toolchain
+
+**Primary Dependencies**: Vite, wagmi v2 + viem, ethers v6 (swap/quote calls), Vitest + React
+Testing Library (tests). No new dependency is introduced.
+
+**Storage**: N/A — configuration and runtime context only; no persistence. (Balance history is
+already in-memory in `DexContext` and is untouched.)
+
+**Testing**: Vitest unit/component tests under `frontend/src/test/`; axe/Lighthouse a11y in CI.
+
+**Target Platform**: Browser SPA (fairwins.app), served by nginx on Cloud Run.
+
+**Project Type**: Web frontend (single `frontend/` app). No backend tier (fixed footprint).
+
+**Performance Goals**: Provider resolution is a pure synchronous config lookup at render time
+(O(1) map access); no added network round-trips, no measurable render impact.
+
+**Constraints**: No-backend footprint; honest-state (no mock DEX, real verified addresses,
+network-scoped identity); WCAG 2.1 AA for the changed UI; contract/network config flows from
+`networks.js` (the established source of truth), never hardcoded in components.
+
+**Scale/Scope**: 5 configured chains (137, 80002, 63, **+61 new**, 1337). ~6 source files +
+~3–4 test files touched. No data migration.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment |
+|-----------|------------|
+| **I. Security-First Smart Contracts** | **N/A / PASS** — no `contracts/` changes. The swap is a value-bearing surface but routes through *external* DEX protocol contracts (ETCswap/Uniswap V3), not project contracts. Risk is mitigated by honest-state gating: real, on-chain-verified addresses only; no mock/placeholder DEX; DEX disabled when addresses are absent. |
+| **II. Test-First & Coverage** | **PASS** — Vitest tests are added/extended alongside the change: provider mapping (`networks`/`getDexProvider`), `DexContext` exposure, `SwapPanel` provider-correct labels & disabled-state per chain, `NetworkSettings` provider link, and the new `61` network entry. No contract-interface change, so no Hardhat tests required. |
+| **III. Honest State, No Mocks** | **PASS (central)** — provider identity is **scoped to the active network** and never leaks; DEX availability stays gated on configured addresses; ETC mainnet uses **on-chain-verified** ETCswap addresses (research.md), never a mock; disabled-state copy names the provider that actually applies to that network. |
+| **IV. Fail Loudly in CI** | **PASS** — no `continue-on-error` added; lint/test/build/a11y gates unchanged. |
+| **V. Accessible, Consistent Frontend** | **PASS** — changed elements are standard headings/anchors with accessible names (`Open {provider} ↗`, external links keep `rel="noopener noreferrer"`); ESLint clean; network config comes from `networks.js` artifacts, not hand-copied into components. External DEX addresses live in `networks.js` exactly as Polygon's canonical Uniswap addresses already do (precedent), so this is consistent with the "config from the source of truth" rule. |
+
+**Result**: PASS — no violations. Complexity Tracking left empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/033-network-aware-swap/
+├── plan.md              # This file (/speckit-plan)
+├── research.md          # Phase 0 — verified ETCswap addresses + design decisions
+├── data-model.md        # Phase 1 — DexProvider descriptor + Network DEX binding shapes
+├── quickstart.md        # Phase 1 — runnable validation guide
+├── contracts/
+│   └── dex-provider-interface.md   # Phase 1 — frontend config/context interface contract
+├── checklists/
+│   └── requirements.md  # from /speckit-specify
+└── tasks.md             # Phase 2 — /speckit-tasks (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/
+├── src/
+│   ├── config/
+│   │   ├── networks.js               # ADD networks[61] (ETC mainnet → ETCswap);
+│   │   │                             #   ADD network-level `dexProvider` to 61/63/137/80002;
+│   │   │                             #   ADD getDexProvider(chainId) helper;
+│   │   │                             #   consolidate resources.dexUrl → dexProvider.url
+│   │   ├── networkCapabilities.js    # provider-neutral "swap" feature description
+│   │   ├── wagmi.js                  # NO CHANGE (chain 61 already wired)
+│   │   └── blockExplorer.js          # NO CHANGE (chain 61 already present)
+│   ├── contexts/
+│   │   └── DexContext.jsx            # expose `dexProvider` in context value
+│   ├── constants/
+│   │   └── dex.js                    # update comments; (optional) export active provider
+│   ├── components/
+│   │   ├── fairwins/SwapPanel.jsx    # provider-aware labels, disabled-state, provider link
+│   │   └── wallet/NetworkSettings.jsx# provider link from dexProvider
+│   └── test/
+│       ├── networks.test.js          # NEW — provider mapping + networks[61]
+│       ├── SwapPanel.test.jsx        # NEW — provider-correct labels/links per chain
+│       ├── DexContext.test.jsx       # NEW — dexProvider exposure per chain
+│       └── NetworkSettings.test.jsx  # EXTEND — provider link assertions
+└── .env.example                      # ADD VITE_ETC_* (chain 61) overrides block
+```
+
+**Structure Decision**: Single existing `frontend/` React app — no new project or module. The
+change is localized to chain configuration (`config/`), the DEX runtime context (`contexts/`),
+and the two surfaces that present provider identity (`SwapPanel`, `NetworkSettings`). The
+provider mapping is data-driven via a per-network `dexProvider` field plus a `getDexProvider`
+helper, so future networks opt in by configuration alone (FR-007).
+
+## Complexity Tracking
+
+> No constitution violations — no entries required.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| _none_    | —          | —                                    |

--- a/specs/033-network-aware-swap/quickstart.md
+++ b/specs/033-network-aware-swap/quickstart.md
@@ -1,0 +1,84 @@
+# Quickstart & Validation: Network-Aware Swap Provider
+
+A runnable guide to prove the feature works end-to-end. Implementation details live in
+[data-model.md](./data-model.md) and [contracts/](./contracts/dex-provider-interface.md); ordered
+work lives in `tasks.md` (after `/speckit-tasks`).
+
+## Prerequisites
+
+```bash
+cd frontend
+npm install            # if not already
+```
+
+Reference values (from [research.md](./research.md)) for ETC mainnet (chainId 61):
+
+| Item | Value |
+|------|-------|
+| ETCswap Factory | `0x2624E907BcC04f93C8f29d7C7149a8700Ceb8cDC` |
+| ETCswap SwapRouter02 | `0xEd88EDD995b00956097bF90d39C9341BBde324d1` |
+| ETCswap QuoterV2 | `0x4d8c163400CB87Cbe1bae76dBf36A09FED85d39B` |
+| ETCswap PositionManager | `0x3CEDe6562D6626A04d7502CC35720901999AB699` |
+| WETC | `0x1953cab0E5bFa6D4a9BaD6E05fD46C1CC6527a5a` (18) |
+| USC (Classic USD) | `0xDE093684c796204224BC081f937aa059D903c52a` (6) |
+| ETCswap app | `https://v3.etcswap.org` |
+
+## 1. Automated tests (primary gate)
+
+```bash
+cd frontend
+npm run test -- networks SwapPanel DexContext NetworkSettings   # focused
+# or the whole suite:
+npm run test:frontend     # from repo root
+```
+
+**Expected**: new/updated specs pass —
+- `networks.test.js`: `NETWORKS[61]` exists & `selectable`; `getDexProvider(61|63)→ETCswap`,
+  `getDexProvider(137|80002)→Uniswap`, `getDexProvider(1337)→null`; `getSelectableNetworks()`
+  includes `61`; `isDexAvailable(61)===true`.
+- `DexContext.test.jsx`: context `dexProvider.name` is `ETCswap` on `61`/`63`, `Uniswap` on `137`.
+- `SwapPanel.test.jsx`: on `61`/`137` the labels/provider link name the correct provider; on a chain
+  with no `dex`, the disabled message names that chain's provider (never the wrong one); switching the
+  mocked chain updates the provider with no stale text.
+- `NetworkSettings.test.jsx`: the provider link uses `dexProvider.url`/`name`.
+
+## 2. Lint & build
+
+```bash
+cd frontend
+npm run lint
+npm run build     # NOTE: may require VITE_PINATA_JWT locally (see memory: local-verification-gotchas)
+```
+
+**Expected**: ESLint clean; no new warnings.
+
+## 3. Manual smoke (dev server)
+
+```bash
+npm run frontend          # from repo root
+```
+
+Then in the browser (My Account → **Swap** tab) and (My Account → **Network** tab):
+
+| Scenario | Steps | Expected (FR) |
+|----------|-------|---------------|
+| ETC mainnet shows ETCswap | Select **Ethereum Classic** in the Network tab → open Swap | Panel says **ETCswap**; "Open ETCswap ↗" → `v3.etcswap.org`; contract links use `etc.blockscout.com` (FR-001/002/003/004) |
+| Polygon shows Uniswap | Switch to **Polygon (Mainnet)** → open Swap | Panel says **Uniswap**; provider link → `app.uniswap.org`; explorer links → `polygonscan.com` (FR-001/002/003) |
+| Re-target on switch | Toggle between ETC and Polygon | Provider name + all links update with **no** leftover references (FR-005) |
+| Honest disabled-state | Select **Mordor** without ETCswap env addresses | Panel disabled; message names **ETCswap** + Mordor (not "Uniswap on Polygon"); no mock (FR-006/010) |
+| Network tab provider link | Network tab, ETC vs Polygon rows | Each shows its provider link from `dexProvider` when `capabilities.dex` (FR-003) |
+| Selectable network | Network tab list | **Ethereum Classic (61)** appears as selectable (FR-011) |
+
+## 4. Optional: exercise a real ETC-mainnet quote
+
+With a wallet on Ethereum Classic mainnet holding a little WETC/USC, open Swap → Swap Tokens, enter an
+amount, and confirm a non-empty quote appears (proves routing through the configured ETCswap QuoterV2).
+Do **not** broadcast unless intentionally trading real funds.
+
+## Done When
+
+- [ ] `npm run test:frontend` passes including the new provider specs.
+- [ ] `npm run lint` clean.
+- [ ] Manual smoke: ETC→ETCswap, Polygon→Uniswap, switch re-targets, disabled-state names the right
+      provider, ETC mainnet is selectable.
+- [ ] No user-facing "Uniswap" text on any ETC-family swap surface; no "ETCswap" on non-ETC (SC-003).

--- a/specs/033-network-aware-swap/research.md
+++ b/specs/033-network-aware-swap/research.md
@@ -1,0 +1,160 @@
+# Phase 0 Research: Network-Aware Swap Provider
+
+All Phase-0 unknowns from the Technical Context are resolved below. Decisions are recorded as
+**Decision / Rationale / Alternatives considered**.
+
+---
+
+## R1. ETCswap V3 contract addresses on Ethereum Classic mainnet (chainId 61)
+
+**Decision**: Bind ETC mainnet to ETCswap V3 using the following **on-chain-verified** addresses,
+supplied as env-overridable defaults in `networks.js` (same inline-default pattern as Polygon's
+canonical Uniswap addresses):
+
+| Role | Address | Verified |
+|------|---------|----------|
+| UniswapV3Factory (`ETCswapV3Factory`) | `0x2624E907BcC04f93C8f29d7C7149a8700Ceb8cDC` | Blockscout-verified (Solidity 0.7.6); on-chain |
+| SwapRouter02 (router) | `0xEd88EDD995b00956097bF90d39C9341BBde324d1` | On-chain `factory()`/`WETH9()` correct (bytecode present) |
+| QuoterV2 | `0x4d8c163400CB87Cbe1bae76dBf36A09FED85d39B` | On-chain `factory()`/`WETH9()` correct (bytecode present) |
+| NonfungiblePositionManager | `0x3CEDe6562D6626A04d7502CC35720901999AB699` | Blockscout-verified (0.7.6); cross-refs factory/WETC |
+| WETC (Wrapped ETC) | `0x1953cab0E5bFa6D4a9BaD6E05fD46C1CC6527a5a` | Blockscout-verified `WETC9`; `symbol=WETC`, `decimals=18` |
+
+**Rationale**: Source of truth is the ETCswap SDK (`etcswap/sdks` → `sdk-core/src/addresses.ts`,
+`ChainId.CLASSIC`), cross-checked live against ETC mainnet RPC (`eth_chainId` = `0x3d` = 61) and
+`https://etc.blockscout.com`. The V3 periphery contracts mutually reference the same factory and
+WETC, confirming a consistent deployment. Using verified addresses (not mocks) satisfies the
+Honest-State principle while making ETC swaps actually functional.
+
+**Alternatives considered**: (a) Leave ETC mainnet DEX env-gated/empty (disabled until an operator
+supplies addresses) — rejected because the user explicitly chose to make "ETC → ETCswap" reachable;
+verified addresses exist, so gating it off would ship a dead feature. (b) Hardcode without env
+override — rejected; keep `VITE_ETC_ETCSWAP_*` overrides for parity with Mordor/Amoy and to allow
+swapping the router if ETCswap upgrades.
+
+**Verification status (T011, 2026-06-24)**: All five addresses were confirmed on ETC mainnet
+(`eth_chainId` = 0x3d). Factory, PositionManager, and WETC are **Blockscout source-verified**.
+SwapRouter02 (`0xEd88…24d1`) and QuoterV2 (`0x4d8c…d39B`) were confirmed by **deployed bytecode +
+correct on-chain wiring** (`factory()`/`WETH9()` return the canonical factory/WETC), but their
+Blockscout *source-verification badge* was not retrievable via the API in this session. The
+addresses are correct and safe to ship as defaults; if a verified-source badge is required, confirm
+the two contract pages directly on `etc.blockscout.com`. They are env-overridable
+(`VITE_ETC_ETCSWAP_SWAP_ROUTER` / `VITE_ETC_ETCSWAP_QUOTER`) if ETCswap ever redeploys.
+
+---
+
+## R2. Classic USD (USC) stablecoin on ETC mainnet
+
+**Decision**: Use `0xDE093684c796204224BC081f937aa059D903c52a`, **6 decimals**, symbol `USC`,
+name `Classic USD`, as the ETC-mainnet stablecoin (env override `VITE_ETC_USC`).
+
+**Rationale**: Verified three ways — `classicusd.com`, `etc.blockscout.com` (verified `ERC1967Proxy`,
+0.8.20; on-chain `name="Classic USD"`, `symbol="USC"`, `decimals=6`), and a direct `eth_call` on a
+confirmed chainId-61 RPC. **Correction to a prior assumption**: this address is the *mainnet* USC, not
+Mordor-only. ETCswap/USC use deterministic addresses, so the same value already appears as Mordor's
+default in `networks.js` — i.e. the existing Mordor `VITE_MORDOR_USC` default is the same token.
+
+**Alternatives considered**: A possible second (Polygon) Brale USC address appeared truncated on the
+Brale page; not confirmed and explicitly **not** used for ETC.
+
+---
+
+## R3. ETC family also covers Mordor (63) — deterministic addresses
+
+**Decision**: Mordor (63) keeps its existing `VITE_MORDOR_ETCSWAP_*` env-gated `dex` config, but
+gains the `dexProvider: { name: 'ETCswap', url }` descriptor so its identity/copy is correct even
+while its `dex` is unconfigured. A follow-on task verifies the deterministic ETCswap addresses on
+`etc-mordor.blockscout.com` and, if confirmed, adds them as Mordor defaults to enable Mordor swaps.
+
+**Rationale**: The ETCswap SDK lists identical addresses for `CLASSIC` (61) and `MORDOR` (63), but
+research could not independently verify them on the Mordor explorer (the local node was Mordor but its
+RPC did not answer). Adding the provider *descriptor* now (cheap, no funds risk) immediately fixes the
+mislabel (FR-002/FR-006) on Mordor; defaulting Mordor's *routing* addresses waits on explicit Mordor
+verification to honor Honest-State.
+
+**Alternatives considered**: Default Mordor's `dex` to the mainnet addresses immediately — rejected
+pending Mordor-side verification (could differ; would risk routing funds to a wrong/absent contract).
+
+---
+
+## R4. DEX provider web-app URLs (the "open DEX" link)
+
+**Decision**:
+- ETCswap (ETC family) → `https://v3.etcswap.org` (canonical domain is **etcswap.org**; the V3 app
+  lives on the `v3.` subdomain; `etcswap.com` redirects/aliases). Env override `VITE_ETC_ETCSWAP_URL`
+  / existing `VITE_MORDOR_ETCSWAP_URL`.
+- Uniswap (Polygon family) → `https://app.uniswap.org/swap?chain=polygon` (Amoy: same base; Uniswap
+  has no Amoy slug, so `app.uniswap.org/swap` without `?chain` is the safe default for testnet).
+
+**Rationale**: Confirmed against ETCswap docs/site and `app.uniswap.org`. Uniswap supports a named
+`?chain=` slug (`mainnet`, `polygon`, …), not numeric chain IDs; Uniswap does **not** support ETC, so
+it is correctly never used on ETC-family chains.
+
+**Alternatives considered**: Linking to the SwapRouter contract on the explorer instead of the DEX app
+— kept as a *separate* link ("{provider} Router ↗" → explorer); the provider-app link is added
+alongside it, not as a replacement.
+
+---
+
+## R5. How to make provider identity data-driven (FR-007) and survive an unconfigured DEX (FR-006)
+
+**Decision**: Add a **network-level** `dexProvider: { name, url }` field to each entry in
+`networks.js` (NOT nested under `dex`), plus a `getDexProvider(chainId)` helper. ETC-family entries
+declare `{ name: 'ETCswap', url }`; Polygon-family entries declare `{ name: 'Uniswap', url }`;
+Hardhat declares none (`null`).
+
+**Rationale**: `dex` is set to `null` when addresses are missing (Amoy/Mordor pattern). Provider
+*identity* must still be known then, so the disabled-state message can say "ETCswap is not configured
+on Mordor" rather than "Uniswap on Polygon" (FR-006). Putting `dexProvider` at the network level keeps
+it independent of address availability. Declaring it per network (rather than computing from a chainId
+allow-list) makes the FR-001 rule explicit, unit-testable, and extensible by configuration alone
+(FR-007). A short comment documents the rule (ETC-family → ETCswap; else → Uniswap).
+
+**Alternatives considered**: (a) Compute provider from a hardcoded `[61, 63]` set inside components —
+rejected: scatters the rule and re-introduces per-chain branching the spec wants to avoid. (b) Nest
+provider under `dex` — rejected: unavailable exactly when the disabled-state message needs it.
+
+---
+
+## R6. Consolidating the existing `resources.dexUrl`
+
+**Decision**: Make `dexProvider.url` the single source for the provider-app link. Update
+`NetworkSettings.jsx` (today reads `net.resources.dexUrl`) to render from `dexProvider`
+(`Open {dexProvider.name} ↗`, gated on `capabilities.dex`). Remove the now-redundant
+`resources.dexUrl` from Mordor; retain `resources.faucet`.
+
+**Rationale**: Mordor already surfaces an `etcswap.org` link on the Network tab via `resources.dexUrl`;
+duplicating the URL in both `resources` and `dexProvider` violates DRY. One source avoids drift.
+
+**Alternatives considered**: Keep both fields — rejected (duplication/drift). Derive `dexProvider.url`
+from `resources.dexUrl` — rejected: Polygon/Amoy have no `resources` block, so provider URL belongs on
+the provider descriptor.
+
+---
+
+## R7. Wallet-layer wiring for ETC mainnet (61)
+
+**Decision**: No change to `wagmi.js` or `blockExplorer.js`. Only `networks.js` (app source of truth)
+needs the new `61` entry.
+
+**Rationale**: `wagmi.js` already defines `ethereumClassic` (id 61) and includes it in `chains`,
+`transports`, and `getExpectedChain`; `blockExplorer.js` already maps `61 → https://etc.blockscout.com`.
+The only gap is the missing `NETWORKS[61]` entry that drives DEX/stablecoin/capabilities/selectability.
+`getSelectableNetworks()` will surface `61` once it has `selectable: true`. The Testnet/Mainnet toggle
+(80002↔137) is unaffected; ETC mainnet/Mordor are reached via the Network-tab selector, as Mordor is
+today.
+
+**Alternatives considered**: None needed.
+
+---
+
+## R8. Capability-tag wording (`networkCapabilities.js`)
+
+**Decision**: Change the static `swap` feature description from "In-app token swaps via Uniswap V3." to
+provider-neutral wording, e.g. "In-app token swaps via the network's DEX (Uniswap or ETCswap)."
+
+**Rationale**: The Network-tab feature tag is a single static description across chains; naming only
+Uniswap mislabels ETC. Provider-neutral wording is accurate everywhere. (A fully chain-aware per-tag
+description is possible but unnecessary; the swap panel itself already names the active provider.)
+
+**Alternatives considered**: Make the description a function of chainId — deferred as gold-plating; the
+neutral string satisfies FR-002 on this surface.

--- a/specs/033-network-aware-swap/spec.md
+++ b/specs/033-network-aware-swap/spec.md
@@ -1,0 +1,117 @@
+# Feature Specification: Network-Aware Swap Provider
+
+**Feature Branch**: `033-network-aware-swap`
+
+**Created**: 2026-06-24
+
+**Status**: Draft
+
+**Input**: User description: "the swap functionality needs to be network awary. on mordor and etc it should default to etcswap (etcswap.com v3 deployment of the uniswap platform. on all other networks it should default to the uniswap implementation"
+
+## User Scenarios & Testing *(mandatory)*
+
+The in-app Swap surface lets a connected user exchange the active network's native, wrapped-native, and stablecoin tokens. Today the swap **routes** through whatever DEX deployment is configured for the active chain, but every user-facing label, message, and external link names the provider "Uniswap V3" — even on Ethereum Classic, where the deployment is actually **ETCswap**. This feature makes the swap's *provider identity* network-aware so users always see, and are linked to, the correct DEX for the chain they are on.
+
+### User Story 1 - Swap on Ethereum Classic shows and uses ETCswap (Priority: P1)
+
+A member connected to an Ethereum Classic network (Mordor testnet today, and Ethereum Classic mainnet) opens Swap. The panel identifies the provider as **ETCswap**, routes the trade through the ETCswap deployment, and every supporting link (provider site, "swap router" reference) points at ETCswap / the Ethereum Classic block explorer — never at Uniswap.
+
+**Why this priority**: This is the core of the request and the only network family currently mislabeled. ETC users are being shown a provider name and (potentially) links that don't match where their funds actually route, which is misleading and erodes trust on the app's value-bearing surface.
+
+**Independent Test**: With the wallet on an ETC-family network that has ETCswap configured, open Swap and confirm the provider is named ETCswap, the external/provider link resolves to the ETCswap site, and a quote/swap executes against the ETCswap deployment. Delivers correct, honest provider identity on ETC with no Uniswap references.
+
+**Acceptance Scenarios**:
+
+1. **Given** the wallet is connected to Mordor (or ETC mainnet) with ETCswap configured, **When** the user opens the Swap panel, **Then** the panel identifies the active provider as "ETCswap" and shows no "Uniswap" wording.
+2. **Given** the user is on an ETC-family network, **When** they follow the provider / DEX link from the swap panel, **Then** the link opens the ETCswap site (and contract/explorer links use the Ethereum Classic explorer for that chain).
+3. **Given** the user is on an ETC-family network with ETCswap configured, **When** they request a quote and confirm a swap, **Then** the trade routes through the ETCswap deployment for that chain.
+
+---
+
+### User Story 2 - Swap on non-ETC networks shows and uses Uniswap (Priority: P2)
+
+A member connected to a non-ETC network (Polygon mainnet, Polygon Amoy) opens Swap. The panel identifies the provider as **Uniswap**, routes through the Uniswap deployment, and supporting links point at Uniswap / that network's explorer.
+
+**Why this priority**: This preserves correct behavior on the production default network and codifies the "everything else defaults to Uniswap" half of the rule, so the mapping is explicit rather than incidental. It is P2 because today's Polygon experience is already routing through Uniswap; the work is making the identity an explicit, data-driven default rather than a hardcoded assumption.
+
+**Independent Test**: With the wallet on Polygon (or Amoy with Uniswap configured), open Swap and confirm the provider is named Uniswap, the provider link resolves to the Uniswap app, and a swap routes through the Uniswap deployment.
+
+**Acceptance Scenarios**:
+
+1. **Given** the wallet is connected to Polygon mainnet, **When** the user opens the Swap panel, **Then** the panel identifies the active provider as "Uniswap" and provider links resolve to the Uniswap app.
+2. **Given** the wallet is connected to a non-ETC network with a configured DEX, **When** the user swaps, **Then** the trade routes through the Uniswap deployment for that chain.
+
+---
+
+### User Story 3 - Network switch re-targets the provider; unavailable DEX explained honestly (Priority: P3)
+
+A member switches networks mid-session (e.g., Testnet/Mainnet toggle, or switching to/from an ETC network). The swap panel immediately re-targets the correct provider identity and links for the new network with no stale branding. When the active network has no configured DEX, the panel explains *which* provider applies to that network and how swaps become available, without implying the wrong provider.
+
+**Why this priority**: Correct identity must survive runtime network changes and degrade honestly when a DEX is not configured. It is P3 because it builds on the per-network identity established in P1/P2; without those, there is nothing correct to re-target to.
+
+**Independent Test**: Switch the active network back and forth across an ETC and a non-ETC network and confirm the provider name and links update each time with no leftover references; then switch to a network with no configured DEX and confirm the disabled-state message names the provider that *would* apply to that network.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user is viewing Swap on an ETC network, **When** they switch to Polygon, **Then** the provider identity and all links update to Uniswap with no remaining ETCswap references (and vice versa), without a page reload.
+2. **Given** the active network has no configured DEX deployment, **When** the user opens Swap, **Then** the panel is disabled and the explanation names the provider applicable to that network and how to enable swaps, without naming the wrong provider.
+3. **Given** an ETC-family network is selected but ETCswap addresses are not configured, **When** the user opens Swap, **Then** the panel reports that ETCswap is not configured for that network (not "Uniswap on Polygon") and offers no mock provider.
+
+---
+
+### Edge Cases
+
+- **Mislabel risk**: an ETC-family chain whose DEX addresses happen to be present must still show **ETCswap**, never the generic "Uniswap V3" wording the panel currently hardcodes.
+- **Runtime switch**: switching the active network must clear the previous provider's name and links so no stale branding/links from the prior network remain.
+- **DEX not configured**: when required addresses are missing, the swap is disabled with a provider-correct, network-specific message — no mock or placeholder DEX is ever presented (honest-state).
+- **Unsupported / unknown chain**: with no provider mapping, the swap surface is hidden or disabled with a generic, non-misleading message.
+- **Provider site vs explorer links**: provider/marketing links resolve to the active provider's canonical site; contract/transaction links resolve to the active network's block explorer — the two must not be conflated.
+- **Provider name leakage**: provider identity is scoped to the active network and never carried over when data for another network is shown.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST determine the swap DEX provider from the active network: Ethereum Classic networks (ETC mainnet and Mordor testnet) MUST default to **ETCswap**; all other supported networks MUST default to **Uniswap**.
+- **FR-002**: Every user-facing swap surface (headings, body copy, disabled-state messages, link labels) MUST name the active provider correctly and MUST NOT display a provider name that does not match the active network.
+- **FR-003**: Provider / "open DEX" links presented in the swap surface MUST resolve to the active provider's canonical site (ETCswap for ETC-family networks; the Uniswap app for other networks).
+- **FR-004**: Contract and transaction links in the swap surface MUST use the active network's block explorer and the active provider's deployed contract addresses for that network.
+- **FR-005**: When the user changes the active network, provider identity, links, and routing MUST update automatically (no page reload) with no residual references to the previously active network's provider.
+- **FR-006**: When the active network has no configured DEX deployment, the swap surface MUST be disabled and MUST display a message that names the provider applicable to that network and how swaps become available, without naming a provider from a different network.
+- **FR-007**: The network-to-provider mapping MUST be data-driven (each supported network declares its DEX provider identity), so adding or adjusting a network requires configuration rather than special-case branching.
+- **FR-008**: Because both providers are Uniswap-V3-compatible deployments, the quote, approval, and swap mechanics MUST remain identical across providers; only the provider identity, contract addresses, and links differ by network.
+- **FR-009**: Provider identity MUST be scoped to the active network and MUST NOT leak across networks or across the testnet/mainnet boundary.
+- **FR-010**: The system MUST continue to gate swap availability on configured DEX addresses (no mock/placeholder provider); an ETC-family network without ETCswap addresses presents as "ETCswap not configured," and a non-ETC network without Uniswap addresses presents as "Uniswap not configured."
+- **FR-011**: The system MUST add Ethereum Classic mainnet (chainId 61) as a user-selectable network bound to **ETCswap**, so the "ETC → ETCswap" default is reachable by users. The network MUST supply ETCswap contract addresses, the ETC stablecoin and wrapped-native token, and the Ethereum Classic block explorer. Swap availability on ETC mainnet is gated on those addresses being configured (FR-010); adding the network MUST NOT require live v2 wager contracts on ETC (the swap depends only on the DEX deployment).
+
+### Key Entities *(include if data involved)*
+
+- **DEX Provider**: a named DEX deployment family the swap can route through. Attributes: display name (e.g., "ETCswap", "Uniswap"), canonical site URL, optional icon/branding. Both providers are Uniswap-V3-compatible.
+- **Network DEX Binding**: the association of a supported network to exactly one DEX provider plus that network's deployed DEX contract addresses, stablecoin, and wrapped-native token. Drives which provider identity and which addresses the swap uses on that network.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On every supported network that has a configured DEX, the swap surface shows the correct provider name 100% of the time — ETCswap on ETC-family networks, Uniswap on all others.
+- **SC-002**: After switching the active network, provider identity and all provider/explorer links update within a single interaction (no reload), with zero references to the previously active network's provider.
+- **SC-003**: Zero user-facing "Uniswap" references appear on any ETC-family network's swap surface, and zero "ETCswap" references appear on any non-ETC network's swap surface.
+- **SC-004**: For 100% of supported networks, the provider link resolves to that network's correct provider site, and contract/transaction links resolve to that network's block explorer.
+- **SC-005**: A new network can be given correct provider identity through configuration alone (no per-network code branches), verifiable by adding a test network and confirming its provider name and links without modifying swap logic.
+- **SC-006**: When a network's DEX is unconfigured, 100% of disabled-state messages name the provider applicable to that network (and never a different network's provider).
+
+## Assumptions
+
+- Each supported network has **at most one** DEX provider deployed; ETCswap and Uniswap are not both available on the same chain, so "default" means "the provider used on that network" and there is no in-network provider switcher.
+- ETCswap is a Uniswap-V3 deployment, so the existing V3 quote/approve/swap logic is reused unchanged; only provider identity, addresses, and links become network-aware.
+- Swap availability remains gated on configured DEX addresses using the existing per-network configuration pattern; missing addresses disable swaps with an honest message and never substitute a mock provider (constitution: Honest State).
+- This is a frontend-only change — no new backend, no new smart contracts — consistent with the project's fixed no-backend footprint.
+- Ethereum Classic mainnet (chainId 61) is added by this feature (FR-011) alongside the existing Mordor testnet (chainId 63); both are ETC-family networks bound to ETCswap and follow the same address-gated configuration pattern (no mock deployment). ETC mainnet's wager surface remains legacy/read-only — only the swap surface is enabled there.
+- The ETCswap canonical site is the value referenced in the network configuration (e.g., the existing `etcswap.org` / `etcswap.com` link); the exact host is a configuration value, not a behavioral requirement.
+- Provider/branding wording is English UI copy only; no localization work is implied.
+
+## Dependencies
+
+- Existing per-network configuration that already supplies per-chain DEX addresses, stablecoin, wrapped-native token, and block-explorer base URL.
+- Existing swap/quote/wrap context that reads the active chain at runtime and exposes a DEX-available flag.
+- For ETC-family swaps to function, valid ETCswap contract addresses must be configured for the relevant chain (already the case for Mordor when its addresses are supplied).

--- a/specs/033-network-aware-swap/tasks.md
+++ b/specs/033-network-aware-swap/tasks.md
@@ -1,0 +1,190 @@
+---
+
+description: "Task list for Network-Aware Swap Provider"
+---
+
+# Tasks: Network-Aware Swap Provider
+
+**Input**: Design documents from `/specs/033-network-aware-swap/`
+
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅, quickstart.md ✅
+
+**Tests**: INCLUDED — required by Constitution Principle II (Test-First, NON-NEGOTIABLE). Write each
+test task first and confirm it FAILS before the matching implementation task.
+
+**Organization**: Tasks are grouped by user story (US1=P1, US2=P2, US3=P3) so each story is an
+independently testable increment.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1 / US2 / US3 (omitted for Setup, Foundational, Polish)
+- Exact file paths are included in each task.
+
+## Path Conventions
+
+Single React app under `frontend/`. All source paths are repo-relative: `frontend/src/...`.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Branch hygiene before any edits.
+
+- [X] T001 Create and switch to feature branch `033-network-aware-swap` off `origin/main` (never commit to `main`; fetch first so the branch is current).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The shared provider-resolution mechanism every story consumes.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T002 [P] Add the `getDexProvider(chainId)` helper and a `DexProvider` JSDoc shape comment (`{ name, url }`) to `frontend/src/config/networks.js`; export `getDexProvider` returning `getNetwork(chainId)?.dexProvider ?? null` (no per-network data yet — added per story).
+- [X] T003 [P] Expose `dexProvider` in the DexContext value in `frontend/src/contexts/DexContext.jsx`, derived from the active `network` (`network?.dexProvider ?? null`); keep all existing keys unchanged.
+- [X] T004 Add foundational unit test in `frontend/src/test/networks.test.js` asserting `getDexProvider` is a pure per-chain lookup that returns `null` for `1337` and for an unknown chain id (depends on T002).
+
+**Checkpoint**: Provider plumbing exists (returns `null` everywhere until stories supply data); UI stories can begin.
+
+---
+
+## Phase 3: User Story 1 - Swap on Ethereum Classic shows and uses ETCswap (Priority: P1) 🎯 MVP
+
+**Goal**: On ETC-family networks the Swap surface is identified as **ETCswap**, links to ETCswap / the ETC explorer, and routes through the ETCswap deployment. Adds ETC mainnet (61) as a selectable network.
+
+**Independent Test**: With the wallet/mock on chain 61 (or 63 with ETCswap configured), open Swap → panel says "ETCswap", "Open ETCswap ↗" → `v3.etcswap.org`, contract links use `etc.blockscout.com`, and no "Uniswap" text appears.
+
+### Tests for User Story 1 (write first, confirm FAIL)
+
+- [X] T005 [P] [US1] Add ETC mapping assertions to `frontend/src/test/networks.test.js`: `NETWORKS[61]` exists and is `selectable`; `getDexProvider(61)`/`getDexProvider(63)` → `{ name: 'ETCswap' }`; `getSelectableNetworks()` includes `61`; `isDexAvailable(61) === true` (depends on T002).
+- [X] T006 [P] [US1] Create `frontend/src/test/SwapPanel.test.jsx`: mock chain `61`, render `SwapPanel` (connected, DEX available) and assert the provider name "ETCswap" appears, the provider link href is `v3.etcswap.org`, the router-link label reads `ETCswap Router ↗`, and there is no "Uniswap" text (use `frontend/src/test/helpers/chainMocks.js`).
+
+### Implementation for User Story 1
+
+- [X] T007 [US1] Add the `NETWORKS[61]` (Ethereum Classic mainnet) entry to `frontend/src/config/networks.js`: `isTestnet:false`, `selectable:true`, `nativeCurrency {18,'Ethereum Classic','ETC'}`, `rpcUrl = VITE_RPC_URL_ETC || 'https://etc.rivet.link'`, `explorer {Blockscout, https://etc.blockscout.com}`, `subgraphUrl:null`, `stablecoin` USC `0xDE093684c796204224BC081f937aa059D903c52a`/USC/6 (`VITE_ETC_USC` override), `dex` = verified ETCswap V3 addresses from research.md (`VITE_ETC_ETCSWAP_FACTORY/SWAP_ROUTER/QUOTER/POSITION_MANAGER` + `VITE_ETC_WETC` overrides), `dexProvider {name:'ETCswap', url: VITE_ETC_ETCSWAP_URL || 'https://v3.etcswap.org'}`, and a `capabilities` getter (`polymarketSidebets:false`, `dex:Boolean(this.dex)`, `friendMarkets:true`) (depends on T002).
+- [X] T008 [US1] Add `dexProvider: { name: 'ETCswap', url: VITE_MORDOR_ETCSWAP_URL || 'https://etcswap.org' }` to the existing Mordor (63) entry in `frontend/src/config/networks.js` so its identity is correct even while its `dex` is env-unconfigured (depends on T007 — same file).
+- [X] T009 [US1] Make the active (DEX-available) view of `frontend/src/components/fairwins/SwapPanel.jsx` provider-aware: read `dexProvider` from `useDex()`; use `dexProvider.name` in the subtitle and the router-link label (`{name} Router ↗`); add an `Open {name} ↗` link → `dexProvider.url` (`target="_blank" rel="noopener noreferrer"`); remove the hardcoded "Uniswap" wording from this view (depends on T003).
+- [X] T010 [P] [US1] Add a `VITE_ETC_*` override block (RPC, USC, `ETCSWAP_FACTORY/SWAP_ROUTER/QUOTER/POSITION_MANAGER`, `WETC`, `ETCSWAP_URL`) to `frontend/.env.example`, mirroring the existing Mordor block and noting the verified defaults are optional overrides.
+- [X] T011 [US1] Re-confirm ETCswap `SwapRouter02` (`0xEd88…24d1`) and `QuoterV2` (`0x4d8c…d39B`) source-verification on `etc.blockscout.com`; record the result in the research.md R1 caveat (verification only — change addresses solely if a mismatch is found).
+
+**Checkpoint**: ETC mainnet is selectable; ETC-family Swap shows/links ETCswap; T005/T006 pass.
+
+---
+
+## Phase 4: User Story 2 - Swap on non-ETC networks shows and uses Uniswap (Priority: P2)
+
+**Goal**: Polygon/Amoy Swap is identified as **Uniswap** with Uniswap links, via the same provider-aware panel built in US1.
+
+**Independent Test**: Mock chain `137`, open Swap → panel says "Uniswap", provider link → `app.uniswap.org`, no "ETCswap" text.
+
+### Tests for User Story 2 (write first, confirm FAIL)
+
+- [X] T012 [P] [US2] Add to `frontend/src/test/networks.test.js`: `getDexProvider(137)` and `getDexProvider(80002)` → `{ name: 'Uniswap' }`.
+- [X] T013 [P] [US2] Add to `frontend/src/test/SwapPanel.test.jsx`: mock chain `137`, assert provider name "Uniswap", provider link href contains `app.uniswap.org`, and no "ETCswap" text.
+
+### Implementation for User Story 2
+
+- [X] T014 [US2] Add `dexProvider: { name: 'Uniswap', url }` to the Polygon (`137` → `https://app.uniswap.org/swap?chain=polygon`) and Amoy (`80002` → `https://app.uniswap.org/swap`) entries in `frontend/src/config/networks.js` (depends on T007/T008 — same file, sequential).
+
+**Checkpoint**: US1 (ETC) and US2 (Uniswap) both render correct provider identity; T012/T013 pass.
+
+> Note: US2 reuses the provider-aware panel from US1 (T009); it is independently *testable* but builds on T009.
+
+---
+
+## Phase 5: User Story 3 - Network switch re-targets the provider; unavailable DEX explained honestly (Priority: P3)
+
+**Goal**: Switching networks re-targets provider identity/links with no stale text; an unconfigured DEX is explained with the provider that actually applies to that network; the Network tab and capability tags are provider-correct.
+
+**Independent Test**: Re-render across an ETC and a non-ETC chain and confirm provider name/links update with no leftovers; on a chain with `dex === null`, the disabled message names that chain's provider (never "Uniswap on Polygon").
+
+### Tests for User Story 3 (write first, confirm FAIL)
+
+- [X] T015 [P] [US3] Add to `frontend/src/test/SwapPanel.test.jsx`: (a) disabled-state — mock an ETC-family chain with `isDexAvailable=false`, assert the message names "ETCswap" + the network name and contains no "Uniswap"/"Polygon"; (b) re-target — re-render from chain `63` to `137` and assert provider name/link switch from ETCswap to Uniswap with no stale ETCswap text.
+- [X] T016 [P] [US3] Extend `frontend/src/test/NetworkSettings.test.jsx`: the DEX link is rendered from `dexProvider` (label includes the provider name, href = `dexProvider.url`), gated on `capabilities.dex`; an ETC row shows the ETCswap link.
+
+### Implementation for User Story 3
+
+- [X] T017 [US3] Rework the `!isDexAvailable` branch of `frontend/src/components/fairwins/SwapPanel.jsx` to be provider/network-correct using `dexProvider?.name` and `network?.name`; remove the hardcoded "Uniswap V3 is wired on Polygon Mainnet…/VITE_AMOY_UNISWAP_*" copy in favor of an honest, provider-named message (depends on T009).
+- [X] T018 [US3] Update `frontend/src/components/wallet/NetworkSettings.jsx` to render the DEX link from `dexProvider` (`Open {dexProvider.name} ↗`, `href={dexProvider.url}`), gated on `capabilities.dex`, replacing the `net.resources.dexUrl` usage (depends on T003, T014).
+- [X] T019 [US3] Remove the now-redundant `resources.dexUrl` from the Mordor (63) entry in `frontend/src/config/networks.js` (retain `resources.faucet`) (depends on T018).
+- [X] T020 [US3] Change the `swap` feature `description` in `frontend/src/config/networkCapabilities.js` from "In-app token swaps via Uniswap V3." to provider-neutral wording (e.g. "In-app token swaps via the network's DEX (Uniswap or ETCswap).").
+
+**Checkpoint**: All three stories functional; provider identity correct across Swap panel, disabled-state, network switch, and Network tab.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T021 [P] Update non-user-facing comments that say "Uniswap V3" to be provider-neutral in `frontend/src/constants/dex.js` and `frontend/src/contexts/DexContext.jsx`.
+- [X] T022 [P] (Optional enablement) Verify the deterministic ETCswap V3 addresses on `etc-mordor.blockscout.com`; if confirmed, add them as Mordor (63) `dex` defaults (env-overridable) in `frontend/src/config/networks.js` to enable Mordor swaps. Skip (leave Mordor env-gated) if not independently verifiable — do not guess (Honest-State).
+- [X] T023 Run the gauntlet from repo root: `npm run lint` (frontend) and `npm run test:frontend`; both green. Fix any regressions.
+- [ ] T024 Execute `specs/033-network-aware-swap/quickstart.md` manual smoke (ETC→ETCswap, Polygon→Uniswap, switch re-target, honest disabled-state, ETC mainnet selectable) and verify SC-003 (no cross-provider text on any chain).
+- [X] T025 [P] Grep `docs/` for swap/DEX copy that implies "Uniswap only" and update to mention ETC mainnet + ETCswap where relevant.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (P1)**: none.
+- **Foundational (P2)**: after Setup — BLOCKS all stories.
+- **US1 (P3)**: after Foundational. MVP.
+- **US2 (P4)**: after Foundational; reuses US1's `SwapPanel` change (T009).
+- **US3 (P5)**: after Foundational; reuses US1's `SwapPanel` change (T009) and US2's Uniswap config (for the re-target test).
+- **Polish (P6)**: after the desired stories.
+
+### Key task-level dependencies
+
+- T004, T005 → T002. T007 → T002. T008 → T007. T009 → T003.
+- T014 → T007/T008 (same file). T017 → T009. T018 → T003/T014. T019 → T018.
+- T022 (optional) → independent verification of Mordor addresses.
+
+### Within each story
+
+- Write tests (FAIL) → implement → checkpoint. Config (`networks.js`) before the UI that reads it; same-file edits to `networks.js` and `SwapPanel.test.jsx`/`SwapPanel.jsx` are sequential (not parallel).
+
+### Parallel Opportunities
+
+- Foundational: T003 ∥ (T002 then T004).
+- US1: T005 ∥ T006 ∥ T010 (different files). Implementation T007→T008 sequential; T009, T011 independent.
+- US2: T012 ∥ T013.
+- US3: T015 ∥ T016.
+- Polish: T021 ∥ T022 ∥ T025.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Tests first (different files → parallel):
+Task: "networks.test.js ETC mapping assertions (T005)"
+Task: "SwapPanel.test.jsx ETCswap rendering (T006)"
+Task: "frontend/.env.example VITE_ETC_* block (T010)"
+# Then implementation (networks.js edits are sequential):
+Task: "Add NETWORKS[61] entry (T007)"  →  "Add Mordor dexProvider (T008)"
+Task: "SwapPanel provider-aware active view (T009)"   # parallel with T007/T008 (different file)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Phase 1 Setup → 2. Phase 2 Foundational → 3. Phase 3 US1 → **STOP & VALIDATE** ETC→ETCswap on its own (the most-broken case). Demo-able MVP: ETC mainnet selectable, ETCswap correctly named/linked.
+
+### Incremental Delivery
+
+US1 (ETC/ETCswap, MVP) → US2 (Uniswap parity) → US3 (switch re-target, honest disabled-state, Network-tab consistency) → Polish (comment/doc cleanup, optional Mordor enablement). Each story is testable before the next.
+
+---
+
+## Notes
+
+- `[P]` = different files, no incomplete dependency. Same-file tasks (`networks.js`, `SwapPanel.jsx`, `SwapPanel.test.jsx`) are intentionally sequential.
+- Honest-State: ETC mainnet ships with **on-chain-verified** ETCswap addresses (research.md), never mocks; DEX stays gated on configured addresses; provider identity is per-chain and never leaks.
+- No `contracts/` (Solidity) changes; no new dependencies; frontend-only — consistent with the no-backend footprint.
+- Commit after each task or logical group; open a PR (never push to `main`).


### PR DESCRIPTION
## Summary
The in-app Swap surface routed per-chain but hardcoded "Uniswap V3" in every label, message, and link — mislabelling Ethereum Classic, where the deployment is actually ETCswap. This PR makes the swap provider identity network-aware and adds Ethereum Classic mainnet as a swap-capable network.

Mapping (FR-001): ETC family (61 mainnet, 63 Mordor) defaults to **ETCswap**; all other networks (137 Polygon, 80002 Amoy) default to **Uniswap**.

Implements spec 033 (`specs/033-network-aware-swap/`). Frontend-only: no contracts, no new dependencies, no backend.

## What changed
- **`config/networks.js`**: per-network `dexProvider` descriptor (`{ name, url }`) + `getDexProvider(chainId)` helper. Declared at the network level so the swap UI can name the provider even when `dex` is unconfigured (honest disabled-state). Resolution is strictly per-chain — identity never leaks across networks.
- **`contexts/DexContext.jsx`**: exposes `dexProvider`; re-targets automatically on network switch (no reload).
- **`components/fairwins/SwapPanel.jsx`**: provider-aware subtitle, `{provider} Router` label, new `Open {provider}` link, and an honest disabled-state naming the provider/network that actually apply (no more "Uniswap on Polygon" on ETC).
- **`components/wallet/NetworkSettings.jsx`**: DEX link now derives from `dexProvider` (consolidates the old Mordor-only `resources.dexUrl`).
- **`networkCapabilities.js` + `constants/dex.js`**: provider-neutral copy/comments.
- **`.env.example`**: `VITE_ETC_*` overrides block for chain 61.

## Ethereum Classic mainnet (chainId 61)
Added as a selectable network bound to ETCswap, using **on-chain-verified** ETCswap V3 addresses (factory / SwapRouter02 / QuoterV2 / NonfungiblePositionManager + WETC) and the Classic USD (USC, 6 decimals) stablecoin — all env-overridable. The DEX stays gated on configured addresses (no mock DEX). ETC mainnet enables only the swap surface (it remains wager-legacy). wagmi.js / blockExplorer.js already wired chain 61; only the app config in networks.js was missing.

## Honest-state and scope notes
- **Mordor (63)** gains the ETCswap **identity**, but its routing stays env-gated: its deterministic ETCswap addresses could not be independently verified on the Mordor explorer during research, so they were left off rather than guessed (defaulting them would also falsely flip its "swap unavailable" tag).
- **ETCswap router + quoter**: addresses confirmed by deployed bytecode + correct on-chain factory()/WETH9() wiring; factory / positionManager / WETC are Blockscout source-verified. Details in `research.md` R1.

## Testing
- `npm run test:frontend`: **1694/1694 pass** (190 files), including 30 new assertions across `networks.test.js`, `SwapPanel.test.jsx`, `DexContext.test.jsx`, `NetworkSettings.test.jsx`.
- `npm run lint`: **0 errors** (3 pre-existing warnings in untouched files).
- Manual browser smoke (`quickstart.md`) not run in this environment; recommended before merge.

## Spec Kit
Full artifacts under `specs/033-network-aware-swap/`: spec, plan, research, data-model, contracts, quickstart, tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)