### PR TITLE
fix(clearpath): proposal list crash on decode — ProposalCreated `values` name-collision

### DIFF
--- a/frontend/src/components/clearpath/__tests__/governorConnector.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/governorConnector.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
-import { getLogsRange } from '../governorConnector'
+import { ethers } from 'ethers'
+import { getLogsRange, parseProposalLog } from '../governorConnector'
 
 // Spec 030 (US5) — the subgraph-less proposal indexer must survive RPC block-range caps. ETC/Mordor public
 // nodes (and many wallet RPC backends) reject an `eth_getLogs` window wider than a provider-specific limit;
@@ -46,5 +47,40 @@ describe('getLogsRange (spec 030 — RPC range-cap resilience)', () => {
   it('throws if even a minSpan-wide window is rejected (caller decides partial vs fail)', async () => {
     const reader = cappedReader(100) // smaller than the 2000-block minSpan floor → unrecoverable
     await expect(getLogsRange(reader, GOV, 1, 50000, 2000)).rejects.toThrow()
+  })
+})
+
+describe('parseProposalLog (spec 030 — ProposalCreated decode)', () => {
+  const EVENT_ABI = [
+    'event ProposalCreated(uint256 proposalId, address proposer, address[] targets, uint256[] values, string[] signatures, bytes[] calldatas, uint256 voteStart, uint256 voteEnd, string description)',
+  ]
+  const enc = new ethers.Interface(EVENT_ABI)
+  const frag = enc.getEvent('ProposalCreated')
+  const A1 = '0x0000000000000000000000000000000000000a01'
+  const A2 = '0x0000000000000000000000000000000000000a02'
+  const PROPOSER = '0x0000000000000000000000000000000000000b01'
+
+  // Regression: the event's 4th arg is named `values`, which on an ethers v6 Result shadows
+  // Array.prototype.values — `args.values.map(...)` threw "values.map is not a function", aborting the whole
+  // proposal scan (list stuck on "Indexing…", error toast on submit). A multi-action proposal (native ETC +
+  // token USDC) exercises that exact path.
+  it('decodes a multi-action (native + token) proposal without the values name-collision', () => {
+    const targets = [A1, A2]
+    const values = [ethers.parseEther('1'), 0n] // ETC action carries native value; the USDC action carries 0
+    const signatures = ['', '']
+    const calldatas = ['0x', '0xabcdef']
+    const { data, topics } = enc.encodeEventLog(frag, [
+      123n, PROPOSER, targets, values, signatures, calldatas, 10n, 110n, '# Multi-action',
+    ])
+
+    const p = parseProposalLog({ data, topics })
+
+    expect(p.id).toBe('123')
+    expect(p.proposer.toLowerCase()).toBe(PROPOSER)
+    expect(p.values).toEqual(['1000000000000000000', '0']) // the previously-throwing line
+    expect(p.targets.map((t) => t.toLowerCase())).toEqual([A1, A2])
+    expect(p.calldatas).toEqual(['0x', '0xabcdef'])
+    expect(p.description).toBe('# Multi-action')
+    expect(p.descriptionHash).toBe(ethers.id('# Multi-action'))
   })
 })

