### PR TITLE
Route group-pool lifecycle events into the notification system (spec 037 follow-up)

### DIFF
--- a/frontend/src/data/notifications/domains.js
+++ b/frontend/src/data/notifications/domains.js
@@ -8,6 +8,7 @@ export const DOMAIN_META = {
   dao: { label: 'DAO' },
   token: { label: 'Token' },
   membership: { label: 'Membership' },
+  pools: { label: 'Pool' },
 }
 
 /** Display label for a domain key (falls back to the key itself for an unknown/future domain). */

--- a/frontend/src/data/notifications/sources/index.js
+++ b/frontend/src/data/notifications/sources/index.js
@@ -9,7 +9,8 @@ import { wagerSource } from './wagerSource'
 import { daoSource } from './daoSource'
 import { tokenSource } from './tokenSource'
 import { membershipSource } from './membershipSource'
+import { poolsSource } from './poolsSource'
 
-export const activitySources = [wagerSource, daoSource, tokenSource, membershipSource]
+export const activitySources = [wagerSource, daoSource, tokenSource, membershipSource, poolsSource]
 
 export default activitySources

--- a/frontend/src/data/notifications/sources/poolsSource.js
+++ b/frontend/src/data/notifications/sources/poolsSource.js
@@ -1,0 +1,88 @@
+/**
+ * Group-pool activity source (spec 037 follow-up). Snapshot-diffs the user's created + joined pools each
+ * cycle and routes lifecycle changes into the platform notification system (feed + toasts + action-needed
+ * badge), the same way wagerSource does for 1v1 wagers. Pure snapshot-diff (first sight = baseline); a read
+ * failure retains the prior slice. Read-only — no wallet signature.
+ *
+ * Emitted transitions per pool:
+ *  - joining closed (state 0→1) — informational
+ *  - resolved (→2) — success, actionable: open the pool to see if you can claim
+ *  - cancelled (→3) — warning, actionable: refund your buy-in
+ *  - a new member joined while still open — informational
+ * Action-needed (drives the badge): pools that are Resolved (check/claim) or Cancelled (refund).
+ */
+import { loadMyWagersSources } from '../../../lib/lookup/myWagersSources'
+
+export const poolsSource = {
+  key: 'pools',
+  label: 'Pool',
+  async detect({ account, chainId, nowMs, prior }) {
+    if (!account) {
+      return { ok: true, entries: [], nextSnapshots: {}, currentIds: [], actionNeededById: {} }
+    }
+
+    let pools
+    try {
+      const { createdPools = [], joinedPools = [] } = await loadMyWagersSources({ chainId, account })
+      // Union created + joined, de-duped by pool address.
+      const byAddr = new Map()
+      for (const p of [...createdPools, ...joinedPools]) {
+        if (p && p.address) byAddr.set(String(p.address).toLowerCase(), p)
+      }
+      pools = [...byAddr.values()]
+    } catch {
+      return { ok: false } // couldn't read — retain the prior pools slice
+    }
+
+    const entries = []
+    const actionNeededById = {}
+    const currentIds = []
+    const nextSnapshots = {}
+
+    const mk = (refId, type, message, severity, actionable) => ({
+      id: `pools:${refId}:${type}:${nowMs}`,
+      domain: 'pools',
+      refId,
+      type,
+      message,
+      severity,
+      actionable,
+      link: { to: `/pools/${refId}` },
+      createdAt: nowMs,
+      read: false,
+    })
+
+    for (const p of pools) {
+      const refId = String(p.address)
+      const state = Number(p.state)
+      const memberCount = Number(p.memberCount ?? 0)
+      currentIds.push(refId)
+      nextSnapshots[refId] = { state, memberCount, snappedAt: nowMs }
+
+      // Action-needed: a resolved pool may have a claim; a cancelled pool can be refunded.
+      if (state === 2) actionNeededById[refId] = 'checkPool'
+      else if (state === 3) actionNeededById[refId] = 'refund'
+
+      const prev = prior.snapshots?.[refId]
+      if (!prev) continue // first sight = baseline (no entry, just snapshot)
+
+      const label = p.poolId != null ? `Pool #${p.poolId}` : 'A pool you’re in'
+      if (prev.state !== state) {
+        if (state === 1) {
+          entries.push(mk(refId, 'pool-closed', `${label} closed joining — resolution can begin`, 'info', false))
+        } else if (state === 2) {
+          entries.push(mk(refId, 'pool-resolved', `${label} resolved — open it to see if you can claim`, 'success', true))
+        } else if (state === 3) {
+          entries.push(mk(refId, 'pool-cancelled', `${label} was cancelled — you can refund your buy-in`, 'warning', true))
+        }
+      } else if (state === 0 && memberCount > (prev.memberCount ?? 0)) {
+        const cap = p.maxMembers ? `/${p.maxMembers}` : ''
+        entries.push(mk(refId, 'pool-member-joined', `${label} now has ${memberCount}${cap} members`, 'info', false))
+      }
+    }
+
+    return { ok: true, entries, nextSnapshots, currentIds, actionNeededById }
+  },
+}
+
+export default poolsSource

