### PR TITLE
fix(034): make pool nicknames deterministic across users (normalize address casing)

### DIFF
--- a/frontend/src/lib/pools/nickname.js
+++ b/frontend/src/lib/pools/nickname.js
@@ -18,8 +18,16 @@ const DOMAIN = `FAIRWINS_POOL_NICK_v${NICKNAME_VERSION}`
  */
 export function deriveNickname(identityCommitment, poolId = '') {
   const commitment = getBigInt(identityCommitment)
+  // Normalise the pool scope so the SAME member renders the SAME two words for EVERYONE, regardless of
+  // how the pool address was cased in the URL / navigation that produced it. A checksummed `0xAbC…` and
+  // a lowercase `0xabc…` are the same pool, but `solidityPacked(['string'], …)` packs their raw bytes,
+  // so an un-normalised scope hashed to different words per viewer — while the commitment-only `suffix`
+  // stayed identical (exactly the "#12 / #ba match but the names differ across users" bug). Lowercasing
+  // is address-safe and can't throw. NB: this changes the words for any in-flight pool once, after which
+  // every viewer agrees.
+  const scope = String(poolId).toLowerCase()
   const h = getBigInt(
-    keccak256(solidityPacked(['uint256', 'string', 'string'], [commitment, String(poolId), DOMAIN]))
+    keccak256(solidityPacked(['uint256', 'string', 'string'], [commitment, scope, DOMAIN]))
   )
 
   const adjCount = BigInt(ADJECTIVES.length)

--- a/frontend/src/test/poolNickname.test.js
+++ b/frontend/src/test/poolNickname.test.js
@@ -23,6 +23,21 @@ describe('pool nickname', () => {
     expect(fromStr).toEqual(fromBig)
   })
 
+  it('is INVARIANT to pool-address casing so every viewer sees the same words (cross-user determinism)', () => {
+    // Different users reach a pool via differently-cased addresses (creator: the contract's checksummed
+    // address; a shared link: lowercase). The words must not depend on that casing — only the
+    // commitment-only suffix was casing-invariant before, which is why suffixes matched but names didn't.
+    const checksummed = '0x5aA0Ea1a5Cd4C1b0f0B8a3B2C1D0e9F8a7B6C5d4'
+    const lower = checksummed.toLowerCase()
+    const upper = checksummed.toUpperCase().replace('0X', '0x')
+    const a = deriveNickname(commitment, checksummed)
+    const b = deriveNickname(commitment, lower)
+    const c = deriveNickname(commitment, upper)
+    expect(a.label).toEqual(b.label)
+    expect(a.label).toEqual(c.label)
+    expect(a).toEqual(b)
+  })
+
   it('varies across commitments and scopes', () => {
     const a = deriveNickname(commitment, 'pool-1')
     const b = deriveNickname(commitment + 1n, 'pool-1')


### PR DESCRIPTION
## Summary

Three users viewing the same pool saw matching disambiguation suffixes (`#12`, `#ba`) but **different** two-word names for the same members — the creator and one participant saw "Desert Meteor / Thunder Otter", while another participant saw "Daring Canyon / Ivory Aspen" for the same commitments.

Root cause: `deriveNickname` builds the suffix from the commitment alone (casing-invariant, which is why suffixes matched), but derives the two words from `keccak256(solidityPacked(['uint256','string','string'], [commitment, poolId, DOMAIN]))`. The `'string'` packing of `poolId` hashes the address's **raw bytes**, so a checksummed `0xAbC…` and a lowercase `0xabc…` — the same pool, reached via different navigation (the creator uses the contract's checksummed address; a shared link is lowercase) — produced different words per viewer.

## Fix

Normalize the pool scope to lowercase inside `deriveNickname` — the single chokepoint every call site (`PoolPage` roster, `usePools` identity paths) routes through — so the same member renders the same name for everyone regardless of how the address was cased.

- **Display-only and safe**: the nickname is never written on-chain and does not affect identity derivation, commitments, approvals, or claims. The `identity`/`commitment`/`suffix` paths are untouched, which is why the suffixes were already consistent. In-flight pools' words shift once, after which all viewers agree.
- Deliberately **not** touching `identityMessage`'s address (which feeds the signed identity seed): normalizing that would change the derived commitment for anyone who already joined with a non-lowercase address and lock them out of restore/claim. The reported bug is purely the display words, and the consistent on-chain-read suffixes confirm identity derivation is fine.

Added a casing-invariance regression test (checksummed vs lowercase vs uppercase address → identical nickname).

## Testing

- `poolNickname.test.js` (incl. the new casing-invariance case), `PoolParticipants`, `PoolPages` all pass.
- ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119ZjFVzptqmG4wacdK6pKo

---
_Generated by [Claude Code](https://claude.ai/code/session_0119ZjFVzptqmG4wacdK6pKo)_