### PR TITLE
fix(ci): harden hardhat compile against solc download/HH505 flakiness

### DIFF
--- a/.github/workflows/deploy-contracts.yml
+++ b/.github/workflows/deploy-contracts.yml
@@ -39,8 +39,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Hardhat compilers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/hardhat-nodejs/compilers-v2
+          key: ${{ runner.os }}-hardhat-solc-0.8.24
+          restore-keys: |
+            ${{ runner.os }}-hardhat-solc-
+
       - name: Compile contracts
-        run: npm run compile
+        run: npm run compile:ci
 
       - name: Deploy contracts (Deterministic)
         env:

--- a/.github/workflows/oracle-fork-tests.yml
+++ b/.github/workflows/oracle-fork-tests.yml
@@ -51,8 +51,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Hardhat compilers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/hardhat-nodejs/compilers-v2
+          key: ${{ runner.os }}-hardhat-solc-0.8.24
+          restore-keys: |
+            ${{ runner.os }}-hardhat-solc-
+
       - name: Compile contracts
-        run: npm run compile
+        run: npm run compile:ci
 
       # Soft check: fork tests rely on an archive-mode Amoy RPC. Without the
       # AMOY_RPC_URL secret the test file enters describe.skip and the job

--- a/.github/workflows/security-testing.yml
+++ b/.github/workflows/security-testing.yml
@@ -37,8 +37,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Hardhat compilers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/hardhat-nodejs/compilers-v2
+          key: ${{ runner.os }}-hardhat-solc-0.8.24
+          restore-keys: |
+            ${{ runner.os }}-hardhat-solc-
+
       - name: Compile contracts
-        run: npm run compile
+        run: npm run compile:ci
 
       - name: Run tests with gas reporting
         env:
@@ -134,6 +142,14 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Cache Hardhat compilers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/hardhat-nodejs/compilers-v2
+          key: ${{ runner.os }}-hardhat-solc-0.8.24
+          restore-keys: |
+            ${{ runner.os }}-hardhat-solc-
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Hardhat compilers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/hardhat-nodejs/compilers-v2
+          key: ${{ runner.os }}-hardhat-solc-0.8.24
+          restore-keys: |
+            ${{ runner.os }}-hardhat-solc-
+
       - name: Compile contracts
-        run: npm run compile
+        run: npm run compile:ci
 
       # Gate (spec 025, FR-010/SC-005): block a storage-incompatible / upgrade-unsafe implementation BEFORE
       # it can ship. Must fail the pipeline loudly — do NOT add continue-on-error (Constitution IV).

--- a/.github/workflows/torture-test.yml
+++ b/.github/workflows/torture-test.yml
@@ -28,8 +28,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Hardhat compilers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/hardhat-nodejs/compilers-v2
+          key: ${{ runner.os }}-hardhat-solc-0.8.24
+          restore-keys: |
+            ${{ runner.os }}-hardhat-solc-
+
       - name: Compile contracts
-        run: npm run compile
+        run: npm run compile:ci
 
       - name: Run tests with gas reporting
         env:
@@ -75,6 +83,14 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Cache Hardhat compilers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/hardhat-nodejs/compilers-v2
+          key: ${{ runner.os }}-hardhat-solc-0.8.24
+          restore-keys: |
+            ${{ runner.os }}-hardhat-solc-
 
       - name: Generate coverage report
         run: npm run test:coverage
@@ -125,6 +141,14 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Cache Hardhat compilers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/hardhat-nodejs/compilers-v2
+          key: ${{ runner.os }}-hardhat-solc-0.8.24
+          restore-keys: |
+            ${{ runner.os }}-hardhat-solc-
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -178,8 +202,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Hardhat compilers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/hardhat-nodejs/compilers-v2
+          key: ${{ runner.os }}-hardhat-solc-0.8.24
+          restore-keys: |
+            ${{ runner.os }}-hardhat-solc-
+
       - name: Compile contracts
-        run: npm run compile
+        run: npm run compile:ci
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -284,6 +316,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache Hardhat compilers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/hardhat-nodejs/compilers-v2
+          key: ${{ runner.os }}-hardhat-solc-0.8.24
+          restore-keys: |
+            ${{ runner.os }}-hardhat-solc-
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -299,7 +339,7 @@ jobs:
           pip install crytic-compile
 
       - name: Compile contracts
