### PR TITLE
fix(039): make info-tooltip triggers blend into labels and read more compact

### DIFF
--- a/frontend/src/components/ui/InfoTip.css
+++ b/frontend/src/components/ui/InfoTip.css
@@ -2,9 +2,13 @@
   position: relative;
   display: inline-flex;
   vertical-align: middle;
-  margin-left: 0.35rem;
+  margin-left: 0.2rem;
 }
 
+/* The trigger is a borderless glyph so it blends into the label text instead
+   of reading as a second bordered control. The 24×24 hit area (contract
+   requirement) stays intact; only the visible chrome is dropped, and the ⓘ
+   SVG itself supplies the ring. */
 .infotip-btn {
   display: inline-flex;
   align-items: center;
@@ -13,17 +17,24 @@
   width: 24px;
   height: 24px;
   padding: 0;
-  border: 1px solid var(--border-color, #cbd5e1);
+  border: 0;
   border-radius: 50%;
   background: transparent;
-  color: var(--text-muted, #64748b);
+  color: var(--text-muted, #94a3b8);
+  opacity: 0.75;
   cursor: pointer;
+  transition: color 0.15s ease, opacity 0.15s ease;
 }
 
 .infotip-btn:hover,
 .infotip-btn:focus-visible {
   color: var(--accent, #2563eb);
-  border-color: var(--accent, #2563eb);
+  opacity: 1;
+}
+
+.infotip-btn[aria-expanded='true'] {
+  color: var(--accent, #2563eb);
+  opacity: 1;
 }
 
 .infotip-btn:focus-visible {


### PR DESCRIPTION
## Summary

Follow-up to the spec 039 info-tooltip sweep. Testers found the ⓘ info buttons too visually prominent — they take up too much room and don't blend into the page.

The shared `InfoTip` trigger rendered a **24px bordered circle** wrapped around the **14px ⓘ glyph**, producing a heavy *double-ring* that read as a separate control competing with each form field instead of a quiet helper beside its label.

This change strips the button's own chrome so only the muted ⓘ glyph (which already draws its own ring) shows:

- Remove the trigger's `1px` border and keep the background transparent → no more double-ring.
- Set a muted resting color at `0.75` opacity so the icon recedes into the label text.
- On hover / focus / open, the glyph brightens to the accent color (added an `[aria-expanded="true"]` active state).
- Tighten the wrapper's left margin (`0.35rem` → `0.2rem`) for a more compact label row.

Because `InfoTip` is the shared component, this fixes every view at once — Open Challenge, Create-a-Wager (FriendMarkets), the `DeadlineTimeline` corner tips, group pools, and the address-screening button.

### Before / After

The bordered circle (left) vs. the borderless glyph that blends into the label (right):

`Before` — heavy double-ring · `After` — subtle glyph that recedes into the label text.

## Constraints preserved

- **24×24 CSS px hit area** is untouched (only the *visible* chrome is dropped), satisfying the `infotip-component.md` contract requirement.
- Hover/focus/open accent styling and the focus-visible outline are preserved for accessibility.
- No JSX or behavior changes.

## Testing

- `InfoTip.test.jsx` (11) — pass
- `ScreeningInfoButton.test.jsx` (3) — pass
- `DeadlineTimeline.test.jsx` + `.axe.test.jsx` (axe-gated) — pass
- `PillSelect.test.jsx` + `.axe.test.jsx` (axe-gated) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2Yw6AEw8Wm8W148GHgSHv

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2Yw6AEw8Wm8W148GHgSHv)_