### PR TITLE
Extend max wager resolve window from 180 days to 72 months

### DIFF
--- a/contracts/wagers/WagerRegistry.sol
+++ b/contracts/wagers/WagerRegistry.sol
@@ -38,7 +38,7 @@ contract WagerRegistry is IWagerRegistry, UUPSManaged, ReentrancyGuardUpgradeabl
     bytes32 public constant ACCOUNT_MODERATOR_ROLE = keccak256("ACCOUNT_MODERATOR_ROLE");
 
     uint64 public constant MAX_ACCEPT_WINDOW = 30 days;
-    uint64 public constant MAX_RESOLVE_WINDOW = 180 days;
+    uint64 public constant MAX_RESOLVE_WINDOW = 2160 days; // 72 months — supports elections and long-term contracts
 
     /// @notice EIP-712 typehash for an open-challenge acceptance. Binding `taker` (= msg.sender) to the
     ///         signature is the front-running defense (FR-011): a copied signature is useless to anyone else.

--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -789,7 +789,7 @@ function FriendMarketsModal({
     } else if (endDate < minDate) {
       newErrors.endDateTime = 'End date must be at least 1 hour from now'
     } else if (endDate > maxDate) {
-      newErrors.endDateTime = 'End date must be within 21 days'
+      newErrors.endDateTime = 'End date must be within 72 months'
     }
 
     // Acceptance deadline is deterministic (midpoint of now → end), so
@@ -830,7 +830,7 @@ function FriendMarketsModal({
             if (linkedEnd.getTime() <= Date.now()) {
               newErrors.oracleConditionId = 'This Polymarket has already ended. Pick an active market.'
             } else if (linkedEnd.getTime() > maxLinkedEnd) {
-              newErrors.oracleConditionId = 'This market ends too far in the future to wager on (it must resolve within ~180 days). Pick a sooner-resolving market.'
+              newErrors.oracleConditionId = 'This market ends too far in the future to wager on (it must resolve within ~72 months). Pick a sooner-resolving market.'
             } else if (freshDeadline) {
               const acceptEnd = new Date(freshDeadline)
               if (!Number.isNaN(acceptEnd.getTime()) && acceptEnd.getTime() >= linkedEnd.getTime()) {

--- a/frontend/src/constants/wagerDefaults.js
+++ b/frontend/src/constants/wagerDefaults.js
@@ -51,8 +51,8 @@ export const WAGER_DEFAULTS = {
    */
   MIN_TRADING_PERIOD_SECONDS: 60 * 60,
 
-  /** Maximum trading period in seconds (mirrors contract MAX_TRADING_PERIOD). */
-  MAX_TRADING_PERIOD_SECONDS: 21 * 24 * 60 * 60,
+  /** Maximum trading period in seconds (mirrors contract MAX_RESOLVE_WINDOW minus resolution buffer). */
+  MAX_TRADING_PERIOD_SECONDS: 72 * 30 * 24 * 60 * 60,
 
   /** Extra window (seconds) added to resolveDeadline beyond the trading end
    *  so that participants have time to declare a winner after the event ends.
@@ -64,7 +64,7 @@ export const WAGER_DEFAULTS = {
    *  MAX_RESOLVE_WINDOW; exceeding either reverts with BadDeadlines. Mirrored
    *  here so the client can clamp/validate before submitting. */
   MAX_ACCEPT_WINDOW_SECONDS: 30 * 24 * 60 * 60,
-  MAX_RESOLVE_WINDOW_SECONDS: 180 * 24 * 60 * 60,
+  MAX_RESOLVE_WINDOW_SECONDS: 72 * 30 * 24 * 60 * 60, // 72 months — supports elections and long-term contracts
 }
 
 /**

--- a/frontend/src/hooks/useFriendMarketCreation.js
+++ b/frontend/src/hooks/useFriendMarketCreation.js
@@ -501,7 +501,7 @@ export function translateRevert(reason) {
   if (reason.includes('MembershipDenied')) return 'Your membership is inactive or you have reached your wager limit. If you have expired wagers, try again — they will be cleaned up automatically. Otherwise, upgrade your tier for higher limits.'
   if (reason.includes('SelfWager')) return 'Cannot wager against yourself.'
   if (reason.includes('NotAllowedToken')) return 'Stake token is not on the allowlist. Use USDC or WMATIC.'
-  if (reason.includes('BadDeadlines')) return 'Invalid deadlines. Accept window must be within 30 days; resolve window within 180 days.'
+  if (reason.includes('BadDeadlines')) return 'Invalid deadlines. Accept window must be within 30 days; resolve window within 72 months.'
   if (reason.includes('ZeroStake')) return 'Stakes must be greater than zero.'
   if (reason.includes('ConditionAlreadyResolved')) return 'That Polymarket condition is already resolved. Pick an unresolved one.'
   if (reason.includes('PolymarketRequired')) return 'Polymarket resolution requires a non-zero conditionId.'


### PR DESCRIPTION
## Summary

- **Root cause was both layers**: the frontend UX was capping the date picker to 21 days (`MAX_TRADING_PERIOD_SECONDS`), and the contract hard-limits resolution to 180 days (`MAX_RESOLVE_WINDOW`). Both needed extending for elections and long-term contracts.
- Extended `MAX_RESOLVE_WINDOW` in `WagerRegistry.sol` from `180 days` to `2160 days` (72 months). This is a `public constant` baked into bytecode — taking effect on-chain requires a UUPS in-place upgrade via `scripts/deploy/lib/upgradeable.js`.
- Extended `MAX_TRADING_PERIOD_SECONDS` and `MAX_RESOLVE_WINDOW_SECONDS` in `wagerDefaults.js` from 21 days / 180 days to 72 months each.
- Updated all downstream validation messages and error strings to reference 72 months instead of the old limits.
- `MAX_ACCEPT_WINDOW` (30 days) is unchanged — proposers still have up to 30 days to find a counterparty, but the resolution date can now be years out.

## Changes

| File | Change |
|------|--------|
| `contracts/wagers/WagerRegistry.sol` | `MAX_RESOLVE_WINDOW`: `180 days` → `2160 days` |
| `frontend/src/constants/wagerDefaults.js` | `MAX_TRADING_PERIOD_SECONDS`: 21d → 72mo; `MAX_RESOLVE_WINDOW_SECONDS`: 180d → 72mo |
| `frontend/src/components/fairwins/FriendMarketsModal.jsx` | Date picker cap and Polymarket linked-market error updated |
| `frontend/src/hooks/useFriendMarketCreation.js` | `BadDeadlines` revert message updated |

## On-chain deployment note

The contract constant change has **no effect until a proxy upgrade is deployed**. Run:
```
npm run check:storage-layout   # verify no layout drift
# then deploy new impl and upgrade proxy via scripts/deploy/lib/upgradeable.js
```

## Test plan

- [ ] Wager creation form: date picker now allows selecting dates up to ~6 years out
- [ ] Creating a wager with a 2-year end date submits without "End date must be within 21 days" error
- [ ] After contract upgrade: on-chain `createWager` with `resolveDeadline = now + 2 years` no longer reverts with `BadDeadlines`
- [ ] Existing short-term wagers (< 30 days) unaffected
- [ ] Polymarket-linked wagers: error message correctly references 72 months

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016z3A7NgGngD4EjY86BHCwz

---
_Generated by [Claude Code](https://claude.ai/code/session_016z3A7NgGngD4EjY86BHCwz)_