### PR TITLE
fix(034): pool join broken — load Semaphore via static dynamic import

### DIFF
--- a/frontend/src/lib/pools/identity.js
+++ b/frontend/src/lib/pools/identity.js
@@ -4,8 +4,8 @@
  * The identity is derived deterministically from a wallet signature over a pool-scoped, domain-separated
  * message, so the same wallet always reproduces the same in-pool identity (and therefore the same public
  * commitment + nickname) without any server. The secret never leaves the device. The Semaphore package is
- * loaded lazily (and kept out of the bundle via `@vite-ignore`) so the rest of the app builds without it
- * until pool joins ship.
+ * code-split into a lazy chunk (a static-specifier dynamic import) so it only loads when a user actually
+ * joins/interacts with a pool, without bloating the main bundle.
  */
 
 /** Stable, domain-separated message the wallet signs to seed its in-pool identity. */
@@ -20,14 +20,13 @@ export function identityMessage(poolAddress) {
  * @returns {Promise<{ identity: any, commitment: bigint }>}
  */
 export async function createPoolIdentity(signer, poolAddress) {
-  // The specifier is held in a variable so the bundler does NOT statically resolve it at build
-  // time (the package ships with pool joins, not yet). It resolves at runtime once installed.
-  const identityPackage = '@semaphore-protocol/identity'
+  // Static specifier → Vite/Rollup code-splits @semaphore-protocol/identity into a lazy chunk that
+  // loads on first pool interaction (the package is a real dependency; see frontend/package.json).
   let mod
   try {
-    mod = await import(/* @vite-ignore */ identityPackage)
-  } catch {
-    throw new Error('Anonymous identity support is not installed yet (@semaphore-protocol/identity).')
+    mod = await import('@semaphore-protocol/identity')
+  } catch (e) {
+    throw new Error(`Could not load anonymous identity support (@semaphore-protocol/identity): ${e?.message || e}`)
   }
   const Identity = mod.Identity
   const seed = await signer.signMessage(identityMessage(poolAddress))

--- a/frontend/src/lib/pools/semaphoreProof.js
+++ b/frontend/src/lib/pools/semaphoreProof.js
@@ -4,24 +4,24 @@
  * A member proves group membership anonymously: the proof reveals only a nullifier (one per scope) and
  * the message, never which member. For an approval the scope is the proposalId; for a claim it is the
  * pool's fixed claim scope and the message binds the payout recipient. The Semaphore packages and their
- * wasm/zkey artifacts are heavy, so they load lazily; specifiers are held in variables so the bundler
- * defers resolution until pool voting ships (kept out of the build until then).
+ * wasm/zkey artifacts are heavy, so they are code-split into a lazy chunk (static-specifier dynamic
+ * imports) that only loads when a member actually votes/claims.
  *
  * NOTE: building the prover's group requires the full list of member identity commitments, which the
- * app reads from the subgraph. Until that lands, callers pass `memberCommitments` explicitly.
+ * app reads on-chain from the pool's `Joined` events; callers pass `memberCommitments` explicitly.
  */
 
 async function loadSemaphore() {
-  const groupPkg = '@semaphore-protocol/group'
-  const proofPkg = '@semaphore-protocol/proof'
+  // Static specifiers → Vite/Rollup code-split these into a lazy chunk (both are real dependencies;
+  // see frontend/package.json). They only load on first vote/claim.
   try {
     const [groupMod, proofMod] = await Promise.all([
-      import(/* @vite-ignore */ groupPkg),
-      import(/* @vite-ignore */ proofPkg),
+      import('@semaphore-protocol/group'),
+      import('@semaphore-protocol/proof'),
     ])
     return { Group: groupMod.Group, generateProof: proofMod.generateProof }
-  } catch {
-    throw new Error('Anonymous voting support is not installed yet (@semaphore-protocol/group,/proof).')
+  } catch (e) {
+    throw new Error(`Could not load anonymous voting support (@semaphore-protocol/group,/proof): ${e?.message || e}`)
   }
 }
 


### PR DESCRIPTION
## Problem
Joining a pool fails with **"Anonymous identity support is not installed yet"**.

`createPoolIdentity` imported `@semaphore-protocol/identity` via a variable specifier marked `/* @vite-ignore */` — a build-time workaround from when the package wasn't a dependency. `@vite-ignore` tells the bundler *not* to bundle the module, so at runtime the browser tried to resolve a bare specifier, failed, and the `catch` surfaced the misleading "not installed" message. Same pattern in `semaphoreProof.js` (voting/claiming).

## Fix
The three `@semaphore-protocol` packages are now real deps (added when pool joins shipped), so both `identity.js` and `semaphoreProof.js` now use **static-specifier dynamic imports**. Vite/Rollup code-split them into lazy chunks (browser entry — verified a `index.browser` chunk in `dist/`) that load on first pool interaction and actually resolve at runtime. Error text now surfaces the real underlying failure instead of a wrong "not installed".

## Verification
- `npm run build` ✓ (6239 modules, semaphore browser chunk emitted, no errors)
- Pool tests ✓ (GroupPoolModal, PoolPages, poolGasless — 12/12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)