### PR TITLE
fix(024): open-challenge screen patches from testing feedback

### DIFF
--- a/frontend/src/components/fairwins/Dashboard.jsx
+++ b/frontend/src/components/fairwins/Dashboard.jsx
@@ -498,7 +498,6 @@ function Dashboard() {
   const [showOpenChallenge, setShowOpenChallenge] = useState(false)
   const [showGroupPool, setShowGroupPool] = useState(false)
   const [groupPoolTab, setGroupPoolTab] = useState('create')
-  const [openChallengeTab, setOpenChallengeTab] = useState('maker')
   // Unified phrase lookup (spec 037): one entry point for taking a challenge or joining a pool.
   const [showUnifiedLookup, setShowUnifiedLookup] = useState(false)
   const [unifiedInitialPhrase, setUnifiedInitialPhrase] = useState('')
@@ -570,7 +569,6 @@ function Dashboard() {
         setShowCreateWager(true)
         break
       case 'open-challenge':
-        setOpenChallengeTab('maker')
         setShowOpenChallenge(true)
         break
       case 'create-pool':
@@ -729,7 +727,6 @@ function Dashboard() {
       <OpenChallengeModal
         key={showOpenChallenge ? 'oc-open' : 'oc-closed'}
         isOpen={showOpenChallenge}
-        initialTab={openChallengeTab}
         onClose={() => setShowOpenChallenge(false)}
         onBuyMembership={() => {
           setShowOpenChallenge(false)

--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -34,6 +34,7 @@ import PolymarketBrowser from './PolymarketBrowser'
 import OracleConditionPicker from './OracleConditionPicker'
 import { getContractAddressForChain } from '../../config/contracts'
 import { formatUSD, getMarketUrl } from './marketHelpers'
+import { formatTileClock, formatTileDay, formatTimelineSpan } from './wagerTimeline'
 import { getTransactionUrl } from '../../config/blockExplorer'
 import TransactionProgress from './TransactionProgress'
 import './FriendMarketsModal.css'
@@ -132,31 +133,8 @@ const RESOLUTION_TAB_ICONS = {
   [ResolutionType.UMA]: '🔮',
 }
 
-// ── End-date timeline formatters (compact-chips redesign) ───────────
-// The end-date region renders three glanceable stat tiles (Accept by /
-// Ends / Resolve by). Each shows a short clock + day, so the timeline reads
-// at a glance without the tall stack of labelled read-only rows it replaces.
-
-/** "2:05 PM" — short local clock for a stat tile. */
-const formatTileClock = (date) =>
-  date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
-
-/** "Jun 17" — short local month + day for a stat tile. */
-const formatTileDay = (date) =>
-  date.toLocaleDateString([], { month: 'short', day: 'numeric' })
-
-/**
- * Human duration between two dates as "1 day 0h" / "3h" — used for the
- * "lasts …" summary so the wager length is legible before committing.
- */
-const formatTimelineSpan = (from, to) => {
-  let minutes = Math.max(0, Math.round((to.getTime() - from.getTime()) / 60000))
-  const days = Math.floor(minutes / 1440)
-  minutes -= days * 1440
-  const hours = Math.floor(minutes / 60)
-  if (days > 0) return `${days} day${days > 1 ? 's' : ''} ${hours}h`
-  return `${hours}h`
-}
+// End-date timeline formatters (compact-chips redesign) live in
+// wagerTimeline.js so the open-challenge deadline timeline reuses them.
 
 /**
  * FriendMarketsModal

--- a/frontend/src/components/fairwins/OpenChallengeModal.css
+++ b/frontend/src/components/fairwins/OpenChallengeModal.css
@@ -1,9 +1,5 @@
 /* Open-challenge modal — small additions on top of the shared fm-* (FriendMarketsModal) styles. */
 
-.oc-mode-tabs {
-  margin-bottom: 1.25rem;
-}
-
 .oc-code-display {
   display: flex;
   align-items: center;
@@ -22,6 +18,28 @@
   word-spacing: 0.18em;
   color: var(--fm-accent, #2fbf71);
   user-select: all;
+}
+
+/* Icon-only copy button beside the four-word code (testing feedback). */
+.oc-copy-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  flex-shrink: 0;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--fm-border, rgba(255, 255, 255, 0.2));
+  border-radius: 8px;
+  color: var(--fm-accent, #2fbf71);
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.oc-copy-btn:hover {
+  background: rgba(47, 191, 113, 0.12);
+  border-color: var(--fm-accent, #2fbf71);
 }
 
 .oc-terms-body {
@@ -133,6 +151,61 @@
 
 .oc-deadline-warn {
   color: #d99b00;
+}
+
+/* ── Deadline timeline (testing feedback) ────────────────────────────
+   Reuses the 1v1 create-wager timeline element (fm-endtime track + stat
+   tiles) with a slider per deadline; tapping a tile opens exact entry. */
+.oc-timeline {
+  gap: 0.5rem;
+}
+
+.oc-deadline-slider .fm-odds-slider {
+  margin: 0.4rem 0 0.25rem;
+}
+
+/* Two deadlines → two tiles (the 1v1 grid is three-up). */
+.oc-stat-tiles {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+/* Stat tiles double as buttons that open manual date entry. */
+.oc-stat-tile-btn {
+  appearance: none;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.oc-stat-tile-btn:hover:not(:disabled) {
+  border-color: var(--tile-accent);
+  box-shadow: 0 0 0 2px var(--tile-border);
+}
+
+.oc-stat-tile-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.oc-tile-edit {
+  margin-top: 0.125rem;
+  font-size: 0.62rem;
+  color: var(--text-muted, #7A8590);
+  text-decoration: underline;
+  text-decoration-style: dotted;
+}
+
+.oc-manual-entry {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-top: 0.25rem;
+}
+
+/* Purple resolve-by node on the shared timeline track. */
+.fm-timeline-node.is-resolve {
+  background: var(--fm-resolve);
 }
 
 /* Read-only deadline summary on the taker's "challenge found" view. */

--- a/frontend/src/components/fairwins/OpenChallengeModal.jsx
+++ b/frontend/src/components/fairwins/OpenChallengeModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { isAddress } from 'ethers'
 import { useOpenChallengeCreate, OPEN_RESOLUTION_TYPES } from '../../hooks/useOpenChallengeCreate'
 import { useOpenChallengeCodeVault } from '../../hooks/useOpenChallengeCodeVault'
@@ -8,6 +8,7 @@ import AddressInput from '../ui/AddressInput'
 import AddressBookButton from '../ui/AddressBookButton'
 import QRScanner from '../ui/QRScanner'
 import { buildTakeChallengeUrl } from '../../utils/claimCode/deepLink.js'
+import { formatTileClock, formatTileDay, formatTimelineSpan } from './wagerTimeline'
 import './FriendMarketsModal.css'
 import './OpenChallengeModal.css'
 
@@ -17,14 +18,26 @@ const CloseIcon = () => (
   </svg>
 )
 
+const CopyIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+    <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+  </svg>
+)
+
+const CheckIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden="true">
+    <path d="M20 6L9 17l-5-5" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+)
+
 /**
  * Open-challenge modal (feature 024) — create a code-gated wager with no named opponent (Silver+).
  * Taking a challenge moved to the unified phrase lookup (spec 037, UnifiedLookupModal). Styled to match
- * the create-a-wager modal (shared `fm-*` classes).
+ * the create-a-wager modal (shared `fm-*` classes). Create-only, so no mode tabs — the header alone
+ * says what this modal does (testing feedback).
  */
-function OpenChallengeModal({ isOpen, onClose, initialTab = 'maker' }) {
-  const [tab, setTab] = useState(initialTab)
-
+function OpenChallengeModal({ isOpen, onClose }) {
   useEffect(() => {
     if (!isOpen) return
     const onKey = (e) => { if (e.key === 'Escape') onClose() }
@@ -59,17 +72,6 @@ function OpenChallengeModal({ isOpen, onClose, initialTab = 'maker' }) {
 
         <div className="fm-content">
           <div className="fm-panel">
-            {/* Maker / Taker tabs (same tab styling as the create-wager resolution tabs) */}
-            <div className="fm-resolution-tabs oc-mode-tabs" role="tablist" aria-label="Open challenge mode">
-              <button
-                type="button" role="tab" aria-selected={tab === 'maker'}
-                className={`fm-resolution-tab ${tab === 'maker' ? 'active' : ''}`}
-                onClick={() => setTab('maker')}
-              >
-                <span className="fm-resolution-tab-label">Create a challenge</span>
-              </button>
-            </div>
-
             {/* Taking a challenge moved to the unified phrase lookup (spec 037). */}
             <MakerPanel onClose={onClose} />
           </div>
@@ -85,7 +87,7 @@ function OpenChallengeModal({ isOpen, onClose, initialTab = 'maker' }) {
 function MakerPanel({ onClose }) {
   const { createOpenChallenge, busy } = useOpenChallengeCreate()
   const [description, setDescription] = useState('')
-  const [stake, setStake] = useState('10')
+  const [stake, setStake] = useState('10.00')
   const [resolutionType, setResolutionType] = useState(String(OPEN_RESOLUTION_TYPES.Either))
   const [arbitrator, setArbitrator] = useState('')
   const [arbitratorResolved, setArbitratorResolved] = useState('')
@@ -102,6 +104,7 @@ function MakerPanel({ onClose }) {
   const { saveCode, canUse: canBackup } = useOpenChallengeCodeVault()
   const [backupState, setBackupState] = useState('idle') // idle | saving | saved | error
   const [backupError, setBackupError] = useState(null)
+  const autoBackupStarted = useRef(false)
 
   const isThirdParty = Number(resolutionType) === OPEN_RESOLUTION_TYPES.ThirdParty
   const arbitratorAddr = arbitratorResolved || arbitrator
@@ -162,16 +165,33 @@ function MakerPanel({ onClose }) {
     }
   }, [result, saveCode, description, stake])
 
+  // Save the share words locally without the user having to do anything (testing feedback):
+  // as soon as the challenge exists, write the encrypted device backup automatically. If it
+  // can't complete (no wallet, signature declined), the manual save button below is the fallback.
+  useEffect(() => {
+    if (!result || !canBackup || autoBackupStarted.current) return
+    autoBackupStarted.current = true
+    handleSaveBackup()
+  }, [result, canBackup, handleSaveBackup])
+
   if (result) {
     return (
       <div className="fm-success">
         <div className="fm-success-icon" aria-hidden="true">&#127881;</div>
-        <h3>Open challenge created{result.wagerId != null ? ` (#${result.wagerId})` : ''}</h3>
+        <h3>Open challenge created</h3>
         <p className="fm-success-desc">Share this four-word code with whoever you want to take the other side.</p>
 
         <div className="oc-code-display">
           <code className="oc-code">{result.code}</code>
-          <button type="button" className="fm-btn-secondary" onClick={handleCopy}>{copied ? 'Copied ✓' : 'Copy'}</button>
+          <button
+            type="button"
+            className="oc-copy-btn"
+            onClick={handleCopy}
+            title={copied ? 'Copied' : 'Copy code'}
+            aria-label={copied ? 'Copied' : 'Copy code'}
+          >
+            {copied ? <CheckIcon /> : <CopyIcon />}
+          </button>
         </div>
 
         <div className="oc-qr">
@@ -184,12 +204,16 @@ function MakerPanel({ onClose }) {
           don't store it server-side. Anyone with the code can take the other side.
         </div>
 
-        {/* Encrypted backup (recovery) — stored only on this device, readable only with this wallet. */}
+        {/* Encrypted backup (recovery) — saved automatically, stored only on this device, readable only with this wallet. */}
         <div className="oc-backup">
           {backupState === 'saved' ? (
             <p className="oc-backup-ok" role="status">
               <span aria-hidden="true">&#128274;</span> Encrypted backup saved to this device. Recover it
               anytime from the <strong>Recover codes</strong> tab with this wallet.
+            </p>
+          ) : backupState === 'saving' ? (
+            <p className="oc-backup-ok" role="status">
+              <span aria-hidden="true">&#128274;</span> Saving an encrypted backup to this device…
             </p>
           ) : (
             <>
@@ -197,9 +221,9 @@ function MakerPanel({ onClose }) {
                 type="button"
                 className="fm-btn-secondary"
                 onClick={handleSaveBackup}
-                disabled={!canBackup || backupState === 'saving'}
+                disabled={!canBackup}
               >
-                {backupState === 'saving' ? 'Saving…' : 'Save encrypted backup to this device'}
+                Save encrypted backup to this device
               </button>
               <span className="fm-hint">
                 {canBackup
@@ -242,8 +266,23 @@ function MakerPanel({ onClose }) {
       </div>
 
       <div className="fm-form-group fm-form-full">
-        <label htmlFor="oc-stake">Stake — each side (USDC) <span className="fm-required">*</span></label>
-        <input id="oc-stake" type="number" min="0" step="0.01" value={stake} onChange={(e) => setStake(e.target.value)} disabled={busy} />
+        <label htmlFor="oc-stake">Stake — each side <span className="fm-required">*</span></label>
+        <div className="fm-stake-input-wrapper">
+          <span className="fm-stake-prefix">$</span>
+          <input
+            id="oc-stake" type="number" inputMode="decimal" min="0" step="0.01"
+            placeholder="10.00" className="fm-stake-usd"
+            value={stake}
+            onChange={(e) => setStake(e.target.value)}
+            onBlur={() => {
+              const n = Number(stake)
+              if (stake !== '' && Number.isFinite(n) && n > 0) setStake(n.toFixed(2))
+            }}
+            disabled={busy}
+          />
+          <span className="fm-stake-suffix">USDC</span>
+        </div>
+        <span className="fm-hint">Enter the amount in USD — both sides stake this much in USDC.</span>
       </div>
 
       <div className="fm-form-group fm-form-full">
@@ -266,25 +305,15 @@ function MakerPanel({ onClose }) {
         />
       )}
 
-      {/* Time constraints (feature 024 feedback): make the deadlines explicit and editable. */}
-      <div className="fm-form-group">
-        <label htmlFor="oc-accept-by">Open for acceptance until <span className="fm-required">*</span></label>
-        <input
-          id="oc-accept-by" type="datetime-local" className="oc-datetime"
-          value={acceptBy} min={toDatetimeLocal(Date.now())}
-          onChange={(e) => setAcceptBy(e.target.value)} disabled={busy}
-        />
-        <span className="fm-hint">After this, the challenge can no longer be taken and your stake is refundable.</span>
-      </div>
-      <div className="fm-form-group">
-        <label htmlFor="oc-resolve-by">Must be resolved by <span className="fm-required">*</span></label>
-        <input
-          id="oc-resolve-by" type="datetime-local" className="oc-datetime"
-          value={resolveBy} min={acceptBy || toDatetimeLocal(Date.now())}
-          onChange={(e) => setResolveBy(e.target.value)} disabled={busy}
-        />
-        <span className="fm-hint">The outcome must be submitted before this time.</span>
-      </div>
+      {/* Time constraints (testing feedback): the 1v1-wager timeline element — slide to pick each
+          time, or tap a tile to type the exact date & time. */}
+      <DeadlineTimeline
+        acceptBy={acceptBy}
+        resolveBy={resolveBy}
+        onAcceptChange={setAcceptBy}
+        onResolveChange={setResolveBy}
+        disabled={busy}
+      />
       {!deadlinesValid && (acceptBy || resolveBy) && (
         <p className="fm-hint oc-deadline-warn" role="alert">
           Pick an acceptance time in the future and a resolve time after it.
@@ -300,6 +329,159 @@ function MakerPanel({ onClose }) {
         </button>
       </div>
     </form>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Deadline timeline — reuses the 1v1 create-wager timeline element (track +
+// stat tiles, shared fm-* styles) for the open challenge's two deadlines.
+// Each deadline has a slider for coarse picking; tapping its stat tile opens
+// a datetime-local input for exact manual entry (testing feedback).
+// ---------------------------------------------------------------------------
+const HOUR_MS = 3600 * 1000
+const ACCEPT_MAX_HOURS = 30 * 24    // contract MAX_ACCEPT_WINDOW (30 days)
+const RESOLVE_MAX_HOURS = 90 * 24   // slider cap — comfortably under the contract's 180-day resolve window
+const DEFAULT_RESOLVE_GAP_MS = 7 * 24 * HOUR_MS
+
+function DeadlineTimeline({ acceptBy, resolveBy, onAcceptChange, onResolveChange, disabled }) {
+  const [manualFor, setManualFor] = useState(null) // null | 'accept' | 'resolve'
+  // Mount-time "now" anchors the slider scale so positions don't drift while the form is open.
+  const [nowMs] = useState(() => Date.now())
+  const acceptMs = acceptBy ? new Date(acceptBy).getTime() : NaN
+  const resolveMs = resolveBy ? new Date(resolveBy).getTime() : NaN
+  const acceptValid = Number.isFinite(acceptMs)
+  const resolveValid = Number.isFinite(resolveMs)
+
+  const clampHours = (h, max) => Math.min(max, Math.max(1, h))
+  const acceptHours = acceptValid ? clampHours(Math.round((acceptMs - nowMs) / HOUR_MS), ACCEPT_MAX_HOURS) : 48
+  const resolveHours = acceptValid && resolveValid
+    ? clampHours(Math.round((resolveMs - acceptMs) / HOUR_MS), RESOLVE_MAX_HOURS)
+    : 7 * 24
+
+  const handleAcceptSlide = (e) => {
+    const nextAccept = nowMs + Number(e.target.value) * HOUR_MS
+    // Sliding the acceptance point drags the resolve point with it (constant gap) so the
+    // timeline can never be slid into an accept-after-resolve state.
+    const gap = acceptValid && resolveValid && resolveMs > acceptMs ? resolveMs - acceptMs : DEFAULT_RESOLVE_GAP_MS
+    onAcceptChange(toDatetimeLocal(nextAccept))
+    onResolveChange(toDatetimeLocal(nextAccept + gap))
+  }
+
+  const handleResolveSlide = (e) => {
+    const base = acceptValid ? acceptMs : nowMs + 48 * HOUR_MS
+    onResolveChange(toDatetimeLocal(base + Number(e.target.value) * HOUR_MS))
+  }
+
+  const describe = (ms) => Number.isFinite(ms)
+    ? `${formatTileClock(new Date(ms))} · ${formatTileDay(new Date(ms))}`
+    : '—'
+
+  // Track percentages over the full now → resolve span (amber = open for acceptance,
+  // green = active wager window) — same visual grammar as the 1v1 timeline.
+  const span = Math.max(1, (resolveValid ? resolveMs : nowMs + 1) - nowMs)
+  const acceptPct = acceptValid ? Math.max(0, Math.min(100, ((acceptMs - nowMs) / span) * 100)) : 0
+  const trackStyle = {
+    background: `linear-gradient(to right,` +
+      ` var(--fm-accept) 0%, var(--fm-accept) ${acceptPct}%,` +
+      ` var(--fm-active) ${acceptPct}%, var(--fm-active) 100%)`
+  }
+
+  const toggleManual = (which) => setManualFor((cur) => (cur === which ? null : which))
+
+  return (
+    <div className="fm-form-group fm-form-full fm-endtime oc-timeline">
+      <div className="oc-deadline-slider">
+        <div className="fm-input-header">
+          <label htmlFor="oc-accept-slider">Open for acceptance until <span className="fm-required">*</span></label>
+          <span className="fm-odds-value">{describe(acceptMs)}</span>
+        </div>
+        <input
+          id="oc-accept-slider" type="range" className="fm-odds-slider"
+          min={1} max={ACCEPT_MAX_HOURS} step={1}
+          value={acceptHours} onChange={handleAcceptSlide} disabled={disabled}
+          aria-valuetext={describe(acceptMs)}
+        />
+        <span className="fm-hint">After this, the challenge can no longer be taken and your stake is refundable.</span>
+      </div>
+
+      <div className="oc-deadline-slider">
+        <div className="fm-input-header">
+          <label htmlFor="oc-resolve-slider">Must be resolved by <span className="fm-required">*</span></label>
+          <span className="fm-odds-value">{describe(resolveMs)}</span>
+        </div>
+        <input
+          id="oc-resolve-slider" type="range" className="fm-odds-slider"
+          min={1} max={RESOLVE_MAX_HOURS} step={1}
+          value={resolveHours} onChange={handleResolveSlide} disabled={disabled}
+          aria-valuetext={describe(resolveMs)}
+        />
+        <span className="fm-hint">The outcome must be submitted before this time.</span>
+      </div>
+
+      {acceptValid && resolveValid && (
+        <>
+          <span className="fm-endtime-summary">
+            Open {formatTimelineSpan(new Date(nowMs), new Date(acceptMs))} for a taker · then up
+            to {formatTimelineSpan(new Date(acceptMs), new Date(resolveMs))} to settle
+          </span>
+
+          <div className="fm-timeline-track" style={trackStyle} aria-hidden="true">
+            <span className="fm-timeline-node is-accept" style={{ left: `${acceptPct}%` }} />
+            <span className="fm-timeline-node is-resolve" style={{ left: '100%' }} />
+          </div>
+        </>
+      )}
+
+      <div className="fm-stat-tiles oc-stat-tiles">
+        <button
+          type="button"
+          className="fm-stat-tile is-accept oc-stat-tile-btn"
+          onClick={() => toggleManual('accept')}
+          disabled={disabled}
+          aria-expanded={manualFor === 'accept'}
+          aria-controls={manualFor === 'accept' ? 'oc-accept-by' : undefined}
+        >
+          <span className="fm-stat-head"><span className="fm-stat-dot" aria-hidden="true" />Open until</span>
+          <span className="fm-stat-time">{acceptValid ? formatTileClock(new Date(acceptMs)) : '—'}</span>
+          <span className="fm-stat-day">{acceptValid ? formatTileDay(new Date(acceptMs)) : ''}</span>
+          <span className="oc-tile-edit">Tap to type a date</span>
+        </button>
+        <button
+          type="button"
+          className="fm-stat-tile is-resolve oc-stat-tile-btn"
+          onClick={() => toggleManual('resolve')}
+          disabled={disabled}
+          aria-expanded={manualFor === 'resolve'}
+          aria-controls={manualFor === 'resolve' ? 'oc-resolve-by' : undefined}
+        >
+          <span className="fm-stat-head"><span className="fm-stat-dot" aria-hidden="true" />Resolve by</span>
+          <span className="fm-stat-time">{resolveValid ? formatTileClock(new Date(resolveMs)) : '—'}</span>
+          <span className="fm-stat-day">{resolveValid ? formatTileDay(new Date(resolveMs)) : ''}</span>
+          <span className="oc-tile-edit">Tap to type a date</span>
+        </button>
+      </div>
+
+      {manualFor === 'accept' && (
+        <div className="oc-manual-entry">
+          <label htmlFor="oc-accept-by">Exact date &amp; time — open for acceptance until</label>
+          <input
+            id="oc-accept-by" type="datetime-local" className="oc-datetime fm-datetime-input"
+            value={acceptBy} min={toDatetimeLocal(nowMs)}
+            onChange={(e) => onAcceptChange(e.target.value)} disabled={disabled}
+          />
+        </div>
+      )}
+      {manualFor === 'resolve' && (
+        <div className="oc-manual-entry">
+          <label htmlFor="oc-resolve-by">Exact date &amp; time — must be resolved by</label>
+          <input
+            id="oc-resolve-by" type="datetime-local" className="oc-datetime fm-datetime-input"
+            value={resolveBy} min={acceptBy || toDatetimeLocal(nowMs)}
+            onChange={(e) => onResolveChange(e.target.value)} disabled={disabled}
+          />
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/frontend/src/components/fairwins/__tests__/OpenChallengeModal.norecover.test.jsx
+++ b/frontend/src/components/fairwins/__tests__/OpenChallengeModal.norecover.test.jsx
@@ -10,9 +10,10 @@ vi.mock('../../../hooks/useOpenChallengeCreate', async (importOriginal) => {
 import OpenChallengeModal from '../OpenChallengeModal'
 
 describe('OpenChallengeModal — create-only after spec 037 (recovery + taking relocated)', () => {
-  it('shows only the Create tab — no "Take a challenge" or "Recover codes" tabs', () => {
+  it('shows no tabs at all — the lone "Create a challenge" pill was removed (testing feedback)', () => {
     render(<OpenChallengeModal isOpen onClose={() => {}} />)
-    expect(screen.getByRole('tab', { name: /create a challenge/i })).toBeInTheDocument()
+    expect(screen.queryByRole('tablist')).toBeNull()
+    expect(screen.queryAllByRole('tab')).toHaveLength(0)
     expect(screen.queryByRole('tab', { name: /take a challenge/i })).toBeNull()
     expect(screen.queryByRole('tab', { name: /recover codes/i })).toBeNull()
   })

--- a/frontend/src/components/fairwins/wagerTimeline.js
+++ b/frontend/src/components/fairwins/wagerTimeline.js
@@ -1,0 +1,26 @@
+// ── Wager timeline formatters (compact-chips redesign) ──────────────
+// Shared by the 1v1 create-wager end-date timeline (FriendMarketsModal) and the
+// open-challenge deadline timeline (OpenChallengeModal). Each stat tile shows a
+// short clock + day so the timeline reads at a glance without a tall stack of
+// labelled read-only rows.
+
+/** "2:05 PM" — short local clock for a stat tile. */
+export const formatTileClock = (date) =>
+  date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+
+/** "Jun 17" — short local month + day for a stat tile. */
+export const formatTileDay = (date) =>
+  date.toLocaleDateString([], { month: 'short', day: 'numeric' })
+
+/**
+ * Human duration between two dates as "1 day 0h" / "3h" — used for the
+ * "lasts …" summary so the wager length is legible before committing.
+ */
+export const formatTimelineSpan = (from, to) => {
+  let minutes = Math.max(0, Math.round((to.getTime() - from.getTime()) / 60000))
+  const days = Math.floor(minutes / 1440)
+  minutes -= days * 1440
+  const hours = Math.floor(minutes / 60)
+  if (days > 0) return `${days} day${days > 1 ? 's' : ''} ${hours}h`
+  return `${hours}h`
+}

--- a/frontend/src/test/accessibility.test.jsx
+++ b/frontend/src/test/accessibility.test.jsx
@@ -245,13 +245,13 @@ describe('OpenChallengeModal Accessibility (feature 024, WCAG 2.1 AA)', () => {
   beforeEach(() => { createOpenChallenge.mockReset(); discover.mockReset(); accept.mockReset() })
 
   it('has no axe violations on the create modal', async () => {
-    const { container } = render(<OpenChallengeModal isOpen onClose={() => {}} initialTab="maker" />)
+    const { container } = render(<OpenChallengeModal isOpen onClose={() => {}} />)
     const results = await axe(container)
     expect(results).toHaveNoViolations()
   })
 
   it('the residual-risk / save-your-code notice is conveyed as TEXT, not color alone', () => {
-    render(<OpenChallengeModal isOpen onClose={() => {}} initialTab="maker" />)
+    render(<OpenChallengeModal isOpen onClose={() => {}} />)
     // Create form residual-risk disclosure: text is present (not color-only signaling).
     expect(
       screen.getByText(/anyone you share the code with can take the other side/i)

--- a/frontend/src/test/claimCode/OpenChallengeCodeBackup.test.jsx
+++ b/frontend/src/test/claimCode/OpenChallengeCodeBackup.test.jsx
@@ -32,7 +32,7 @@ function withWallet(ui) {
 describe('OpenChallengeModal — encrypted code backup & recovery (feature 024)', () => {
   beforeEach(() => { createOpenChallenge.mockReset(); localStorage.clear() })
 
-  it('saves an encrypted backup after creating, then recovers it from the Security panel (spec 037, FR-022)', async () => {
+  it('auto-saves an encrypted backup after creating (no interaction), then recovers it from the Security panel (spec 037, FR-022)', async () => {
     createOpenChallenge.mockResolvedValue({ code: 'river tiger kite zoo', wagerId: 12n, txHash: '0xabc' })
     const { unmount } = withWallet(<OpenChallengeModal isOpen onClose={() => {}} />)
 
@@ -41,8 +41,7 @@ describe('OpenChallengeModal — encrypted code backup & recovery (feature 024)'
     fireEvent.click(screen.getByRole('button', { name: /create & generate code/i }))
     await screen.findByText('river tiger kite zoo')
 
-    // Save the encrypted backup (MakerPanel — unchanged by the relocation).
-    fireEvent.click(screen.getByRole('button', { name: /save encrypted backup/i }))
+    // The encrypted backup saves automatically — no button press (testing feedback).
     expect(await screen.findByText(/encrypted backup saved/i)).toBeInTheDocument()
 
     // Nothing recoverable is stored in cleartext.

--- a/frontend/src/test/claimCode/OpenChallengeModal.test.jsx
+++ b/frontend/src/test/claimCode/OpenChallengeModal.test.jsx
@@ -19,11 +19,10 @@ describe('OpenChallengeModal (create-only; taking moved to the unified lookup, s
     expect(container.firstChild).toBeNull()
   })
 
-  it('is create-only — the Create tab is shown and there are no Take/Recover tabs', () => {
+  it('is create-only — no mode tabs/pills at all, just the create form (testing feedback)', () => {
     render(<OpenChallengeModal isOpen onClose={() => {}} />)
-    expect(screen.getByRole('tab', { name: /create a challenge/i })).toHaveAttribute('aria-selected', 'true')
-    expect(screen.queryByRole('tab', { name: /take a challenge/i })).toBeNull()
-    expect(screen.queryByRole('tab', { name: /recover codes/i })).toBeNull()
+    expect(screen.queryAllByRole('tab')).toHaveLength(0)
+    expect(screen.queryByRole('tablist')).toBeNull()
     expect(screen.getByLabelText(/what's the wager/i)).toBeInTheDocument()
   })
 
@@ -41,6 +40,11 @@ describe('OpenChallengeModal (create-only; taking moved to the unified lookup, s
     // A scannable QR (deep link into the unified take flow) is shown alongside the code.
     expect(screen.getByText(/scan to take/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/QR code to take this challenge/i)).toBeInTheDocument()
+    // Testing feedback: the created view hides the wager id and copies via an icon button.
+    expect(screen.queryByText(/#9/)).toBeNull()
+    const copyBtn = screen.getByRole('button', { name: /copy code/i })
+    expect(copyBtn).toBeInTheDocument()
+    expect(copyBtn).not.toHaveTextContent(/copy/i) // icon-only — the name comes from aria-label
   })
 
   it('Maker: passes the chosen accept/resolve deadlines (seconds) to createOpenChallenge', async () => {
@@ -56,14 +60,45 @@ describe('OpenChallengeModal (create-only; taking moved to the unified lookup, s
     expect(form.acceptDeadline).toBeGreaterThan(Math.floor(Date.now() / 1000))
   })
 
+  it('Maker: deadlines use the timeline element — sliders plus tap-to-type manual entry', () => {
+    render(<OpenChallengeModal isOpen onClose={() => {}} />)
+    // Slide the acceptance deadline out to 72h — the resolve deadline keeps its gap.
+    const acceptSlider = screen.getByLabelText(/open for acceptance until/i)
+    const resolveSlider = screen.getByLabelText(/must be resolved by/i)
+    expect(acceptSlider).toHaveAttribute('type', 'range')
+    expect(resolveSlider).toHaveAttribute('type', 'range')
+    fireEvent.change(acceptSlider, { target: { value: '72' } })
+    expect(Number(acceptSlider.value)).toBe(72)
+    expect(Number(resolveSlider.value)).toBe(7 * 24)
+
+    // No manual input until a tile is tapped.
+    expect(screen.queryByLabelText(/exact date & time/i)).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: /resolve by/i }))
+    expect(screen.getByLabelText(/exact date & time/i)).toBeInTheDocument()
+  })
+
   it('Maker: disables create when the resolve time is not after the accept time', () => {
     render(<OpenChallengeModal isOpen onClose={() => {}} />)
     fireEvent.change(screen.getByLabelText(/what's the wager/i), { target: { value: 'Will it rain?' } })
     const createBtn = screen.getByRole('button', { name: /create & generate code/i })
     expect(createBtn).toBeEnabled()
-    fireEvent.change(screen.getByLabelText(/must be resolved by/i), { target: { value: '2000-01-01T00:00' } })
+    // Tap the Resolve-by tile to type an exact (past) time manually.
+    fireEvent.click(screen.getByRole('button', { name: /resolve by/i }))
+    fireEvent.change(screen.getByLabelText(/exact date & time/i), { target: { value: '2000-01-01T00:00' } })
     expect(createBtn).toBeDisabled()
     expect(screen.getByRole('alert')).toHaveTextContent(/future/i)
+  })
+
+  it('Maker: the USDC stake entry is formatted as money ($ prefix, 2-decimal blur)', () => {
+    render(<OpenChallengeModal isOpen onClose={() => {}} />)
+    const stake = screen.getByLabelText(/stake — each side/i)
+    expect(stake).toHaveValue(10) // default 10.00
+    fireEvent.change(stake, { target: { value: '12.5' } })
+    fireEvent.blur(stake)
+    expect(stake.value).toBe('12.50')
+    // Money chrome around the input.
+    expect(screen.getByText('$')).toBeInTheDocument()
+    expect(screen.getByText('USDC')).toBeInTheDocument()
   })
 
   it('deep-link helpers round-trip the code through a take URL', () => {


### PR DESCRIPTION
Implements the testing-feedback patches for the open challenges create/created screens.

## Create a challenge screen

- **Deadlines reuse the 1v1 wager timeline element.** "Open for acceptance until" and "Must be resolved by" are now a slider each (1h–30d for acceptance, matching the contract's `MAX_ACCEPT_WINDOW`; up to 90d after acceptance for resolution) rendered over the shared `fm-endtime` accent track + stat tiles, and tapping a tile opens a `datetime-local` input for exact manual entry. Sliding the acceptance point drags the resolve point with it (constant gap) so the timeline can't be slid into an accept-after-resolve state. The tile/duration formatters were extracted from `FriendMarketsModal.jsx` into `wagerTimeline.js` so both modals share them.
- **Removed the "Create a challenge" tab/pill.** The modal has been create-only since spec 037, so the lone tab was noise; the dead `initialTab` wiring in `Dashboard.jsx` is gone too.
- **USDC entry formatted as money.** The stake input now uses the shared `fm-stake-input-wrapper` chrome ($ prefix, USDC suffix) and formats to two decimals on blur (`12.5` → `12.50`), defaulting to `10.00`.

## Challenge created screen

- **Tab/pill removed** (same header change as above — the success view renders in the same panel).
- **Wager id hidden** — the heading is just "Open challenge created", no `(#12)`.
- **Copy is an icon button** — clipboard icon that flips to a check while "copied", with `aria-label`/`title` for accessibility.
- **Share words save locally without user interaction** — the encrypted device backup (code vault) is written automatically as soon as the challenge is created. The one remaining prompt is the wallet's vault-unlock signature (first save per session); if it can't complete (no wallet, signature declined), the manual "Save encrypted backup" button remains as the fallback. The backup stays encrypted — nothing recoverable lands in cleartext localStorage.

## Testing

- Updated `OpenChallengeModal.test.jsx` (no tabs, slider + tap-to-type deadline flow, money formatting, icon copy button, hidden wager id), `OpenChallengeCodeBackup.test.jsx` (auto-save without a button press), `OpenChallengeModal.norecover.test.jsx`, and the axe accessibility suite — all green (`npx vitest run` on the affected suites: 109 passed).
- Full frontend suite: only the pre-existing `AddressBookPanel.test.jsx` failures remain (reproduced on the base commit, unrelated).
- Verified live in the running app (Vite demo mode + Chromium): no tab pill, `$ 12.5 → 12.50` blur formatting, sliders drive the amber/green track and tiles, tapping a tile opens exact entry, a manually-typed past date disables Create with the warning, and sliding fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011g7w24HgQLZ3kvvsy6j9E1

---
_Generated by [Claude Code](https://claude.ai/code/session_011g7w24HgQLZ3kvvsy6j9E1)_