### PR TITLE
fix(ci): register Semaphore viaIR:false override so contract compile stops timing out

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -244,14 +244,23 @@ const etherscanConfig = BLOCKSCOUT_VERIFY_NETWORKS.has(verifyTargetNetwork())
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
   solidity: {
-    version: "0.8.24",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 1,  // Optimize for deployment size over runtime gas
+    // NOTE: use the multi-compiler shape (`compilers: [...]` + `overrides`), NOT the
+    // shorthand `{ version, settings, overrides }`. Hardhat treats any solidity config
+    // object that has a top-level `version` key as a single SolcUserConfig and SILENTLY
+    // DROPS a sibling `overrides` field — so the shorthand form compiles the Semaphore
+    // closure below under viaIR:true, which OOM-thrashes the compiler past CI's timeout.
+    compilers: [
+      {
+        version: "0.8.24",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 1,  // Optimize for deployment size over runtime gas
+          },
+          viaIR: true,
+        },
       },
-      viaIR: true,
-    },
+    ],
     // Compile the vendored Semaphore V4 self-deploy closure (spec 034, ETC/Mordor) WITHOUT viaIR.
     // PoseidonT3 (auto-generated assembly) and SemaphoreVerifier (bn128 pairing assembly) are
     // hand-optimized for legacy codegen; the Yul IR pipeline balloons their compile to ~13 GB RSS


### PR DESCRIPTION
## Summary

CI has been red across the last several PRs. Every failing workflow — **Test Pipeline**, **Security Testing & Analysis** (Slither / Coverage / Unit Tests & Gas), and **CI Manager – Smart Test Selection** — dies at the same step: `hardhat compile` hangs and is killed by CI's `timeout 1200` (exit 124), which then fails all downstream contract jobs.

## Root cause

`hardhat.config.js` declared the compiler using the shorthand shape:

```js
solidity: { version: "0.8.24", settings: {…, viaIR: true}, overrides: {…} }
```

Hardhat treats any `solidity` config object that has a top-level `version` key as a **single `SolcUserConfig`** and **silently drops a sibling `overrides` field**. `overrides` is only read in the multi-compiler shape (`{ compilers: [...], overrides: {...} }`).

So the per-file `viaIR:false` overrides added for the vendored Semaphore V4 / PoseidonT3 self-deploy closure (spec 034, `contracts/pools/SemaphoreDeploy.sol`) **never applied**. The closure compiled under `viaIR:true`, where its auto-generated Poseidon assembly and bn128 pairing verifier balloon `solc` past ~10 GB RSS and OOM-thrash — pushing `hardhat compile` past the 1200s budget.

This regressed exactly at the **ZK-Wager Pools merge (#776)** — the first commit to introduce the closure and these overrides. Last green contract run was the commit immediately before it.

## Fix

Switch the `solidity` block to the multi-compiler shape `{ compilers: [{ version, settings }], overrides }` so the overrides register. No change to the actual optimizer/viaIR settings — only the config shape.

## Verification

Reproduced and verified against the pinned toolchain (`solc 0.8.24` + `hardhat 2.28.4`) in an isolated project with the Semaphore closure:

- **Before (shorthand):** resolved `solidity.overrides` = `[]`; every compilation job resolves to `viaIR=true`; `solc` RSS climbs unbounded (>5 GB and rising) → timeout. This reproduces the CI hang.
- **After (`compilers: [...]` + `overrides`):** overrides register; `SemaphoreDeploy.sol` + closure land in `viaIR=false` jobs; full closure compiles in **~5s**.

Inspected via Hardhat's own `GET_COMPILATION_JOBS` task and the resolved `hre.config.solidity`.

The app contracts continue to compile under `viaIR:true` unchanged; only the isolated Semaphore self-deploy closure moves to `viaIR:false`, which is its intended (and documented) codegen path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016aiWFDtggfWoaCYZeC7PQy)_