--- a/frontend/src/test/sources/poolsSource.test.js
+++ b/frontend/src/test/sources/poolsSource.test.js
@@ -1,0 +1,75 @@
+/**
+ * poolsSource tests (spec 037 follow-up) — group-pool lifecycle snapshot-diff into the activity feed:
+ * joining-closed / resolved / cancelled / member-joined transitions, action-needed for resolved+cancelled,
+ * baseline on first sight, and ok:false on read failure.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const h = vi.hoisted(() => ({ load: vi.fn() }))
+vi.mock('../../lib/lookup/myWagersSources', () => ({ loadMyWagersSources: h.load }))
+
+import { poolsSource } from '../../data/notifications/sources/poolsSource'
+
+const pool = (over = {}) => ({ address: '0xpool1', poolId: 3, state: 0, stateLabel: 'Joining open', memberCount: 2, maxMembers: 10, ...over })
+const detect = (args) => poolsSource.detect({ account: '0xUser', chainId: 137, nowMs: 1_000_000, prior: { snapshots: {} }, ...args })
+
+describe('poolsSource', () => {
+  beforeEach(() => { h.load.mockReset() })
+
+  it('returns empty (no read) when there is no account', async () => {
+    const out = await poolsSource.detect({ account: null, chainId: 137, nowMs: 1, prior: { snapshots: {} } })
+    expect(out).toEqual({ ok: true, entries: [], nextSnapshots: {}, currentIds: [], actionNeededById: {} })
+    expect(h.load).not.toHaveBeenCalled()
+  })
+
+  it('first sight is a baseline — snapshots but no entries', async () => {
+    h.load.mockResolvedValue({ createdPools: [pool()], joinedPools: [] })
+    const out = await detect({ prior: { snapshots: {} } })
+    expect(out.ok).toBe(true)
+    expect(out.entries).toEqual([])
+    expect(out.nextSnapshots['0xpool1']).toMatchObject({ state: 0, memberCount: 2 })
+    expect(out.currentIds).toEqual(['0xpool1'])
+  })
+
+  it('emits a resolved entry + action-needed on 0→2', async () => {
+    h.load.mockResolvedValue({ createdPools: [pool({ state: 2 })], joinedPools: [] })
+    const out = await detect({ prior: { snapshots: { '0xpool1': { state: 0, memberCount: 2 } } } })
+    expect(out.entries).toHaveLength(1)
+    expect(out.entries[0]).toMatchObject({ domain: 'pools', type: 'pool-resolved', severity: 'success', actionable: true, refId: '0xpool1' })
+    expect(out.entries[0].link).toEqual({ to: '/pools/0xpool1' })
+    expect(out.actionNeededById).toEqual({ '0xpool1': 'checkPool' })
+  })
+
+  it('emits a cancelled entry + refund action on →3', async () => {
+    h.load.mockResolvedValue({ createdPools: [], joinedPools: [pool({ state: 3 })] })
+    const out = await detect({ prior: { snapshots: { '0xpool1': { state: 1, memberCount: 5 } } } })
+    expect(out.entries[0]).toMatchObject({ type: 'pool-cancelled', severity: 'warning', actionable: true })
+    expect(out.actionNeededById).toEqual({ '0xpool1': 'refund' })
+  })
+
+  it('emits joining-closed on 0→1 (informational, no action)', async () => {
+    h.load.mockResolvedValue({ createdPools: [pool({ state: 1 })], joinedPools: [] })
+    const out = await detect({ prior: { snapshots: { '0xpool1': { state: 0, memberCount: 2 } } } })
+    expect(out.entries[0]).toMatchObject({ type: 'pool-closed', severity: 'info', actionable: false })
+    expect(out.actionNeededById).toEqual({})
+  })
+
+  it('emits a member-joined entry when the count grows while still open', async () => {
+    h.load.mockResolvedValue({ createdPools: [pool({ state: 0, memberCount: 4 })], joinedPools: [] })
+    const out = await detect({ prior: { snapshots: { '0xpool1': { state: 0, memberCount: 2 } } } })
+    expect(out.entries[0]).toMatchObject({ type: 'pool-member-joined', severity: 'info' })
+    expect(out.entries[0].message).toMatch(/4\/10 members/)
+  })
+
+  it('de-dups a pool that is both created and joined', async () => {
+    h.load.mockResolvedValue({ createdPools: [pool()], joinedPools: [pool()] })
+    const out = await detect({ prior: { snapshots: {} } })
+    expect(out.currentIds).toEqual(['0xpool1'])
+  })
+
+  it('returns ok:false when the pool read fails (retain prior slice)', async () => {
+    h.load.mockRejectedValue(new Error('subgraph down'))
+    const out = await detect({ prior: { snapshots: {} } })
+    expect(out).toEqual({ ok: false })
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to the merged spec-037 work (#782). That PR routed the **immediate** take-challenge / join-pool success events into the notification toasts. This adds the missing piece: a **group-pool activity source** so pool *lifecycle* changes flow through the platform notification system the same way wager events do — appearing in the persistent activity **feed**, as **toasts**, and in the **action-needed badge**.

Frontend-only; no contract/subgraph-schema changes.

## What it does

New `data/notifications/sources/poolsSource.js` implements the existing `ActivitySource` contract (`{ key, label, detect(...) }` → `{ ok, entries, nextSnapshots, currentIds, actionNeededById }`), reusing `loadMyWagersSources` to snapshot-diff the user's created + joined pools each cycle:

- **Joining closed** (state 0→1) — informational.
- **Resolved** (→2) — success; **action-needed** ("open it to see if you can claim").
- **Cancelled** (→3) — warning; **action-needed** ("refund your buy-in").
- **New member joined** while still open — informational.

First sight is a baseline (no entries, just a snapshot); a read failure returns `ok:false` so the prior slice is retained. Read-only — no wallet signature. Statuses are surfaced honestly (e.g. "see if you can claim") rather than implying finality.

Wiring is minimal per the source contract: register `poolsSource` in `sources/index.js` and add the `pools` domain label in `domains.js` — no engine/store/feed/bell edits.

## Tests & checks

- 8 new `poolsSource` tests (all transitions, action-needed, de-dup, baseline, `ok:false`).
- Notification/activity suites green (88); `vite build` passes; ESLint 0 errors.

## Note on the branch

The previous PR (#782) for this branch is merged; per the repo's merged-PR workflow this branch was restarted from the latest `main` (which includes spec 037) and force-pushed with the already-merged history replaced. This is a **new** PR, not a reopen of #782.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEDqX9MRrBm8ob2vjaEskX

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEDqX9MRrBm8ob2vjaEskX)_