### PR TITLE
Group pool UX: create-flow punchlist + always-auto identity on the manager page (spec 034)

### DIFF
--- a/frontend/src/components/fairwins/Dashboard.jsx
+++ b/frontend/src/components/fairwins/Dashboard.jsx
@@ -497,7 +497,6 @@ function Dashboard() {
   const [showCreateWager, setShowCreateWager] = useState(false)
   const [showOpenChallenge, setShowOpenChallenge] = useState(false)
   const [showGroupPool, setShowGroupPool] = useState(false)
-  const [groupPoolTab, setGroupPoolTab] = useState('create')
   // Unified phrase lookup (spec 037): one entry point for taking a challenge or joining a pool.
   const [showUnifiedLookup, setShowUnifiedLookup] = useState(false)
   const [unifiedInitialPhrase, setUnifiedInitialPhrase] = useState('')
@@ -572,7 +571,6 @@ function Dashboard() {
         setShowOpenChallenge(true)
         break
       case 'create-pool':
-        setGroupPoolTab('create')
         setShowGroupPool(true)
         break
       case 'enter-phrase':
@@ -747,11 +745,11 @@ function Dashboard() {
         }}
       />
 
-      {/* Group Pool (spec 034) — one modal, Create/Join tabs, matching the wager bottom-sheet UX. */}
+      {/* Group Pool (spec 034) — create-only modal matching the wager bottom-sheet UX;
+          joining lives in the unified phrase lookup (spec 037). */}
       <GroupPoolModal
         key={showGroupPool ? 'gp-open' : 'gp-closed'}
         isOpen={showGroupPool}
-        initialTab={groupPoolTab}
         onClose={() => setShowGroupPool(false)}
       />
 

--- a/frontend/src/components/fairwins/DeadlineTimeline.jsx
+++ b/frontend/src/components/fairwins/DeadlineTimeline.jsx
@@ -1,0 +1,180 @@
+import { useState } from 'react'
+import { formatTileClock, formatTileDay, formatTimelineSpan, toDatetimeLocal } from './wagerTimeline'
+import './FriendMarketsModal.css'
+import './OpenChallengeModal.css'
+
+/**
+ * DeadlineTimeline — the two-deadline timeline element shared by the wager create flows (open
+ * challenge, group pool). Extracted from OpenChallengeModal (feature 024) so group pools present
+ * their join/resolution windows the same way (pool-manager tester feedback): each deadline has a
+ * slider for coarse picking, and tapping its stat tile opens a datetime-local input for exact
+ * manual entry. All labels default to the open-challenge wording; callers rename them per surface.
+ *
+ * Both deadlines are controlled <input type="datetime-local"> string values. Sliding the first
+ * deadline drags the second with it (constant gap) so the timeline can never be slid into a
+ * first-after-second state.
+ */
+const HOUR_MS = 3600 * 1000
+const DEFAULT_ACCEPT_MAX_HOURS = 30 * 24  // open-challenge contract MAX_ACCEPT_WINDOW (30 days)
+const DEFAULT_RESOLVE_MAX_HOURS = 90 * 24 // slider cap — comfortably under the 180-day resolve window
+const DEFAULT_RESOLVE_GAP_MS = 7 * 24 * HOUR_MS
+
+export default function DeadlineTimeline({
+  acceptBy,
+  resolveBy,
+  onAcceptChange,
+  onResolveChange,
+  disabled,
+  idPrefix = 'oc',
+  acceptLabel = 'Open for acceptance until',
+  acceptHint = 'After this, the challenge can no longer be taken and your stake is refundable.',
+  acceptTileHead = 'Open until',
+  resolveLabel = 'Must be resolved by',
+  resolveHint = 'The outcome must be submitted before this time.',
+  resolveTileHead = 'Resolve by',
+  acceptMaxHours = DEFAULT_ACCEPT_MAX_HOURS,
+  resolveMaxHours = DEFAULT_RESOLVE_MAX_HOURS,
+  summary = (openSpan, settleSpan) => `Open ${openSpan} for a taker · then up to ${settleSpan} to settle`,
+}) {
+  const [manualFor, setManualFor] = useState(null) // null | 'accept' | 'resolve'
+  // Mount-time "now" anchors the slider scale so positions don't drift while the form is open.
+  const [nowMs] = useState(() => Date.now())
+  const acceptMs = acceptBy ? new Date(acceptBy).getTime() : NaN
+  const resolveMs = resolveBy ? new Date(resolveBy).getTime() : NaN
+  const acceptValid = Number.isFinite(acceptMs)
+  const resolveValid = Number.isFinite(resolveMs)
+
+  const clampHours = (h, max) => Math.min(max, Math.max(1, h))
+  const acceptHours = acceptValid ? clampHours(Math.round((acceptMs - nowMs) / HOUR_MS), acceptMaxHours) : 48
+  const resolveHours = acceptValid && resolveValid
+    ? clampHours(Math.round((resolveMs - acceptMs) / HOUR_MS), resolveMaxHours)
+    : 7 * 24
+
+  const handleAcceptSlide = (e) => {
+    const nextAccept = nowMs + Number(e.target.value) * HOUR_MS
+    // Sliding the acceptance point drags the resolve point with it (constant gap) so the
+    // timeline can never be slid into an accept-after-resolve state.
+    const gap = acceptValid && resolveValid && resolveMs > acceptMs ? resolveMs - acceptMs : DEFAULT_RESOLVE_GAP_MS
+    onAcceptChange(toDatetimeLocal(nextAccept))
+    onResolveChange(toDatetimeLocal(nextAccept + gap))
+  }
+
+  const handleResolveSlide = (e) => {
+    const base = acceptValid ? acceptMs : nowMs + 48 * HOUR_MS
+    onResolveChange(toDatetimeLocal(base + Number(e.target.value) * HOUR_MS))
+  }
+
+  const describe = (ms) => Number.isFinite(ms)
+    ? `${formatTileClock(new Date(ms))} · ${formatTileDay(new Date(ms))}`
+    : '—'
+
+  // Track percentages over the full now → resolve span (amber = open for acceptance,
+  // green = active wager window) — same visual grammar as the 1v1 timeline.
+  const span = Math.max(1, (resolveValid ? resolveMs : nowMs + 1) - nowMs)
+  const acceptPct = acceptValid ? Math.max(0, Math.min(100, ((acceptMs - nowMs) / span) * 100)) : 0
+  const trackStyle = {
+    background: `linear-gradient(to right,` +
+      ` var(--fm-accept) 0%, var(--fm-accept) ${acceptPct}%,` +
+      ` var(--fm-active) ${acceptPct}%, var(--fm-active) 100%)`
+  }
+
+  const toggleManual = (which) => setManualFor((cur) => (cur === which ? null : which))
+
+  return (
+    <div className="fm-form-group fm-form-full fm-endtime oc-timeline">
+      <div className="oc-deadline-slider">
+        <div className="fm-input-header">
+          <label htmlFor={`${idPrefix}-accept-slider`}>{acceptLabel} <span className="fm-required">*</span></label>
+          <span className="fm-odds-value">{describe(acceptMs)}</span>
+        </div>
+        <input
+          id={`${idPrefix}-accept-slider`} type="range" className="fm-odds-slider"
+          min={1} max={acceptMaxHours} step={1}
+          value={acceptHours} onChange={handleAcceptSlide} disabled={disabled}
+          aria-valuetext={describe(acceptMs)}
+        />
+        <span className="fm-hint">{acceptHint}</span>
+      </div>
+
+      <div className="oc-deadline-slider">
+        <div className="fm-input-header">
+          <label htmlFor={`${idPrefix}-resolve-slider`}>{resolveLabel} <span className="fm-required">*</span></label>
+          <span className="fm-odds-value">{describe(resolveMs)}</span>
+        </div>
+        <input
+          id={`${idPrefix}-resolve-slider`} type="range" className="fm-odds-slider"
+          min={1} max={resolveMaxHours} step={1}
+          value={resolveHours} onChange={handleResolveSlide} disabled={disabled}
+          aria-valuetext={describe(resolveMs)}
+        />
+        <span className="fm-hint">{resolveHint}</span>
+      </div>
+
+      {acceptValid && resolveValid && (
+        <>
+          <span className="fm-endtime-summary">
+            {summary(
+              formatTimelineSpan(new Date(nowMs), new Date(acceptMs)),
+              formatTimelineSpan(new Date(acceptMs), new Date(resolveMs))
+            )}
+          </span>
+
+          <div className="fm-timeline-track" style={trackStyle} aria-hidden="true">
+            <span className="fm-timeline-node is-accept" style={{ left: `${acceptPct}%` }} />
+            <span className="fm-timeline-node is-resolve" style={{ left: '100%' }} />
+          </div>
+        </>
+      )}
+
+      <div className="fm-stat-tiles oc-stat-tiles">
+        <button
+          type="button"
+          className="fm-stat-tile is-accept oc-stat-tile-btn"
+          onClick={() => toggleManual('accept')}
+          disabled={disabled}
+          aria-expanded={manualFor === 'accept'}
+          aria-controls={manualFor === 'accept' ? `${idPrefix}-accept-by` : undefined}
+        >
+          <span className="fm-stat-head"><span className="fm-stat-dot" aria-hidden="true" />{acceptTileHead}</span>
+          <span className="fm-stat-time">{acceptValid ? formatTileClock(new Date(acceptMs)) : '—'}</span>
+          <span className="fm-stat-day">{acceptValid ? formatTileDay(new Date(acceptMs)) : ''}</span>
+          <span className="oc-tile-edit">Tap to type a date</span>
+        </button>
+        <button
+          type="button"
+          className="fm-stat-tile is-resolve oc-stat-tile-btn"
+          onClick={() => toggleManual('resolve')}
+          disabled={disabled}
+          aria-expanded={manualFor === 'resolve'}
+          aria-controls={manualFor === 'resolve' ? `${idPrefix}-resolve-by` : undefined}
+        >
+          <span className="fm-stat-head"><span className="fm-stat-dot" aria-hidden="true" />{resolveTileHead}</span>
+          <span className="fm-stat-time">{resolveValid ? formatTileClock(new Date(resolveMs)) : '—'}</span>
+          <span className="fm-stat-day">{resolveValid ? formatTileDay(new Date(resolveMs)) : ''}</span>
+          <span className="oc-tile-edit">Tap to type a date</span>
+        </button>
+      </div>
+
+      {manualFor === 'accept' && (
+        <div className="oc-manual-entry">
+          <label htmlFor={`${idPrefix}-accept-by`}>Exact date &amp; time — {acceptLabel.toLowerCase()}</label>
+          <input
+            id={`${idPrefix}-accept-by`} type="datetime-local" className="oc-datetime fm-datetime-input"
+            value={acceptBy} min={toDatetimeLocal(nowMs)}
+            onChange={(e) => onAcceptChange(e.target.value)} disabled={disabled}
+          />
+        </div>
+      )}
+      {manualFor === 'resolve' && (
+        <div className="oc-manual-entry">
+          <label htmlFor={`${idPrefix}-resolve-by`}>Exact date &amp; time — {resolveLabel.toLowerCase()}</label>
+          <input
+            id={`${idPrefix}-resolve-by`} type="datetime-local" className="oc-datetime fm-datetime-input"
+            value={resolveBy} min={acceptBy || toDatetimeLocal(nowMs)}
+            onChange={(e) => onResolveChange(e.target.value)} disabled={disabled}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/fairwins/FriendMarketsModal.css
+++ b/frontend/src/components/fairwins/FriendMarketsModal.css
@@ -167,7 +167,8 @@
   gap: 0.375rem;
 }
 
-.fm-form-group label {
+.fm-form-group label,
+.fm-form-group .fm-label {
   font-size: 0.8rem;
   font-weight: 500;
   color: var(--text-primary, #E6EDF3);

--- a/frontend/src/components/fairwins/GroupPoolModal.jsx
+++ b/frontend/src/components/fairwins/GroupPoolModal.jsx
@@ -2,7 +2,12 @@ import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useWallet } from '../../hooks/useWalletManagement'
 import { usePools } from '../../hooks/usePools'
+import WagerQRCode from '../ui/WagerQRCode'
+import { buildTakeChallengeUrl } from '../../utils/claimCode/deepLink.js'
+import DeadlineTimeline from './DeadlineTimeline'
+import { toDatetimeLocal } from './wagerTimeline'
 import './FriendMarketsModal.css'
+import './OpenChallengeModal.css'
 import '../../pages/pools.css'
 
 const CloseIcon = () => (
@@ -11,15 +16,27 @@ const CloseIcon = () => (
   </svg>
 )
 
+const CopyIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+    <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+  </svg>
+)
+
+const CheckIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden="true">
+    <path d="M20 6L9 17l-5-5" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+)
+
 /**
- * GroupPoolModal (spec 034) — the group-pool create/join entry flow, styled to match the other wager
- * bottom-sheets (FriendMarketsModal / OpenChallengeModal): same backdrop, fm-header, fm-content/fm-panel,
- * and fm-resolution-tabs. Replaces the standalone /pools/create and /pools/join routes so group pools
- * conform to the rest of the wager UX. Managing a created/joined pool still lives at /pools/:address.
+ * GroupPoolModal (spec 034 + create-flow tester punchlist) — the group-pool create entry flow, styled
+ * to match the other wager bottom-sheets (FriendMarketsModal / OpenChallengeModal): same backdrop,
+ * fm-header, and fm-content/fm-panel. Create-only, so no mode tabs/pills — the header alone says what
+ * this modal does (same testing feedback as the open challenge). Joining lives in the unified phrase
+ * lookup (spec 037); managing a created/joined pool lives at /pools/:address.
  */
-export default function GroupPoolModal({ isOpen, onClose, initialTab = 'create' }) {
-  // Dashboard remounts this modal via `key` on each open, so useState(initialTab) is fresh per open.
-  const [tab, setTab] = useState(initialTab)
+export default function GroupPoolModal({ isOpen, onClose }) {
   useEffect(() => {
     if (!isOpen) return undefined
     const onKey = (e) => e.key === 'Escape' && onClose()
@@ -56,16 +73,6 @@ export default function GroupPoolModal({ isOpen, onClose, initialTab = 'create' 
 
         <div className="fm-content">
           <div className="fm-panel">
-            <div className="fm-resolution-tabs" role="tablist" aria-label="Group pool mode">
-              <button
-                type="button" role="tab" aria-selected={tab === 'create'}
-                className={`fm-resolution-tab ${tab === 'create' ? 'active' : ''}`}
-                onClick={() => setTab('create')}
-              >
-                <span className="fm-resolution-tab-label">Create a pool</span>
-              </button>
-            </div>
-
             {/* Joining a pool moved to the unified phrase lookup (spec 037): enter four words there. */}
             <CreatePanel onClose={onClose} />
           </div>
@@ -75,19 +82,52 @@ export default function GroupPoolModal({ isOpen, onClose, initialTab = 'create' 
   )
 }
 
+// Approval-threshold choices (tester feedback): a raw percent input read as jargon — offer named
+// levels of group agreement instead. Percent of members who joined; the contract stores bips.
+const THRESHOLD_CHOICES = [
+  { pct: 51, label: 'Majority', detail: 'More than half of the group must approve the payout.' },
+  { pct: 67, label: 'Two-thirds', detail: 'Two of every three members must approve the payout.' },
+  { pct: 100, label: 'Everyone', detail: 'Every member must approve the payout — one holdout blocks it.' },
+]
+
+const DAY_MS = 24 * 3600 * 1000
+
 function CreatePanel({ onClose }) {
   const { isConnected } = useWallet()
   const { createPool, status, error } = usePools()
   const navigate = useNavigate()
-  const [form, setForm] = useState({ buyIn: '10', maxMembers: '10', thresholdPct: '60', joinDays: '7', resolutionDays: '3' })
+  const [buyIn, setBuyIn] = useState('10.00')
+  const [maxMembers, setMaxMembers] = useState('10')
+  const [thresholdPct, setThresholdPct] = useState(THRESHOLD_CHOICES[0].pct)
+  // Windows as concrete instants (tester feedback): the same slider + tap-to-type timeline as the
+  // open challenge, instead of bare day counts. joinBy → the on-chain joinDeadline; resolveBy − joinBy
+  // → the resolutionWindow that starts when joining actually closes. Mount-time "now" anchors the
+  // future check (same anchor the timeline's sliders use); the contract re-checks at create time.
+  const [mountedAtMs] = useState(() => Date.now())
+  const [joinBy, setJoinBy] = useState(() => toDatetimeLocal(mountedAtMs + 7 * DAY_MS))
+  const [resolveBy, setResolveBy] = useState(() => toDatetimeLocal(mountedAtMs + 10 * DAY_MS))
   const [result, setResult] = useState(null)
   const [copied, setCopied] = useState(false)
-  const set = (k) => (e) => setForm((f) => ({ ...f, [k]: e.target.value }))
+
+  const joinMs = joinBy ? new Date(joinBy).getTime() : NaN
+  const resolveMs = resolveBy ? new Date(resolveBy).getTime() : NaN
+  const deadlinesValid =
+    Number.isFinite(joinMs) && Number.isFinite(resolveMs) &&
+    joinMs > mountedAtMs && resolveMs > joinMs
+  const membersValid = Number(maxMembers) >= 2 && Number(maxMembers) <= 1000
+  const canCreate = Number(buyIn) > 0 && membersValid && deadlinesValid && isConnected && status !== 'creating'
+  const chosen = THRESHOLD_CHOICES.find((c) => c.pct === thresholdPct) || THRESHOLD_CHOICES[0]
 
   const onSubmit = async (e) => {
     e.preventDefault()
     try {
-      setResult(await createPool(form))
+      setResult(await createPool({
+        buyIn,
+        maxMembers,
+        thresholdPct,
+        joinDeadline: Math.floor(joinMs / 1000),
+        resolutionWindow: Math.max(1, Math.floor((resolveMs - joinMs) / 1000)),
+      }))
     } catch {
       /* surfaced via hook error */
     }
@@ -102,18 +142,49 @@ function CreatePanel({ onClose }) {
     }
   }
 
+  // Share view (tester feedback): the same shape as the open-challenge share view — the four words in
+  // a code display with an icon copy button, plus a QR deep link into the unified phrase lookup.
   if (result) {
     return (
-      <div className="fm-form" data-testid="pool-created">
-        <p>Share these four words so friends can find and join — no address needed:</p>
-        <p className="pool-phrase" data-testid="pool-phrase">{result.phrase}</p>
-        <div className="fm-actions">
-          <button type="button" className="fm-submit-btn" data-testid="copy-phrase" onClick={copyPhrase}>
-            {copied ? 'Copied' : 'Copy words'}
+      <div className="fm-success" data-testid="pool-created">
+        <div className="fm-success-icon" aria-hidden="true">&#127881;</div>
+        <h3>Group pool created</h3>
+        <p className="fm-success-desc">
+          Share these four words — friends type them into the app to find and join your pool. No address needed.
+        </p>
+
+        <div className="oc-code-display">
+          <code className="oc-code" data-testid="pool-phrase">{result.phrase}</code>
+          <button
+            type="button"
+            className="oc-copy-btn"
+            data-testid="copy-phrase"
+            onClick={copyPhrase}
+            title={copied ? 'Copied' : 'Copy words'}
+            aria-label={copied ? 'Copied' : 'Copy words'}
+          >
+            {copied ? <CheckIcon /> : <CopyIcon />}
           </button>
-          <button type="button" className="fm-secondary-btn" onClick={() => { onClose(); navigate(`/pools/${result.pool}`) }}>
-            Open pool
+        </div>
+
+        <div className="oc-qr">
+          <WagerQRCode value={buildTakeChallengeUrl(result.phrase)} size={180} ariaLabel="QR code to join this pool" />
+          <span className="oc-qr-caption">Scan to join — opens the app with the words filled in</span>
+        </div>
+
+        <p className="fm-hint">
+          Anyone you give the words to can join (after paying the buy-in), so share them with the group you mean.
+        </p>
+
+        <div className="fm-success-actions">
+          <button
+            type="button"
+            className="fm-btn-primary fm-success-done"
+            onClick={() => { onClose(); navigate(`/pools/${result.pool}`) }}
+          >
+            Open my pool
           </button>
+          <button type="button" className="fm-btn-secondary" onClick={onClose}>Done</button>
         </div>
       </div>
     )
@@ -121,32 +192,91 @@ function CreatePanel({ onClose }) {
 
   return (
     <form className="fm-form" onSubmit={onSubmit}>
-      <div className="fm-form-grid">
-        <div className="fm-form-group">
-          <label htmlFor="gp-buyin">Buy-in (USDC) <span className="fm-required">*</span></label>
-          <input id="gp-buyin" type="number" min="0" step="0.01" value={form.buyIn} onChange={set('buyIn')} required />
+      <p className="fm-hint">
+        Everyone pays the same buy-in into one pot. When it&apos;s decided, you propose the payout and the
+        group approves it anonymously.
+      </p>
+
+      <div className="fm-form-group fm-form-full">
+        <label htmlFor="gp-buyin">Buy-in — each member <span className="fm-required">*</span></label>
+        <div className="fm-stake-input-wrapper">
+          <span className="fm-stake-prefix">$</span>
+          <input
+            id="gp-buyin" type="number" inputMode="decimal" min="0" step="0.01"
+            placeholder="10.00" className="fm-stake-usd"
+            value={buyIn}
+            onChange={(e) => setBuyIn(e.target.value)}
+            onBlur={() => {
+              const n = Number(buyIn)
+              if (buyIn !== '' && Number.isFinite(n) && n > 0) setBuyIn(n.toFixed(2))
+            }}
+            required
+          />
+          <span className="fm-stake-suffix">USDC</span>
         </div>
-        <div className="fm-form-group">
-          <label htmlFor="gp-max">Maximum members <span className="fm-required">*</span></label>
-          <input id="gp-max" type="number" min="2" max="1000" value={form.maxMembers} onChange={set('maxMembers')} required />
-        </div>
-        <div className="fm-form-group">
-          <label htmlFor="gp-threshold">Approval threshold (% of members)</label>
-          <input id="gp-threshold" type="number" min="1" max="100" value={form.thresholdPct} onChange={set('thresholdPct')} required />
-        </div>
-        <div className="fm-form-group">
-          <label htmlFor="gp-joindays">Join window (days)</label>
-          <input id="gp-joindays" type="number" min="1" value={form.joinDays} onChange={set('joinDays')} required />
-        </div>
-        <div className="fm-form-group">
-          <label htmlFor="gp-resdays">Resolution window (days)</label>
-          <input id="gp-resdays" type="number" min="1" value={form.resolutionDays} onChange={set('resolutionDays')} required />
-        </div>
+        <span className="fm-hint">Enter the amount in USD — every member pays this much in USDC to join.</span>
       </div>
-      {error && <p className="fm-error" role="alert">{error}</p>}
-      <button type="submit" className="fm-submit-btn" disabled={!isConnected || status === 'creating'}>
-        {!isConnected ? 'Connect wallet to create' : status === 'creating' ? 'Creating…' : 'Create pool'}
-      </button>
+
+      <div className="fm-form-group fm-form-full">
+        <label htmlFor="gp-max">Maximum members <span className="fm-required">*</span></label>
+        <input
+          id="gp-max" type="number" min="2" max="1000"
+          value={maxMembers} onChange={(e) => setMaxMembers(e.target.value)} required
+        />
+        <span className="fm-hint">Joining closes automatically once the pool fills.</span>
+      </div>
+
+      <div className="fm-form-group fm-form-full">
+        <span className="fm-label" id="gp-threshold-label">Who must approve the payout? <span className="fm-required">*</span></span>
+        <div className="fm-resolution-tabs" role="radiogroup" aria-labelledby="gp-threshold-label">
+          {THRESHOLD_CHOICES.map((c) => (
+            <button
+              key={c.pct}
+              type="button"
+              role="radio"
+              aria-checked={thresholdPct === c.pct}
+              className={`fm-resolution-tab ${thresholdPct === c.pct ? 'active' : ''}`}
+              onClick={() => setThresholdPct(c.pct)}
+            >
+              <span className="fm-resolution-tab-label">{c.label}</span>
+            </button>
+          ))}
+        </div>
+        <span className="fm-hint">
+          {chosen.detail} If the group never agrees, everyone can take their buy-in back after the resolve time.
+        </span>
+      </div>
+
+      {/* Windows (tester feedback): the open-challenge timeline element — slide to pick each time,
+          or tap a tile to type the exact date & time. */}
+      <DeadlineTimeline
+        acceptBy={joinBy}
+        resolveBy={resolveBy}
+        onAcceptChange={setJoinBy}
+        onResolveChange={setResolveBy}
+        disabled={status === 'creating'}
+        idPrefix="gp"
+        acceptLabel="Joining open until"
+        acceptHint="Friends can join with the four words until this time. You can also close joining early once everyone is in."
+        acceptTileHead="Join by"
+        resolveLabel="Must be resolved by"
+        resolveHint="After joining closes, the group has until about this time to approve the payout — otherwise buy-ins become refundable."
+        resolveTileHead="Resolve by"
+        summary={(openSpan, settleSpan) => `Open ${openSpan} for friends to join · then up to ${settleSpan} to settle`}
+      />
+      {!deadlinesValid && (joinBy || resolveBy) && (
+        <p className="fm-hint oc-deadline-warn" role="alert">
+          Pick a join time in the future and a resolve time after it.
+        </p>
+      )}
+
+      {error && <div className="fm-error-banner" role="alert">{error}</div>}
+
+      <div className="fm-success-actions">
+        <button type="submit" className="fm-btn-primary" disabled={!canCreate}>
+          {!isConnected ? 'Connect wallet to create' : status === 'creating' ? 'Creating…' : 'Create pool'}
+        </button>
+      </div>
     </form>
   )
 }

--- a/frontend/src/components/fairwins/OpenChallengeModal.jsx
+++ b/frontend/src/components/fairwins/OpenChallengeModal.jsx
@@ -8,7 +8,8 @@ import AddressInput from '../ui/AddressInput'
 import AddressBookButton from '../ui/AddressBookButton'
 import QRScanner from '../ui/QRScanner'
 import { buildTakeChallengeUrl } from '../../utils/claimCode/deepLink.js'
-import { formatTileClock, formatTileDay, formatTimelineSpan } from './wagerTimeline'
+import DeadlineTimeline from './DeadlineTimeline'
+import { toDatetimeLocal } from './wagerTimeline'
 import './FriendMarketsModal.css'
 import './OpenChallengeModal.css'
 
@@ -332,158 +333,9 @@ function MakerPanel({ onClose }) {
   )
 }
 
-// ---------------------------------------------------------------------------
-// Deadline timeline — reuses the 1v1 create-wager timeline element (track +
-// stat tiles, shared fm-* styles) for the open challenge's two deadlines.
-// Each deadline has a slider for coarse picking; tapping its stat tile opens
-// a datetime-local input for exact manual entry (testing feedback).
-// ---------------------------------------------------------------------------
-const HOUR_MS = 3600 * 1000
-const ACCEPT_MAX_HOURS = 30 * 24    // contract MAX_ACCEPT_WINDOW (30 days)
-const RESOLVE_MAX_HOURS = 90 * 24   // slider cap — comfortably under the contract's 180-day resolve window
-const DEFAULT_RESOLVE_GAP_MS = 7 * 24 * HOUR_MS
-
-function DeadlineTimeline({ acceptBy, resolveBy, onAcceptChange, onResolveChange, disabled }) {
-  const [manualFor, setManualFor] = useState(null) // null | 'accept' | 'resolve'
-  // Mount-time "now" anchors the slider scale so positions don't drift while the form is open.
-  const [nowMs] = useState(() => Date.now())
-  const acceptMs = acceptBy ? new Date(acceptBy).getTime() : NaN
-  const resolveMs = resolveBy ? new Date(resolveBy).getTime() : NaN
-  const acceptValid = Number.isFinite(acceptMs)
-  const resolveValid = Number.isFinite(resolveMs)
-
-  const clampHours = (h, max) => Math.min(max, Math.max(1, h))
-  const acceptHours = acceptValid ? clampHours(Math.round((acceptMs - nowMs) / HOUR_MS), ACCEPT_MAX_HOURS) : 48
-  const resolveHours = acceptValid && resolveValid
-    ? clampHours(Math.round((resolveMs - acceptMs) / HOUR_MS), RESOLVE_MAX_HOURS)
-    : 7 * 24
-
-  const handleAcceptSlide = (e) => {
-    const nextAccept = nowMs + Number(e.target.value) * HOUR_MS
-    // Sliding the acceptance point drags the resolve point with it (constant gap) so the
-    // timeline can never be slid into an accept-after-resolve state.
-    const gap = acceptValid && resolveValid && resolveMs > acceptMs ? resolveMs - acceptMs : DEFAULT_RESOLVE_GAP_MS
-    onAcceptChange(toDatetimeLocal(nextAccept))
-    onResolveChange(toDatetimeLocal(nextAccept + gap))
-  }
-
-  const handleResolveSlide = (e) => {
-    const base = acceptValid ? acceptMs : nowMs + 48 * HOUR_MS
-    onResolveChange(toDatetimeLocal(base + Number(e.target.value) * HOUR_MS))
-  }
-
-  const describe = (ms) => Number.isFinite(ms)
-    ? `${formatTileClock(new Date(ms))} · ${formatTileDay(new Date(ms))}`
-    : '—'
-
-  // Track percentages over the full now → resolve span (amber = open for acceptance,
-  // green = active wager window) — same visual grammar as the 1v1 timeline.
-  const span = Math.max(1, (resolveValid ? resolveMs : nowMs + 1) - nowMs)
-  const acceptPct = acceptValid ? Math.max(0, Math.min(100, ((acceptMs - nowMs) / span) * 100)) : 0
-  const trackStyle = {
-    background: `linear-gradient(to right,` +
-      ` var(--fm-accept) 0%, var(--fm-accept) ${acceptPct}%,` +
-      ` var(--fm-active) ${acceptPct}%, var(--fm-active) 100%)`
-  }
-
-  const toggleManual = (which) => setManualFor((cur) => (cur === which ? null : which))
-
-  return (
-    <div className="fm-form-group fm-form-full fm-endtime oc-timeline">
-      <div className="oc-deadline-slider">
-        <div className="fm-input-header">
-          <label htmlFor="oc-accept-slider">Open for acceptance until <span className="fm-required">*</span></label>
-          <span className="fm-odds-value">{describe(acceptMs)}</span>
-        </div>
-        <input
-          id="oc-accept-slider" type="range" className="fm-odds-slider"
-          min={1} max={ACCEPT_MAX_HOURS} step={1}
-          value={acceptHours} onChange={handleAcceptSlide} disabled={disabled}
-          aria-valuetext={describe(acceptMs)}
-        />
-        <span className="fm-hint">After this, the challenge can no longer be taken and your stake is refundable.</span>
-      </div>
-
-      <div className="oc-deadline-slider">
-        <div className="fm-input-header">
-          <label htmlFor="oc-resolve-slider">Must be resolved by <span className="fm-required">*</span></label>
-          <span className="fm-odds-value">{describe(resolveMs)}</span>
-        </div>
-        <input
-          id="oc-resolve-slider" type="range" className="fm-odds-slider"
-          min={1} max={RESOLVE_MAX_HOURS} step={1}
-          value={resolveHours} onChange={handleResolveSlide} disabled={disabled}
-          aria-valuetext={describe(resolveMs)}
-        />
-        <span className="fm-hint">The outcome must be submitted before this time.</span>
-      </div>
-
-      {acceptValid && resolveValid && (
-        <>
-          <span className="fm-endtime-summary">
-            Open {formatTimelineSpan(new Date(nowMs), new Date(acceptMs))} for a taker · then up
-            to {formatTimelineSpan(new Date(acceptMs), new Date(resolveMs))} to settle
-          </span>
-
-          <div className="fm-timeline-track" style={trackStyle} aria-hidden="true">
-            <span className="fm-timeline-node is-accept" style={{ left: `${acceptPct}%` }} />
-            <span className="fm-timeline-node is-resolve" style={{ left: '100%' }} />
-          </div>
-        </>
-      )}
-
-      <div className="fm-stat-tiles oc-stat-tiles">
-        <button
-          type="button"
-          className="fm-stat-tile is-accept oc-stat-tile-btn"
-          onClick={() => toggleManual('accept')}
-          disabled={disabled}
-          aria-expanded={manualFor === 'accept'}
-          aria-controls={manualFor === 'accept' ? 'oc-accept-by' : undefined}
-        >
-          <span className="fm-stat-head"><span className="fm-stat-dot" aria-hidden="true" />Open until</span>
-          <span className="fm-stat-time">{acceptValid ? formatTileClock(new Date(acceptMs)) : '—'}</span>
-          <span className="fm-stat-day">{acceptValid ? formatTileDay(new Date(acceptMs)) : ''}</span>
-          <span className="oc-tile-edit">Tap to type a date</span>
-        </button>
-        <button
-          type="button"
-          className="fm-stat-tile is-resolve oc-stat-tile-btn"
-          onClick={() => toggleManual('resolve')}
-          disabled={disabled}
-          aria-expanded={manualFor === 'resolve'}
-          aria-controls={manualFor === 'resolve' ? 'oc-resolve-by' : undefined}
-        >
-          <span className="fm-stat-head"><span className="fm-stat-dot" aria-hidden="true" />Resolve by</span>
-          <span className="fm-stat-time">{resolveValid ? formatTileClock(new Date(resolveMs)) : '—'}</span>
-          <span className="fm-stat-day">{resolveValid ? formatTileDay(new Date(resolveMs)) : ''}</span>
-          <span className="oc-tile-edit">Tap to type a date</span>
-        </button>
-      </div>
-
-      {manualFor === 'accept' && (
-        <div className="oc-manual-entry">
-          <label htmlFor="oc-accept-by">Exact date &amp; time — open for acceptance until</label>
-          <input
-            id="oc-accept-by" type="datetime-local" className="oc-datetime fm-datetime-input"
-            value={acceptBy} min={toDatetimeLocal(nowMs)}
-            onChange={(e) => onAcceptChange(e.target.value)} disabled={disabled}
-          />
-        </div>
-      )}
-      {manualFor === 'resolve' && (
-        <div className="oc-manual-entry">
-          <label htmlFor="oc-resolve-by">Exact date &amp; time — must be resolved by</label>
-          <input
-            id="oc-resolve-by" type="datetime-local" className="oc-datetime fm-datetime-input"
-            value={resolveBy} min={acceptBy || toDatetimeLocal(nowMs)}
-            onChange={(e) => onResolveChange(e.target.value)} disabled={disabled}
-          />
-        </div>
-      )}
-    </div>
-  )
-}
+// Deadline timeline moved to the shared DeadlineTimeline component (./DeadlineTimeline.jsx) so the
+// group-pool create flow presents its windows the same way (pool-manager tester feedback). This
+// modal renders it with its default open-challenge labels.
 
 // ---------------------------------------------------------------------------
 // Arbitrator entry — ENS-aware address input with address-book + QR-scan helpers
@@ -543,12 +395,6 @@ function ArbitratorField({ value, onChange, onResolvedChange, disabled }) {
 
 // Recover codes moved to My Account → Security (spec 037, US3):
 // see components/account/RecoveryCodesPanel.jsx.
-
-/** Format a unix-ms instant as a value for <input type="datetime-local"> (local time, minute precision). */
-function toDatetimeLocal(ms) {
-  const d = new Date(ms - new Date(ms).getTimezoneOffset() * 60000)
-  return d.toISOString().slice(0, 16)
-}
 
 /** Pull a 0x-address out of scanned QR text — a bare address or one embedded in a URL path/query. */
 function extractAddress(decodedText) {

--- a/frontend/src/components/fairwins/wagerTimeline.js
+++ b/frontend/src/components/fairwins/wagerTimeline.js
@@ -24,3 +24,9 @@ export const formatTimelineSpan = (from, to) => {
   if (days > 0) return `${days} day${days > 1 ? 's' : ''} ${hours}h`
   return `${hours}h`
 }
+
+/** Format a unix-ms instant as a value for <input type="datetime-local"> (local time, minute precision). */
+export const toDatetimeLocal = (ms) => {
+  const d = new Date(ms - new Date(ms).getTimezoneOffset() * 60000)
+  return d.toISOString().slice(0, 16)
+}

--- a/frontend/src/components/pools/PoolLeaderboard.jsx
+++ b/frontend/src/components/pools/PoolLeaderboard.jsx
@@ -42,7 +42,11 @@ export default function PoolLeaderboard({
       )}
 
       {sorted.length === 0 ? (
-        <p className="leaderboard-empty">No standings yet.</p>
+        <p className="leaderboard-empty">
+          {editable
+            ? 'Standings fill in automatically as members join — no need to enter anyone by hand.'
+            : 'No standings yet.'}
+        </p>
       ) : (
         <ol className="leaderboard-list">
           {sorted.map((e, i) => (
@@ -82,18 +86,23 @@ export default function PoolLeaderboard({
         </ol>
       )}
 
+      {/* Manual entry is an edge-case tool (guests, corrections) — the roster auto-populates the
+          standings, so keep this tucked away instead of front-and-center (live-app tester feedback). */}
       {editable && (
-        <form className="leaderboard-add" onSubmit={submitAdd}>
-          <label htmlFor="lb-add-player">Add player (nickname)</label>
-          <input
-            id="lb-add-player"
-            value={newName}
-            onChange={(e) => setNewName(e.target.value)}
-            placeholder="e.g. Prismatic Fox"
-            autoComplete="off"
-          />
-          <button type="submit">Add</button>
-        </form>
+        <details className="leaderboard-add-details">
+          <summary>Add a player manually</summary>
+          <form className="leaderboard-add" onSubmit={submitAdd}>
+            <label htmlFor="lb-add-player">Add player (nickname)</label>
+            <input
+              id="lb-add-player"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="e.g. Prismatic Fox"
+              autoComplete="off"
+            />
+            <button type="submit">Add</button>
+          </form>
+        </details>
       )}
     </section>
   )

--- a/frontend/src/components/pools/PoolParticipants.jsx
+++ b/frontend/src/components/pools/PoolParticipants.jsx
@@ -23,7 +23,20 @@ import { sortParticipants } from '../../lib/pools/participantOrder'
 export default function PoolParticipants({ participants, isCreator = false, order = null, onReorder }) {
   const [dragIndex, setDragIndex] = useState(null)
 
-  if (!participants || participants.length === 0) return null
+  if (!participants) return null // still loading — render nothing rather than a false "empty"
+
+  // Loaded but empty (live-app tester feedback): tell the creator what fills this in instead of
+  // silently omitting the section.
+  if (participants.length === 0) {
+    return (
+      <section className="pool-participants" aria-label="Participants" data-testid="pool-participants">
+        <h2>Participants (0)</h2>
+        <p className="pool-participants-hint" data-testid="participants-empty">
+          No one has joined yet — share the pool&apos;s four words so friends can find and join it.
+        </p>
+      </section>
+    )
+  }
 
   const sorted = sortParticipants(participants, order)
   const arranged = Boolean(order && order.length)

--- a/frontend/src/components/pools/PoolResolutionActions.jsx
+++ b/frontend/src/components/pools/PoolResolutionActions.jsx
@@ -18,14 +18,22 @@ import { sortParticipants } from '../../lib/pools/participantOrder'
  * Controlled by the parent (PoolPage), which supplies the connected `pools` hook, the pool `summary`,
  * the anonymous `participants` roster, and the creator's `rankOrder`.
  */
-export default function PoolResolutionActions({ summary, pools, participants = null, rankOrder = null, onChanged }) {
+export default function PoolResolutionActions({
+  summary, pools, participants = null, rankOrder = null, claimCode: restoredClaimCode = null, onChanged,
+}) {
   const { proposeOutcome, claimWinnings, getMyClaimCode, peekPoolIdentity, status } = pools
   const decimals = summary.tokenDecimals || 6
   const escrow = BigInt(summary.frozenDenominator || summary.memberCount || 0) * BigInt(summary.buyIn || 0)
 
-  const [claimCode, setClaimCode] = useState(null)
+  const [claimCode, setClaimCode] = useState(restoredClaimCode)
   const [busy, setBusy] = useState(false)
   const [notice, setNotice] = useState(null)
+
+  // The page-level identity restore (PoolPage) supplies the code with at most one signature; adopt it
+  // whenever it lands after mount.
+  useEffect(() => {
+    if (restoredClaimCode && !claimCode) setClaimCode(restoredClaimCode)
+  }, [restoredClaimCode, claimCode])
 
   // Auto-show the member's claim code (tester feedback) — cache-only read, derived at join time; the
   // Reveal button stays as the fallback for members who joined before caching existed.

--- a/frontend/src/hooks/usePools.js
+++ b/frontend/src/hooks/usePools.js
@@ -286,6 +286,45 @@ export function usePools() {
   }, [requireSigner])
 
   /**
+   * Restore the connected member's full display identity for a pool with at most ONE wallet signature.
+   * Cache-first (no signature at all when the join-time cache is present); otherwise re-derives the
+   * identity, derives the claim-scope nullifier ("claim code"), caches both, and returns
+   * { commitment, claimCode, nickname }. Lets the pool page auto-show a joined member's nickname and
+   * claim code even on devices where the join-time cache is missing (live-app tester feedback: a
+   * joined member should never have to click to reveal who they are).
+   */
+  const restorePoolIdentity = useCallback(async (poolAddress) => {
+    const { signer: s, account } = await requireSigner()
+    const cached = readPoolIdentity(account, poolAddress)
+    if (cached?.commitment && cached?.claimCode) {
+      return {
+        commitment: cached.commitment,
+        claimCode: cached.claimCode,
+        nickname: deriveNickname(cached.commitment, poolAddress),
+      }
+    }
+    const { identity, commitment } = await createPoolIdentity(s, poolAddress)
+    cachePoolIdentity(account, poolAddress, { commitment: commitment.toString() })
+    let claimCode = cached?.claimCode || null
+    if (!claimCode) {
+      try {
+        const memberCommitments = await getMemberCommitments(poolAddress)
+        const proof = await generatePoolProof({
+          identity,
+          memberCommitments,
+          message: 0n,
+          scope: poolClaimScope(poolAddress),
+        })
+        claimCode = proof.nullifier.toString()
+        cachePoolIdentity(account, poolAddress, { claimCode })
+      } catch {
+        /* non-fatal — the nickname still shows; the claim-code reveal path can backfill later */
+      }
+    }
+    return { commitment: commitment.toString(), claimCode, nickname: deriveNickname(commitment, poolAddress) }
+  }, [requireSigner, getMemberCommitments])
+
+  /**
    * Reveal the connected member's "claim code" — their claim-scope Semaphore nullifier. The member shares
    * this off-chain with the creator, who places it (with an amount) in the payout matrix. It is unlinkable
    * to the wallet, and is the value the contract matches at claim time. Returns a decimal string.
@@ -416,6 +455,7 @@ export function usePools() {
     getMyNickname,
     getMyClaimCode,
     peekPoolIdentity,
+    restorePoolIdentity,
     closeJoining,
     cancelPool,
     proposeOutcome,

--- a/frontend/src/hooks/usePools.js
+++ b/frontend/src/hooks/usePools.js
@@ -109,7 +109,12 @@ export function usePools() {
     return { signer, chainId: Number(net.chainId), account }
   }, [signer])
 
-  /** Create a pool. `form`: { buyIn, maxMembers, thresholdPct, joinDays, resolutionDays, token? } */
+  /**
+   * Create a pool. `form`: { buyIn, maxMembers, thresholdPct, token?, joinDeadline?, resolutionWindow?,
+   * joinDays?, resolutionDays? }. The create UI passes exact instants from its timeline element —
+   * `joinDeadline` (unix seconds) and `resolutionWindow` (seconds after joining closes); the older
+   * day-count fields remain as a fallback.
+   */
   const createPool = useCallback(async (form) => {
     setStatus('creating')
     setError(null)
@@ -131,8 +136,9 @@ export function usePools() {
         buyIn: ethers.parseUnits(String(form.buyIn), decimals),
         maxMembers: Number(form.maxMembers),
         thresholdBips: Math.round(Number(form.thresholdPct) * 100),
-        joinDeadline: now + Number(form.joinDays) * 86400,
-        resolutionWindow: Number(form.resolutionDays) * 86400,
+        joinDeadline: form.joinDeadline != null ? Number(form.joinDeadline) : now + Number(form.joinDays) * 86400,
+        resolutionWindow:
+          form.resolutionWindow != null ? Number(form.resolutionWindow) : Number(form.resolutionDays) * 86400,
       }
       const tx = await factory.createPool(params)
       const receipt = await tx.wait()

--- a/frontend/src/pages/PoolPage.jsx
+++ b/frontend/src/pages/PoolPage.jsx
@@ -38,12 +38,14 @@ export default function PoolPage() {
   const { address } = useParams()
   const pools = usePools()
   const {
-    getPoolSummary, getMyNickname, peekPoolIdentity, getMemberCommitments,
+    getPoolSummary, peekPoolIdentity, restorePoolIdentity, getMemberCommitments,
     closeJoining, cancelPool, vote, refund, status,
   } = pools
   const [summary, setSummary] = useState(null)
   const [error, setError] = useState(null)
-  const [nickname, setNickname] = useState(null)
+  // The member's display identity ({ nickname, claimCode }) — auto-restored, never click-gated.
+  const [identity, setIdentity] = useState(null)
+  const [identityStatus, setIdentityStatus] = useState('idle') // idle | restoring | failed
   const [notice, setNotice] = useState(null)
 
   // The anonymous participant roster (alias cards) + the creator's device-local rank arrangement.
@@ -120,18 +122,34 @@ export default function PoolPage() {
     )
   }, [participants])
 
-  // Auto-show the member's nickname (tester feedback) — from the device cache only, so nothing here can
-  // pop an unrequested wallet signature. The Reveal button remains as the fallback for uncached devices.
+  // ALWAYS auto-show a joined member's identity (live-app tester feedback): cache-first (no prompt at
+  // all on the device they joined from); when the cache is missing (new device, cleared storage,
+  // pre-cache join) restore it automatically with one wallet signature. Declining the signature falls
+  // back to the manual Reveal button.
   useEffect(() => {
-    if (!loaded || !summary.hasJoined || nickname) return
+    if (!loaded || !summary.hasJoined || identity) return undefined
     let active = true
-    peekPoolIdentity?.(address)
-      .then((id) => active && id?.nickname && setNickname(id.nickname))
-      .catch(() => {})
+    ;(async () => {
+      try {
+        const peeked = await peekPoolIdentity?.(address)
+        if (!active) return
+        if (peeked?.nickname) {
+          setIdentity({ nickname: peeked.nickname, claimCode: peeked.claimCode || null })
+          return
+        }
+        setIdentityStatus('restoring')
+        const restored = await restorePoolIdentity(address)
+        if (!active) return
+        setIdentity({ nickname: restored.nickname, claimCode: restored.claimCode })
+        setIdentityStatus('idle')
+      } catch {
+        if (active) setIdentityStatus('failed')
+      }
+    })()
     return () => {
       active = false
     }
-  }, [loaded, summary, nickname, address, peekPoolIdentity])
+  }, [loaded, summary, identity, address, peekPoolIdentity, restorePoolIdentity])
 
   const run = async (fn) => {
     setNotice(null)
@@ -143,7 +161,13 @@ export default function PoolPage() {
     }
   }
 
-  const revealNickname = () => run(async () => setNickname(await getMyNickname(address)))
+  // Manual fallback, only reached when the automatic restore failed (e.g. the signature was declined).
+  const revealNickname = () =>
+    run(async () => {
+      const restored = await restorePoolIdentity(address)
+      setIdentity({ nickname: restored.nickname, claimCode: restored.claimCode })
+      setIdentityStatus('idle')
+    })
 
   if (error) {
     return (
@@ -180,13 +204,21 @@ export default function PoolPage() {
         </dl>
       </section>
 
-      <section className="pool-identity" aria-label="Your identity">
-        {nickname ? (
-          <p>You are <strong data-testid="my-nickname">{nickname.label}</strong> in this pool.</p>
-        ) : (
-          <Button variant="secondary" onClick={revealNickname}>Reveal my nickname</Button>
-        )}
-      </section>
+      {/* Identity is only meaningful for joined members — a viewer (or a creator who hasn't joined
+          their own pool) has no alias here, so no Reveal button is dangled at them. */}
+      {summary.hasJoined && (
+        <section className="pool-identity" aria-label="Your identity">
+          {identity?.nickname ? (
+            <p>You are <strong data-testid="my-nickname">{identity.nickname.label}</strong> in this pool.</p>
+          ) : identityStatus === 'restoring' ? (
+            <p data-testid="identity-restoring">
+              Restoring your pool identity… confirm the signature in your wallet if prompted.
+            </p>
+          ) : (
+            <Button variant="secondary" onClick={revealNickname}>Reveal my nickname</Button>
+          )}
+        </section>
+      )}
 
       {/* Anonymous roster: alias cards for everyone; the creator can drag/arrange the rank order */}
       {summary.state !== 3 && (
@@ -249,6 +281,7 @@ export default function PoolPage() {
           pools={pools}
           participants={participants}
           rankOrder={rankOrder}
+          claimCode={identity?.claimCode || null}
           onChanged={reload}
         />
       )}

--- a/frontend/src/pages/pools.css
+++ b/frontend/src/pages/pools.css
@@ -160,6 +160,10 @@
   margin-top: 0.75rem;
 }
 
+/* Manual player entry is an edge-case tool — collapsed by default behind a small disclosure. */
+.leaderboard-add-details { margin-top: 0.75rem; }
+.leaderboard-add-details > summary { font-size: 0.85rem; opacity: 0.75; cursor: pointer; }
+
 /* Participant roster (pool-manager tester feedback): anonymous alias cards + creator rank arrangement */
 .pool-participants { margin: 1rem 0; }
 .pool-participants h2 { font-size: 1rem; margin: 0 0 0.25rem; }

--- a/frontend/src/test/GroupPoolModal.test.jsx
+++ b/frontend/src/test/GroupPoolModal.test.jsx
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 
-// Spec 034: the group-pool create/join flow as a wager-style bottom-sheet modal (matches
-// FriendMarketsModal / OpenChallengeModal). Replaces the old /pools/create + /pools/join routes.
+// Spec 034 + create-flow tester punchlist: the group-pool create flow as a wager-style bottom-sheet
+// (matches FriendMarketsModal / OpenChallengeModal) — create-only (no tabs/pills), money-formatted
+// buy-in, the shared deadline timeline (sliders + tap-to-type), a named approval-threshold selector,
+// and an open-challenge-style share view (code display + copy icon + QR).
 
 vi.mock('../hooks/useWalletManagement', () => ({ useWallet: vi.fn() }))
 vi.mock('../hooks/usePools', () => ({ usePools: vi.fn() }))
@@ -12,11 +14,7 @@ import { useWallet } from '../hooks/useWalletManagement'
 import { usePools } from '../hooks/usePools'
 import GroupPoolModal from '../components/fairwins/GroupPoolModal'
 
-const openSummary = {
-  address: '0x00000000000000000000000000000000000000aa',
-  state: 0, stateLabel: 'JoiningOpen', buyInFormatted: '10.0', tokenSymbol: 'USDC',
-  memberCount: 2, maxMembers: 5, slotsRemaining: 3, thresholdPct: 60,
-}
+const POOL_ADDR = '0x00000000000000000000000000000000000000aa'
 
 function pools(over = {}) {
   return { status: 'idle', error: null, createPool: vi.fn(), resolvePhrase: vi.fn(), joinPool: vi.fn(), ...over }
@@ -31,20 +29,84 @@ describe('GroupPoolModal', () => {
     useWallet.mockReturnValue({ account: '0x1111111111111111111111111111111111111111', isConnected: true })
   })
 
-  it('renders as a wager-style bottom sheet, create-only (joining moved to the unified lookup, spec 037)', () => {
+  it('renders as a wager-style bottom sheet, create-only — no mode tabs/pills at all (tester feedback)', () => {
     usePools.mockReturnValue(pools())
-    renderModal({ initialTab: 'create' })
+    renderModal()
     expect(screen.getByRole('dialog')).toHaveClass('friend-markets-modal-backdrop')
-    expect(screen.getByRole('tab', { name: /create a pool/i })).toBeInTheDocument()
-    expect(screen.queryByRole('tab', { name: /join a pool/i })).toBeNull()
+    expect(screen.queryAllByRole('tab')).toHaveLength(0)
+    expect(screen.queryByRole('tablist')).toBeNull()
+    expect(screen.getByLabelText(/buy-in — each member/i)).toBeInTheDocument()
   })
 
-  it('Create tab: submitting yields a shareable four-word phrase', async () => {
+  it('the buy-in entry is formatted as money ($ prefix, USDC suffix, 2-decimal blur)', () => {
+    usePools.mockReturnValue(pools())
+    renderModal()
+    const buyIn = screen.getByLabelText(/buy-in — each member/i)
+    expect(buyIn).toHaveValue(10) // default 10.00
+    fireEvent.change(buyIn, { target: { value: '12.5' } })
+    fireEvent.blur(buyIn)
+    expect(buyIn.value).toBe('12.50')
+    expect(screen.getByText('$')).toBeInTheDocument()
+    expect(screen.getByText('USDC')).toBeInTheDocument()
+  })
+
+  it('join/resolve windows use the timeline element — sliders plus tap-to-type manual entry', () => {
+    usePools.mockReturnValue(pools())
+    renderModal()
+    const joinSlider = screen.getByLabelText(/joining open until/i)
+    const resolveSlider = screen.getByLabelText(/must be resolved by/i)
+    expect(joinSlider).toHaveAttribute('type', 'range')
+    expect(resolveSlider).toHaveAttribute('type', 'range')
+
+    // No manual input until a tile is tapped.
+    expect(screen.queryByLabelText(/exact date & time/i)).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: /join by/i }))
+    expect(screen.getByLabelText(/exact date & time — joining open until/i)).toBeInTheDocument()
+  })
+
+  it('the approval threshold is a named selector, not a raw percent field', async () => {
+    const createPool = vi.fn().mockResolvedValue({ pool: POOL_ADDR, phrase: 'crystal orbit harbor violet' })
+    usePools.mockReturnValue(pools({ createPool }))
+    renderModal()
+    expect(screen.queryByLabelText(/approval threshold/i)).toBeNull()
+    const group = screen.getByRole('radiogroup', { name: /who must approve the payout/i })
+    expect(group).toBeInTheDocument()
+    // Majority is the default; switching to Everyone submits 100%.
+    expect(screen.getByRole('radio', { name: /majority/i })).toHaveAttribute('aria-checked', 'true')
+    fireEvent.click(screen.getByRole('radio', { name: /everyone/i }))
+    fireEvent.click(screen.getByRole('button', { name: /create pool/i }))
+    await waitFor(() => expect(createPool).toHaveBeenCalled())
+    expect(createPool.mock.calls[0][0].thresholdPct).toBe(100)
+  })
+
+  it('passes the chosen windows as an exact joinDeadline (unix s) + resolutionWindow (s)', async () => {
+    const createPool = vi.fn().mockResolvedValue({ pool: POOL_ADDR, phrase: 'crystal orbit harbor violet' })
+    usePools.mockReturnValue(pools({ createPool }))
+    renderModal()
+    fireEvent.click(screen.getByRole('button', { name: /create pool/i }))
+    await waitFor(() => expect(createPool).toHaveBeenCalled())
+    const form = createPool.mock.calls[0][0]
+    expect(typeof form.joinDeadline).toBe('number')
+    expect(form.joinDeadline).toBeGreaterThan(Math.floor(Date.now() / 1000))
+    expect(typeof form.resolutionWindow).toBe('number')
+    expect(form.resolutionWindow).toBeGreaterThan(0)
+  })
+
+  it('share view matches the open-challenge share view: four words + copy icon + join QR', async () => {
     usePools.mockReturnValue(pools({
-      createPool: vi.fn().mockResolvedValue({ pool: openSummary.address, wordIndices: [1, 2, 3, 4], phrase: 'crystal orbit harbor violet' }),
+      createPool: vi.fn().mockResolvedValue({
+        pool: POOL_ADDR, wordIndices: [1, 2, 3, 4], phrase: 'crystal orbit harbor violet',
+      }),
     }))
-    renderModal({ initialTab: 'create' })
+    renderModal()
     fireEvent.click(screen.getByRole('button', { name: /create pool/i }))
     expect(await screen.findByTestId('pool-phrase')).toHaveTextContent('crystal orbit harbor violet')
+    // Icon-only copy button (name from aria-label), like the open-challenge code display.
+    const copyBtn = screen.getByRole('button', { name: /copy words/i })
+    expect(copyBtn).not.toHaveTextContent(/copy/i)
+    // A scannable QR deep link into the unified lookup, with the words pre-filled.
+    expect(screen.getByLabelText(/QR code to join this pool/i)).toBeInTheDocument()
+    expect(screen.getByText(/scan to join/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /open my pool/i })).toBeInTheDocument()
   })
 })

--- a/frontend/src/test/PoolLeaderboard.test.jsx
+++ b/frontend/src/test/PoolLeaderboard.test.jsx
@@ -53,6 +53,15 @@ describe('PoolLeaderboard (US4)', () => {
     expect(onAddPlayer).toHaveBeenCalledWith('Cobalt Lynx')
   })
 
+  it('tells the creator standings auto-fill and tucks manual entry behind a disclosure', () => {
+    render(<PoolLeaderboard entries={[]} isCreator />)
+    expect(screen.getByText(/fill in automatically as members join/i)).toBeInTheDocument()
+    // Manual add still exists as an edge-case tool, but collapsed behind a <details> disclosure.
+    const details = screen.getByText(/add a player manually/i).closest('details')
+    expect(details).not.toBeNull()
+    expect(details.open).toBe(false)
+  })
+
   it('hides the interim marker and editing when final', () => {
     render(<PoolLeaderboard entries={entries} isCreator isFinal />)
     expect(screen.queryByRole('note')).toBeNull()

--- a/frontend/src/test/PoolPages.test.jsx
+++ b/frontend/src/test/PoolPages.test.jsx
@@ -25,6 +25,9 @@ function base(overrides = {}) {
     createPool: vi.fn(), resolvePhrase: vi.fn(), getPoolSummary: vi.fn(), joinPool: vi.fn(),
     getMyNickname: vi.fn(), getMyClaimCode: vi.fn(), getMemberCommitments: vi.fn(),
     peekPoolIdentity: vi.fn().mockResolvedValue(null),
+    restorePoolIdentity: vi.fn().mockResolvedValue({
+      commitment: '123', claimCode: '987654321', nickname: { label: 'Prismatic Fox', suffix: '7b' },
+    }),
     closeJoining: vi.fn().mockResolvedValue('0xtx'), cancelPool: vi.fn().mockResolvedValue('0xtx'),
     proposeOutcome: vi.fn(), vote: vi.fn().mockResolvedValue('0xtx'), claimWinnings: vi.fn(),
     refund: vi.fn().mockResolvedValue('0xtx'),
@@ -60,10 +63,43 @@ describe('PoolPage', () => {
     const peekPoolIdentity = vi.fn().mockResolvedValue({
       commitment: '123', claimCode: null, nickname: { label: 'Prismatic Fox', suffix: '7b' },
     })
-    usePools.mockReturnValue(base({ getPoolSummary: vi.fn().mockResolvedValue(sum), peekPoolIdentity }))
+    const restorePoolIdentity = vi.fn()
+    usePools.mockReturnValue(base({ getPoolSummary: vi.fn().mockResolvedValue(sum), peekPoolIdentity, restorePoolIdentity }))
     renderPoolAt(sum)
     expect(await screen.findByTestId('my-nickname')).toHaveTextContent('Prismatic Fox')
     expect(screen.queryByRole('button', { name: /reveal my nickname/i })).toBeNull()
+    expect(restorePoolIdentity).not.toHaveBeenCalled() // cache hit — no signature path
+  })
+
+  it('auto-RESTORES the identity when nothing is cached — still no click (live-app tester feedback)', async () => {
+    const sum = { ...openSummary, hasJoined: true }
+    const restorePoolIdentity = vi.fn().mockResolvedValue({
+      commitment: '123', claimCode: '987654321', nickname: { label: 'Gentle Fox', suffix: '14' },
+    })
+    usePools.mockReturnValue(base({ getPoolSummary: vi.fn().mockResolvedValue(sum), restorePoolIdentity }))
+    renderPoolAt(sum)
+    expect(await screen.findByTestId('my-nickname')).toHaveTextContent('Gentle Fox')
+    expect(restorePoolIdentity).toHaveBeenCalledWith(sum.address)
+    expect(screen.queryByRole('button', { name: /reveal my nickname/i })).toBeNull()
+    // The restored claim code flows into the resolution actions — also no click.
+    expect(await screen.findByTestId('my-claim-code')).toHaveTextContent('987654321')
+  })
+
+  it('falls back to the Reveal button only when the automatic restore fails (declined signature)', async () => {
+    const sum = { ...openSummary, hasJoined: true }
+    const restorePoolIdentity = vi.fn().mockRejectedValue(new Error('user rejected signature'))
+    usePools.mockReturnValue(base({ getPoolSummary: vi.fn().mockResolvedValue(sum), restorePoolIdentity }))
+    renderPoolAt(sum)
+    expect(await screen.findByRole('button', { name: /reveal my nickname/i })).toBeInTheDocument()
+  })
+
+  it('shows no identity section to a viewer who has not joined (e.g. a creator outside the pool)', async () => {
+    const sum = { ...openSummary, isCreator: true, hasJoined: false }
+    usePools.mockReturnValue(base({ getPoolSummary: vi.fn().mockResolvedValue(sum) }))
+    renderPoolAt(sum)
+    await screen.findByTestId('pool-state')
+    expect(screen.queryByRole('button', { name: /reveal my nickname/i })).toBeNull()
+    expect(screen.queryByTestId('my-nickname')).toBeNull()
   })
 
   it('the creator sees close/cancel while joining is open', async () => {

--- a/frontend/src/test/PoolParticipants.test.jsx
+++ b/frontend/src/test/PoolParticipants.test.jsx
@@ -25,9 +25,14 @@ describe('sortParticipants', () => {
 })
 
 describe('PoolParticipants', () => {
-  it('renders nothing with no participants', () => {
-    const { container } = render(<PoolParticipants participants={[]} />)
+  it('renders nothing while the roster is still loading (null)', () => {
+    const { container } = render(<PoolParticipants participants={null} />)
     expect(container.firstChild).toBeNull()
+  })
+
+  it('shows a share-the-words empty state once loaded with no members (live-app tester feedback)', () => {
+    render(<PoolParticipants participants={[]} />)
+    expect(screen.getByTestId('participants-empty')).toHaveTextContent(/share the pool.s four words/i)
   })
 
   it('members see a read-only alphabetical roster (no reorder controls)', () => {

--- a/frontend/src/test/PoolResolutionActions.test.jsx
+++ b/frontend/src/test/PoolResolutionActions.test.jsx
@@ -37,6 +37,18 @@ describe('PoolResolutionActions (US1)', () => {
     expect(await screen.findByTestId('my-claim-code')).toHaveTextContent('123456789')
   })
 
+  it('shows the claim code handed down from the page-level identity restore (no click)', async () => {
+    render(
+      <PoolResolutionActions
+        summary={{ ...baseSummary, hasJoined: true, state: 1, withinResolutionWindow: true }}
+        pools={mockPools()}
+        claimCode="555666777"
+      />
+    )
+    expect(await screen.findByTestId('my-claim-code')).toHaveTextContent('555666777')
+    expect(screen.queryByRole('button', { name: /reveal my claim code/i })).toBeNull()
+  })
+
   it('auto-shows the claim code from the device cache without a click (tester feedback)', async () => {
     const pools = mockPools({
       peekPoolIdentity: vi.fn().mockResolvedValue({ commitment: '1', claimCode: '424242', nickname: null }),

--- a/frontend/src/test/pools.axe.test.jsx
+++ b/frontend/src/test/pools.axe.test.jsx
@@ -52,13 +52,8 @@ describe('ZK-Wager Pool UI accessibility', () => {
     usePools.mockReturnValue(poolsMock())
   })
 
-  it('GroupPoolModal (create tab) has no a11y violations', async () => {
-    const { container } = render(<MemoryRouter><GroupPoolModal isOpen onClose={() => {}} initialTab="create" /></MemoryRouter>)
-    expect(await axe(container)).toHaveNoViolations()
-  })
-
-  it('GroupPoolModal (join tab) has no a11y violations', async () => {
-    const { container } = render(<MemoryRouter><GroupPoolModal isOpen onClose={() => {}} initialTab="join" /></MemoryRouter>)
+  it('GroupPoolModal (create-only) has no a11y violations', async () => {
+    const { container } = render(<MemoryRouter><GroupPoolModal isOpen onClose={() => {}} /></MemoryRouter>)
     expect(await axe(container)).toHaveNoViolations()
   })
 

--- a/specs/034-zk-wager-pools/implementation-notes.md
+++ b/specs/034-zk-wager-pools/implementation-notes.md
@@ -94,6 +94,29 @@ and feel of the other wager create surfaces:
   icon copy button and a QR that deep-links into the unified phrase lookup (`?oc=take&code=<words>`
   resolves pools as well as challenges), plus "Open my pool" / "Done" actions.
 
+### Live-app verification follow-up (round 3)
+
+Screenshots from fairwins.app showed the round-1 manager fixes only partially landing in practice:
+the nickname/claim-code auto-show was **cache-only**, so any member whose device lacked the join-time
+cache (joined pre-cache, another device, cleared storage) still saw click-to-reveal buttons; the
+identity section rendered even for viewers who never joined; and the creator's first sight of "Live
+standings" was a manual add-player form. Fixes:
+
+- **`usePools.restorePoolIdentity`**: one-signature full restore — cache-first (no prompt on the
+  join device), otherwise re-derive the identity, derive + cache the claim code, return
+  `{ commitment, claimCode, nickname }`. `PoolPage` now auto-runs it whenever a joined member has no
+  cached identity, so the nickname AND claim code always auto-show; declining the signature falls
+  back to the manual Reveal button. The restored claim code is passed down to
+  `PoolResolutionActions`.
+- **Identity section only for joined members** — a viewer (including a creator who hasn't joined
+  their own pool, the 0/N case in the screenshots) no longer sees a meaningless "Reveal my
+  nickname" button.
+- **Roster empty state**: once loaded with zero members, `PoolParticipants` says "share the pool's
+  four words" instead of omitting the section.
+- **Leaderboard**: the creator's empty state now says standings fill in automatically from the
+  roster, and the manual add-player form is collapsed behind an "Add a player manually" disclosure
+  (edge-case tool, not the primary flow).
+
 ## Actual on-chain deployment (ops, post-merge)
 
 Not a tasks.md code task. Sequence: adversarial pre-deploy audit → Amoy (`deploy-zk-wager-pool-factory.js`)

--- a/specs/034-zk-wager-pools/implementation-notes.md
+++ b/specs/034-zk-wager-pools/implementation-notes.md
@@ -67,6 +67,33 @@ integration + gasless; fork skips without RPC), `graph codegen` + `graph build` 
 tests pass, `vite build` green (with the local `.env` `VITE_PINATA_JWT` unset — a known local-only
 guard; CI is clean). Matchstick (T022) is Docker-gated on this host and runs in CI.
 
+## Create-flow UX punchlist (tester feedback, round 2)
+
+Testers reviewed the group-pool UX end to end. The **pool-manager** items (auto-shown nickname,
+human-readable status, participant roster with creator drag-ranking, alphabetical member view,
+auto-populated leaderboard/propose-builder, cached claim code, member-visible verified proposals)
+shipped in the prior round (PR #786). This round refines the **create** flow so it matches the look
+and feel of the other wager create surfaces:
+
+- **No mode pill**: the lone "Create a pool" tab is gone — the modal is create-only (joining lives in
+  the unified phrase lookup, spec 037) and the header alone says what it does, same as the open
+  challenge.
+- **Money-formatted buy-in**: `$`-prefixed, `USDC`-suffixed, 2-decimal-on-blur — identical chrome to
+  the open-challenge stake entry.
+- **Windows as the shared deadline timeline**: join and resolution windows are no longer bare
+  day-count inputs. The open-challenge timeline element (sliders + track + stat tiles +
+  tap-to-type `datetime-local`) was extracted into the shared
+  `frontend/src/components/fairwins/DeadlineTimeline.jsx` and both surfaces render it (pools with
+  "Joining open until" / "Must be resolved by" wording). The create form now passes an exact
+  `joinDeadline` (unix seconds) and `resolutionWindow` (seconds after joining closes) to
+  `usePools.createPool`, which still accepts the older day-count fields as a fallback.
+- **Approval threshold as a named selector**: the raw percent field read as jargon — replaced with a
+  Majority (51%) / Two-thirds (67%) / Everyone (100%) radio-pill selector with a plain-language hint,
+  still stored as bips on-chain.
+- **Share view matches the open challenge**: the four words render in the shared code display with an
+  icon copy button and a QR that deep-links into the unified phrase lookup (`?oc=take&code=<words>`
+  resolves pools as well as challenges), plus "Open my pool" / "Done" actions.
+
 ## Actual on-chain deployment (ops, post-merge)
 
 Not a tasks.md code task. Sequence: adversarial pre-deploy audit → Amoy (`deploy-zk-wager-pool-factory.js`)


### PR DESCRIPTION
## Summary

Testers returned a UX punchlist for the group-pool feature, then followed up with live-app screenshots showing the manager page still only partially matching the intent. This PR has two parts:

1. **Create flow** (`GroupPoolModal`) — brought in line with the app's other wager create surfaces.
2. **Manager page** (`PoolPage` + pool components) — closes the gaps the live screenshots exposed: identity was only auto-shown when the join-time device cache happened to exist, and the leaderboard led with manual data entry.

## Create flow

- **No mode pill** — the modal is create-only (joining lives in the unified phrase lookup, spec 037); the lone "Create a pool" tab is removed.
- **Buy-in as a USD money amount** — `$` prefix, `USDC` suffix, 2-decimal on blur.
- **Join/resolution windows use the open-challenge timeline** — the slider + stat-tile + tap-to-type element was extracted into a shared `DeadlineTimeline` component rendered by both modals. The form passes an exact `joinDeadline` (unix s) and `resolutionWindow` (s) to `usePools.createPool` (day-count fields kept as fallback).
- **Approval threshold as a named selector** — Majority (51%) / Two-thirds (67%) / Everyone (100%) radio pills with a plain-language hint; still stored as bips on-chain.
- **Share view mirrors the open challenge** — four words in the code display with an icon copy button, a QR deep-linking into the unified phrase lookup, and "Open my pool" / "Done" actions.

## Manager page (live-app follow-up)

- **`usePools.restorePoolIdentity`** — one-signature full identity restore (cache-first; otherwise re-derive identity, derive + cache the claim code). `PoolPage` auto-runs it for joined members with nothing cached, so the **nickname and claim code always auto-show** — on any device, not just the one they joined from. Declining the signature falls back to the manual Reveal button. The restored claim code flows into `PoolResolutionActions`.
- **Identity section renders only for joined members** — no "Reveal my nickname" dangled at a creator who hasn't joined their own pool (the 0/N screenshot case).
- **Roster empty state** — a loaded-but-empty participant list now says "share the pool's four words" instead of omitting the section.
- **Leaderboard** — the creator's empty state explains standings auto-fill from the roster; the manual add-player form is collapsed behind an "Add a player manually" disclosure.

Punchlist resolutions are recorded in `specs/034-zk-wager-pools/implementation-notes.md`.

## Testing

- `GroupPoolModal.test.jsx` rewritten for the new create UX; new tests in `PoolPages.test.jsx` (auto-restore with cache hit / cache miss / declined signature / not-joined), `PoolResolutionActions.test.jsx` (page-supplied claim code), `PoolParticipants.test.jsx` (empty state), `PoolLeaderboard.test.jsx` (auto-fill copy + collapsed manual entry).
- Full frontend suite: **1848 passed**; the only 4 failures (`AddressBookPanel.test.jsx`) reproduce on the unmodified tree in this environment and are unrelated.
- ESLint clean on changed files; `vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119ZjFVzptqmG4wacdK6pKo