### PR TITLE
fix(clearpath): two DAO-view bugs — false over-treasury warning + proposal indexing on ETC

### DIFF
--- a/frontend/src/components/clearpath/ProposalBuilder.jsx
+++ b/frontend/src/components/clearpath/ProposalBuilder.jsx
@@ -76,7 +76,15 @@ export default function ProposalBuilder({ record, signer, reader, usdcAddress, n
   const valid = A.ok && !anyPending
 
   // Pre-sign guards: over-treasury (warn, allow) + duplicate proposal (block submit — it would revert).
-  const timelock = treasuries.find((t) => t.label === 'Timelock') || treasuries[0]
+  // Measure the spend against the DAO's TOTAL holdings across ALL known treasuries (timelock + vaults), not
+  // just the timelock. A Governor's funds commonly live in a separate vault while its timelock holds ~0, so a
+  // timelock-only check false-warns on every spend (it reads 0 and flags any positive amount). USDC meta is
+  // stamped identically across vaults, so summing `usdc` is apples-to-apples.
+  const nativeHeld = treasuries.reduce((sum, t) => sum + (t.native ?? 0n), 0n)
+  const usdcHeld = treasuries.reduce((sum, t) => sum + (t.usdc ?? 0n), 0n)
+  const anyNativeKnown = treasuries.some((t) => t.native != null)
+  const anyUsdcKnown = treasuries.some((t) => t.usdc != null)
+  const usdcSymbol = treasuries.find((t) => t.usdcSymbol)?.usdcSymbol || 'USDC'
   let nativeTotal = 0n
   let usdcTotal = 0n
   for (const p of A.perAction) {
@@ -86,8 +94,9 @@ export default function ProposalBuilder({ record, signer, reader, usdcAddress, n
       try { const [, amt] = ERC20_TRANSFER_IFACE.decodeFunctionData('transfer', p.encoded.calldata); usdcTotal += amt } catch { /* not a transfer */ }
     }
   }
-  const overNative = valid && timelock?.native != null && nativeTotal > timelock.native
-  const overUsdc = valid && timelock?.usdc != null && usdcTotal > timelock.usdc
+  // Only warn once balances are known, and only when the spend truly exceeds total DAO holdings.
+  const overNative = valid && anyNativeKnown && nativeTotal > nativeHeld
+  const overUsdc = valid && anyUsdcKnown && usdcTotal > usdcHeld
   const dupId = valid ? predictProposalId(A.targets, A.values, A.calldatas, A.descriptionHash) : null
   // FR-025 duplicate pre-check: an identical action set + description hashes to the same id as a live proposal.
   const isDuplicate = !!dupId && proposals.some((p) => p.id === dupId)
@@ -158,7 +167,7 @@ export default function ProposalBuilder({ record, signer, reader, usdcAddress, n
         <div className="cp-kv"><span className="k">Actions</span><span>{actions.length}</span></div>
         <div className="cp-kv"><span className="k">Total native value</span><span className="cp-mono">{ethers.formatEther(nativeTotal)} {nativeSymbol || ''}</span></div>
         {overNative && <div className="cp-warn" role="status">Sends more {nativeSymbol} than the treasury holds. The proposal can still be created; execution will revert if not funded by then.</div>}
-        {overUsdc && <div className="cp-warn" role="status">Sends more {timelock?.usdcSymbol || 'USDC'} than the treasury holds. The proposal can still be created; execution will revert if not funded.</div>}
+        {overUsdc && <div className="cp-warn" role="status">Sends more {usdcSymbol} than the treasury holds. The proposal can still be created; execution will revert if not funded.</div>}
         {isDuplicate && <div className="cp-error" role="alert">This exact proposal already exists (id {dupId.length > 14 ? `${dupId.slice(0, 8)}…${dupId.slice(-4)}` : dupId}). Submitting it would revert — change an action or the description.</div>}
         {!valid && <p className="cp-row-sub">{anyPending ? 'Reading token details…' : 'Add a title/description and at least one valid action to submit.'}</p>}
 

--- a/frontend/src/components/clearpath/__tests__/ProposalBuilder.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ProposalBuilder.test.jsx
@@ -134,4 +134,27 @@ describe('ProposalBuilder (spec 030 / US5)', () => {
     // still submittable (execution, not proposal, would revert)
     await waitFor(() => expect(screen.getByRole('button', { name: /submit proposal/i })).toBeEnabled())
   })
+
+  // Regression: a Governor whose Timelock holds ~0 but whose funds live in a separate vault must NOT
+  // false-warn on a spend the DAO can actually cover. The over-treasury guard measures total holdings
+  // across ALL treasuries (timelock + vaults), not just the (commonly empty) timelock.
+  it('does not false-warn when the timelock is empty but a vault holds the funds', async () => {
+    const splitTreasuries = [
+      { label: 'Timelock', address: '0x0000000000000000000000000000000000000222', native: 0n, usdc: 0n, usdcSymbol: 'cUSD', usdcDecimals: 6 },
+      { label: 'Olympia Treasury', address: '0x0000000000000000000000000000000000000333', native: ethers.parseEther('2'), usdc: 50_000000n, usdcSymbol: 'cUSD', usdcDecimals: 6 },
+    ]
+    const user = userEvent.setup()
+    renderBuilder({ treasuries: splitTreasuries })
+    await user.click(screen.getByRole('button', { name: /\+ new proposal/i }))
+    await user.type(screen.getByLabelText(/^title$/i), 'Small spend')
+    await user.type(screen.getByLabelText(/recipient/i), TO)
+    await user.type(screen.getByLabelText(/amount/i), '1') // 1 cUSD ≤ 50 cUSD held in the vault
+    const submit = screen.getByRole('button', { name: /submit proposal/i })
+    await waitFor(() => expect(submit).toBeEnabled())
+    expect(screen.queryByText(/than the treasury holds/i)).not.toBeInTheDocument()
+    // but a spend beyond the DAO's total holdings still warns
+    await user.clear(screen.getByLabelText(/amount/i))
+    await user.type(screen.getByLabelText(/amount/i), '51') // > 50 cUSD total
+    expect(await screen.findByText(/more cUSD than the treasury holds/i)).toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/clearpath/__tests__/governorConnector.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/governorConnector.test.jsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import { getLogsRange } from '../governorConnector'
+
+// Spec 030 (US5) — the subgraph-less proposal indexer must survive RPC block-range caps. ETC/Mordor public
+// nodes (and many wallet RPC backends) reject an `eth_getLogs` window wider than a provider-specific limit;
+// `getLogsRange` bisects on rejection so a wide chunk degrades to smaller requests instead of losing the scan.
+
+const GOV = '0x00000000000000000000000000000000000000d0'
+
+// A fake reader that mimics an RPC which rejects any getLogs window wider than `cap` blocks, and otherwise
+// returns one synthetic log per block whose number is divisible by `every` (so we can assert completeness).
+function cappedReader(cap, every = 1000) {
+  return {
+    getLogs: vi.fn(async ({ fromBlock, toBlock }) => {
+      if (toBlock - fromBlock + 1 > cap) {
+        throw new Error('query returned more than 10000 results / range too wide')
+      }
+      const logs = []
+      for (let b = fromBlock; b <= toBlock; b++) {
+        if (b % every === 0) logs.push({ blockNumber: b })
+      }
+      return logs
+    }),
+  }
+}
+
+describe('getLogsRange (spec 030 — RPC range-cap resilience)', () => {
+  it('returns logs directly when the range is within the RPC cap', async () => {
+    const reader = cappedReader(50000)
+    const logs = await getLogsRange(reader, GOV, 1, 10000)
+    expect(reader.getLogs).toHaveBeenCalledTimes(1) // no bisection needed
+    expect(logs.map((l) => l.blockNumber)).toEqual([1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000])
+  })
+
+  it('bisects a too-wide range and still collects every log', async () => {
+    const reader = cappedReader(5000) // rejects > 5000-block windows → must split the 50k request
+    const logs = await getLogsRange(reader, GOV, 1, 50000)
+    // 50 logs (every 1000th block from 1000..50000), gathered across the bisected sub-ranges in order
+    expect(logs).toHaveLength(50)
+    expect(logs[0].blockNumber).toBe(1000)
+    expect(logs[logs.length - 1].blockNumber).toBe(50000)
+    // it had to make more than one request to get under the cap
+    expect(reader.getLogs.mock.calls.length).toBeGreaterThan(1)
+  })
+
+  it('throws if even a minSpan-wide window is rejected (caller decides partial vs fail)', async () => {
+    const reader = cappedReader(100) // smaller than the 2000-block minSpan floor → unrecoverable
+    await expect(getLogsRange(reader, GOV, 1, 50000, 2000)).rejects.toThrow()
+  })
+})

--- a/frontend/src/components/clearpath/governorConnector.js
+++ b/frontend/src/components/clearpath/governorConnector.js
@@ -144,6 +144,25 @@ const PROPOSAL_CREATED_TOPIC = ethers.id(
 const PROPOSAL_IFACE = new ethers.Interface(GOVERNOR_PROPOSAL_ABI)
 
 /**
+ * `eth_getLogs` over [from, to] that is resilient to RPC block-range caps. Public ETC/Mordor nodes (and many
+ * wallet RPC backends) reject a `getLogs` window wider than some provider-specific limit. On any failure we
+ * bisect the range and retry each half, down to `minSpan` blocks — so a single oversized chunk degrades to a
+ * few smaller requests instead of losing the whole scan. Throws only if even a `minSpan`-wide window is
+ * rejected, letting the caller decide partial-vs-fail. Exported for unit testing.
+ */
+export async function getLogsRange(reader, governor, from, to, minSpan = 2000) {
+  try {
+    return await reader.getLogs({ address: governor, topics: [PROPOSAL_CREATED_TOPIC], fromBlock: from, toBlock: to })
+  } catch (e) {
+    if (to - from + 1 <= minSpan) throw e
+    const mid = Math.floor((from + to) / 2)
+    const left = await getLogsRange(reader, governor, from, mid, minSpan)
+    const right = await getLogsRange(reader, governor, mid + 1, to, minSpan)
+    return [...left, ...right]
+  }
+}
+
+/**
  * Limited LIVE on-chain indexing for chains without a subgraph (Mordor/ETC): a bounded, chunked `eth_getLogs`
  * scan of the Governor's `ProposalCreated` events, newest-first, enriched with live `state` + `proposalVotes`.
  * Resilient: if the RPC rejects a chunk it stops and returns what it has (marked `partial`) rather than failing
@@ -166,7 +185,7 @@ export async function fetchGovernorProposals(reader, governor, { lookbackBlocks 
   for (let to = current; to >= floor; to -= chunk) {
     const from = Math.max(floor, to - chunk + 1)
     try {
-      const logs = await reader.getLogs({ address: governor, topics: [PROPOSAL_CREATED_TOPIC], fromBlock: from, toBlock: to })
+      const logs = await getLogsRange(reader, governor, from, to)
       raw.push(...logs)
       scannedFrom = from
       firstChunk = false

--- a/frontend/src/components/clearpath/useClearPath.js
+++ b/frontend/src/components/clearpath/useClearPath.js
@@ -3,11 +3,27 @@ import { ethers } from 'ethers'
 import { useWallet } from '../../hooks/useWalletManagement'
 import { useNotification } from '../../hooks/useUI'
 import { getContractAddressForChain } from '../../config/contracts'
+import { getNetwork } from '../../config/networks'
+import { makeReadProvider } from '../../utils/rpcProvider'
 import { EXTERNAL_DAO_REGISTRY_ABI } from '../../abis/externalDAORegistry'
 
 // Upper bound on awaiting a confirmation — a broadcast-but-dropped tx must not hang wait() forever (it would
 // orphan the persistent in-flight toast). 120s is well beyond a normal confirmation on the live networks.
 const CONFIRM_TIMEOUT_MS = 120000
+
+// Cache read providers by (chainId → rpcUrl) so the same network always yields the SAME provider instance
+// across renders — dependent effects (ExternalDaoView keys reads on `reader`) must not see a fresh provider
+// every render. A plain memoized factory keeps referential stability without a hook (React-Compiler friendly).
+const READ_PROVIDERS = new Map()
+function cachedReadProvider(rpcUrl, chainId) {
+  const key = `${chainId}:${rpcUrl}`
+  let p = READ_PROVIDERS.get(key)
+  if (!p) {
+    p = makeReadProvider(rpcUrl, chainId)
+    READ_PROVIDERS.set(key, p)
+  }
+  return p
+}
 
 /**
  * Spec 030 — ClearPath hook (external-DAO pillar). Resolves the per-chain ExternalDAORegistry, exposes whether
@@ -22,7 +38,13 @@ export function useClearPath() {
   const registryAddress = getContractAddressForChain('externalDAORegistry', chainId)
   const usdcAddress = getContractAddressForChain('paymentToken', chainId) // per-network USDC for treasury balances
   const isSupported = ethers.isAddress(registryAddress || '')
-  const reader = provider || signer?.provider || null
+
+  // Read over the active network's OWN RPC, not the wallet provider. ClearPath's proposal indexer runs wide
+  // `eth_getLogs` scans, which injected/mobile wallet RPC backends routinely reject or choke on (the public
+  // node handles them reliably); `makeReadProvider` also disables JSON-RPC batching on ETC/Mordor. The wallet
+  // (`signer`) is still used for every write. Falls back to the wallet provider only if no RPC is configured.
+  const net = getNetwork(chainId)
+  const reader = net?.rpcUrl ? cachedReadProvider(net.rpcUrl, chainId) : (provider || signer?.provider || null)
 
   const registryReader = useCallback(() => {
     if (!isSupported || !reader) return null


### PR DESCRIPTION
Two related fixes to the ClearPath external-DAO view, both found while testing the live **Olympia DAO** on Ethereum Classic Mordor.

---

## Fix 1 — false "over treasury" warning on every spend

**Symptom:** entering *any* USDC/ETC amount in the proposal builder — even one the DAO can clearly cover — warned "Sends more … than the treasury holds."

**Cause:** `ProposalBuilder.jsx` compared the spend against the **Timelock balance only**, but the DAO keeps funds in a separate vault (the Timelock holds ~0, the "Olympia Treasury" vault holds 50.05 USC / 2.15 ETC). Every positive amount tripped the guard.

**Fix:** measure the spend against the DAO's **total holdings across all known treasuries** (timelock + vaults). Coverable amounts no longer warn; genuine over-spends still do; the guard stays non-blocking. Regression test added.

---

## Fix 2 — proposals don't load on ETC/Mordor (the indexing issue)

**Symptom:** ~4 proposals exist on-chain but the DAO view couldn't display them.

**Cause:** the subgraph-less proposal indexer ran its wide `eth_getLogs` scan through the **wallet provider** (`useClearPath`'s `reader` was the wallet's provider). Injected/mobile wallet RPC backends routinely reject or choke on large `getLogs` ranges. Verified directly against `rpc.mordor.etccooperative.org`: the **identical** 50k-block scan returns all proposals (state=Defeated, 0 votes) — so the logic and public node are fine; only the wallet-provider path failed.

**Fix:**
- `useClearPath` now reads over the **active network's own RPC** via the existing `makeReadProvider` helper (which also disables JSON-RPC batching on ETC/Mordor — the same path the wager RPC-reads use). The wallet/`signer` is still used for every write. A small per-`(chainId, rpcUrl)` cache keeps the provider instance referentially stable so `reader`-keyed effects don't re-run each render.
- Hardened the scan: `getLogsRange` **bisects a rejected block range** and retries down to a 2000-block floor, so range-capped RPCs (e.g. ETC mainnet) degrade to smaller requests instead of losing the whole scan. Unit tests added.

---

## Testing

- `npx vitest run src/components/clearpath/` → **38/38 pass** (incl. new `governorConnector` adaptive-scan tests + the over-treasury regression test).
- ESLint clean (incl. React Compiler `preserve-manual-memoization`).
- Live RPC probe confirming the scan returns all 4 proposals over the public Mordor node.

Both fixes are **frontend read/display only** — no funds logic, contracts, or Governor execution semantics are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vZhmotmvmuysKR8bFtTJg