### PR TITLE
feat(address-book): icon-only buttons on mobile, icon+label on desktop

### DIFF
--- a/frontend/src/components/account/AddressBookPanel.css
+++ b/frontend/src/components/account/AddressBookPanel.css
@@ -188,29 +188,70 @@
 
 .ab-btn {
   cursor: pointer;
-  border: 1px solid var(--border-color, #cbd5e1);
-  background: var(--btn-bg, #f8fafc);
-  color: inherit;
+  border: none;
+  background: transparent;
+  color: var(--text-muted, #64748b);
   border-radius: 0.375rem;
-  padding: 0.45rem 0.7rem;
+  padding: 0.3rem;
   font: inherit;
   font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  line-height: 1;
+  transition: color 0.1s, background 0.1s;
+}
+
+.ab-btn:hover,
+.ab-btn:focus-visible {
+  color: var(--text, #0f172a);
+  background: var(--btn-hover-bg, rgba(0, 0, 0, 0.06));
+  outline: none;
+}
+
+.ab-icon {
+  width: 1rem;
+  height: 1rem;
+  flex: none;
+}
+
+/* Labels hidden on small screens; shown alongside icon on larger screens */
+.ab-btn-label {
+  display: none;
+}
+
+@media (min-width: 640px) {
+  .ab-btn-label {
+    display: inline;
+  }
+
+  .ab-btn-sm {
+    padding: 0.3rem 0.55rem;
+  }
+
+  .ab-btn-xs {
+    padding: 0.2rem 0.45rem;
+  }
 }
 
 .ab-btn-sm {
-  padding: 0.3rem 0.55rem;
   font-size: 0.8rem;
 }
 
 .ab-btn-xs {
-  padding: 0.2rem 0.45rem;
   font-size: 0.72rem;
   align-self: flex-start;
 }
 
 .ab-btn-primary {
   background: var(--accent, #2563eb);
-  border-color: var(--accent, #2563eb);
+  color: #fff;
+  padding: 0.4rem 0.75rem;
+}
+
+.ab-btn-primary:hover,
+.ab-btn-primary:focus-visible {
+  background: var(--accent-hover, #1d4ed8);
   color: #fff;
 }
 
@@ -218,14 +259,24 @@
   color: #b91c1c;
 }
 
+.ab-btn-danger:hover,
+.ab-btn-danger:focus-visible {
+  background: rgba(185, 28, 28, 0.07);
+  color: #b91c1c;
+}
+
 .ab-copy-btn {
   color: var(--text-muted, #64748b);
-  min-width: 3.2rem;
 }
 
 .ab-copy-btn--copied {
   color: #15803d;
-  border-color: #15803d;
+}
+
+.ab-copy-btn--copied:hover,
+.ab-copy-btn--copied:focus-visible {
+  background: rgba(21, 128, 61, 0.07);
+  color: #15803d;
 }
 
 .ab-modal-backdrop {

--- a/frontend/src/components/account/AddressBookPanel.jsx
+++ b/frontend/src/components/account/AddressBookPanel.jsx
@@ -12,6 +12,14 @@ import { useAddressBook } from '../../hooks/useAddressBook'
 import { useAddressScreening } from '../../hooks/useAddressScreening'
 import { getNetwork, getSelectableNetworks, getCurrentChainId } from '../../config/networks'
 import { addressKey, listEntries } from '../../lib/addressBook/addressBookStore'
+function IconPlus() {
+  return (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" className="ab-icon">
+      <path d="M7.75 2a.75.75 0 0 1 .75.75V7h4.25a.75.75 0 0 1 0 1.5H8.5v4.25a.75.75 0 0 1-1.5 0V8.5H2.75a.75.75 0 0 1 0-1.5H7V2.75A.75.75 0 0 1 7.75 2Z" />
+    </svg>
+  )
+}
+
 import ContactCard from './ContactCard'
 import ContactEditModal from './ContactEditModal'
 import AddressBookImportExport from './AddressBookImportExport'
@@ -110,8 +118,10 @@ export default function AddressBookPanel({ address }) {
             type="button"
             className="ab-btn ab-btn-primary"
             onClick={() => setEditing({ contact: null })}
+            aria-label="Add contact"
           >
-            + Add contact
+            <IconPlus />
+            <span className="ab-btn-label">Add contact</span>
           </button>
         </div>
       </div>

--- a/frontend/src/components/account/ContactCard.jsx
+++ b/frontend/src/components/account/ContactCard.jsx
@@ -16,6 +16,47 @@ function shorten(addr) {
 
 const noStatus = () => 'clear'
 
+function IconEdit() {
+  return (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" className="ab-icon">
+      <path d="M11.013 1.427a1.75 1.75 0 0 1 2.474 0l1.086 1.086a1.75 1.75 0 0 1 0 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 0 1-.927-.928l.929-3.25c.081-.286.235-.547.445-.758l8.61-8.61Z" />
+    </svg>
+  )
+}
+
+function IconTrash() {
+  return (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" className="ab-icon">
+      <path d="M11 1.75V3h2.25a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1 0-1.5H5V1.75C5 .784 5.784 0 6.75 0h2.5C10.216 0 11 .784 11 1.75ZM4.496 6.675l.66 6.6a.25.25 0 0 0 .249.225h5.19a.25.25 0 0 0 .249-.225l.66-6.6a.75.75 0 0 1 1.492.149l-.66 6.6A1.748 1.748 0 0 1 10.595 15h-5.19a1.75 1.75 0 0 1-1.741-1.575l-.66-6.6a.75.75 0 1 1 1.492-.15ZM6.5 1.75V3h3V1.75a.25.25 0 0 0-.25-.25h-2.5a.25.25 0 0 0-.25.25Z" />
+    </svg>
+  )
+}
+
+function IconCopy() {
+  return (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" className="ab-icon">
+      <path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z" />
+      <path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z" />
+    </svg>
+  )
+}
+
+function IconCheck() {
+  return (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" className="ab-icon">
+      <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z" />
+    </svg>
+  )
+}
+
+function IconX() {
+  return (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" className="ab-icon">
+      <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
+    </svg>
+  )
+}
+
 export default function ContactCard({
   contact,
   getStatus = noStatus,
@@ -26,6 +67,7 @@ export default function ContactCard({
 }) {
   const [copiedKey, setCopiedKey] = useState(null)
   const statuses = contact.addresses.map((a) => getStatus(a.address, a.chainId))
+  const containsRestricted = statuses.includes('restricted')
 
   function handleCopy(addr, key) {
     navigator.clipboard.writeText(addr).then(() => {
@@ -33,7 +75,6 @@ export default function ContactCard({
       setTimeout(() => setCopiedKey(null), 1500)
     })
   }
-  const containsRestricted = statuses.includes('restricted')
 
   return (
     <div className="ab-contact-card">
@@ -47,8 +88,14 @@ export default function ContactCard({
           )}
         </div>
         <div className="ab-contact-actions">
-          <button type="button" className="ab-btn ab-btn-sm" onClick={() => onEdit?.(contact)}>
-            Edit
+          <button
+            type="button"
+            className="ab-btn ab-btn-sm"
+            onClick={() => onEdit?.(contact)}
+            aria-label={`Edit contact ${contact.nickname}`}
+          >
+            <IconEdit />
+            <span className="ab-btn-label">Edit</span>
           </button>
           <button
             type="button"
@@ -56,7 +103,8 @@ export default function ContactCard({
             onClick={() => onDeleteContact?.(contact.id)}
             aria-label={`Delete contact ${contact.nickname}`}
           >
-            Delete
+            <IconTrash />
+            <span className="ab-btn-label">Delete</span>
           </button>
         </div>
       </div>
@@ -77,7 +125,8 @@ export default function ContactCard({
                   onClick={() => handleCopy(a.address, key)}
                   aria-label={`Copy address ${a.address}`}
                 >
-                  {copied ? 'Copied!' : 'Copy'}
+                  {copied ? <IconCheck /> : <IconCopy />}
+                  <span className="ab-btn-label">{copied ? 'Copied!' : 'Copy'}</span>
                 </button>
                 <span className="ab-address-network">{networkName(a.chainId)}</span>
                 <RestrictionTag status={statuses[i]} />
@@ -89,7 +138,8 @@ export default function ContactCard({
                 onClick={() => onDeleteAddress?.(contact.id, key)}
                 aria-label={`Remove address ${shorten(a.address)} from ${contact.nickname}`}
               >
-                Remove
+                <IconX />
+                <span className="ab-btn-label">Remove</span>
               </button>
             </li>
           )


### PR DESCRIPTION
## Summary

- All address book action buttons (Edit, Delete, Copy, Remove, Add contact) now use inline SVG icons with no visible border or background — they blend into the card surface
- On screens **< 640 px**: icon only (text is `display: none`, still present for screen readers via `aria-label`)
- On screens **≥ 640 px**: icon + text label side-by-side
- Ghost hover state: subtle background tint on hover/focus, no frame at rest
- Danger actions (Delete, Remove) retain red color; primary "Add contact" keeps its filled accent style
- Copy button still flips to a check icon + "Copied!" in green for 1.5 s after click
- No new dependencies — icons are inline SVG

## Changes

- `ContactCard.jsx` — added `IconEdit`, `IconTrash`, `IconCopy`, `IconCheck`, `IconX` SVG components; wrapped button text in `<span class="ab-btn-label">` and prepended icons
- `AddressBookPanel.jsx` — added `IconPlus` SVG component; updated "+ Add contact" button the same way
- `AddressBookPanel.css` — replaced solid bordered `.ab-btn` base with a ghost/transparent base; added `.ab-icon` sizing, `.ab-btn-label` responsive show/hide at 640 px breakpoint, hover/focus tints for default and danger variants

## Test plan

- [ ] Mobile (<640 px): only icons visible for Edit, Delete, Copy, Remove, Add contact — no labels, no visible borders
- [ ] Desktop (≥640 px): icon + label shown for all buttons
- [ ] Hover on any button: subtle background tint, no border appears
- [ ] Delete / Remove: red icon, red hover tint
- [ ] Copy → check icon + "Copied!" for 1.5 s then reverts
- [ ] "Add contact" button remains visually prominent (filled blue) at all sizes
- [ ] All `aria-label` attributes still describe the action for screen readers

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeUFBaRkFc4vt1dmopJjqT)_