### PR TITLE
Spec 040: My Wagers tester feedback refinements

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/039-wager-info-tooltips"
+  "feature_directory": "specs/040-my-wagers-refinements"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,5 +85,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/039-wager-info-tooltips/plan.md
+at specs/040-my-wagers-refinements/plan.md
 <!-- SPECKIT END -->

--- a/frontend/src/components/fairwins/MyMarketsModal.css
+++ b/frontend/src/components/fairwins/MyMarketsModal.css
@@ -552,6 +552,14 @@
   white-space: nowrap;
 }
 
+/* Opponent name subtitle under the wager title (spec 040 US1). */
+.mm-table-market-opponent {
+  display: block;
+  margin-top: 0.125rem;
+  font-size: 0.8125rem;
+  opacity: 0.75;
+}
+
 /* Unread row indicator (matches FriendMarketsModal pattern) */
 .mm-table-row.mm-unread {
   position: relative;

--- a/frontend/src/components/fairwins/MyMarketsModal.css
+++ b/frontend/src/components/fairwins/MyMarketsModal.css
@@ -96,24 +96,7 @@
 
 /* Network tag — signals which network's wagers are being shown so testnet
    wagers are never mistaken for mainnet ones (and vice versa). */
-.mm-network-tag {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.15rem 0.5rem;
-  border-radius: 999px;
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  color: var(--text-primary, #E6EDF3);
-  background: rgba(76, 154, 255, 0.15);
-  border: 1px solid rgba(76, 154, 255, 0.45);
-}
-
-.mm-network-tag-testnet {
-  color: #F5C451;
-  background: rgba(245, 196, 81, 0.12);
-  border-color: rgba(245, 196, 81, 0.45);
-}
+/* .mm-network-tag removed with the header network pill (spec 040 US7). */
 
 .mm-close-btn {
   background: var(--bg-primary, #0E141B);

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -17,8 +17,11 @@ import OpenChallengeDecryptModal from './OpenChallengeDecryptModal'
 import WagerList from './WagerList'
 import MyPoolsSection from './MyPoolsSection'
 import { isCodeEnvelope } from '../../utils/crypto/envelopeEncryption.js'
+import { fetchDrawProposals } from '../../data/notifications/drawProposalScan'
 import ResolveButtonWithCountdown from './ResolveButtonWithCountdown'
 import { getMarketDisplayTitle, isWinnerUnpaid } from './wagerCardHelpers'
+import OpponentName from './OpponentName'
+import { useOpponentName } from '../../hooks/useOpponentName'
 import './MyMarketsModal.css'
 import './WagerCard.css'
 
@@ -68,6 +71,11 @@ function MyMarketsModal({
   // Markets data state
   const [markets, setMarkets] = useState([])
   const [userPositions, setUserPositions] = useState([])
+
+  // Open draw proposals per wager (spec 040 US2). The proposer is not in the
+  // WagerRegistry struct, so it's read from the subgraph scan and mapped onto
+  // each wager so the card can show who has submitted a draw. { wagerId: proposer }.
+  const [drawProposerById, setDrawProposerById] = useState({})
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
 
@@ -126,6 +134,30 @@ function MyMarketsModal({
     const id = setInterval(() => { refreshFriendMarkets() }, 30000)
     return () => clearInterval(id)
   }, [isOpen, account, refreshFriendMarkets])
+
+  // Draw-proposal scan (spec 040 US2). Keeps the per-wager draw proposer current
+  // while the modal is open (same 30s cadence as the market refresh). A failed
+  // read retains prior state rather than fabricating revokes (honest state).
+  const drawScanKey = useMemo(
+    () => decryptableMarkets.map(m => String(m.id)).sort().join(','),
+    [decryptableMarkets]
+  )
+  useEffect(() => {
+    if (!isOpen || !account) return
+    const wagerIds = drawScanKey ? drawScanKey.split(',').filter(Boolean) : []
+    if (wagerIds.length === 0) { setDrawProposerById({}); return }
+    let alive = true
+    const run = async () => {
+      const { proposals, ok } = await fetchDrawProposals({ chainId, wagerIds })
+      if (!alive || !ok) return
+      const map = {}
+      for (const p of proposals) map[String(p.wagerId)] = p.proposer
+      setDrawProposerById(map)
+    }
+    run()
+    const id = setInterval(run, 30000)
+    return () => { alive = false; clearInterval(id) }
+  }, [isOpen, account, chainId, drawScanKey])
 
   const handleDecryptMarket = useCallback(async (marketId) => {
     try {
@@ -326,7 +358,11 @@ function MyMarketsModal({
       if (dismissedIds?.has(String(market.id))) return
 
       const status = getMarketStatus(market)
-      const marketWithStatus = { ...market, computedStatus: status }
+      const marketWithStatus = {
+        ...market,
+        computedStatus: status,
+        drawProposedBy: drawProposerById[String(market.id)] ?? null,
+      }
 
       // Apply status filter. The default ("all") view also hides expired
       // offers so they don't clutter the list — pick "Expired" explicitly
@@ -400,7 +436,7 @@ function MyMarketsModal({
     history.sort(comparator)
 
     return { participating, created, arbitrating, history }
-  }, [markets, decryptableMarkets, userPositions, account, sortKey, statusFilter, dismissedIds, chainId])
+  }, [markets, decryptableMarkets, userPositions, account, sortKey, statusFilter, dismissedIds, chainId, drawProposerById])
 
   // Derive the selected market from the live categorized lists so the detail
   // view reflects fresh data (e.g., decryptedMetadata) after decryption
@@ -1524,8 +1560,7 @@ function MarketDetailView({
         <div className="mm-detail-item">
           <span className="mm-detail-label">Creator</span>
           <span className="mm-detail-value">
-            {formatAddress(market.creator)}
-            {isCreator && <span className="mm-you-tag">You</span>}
+            <OpponentName address={market.creator} isSelf={isCreator} />
           </span>
         </div>
         <div className="mm-detail-item">
@@ -1788,15 +1823,23 @@ function ResolutionModal({
 
   // Participant-anchored display labels so the resolver clearly sees which party each
   // choice pays out, instead of an ambiguous "Pass/Fail" (Bug #2).
-  const fmtParty = (addr) => {
+  // Resolve both parties to friendly names (spec 040). Fixed two calls, so the
+  // hook order is stable across renders.
+  const creatorName = useOpponentName(market.creator)
+  const opponentName = useOpponentName(market.opponent)
+
+  // Friendly party names (spec 040) so the resolver sees who each choice pays,
+  // by name, alongside the short address for certainty.
+  const fmtParty = (addr, resolvedName) => {
     if (!addr) return 'Unknown'
     const short = `${addr.slice(0, 6)}…${addr.slice(-4)}`
     const isYou = account && addr.toLowerCase() === account.toLowerCase()
-    return isYou ? `${short} (You)` : short
+    const name = isYou ? 'You' : (resolvedName || short)
+    return name === short ? short : `${name} · ${short}`
   }
   const outcomeLabels = {
-    [outcomes[0]]: { title: 'Creator wins', who: fmtParty(market.creator) },
-    [outcomes[1]]: { title: 'Opponent wins', who: fmtParty(market.opponent) },
+    [outcomes[0]]: { title: 'Creator wins', who: fmtParty(market.creator, creatorName.displayName) },
+    [outcomes[1]]: { title: 'Opponent wins', who: fmtParty(market.opponent, opponentName.displayName) },
   }
   const labelFor = (outcome) => {
     if (outcome === DRAW) return 'Draw — both parties refunded'

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -18,6 +18,8 @@ import WagerList from './WagerList'
 import MyPoolsSection from './MyPoolsSection'
 import { isCodeEnvelope } from '../../utils/crypto/envelopeEncryption.js'
 import { fetchDrawProposals } from '../../data/notifications/drawProposalScan'
+import { useOpenChallengeCodeVault } from '../../hooks/useOpenChallengeCodeVault'
+import { findSavedCode, decryptWithCode } from '../../lib/openChallenge/autoUnlock'
 import ResolveButtonWithCountdown from './ResolveButtonWithCountdown'
 import { getMarketDisplayTitle, isWinnerUnpaid } from './wagerCardHelpers'
 import OpponentName from './OpponentName'
@@ -64,6 +66,11 @@ function MyMarketsModal({
   // read with the wallet-key path, so a click on a code-keyed wager routes here
   // to collect the four-word code. Holds the target market id + its envelope.
   const [codeDecrypt, setCodeDecrypt] = useState(null)
+
+  // Open-challenge code vault (spec 040 US3). Lets us auto-unlock a challenge the
+  // member already saved a code for (one cached wallet signature, no re-typing),
+  // and remember codes entered manually so they aren't asked again.
+  const { canUse: canUseVault, hasBackup, recoverCodes, saveCode } = useOpenChallengeCodeVault()
 
   // Tab state
   const [activeTab, setActiveTab] = useState('participating')
@@ -159,6 +166,23 @@ function MyMarketsModal({
     return () => { alive = false; clearInterval(id) }
   }, [isOpen, account, chainId, drawScanKey])
 
+  // Auto-unlock an open challenge from a saved code (spec 040 US3). Returns true
+  // when it decrypted without prompting. Only attempts when the member has a
+  // vault (avoids a needless signature for takers with nothing saved), and any
+  // failure falls back to the manual prompt.
+  const tryAutoUnlockCode = useCallback(async (marketId, envelope) => {
+    if (!hasBackup) return false
+    try {
+      const codes = await recoverCodes()
+      const saved = findSavedCode(codes, marketId)
+      if (!saved) return false
+      setDecryptedMetadata(marketId, decryptWithCode(envelope, saved.code))
+      return true
+    } catch {
+      return false
+    }
+  }, [hasBackup, recoverCodes, setDecryptedMetadata])
+
   const handleDecryptMarket = useCallback(async (marketId) => {
     try {
       // Pass the just-fetched envelope straight into decryptMarket. The merged
@@ -167,17 +191,19 @@ function MyMarketsModal({
       // pass instead of the old fetch-then-(re-click)-to-decrypt flow.
       const envelope = await fetchEnvelope(marketId)
       // Open challenges (feature 024) seal their terms under the four-word code, not a
-      // recipient key — the wallet-key path can't read them. Route those to the code
-      // prompt instead; everything else decrypts with the connected wallet as before.
+      // recipient key — the wallet-key path can't read them. Try a saved code first
+      // (spec 040 US3), then fall back to the code prompt; everything else decrypts
+      // with the connected wallet as before.
       if (isCodeEnvelope(envelope)) {
-        setCodeDecrypt({ marketId, envelope })
+        const unlocked = await tryAutoUnlockCode(marketId, envelope)
+        if (!unlocked) setCodeDecrypt({ marketId, envelope })
         return
       }
       await decryptMarket(marketId, envelope)
     } catch (err) {
       console.error('[MyMarketsModal] Decryption failed:', err)
     }
-  }, [fetchEnvelope, decryptMarket])
+  }, [fetchEnvelope, decryptMarket, tryAutoUnlockCode])
 
   // Fetch markets data (friend markets are passed via props)
   const fetchMarketsData = useCallback(async () => {
@@ -1282,7 +1308,13 @@ function MyMarketsModal({
           isOpen
           envelope={codeDecrypt.envelope}
           onClose={() => setCodeDecrypt(null)}
-          onDecrypted={(metadata) => setDecryptedMetadata(codeDecrypt.marketId, metadata)}
+          onDecrypted={(metadata, code) => {
+            setDecryptedMetadata(codeDecrypt.marketId, metadata)
+            // Remember the code so this challenge auto-unlocks next time (spec 040 US3).
+            if (code && canUseVault) {
+              saveCode({ code, wagerId: String(codeDecrypt.marketId) }).catch(() => {})
+            }
+          }}
         />
       )}
 

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -978,8 +978,9 @@ function MyMarketsModal({
 
         {/* Content Area */}
         <div className="mm-content">
-          {/* Group pools (spec 037) — self-hides when the user has none, so the wager view is unchanged. */}
-          <MyPoolsSection />
+          {/* Group pools (spec 037; spec 040 US5) — tab-aware: active pools show in the active
+              tabs, terminal pools move to History. Self-hides when the user has none for the tab. */}
+          <MyPoolsSection activeTab={activeTab} />
           {!isConnected ? (
             <div className="mm-empty-state">
               <div className="mm-empty-icon">&#128274;</div>

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -850,14 +850,8 @@ function MyMarketsModal({
             <div className="mm-brand">
               <span className="mm-brand-icon">&#128202;</span>
               <h2 id="my-markets-modal-title">My Wagers</h2>
-              {activeNetwork && (
-                <span
-                  className={`mm-network-tag${activeNetwork.isTestnet ? ' mm-network-tag-testnet' : ''}`}
-                  title={`Showing wagers on ${activeNetwork.name}`}
-                >
-                  {activeNetwork.name}
-                </span>
-              )}
+              {/* Network pill removed (spec 040 US7) — the subtitle below already
+                  names the active network, so a separate pill was redundant. */}
             </div>
             <p className="mm-subtitle">
               Manage your wagers and positions on {activeNetwork?.name || 'the current network'}
@@ -970,13 +964,14 @@ function MyMarketsModal({
               onChange={(e) => setStatusFilter(e.target.value)}
               className="mm-filter-select"
             >
+              {/* Disputed and Expired options removed (spec 040 US6): Expired is
+                  hidden from the default view, and Disputed is not a reachable
+                  state here — offering them returned empty/misleading results. */}
               <option value="all">All Status</option>
               <option value={MarketStatus.PENDING_ACCEPTANCE}>Pending Acceptance</option>
               <option value={MarketStatus.ACTIVE}>Active</option>
               <option value={MarketStatus.PENDING_RESOLUTION}>Pending Resolution</option>
-              <option value={MarketStatus.DISPUTED}>Disputed</option>
               <option value={MarketStatus.RESOLVED}>Resolved</option>
-              <option value={MarketStatus.EXPIRED}>Expired</option>
             </select>
           </div>
         </div>

--- a/frontend/src/components/fairwins/MyPoolsSection.jsx
+++ b/frontend/src/components/fairwins/MyPoolsSection.jsx
@@ -3,24 +3,33 @@ import { useMyPools } from '../../hooks/useMyPools'
 import './MyPoolsSection.css'
 
 /**
- * Group pools in the consolidated My Wagers view (spec 037, US2 / FR-015..018).
+ * Group pools in the consolidated My Wagers view (spec 037, US2 / FR-015..018; spec 040 US5).
  *
- * Lists the connected user's created + joined pools with a type indicator, status, and active/history
- * grouping; selecting one opens the pool's management page. Renders nothing when the user has no pools,
- * so the existing wager-only view is unchanged (FR-019). Pools known only from this device (anonymous
- * on-chain membership) are device-scoped (FR-024).
+ * Lists the connected user's created + joined pools with a type indicator and status; selecting one
+ * opens the pool's management page. Renders nothing when the user has no pools for the active tab, so
+ * the existing wager-only view is unchanged. Pools known only from this device (anonymous on-chain
+ * membership) are device-scoped (FR-024).
+ *
+ * Tab-aware (spec 040 US5 / FR-015..016): pools in a terminal state (resolved/cancelled) move out of
+ * the active tabs and into the History tab alongside terminal wagers, so finished pools no longer
+ * clutter the active view. The tab conveys the bucket, so the per-row Active/Past chip is dropped.
  */
-export default function MyPoolsSection() {
+export default function MyPoolsSection({ activeTab }) {
   const { items } = useMyPools()
   const navigate = useNavigate()
 
-  if (!items.length) return null
+  const wantHistory = activeTab === 'history'
+  const visible = items.filter((it) =>
+    wantHistory ? it.bucket === 'history' : it.bucket !== 'history'
+  )
+
+  if (!visible.length) return null
 
   return (
     <section className="mm-pools-section" aria-label="Your group pools">
       <h3 className="mm-pools-heading">Group pools</h3>
       <ul className="mm-pools-list">
-        {items.map((it) => (
+        {visible.map((it) => (
           <li key={it.id} className="mm-pool-item">
             <button
               type="button"
@@ -31,9 +40,6 @@ export default function MyPoolsSection() {
               <span className="mm-pool-type">Pool</span>
               <span className="mm-pool-title">{it.title}</span>
               <span className="mm-pool-status">{it.status}</span>
-              <span className={`mm-pool-bucket mm-pool-bucket--${it.bucket}`}>
-                {it.bucket === 'history' ? 'Past' : 'Active'}
-              </span>
             </button>
           </li>
         ))}

--- a/frontend/src/components/fairwins/OpenChallengeDecryptModal.jsx
+++ b/frontend/src/components/fairwins/OpenChallengeDecryptModal.jsx
@@ -44,7 +44,9 @@ export default function OpenChallengeDecryptModal({ isOpen, onClose, envelope, o
       }
       const { symKey } = deriveFromCode(code)
       const terms = decryptEnvelopeCode(envelope, symKey) // throws on a wrong code / tampered bytes
-      onDecrypted?.(typeof terms === 'string' ? { description: terms } : terms)
+      // Pass the validated code back so the caller can remember it (spec 040 US3),
+      // sparing the member from re-entering it next time.
+      onDecrypted?.(typeof terms === 'string' ? { description: terms } : terms, code)
       onClose()
     } catch {
       // Wrong code and tampered bytes both surface as a decryption failure; don't distinguish (no oracle).

--- a/frontend/src/components/fairwins/OpponentName.css
+++ b/frontend/src/components/fairwins/OpponentName.css
@@ -1,0 +1,72 @@
+/* OpponentName (spec 040, US1) — friendly opponent label with click-to-reveal address. */
+
+.opponent-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.opponent-name--self {
+  font-weight: 600;
+}
+
+.opponent-name-toggle {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 2px;
+}
+
+.opponent-name-toggle:hover,
+.opponent-name-toggle:focus-visible {
+  text-decoration-style: solid;
+}
+
+.opponent-name-toggle:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+.opponent-name-address {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.opponent-name-full {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85em;
+  opacity: 0.85;
+}
+
+.opponent-name-copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 2px;
+  margin: 0;
+  color: inherit;
+  opacity: 0.7;
+  cursor: pointer;
+}
+
+.opponent-name-copy:hover,
+.opponent-name-copy:focus-visible {
+  opacity: 1;
+}
+
+.opponent-name-copy:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 1px;
+  border-radius: 3px;
+}

--- a/frontend/src/components/fairwins/OpponentName.jsx
+++ b/frontend/src/components/fairwins/OpponentName.jsx
@@ -1,0 +1,69 @@
+import { useState } from 'react'
+import { useOpponentName } from '../../hooks/useOpponentName'
+import { formatShortAddress } from './wagerCardHelpers'
+import './OpponentName.css'
+
+/**
+ * OpponentName (spec 040, US1 / FR-001..004)
+ *
+ * The single opponent renderer for My Wagers. Shows the friendliest available name
+ * (address book → ENS → deterministic two-word name) and, when interactive, lets the
+ * member tap to reveal + copy the full address.
+ *
+ * - `isSelf` renders "You" and skips resolution.
+ * - `interactive={false}` renders a plain, non-focusable span — use inside another
+ *   interactive element (e.g. the card's clickable preview header) to avoid nesting
+ *   a button in a button.
+ */
+export default function OpponentName({ address, isSelf = false, interactive = true }) {
+  const [revealed, setRevealed] = useState(false)
+  const { displayName } = useOpponentName(isSelf ? undefined : address)
+
+  if (isSelf) return <span className="opponent-name opponent-name--self">You</span>
+
+  if (!address || typeof address !== 'string' || !address.startsWith('0x')) {
+    return <span className="opponent-name">{formatShortAddress(address)}</span>
+  }
+
+  const full = formatShortAddress(address)
+
+  if (!interactive) {
+    return <span className="opponent-name">{displayName}</span>
+  }
+
+  const copy = (e) => {
+    e.stopPropagation()
+    navigator.clipboard?.writeText(address).catch(() => {})
+  }
+
+  return (
+    <span className="opponent-name opponent-name--interactive">
+      <button
+        type="button"
+        className="opponent-name-toggle"
+        aria-expanded={revealed}
+        aria-label={revealed ? `Hide address for ${displayName}` : `Show full address for ${displayName}`}
+        onClick={(e) => { e.stopPropagation(); setRevealed((v) => !v) }}
+      >
+        {displayName}
+      </button>
+      {revealed && (
+        <span className="opponent-name-address">
+          <code className="opponent-name-full" title={address}>{full}</code>
+          <button
+            type="button"
+            className="opponent-name-copy"
+            aria-label={`Copy address ${address}`}
+            title="Copy address"
+            onClick={copy}
+          >
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+          </button>
+        </span>
+      )}
+    </span>
+  )
+}

--- a/frontend/src/components/fairwins/WagerCard.css
+++ b/frontend/src/components/fairwins/WagerCard.css
@@ -167,6 +167,63 @@
 
 .wc-action-needed { vertical-align: middle; }
 
+/* Draw submission state (spec 040 US2) — evident on the card, text + icon (not colour alone). */
+.wc-draw-badge { vertical-align: middle; }
+
+.wc-draw {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  margin-bottom: 0.75rem;
+  border-radius: 8px;
+  background: rgba(159, 122, 234, 0.1);
+  border: 1px solid rgba(159, 122, 234, 0.28);
+}
+
+.wc-draw-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #9F7AEA;
+}
+
+.wc-draw-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.wc-draw-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  border-radius: 999px;
+}
+
+.wc-draw-chip::before {
+  content: '';
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.wc-draw-chip--done { background: rgba(54, 179, 126, 0.15); color: #36B37E; }
+.wc-draw-chip--pending { background: rgba(245, 166, 35, 0.15); color: #C77700; }
+
+.mm-table-draw {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #9F7AEA;
+}
+
 .wc-chevron {
   color: var(--text-muted, #7A8590);
   transition: transform 0.2s;

--- a/frontend/src/components/fairwins/WagerCard.jsx
+++ b/frontend/src/components/fairwins/WagerCard.jsx
@@ -1,5 +1,6 @@
 import Badge from '../ui/Badge'
 import ResolveButtonWithCountdown from './ResolveButtonWithCountdown'
+import OpponentName from './OpponentName'
 
 // spec 012 FR-007 action-needed labels, reused on the card's status row.
 const ACTION_NEEDED_LABELS = {
@@ -87,7 +88,11 @@ export default function WagerCard({
           {vm.showPreview && (
             <div className="wc-preview">
               <span className="wc-avatar" style={{ background: vm.avatarColor }} aria-hidden="true"></span>
-              <span className="wc-preview-text">{vm.opponent}</span>
+              <span className="wc-preview-text">
+                {vm.opponentAddress
+                  ? <OpponentName address={vm.opponentAddress} interactive={false} />
+                  : vm.opponent}
+              </span>
               <span className="wc-dot">·</span>
               <span className="wc-preview-text">{vm.timeLeft}</span>
             </div>
@@ -190,7 +195,11 @@ export default function WagerCard({
             {vm.meta.map((m, i) => (
               <div className="wc-meta-item" key={i}>
                 <div className="wc-meta-label">{m.label}</div>
-                <div className={`wc-meta-value${m.tone ? ` ${m.tone}` : ''}`}>{m.value}</div>
+                <div className={`wc-meta-value${m.tone ? ` ${m.tone}` : ''}`}>
+                  {m.kind === 'address'
+                    ? <OpponentName address={m.address} isSelf={m.isSelf} />
+                    : m.value}
+                </div>
               </div>
             ))}
           </div>

--- a/frontend/src/components/fairwins/WagerCard.jsx
+++ b/frontend/src/components/fairwins/WagerCard.jsx
@@ -70,7 +70,11 @@ export default function WagerCard({
             <span className="wc-stake">{vm.stake}</span>
             <span className="wc-token">{vm.tokenSymbol}</span>
             {vm.outcome && (
-              <span className={`wc-outcome ${vm.outcome.tone}`}>{vm.outcome.label}</span>
+              <span className={`wc-outcome ${vm.outcome.tone}`}>
+                {vm.outcome.address
+                  ? <OpponentName address={vm.outcome.address} interactive={false} />
+                  : vm.outcome.label}
+              </span>
             )}
           </div>
           <div className="wc-title" id={headingId} title={vm.displayTitle}>
@@ -100,6 +104,9 @@ export default function WagerCard({
         </div>
         <div className="wc-header-side">
           <span className={`wc-status ${vm.statusClass}`}>{vm.statusText}</span>
+          {vm.draw?.phase === 'proposed' && (
+            <Badge variant="warning" className="wc-draw-badge">Draw pending</Badge>
+          )}
           {/* Action-needed tag. While the card is collapsed this tag is the only
               signal that the wager needs attention — its action buttons live in
               the expanded body, and on phones the grid never auto-expands, so a
@@ -126,6 +133,26 @@ export default function WagerCard({
       {isOpen && (
         <div className="wc-body" id={panelId}>
           <div className="wc-divider"></div>
+
+          {/* Draw submission state (spec 040 US2) — which party has submitted a draw. */}
+          {vm.draw && (
+            <div className={`wc-draw wc-draw--${vm.draw.phase}`} role="status">
+              <div className="wc-draw-head">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  <path d="M12 3v18M5 7h14M5 7l-3 6a4 4 0 008 0L5 7zM19 7l-3 6a4 4 0 008 0l-5-6z" />
+                </svg>
+                <span className="wc-draw-label">{vm.draw.label}</span>
+              </div>
+              <div className="wc-draw-chips">
+                <span className={`wc-draw-chip${vm.draw.mySubmitted ? ' wc-draw-chip--done' : ' wc-draw-chip--pending'}`}>
+                  You: {vm.draw.mySubmitted ? 'submitted' : 'not yet'}
+                </span>
+                <span className={`wc-draw-chip${vm.draw.opponentSubmitted ? ' wc-draw-chip--done' : ' wc-draw-chip--pending'}`}>
+                  Opponent: {vm.draw.opponentSubmitted ? 'submitted' : 'not yet'}
+                </span>
+              </div>
+            </div>
+          )}
 
           {/* Terms / decrypt affordance */}
           {vm.encState === 'locked' && (

--- a/frontend/src/components/fairwins/WagerTable.jsx
+++ b/frontend/src/components/fairwins/WagerTable.jsx
@@ -114,12 +114,19 @@ export default function WagerTable({
               <td className="wc-table-amount">
                 <strong>{vm.stake}</strong> {vm.tokenSymbol}
                 {vm.outcome && (
-                  <span className={`wc-outcome ${vm.outcome.tone}`} style={{ marginLeft: 6 }}>{vm.outcome.label}</span>
+                  <span className={`wc-outcome ${vm.outcome.tone}`} style={{ marginLeft: 6 }}>
+                    {vm.outcome.address
+                      ? <OpponentName address={vm.outcome.address} interactive={false} />
+                      : vm.outcome.label}
+                  </span>
                 )}
               </td>
               <td className="mm-table-time">{vm.meta[1]?.value}</td>
               <td>
                 <span className={`mm-status-badge ${vm.statusClass}`}>{vm.statusText}</span>
+                {vm.draw?.phase === 'proposed' && (
+                  <span className="mm-table-draw" title={vm.draw.label}>Draw pending</span>
+                )}
               </td>
               {hasActionsColumn && (
                 <td className="mm-table-actions" onClick={(e) => e.stopPropagation()}>

--- a/frontend/src/components/fairwins/WagerTable.jsx
+++ b/frontend/src/components/fairwins/WagerTable.jsx
@@ -3,6 +3,7 @@ import { WagerStatus as MarketStatus } from '../../constants/wagerDefaults'
 import { useWagerActivityOptional } from '../../hooks/useWagerActivity'
 import { buildWagerVm } from './wagerVm'
 import ResolveButtonWithCountdown from './ResolveButtonWithCountdown'
+import OpponentName from './OpponentName'
 
 const VARIANT_CLASS = {
   primary: 'wc-action-primary',
@@ -104,6 +105,11 @@ export default function WagerTable({
                 <span className="mm-table-market-title">
                   <span>{vm.displayTitle}</span>
                 </span>
+                {vm.opponentAddress && (
+                  <span className="mm-table-market-opponent">
+                    <OpponentName address={vm.opponentAddress} interactive={false} />
+                  </span>
+                )}
               </td>
               <td className="wc-table-amount">
                 <strong>{vm.stake}</strong> {vm.tokenSymbol}

--- a/frontend/src/components/fairwins/__tests__/MyPoolsSection.test.jsx
+++ b/frontend/src/components/fairwins/__tests__/MyPoolsSection.test.jsx
@@ -16,16 +16,19 @@ describe('MyPoolsSection (spec 037, US2)', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('lists pools with type + status + active/history bucket and routes on click (FR-016/017/018)', () => {
+  it('lists active pools with type + status and routes on click; terminal pools move to History (spec 040 US5)', () => {
     mockPools.current = [
       { type: 'pool', id: '0xa', title: 'Pool #3', status: 'Joining open', bucket: 'active', route: '/pools/0xa' },
       { type: 'pool', id: '0xb', title: 'Pool #4', status: 'Resolved', bucket: 'history', route: '/pools/0xb' },
     ]
-    render(<MyPoolsSection />)
+    // Active (non-history) tab shows only the active pool — the terminal pool is filed under History.
+    render(<MyPoolsSection activeTab="participating" />)
     expect(screen.getByText('Pool #3')).toBeInTheDocument()
     expect(screen.getByText('Joining open')).toBeInTheDocument()
-    expect(screen.getAllByText('Pool')).toHaveLength(2) // a type indicator per item
-    expect(screen.getByText('Past')).toBeInTheDocument() // history bucket label
+    expect(screen.queryByText('Pool #4')).not.toBeInTheDocument()
+    expect(screen.getAllByText('Pool')).toHaveLength(1) // only the active pool renders here
+    // The per-row Active/Past chip was removed (the tab conveys the bucket).
+    expect(screen.queryByText('Past')).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /open pool #3/i }))
     expect(navigate).toHaveBeenCalledWith('/pools/0xa')
   })

--- a/frontend/src/components/fairwins/wagerCardHelpers.js
+++ b/frontend/src/components/fairwins/wagerCardHelpers.js
@@ -84,7 +84,8 @@ export function getRowOutcome(market, account) {
       if (isCreator || isParticipant) return { label: 'Lost', tone: 'negative' }
     }
     if (market.winner) {
-      return { label: `${market.winner.slice(0, 6)}…${market.winner.slice(-4)}`, tone: 'neutral' }
+      // Carry the winner address so views can render a friendly name (spec 040).
+      return { label: formatShortAddress(market.winner), tone: 'neutral', address: market.winner }
     }
     return { label: 'Resolved', tone: 'neutral' }
   }

--- a/frontend/src/components/fairwins/wagerVm.js
+++ b/frontend/src/components/fairwins/wagerVm.js
@@ -100,9 +100,35 @@ export function buildWagerVm(market, ctx) {
   const creatorLabel = creatorIsSelf ? 'You' : formatShortAddress(market.creator)
   const endRaw = market.tradingEndTime || market.endDate
 
+  // Draw state (spec 040 US2). A terminal DRAW means both parties agreed and
+  // stakes were returned. Otherwise, an open proposer (from the subgraph scan,
+  // attached as `drawProposedBy`) means a draw is proposed and awaiting the
+  // other party — surfaced regardless of who proposed, so the proposer also
+  // sees that their submission is recorded.
+  const drawProposer = market.drawProposedBy ? String(market.drawProposedBy).toLowerCase() : null
+  let draw = null
+  if (market.computedStatus === MarketStatus.DRAW) {
+    draw = {
+      phase: 'settled',
+      proposer: drawProposer,
+      mySubmitted: true,
+      opponentSubmitted: true,
+      label: 'Both agreed · stakes returned',
+    }
+  } else if (drawProposer) {
+    const mine = drawProposer === me
+    draw = {
+      phase: 'proposed',
+      proposer: drawProposer,
+      mySubmitted: mine,
+      opponentSubmitted: !mine,
+      label: mine ? 'You proposed · awaiting opponent' : 'Opponent proposed · your turn',
+    }
+  }
+
   const meta = [
     showOutcome && outcome
-      ? { label: 'Outcome', value: outcome.label, tone: outcome.tone }
+      ? { label: 'Outcome', value: outcome.label, tone: outcome.tone, kind: outcome.address ? 'address' : undefined, address: outcome.address }
       : { label: 'Opponent', value: opponent, kind: opponentAddress ? 'address' : undefined, address: opponentAddress },
     { label: showOutcome ? 'Settled' : 'Ends', value: showOutcome ? formatDate(endRaw) : timeLeft },
     { label: 'Wager ID', value: `#${market.id}` },
@@ -185,6 +211,7 @@ export function buildWagerVm(market, ctx) {
     actionBadgeRedundant,
     opponent,
     opponentAddress,
+    draw,
     avatarColor: avatarColor(others[0] || idStr),
   }
 }

--- a/frontend/src/components/fairwins/wagerVm.js
+++ b/frontend/src/components/fairwins/wagerVm.js
@@ -94,17 +94,19 @@ export function buildWagerVm(market, ctx) {
   // Counterparty / creator labels (on-chain public; display only).
   const others = [market.creator, ...(market.participants || [])]
     .filter(a => a && a.toLowerCase?.() !== me)
-  const opponent = others.length ? formatShortAddress(others[0]) : '—'
-  const creatorLabel = market.creator?.toLowerCase?.() === me ? 'You' : formatShortAddress(market.creator)
+  const opponentAddress = others.length ? others[0] : null
+  const opponent = opponentAddress ? formatShortAddress(opponentAddress) : '—'
+  const creatorIsSelf = market.creator?.toLowerCase?.() === me
+  const creatorLabel = creatorIsSelf ? 'You' : formatShortAddress(market.creator)
   const endRaw = market.tradingEndTime || market.endDate
 
   const meta = [
     showOutcome && outcome
       ? { label: 'Outcome', value: outcome.label, tone: outcome.tone }
-      : { label: 'Opponent', value: opponent },
+      : { label: 'Opponent', value: opponent, kind: opponentAddress ? 'address' : undefined, address: opponentAddress },
     { label: showOutcome ? 'Settled' : 'Ends', value: showOutcome ? formatDate(endRaw) : timeLeft },
     { label: 'Wager ID', value: `#${market.id}` },
-    { label: 'Creator', value: creatorLabel },
+    { label: 'Creator', value: creatorLabel, kind: 'address', address: market.creator, isSelf: creatorIsSelf },
   ]
 
   // Action visibility — identical rules to the former MarketsTable.
@@ -182,6 +184,7 @@ export function buildWagerVm(market, ctx) {
     actionNeeded,
     actionBadgeRedundant,
     opponent,
+    opponentAddress,
     avatarColor: avatarColor(others[0] || idStr),
   }
 }

--- a/frontend/src/hooks/useMyPools.js
+++ b/frontend/src/hooks/useMyPools.js
@@ -54,6 +54,18 @@ export function useMyPools() {
     return aggregateMyItems({ createdPools, joinedPools: [...joinedPools, ...fallback] })
   }, [account, chainId, getPoolSummary])
 
+  // Manual refresh — re-run the idempotent load. Used by callers and the poll.
+  const refresh = useCallback(() => {
+    if (!account) { setItems([]); return Promise.resolve() }
+    return load()
+      .then((list) => setItems(list))
+      .catch(() => { /* keep prior items on a transient failure */ })
+  }, [account, load])
+
+  // Load on mount and auto-refresh on an interval while mounted (spec 040 US4 /
+  // FR-012..014), so pools stay current alongside wagers without a manual
+  // refresh. The interval is cleared on unmount, so polling stops when My
+  // Wagers closes.
   useEffect(() => {
     let alive = true
     if (!account) {
@@ -65,10 +77,17 @@ export function useMyPools() {
       .then((list) => { if (alive) setItems(list) })
       .catch(() => { if (alive) setItems([]) })
       .finally(() => { if (alive) setLoading(false) })
-    return () => { alive = false }
+
+    const id = setInterval(() => {
+      load()
+        .then((list) => { if (alive) setItems(list) })
+        .catch(() => { /* retain prior items */ })
+    }, 30000)
+
+    return () => { alive = false; clearInterval(id) }
   }, [account, load])
 
-  return { items, loading }
+  return { items, loading, refresh }
 }
 
 export default useMyPools

--- a/frontend/src/hooks/useOpponentName.js
+++ b/frontend/src/hooks/useOpponentName.js
@@ -1,0 +1,64 @@
+/**
+ * useOpponentName (spec 040, US1 / FR-001..002) — resolve a counterparty address to the friendliest
+ * available display name, in priority order:
+ *
+ *   1. Address book — the member's own nickname for the address (authoritative).
+ *   2. ENS — the reverse-resolved mainnet name, if any.
+ *   3. Generated — a deterministic two-word name derived from the address.
+ *
+ * The generated fallback is always available synchronously, so a card never shows a spinner or a raw
+ * address while ENS resolves. Read-only; no wallet signature.
+ *
+ * It reads the wallet context OPTIONALLY (via useContext, not the throwing useWallet) and loads the
+ * address book through the pure store — so this display helper works even in lightweight renders that
+ * have no WalletProvider (e.g. a single card in a test), degrading gracefully to ENS + generated.
+ */
+import { useContext, useMemo } from 'react'
+import { WalletContext } from '../contexts'
+import { useEnsReverseLookup } from './useEnsResolution'
+import { loadAddressBook, findByAddress as findByAddressPure } from '../lib/addressBook/addressBookStore'
+import { deriveAddressName } from '../lib/naming/addressName'
+import { isValidEthereumAddress } from '../utils/validation'
+
+/**
+ * @param {string} address the counterparty address to resolve
+ * @param {{ chainId?: number }} [opts]
+ * @returns {{ displayName: string, source: 'addressBook'|'ens'|'generated', address: string, isLoading: boolean }}
+ */
+export function useOpponentName(address, { chainId: chainIdArg } = {}) {
+  const wallet = useContext(WalletContext)
+  const walletAddress = wallet?.address || wallet?.account
+  const chainId = chainIdArg ?? wallet?.chainId
+  const isAddress = isValidEthereumAddress(address)
+  const { ensName, isLoading } = useEnsReverseLookup(isAddress ? address : undefined)
+
+  return useMemo(() => {
+    if (!isAddress) {
+      return { displayName: address || '—', source: 'generated', address: address || '', isLoading: false }
+    }
+
+    // 1) Address book nickname wins. findByAddress → { contact, savedAddress } | undefined.
+    let bookName
+    if (walletAddress) {
+      try {
+        const entry = findByAddressPure(loadAddressBook(walletAddress), address, chainId)
+        bookName = entry?.contact?.nickname
+      } catch {
+        // No/unreadable book — fall through to ENS / generated.
+      }
+    }
+    if (bookName) {
+      return { displayName: bookName, source: 'addressBook', address, isLoading: false }
+    }
+
+    // 2) ENS reverse record.
+    if (ensName) {
+      return { displayName: ensName, source: 'ens', address, isLoading: false }
+    }
+
+    // 3) Deterministic generated name (always available).
+    return { displayName: deriveAddressName(address).label, source: 'generated', address, isLoading }
+  }, [isAddress, address, chainId, walletAddress, ensName, isLoading])
+}
+
+export default useOpponentName

--- a/frontend/src/lib/naming/addressName.js
+++ b/frontend/src/lib/naming/addressName.js
@@ -1,0 +1,41 @@
+/**
+ * Deterministic two-word display names for wallet addresses (spec 040, US1 / FR-002).
+ *
+ * When an opponent has no address-book nickname and no ENS reverse record, the My Wagers card still
+ * needs a memorable, human-readable label instead of a bare `0x1234…ABCD`. This derives a stable
+ * adjective-noun name from the address itself: the SAME address always renders the SAME name, so a
+ * repeat opponent is recognizable across wagers and sessions.
+ *
+ * It reuses ONLY the shared vocabulary from the pool nicknames (spec 034); it is intentionally a
+ * separate function from `deriveNickname`, which is keyed on a Semaphore identity commitment and is
+ * pool-scoped. This one is address-keyed and pure client-side display — never written to chain.
+ */
+import { keccak256, toUtf8Bytes, getBigInt } from 'ethers'
+import { ADJECTIVES, NOUNS } from '../pools/nicknameWords'
+
+const DOMAIN = 'FAIRWINS_ADDRESS_NAME_v1'
+
+/**
+ * Derive a stable two-word name for an address.
+ *
+ * @param {string} address a 0x-prefixed 20-byte hex address
+ * @returns {{ adjective: string, noun: string, label: string }}
+ * @throws if `address` is not a hex-like string
+ */
+export function deriveAddressName(address) {
+  if (typeof address !== 'string' || !address.startsWith('0x')) {
+    throw new Error('deriveAddressName: a 0x-prefixed address is required')
+  }
+  // Lowercase so a checksummed `0xAbC…` and a lowercase `0xabc…` — the same account — hash identically.
+  const normalized = address.toLowerCase()
+  const h = getBigInt(keccak256(toUtf8Bytes(DOMAIN + normalized)))
+
+  const adjCount = BigInt(ADJECTIVES.length)
+  const nounCount = BigInt(NOUNS.length)
+  const adjective = ADJECTIVES[Number(h % adjCount)]
+  const noun = NOUNS[Number((h / adjCount) % nounCount)]
+
+  return { adjective, noun, label: `${adjective} ${noun}` }
+}
+
+export default deriveAddressName

--- a/frontend/src/lib/openChallenge/autoUnlock.js
+++ b/frontend/src/lib/openChallenge/autoUnlock.js
@@ -1,0 +1,34 @@
+/**
+ * Auto-unlock helpers for open-challenge terms (spec 040, US3 / FR-009..011).
+ *
+ * A member who has already supplied an open challenge's four-word code has it saved (encrypted,
+ * wallet-scoped) in the code vault. These pure helpers let My Wagers find that saved code and
+ * decrypt the terms WITHOUT re-prompting the member for the words. First-encounter items (no saved
+ * code) still fall back to the manual prompt.
+ */
+import { deriveFromCode } from '../../utils/claimCode/deriveFromCode.js'
+import { decryptEnvelopeCode } from '../../utils/crypto/envelopeEncryption.js'
+
+/**
+ * Find the saved vault entry whose code unlocks the given wager, if any.
+ * @param {Array<{code?: string, wagerId?: string|number}>} codes vault entries (newest first)
+ * @param {string|number} wagerId the wager to unlock
+ * @returns {{code: string, wagerId: string|number}|null}
+ */
+export function findSavedCode(codes, wagerId) {
+  if (!Array.isArray(codes) || wagerId == null) return null
+  return codes.find((e) => e && e.code && String(e.wagerId) === String(wagerId)) || null
+}
+
+/**
+ * Decrypt a code-keyed envelope with a saved four-word code, returning display metadata.
+ * Throws if the code doesn't unlock the envelope (wrong code / tampered bytes).
+ * @param {object} envelope the code-keyed terms envelope
+ * @param {string} code the four-word claim code
+ * @returns {object} decrypted metadata (`{ description }` when the terms are a plain string)
+ */
+export function decryptWithCode(envelope, code) {
+  const { symKey } = deriveFromCode(code)
+  const terms = decryptEnvelopeCode(envelope, symKey)
+  return typeof terms === 'string' ? { description: terms } : terms
+}

--- a/frontend/src/test/MyMarketsModal.test.jsx
+++ b/frontend/src/test/MyMarketsModal.test.jsx
@@ -231,6 +231,15 @@ describe('MyMarketsModal', () => {
       expect(screen.getByText(/Manage your wagers and positions/)).toBeInTheDocument()
     })
 
+    it('no longer renders the redundant network pill (spec 040 US7)', async () => {
+      const { container } = renderWithProviders(
+        <MyMarketsModal isOpen={true} onClose={mockOnClose} />
+      )
+      // The pill is gone; the network name still lives in the subtitle.
+      expect(container.querySelector('.mm-network-tag')).toBeNull()
+      expect(screen.getByText(/Manage your wagers and positions/)).toBeInTheDocument()
+    })
+
     it('should have close button', async () => {
       await act(async () => {
         renderWithProviders(
@@ -366,6 +375,23 @@ describe('MyMarketsModal', () => {
         expect(screen.getByText('Sort:')).toBeInTheDocument()
       })
       expect(screen.queryByRole('button', { name: /refresh/i })).not.toBeInTheDocument()
+    })
+
+    it('drops the Expired and Disputed status options (spec 040 US6)', async () => {
+      await act(async () => {
+        renderWithProviders(
+          <MyMarketsModal isOpen={true} onClose={mockOnClose} />
+        )
+      })
+
+      await waitFor(() => expect(screen.getByText('Status:')).toBeInTheDocument())
+      const statusSelect = screen.getByText('Status:').nextElementSibling
+      const optionValues = Array.from(statusSelect.options).map((o) => o.value)
+      expect(optionValues).toEqual([
+        'all', 'pending_acceptance', 'active', 'pending_resolution', 'resolved',
+      ])
+      expect(optionValues).not.toContain('expired')
+      expect(optionValues).not.toContain('disputed')
     })
   })
 
@@ -520,50 +546,9 @@ describe('MyMarketsModal', () => {
       expect(screen.getByText(/No Active Positions/i)).toBeInTheDocument()
     })
 
-    it('shows expired offers with "Expired" time-left and Clear button when filter is Expired', async () => {
-      const user = userEvent.setup()
-      const dismissMarket = vi.fn()
-      const expiredMarket = {
-        id: '99',
-        description: 'Expired Offer',
-        creator: '0xABCDEF1234567890ABCDEF1234567890ABCDEF12',
-        participants: ['0x1234567890123456789012345678901234567890'],
-        status: 'pending_acceptance',
-        acceptanceDeadline: Date.now() - 60 * 60 * 1000,
-        endDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-        marketType: 'friend'
-      }
-
-      await act(async () => {
-        renderWithProviders(
-          <MyMarketsModal isOpen={true} onClose={mockOnClose} friendMarkets={[expiredMarket]} />,
-          {
-            friendMarketsContext: {
-              ...defaultFriendMarketsContext,
-              dismissMarket,
-            }
-          }
-        )
-      })
-
-      const statusSelect = screen.getAllByRole('combobox')[1]
-      await user.selectOptions(statusSelect, 'expired')
-
-      await waitFor(() => {
-        expect(screen.getByText('Expired Offer')).toBeInTheDocument()
-      })
-
-      // Status pill reads "Expired" while collapsed.
-      expect(screen.getAllByText('Expired').length).toBeGreaterThan(0)
-
-      // Expand the card to reveal its actions, then clear.
-      await user.click(screen.getByText('Expired Offer'))
-
-      // Invitee (not creator) → button label is just "Clear"
-      const clearBtn = await screen.findByRole('button', { name: /^clear$/i })
-      await user.click(clearBtn)
-      expect(dismissMarket).toHaveBeenCalledWith('99')
-    })
+    // The "Expired" status filter was removed (spec 040 US6): expired offers stay
+    // hidden from the default view and are no longer selectable via the dropdown,
+    // so the former filter-to-Expired-then-Clear flow no longer applies here.
 
   })
 

--- a/frontend/src/test/MyPoolsSection.test.jsx
+++ b/frontend/src/test/MyPoolsSection.test.jsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+const items = []
+vi.mock('../hooks/useMyPools', () => ({
+  useMyPools: () => ({ items, loading: false, refresh: vi.fn() }),
+}))
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+import MyPoolsSection from '../components/fairwins/MyPoolsSection'
+
+const activePool = { id: 'a', title: 'Active Pool', status: 'Open', bucket: 'active', route: '/pool/a' }
+const pastPool = { id: 'b', title: 'Past Pool', status: 'Resolved', bucket: 'history', route: '/pool/b' }
+
+describe('MyPoolsSection (spec 040 US5)', () => {
+  beforeEach(() => { items.length = 0 })
+
+  it('shows only active pools on a non-history tab', () => {
+    items.push(activePool, pastPool)
+    render(<MyPoolsSection activeTab="participating" />)
+    expect(screen.getByText('Active Pool')).toBeInTheDocument()
+    expect(screen.queryByText('Past Pool')).not.toBeInTheDocument()
+  })
+
+  it('shows only terminal pools on the History tab', () => {
+    items.push(activePool, pastPool)
+    render(<MyPoolsSection activeTab="history" />)
+    expect(screen.getByText('Past Pool')).toBeInTheDocument()
+    expect(screen.queryByText('Active Pool')).not.toBeInTheDocument()
+  })
+
+  it('renders nothing when there are no pools for the active tab', () => {
+    items.push(pastPool) // only a terminal pool
+    const { container } = render(<MyPoolsSection activeTab="created" />)
+    expect(container.querySelector('.mm-pools-section')).toBeNull()
+  })
+
+  it('drops the per-row Active/Past chip (the tab conveys bucket)', () => {
+    items.push(activePool)
+    render(<MyPoolsSection activeTab="participating" />)
+    expect(screen.queryByText('Active')).not.toBeInTheDocument()
+    expect(screen.queryByText('Past')).not.toBeInTheDocument()
+  })
+
+  it('never prompts for decrypt words to view a member pool (spec 040 US3)', () => {
+    items.push(activePool)
+    render(<MyPoolsSection activeTab="participating" />)
+    // Pools deep-link out; there is no code/word entry field in this surface.
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+    expect(screen.queryByText(/decrypt|claim code|four-word/i)).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/OpponentName.test.jsx
+++ b/frontend/src/test/OpponentName.test.jsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('../hooks/useWalletManagement', () => ({
+  useWallet: () => ({ chainId: 1, account: '0x9999999999999999999999999999999999999999' }),
+}))
+vi.mock('../hooks/useOpponentName', () => ({
+  useOpponentName: () => ({ displayName: 'Cobalt Otter', source: 'generated', address: ADDR, isLoading: false }),
+}))
+
+import OpponentName from '../components/fairwins/OpponentName'
+
+const ADDR = '0x1234567890123456789012345678901234567890'
+
+describe('OpponentName', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders "You" for the self case and skips resolution', () => {
+    render(<OpponentName address={ADDR} isSelf />)
+    expect(screen.getByText('You')).toBeInTheDocument()
+  })
+
+  it('renders the resolved name as an accessible toggle button', () => {
+    render(<OpponentName address={ADDR} />)
+    const btn = screen.getByRole('button', { name: /show full address for cobalt otter/i })
+    expect(btn).toHaveTextContent('Cobalt Otter')
+    expect(btn).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('reveals the full address on click', async () => {
+    const user = userEvent.setup()
+    render(<OpponentName address={ADDR} />)
+    await user.click(screen.getByRole('button', { name: /show full address/i }))
+    expect(screen.getByText('0x1234…7890')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /copy address/i })).toBeInTheDocument()
+  })
+
+  it('renders a non-interactive span when interactive is false', () => {
+    render(<OpponentName address={ADDR} interactive={false} />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.getByText('Cobalt Otter')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/WagerCard.test.jsx
+++ b/frontend/src/test/WagerCard.test.jsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import WagerCardGrid from '../components/fairwins/WagerCardGrid'
+import { deriveAddressName } from '../lib/naming/addressName'
 
 // The activity watcher is optional; stub it so the grid renders without a
 // provider. Tests assign activityRef.current per scenario to drive the
@@ -163,10 +164,26 @@ describe('WagerCard (via WagerCardGrid)', () => {
   })
 
   it('renders the opponent preview line only in comfortable density', () => {
+    // The opponent now renders by friendly name (spec 040), not the raw address.
+    const oppName = deriveAddressName(OTHER).label
     const { rerender } = render(<WagerCardGrid {...baseProps} density="compact" markets={[activeWager()]} />)
-    // Compact: no preview line (the short opponent address is not shown collapsed).
-    expect(screen.queryByText(/0xABCD/i)).not.toBeInTheDocument()
+    // Compact: no preview line.
+    expect(screen.queryByText(oppName)).not.toBeInTheDocument()
     rerender(<WagerCardGrid {...baseProps} density="comfortable" markets={[activeWager()]} />)
-    expect(screen.getByText(/0xABCD/i)).toBeInTheDocument()
+    expect(screen.getByText(oppName)).toBeInTheDocument()
+  })
+
+  it('shows the opponent by generated name and reveals the address on click (spec 040 US1)', async () => {
+    const user = userEvent.setup()
+    render(<WagerCardGrid {...baseProps} markets={[activeWager()]} />)
+    await user.click(screen.getByText('Lakers ML vs Mike'))
+    const oppName = deriveAddressName(OTHER).label
+    const toggle = screen.getByRole('button', { name: new RegExp(`show full address for ${oppName}`, 'i') })
+    expect(toggle).toBeInTheDocument()
+    // Raw address hidden until revealed; creator side is "You".
+    expect(screen.queryByText('0xABCD…EF12')).not.toBeInTheDocument()
+    expect(screen.getByText('You')).toBeInTheDocument()
+    await user.click(toggle)
+    expect(screen.getByText('0xABCD…EF12')).toBeInTheDocument()
   })
 })

--- a/frontend/src/test/WagerCard.test.jsx
+++ b/frontend/src/test/WagerCard.test.jsx
@@ -173,6 +173,18 @@ describe('WagerCard (via WagerCardGrid)', () => {
     expect(screen.getByText(oppName)).toBeInTheDocument()
   })
 
+  it('shows draw submission chips when a draw is proposed (spec 040 US2)', async () => {
+    const user = userEvent.setup()
+    const w = activeWager({ id: '99', description: 'Draw Pending', drawProposedBy: ME })
+    render(<WagerCardGrid {...baseProps} markets={[w]} />)
+    // Evident even collapsed via the header badge.
+    expect(screen.getByText('Draw pending')).toBeInTheDocument()
+    await user.click(screen.getByText('Draw Pending'))
+    expect(screen.getByText(/you proposed/i)).toBeInTheDocument()
+    expect(screen.getByText(/You: submitted/i)).toBeInTheDocument()
+    expect(screen.getByText(/Opponent: not yet/i)).toBeInTheDocument()
+  })
+
   it('shows the opponent by generated name and reveals the address on click (spec 040 US1)', async () => {
     const user = userEvent.setup()
     render(<WagerCardGrid {...baseProps} markets={[activeWager()]} />)

--- a/frontend/src/test/actionNeededBadges.test.jsx
+++ b/frontend/src/test/actionNeededBadges.test.jsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import Dashboard from '../components/fairwins/Dashboard'
 import MyMarketsModal from '../components/fairwins/MyMarketsModal'
+import WagerCardGrid from '../components/fairwins/WagerCardGrid'
 import {
   WalletContext,
   ThemeContext,
@@ -339,13 +340,17 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
     it('suppresses the "refund" badge when the row shows a Clear/Reclaim button', async () => {
       const user = userEvent.setup()
       // An expired pending offer → computedStatus EXPIRED → the row renders a
-      // Clear button, which makes the "refund" action badge redundant.
+      // Clear button, which makes the "refund" action badge redundant. The
+      // My Wagers modal no longer surfaces expired offers (spec 040 US6 removed
+      // the Expired filter), so this suppression is exercised at the card level
+      // where the logic lives.
       const expired = {
         id: '7',
         description: 'Expired Offer',
         creator: OTHER,
         participants: [ME],
         status: 'pending_acceptance',
+        computedStatus: 'expired',
         acceptanceDeadline: Date.now() - 60 * 60 * 1000,
         endDate: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
         marketType: 'friend'
@@ -354,15 +359,21 @@ describe('Action-needed badges (spec 012 T023, FR-007)', () => {
         actionNeededByWagerId: { '7': 'refund' }
       })
 
-      await act(async () => {
-        render(modalUi([expired]))
-      })
-
-      // Expired offers are hidden under the default "all" filter — switch to Expired.
-      const statusSelect = screen.getAllByRole('combobox')[1]
-      await act(async () => {
-        await user.selectOptions(statusSelect, 'expired')
-      })
+      render(
+        <WagerCardGrid
+          markets={[expired]}
+          account={ME}
+          getStatusClass={() => 'status-expired'}
+          getStatusLabel={() => 'Expired'}
+          getTimeRemaining={() => 'Expired'}
+          formatDate={() => 'Jun 1, 2026'}
+          onClearExpired={vi.fn()}
+          onResolve={vi.fn()}
+          onAccept={vi.fn()}
+          onClaim={vi.fn()}
+          onRefund={vi.fn()}
+        />
+      )
 
       expect(screen.getByText('Expired Offer')).toBeInTheDocument()
       // Expand the card to reveal its actions.

--- a/frontend/src/test/addressName.test.js
+++ b/frontend/src/test/addressName.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { deriveAddressName } from '../lib/naming/addressName'
+import { ADJECTIVES, NOUNS } from '../lib/pools/nicknameWords'
+
+const ADDR_A = '0x1111111111111111111111111111111111111111'
+const ADDR_B = '0x2222222222222222222222222222222222222222'
+
+describe('deriveAddressName', () => {
+  it('returns a two-word label drawn from the shared vocabulary', () => {
+    const { adjective, noun, label } = deriveAddressName(ADDR_A)
+    expect(ADJECTIVES).toContain(adjective)
+    expect(NOUNS).toContain(noun)
+    expect(label).toBe(`${adjective} ${noun}`)
+  })
+
+  it('is deterministic — the same address always yields the same name', () => {
+    expect(deriveAddressName(ADDR_A).label).toBe(deriveAddressName(ADDR_A).label)
+  })
+
+  it('is casing-invariant — checksum and lowercase map to the same name', () => {
+    const checksummed = '0xAbC1230000000000000000000000000000000000'
+    const lowercased = checksummed.toLowerCase()
+    expect(deriveAddressName(checksummed).label).toBe(deriveAddressName(lowercased).label)
+  })
+
+  it('produces different names for different addresses (typically)', () => {
+    expect(deriveAddressName(ADDR_A).label).not.toBe(deriveAddressName(ADDR_B).label)
+  })
+
+  it('throws on a non-address input', () => {
+    expect(() => deriveAddressName('not-an-address')).toThrow()
+    expect(() => deriveAddressName(null)).toThrow()
+  })
+})

--- a/frontend/src/test/claimCode/OpenChallengeDecryptModal.test.jsx
+++ b/frontend/src/test/claimCode/OpenChallengeDecryptModal.test.jsx
@@ -36,7 +36,8 @@ describe('OpenChallengeDecryptModal', () => {
     expect(unlock).toBeEnabled()
     fireEvent.click(unlock)
 
-    await waitFor(() => expect(onDecrypted).toHaveBeenCalledWith(terms))
+    // Reports the terms plus the validated code so the caller can remember it (spec 040 US3).
+    await waitFor(() => expect(onDecrypted).toHaveBeenCalledWith(terms, code))
     expect(onClose).toHaveBeenCalled()
   })
 

--- a/frontend/src/test/decryptAutoUnlock.test.js
+++ b/frontend/src/test/decryptAutoUnlock.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../utils/claimCode/deriveFromCode.js', () => ({
+  deriveFromCode: (code) => ({ symKey: `key:${code}` }),
+}))
+vi.mock('../utils/crypto/envelopeEncryption.js', () => ({
+  decryptEnvelopeCode: (envelope, symKey) => {
+    if (symKey !== 'key:river tiger kite zoo') throw new Error('wrong code')
+    return 'the secret terms'
+  },
+}))
+
+import { findSavedCode, decryptWithCode } from '../lib/openChallenge/autoUnlock'
+
+const codes = [
+  { code: 'apple berry cherry date', wagerId: '5', savedAt: 2 },
+  { code: 'river tiger kite zoo', wagerId: '7', savedAt: 1 },
+]
+
+describe('open-challenge auto-unlock (spec 040 US3)', () => {
+  it('finds the saved code for a wager by id', () => {
+    expect(findSavedCode(codes, '7')?.code).toBe('river tiger kite zoo')
+    expect(findSavedCode(codes, 7)?.code).toBe('river tiger kite zoo')
+  })
+
+  it('returns null when no saved code matches (first encounter → prompt)', () => {
+    expect(findSavedCode(codes, '99')).toBeNull()
+    expect(findSavedCode([], '7')).toBeNull()
+    expect(findSavedCode(null, '7')).toBeNull()
+  })
+
+  it('decrypts terms with a saved code without prompting', () => {
+    expect(decryptWithCode({}, 'river tiger kite zoo')).toEqual({ description: 'the secret terms' })
+  })
+
+  it('throws when the saved code does not unlock the envelope', () => {
+    expect(() => decryptWithCode({}, 'apple berry cherry date')).toThrow()
+  })
+})

--- a/frontend/src/test/useMyPools.test.jsx
+++ b/frontend/src/test/useMyPools.test.jsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+const loadMyWagersSources = vi.fn()
+const aggregateMyItems = vi.fn(() => [])
+// Stable reference across renders so useMyPools' `load` callback identity is
+// stable and its effect doesn't re-run on every render.
+const getPoolSummary = vi.hoisted(() => vi.fn())
+
+vi.mock('../hooks/useWalletManagement', () => ({
+  useWallet: () => ({ account: '0x1111111111111111111111111111111111111111', chainId: 1 }),
+}))
+vi.mock('../hooks/usePools', () => ({
+  usePools: () => ({ getPoolSummary }),
+}))
+vi.mock('../lib/lookup/myWagersSources', () => ({
+  loadMyWagersSources: (...a) => loadMyWagersSources(...a),
+  readJoinedPoolAddresses: () => [],
+}))
+vi.mock('../lib/lookup/myWagersAggregation', () => ({
+  aggregateMyItems: (...a) => aggregateMyItems(...a),
+}))
+
+import { useMyPools } from '../hooks/useMyPools'
+
+describe('useMyPools auto-refresh (spec 040 US4)', () => {
+  beforeEach(() => {
+    loadMyWagersSources.mockReset().mockResolvedValue({ createdPools: [], joinedPools: [] })
+    aggregateMyItems.mockClear()
+  })
+
+  it('registers a poll interval and clears it on unmount', () => {
+    const setSpy = vi.spyOn(global, 'setInterval')
+    const clearSpy = vi.spyOn(global, 'clearInterval')
+    const { unmount } = renderHook(() => useMyPools())
+    expect(setSpy).toHaveBeenCalledWith(expect.any(Function), 30000)
+    const intervalId = setSpy.mock.results[setSpy.mock.results.length - 1].value
+    unmount()
+    expect(clearSpy).toHaveBeenCalledWith(intervalId)
+    setSpy.mockRestore()
+    clearSpy.mockRestore()
+  })
+
+  it('loads on mount and exposes a manual refresh() that re-loads', async () => {
+    const { result } = renderHook(() => useMyPools())
+    await waitFor(() => expect(loadMyWagersSources).toHaveBeenCalled())
+    loadMyWagersSources.mockClear()
+    await act(async () => { await result.current.refresh() })
+    expect(loadMyWagersSources).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/test/useOpponentName.test.jsx
+++ b/frontend/src/test/useOpponentName.test.jsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { WalletContext } from '../contexts'
+
+const findByAddress = vi.fn()
+const ensState = { ensName: null, isLoading: false }
+
+vi.mock('../lib/addressBook/addressBookStore', () => ({
+  loadAddressBook: () => ({ contacts: [] }),
+  findByAddress: (...args) => findByAddress(...args),
+}))
+vi.mock('../hooks/useEnsResolution', () => ({
+  useEnsReverseLookup: () => ensState,
+}))
+
+import { useOpponentName } from '../hooks/useOpponentName'
+import { deriveAddressName } from '../lib/naming/addressName'
+
+const ME = '0x9999999999999999999999999999999999999999'
+const ADDR = '0x1111111111111111111111111111111111111111'
+
+const wrapper = ({ children }) => (
+  <WalletContext.Provider value={{ address: ME, chainId: 1 }}>{children}</WalletContext.Provider>
+)
+
+describe('useOpponentName', () => {
+  beforeEach(() => {
+    findByAddress.mockReset()
+    ensState.ensName = null
+    ensState.isLoading = false
+  })
+
+  it('prefers the address-book nickname', () => {
+    findByAddress.mockReturnValue({ contact: { nickname: 'Alice' } })
+    ensState.ensName = 'alice.eth'
+    const { result } = renderHook(() => useOpponentName(ADDR), { wrapper })
+    expect(result.current.displayName).toBe('Alice')
+    expect(result.current.source).toBe('addressBook')
+  })
+
+  it('falls back to ENS when no address-book entry exists', () => {
+    findByAddress.mockReturnValue(undefined)
+    ensState.ensName = 'bob.eth'
+    const { result } = renderHook(() => useOpponentName(ADDR), { wrapper })
+    expect(result.current.displayName).toBe('bob.eth')
+    expect(result.current.source).toBe('ens')
+  })
+
+  it('falls back to a deterministic generated name when neither exists', () => {
+    findByAddress.mockReturnValue(undefined)
+    const { result } = renderHook(() => useOpponentName(ADDR), { wrapper })
+    expect(result.current.displayName).toBe(deriveAddressName(ADDR).label)
+    expect(result.current.source).toBe('generated')
+  })
+
+  it('never returns a raw hex address as the display name', () => {
+    findByAddress.mockReturnValue(undefined)
+    const { result } = renderHook(() => useOpponentName(ADDR), { wrapper })
+    expect(result.current.displayName).not.toMatch(/^0x[0-9a-fA-F]{40}$/)
+  })
+
+  it('works without a wallet provider (degrades to generated)', () => {
+    findByAddress.mockReturnValue(undefined)
+    const { result } = renderHook(() => useOpponentName(ADDR))
+    expect(result.current.displayName).toBe(deriveAddressName(ADDR).label)
+  })
+
+  it('handles a missing/invalid address without throwing', () => {
+    findByAddress.mockReturnValue(undefined)
+    const { result } = renderHook(() => useOpponentName(undefined), { wrapper })
+    expect(result.current.displayName).toBe('—')
+  })
+})

--- a/frontend/src/test/wagerVmDraw.test.js
+++ b/frontend/src/test/wagerVmDraw.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { buildWagerVm } from '../components/fairwins/wagerVm'
+
+const ME = '0x1234567890123456789012345678901234567890'
+const OPP = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+
+const ctx = {
+  account: ME,
+  getStatusClass: () => 'status-active',
+  getStatusLabel: (s) => s,
+  getTimeRemaining: () => '2d',
+  formatDate: () => 'Jun 1',
+}
+
+const market = (over = {}) => ({
+  id: '7', marketType: 'friend', creator: ME, participants: [ME, OPP],
+  status: 'active', computedStatus: 'active', stakeAmount: '5', stakeTokenSymbol: 'USDC', ...over,
+})
+
+describe('buildWagerVm draw descriptor (spec 040 US2)', () => {
+  it('is null when there is no draw', () => {
+    expect(buildWagerVm(market(), ctx).draw).toBeNull()
+  })
+
+  it('marks "you proposed · awaiting opponent" when the connected wallet proposed', () => {
+    const vm = buildWagerVm(market({ drawProposedBy: ME }), ctx)
+    expect(vm.draw.phase).toBe('proposed')
+    expect(vm.draw.mySubmitted).toBe(true)
+    expect(vm.draw.opponentSubmitted).toBe(false)
+    expect(vm.draw.label).toMatch(/you proposed/i)
+  })
+
+  it('marks "opponent proposed · your turn" when the counterparty proposed', () => {
+    const vm = buildWagerVm(market({ drawProposedBy: OPP }), ctx)
+    expect(vm.draw.phase).toBe('proposed')
+    expect(vm.draw.mySubmitted).toBe(false)
+    expect(vm.draw.opponentSubmitted).toBe(true)
+    expect(vm.draw.label).toMatch(/opponent proposed/i)
+  })
+
+  it('marks a settled draw with both stakes returned', () => {
+    const vm = buildWagerVm(market({ status: 'draw', computedStatus: 'draw' }), ctx)
+    expect(vm.draw.phase).toBe('settled')
+    expect(vm.draw.mySubmitted).toBe(true)
+    expect(vm.draw.opponentSubmitted).toBe(true)
+    expect(vm.draw.label).toMatch(/both agreed/i)
+  })
+})

--- a/specs/040-my-wagers-refinements/checklists/requirements.md
+++ b/specs/040-my-wagers-refinements/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Specification Quality Checklist: My Wagers — Tester Feedback Refinements
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-04
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All eight tester notes are captured across seven prioritized, independently testable user
+  stories (US1–US7) and FR-001 through FR-021.
+- Two terminology reconciliations were resolved via documented Assumptions rather than
+  clarification markers: (a) "Archive tab" maps to the existing terminal "History" tab;
+  (b) the "network pill" is the redundant network badge in the modal header, not a per-card
+  badge (none exists today).
+- Scope is bounded to frontend presentation + local client state; no contract/oracle/subgraph
+  changes, so the Security-First and Test-First constitution principles apply at the frontend
+  (Vitest) level.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.

--- a/specs/040-my-wagers-refinements/contracts/decrypt-autounlock.md
+++ b/specs/040-my-wagers-refinements/contracts/decrypt-autounlock.md
@@ -1,0 +1,34 @@
+# Contract: Decrypt Auto-Unlock (US3)
+
+## Open-challenge auto-decrypt flow
+
+When the member opens an encrypted open-challenge item in My Wagers:
+
+```
+1. If terms already decrypted -> render.
+2. Else look up a saved code in the vault:
+     key   = sessionVaultKey ?? deriveVaultKey(await signOnce(CODE_VAULT_SIGN_MESSAGE))
+     codes = readEntries(wallet, key)               // lib/openChallenge/codeVault.js
+     match = codes.find(matches this challenge)
+   If match -> deriveFromCode(match.code) -> decrypt -> render (NO words prompt).  (FR-011)
+3. Else -> show OpenChallengeDecryptModal (prompt once). On success:
+     addEntry(wallet, key, { code, challengeId, label })   // remember for next time  (FR-009)
+```
+
+**Session vault key**
+```
+getSessionVaultKey(wallet) -> Uint8Array | null   // in-memory only
+```
+- Derived once per session from a single wallet signature; cached in memory (never persisted).
+- Cleared on wallet change / unmount. Enables auto-decrypt of every saved item without re-signing.
+
+**Guarantees**
+- Stored codes stay wallet-scoped and at-rest encrypted; no plaintext persistence (FR-010).
+- A member who unlocked an item once is not prompted again on the same wallet+device (FR-009/011).
+
+## Pools
+
+- Pools use Semaphore identities, not passphrase decrypt words. My Wagers MUST NOT prompt for words to
+  view the member's own pools (it does not today). Requirement is satisfied by reusing the
+  device-persisted pool identity; covered by a regression test asserting no words prompt appears for a
+  member's pool.

--- a/specs/040-my-wagers-refinements/contracts/draw-state.md
+++ b/specs/040-my-wagers-refinements/contracts/draw-state.md
@@ -1,0 +1,50 @@
+# Contract: Draw State & Submission (US2)
+
+## Market enrichment (modal data path)
+
+`MyMarketsModal` MUST attach the draw proposer to each market before building the card view model,
+reusing the existing scan:
+
+```
+fetchDrawProposals({ chainId, wagerIds }) -> { proposals: {wagerId, proposer}[], ok: boolean }
+```
+
+- Map `proposer` (lowercased) onto each market as `market.drawProposedBy` (null when not proposed).
+- On `ok:false`, retain prior draw state (never fabricate a revoke — honest state, Constitution III).
+- This mirrors what `data/notifications/sources/wagerSource.js` already does for notifications.
+
+## `wagerVm.js` — draw submission fields
+
+The card view model gains a derived draw descriptor:
+
+```
+draw: {
+  phase: 'proposed' | 'settled' | 'none',
+  proposer: string | null,
+  mySubmitted: boolean,
+  opponentSubmitted: boolean,
+  label: string,          // human summary of who has submitted
+} | null
+```
+
+**Derivation**
+- `phase`: `computedStatus==='draw_proposed'` → `'proposed'`; `==='draw'` → `'settled'`; else `'none'`.
+- `mySubmitted`: `phase==='settled'` OR (`phase==='proposed'` AND `proposer===me`).
+- `opponentSubmitted`: `phase==='settled'` OR (`phase==='proposed'` AND `proposer===opponent`).
+- `label` examples: "You proposed · awaiting opponent", "Opponent proposed · your turn",
+  "Both agreed · stakes returned".
+
+## `WagerCard.jsx` / `WagerTable.jsx` — rendering
+
+- A `draw_proposed` or `draw` wager MUST show a distinct draw status treatment (text + icon), not only
+  the "Respond to Draw" action button (FR-005).
+- MUST render a per-party submission chip pair reflecting `draw.mySubmitted` / `draw.opponentSubmitted`
+  (FR-006).
+- Terminal `draw` copy MUST state both stakes are returned (FR-008).
+
+## Notification (FR-007)
+
+- Draw proposals already flow `drawProposalScan → diffWagers → activityEngine`. Requirement: a
+  `null → proposer` transition MUST produce a user-facing notification labeled clearly as a pending
+  draw ("Draw proposed — respond"). Verified by a `diffEngine`/`wagerSource` regression test; the
+  detection is added only if it is not already emitted.

--- a/specs/040-my-wagers-refinements/contracts/my-wagers-ui.md
+++ b/specs/040-my-wagers-refinements/contracts/my-wagers-ui.md
@@ -1,0 +1,33 @@
+# Contract: My Wagers UI (US4, US5, US6, US7)
+
+## US4 — `hooks/useMyPools.js` periodic refresh
+
+```
+useMyPools() -> { items: PoolListItem[], loading: boolean, refresh: () => void }
+```
+- Adds `refresh()` (re-runs the existing idempotent `load()`).
+- Runs `refresh()` on a ~30s interval while mounted; clears the interval on unmount so polling stops
+  when My Wagers closes (FR-012/013/014). Interval cadence matches the wager poll (spec 019).
+
+## US5 — `components/fairwins/MyPoolsSection.jsx` tab-aware bucketing
+
+```
+<MyPoolsSection activeTab={'participating'|'created'|'arbitrating'|'history'} />
+```
+- History tab → render only `items.filter(i => i.bucket === 'history')`.
+- Any other tab → render only `items.filter(i => i.bucket === 'active')`.
+- Renders nothing when the filtered list is empty (preserves the "no pools ⇒ unchanged view"
+  guarantee).
+- The per-row Active/Past chip is removed (the tab conveys bucket).
+- `MyMarketsModal` passes its `activeTab` down (`MyMarketsModal.jsx:951`).
+
+## US6 — Status filter options (`MyMarketsModal.jsx:929-945`)
+
+Final `<option>` set: `all`, `pending_acceptance`, `active`, `pending_resolution`, `resolved`.
+- REMOVE `disputed` (FR-018) and `expired` (FR-017).
+- No change to `getMarketStatus`/categorization; expired wagers stay hidden by default (FR-019).
+
+## US7 — Header network pill (`MyMarketsModal.jsx:817-824`)
+
+- REMOVE the `mm-network-tag` `<span>` and its `.mm-network-tag*` CSS in `MyMarketsModal.css`.
+- KEEP the subtitle "Manage your wagers and positions on {activeNetwork.name}" (FR-021).

--- a/specs/040-my-wagers-refinements/contracts/opponent-name.md
+++ b/specs/040-my-wagers-refinements/contracts/opponent-name.md
@@ -1,0 +1,54 @@
+# Contract: Opponent Name Resolution (US1)
+
+## `lib/naming/addressName.js` — `deriveAddressName(address)`
+
+Pure, deterministic generator of a two-word display name from an address. Reuses the
+`ADJECTIVES`/`NOUNS` vocabulary from `lib/pools/nicknameWords.js` (shared vocabulary only — this is
+address-keyed, distinct from the commitment-keyed pool `deriveNickname`).
+
+```
+deriveAddressName(address: string) -> {
+  adjective: string,
+  noun: string,
+  label: string,   // `${adjective} ${noun}`
+}
+```
+
+**Behavior**
+- Normalizes the address (lowercase/checksum-safe) before hashing so casing never changes the result.
+- `label` is a pure function of the address: same address ⇒ same label (FR-002).
+- Returns a stable placeholder-free label for any 20-byte address; throws only on a non-address input.
+- MUST NOT read chain, storage, or network.
+
+## `hooks/useOpponentName.js` — `useOpponentName(address)`
+
+Resolves one address to a display identity in priority order.
+
+```
+useOpponentName(address: string, opts?: { chainId?: number }) -> {
+  displayName: string,
+  source: 'addressBook' | 'ens' | 'generated',
+  address: string,
+  isLoading: boolean,   // ENS in flight; displayName already holds the generated fallback
+}
+```
+
+**Resolution order**: `useAddressBook().findByAddress(address, chainId)` nickname → 
+`useEnsReverseLookup(address).ensName` → `deriveAddressName(address).label`. First non-empty wins.
+Never returns an empty/raw-address `displayName`; the generated fallback is always available
+synchronously so no card shows a spinner in place of a name.
+
+## `components/fairwins/OpponentName.jsx`
+
+Presentational component; the only opponent renderer used by `WagerCard`/`WagerTable`.
+
+```
+<OpponentName address={string} isSelf={boolean} />
+```
+
+**Behavior / a11y**
+- Renders "You" when `isSelf` (bypasses resolution).
+- Otherwise renders `useOpponentName(address).displayName` inside a real `<button>` with an
+  accessible label (e.g. `aria-label="Show full address for {displayName}"`).
+- On click/Enter/Space toggles reveal of the full `address` with a copy affordance (FR-003).
+- Reveal state is local; conveyed by text (not color alone). Meets WCAG 2.1 AA.

--- a/specs/040-my-wagers-refinements/data-model.md
+++ b/specs/040-my-wagers-refinements/data-model.md
@@ -1,0 +1,94 @@
+# Phase 1 Data Model: My Wagers Refinements
+
+This feature adds **no on-chain or subgraph schema**. The "entities" here are client-side view
+models and one reused local-storage record. All are scoped to the connected wallet and the active
+`chainId`.
+
+## Entity: ResolvedOpponent (view model)
+
+The display identity for a counterparty address, produced by `useOpponentName(address)`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `address` | string (0x…) | The real on-chain counterparty address (source of truth). |
+| `source` | `'addressBook' \| 'ens' \| 'generated'` | Which resolver produced `displayName`. |
+| `displayName` | string | Address-book nickname, ENS name, or generated two-word label. |
+| `isSelf` | boolean | True when `address` is the connected wallet → render "You". |
+| `revealed` | boolean (UI state) | Whether the full address is currently shown (toggled by tap). |
+
+**Resolution order (validation rule)**: address book → ENS reverse → generated. First non-empty wins.
+The generated name is **deterministic**: same address ⇒ same `displayName` (FR-002). Never blocks on
+ENS — an in-flight/failed ENS lookup falls straight through to `generated`.
+
+**Derivation**: `generated` = `deriveAddressName(address)` → `{ adjective, noun, label }` from the
+64×64 `nicknameWords` vocabulary keyed by `keccak256(checksum(address))`.
+
+## Entity: DrawSubmissionState (view model)
+
+Per-wager draw progress, derived from indexed state; attached to the card view model.
+
+| Field | Type | Notes |
+|---|---|---|
+| `phase` | `'proposed' \| 'settled' \| 'none'` | `proposed` = `status==='draw_proposed'`; `settled` = `status==='draw'`. |
+| `proposer` | string (0x…) \| null | From subgraph `drawProposer` via `fetchDrawProposals`; null if not proposed. |
+| `mySubmitted` | boolean | `phase!=='none'` AND (`proposer===me` OR `phase==='settled'`). |
+| `opponentSubmitted` | boolean | `proposer===opponent` OR `phase==='settled'`. |
+| `label` | string | e.g. "You proposed · awaiting opponent" / "Opponent proposed · your turn" / "Both agreed · stakes returned". |
+
+**Validation rules**: `phase` and `proposer` come only from on-chain/subgraph reads (honest state). If
+the proposer read fails (`ok:false`), prior state is retained rather than cleared (no fabricated
+revoke) — same guarantee `drawProposalScan` already enforces.
+
+**State transitions**: `none → proposed` (one party submits) → `settled` (both agree, `WagerDrawn`
+event). A `proposed → none` transition is a revoke. `settled` is terminal (History tab).
+
+## Entity: OpenChallengeCodeVaultEntry (reused local storage — spec 024)
+
+Already defined in `lib/openChallenge/codeVault.js`; this feature only changes **when** it is
+read/written (auto-decrypt instead of manual recovery).
+
+| Field | Type | Notes |
+|---|---|---|
+| `code` | string (4 words) | The open-challenge claim code (dedupe key). |
+| `savedAt` | number (epoch ms) | Set on save; newest-first ordering. |
+| `label`/`challengeId` | string (optional) | Reference to the challenge, for display. |
+
+**Storage**: `localStorage` key `fairwins.ocCodeVault.<wallet>`, envelope encrypted with
+ChaCha20-Poly1305 under a key derived from a one-time wallet signature (`CODE_VAULT_SIGN_MESSAGE`).
+Per-wallet; never plaintext; never cross-wallet (FR-010).
+
+**New in-memory companion — `SessionVaultKey`** (not persisted): the derived 32-byte vault key cached
+for the session so items auto-decrypt without re-signing per item. Cleared on wallet change / session
+end.
+
+## Entity: PoolListItem (reused view model — spec 037)
+
+Produced by `useMyPools()` / `aggregateMyItems`; this feature filters it by `bucket` per active tab.
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string | Pool identifier. |
+| `title` | string | Pool display title (client-side two-word nickname allowed). |
+| `status` | string | Human pool status label. |
+| `bucket` | `'active' \| 'history'` | `history` when pool state ∈ `TERMINAL_POOL_STATES` (2 Resolved, 3 Cancelled). |
+| `route` | string | Deep link to the pool page. |
+
+**Placement rule (FR-015/016)**: History tab renders `bucket==='history'` pools; all other tabs render
+`bucket==='active'` pools. The per-row Active/Past chip is removed (the tab conveys it).
+
+## Entity: StatusFilterOption (UI enumeration)
+
+The status `<select>` option list. After this feature:
+
+| Value | Label | Kept? |
+|---|---|---|
+| `all` | All Status | ✅ |
+| `pending_acceptance` | Pending Acceptance | ✅ |
+| `active` | Active | ✅ |
+| `pending_resolution` | Pending Resolution | ✅ |
+| `disputed` | Disputed | ❌ removed (FR-018) |
+| `resolved` | Resolved | ✅ |
+| `expired` | Expired | ❌ removed (FR-017) |
+
+**Rule**: Removing options does not alter categorization; expired wagers remain hidden from the default
+view (FR-019). Underlying `WagerStatus` enum values are unchanged.

--- a/specs/040-my-wagers-refinements/plan.md
+++ b/specs/040-my-wagers-refinements/plan.md
@@ -1,0 +1,136 @@
+# Implementation Plan: My Wagers — Tester Feedback Refinements
+
+**Branch**: `claude/my-wagers-refinements-729gjz` | **Date**: 2026-07-04 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/040-my-wagers-refinements/spec.md`
+
+## Summary
+
+Eight tester-driven refinements to the **My Wagers** modal (`frontend/src/components/fairwins/MyMarketsModal.jsx`
+and its card/pool children). All are frontend presentation + local client-state changes; no
+contract, oracle, or subgraph schema changes. The work reuses existing subsystems rather than
+building new ones: the address book (spec 021), ENS reverse lookup, the pool nickname vocabulary
+(spec 034), the open-challenge code vault (spec 024), the notification/activity engine (spec 031),
+the pool aggregation layer (spec 037), and the existing 30s auto-refresh (spec 019). The two
+larger slices are (1) an **opponent-name resolver** (address book → ENS → deterministic two-word
+name) with click-to-reveal, and (2) **draw clarity** (a visible draw state on the card plus a
+per-party submission indicator, backed by the already-indexed `drawProposer`). The rest are small,
+surgical edits: prune two filter options, drop the redundant header network pill, auto-decrypt from
+the code vault instead of re-prompting, extend pool polling, and file terminal pools under History.
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES2022), React 18 function components + hooks
+
+**Primary Dependencies**: React, Vite; `wagmi`/`viem` (ENS reverse lookup on mainnet); `ethers`
+(keccak hashing for deterministic name derivation, reused from pool nickname); `react-router-dom`;
+existing app modules — `useAddressBook` (spec 021), `useEnsReverseLookup` (`hooks/useEnsResolution.js`),
+`lib/pools/nicknameWords.js`, `lib/openChallenge/codeVault.js`, notification `activityEngine`/
+`wagerSource`/`drawProposalScan` (spec 031/017), `useMyPools` + `lib/lookup/myWagersAggregation.js`
+(spec 037), `FriendMarketsContext` auto-refresh (spec 019)
+
+**Storage**: Browser `localStorage` (address book, open-challenge code vault — both wallet-scoped,
+at-rest encrypted) and in-memory session cache for the derived vault key. No backend; no new
+persisted schema beyond what the code vault already stores.
+
+**Testing**: Vitest (`npm run test:frontend`) — unit tests for new pure helpers + component tests
+for `MyMarketsModal`, `WagerCard`, `MyPoolsSection`
+
+**Target Platform**: Web (mobile-first PWA); My Wagers is a modal reachable from `/app`
+
+**Project Type**: Web application — this feature touches the `frontend/` project only
+
+**Performance Goals**: Name resolution and draw enrichment must not block card render; ENS lookups
+are cached (5-min `staleTime`, 30-min `gcTime`) and fall back immediately to the generated name so no
+card ever shows a spinner in place of an opponent. Auto-update cadence matches the existing 30s poll.
+
+**Constraints**: WCAG 2.1 AA (keyboard-accessible name reveal; draw state conveyed by text + icon,
+not color alone); honest state (names are display-only; draw submission state derives from real
+on-chain/subgraph state; no fabricated finality); strict per-network (chainId) data isolation.
+
+**Scale/Scope**: One modal, up to a few hundred wager cards + a handful of pools per member; two new
+small modules, one new presentational component, and edits to ~6 existing files.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+- **I. Security-First Smart Contracts (NON-NEGOTIABLE)** — **N/A / Pass.** No `contracts/` changes;
+  no escrow, access-control, or oracle-resolution paths are touched. Slither/Medusa scope unchanged.
+- **II. Test-First & Comprehensive Coverage (NON-NEGOTIABLE)** — **Pass.** Every new pure helper
+  (`deriveAddressName`, opponent resolution order, terminal-pool bucketing filter, vault
+  auto-unlock decision) gets Vitest unit tests written alongside it; `MyMarketsModal`/`WagerCard`/
+  `MyPoolsSection` component tests are updated for the filter, network-pill, draw, and pool-archive
+  changes. No contract interface changes, so no contract-test updates required.
+- **III. Honest State, No Mocks in Shipped Paths** — **Pass.** Opponent names are a display layer over
+  the real on-chain address (revealable in one tap); draw submission state is derived from the indexed
+  `drawProposer` and the `WagerDrawn` event, never assumed; terminal-pool bucketing uses real pool
+  state. All data stays scoped to the active `chainId` (no testnet/mainnet leakage). No mock data added.
+- **IV. Fail Loudly in CI** — **Pass.** No `continue-on-error` added; new tests gate the pipeline.
+- **V. Accessible, Consistent Frontend** — **Pass.** The opponent-name control is a real
+  `<button>`/toggle with an accessible label and copy affordance; the draw status uses text + icon and
+  meets contrast; the filter `<select>` keeps its `<label>`. No hardcoded addresses/ABIs — ENS and
+  address-book data come from existing hooks; network config is untouched.
+
+**Result: PASS — no violations, Complexity Tracking not required.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/040-my-wagers-refinements/
+├── plan.md              # This file (/speckit-plan output)
+├── research.md          # Phase 0 output — design decisions per user story
+├── data-model.md        # Phase 1 output — client-side view entities
+├── quickstart.md        # Phase 1 output — validation scenarios
+├── contracts/           # Phase 1 output — module/component interface contracts
+│   ├── opponent-name.md
+│   ├── draw-state.md
+│   ├── decrypt-autounlock.md
+│   └── my-wagers-ui.md
+├── checklists/
+│   └── requirements.md  # Created by /speckit-specify
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/
+├── components/fairwins/
+│   ├── MyMarketsModal.jsx        # EDIT: remove network pill + Disputed/Expired options;
+│   │                             #        pass activeTab to MyPoolsSection; enrich markets
+│   │                             #        with drawProposer for the card view model
+│   ├── MyMarketsModal.css        # EDIT: drop unused .mm-network-tag rules
+│   ├── wagerVm.js                # EDIT: opponent field → OpponentName; add draw submission meta
+│   ├── WagerCard.jsx             # EDIT: render OpponentName; render draw state + submission chips
+│   ├── WagerTable.jsx            # EDIT: same opponent/draw treatment for the table view
+│   ├── MyPoolsSection.jsx        # EDIT: tab-aware — active pools in active tabs, terminal in History
+│   ├── OpponentName.jsx          # NEW: presentational component — resolves + reveals opponent
+│   └── wagerCardHelpers.js       # (reuse formatShortAddress; no behavior change)
+├── hooks/
+│   ├── useOpponentName.js        # NEW: address-book → ENS → generated resolution for one address
+│   ├── useMyPools.js             # EDIT: add periodic refresh + manual refresh(), stop when unmounted
+│   └── useEnsResolution.js       # (reuse useEnsReverseLookup)
+├── lib/
+│   ├── naming/addressName.js     # NEW: deriveAddressName(address) → deterministic two-word label
+│   ├── openChallenge/codeVault.js# (reuse; add session vault-key cache helper if needed)
+│   └── lookup/myWagersAggregation.js # (reuse bucket logic; align terminal-state definition)
+└── test/
+    ├── addressName.test.js           # NEW
+    ├── useOpponentName.test.jsx       # NEW
+    ├── OpponentName.test.jsx          # NEW
+    ├── MyMarketsModal.test.jsx        # EDIT: filter options, no network pill, draw, pool archive
+    ├── MyPoolsSection.test.jsx        # NEW/EDIT: tab-aware bucketing
+    └── decryptAutoUnlock.test.js      # NEW: vault auto-decrypt vs prompt decision
+```
+
+**Structure Decision**: Single existing `frontend/` React project. New logic lands as small,
+independently testable modules (`lib/naming/addressName.js`, `hooks/useOpponentName.js`,
+`components/fairwins/OpponentName.jsx`) plus surgical edits to the My Wagers modal and its card/table/
+pool children. No new top-level directories, no backend, no build-tooling changes.
+
+## Complexity Tracking
+
+> No constitution violations — this section intentionally left empty.

--- a/specs/040-my-wagers-refinements/quickstart.md
+++ b/specs/040-my-wagers-refinements/quickstart.md
@@ -1,0 +1,80 @@
+# Quickstart & Validation: My Wagers Refinements
+
+Validation guide for spec 040. Implementation details live in [contracts/](./contracts/) and
+`tasks.md`; this file lists how to prove each user story works end-to-end.
+
+## Prerequisites
+
+- `frontend/` dependencies installed (`npm install` at repo root).
+- Dev server: `npm run frontend`, then open `/app` and launch the **My Wagers** modal.
+- Tests: `npm run test:frontend` (Vitest).
+- A connected wallet with a mix of wagers (pending, active, draw-proposed, resolved, draw) and at
+  least one active and one terminal group pool on the active network.
+
+## Automated checks
+
+```bash
+npm run test:frontend        # unit + component tests for all seven slices
+npm run lint --workspace frontend   # ESLint must pass (Constitution IV/V)
+```
+
+New/updated tests to expect green:
+`addressName.test.js`, `useOpponentName.test.jsx`, `OpponentName.test.jsx`,
+`MyMarketsModal.test.jsx`, `MyPoolsSection.test.jsx`, `decryptAutoUnlock.test.js`,
+plus draw-notification coverage in `diffEngine.test.js`/`wagerSource.test.js`.
+
+## Scenario walkthroughs (manual)
+
+### US1 — Opponent names + reveal
+1. View a wager whose opponent is in your **address book** → card shows the saved nickname.
+2. View one whose opponent has an **ENS reverse record** (no address-book entry) → card shows the ENS
+   name.
+3. View one with neither → card shows a **two-word generated name**; reload → same name (deterministic).
+4. Tap any opponent name → full `0x…` address is revealed and copyable. Keyboard: Tab to it, Enter
+   toggles.
+5. Your own side still reads **"You"**.
+
+### US2 — Draw clarity
+1. Propose a draw on a wager → its card shows a **distinct draw state** and "You proposed · awaiting
+   opponent".
+2. As the counterparty (other wallet) → card shows "Opponent proposed · your turn" and a "Respond to
+   Draw" action; a **notification** for the pending draw appears (bell), even without the modal open.
+3. Both submit → card shows terminal **Draw**, "Both agreed · stakes returned".
+
+### US3 — No repeated decrypt prompts
+1. Open an encrypted **open challenge**, enter the four-word code once → details reveal.
+2. Close and reopen My Wagers → the same challenge is **unlocked automatically**, no words prompt
+   (at most one wallet signature per session).
+3. Open one of **your pools** → no decrypt-words prompt at any point.
+
+### US4 — Auto-update
+1. Open My Wagers; from another actor, change a wager's state → the card updates within ~30s, no manual
+   refresh.
+2. Resolve/cancel a **pool** from elsewhere → the pool entry updates within ~30s.
+3. Close the modal → polling stops (verify via network panel / test that the interval is cleared).
+
+### US5 — Terminal pools archived
+1. With an active pool and a terminal (resolved/cancelled) pool: on **Participating/Created** tabs only
+   the **active** pool shows.
+2. Open the **History** tab → the **terminal** pool appears there; the active pool does not.
+
+### US6 — Status filter
+1. Open the **Status** dropdown → **Expired** and **Disputed** are absent; remaining options
+   (All, Pending Acceptance, Active, Pending Resolution, Resolved) filter correctly.
+2. Default "All Status" view still hides expired wagers.
+
+### US7 — Network pill
+1. Open My Wagers → the standalone network **pill** next to the title is gone.
+2. The **subtitle** still names the active network (appears exactly once in the header).
+
+## Success criteria mapping
+
+| Scenario | Spec success criteria |
+|---|---|
+| US1 steps 1–5 | SC-001 |
+| US2 steps 1–3 | SC-002, SC-008 |
+| US3 steps 1–3 | SC-003 |
+| US4 steps 1–3 | SC-004 |
+| US5 steps 1–2 | SC-005 |
+| US6 steps 1–2 | SC-006 |
+| US7 steps 1–2 | SC-007 |

--- a/specs/040-my-wagers-refinements/research.md
+++ b/specs/040-my-wagers-refinements/research.md
@@ -1,0 +1,172 @@
+# Phase 0 Research: My Wagers Refinements
+
+All eight refinements map onto existing subsystems. There were no open `NEEDS CLARIFICATION`
+markers in the spec; this document records the design decision, rationale, and rejected
+alternative for each non-trivial slice, grounded in the current code.
+
+## D1 — Opponent name resolution (US1 / FR-001..004)
+
+**Current state**: `wagerVm.js:97-98,184` renders the opponent as `formatShortAddress(others[0])`
+— a bare `0x1234…ABCD`. No ENS, address book, or generated name is applied to wager cards.
+
+**Decision**: Add a `useOpponentName(address)` hook that resolves in priority order:
+1. **Address book** — `useAddressBook().findByAddress(address, chainId)` → contact nickname (member's
+   own labeling is authoritative).
+2. **ENS** — `useEnsReverseLookup(address)` (`hooks/useEnsResolution.js`) resolves the reverse record
+   on mainnet, already cached (5-min stale / 30-min gc).
+3. **Generated** — a new `deriveAddressName(address)` (`lib/naming/addressName.js`) that hashes the
+   checksum-normalized address with `keccak256` and indexes the existing 64×64 `ADJECTIVES`/`NOUNS`
+   vocabulary from `lib/pools/nicknameWords.js`, yielding a stable adjective-noun label.
+
+Rendering moves into a small presentational **`OpponentName.jsx`** that shows the resolved name and,
+on click/Enter (a real `<button>`), reveals the full address with a copy affordance. `wagerVm.js`
+keeps the raw address available; the card/table swap the plain opponent string for `<OpponentName>`.
+The connected wallet continues to render "You" (existing `creatorLabel` logic, FR-004).
+
+**Rationale**: Reuses three audited subsystems; the generated fallback guarantees a name even with no
+address book entry and no ENS, and is deterministic so repeat opponents are recognizable (FR-002).
+Resolving inside a per-card component is the idiomatic way to call the per-address ENS hook.
+
+**Alternatives rejected**:
+- *Reuse `deriveNickname` (pool nickname) directly* — it is keyed on a Semaphore **identity
+  commitment**, not an address, and is pool-scoped; overloading it would conflate two concepts. A
+  separate `deriveAddressName` sharing only the vocabulary keeps semantics clean.
+- *Resolve names in the pure `wagerVm` builder* — hooks can't be called there; and batching ENS for
+  all cards at once adds complexity for no benefit over per-card cached lookups.
+
+## D2 — Draw state clarity + per-party submission (US2 / FR-005..008)
+
+**Current state**: `WagerStatus.DRAW='draw'` is terminal (`wagerDefaults.js:123`), classed
+`status-draw`. A pending proposal (`draw_proposed`) only surfaces as an action badge/button "Respond
+to Draw" (`wagerVm.js:117,162-164`). The proposer identity (`drawProposer`) is indexed by the v2
+subgraph and read via `drawProposalScan.js`, but that enrichment currently flows only into the
+notification engine (`sources/wagerSource.js:63-67`), **not** into the My Wagers card view model.
+
+**Decision**:
+- **Visible draw state (FR-005)**: give `draw_proposed` its own status treatment on the card (not just
+  an action button) and keep the terminal `draw` treatment, both with text + icon.
+- **Per-party submission (FR-006)**: thread the `drawProposer` onto the market objects the modal feeds
+  to `wagerVm` (run/`fetchDrawProposals` for the user's wager ids in the modal's data path, matching
+  what `wagerSource` already does). Derive: `proposer === me` → "You proposed · awaiting opponent";
+  `proposer === opponent` → "Opponent proposed · your turn"; terminal `draw` → "Both agreed · stakes
+  returned". Render as a small submission chip pair.
+- **Notification (FR-007)**: draw proposals already pass through `diffWagers` → `activityEngine`. The
+  work is to **verify** a `null → proposer` transition emits a user-facing entry and label it clearly
+  as "Draw proposed — respond"; add a regression test. Only if the diff does not already emit it do we
+  add the transition (kept as a contingency in tasks).
+- **Settled draw (FR-008)**: the terminal `draw` state already reflects both stakes returned; ensure
+  the card copy states it.
+
+**Rationale**: The proposer datum is already indexed and free to reuse; surfacing it on the card is a
+read-only display change that respects honest-state (no assumption about who submitted).
+
+**Alternatives rejected**:
+- *Add a new on-chain read for both signatures* — unnecessary; `drawProposer` + the `WagerDrawn` event
+  (already detected in the resolution modal, `MyMarketsModal.jsx:1881-1886`) fully determine the state.
+- *Infer submission purely client-side from local action history* — violates honest-state and breaks
+  across devices; the subgraph proposer is the source of truth.
+
+## D3 — Frictionless decryption for challenges & pools (US3 / FR-009..011)
+
+**Current state**: Open-challenge terms are sealed under a four-word claim code; the user is prompted
+every time via `OpenChallengeDecryptModal.jsx` (`MyMarketsModal.jsx:140-142`). A wallet-scoped,
+at-rest-encrypted **code vault** already exists (`lib/openChallenge/codeVault.js`) but is a manual
+recovery store, not wired into the decrypt flow. Pools use Semaphore identities (no passphrase-style
+decrypt words); `MyPoolsSection` just deep-links out and never prompts for words.
+
+**Decision**:
+- **Challenges**: when opening an encrypted open-challenge item, first look up a saved code in the
+  vault and **auto-decrypt** without prompting; only show the words prompt when no saved code exists
+  (FR-011). After any successful manual entry, `addEntry` the code to the vault so the next visit is
+  automatic (FR-009). The vault key is derived from a one-time wallet signature
+  (`CODE_VAULT_SIGN_MESSAGE`); cache the derived key in memory for the session so the member is not
+  re-signed per item. Storage stays wallet-scoped and encrypted (FR-010) — no new plaintext.
+- **Pools**: confirm the pool path requires no decrypt words in My Wagers (it does not today). The
+  member's pool identity/secret is already device-persisted; "do not ask" is satisfied by ensuring
+  that persisted identity is reused. This slice is primarily **verify + regression test** for pools.
+
+**Rationale**: Reuses the audited ChaCha20-Poly1305 vault and its wallet-derived key; a session-cached
+key trades a per-item prompt for at most one signature per session — a large friction win with no
+weakening of at-rest protection.
+
+**Alternatives rejected**:
+- *Persist claim codes in plaintext localStorage* — violates the key-management constraint and the
+  spec's FR-010. The encrypted vault already exists; use it.
+- *Store the derived vault key persistently* — unnecessary and riskier than an in-memory session cache.
+
+## D4 — Periodic auto-update incl. pools (US4 / FR-012..014)
+
+**Current state**: The wager list already polls every 30s while the modal is open via
+`refreshFriendMarkets()` (`MyMarketsModal.jsx:121-128`, spec 019), cleared on close. But
+`useMyPools` (`hooks/useMyPools.js:57-69`) loads **once** on mount and never re-polls.
+
+**Decision**: Add a periodic refresh to `useMyPools` (expose `refresh()` and run it on the same ~30s
+cadence while mounted), and clear the interval on unmount so polling stops when the modal closes
+(FR-014). Keep the wager poll as-is.
+
+**Rationale**: Smallest change that brings pools to parity with wagers; the hook already has an
+idempotent `load()` to call.
+
+**Alternatives rejected**:
+- *Lift pool loading into the modal's existing poll* — more invasive and couples the pool data path to
+  the wager context; a self-contained interval in the hook is simpler and testable.
+
+## D5 — Terminal group pools filed under History (US5 / FR-015..016)
+
+**Current state**: `MyPoolsSection` renders **all** pools flat at the top of the modal on **every**
+tab, each with an inline "Active"/"Past" chip (`MyPoolsSection.jsx:19-42`). `aggregateMyItems`
+already computes `bucket: 'active' | 'history'` from `TERMINAL_POOL_STATES = {2 Resolved, 3 Cancelled}`
+(`myWagersAggregation.js`).
+
+**Decision**: Make `MyPoolsSection` tab-aware: pass `activeTab` in; when the History tab is active show
+only `bucket === 'history'` pools, otherwise show only `bucket === 'active'` pools. Terminal pools
+thus leave the active view (FR-015) and appear under History (FR-016). Drop the per-row Active/Past
+chip since the tab now conveys it.
+
+**Rationale**: The bucket is already computed; this is a filter + placement change, no new state.
+
+**Alternatives rejected**:
+- *Split pools into participating vs created buckets* — pools don't have that inbound/outbound
+  distinction cleanly; active-vs-terminal is the meaningful split the tester asked for.
+
+## D6 — Status filter cleanup (US6 / FR-017..019)
+
+**Current state**: The status `<select>` offers "Disputed" (`MyMarketsModal.jsx:941`) and "Expired"
+(`:943`). The default "all" view already hides expired wagers unless "Expired" is chosen
+(`:332-338`).
+
+**Decision**: Remove the Disputed and Expired `<option>`s. Leave categorization/`getMarketStatus`
+untouched so expired wagers stay hidden by default (FR-019). The underlying `WagerStatus.DISPUTED`/
+`EXPIRED` values remain defined (other code may reference them); only the filter options are removed.
+
+**Rationale**: Directly addresses the tester note; zero behavioral risk to non-removed filters.
+
+**Alternatives rejected**:
+- *Delete the statuses from `WagerStatus`* — out of scope and risky; they're referenced elsewhere
+  (status labels/classes). The note is specifically about the dropdown options.
+
+## D7 — Remove redundant header network pill (US7 / FR-020..021)
+
+**Current state**: The header shows a `mm-network-tag` pill with `activeNetwork.name`
+(`MyMarketsModal.jsx:817-824`) **and** a subtitle "Manage your wagers … on {activeNetwork.name}"
+(`:826-828`) — the network name appears twice.
+
+**Decision**: Remove the `mm-network-tag` `<span>` and its CSS; keep the subtitle (FR-021).
+
+**Rationale**: Eliminates the duplication the tester flagged; the subtitle already communicates the
+active network.
+
+**Alternatives rejected**:
+- *Remove the network name from the subtitle instead* — the pill is the redundant element; the
+  subtitle sentence is the primary, screen-reader-friendly statement of network.
+
+## Cross-cutting notes
+
+- **Terminal-state definitions differ across layers**: wagers use `TERMINAL_STATUSES` (`draw`,
+  `oracle_timed_out`, …) while `myWagersAggregation` uses `TERMINAL_WAGER_STATUSES`/
+  `TERMINAL_POOL_STATES`. This feature only relies on the **pool** bucket for D5; no reconciliation of
+  the wager definitions is required, but tasks note the discrepancy so it isn't widened.
+- **Accessibility**: name reveal and draw chips must pass axe/Lighthouse; convey state with text+icon,
+  not color alone.
+- **Network isolation**: opponent resolution, draw enrichment, and pool bucketing all remain scoped to
+  the active `chainId`, preserving Constitution III.

--- a/specs/040-my-wagers-refinements/spec.md
+++ b/specs/040-my-wagers-refinements/spec.md
@@ -1,0 +1,365 @@
+# Feature Specification: My Wagers — Tester Feedback Refinements
+
+**Feature Branch**: `claude/my-wagers-refinements-729gjz`
+
+**Created**: 2026-07-04
+
+**Status**: Draft
+
+**Input**: Tester feedback on the My Wagers tab:
+- Remove "Expired" and "Disputed" from the status filter dropdown (Expired is not shown; Disputed may not be a valid state)
+- Remove the network pill next to a wager — the network name already appears in the subtitle
+- Store the decrypt words locally and do not ask the user for them for pools or challenges
+- When a wager enters a draw state it should be evident in the card, and the alert needs to come as a notification
+- When resolving to a draw, there is no indication that the player has submitted or the counterparty has submitted a draw — show submission state for both parties
+- My Wagers needs to auto-update periodically so the user does not need to manually refresh
+- Opponent name should be derived from either address book, ENS, or a two-name generator, with click-to-see-address
+- Group pools need to move to the Archive tab when they reach a terminal state
+
+## Overview
+
+This feature collects a batch of usability refinements to the **My Wagers** surface,
+each raised during tester review. Individually they are small; together they raise the
+polish and trustworthiness of the primary place members go to track their money. The
+work spans how opponents are identified, how draw resolution is communicated, how often
+the list refreshes, how encrypted items are unlocked, and how terminal items are filed
+away. Every change is presentation- and client-state-only — no on-chain contract,
+escrow, or oracle behavior changes.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Recognizable opponents with click-to-reveal address (Priority: P1)
+
+A member opening My Wagers wants to know **who** each wager is with at a glance, not
+decode a hex address. The opponent should be shown by the friendliest name available,
+and the member can tap the name to reveal the full address when they need it.
+
+**Why this priority**: Raw `0x1234…ABCD` addresses are the single biggest readability
+problem on the card; a real name (or a memorable generated one) is what makes the list
+scannable and builds trust that the member is wagering with the person they intended.
+
+**Independent Test**: Create/participate in wagers with three kinds of counterparty —
+one saved in the address book, one with an ENS reverse record, one with neither — and
+confirm each renders the expected label and that tapping reveals the full address.
+
+**Acceptance Scenarios**:
+
+1. **Given** the opponent's address is saved in the member's address book, **When** the
+   wager card renders, **Then** the saved nickname is shown as the opponent name.
+2. **Given** the opponent is not in the address book but has an ENS reverse record,
+   **When** the card renders, **Then** the ENS name is shown.
+3. **Given** the opponent has neither an address-book entry nor ENS, **When** the card
+   renders, **Then** a deterministic two-word generated name derived from the address is
+   shown (the same address always yields the same name).
+4. **Given** any opponent name is shown, **When** the member taps/clicks the name,
+   **Then** the full opponent address is revealed (and can be copied).
+5. **Given** the opponent is the connected wallet, **When** the card renders, **Then**
+   it continues to show "You" rather than a derived name.
+
+---
+
+### User Story 2 - Clear draw state and both-party submission status (Priority: P1)
+
+When a wager is heading toward or resolved as a draw, the member must be able to see
+the draw status directly on the card, see whether **each** party has submitted their
+draw choice, and receive a notification when a draw needs their attention.
+
+**Why this priority**: Draw resolution requires both parties to independently submit;
+today the member cannot tell whether their own submission registered or whether they
+are waiting on the counterparty, which causes duplicate attempts and confusion about
+whether funds will be returned.
+
+**Independent Test**: Drive a wager through a draw proposal from each side and confirm
+the card reflects "proposed by you / awaiting counterparty" and the inverse, that a
+notification fires when the counterparty proposes, and that the card shows a settled
+"Draw" state once both have submitted.
+
+**Acceptance Scenarios**:
+
+1. **Given** a wager has entered a draw-proposed state, **When** the member views the
+   card, **Then** the draw state is visually evident (distinct status treatment), not
+   only inferable from an action button.
+2. **Given** the member has submitted a draw but the counterparty has not, **When** the
+   card renders, **Then** it indicates the member's submission is recorded and the
+   counterparty's is still pending.
+3. **Given** the counterparty has submitted a draw but the member has not, **When** the
+   card renders, **Then** it indicates the counterparty proposed and prompts the member
+   to respond.
+4. **Given** the counterparty proposes a draw, **When** the proposal is detected, **Then**
+   the member receives a platform notification about the pending draw.
+5. **Given** both parties have submitted a draw, **When** the wager settles, **Then** the
+   card shows a terminal "Draw" state and both stakes are reflected as returned.
+
+---
+
+### User Story 3 - No repeated decrypt-word prompts for challenges and pools (Priority: P1)
+
+A member who has already unlocked an open challenge or a pool should not be asked for
+its decrypt words again on subsequent visits; the words are remembered locally and
+applied automatically.
+
+**Why this priority**: Re-entering four-word claim codes every session is high-friction
+and error-prone, and it undermines the perception that My Wagers "just knows" the
+member's own items.
+
+**Independent Test**: Unlock an open-challenge wager once, close and reopen My Wagers,
+and confirm the details are available without a second prompt; repeat for a pool the
+member belongs to.
+
+**Acceptance Scenarios**:
+
+1. **Given** a member has previously supplied the decrypt words for an open challenge,
+   **When** they return to My Wagers, **Then** the challenge details are unlocked
+   automatically without prompting for the words again.
+2. **Given** a member belongs to a pool, **When** they view it in My Wagers, **Then**
+   they are not prompted for decrypt words to see their own pool.
+3. **Given** stored decrypt words exist for an item, **When** they are persisted at
+   rest, **Then** they are stored encrypted and scoped to the member's own wallet, never
+   in plaintext and never shared across wallets.
+4. **Given** no stored words exist for an item yet (first encounter), **When** the member
+   opens it, **Then** they are prompted once, and the words are remembered for next time.
+
+---
+
+### User Story 4 - Always-current list without manual refresh (Priority: P2)
+
+While My Wagers is open, all of its content — individual wagers **and** group pools —
+updates on its own so the member never has to manually refresh to see new state.
+
+**Why this priority**: Stale data on a money screen erodes trust; members should see an
+accepted wager, a new draw, or a resolved pool appear without hunting for a refresh
+control.
+
+**Independent Test**: Open My Wagers, trigger a state change (acceptance, resolution,
+draw) from another actor, and confirm the change appears within the refresh interval
+with no manual action.
+
+**Acceptance Scenarios**:
+
+1. **Given** My Wagers is open, **When** a wager's state changes on-chain, **Then** the
+   card reflects the new state within the auto-update interval without a manual refresh.
+2. **Given** My Wagers is open, **When** a group pool's state changes, **Then** the pool
+   entry reflects it within the auto-update interval.
+3. **Given** My Wagers is closed, **When** it is not visible, **Then** background polling
+   stops so no unnecessary work runs.
+
+---
+
+### User Story 5 - Terminal group pools filed under the archive tab (Priority: P2)
+
+Group pools that have reached a terminal state (resolved or cancelled) move out of the
+active pool listing and into the archive/history tab, alongside terminal wagers.
+
+**Why this priority**: Finished pools clutter the active area and make it harder to focus
+on live commitments; they belong with the member's other settled items.
+
+**Independent Test**: Take a pool to a terminal state and confirm it no longer appears in
+the active pool section and instead appears in the archive/history tab.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pool is active (not terminal), **When** the member views My Wagers,
+   **Then** the pool appears in the active pool listing.
+2. **Given** a pool has reached a terminal state, **When** the member views the active
+   listing, **Then** the pool no longer appears there.
+3. **Given** a pool has reached a terminal state, **When** the member opens the
+   archive/history tab, **Then** the pool appears there.
+
+---
+
+### User Story 6 - Accurate status filter options (Priority: P3)
+
+The status filter dropdown lists only statuses that are real and reachable in My Wagers,
+so members are not offered filters that return nothing or refer to states the system
+does not use.
+
+**Why this priority**: Offering "Expired" (which is hidden from the default view) and
+"Disputed" (which may not be a valid state) produces empty or misleading results and
+makes the filter feel broken.
+
+**Independent Test**: Open the status filter and confirm "Expired" and "Disputed" are
+absent while the remaining valid statuses still filter correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the status filter is open, **When** the member views the options, **Then**
+   "Expired" is not offered.
+2. **Given** the status filter is open, **When** the member views the options, **Then**
+   "Disputed" is not offered.
+3. **Given** the remaining status options, **When** the member selects one, **Then** the
+   list filters correctly to wagers in that status.
+
+---
+
+### User Story 7 - No redundant network pill (Priority: P3)
+
+The network badge shown next to the My Wagers title is removed because the network name
+is already stated in the subtitle, freeing space and reducing duplication.
+
+**Why this priority**: Showing the network name twice in the same header is redundant and
+crowds the title area on small screens.
+
+**Independent Test**: Open My Wagers and confirm the network name appears only once (in
+the subtitle) and the separate pill/badge is gone.
+
+**Acceptance Scenarios**:
+
+1. **Given** My Wagers is open, **When** the header renders, **Then** the standalone
+   network pill/badge is no longer shown.
+2. **Given** My Wagers is open, **When** the member reads the subtitle, **Then** the
+   active network name is still stated there.
+
+---
+
+### Edge Cases
+
+- **Name resolution conflicts / staleness**: If an address-book nickname and an ENS name
+  both exist, the address book wins (member's own labeling is authoritative). If an ENS
+  lookup is slow or fails, the card falls back to the generated two-word name rather than
+  showing a raw address or a spinner indefinitely.
+- **ENS availability**: ENS reverse resolution is only meaningful on networks that support
+  it; on networks without ENS the resolution chain skips straight to the generated name.
+- **Draw disagreement**: If one party proposes a draw and the other resolves to a winner
+  instead, the card must not imply the draw is settled; it reflects the actual on-chain
+  outcome.
+- **Decrypt-word vault portability**: Stored words are per-wallet and local; on a new
+  device the member is prompted once again (the vault does not sync unless a separate
+  backup/restore is used).
+- **Filter + hidden statuses**: Removing "Expired" from the dropdown must not resurface
+  expired wagers in the default "all" view; expired items remain hidden as they are today.
+- **Pool relocation timing**: A pool that becomes terminal while My Wagers is open should
+  move to the archive tab on the next auto-update, not require a reopen.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Opponent identity**
+
+- **FR-001**: My Wagers MUST display the opponent by name using this resolution priority:
+  (1) address-book nickname for the opponent's address, else (2) ENS reverse-resolved
+  name where supported, else (3) a deterministic two-word name derived from the address.
+- **FR-002**: The generated two-word name MUST be deterministic — the same address always
+  produces the same name — so members can recognize repeat opponents.
+- **FR-003**: The opponent name MUST be interactive: activating it reveals the full
+  opponent address and allows copying it.
+- **FR-004**: When the opponent is the connected wallet, the card MUST continue to show
+  "You" (or equivalent self label) rather than a derived name.
+
+**Draw clarity**
+
+- **FR-005**: A wager in a draw-proposed or draw-settled state MUST present a visually
+  distinct draw status on the card, discoverable without relying on an action button.
+- **FR-006**: The card MUST indicate, for a pending draw, which party has already
+  submitted their draw choice and which party is still pending.
+- **FR-007**: When a counterparty proposes a draw, the system MUST raise a platform
+  notification informing the member that a draw awaits their response.
+- **FR-008**: Once both parties have submitted a draw, the card MUST reflect the terminal
+  "Draw" outcome with both stakes shown as returned.
+
+**Frictionless decryption**
+
+- **FR-009**: Decrypt words / claim codes that a member supplies for an open challenge or
+  a pool MUST be persisted locally so the member is not prompted for them again.
+- **FR-010**: Persisted decrypt words MUST be stored encrypted at rest and scoped to the
+  member's own wallet; they MUST NOT be stored in plaintext or be usable by another
+  wallet.
+- **FR-011**: When persisted decrypt words exist for an item, My Wagers MUST unlock that
+  item automatically without prompting; the prompt appears only on first encounter (or
+  when no valid stored words exist).
+
+**Auto-update**
+
+- **FR-012**: While My Wagers is open, its wager list MUST refresh automatically on a
+  periodic interval without requiring a manual refresh action.
+- **FR-013**: The periodic auto-update MUST also cover group pools shown in My Wagers, not
+  only individual wagers.
+- **FR-014**: Auto-update polling MUST stop when My Wagers is not open to avoid
+  unnecessary work.
+
+**Pool archiving**
+
+- **FR-015**: Group pools that have reached a terminal state MUST be removed from the
+  active pool listing.
+- **FR-016**: Terminal group pools MUST appear in the archive/history tab alongside
+  terminal wagers.
+
+**Status filter**
+
+- **FR-017**: The status filter dropdown MUST NOT offer "Expired".
+- **FR-018**: The status filter dropdown MUST NOT offer "Disputed".
+- **FR-019**: Removing these options MUST NOT change the behavior of the remaining status
+  filters or resurface expired wagers in the default view.
+
+**Header network badge**
+
+- **FR-020**: The standalone network pill/badge in the My Wagers header MUST be removed.
+- **FR-021**: The active network name MUST still be communicated to the member via the
+  header subtitle.
+
+### Key Entities
+
+- **Opponent Identity**: The resolved display representation of a counterparty address —
+  its source (address book / ENS / generated), the display name, and the underlying full
+  address revealed on demand.
+- **Draw Resolution State**: The per-wager view of a draw — which party has proposed/
+  submitted, which party is pending, and whether the draw has settled.
+- **Decrypt-Word Vault Entry**: A locally stored, wallet-scoped, encrypted record of the
+  decrypt words / claim code for a specific challenge or pool the member has unlocked.
+- **My Wagers Bucket**: The categorization that places each wager or pool into an active
+  tab or the archive/history tab, based on whether it has reached a terminal state.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In My Wagers, 100% of opponent references show a name (address-book, ENS, or
+  generated) rather than a bare hex address, and the full address is retrievable in one
+  interaction.
+- **SC-002**: For any wager in a draw flow, a member can determine from the card alone —
+  without external tools — whether their own draw submission is recorded and whether the
+  counterparty's is pending.
+- **SC-003**: A member who has unlocked a challenge or pool once is not prompted for its
+  decrypt words on any subsequent visit within the same wallet on the same device.
+- **SC-004**: State changes to wagers and pools become visible in an open My Wagers view
+  within one auto-update interval, with zero manual refresh actions required.
+- **SC-005**: 100% of pools in a terminal state appear only in the archive/history tab and
+  not in the active pool listing.
+- **SC-006**: The status filter offers only statuses that can return results; selecting any
+  offered status never yields a "this status is never shown here" empty result caused by
+  Expired/Disputed.
+- **SC-007**: The active network name appears exactly once in the My Wagers header.
+- **SC-008**: When a counterparty proposes a draw, the member receives a notification about
+  it without having My Wagers open.
+
+## Assumptions
+
+- **Terminology**: The tester's "Archive tab" refers to the existing terminal-state tab in
+  My Wagers (currently labeled "History"). This feature files terminal pools into that same
+  tab; renaming the tab is out of scope unless separately requested.
+- **Network pill location**: The "network pill next to my wager" refers to the network
+  badge in the My Wagers modal header (adjacent to the title), which duplicates the network
+  name already present in the header subtitle. No per-card network badge exists today, so
+  none is added.
+- **Reuse of existing infrastructure**: The address book, ENS resolution, and a two-word
+  name generator already exist in the app; this feature wires them into the wager card's
+  opponent display rather than building new naming systems. The generated opponent name is
+  derived deterministically from the opponent's address.
+- **Decrypt-word storage**: Open-challenge claim codes already have a local, wallet-scoped,
+  encrypted vault; this feature extends automatic use of that vault (and equivalent local
+  storage for pools) so the member is not re-prompted. Pools authenticate via their own
+  membership mechanism; where a pool has no passphrase-style secret, "not prompting" simply
+  means the member's own pools are visible without any words request.
+- **Auto-update baseline**: My Wagers already polls periodically while open; this feature
+  ensures that behavior is reliable and extends its coverage to pools, rather than
+  introducing polling from scratch.
+- **Draw resolution semantics**: The two-party, two-signature draw flow (each party submits
+  a draw and both stakes are returned when both agree) is unchanged; this feature only makes
+  its state and submission progress visible and notified.
+- **Notifications**: The platform notification/activity system is the delivery channel for
+  the draw alert; draw proposals are already detectable from indexed on-chain data.
+- **Scope**: All changes are frontend presentation and local client state only — no smart
+  contract, escrow, oracle, or subgraph schema changes. Network-scoped data isolation is
+  preserved (items remain scoped to the active network).
+- **Accessibility**: New/changed UI (opponent name reveal, draw status, filter) meets the
+  same WCAG 2.1 AA bar the rest of the frontend is held to.

--- a/specs/040-my-wagers-refinements/tasks.md
+++ b/specs/040-my-wagers-refinements/tasks.md
@@ -120,14 +120,14 @@ open a pool → no decrypt-words prompt at any point.
 
 ### Tests for User Story 3
 
-- [ ] T021 [P] [US3] Unit test the auto-unlock decision (saved code → auto-decrypt, no prompt; no saved code → prompt once then `addEntry`) in `frontend/src/test/decryptAutoUnlock.test.js`
+- [X] T021 [P] [US3] Unit test the auto-unlock decision (saved code → auto-decrypt, no prompt; no saved code → prompt once then `addEntry`) in `frontend/src/test/decryptAutoUnlock.test.js`
 - [X] T022 [P] [US3] Regression test that viewing a member's own pool triggers no decrypt-words prompt in `frontend/src/test/MyPoolsSection.test.jsx`
 
 ### Implementation for User Story 3
 
-- [ ] T023 [US3] Add an in-memory session vault-key cache (`getSessionVaultKey(wallet)` derived once from `CODE_VAULT_SIGN_MESSAGE`, cleared on wallet change) in `frontend/src/lib/openChallenge/codeVault.js` (or a small `sessionKey.js` sibling)
-- [ ] T024 [US3] Wire auto-decrypt into the open-challenge open handler in `frontend/src/components/fairwins/MyMarketsModal.jsx`: check the vault (`readEntries`) before showing `OpenChallengeDecryptModal`; on successful manual entry, `addEntry` the code (depends on T023)
-- [ ] T025 [US3] Confirm the pool view path (`MyPoolsSection` / `useMyPools`) reuses the device-persisted pool identity and never prompts for words; document/adjust if a prompt exists
+- [X] T023 [US3] Add an in-memory session vault-key cache (`getSessionVaultKey(wallet)` derived once from `CODE_VAULT_SIGN_MESSAGE`, cleared on wallet change) in `frontend/src/lib/openChallenge/codeVault.js` (or a small `sessionKey.js` sibling)
+- [X] T024 [US3] Wire auto-decrypt into the open-challenge open handler in `frontend/src/components/fairwins/MyMarketsModal.jsx`: check the vault (`readEntries`) before showing `OpenChallengeDecryptModal`; on successful manual entry, `addEntry` the code (depends on T023)
+- [X] T025 [US3] Confirm the pool view path (`MyPoolsSection` / `useMyPools`) reuses the device-persisted pool identity and never prompts for words; document/adjust if a prompt exists
 
 **Checkpoint**: Challenges auto-unlock after first entry; pools never ask for words.
 

--- a/specs/040-my-wagers-refinements/tasks.md
+++ b/specs/040-my-wagers-refinements/tasks.md
@@ -1,0 +1,317 @@
+---
+description: "Task list for My Wagers — Tester Feedback Refinements"
+---
+
+# Tasks: My Wagers — Tester Feedback Refinements
+
+**Input**: Design documents from `specs/040-my-wagers-refinements/`
+
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅
+
+**Tests**: INCLUDED — Constitution Principle II (Test-First) mandates Vitest coverage for all
+non-trivial frontend logic; the plan calls for it explicitly.
+
+**Organization**: Tasks are grouped by the seven user stories (US1–US7) so each can be implemented,
+tested, and shipped independently. All work is in the `frontend/` project — no contract/subgraph
+changes.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1–US7 (maps to spec.md user stories)
+- Exact file paths are included in each task
+
+## ⚠️ Shared-file coordination (breaks naive parallelism)
+
+Several tasks edit the same files across stories — do NOT run these in parallel even though they live
+in different story phases:
+
+- `frontend/src/components/fairwins/MyMarketsModal.jsx` → T015 (US2), T024 (US3), T030 (US5), T032 (US6), T034 (US7)
+- `frontend/src/components/fairwins/wagerVm.js` → T009 (US1), T016 (US2)
+- `frontend/src/components/fairwins/WagerCard.jsx` → T010 (US1), T017 (US2)
+- `frontend/src/components/fairwins/WagerTable.jsx` → T011 (US1), T018 (US2)
+- `frontend/src/test/MyMarketsModal.test.jsx` → T012 (US1), T031 (US6), T033 (US7)
+
+Sequence these by task ID. US1 and US2 share the card files, so prefer completing US1 before US2.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the working baseline; no new dependencies are introduced by this feature.
+
+- [ ] T001 Confirm `npm run test:frontend` and `npm run lint --workspace frontend` pass on a clean tree before changes; verify no new npm dependencies are required (ENS via existing `wagmi`, hashing via existing `ethers`).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared test scaffolding used by multiple story tests. These refinements are otherwise
+independent — there is no blocking production code shared across all stories.
+
+- [ ] T002 [P] Add/extend shared Vitest fixtures for wager states (pending, active, `draw_proposed` with a known `drawProposer`, terminal `draw`, resolved) and pool items (one `bucket:'active'`, one `bucket:'history'`) in `frontend/src/test/fixtures/myWagers.js` (create if absent), reused by US1–US7 tests.
+
+**Checkpoint**: Fixtures ready — user stories can proceed (in priority order or in parallel where files don't collide).
+
+---
+
+## Phase 3: User Story 1 - Recognizable opponents + click-to-reveal address (Priority: P1) 🎯 MVP
+
+**Goal**: Show each opponent by the friendliest available name (address book → ENS → deterministic
+two-word name), with a tap to reveal the full address.
+
+**Independent Test**: Render cards for three opponent kinds (address-book / ENS / neither) and confirm
+the expected label; tap to reveal and copy the full address; own side still reads "You".
+
+### Tests for User Story 1
+
+- [ ] T003 [P] [US1] Unit test `deriveAddressName` (deterministic, casing-invariant, always returns a two-word label) in `frontend/src/test/addressName.test.js`
+- [ ] T004 [P] [US1] Hook test `useOpponentName` resolution priority (address book > ENS > generated; never returns raw address; synchronous generated fallback) in `frontend/src/test/useOpponentName.test.jsx`
+- [ ] T005 [P] [US1] Component test `OpponentName` — renders "You" when self, toggles full-address reveal on click/Enter, exposes copy + accessible label — in `frontend/src/test/OpponentName.test.jsx`
+
+### Implementation for User Story 1
+
+- [ ] T006 [P] [US1] Implement `deriveAddressName(address)` reusing the `ADJECTIVES`/`NOUNS` vocab from `lib/pools/nicknameWords.js`, keyed by `keccak256` of the normalized address, in `frontend/src/lib/naming/addressName.js`
+- [ ] T007 [US1] Implement `useOpponentName(address, { chainId })` (address book via `useAddressBook().findByAddress` → `useEnsReverseLookup` → `deriveAddressName`) in `frontend/src/hooks/useOpponentName.js` (depends on T006)
+- [ ] T008 [US1] Implement `OpponentName.jsx` presentational component (button + reveal + copy, WCAG 2.1 AA) in `frontend/src/components/fairwins/OpponentName.jsx` (depends on T007)
+- [ ] T009 [US1] In `frontend/src/components/fairwins/wagerVm.js`, expose the raw `opponentAddress` and an `isSelf` flag on the view model (keep existing `opponent` for back-compat) so the card can render `<OpponentName>`
+- [ ] T010 [US1] Render `<OpponentName address={vm.opponentAddress} isSelf={…} />` in the opponent slot of `frontend/src/components/fairwins/WagerCard.jsx` (depends on T008, T009)
+- [ ] T011 [US1] Render `<OpponentName>` in the opponent column of `frontend/src/components/fairwins/WagerTable.jsx` (depends on T008, T009)
+- [ ] T012 [US1] Update opponent-name assertions in `frontend/src/test/MyMarketsModal.test.jsx` (name shown instead of raw address; reveal works)
+
+**Checkpoint**: Opponents render by name with click-to-reveal in both card and table views.
+
+---
+
+## Phase 4: User Story 2 - Draw state clarity + per-party submission (Priority: P1)
+
+**Goal**: Make draw state visible on the card, show which party has submitted, and notify the member
+when a counterparty proposes a draw.
+
+**Independent Test**: Drive a wager through a draw proposal from each side; confirm card copy
+("You proposed · awaiting opponent" / "Opponent proposed · your turn"), a notification on the
+counterparty's proposal, and a terminal "Draw — stakes returned" once both submit.
+
+### Tests for User Story 2
+
+- [ ] T013 [P] [US2] Unit test the draw descriptor derivation (phase/proposer/mySubmitted/opponentSubmitted/label from `computedStatus` + `drawProposedBy`) in `frontend/src/test/wagerVmDraw.test.js`
+- [ ] T014 [P] [US2] Regression test that a `null → proposer` draw transition emits a user-facing, clearly-labeled "Draw proposed — respond" notification in `frontend/src/test/diffEngine.test.js` (and/or `frontend/src/test/sources/wagerSource.test.js`)
+
+### Implementation for User Story 2
+
+- [ ] T015 [US2] Enrich the modal's markets with `drawProposedBy` by calling `fetchDrawProposals({ chainId, wagerIds })` (retain prior state on `ok:false`) and mapping the proposer onto each market before building the view model, in `frontend/src/components/fairwins/MyMarketsModal.jsx`
+- [ ] T016 [US2] Add the `draw` descriptor (`phase`, `proposer`, `mySubmitted`, `opponentSubmitted`, `label`) to the view model in `frontend/src/components/fairwins/wagerVm.js` (depends on T015; sequence after T009)
+- [ ] T017 [US2] Render a distinct draw status treatment + per-party submission chip pair (text + icon, not color alone) in `frontend/src/components/fairwins/WagerCard.jsx` (depends on T016; sequence after T010)
+- [ ] T018 [US2] Render draw state in `frontend/src/components/fairwins/WagerTable.jsx` (depends on T016; sequence after T011)
+- [ ] T019 [US2] Verify the draw-proposal notification path (`data/notifications/derivedState.js` / `diffEngine.js` / `sources/wagerSource.js`); add/label the emission only if T014 shows it is not already produced
+- [ ] T020 [US2] Add draw-state / submission-chip styles in `frontend/src/components/fairwins/WagerCard.css` (and `MyMarketsModal.css` if needed)
+
+**Checkpoint**: Draw wagers show state + submission progress on the card, and proposals notify.
+
+---
+
+## Phase 5: User Story 3 - No repeated decrypt-word prompts (Priority: P1)
+
+**Goal**: Auto-decrypt open challenges (and never prompt for pools) using locally stored, wallet-scoped
+encrypted codes, so the member is prompted at most once.
+
+**Independent Test**: Enter a challenge code once, reopen My Wagers → challenge unlocks with no prompt;
+open a pool → no decrypt-words prompt at any point.
+
+### Tests for User Story 3
+
+- [ ] T021 [P] [US3] Unit test the auto-unlock decision (saved code → auto-decrypt, no prompt; no saved code → prompt once then `addEntry`) in `frontend/src/test/decryptAutoUnlock.test.js`
+- [ ] T022 [P] [US3] Regression test that viewing a member's own pool triggers no decrypt-words prompt in `frontend/src/test/MyPoolsSection.test.jsx`
+
+### Implementation for User Story 3
+
+- [ ] T023 [US3] Add an in-memory session vault-key cache (`getSessionVaultKey(wallet)` derived once from `CODE_VAULT_SIGN_MESSAGE`, cleared on wallet change) in `frontend/src/lib/openChallenge/codeVault.js` (or a small `sessionKey.js` sibling)
+- [ ] T024 [US3] Wire auto-decrypt into the open-challenge open handler in `frontend/src/components/fairwins/MyMarketsModal.jsx`: check the vault (`readEntries`) before showing `OpenChallengeDecryptModal`; on successful manual entry, `addEntry` the code (depends on T023)
+- [ ] T025 [US3] Confirm the pool view path (`MyPoolsSection` / `useMyPools`) reuses the device-persisted pool identity and never prompts for words; document/adjust if a prompt exists
+
+**Checkpoint**: Challenges auto-unlock after first entry; pools never ask for words.
+
+---
+
+## Phase 6: User Story 4 - Always-current list incl. pools (Priority: P2)
+
+**Goal**: Auto-update pools on the same cadence wagers already use, and stop polling when the modal
+closes.
+
+**Independent Test**: Change a pool's state elsewhere → it updates within ~30s with no manual refresh;
+close the modal → interval is cleared.
+
+### Tests for User Story 4
+
+- [ ] T026 [P] [US4] Test that `useMyPools` re-runs `load()` on its interval and clears the interval on unmount in `frontend/src/test/useMyPools.test.jsx`
+
+### Implementation for User Story 4
+
+- [ ] T027 [US4] Add `refresh()` + a ~30s interval (matching the wager poll) with unmount cleanup to `frontend/src/hooks/useMyPools.js`
+
+**Checkpoint**: Pools refresh automatically while the modal is open; polling stops on close.
+
+---
+
+## Phase 7: User Story 5 - Terminal group pools filed under History (Priority: P2)
+
+**Goal**: Show active pools in the active tabs and terminal pools only under History.
+
+**Independent Test**: With one active and one terminal pool, active tabs show only the active pool;
+the History tab shows the terminal pool.
+
+### Tests for User Story 5
+
+- [ ] T028 [P] [US5] Test that `MyPoolsSection` renders `bucket:'active'` pools on non-history tabs and `bucket:'history'` pools on the History tab (and nothing when the filtered list is empty) in `frontend/src/test/MyPoolsSection.test.jsx`
+
+### Implementation for User Story 5
+
+- [ ] T029 [US5] Make `MyPoolsSection` tab-aware: accept an `activeTab` prop, filter `items` by `bucket` per tab, and remove the per-row Active/Past chip, in `frontend/src/components/fairwins/MyPoolsSection.jsx`
+- [ ] T030 [US5] Pass `activeTab` from `frontend/src/components/fairwins/MyMarketsModal.jsx` into `<MyPoolsSection>` (depends on T029)
+
+**Checkpoint**: Terminal pools live under History; active pools stay in the active tabs.
+
+---
+
+## Phase 8: User Story 6 - Accurate status filter (Priority: P3)
+
+**Goal**: Remove the "Disputed" and "Expired" options from the status dropdown without changing
+default hiding of expired wagers.
+
+**Independent Test**: Open the Status dropdown → Expired and Disputed absent; remaining options filter
+correctly; default view still hides expired wagers.
+
+### Tests for User Story 6
+
+- [ ] T031 [US6] Test that the status `<select>` no longer offers Disputed/Expired and remaining options still filter, in `frontend/src/test/MyMarketsModal.test.jsx` (shares the file with T012/T033 — sequence, do not parallelize)
+
+### Implementation for User Story 6
+
+- [ ] T032 [US6] Remove the `Disputed` and `Expired` `<option>`s from the status filter in `frontend/src/components/fairwins/MyMarketsModal.jsx` (leave `getMarketStatus`/categorization untouched)
+
+**Checkpoint**: Filter offers only reachable statuses; expired wagers stay hidden by default.
+
+---
+
+## Phase 9: User Story 7 - No redundant network pill (Priority: P3)
+
+**Goal**: Remove the header network pill; keep the network name in the subtitle.
+
+**Independent Test**: Open My Wagers → the standalone pill is gone; the subtitle still names the network
+(appears exactly once).
+
+### Tests for User Story 7
+
+- [ ] T033 [US7] Test that the header renders no `mm-network-tag` pill and the subtitle still states the active network, in `frontend/src/test/MyMarketsModal.test.jsx` (shares the file with T012/T031 — sequence, do not parallelize)
+
+### Implementation for User Story 7
+
+- [ ] T034 [US7] Remove the `mm-network-tag` `<span>` from the header in `frontend/src/components/fairwins/MyMarketsModal.jsx` and delete the `.mm-network-tag*` rules from `frontend/src/components/fairwins/MyMarketsModal.css`
+
+**Checkpoint**: Network name appears once (subtitle); the redundant pill is gone.
+
+---
+
+## Phase 10: Polish & Cross-Cutting Concerns
+
+- [ ] T035 [P] Run an accessibility audit (axe/Lighthouse) over the changed My Wagers surface — opponent-name reveal, draw status/chips, filter, header — and fix any WCAG 2.1 AA regressions
+- [ ] T036 [P] Verify per-network (chainId) isolation across opponent resolution, draw enrichment, and pool bucketing (no testnet/mainnet leakage), per Constitution III
+- [ ] T037 Run `npm run test:frontend` and `npm run lint --workspace frontend` — both green with no new warnings
+- [ ] T038 Execute the manual scenarios in `specs/040-my-wagers-refinements/quickstart.md` (US1–US7) and confirm the success-criteria mapping
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies.
+- **Foundational (Phase 2)**: after Setup; provides shared test fixtures.
+- **User Stories (Phases 3–9)**: after Foundational. Independent by story, but see shared-file
+  coordination — US2 shares the card files (`wagerVm.js`, `WagerCard.jsx`, `WagerTable.jsx`) with US1,
+  and US2/US3/US5/US6/US7 all edit `MyMarketsModal.jsx`.
+- **Polish (Phase 10)**: after all targeted stories are complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: independent — the MVP slice.
+- **US2 (P1)**: independent in behavior, but **sequence after US1** because it edits the same card
+  files; also depends on the `drawProposedBy` enrichment (T015) before the view-model change (T016).
+- **US3 (P1)**: independent; only shares `MyMarketsModal.jsx` (T024) with other stories.
+- **US4 (P2)**: fully independent (`useMyPools.js` only).
+- **US5 (P2)**: independent; `MyPoolsSection.jsx` (T029) + one line in `MyMarketsModal.jsx` (T030).
+- **US6 (P3)** and **US7 (P3)**: independent; both edit `MyMarketsModal.jsx` + its test file — sequence
+  them.
+
+### Within Each User Story
+
+- Tests are written first and expected to FAIL before implementation.
+- `deriveAddressName` (T006) → `useOpponentName` (T007) → `OpponentName` (T008) → card/table wiring.
+- Draw: enrichment (T015) → view model (T016) → rendering (T017/T018).
+- Decrypt: session key (T023) → open-handler wiring (T024).
+
+### Parallel Opportunities
+
+- Phase 2 fixture task (T002) is [P].
+- Within US1: T003/T004/T005 (tests) run in parallel; T006 is [P] (new file).
+- Across stories, the safely-parallel production files are: US4 (`useMyPools.js`) and US5
+  (`MyPoolsSection.jsx`) — these don't collide with the card/modal files.
+- Test files for different stories are [P] **except** the three tasks that all edit
+  `MyMarketsModal.test.jsx` (T012/T031/T033), which must be sequenced.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Tests first (all different files):
+Task: "Unit test deriveAddressName in frontend/src/test/addressName.test.js"      # T003
+Task: "Hook test useOpponentName in frontend/src/test/useOpponentName.test.jsx"    # T004
+Task: "Component test OpponentName in frontend/src/test/OpponentName.test.jsx"      # T005
+
+# Then the leaf implementation:
+Task: "Implement deriveAddressName in frontend/src/lib/naming/addressName.js"       # T006
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Phase 1 Setup → Phase 2 fixtures.
+2. Complete US1 (opponent names + reveal) — the single most-requested readability win.
+3. **STOP and VALIDATE** US1 independently (quickstart US1), then demo.
+
+### Incremental Delivery (by priority)
+
+1. Setup + Foundational → ready.
+2. **US1** (names) → validate → ship.
+3. **US2** (draw clarity) → validate → ship (sequence after US1 for card files).
+4. **US3** (frictionless decrypt) → validate → ship.
+5. **US4** (auto-update pools), **US5** (pool archiving) → validate → ship.
+6. **US6** (filter), **US7** (network pill) → validate → ship.
+7. Polish (a11y, isolation, quickstart).
+
+### Parallel Team Strategy
+
+- Dev A: US1 then US2 (owns the card files end-to-end to avoid conflicts).
+- Dev B: US3 + US4 + US5 (pool/decrypt paths — minimal overlap with the card files).
+- Dev C: US6 + US7 (both small, both in `MyMarketsModal.jsx` — one owner to serialize edits).
+
+---
+
+## Notes
+
+- [P] = different files, no dependency on an incomplete task.
+- Write tests first; confirm they fail before implementing (Constitution II).
+- Commit after each task or logical group; keep the branch green.
+- No `contracts/` (Solidity) changes — Slither/Medusa scope is untouched; this is a frontend-only feature.
+- Watch the shared-file list above — it is the main source of accidental conflicts.
+
+## Task Summary
+
+- **Total tasks**: 38 (T001–T038)
+- **Per story**: US1 = 10 (T003–T012), US2 = 8 (T013–T020), US3 = 5 (T021–T025), US4 = 2 (T026–T027), US5 = 3 (T028–T030), US6 = 2 (T031–T032), US7 = 2 (T033–T034)
+- **Setup/Foundational**: 2 (T001–T002) · **Polish**: 4 (T035–T038)
+- **Tests included**: yes (per Constitution II)

--- a/specs/040-my-wagers-refinements/tasks.md
+++ b/specs/040-my-wagers-refinements/tasks.md
@@ -121,7 +121,7 @@ open a pool → no decrypt-words prompt at any point.
 ### Tests for User Story 3
 
 - [ ] T021 [P] [US3] Unit test the auto-unlock decision (saved code → auto-decrypt, no prompt; no saved code → prompt once then `addEntry`) in `frontend/src/test/decryptAutoUnlock.test.js`
-- [ ] T022 [P] [US3] Regression test that viewing a member's own pool triggers no decrypt-words prompt in `frontend/src/test/MyPoolsSection.test.jsx`
+- [X] T022 [P] [US3] Regression test that viewing a member's own pool triggers no decrypt-words prompt in `frontend/src/test/MyPoolsSection.test.jsx`
 
 ### Implementation for User Story 3
 
@@ -143,11 +143,11 @@ close the modal → interval is cleared.
 
 ### Tests for User Story 4
 
-- [ ] T026 [P] [US4] Test that `useMyPools` re-runs `load()` on its interval and clears the interval on unmount in `frontend/src/test/useMyPools.test.jsx`
+- [X] T026 [P] [US4] Test that `useMyPools` re-runs `load()` on its interval and clears the interval on unmount in `frontend/src/test/useMyPools.test.jsx`
 
 ### Implementation for User Story 4
 
-- [ ] T027 [US4] Add `refresh()` + a ~30s interval (matching the wager poll) with unmount cleanup to `frontend/src/hooks/useMyPools.js`
+- [X] T027 [US4] Add `refresh()` + a ~30s interval (matching the wager poll) with unmount cleanup to `frontend/src/hooks/useMyPools.js`
 
 **Checkpoint**: Pools refresh automatically while the modal is open; polling stops on close.
 
@@ -162,12 +162,12 @@ the History tab shows the terminal pool.
 
 ### Tests for User Story 5
 
-- [ ] T028 [P] [US5] Test that `MyPoolsSection` renders `bucket:'active'` pools on non-history tabs and `bucket:'history'` pools on the History tab (and nothing when the filtered list is empty) in `frontend/src/test/MyPoolsSection.test.jsx`
+- [X] T028 [P] [US5] Test that `MyPoolsSection` renders `bucket:'active'` pools on non-history tabs and `bucket:'history'` pools on the History tab (and nothing when the filtered list is empty) in `frontend/src/test/MyPoolsSection.test.jsx`
 
 ### Implementation for User Story 5
 
-- [ ] T029 [US5] Make `MyPoolsSection` tab-aware: accept an `activeTab` prop, filter `items` by `bucket` per tab, and remove the per-row Active/Past chip, in `frontend/src/components/fairwins/MyPoolsSection.jsx`
-- [ ] T030 [US5] Pass `activeTab` from `frontend/src/components/fairwins/MyMarketsModal.jsx` into `<MyPoolsSection>` (depends on T029)
+- [X] T029 [US5] Make `MyPoolsSection` tab-aware: accept an `activeTab` prop, filter `items` by `bucket` per tab, and remove the per-row Active/Past chip, in `frontend/src/components/fairwins/MyPoolsSection.jsx`
+- [X] T030 [US5] Pass `activeTab` from `frontend/src/components/fairwins/MyMarketsModal.jsx` into `<MyPoolsSection>` (depends on T029)
 
 **Checkpoint**: Terminal pools live under History; active pools stay in the active tabs.
 

--- a/specs/040-my-wagers-refinements/tasks.md
+++ b/specs/040-my-wagers-refinements/tasks.md
@@ -183,11 +183,11 @@ correctly; default view still hides expired wagers.
 
 ### Tests for User Story 6
 
-- [ ] T031 [US6] Test that the status `<select>` no longer offers Disputed/Expired and remaining options still filter, in `frontend/src/test/MyMarketsModal.test.jsx` (shares the file with T012/T033 — sequence, do not parallelize)
+- [X] T031 [US6] Test that the status `<select>` no longer offers Disputed/Expired and remaining options still filter, in `frontend/src/test/MyMarketsModal.test.jsx` (shares the file with T012/T033 — sequence, do not parallelize)
 
 ### Implementation for User Story 6
 
-- [ ] T032 [US6] Remove the `Disputed` and `Expired` `<option>`s from the status filter in `frontend/src/components/fairwins/MyMarketsModal.jsx` (leave `getMarketStatus`/categorization untouched)
+- [X] T032 [US6] Remove the `Disputed` and `Expired` `<option>`s from the status filter in `frontend/src/components/fairwins/MyMarketsModal.jsx` (leave `getMarketStatus`/categorization untouched)
 
 **Checkpoint**: Filter offers only reachable statuses; expired wagers stay hidden by default.
 
@@ -202,11 +202,11 @@ correctly; default view still hides expired wagers.
 
 ### Tests for User Story 7
 
-- [ ] T033 [US7] Test that the header renders no `mm-network-tag` pill and the subtitle still states the active network, in `frontend/src/test/MyMarketsModal.test.jsx` (shares the file with T012/T031 — sequence, do not parallelize)
+- [X] T033 [US7] Test that the header renders no `mm-network-tag` pill and the subtitle still states the active network, in `frontend/src/test/MyMarketsModal.test.jsx` (shares the file with T012/T031 — sequence, do not parallelize)
 
 ### Implementation for User Story 7
 
-- [ ] T034 [US7] Remove the `mm-network-tag` `<span>` from the header in `frontend/src/components/fairwins/MyMarketsModal.jsx` and delete the `.mm-network-tag*` rules from `frontend/src/components/fairwins/MyMarketsModal.css`
+- [X] T034 [US7] Remove the `mm-network-tag` `<span>` from the header in `frontend/src/components/fairwins/MyMarketsModal.jsx` and delete the `.mm-network-tag*` rules from `frontend/src/components/fairwins/MyMarketsModal.css`
 
 **Checkpoint**: Network name appears once (subtitle); the redundant pill is gone.
 

--- a/specs/040-my-wagers-refinements/tasks.md
+++ b/specs/040-my-wagers-refinements/tasks.md
@@ -94,17 +94,17 @@ counterparty's proposal, and a terminal "Draw — stakes returned" once both sub
 
 ### Tests for User Story 2
 
-- [ ] T013 [P] [US2] Unit test the draw descriptor derivation (phase/proposer/mySubmitted/opponentSubmitted/label from `computedStatus` + `drawProposedBy`) in `frontend/src/test/wagerVmDraw.test.js`
-- [ ] T014 [P] [US2] Regression test that a `null → proposer` draw transition emits a user-facing, clearly-labeled "Draw proposed — respond" notification in `frontend/src/test/diffEngine.test.js` (and/or `frontend/src/test/sources/wagerSource.test.js`)
+- [X] T013 [P] [US2] Unit test the draw descriptor derivation (phase/proposer/mySubmitted/opponentSubmitted/label from `computedStatus` + `drawProposedBy`) in `frontend/src/test/wagerVmDraw.test.js`
+- [X] T014 [P] [US2] Regression test that a `null → proposer` draw transition emits a user-facing, clearly-labeled "Draw proposed — respond" notification in `frontend/src/test/diffEngine.test.js` (and/or `frontend/src/test/sources/wagerSource.test.js`)
 
 ### Implementation for User Story 2
 
-- [ ] T015 [US2] Enrich the modal's markets with `drawProposedBy` by calling `fetchDrawProposals({ chainId, wagerIds })` (retain prior state on `ok:false`) and mapping the proposer onto each market before building the view model, in `frontend/src/components/fairwins/MyMarketsModal.jsx`
-- [ ] T016 [US2] Add the `draw` descriptor (`phase`, `proposer`, `mySubmitted`, `opponentSubmitted`, `label`) to the view model in `frontend/src/components/fairwins/wagerVm.js` (depends on T015; sequence after T009)
-- [ ] T017 [US2] Render a distinct draw status treatment + per-party submission chip pair (text + icon, not color alone) in `frontend/src/components/fairwins/WagerCard.jsx` (depends on T016; sequence after T010)
-- [ ] T018 [US2] Render draw state in `frontend/src/components/fairwins/WagerTable.jsx` (depends on T016; sequence after T011)
-- [ ] T019 [US2] Verify the draw-proposal notification path (`data/notifications/derivedState.js` / `diffEngine.js` / `sources/wagerSource.js`); add/label the emission only if T014 shows it is not already produced
-- [ ] T020 [US2] Add draw-state / submission-chip styles in `frontend/src/components/fairwins/WagerCard.css` (and `MyMarketsModal.css` if needed)
+- [X] T015 [US2] Enrich the modal's markets with `drawProposedBy` by calling `fetchDrawProposals({ chainId, wagerIds })` (retain prior state on `ok:false`) and mapping the proposer onto each market before building the view model, in `frontend/src/components/fairwins/MyMarketsModal.jsx`
+- [X] T016 [US2] Add the `draw` descriptor (`phase`, `proposer`, `mySubmitted`, `opponentSubmitted`, `label`) to the view model in `frontend/src/components/fairwins/wagerVm.js` (depends on T015; sequence after T009)
+- [X] T017 [US2] Render a distinct draw status treatment + per-party submission chip pair (text + icon, not color alone) in `frontend/src/components/fairwins/WagerCard.jsx` (depends on T016; sequence after T010)
+- [X] T018 [US2] Render draw state in `frontend/src/components/fairwins/WagerTable.jsx` (depends on T016; sequence after T011)
+- [X] T019 [US2] Verify the draw-proposal notification path (`data/notifications/derivedState.js` / `diffEngine.js` / `sources/wagerSource.js`); add/label the emission only if T014 shows it is not already produced
+- [X] T020 [US2] Add draw-state / submission-chip styles in `frontend/src/components/fairwins/WagerCard.css` (and `MyMarketsModal.css` if needed)
 
 **Checkpoint**: Draw wagers show state + submission progress on the card, and proposals notify.
 

--- a/specs/040-my-wagers-refinements/tasks.md
+++ b/specs/040-my-wagers-refinements/tasks.md
@@ -214,10 +214,10 @@ correctly; default view still hides expired wagers.
 
 ## Phase 10: Polish & Cross-Cutting Concerns
 
-- [ ] T035 [P] Run an accessibility audit (axe/Lighthouse) over the changed My Wagers surface — opponent-name reveal, draw status/chips, filter, header — and fix any WCAG 2.1 AA regressions
-- [ ] T036 [P] Verify per-network (chainId) isolation across opponent resolution, draw enrichment, and pool bucketing (no testnet/mainnet leakage), per Constitution III
-- [ ] T037 Run `npm run test:frontend` and `npm run lint --workspace frontend` — both green with no new warnings
-- [ ] T038 Execute the manual scenarios in `specs/040-my-wagers-refinements/quickstart.md` (US1–US7) and confirm the success-criteria mapping
+- [X] T035 [P] Run an accessibility audit (axe/Lighthouse) over the changed My Wagers surface — opponent-name reveal, draw status/chips, filter, header — and fix any WCAG 2.1 AA regressions
+- [X] T036 [P] Verify per-network (chainId) isolation across opponent resolution, draw enrichment, and pool bucketing (no testnet/mainnet leakage), per Constitution III
+- [X] T037 Run `npm run test:frontend` and `npm run lint --workspace frontend` — both green with no new warnings
+- [X] T038 Execute the manual scenarios in `specs/040-my-wagers-refinements/quickstart.md` (US1–US7) and confirm the success-criteria mapping
 
 ---
 

--- a/specs/040-my-wagers-refinements/tasks.md
+++ b/specs/040-my-wagers-refinements/tasks.md
@@ -40,7 +40,7 @@ Sequence these by task ID. US1 and US2 share the card files, so prefer completin
 
 **Purpose**: Confirm the working baseline; no new dependencies are introduced by this feature.
 
-- [ ] T001 Confirm `npm run test:frontend` and `npm run lint --workspace frontend` pass on a clean tree before changes; verify no new npm dependencies are required (ENS via existing `wagmi`, hashing via existing `ethers`).
+- [X] T001 Confirm `npm run test:frontend` and `npm run lint --workspace frontend` pass on a clean tree before changes; verify no new npm dependencies are required (ENS via existing `wagmi`, hashing via existing `ethers`).
 
 ---
 
@@ -49,7 +49,7 @@ Sequence these by task ID. US1 and US2 share the card files, so prefer completin
 **Purpose**: Shared test scaffolding used by multiple story tests. These refinements are otherwise
 independent — there is no blocking production code shared across all stories.
 
-- [ ] T002 [P] Add/extend shared Vitest fixtures for wager states (pending, active, `draw_proposed` with a known `drawProposer`, terminal `draw`, resolved) and pool items (one `bucket:'active'`, one `bucket:'history'`) in `frontend/src/test/fixtures/myWagers.js` (create if absent), reused by US1–US7 tests.
+- [X] T002 [P] Add/extend shared Vitest fixtures for wager states (pending, active, `draw_proposed` with a known `drawProposer`, terminal `draw`, resolved) and pool items (one `bucket:'active'`, one `bucket:'history'`) in `frontend/src/test/fixtures/myWagers.js` (create if absent), reused by US1–US7 tests.
 
 **Checkpoint**: Fixtures ready — user stories can proceed (in priority order or in parallel where files don't collide).
 
@@ -65,19 +65,19 @@ the expected label; tap to reveal and copy the full address; own side still read
 
 ### Tests for User Story 1
 
-- [ ] T003 [P] [US1] Unit test `deriveAddressName` (deterministic, casing-invariant, always returns a two-word label) in `frontend/src/test/addressName.test.js`
-- [ ] T004 [P] [US1] Hook test `useOpponentName` resolution priority (address book > ENS > generated; never returns raw address; synchronous generated fallback) in `frontend/src/test/useOpponentName.test.jsx`
-- [ ] T005 [P] [US1] Component test `OpponentName` — renders "You" when self, toggles full-address reveal on click/Enter, exposes copy + accessible label — in `frontend/src/test/OpponentName.test.jsx`
+- [X] T003 [P] [US1] Unit test `deriveAddressName` (deterministic, casing-invariant, always returns a two-word label) in `frontend/src/test/addressName.test.js`
+- [X] T004 [P] [US1] Hook test `useOpponentName` resolution priority (address book > ENS > generated; never returns raw address; synchronous generated fallback) in `frontend/src/test/useOpponentName.test.jsx`
+- [X] T005 [P] [US1] Component test `OpponentName` — renders "You" when self, toggles full-address reveal on click/Enter, exposes copy + accessible label — in `frontend/src/test/OpponentName.test.jsx`
 
 ### Implementation for User Story 1
 
-- [ ] T006 [P] [US1] Implement `deriveAddressName(address)` reusing the `ADJECTIVES`/`NOUNS` vocab from `lib/pools/nicknameWords.js`, keyed by `keccak256` of the normalized address, in `frontend/src/lib/naming/addressName.js`
-- [ ] T007 [US1] Implement `useOpponentName(address, { chainId })` (address book via `useAddressBook().findByAddress` → `useEnsReverseLookup` → `deriveAddressName`) in `frontend/src/hooks/useOpponentName.js` (depends on T006)
-- [ ] T008 [US1] Implement `OpponentName.jsx` presentational component (button + reveal + copy, WCAG 2.1 AA) in `frontend/src/components/fairwins/OpponentName.jsx` (depends on T007)
-- [ ] T009 [US1] In `frontend/src/components/fairwins/wagerVm.js`, expose the raw `opponentAddress` and an `isSelf` flag on the view model (keep existing `opponent` for back-compat) so the card can render `<OpponentName>`
-- [ ] T010 [US1] Render `<OpponentName address={vm.opponentAddress} isSelf={…} />` in the opponent slot of `frontend/src/components/fairwins/WagerCard.jsx` (depends on T008, T009)
-- [ ] T011 [US1] Render `<OpponentName>` in the opponent column of `frontend/src/components/fairwins/WagerTable.jsx` (depends on T008, T009)
-- [ ] T012 [US1] Update opponent-name assertions in `frontend/src/test/MyMarketsModal.test.jsx` (name shown instead of raw address; reveal works)
+- [X] T006 [P] [US1] Implement `deriveAddressName(address)` reusing the `ADJECTIVES`/`NOUNS` vocab from `lib/pools/nicknameWords.js`, keyed by `keccak256` of the normalized address, in `frontend/src/lib/naming/addressName.js`
+- [X] T007 [US1] Implement `useOpponentName(address, { chainId })` (address book via `useAddressBook().findByAddress` → `useEnsReverseLookup` → `deriveAddressName`) in `frontend/src/hooks/useOpponentName.js` (depends on T006)
+- [X] T008 [US1] Implement `OpponentName.jsx` presentational component (button + reveal + copy, WCAG 2.1 AA) in `frontend/src/components/fairwins/OpponentName.jsx` (depends on T007)
+- [X] T009 [US1] In `frontend/src/components/fairwins/wagerVm.js`, expose the raw `opponentAddress` and an `isSelf` flag on the view model (keep existing `opponent` for back-compat) so the card can render `<OpponentName>`
+- [X] T010 [US1] Render `<OpponentName address={vm.opponentAddress} isSelf={…} />` in the opponent slot of `frontend/src/components/fairwins/WagerCard.jsx` (depends on T008, T009)
+- [X] T011 [US1] Render `<OpponentName>` in the opponent column of `frontend/src/components/fairwins/WagerTable.jsx` (depends on T008, T009)
+- [X] T012 [US1] Update opponent-name assertions in `frontend/src/test/MyMarketsModal.test.jsx` (name shown instead of raw address; reveal works)
 
 **Checkpoint**: Opponents render by name with click-to-reveal in both card and table views.
 


### PR DESCRIPTION
## Summary

Implements the eight **My Wagers** tester notes as Spec Kit feature `specs/040-my-wagers-refinements/`, taken through the full flow (specify → plan → tasks → implement). Frontend presentation and local client state only — no smart contract, escrow, oracle, or subgraph changes. Network-scoped (chainId) data isolation is preserved throughout.

## Tester notes → user stories (all implemented)

| Story | Priority | Delivered |
|---|---|---|
| US1 — Recognizable opponents + click-to-reveal | P1 | `deriveAddressName` (deterministic two-word name) + `useOpponentName` (address book → ENS → generated) + accessible `OpponentName` (tap to reveal/copy the full address). Wired into card metadata, preview, table. |
| US2 — Draw state + both-party submission + notification | P1 | Draw descriptor on the view model from the subgraph `drawProposer` (scanned in the modal); evident card badge + per-party submission chips + table state. Draw-proposal notifications already flow through the diff engine (verified). |
| US3 — No repeated decrypt-word prompts | P1 | Open challenges auto-unlock from the wallet-scoped encrypted code vault (one cached signature, no four-word re-entry); manual entries are saved back. Pools never prompt. |
| US4 — Always-current list (wagers + pools) | P2 | `useMyPools` polls every 30s and clears on unmount, matching the wager auto-refresh. |
| US5 — Terminal pools filed under archive tab | P2 | `MyPoolsSection` is tab-aware: terminal pools move to History; active pools stay in the active tabs; per-row chip dropped. |
| US6 — Accurate status filter | P3 | Removed the Expired & Disputed options. |
| US7 — No redundant network pill | P3 | Removed the header network pill (network stays in the subtitle). |

Encoded as 7 prioritized, independently testable user stories and 21 functional requirements (FR-001–FR-021).

## Extra: friendly names across all raw-address views

Per reviewer request, the friendly naming (via the shared `OpponentName`) also covers the **resolution modal** party labels (name · short address), the **detail-view Creator**, and the **winner outcome** on cards/table — so names are consistent everywhere, not just the opponent field.

## Behavior change worth noting

Removing the **Expired** status filter (US6) also removes the only in-modal path that surfaced expired offers for the "Clear / reclaim stake" action; expired offers are now hidden everywhere in My Wagers (matches FR-019). If reclaiming an expired offer's stake still needs a home in this UI, that's a follow-up.

## Validation

- Full frontend suite: **1997 tests pass** (new US1–US7 unit/component tests included).
- ESLint: **0 errors**; production build succeeds.
- CI green: Frontend Tests/Lint/Build, Cypress fast E2E, axe + Lighthouse accessibility, contract tests, Slither, coverage, docs.

## Resolved ambiguities (documented as Assumptions)

- **"Archive tab"** → the existing terminal-state tab (currently labeled **History**); renaming is out of scope.
- **"Network pill next to my wager"** → the redundant network badge in the modal **header** (no per-card badge exists today).

## Key files

- Spec Kit: `specs/040-my-wagers-refinements/` (spec, plan, research, data-model, contracts, quickstart, tasks — all 38 tasks complete)
- New: `lib/naming/addressName.js`, `hooks/useOpponentName.js`, `components/fairwins/OpponentName.jsx`, `lib/openChallenge/autoUnlock.js`
- Edited: `MyMarketsModal.jsx`, `wagerVm.js`, `WagerCard.jsx`, `WagerTable.jsx`, `MyPoolsSection.jsx`, `useMyPools.js`, `wagerCardHelpers.js`, `OpenChallengeDecryptModal.jsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CAj9Rt2qCsJ49s9yTLDmW1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAj9Rt2qCsJ49s9yTLDmW1)_