--- a/frontend/src/components/clearpath/governorConnector.js
+++ b/frontend/src/components/clearpath/governorConnector.js
@@ -144,6 +144,32 @@ const PROPOSAL_CREATED_TOPIC = ethers.id(
 const PROPOSAL_IFACE = new ethers.Interface(GOVERNOR_PROPOSAL_ABI)
 
 /**
+ * Decode a `ProposalCreated` log into a plain proposal object (without the live state/votes enrichment).
+ *
+ * Uses POSITIONAL destructuring, never named field access: the event's 4th argument is literally named
+ * `values`, which on an ethers v6 `Result` shadows `Array.prototype.values` (a function) — so `args.values`
+ * returns that function and `args.values.map(...)` throws "values.map is not a function". Positional access
+ * sidesteps that (and any other reserved-name collision). Exported for unit testing. Throws if the log is not
+ * a parseable `ProposalCreated`.
+ */
+export function parseProposalLog(log) {
+  const parsed = PROPOSAL_IFACE.parseLog(log)
+  // order: proposalId, proposer, targets, values, signatures, calldatas, voteStart, voteEnd, description
+  const [id, proposer, targets, values, , calldatas, voteStart, voteEnd, description] = parsed.args
+  return {
+    id: id.toString(),
+    proposer,
+    description,
+    targets: Array.from(targets),
+    values: Array.from(values, (v) => v.toString()),
+    calldatas: Array.from(calldatas),
+    descriptionHash: ethers.id(description),
+    voteStart: voteStart.toString(),
+    voteEnd: voteEnd.toString(),
+  }
+}
+
+/**
  * `eth_getLogs` over [from, to] that is resilient to RPC block-range caps. Public ETC/Mordor nodes (and many
  * wallet RPC backends) reject a `getLogs` window wider than some provider-specific limit. On any failure we
  * bisect the range and retry each half, down to `minSpan` blocks — so a single oversized chunk degrades to a
@@ -201,30 +227,18 @@ export async function fetchGovernorProposals(reader, governor, { lookbackBlocks 
   raw.reverse()
   const proposals = []
   for (const log of raw.slice(0, max)) {
-    let parsed
-    try { parsed = PROPOSAL_IFACE.parseLog(log) } catch { continue }
-    const a = parsed.args
-    const id = a.proposalId
-    const state = await (async () => { try { return Number(await govRead.state(id)) } catch { return null } })()
+    // Decode is fault-isolated per proposal: a single un-parseable/odd log is skipped, never aborting the
+    // whole scan (which previously hid every proposal behind one decode error).
+    let base
+    try { base = parseProposalLog(log) } catch { continue }
+    const state = await (async () => { try { return Number(await govRead.state(base.id)) } catch { return null } })()
     const votes = await (async () => {
       try {
-        const [against, forV, abstain] = await govRead.proposalVotes(id)
+        const [against, forV, abstain] = await govRead.proposalVotes(base.id)
         return { against: against.toString(), for: forV.toString(), abstain: abstain.toString() }
       } catch { return null }
     })()
-    proposals.push({
-      id: id.toString(),
-      proposer: a.proposer,
-      description: a.description,
-      targets: a.targets,
-      values: a.values.map((v) => v.toString()),
-      calldatas: a.calldatas,
-      descriptionHash: ethers.id(a.description),
-      voteStart: a.voteStart.toString(),
-      voteEnd: a.voteEnd.toString(),
-      state,
-      votes,
-    })
+    proposals.push({ ...base, state, votes })
   }
   return { ok: true, proposals, scannedFrom, scannedTo: current, partial }
 }


### PR DESCRIPTION
## Symptom (reported)

On Mordor, after submitting a proposal with **USDC + ETC actions**: the proposal list never appeared, and right after confirmation a toast briefly flashed an error **"unable to map…"**.

## Root cause

The `ProposalCreated` event's 4th argument is literally named **`values`**. On an ethers v6 `Result`, the field `values` collides with **`Array.prototype.values`** (a function), so:

```js
args.values        // → the Array.prototype.values function, NOT the decoded array
args.values.map()  // → throws "values.map is not a function"
```

That throw is **not** caught per-iteration, so the whole `fetchGovernorProposals` promise rejects → `setProps` never runs → the list stays stuck on "Indexing proposals on-chain…", and the propose success path surfaces the raw error in a toast ("…map…").

This was **masked until PR #769**: previously the wallet-provider `getLogs` failed first, so enrichment never ran. Fixing the reader (PR #769) advanced execution to this latent decode bug — it only triggers once there are proposals to decode, which is why an empty list looked fine. Confirmed directly against the live event: `typeof args.values === 'function'`.

## Fix

- **Decode positionally** via an extracted, exported `parseProposalLog` (destructures by index), avoiding the named-`values` collision and any other reserved-name clash.
- **Fault-isolate decode per proposal** — one odd/unparseable log is skipped, never aborting the entire scan.
- **Regression test**: decodes a multi-action proposal (native ETC + token USDC) — the exact shape that crashed — and asserts `values` maps to `["1000000000000000000","0"]`.

## Verification

- `npx vitest run src/components/clearpath/` → **39/39 pass**; ESLint clean.
- **Live end-to-end** against the Olympia governor on Mordor: all 5 proposals now decode, **including the user's just-submitted multi-action one** (state=Active, `targets=2`, `values=["0","1000000000000000000"]` = the USDC action + the 1-ETC action).

Frontend read/decode only — no contracts, funds, or Governor execution semantics touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vZhmotmvmuysKR8bFtTJg

---
_Generated by [Claude Code](https://claude.ai/code/session_017vZhmotmvmuysKR8bFtTJg)_