### PR TITLE
feat(clearpath): detect executor-gated treasuries + first-class "Fund from treasury" action

### DIFF
--- a/frontend/src/components/clearpath/ExternalDaoView.jsx
+++ b/frontend/src/components/clearpath/ExternalDaoView.jsx
@@ -7,6 +7,7 @@ import {
   readGovernorSummary,
   readTreasuries,
   extraTreasuries,
+  detectTreasuryFunding,
   fetchGovernorProposals,
   readVoterState,
   readProposalEta,
@@ -140,7 +141,15 @@ export default function ExternalDaoView({ record, reader, signer, account, chain
         if (vaults.length) {
           try {
             const t = await readTreasuries(reader, vaults, usdcAddress)
-            if (!cancelled) setTreasuries(t)
+            // Detect the executor-gated funding pattern per vault (ECIP-1112/1113) so the UI can both label it
+            // and offer the correct "Fund from treasury" proposal action. Plain timelock vaults stay funding=null.
+            const enriched = await Promise.all(
+              t.map(async (entry) => {
+                const funding = await detectTreasuryFunding(reader, entry.address, summary?.timelock)
+                return funding ? { ...entry, funding } : entry
+              })
+            )
+            if (!cancelled) setTreasuries(enriched)
           } catch { /* treasury balances are best-effort */ }
         }
       })
@@ -267,9 +276,13 @@ export default function ExternalDaoView({ record, reader, signer, account, chain
             {treasuries.length === 0 && <p className="cp-row-sub">Reading balances…</p>}
             {treasuries.map((t) => (
               <div key={t.address} className="cp-section" style={{ marginBottom: '0.5rem' }}>
-                <div className="cp-kv"><span className="k">{t.label}</span><code className="cp-mono">{short(t.address)}</code></div>
+                <div className="cp-kv">
+                  <span className="k">{t.label}{t.funding && <span className="cp-badge" style={{ marginLeft: '0.4rem' }} title="Spendable by proposal via its on-chain executor">Governable</span>}</span>
+                  <code className="cp-mono">{short(t.address)}</code>
+                </div>
                 <div className="cp-kv"><span className="k">Native</span><span className="cp-mono">{t.native != null ? `${ethers.formatEther(t.native)} ${net?.nativeCurrency?.symbol || ''}` : '—'}</span></div>
                 <div className="cp-kv"><span className="k">{t.usdcSymbol || 'USDC'}</span><span className="cp-mono">{fmtUsdc(t.usdc, t.usdcDecimals)}</span></div>
+                {t.funding && <p className="cp-row-sub" style={{ marginTop: '0.2rem' }}>Fundable through a proposal (native {net?.nativeCurrency?.symbol || ''} only) — “Fund from treasury”.</p>}
                 {explorerBase && <a className="cp-btn-link" href={`${explorerBase}/address/${t.address}`} target="_blank" rel="noreferrer">View ↗</a>}
               </div>
             ))}
@@ -295,6 +308,9 @@ export default function ExternalDaoView({ record, reader, signer, account, chain
           usdcAddress={usdcAddress}
           nativeSymbol={net?.nativeCurrency?.symbol}
           treasuries={treasuries}
+          fundingSources={treasuries
+            .filter((t) => t.funding)
+            .map((t) => ({ executor: t.funding.executor, label: t.label, address: t.address, native: t.native }))}
           proposals={props.proposals}
           run={run}
           busy={busy}

--- a/frontend/src/components/clearpath/ProposalBuilder.jsx
+++ b/frontend/src/components/clearpath/ProposalBuilder.jsx
@@ -12,9 +12,11 @@ import CpBottomSheet from './CpBottomSheet'
 // guards: non-blocking over-treasury warning; duplicate-proposal detection; the DAO's own revert surfaced.
 
 const ERC20_TRANSFER_IFACE = new ethers.Interface(['function transfer(address to, uint256 amount)'])
+const EXECUTE_TREASURY_IFACE = new ethers.Interface(['function executeTreasury(address recipient, uint256 amount)'])
+const EXECUTE_TREASURY_SELECTOR = EXECUTE_TREASURY_IFACE.getFunction('executeTreasury').selector
 const short = (a) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '—')
 
-export default function ProposalBuilder({ record, signer, reader, account, usdcAddress, nativeSymbol, treasuries = [], proposals = [], run, busy, onSubmitted }) {
+export default function ProposalBuilder({ record, signer, reader, account, usdcAddress, nativeSymbol, treasuries = [], fundingSources = [], proposals = [], run, busy, onSubmitted }) {
   const [open, setOpen] = useState(false)
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
@@ -86,10 +88,18 @@ export default function ProposalBuilder({ record, signer, reader, account, usdcA
   const anyNativeKnown = treasuries.some((t) => t.native != null)
   const anyUsdcKnown = treasuries.some((t) => t.usdc != null)
   const usdcSymbol = treasuries.find((t) => t.usdcSymbol)?.usdcSymbol || 'USDC'
+  // "Fund from treasury" actions draw native from the governable vault(s), not the timelock — checked against
+  // the funding sources' own balance.
+  const treasuryHeld = fundingSources.reduce((sum, f) => sum + (f.native ?? 0n), 0n)
   let nativeTotal = 0n
   let usdcTotal = 0n
+  let treasuryTotal = 0n
   for (const p of A.perAction) {
     if (!p.encoded) continue
+    if (p.encoded.calldata.startsWith(EXECUTE_TREASURY_SELECTOR)) {
+      try { const [, amt] = EXECUTE_TREASURY_IFACE.decodeFunctionData('executeTreasury', p.encoded.calldata); treasuryTotal += amt } catch { /* not a treasury fund */ }
+      continue
+    }
     nativeTotal += p.encoded.value
     if (usdcAddress && p.encoded.target.toLowerCase() === usdcAddress.toLowerCase()) {
       try { const [, amt] = ERC20_TRANSFER_IFACE.decodeFunctionData('transfer', p.encoded.calldata); usdcTotal += amt } catch { /* not a transfer */ }
@@ -98,6 +108,7 @@ export default function ProposalBuilder({ record, signer, reader, account, usdcA
   // Only warn once balances are known, and only when the spend truly exceeds total DAO holdings.
   const overNative = valid && anyNativeKnown && nativeTotal > nativeHeld
   const overUsdc = valid && anyUsdcKnown && usdcTotal > usdcHeld
+  const overTreasury = valid && fundingSources.length > 0 && treasuryTotal > treasuryHeld
   const dupId = valid ? predictProposalId(A.targets, A.values, A.calldatas, A.descriptionHash) : null
   // FR-025 duplicate pre-check: an identical action set + description hashes to the same id as a live proposal.
   const isDuplicate = !!dupId && proposals.some((p) => p.id === dupId)
@@ -121,10 +132,28 @@ export default function ProposalBuilder({ record, signer, reader, account, usdcA
     ).then((ok) => { if (ok) { reset(); setOpen(false); onSubmitted?.() } })
   }
 
+  // "Fund from treasury" is offered FIRST when the DAO has a governable (executor-gated) vault; the generic
+  // actions stay available for the common pattern.
+  const typeOptions = fundingSources.length
+    ? [{ v: ACTION_TYPE.TREASURY, label: 'Fund from treasury' }, ...TYPE_OPTIONS]
+    : TYPE_OPTIONS
+
+  // On open, for a DAO with a governable treasury, pre-select "Fund from treasury" if the single action is still
+  // the pristine default — non-destructive, and steers the member to the workflow that actually funds.
+  function openBuilder() {
+    if (fundingSources.length && actions.length === 1) {
+      const a0 = actions[0]
+      if (a0.type === ACTION_TYPE.TOKEN && !a0.tokenTo && !a0.tokenAmount && !a0.treasuryTo && !a0.treasuryAmount) {
+        setActions([{ ...a0, type: ACTION_TYPE.TREASURY, treasuryExecutor: fundingSources[0].executor }])
+      }
+    }
+    setOpen(true)
+  }
+
   return (
     <>
       <div style={{ marginBottom: '0.8rem' }}>
-        <button type="button" className="cp-btn cp-btn-primary" onClick={() => setOpen(true)}>+ New proposal</button>
+        <button type="button" className="cp-btn cp-btn-primary" onClick={openBuilder}>+ New proposal</button>
       </div>
 
       <CpBottomSheet open={open} onClose={() => { reset(); setOpen(false) }} title="New proposal">
@@ -136,6 +165,13 @@ export default function ProposalBuilder({ record, signer, reader, account, usdcA
         <label className="cp-label" htmlFor="cp-prop-body">Description (Markdown)</label>
         <textarea id="cp-prop-body" className="cp-input cp-textarea" rows={4} value={body} onChange={(e) => setBody(e.target.value)} placeholder="What this proposal does and why." />
       </div>
+
+      {fundingSources.length > 0 && (
+        <p className="cp-row-sub" style={{ marginBottom: '0.6rem' }}>
+          This DAO spends from its treasury via an on-chain executor — use <strong>Fund from treasury</strong> to
+          disburse native {nativeSymbol}. Generic sends draw from the timelock.
+        </p>
+      )}
 
       <div className="cp-action-head">
         <h4 style={{ margin: 0 }}>Actions</h4>
@@ -154,6 +190,8 @@ export default function ProposalBuilder({ record, signer, reader, account, usdcA
           nativeSymbol={nativeSymbol}
           canRemove={actions.length > 1}
           account={account}
+          typeOptions={typeOptions}
+          fundingSources={fundingSources}
           onChange={(patch) => setAction(a.id, patch)}
           onRemove={() => removeAction(a.id)}
         />
@@ -165,6 +203,7 @@ export default function ProposalBuilder({ record, signer, reader, account, usdcA
         <div className="cp-kv"><span className="k">Total native value</span><span className="cp-mono">{ethers.formatEther(nativeTotal)} {nativeSymbol || ''}</span></div>
         {overNative && <div className="cp-warn" role="status">Sends more {nativeSymbol} than the treasury holds. The proposal can still be created; execution will revert if not funded by then.</div>}
         {overUsdc && <div className="cp-warn" role="status">Sends more {usdcSymbol} than the treasury holds. The proposal can still be created; execution will revert if not funded.</div>}
+        {overTreasury && <div className="cp-warn" role="status">Funds more {nativeSymbol} than the treasury vault holds. The proposal can still be created; execution will revert if not funded.</div>}
         {isDuplicate && <div className="cp-error" role="alert">This exact proposal already exists (id {dupId.length > 14 ? `${dupId.slice(0, 8)}…${dupId.slice(-4)}` : dupId}). Submitting it would revert — change an action or the description.</div>}
         {!valid && <p className="cp-row-sub">{anyPending ? 'Reading token details…' : 'Add a title/description and at least one valid action to submit.'}</p>}
 
@@ -199,23 +238,43 @@ const TYPE_OPTIONS = [
   { v: ACTION_TYPE.CUSTOM, label: 'Custom call (advanced)' },
 ]
 
-function ActionCard({ index, action, diag, meta, usdcAddress, nativeSymbol, canRemove, account, onChange, onRemove }) {
+function ActionCard({ index, action, diag, meta, usdcAddress, nativeSymbol, canRemove, account, typeOptions = TYPE_OPTIONS, fundingSources = [], onChange, onRemove }) {
   const a = action
   const useDefaultUsdc = a.tokenMode !== 'other'
   const tokenAddr = useDefaultUsdc ? (usdcAddress || '') : a.tokenAddress.trim()
   const tokenMeta = a.type === ACTION_TYPE.TOKEN && tokenAddr ? meta(tokenAddr) : null
   const tokenSym = tokenMeta?.symbol || (useDefaultUsdc ? 'USDC' : 'token')
+  // Switching to "Fund from treasury" auto-selects the (only / first) governable source's executor.
+  const onType = (v) =>
+    onChange(v === ACTION_TYPE.TREASURY ? { type: ACTION_TYPE.TREASURY, treasuryExecutor: a.treasuryExecutor || fundingSources[0]?.executor || '' } : { type: v })
 
   return (
     <div className="cp-card" style={{ background: 'var(--cp-surface)' }}>
       <div className="cp-action-head">
         <span className="cp-badge">#{index + 1}</span>
         <label className="sr-only" htmlFor={`cp-act-type-${a.id}`}>Action {index + 1} type</label>
-        <select id={`cp-act-type-${a.id}`} className="cp-input cp-select" value={a.type} onChange={(e) => onChange({ type: e.target.value })} style={{ maxWidth: '14rem' }}>
-          {TYPE_OPTIONS.map((o) => <option key={o.v} value={o.v}>{o.label}</option>)}
+        <select id={`cp-act-type-${a.id}`} className="cp-input cp-select" value={a.type} onChange={(e) => onType(e.target.value)} style={{ maxWidth: '14rem' }}>
+          {typeOptions.map((o) => <option key={o.v} value={o.v}>{o.label}</option>)}
         </select>
         {canRemove && <button type="button" className="cp-btn" aria-label={`Remove action ${index + 1}`} onClick={onRemove}>✕</button>}
       </div>
+
+      {a.type === ACTION_TYPE.TREASURY && (
+        <>
+          {fundingSources.length > 1 ? (
+            <div className="cp-field">
+              <label className="cp-label" htmlFor={`f-${a.id}-tsrc`}>Treasury</label>
+              <select id={`f-${a.id}-tsrc`} className="cp-input cp-select" value={a.treasuryExecutor} onChange={(e) => onChange({ treasuryExecutor: e.target.value })}>
+                {fundingSources.map((f) => <option key={f.executor} value={f.executor}>{f.label}</option>)}
+              </select>
+            </div>
+          ) : (
+            <p className="cp-row-sub">From {fundingSources[0]?.label || 'the treasury'} · native {nativeSymbol} via its on-chain executor.</p>
+          )}
+          <CpAddressField id={`f-${a.id}-trto`} label="Recipient" value={a.treasuryTo} onChange={(v) => onChange({ treasuryTo: v })} selfAddress={account} />
+          <div className="cp-field"><label className="cp-label" htmlFor={`f-${a.id}-tramt`}>Amount<span className="cp-suffix">{nativeSymbol}</span></label><input id={`f-${a.id}-tramt`} className="cp-input cp-mono" value={a.treasuryAmount} onChange={(e) => onChange({ treasuryAmount: e.target.value })} placeholder="0.0" /></div>
+        </>
+      )}
 
       {a.type === ACTION_TYPE.NATIVE && (
         <>
@@ -258,6 +317,16 @@ function ActionCard({ index, action, diag, meta, usdcAddress, nativeSymbol, canR
 }
 
 function ActionPreview({ type, enc, nativeSymbol, tokenSym }) {
+  if (type === ACTION_TYPE.TREASURY) {
+    let to = '—'
+    let amt = '0'
+    try {
+      const [t, a] = EXECUTE_TREASURY_IFACE.decodeFunctionData('executeTreasury', enc.calldata)
+      to = short(t)
+      amt = ethers.formatEther(a)
+    } catch { /* */ }
+    return <span>Fund {amt} {nativeSymbol} → {to} · from treasury via {short(enc.target)}</span>
+  }
   if (type === ACTION_TYPE.NATIVE) {
     return <span>Send {ethers.formatEther(enc.value)} {nativeSymbol} → {short(enc.target)}</span>
   }

--- a/frontend/src/components/clearpath/__tests__/ClearPathPanel.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ClearPathPanel.test.jsx
@@ -19,12 +19,13 @@ const cp = {
 vi.mock('../useClearPath', () => ({ useClearPath: () => cp }))
 vi.mock('../../../hooks/useUI', () => ({ useNotification: () => ({ showNotification: vi.fn() }) }))
 
-const conn = { validateGovernor: vi.fn(), readGovernorSummary: vi.fn(), fetchGovernorProposals: vi.fn(), readTreasuries: vi.fn(), readVoterState: vi.fn(), readProposalEta: vi.fn() }
+const conn = { validateGovernor: vi.fn(), readGovernorSummary: vi.fn(), fetchGovernorProposals: vi.fn(), readTreasuries: vi.fn(), readVoterState: vi.fn(), readProposalEta: vi.fn(), detectTreasuryFunding: vi.fn() }
 vi.mock('../governorConnector', () => ({
   validateGovernor: (...a) => conn.validateGovernor(...a),
   readGovernorSummary: (...a) => conn.readGovernorSummary(...a),
   readTreasuries: (...a) => conn.readTreasuries(...a),
   extraTreasuries: () => [{ label: 'Olympia Treasury', address: '0x035b2e3c189B772e52F4C3DA6c45c84A3bB871bf' }],
+  detectTreasuryFunding: (...a) => conn.detectTreasuryFunding(...a),
   fetchGovernorProposals: (...a) => conn.fetchGovernorProposals(...a),
   readVoterState: (...a) => conn.readVoterState(...a),
   readProposalEta: (...a) => conn.readProposalEta(...a),
@@ -61,6 +62,7 @@ describe('ClearPathPanel (spec 030 / US3)', () => {
     conn.readTreasuries.mockResolvedValue([])
     conn.readVoterState.mockResolvedValue({ hasVoted: false, votingPower: null, support: null })
     conn.readProposalEta.mockResolvedValue(null)
+    conn.detectTreasuryFunding.mockResolvedValue(null)
   })
 
   it('self-disables truthfully on an unsupported network', async () => {

--- a/frontend/src/components/clearpath/__tests__/ExternalDaoView.notifications.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ExternalDaoView.notifications.test.jsx
@@ -21,6 +21,7 @@ vi.mock('../governorConnector', () => ({
   readGovernorSummary: (...a) => h.readGovernorSummary(...a),
   readTreasuries: (...a) => h.readTreasuries(...a),
   extraTreasuries: () => [],
+  detectTreasuryFunding: () => Promise.resolve(null),
   fetchGovernorProposals: (...a) => h.fetchGovernorProposals(...a),
   readVoterState: () => Promise.resolve({ hasVoted: null, votingPower: null, support: null }),
   readProposalEta: () => Promise.resolve(null),

--- a/frontend/src/components/clearpath/__tests__/ProposalBuilder.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ProposalBuilder.test.jsx
@@ -176,4 +176,28 @@ describe('ProposalBuilder (spec 030 / US5)', () => {
     await user.click(trigger)
     expect(screen.getByRole('dialog', { name: /new proposal/i })).toBeInTheDocument()
   })
+
+  it('builds an executeTreasury proposal via the "Fund from treasury" action (executor-gated DAO)', async () => {
+    const EXECUTOR = '0x00000000000000000000000000000000000000e1'
+    const EXEC_IFACE = new ethers.Interface(['function executeTreasury(address recipient, uint256 amount)'])
+    proposeAction.mockResolvedValue({})
+    const user = userEvent.setup()
+    // a governable funding source → opening pre-selects "Fund from treasury" (the correct path for this DAO)
+    renderBuilder({ fundingSources: [{ executor: EXECUTOR, label: 'Olympia Treasury', address: '0x0000000000000000000000000000000000000333', native: ethers.parseEther('2') }] })
+    await user.click(screen.getByRole('button', { name: /\+ new proposal/i }))
+    expect(screen.getByText(/spends from its treasury via an on-chain executor/i)).toBeInTheDocument()
+    await user.type(screen.getByLabelText(/^title$/i), 'Dev grant')
+    await user.type(screen.getByLabelText(/recipient/i), TO)
+    await user.type(screen.getByLabelText(/amount/i), '1')
+    const submit = screen.getByRole('button', { name: /submit proposal/i })
+    await waitFor(() => expect(submit).toBeEnabled())
+    await user.click(submit)
+    await waitFor(() => expect(proposeAction).toHaveBeenCalled())
+    const [, , payload] = proposeAction.mock.calls[0]
+    expect(payload.targets).toEqual([EXECUTOR]) // targets the executor, not the recipient
+    expect(payload.values).toEqual([0n])
+    const [to, amount] = EXEC_IFACE.decodeFunctionData('executeTreasury', payload.calldatas[0])
+    expect(to.toLowerCase()).toBe(TO)
+    expect(amount).toBe(ethers.parseEther('1'))
+  })
 })

--- a/frontend/src/components/clearpath/__tests__/governorConnector.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/governorConnector.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { ethers } from 'ethers'
-import { getLogsRange, parseProposalLog, readVoterState, readVoteSupport, explainTxError } from '../governorConnector'
+import { getLogsRange, parseProposalLog, readVoterState, readVoteSupport, explainTxError, detectTreasuryFunding } from '../governorConnector'
 
 // Spec 030 (US5) — the subgraph-less proposal indexer must survive RPC block-range caps. ETC/Mordor public
 // nodes (and many wallet RPC backends) reject an `eth_getLogs` window wider than a provider-specific limit;
@@ -127,5 +127,19 @@ describe('explainTxError (spec 030 — decode opaque custom-error reverts)', () 
   it('falls back to the ethers message for unknown selectors', () => {
     expect(explainTxError({ shortMessage: 'user rejected' })).toBe('user rejected')
     expect(explainTxError({ data: '0xdeadbeef', message: 'boom' })).toBe('boom')
+  })
+})
+
+describe('detectTreasuryFunding (spec 030 — executor-gated treasury detection)', () => {
+  it('returns null on missing reader or non-address inputs (never guesses)', async () => {
+    expect(await detectTreasuryFunding(null, GOV, GOV)).toBeNull()
+    expect(await detectTreasuryFunding({}, 'not-an-address', GOV)).toBeNull()
+    expect(await detectTreasuryFunding({}, GOV, 'not-an-address')).toBeNull()
+  })
+
+  it('returns null when the vault has no executor() (a plain timelock vault)', async () => {
+    // A reader whose call() always reverts mimics a vault without the executor() getter.
+    const reader = { call: async () => { throw new Error('execution reverted') } }
+    expect(await detectTreasuryFunding(reader, GOV, GOV)).toBeNull()
   })
 })

--- a/frontend/src/components/clearpath/__tests__/proposalEncoding.test.js
+++ b/frontend/src/components/clearpath/__tests__/proposalEncoding.test.js
@@ -27,6 +27,20 @@ describe('proposalEncoding', () => {
     expect(descriptionHash(d)).toBe(ethers.id(d))
   })
 
+  it('encodes a "fund from treasury" action as executeTreasury(recipient, amount) on the executor', () => {
+    const EXECUTOR = '0x00000000000000000000000000000000000000e1'
+    const EXEC_IFACE = new ethers.Interface(['function executeTreasury(address recipient, uint256 amount)'])
+    const enc = encodeAction(
+      { ...newAction(ACTION_TYPE.TREASURY), treasuryExecutor: EXECUTOR, treasuryTo: TO, treasuryAmount: '1.5' },
+      { usdcAddress: USDC, meta: usdcMeta }
+    )
+    expect(enc.target).toBe(EXECUTOR) // target is the executor, NOT the recipient or the vault
+    expect(enc.value).toBe(0n) // the call carries no value — the executor pulls from the vault
+    const [to, amount] = EXEC_IFACE.decodeFunctionData('executeTreasury', enc.calldata)
+    expect(to.toLowerCase()).toBe(TO)
+    expect(amount).toBe(ethers.parseEther('1.5')) // native (18 decimals)
+  })
+
   it('encodes a native send (value + empty calldata)', () => {
     const a = { ...newAction(ACTION_TYPE.NATIVE), nativeTo: TO, nativeAmount: '1.5' }
     const enc = encodeAction(a, { usdcAddress: USDC, meta: usdcMeta })

--- a/frontend/src/components/clearpath/governorConnector.js
+++ b/frontend/src/components/clearpath/governorConnector.js
@@ -188,6 +188,37 @@ export async function getLogsRange(reader, governor, from, to, minSpan = 2000, t
   }
 }
 
+const TREASURY_VAULT_ABI = ['function executor() view returns (address)']
+const TREASURY_EXECUTOR_ABI = [
+  'function treasury() view returns (address)',
+  'function timelock() view returns (address)',
+]
+
+/**
+ * Detect whether a treasury vault is governable through an on-chain executor — the ECIP-1112/1113 pattern used
+ * by Olympia and the network treasuries, where funds live in an immutable vault spent via
+ * `Governor → Timelock → Executor → Treasury.withdraw`, NOT held by the timelock directly.
+ *
+ * Verified on-chain, never guessed: the vault must expose `executor()`, and that executor's `treasury()` /
+ * `timelock()` must round-trip back to THIS vault and the Governor's own timelock. Returns `{ executor }` for the
+ * executor-gated pattern, or null for the plain "timelock holds the funds" pattern (a generic OZ Governor).
+ */
+export async function detectTreasuryFunding(reader, vault, governorTimelock) {
+  try {
+    if (!reader || !ethers.isAddress(vault || '') || !ethers.isAddress(governorTimelock || '')) return null
+    const executor = await new ethers.Contract(vault, TREASURY_VAULT_ABI, reader).executor()
+    if (!ethers.isAddress(executor) || executor === ethers.ZeroAddress) return null
+    const ex = new ethers.Contract(executor, TREASURY_EXECUTOR_ABI, reader)
+    const [exTreasury, exTimelock] = await Promise.all([ex.treasury(), ex.timelock()])
+    const wired =
+      exTreasury.toLowerCase() === vault.toLowerCase() &&
+      exTimelock.toLowerCase() === governorTimelock.toLowerCase()
+    return wired ? { executor } : null
+  } catch {
+    return null
+  }
+}
+
 const VOTE_CAST_TOPIC = ethers.id('VoteCast(address,uint256,uint8,uint256,string)')
 const VOTE_CAST_IFACE = new ethers.Interface([
   'event VoteCast(address indexed voter, uint256 proposalId, uint8 support, uint256 weight, string reason)',

--- a/frontend/src/components/clearpath/proposalEncoding.js
+++ b/frontend/src/components/clearpath/proposalEncoding.js
@@ -6,9 +6,11 @@ import { ethers } from 'ethers'
 // testable. Governor correctness invariants live here: value=0 for ERC-20, description reused byte-for-byte,
 // description hash = keccak256(utf8), arrays equal length.
 
-export const ACTION_TYPE = { NATIVE: 'native', TOKEN: 'token', CUSTOM: 'custom' }
+export const ACTION_TYPE = { TREASURY: 'treasury', NATIVE: 'native', TOKEN: 'token', CUSTOM: 'custom' }
 
 const ERC20_TRANSFER_IFACE = new ethers.Interface(['function transfer(address to, uint256 amount)'])
+// The executor-gated treasury withdrawal (ECIP-1112/1113 pattern: Governor → Timelock → Executor → Treasury).
+const EXECUTE_TREASURY_IFACE = new ethers.Interface(['function executeTreasury(address recipient, uint256 amount)'])
 
 let _seq = 0
 /** A fresh blank action. `id` is a React key only — never submitted. */
@@ -17,6 +19,9 @@ export function newAction(type = ACTION_TYPE.TOKEN) {
   return {
     id: `a${_seq}`,
     type,
+    treasuryExecutor: '', // the on-chain executor for the "Fund from treasury" action (set from the detected source)
+    treasuryTo: '',
+    treasuryAmount: '',
     nativeTo: '',
     nativeAmount: '',
     tokenMode: 'usdc', // 'usdc' (treasury default) | 'other' (arbitrary ERC-20 at tokenAddress)
@@ -64,6 +69,17 @@ function requireAddress(v, label) {
  * @param meta (tokenAddr) => { decimals, symbol } | null
  */
 export function encodeAction(a, { usdcAddress, meta }) {
+  if (a.type === ACTION_TYPE.TREASURY) {
+    // Fund a recipient from the DAO's treasury via its executor (native only). The call carries NO value — the
+    // executor pulls from the vault — so target = executor, value = 0, calldata = executeTreasury(to, amount).
+    requireAddress(a.treasuryExecutor, 'Treasury executor')
+    requireAddress(a.treasuryTo, 'Recipient')
+    return {
+      target: a.treasuryExecutor.trim(),
+      value: 0n,
+      calldata: EXECUTE_TREASURY_IFACE.encodeFunctionData('executeTreasury', [a.treasuryTo.trim(), parseHuman(a.treasuryAmount, 18, 'Amount')]),
+    }
+  }
   if (a.type === ACTION_TYPE.NATIVE) {
     requireAddress(a.nativeTo, 'Recipient')
     return { target: a.nativeTo.trim(), value: parseHuman(a.nativeAmount, 18, 'Amount'), calldata: '0x' }


### PR DESCRIPTION
Validated the Olympia DAO contract wiring and implemented full support for the **executor-gated treasury** pattern used across the network contracts, while keeping the generic Governor actions.

> Was stacked on #772 (now merged); rebased onto `main` — this PR is a clean, treasury-only diff (1 commit).

## Validated wiring (on-chain)

```
Governor 0xB85d…  →  Timelock 0xA583… (minDelay 1h)  →  OlympiaExecutor 0x64624f… (ECIP-1113 sanctions gate)  →  OlympiaTreasury 0x035b… (ECIP-1112 vault, holds the ETC)
```

The vault's only spend path is `withdraw(to, amount)`, gated to its immutable `executor` (= the OlympiaExecutor), whose `timelock()` is the Governor's timelock. A funding proposal must call `OlympiaExecutor.executeTreasury(recipient, amount)` — **not** a direct transfer from the (empty) timelock.

**Proven by simulation:** `executeTreasury(recipient, 1 ETC)` called **from the timelock succeeds**; the same call from a non-timelock caller reverts `OnlyTimelock` (`0x1c0be90a`).

## What ClearPath now does — both patterns

- **Auto-detection** (`detectTreasuryFunding`): reads the vault's own `executor()` getter and **verifies on-chain** that `executor.treasury() == vault` and `executor.timelock() == the Governor's timelock` before trusting it (never guesses an address). Returns the executor for the gated pattern; `null` for a plain timelock-funded Governor.
- **"Fund from treasury" action**: encodes `executeTreasury(recipient, amount)` on the executor (native, value 0). It's listed **first and pre-selected** when a DAO has a governable treasury; the generic **Send native / Send token / Custom call** actions remain for the common pattern.
- **Display**: governable vaults are marked **"Governable"** with a "fundable via proposal (native only)" note; a builder hint explains generic sends draw from the timelock.
- **Guard**: the over-treasury check measures treasury-funding amounts against the vault balance.

## End-to-end funding workflow (now correct on Olympia)

Create (pre-filled `Fund from treasury`) → vote For → **queue** → wait the **1-hour** timelock ETA → **execute** → Governor → Timelock → Executor (sanctions-screens) → Treasury → recipient receives native ETC.

## Testing

- `npx vitest run src/components/clearpath/` → **55 pass** (4 new: treasury encoding, detection guards, builder → `executeTreasury` payload).
- Live simulation of the funding path; ESLint clean; production `vite build` succeeds.

Frontend read/encode only — no contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vZhmotmvmuysKR8bFtTJg