### PR TITLE
feat(wallet): My Account section nav as a slide-over drawer on mobile

### DIFF
--- a/frontend/src/pages/WalletPage.css
+++ b/frontend/src/pages/WalletPage.css
@@ -297,12 +297,74 @@
 }
 
 @media (max-width: 768px) {
+  /* On phones the section nav becomes a slide-over drawer that overlays the
+     content instead of a docked column that pushes it down. The drawer is
+     anchored to the wallet card and animates in/out from the left edge. */
   .wallet-portal.portal-shell {
     min-height: 0;
+    position: relative;
   }
 
   .wallet-portal-current {
     font-size: 14px;
+  }
+
+  .wallet-portal-sidebar.portal-sidebar {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 30;
+    display: flex;
+    width: 80%;
+    max-width: 300px;
+    flex-basis: auto;
+    overflow-y: auto;
+    border-right: 1px solid var(--color-border);
+    box-shadow: 4px 0 24px rgba(0, 0, 0, 0.18);
+    transform: translateX(-100%);
+    visibility: hidden;
+    transition: transform 0.25s ease, visibility 0s linear 0.25s;
+  }
+
+  /* Open state: slide in and become focusable. */
+  .wallet-portal.portal-shell:not(.portal-collapsed) .wallet-portal-sidebar.portal-sidebar {
+    transform: translateX(0);
+    visibility: visible;
+    transition: transform 0.25s ease, visibility 0s;
+  }
+
+  /* Closed state: keep it rendered (override the shared display:none) so it can
+     animate back out rather than vanish. */
+  .wallet-portal.portal-shell.portal-collapsed .wallet-portal-sidebar.portal-sidebar {
+    display: flex;
+  }
+
+  .wallet-portal-backdrop {
+    position: absolute;
+    inset: 0;
+    z-index: 20;
+    padding: 0;
+    border: none;
+    cursor: pointer;
+    background: rgba(0, 0, 0, 0.4);
+    animation: wallet-portal-backdrop-fade 0.2s ease;
+  }
+}
+
+@keyframes wallet-portal-backdrop-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wallet-portal-sidebar.portal-sidebar,
+  .wallet-portal.portal-shell:not(.portal-collapsed) .wallet-portal-sidebar.portal-sidebar {
+    transition: visibility 0s;
+  }
+
+  .wallet-portal-backdrop {
+    animation: none;
   }
 }
 

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -79,7 +79,12 @@ function WalletPage() {
   const polymarketSidebetsEnabled = Boolean(capabilities?.polymarketSidebets)
   const navigate = useNavigate()
   const [activeTab, setActiveTab] = useState('account')
-  const [sidebarOpen, setSidebarOpen] = useState(true)
+  // On phones the section nav is a slide-over drawer that overlays the content,
+  // so it starts closed; on wider screens it stays docked open like a portal.
+  const [isMobile, setIsMobile] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia('(max-width: 768px)').matches
+  )
+  const [sidebarOpen, setSidebarOpen] = useState(() => !isMobile)
   const [connectingConnectorId, setConnectingConnectorId] = useState(null)
   const [connectionError, setConnectionError] = useState(null)
   const [keyRegistered, setKeyRegistered] = useState(null)
@@ -177,6 +182,35 @@ function WalletPage() {
     }
   }, [activeTab, isConnected, keyRegistered, handleCheckKeyStatus])
 
