### PR TITLE
feat(clearpath): proposal timeline, vote receipts, bottom-sheet builder, Self recipient

### DIFF
--- a/frontend/src/components/clearpath/ClearPathPanel.jsx
+++ b/frontend/src/components/clearpath/ClearPathPanel.jsx
@@ -19,7 +19,7 @@ const TABS = [
 const short = (a) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '')
 
 export default function ClearPathPanel() {
-  const { isSupported, chainId, reader, signer, usdcAddress, listExternalDAOs, registerExternalDAO } = useClearPath()
+  const { isSupported, chainId, reader, signer, account, usdcAddress, listExternalDAOs, registerExternalDAO } = useClearPath()
   const [tab, setTab] = useState('daos')
   const [loading, setLoading] = useState(true)
   const [daos, setDaos] = useState([])
@@ -66,7 +66,7 @@ export default function ClearPathPanel() {
   if (selected) {
     return (
       <div className="clearpath">
-        <ExternalDaoView record={selected} reader={reader} signer={signer} chainId={chainId} usdcAddress={usdcAddress} onBack={() => setSelected(null)} />
+        <ExternalDaoView record={selected} reader={reader} signer={signer} account={account} chainId={chainId} usdcAddress={usdcAddress} onBack={() => setSelected(null)} />
       </div>
     )
   }

--- a/frontend/src/components/clearpath/CpAddressField.jsx
+++ b/frontend/src/components/clearpath/CpAddressField.jsx
@@ -15,6 +15,7 @@ export default function CpAddressField({
   placeholder = '0x…',
   disabled = false,
   hint,
+  selfAddress = null,
 }) {
   const [scanOpen, setScanOpen] = useState(false)
 
@@ -43,6 +44,17 @@ export default function CpAddressField({
           autoComplete="off"
           spellCheck="false"
         />
+        {selfAddress && (
+          <button
+            type="button"
+            className="cp-self-btn"
+            onClick={() => onChange(selfAddress)}
+            disabled={disabled}
+            title="Use my connected wallet address"
+          >
+            Self
+          </button>
+        )}
         <AddressBookButton disabled={disabled} onSelect={(entry) => onChange(entry.address)} />
         <button
           type="button"

--- a/frontend/src/components/clearpath/CpBottomSheet.jsx
+++ b/frontend/src/components/clearpath/CpBottomSheet.jsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react'
+
+// Spec 030 — a lightweight bottom-sheet overlay for the ClearPath surface, mirroring the "My Wagers" panel
+// (centered card on desktop, sheet rising from the bottom on mobile). Keeps the `cp-*` styling and stays
+// self-contained (no global modal singleton). Renders nothing when closed; closes on backdrop click + Escape.
+export default function CpBottomSheet({ open, onClose, title, children, labelledBy }) {
+  const panelRef = useRef(null)
+  // Keep the latest onClose in a ref so the open/focus effect depends ONLY on `open`. Otherwise an inline
+  // onClose (new identity each render) would re-run the effect on every keystroke and re-focus the panel,
+  // stealing focus from the form inputs mid-typing.
+  const onCloseRef = useRef(onClose)
+  useEffect(() => { onCloseRef.current = onClose })
+
+  useEffect(() => {
+    if (!open) return undefined
+    const onKey = (e) => { if (e.key === 'Escape') onCloseRef.current?.() }
+    document.addEventListener('keydown', onKey)
+    // Lock background scroll while the sheet is up; restore on close.
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    panelRef.current?.focus()
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.body.style.overflow = prevOverflow
+    }
+  }, [open])
+
+  if (!open) return null
+
+  return (
+    <div className="cp-sheet-backdrop" role="presentation" onClick={(e) => { if (e.target === e.currentTarget) onClose?.() }}>
+      <div
+        ref={panelRef}
+        className="cp-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title && !labelledBy ? title : undefined}
+        aria-labelledby={labelledBy}
+        tabIndex={-1}
+      >
+        <div className="cp-sheet-handle" aria-hidden="true" />
+        {title && (
+          <div className="cp-sheet-head">
+            <h3 className="cp-sheet-title">{title}</h3>
+            <button type="button" className="cp-icon-btn cp-sheet-close" onClick={onClose} aria-label="Close">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                <path d="M6 6l12 12M18 6L6 18" strokeLinecap="round" />
+              </svg>
+            </button>
+          </div>
+        )}
+        <div className="cp-sheet-body">{children}</div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/clearpath/ExternalDaoView.jsx
+++ b/frontend/src/components/clearpath/ExternalDaoView.jsx
@@ -8,6 +8,7 @@ import {
   readTreasuries,
   extraTreasuries,
   fetchGovernorProposals,
+  readVoterState,
   castVote,
   queueProposal,
   executeProposal,
@@ -53,7 +54,33 @@ function fmtUsdc(bal, decimals) {
   try { return ethers.formatUnits(bal, decimals) } catch { return '—' }
 }
 
-export default function ExternalDaoView({ record, reader, signer, chainId, usdcAddress, onBack }) {
+const SUPPORT_LABEL = { 0: 'Against', 1: 'For', 2: 'Abstain' }
+const SECONDS_PER_BLOCK = 15 // ETC/Mordor ~15s blocks; only used to humanize block deltas in the timeline.
+
+function humanizeDelta(units, isTimestamp) {
+  const secs = Math.max(0, Math.round(isTimestamp ? units : units * SECONDS_PER_BLOCK))
+  if (secs < 60) return `~${secs}s`
+  const m = Math.round(secs / 60)
+  if (m < 60) return `~${m}m`
+  const h = Math.floor(m / 60); const rm = m % 60
+  if (h < 24) return rm ? `~${h}h ${rm}m` : `~${h}h`
+  const d = Math.floor(h / 24); const rh = h % 24
+  return rh ? `~${d}d ${rh}h` : `~${d}d`
+}
+
+// Proposal timeline relative to "now" (current block, or wall-clock for timestamp-clock Governors). Honest: if
+// the voting window can't be parsed, say so rather than inventing a phase.
+function describeProposalTiming(p, currentBlock, clockMode) {
+  const isTs = /timestamp/.test(clockMode || '')
+  const snapshot = Number(p.voteStart); const deadline = Number(p.voteEnd)
+  const now = isTs ? Math.floor(Date.now() / 1000) : Number(currentBlock)
+  if (![snapshot, deadline, now].every(Number.isFinite)) return { label: 'Voting window unavailable', phase: 'unknown' }
+  if (now < snapshot) return { label: `Voting opens in ${humanizeDelta(snapshot - now, isTs)}${isTs ? '' : ` (${snapshot - now} blocks)`}`, phase: 'pending' }
+  if (now <= deadline) return { label: `Voting ends in ${humanizeDelta(deadline - now, isTs)}${isTs ? '' : ` (${deadline - now} blocks)`}`, phase: 'open' }
+  return { label: 'Voting closed', phase: 'closed' }
+}
+
+export default function ExternalDaoView({ record, reader, signer, account, chainId, usdcAddress, onBack }) {
   const { showNotification } = useNotification()
   const net = getNetwork(chainId)
   const explorerBase = (net?.explorer?.baseUrl || '').replace(/\/$/, '')
@@ -64,6 +91,7 @@ export default function ExternalDaoView({ record, reader, signer, chainId, usdcA
   const [props, setProps] = useState({ key: null, ok: true, proposals: [], scannedFrom: null, partial: false, error: null })
   const propsLoading = props.key !== record.dao
   const [busy, setBusy] = useState(false)
+  const [voterStates, setVoterStates] = useState({}) // proposalId → { hasVoted, votingPower, support }
   const s = sum.summary
 
   // Summary + treasuries (timelock + known extra vaults), native + USDC.
@@ -96,6 +124,23 @@ export default function ExternalDaoView({ record, reader, signer, chainId, usdcA
     setProps({ key: record.dao, ...res })
   }, [reader, record.dao])
   useEffect(() => { loadProposals() }, [loadProposals])
+
+  // Per-user voting state (have I voted, my power at the snapshot, how I voted) for each listed proposal, keyed
+  // by proposal id. Only attempted with a connected wallet; missing Governor views degrade to null (honest).
+  useEffect(() => {
+    if (!reader || !account || !props.ok || props.key !== record.dao || !props.proposals.length) {
+      setVoterStates({})
+      return undefined
+    }
+    let cancelled = false
+    ;(async () => {
+      const entries = await Promise.all(
+        props.proposals.map(async (p) => [p.id, await readVoterState(reader, record.dao, p, account)])
+      )
+      if (!cancelled) setVoterStates(Object.fromEntries(entries))
+    })()
+    return () => { cancelled = true }
+  }, [reader, account, record.dao, props.key, props.ok, props.proposals])
 
   // Surfaces the whole on-chain activity to the app notification system so the user stays aware end-to-end:
   // a persistent "confirm in your wallet" prompt during signing, a persistent "awaiting confirmation" toast
@@ -189,6 +234,20 @@ export default function ExternalDaoView({ record, reader, signer, chainId, usdcA
           gated by the DAO's own rules.
         </p>
 
+        <ProposalBuilder
+          record={record}
+          signer={signer}
+          reader={reader}
+          account={account}
+          usdcAddress={usdcAddress}
+          nativeSymbol={net?.nativeCurrency?.symbol}
+          treasuries={treasuries}
+          proposals={props.proposals}
+          run={run}
+          busy={busy}
+          onSubmitted={loadProposals}
+        />
+
         {propsLoading && <div className="cp-notice" role="status">Indexing proposals on-chain…</div>}
         {!propsLoading && !props.ok && (
           <div className="cp-error" role="alert">Couldn’t load proposals from this RPC: {props.error}</div>
@@ -200,45 +259,62 @@ export default function ExternalDaoView({ record, reader, signer, chainId, usdcA
           <p className="cp-row-sub">Showing the most recent proposals; older ones may exist beyond the scanned range.</p>
         )}
 
-        {props.proposals.map((p) => (
-          <div key={p.id} className="cp-card" style={{ background: 'var(--cp-canvas)' }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.6rem', alignItems: 'center', flexWrap: 'wrap' }}>
-              <span className="cp-row-name">{p.description ? p.description.slice(0, 80) : `Proposal ${short(p.id)}`}</span>
-              <span className="cp-badge">{PROPOSAL_STATE_LABEL[p.state] ?? 'Unknown'}</span>
-            </div>
-            <div className="cp-row-sub" style={{ marginTop: '0.3rem' }}>#{p.id.length > 12 ? short(p.id) : p.id} · by {short(p.proposer)}</div>
-            {p.votes && (
-              <div className="cp-row-sub" style={{ marginTop: '0.3rem' }}>
-                For {p.votes.for} · Against {p.votes.against} · Abstain {p.votes.abstain}
+        {props.proposals.map((p) => {
+          const vs = voterStates[p.id]
+          const timing = describeProposalTiming(p, props.scannedTo, s?.clockMode)
+          const noPower = vs?.votingPower === '0'
+          const canVote = p.state === 1 && !vs?.hasVoted && !noPower
+          return (
+            <div key={p.id} className="cp-card" style={{ background: 'var(--cp-canvas)' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '0.6rem', alignItems: 'center', flexWrap: 'wrap' }}>
+                <span className="cp-row-name">{p.description ? p.description.slice(0, 80) : `Proposal ${short(p.id)}`}</span>
+                <span className="cp-badge">{PROPOSAL_STATE_LABEL[p.state] ?? 'Unknown'}</span>
               </div>
-            )}
-            <div className="cp-row-actions" style={{ marginTop: '0.6rem' }}>
-              {p.state === 1 && (
-                <>
-                  <button type="button" className="cp-btn cp-btn-primary" disabled={busy} onClick={() => run('Vote For', () => castVote(signer, record.dao, p.id, VOTE_SUPPORT.For))}>Vote For</button>
-                  <button type="button" className="cp-btn" disabled={busy} onClick={() => run('Vote Against', () => castVote(signer, record.dao, p.id, VOTE_SUPPORT.Against))}>Against</button>
-                  <button type="button" className="cp-btn" disabled={busy} onClick={() => run('Vote Abstain', () => castVote(signer, record.dao, p.id, VOTE_SUPPORT.Abstain))}>Abstain</button>
-                </>
-              )}
-              {p.state === 4 && <button type="button" className="cp-btn cp-btn-primary" disabled={busy} onClick={() => run('Queue', () => queueProposal(signer, record.dao, p))}>Queue</button>}
-              {p.state === 5 && <button type="button" className="cp-btn cp-btn-primary" disabled={busy} onClick={() => run('Execute', () => executeProposal(signer, record.dao, p))}>Execute</button>}
-              {explorerBase && <a className="cp-btn-link" href={`${explorerBase}/address/${record.dao}`} target="_blank" rel="noreferrer">Details ↗</a>}
-            </div>
-          </div>
-        ))}
+              <div className="cp-row-sub" style={{ marginTop: '0.3rem' }}>#{p.id.length > 12 ? short(p.id) : p.id} · by {short(p.proposer)}</div>
 
-        <ProposalBuilder
-          record={record}
-          signer={signer}
-          reader={reader}
-          usdcAddress={usdcAddress}
-          nativeSymbol={net?.nativeCurrency?.symbol}
-          treasuries={treasuries}
-          proposals={props.proposals}
-          run={run}
-          busy={busy}
-          onSubmitted={loadProposals}
-        />
+              {/* Timeline: proposed → voting window → outcome, with the live relative position. */}
+              <div className="cp-timeline" aria-label="Proposal timeline">
+                <span className="t is-done"><span className="dot" />Proposed</span>
+                <span className={`t ${timing.phase === 'open' ? 'is-now' : timing.phase === 'closed' ? 'is-done' : ''}`}><span className="dot" />{timing.label}</span>
+                <span className={`t ${p.state >= 2 && p.state !== 5 ? 'is-done' : ''}`}><span className="dot" />{PROPOSAL_STATE_LABEL[p.state] ?? '—'}</span>
+              </div>
+
+              {p.votes && (
+                <div className="cp-row-sub" style={{ marginTop: '0.3rem' }}>
+                  For {p.votes.for} · Against {p.votes.against} · Abstain {p.votes.abstain}
+                </div>
+              )}
+
+              {/* Per-user voting state: receipt if voted, no-power note, or current voting power when eligible. */}
+              {vs?.hasVoted && (
+                <div style={{ marginTop: '0.5rem' }}>
+                  <span className={`cp-voted ${vs.support === 1 ? 'is-for' : vs.support === 0 ? 'is-against' : ''}`}>
+                    ✓ You voted{vs.support != null ? `: ${SUPPORT_LABEL[vs.support]}` : ''}
+                  </span>
+                </div>
+              )}
+              {p.state === 1 && !vs?.hasVoted && noPower && (
+                <p className="cp-vote-note" style={{ marginTop: '0.5rem' }}>You had no voting power at the snapshot, so you can’t vote on this proposal.</p>
+              )}
+              {canVote && vs?.votingPower != null && vs.votingPower !== '0' && (
+                <p className="cp-vote-note" style={{ marginTop: '0.5rem' }}>Your voting power: {vs.votingPower}</p>
+              )}
+
+              <div className="cp-row-actions" style={{ marginTop: '0.6rem' }}>
+                {canVote && (
+                  <>
+                    <button type="button" className="cp-btn cp-btn-primary" disabled={busy} onClick={() => run('Vote For', () => castVote(signer, record.dao, p.id, VOTE_SUPPORT.For))}>Vote For</button>
+                    <button type="button" className="cp-btn" disabled={busy} onClick={() => run('Vote Against', () => castVote(signer, record.dao, p.id, VOTE_SUPPORT.Against))}>Against</button>
+                    <button type="button" className="cp-btn" disabled={busy} onClick={() => run('Vote Abstain', () => castVote(signer, record.dao, p.id, VOTE_SUPPORT.Abstain))}>Abstain</button>
+                  </>
+                )}
+                {p.state === 4 && <button type="button" className="cp-btn cp-btn-primary" disabled={busy} onClick={() => run('Queue', () => queueProposal(signer, record.dao, p))}>Queue</button>}
+                {p.state === 5 && <button type="button" className="cp-btn cp-btn-primary" disabled={busy} onClick={() => run('Execute', () => executeProposal(signer, record.dao, p))}>Execute</button>}
+                {explorerBase && <a className="cp-btn-link" href={`${explorerBase}/address/${record.dao}`} target="_blank" rel="noreferrer">Details ↗</a>}
+              </div>
+            </div>
+          )
+        })}
       </div>
     </div>
   )

--- a/frontend/src/components/clearpath/ProposalBuilder.jsx
+++ b/frontend/src/components/clearpath/ProposalBuilder.jsx
@@ -4,6 +4,7 @@ import { ERC20_BALANCE_ABI } from '../../abis/externalDAORegistry'
 import { proposeAction } from './governorConnector'
 import { ACTION_TYPE, newAction, assemble, predictProposalId } from './proposalEncoding'
 import CpAddressField from './CpAddressField'
+import CpBottomSheet from './CpBottomSheet'
 
 // Spec 030 (US5, FR-023/024/025) — rich Governor proposal builder. Compose a proposal from named action types
 // (send native / send token / custom call), multiple actions, asset-aware human amounts — no hand-written
@@ -13,7 +14,7 @@ import CpAddressField from './CpAddressField'
 const ERC20_TRANSFER_IFACE = new ethers.Interface(['function transfer(address to, uint256 amount)'])
 const short = (a) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '—')
 
-export default function ProposalBuilder({ record, signer, reader, usdcAddress, nativeSymbol, treasuries = [], proposals = [], run, busy, onSubmitted }) {
+export default function ProposalBuilder({ record, signer, reader, account, usdcAddress, nativeSymbol, treasuries = [], proposals = [], run, busy, onSubmitted }) {
   const [open, setOpen] = useState(false)
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
@@ -120,18 +121,13 @@ export default function ProposalBuilder({ record, signer, reader, usdcAddress, n
     ).then((ok) => { if (ok) { reset(); setOpen(false); onSubmitted?.() } })
   }
 
-  if (!open) {
-    return (
-      <div style={{ marginTop: '0.8rem' }}>
-        <button type="button" className="cp-btn-link" onClick={() => setOpen(true)}>+ New proposal</button>
-      </div>
-    )
-  }
-
   return (
-    <section className="cp-card" style={{ marginTop: '0.8rem', background: 'var(--cp-canvas)' }} aria-label="New proposal">
-      <h4 style={{ marginBottom: '0.6rem' }}>New proposal</h4>
+    <>
+      <div style={{ marginBottom: '0.8rem' }}>
+        <button type="button" className="cp-btn cp-btn-primary" onClick={() => setOpen(true)}>+ New proposal</button>
+      </div>
 
+      <CpBottomSheet open={open} onClose={() => { reset(); setOpen(false) }} title="New proposal">
       <div className="cp-field">
         <label className="cp-label" htmlFor="cp-prop-title">Title</label>
         <input id="cp-prop-title" className="cp-input" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Fund core development" />
@@ -157,6 +153,7 @@ export default function ProposalBuilder({ record, signer, reader, usdcAddress, n
           usdcAddress={usdcAddress}
           nativeSymbol={nativeSymbol}
           canRemove={actions.length > 1}
+          account={account}
           onChange={(patch) => setAction(a.id, patch)}
           onRemove={() => removeAction(a.id)}
         />
@@ -191,7 +188,8 @@ ${dupId ? `proposalId: ${dupId}` : ''}`}
           <button type="button" className="cp-btn" onClick={() => { reset(); setOpen(false) }}>Cancel</button>
         </div>
       </div>
-    </section>
+      </CpBottomSheet>
+    </>
   )
 }
 
@@ -201,7 +199,7 @@ const TYPE_OPTIONS = [
   { v: ACTION_TYPE.CUSTOM, label: 'Custom call (advanced)' },
 ]
 
-function ActionCard({ index, action, diag, meta, usdcAddress, nativeSymbol, canRemove, onChange, onRemove }) {
+function ActionCard({ index, action, diag, meta, usdcAddress, nativeSymbol, canRemove, account, onChange, onRemove }) {
   const a = action
   const useDefaultUsdc = a.tokenMode !== 'other'
   const tokenAddr = useDefaultUsdc ? (usdcAddress || '') : a.tokenAddress.trim()
@@ -221,7 +219,7 @@ function ActionCard({ index, action, diag, meta, usdcAddress, nativeSymbol, canR
 
       {a.type === ACTION_TYPE.NATIVE && (
         <>
-          <CpAddressField id={`f-${a.id}-nto`} label="Recipient" value={a.nativeTo} onChange={(v) => onChange({ nativeTo: v })} />
+          <CpAddressField id={`f-${a.id}-nto`} label="Recipient" value={a.nativeTo} onChange={(v) => onChange({ nativeTo: v })} selfAddress={account} />
           <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-namt`}>Amount<span className="cp-suffix">{nativeSymbol}</span></label><input id={`f-${a.id}-namt`} className="cp-input cp-mono" value={a.nativeAmount} onChange={(e) => onChange({ nativeAmount: e.target.value })} placeholder="0.0" /></div>
         </>
       )}
@@ -236,7 +234,7 @@ function ActionCard({ index, action, diag, meta, usdcAddress, nativeSymbol, canR
             </select>
           </div>
           {!useDefaultUsdc && <CpAddressField id={`f-${a.id}-taddr`} label="Token address" value={a.tokenAddress} onChange={(v) => onChange({ tokenAddress: v })} hint="The ERC-20 contract to transfer (not the recipient)." />}
-          <CpAddressField id={`f-${a.id}-tto`} label="Recipient" value={a.tokenTo} onChange={(v) => onChange({ tokenTo: v })} />
+          <CpAddressField id={`f-${a.id}-tto`} label="Recipient" value={a.tokenTo} onChange={(v) => onChange({ tokenTo: v })} selfAddress={account} />
           <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-tamt`}>Amount<span className="cp-suffix">{tokenSym}</span></label><input id={`f-${a.id}-tamt`} className="cp-input cp-mono" value={a.tokenAmount} onChange={(e) => onChange({ tokenAmount: e.target.value })} placeholder="0.0" /></div>
         </>
       )}

--- a/frontend/src/components/clearpath/__tests__/ClearPathPanel.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ClearPathPanel.test.jsx
@@ -19,13 +19,14 @@ const cp = {
 vi.mock('../useClearPath', () => ({ useClearPath: () => cp }))
 vi.mock('../../../hooks/useUI', () => ({ useNotification: () => ({ showNotification: vi.fn() }) }))
 
-const conn = { validateGovernor: vi.fn(), readGovernorSummary: vi.fn(), fetchGovernorProposals: vi.fn(), readTreasuries: vi.fn() }
+const conn = { validateGovernor: vi.fn(), readGovernorSummary: vi.fn(), fetchGovernorProposals: vi.fn(), readTreasuries: vi.fn(), readVoterState: vi.fn() }
 vi.mock('../governorConnector', () => ({
   validateGovernor: (...a) => conn.validateGovernor(...a),
   readGovernorSummary: (...a) => conn.readGovernorSummary(...a),
   readTreasuries: (...a) => conn.readTreasuries(...a),
   extraTreasuries: () => [{ label: 'Olympia Treasury', address: '0x035b2e3c189B772e52F4C3DA6c45c84A3bB871bf' }],
   fetchGovernorProposals: (...a) => conn.fetchGovernorProposals(...a),
+  readVoterState: (...a) => conn.readVoterState(...a),
   castVote: vi.fn(),
   queueProposal: vi.fn(),
   executeProposal: vi.fn(),
@@ -53,8 +54,10 @@ describe('ClearPathPanel (spec 030 / US3)', () => {
     vi.clearAllMocks()
     cp.isSupported = true
     cp.listExternalDAOs.mockResolvedValue([olympiaRecord])
+    conn.readGovernorSummary.mockResolvedValue({ clockMode: 'mode=blocknumber' })
     conn.fetchGovernorProposals.mockResolvedValue({ ok: true, proposals: [], scannedFrom: 16000000, scannedTo: 16500000, partial: false })
     conn.readTreasuries.mockResolvedValue([])
+    conn.readVoterState.mockResolvedValue({ hasVoted: false, votingPower: null, support: null })
   })
 
   it('self-disables truthfully on an unsupported network', async () => {
@@ -113,9 +116,27 @@ describe('ClearPathPanel (spec 030 / US3)', () => {
     render(<ClearPathPanel />)
     await user.click(await screen.findByText('Olympia DAO'))
     expect(await screen.findByText('Fund core dev')).toBeInTheDocument()
-    expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(screen.getByText('Active', { selector: '.cp-badge' })).toBeInTheDocument()
+    // the proposal timeline surfaces the voting window position
+    expect(screen.getByLabelText('Proposal timeline')).toBeInTheDocument()
     // US5: an Active proposal offers vote actions
     expect(screen.getByRole('button', { name: /vote for/i })).toBeInTheDocument()
+  })
+
+  it('shows the user vote receipt and hides vote buttons once they have voted', async () => {
+    conn.fetchGovernorProposals.mockResolvedValue({
+      ok: true, partial: false, scannedFrom: 16000000, scannedTo: 16500000,
+      proposals: [
+        { id: '42', proposer: '0xB85dbc899472756470EF4033b9637ff8fa2FD23D', description: 'Fund core dev', targets: [], values: [], calldatas: [], descriptionHash: '0x', voteStart: '1', voteEnd: '16500001', state: 1, votes: { for: '3', against: '1', abstain: '0' } },
+      ],
+    })
+    conn.readVoterState.mockResolvedValue({ hasVoted: true, votingPower: '5', support: 1 /* For */ })
+    const user = userEvent.setup()
+    render(<ClearPathPanel />)
+    await user.click(await screen.findByText('Olympia DAO'))
+    expect(await screen.findByText(/You voted: For/i)).toBeInTheDocument()
+    // having voted, the vote buttons are not offered again
+    expect(screen.queryByRole('button', { name: /vote for/i })).not.toBeInTheDocument()
   })
 
   it('validates then registers a new external DAO', async () => {

--- a/frontend/src/components/clearpath/__tests__/CpAddressField.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/CpAddressField.test.jsx
@@ -57,6 +57,17 @@ describe('CpAddressField (spec 030)', () => {
     expect(onChange).toHaveBeenCalledWith(A_SCAN)
   })
 
+  it('shows a "Self" button only when selfAddress is given, filling the field with it', async () => {
+    const SELF = '0x00000000000000000000000000000000000000c3'
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    const { rerender } = render(<CpAddressField id="f1" label="Recipient" value="" onChange={onChange} />)
+    expect(screen.queryByRole('button', { name: /^self$/i })).not.toBeInTheDocument()
+    rerender(<CpAddressField id="f1" label="Recipient" value="" onChange={onChange} selfAddress={SELF} />)
+    await user.click(screen.getByRole('button', { name: /^self$/i }))
+    expect(onChange).toHaveBeenCalledWith(SELF)
+  })
+
   it('disables the input and affordances when disabled', () => {
     render(<CpAddressField id="f1" label="Recipient" value="" onChange={() => {}} disabled />)
     expect(screen.getByLabelText('Recipient')).toBeDisabled()

--- a/frontend/src/components/clearpath/__tests__/ProposalBuilder.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ProposalBuilder.test.jsx
@@ -157,4 +157,23 @@ describe('ProposalBuilder (spec 030 / US5)', () => {
     await user.type(screen.getByLabelText(/amount/i), '51') // > 50 cUSD total
     expect(await screen.findByText(/more cUSD than the treasury holds/i)).toBeInTheDocument()
   })
+
+  it('fills the recipient with the connected wallet via the Self button', async () => {
+    const user = userEvent.setup()
+    renderBuilder({ account: TO }) // TO doubles as the connected address here
+    await user.click(screen.getByRole('button', { name: /\+ new proposal/i }))
+    await user.click(screen.getByRole('button', { name: /^self$/i }))
+    expect(screen.getByLabelText(/recipient/i)).toHaveValue(TO)
+  })
+
+  it('opens the builder in a bottom-sheet dialog and keeps the trigger visible', async () => {
+    const user = userEvent.setup()
+    renderBuilder()
+    // the trigger is always present (it sits above the proposal list)
+    const trigger = screen.getByRole('button', { name: /\+ new proposal/i })
+    expect(trigger).toBeInTheDocument()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    await user.click(trigger)
+    expect(screen.getByRole('dialog', { name: /new proposal/i })).toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/clearpath/__tests__/governorConnector.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/governorConnector.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { ethers } from 'ethers'
-import { getLogsRange, parseProposalLog } from '../governorConnector'
+import { getLogsRange, parseProposalLog, readVoterState, readVoteSupport } from '../governorConnector'
 
 // Spec 030 (US5) — the subgraph-less proposal indexer must survive RPC block-range caps. ETC/Mordor public
 // nodes (and many wallet RPC backends) reject an `eth_getLogs` window wider than a provider-specific limit;
@@ -82,5 +82,32 @@ describe('parseProposalLog (spec 030 — ProposalCreated decode)', () => {
     expect(p.calldatas).toEqual(['0x', '0xabcdef'])
     expect(p.description).toBe('# Multi-action')
     expect(p.descriptionHash).toBe(ethers.id('# Multi-action'))
+  })
+})
+
+describe('readVoterState / readVoteSupport (spec 030 — per-user voting state)', () => {
+  const VOTER = '0x00000000000000000000000000000000000000c3'
+  const VOTE_ABI = ['event VoteCast(address indexed voter, uint256 proposalId, uint8 support, uint256 weight, string reason)']
+  const vc = new ethers.Interface(VOTE_ABI)
+  const frag = vc.getEvent('VoteCast')
+
+  it('returns all-null without an account (no fabricated state)', async () => {
+    expect(await readVoterState({}, GOV, { id: '42', voteStart: '1', voteEnd: '2' }, null)).toEqual({
+      hasVoted: null, votingPower: null, support: null,
+    })
+  })
+
+  it('recovers HOW a voter voted from their VoteCast receipt', async () => {
+    const { data, topics } = vc.encodeEventLog(frag, [VOTER, 42n, 1 /* For */, 100n, ''])
+    const reader = { getLogs: vi.fn(async () => [{ data, topics }]) }
+    const support = await readVoteSupport(reader, GOV, { id: '42', voteStart: '1', voteEnd: '100' }, VOTER)
+    expect(support).toBe(1)
+  })
+
+  it('returns null when no VoteCast matches the proposal (honest degradation)', async () => {
+    const { data, topics } = vc.encodeEventLog(frag, [VOTER, 99n /* different proposal */, 0, 100n, ''])
+    const reader = { getLogs: vi.fn(async () => [{ data, topics }]) }
+    const support = await readVoteSupport(reader, GOV, { id: '42', voteStart: '1', voteEnd: '100' }, VOTER)
+    expect(support).toBeNull()
   })
 })

--- a/frontend/src/components/clearpath/clearpath.css
+++ b/frontend/src/components/clearpath/clearpath.css
@@ -107,3 +107,59 @@
 }
 .clearpath .fm-scan-btn:disabled,
 .clearpath .cp-icon-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* "Self" affordance on an address row — fills the field with the connected wallet address. */
+.clearpath .cp-self-btn {
+  align-self: stretch; padding: 0 0.7rem; min-width: 44px; box-sizing: border-box;
+  background: var(--cp-canvas); border: 1px solid var(--cp-border); border-radius: var(--cp-radius);
+  color: var(--cp-text-2); cursor: pointer; font-weight: 600; font-size: 0.8rem;
+}
+.clearpath .cp-self-btn:hover:not(:disabled) {
+  border-color: var(--cp-accent); color: var(--cp-accent);
+  background: color-mix(in srgb, var(--cp-accent) 10%, transparent);
+}
+.clearpath .cp-self-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Bottom sheet (CpBottomSheet) — centered card on desktop, sheet from the bottom on mobile (My Wagers pattern). */
+.cp-sheet-backdrop {
+  position: fixed; inset: 0; z-index: 1000; background: rgba(0, 0, 0, 0.5);
+  display: flex; align-items: center; justify-content: center; padding: 1rem;
+}
+.cp-sheet {
+  width: 100%; max-width: 540px; max-height: 92vh; overflow-y: auto;
+  background: var(--bg-primary, #fff); color: var(--text-primary, #111);
+  border: 1px solid var(--border-color); border-radius: var(--radius-lg, 12px);
+  padding: 1rem 1.1rem 1.3rem; box-shadow: 0 12px 40px rgba(0, 0, 0, 0.28);
+  animation: cpSheetUp 0.18s ease-out;
+}
+@keyframes cpSheetUp { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
+.cp-sheet-handle { display: none; }
+.cp-sheet-head { display: flex; align-items: center; justify-content: space-between; gap: 0.6rem; margin-bottom: 0.6rem; }
+.cp-sheet-title { margin: 0; font-weight: 600; font-size: 1.05rem; }
+.cp-sheet-close { width: 38px; min-width: 38px; height: 38px; }
+@media (max-width: 768px) {
+  .cp-sheet-backdrop { align-items: flex-end; padding: 0; }
+  .cp-sheet {
+    max-width: 100%; max-height: 95vh; border-radius: 20px 20px 0 0;
+    padding-bottom: calc(1.3rem + env(safe-area-inset-bottom, 0px));
+  }
+  .cp-sheet-handle {
+    display: block; width: 40px; height: 4px; border-radius: 999px;
+    background: var(--border-color); margin: 0 auto 0.7rem;
+  }
+}
+
+/* Proposal timeline + per-user voting state. */
+.clearpath .cp-timeline { display: flex; flex-wrap: wrap; gap: 0.4rem 0.9rem; margin: 0.5rem 0; font-size: 0.78rem; color: var(--cp-text-2); }
+.clearpath .cp-timeline .t { display: inline-flex; align-items: center; gap: 0.3rem; }
+.clearpath .cp-timeline .t .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--cp-text-3); }
+.clearpath .cp-timeline .t.is-now .dot { background: var(--cp-accent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--cp-accent) 22%, transparent); }
+.clearpath .cp-timeline .t.is-done .dot { background: var(--semantic-win, #2e7d32); }
+.clearpath .cp-voted {
+  display: inline-flex; align-items: center; gap: 0.35rem; font-size: 0.8rem; font-weight: 600;
+  padding: 0.25rem 0.6rem; border-radius: 6px;
+  color: var(--cp-accent); background: color-mix(in srgb, var(--cp-accent) 14%, transparent);
+}
+.clearpath .cp-voted.is-for { color: var(--semantic-win, #2e7d32); background: color-mix(in srgb, var(--semantic-win, #2e7d32) 14%, transparent); }
+.clearpath .cp-voted.is-against { color: var(--semantic-loss, #c0492f); background: color-mix(in srgb, var(--semantic-loss, #c0492f) 14%, transparent); }
+.clearpath .cp-vote-note { color: var(--cp-text-3); font-size: 0.8rem; }

--- a/frontend/src/components/clearpath/governorConnector.js
+++ b/frontend/src/components/clearpath/governorConnector.js
@@ -176,15 +176,65 @@ export function parseProposalLog(log) {
  * few smaller requests instead of losing the whole scan. Throws only if even a `minSpan`-wide window is
  * rejected, letting the caller decide partial-vs-fail. Exported for unit testing.
  */
-export async function getLogsRange(reader, governor, from, to, minSpan = 2000) {
+export async function getLogsRange(reader, governor, from, to, minSpan = 2000, topics = [PROPOSAL_CREATED_TOPIC]) {
   try {
-    return await reader.getLogs({ address: governor, topics: [PROPOSAL_CREATED_TOPIC], fromBlock: from, toBlock: to })
+    return await reader.getLogs({ address: governor, topics, fromBlock: from, toBlock: to })
   } catch (e) {
     if (to - from + 1 <= minSpan) throw e
     const mid = Math.floor((from + to) / 2)
-    const left = await getLogsRange(reader, governor, from, mid, minSpan)
-    const right = await getLogsRange(reader, governor, mid + 1, to, minSpan)
+    const left = await getLogsRange(reader, governor, from, mid, minSpan, topics)
+    const right = await getLogsRange(reader, governor, mid + 1, to, minSpan, topics)
     return [...left, ...right]
+  }
+}
+
+const VOTE_CAST_TOPIC = ethers.id('VoteCast(address,uint256,uint8,uint256,string)')
+const VOTE_CAST_IFACE = new ethers.Interface([
+  'event VoteCast(address indexed voter, uint256 proposalId, uint8 support, uint256 weight, string reason)',
+])
+
+/**
+ * Per-user voting state for one proposal, for the member-facing view: whether they've voted, their voting power
+ * at the proposal snapshot, and (if they voted) HOW. Standard OZ IGovernor reads with honest degradation — a
+ * Governor missing a given view yields `null` for that field (never a fabricated value); `account` null ⇒ all
+ * null. Exported for unit testing.
+ */
+export async function readVoterState(reader, governor, proposal, account) {
+  if (!account || !reader) return { hasVoted: null, votingPower: null, support: null }
+  const gov = new ethers.Contract(governor, GOVERNOR_READ_ABI, reader)
+  const safe = async (p) => { try { return await p } catch { return null } }
+  const hasVoted = await safe(gov.hasVoted(proposal.id, account))
+  // Voting power is measured at the snapshot (voteStart, in the Governor's clock units).
+  const power = proposal.voteStart != null ? await safe(gov.getVotes(account, proposal.voteStart)) : null
+  let support = null
+  if (hasVoted) support = await readVoteSupport(reader, governor, proposal, account)
+  return {
+    hasVoted: hasVoted == null ? null : Boolean(hasVoted),
+    votingPower: power == null ? null : power.toString(),
+    support,
+  }
+}
+
+/**
+ * Recover HOW `account` voted by scanning the proposal's `VoteCast` events (voter is indexed; proposalId is not,
+ * so filter client-side), bounded to the voting window via the adaptive range scanner. Returns the support
+ * value (0 Against / 1 For / 2 Abstain) or null if not found / unreadable (honest degradation).
+ */
+export async function readVoteSupport(reader, governor, proposal, account) {
+  try {
+    const from = Number(proposal.voteStart)
+    const to = Number(proposal.voteEnd)
+    if (!Number.isFinite(from) || !Number.isFinite(to) || to < from) return null
+    const voterTopic = ethers.zeroPadValue(ethers.getAddress(account), 32)
+    const logs = await getLogsRange(reader, governor, from, to, 2000, [VOTE_CAST_TOPIC, voterTopic])
+    for (const log of logs) {
+      let parsed
+      try { parsed = VOTE_CAST_IFACE.parseLog(log) } catch { continue }
+      if (parsed.args.proposalId.toString() === proposal.id) return Number(parsed.args.support)
+    }
+    return null
+  } catch {
+    return null
   }
 }
 


### PR DESCRIPTION
Member-facing upgrades to the ClearPath external-DAO proposal view, per request.

## 1. Proposal timeline + voting awareness

Each proposal card now shows:
- **Timeline** — a `Proposed → Voting window → Outcome` stepper with the live relative position ("Voting ends in ~2h", "Voting opens in ~5m", "Voting closed"), computed from the proposal snapshot/deadline and the Governor's clock mode (block-number or timestamp).
- **Your voting state** — whether you can vote, your **voting power at the snapshot**, and, if you've already voted, a **receipt of how you voted** (For / Against / Abstain). Vote buttons are hidden once you've voted, and replaced with a clear note if you had no voting power at the snapshot.
- **Honest degradation** — if a Governor lacks a view (`hasVoted`/`getVotes`), that field reads `null` and nothing is fabricated.

The "how you voted" receipt is recovered from your `VoteCast` event (voter is indexed; proposalId filtered client-side), bounded to the voting window via the adaptive range scanner.

## 2. "+ New proposal" → above the list, in a bottom sheet

The trigger now sits **above** the proposals and opens the builder in a **bottom sheet** (`CpBottomSheet`) — centered card on desktop, rising from the bottom on mobile, mirroring the **My Wagers** panel — instead of expanding inline.

## 3. "Self" on the recipient field

Each action's **Recipient** field gains a **Self** button that fills in the connected wallet address.

## Implementation notes

- `governorConnector`: added `readVoterState` / `readVoteSupport`; generalized `getLogsRange` to accept topics (reused for the `VoteCast` scan). All reads run over the network RPC (per the prior indexing fix), not the wallet provider.
- New `CpBottomSheet` is self-contained (no global modal singleton); focuses once on open (a ref keeps `onClose` stable so typing in the form isn't interrupted).
- `CpAddressField` gains an optional `selfAddress` prop.

## Testing

- `npx vitest run src/components/clearpath/` → **46 pass** (7 new): Self button, bottom-sheet dialog, `readVoterState`/`readVoteSupport` decode, vote-receipt rendering + vote-button hiding.
- ESLint clean (incl. React Compiler rules); production `vite build` succeeds.

Frontend read/display only — no contracts, funds, or Governor execution semantics changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vZhmotmvmuysKR8bFtTJg

---
_Generated by [Claude Code](https://claude.ai/code/session_017vZhmotmvmuysKR8bFtTJg)_