### PR TITLE
feat(address-book): add copy-to-clipboard button per address

### DIFF
--- a/frontend/src/components/account/AddressBookPanel.css
+++ b/frontend/src/components/account/AddressBookPanel.css
@@ -218,6 +218,16 @@
   color: #b91c1c;
 }
 
+.ab-copy-btn {
+  color: var(--text-muted, #64748b);
+  min-width: 3.2rem;
+}
+
+.ab-copy-btn--copied {
+  color: #15803d;
+  border-color: #15803d;
+}
+
 .ab-modal-backdrop {
   position: fixed;
   inset: 0;

--- a/frontend/src/components/account/ContactCard.jsx
+++ b/frontend/src/components/account/ContactCard.jsx
@@ -5,6 +5,7 @@
  * at the contact level (FR-012).
  */
 
+import { useState } from 'react'
 import { addressKey } from '../../lib/addressBook/addressBookStore'
 import RestrictionTag from './RestrictionTag'
 
@@ -23,7 +24,15 @@ export default function ContactCard({
   onDeleteContact,
   onDeleteAddress,
 }) {
+  const [copiedKey, setCopiedKey] = useState(null)
   const statuses = contact.addresses.map((a) => getStatus(a.address, a.chainId))
+
+  function handleCopy(addr, key) {
+    navigator.clipboard.writeText(addr).then(() => {
+      setCopiedKey(key)
+      setTimeout(() => setCopiedKey(null), 1500)
+    })
+  }
   const containsRestricted = statuses.includes('restricted')
 
   return (
@@ -55,12 +64,21 @@ export default function ContactCard({
       <ul className="ab-address-list">
         {contact.addresses.map((a, i) => {
           const key = addressKey(a.address, a.chainId)
+          const copied = copiedKey === key
           return (
             <li key={key} className="ab-address-row">
               <div className="ab-address-main">
                 <code className="ab-address-value" title={a.address}>
                   {shorten(a.address)}
                 </code>
+                <button
+                  type="button"
+                  className={`ab-btn ab-btn-xs ab-copy-btn${copied ? ' ab-copy-btn--copied' : ''}`}
+                  onClick={() => handleCopy(a.address, key)}
+                  aria-label={`Copy address ${a.address}`}
+                >
+                  {copied ? 'Copied!' : 'Copy'}
+                </button>
                 <span className="ab-address-network">{networkName(a.chainId)}</span>
                 <RestrictionTag status={statuses[i]} />
               </div>


### PR DESCRIPTION
## Summary

- Adds a **Copy** button to each address row in the address book (`ContactCard`)
- Clicking it writes the full address to the clipboard via `navigator.clipboard.writeText`
- The button label flips to **Copied!** (green) for 1.5 s then resets — giving clear feedback without needing a toast system

## Changes

- `frontend/src/components/account/ContactCard.jsx` — added `useState` for per-address copied state, `handleCopy` handler, and a `Copy`/`Copied!` button inside `.ab-address-main` next to the shortened address display
- `frontend/src/components/account/AddressBookPanel.css` — added `.ab-copy-btn` (muted default) and `.ab-copy-btn--copied` (green) utility classes

## Test plan

- [ ] Open the Address Book tab in My Account
- [ ] Click **Copy** on any address row — full address is in clipboard
- [ ] Button reads **Copied!** in green for ~1.5 s, then reverts to **Copy**
- [ ] Multiple addresses on the same contact each have independent copy state
- [ ] No regressions on Edit / Delete / Remove buttons

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeUFBaRkFc4vt1dmopJjqT)_