+  // Track viewport so the section nav can dock (desktop) or slide over (mobile).
+  // Crossing the breakpoint resets the drawer to its natural state for that size.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const mq = window.matchMedia('(max-width: 768px)')
+    const handleChange = (event) => {
+      setIsMobile(event.matches)
+      setSidebarOpen(!event.matches)
+    }
+    mq.addEventListener('change', handleChange)
+    return () => mq.removeEventListener('change', handleChange)
+  }, [])
+
+  // Close the slide-over drawer on Escape (mobile only).
+  useEffect(() => {
+    if (!isMobile || !sidebarOpen) return
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') setSidebarOpen(false)
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isMobile, sidebarOpen])
+
+  // Jumping to a section closes the drawer on mobile so the content is visible.
+  const handleSelectTab = useCallback((id) => {
+    setActiveTab(id)
+    if (isMobile) setSidebarOpen(false)
+  }, [isMobile])
+
   const selectedPolymarketCategories = useMemo(
     () => preferences?.polymarketCategories || [],
     [preferences?.polymarketCategories],
@@ -254,7 +288,10 @@ function WalletPage() {
             </div>
           ) : (
             <div className={`wallet-portal portal-shell ${sidebarOpen ? '' : 'portal-collapsed'}`}>
-              <aside className="portal-sidebar wallet-portal-sidebar">
+              <aside
+                id="wallet-portal-nav"
+                className="portal-sidebar wallet-portal-sidebar"
+              >
                 <div className="wallet-portal-identity">
                   <BlockiesAvatar address={address} size={36} className="wallet-avatar" />
                   <span className="wallet-address-display">{shortenAddress(address)}</span>
@@ -263,10 +300,20 @@ function WalletPage() {
                 <PortalNav
                   items={WALLET_TABS}
                   activeId={activeTab}
-                  onSelect={setActiveTab}
+                  onSelect={handleSelectTab}
                   ariaLabel="Account sections"
                 />
               </aside>
+
+              {/* Mobile only: dim + dismiss the slide-over drawer by tapping outside it. */}
+              {isMobile && sidebarOpen && (
+                <button
+                  type="button"
+                  className="wallet-portal-backdrop"
+                  aria-label="Close menu"
+                  onClick={() => setSidebarOpen(false)}
+                />
+              )}
 
               <div className="portal-main wallet-portal-main">
                 <div className="wallet-portal-topbar">
@@ -274,7 +321,8 @@ function WalletPage() {
                     type="button"
                     className="portal-sidebar-toggle"
                     aria-expanded={sidebarOpen}
-                    aria-label={sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
+                    aria-controls="wallet-portal-nav"
+                    aria-label={sidebarOpen ? 'Hide menu' : 'Show menu'}
                     onClick={() => setSidebarOpen((o) => !o)}
                   >
                     <span aria-hidden="true">{'☰'}</span>

--- a/frontend/src/test/WalletPage.test.jsx
+++ b/frontend/src/test/WalletPage.test.jsx
@@ -156,3 +156,83 @@ describe('WalletPage — address QR entry point', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 })
+
+describe('WalletPage — section nav slide-over drawer', () => {
+  // matchMedia defaults to matches:false (desktop) in setup.js. Force a mobile
+  // match so the section nav behaves as an overlay drawer.
+  const setViewport = (isMobile) => {
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: isMobile,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+  }
+
+  it('docks the nav open on desktop (no backdrop)', () => {
+    setViewport(false)
+    renderPage(connectedWalletContext)
+
+    expect(
+      screen.getByRole('button', { name: /hide menu/i })
+    ).toHaveAttribute('aria-expanded', 'true')
+    expect(
+      screen.queryByRole('button', { name: /close menu/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it('starts closed on mobile and toggles open with a backdrop', () => {
+    setViewport(true)
+    renderPage(connectedWalletContext)
+
+    const toggle = screen.getByRole('button', { name: /show menu/i })
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(
+      screen.queryByRole('button', { name: /close menu/i })
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(toggle)
+
+    expect(
+      screen.getByRole('button', { name: /hide menu/i })
+    ).toHaveAttribute('aria-expanded', 'true')
+    expect(
+      screen.getByRole('button', { name: /close menu/i })
+    ).toBeInTheDocument()
+  })
+
+  it('closes the drawer after a section is selected on mobile', () => {
+    setViewport(true)
+    renderPage(connectedWalletContext)
+
+    fireEvent.click(screen.getByRole('button', { name: /show menu/i }))
+    expect(
+      screen.getByRole('button', { name: /close menu/i })
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Membership' }))
+
+    expect(
+      screen.queryByRole('button', { name: /close menu/i })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /show menu/i })
+    ).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('dismisses the drawer when the backdrop is tapped on mobile', () => {
+    setViewport(true)
+    renderPage(connectedWalletContext)
+
+    fireEvent.click(screen.getByRole('button', { name: /show menu/i }))
+    fireEvent.click(screen.getByRole('button', { name: /close menu/i }))
+
+    expect(
+      screen.getByRole('button', { name: /show menu/i })
+    ).toHaveAttribute('aria-expanded', 'false')
+  })
+})


### PR DESCRIPTION
## Summary

The **My Account** section menu previously docked as a column that, on phones, squeezed the content and pushed it down the page (see the reported screenshots). This reworks it into a **left-hand slide-over drawer** that overlays the current view, so users can quickly jump between sections without losing their place.

### Behavior
- **Mobile (≤768px):** the section nav slides in from the left *over* the content with a dimmed backdrop. It starts **closed** so content is visible by default. The drawer closes when you:
  - tap a section (and jumps you there),
  - tap the backdrop, or
  - press `Escape`.
- **Desktop (>768px):** unchanged — the nav stays docked open like a portal and is still collapsible via the ☰ toggle.
- Honors `prefers-reduced-motion` (skips the slide/fade animation).

### Implementation notes
- All overlay styles are **scoped to `.wallet-portal`**, so the shared admin-portal layout (`AdminPanel`) is unaffected.
- Viewport is tracked with `matchMedia('(max-width: 768px)')`; crossing the breakpoint resets the drawer to its natural state for that size.
- The drawer keeps `display: flex` while closed (overriding the shared `display:none`) so it can animate out, and uses delayed `visibility` so it's removed from the tab order when hidden.
- Toggle button wired with `aria-expanded` / `aria-controls`; backdrop exposed as a labelled "Close menu" button.

## Testing
- `npx vitest run src/test/WalletPage.test.jsx` — 8/8 passing, including new tests for: desktop docked state, mobile starts-closed + toggle-open + backdrop, select-to-close, and backdrop dismissal.
- `eslint` clean on changed files.

## Files changed
- `frontend/src/pages/WalletPage.jsx` — viewport tracking, Escape handler, select-to-close, backdrop, ARIA wiring.
- `frontend/src/pages/WalletPage.css` — mobile slide-over drawer + backdrop styles, reduced-motion handling.
- `frontend/src/test/WalletPage.test.jsx` — drawer behavior tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pbzNL22saGcYmv3pdQxvC

---
_Generated by [Claude Code](https://claude.ai/code/session_011pbzNL22saGcYmv3pdQxvC)_