-        run: npm run compile
+        run: npm run compile:ci
 
       - name: Run Medusa fuzzing (extended)
         run: |

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "compile": "hardhat compile",
+    "compile:ci": "bash scripts/ci/compile-with-retry.sh",
     "test": "hardhat test",
     "test:unit": "hardhat test test/*.test.js",
     "test:integration": "hardhat test test/integration/**/*.test.js",

--- a/scripts/ci/compile-with-retry.sh
+++ b/scripts/ci/compile-with-retry.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Hardens `hardhat compile` against the two observed CI failure modes: a hung/interrupted
+# solc download (job runs out the clock waiting on "Downloading compiler ...") and a
+# corrupted binary left on disk from a prior interrupted download (Hardhat error HH505,
+# "A native version of solc failed to run"). Both leave a bad artifact under
+# ~/.cache/hardhat-nodejs/compilers-v2 that a naive retry will keep hitting, so on failure
+# this purges that cache before retrying — forcing a fresh download instead of repeating
+# the same corrupt state. Each attempt is bounded so one bad attempt can't burn the whole
+# job budget; failure after all attempts still exits non-zero (no continue-on-error masking).
+set -uo pipefail
+
+MAX_ATTEMPTS="${COMPILE_RETRY_ATTEMPTS:-3}"
+ATTEMPT_TIMEOUT_SECONDS="${COMPILE_RETRY_TIMEOUT:-420}"
+COMPILER_CACHE_DIR="${HOME}/.cache/hardhat-nodejs/compilers-v2"
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+  echo "::group::Compile attempt ${attempt}/${MAX_ATTEMPTS}"
+  timeout "$ATTEMPT_TIMEOUT_SECONDS" npx hardhat compile
+  code=$?
+  echo "::endgroup::"
+
+  if [ "$code" -eq 0 ]; then
+    echo "Contracts compiled on attempt ${attempt}."
+    exit 0
+  fi
+
+  if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+    break
+  fi
+
+  if [ "$code" -eq 124 ]; then
+    echo "::warning::compile attempt ${attempt} timed out after ${ATTEMPT_TIMEOUT_SECONDS}s; purging compiler cache and retrying" >&2
+  else
+    echo "::warning::compile attempt ${attempt} failed (exit ${code}); purging compiler cache and retrying" >&2
+  fi
+  rm -rf "$COMPILER_CACHE_DIR"
+  sleep 5
+done
+
+echo "::error::npm run compile did not succeed after ${MAX_ATTEMPTS} attempts" >&2
+exit 1


### PR DESCRIPTION
## Summary
main's CI (and other unrelated open PRs) has been intermittently failing across every job that runs `hardhat compile`: some hang indefinitely on `Downloading compiler 0.8.24` until the runner is killed ("The runner has received a shutdown signal"), others hit `HardhatError: HH505: A native version of solc failed to run` from a corrupted binary left by a prior interrupted download. Confirmed **not** a defect in spec 034's contracts — compile succeeds locally, and the same failure signature hit an unrelated PR (#782) at the same time.

## Root cause
Every job independently downloads solc fresh (no caching), and a naive retry (as already added in #782) doesn't help once a bad/partial binary is on disk — every subsequent attempt keeps hitting the same corrupted file.

## Fix
- `scripts/ci/compile-with-retry.sh` (wired as `npm run compile:ci`): bounded per-attempt timeout; **purges `~/.cache/hardhat-nodejs/compilers-v2` on failure** before retrying, so a corrupt binary can't wedge every attempt; fails loudly (non-zero) after exhausting attempts — no `continue-on-error` masking.
- `actions/cache` for the hardhat compiler cache in every job that compiles (`test.yml`, `oracle-fork-tests.yml`, `deploy-contracts.yml`, `security-testing.yml`, `torture-test.yml` — including the Slither/coverage jobs that invoke `hardhat compile` internally via `crytic-compile`/`solidity-coverage`), so once populated a run skips the network step entirely.

## Scope
CI workflow config + one new shell script + one `package.json` script entry. No contract, frontend, or deploy code changed.

## Test plan
- [x] All 5 edited workflow YAML files parse (`python3 -c "import yaml..."`)
- [x] `bash -n scripts/ci/compile-with-retry.sh` — syntax OK
- [ ] CI on this PR itself exercises the new cache + retry path end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)