### PR TITLE
Group pool manager: tester feedback — roster, ranks, visible proposals, auto identity

### DIFF
--- a/frontend/src/components/fairwins/JoinPoolPanel.jsx
+++ b/frontend/src/components/fairwins/JoinPoolPanel.jsx
@@ -4,6 +4,7 @@ import { useWallet } from '../../hooks/useWalletManagement'
 import { usePools } from '../../hooks/usePools'
 import { UIContext } from '../../contexts/UIContext'
 import { recordJoinedPool } from '../../lib/lookup/myWagersSources'
+import { poolStateDisplay } from '../../lib/pools/poolContracts'
 import './FriendMarketsModal.css'
 import '../../pages/pools.css'
 
@@ -43,7 +44,7 @@ export default function JoinPoolPanel({ summary, onClose }) {
       <dl>
         <dt>Buy-in</dt><dd>{summary.buyInFormatted} {summary.tokenSymbol}</dd>
         <dt>Members</dt><dd>{summary.memberCount} / {summary.maxMembers} ({summary.slotsRemaining} left)</dd>
-        <dt>Status</dt><dd>{summary.stateLabel}</dd>
+        <dt>Status</dt><dd>{poolStateDisplay(summary.state)}</dd>
         <dt>Approval threshold</dt><dd>{summary.thresholdPct}% of members</dd>
       </dl>
       {joinable ? (
@@ -60,7 +61,7 @@ export default function JoinPoolPanel({ summary, onClose }) {
         </>
       ) : (
         <p className="pool-closed-note">
-          This pool isn’t accepting new members ({summary.stateLabel === 'JoiningOpen' ? 'full' : summary.stateLabel}).
+          This pool isn’t accepting new members ({summary.state === 0 ? 'full' : poolStateDisplay(summary.state).toLowerCase()}).
         </p>
       )}
     </div>

--- a/frontend/src/components/fairwins/JoinPoolPanel.jsx
+++ b/frontend/src/components/fairwins/JoinPoolPanel.jsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom'
 import { useWallet } from '../../hooks/useWalletManagement'
 import { usePools } from '../../hooks/usePools'
 import { UIContext } from '../../contexts/UIContext'
-import { recordJoinedPool } from '../../lib/lookup/myWagersSources'
 import { poolStateDisplay } from '../../lib/pools/poolContracts'
 import './FriendMarketsModal.css'
 import '../../pages/pools.css'
@@ -15,7 +14,7 @@ import '../../pages/pools.css'
  * resolved summary and performs the join.
  */
 export default function JoinPoolPanel({ summary, onClose }) {
-  const { isConnected, account } = useWallet()
+  const { isConnected } = useWallet()
   const { joinPool, status, error } = usePools()
   const navigate = useNavigate()
   // Optional notification access — routes the join-success event into the app's toasts without
@@ -27,10 +26,8 @@ export default function JoinPoolPanel({ summary, onClose }) {
 
   const onJoin = async () => {
     try {
+      // joinPool records the membership device-locally (usePools) so the pool surfaces in My Wagers.
       await joinPool(summary.address)
-      // Record the join device-locally so this pool can surface in My Wagers (FR-024): on-chain
-      // membership is anonymous, so the joining wallet is only known on this device.
-      recordJoinedPool(account, summary.address)
       ui?.showNotification?.('You’ve joined the pool.', 'success', 6000)
       onClose?.()
       navigate(`/pools/${summary.address}`)

--- a/frontend/src/components/pools/PoolParticipants.jsx
+++ b/frontend/src/components/pools/PoolParticipants.jsx
@@ -1,0 +1,89 @@
+import { useState } from 'react'
+import { sortParticipants } from '../../lib/pools/participantOrder'
+
+/**
+ * PoolParticipants (pool-manager tester feedback, items 3–4).
+ *
+ * The joined members of a pool as anonymous alias cards. Nicknames derive from PUBLIC identity
+ * commitments (Joined events), so every member can render the same list and nobody can be
+ * de-anonymized — real names/wallets are never shown.
+ *
+ * - Everyone sees the active participant list, alphabetical by alias when the creator has not
+ *   arranged an order.
+ * - The creator can drag cards (or use the accessible up/down buttons) into a rank order, reported
+ *   via onReorder(orderedCommitments). The arrangement is device-local until a sync channel ships
+ *   (same honest limitation as the interim leaderboard), so other members keep the alphabetical view.
+ *
+ * Props:
+ *   participants: [{ commitment: string, label: string, suffix: string }]
+ *   isCreator: boolean — enables reordering
+ *   order: string[] | null — creator's arranged commitment order (null = alphabetical)
+ *   onReorder: (orderedCommitments: string[]) => void
+ */
+export default function PoolParticipants({ participants, isCreator = false, order = null, onReorder }) {
+  const [dragIndex, setDragIndex] = useState(null)
+
+  if (!participants || participants.length === 0) return null
+
+  const sorted = sortParticipants(participants, order)
+  const arranged = Boolean(order && order.length)
+
+  const move = (from, to) => {
+    if (to < 0 || to >= sorted.length || from === to) return
+    const next = sorted.map((p) => p.commitment)
+    const [item] = next.splice(from, 1)
+    next.splice(to, 0, item)
+    onReorder?.(next)
+  }
+
+  return (
+    <section className="pool-participants" aria-label="Participants" data-testid="pool-participants">
+      <h2>Participants ({sorted.length})</h2>
+      <p className="pool-participants-hint">
+        {isCreator
+          ? 'Drag cards (or use the arrows) to set the rank order. Aliases are anonymous — no wallets or names.'
+          : arranged
+            ? 'Ranked by the creator. Aliases are anonymous — no wallets or names.'
+            : 'Alphabetical until the creator arranges the group. Aliases are anonymous — no wallets or names.'}
+      </p>
+      <ol className="pool-participants-list">
+        {sorted.map((p, i) => (
+          <li
+            key={p.commitment}
+            className={`pool-participant-card${dragIndex === i ? ' dragging' : ''}`}
+            data-testid="participant-card"
+            draggable={isCreator}
+            onDragStart={() => setDragIndex(i)}
+            onDragEnd={() => setDragIndex(null)}
+            onDragOver={(e) => isCreator && e.preventDefault()}
+            onDrop={() => {
+              if (isCreator && dragIndex != null) move(dragIndex, i)
+              setDragIndex(null)
+            }}
+          >
+            {arranged && <span className="pool-participant-rank" aria-label={`Rank ${i + 1}`}>{i + 1}</span>}
+            <span className="pool-participant-alias">
+              {p.label}
+              <span className="pool-participant-suffix" aria-hidden="true">#{p.suffix}</span>
+            </span>
+            {isCreator && (
+              <span className="pool-participant-controls">
+                <button type="button" aria-label={`Move ${p.label} up`} onClick={() => move(i, i - 1)} disabled={i === 0}>
+                  ↑
+                </button>
+                <button
+                  type="button"
+                  aria-label={`Move ${p.label} down`}
+                  onClick={() => move(i, i + 1)}
+                  disabled={i === sorted.length - 1}
+                >
+                  ↓
+                </button>
+              </span>
+            )}
+          </li>
+        ))}
+      </ol>
+    </section>
+  )
+}

--- a/frontend/src/components/pools/PoolResolutionActions.jsx
+++ b/frontend/src/components/pools/PoolResolutionActions.jsx
@@ -2,18 +2,23 @@ import { useEffect, useState } from 'react'
 import { ethers } from 'ethers'
 import Button from '../ui/Button'
 import { payoutMatrixHash, payoutMatrixSum, serializeMatrix, parseMatrix } from '../../lib/pools/payout'
+import { saveProposedMatrix, readProposedMatrix, readStoredMatrix } from '../../lib/pools/proposalStore'
+import { sortParticipants } from '../../lib/pools/participantOrder'
 
 /**
- * PoolResolutionActions (spec 034, US1) — the creator proposes a payout outcome and winners claim.
+ * PoolResolutionActions (spec 034, US1 + pool-manager tester feedback) — the creator proposes a payout
+ * outcome, members SEE and verify it before approving, and winners claim.
  *
  * Off-chain coordination (inherent to the anonymous design, no backend): each winner reveals their
  * "claim code" (claim-scope nullifier) to the creator; the creator builds the payout matrix
  * (claimCode → amount), proposes its hash on-chain, and shares the matrix preimage back so winners can
- * claim. Only the matrix HASH is on-chain; the preimage is copied/shared off-chain.
+ * claim. Only the matrix HASH is on-chain; the preimage is copied/shared off-chain and verified against
+ * the on-chain proposalId before anything renders as "the proposal".
  *
- * Controlled by the parent (PoolPage), which supplies the connected `pools` hook + the pool `summary`.
+ * Controlled by the parent (PoolPage), which supplies the connected `pools` hook, the pool `summary`,
+ * the anonymous `participants` roster, and the creator's `rankOrder`.
  */
-export default function PoolResolutionActions({ summary, pools, onChanged }) {
+export default function PoolResolutionActions({ summary, pools, participants = null, rankOrder = null, onChanged }) {
   const { proposeOutcome, claimWinnings, getMyClaimCode, peekPoolIdentity, status } = pools
   const decimals = summary.tokenDecimals || 6
   const escrow = BigInt(summary.frozenDenominator || summary.memberCount || 0) * BigInt(summary.buyIn || 0)
@@ -35,8 +40,20 @@ export default function PoolResolutionActions({ summary, pools, onChanged }) {
     }
   }, [summary.hasJoined, summary.address, claimCode, peekPoolIdentity])
 
-  // Creator propose-builder rows: { claimCode, amount (human USDC) }
+  // Creator propose-builder rows: { nickname?, claimCode, amount (human USDC) }
   const [rows, setRows] = useState([{ claimCode: '', amount: '' }])
+
+  // Auto-populate the builder with one row per participant, in the creator's rank order (tester
+  // feedback item 5) — the creator pairs each alias with the claim code that member reveals, instead
+  // of assembling the list by hand. Only seeds while the builder is untouched.
+  useEffect(() => {
+    if (!participants || participants.length === 0) return
+    setRows((rs) => {
+      const pristine = rs.length === 1 && !rs[0].claimCode && !rs[0].amount && !rs[0].nickname
+      if (!pristine) return rs
+      return sortParticipants(participants, rankOrder).map((p) => ({ nickname: p.label, claimCode: '', amount: '' }))
+    })
+  }, [participants, rankOrder])
   const entries = rows
     .filter((r) => r.claimCode && r.amount)
     .map((r) => ({ claimNullifier: r.claimCode.trim(), amount: ethers.parseUnits(String(r.amount), decimals) }))
@@ -49,6 +66,31 @@ export default function PoolResolutionActions({ summary, pools, onChanged }) {
   const [matrixText, setMatrixText] = useState('')
   const [claimIndex, setClaimIndex] = useState('0')
   const [recipient, setRecipient] = useState('')
+
+  // Members' view of the proposed split (tester bug item 7): the shared matrix, verified on-device
+  // against the on-chain proposalId before it renders as "the proposal".
+  const [sharedText, setSharedText] = useState('')
+  useEffect(() => {
+    if (summary.state !== 1 || !summary.currentProposalId) return
+    const stored = readProposedMatrix(summary.address, summary.currentProposalId)
+    if (stored) setSharedText((t) => t || stored.text)
+  }, [summary.state, summary.currentProposalId, summary.address])
+
+  // Prefill the claim form from this device's stored matrix once the pool resolves.
+  useEffect(() => {
+    if (summary.state !== 2) return
+    const stored = readStoredMatrix(summary.address)
+    if (stored) setMatrixText((t) => t || stored.text)
+  }, [summary.state, summary.address])
+
+  // Auto-detect the claimant's row: their claim code is unique in the matrix (tester feedback item 5).
+  useEffect(() => {
+    if (!claimCode || !matrixText) return
+    const parsed = parseMatrix(matrixText)
+    if (!parsed) return
+    const idx = parsed.findIndex((e) => String(e.claimNullifier) === String(claimCode))
+    if (idx >= 0) setClaimIndex(String(idx))
+  }, [claimCode, matrixText])
 
   const reveal = async () => {
     setBusy(true)
@@ -66,7 +108,10 @@ export default function PoolResolutionActions({ summary, pools, onChanged }) {
     setNotice(null)
     try {
       await proposeOutcome(summary.address, proposalId)
-      setNotice('Outcome proposed. Share the matrix with winners so they can claim.')
+      // Persist the preimage on this device so the creator can always re-copy it and the breakdown
+      // renders after reload (only the hash lives on-chain).
+      saveProposedMatrix(summary.address, proposalId, entries)
+      setNotice('Outcome proposed. Share the matrix with the members so they can review and claim.')
       onChanged?.()
     } catch (e) {
       setNotice(e?.shortMessage || e?.message || String(e))
@@ -95,6 +140,17 @@ export default function PoolResolutionActions({ summary, pools, onChanged }) {
 
   const setRow = (i, k) => (e) => setRows((rs) => rs.map((r, j) => (j === i ? { ...r, [k]: e.target.value } : r)))
 
+  // Member-side verification of the shared proposal (item 7): render as "the proposal" ONLY when its
+  // hash equals the on-chain proposalId; persist a verified paste so it survives reload.
+  const sharedParsed = sharedText ? parseMatrix(sharedText) : null
+  const sharedVerified = Boolean(
+    sharedParsed && summary.currentProposalId && payoutMatrixHash(sharedParsed) === summary.currentProposalId
+  )
+  useEffect(() => {
+    if (sharedVerified) saveProposedMatrix(summary.address, summary.currentProposalId, sharedParsed)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sharedVerified, sharedText])
+
   return (
     <section className="pool-resolution-actions" aria-label="Resolution actions">
       {/* Any joined member can reveal their claim code to give to the creator */}
@@ -113,19 +169,71 @@ export default function PoolResolutionActions({ summary, pools, onChanged }) {
         </div>
       )}
 
+      {/* What's actually being approved (item 7): visible + verified for every member during voting */}
+      {summary.state === 1 && summary.currentProposalId && (
+        <div className="pool-proposal-details" data-testid="proposal-details">
+          <h2>Proposed payout</h2>
+          {sharedVerified ? (
+            <>
+              <p data-testid="proposal-verified">
+                Verified against the on-chain proposal ✓ — this is exactly what an approval endorses.
+              </p>
+              <table className="pool-proposal-table">
+                <thead>
+                  <tr><th scope="col">#</th><th scope="col">Claim code</th><th scope="col">Amount</th></tr>
+                </thead>
+                <tbody>
+                  {sharedParsed.map((e, i) => {
+                    const mine = claimCode != null && String(e.claimNullifier) === String(claimCode)
+                    return (
+                      <tr key={i} className={mine ? 'is-you' : undefined}>
+                        <td>{i + 1}</td>
+                        <td><code>{shortCode(e.claimNullifier)}</code>{mine ? ' (you)' : ''}</td>
+                        <td>{ethers.formatUnits(BigInt(e.amount), decimals)} {summary.tokenSymbol}</td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </>
+          ) : (
+            <>
+              <p>
+                The creator proposed a split — only its fingerprint is on-chain. Paste the matrix the
+                creator shared to see and verify exactly what you&apos;d be approving.
+              </p>
+              <label htmlFor="shared-matrix">Payout matrix (shared by the creator)</label>
+              <textarea id="shared-matrix" rows={3} value={sharedText} onChange={(e) => setSharedText(e.target.value)} />
+              {sharedText && !sharedVerified && (
+                <p className="form-error" role="alert" data-testid="proposal-mismatch">
+                  {sharedParsed
+                    ? 'This matrix does NOT match the on-chain proposal — do not approve based on it.'
+                    : 'Could not parse that matrix.'}
+                </p>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
       {/* Creator: build + propose the payout outcome (while resolving) */}
       {summary.isCreator && summary.state === 1 && summary.withinResolutionWindow && (
         <div className="pool-propose" data-testid="propose-builder">
           <h2>Propose the payout</h2>
           <p>
-            Enter each winner&apos;s claim code and amount. The total must equal the escrow (
-            {ethers.formatUnits(escrow, decimals)} {summary.tokenSymbol}).
+            {rows.some((r) => r.nickname)
+              ? 'One row per participant, in your rank order — pair each alias with the claim code that member reveals.'
+              : 'Enter each winner’s claim code and amount.'}{' '}
+            The total must equal the escrow ({ethers.formatUnits(escrow, decimals)} {summary.tokenSymbol}).
           </p>
           {rows.map((r, i) => (
             <div className="pool-propose-row" key={i}>
+              {r.nickname && (
+                <span className="pool-propose-nick" data-testid={`propose-nick-${i}`}>{r.nickname}</span>
+              )}
               <input
                 aria-label={`Claim code ${i + 1}`}
-                placeholder="winner claim code"
+                placeholder={r.nickname ? `claim code from ${r.nickname}` : 'winner claim code'}
                 value={r.claimCode}
                 onChange={setRow(i, 'claimCode')}
               />
@@ -180,4 +288,10 @@ export default function PoolResolutionActions({ summary, pools, onChanged }) {
       {notice && <p role="alert" className="pool-resolution-notice">{notice}</p>}
     </section>
   )
+}
+
+/** Truncate a long claim-code integer for table display. */
+function shortCode(code) {
+  const s = String(code)
+  return s.length > 12 ? `${s.slice(0, 6)}…${s.slice(-4)}` : s
 }

--- a/frontend/src/components/pools/PoolResolutionActions.jsx
+++ b/frontend/src/components/pools/PoolResolutionActions.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ethers } from 'ethers'
 import Button from '../ui/Button'
 import { payoutMatrixHash, payoutMatrixSum, serializeMatrix, parseMatrix } from '../../lib/pools/payout'
@@ -14,13 +14,26 @@ import { payoutMatrixHash, payoutMatrixSum, serializeMatrix, parseMatrix } from 
  * Controlled by the parent (PoolPage), which supplies the connected `pools` hook + the pool `summary`.
  */
 export default function PoolResolutionActions({ summary, pools, onChanged }) {
-  const { proposeOutcome, claimWinnings, getMyClaimCode, status } = pools
+  const { proposeOutcome, claimWinnings, getMyClaimCode, peekPoolIdentity, status } = pools
   const decimals = summary.tokenDecimals || 6
   const escrow = BigInt(summary.frozenDenominator || summary.memberCount || 0) * BigInt(summary.buyIn || 0)
 
   const [claimCode, setClaimCode] = useState(null)
   const [busy, setBusy] = useState(false)
   const [notice, setNotice] = useState(null)
+
+  // Auto-show the member's claim code (tester feedback) — cache-only read, derived at join time; the
+  // Reveal button stays as the fallback for members who joined before caching existed.
+  useEffect(() => {
+    if (!summary.hasJoined || claimCode) return
+    let active = true
+    peekPoolIdentity?.(summary.address)
+      .then((id) => active && id?.claimCode && setClaimCode(id.claimCode))
+      .catch(() => {})
+    return () => {
+      active = false
+    }
+  }, [summary.hasJoined, summary.address, claimCode, peekPoolIdentity])
 
   // Creator propose-builder rows: { claimCode, amount (human USDC) }
   const [rows, setRows] = useState([{ claimCode: '', amount: '' }])

--- a/frontend/src/hooks/__tests__/useMyPools.test.jsx
+++ b/frontend/src/hooks/__tests__/useMyPools.test.jsx
@@ -1,0 +1,61 @@
+/**
+ * useMyPools tests (tester feedback: pools must reliably surface in My Wagers).
+ * Covers the on-chain fallback: a device-recorded pool the subgraph did not return is backfilled with a
+ * direct summary read, so it still lists.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+
+const h = vi.hoisted(() => ({
+  load: vi.fn(),
+  readJoined: vi.fn(),
+  getPoolSummary: vi.fn(),
+}))
+vi.mock('../useWalletManagement', () => ({ useWallet: () => ({ account: '0xUser', chainId: 137 }) }))
+vi.mock('../usePools', () => ({ usePools: () => ({ getPoolSummary: h.getPoolSummary }) }))
+vi.mock('../../lib/lookup/myWagersSources', () => ({
+  loadMyWagersSources: h.load,
+  readJoinedPoolAddresses: h.readJoined,
+}))
+
+import { useMyPools } from '../useMyPools'
+
+describe('useMyPools', () => {
+  beforeEach(() => {
+    h.load.mockReset()
+    h.readJoined.mockReset().mockReturnValue([])
+    h.getPoolSummary.mockReset()
+  })
+
+  it('aggregates subgraph-indexed pools', async () => {
+    h.load.mockResolvedValue({
+      createdPools: [{ address: '0xa', poolId: 1, state: 0, stateLabel: 'Open', memberCount: 2, maxMembers: 10 }],
+      joinedPools: [],
+    })
+    const { result } = renderHook(() => useMyPools())
+    await waitFor(() => expect(result.current.items).toHaveLength(1))
+    expect(result.current.items[0]).toMatchObject({ type: 'pool', id: '0xa' })
+    expect(h.getPoolSummary).not.toHaveBeenCalled()
+  })
+
+  it('backfills device-recorded pools missing from the subgraph with on-chain reads', async () => {
+    h.load.mockResolvedValue({ createdPools: [], joinedPools: [] })
+    h.readJoined.mockReturnValue(['0xdeviceonly'])
+    h.getPoolSummary.mockResolvedValue({
+      address: '0xdeviceonly', state: 1, stateDisplay: 'Closed — resolving', memberCount: 4, maxMembers: 5,
+    })
+    const { result } = renderHook(() => useMyPools())
+    await waitFor(() => expect(result.current.items).toHaveLength(1))
+    expect(h.getPoolSummary).toHaveBeenCalledWith('0xdeviceonly')
+    expect(result.current.items[0]).toMatchObject({ type: 'pool', id: '0xdeviceonly', status: 'Closed — resolving' })
+  })
+
+  it('stays empty (no errors) when a fallback read also fails', async () => {
+    h.load.mockResolvedValue({ createdPools: [], joinedPools: [] })
+    h.readJoined.mockReturnValue(['0xgone'])
+    h.getPoolSummary.mockRejectedValue(new Error('no contract'))
+    const { result } = renderHook(() => useMyPools())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.items).toEqual([])
+  })
+})

--- a/frontend/src/hooks/useMyPools.js
+++ b/frontend/src/hooks/useMyPools.js
@@ -1,7 +1,11 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useWallet } from './useWalletManagement'
-import { loadMyWagersSources } from '../lib/lookup/myWagersSources'
+import { usePools } from './usePools'
+import { loadMyWagersSources, readJoinedPoolAddresses } from '../lib/lookup/myWagersSources'
 import { aggregateMyItems } from '../lib/lookup/myWagersAggregation'
+
+// Bound the RPC fallback so a long device history can't fan out into dozens of reads per open.
+const MAX_FALLBACK_READS = 12
 
 /**
  * The connected user's group pools for the consolidated My Wagers view (spec 037, US2).
@@ -9,11 +13,46 @@ import { aggregateMyItems } from '../lib/lookup/myWagersAggregation'
  * Pools are a parallel system to the wager registry, so they don't arrive through the wager repository.
  * This loads the user's created + joined pools (scoped to the active network), aggregates them into
  * MyWagersItem[]s, and returns them for display. Read-only; no wallet signature.
+ *
+ * Reliability (tester feedback — "users must be able to locate their pools"): device-recorded pool
+ * addresses that the subgraph did NOT return (indexer lagging, or a chain with no subgraph configured)
+ * are backfilled with direct on-chain summary reads, so a pool the user created or joined on this
+ * device always surfaces.
  */
 export function useMyPools() {
   const { account, chainId } = useWallet()
+  const { getPoolSummary } = usePools()
   const [items, setItems] = useState([])
   const [loading, setLoading] = useState(false)
+
+  const load = useCallback(async () => {
+    const { createdPools = [], joinedPools = [] } = await loadMyWagersSources({ chainId, account })
+      .catch(() => ({ createdPools: [], joinedPools: [] }))
+
+    // On-chain fallback for device-known pools the subgraph didn't return.
+    const indexed = new Set([...createdPools, ...joinedPools].map((p) => String(p.address).toLowerCase()))
+    const missing = readJoinedPoolAddresses(account)
+      .filter((a) => !indexed.has(String(a).toLowerCase()))
+      .slice(0, MAX_FALLBACK_READS)
+    const fallback = (
+      await Promise.all(
+        missing.map((addr) =>
+          getPoolSummary(addr)
+            .then((s) => ({
+              address: s.address,
+              poolId: null,
+              state: s.state,
+              stateLabel: s.stateDisplay || s.stateLabel,
+              memberCount: s.memberCount,
+              maxMembers: s.maxMembers,
+            }))
+            .catch(() => null)
+        )
+      )
+    ).filter(Boolean)
+
+    return aggregateMyItems({ createdPools, joinedPools: [...joinedPools, ...fallback] })
+  }, [account, chainId, getPoolSummary])
 
   useEffect(() => {
     let alive = true
@@ -22,15 +61,12 @@ export function useMyPools() {
       return undefined
     }
     setLoading(true)
-    loadMyWagersSources({ chainId, account })
-      .then(({ createdPools, joinedPools }) => {
-        if (!alive) return
-        setItems(aggregateMyItems({ createdPools, joinedPools }))
-      })
+    load()
+      .then((list) => { if (alive) setItems(list) })
       .catch(() => { if (alive) setItems([]) })
       .finally(() => { if (alive) setLoading(false) })
     return () => { alive = false }
-  }, [account, chainId])
+  }, [account, load])
 
   return { items, loading }
 }

--- a/frontend/src/hooks/usePools.js
+++ b/frontend/src/hooks/usePools.js
@@ -12,6 +12,7 @@ import { phraseToIndices, resolvePool, indicesToPhrase } from '../lib/pools/gate
 import { createPoolIdentity } from '../lib/pools/identity'
 import { deriveNickname } from '../lib/pools/nickname'
 import { readPoolIdentity, cachePoolIdentity } from '../lib/pools/identityCache'
+import { recordJoinedPool } from '../lib/lookup/myWagersSources'
 import { generatePoolProof } from '../lib/pools/semaphoreProof'
 
 function requiredApprovals(frozenDenominator, thresholdBips) {
@@ -113,7 +114,7 @@ export function usePools() {
     setStatus('creating')
     setError(null)
     try {
-      const { signer: s, chainId } = await requireSigner()
+      const { signer: s, chainId, account } = await requireSigner()
       const factory = getFactory(s, chainId)
       const tokenAddr = form.token || getContractAddressForChain('paymentToken', chainId)
       if (!tokenAddr) throw new Error('No buy-in token configured for this network.')
@@ -145,6 +146,9 @@ export function usePools() {
         })
         .find((e) => e && e.name === 'PoolCreated')
       const wordIndices = ev ? ev.args.wordIndices.map((x) => Number(x)) : null
+      // Record the pool device-locally so My Wagers can always list it, even when the subgraph for this
+      // chain is lagging or absent (tester feedback: pools must be easy to locate again).
+      if (ev) recordJoinedPool(account, ev.args.pool)
       setStatus('idle')
       return {
         poolId: ev ? ev.args.poolId : null,
@@ -197,6 +201,10 @@ export function usePools() {
       const { identity, commitment } = await createPoolIdentity(s, poolAddress)
       const tx = await pool.join(commitment)
       const receipt = await tx.wait()
+
+      // Record the join device-locally at the hook level so EVERY join path (unified lookup, pool page,
+      // future surfaces) makes the pool findable in My Wagers (tester feedback).
+      recordJoinedPool(account, poolAddress)
 
       // Best-effort (tester feedback): derive + cache the display values NOW, while the identity is in
       // memory from the join signature, so nickname and claim code auto-show later with no re-prompt.

--- a/frontend/src/hooks/usePools.js
+++ b/frontend/src/hooks/usePools.js
@@ -7,7 +7,7 @@ import { useCallback, useState } from 'react'
 import { ethers } from 'ethers'
 import { useWeb3 } from './useWeb3'
 import { getContractAddressForChain } from '../config/contracts'
-import { ERC20_ABI, getFactory, getPool, POOL_STATE, poolClaimScope } from '../lib/pools/poolContracts'
+import { ERC20_ABI, getFactory, getPool, POOL_STATE, poolStateDisplay, poolClaimScope } from '../lib/pools/poolContracts'
 import { phraseToIndices, resolvePool, indicesToPhrase } from '../lib/pools/gateway'
 import { createPoolIdentity } from '../lib/pools/identity'
 import { deriveNickname } from '../lib/pools/nickname'
@@ -71,6 +71,7 @@ async function summarizePool(poolContract, account) {
     address: await poolContract.getAddress(),
     state,
     stateLabel: POOL_STATE[state] ?? 'Unknown',
+    stateDisplay: poolStateDisplay(state),
     buyIn,
     buyInFormatted: ethers.formatUnits(buyIn, decimals),
     tokenAddress: tokenAddr,

--- a/frontend/src/hooks/usePools.js
+++ b/frontend/src/hooks/usePools.js
@@ -11,6 +11,7 @@ import { ERC20_ABI, getFactory, getPool, POOL_STATE, poolStateDisplay, poolClaim
 import { phraseToIndices, resolvePool, indicesToPhrase } from '../lib/pools/gateway'
 import { createPoolIdentity } from '../lib/pools/identity'
 import { deriveNickname } from '../lib/pools/nickname'
+import { readPoolIdentity, cachePoolIdentity } from '../lib/pools/identityCache'
 import { generatePoolProof } from '../lib/pools/semaphoreProof'
 
 function requiredApprovals(frozenDenominator, thresholdBips) {
@@ -193,9 +194,28 @@ export function usePools() {
         const approveTx = await token.approve(poolAddress, summary.buyIn)
         await approveTx.wait()
       }
-      const { commitment } = await createPoolIdentity(s, poolAddress)
+      const { identity, commitment } = await createPoolIdentity(s, poolAddress)
       const tx = await pool.join(commitment)
       const receipt = await tx.wait()
+
+      // Best-effort (tester feedback): derive + cache the display values NOW, while the identity is in
+      // memory from the join signature, so nickname and claim code auto-show later with no re-prompt.
+      // The identity secret itself is never persisted.
+      try {
+        cachePoolIdentity(account, poolAddress, { commitment: commitment.toString() })
+        const joined = await pool.queryFilter(pool.filters.Joined())
+        const memberCommitments = joined.map((e) => BigInt(e.args.identityCommitment))
+        const proof = await generatePoolProof({
+          identity,
+          memberCommitments,
+          message: 0n,
+          scope: poolClaimScope(poolAddress),
+        })
+        cachePoolIdentity(account, poolAddress, { claimCode: proof.nullifier.toString() })
+      } catch {
+        /* non-fatal — the reveal paths below still work and will backfill the cache */
+      }
+
       setStatus('idle')
       return { txHash: receipt.hash }
     } catch (e) {
@@ -217,11 +237,38 @@ export function usePools() {
     return events.map((e) => BigInt(e.args.identityCommitment))
   }, [requireSigner])
 
-  /** Derive the connected member's anonymous nickname for a pool (signs to seed the local identity). */
+  /**
+   * The connected member's anonymous nickname for a pool. Cache-first: after joining on this device the
+   * public commitment is cached, so this resolves with NO signature; otherwise it signs once to re-derive
+   * the identity and backfills the cache.
+   */
   const getMyNickname = useCallback(async (poolAddress) => {
-    const { signer: s } = await requireSigner()
+    const { signer: s, account } = await requireSigner()
+    const cached = readPoolIdentity(account, poolAddress)
+    if (cached?.commitment) return deriveNickname(cached.commitment, poolAddress)
     const { commitment } = await createPoolIdentity(s, poolAddress)
+    cachePoolIdentity(account, poolAddress, { commitment: commitment.toString() })
     return deriveNickname(commitment, poolAddress)
+  }, [requireSigner])
+
+  /**
+   * Non-prompting read of the member's cached display identity for a pool: { commitment, claimCode,
+   * nickname } or null when nothing is cached / no wallet. Lets pages auto-show the nickname and claim
+   * code (tester feedback) without ever popping an unrequested signature.
+   */
+  const peekPoolIdentity = useCallback(async (poolAddress) => {
+    try {
+      const { account } = await requireSigner()
+      const cached = readPoolIdentity(account, poolAddress)
+      if (!cached?.commitment && !cached?.claimCode) return null
+      return {
+        commitment: cached.commitment || null,
+        claimCode: cached.claimCode || null,
+        nickname: cached.commitment ? deriveNickname(cached.commitment, poolAddress) : null,
+      }
+    } catch {
+      return null
+    }
   }, [requireSigner])
 
   /**
@@ -230,9 +277,13 @@ export function usePools() {
    * to the wallet, and is the value the contract matches at claim time. Returns a decimal string.
    */
   const getMyClaimCode = useCallback(async (poolAddress) => {
-    const { signer: s } = await requireSigner()
+    const { signer: s, account } = await requireSigner()
+    // Cache-first (tester feedback): the code is derived at join (or first reveal) and cached, so
+    // subsequent views auto-show it without a signature or a fresh proof.
+    const cached = readPoolIdentity(account, poolAddress)
+    if (cached?.claimCode) return cached.claimCode
     const memberCommitments = await getMemberCommitments(poolAddress)
-    const { identity } = await createPoolIdentity(s, poolAddress)
+    const { identity, commitment } = await createPoolIdentity(s, poolAddress)
     // The nullifier is a deterministic function of (claimScope, identity); message/group-validity don't
     // affect it, so this matches the nullifier the real claim proof will produce.
     const proof = await generatePoolProof({
@@ -241,7 +292,9 @@ export function usePools() {
       message: 0n,
       scope: poolClaimScope(poolAddress),
     })
-    return proof.nullifier.toString()
+    const code = proof.nullifier.toString()
+    cachePoolIdentity(account, poolAddress, { commitment: commitment.toString(), claimCode: code })
+    return code
   }, [requireSigner, getMemberCommitments])
 
   /** Creator: close joining early (freezes the denominator). */
@@ -348,6 +401,7 @@ export function usePools() {
     getMemberCommitments,
     getMyNickname,
     getMyClaimCode,
+    peekPoolIdentity,
     closeJoining,
     cancelPool,
     proposeOutcome,

--- a/frontend/src/lib/pools/identityCache.js
+++ b/frontend/src/lib/pools/identityCache.js
@@ -1,0 +1,39 @@
+/**
+ * Device-local cache of a member's pool-identity DISPLAY values (tester feedback on spec 034).
+ *
+ * Auto-showing the member's nickname and claim code (instead of click-to-reveal) must not re-prompt a
+ * wallet signature or re-run a ZK proof on every page view. Both values are derived from the pool
+ * identity, whose secret we deliberately do NOT persist (a stolen identity secret could vote/claim as
+ * the member). What we cache is safe by construction:
+ *   - `commitment` — the member's PUBLIC Semaphore commitment, already visible on-chain in the pool's
+ *     Joined event; the nickname derives from it.
+ *   - `claimCode`  — the claim-scope nullifier the member deliberately reveals to the creator anyway;
+ *     knowing it does not let anyone else claim (claiming needs a fresh proof from the secret).
+ * Scoped per account + pool; never throws (private browsing / quota degrade to session-only).
+ */
+
+const key = (account, pool) =>
+  `fairwins_pool_identity_v1_${String(account || '').toLowerCase()}_${String(pool || '').toLowerCase()}`
+
+/** Read the cached identity display values for (account, pool): { commitment?, claimCode? } or null. */
+export function readPoolIdentity(account, pool) {
+  if (!account || !pool) return null
+  try {
+    const raw = localStorage.getItem(key(account, pool))
+    const parsed = raw ? JSON.parse(raw) : null
+    return parsed && typeof parsed === 'object' ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+/** Merge-write display values for (account, pool). Unknown fields are preserved. */
+export function cachePoolIdentity(account, pool, patch) {
+  if (!account || !pool || !patch) return
+  try {
+    const current = readPoolIdentity(account, pool) || {}
+    localStorage.setItem(key(account, pool), JSON.stringify({ ...current, ...patch }))
+  } catch {
+    /* private browsing / quota — degrade to session-only */
+  }
+}

--- a/frontend/src/lib/pools/participantOrder.js
+++ b/frontend/src/lib/pools/participantOrder.js
@@ -1,0 +1,17 @@
+/**
+ * Participant ordering for the pool roster (pool-manager tester feedback, items 3–4).
+ * Alphabetical by alias (then suffix) by default; the creator's arranged commitment order wins when
+ * present, with unknown commitments appended alphabetically.
+ */
+export function sortParticipants(participants, order) {
+  const alphabetical = [...participants].sort(
+    (a, b) => a.label.localeCompare(b.label) || a.suffix.localeCompare(b.suffix)
+  )
+  if (!order || !order.length) return alphabetical
+  const rank = new Map(order.map((c, i) => [String(c), i]))
+  return [...alphabetical].sort((a, b) => {
+    const ra = rank.has(a.commitment) ? rank.get(a.commitment) : Number.MAX_SAFE_INTEGER
+    const rb = rank.has(b.commitment) ? rank.get(b.commitment) : Number.MAX_SAFE_INTEGER
+    return ra - rb
+  })
+}

--- a/frontend/src/lib/pools/poolContracts.js
+++ b/frontend/src/lib/pools/poolContracts.js
@@ -35,6 +35,17 @@ export function getPool(address, runner) {
 
 export const POOL_STATE = ['JoiningOpen', 'JoiningClosed', 'Resolved', 'Cancelled']
 
+/**
+ * Human display labels for POOL_STATE (tester feedback: the raw enum name "JoiningOpen" leaked into
+ * the UI). Keep POOL_STATE as the stable enum-name mapping; render THIS in user-facing surfaces.
+ */
+export const POOL_STATE_DISPLAY = ['Open', 'Closed — resolving', 'Resolved', 'Cancelled']
+
+/** User-facing label for a pool state (falls back to 'Unknown' for an unrecognized value). */
+export function poolStateDisplay(state) {
+  return POOL_STATE_DISPLAY[Number(state)] ?? 'Unknown'
+}
+
 /** The pool's fixed claim scope: keccak256(abi.encodePacked(pool, "ZKPOOL_CLAIM")) — matches the contract. */
 export function poolClaimScope(poolAddress) {
   return BigInt(ethers.keccak256(ethers.solidityPacked(['address', 'string'], [poolAddress, 'ZKPOOL_CLAIM'])))

--- a/frontend/src/lib/pools/proposalStore.js
+++ b/frontend/src/lib/pools/proposalStore.js
@@ -1,0 +1,57 @@
+/**
+ * Device-local store of a pool's proposed payout-matrix PREIMAGE (tester bug: "participants are
+ * currently unable to see proposed solution").
+ *
+ * Only the matrix HASH (proposalId) lives on-chain by design; the preimage is coordinated off-chain.
+ * The creator's device saves the matrix at propose time so (a) the creator can always re-copy/share it
+ * and (b) any device that has received the matrix can re-render the breakdown later. A member who
+ * pastes a shared matrix gets it verified against the on-chain proposalId before it is trusted or
+ * stored. Never throws.
+ */
+import { serializeMatrix, parseMatrix, payoutMatrixHash } from './payout'
+
+const key = (pool) => `fairwins_pool_matrix_v1_${String(pool || '').toLowerCase()}`
+
+/** Save the proposed matrix for a pool (overwrites any earlier proposal's copy). */
+export function saveProposedMatrix(pool, proposalId, entries) {
+  if (!pool || !proposalId || !entries) return
+  try {
+    localStorage.setItem(key(pool), JSON.stringify({ proposalId, matrix: serializeMatrix(entries) }))
+  } catch {
+    /* private browsing / quota — degrade to session-only */
+  }
+}
+
+/** Read the stored matrix for a pool without an id check (used to prefill the claim form once the
+ * pool is resolved and the on-chain currentProposalId may no longer be exposed). Parse-checked only —
+ * the contract still verifies the hash against lockedOutcome at claim time. Returns { text, entries }
+ * or null. */
+export function readStoredMatrix(pool) {
+  if (!pool) return null
+  try {
+    const raw = localStorage.getItem(key(pool))
+    const stored = raw ? JSON.parse(raw) : null
+    const entries = stored ? parseMatrix(stored.matrix) : null
+    return entries ? { text: stored.matrix, entries } : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Read the stored matrix for a pool IF it matches `proposalId` (a stale copy of an older proposal is
+ * ignored). Returns { text, entries } or null.
+ */
+export function readProposedMatrix(pool, proposalId) {
+  if (!pool || !proposalId) return null
+  try {
+    const raw = localStorage.getItem(key(pool))
+    const stored = raw ? JSON.parse(raw) : null
+    if (!stored || stored.proposalId !== proposalId) return null
+    const entries = parseMatrix(stored.matrix)
+    if (!entries || payoutMatrixHash(entries) !== proposalId) return null
+    return { text: stored.matrix, entries }
+  } catch {
+    return null
+  }
+}

--- a/frontend/src/pages/PoolPage.jsx
+++ b/frontend/src/pages/PoolPage.jsx
@@ -15,7 +15,7 @@ import './pools.css'
 export default function PoolPage() {
   const { address } = useParams()
   const pools = usePools()
-  const { getPoolSummary, getMyNickname, closeJoining, cancelPool, vote, refund, status } = pools
+  const { getPoolSummary, getMyNickname, peekPoolIdentity, closeJoining, cancelPool, vote, refund, status } = pools
   const [summary, setSummary] = useState(null)
   const [error, setError] = useState(null)
   const [nickname, setNickname] = useState(null)
@@ -55,6 +55,19 @@ export default function PoolPage() {
   }, [address, getPoolSummary])
 
   const loaded = summary && summary.address === address
+
+  // Auto-show the member's nickname (tester feedback) — from the device cache only, so nothing here can
+  // pop an unrequested wallet signature. The Reveal button remains as the fallback for uncached devices.
+  useEffect(() => {
+    if (!loaded || !summary.hasJoined || nickname) return
+    let active = true
+    peekPoolIdentity?.(address)
+      .then((id) => active && id?.nickname && setNickname(id.nickname))
+      .catch(() => {})
+    return () => {
+      active = false
+    }
+  }, [loaded, summary, nickname, address, peekPoolIdentity])
 
   const run = async (fn) => {
     setNotice(null)

--- a/frontend/src/pages/PoolPage.jsx
+++ b/frontend/src/pages/PoolPage.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { usePools } from '../hooks/usePools'
+import { poolStateDisplay } from '../lib/pools/poolContracts'
 import Button from '../components/ui/Button'
 import PoolLeaderboard from '../components/pools/PoolLeaderboard'
 import PoolResolutionActions from '../components/pools/PoolResolutionActions'
@@ -92,7 +93,7 @@ export default function PoolPage() {
       <section className="pool-summary" aria-label="Pool details" data-testid="pool-summary">
         <dl>
           <dt>Status</dt>
-          <dd data-testid="pool-state">{summary.stateLabel}</dd>
+          <dd data-testid="pool-state">{poolStateDisplay(summary.state)}</dd>
           <dt>Buy-in</dt>
           <dd>{summary.buyInFormatted} {summary.tokenSymbol}</dd>
           <dt>Members</dt>

--- a/frontend/src/pages/PoolPage.jsx
+++ b/frontend/src/pages/PoolPage.jsx
@@ -2,10 +2,32 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { usePools } from '../hooks/usePools'
 import { poolStateDisplay } from '../lib/pools/poolContracts'
+import { deriveNickname } from '../lib/pools/nickname'
 import Button from '../components/ui/Button'
 import PoolLeaderboard from '../components/pools/PoolLeaderboard'
+import PoolParticipants from '../components/pools/PoolParticipants'
 import PoolResolutionActions from '../components/pools/PoolResolutionActions'
 import './pools.css'
+
+// Creator's device-local rank arrangement (until a sync channel ships — same honest limitation as the
+// interim leaderboard, so other members keep the alphabetical view).
+const rankKey = (pool) => `fairwins_pool_rank_v1_${String(pool || '').toLowerCase()}`
+function readRankOrder(pool) {
+  try {
+    const raw = localStorage.getItem(rankKey(pool))
+    const arr = raw ? JSON.parse(raw) : null
+    return Array.isArray(arr) ? arr : null
+  } catch {
+    return null
+  }
+}
+function writeRankOrder(pool, order) {
+  try {
+    localStorage.setItem(rankKey(pool), JSON.stringify(order))
+  } catch {
+    /* private browsing / quota — degrade to session-only */
+  }
+}
 
 /**
  * PoolPage (spec 034) — view a pool's live, on-chain state and take the state-appropriate action
@@ -15,11 +37,22 @@ import './pools.css'
 export default function PoolPage() {
   const { address } = useParams()
   const pools = usePools()
-  const { getPoolSummary, getMyNickname, peekPoolIdentity, closeJoining, cancelPool, vote, refund, status } = pools
+  const {
+    getPoolSummary, getMyNickname, peekPoolIdentity, getMemberCommitments,
+    closeJoining, cancelPool, vote, refund, status,
+  } = pools
   const [summary, setSummary] = useState(null)
   const [error, setError] = useState(null)
   const [nickname, setNickname] = useState(null)
   const [notice, setNotice] = useState(null)
+
+  // The anonymous participant roster (alias cards) + the creator's device-local rank arrangement.
+  const [participants, setParticipants] = useState(null)
+  const [rankOrder, setRankOrder] = useState(() => readRankOrder(address))
+  const handleReorder = (order) => {
+    setRankOrder(order)
+    writeRankOrder(address, order)
+  }
 
   // Off-chain interim leaderboard (US4). Local to this session until the sync channel ships (T050);
   // PoolLeaderboard marks it non-final/off-chain so this is honest.
@@ -55,6 +88,37 @@ export default function PoolPage() {
   }, [address, getPoolSummary])
 
   const loaded = summary && summary.address === address
+
+  // Load the anonymous roster from PUBLIC Joined-event commitments (no signature) and derive each
+  // member's alias — so everyone sees who's in, and the creator can rank (tester feedback, items 3–4).
+  useEffect(() => {
+    if (!loaded) return undefined
+    let active = true
+    Promise.resolve()
+      .then(() => getMemberCommitments(address))
+      .then((commitments) => {
+        if (!active || !Array.isArray(commitments)) return
+        setParticipants(
+          commitments.map((c) => {
+            const n = deriveNickname(c, address)
+            return { commitment: c.toString(), label: n.label, suffix: n.suffix }
+          })
+        )
+      })
+      .catch(() => {})
+    return () => {
+      active = false
+    }
+  }, [loaded, address, getMemberCommitments])
+
+  // Auto-populate the interim leaderboard from the roster so the creator never types names in by hand
+  // (tester feedback, item 5). Manual additions stay possible for guests/edge cases.
+  useEffect(() => {
+    if (!participants || participants.length === 0) return
+    setStandings((s) =>
+      s.length ? s : participants.map((p) => ({ id: p.commitment, nickname: p.label, score: 0, eliminated: false }))
+    )
+  }, [participants])
 
   // Auto-show the member's nickname (tester feedback) — from the device cache only, so nothing here can
   // pop an unrequested wallet signature. The Reveal button remains as the fallback for uncached devices.
@@ -124,6 +188,16 @@ export default function PoolPage() {
         )}
       </section>
 
+      {/* Anonymous roster: alias cards for everyone; the creator can drag/arrange the rank order */}
+      {summary.state !== 3 && (
+        <PoolParticipants
+          participants={participants}
+          isCreator={summary.isCreator}
+          order={rankOrder}
+          onReorder={handleReorder}
+        />
+      )}
+
       {/* Creator controls while joining is open */}
       {summary.isCreator && summary.state === 0 && (
         <section className="pool-actions" aria-label="Creator actions">
@@ -170,7 +244,13 @@ export default function PoolPage() {
 
       {/* Reveal-claim-code, creator propose-builder, and winner claim (US1 resolution loop) */}
       {(summary.hasJoined || summary.isCreator || summary.state === 2) && summary.state !== 3 && (
-        <PoolResolutionActions summary={summary} pools={pools} onChanged={reload} />
+        <PoolResolutionActions
+          summary={summary}
+          pools={pools}
+          participants={participants}
+          rankOrder={rankOrder}
+          onChanged={reload}
+        />
       )}
 
       {summary.refundEligible && (

--- a/frontend/src/pages/pools.css
+++ b/frontend/src/pages/pools.css
@@ -185,3 +185,16 @@
   border-radius: 6px; padding: 0.1rem 0.5rem; cursor: pointer; font: inherit;
 }
 .pool-participant-controls button:disabled { opacity: 0.35; cursor: default; }
+
+/* Proposed-payout visibility (tester bug item 7) + builder alias chips (item 5) */
+.pool-proposal-details { margin: 1rem 0; }
+.pool-proposal-table { border-collapse: collapse; width: 100%; max-width: 32rem; }
+.pool-proposal-table th, .pool-proposal-table td {
+  text-align: left; padding: 0.35rem 0.6rem; border-bottom: 1px solid var(--border-color, rgba(0, 0, 0, 0.1));
+}
+.pool-proposal-table tr.is-you td { background: var(--accent-soft, rgba(59, 156, 120, 0.12)); font-weight: 600; }
+.pool-propose-nick {
+  display: inline-flex; align-items: center; min-width: 9rem;
+  font-size: 0.85rem; font-weight: 600; padding: 0.15rem 0.5rem; border-radius: 8px;
+  background: var(--accent-soft, rgba(59, 156, 120, 0.12));
+}

--- a/frontend/src/pages/pools.css
+++ b/frontend/src/pages/pools.css
@@ -159,3 +159,29 @@
   align-items: end;
   margin-top: 0.75rem;
 }
+
+/* Participant roster (pool-manager tester feedback): anonymous alias cards + creator rank arrangement */
+.pool-participants { margin: 1rem 0; }
+.pool-participants h2 { font-size: 1rem; margin: 0 0 0.25rem; }
+.pool-participants-hint { font-size: 0.8rem; opacity: 0.7; margin: 0 0 0.5rem; }
+.pool-participants-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.4rem; }
+.pool-participant-card {
+  display: flex; align-items: center; gap: 0.6rem;
+  padding: 0.5rem 0.75rem; border: 1px solid var(--border-color, rgba(0, 0, 0, 0.12));
+  border-radius: 10px; background: var(--surface-2, rgba(0, 0, 0, 0.02));
+}
+.pool-participant-card.dragging { opacity: 0.5; border-style: dashed; }
+.pool-participant-card[draggable='true'] { cursor: grab; }
+.pool-participant-rank {
+  min-width: 1.5rem; height: 1.5rem; display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 50%; font-size: 0.75rem; font-weight: 700;
+  background: var(--accent-soft, rgba(59, 156, 120, 0.15)); color: var(--accent, #3b9c78);
+}
+.pool-participant-alias { flex: 1; font-weight: 600; }
+.pool-participant-suffix { margin-left: 0.35rem; font-size: 0.7rem; font-weight: 400; opacity: 0.55; }
+.pool-participant-controls { display: inline-flex; gap: 0.25rem; }
+.pool-participant-controls button {
+  border: 1px solid var(--border-color, rgba(0, 0, 0, 0.15)); background: none;
+  border-radius: 6px; padding: 0.1rem 0.5rem; cursor: pointer; font: inherit;
+}
+.pool-participant-controls button:disabled { opacity: 0.35; cursor: default; }

--- a/frontend/src/test/PoolPages.test.jsx
+++ b/frontend/src/test/PoolPages.test.jsx
@@ -24,6 +24,7 @@ function base(overrides = {}) {
     status: 'idle', error: null,
     createPool: vi.fn(), resolvePhrase: vi.fn(), getPoolSummary: vi.fn(), joinPool: vi.fn(),
     getMyNickname: vi.fn(), getMyClaimCode: vi.fn(), getMemberCommitments: vi.fn(),
+    peekPoolIdentity: vi.fn().mockResolvedValue(null),
     closeJoining: vi.fn().mockResolvedValue('0xtx'), cancelPool: vi.fn().mockResolvedValue('0xtx'),
     proposeOutcome: vi.fn(), vote: vi.fn().mockResolvedValue('0xtx'), claimWinnings: vi.fn(),
     refund: vi.fn().mockResolvedValue('0xtx'),
@@ -52,6 +53,17 @@ describe('PoolPage', () => {
     const state = await screen.findByTestId('pool-state')
     expect(state).toHaveTextContent('Open')
     expect(state).not.toHaveTextContent('JoiningOpen')
+  })
+
+  it('auto-shows a joined member’s nickname from the device cache (no click, no signature)', async () => {
+    const sum = { ...openSummary, hasJoined: true }
+    const peekPoolIdentity = vi.fn().mockResolvedValue({
+      commitment: '123', claimCode: null, nickname: { label: 'Prismatic Fox', suffix: '7b' },
+    })
+    usePools.mockReturnValue(base({ getPoolSummary: vi.fn().mockResolvedValue(sum), peekPoolIdentity }))
+    renderPoolAt(sum)
+    expect(await screen.findByTestId('my-nickname')).toHaveTextContent('Prismatic Fox')
+    expect(screen.queryByRole('button', { name: /reveal my nickname/i })).toBeNull()
   })
 
   it('the creator sees close/cancel while joining is open', async () => {

--- a/frontend/src/test/PoolPages.test.jsx
+++ b/frontend/src/test/PoolPages.test.jsx
@@ -46,10 +46,12 @@ describe('PoolPage', () => {
     useWallet.mockReturnValue({ account: '0x1111111111111111111111111111111111111111', isConnected: true })
   })
 
-  it('renders live on-chain state for a pool address', async () => {
+  it('renders live on-chain state with a human status label (not the raw enum name)', async () => {
     usePools.mockReturnValue(base({ getPoolSummary: vi.fn().mockResolvedValue(openSummary) }))
     renderPoolAt(openSummary)
-    expect(await screen.findByTestId('pool-state')).toHaveTextContent('JoiningOpen')
+    const state = await screen.findByTestId('pool-state')
+    expect(state).toHaveTextContent('Open')
+    expect(state).not.toHaveTextContent('JoiningOpen')
   })
 
   it('the creator sees close/cancel while joining is open', async () => {

--- a/frontend/src/test/PoolParticipants.test.jsx
+++ b/frontend/src/test/PoolParticipants.test.jsx
@@ -1,0 +1,55 @@
+/**
+ * PoolParticipants tests (pool-manager tester feedback, items 3–4): anonymous alias cards for everyone,
+ * alphabetical until the creator arranges an order, creator-only reordering.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import PoolParticipants from '../components/pools/PoolParticipants'
+import { sortParticipants } from '../lib/pools/participantOrder'
+
+const P = [
+  { commitment: '3', label: 'Silent Owl', suffix: '03' },
+  { commitment: '1', label: 'Amber Fox', suffix: '01' },
+  { commitment: '2', label: 'Prismatic Newt', suffix: '02' },
+]
+
+const aliases = () => screen.getAllByTestId('participant-card').map((el) => el.textContent)
+
+describe('sortParticipants', () => {
+  it('is alphabetical by alias without a creator order', () => {
+    expect(sortParticipants(P, null).map((p) => p.label)).toEqual(['Amber Fox', 'Prismatic Newt', 'Silent Owl'])
+  })
+  it('follows the creator order, appending unknown commitments alphabetically', () => {
+    expect(sortParticipants(P, ['2', '3']).map((p) => p.label)).toEqual(['Prismatic Newt', 'Silent Owl', 'Amber Fox'])
+  })
+})
+
+describe('PoolParticipants', () => {
+  it('renders nothing with no participants', () => {
+    const { container } = render(<PoolParticipants participants={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('members see a read-only alphabetical roster (no reorder controls)', () => {
+    render(<PoolParticipants participants={P} isCreator={false} />)
+    expect(aliases()[0]).toContain('Amber Fox')
+    expect(aliases()[2]).toContain('Silent Owl')
+    expect(screen.queryByRole('button', { name: /move/i })).toBeNull()
+    expect(screen.getByText(/alphabetical until the creator arranges/i)).toBeInTheDocument()
+  })
+
+  it('the creator can move a card into rank order (accessible buttons)', () => {
+    const onReorder = vi.fn()
+    render(<PoolParticipants participants={P} isCreator order={null} onReorder={onReorder} />)
+    // Alphabetical start: Amber Fox, Prismatic Newt, Silent Owl. Move Silent Owl up one.
+    fireEvent.click(screen.getByRole('button', { name: /move silent owl up/i }))
+    expect(onReorder).toHaveBeenCalledWith(['1', '3', '2'])
+  })
+
+  it('shows rank numbers once an order exists and never shows wallets', () => {
+    render(<PoolParticipants participants={P} isCreator={false} order={['2', '1', '3']} />)
+    expect(screen.getByLabelText('Rank 1')).toBeInTheDocument()
+    expect(aliases()[0]).toContain('Prismatic Newt')
+    expect(screen.queryByText(/0x/)).toBeNull()
+  })
+})

--- a/frontend/src/test/PoolResolutionActions.test.jsx
+++ b/frontend/src/test/PoolResolutionActions.test.jsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { ethers } from 'ethers'
 import PoolResolutionActions from '../components/pools/PoolResolutionActions'
+import { payoutMatrixHash, serializeMatrix } from '../lib/pools/payout'
 
 // US1 resolution UI (spec 034): reveal claim code, creator propose-builder (sum must equal escrow),
 // winner claim. Wired through a mocked usePools.
@@ -27,6 +28,8 @@ function mockPools(over = {}) {
 }
 
 describe('PoolResolutionActions (US1)', () => {
+  beforeEach(() => localStorage.clear())
+
   it('a joined member can reveal their claim code', async () => {
     const pools = mockPools()
     render(<PoolResolutionActions summary={{ ...baseSummary, hasJoined: true, state: 1, withinResolutionWindow: true }} pools={pools} />)
@@ -77,5 +80,83 @@ describe('PoolResolutionActions (US1)', () => {
     fireEvent.click(screen.getByTestId('claim'))
     await waitFor(() => expect(pools.claimWinnings).toHaveBeenCalled())
     expect(pools.claimWinnings.mock.calls[0][1].recipient).toBe('0x1111111111111111111111111111111111111111')
+  })
+
+  it('seeds the propose builder with one alias row per participant, in rank order (item 5)', async () => {
+    const participants = [
+      { commitment: '10', label: 'Silent Owl', suffix: '0a' },
+      { commitment: '11', label: 'Amber Fox', suffix: '0b' },
+    ]
+    render(
+      <PoolResolutionActions
+        summary={{ ...baseSummary, isCreator: true, state: 1, withinResolutionWindow: true }}
+        pools={mockPools()}
+        participants={participants}
+        rankOrder={['10', '11']}
+      />
+    )
+    expect(await screen.findByTestId('propose-nick-0')).toHaveTextContent('Silent Owl')
+    expect(screen.getByTestId('propose-nick-1')).toHaveTextContent('Amber Fox')
+    expect(screen.getByPlaceholderText('claim code from Silent Owl')).toBeInTheDocument()
+  })
+
+  it('BUG item 7: a member sees + verifies the proposed split by pasting the shared matrix', async () => {
+    const entries = [
+      { claimNullifier: '111', amount: '10000000' },
+      { claimNullifier: '222', amount: '10000000' },
+    ]
+    const proposalId = payoutMatrixHash(entries)
+    const summary = {
+      ...baseSummary, hasJoined: true, state: 1, withinResolutionWindow: true, currentProposalId: proposalId,
+    }
+    render(<PoolResolutionActions summary={summary} pools={mockPools()} />)
+
+    const details = await screen.findByTestId('proposal-details')
+    expect(details).toBeInTheDocument()
+
+    // A tampered matrix is called out, never rendered as the proposal.
+    fireEvent.change(screen.getByLabelText(/payout matrix \(shared by the creator\)/i), {
+      target: { value: '[{"claimNullifier":"111","amount":"20000000"}]' },
+    })
+    expect(await screen.findByTestId('proposal-mismatch')).toHaveTextContent(/does not match/i)
+
+    // The genuine matrix verifies and renders the breakdown.
+    fireEvent.change(screen.getByLabelText(/payout matrix \(shared by the creator\)/i), {
+      target: { value: serializeMatrix(entries) },
+    })
+    expect(await screen.findByTestId('proposal-verified')).toHaveTextContent(/verified/i)
+    expect(screen.getAllByRole('row')).toHaveLength(3) // header + 2 entries
+    expect(screen.getAllByText('10.0 USDC')).toHaveLength(2)
+  })
+
+  it('the creator sees the proposal breakdown automatically after proposing (stored preimage)', async () => {
+    const entries = [{ claimNullifier: '333', amount: '20000000' }]
+    const proposalId = payoutMatrixHash(entries)
+    localStorage.setItem(
+      `fairwins_pool_matrix_v1_${baseSummary.address.toLowerCase()}`,
+      JSON.stringify({ proposalId, matrix: serializeMatrix(entries) })
+    )
+    const summary = {
+      ...baseSummary, isCreator: true, state: 1, withinResolutionWindow: true, currentProposalId: proposalId,
+    }
+    render(<PoolResolutionActions summary={summary} pools={mockPools()} />)
+    expect(await screen.findByTestId('proposal-verified')).toBeInTheDocument()
+  })
+
+  it('auto-fills the claim matrix from the stored preimage and detects the claimant’s row', async () => {
+    const entries = [
+      { claimNullifier: '999', amount: '10000000' },
+      { claimNullifier: '424242', amount: '10000000' },
+    ]
+    localStorage.setItem(
+      `fairwins_pool_matrix_v1_${baseSummary.address.toLowerCase()}`,
+      JSON.stringify({ proposalId: payoutMatrixHash(entries), matrix: serializeMatrix(entries) })
+    )
+    const pools = mockPools({
+      peekPoolIdentity: vi.fn().mockResolvedValue({ commitment: '1', claimCode: '424242', nickname: null }),
+    })
+    render(<PoolResolutionActions summary={{ ...baseSummary, hasJoined: true, state: 2 }} pools={pools} />)
+    await waitFor(() => expect(screen.getByLabelText(/payout matrix/i)).toHaveValue(serializeMatrix(entries)))
+    await waitFor(() => expect(screen.getByLabelText(/your row index/i)).toHaveValue(1))
   })
 })

--- a/frontend/src/test/PoolResolutionActions.test.jsx
+++ b/frontend/src/test/PoolResolutionActions.test.jsx
@@ -34,6 +34,15 @@ describe('PoolResolutionActions (US1)', () => {
     expect(await screen.findByTestId('my-claim-code')).toHaveTextContent('123456789')
   })
 
+  it('auto-shows the claim code from the device cache without a click (tester feedback)', async () => {
+    const pools = mockPools({
+      peekPoolIdentity: vi.fn().mockResolvedValue({ commitment: '1', claimCode: '424242', nickname: null }),
+    })
+    render(<PoolResolutionActions summary={{ ...baseSummary, hasJoined: true, state: 1, withinResolutionWindow: true }} pools={pools} />)
+    expect(await screen.findByTestId('my-claim-code')).toHaveTextContent('424242')
+    expect(screen.queryByRole('button', { name: /reveal my claim code/i })).toBeNull()
+  })
+
   it('creator propose is gated until the matrix sums to the escrow', async () => {
     const pools = mockPools()
     render(

--- a/frontend/src/test/poolIdentityCache.test.js
+++ b/frontend/src/test/poolIdentityCache.test.js
@@ -1,0 +1,37 @@
+/**
+ * identityCache tests (pool-manager tester feedback) — device-local cache of a member's pool display
+ * identity (public commitment + claim code) that lets nickname/claim-code auto-show without re-prompting
+ * signatures. The identity secret itself is never stored.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { readPoolIdentity, cachePoolIdentity } from '../lib/pools/identityCache'
+
+const ACCOUNT = '0xAbC0000000000000000000000000000000000001'
+const POOL = '0xP00L000000000000000000000000000000000001'
+
+describe('pool identityCache', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('round-trips and merge-writes per (account, pool)', () => {
+    cachePoolIdentity(ACCOUNT, POOL, { commitment: '123' })
+    expect(readPoolIdentity(ACCOUNT, POOL)).toEqual({ commitment: '123' })
+    cachePoolIdentity(ACCOUNT, POOL, { claimCode: '456' })
+    expect(readPoolIdentity(ACCOUNT, POOL)).toEqual({ commitment: '123', claimCode: '456' })
+  })
+
+  it('is case-insensitive on account/pool and isolated between pools', () => {
+    cachePoolIdentity(ACCOUNT.toUpperCase(), POOL.toUpperCase(), { commitment: '1' })
+    expect(readPoolIdentity(ACCOUNT.toLowerCase(), POOL.toLowerCase())).toEqual({ commitment: '1' })
+    expect(readPoolIdentity(ACCOUNT, '0xother')).toBeNull()
+  })
+
+  it('returns null (never throws) on missing keys or malformed values', () => {
+    expect(readPoolIdentity(null, POOL)).toBeNull()
+    expect(readPoolIdentity(ACCOUNT, null)).toBeNull()
+    localStorage.setItem(
+      `fairwins_pool_identity_v1_${ACCOUNT.toLowerCase()}_${POOL.toLowerCase()}`,
+      'not-json'
+    )
+    expect(readPoolIdentity(ACCOUNT, POOL)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Implements the full group-pool-manager tester feedback list, plus a reliability fix so pools always surface in My Wagers. Frontend-only; no contract or subgraph-schema changes — pool anonymity properties are preserved throughout (everything renders from PUBLIC identity commitments; the identity secret is never persisted).

## Tester feedback → what shipped

| # | Feedback | Change |
|---|----------|--------|
| 1 | Auto-show the user's nickname (no click to reveal) | Nickname (and claim code) are derived at **join time**, while the wallet signature is already in hand, and cached device-locally (`lib/pools/identityCache.js` — public commitment + claim code only, never the identity secret). `PoolPage` auto-shows via a new non-prompting `peekPoolIdentity()`; the Reveal button remains only as a fallback for pre-caching members. |
| 2 | Status "JoiningOpen" should say "open" | `POOL_STATE_DISPLAY` / `poolStateDisplay()` ("Open", "Closed — resolving", "Resolved", "Cancelled") rendered on `PoolPage` and `JoinPoolPanel`; the enum names stay for logic. |
| 3 | Creator sees participant alias cards and drags them into rank order | New `PoolParticipants` roster derived from public Joined-event commitments via `deriveNickname` — anonymous by construction. Creator reorders via native drag **and** accessible up/down buttons (no new dependency); the arrangement persists device-locally (honest limitation until a sync channel ships, like the interim leaderboard). |
| 4 | All participants see the active list, alphabetical unless arranged | Same roster renders read-only for every member, alphabetical by alias by default (`lib/pools/participantOrder.js`). |
| 5 | Live standings + winning claim auto-populate with participant names | The interim leaderboard seeds itself from the roster (no more typing names). The propose builder seeds one alias-labelled row per participant in rank order. The claim form auto-fills the matrix from the stored preimage and auto-detects the claimant's row by matching their cached claim code. (Claim codes themselves still come from members — they are unlinkable from public data by design.) |
| 6 | Claim code should be an auto-generated integer | The claim code (already an integer nullifier) is generated automatically at join and auto-shown thereafter — no click, no repeat signature/proof. |
| 7 | 🐞 Participants can't see the proposed solution | **Fixed.** During voting, every member gets a "Proposed payout" panel: the shared matrix preimage (auto-loaded on the creator's device, pasted elsewhere) is verified on-device against the on-chain `proposalId` before it renders as the proposal; a tampered matrix is called out and never displayed as genuine. The member's own row is highlighted "(you)". The creator's device persists the preimage at propose time (`lib/pools/proposalStore.js`). |

## Also: pools reliably locatable from My Wagers

- Pool membership is now recorded at the `usePools` level — `joinPool` covers **every** join path and `createPool` records the creator's new pool (previously only the unified-lookup panel recorded joins).
- `useMyPools` backfills device-recorded pools the subgraph didn't return (indexer lag or a chain without a subgraph) with direct on-chain summary reads, bounded to 12 per open.

## Tests & checks

- 112 tests green across 21 pool/lookup/notification suites, including new suites for the identity cache, participant roster/ordering, `useMyPools` fallback, and the proposal-visibility flows (verify, tamper-detection, creator auto-breakdown, claim row auto-detect).
- `vite build` passes; ESLint 0 errors; axe accessibility suite green.
- Note: the always-run contract CI jobs fail on the pre-existing `main`-side compile OOM (unrelated to this frontend-only PR); **Frontend Unit Tests** is the relevant check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEDqX9MRrBm8ob2vjaEskX

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEDqX9MRrBm8ob2vjaEskX)_