### PR TITLE
feat(035+036): gasless intent contracts, relay client, and fully configured relayer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,19 @@ artifacts live under `specs/<feature>/`.
   `getContractAddressForChain('wagerRegistry', chainId)` and read `WagerRegistry`
   events; do not depend on `friendGroupMarketFactory` except as an explicit
   legacy fallback.
+- **Gasless intents (specs 035 + 036).** The wager registry is TWO facets behind one proxy:
+  `WagerRegistry` (main impl) delegatecalls unknown selectors to `WagerRegistryIntents`
+  (the `…WithSig`/`…WithAuthorization` twins + relocated `batchExpireOpen`/`autoResolveFrom*`)
+  because the main impl sits against the 24 KB code limit. BOTH facets MUST inherit
+  `WagerRegistryCore` — the single storage-layout definition; never declare registry state
+  anywhere else — and `check:storage-layout` validates the pair. In tests use
+  `test/helpers/proxy.js#deployWagerRegistry` (deploys + wires both facets, returns a merged-ABI
+  contract). The EIP-712 intent structs exist in THREE places that must stay byte-identical:
+  the contract typehashes, `frontend/src/lib/relay/intentTypes.js`, and
+  `services/relay-gateway/src/intent/intentTypes.js`. The relayer (spec 036:
+  `services/relay-gateway` policy gateway + `services/oz-relayer` engine config) is optional
+  infrastructure — every gasless flow keeps a self-submit fallback (never-stranded rule).
+  See `docs/developer-guide/gasless-intents.md` + `docs/runbooks/relayer-operations.md`.
 - **ZK-Wager Pools (spec 034) are a documented exception to the "route escrow
   through `wagerRegistry`" rule.** Group wager pools are a **parallel system**: the
   `ZKWagerPoolFactory` (UUPS proxy, deployment keys `zkWagerPoolFactory` /

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -58,9 +58,51 @@ steps:
       - 'managed'
       - '--allow-unauthenticated'
 
+  # --- Relay gateway (spec 036) ---------------------------------------------------------------
+  # Build from the REPO ROOT context so deployments/ is baked into the image (the FR-025
+  # startup consistency check pins target addresses to those records).
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-f'
+      - 'services/relay-gateway/Dockerfile'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway:$COMMIT_SHA'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway:latest'
+      - '.'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway']
+
+  # Deploy the relay gateway to Cloud Run (Phase 1: single instance — in-process dedup/quota
+  # state stays correct; see services/relay-gateway/README.md "Phase 1 vs Phase 2").
+  # Secrets (ORIGIN_AUTH_SECRET, WEBHOOK_SHARED_SECRET) are configured on the Cloud Run service
+  # from Secret Manager — like ORIGIN_LOCK_SECRET above, they are intentionally NOT set here so
+  # deploys don't fail before the secrets exist. Once created, wire them declaratively with:
+  #   - '--update-secrets'
+  #   - 'ORIGIN_AUTH_SECRET=origin-lock-secret:latest,WEBHOOK_SHARED_SECRET=relay-webhook-secret:latest'
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'deploy'
+      - 'fairwins-relay-gateway'
+      - '--image'
+      - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway:$COMMIT_SHA'
+      - '--region'
+      - 'us-central1'
+      - '--platform'
+      - 'managed'
+      - '--allow-unauthenticated'
+      - '--max-instances'
+      - '1'
+
 images:
   - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/prediction-dao-research:$COMMIT_SHA'
   - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/prediction-dao-research:latest'
+  - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway:$COMMIT_SHA'
+  - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway:latest'
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/contracts/access/MembershipManager.sol
+++ b/contracts/access/MembershipManager.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.24;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {UUPSManaged} from "../upgradeable/UUPSManaged.sol";
+import {SignerIntentBase} from "../upgradeable/SignerIntentBase.sol";
+import {ERC3009Auth} from "../interfaces/IERC3009.sol";
 import "../interfaces/IMembershipManager.sol";
 import "../interfaces/IMembershipVoucher.sol";
 import "../interfaces/ISanctionsGuard.sol";
@@ -16,12 +18,27 @@ import "../interfaces/ISanctionsGuard.sol";
 ///           DEFAULT_ADMIN_ROLE     — treasury, tier config, role administration
 ///           ROLE_MANAGER_ROLE      — grant / revoke memberships out-of-band
 ///           authorizedCallers map  — kept for the WagerRegistry hook surface
-contract MembershipManager is IMembershipManager, UUPSManaged {
+contract MembershipManager is IMembershipManager, UUPSManaged, SignerIntentBase {
     using SafeERC20 for IERC20;
 
     uint64 private constant ROLLING_WINDOW = 30 days;
 
     bytes32 public constant ROLE_MANAGER_ROLE = keccak256("ROLE_MANAGER_ROLE");
+
+    // ---- Signer-attributed intent typehashes (spec 035). Money-in structs bind the EIP-3009
+    //      payment nonce so the money leg is stapled to this exact action (FR-007/FR-013). ----
+    bytes32 private constant PURCHASE_TIER_INTENT_TYPEHASH = keccak256(
+        "PurchaseTierIntent(bytes32 role,uint8 tier,bytes32 acceptedTermsHash,address member,bytes32 paymentNonce,bytes32 nonce,uint256 validAfter,uint256 validBefore)"
+    );
+    bytes32 private constant UPGRADE_TIER_INTENT_TYPEHASH = keccak256(
+        "UpgradeTierIntent(bytes32 role,uint8 tier,bytes32 acceptedTermsHash,address member,bytes32 paymentNonce,bytes32 nonce,uint256 validAfter,uint256 validBefore)"
+    );
+    bytes32 private constant EXTEND_MEMBERSHIP_INTENT_TYPEHASH = keccak256(
+        "ExtendMembershipIntent(bytes32 role,address member,bytes32 paymentNonce,bytes32 nonce,uint256 validAfter,uint256 validBefore)"
+    );
+    bytes32 private constant REDEEM_VOUCHER_INTENT_TYPEHASH = keccak256(
+        "RedeemVoucherIntent(uint256 voucherId,bytes32 acceptedTermsHash,address redeemer,bytes32 nonce,uint256 validAfter,uint256 validBefore)"
+    );
 
     mapping(bytes32 => mapping(Tier => TierConfig)) private _tiers;
     mapping(address => mapping(bytes32 => Membership)) private _memberships;
@@ -43,10 +60,23 @@ contract MembershipManager is IMembershipManager, UUPSManaged {
     ///         Appended after all prior state (consumes one `__gap` slot — append-only).
     address public voucher;
 
+    // ---- Fee netting (spec 035), appended after all prior state (consumes 2 __gap slots; the intent
+    //      replay-nonce map lives in SignerIntentBase's ERC-7201 namespaced storage — zero gap cost) ----
+    /// @notice When true, the `…WithAuthorization` twins consume the signer's second (bounded) EIP-3009
+    ///         fee authorization and forward it to {gasFeeRecipient} atomically (FR-015/FR-016).
+    bool public feeNettingEnabled;
+    /// @notice Segregated stablecoin fee recipient — MUST NOT be the relayer hot key (spec 036 SC-015).
+    ///         Packs with {feeNettingEnabled} into one slot.
+    address public gasFeeRecipient;
+    /// @notice Hard per-transaction ceiling on the fee authorization a twin will consume.
+    uint256 public maxGasFee;
+
     /// @dev Trailing reserve so future upgrades can append state append-only without shifting layout
     ///      (spec 027 — UUPS migration). Validated by `npm run check:storage-layout`. Never insert/reorder/
-    ///      remove the state above. (Reduced from 50 → 49 when `voucher` was appended in spec 026.)
-    uint256[49] private __gap;
+    ///      remove the state above. (Reduced from 50 → 49 when `voucher` was appended in spec 026, then
+    ///      49 → 47 for the spec 035 fee-netting scalars — `feeNettingEnabled`+`gasFeeRecipient` pack into
+    ///      one slot, `maxGasFee` the second.)
+    uint256[47] private __gap;
 
     event TierSet(bytes32 indexed role, Tier indexed tier, uint128 priceUSDC, uint32 durationDays, bool active);
     event TreasuryUpdated(address indexed treasury);
@@ -54,6 +84,7 @@ contract MembershipManager is IMembershipManager, UUPSManaged {
     event AuthorizedCallerSet(address indexed caller, bool allowed);
     event SanctionsGuardUpdated(address indexed guard);
     event MembershipTermsRecorded(address indexed user, bytes32 indexed role, bytes32 termsHash, uint64 at);
+    event FeeNettingUpdated(bool enabled, address indexed gasFeeRecipient, uint256 maxGasFee);
     event MembershipPurchased(address indexed user, bytes32 indexed role, Tier tier, uint128 price, uint64 expiresAt);
     event MembershipUpgraded(address indexed user, bytes32 indexed role, Tier fromTier, Tier toTier, uint128 delta);
     event MembershipExtended(address indexed user, bytes32 indexed role, uint32 durationDays, uint128 price, uint64 expiresAt);
@@ -89,9 +120,18 @@ contract MembershipManager is IMembershipManager, UUPSManaged {
     function initialize(address admin, address paymentToken_, address treasury_) external initializer {
         if (admin == address(0) || paymentToken_ == address(0) || treasury_ == address(0)) revert ZeroAddress();
         __UUPSManaged_init(admin);
+        __EIP712_init("FairWins MembershipManager", "1"); // signer-attributed intents (spec 035)
         paymentToken = IERC20(paymentToken_);
         treasury = treasury_;
         _grantRole(ROLE_MANAGER_ROLE, admin);
+    }
+
+    /// @notice One-time upgrade initializer for spec 035 (gasless intents). The live proxy was
+    ///         initialized before this contract carried an EIP-712 domain, so the domain used by the
+    ///         `…WithAuthorization`/`…WithSig` twins is set here, invoked via `upgradeToAndCall`
+    ///         during the in-place upgrade. Fresh deploys set it in {initialize} and never call this.
+    function initializeIntents() external reinitializer(2) {
+        __EIP712_init("FairWins MembershipManager", "1");
     }
 
     // ---------- Admin ----------
@@ -140,6 +180,16 @@ contract MembershipManager is IMembershipManager, UUPSManaged {
         emit VoucherSet(voucher_);
     }
 
+    /// @notice Configure atomic fee netting for the `…WithAuthorization` twins (spec 035 FR-015/FR-016).
+    ///         `recipient` is the segregated stablecoin fee sink — never the relayer hot key (036 SC-015).
+    function setFeeNetting(bool enabled, address recipient, uint256 cap) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (enabled && recipient == address(0)) revert ZeroAddress();
+        feeNettingEnabled = enabled;
+        gasFeeRecipient = recipient;
+        maxGasFee = cap;
+        emit FeeNettingUpdated(enabled, recipient, cap);
+    }
+
     /// @dev Sanctions screen (Spec 007, FR-054). No-op when unset; otherwise reverts for a
     ///      listed/sanctioned address. Read-only Check, before any fee transfer/effects.
     function _screen(address account) internal view {
@@ -147,13 +197,28 @@ contract MembershipManager is IMembershipManager, UUPSManaged {
         if (address(guard) != address(0)) guard.checkBlocked(account);
     }
 
-    /// @dev Record the accepted T&C version hash for msg.sender (Spec 007, FR-039).
-    function _recordTerms(bytes32 role, bytes32 acceptedTermsHash) internal {
+    /// @dev Record the accepted T&C version hash for the acting identity (Spec 007, FR-039) —
+    ///      msg.sender when self-submitted, the recovered intent signer when relayed (spec 035).
+    function _recordTerms(address actor, bytes32 role, bytes32 acceptedTermsHash) internal {
         if (acceptedTermsHash != bytes32(0)) {
-            memberTermsHash[msg.sender][role] = acceptedTermsHash;
-            emit MembershipTermsRecorded(msg.sender, role, acceptedTermsHash, uint64(block.timestamp));
+            memberTermsHash[actor][role] = acceptedTermsHash;
+            emit MembershipTermsRecorded(actor, role, acceptedTermsHash, uint64(block.timestamp));
         }
     }
+
+    /// @dev Collect a payment from `from`: allowance pull when self-submitted, the signer's stapled
+    ///      EIP-3009 authorization when relayed (bound to amount + paymentNonce, spec 035 FR-007).
+    function _collectPayment(address from, uint128 amount, bool viaAuth, ERC3009Auth memory auth, bytes32 paymentNonce) private {
+        if (viaAuth) {
+            _pullWithAuthorization(address(paymentToken), from, amount, paymentNonce, auth);
+        } else {
+            paymentToken.safeTransferFrom(from, address(this), amount);
+        }
+        accruedFees += amount;
+    }
+
+    /// @dev Zero-value authorization placeholder for the self-submit paths (never consumed).
+    function _emptyAuth() private pure returns (ERC3009Auth memory auth) {}
 
     function grantMembership(address user, bytes32 role, Tier tier, uint32 durationDays) external onlyRole(ROLE_MANAGER_ROLE) {
         if (user == address(0)) revert ZeroAddress();
@@ -190,28 +255,30 @@ contract MembershipManager is IMembershipManager, UUPSManaged {
     // ---------- User ----------
 
     function purchaseTier(bytes32 role, Tier tier) external {
-        _purchaseTier(role, tier);
+        _purchaseTier(msg.sender, role, tier, false, _emptyAuth(), bytes32(0));
     }
 
     /// @notice Like {purchaseTier} but records the accepted T&C version hash on-chain
     ///         (Spec 007, FR-039). Existing purchaseTier ABI is preserved.
     function purchaseTierWithTerms(bytes32 role, Tier tier, bytes32 acceptedTermsHash) external {
-        _purchaseTier(role, tier);
-        _recordTerms(role, acceptedTermsHash);
+        _purchaseTier(msg.sender, role, tier, false, _emptyAuth(), bytes32(0));
+        _recordTerms(msg.sender, role, acceptedTermsHash);
     }
 
-    function _purchaseTier(bytes32 role, Tier tier) internal {
-        _screen(msg.sender); // Sanctions screen (Spec 007, FR-054) — before any fee transfer
+    /// @dev Shared purchase body. `actor` is the acting identity — msg.sender when self-submitted,
+    ///      the recovered intent signer when relayed (spec 035 twin invariant). Every check
+    ///      (sanctions, tier state) evaluates `actor`; the price is pulled from `actor`.
+    function _purchaseTier(address actor, bytes32 role, Tier tier, bool viaAuth, ERC3009Auth memory priceAuth, bytes32 paymentNonce) internal {
+        _screen(actor); // Sanctions screen (Spec 007, FR-054) — before any fee transfer
         if (tier == Tier.None) revert TierNone();
         TierConfig memory cfg = _tiers[role][tier];
         if (!cfg.active) revert TierInactive();
         if (cfg.priceUSDC == 0) revert PriceZero();
 
-        Membership storage m = _memberships[msg.sender][role];
+        Membership storage m = _memberships[actor][role];
         if (m.tier != Tier.None && m.expiresAt > block.timestamp) revert AlreadyActive();
 
-        paymentToken.safeTransferFrom(msg.sender, address(this), cfg.priceUSDC);
-        accruedFees += cfg.priceUSDC;
+        _collectPayment(actor, cfg.priceUSDC, viaAuth, priceAuth, paymentNonce);
 
         m.tier = tier;
         m.expiresAt = uint64(block.timestamp) + uint64(cfg.durationDays) * 1 days;
@@ -219,23 +286,25 @@ contract MembershipManager is IMembershipManager, UUPSManaged {
         m.monthAnchor = uint64(block.timestamp);
         // activeCount preserved: in-flight wagers from a prior tier still count
 
-        emit MembershipPurchased(msg.sender, role, tier, cfg.priceUSDC, m.expiresAt);
+        emit MembershipPurchased(actor, role, tier, cfg.priceUSDC, m.expiresAt);
     }
 
     function upgradeTier(bytes32 role, Tier newTier) external {
-        _upgradeTier(role, newTier);
+        _upgradeTier(msg.sender, role, newTier, false, _emptyAuth(), bytes32(0));
     }
 
     /// @notice Like {upgradeTier} but records the accepted T&C version hash on-chain
     ///         (Spec 007, FR-039). Existing upgradeTier ABI is preserved.
     function upgradeTierWithTerms(bytes32 role, Tier newTier, bytes32 acceptedTermsHash) external {
-        _upgradeTier(role, newTier);
-        _recordTerms(role, acceptedTermsHash);
+        _upgradeTier(msg.sender, role, newTier, false, _emptyAuth(), bytes32(0));
+        _recordTerms(msg.sender, role, acceptedTermsHash);
     }
 
-    function _upgradeTier(bytes32 role, Tier newTier) internal {
-        _screen(msg.sender); // Sanctions screen (Spec 007, FR-054) — before any fee transfer
-        Membership storage m = _memberships[msg.sender][role];
+    /// @dev Shared upgrade body; `actor` semantics as in {_purchaseTier}. The relayed price binding
+    ///      is the on-chain computed `delta` — the signer's authorization must match it exactly.
+    function _upgradeTier(address actor, bytes32 role, Tier newTier, bool viaAuth, ERC3009Auth memory priceAuth, bytes32 paymentNonce) internal {
+        _screen(actor); // Sanctions screen (Spec 007, FR-054) — before any fee transfer
+        Membership storage m = _memberships[actor][role];
         if (m.tier == Tier.None || m.expiresAt <= block.timestamp) revert NoActiveMembership();
         TierConfig memory current = _tiers[role][m.tier];
         TierConfig memory upgraded = _tiers[role][newTier];
@@ -243,30 +312,33 @@ contract MembershipManager is IMembershipManager, UUPSManaged {
         if (upgraded.priceUSDC <= current.priceUSDC) revert NotUpgrade();
 
         uint128 delta = upgraded.priceUSDC - current.priceUSDC;
-        paymentToken.safeTransferFrom(msg.sender, address(this), delta);
-        accruedFees += delta;
+        _collectPayment(actor, delta, viaAuth, priceAuth, paymentNonce);
 
         Tier fromTier = m.tier;
         m.tier = newTier;
-        emit MembershipUpgraded(msg.sender, role, fromTier, newTier, delta);
+        emit MembershipUpgraded(actor, role, fromTier, newTier, delta);
     }
 
     function extendMembership(bytes32 role) external {
-        _screen(msg.sender); // Sanctions screen (Spec 007, FR-054) — paid path, same risk class
-        Membership storage m = _memberships[msg.sender][role];
+        _extendMembership(msg.sender, role, false, _emptyAuth(), bytes32(0));
+    }
+
+    /// @dev Shared extension body; `actor` semantics as in {_purchaseTier}.
+    function _extendMembership(address actor, bytes32 role, bool viaAuth, ERC3009Auth memory priceAuth, bytes32 paymentNonce) internal {
+        _screen(actor); // Sanctions screen (Spec 007, FR-054) — paid path, same risk class
+        Membership storage m = _memberships[actor][role];
         if (m.tier == Tier.None) revert NoActiveMembership();
         TierConfig memory cfg = _tiers[role][m.tier];
         if (!cfg.active) revert TierInactive();
         if (cfg.priceUSDC == 0) revert PriceZero();
 
-        paymentToken.safeTransferFrom(msg.sender, address(this), cfg.priceUSDC);
-        accruedFees += cfg.priceUSDC;
+        _collectPayment(actor, cfg.priceUSDC, viaAuth, priceAuth, paymentNonce);
 
         uint64 nowTs = uint64(block.timestamp);
         uint64 base = m.expiresAt > nowTs ? m.expiresAt : nowTs;
         m.expiresAt = base + uint64(cfg.durationDays) * 1 days;
 
-        emit MembershipExtended(msg.sender, role, cfg.durationDays, cfg.priceUSDC, m.expiresAt);
+        emit MembershipExtended(actor, role, cfg.durationDays, cfg.priceUSDC, m.expiresAt);
     }
 
     /// @notice Redeem a voucher (spec 026): burns the voucher and writes a soulbound membership of the
@@ -276,28 +348,124 @@ contract MembershipManager is IMembershipManager, UUPSManaged {
     ///         or failed redemption leaves the voucher intact and re-tradable (FR-015). No new fund flow, so no
     ///         reentrancy guard is needed; the only external call is the trusted voucher burn, performed last.
     function redeemVoucher(uint256 voucherId, bytes32 acceptedTermsHash) external {
+        _redeemVoucher(msg.sender, voucherId, acceptedTermsHash);
+    }
+
+    /// @dev Shared redemption body. `actor` is the acting identity — msg.sender when self-submitted,
+    ///      the recovered intent signer when relayed (spec 035). Ownership, activity, and sanctions
+    ///      checks all evaluate `actor`; the membership is written to `actor`.
+    function _redeemVoucher(address actor, uint256 voucherId, bytes32 acceptedTermsHash) internal {
         address v = voucher;
         if (v == address(0)) revert VoucherNotSet();
-        if (IMembershipVoucher(v).ownerOf(voucherId) != msg.sender) revert NotVoucherOwner();
+        if (IMembershipVoucher(v).ownerOf(voucherId) != actor) revert NotVoucherOwner();
 
         IMembershipVoucher.VoucherInfo memory info = IMembershipVoucher(v).voucherInfo(voucherId);
 
-        Membership storage m = _memberships[msg.sender][info.role];
+        Membership storage m = _memberships[actor][info.role];
         if (m.tier != Tier.None && m.expiresAt > block.timestamp) revert AlreadyActive(); // FR-011
 
-        _screen(msg.sender); // Sanctions screen (Spec 007 FR-054 / spec 026 FR-012) — fail-closed, before effects
+        _screen(actor); // Sanctions screen (Spec 007 FR-054 / spec 026 FR-012) — fail-closed, before effects
 
         // Effects: grant the snapshotted (role, tier); clock starts now; counters reset (like a fresh purchase).
         m.tier = info.tier;
         m.expiresAt = uint64(block.timestamp) + uint64(info.durationDays) * 1 days;
         m.monthCount = 0;
         m.monthAnchor = uint64(block.timestamp);
-        _recordTerms(info.role, acceptedTermsHash); // FR-013
+        _recordTerms(actor, info.role, acceptedTermsHash); // FR-013
 
         // Interaction (last): single-use burn. Reverts roll back all effects atomically.
         IMembershipVoucher(v).burn(voucherId);
 
-        emit MembershipRedeemed(msg.sender, info.role, info.tier, voucherId, m.expiresAt);
+        emit MembershipRedeemed(actor, info.role, info.tier, voucherId, m.expiresAt);
+    }
+
+    // ---------- Signer-attributed twins (spec 035 — gasless intents) ----------
+    // Each is a twin of an existing function: identical effects and checks, but authorized and
+    // attributed to the recovered intent `signer` instead of msg.sender. The existing functions
+    // remain as the self-submit fallback (FR-014). Money-in twins pull the price from the signer
+    // via their stapled EIP-3009 authorization, atomically with the action (FR-007), then settle
+    // the optional bounded fee leg (FR-015/FR-016).
+
+    /// @notice Relayed {purchaseTierWithTerms}: one signature purchases the tier and pays from the
+    ///         signer's EIP-3009 authorization. `signer` becomes the on-chain member.
+    function purchaseTierWithAuthorization(
+        bytes32 role,
+        uint8 tier,
+        bytes32 termsHash,
+        address signer,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata intentSig,
+        ERC3009Auth calldata priceAuth,
+        ERC3009Auth calldata feeAuth
+    ) external {
+        _verifyIntent(
+            keccak256(abi.encode(PURCHASE_TIER_INTENT_TYPEHASH, role, tier, termsHash, signer, priceAuth.nonce, nonce, validAfter, validBefore)),
+            signer, nonce, validAfter, validBefore, intentSig
+        );
+        _purchaseTier(signer, role, Tier(tier), true, priceAuth, priceAuth.nonce);
+        _recordTerms(signer, role, termsHash);
+        _settleGasFee(address(paymentToken), signer, feeAuth, feeNettingEnabled, gasFeeRecipient, maxGasFee);
+    }
+
+    /// @notice Relayed {upgradeTierWithTerms}. The signer's authorization must equal the on-chain
+    ///         upgrade delta exactly (asserted before any funds move).
+    function upgradeTierWithAuthorization(
+        bytes32 role,
+        uint8 tier,
+        bytes32 termsHash,
+        address signer,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata intentSig,
+        ERC3009Auth calldata priceAuth,
+        ERC3009Auth calldata feeAuth
+    ) external {
+        _verifyIntent(
+            keccak256(abi.encode(UPGRADE_TIER_INTENT_TYPEHASH, role, tier, termsHash, signer, priceAuth.nonce, nonce, validAfter, validBefore)),
+            signer, nonce, validAfter, validBefore, intentSig
+        );
+        _upgradeTier(signer, role, Tier(tier), true, priceAuth, priceAuth.nonce);
+        _recordTerms(signer, role, termsHash);
+        _settleGasFee(address(paymentToken), signer, feeAuth, feeNettingEnabled, gasFeeRecipient, maxGasFee);
+    }
+
+    /// @notice Relayed {extendMembership}.
+    function extendMembershipWithAuthorization(
+        bytes32 role,
+        address signer,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata intentSig,
+        ERC3009Auth calldata priceAuth,
+        ERC3009Auth calldata feeAuth
+    ) external {
+        _verifyIntent(
+            keccak256(abi.encode(EXTEND_MEMBERSHIP_INTENT_TYPEHASH, role, signer, priceAuth.nonce, nonce, validAfter, validBefore)),
+            signer, nonce, validAfter, validBefore, intentSig
+        );
+        _extendMembership(signer, role, true, priceAuth, priceAuth.nonce);
+        _settleGasFee(address(paymentToken), signer, feeAuth, feeNettingEnabled, gasFeeRecipient, maxGasFee);
+    }
+
+    /// @notice Relayed {redeemVoucher}: no money leg — USDC was paid at voucher mint (spec 026).
+    function redeemVoucherWithSig(
+        uint256 voucherId,
+        bytes32 termsHash,
+        address signer,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata sig
+    ) external {
+        _verifyIntent(
+            keccak256(abi.encode(REDEEM_VOUCHER_INTENT_TYPEHASH, voucherId, termsHash, signer, nonce, validAfter, validBefore)),
+            signer, nonce, validAfter, validBefore, sig
+        );
+        _redeemVoucher(signer, voucherId, termsHash);
     }
 
     // ---------- Hooks (authorized callers) ----------

--- a/contracts/interfaces/IERC3009.sol
+++ b/contracts/interfaces/IERC3009.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @notice A signed EIP-3009 authorization forwarded by a relayer alongside an intent (spec 035).
+///         `to` is implicit — `receiveWithAuthorization` requires the payee to be the caller, so the
+///         signed `to` MUST be the consuming contract or the token rejects the signature.
+struct ERC3009Auth {
+    uint256 value;
+    uint256 validAfter;
+    uint256 validBefore;
+    bytes32 nonce;
+    uint8 v;
+    bytes32 r;
+    bytes32 s;
+}
+
+/// @title IERC3009
+/// @notice Minimal EIP-3009 surface consumed by the gasless money-in entrypoints (spec 035).
+///         Only `receiveWithAuthorization` is ever used to move funds (sender-bound, not
+///         front-runnable); `transferWithAuthorization` is deliberately absent (FR-007).
+interface IERC3009 {
+    function receiveWithAuthorization(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    function cancelAuthorization(address authorizer, bytes32 nonce, uint8 v, bytes32 r, bytes32 s) external;
+
+    function authorizationState(address authorizer, bytes32 nonce) external view returns (bool);
+}

--- a/contracts/interfaces/IWagerRegistry.sol
+++ b/contracts/interfaces/IWagerRegistry.sol
@@ -1,76 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {IWagerRegistryTypes} from "./IWagerRegistryTypes.sol";
+
 /// @title IWagerRegistry
-/// @notice Public surface area for off-chain integrators (frontend, indexers).
-interface IWagerRegistry {
-    enum ResolutionType { Either, Creator, Opponent, ThirdParty, Polymarket, ChainlinkDataFeed, ChainlinkFunctions, UMA }
-    enum Status { None, Open, Active, Resolved, Cancelled, Refunded, Draw }
-
-    struct Wager {
-        address creator;
-        address opponent;
-        address arbitrator;
-        address token;
-        uint128 creatorStake;
-        uint128 opponentStake;
-        uint64  acceptDeadline;
-        uint64  resolveDeadline;
-        ResolutionType resolutionType;
-        Status  status;
-        bool    paid;
-        bool    creatorIsYes;
-        address winner;
-        bytes32 metadataHash;
-        bytes32 polymarketConditionId;
-        string  metadataUri;
-    }
-
-    event WagerCreated(
-        uint256 indexed wagerId,
-        address indexed creator,
-        address indexed opponent,
-        address token,
-        uint128 creatorStake,
-        uint128 opponentStake,
-        ResolutionType resolutionType,
-        bytes32 metadataHash,
-        string  metadataUri
-    );
-    event WagerAccepted(uint256 indexed wagerId, address indexed opponent);
-    event WagerCancelled(uint256 indexed wagerId);
-    event WagerDeclined(uint256 indexed wagerId, address indexed opponent);
-    event WagerResolved(uint256 indexed wagerId, address indexed winner, address indexed by);
-    event WagerRefunded(uint256 indexed wagerId, address indexed creator, address indexed opponent);
-    event WagerDrawn(uint256 indexed wagerId, address indexed creator, address indexed opponent, address by);
-    event DrawProposed(uint256 indexed wagerId, address indexed proposer);
-    event DrawRevoked(uint256 indexed wagerId, address indexed proposer);
-    event PayoutClaimed(uint256 indexed wagerId, address indexed winner, uint256 amount);
-    event PolymarketLinked(uint256 indexed wagerId, bytes32 indexed conditionId, bool creatorIsYes);
-    event OracleAdapterUpdated(ResolutionType indexed resolutionType, address indexed adapter);
-    event OracleConditionLinked(
-        uint256 indexed wagerId,
-        ResolutionType indexed resolutionType,
-        bytes32 indexed conditionId,
-        bool creatorIsYes
-    );
-
-    event AccountFrozen(address indexed user, address indexed by, string reason);
-    event AccountUnfrozen(address indexed user, address indexed by);
-
-    /// @notice Emitted when an open challenge (no named opponent, code-gated) is created (feature 024).
-    ///         The opponent is bound later via {WagerAccepted} on acceptOpenWager.
-    event OpenWagerCreated(
-        uint256 indexed wagerId,
-        address indexed creator,
-        address indexed claimAuthority,
-        address token,
-        uint128 stake,
-        ResolutionType resolutionType,
-        bytes32 metadataHash,
-        string  metadataUri
-    );
-
+/// @notice Public surface area for off-chain integrators (frontend, indexers). Types and events
+///         live in {IWagerRegistryTypes} (shared with the intents extension facet, spec 035).
+/// @dev    `batchExpireOpen` and the signer-attributed `…WithSig`/`…WithAuthorization` twins are
+///         served at the SAME proxy address but declared on {IWagerRegistryIntents} — they execute
+///         in the {WagerRegistryIntents} extension facet via the registry's fallback (spec 035;
+///         the main implementation sits against the 24 KB code-size limit).
+interface IWagerRegistry is IWagerRegistryTypes {
     function createWager(
         address opponent,
         address arbitrator,
@@ -112,11 +52,8 @@ interface IWagerRegistry {
     function declareWinner(uint256 wagerId, address winner) external;
     function declareDraw(uint256 wagerId) external;
     function revokeDraw(uint256 wagerId) external;
-    function autoResolveFromPolymarket(uint256 wagerId) external;
-    function autoResolveFromOracle(uint256 wagerId) external;
     function claimPayout(uint256 wagerId) external;
     function claimRefund(uint256 wagerId) external;
-    function batchExpireOpen(uint256[] calldata wagerIds) external;
 
     function freezeAccount(address user, string calldata reason) external;
     function unfreezeAccount(address user) external;

--- a/contracts/interfaces/IWagerRegistryIntents.sol
+++ b/contracts/interfaces/IWagerRegistryIntents.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {IWagerRegistryTypes} from "./IWagerRegistryTypes.sol";
+import {ERC3009Auth} from "./IERC3009.sol";
+
+/// @title IWagerRegistryIntents
+/// @notice The signer-attributed (gasless) surface of the wager registry (spec 035). These
+///         functions are called at the SAME proxy address as {IWagerRegistry} — the main
+///         implementation forwards unknown selectors to the {WagerRegistryIntents} extension
+///         facet via delegatecall, so state, events, and the EIP-712 domain are the proxy's own.
+interface IWagerRegistryIntents is IWagerRegistryTypes {
+    /// @notice Parameters for a relayed wager creation. Mirrors `createWagerWithTerms`'s argument
+    ///         list plus `paymentNonce` — the EIP-3009 nonce of the stake authorization the creator
+    ///         stapled to this intent (asserted against `stakeAuth.nonce` on-chain, FR-007).
+    struct CreateArgs {
+        address opponent;
+        address arbitrator;
+        address token;
+        uint128 creatorStake;
+        uint128 opponentStake;
+        uint64 acceptDeadline;
+        uint64 resolveDeadline;
+        ResolutionType resolutionType;
+        bytes32 conditionId;
+        bool creatorIsYes;
+        bytes32 metadataHash;
+        string metadataUri;
+        bytes32 termsVersionHash;
+        bytes32 paymentNonce;
+    }
+
+    event FeeNettingUpdated(bool enabled, address indexed gasFeeRecipient, uint256 maxGasFee);
+
+    // ---- Money-in twins (EIP-3009 stake pull from the signer, atomic with the action) ----
+    function createWagerWithAuthorization(
+        CreateArgs calldata args,
+        address signer,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata intentSig,
+        ERC3009Auth calldata stakeAuth,
+        ERC3009Auth calldata feeAuth
+    ) external returns (uint256 wagerId);
+
+    function acceptWagerWithAuthorization(
+        uint256 wagerId,
+        address signer,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata intentSig,
+        ERC3009Auth calldata stakeAuth,
+        ERC3009Auth calldata feeAuth
+    ) external;
+
+    function acceptOpenWagerWithAuthorization(
+        uint256 wagerId,
+        address signer,
+        bytes calldata claimCodeSig,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata intentSig,
+        ERC3009Auth calldata stakeAuth,
+        ERC3009Auth calldata feeAuth
+    ) external;
+
+    // ---- No-stake twins (…WithSig) ----
+    function claimPayoutWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes calldata sig) external;
+    function claimRefundWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes calldata sig) external;
+    function declareDrawWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes calldata sig) external;
+    function revokeDrawWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes calldata sig) external;
+    function cancelOpenWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes calldata sig) external;
+    function declineWagerWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes calldata sig) external;
+    function declareWinnerWithSig(uint256 wagerId, address winner, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes calldata sig) external;
+
+    // NOTE: the intent-nonce management surface — invalidateNonce(bytes32),
+    // invalidateNonceWithSig(address,bytes32,uint256,bytes), authorizationState(address,bytes32),
+    // DOMAIN_SEPARATOR() — is inherited from {SignerIntentBase} by the implementing facet and is
+    // part of the on-chain ABI at the proxy address. It is not re-declared here to avoid duplicate
+    // base declarations in the implementing contract.
+
+    // ---- Relocated cold paths (previously on IWagerRegistry; same proxy address, unchanged behavior) ----
+    function batchExpireOpen(uint256[] calldata wagerIds) external;
+    function autoResolveFromPolymarket(uint256 wagerId) external;
+    function autoResolveFromOracle(uint256 wagerId) external;
+
+    // ---- Fee-netting admin ----
+    function setFeeNetting(bool enabled, address recipient, uint256 cap) external;
+}

--- a/contracts/interfaces/IWagerRegistryTypes.sol
+++ b/contracts/interfaces/IWagerRegistryTypes.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title IWagerRegistryTypes
+/// @notice Shared enums, structs, and events for the WagerRegistry system. Split from
+///         {IWagerRegistry} (spec 035) so both registry facets — the main {WagerRegistry}
+///         implementation and the {WagerRegistryIntents} extension — reference one
+///         declaration set without inheriting the full function surface.
+interface IWagerRegistryTypes {
+    enum ResolutionType { Either, Creator, Opponent, ThirdParty, Polymarket, ChainlinkDataFeed, ChainlinkFunctions, UMA }
+    enum Status { None, Open, Active, Resolved, Cancelled, Refunded, Draw }
+
+    struct Wager {
+        address creator;
+        address opponent;
+        address arbitrator;
+        address token;
+        uint128 creatorStake;
+        uint128 opponentStake;
+        uint64  acceptDeadline;
+        uint64  resolveDeadline;
+        ResolutionType resolutionType;
+        Status  status;
+        bool    paid;
+        bool    creatorIsYes;
+        address winner;
+        bytes32 metadataHash;
+        bytes32 polymarketConditionId;
+        string  metadataUri;
+    }
+
+    event WagerCreated(
+        uint256 indexed wagerId,
+        address indexed creator,
+        address indexed opponent,
+        address token,
+        uint128 creatorStake,
+        uint128 opponentStake,
+        ResolutionType resolutionType,
+        bytes32 metadataHash,
+        string  metadataUri
+    );
+    event WagerAccepted(uint256 indexed wagerId, address indexed opponent);
+    event WagerCancelled(uint256 indexed wagerId);
+    event WagerDeclined(uint256 indexed wagerId, address indexed opponent);
+    event WagerResolved(uint256 indexed wagerId, address indexed winner, address indexed by);
+    event WagerRefunded(uint256 indexed wagerId, address indexed creator, address indexed opponent);
+    event WagerDrawn(uint256 indexed wagerId, address indexed creator, address indexed opponent, address by);
+    event DrawProposed(uint256 indexed wagerId, address indexed proposer);
+    event DrawRevoked(uint256 indexed wagerId, address indexed proposer);
+    event PayoutClaimed(uint256 indexed wagerId, address indexed winner, uint256 amount);
+    event PolymarketLinked(uint256 indexed wagerId, bytes32 indexed conditionId, bool creatorIsYes);
+    event OracleAdapterUpdated(ResolutionType indexed resolutionType, address indexed adapter);
+    event OracleConditionLinked(
+        uint256 indexed wagerId,
+        ResolutionType indexed resolutionType,
+        bytes32 indexed conditionId,
+        bool creatorIsYes
+    );
+
+    event AccountFrozen(address indexed user, address indexed by, string reason);
+    event AccountUnfrozen(address indexed user, address indexed by);
+
+    /// @notice Emitted when an open challenge (no named opponent, code-gated) is created (feature 024).
+    ///         The opponent is bound later via {WagerAccepted} on acceptOpenWager.
+    event OpenWagerCreated(
+        uint256 indexed wagerId,
+        address indexed creator,
+        address indexed claimAuthority,
+        address token,
+        uint128 stake,
+        ResolutionType resolutionType,
+        bytes32 metadataHash,
+        string  metadataUri
+    );
+
+    /// @notice Governing T&C version bound at creation (Spec 007, FR-056/FR-058).
+    event WagerTermsBound(uint256 indexed wagerId, bytes32 indexed termsVersionHash);
+}

--- a/contracts/mocks/MockUSDCPermit.sol
+++ b/contracts/mocks/MockUSDCPermit.sol
@@ -20,6 +20,9 @@ contract MockUSDCPermit is ERC20Permit {
     /// @notice authorizer => nonce => used.
     mapping(address => mapping(bytes32 => bool)) public authorizationState;
 
+    bytes32 public constant CANCEL_AUTHORIZATION_TYPEHASH =
+        keccak256("CancelAuthorization(address authorizer,bytes32 nonce)");
+
     error AuthorizationExpired();
     error AuthorizationNotYetValid();
     error AuthorizationUsed();
@@ -27,6 +30,7 @@ contract MockUSDCPermit is ERC20Permit {
     error CallerNotPayee();
 
     event AuthorizationUsedEvent(address indexed authorizer, bytes32 indexed nonce);
+    event AuthorizationCanceled(address indexed authorizer, bytes32 indexed nonce);
 
     constructor() ERC20("USD Coin", "USDC") ERC20Permit("USD Coin") {}
 
@@ -65,5 +69,18 @@ contract MockUSDCPermit is ERC20Permit {
         authorizationState[from][nonce] = true;
         emit AuthorizationUsedEvent(from, nonce);
         _transfer(from, to, value);
+    }
+
+    /// @notice EIP-3009: cancel an unused authorization so it can never be consumed (spec 035 FR-006 —
+    ///         payment-leg invalidation). Anyone may submit the authorizer-signed cancellation.
+    function cancelAuthorization(address authorizer, bytes32 nonce, uint8 v, bytes32 r, bytes32 s) external {
+        if (authorizationState[authorizer][nonce]) revert AuthorizationUsed();
+
+        bytes32 structHash = keccak256(abi.encode(CANCEL_AUTHORIZATION_TYPEHASH, authorizer, nonce));
+        address signer = ECDSA.recover(_hashTypedDataV4(structHash), v, r, s);
+        if (signer != authorizer) revert InvalidSignature();
+
+        authorizationState[authorizer][nonce] = true;
+        emit AuthorizationCanceled(authorizer, nonce);
     }
 }

--- a/contracts/test/WagerRegistryFuzzTest.sol
+++ b/contracts/test/WagerRegistryFuzzTest.sol
@@ -41,7 +41,7 @@ contract WagerRegistryFuzzTest {
     // Snapshot of per-wager status for forward-only state check.
     // Medusa calls property functions between arbitrary tx sequences, so we
     // record the last-seen status of each wager to detect backward transitions.
-    mapping(uint256 => IWagerRegistry.Status) private _lastSeenStatus;
+    mapping(uint256 => IWagerRegistryTypes.Status) private _lastSeenStatus;
 
     // ---------- constructor ----------
 
@@ -115,7 +115,7 @@ contract WagerRegistryFuzzTest {
             opponentStake,
             accept,
             resolve,
-            IWagerRegistry.ResolutionType.Either,
+            IWagerRegistryTypes.ResolutionType.Either,
             bytes32(0),
             false,
             keccak256("fuzz"),
@@ -144,12 +144,12 @@ contract WagerRegistryFuzzTest {
         uint256 totalLocked = 0;
         uint256 count = registry.nextWagerId();
         for (uint256 i = 1; i < count; i++) {
-            IWagerRegistry.Wager memory w = registry.getWager(i);
-            if (w.status == IWagerRegistry.Status.Open) {
+            IWagerRegistryTypes.Wager memory w = registry.getWager(i);
+            if (w.status == IWagerRegistryTypes.Status.Open) {
                 totalLocked += w.creatorStake;
-            } else if (w.status == IWagerRegistry.Status.Active && !w.paid) {
+            } else if (w.status == IWagerRegistryTypes.Status.Active && !w.paid) {
                 totalLocked += uint256(w.creatorStake) + uint256(w.opponentStake);
-            } else if (w.status == IWagerRegistry.Status.Resolved && !w.paid) {
+            } else if (w.status == IWagerRegistryTypes.Status.Resolved && !w.paid) {
                 totalLocked += uint256(w.creatorStake) + uint256(w.opponentStake);
             }
         }
@@ -163,8 +163,8 @@ contract WagerRegistryFuzzTest {
     function property_winner_is_participant() public view returns (bool) {
         uint256 count = registry.nextWagerId();
         for (uint256 i = 1; i < count; i++) {
-            IWagerRegistry.Wager memory w = registry.getWager(i);
-            if (w.status == IWagerRegistry.Status.Resolved) {
+            IWagerRegistryTypes.Wager memory w = registry.getWager(i);
+            if (w.status == IWagerRegistryTypes.Status.Resolved) {
                 if (w.winner == address(0)) return false;
                 if (w.winner != w.creator && w.winner != w.opponent) return false;
             }
@@ -181,10 +181,10 @@ contract WagerRegistryFuzzTest {
     function property_no_double_claim() public view returns (bool) {
         uint256 count = registry.nextWagerId();
         for (uint256 i = 1; i < count; i++) {
-            IWagerRegistry.Wager memory w = registry.getWager(i);
-            if (w.status == IWagerRegistry.Status.Resolved && w.paid) {
+            IWagerRegistryTypes.Wager memory w = registry.getWager(i);
+            if (w.status == IWagerRegistryTypes.Status.Resolved && w.paid) {
                 // Re-read to verify the paid flag is still set (storage consistency)
-                IWagerRegistry.Wager memory w2 = registry.getWager(i);
+                IWagerRegistryTypes.Wager memory w2 = registry.getWager(i);
                 if (!w2.paid) return false;
             }
         }
@@ -204,33 +204,33 @@ contract WagerRegistryFuzzTest {
     function property_state_only_progresses_forward() public returns (bool) {
         uint256 count = registry.nextWagerId();
         for (uint256 i = 1; i < count; i++) {
-            IWagerRegistry.Wager memory w = registry.getWager(i);
-            IWagerRegistry.Status current = w.status;
-            IWagerRegistry.Status previous = _lastSeenStatus[i];
+            IWagerRegistryTypes.Wager memory w = registry.getWager(i);
+            IWagerRegistryTypes.Status current = w.status;
+            IWagerRegistryTypes.Status previous = _lastSeenStatus[i];
 
             // Record current for next call
             _lastSeenStatus[i] = current;
 
             // First time we see this wager, skip comparison
-            if (previous == IWagerRegistry.Status.None && current != IWagerRegistry.Status.None) {
+            if (previous == IWagerRegistryTypes.Status.None && current != IWagerRegistryTypes.Status.None) {
                 continue;
             }
 
             // Terminal states must never change
-            if (previous == IWagerRegistry.Status.Resolved && current != IWagerRegistry.Status.Resolved) {
+            if (previous == IWagerRegistryTypes.Status.Resolved && current != IWagerRegistryTypes.Status.Resolved) {
                 return false;
             }
-            if (previous == IWagerRegistry.Status.Refunded && current != IWagerRegistry.Status.Refunded) {
+            if (previous == IWagerRegistryTypes.Status.Refunded && current != IWagerRegistryTypes.Status.Refunded) {
                 return false;
             }
 
             // Active must not go back to Open
-            if (previous == IWagerRegistry.Status.Active && current == IWagerRegistry.Status.Open) {
+            if (previous == IWagerRegistryTypes.Status.Active && current == IWagerRegistryTypes.Status.Open) {
                 return false;
             }
 
             // Resolved wager must have a winner set
-            if (current == IWagerRegistry.Status.Resolved) {
+            if (current == IWagerRegistryTypes.Status.Resolved) {
                 if (w.winner == address(0)) return false;
             }
         }
@@ -247,8 +247,8 @@ contract WagerRegistryFuzzTest {
     function property_payout_equals_total_stakes() public view returns (bool) {
         uint256 count = registry.nextWagerId();
         for (uint256 i = 1; i < count; i++) {
-            IWagerRegistry.Wager memory w = registry.getWager(i);
-            if (w.status == IWagerRegistry.Status.Resolved && w.paid) {
+            IWagerRegistryTypes.Wager memory w = registry.getWager(i);
+            if (w.status == IWagerRegistryTypes.Status.Resolved && w.paid) {
                 // Both stakes must be > 0 (enforced at creation)
                 if (w.creatorStake == 0 || w.opponentStake == 0) return false;
             }
@@ -311,8 +311,8 @@ contract WagerRegistryFuzzTest {
     function property_refund_preserves_stake_values() public view returns (bool) {
         uint256 count = registry.nextWagerId();
         for (uint256 i = 1; i < count; i++) {
-            IWagerRegistry.Wager memory w = registry.getWager(i);
-            if (w.status == IWagerRegistry.Status.Refunded) {
+            IWagerRegistryTypes.Wager memory w = registry.getWager(i);
+            if (w.status == IWagerRegistryTypes.Status.Refunded) {
                 // Stakes should still be recorded (not zeroed)
                 if (w.creatorStake == 0) return false;
                 // If the wager was Active before refund, opponentStake > 0 too
@@ -362,7 +362,7 @@ contract WagerRegistryFuzzTest {
             stake,
             accept,
             resolve,
-            IWagerRegistry.ResolutionType.Either,
+            IWagerRegistryTypes.ResolutionType.Either,
             bytes32(0),
             false,
             keccak256("fuzz-open"),
@@ -380,8 +380,8 @@ contract WagerRegistryFuzzTest {
     function cancelOpenWagerAction(uint256 idxSeed) public {
         if (_openWagerIds.length == 0) return;
         uint256 id = _openWagerIds[idxSeed % _openWagerIds.length];
-        IWagerRegistry.Wager memory w = registry.getWager(id);
-        if (w.status != IWagerRegistry.Status.Open) return;
+        IWagerRegistryTypes.Wager memory w = registry.getWager(id);
+        if (w.status != IWagerRegistryTypes.Status.Open) return;
         try registry.cancelOpen(id) {} catch {}
     }
 
@@ -396,9 +396,9 @@ contract WagerRegistryFuzzTest {
         for (uint256 i = 0; i < _openWagerIds.length; i++) {
             uint256 id = _openWagerIds[i];
             address authority = _openClaimAuthority[id];
-            IWagerRegistry.Wager memory w = registry.getWager(id);
+            IWagerRegistryTypes.Wager memory w = registry.getWager(id);
             uint256 resolved = registry.openWagerIdForClaim(authority);
-            if (w.status == IWagerRegistry.Status.Open) {
+            if (w.status == IWagerRegistryTypes.Status.Open) {
                 if (resolved != id) return false;
             } else if (resolved != 0) {
                 return false; // claim slot released on leaving Open
@@ -410,8 +410,8 @@ contract WagerRegistryFuzzTest {
     // ---- OPEN INVARIANT B: single-binding + equal stakes while Open ----
     function property_open_no_opponent_and_equal_stakes_while_open() public view returns (bool) {
         for (uint256 i = 0; i < _openWagerIds.length; i++) {
-            IWagerRegistry.Wager memory w = registry.getWager(_openWagerIds[i]);
-            if (w.status == IWagerRegistry.Status.Open) {
+            IWagerRegistryTypes.Wager memory w = registry.getWager(_openWagerIds[i]);
+            if (w.status == IWagerRegistryTypes.Status.Open) {
                 if (w.opponent != address(0)) return false;
                 if (w.creatorStake != w.opponentStake) return false;
             }
@@ -425,8 +425,8 @@ contract WagerRegistryFuzzTest {
     // property_escrow_covers_active_stakes this also guards the open escrow path.)
     function property_open_never_active_without_signature() public view returns (bool) {
         for (uint256 i = 0; i < _openWagerIds.length; i++) {
-            IWagerRegistry.Wager memory w = registry.getWager(_openWagerIds[i]);
-            if (w.status == IWagerRegistry.Status.Active) return false;
+            IWagerRegistryTypes.Wager memory w = registry.getWager(_openWagerIds[i]);
+            if (w.status == IWagerRegistryTypes.Status.Active) return false;
         }
         return true;
     }

--- a/contracts/upgradeable/SignerIntentBase.sol
+++ b/contracts/upgradeable/SignerIntentBase.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC3009, ERC3009Auth} from "../interfaces/IERC3009.sol";
+
+/// @title SignerIntentBase
+/// @notice Shared EIP-712 intent layer for signer-attributed (gasless) entrypoints (spec 035).
+///         Generalizes the one-off open-challenge verifier into a reusable mixin: a per-signer
+///         2-D replay-nonce map (EIP-3009 style — random client nonces, out-of-order use, cheap
+///         targeted cancel), `_verifyIntent` for the `…WithSig`/`…WithAuthorization` twins, and
+///         nonce invalidation (FR-006). Inherited by the live UUPS proxies (WagerRegistry,
+///         MembershipManager) and any future intent-capable contract.
+/// @dev    Storage is ERC-7201 namespaced, so — like {EIP712Upgradeable} — adding this base to an
+///         already-deployed proxy shifts NO sequential slots and costs no `__gap`. The per-contract
+///         EIP-712 domain (name/version set by the inheritor's `__EIP712_init`) plus chainId +
+///         verifyingContract give network and contract isolation (FR-005/FR-021): a nonce used on
+///         one contract can never be replayed on another.
+abstract contract SignerIntentBase is Initializable, EIP712Upgradeable {
+    using ECDSA for bytes32;
+    using SafeERC20 for IERC20;
+
+    bytes32 private constant INVALIDATE_NONCE_TYPEHASH =
+        keccak256("InvalidateNonce(address signer,bytes32 nonce,uint256 validBefore)");
+
+    /// @custom:storage-location erc7201:fairwins.storage.SignerIntentBase
+    struct SignerIntentStorage {
+        /// @dev signer => nonce => used/cancelled. Single-use; never cleared.
+        mapping(address => mapping(bytes32 => bool)) used;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("fairwins.storage.SignerIntentBase")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant _SIGNER_INTENT_STORAGE_SLOT =
+        0x4640730a3d190cb8be6100c3dca080ee8efbe182cb87254584c9faca7e6b2400;
+
+    function _getSignerIntentStorage() private pure returns (SignerIntentStorage storage $) {
+        assembly {
+            $.slot := _SIGNER_INTENT_STORAGE_SLOT
+        }
+    }
+
+    /// @notice A signer's intent nonce was consumed by a relayed execution.
+    event IntentNonceUsed(address indexed signer, bytes32 indexed nonce);
+    /// @notice A signer proactively invalidated an unused nonce (FR-006) — the intent can never execute.
+    event NonceInvalidated(address indexed signer, bytes32 indexed nonce);
+
+    error IntentNotYetValid();
+    error IntentExpired();
+    error IntentReplayed(address signer, bytes32 nonce);
+    error InvalidIntentSignature();
+    error IntentSignerZero();
+    error PaymentAuthMismatch();
+    error FeeExceedsCap();
+    error FeeRecipientUnset();
+
+    // ---------- Views ----------
+
+    /// @notice True if `nonce` has been used or cancelled for `signer` (EIP-3009-style semantics).
+    function authorizationState(address signer, bytes32 nonce) external view returns (bool) {
+        return _getSignerIntentStorage().used[signer][nonce];
+    }
+
+    /// @notice This contract's EIP-712 domain separator (client convenience / pre-sign check).
+    // solhint-disable-next-line func-name-mixedcase
+    function DOMAIN_SEPARATOR() external view returns (bytes32) {
+        return _domainSeparatorV4();
+    }
+
+    // ---------- Invalidation (FR-006) ----------
+
+    /// @notice Invalidate an unused nonce for the caller so the corresponding signed-but-unsubmitted
+    ///         intent can never execute. Reverts {IntentReplayed} if already used/cancelled.
+    function invalidateNonce(bytes32 nonce) external {
+        _useNonce(msg.sender, nonce);
+        emit NonceInvalidated(msg.sender, nonce);
+    }
+
+    /// @notice Gasless variant of {invalidateNonce}: anyone may submit the signer's own signed
+    ///         cancellation (a zero-native-balance wallet cancels through the relayer too).
+    function invalidateNonceWithSig(address signer, bytes32 nonce, uint256 validBefore, bytes calldata sig) external {
+        if (signer == address(0)) revert IntentSignerZero();
+        if (block.timestamp > validBefore) revert IntentExpired();
+        bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(INVALIDATE_NONCE_TYPEHASH, signer, nonce, validBefore)));
+        if (digest.recover(sig) != signer) revert InvalidIntentSignature();
+        _useNonce(signer, nonce);
+        emit NonceInvalidated(signer, nonce);
+    }
+
+    // ---------- Internal intent machinery ----------
+
+    /// @dev Mark `nonce` used for `signer`; revert {IntentReplayed} if already used (single-use).
+    function _useNonce(address signer, bytes32 nonce) internal {
+        SignerIntentStorage storage $ = _getSignerIntentStorage();
+        if ($.used[signer][nonce]) revert IntentReplayed(signer, nonce);
+        $.used[signer][nonce] = true;
+    }
+
+    /// @dev Verify a signer-attributed intent: validity window, EIP-712 signature over `structHash`
+    ///      recovering exactly `signer`, then consume the single-use nonce (checks → effects; the
+    ///      nonce is burned before the caller performs any external interaction). Reverts on any
+    ///      failure — a failed intent never consumes the nonce.
+    function _verifyIntent(
+        bytes32 structHash,
+        address signer,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata sig
+    ) internal {
+        if (signer == address(0)) revert IntentSignerZero();
+        if (block.timestamp < validAfter) revert IntentNotYetValid();
+        if (block.timestamp > validBefore) revert IntentExpired();
+        if (_hashTypedDataV4(structHash).recover(sig) != signer) revert InvalidIntentSignature();
+        _useNonce(signer, nonce);
+        emit IntentNonceUsed(signer, nonce);
+    }
+
+    /// @dev Pull the money leg for a `…WithAuthorization` twin. Asserts the relayer-supplied
+    ///      authorization is the one the signer stapled to this exact action — `value` must equal the
+    ///      on-chain expected amount and `nonce` must equal the intent's `paymentNonce` (FR-007/FR-013);
+    ///      a relayer cannot substitute a different authorization. The token itself enforces
+    ///      `to == address(this)` (receiveWithAuthorization requires the payee to be the caller).
+    function _pullWithAuthorization(
+        address token,
+        address from,
+        uint256 expectedValue,
+        bytes32 expectedPaymentNonce,
+        ERC3009Auth memory auth
+    ) internal {
+        if (auth.value != expectedValue || auth.nonce != expectedPaymentNonce) revert PaymentAuthMismatch();
+        IERC3009(token).receiveWithAuthorization(
+            from, address(this), auth.value, auth.validAfter, auth.validBefore, auth.nonce, auth.v, auth.r, auth.s
+        );
+    }
+
+    /// @dev Fee-netting settlement (FR-015/FR-016): consume the signer's second, bounded fee
+    ///      authorization and forward it to the segregated `recipient` — never the relayer hot key
+    ///      (spec 036 SC-015). No-op when netting is disabled or no fee authorization was supplied
+    ///      (sponsored mode sends `feeAuth.value == 0`). Atomic with the action: a revert here
+    ///      unwinds the whole transaction, so the fee can never be taken without the action.
+    function _settleGasFee(
+        address token,
+        address from,
+        ERC3009Auth memory feeAuth,
+        bool enabled,
+        address recipient,
+        uint256 cap
+    ) internal {
+        if (!enabled || feeAuth.value == 0) return;
+        if (feeAuth.value > cap) revert FeeExceedsCap();
+        if (recipient == address(0)) revert FeeRecipientUnset();
+        IERC3009(token).receiveWithAuthorization(
+            from, address(this), feeAuth.value, feeAuth.validAfter, feeAuth.validBefore, feeAuth.nonce, feeAuth.v, feeAuth.r, feeAuth.s
+        );
+        IERC20(token).safeTransfer(recipient, feeAuth.value);
+    }
+}

--- a/contracts/wagers/WagerRegistry.sol
+++ b/contracts/wagers/WagerRegistry.sol
@@ -1,16 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
-import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
-import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
-import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
-import {UUPSManaged} from "../upgradeable/UUPSManaged.sol";
-import "../interfaces/IWagerRegistry.sol";
+import {WagerRegistryCore} from "./WagerRegistryCore.sol";
+import {IWagerRegistry} from "../interfaces/IWagerRegistry.sol";
+import {IWagerRegistryIntents} from "../interfaces/IWagerRegistryIntents.sol";
 import "../interfaces/IMembershipManager.sol";
 import "../interfaces/ISanctionsGuard.sol";
 import "../oracles/IOracleAdapter.sol";
@@ -26,128 +23,27 @@ import "../oracles/IOracleAdapter.sol";
 ///           DEFAULT_ADMIN_ROLE       — config (membership manager, adapter, token allowlist)
 ///           GUARDIAN_ROLE            — emergency pause / unpause
 ///           ACCOUNT_MODERATOR_ROLE   — freeze / unfreeze individual accounts
+///           UPGRADER_ROLE            — implementation upgrades AND the intents extension facet
 ///         A frozen account cannot create, accept, cancel, declare, claim, or refund
 ///         on this contract. See docs/system-overview/account-moderation.md.
-contract WagerRegistry is IWagerRegistry, UUPSManaged, ReentrancyGuardUpgradeable, PausableUpgradeable, EIP712Upgradeable {
+///
+///         FACETS (spec 035): the implementation sits against the 24 KB code-size limit, so the
+///         signer-attributed intent twins (and relocated cold paths like batchExpireOpen) live in
+///         a second implementation, {WagerRegistryIntents}, reached through this contract's
+///         fallback via delegatecall. Both facets inherit {WagerRegistryCore}, so they share one
+///         storage layout and one set of internal action bodies; callers see a single contract at
+///         the proxy address (one ABI, one EIP-712 domain, one event stream).
+contract WagerRegistry is IWagerRegistry, WagerRegistryCore {
     using SafeERC20 for IERC20;
     using EnumerableSet for EnumerableSet.UintSet;
-    using ECDSA for bytes32;
-
-    bytes32 public constant WAGER_PARTICIPANT_ROLE = keccak256("WAGER_PARTICIPANT_ROLE");
-    bytes32 public constant GUARDIAN_ROLE = keccak256("GUARDIAN_ROLE");
-    bytes32 public constant ACCOUNT_MODERATOR_ROLE = keccak256("ACCOUNT_MODERATOR_ROLE");
-
-    uint64 public constant MAX_ACCEPT_WINDOW = 30 days;
-    uint64 public constant MAX_RESOLVE_WINDOW = 180 days;
-
-    /// @notice EIP-712 typehash for an open-challenge acceptance. Binding `taker` (= msg.sender) to the
-    ///         signature is the front-running defense (FR-011): a copied signature is useless to anyone else.
-    bytes32 private constant OPEN_ACCEPT_TYPEHASH = keccak256("OpenAccept(uint256 wagerId,address taker)");
-
-    IMembershipManager public membershipManager;
-    IOracleAdapter public polymarketAdapter;
-
-    /// @notice Non-bypassable on-chain sanctions guard (Spec 007, FR-054). When unset
-    ///         (address(0)) screening is skipped — the production deploy wires it in.
-    ISanctionsGuard public sanctionsGuard;
-
-    /// @notice Generic registry for non-Polymarket oracle adapters keyed by ResolutionType.
-    ///         Polymarket retains its dedicated `polymarketAdapter` slot for ABI compatibility.
-    mapping(ResolutionType => IOracleAdapter) public oracleAdapters;
-
-    mapping(address => bool) private _allowedTokens;
-    mapping(uint256 => Wager) private _wagers;
-    mapping(address => bool) private _frozen;
-
-    /// @notice Governing T&C version hash bound to a wager at creation (Spec 007, FR-056/
-    ///         FR-057). 0 ⇒ legacy/unbound (governed by the launch version). Set only via
-    ///         createWagerWithTerms; never re-bound (prospective-only).
-    mapping(uint256 => bytes32) public wagerTermsVersionHash;
-    /// @dev Initialized to 1 in {initialize} (NOT inline — inline initializers run in constructor context
-    ///      and are ignored behind a proxy, which would start wager ids at 0).
-    uint256 private _nextWagerId;
-
-    /// @notice Per-wager draw-consent bitmask for participant resolution types
-    ///         (Either/Creator/Opponent). bit0 = creator agreed, bit1 = opponent
-    ///         agreed. A draw settles only once both bits are set; cleared on
-    ///         settle or revoke. Kept out of the Wager struct so getWager's ABI
-    ///         is unchanged. Not used for ThirdParty (arbitrator settles solo)
-    ///         or oracle types (a draw arises only from the oracle tie).
-    mapping(uint256 => uint8) private _drawConsent;
-    uint8 private constant _CONSENT_CREATOR = 1;
-    uint8 private constant _CONSENT_OPPONENT = 2;
-    uint8 private constant _CONSENT_BOTH = 3;
-
-    /// @notice Append-only per-user index of every wager a participant has been part of.
-    ///         Populated in `createWager` for both creator and opponent; never removed.
-    ///         Enables O(N_user) lookup without log scans (avoids `eth_getLogs` block-range limits).
-    mapping(address => EnumerableSet.UintSet) private _userWagerIds;
-
-    // ---- Open challenges (feature 024), appended after all prior state (consumes 2 __gap slots) ----
-    /// @notice Code-derived address committed to an open challenge. 0 ⇒ not an open challenge. Set in
-    ///         createOpenWager; cleared when the wager leaves Open (accept / cancel / expire / refund).
-    mapping(uint256 => address) public claimAuthority;
-    /// @notice Reverse index: the single Open open-challenge for a claim authority (0 ⇒ none). Powers code
-    ///         discovery (FR-007) and active-uniqueness (FR-006a).
-    mapping(address => uint256) public openWagerIdByClaim;
-
-    /// @dev Trailing storage reserve for append-only upgrades. Reduced 50 → 48 when the two open-challenge
-    ///      mappings above were appended (feature 024). Never insert or reorder existing state above this gap.
-    uint256[48] private __gap;
 
     event MembershipManagerUpdated(address indexed manager);
     event PolymarketAdapterUpdated(address indexed adapter);
     event SanctionsGuardUpdated(address indexed guard);
-    event WagerTermsBound(uint256 indexed wagerId, bytes32 indexed termsVersionHash);
     event TokenAllowed(address indexed token, bool allowed);
+    event IntentExtensionUpdated(address indexed extension);
 
-    error ZeroAddress();
-    error SelfWager();
-    error NotAllowedToken();
-    error ZeroStake();
-    error BadDeadlines();
-    error ArbitratorRequired();
-    error ArbitratorDisallowed();
-    error PolymarketRequired();
-    error PolymarketDisallowed();
-    error AdapterNotSet();
-    error OracleAdapterNotSet();
-    error OracleConditionRequired();
-    error UnsupportedOracleResolutionType();
-    error ConditionNotResolved();
-    error ConditionAlreadyResolved();
-    error MembershipDenied();
-    error NotOpponent();
-    error NotOpen();
-    error NotActive();
-    error AcceptExpired();
-    error ResolveExpired();
-    error NotAuthorized();
-    error EitherRequiresEqualStakes();
-    error WinnerNotParticipant();
-    error NotWinner();
-    error NotResolved();
-    error AlreadyPaid();
-    error NotRefundable();
-    error NotCreator();
-    error NotParticipant();
-    error DrawNotApplicable();
-    error NoDrawProposal();
-    error AccountFrozenError(address user);
-    // Open challenges (feature 024)
-    error ZeroClaimAuthority();
-    error ClaimAuthorityInUse();
-    error OpenResolutionTypeNotAllowed();
-    error NotOpenChallenge();
-    error BadClaimSignature();
-    error ArbitratorCannotTake();
-    error InsufficientMembershipTier();
-    error DeclineNotAllowedForOpenChallenge();
-
-    modifier notFrozen(address user) {
-        if (_frozen[user]) revert AccountFrozenError(user);
-        _;
-    }
+    error UnknownFunction();
 
     /// @notice One-time initializer (replaces the constructor for the UUPS proxy). Behavior-identical to the
     ///         former constructor. Callable exactly once; the implementation's own initializers are disabled
@@ -186,6 +82,35 @@ contract WagerRegistry is IWagerRegistry, UUPSManaged, ReentrancyGuardUpgradeabl
         __EIP712_init("FairWins WagerRegistry", "1");
     }
 
+    // ---------- Intents extension facet (spec 035) ----------
+
+    /// @notice Route unknown selectors — the signer-attributed intent twins, nonce management, and
+    ///         relocated cold paths — to the {WagerRegistryIntents} extension facet. Executes in THIS
+    ///         proxy's storage context, so state, events, and the EIP-712 domain are the proxy's own.
+    /// @dev    delegatecall to an UPGRADER_ROLE-controlled implementation — the same trust class as a
+    ///         UUPS upgrade, which is why {setIntentExtension} is gated by UPGRADER_ROLE.
+    /// @custom:oz-upgrades-unsafe-allow delegatecall
+    fallback() external {
+        address ext = intentExtension;
+        if (ext == address(0)) revert UnknownFunction();
+        assembly {
+            calldatacopy(0, 0, calldatasize())
+            let ok := delegatecall(gas(), ext, 0, calldatasize(), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+            switch ok
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
+        }
+    }
+
+    /// @notice Point the fallback at a (new) {WagerRegistryIntents} implementation, or zero to disable
+    ///         the intent surface. UPGRADER_ROLE only — the extension runs with full storage access, so
+    ///         changing it is equivalent in authority to an implementation upgrade (floppy-signed).
+    function setIntentExtension(address extension) external onlyRole(UPGRADER_ROLE) {
+        intentExtension = extension;
+        emit IntentExtensionUpdated(extension);
+    }
+
     // ---------- Admin ----------
 
     function setMembershipManager(address manager) external onlyRole(DEFAULT_ADMIN_ROLE) {
@@ -205,14 +130,6 @@ contract WagerRegistry is IWagerRegistry, UUPSManaged, ReentrancyGuardUpgradeabl
         emit SanctionsGuardUpdated(guard);
     }
 
-    /// @dev Sanctions screen (Spec 007, FR-054). No-op when the guard is unset; otherwise
-    ///      reverts ISanctionsGuard.SanctionedAddress(account) for a listed/sanctioned
-    ///      address. Called read-only during the Checks phase (before effects/transfers).
-    function _screen(address account) internal view {
-        ISanctionsGuard guard = sanctionsGuard;
-        if (address(guard) != address(0)) guard.checkBlocked(account);
-    }
-
     /// @notice Set the adapter for one of the new (non-Polymarket) oracle resolution types.
     ///         Pass `address(0)` to disable that resolution type.
     /// @dev Rejects the legacy types — Either/Creator/Opponent/ThirdParty have no adapter,
@@ -221,58 +138,6 @@ contract WagerRegistry is IWagerRegistry, UUPSManaged, ReentrancyGuardUpgradeabl
         if (!_isExtensibleOracleType(rtype)) revert UnsupportedOracleResolutionType();
         oracleAdapters[rtype] = IOracleAdapter(adapter);
         emit OracleAdapterUpdated(rtype, adapter);
-    }
-
-    function _isExtensibleOracleType(ResolutionType rt) internal pure returns (bool) {
-        return rt == ResolutionType.ChainlinkDataFeed
-            || rt == ResolutionType.ChainlinkFunctions
-            || rt == ResolutionType.UMA;
-    }
-
-    function _isOracleResolvedType(ResolutionType rt) internal pure returns (bool) {
-        return rt == ResolutionType.Polymarket || _isExtensibleOracleType(rt);
-    }
-
-    /// @dev Shared deadline checks for both create paths (named-opponent and open challenge).
-    function _checkDeadlines(uint64 acceptDeadline, uint64 resolveDeadline) internal view {
-        if (acceptDeadline <= block.timestamp) revert BadDeadlines();
-        if (resolveDeadline <= acceptDeadline) revert BadDeadlines();
-        if (acceptDeadline > block.timestamp + MAX_ACCEPT_WINDOW) revert BadDeadlines();
-        if (resolveDeadline > block.timestamp + MAX_RESOLVE_WINDOW) revert BadDeadlines();
-    }
-
-    /// @dev Shared oracle-condition validation/linkage for both create paths. For oracle types the condition
-    ///      must be set, the adapter configured, and the condition not already resolved (stale-condition
-    ///      mitigation); non-oracle types must not carry a condition.
-    function _checkOracleLinkage(ResolutionType resolutionType, bytes32 conditionId) internal view {
-        if (resolutionType == ResolutionType.Polymarket) {
-            if (conditionId == bytes32(0)) revert PolymarketRequired();
-            if (address(polymarketAdapter) == address(0)) revert AdapterNotSet();
-            if (polymarketAdapter.isConditionResolved(conditionId)) revert ConditionAlreadyResolved();
-        } else if (_isExtensibleOracleType(resolutionType)) {
-            if (conditionId == bytes32(0)) revert OracleConditionRequired();
-            IOracleAdapter adapter = oracleAdapters[resolutionType];
-            if (address(adapter) == address(0)) revert OracleAdapterNotSet();
-            if (adapter.isConditionResolved(conditionId)) revert ConditionAlreadyResolved();
-        } else {
-            if (conditionId != bytes32(0)) revert PolymarketDisallowed();
-        }
-    }
-
-    /// @dev Shared accept-time gauntlet for both accept paths: sanctions-screen the taker (msg.sender) and
-    ///      the creator, then enforce the membership gate on the taker. (Spec 007 FR-054 + membership.)
-    function _runAcceptGuard(address creator) internal view {
-        _screen(msg.sender);
-        _screen(creator);
-        if (!membershipManager.checkCanCreate(msg.sender, WAGER_PARTICIPANT_ROLE)) revert MembershipDenied();
-    }
-
-    /// @dev Shared accept tail for both accept paths: escrow the opponent's stake, charge the membership
-    ///      counter, and emit {WagerAccepted}. Status/opponent effects happen at the call site first.
-    function _settleAccept(uint256 wagerId, address token, uint128 opponentStake) internal {
-        IERC20(token).safeTransferFrom(msg.sender, address(this), opponentStake);
-        membershipManager.recordCreate(msg.sender, WAGER_PARTICIPANT_ROLE);
-        emit WagerAccepted(wagerId, msg.sender);
     }
 
     function setTokenAllowed(address token, bool allowed) external onlyRole(DEFAULT_ADMIN_ROLE) {
@@ -322,7 +187,12 @@ contract WagerRegistry is IWagerRegistry, UUPSManaged, ReentrancyGuardUpgradeabl
         string calldata metadataUri
     ) external nonReentrant whenNotPaused notFrozen(msg.sender) returns (uint256 wagerId) {
         // Existing ABI preserved: no governing-terms binding (legacy path).
-        return _createWager(opponent, arbitrator, token, creatorStake, opponentStake, acceptDeadline, resolveDeadline, resolutionType, polymarketConditionId, creatorIsYes, metadataHash, metadataUri, bytes32(0));
+        return _createWager(
+            msg.sender,
+            IWagerRegistryIntents.CreateArgs(opponent, arbitrator, token, creatorStake, opponentStake, acceptDeadline, resolveDeadline, resolutionType, polymarketConditionId, creatorIsYes, metadataHash, metadataUri, bytes32(0), bytes32(0)),
+            false,
+            _emptyAuth()
+        );
     }
 
     /// @notice Like {createWager} but binds the governing T&C version hash on-chain at
@@ -344,99 +214,12 @@ contract WagerRegistry is IWagerRegistry, UUPSManaged, ReentrancyGuardUpgradeabl
         string calldata metadataUri,
         bytes32 termsVersionHash
     ) external nonReentrant whenNotPaused notFrozen(msg.sender) returns (uint256 wagerId) {
-        return _createWager(opponent, arbitrator, token, creatorStake, opponentStake, acceptDeadline, resolveDeadline, resolutionType, polymarketConditionId, creatorIsYes, metadataHash, metadataUri, termsVersionHash);
-    }
-
-    function _createWager(
-        address opponent,
-        address arbitrator,
-        address token,
-        uint128 creatorStake,
-        uint128 opponentStake,
-        uint64 acceptDeadline,
-        uint64 resolveDeadline,
-        ResolutionType resolutionType,
-        bytes32 polymarketConditionId,
-        bool creatorIsYes,
-        bytes32 metadataHash,
-        string calldata metadataUri,
-        bytes32 termsVersionHash
-    ) internal returns (uint256 wagerId) {
-        // Sanctions screen (Spec 007, FR-054) — first Check, before any effects/transfers.
-        _screen(msg.sender);
-        if (opponent == address(0)) revert ZeroAddress();
-        if (opponent == msg.sender) revert SelfWager();
-        if (!_allowedTokens[token]) revert NotAllowedToken();
-        if (creatorStake == 0 || opponentStake == 0) revert ZeroStake();
-        _checkDeadlines(acceptDeadline, resolveDeadline);
-
-        // "Either side submits the outcome" (ResolutionType.Either) is a mutual-trust
-        // resolution path — no oracle, no arbitrator, and whoever calls declareWinner
-        // first decides the result. That is only sound on a level peer-to-peer wager
-        // where both sides stake the same amount. On an asymmetric "Offer" (leveraged)
-        // wager the side risking less could self-declare and seize the larger
-        // counterparty stake, so restrict Either to equal-stakes (non-leveraged) bets.
-        if (resolutionType == ResolutionType.Either && creatorStake != opponentStake) {
-            revert EitherRequiresEqualStakes();
-        }
-
-        if (resolutionType == ResolutionType.ThirdParty) {
-            if (arbitrator == address(0)) revert ArbitratorRequired();
-            if (arbitrator == msg.sender || arbitrator == opponent) revert ArbitratorDisallowed();
-        } else {
-            if (arbitrator != address(0)) revert ArbitratorDisallowed();
-        }
-
-        _checkOracleLinkage(resolutionType, polymarketConditionId);
-
-        // Membership gate
-        if (!membershipManager.checkCanCreate(msg.sender, WAGER_PARTICIPANT_ROLE)) revert MembershipDenied();
-
-        // Effects
-        wagerId = _nextWagerId++;
-        Wager storage w = _wagers[wagerId];
-        w.creator = msg.sender;
-        w.opponent = opponent;
-        w.arbitrator = arbitrator;
-        w.token = token;
-        w.creatorStake = creatorStake;
-        w.opponentStake = opponentStake;
-        w.acceptDeadline = acceptDeadline;
-        w.resolveDeadline = resolveDeadline;
-        w.resolutionType = resolutionType;
-        w.status = Status.Open;
-        w.creatorIsYes = creatorIsYes;
-        w.metadataHash = metadataHash;
-        w.polymarketConditionId = polymarketConditionId;
-        w.metadataUri = metadataUri;
-
-        _userWagerIds[msg.sender].add(wagerId);
-        _userWagerIds[opponent].add(wagerId);
-        // Spec Kit 005: index the arbitrator too (ThirdParty wagers set a non-zero
-        // arbitrator) so they can discover the wagers they oversee via
-        // getUserWagers(arbitrator) — enabling third-party resolution end-to-end.
-        if (arbitrator != address(0)) {
-            _userWagerIds[arbitrator].add(wagerId);
-        }
-        // Spec 007 (FR-056/FR-057): bind the governing T&C version (Effect, before
-        // interactions). 0 ⇒ legacy/unbound. Prospective-only — never re-bound elsewhere.
-        if (termsVersionHash != bytes32(0)) {
-            wagerTermsVersionHash[wagerId] = termsVersionHash;
-        }
-
-        // Interactions
-        IERC20(token).safeTransferFrom(msg.sender, address(this), creatorStake);
-        membershipManager.recordCreate(msg.sender, WAGER_PARTICIPANT_ROLE);
-
-        emit WagerCreated(wagerId, msg.sender, opponent, token, creatorStake, opponentStake, resolutionType, metadataHash, metadataUri);
-        if (resolutionType == ResolutionType.Polymarket) {
-            emit PolymarketLinked(wagerId, polymarketConditionId, creatorIsYes);
-        } else if (_isExtensibleOracleType(resolutionType)) {
-            emit OracleConditionLinked(wagerId, resolutionType, polymarketConditionId, creatorIsYes);
-        }
-        if (termsVersionHash != bytes32(0)) {
-            emit WagerTermsBound(wagerId, termsVersionHash);
-        }
+        return _createWager(
+            msg.sender,
+            IWagerRegistryIntents.CreateArgs(opponent, arbitrator, token, creatorStake, opponentStake, acceptDeadline, resolveDeadline, resolutionType, polymarketConditionId, creatorIsYes, metadataHash, metadataUri, termsVersionHash, bytes32(0)),
+            false,
+            _emptyAuth()
+        );
     }
 
     // ---------- Open challenges (feature 024) ----------
@@ -535,38 +318,7 @@ contract WagerRegistry is IWagerRegistry, UUPSManaged, ReentrancyGuardUpgradeabl
         whenNotPaused
         notFrozen(msg.sender)
     {
-        Wager storage w = _wagers[wagerId];
-        address authority = claimAuthority[wagerId];
-        if (w.status != Status.Open || authority == address(0)) revert NotOpenChallenge();
-        if (block.timestamp > w.acceptDeadline) revert AcceptExpired();
-
-        // Front-running resistant: the signature is only valid for this exact taker (= msg.sender). ECDSA
-        // .recover rejects malleable/invalid signatures (never returns address(0) to collide with an unset slot).
-        bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(OPEN_ACCEPT_TYPEHASH, wagerId, msg.sender)));
-        if (digest.recover(signature) != authority) revert BadClaimSignature();
-
-        if (msg.sender == w.creator) revert SelfWager();
-        if (w.resolutionType == ResolutionType.ThirdParty && msg.sender == w.arbitrator) revert ArbitratorCannotTake();
-
-        _runAcceptGuard(w.creator); // no tier floor — any active member may take (FR-013)
-
-        // Effects
-        w.opponent = msg.sender;
-        w.status = Status.Active;
-        _clearClaim(wagerId); // free the code for reuse (FR-006a) before interactions
-        _userWagerIds[msg.sender].add(wagerId);
-        _settleAccept(wagerId, w.token, w.opponentStake);
-    }
-
-    /// @dev Clear the claim-authority mappings when an open challenge leaves the Open state, freeing the code
-    ///      for reuse. Called from acceptOpenWager, cancelOpen, the Open branch of claimRefund, and
-    ///      batchExpireOpen. No-op for non-open-challenge wagers.
-    function _clearClaim(uint256 wagerId) internal {
-        address a = claimAuthority[wagerId];
-        if (a != address(0)) {
-            delete openWagerIdByClaim[a];
-            delete claimAuthority[wagerId];
-        }
+        _acceptOpenWager(msg.sender, wagerId, signature, false, _emptyAuth());
     }
 
     /// @notice Active open wager id for a code-derived authority, or 0 if none. Discovery entrypoint (FR-007).
@@ -580,78 +332,19 @@ contract WagerRegistry is IWagerRegistry, UUPSManaged, ReentrancyGuardUpgradeabl
     }
 
     function acceptWager(uint256 wagerId) external nonReentrant whenNotPaused notFrozen(msg.sender) {
-        Wager storage w = _wagers[wagerId];
-        if (w.status != Status.Open) revert NotOpen();
-        if (msg.sender != w.opponent) revert NotOpponent();
-        if (block.timestamp > w.acceptDeadline) revert AcceptExpired();
-        // Sanctions screen both parties (Spec 007, FR-054) + membership gate on the accepting opponent.
-        _runAcceptGuard(w.creator);
-
-        w.status = Status.Active;
-        _settleAccept(wagerId, w.token, w.opponentStake);
+        _acceptWager(msg.sender, wagerId, false, _emptyAuth());
     }
 
     function cancelOpen(uint256 wagerId) external nonReentrant notFrozen(msg.sender) {
-        Wager storage w = _wagers[wagerId];
-        if (w.status != Status.Open) revert NotOpen();
-        if (msg.sender != w.creator) revert NotCreator();
-
-        IERC20 token = IERC20(w.token);
-        uint128 refund = w.creatorStake;
-        address creator = w.creator;
-
-        membershipManager.recordClose(creator, WAGER_PARTICIPANT_ROLE);
-        _clearClaim(wagerId); // free the code if this was an open challenge (no-op otherwise)
-        delete _wagers[wagerId];
-
-        token.safeTransfer(creator, refund);
-        emit WagerCancelled(wagerId);
+        _cancelOpen(msg.sender, wagerId);
     }
 
     function declineWager(uint256 wagerId) external nonReentrant notFrozen(msg.sender) {
-        Wager storage w = _wagers[wagerId];
-        if (w.status != Status.Open) revert NotOpen();
-        // Decline is a named-opponent action; an open challenge has no bound opponent. Reject it outright so
-        // no party other than the creator (via cancelOpen) can release an unaccepted open challenge (FR-023).
-        if (claimAuthority[wagerId] != address(0)) revert DeclineNotAllowedForOpenChallenge();
-        if (msg.sender != w.opponent) revert NotOpponent();
-
-        IERC20 token = IERC20(w.token);
-        uint128 refund = w.creatorStake;
-        address creator = w.creator;
-
-        membershipManager.recordClose(creator, WAGER_PARTICIPANT_ROLE);
-        delete _wagers[wagerId];
-
-        token.safeTransfer(creator, refund);
-        emit WagerDeclined(wagerId, msg.sender);
+        _declineWager(msg.sender, wagerId);
     }
 
     function declareWinner(uint256 wagerId, address winner) external nonReentrant notFrozen(msg.sender) {
-        Wager storage w = _wagers[wagerId];
-        if (w.status != Status.Active) revert NotActive();
-        if (block.timestamp > w.resolveDeadline) revert ResolveExpired();
-        if (winner != w.creator && winner != w.opponent) revert WinnerNotParticipant();
-        if (_isOracleResolvedType(w.resolutionType)) revert NotAuthorized();
-
-        bool authorized;
-        if (w.resolutionType == ResolutionType.Either) {
-            authorized = (msg.sender == w.creator || msg.sender == w.opponent);
-        } else if (w.resolutionType == ResolutionType.Creator) {
-            authorized = (msg.sender == w.creator);
-        } else if (w.resolutionType == ResolutionType.Opponent) {
-            authorized = (msg.sender == w.opponent);
-        } else if (w.resolutionType == ResolutionType.ThirdParty) {
-            authorized = (msg.sender == w.arbitrator);
-        }
-        if (!authorized) revert NotAuthorized();
-
-        w.status = Status.Resolved;
-        w.winner = winner;
-        membershipManager.recordClose(w.creator, WAGER_PARTICIPANT_ROLE);
-        membershipManager.recordClose(w.opponent, WAGER_PARTICIPANT_ROLE);
-
-        emit WagerResolved(wagerId, winner, msg.sender);
+        _declareWinner(msg.sender, wagerId, winner);
     }
 
     /// @notice Settle, or move toward settling, a wager as a DRAW (each party's
@@ -665,139 +358,22 @@ contract WagerRegistry is IWagerRegistry, UUPSManaged, ReentrancyGuardUpgradeabl
     ///      participants, so it stays available while paused (parity with
     ///      declareWinner / claimRefund). Frozen accounts cannot drive it.
     function declareDraw(uint256 wagerId) external nonReentrant notFrozen(msg.sender) {
-        Wager storage w = _wagers[wagerId];
-        if (w.status != Status.Active) revert NotActive();
-        if (block.timestamp > w.resolveDeadline) revert ResolveExpired();
-        if (_isOracleResolvedType(w.resolutionType)) revert DrawNotApplicable();
-
-        if (w.resolutionType == ResolutionType.ThirdParty) {
-            if (msg.sender != w.arbitrator) revert NotAuthorized();
-            _settleDraw(wagerId, w);
-            return;
-        }
-
-        // Participant types: accumulate mutual consent; settle only when both agree.
-        uint8 bit;
-        if (msg.sender == w.creator) {
-            bit = _CONSENT_CREATOR;
-        } else if (msg.sender == w.opponent) {
-            bit = _CONSENT_OPPONENT;
-        } else {
-            revert NotParticipant();
-        }
-
-        uint8 consent = _drawConsent[wagerId];
-        if ((consent & bit) == 0) {
-            consent |= bit;
-            _drawConsent[wagerId] = consent;
-            emit DrawProposed(wagerId, msg.sender);
-        }
-        if (consent == _CONSENT_BOTH) {
-            _settleDraw(wagerId, w);
-        }
+        _declareDraw(msg.sender, wagerId);
     }
 
     /// @notice Withdraw the caller's pending draw consent (participant types).
     ///         A one-sided proposal never locks the wager; this just clears the
     ///         caller's bit so they no longer agree to a draw.
     function revokeDraw(uint256 wagerId) external nonReentrant notFrozen(msg.sender) {
-        Wager storage w = _wagers[wagerId];
-        if (w.status != Status.Active) revert NotActive();
-
-        uint8 bit;
-        if (msg.sender == w.creator) {
-            bit = _CONSENT_CREATOR;
-        } else if (msg.sender == w.opponent) {
-            bit = _CONSENT_OPPONENT;
-        } else {
-            revert NotParticipant();
-        }
-
-        uint8 consent = _drawConsent[wagerId];
-        if ((consent & bit) == 0) revert NoDrawProposal();
-        _drawConsent[wagerId] = consent & ~bit;
-        emit DrawRevoked(wagerId, msg.sender);
+        _revokeDraw(msg.sender, wagerId);
     }
 
-    /// @dev Shared draw settlement: each party gets their own stake back, no
-    ///      winner. Checks-effects-interactions — status and consent are cleared
-    ///      before any token transfer (parity with claimRefund).
-    function _settleDraw(uint256 wagerId, Wager storage w) internal {
-        w.status = Status.Draw;
-        delete _drawConsent[wagerId];
-        membershipManager.recordClose(w.creator, WAGER_PARTICIPANT_ROLE);
-        membershipManager.recordClose(w.opponent, WAGER_PARTICIPANT_ROLE);
-
-        IERC20 token = IERC20(w.token);
-        token.safeTransfer(w.creator, w.creatorStake);
-        token.safeTransfer(w.opponent, w.opponentStake);
-
-        emit WagerDrawn(wagerId, w.creator, w.opponent, msg.sender);
-    }
-
-    function autoResolveFromPolymarket(uint256 wagerId) external nonReentrant {
-        Wager storage w = _wagers[wagerId];
-        if (w.status != Status.Active) revert NotActive();
-        if (w.resolutionType != ResolutionType.Polymarket) revert NotAuthorized();
-        if (address(polymarketAdapter) == address(0)) revert AdapterNotSet();
-
-        (bool outcome, , uint256 resolvedAt) = polymarketAdapter.getOutcome(w.polymarketConditionId);
-        if (resolvedAt == 0) {
-            // getOutcome returns resolvedAt==0 for BOTH "not resolved" and a
-            // "resolved tie" (equal payout numerators). Disambiguate: a resolved
-            // tie settles a DRAW immediately (both stakes back); a genuinely
-            // unresolved market reverts (unchanged behavior).
-            if (polymarketAdapter.isConditionResolved(w.polymarketConditionId)) {
-                _settleDraw(wagerId, w);
-                return;
-            }
-            revert ConditionNotResolved();
-        }
-        _settleOracleWin(wagerId, w, outcome);
-    }
-
-    /// @notice Generic resolve path for ChainlinkDataFeed / ChainlinkFunctions / UMA wagers.
-    ///         Reads the cached outcome from the wager's configured adapter and sets the winner.
-    function autoResolveFromOracle(uint256 wagerId) external nonReentrant {
-        Wager storage w = _wagers[wagerId];
-        if (w.status != Status.Active) revert NotActive();
-        if (!_isExtensibleOracleType(w.resolutionType)) revert NotAuthorized();
-
-        IOracleAdapter adapter = oracleAdapters[w.resolutionType];
-        if (address(adapter) == address(0)) revert OracleAdapterNotSet();
-
-        (bool outcome, , uint256 resolvedAt) = adapter.getOutcome(w.polymarketConditionId);
-        if (resolvedAt == 0) revert ConditionNotResolved();
-        _settleOracleWin(wagerId, w, outcome);
-    }
-
-    /// @dev Shared body for oracle-driven settlement. creatorIsYes maps outcome to winner:
-    ///      creatorIsYes=true,  outcome=true  -> creator wins
-    ///      creatorIsYes=true,  outcome=false -> opponent wins
-    ///      creatorIsYes=false, outcome=true  -> opponent wins
-    ///      creatorIsYes=false, outcome=false -> creator wins
-    function _settleOracleWin(uint256 wagerId, Wager storage w, bool outcome) internal {
-        address winner = (outcome == w.creatorIsYes) ? w.creator : w.opponent;
-        w.status = Status.Resolved;
-        w.winner = winner;
-        membershipManager.recordClose(w.creator, WAGER_PARTICIPANT_ROLE);
-        membershipManager.recordClose(w.opponent, WAGER_PARTICIPANT_ROLE);
-
-        emit WagerResolved(wagerId, winner, msg.sender);
-    }
+    // NOTE (spec 035): autoResolveFromPolymarket / autoResolveFromOracle / batchExpireOpen are
+    // served by the {WagerRegistryIntents} facet via the fallback — same proxy address, same ABI,
+    // unchanged behavior. Relocated to keep this implementation under the 24 KB code-size limit.
 
     function claimPayout(uint256 wagerId) external nonReentrant notFrozen(msg.sender) {
-        Wager storage w = _wagers[wagerId];
-        if (w.status != Status.Resolved) revert NotResolved();
-        if (msg.sender != w.winner) revert NotWinner();
-        if (w.paid) revert AlreadyPaid();
-
-        w.paid = true;
-        // Compute as uint256 to avoid uint128 overflow on sum
-        uint256 payout = uint256(w.creatorStake) + uint256(w.opponentStake);
-        IERC20(w.token).safeTransfer(w.winner, payout);
-
-        emit PayoutClaimed(wagerId, w.winner, payout);
+        _claimPayout(msg.sender, wagerId);
     }
 
     /// @notice Refund path:
@@ -809,47 +385,7 @@ contract WagerRegistry is IWagerRegistry, UUPSManaged, ReentrancyGuardUpgradeabl
     ///         a frozen account can't drive settlement; either counterparty (or a
     ///         neutral third party) can trigger a refund on a legitimate wager.
     function claimRefund(uint256 wagerId) external nonReentrant notFrozen(msg.sender) {
-        Wager storage w = _wagers[wagerId];
-        if (w.status == Status.Open) {
-            if (block.timestamp <= w.acceptDeadline) revert NotRefundable();
-            w.status = Status.Refunded;
-            membershipManager.recordClose(w.creator, WAGER_PARTICIPANT_ROLE);
-            _clearClaim(wagerId); // free the code if this was an open challenge (no-op otherwise)
-            IERC20(w.token).safeTransfer(w.creator, w.creatorStake);
-            emit WagerRefunded(wagerId, w.creator, address(0));
-        } else if (w.status == Status.Active) {
-            if (block.timestamp <= w.resolveDeadline) revert NotRefundable();
-            w.status = Status.Refunded;
-            membershipManager.recordClose(w.creator, WAGER_PARTICIPANT_ROLE);
-            membershipManager.recordClose(w.opponent, WAGER_PARTICIPANT_ROLE);
-            IERC20 token = IERC20(w.token);
-            token.safeTransfer(w.creator, w.creatorStake);
-            token.safeTransfer(w.opponent, w.opponentStake);
-            emit WagerRefunded(wagerId, w.creator, w.opponent);
-        } else {
-            revert NotRefundable();
-        }
-    }
-
-    // ---------- Batch expire ----------
-
-    /// @notice Expire Open wagers whose accept deadline has passed, refund the
-    ///         creator's stake, and release the concurrent-limit slot on
-    ///         MembershipManager. Any address may call this (the refund always
-    ///         goes to the original creator). Silently skips wager IDs that are
-    ///         not eligible (wrong status, deadline not yet reached, etc.).
-    function batchExpireOpen(uint256[] calldata wagerIds) external nonReentrant whenNotPaused {
-        for (uint256 i = 0; i < wagerIds.length; i++) {
-            Wager storage w = _wagers[wagerIds[i]];
-            if (w.status != Status.Open) continue;
-            if (block.timestamp <= w.acceptDeadline) continue;
-
-            w.status = Status.Refunded;
-            membershipManager.recordClose(w.creator, WAGER_PARTICIPANT_ROLE);
-            _clearClaim(wagerIds[i]); // free the code if this was an open challenge (no-op otherwise)
-            IERC20(w.token).safeTransfer(w.creator, w.creatorStake);
-            emit WagerRefunded(wagerIds[i], w.creator, address(0));
-        }
+        _claimRefund(wagerId);
     }
 
     // ---------- Views ----------

--- a/contracts/wagers/WagerRegistryCore.sol
+++ b/contracts/wagers/WagerRegistryCore.sol
@@ -1,0 +1,624 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import {UUPSManaged} from "../upgradeable/UUPSManaged.sol";
+import {ERC3009Auth} from "../interfaces/IERC3009.sol";
+import {IWagerRegistryTypes} from "../interfaces/IWagerRegistryTypes.sol";
+import {IWagerRegistryIntents} from "../interfaces/IWagerRegistryIntents.sol";
+import "../interfaces/IMembershipManager.sol";
+import "../interfaces/ISanctionsGuard.sol";
+import "../oracles/IOracleAdapter.sol";
+
+/// @title WagerRegistryCore
+/// @notice Shared storage + internal logic for the two wager-registry facets (spec 035):
+///         the main {WagerRegistry} implementation and the {WagerRegistryIntents} extension that
+///         the main facet reaches via a delegatecall fallback. BOTH facets execute against the
+///         SAME proxy storage, so both MUST inherit this exact contract — the storage layout is
+///         defined once, here, and can never drift between facets.
+/// @dev    Every internal action body takes the acting identity (`actor`/`creator`/`taker`) as a
+///         parameter instead of reading msg.sender (spec 035 twin invariant): the self-submit
+///         externals pass msg.sender, the intent twins pass the recovered signer. All checks —
+///         sanctions screen, membership gate, ownership, freeze — evaluate that parameter.
+///         Storage rules are unchanged: append-only above the trailing `__gap`.
+abstract contract WagerRegistryCore is
+    IWagerRegistryTypes,
+    UUPSManaged,
+    ReentrancyGuardUpgradeable,
+    PausableUpgradeable,
+    EIP712Upgradeable
+{
+    using SafeERC20 for IERC20;
+    using EnumerableSet for EnumerableSet.UintSet;
+    using ECDSA for bytes32;
+
+    bytes32 public constant WAGER_PARTICIPANT_ROLE = keccak256("WAGER_PARTICIPANT_ROLE");
+    bytes32 public constant GUARDIAN_ROLE = keccak256("GUARDIAN_ROLE");
+    bytes32 public constant ACCOUNT_MODERATOR_ROLE = keccak256("ACCOUNT_MODERATOR_ROLE");
+
+    uint64 public constant MAX_ACCEPT_WINDOW = 30 days;
+    uint64 public constant MAX_RESOLVE_WINDOW = 180 days;
+
+    /// @notice EIP-712 typehash for an open-challenge acceptance. Binding `taker` to the signature is the
+    ///         front-running defense (FR-011): a copied signature is useless to anyone else. Under a relayer
+    ///         the taker is the recovered intent signer, not msg.sender (spec 035 open-accept rebinding).
+    bytes32 internal constant OPEN_ACCEPT_TYPEHASH = keccak256("OpenAccept(uint256 wagerId,address taker)");
+
+    // ================================================================================================
+    // STORAGE — shared by both facets. Append-only; never insert, reorder, or remove. The trailing
+    // __gap MUST shrink by exactly the number of slots appended. Validated by check:storage-layout.
+    // ================================================================================================
+
+    IMembershipManager public membershipManager;
+    IOracleAdapter public polymarketAdapter;
+
+    /// @notice Non-bypassable on-chain sanctions guard (Spec 007, FR-054). When unset
+    ///         (address(0)) screening is skipped — the production deploy wires it in.
+    ISanctionsGuard public sanctionsGuard;
+
+    /// @notice Generic registry for non-Polymarket oracle adapters keyed by ResolutionType.
+    ///         Polymarket retains its dedicated `polymarketAdapter` slot for ABI compatibility.
+    mapping(ResolutionType => IOracleAdapter) public oracleAdapters;
+
+    mapping(address => bool) internal _allowedTokens;
+    mapping(uint256 => Wager) internal _wagers;
+    mapping(address => bool) internal _frozen;
+
+    /// @notice Governing T&C version hash bound to a wager at creation (Spec 007, FR-056/
+    ///         FR-057). 0 ⇒ legacy/unbound (governed by the launch version). Set only via
+    ///         createWagerWithTerms; never re-bound (prospective-only).
+    mapping(uint256 => bytes32) public wagerTermsVersionHash;
+    /// @dev Initialized to 1 in {WagerRegistry.initialize} (NOT inline — inline initializers run in
+    ///      constructor context and are ignored behind a proxy, which would start wager ids at 0).
+    uint256 internal _nextWagerId;
+
+    /// @notice Per-wager draw-consent bitmask for participant resolution types
+    ///         (Either/Creator/Opponent). bit0 = creator agreed, bit1 = opponent
+    ///         agreed. A draw settles only once both bits are set; cleared on
+    ///         settle or revoke. Kept out of the Wager struct so getWager's ABI
+    ///         is unchanged. Not used for ThirdParty (arbitrator settles solo)
+    ///         or oracle types (a draw arises only from the oracle tie).
+    mapping(uint256 => uint8) internal _drawConsent;
+    uint8 internal constant _CONSENT_CREATOR = 1;
+    uint8 internal constant _CONSENT_OPPONENT = 2;
+    uint8 internal constant _CONSENT_BOTH = 3;
+
+    /// @notice Append-only per-user index of every wager a participant has been part of.
+    ///         Populated in `createWager` for both creator and opponent; never removed.
+    ///         Enables O(N_user) lookup without log scans (avoids `eth_getLogs` block-range limits).
+    mapping(address => EnumerableSet.UintSet) internal _userWagerIds;
+
+    // ---- Open challenges (feature 024), appended after all prior state (consumes 2 __gap slots) ----
+    /// @notice Code-derived address committed to an open challenge. 0 ⇒ not an open challenge. Set in
+    ///         createOpenWager; cleared when the wager leaves Open (accept / cancel / expire / refund).
+    mapping(uint256 => address) public claimAuthority;
+    /// @notice Reverse index: the single Open open-challenge for a claim authority (0 ⇒ none). Powers code
+    ///         discovery (FR-007) and active-uniqueness (FR-006a).
+    mapping(address => uint256) public openWagerIdByClaim;
+
+    // ---- Gasless intents (spec 035), appended after all prior state (consumes 3 __gap slots; the
+    //      intent replay-nonce map lives in SignerIntentBase's ERC-7201 namespaced storage — zero
+    //      gap cost) ----
+    /// @notice When true, the `…WithAuthorization` twins consume the signer's second (bounded) EIP-3009
+    ///         fee authorization and forward it to {_gasFeeRecipient} atomically (FR-015/FR-016).
+    ///         External getters live in the {WagerRegistryIntents} facet (main-facet code-size headroom).
+    bool internal _feeNettingEnabled;
+    /// @notice Segregated stablecoin fee recipient — MUST NOT be the relayer hot key (spec 036 SC-015).
+    ///         Packs with {_feeNettingEnabled} into one slot.
+    address internal _gasFeeRecipient;
+    /// @notice Hard per-transaction ceiling on the fee authorization a twin will consume.
+    uint256 internal _maxGasFee;
+    /// @notice The {WagerRegistryIntents} extension facet the main facet delegatecalls for unknown
+    ///         selectors (the intent twins + relocated cold paths). Zero ⇒ intents disabled. Set only
+    ///         via {WagerRegistry.setIntentExtension} (UPGRADER_ROLE — same authority as an upgrade,
+    ///         because the extension executes with full access to this proxy's storage).
+    address public intentExtension;
+
+    /// @dev Trailing storage reserve for append-only upgrades. Reduced 50 → 48 when the two
+    ///      open-challenge mappings were appended (feature 024), then 48 → 45 for spec 035
+    ///      (`feeNettingEnabled`+`gasFeeRecipient` pack into one slot, `maxGasFee`, `intentExtension`).
+    ///      Never insert or reorder existing state above this gap.
+    uint256[45] private __gap;
+
+    // ================================================================================================
+    // Errors + modifiers (shared by both facets)
+    // ================================================================================================
+
+    error ZeroAddress();
+    error SelfWager();
+    error NotAllowedToken();
+    error ZeroStake();
+    error BadDeadlines();
+    error ArbitratorRequired();
+    error ArbitratorDisallowed();
+    error PolymarketRequired();
+    error PolymarketDisallowed();
+    error AdapterNotSet();
+    error OracleAdapterNotSet();
+    error OracleConditionRequired();
+    error UnsupportedOracleResolutionType();
+    error ConditionNotResolved();
+    error ConditionAlreadyResolved();
+    error MembershipDenied();
+    error NotOpponent();
+    error NotOpen();
+    error NotActive();
+    error AcceptExpired();
+    error ResolveExpired();
+    error NotAuthorized();
+    error EitherRequiresEqualStakes();
+    error WinnerNotParticipant();
+    error NotWinner();
+    error NotResolved();
+    error AlreadyPaid();
+    error NotRefundable();
+    error NotCreator();
+    error NotParticipant();
+    error DrawNotApplicable();
+    error NoDrawProposal();
+    error AccountFrozenError(address user);
+    // Open challenges (feature 024)
+    error ZeroClaimAuthority();
+    error ClaimAuthorityInUse();
+    error OpenResolutionTypeNotAllowed();
+    error NotOpenChallenge();
+    error BadClaimSignature();
+    error ArbitratorCannotTake();
+    error InsufficientMembershipTier();
+    error DeclineNotAllowedForOpenChallenge();
+    // Spec 035
+    error AuthorizationNotSupported();
+
+    modifier notFrozen(address user) {
+        if (_frozen[user]) revert AccountFrozenError(user);
+        _;
+    }
+
+    // ================================================================================================
+    // Shared internal logic
+    // ================================================================================================
+
+    /// @dev Sanctions screen (Spec 007, FR-054). No-op when the guard is unset; otherwise
+    ///      reverts ISanctionsGuard.SanctionedAddress(account) for a listed/sanctioned
+    ///      address. Called read-only during the Checks phase (before effects/transfers).
+    function _screen(address account) internal view {
+        ISanctionsGuard guard = sanctionsGuard;
+        if (address(guard) != address(0)) guard.checkBlocked(account);
+    }
+
+    function _isExtensibleOracleType(ResolutionType rt) internal pure returns (bool) {
+        return rt == ResolutionType.ChainlinkDataFeed
+            || rt == ResolutionType.ChainlinkFunctions
+            || rt == ResolutionType.UMA;
+    }
+
+    function _isOracleResolvedType(ResolutionType rt) internal pure returns (bool) {
+        return rt == ResolutionType.Polymarket || _isExtensibleOracleType(rt);
+    }
+
+    /// @dev Shared deadline checks for both create paths (named-opponent and open challenge).
+    function _checkDeadlines(uint64 acceptDeadline, uint64 resolveDeadline) internal view {
+        if (acceptDeadline <= block.timestamp) revert BadDeadlines();
+        if (resolveDeadline <= acceptDeadline) revert BadDeadlines();
+        if (acceptDeadline > block.timestamp + MAX_ACCEPT_WINDOW) revert BadDeadlines();
+        if (resolveDeadline > block.timestamp + MAX_RESOLVE_WINDOW) revert BadDeadlines();
+    }
+
+    /// @dev Shared oracle-condition validation/linkage for both create paths. For oracle types the condition
+    ///      must be set, the adapter configured, and the condition not already resolved (stale-condition
+    ///      mitigation); non-oracle types must not carry a condition.
+    function _checkOracleLinkage(ResolutionType resolutionType, bytes32 conditionId) internal view {
+        if (resolutionType == ResolutionType.Polymarket) {
+            if (conditionId == bytes32(0)) revert PolymarketRequired();
+            if (address(polymarketAdapter) == address(0)) revert AdapterNotSet();
+            if (polymarketAdapter.isConditionResolved(conditionId)) revert ConditionAlreadyResolved();
+        } else if (_isExtensibleOracleType(resolutionType)) {
+            if (conditionId == bytes32(0)) revert OracleConditionRequired();
+            IOracleAdapter adapter = oracleAdapters[resolutionType];
+            if (address(adapter) == address(0)) revert OracleAdapterNotSet();
+            if (adapter.isConditionResolved(conditionId)) revert ConditionAlreadyResolved();
+        } else {
+            if (conditionId != bytes32(0)) revert PolymarketDisallowed();
+        }
+    }
+
+    /// @dev Stake escrow pull. The base implementation supports only the allowance path
+    ///      (self-submit); the {WagerRegistryIntents} facet overrides it to add the EIP-3009
+    ///      authorization path for relayed intents. Keeping the 3009 code out of the main facet
+    ///      preserves its code-size headroom.
+    function _pullStake(
+        address token,
+        address from,
+        uint128 amount,
+        bytes32 paymentNonce,
+        ERC3009Auth memory auth,
+        bool viaAuth
+    ) internal virtual {
+        (paymentNonce, auth); // unused in the base (allowance) path
+        if (viaAuth) revert AuthorizationNotSupported();
+        IERC20(token).safeTransferFrom(from, address(this), amount);
+    }
+
+    /// @dev Zero-value authorization placeholder for the self-submit paths (never consumed).
+    function _emptyAuth() internal pure returns (ERC3009Auth memory auth) {}
+
+    /// @dev Shared accept-time gauntlet for both accept paths: sanctions-screen the taker (the acting
+    ///      identity — msg.sender when self-submitted, the recovered signer when relayed) and the creator,
+    ///      then enforce the membership gate on the taker. (Spec 007 FR-054 + membership; spec 035 FR-003.)
+    function _runAcceptGuard(address taker, address creator) internal view {
+        _screen(taker);
+        _screen(creator);
+        if (!membershipManager.checkCanCreate(taker, WAGER_PARTICIPANT_ROLE)) revert MembershipDenied();
+    }
+
+    /// @dev Shared accept tail for both accept paths: escrow the taker's stake, charge the membership
+    ///      counter, and emit {WagerAccepted}. Status/opponent effects happen at the call site first
+    ///      (checks-effects-interactions).
+    function _settleAccept(
+        address taker,
+        uint256 wagerId,
+        address token,
+        uint128 opponentStake,
+        bool viaAuth,
+        ERC3009Auth memory stakeAuth
+    ) internal {
+        _pullStake(token, taker, opponentStake, stakeAuth.nonce, stakeAuth, viaAuth);
+        membershipManager.recordCreate(taker, WAGER_PARTICIPANT_ROLE);
+        emit WagerAccepted(wagerId, taker);
+    }
+
+    /// @dev Shared create body for both submission paths. `creator` is the acting identity —
+    ///      msg.sender when self-submitted, the recovered intent signer when relayed (spec 035).
+    ///      Every check (sanctions, membership, self-wager, arbitrator) evaluates `creator`; the
+    ///      stake is pulled from `creator` by allowance or by their stapled EIP-3009 authorization.
+    function _createWager(
+        address creator,
+        IWagerRegistryIntents.CreateArgs memory a,
+        bool viaAuth,
+        ERC3009Auth memory stakeAuth
+    ) internal returns (uint256 wagerId) {
+        // Sanctions screen (Spec 007, FR-054) — first Check, before any effects/transfers.
+        _screen(creator);
+        if (a.opponent == address(0)) revert ZeroAddress();
+        if (a.opponent == creator) revert SelfWager();
+        if (!_allowedTokens[a.token]) revert NotAllowedToken();
+        if (a.creatorStake == 0 || a.opponentStake == 0) revert ZeroStake();
+        _checkDeadlines(a.acceptDeadline, a.resolveDeadline);
+
+        // "Either side submits the outcome" (ResolutionType.Either) is a mutual-trust
+        // resolution path — no oracle, no arbitrator, and whoever calls declareWinner
+        // first decides the result. That is only sound on a level peer-to-peer wager
+        // where both sides stake the same amount. On an asymmetric "Offer" (leveraged)
+        // wager the side risking less could self-declare and seize the larger
+        // counterparty stake, so restrict Either to equal-stakes (non-leveraged) bets.
+        if (a.resolutionType == ResolutionType.Either && a.creatorStake != a.opponentStake) {
+            revert EitherRequiresEqualStakes();
+        }
+
+        if (a.resolutionType == ResolutionType.ThirdParty) {
+            if (a.arbitrator == address(0)) revert ArbitratorRequired();
+            if (a.arbitrator == creator || a.arbitrator == a.opponent) revert ArbitratorDisallowed();
+        } else {
+            if (a.arbitrator != address(0)) revert ArbitratorDisallowed();
+        }
+
+        _checkOracleLinkage(a.resolutionType, a.conditionId);
+
+        // Membership gate
+        if (!membershipManager.checkCanCreate(creator, WAGER_PARTICIPANT_ROLE)) revert MembershipDenied();
+
+        // Effects
+        wagerId = _nextWagerId++;
+        Wager storage w = _wagers[wagerId];
+        w.creator = creator;
+        w.opponent = a.opponent;
+        w.arbitrator = a.arbitrator;
+        w.token = a.token;
+        w.creatorStake = a.creatorStake;
+        w.opponentStake = a.opponentStake;
+        w.acceptDeadline = a.acceptDeadline;
+        w.resolveDeadline = a.resolveDeadline;
+        w.resolutionType = a.resolutionType;
+        w.status = Status.Open;
+        w.creatorIsYes = a.creatorIsYes;
+        w.metadataHash = a.metadataHash;
+        w.polymarketConditionId = a.conditionId;
+        w.metadataUri = a.metadataUri;
+
+        _userWagerIds[creator].add(wagerId);
+        _userWagerIds[a.opponent].add(wagerId);
+        // Spec Kit 005: index the arbitrator too (ThirdParty wagers set a non-zero
+        // arbitrator) so they can discover the wagers they oversee via
+        // getUserWagers(arbitrator) — enabling third-party resolution end-to-end.
+        if (a.arbitrator != address(0)) {
+            _userWagerIds[a.arbitrator].add(wagerId);
+        }
+        // Spec 007 (FR-056/FR-057): bind the governing T&C version (Effect, before
+        // interactions). 0 ⇒ legacy/unbound. Prospective-only — never re-bound elsewhere.
+        if (a.termsVersionHash != bytes32(0)) {
+            wagerTermsVersionHash[wagerId] = a.termsVersionHash;
+        }
+
+        // Interactions — allowance pull when self-submitted; the creator's stapled EIP-3009
+        // authorization when relayed (bound to stake amount + paymentNonce, spec 035 FR-007).
+        _pullStake(a.token, creator, a.creatorStake, a.paymentNonce, stakeAuth, viaAuth);
+        membershipManager.recordCreate(creator, WAGER_PARTICIPANT_ROLE);
+
+        emit WagerCreated(wagerId, creator, a.opponent, a.token, a.creatorStake, a.opponentStake, a.resolutionType, a.metadataHash, a.metadataUri);
+        if (a.resolutionType == ResolutionType.Polymarket) {
+            emit PolymarketLinked(wagerId, a.conditionId, a.creatorIsYes);
+        } else if (_isExtensibleOracleType(a.resolutionType)) {
+            emit OracleConditionLinked(wagerId, a.resolutionType, a.conditionId, a.creatorIsYes);
+        }
+        if (a.termsVersionHash != bytes32(0)) {
+            emit WagerTermsBound(wagerId, a.termsVersionHash);
+        }
+    }
+
+    /// @dev Shared open-challenge accept body. `taker` is the acting identity (msg.sender when
+    ///      self-submitted, the recovered intent signer when relayed) — the claim-code proof is
+    ///      verified against `taker`, preserving front-running resistance under a relayer.
+    function _acceptOpenWager(
+        address taker,
+        uint256 wagerId,
+        bytes calldata signature,
+        bool viaAuth,
+        ERC3009Auth memory stakeAuth
+    ) internal {
+        Wager storage w = _wagers[wagerId];
+        address authority = claimAuthority[wagerId];
+        if (w.status != Status.Open || authority == address(0)) revert NotOpenChallenge();
+        if (block.timestamp > w.acceptDeadline) revert AcceptExpired();
+
+        // Front-running resistant: the signature is only valid for this exact taker. ECDSA
+        // .recover rejects malleable/invalid signatures (never returns address(0) to collide with an unset slot).
+        bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(OPEN_ACCEPT_TYPEHASH, wagerId, taker)));
+        if (digest.recover(signature) != authority) revert BadClaimSignature();
+
+        if (taker == w.creator) revert SelfWager();
+        if (w.resolutionType == ResolutionType.ThirdParty && taker == w.arbitrator) revert ArbitratorCannotTake();
+
+        _runAcceptGuard(taker, w.creator); // no tier floor — any active member may take (FR-013)
+
+        // Effects
+        w.opponent = taker;
+        w.status = Status.Active;
+        _clearClaim(wagerId); // free the code for reuse (FR-006a) before interactions
+        _userWagerIds[taker].add(wagerId);
+        _settleAccept(taker, wagerId, w.token, w.opponentStake, viaAuth, stakeAuth);
+    }
+
+    /// @dev Shared named-opponent accept body; `taker` is the acting identity (spec 035 twin invariant).
+    function _acceptWager(address taker, uint256 wagerId, bool viaAuth, ERC3009Auth memory stakeAuth) internal {
+        Wager storage w = _wagers[wagerId];
+        if (w.status != Status.Open) revert NotOpen();
+        if (taker != w.opponent) revert NotOpponent();
+        if (block.timestamp > w.acceptDeadline) revert AcceptExpired();
+        // Sanctions screen both parties (Spec 007, FR-054) + membership gate on the accepting opponent.
+        _runAcceptGuard(taker, w.creator);
+
+        w.status = Status.Active;
+        _settleAccept(taker, wagerId, w.token, w.opponentStake, viaAuth, stakeAuth);
+    }
+
+    /// @dev Clear the claim-authority mappings when an open challenge leaves the Open state, freeing the code
+    ///      for reuse. Called from acceptOpenWager, cancelOpen, the Open branch of claimRefund, and
+    ///      batchExpireOpen. No-op for non-open-challenge wagers.
+    function _clearClaim(uint256 wagerId) internal {
+        address a = claimAuthority[wagerId];
+        if (a != address(0)) {
+            delete openWagerIdByClaim[a];
+            delete claimAuthority[wagerId];
+        }
+    }
+
+    function _cancelOpen(address actor, uint256 wagerId) internal {
+        Wager storage w = _wagers[wagerId];
+        if (w.status != Status.Open) revert NotOpen();
+        if (actor != w.creator) revert NotCreator();
+
+        IERC20 token = IERC20(w.token);
+        uint128 refund = w.creatorStake;
+        address creator = w.creator;
+
+        membershipManager.recordClose(creator, WAGER_PARTICIPANT_ROLE);
+        _clearClaim(wagerId); // free the code if this was an open challenge (no-op otherwise)
+        delete _wagers[wagerId];
+
+        token.safeTransfer(creator, refund);
+        emit WagerCancelled(wagerId);
+    }
+
+    function _declineWager(address actor, uint256 wagerId) internal {
+        Wager storage w = _wagers[wagerId];
+        if (w.status != Status.Open) revert NotOpen();
+        // Decline is a named-opponent action; an open challenge has no bound opponent. Reject it outright so
+        // no party other than the creator (via cancelOpen) can release an unaccepted open challenge (FR-023).
+        if (claimAuthority[wagerId] != address(0)) revert DeclineNotAllowedForOpenChallenge();
+        if (actor != w.opponent) revert NotOpponent();
+
+        IERC20 token = IERC20(w.token);
+        uint128 refund = w.creatorStake;
+        address creator = w.creator;
+
+        membershipManager.recordClose(creator, WAGER_PARTICIPANT_ROLE);
+        delete _wagers[wagerId];
+
+        token.safeTransfer(creator, refund);
+        emit WagerDeclined(wagerId, actor);
+    }
+
+    function _declareWinner(address actor, uint256 wagerId, address winner) internal {
+        Wager storage w = _wagers[wagerId];
+        if (w.status != Status.Active) revert NotActive();
+        if (block.timestamp > w.resolveDeadline) revert ResolveExpired();
+        if (winner != w.creator && winner != w.opponent) revert WinnerNotParticipant();
+        if (_isOracleResolvedType(w.resolutionType)) revert NotAuthorized();
+
+        bool authorized;
+        if (w.resolutionType == ResolutionType.Either) {
+            authorized = (actor == w.creator || actor == w.opponent);
+        } else if (w.resolutionType == ResolutionType.Creator) {
+            authorized = (actor == w.creator);
+        } else if (w.resolutionType == ResolutionType.Opponent) {
+            authorized = (actor == w.opponent);
+        } else if (w.resolutionType == ResolutionType.ThirdParty) {
+            authorized = (actor == w.arbitrator);
+        }
+        if (!authorized) revert NotAuthorized();
+
+        w.status = Status.Resolved;
+        w.winner = winner;
+        membershipManager.recordClose(w.creator, WAGER_PARTICIPANT_ROLE);
+        membershipManager.recordClose(w.opponent, WAGER_PARTICIPANT_ROLE);
+
+        emit WagerResolved(wagerId, winner, actor);
+    }
+
+    function _declareDraw(address actor, uint256 wagerId) internal {
+        Wager storage w = _wagers[wagerId];
+        if (w.status != Status.Active) revert NotActive();
+        if (block.timestamp > w.resolveDeadline) revert ResolveExpired();
+        if (_isOracleResolvedType(w.resolutionType)) revert DrawNotApplicable();
+
+        if (w.resolutionType == ResolutionType.ThirdParty) {
+            if (actor != w.arbitrator) revert NotAuthorized();
+            _settleDraw(wagerId, w, actor);
+            return;
+        }
+
+        // Participant types: accumulate mutual consent; settle only when both agree.
+        uint8 bit;
+        if (actor == w.creator) {
+            bit = _CONSENT_CREATOR;
+        } else if (actor == w.opponent) {
+            bit = _CONSENT_OPPONENT;
+        } else {
+            revert NotParticipant();
+        }
+
+        uint8 consent = _drawConsent[wagerId];
+        if ((consent & bit) == 0) {
+            consent |= bit;
+            _drawConsent[wagerId] = consent;
+            emit DrawProposed(wagerId, actor);
+        }
+        if (consent == _CONSENT_BOTH) {
+            _settleDraw(wagerId, w, actor);
+        }
+    }
+
+    function _revokeDraw(address actor, uint256 wagerId) internal {
+        Wager storage w = _wagers[wagerId];
+        if (w.status != Status.Active) revert NotActive();
+
+        uint8 bit;
+        if (actor == w.creator) {
+            bit = _CONSENT_CREATOR;
+        } else if (actor == w.opponent) {
+            bit = _CONSENT_OPPONENT;
+        } else {
+            revert NotParticipant();
+        }
+
+        uint8 consent = _drawConsent[wagerId];
+        if ((consent & bit) == 0) revert NoDrawProposal();
+        _drawConsent[wagerId] = consent & ~bit;
+        emit DrawRevoked(wagerId, actor);
+    }
+
+    /// @dev Shared draw settlement: each party gets their own stake back, no
+    ///      winner. Checks-effects-interactions — status and consent are cleared
+    ///      before any token transfer (parity with claimRefund). `by` is the
+    ///      acting identity that completed the draw (msg.sender or intent signer).
+    function _settleDraw(uint256 wagerId, Wager storage w, address by) internal {
+        w.status = Status.Draw;
+        delete _drawConsent[wagerId];
+        membershipManager.recordClose(w.creator, WAGER_PARTICIPANT_ROLE);
+        membershipManager.recordClose(w.opponent, WAGER_PARTICIPANT_ROLE);
+
+        IERC20 token = IERC20(w.token);
+        token.safeTransfer(w.creator, w.creatorStake);
+        token.safeTransfer(w.opponent, w.opponentStake);
+
+        emit WagerDrawn(wagerId, w.creator, w.opponent, by);
+    }
+
+    /// @dev Shared body for oracle-driven settlement. creatorIsYes maps outcome to winner:
+    ///      creatorIsYes=true,  outcome=true  -> creator wins
+    ///      creatorIsYes=true,  outcome=false -> opponent wins
+    ///      creatorIsYes=false, outcome=true  -> opponent wins
+    ///      creatorIsYes=false, outcome=false -> creator wins
+    function _settleOracleWin(uint256 wagerId, Wager storage w, bool outcome) internal {
+        address winner = (outcome == w.creatorIsYes) ? w.creator : w.opponent;
+        w.status = Status.Resolved;
+        w.winner = winner;
+        membershipManager.recordClose(w.creator, WAGER_PARTICIPANT_ROLE);
+        membershipManager.recordClose(w.opponent, WAGER_PARTICIPANT_ROLE);
+
+        emit WagerResolved(wagerId, winner, msg.sender);
+    }
+
+    function _claimPayout(address actor, uint256 wagerId) internal {
+        Wager storage w = _wagers[wagerId];
+        if (w.status != Status.Resolved) revert NotResolved();
+        if (actor != w.winner) revert NotWinner();
+        if (w.paid) revert AlreadyPaid();
+
+        w.paid = true;
+        // Compute as uint256 to avoid uint128 overflow on sum
+        uint256 payout = uint256(w.creatorStake) + uint256(w.opponentStake);
+        IERC20(w.token).safeTransfer(w.winner, payout);
+
+        emit PayoutClaimed(wagerId, w.winner, payout);
+    }
+
+    /// @dev Refunds always pay the original participants, so no actor threading is needed — the
+    ///      caller/signer only has to pass the freeze gate (either counterparty or a neutral third
+    ///      party can drive settlement, unchanged behavior).
+    function _claimRefund(uint256 wagerId) internal {
+        Wager storage w = _wagers[wagerId];
+        if (w.status == Status.Open) {
+            if (block.timestamp <= w.acceptDeadline) revert NotRefundable();
+            w.status = Status.Refunded;
+            membershipManager.recordClose(w.creator, WAGER_PARTICIPANT_ROLE);
+            _clearClaim(wagerId); // free the code if this was an open challenge (no-op otherwise)
+            IERC20(w.token).safeTransfer(w.creator, w.creatorStake);
+            emit WagerRefunded(wagerId, w.creator, address(0));
+        } else if (w.status == Status.Active) {
+            if (block.timestamp <= w.resolveDeadline) revert NotRefundable();
+            w.status = Status.Refunded;
+            membershipManager.recordClose(w.creator, WAGER_PARTICIPANT_ROLE);
+            membershipManager.recordClose(w.opponent, WAGER_PARTICIPANT_ROLE);
+            IERC20 token = IERC20(w.token);
+            token.safeTransfer(w.creator, w.creatorStake);
+            token.safeTransfer(w.opponent, w.opponentStake);
+            emit WagerRefunded(wagerId, w.creator, w.opponent);
+        } else {
+            revert NotRefundable();
+        }
+    }
+
+    /// @dev Body of batchExpireOpen (served by the {WagerRegistryIntents} facet since spec 035 —
+    ///      the main facet forwards the selector through its fallback; behavior is unchanged).
+    function _batchExpireOpen(uint256[] calldata wagerIds) internal {
+        for (uint256 i = 0; i < wagerIds.length; i++) {
+            Wager storage w = _wagers[wagerIds[i]];
+            if (w.status != Status.Open) continue;
+            if (block.timestamp <= w.acceptDeadline) continue;
+
+            w.status = Status.Refunded;
+            membershipManager.recordClose(w.creator, WAGER_PARTICIPANT_ROLE);
+            _clearClaim(wagerIds[i]); // free the code if this was an open challenge (no-op otherwise)
+            IERC20(w.token).safeTransfer(w.creator, w.creatorStake);
+            emit WagerRefunded(wagerIds[i], w.creator, address(0));
+        }
+    }
+}

--- a/contracts/wagers/WagerRegistryIntents.sol
+++ b/contracts/wagers/WagerRegistryIntents.sol
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {WagerRegistryCore} from "./WagerRegistryCore.sol";
+import {SignerIntentBase} from "../upgradeable/SignerIntentBase.sol";
+import {IWagerRegistryIntents} from "../interfaces/IWagerRegistryIntents.sol";
+import {ERC3009Auth} from "../interfaces/IERC3009.sol";
+import {IOracleAdapter} from "../oracles/IOracleAdapter.sol";
+
+/// @title WagerRegistryIntents
+/// @notice The signer-attributed (gasless) extension facet of the wager registry (spec 035).
+///         Deployed as a SEPARATE implementation and reached through {WagerRegistry}'s fallback
+///         via delegatecall — it executes in the proxy's storage context, so all state, events,
+///         and the "FairWins WagerRegistry" EIP-712 domain (bound to the proxy address) are the
+///         registry's own. Exists because the main implementation sits against the 24 KB
+///         code-size limit; both facets inherit {WagerRegistryCore} so the storage layout and
+///         action bodies cannot drift.
+/// @dev    Every twin: (1) verifies the intent (window, signature recovering exactly `signer`,
+///         single-use nonce — {SignerIntentBase}), (2) runs the SAME checks as the self-submit
+///         path against the recovered `signer` (sanctions, membership, ownership, freeze —
+///         fail-closed, FR-003/FR-013), (3) for money-in, pulls the stake from the signer via
+///         their stapled EIP-3009 authorization atomically with the action (FR-007), and
+///         (4) settles the optional bounded fee leg to the segregated recipient (FR-015/FR-016).
+///         Never callable meaningfully at its own address: state there is empty/uninitialized and
+///         initializers are disabled by {UUPSManaged}'s constructor.
+///
+///         `missing-initializer` is allowed BY DESIGN: this facet is never initialized — the proxy is
+///         initialized exactly once through the main {WagerRegistry} facet, and this contract only ever
+///         executes via delegatecall against that already-initialized storage.
+/// @custom:oz-upgrades-unsafe-allow missing-initializer
+contract WagerRegistryIntents is WagerRegistryCore, SignerIntentBase, IWagerRegistryIntents {
+    // ---- Intent typehashes. Every struct binds the acting address, a single-use replay nonce, and
+    //      a validity window; money-in structs also bind the EIP-3009 payment nonce so the money leg
+    //      is stapled to this exact action (FR-007/FR-013). ----
+    bytes32 private constant CREATE_WAGER_INTENT_TYPEHASH = keccak256(
+        "CreateWagerIntent(address creator,address opponent,address arbitrator,address token,uint128 creatorStake,uint128 opponentStake,uint64 acceptDeadline,uint64 resolveDeadline,uint8 resolutionType,bytes32 conditionId,bool creatorIsYes,bytes32 metadataHash,string metadataUri,bytes32 termsVersionHash,bytes32 paymentNonce,bytes32 nonce,uint256 validAfter,uint256 validBefore)"
+    );
+    bytes32 private constant ACCEPT_WAGER_INTENT_TYPEHASH = keccak256(
+        "AcceptWagerIntent(uint256 wagerId,address taker,bytes32 paymentNonce,bytes32 nonce,uint256 validAfter,uint256 validBefore)"
+    );
+    bytes32 private constant CLAIM_PAYOUT_INTENT_TYPEHASH = keccak256(
+        "ClaimPayoutIntent(uint256 wagerId,address claimant,bytes32 nonce,uint256 validAfter,uint256 validBefore)"
+    );
+    bytes32 private constant CLAIM_REFUND_INTENT_TYPEHASH = keccak256(
+        "ClaimRefundIntent(uint256 wagerId,address actor,bytes32 nonce,uint256 validAfter,uint256 validBefore)"
+    );
+    bytes32 private constant DECLARE_DRAW_INTENT_TYPEHASH = keccak256(
+        "DeclareDrawIntent(uint256 wagerId,address actor,bytes32 nonce,uint256 validAfter,uint256 validBefore)"
+    );
+    bytes32 private constant REVOKE_DRAW_INTENT_TYPEHASH = keccak256(
+        "RevokeDrawIntent(uint256 wagerId,address actor,bytes32 nonce,uint256 validAfter,uint256 validBefore)"
+    );
+    bytes32 private constant CANCEL_OPEN_INTENT_TYPEHASH = keccak256(
+        "CancelOpenIntent(uint256 wagerId,address actor,bytes32 nonce,uint256 validAfter,uint256 validBefore)"
+    );
+    bytes32 private constant DECLINE_INTENT_TYPEHASH = keccak256(
+        "DeclineIntent(uint256 wagerId,address actor,bytes32 nonce,uint256 validAfter,uint256 validBefore)"
+    );
+    bytes32 private constant DECLARE_WINNER_INTENT_TYPEHASH = keccak256(
+        "DeclareWinnerIntent(uint256 wagerId,address winner,address actor,bytes32 nonce,uint256 validAfter,uint256 validBefore)"
+    );
+
+    /// @dev EIP-3009 stake pull for the money-in twins: assert the authorization is the one the
+    ///      signer stapled to the intent, then pull via receiveWithAuthorization. Self-submit calls
+    ///      still take the allowance path (viaAuth=false).
+    function _pullStake(
+        address token,
+        address from,
+        uint128 amount,
+        bytes32 paymentNonce,
+        ERC3009Auth memory auth,
+        bool viaAuth
+    ) internal override {
+        if (viaAuth) {
+            _pullWithAuthorization(token, from, amount, paymentNonce, auth);
+        } else {
+            super._pullStake(token, from, amount, paymentNonce, auth, viaAuth);
+        }
+    }
+
+    // ---------- Money-in twins (…WithAuthorization) ----------
+
+    /// @notice Relayed {WagerRegistry.createWagerWithTerms}: one signature creates the wager and
+    ///         escrows the creator's stake from their EIP-3009 authorization. `signer` becomes the
+    ///         on-chain creator.
+    function createWagerWithAuthorization(
+        CreateArgs calldata args,
+        address signer,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata intentSig,
+        ERC3009Auth calldata stakeAuth,
+        ERC3009Auth calldata feeAuth
+    ) external nonReentrant whenNotPaused notFrozen(signer) returns (uint256 wagerId) {
+        _verifyIntent(_hashCreateIntent(args, signer, nonce, validAfter, validBefore), signer, nonce, validAfter, validBefore, intentSig);
+        wagerId = _createWager(signer, args, true, stakeAuth);
+        _settleGasFee(args.token, signer, feeAuth, _feeNettingEnabled, _gasFeeRecipient, _maxGasFee);
+    }
+
+    /// @notice Relayed {WagerRegistry.acceptWager}. The stake authorization's EIP-3009 nonce is bound
+    ///         into the signed intent as `paymentNonce`, so a relayer cannot pair the intent with a
+    ///         different authorization.
+    function acceptWagerWithAuthorization(
+        uint256 wagerId,
+        address signer,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata intentSig,
+        ERC3009Auth calldata stakeAuth,
+        ERC3009Auth calldata feeAuth
+    ) external nonReentrant whenNotPaused notFrozen(signer) {
+        _verifyIntent(
+            keccak256(abi.encode(ACCEPT_WAGER_INTENT_TYPEHASH, wagerId, signer, stakeAuth.nonce, nonce, validAfter, validBefore)),
+            signer, nonce, validAfter, validBefore, intentSig
+        );
+        _acceptWager(signer, wagerId, true, stakeAuth);
+        _settleGasFee(_wagers[wagerId].token, signer, feeAuth, _feeNettingEnabled, _gasFeeRecipient, _maxGasFee);
+    }
+
+    /// @notice Relayed {WagerRegistry.acceptOpenWager}: two signatures — the claim-code proof rebound
+    ///         to `taker = signer` (front-running defense preserved under a relayer, FR-011) plus the
+    ///         taker's own accept intent carrying the stake authorization.
+    function acceptOpenWagerWithAuthorization(
+        uint256 wagerId,
+        address signer,
+        bytes calldata claimCodeSig,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata intentSig,
+        ERC3009Auth calldata stakeAuth,
+        ERC3009Auth calldata feeAuth
+    ) external nonReentrant whenNotPaused notFrozen(signer) {
+        _verifyIntent(
+            keccak256(abi.encode(ACCEPT_WAGER_INTENT_TYPEHASH, wagerId, signer, stakeAuth.nonce, nonce, validAfter, validBefore)),
+            signer, nonce, validAfter, validBefore, intentSig
+        );
+        _acceptOpenWager(signer, wagerId, claimCodeSig, true, stakeAuth);
+        _settleGasFee(_wagers[wagerId].token, signer, feeAuth, _feeNettingEnabled, _gasFeeRecipient, _maxGasFee);
+    }
+
+    // ---------- No-stake twins (…WithSig) ----------
+
+    /// @notice Relayed {WagerRegistry.claimPayout}: the payout lands in the winning signer's wallet,
+    ///         zero native gas.
+    function claimPayoutWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes calldata sig)
+        external nonReentrant notFrozen(signer)
+    {
+        _verifyIntent(
+            keccak256(abi.encode(CLAIM_PAYOUT_INTENT_TYPEHASH, wagerId, signer, nonce, validAfter, validBefore)),
+            signer, nonce, validAfter, validBefore, sig
+        );
+        _claimPayout(signer, wagerId);
+    }
+
+    /// @notice Relayed {WagerRegistry.claimRefund}.
+    function claimRefundWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes calldata sig)
+        external nonReentrant notFrozen(signer)
+    {
+        _verifyIntent(
+            keccak256(abi.encode(CLAIM_REFUND_INTENT_TYPEHASH, wagerId, signer, nonce, validAfter, validBefore)),
+            signer, nonce, validAfter, validBefore, sig
+        );
+        _claimRefund(wagerId);
+    }
+
+    /// @notice Relayed {WagerRegistry.declareDraw}.
+    function declareDrawWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes calldata sig)
+        external nonReentrant notFrozen(signer)
+    {
+        _verifyIntent(
+            keccak256(abi.encode(DECLARE_DRAW_INTENT_TYPEHASH, wagerId, signer, nonce, validAfter, validBefore)),
+            signer, nonce, validAfter, validBefore, sig
+        );
+        _declareDraw(signer, wagerId);
+    }
+
+    /// @notice Relayed {WagerRegistry.revokeDraw}.
+    function revokeDrawWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes calldata sig)
+        external nonReentrant notFrozen(signer)
+    {
+        _verifyIntent(
+            keccak256(abi.encode(REVOKE_DRAW_INTENT_TYPEHASH, wagerId, signer, nonce, validAfter, validBefore)),
+            signer, nonce, validAfter, validBefore, sig
+        );
+        _revokeDraw(signer, wagerId);
+    }
+
+    /// @notice Relayed {WagerRegistry.cancelOpen}.
+    function cancelOpenWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes calldata sig)
+        external nonReentrant notFrozen(signer)
+    {
+        _verifyIntent(
+            keccak256(abi.encode(CANCEL_OPEN_INTENT_TYPEHASH, wagerId, signer, nonce, validAfter, validBefore)),
+            signer, nonce, validAfter, validBefore, sig
+        );
+        _cancelOpen(signer, wagerId);
+    }
+
+    /// @notice Relayed {WagerRegistry.declineWager}.
+    function declineWagerWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes calldata sig)
+        external nonReentrant notFrozen(signer)
+    {
+        _verifyIntent(
+            keccak256(abi.encode(DECLINE_INTENT_TYPEHASH, wagerId, signer, nonce, validAfter, validBefore)),
+            signer, nonce, validAfter, validBefore, sig
+        );
+        _declineWager(signer, wagerId);
+    }
+
+    /// @notice Relayed {WagerRegistry.declareWinner}.
+    function declareWinnerWithSig(uint256 wagerId, address winner, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes calldata sig)
+        external nonReentrant notFrozen(signer)
+    {
+        _verifyIntent(
+            keccak256(abi.encode(DECLARE_WINNER_INTENT_TYPEHASH, wagerId, winner, signer, nonce, validAfter, validBefore)),
+            signer, nonce, validAfter, validBefore, sig
+        );
+        _declareWinner(signer, wagerId, winner);
+    }
+
+    // ---------- Relocated cold paths (behavior unchanged; served via the fallback) ----------
+
+    function autoResolveFromPolymarket(uint256 wagerId) external nonReentrant {
+        Wager storage w = _wagers[wagerId];
+        if (w.status != Status.Active) revert NotActive();
+        if (w.resolutionType != ResolutionType.Polymarket) revert NotAuthorized();
+        if (address(polymarketAdapter) == address(0)) revert AdapterNotSet();
+
+        (bool outcome, , uint256 resolvedAt) = polymarketAdapter.getOutcome(w.polymarketConditionId);
+        if (resolvedAt == 0) {
+            // getOutcome returns resolvedAt==0 for BOTH "not resolved" and a
+            // "resolved tie" (equal payout numerators). Disambiguate: a resolved
+            // tie settles a DRAW immediately (both stakes back); a genuinely
+            // unresolved market reverts (unchanged behavior).
+            if (polymarketAdapter.isConditionResolved(w.polymarketConditionId)) {
+                _settleDraw(wagerId, w, msg.sender);
+                return;
+            }
+            revert ConditionNotResolved();
+        }
+        _settleOracleWin(wagerId, w, outcome);
+    }
+
+    /// @notice Generic resolve path for ChainlinkDataFeed / ChainlinkFunctions / UMA wagers.
+    ///         Reads the cached outcome from the wager's configured adapter and sets the winner.
+    function autoResolveFromOracle(uint256 wagerId) external nonReentrant {
+        Wager storage w = _wagers[wagerId];
+        if (w.status != Status.Active) revert NotActive();
+        if (!_isExtensibleOracleType(w.resolutionType)) revert NotAuthorized();
+
+        IOracleAdapter adapter = oracleAdapters[w.resolutionType];
+        if (address(adapter) == address(0)) revert OracleAdapterNotSet();
+
+        (bool outcome, , uint256 resolvedAt) = adapter.getOutcome(w.polymarketConditionId);
+        if (resolvedAt == 0) revert ConditionNotResolved();
+        _settleOracleWin(wagerId, w, outcome);
+    }
+
+    /// @notice Expire Open wagers whose accept deadline has passed, refund the
+    ///         creator's stake, and release the concurrent-limit slot on
+    ///         MembershipManager. Any address may call this (the refund always
+    ///         goes to the original creator). Silently skips wager IDs that are
+    ///         not eligible (wrong status, deadline not yet reached, etc.).
+    function batchExpireOpen(uint256[] calldata wagerIds) external nonReentrant whenNotPaused {
+        _batchExpireOpen(wagerIds);
+    }
+
+    // ---------- Fee-netting views (state lives in Core; getters here for main-facet headroom) ----------
+
+    function feeNettingEnabled() external view returns (bool) { return _feeNettingEnabled; }
+    function gasFeeRecipient() external view returns (address) { return _gasFeeRecipient; }
+    function maxGasFee() external view returns (uint256) { return _maxGasFee; }
+
+    // ---------- Fee-netting admin ----------
+
+    /// @notice Configure atomic fee netting for the `…WithAuthorization` twins (FR-015/FR-016).
+    ///         `recipient` is the segregated stablecoin fee sink — never the relayer hot key
+    ///         (spec 036 SC-015). Signed by the floppy-keystore admin like every other admin call.
+    function setFeeNetting(bool enabled, address recipient, uint256 cap) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (enabled && recipient == address(0)) revert ZeroAddress();
+        _feeNettingEnabled = enabled;
+        _gasFeeRecipient = recipient;
+        _maxGasFee = cap;
+        emit FeeNettingUpdated(enabled, recipient, cap);
+    }
+
+    // ---------- Hash helpers ----------
+
+    /// @dev EIP-712 struct hash for {createWagerWithAuthorization}. `metadataUri` is hashed per
+    ///      EIP-712 dynamic-type rules.
+    function _hashCreateIntent(
+        CreateArgs calldata a,
+        address signer,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore
+    ) internal pure returns (bytes32) {
+        // Two abi.encode chunks concatenated — every field is a static 32-byte word, so this equals
+        // the single flat abi.encode the EIP-712 spec requires (avoids stack-too-deep on 19 words).
+        return keccak256(
+            bytes.concat(
+                abi.encode(
+                    CREATE_WAGER_INTENT_TYPEHASH,
+                    signer,
+                    a.opponent,
+                    a.arbitrator,
+                    a.token,
+                    a.creatorStake,
+                    a.opponentStake,
+                    a.acceptDeadline,
+                    a.resolveDeadline
+                ),
+                abi.encode(
+                    uint8(a.resolutionType),
+                    a.conditionId,
+                    a.creatorIsYes,
+                    a.metadataHash,
+                    keccak256(bytes(a.metadataUri)),
+                    a.termsVersionHash,
+                    a.paymentNonce,
+                    nonce,
+                    validAfter,
+                    validBefore
+                )
+            )
+        );
+    }
+}

--- a/docs/developer-guide/gasless-intents.md
+++ b/docs/developer-guide/gasless-intents.md
@@ -1,0 +1,101 @@
+# Gasless Intents (Specs 035 + 036)
+
+FairWins users can authorize every core action with **one off-chain signature** — no separate
+ERC-20 approval, no native gas token. A relayer (spec 036) submits the signed intent; the on-chain
+effect is always attributed to the **signer**, never the submitter.
+
+## How it works
+
+```
+wallet ──sign EIP-712 intent (+ EIP-3009 payment leg)──▶ relay gateway ──calldata──▶ OZ Relayer ──tx──▶ chain
+   │                                                        (policy)                  (mechanics)
+   └────────────────────── self-submit fallback (user pays own gas — always available) ──────────────▶ chain
+```
+
+- **Intent leg** — an EIP-712 struct (e.g. `ClaimPayoutIntent`) signed under the verifying
+  contract's domain (`FairWins WagerRegistry` / `FairWins MembershipManager`, version `1`,
+  chainId + proxy address). Binds the acting address, every action parameter, a single-use random
+  32-byte nonce, and a validity window.
+- **Payment leg** (money-in actions only) — an EIP-3009 `ReceiveWithAuthorization` signed under the
+  **stablecoin's own** domain, `to` = the consuming contract. Its nonce is stapled into the intent's
+  `paymentNonce`, and the contract asserts `stakeAuth.value == signed amount` and
+  `stakeAuth.nonce == paymentNonce` — a relayer can censor, but can never substitute, redirect, or
+  resize a payment.
+- **Fee netting** (optional, admin-toggled `setFeeNetting`) — a second, bounded authorization
+  settled atomically to a segregated `gasFeeRecipient` (never the relayer hot key).
+
+## Contract architecture: the registry facet split
+
+`WagerRegistry`'s implementation sits against the EVM 24 KB code-size limit (24,460 of 24,576 bytes
+before this feature), so the intent surface ships as a **second implementation facet**:
+
+| Piece | Role |
+|-------|------|
+| `contracts/wagers/WagerRegistryCore.sol` | Abstract: THE storage layout + all internal action bodies (actor-threaded). Both facets inherit it, so layouts cannot drift. Validated by `npm run check:storage-layout`. |
+| `contracts/wagers/WagerRegistry.sol` | Main facet (the UUPS implementation): every pre-existing external + a `fallback()` that delegatecalls unknown selectors to the extension. |
+| `contracts/wagers/WagerRegistryIntents.sol` | Extension facet: the `…WithSig`/`…WithAuthorization` twins, `invalidateNonce(+WithSig)`, `setFeeNetting`, and the relocated cold paths `batchExpireOpen` / `autoResolveFromPolymarket` / `autoResolveFromOracle`. |
+| `contracts/upgradeable/SignerIntentBase.sol` | Shared mixin: EIP-712 verify + ERC-7201-namespaced per-signer replay-nonce map + invalidation. Zero sequential storage — safe to add to live proxies. |
+
+Callers see **one contract at the proxy address**: one ABI (merge `WagerRegistry` +
+`WagerRegistryIntents` artifacts — see `test/helpers/proxy.js#mergeAbis`), one event stream, one
+EIP-712 domain (under delegatecall `address(this)` is the proxy). `setIntentExtension` is gated by
+`UPGRADER_ROLE` because pointing the fallback at new code is equivalent in authority to an upgrade.
+
+`MembershipManager` (11 KB) hosts its four twins inline — no facet needed. Its EIP-712 domain is
+initialized by `initializeIntents()` (`reinitializer(2)`) during the in-place upgrade.
+
+## Twin invariant
+
+Every covered action has two entrypoints with **identical checks and effects** against the acting
+identity (`msg.sender` for self-submit, the recovered signer for intents): sanctions screen,
+membership gate, ownership, freeze — all fail-closed on the signer. The self-submit path is never
+removed: it is the guaranteed fallback when no relayer is reachable.
+
+Covered: create / accept / accept-open (money-in) · claim payout / refund / declare & revoke draw /
+cancel open / decline / declare winner (no-stake) · membership purchase / upgrade / extend
+(money-in) · voucher redeem (no-stake).
+
+## Replay + invalidation
+
+- Nonces are client-generated random 32-byte values, single-use per `(contract, signer)`,
+  usable out of order. State: `authorizationState(signer, nonce)`.
+- Cancel an unsubmitted intent: `invalidateNonce(nonce)` (self) or
+  `invalidateNonceWithSig(signer, nonce, validBefore, sig)` (relayed).
+- Cancel an unsubmitted payment leg: the token's `cancelAuthorization`.
+
+## Frontend
+
+`frontend/src/lib/relay/` is the one client every flow uses:
+
+- `intentTypes.js` — the EIP-712 struct definitions (MUST stay byte-identical to the contract
+  typehashes) + per-contract domain builders + the FR-020 stablecoin-domain pre-sign check
+  (`domainVersion` in `config/networks.js`: native USDC `'2'`, bridged `'1'`, Mordor USC `null` ⇒
+  payment intents unavailable, self-submit only).
+- `intentClient.js` — `signIntent` / `relayIntent` / `pollStatus` / `probeHealth` / `makeRelayer`.
+  `VITE_RELAYER_URL` unset ⇒ `makeRelayer` returns null ⇒ everything self-submits.
+- `useIntentAction.js` — the **never-stranded enforcement point**: relayer unset, unhealthy, 429,
+  503, `payment_unsupported_on_chain`, or timeout ⇒ transparent fallback to the caller-supplied
+  `selfSubmit()`. Status is honest: never `confirmed` before on-chain inclusion.
+- `components/intents/IntentStatus.jsx` — WCAG 2.1 AA status renderer.
+
+## Relayer (spec 036)
+
+See `services/relay-gateway/README.md` (policy gateway: signer recovery, fail-closed sanctions
+re-screen, dedup, quotas, kill switch, audit) and `services/oz-relayer/README.md` (submission
+engine: nonce lanes, gas pricing — legacy type-0 on ETC/Mordor — inclusion tracking, KMS-held hot
+key). Runbook: `docs/runbooks/relayer-operations.md`.
+
+## Upgrade & rollout
+
+```bash
+npm run check:storage-layout                                            # gating
+npx hardhat run scripts/deploy/upgrade-gasless-intents.js --network amoy
+npm run sync:frontend-contracts:amoy
+# optional: FEE_ENABLED=true FEE_RECIPIENT=0x... FEE_MAX=1000000 \
+#   npx hardhat run scripts/operations/set-fee-netting.js --network amoy
+```
+
+Rollout: **Amoy** (full flow) → **Mordor** (no-stake intents only — USC lacks EIP-3009) →
+**Polygon** (after the 025/027 UUPS migration; the recorded Polygon addresses predate the proxy
+migration). Storage deltas: WagerRegistry `__gap` 48→45 (fee scalars ×2 + `intentExtension`),
+MembershipManager `__gap` 49→47 (fee scalars ×2); the nonce map is namespaced (zero gap).

--- a/docs/runbooks/relayer-operations.md
+++ b/docs/runbooks/relayer-operations.md
@@ -1,0 +1,73 @@
+# Runbook: Intent Relayer Operations (Spec 036)
+
+The relayer is **optional gas infrastructure** — it can censor, never steal. Every flow keeps a
+self-submit fallback, so the worst failure mode of everything below is "users pay their own gas".
+
+## Components
+
+| Component | Where | Owns |
+|-----------|-------|------|
+| `relay-gateway` | Cloud Run (`services/relay-gateway`) | Policy: signer recovery, intent binding, fail-closed sanctions re-screen, dedup, quotas/spend caps, back-pressure, kill switch, audit log |
+| `oz-relayer` | Container next to the gateway (`services/oz-relayer`) | Mechanics: per-chain nonce lanes, gas pricing/bumping (legacy type-0 on 61/63), inclusion tracking, RPC failover, the KMS-held gas key |
+| Frontend probe | `frontend/src/lib/relay` | `VITE_RELAYER_URL` + health probe → self-submit routing |
+
+## Local bring-up (validation)
+
+```bash
+cd services/relay-gateway
+cp .env.example .env        # set ORIGIN_AUTH_SECRET + WEBHOOK secrets; never commit .env
+docker compose up --build   # gateway :8788, engine :8080, redis :6379
+curl -s localhost:8788/healthz | jq
+```
+
+## Key management (hot gas key)
+
+- One dedicated, low-value key per chain, held in **GCP KMS / Secret Manager** (see
+  `services/oz-relayer/config/config.json` signer refs). NEVER the floppy admin key; never in env
+  files, logs, or the audit stream.
+- Funding: keep balance ≥ 12h of peak burn (healthz `gasWalletRunwayHrs` alerts via
+  `GAS_WALLET_<id>` + `PEAK_BURN_WEI_PER_HR_<id>`).
+- Rotation: create the new KMS key version → update `key_version` in the engine config → restart
+  engine → fund new address → drain old. The gateway needs no change (it never signs).
+- Compromise bound: gas balance + censorship. The key holds no user funds and no contract
+  authority; `whitelist_receivers` pins it to the FairWins proxies.
+
+## Kill switch
+
+- Activate: set `KILL_SWITCH=true` on the gateway (redeploy/restart) — `POST /v1/intents` returns
+  `503 killswitch_active`; clients fall back to self-submit automatically. In-flight engine
+  transactions still track to inclusion (no accepted intent is dropped).
+- Per-chain stop: pause the chain's relayer in the engine config (`"paused": true`).
+- Full contract stop remains `pause()` on the registry (GUARDIAN_ROLE) — independent of the relayer.
+
+## Common incidents
+
+| Symptom | Check | Action |
+|---------|-------|--------|
+| 503 `screening_unavailable` spike | Sanctions RPC health (gateway logs `sanctions` errors) | Fail-closed is BY DESIGN — fix RPC (rotate `RPC_URLS_<id>`); do NOT bypass screening |
+| 503 `chain_unavailable` | Both RPC endpoints down | Rotate/add endpoints (env), restart |
+| Stuck transactions | Engine logs; lane nonce vs `eth_getTransactionCount(pending)` | Engine bumps to `gas_price_cap`; if capped, raise cap (config) or cancel + drain lane |
+| 429 storms | Quota counters (`SIGNER_QUOTA_PER_MIN`, `GLOBAL_QUOTA_PER_MIN`, `MAX_QUEUE_DEPTH`) | Raise deliberately or let back-pressure shed to self-submit |
+| Gas runway low | `/healthz` `gasWalletRunwayHrs` | Fund the chain's gas wallet |
+| Webhook auth failures | `WEBHOOK_SHARED_SECRET` mismatch gateway↔engine | Re-sync the secret; webhooks are rejected (fail closed) until then |
+
+## Fee netting (optional)
+
+`scripts/operations/set-fee-netting.js` (floppy-signed admin). `FEE_RECIPIENT` MUST be a segregated
+treasury address — **never** a relayer gas wallet (SC-015). Reconciliation: on-chain gas spent by
+the gas wallets vs stablecoin received by the recipient; both are fully on-chain.
+
+## Audit
+
+Structured JSON events on stdout (`intent → recovered signer → outcome → txHash`) — route via
+Cloud Logging Log Router to the WORM bucket (≥ 5-year retention). The audit stream contains no
+secrets and no PII beyond on-chain-public addresses. On-chain remains the record of record.
+
+## ETC / Mordor caveats
+
+- Legacy type-0 gas only (no EIP-1559 fields); engine networks 61/63 carry no `eip1559` feature.
+- Several public ETC RPCs reject batched JSON-RPC — endpoints are used with batch size 1.
+- **Payment-class intents are blocked** on 61/63 (`503 payment_unsupported_on_chain`): live USC has
+  no EIP-3009. No-stake intents relay normally; money-in flows self-submit.
+- Chain 61 stays `paused` in the engine and unlisted in the gateway until the spec-025/027 proxies
+  exist there (the gateway refuses to start for a chain without a deployments record).

--- a/frontend/src/components/intents/IntentStatus.jsx
+++ b/frontend/src/components/intents/IntentStatus.jsx
@@ -1,0 +1,56 @@
+/**
+ * IntentStatus — honest lifecycle readout for one gasless intent (spec 035 FR-018/FR-023, spec 036
+ * frontend-relay-client.md "Honest status + accessibility").
+ *
+ * Purely presentational: state arrives as the `status` prop (useIntentAction's machine) and actions
+ * arrive as callbacks. WCAG 2.1 AA: the container is a polite live region (role="status" +
+ * aria-live="polite") so transitions are announced; every state is conveyed IN TEXT (never color or
+ * icon alone); 'Confirmed' is only ever rendered when the caller's machine reached a txHash-bearing
+ * confirmed state — this component adds no optimism of its own.
+ */
+/** Honest, user-facing label per lifecycle state. `idle` renders an empty (but present) live region. */
+const INTENT_STATUS_LABELS = {
+  idle: '',
+  signing: 'Waiting for your signature…',
+  signed: 'Signed — not yet submitted',
+  submitting: 'Submitting…',
+  pending: 'Pending on-chain…',
+  confirmed: 'Confirmed',
+  failed: 'Failed',
+  expired: 'Expired',
+  invalidated: 'Invalidated',
+  'self-submitting': 'Self-submit fallback — sending from your wallet (you pay gas)…',
+  'self-submitted': 'Self-submit fallback — sent from your wallet',
+}
+
+/** States where the signed intent has NOT executed, so "Pay my own gas" is a meaningful offer. */
+const SELF_SUBMIT_OFFER = new Set(['signed', 'failed', 'expired'])
+
+function IntentStatus({ status = 'idle', txHash = null, error = null, onInvalidate = null, onSelfSubmit = null }) {
+  const label = INTENT_STATUS_LABELS[status] ?? status
+  const detail = status === 'failed' && error?.message ? error.message : null
+
+  return (
+    // Persistent polite live region: assistive tech announces each label change without stealing focus.
+    <div className="intent-status" role="status" aria-live="polite" data-status={status}>
+      {label ? <span className="intent-status__label">{label}</span> : null}
+      {detail ? <span className="intent-status__detail"> — {detail}</span> : null}
+      {status === 'confirmed' && txHash ? (
+        <span className="intent-status__tx"> (transaction {txHash})</span>
+      ) : null}
+      {status === 'signed' && typeof onInvalidate === 'function' ? (
+        <button type="button" className="intent-status__action" onClick={onInvalidate}>
+          Invalidate
+        </button>
+      ) : null}
+      {SELF_SUBMIT_OFFER.has(status) && typeof onSelfSubmit === 'function' ? (
+        <button type="button" className="intent-status__action" onClick={onSelfSubmit}>
+          Pay my own gas
+        </button>
+      ) : null}
+    </div>
+  )
+}
+
+export default IntentStatus
+export { IntentStatus }

--- a/frontend/src/config/networks.js
+++ b/frontend/src/config/networks.js
@@ -57,6 +57,9 @@ const NETWORKS = {
       symbol: 'USDC',
       name: 'USD Coin',
       decimals: 6,
+      // EIP-712 domain version for the EIP-3009 payment leg (spec 035 FR-020):
+      // native Circle USDC signs under version '2' (bridged USDC.e would be '1').
+      domainVersion: '2',
     },
     // Uniswap V3 has no canonical deployment on Polygon Amoy. Community
     // deployments exist; supply them via VITE_AMOY_UNISWAP_* env vars to
@@ -120,6 +123,9 @@ const NETWORKS = {
       symbol: 'USC',
       name: 'Classic USD',
       decimals: 6,
+      // USC has no EIP-3009 receiveWithAuthorization — null disables payment-class
+      // gasless intents on this chain (self-submit only; spec 035 FR-020).
+      domainVersion: null,
     },
     // ETCswap (Uniswap V3 fork on Ethereum Classic). Supply all addresses via
     // VITE_MORDOR_ETCSWAP_* + VITE_MORDOR_WETC to enable in-app swaps on Mordor.
@@ -185,6 +191,9 @@ const NETWORKS = {
       symbol: 'USC',
       name: 'Classic USD',
       decimals: 6,
+      // USC has no EIP-3009 receiveWithAuthorization — null disables payment-class
+      // gasless intents on this chain (self-submit only; spec 035 FR-020).
+      domainVersion: null,
     },
     // ETCswap V3 (a Uniswap V3 deployment on Ethereum Classic). Addresses are the
     // on-chain-verified canonical deployment (Spec 033 research R1); override via
@@ -242,6 +251,9 @@ const NETWORKS = {
       symbol: 'USDC',
       name: 'USD Coin',
       decimals: 6,
+      // EIP-712 domain version for the EIP-3009 payment leg (spec 035 FR-020):
+      // native Circle USDC signs under version '2' (bridged USDC.e would be '1').
+      domainVersion: '2',
     },
     // Canonical Uniswap V3 deployment on Polygon Mainnet.
     // https://docs.uniswap.org/contracts/v3/reference/deployments

--- a/frontend/src/data/notifications/domains.js
+++ b/frontend/src/data/notifications/domains.js
@@ -9,6 +9,8 @@ export const DOMAIN_META = {
   token: { label: 'Token' },
   membership: { label: 'Membership' },
   pools: { label: 'Pool' },
+  // Spec 035 intent lifecycle entries (emitted via useIntentAction's onActivity callback).
+  intents: { label: 'Gasless' },
 }
 
 /** Display label for a domain key (falls back to the key itself for an unknown/future domain). */

--- a/frontend/src/lib/relay/__tests__/intentClient.test.js
+++ b/frontend/src/lib/relay/__tests__/intentClient.test.js
@@ -1,0 +1,327 @@
+/**
+ * Shared intent-relay client tests (specs 035 + 036).
+ *
+ * Covers: makeRelayer's dormant-safe null (VITE_RELAYER_URL unset), signIntent's gateway-Intent body
+ * shape for both intent classes, the FR-020 pre-sign stablecoin-domain check (PaymentUnsupportedOnChain
+ * before ANY wallet prompt), and relayIntent's typed error contract (RelayerUnavailable on
+ * 429/503/network error vs RelayRejected with the gateway's error.code). global.fetch is mocked in
+ * src/test/setup.js; we override it per test.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { makeRelayer, signIntent, relayIntent, pollStatus, probeHealth, randomNonce } from '../intentClient'
+import { PaymentUnsupportedOnChain, RelayRejected, RelayerUnavailable } from '../errors'
+import { stablecoinDomain, wagerRegistryDomain, membershipManagerDomain } from '../intentTypes'
+
+const RELAYER_URL = 'https://relayer.fairwins.example'
+const REGISTRY = '0x00000000000000000000000000000000000000aa'
+const SIGNER_ADDRESS = '0x00000000000000000000000000000000000000bb'
+
+/** Minimal ethers-signer stub capturing every signTypedData call. */
+function makeSigner() {
+  const calls = []
+  return {
+    calls,
+    getAddress: async () => SIGNER_ADDRESS,
+    signTypedData: async (domain, types, message) => {
+      calls.push({ domain, types, message })
+      // A structurally valid 65-byte signature so ethers.Signature.from can parse it (EIP-3009 leg).
+      return '0x' + '11'.repeat(32) + '22'.repeat(32) + '1b'
+    },
+  }
+}
+
+describe('intent relay client', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs()
+  })
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  describe('makeRelayer', () => {
+    it('returns null when VITE_RELAYER_URL is unset (gasless disabled — every flow self-submits)', () => {
+      vi.stubEnv('VITE_RELAYER_URL', '')
+      expect(makeRelayer(137)).toBeNull()
+    })
+
+    it('returns a chain-bound handle when configured', () => {
+      vi.stubEnv('VITE_RELAYER_URL', `${RELAYER_URL}/`)
+      const relayer = makeRelayer(137)
+      expect(relayer).not.toBeNull()
+      expect(relayer.chainId).toBe(137)
+      expect(relayer.baseUrl).toBe(RELAYER_URL) // trailing slash trimmed
+      expect(typeof relayer.relayIntent).toBe('function')
+      expect(typeof relayer.pollStatus).toBe('function')
+      expect(typeof relayer.probeHealth).toBe('function')
+    })
+  })
+
+  describe('domain builders', () => {
+    it('builds the per-contract FairWins domains (network + contract isolation, FR-005/FR-021)', () => {
+      expect(wagerRegistryDomain(137, REGISTRY)).toEqual({
+        name: 'FairWins WagerRegistry',
+        version: '1',
+        chainId: 137,
+        verifyingContract: REGISTRY,
+      })
+      expect(membershipManagerDomain(80002, REGISTRY)).toEqual({
+        name: 'FairWins MembershipManager',
+        version: '1',
+        chainId: 80002,
+        verifyingContract: REGISTRY,
+      })
+    })
+
+    it('builds the stablecoin domain from networks.js domainVersion (native Circle USDC = "2")', () => {
+      const domain = stablecoinDomain(137)
+      expect(domain.name).toBe('USD Coin')
+      expect(domain.version).toBe('2')
+      expect(domain.chainId).toBe(137)
+    })
+
+    it('throws PaymentUnsupportedOnChain for Mordor USC (domainVersion null, FR-020)', () => {
+      expect(() => stablecoinDomain(63)).toThrow(PaymentUnsupportedOnChain)
+      expect(() => stablecoinDomain(61)).toThrow(PaymentUnsupportedOnChain)
+      try {
+        stablecoinDomain(63)
+      } catch (e) {
+        expect(e.code).toBe('payment_unsupported_on_chain')
+        expect(e.chainId).toBe(63)
+      }
+    })
+  })
+
+  describe('signIntent', () => {
+    it('builds a signer-attributed Intent body with the gateway shape', async () => {
+      const signer = makeSigner()
+      const intent = await signIntent({
+        signer,
+        chainId: 137,
+        action: 'claimPayout',
+        targetContract: REGISTRY,
+        params: { wagerId: 7n },
+        nowSeconds: 1_000_000,
+        validitySeconds: 600,
+      })
+
+      expect(intent.intentClass).toBe('signer-attributed')
+      expect(intent.chainId).toBe(137)
+      expect(intent.targetContract).toBe(REGISTRY)
+      expect(intent.action).toBe('claimPayout')
+      expect(intent.signature).toMatch(/^0x/)
+      expect(intent.fundingMode).toBe('sponsored')
+      expect(intent.validAfter).toBe(0)
+      expect(intent.validBefore).toBe(1_000_600)
+      expect(intent.uniquenessMarker).toMatch(/^0x[0-9a-f]{64}$/)
+      expect(intent.authorization).toBeUndefined()
+      // Params carry the signed struct (bigints JSON-safe) with the actor auto-bound to the wallet.
+      expect(intent.params).toEqual({
+        wagerId: '7',
+        claimant: SIGNER_ADDRESS,
+        nonce: intent.uniquenessMarker,
+        validAfter: 0,
+        validBefore: 1_000_600,
+      })
+
+      // Exactly one wallet prompt, under the WagerRegistry domain with the ClaimPayoutIntent struct.
+      expect(signer.calls).toHaveLength(1)
+      const call = signer.calls[0]
+      expect(call.domain).toEqual(wagerRegistryDomain(137, REGISTRY))
+      expect(Object.keys(call.types)).toEqual(['ClaimPayoutIntent'])
+      expect(call.message.claimant).toBe(SIGNER_ADDRESS)
+      expect(call.message.nonce).toBe(intent.uniquenessMarker)
+    })
+
+    it('staples the EIP-3009 authorization to a payment-class intent (paymentNonce binding, FR-007)', async () => {
+      const signer = makeSigner()
+      const intent = await signIntent({
+        signer,
+        chainId: 137,
+        action: 'purchaseTier',
+        targetContract: REGISTRY,
+        params: { role: '0x' + 'ab'.repeat(32), tier: 2, acceptedTermsHash: '0x' + 'cd'.repeat(32) },
+        payment: { value: 25_000_000n },
+        fundingMode: 'fee-netted',
+        maxFee: 100_000n,
+        nowSeconds: 1_000_000,
+      })
+
+      expect(intent.intentClass).toBe('payment')
+      expect(intent.fundingMode).toBe('fee-netted')
+      expect(intent.maxFee).toBe('100000')
+      // Money leg: recipient-bound to the target contract, nonce == the struct's paymentNonce.
+      expect(intent.authorization).toMatchObject({
+        from: SIGNER_ADDRESS,
+        to: REGISTRY,
+        value: '25000000',
+      })
+      expect(intent.authorization.v).toBeTypeOf('number')
+      expect(intent.params.paymentNonce).toBe(intent.authorization.nonce)
+      // ONE marker per payment intent (spec 036 data-model: the uniquenessMarker IS the EIP-3009
+      // nonce) — the gateway rejects payment intents where these differ.
+      expect(intent.params.paymentNonce).toBe(intent.uniquenessMarker)
+
+      // Two signatures: EIP-3009 under the TOKEN's domain (version '2'), intent under the manager's.
+      expect(signer.calls).toHaveLength(2)
+      expect(signer.calls[0].domain.version).toBe('2')
+      expect(signer.calls[0].domain.name).toBe('USD Coin')
+      expect(Object.keys(signer.calls[0].types)).toEqual(['ReceiveWithAuthorization'])
+      expect(signer.calls[1].domain).toEqual(membershipManagerDomain(137, REGISTRY))
+      expect(Object.keys(signer.calls[1].types)).toEqual(['PurchaseTierIntent'])
+    })
+
+    it('rejects payment-class intents on Mordor BEFORE any wallet prompt (FR-020 pre-sign check)', async () => {
+      const signer = makeSigner()
+      await expect(
+        signIntent({
+          signer,
+          chainId: 63,
+          action: 'createWager',
+          targetContract: REGISTRY,
+          params: {},
+          payment: { value: 1_000_000n },
+        })
+      ).rejects.toBeInstanceOf(PaymentUnsupportedOnChain)
+      expect(signer.calls).toHaveLength(0) // no signature was requested
+    })
+
+    it('requires an explicit verifier for invalidateNonce (both contracts expose it)', async () => {
+      const signer = makeSigner()
+      await expect(
+        signIntent({ signer, chainId: 137, action: 'invalidateNonce', targetContract: REGISTRY, params: { nonce: randomNonce() } })
+      ).rejects.toThrow(/verifier/)
+
+      const intent = await signIntent({
+        signer,
+        chainId: 137,
+        action: 'invalidateNonce',
+        targetContract: REGISTRY,
+        verifier: 'wagerRegistry',
+        params: { nonce: '0x' + '55'.repeat(32) },
+        nowSeconds: 1_000_000,
+      })
+      expect(Object.keys(signer.calls[0].types)).toEqual(['InvalidateNonce'])
+      expect(intent.params.signer).toBe(SIGNER_ADDRESS)
+    })
+  })
+
+  describe('relayIntent', () => {
+    const intentBody = { intentClass: 'signer-attributed', chainId: 137, action: 'claimPayout' }
+
+    it('POSTs to /v1/intents and returns the accepted envelope', async () => {
+      vi.stubEnv('VITE_RELAYER_URL', RELAYER_URL)
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 202,
+        headers: { get: () => null },
+        json: async () => ({ intentId: 'in_1', status: 'queued' }),
+      })
+      globalThis.fetch = fetchMock
+
+      const res = await relayIntent(intentBody)
+      expect(res).toEqual({ intentId: 'in_1', status: 'queued' })
+      const [url, opts] = fetchMock.mock.calls[0]
+      expect(url).toBe(`${RELAYER_URL}/v1/intents`)
+      expect(opts.method).toBe('POST')
+      expect(opts.headers['Content-Type']).toBe('application/json')
+      expect(JSON.parse(opts.body)).toMatchObject(intentBody)
+    })
+
+    it('throws RelayerUnavailable when no relayer is configured', async () => {
+      vi.stubEnv('VITE_RELAYER_URL', '')
+      await expect(relayIntent(intentBody)).rejects.toBeInstanceOf(RelayerUnavailable)
+    })
+
+    it('throws RelayerUnavailable on 429 back-pressure (with Retry-After)', async () => {
+      vi.stubEnv('VITE_RELAYER_URL', RELAYER_URL)
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: { get: (h) => (h === 'Retry-After' ? '30' : null) },
+        json: async () => ({ error: { code: 'quota_exceeded', reason: 'per-signer quota reached' } }),
+      })
+      const err = await relayIntent(intentBody).catch((e) => e)
+      expect(err).toBeInstanceOf(RelayerUnavailable)
+      expect(err.code).toBe('quota_exceeded')
+      expect(err.status).toBe(429)
+      expect(err.retryAfterSeconds).toBe(30)
+    })
+
+    it('throws RelayerUnavailable on 503 (kill switch / screening outage / chain down)', async () => {
+      vi.stubEnv('VITE_RELAYER_URL', RELAYER_URL)
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        headers: { get: () => null },
+        json: async () => ({ error: { code: 'killswitch_active', reason: 'relaying paused' } }),
+      })
+      const err = await relayIntent(intentBody).catch((e) => e)
+      expect(err).toBeInstanceOf(RelayerUnavailable)
+      expect(err.code).toBe('killswitch_active')
+    })
+
+    it('throws RelayerUnavailable on a network error', async () => {
+      vi.stubEnv('VITE_RELAYER_URL', RELAYER_URL)
+      globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+      await expect(relayIntent(intentBody)).rejects.toBeInstanceOf(RelayerUnavailable)
+    })
+
+    it('throws RelayRejected with the gateway error.code on validation failures', async () => {
+      vi.stubEnv('VITE_RELAYER_URL', RELAYER_URL)
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        headers: { get: () => null },
+        json: async () => ({ error: { code: 'param_binding_mismatch', reason: 'params do not match signature' } }),
+      })
+      const err = await relayIntent(intentBody).catch((e) => e)
+      expect(err).toBeInstanceOf(RelayRejected)
+      expect(err).not.toBeInstanceOf(RelayerUnavailable)
+      expect(err.code).toBe('param_binding_mismatch')
+      expect(err.reason).toMatch(/do not match/)
+    })
+  })
+
+  describe('pollStatus / probeHealth', () => {
+    it('GETs intent status by id', async () => {
+      vi.stubEnv('VITE_RELAYER_URL', RELAYER_URL)
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ intentId: 'in_1', status: 'confirmed', txHash: '0xdead' }),
+      })
+      globalThis.fetch = fetchMock
+      const res = await pollStatus('in_1')
+      expect(res).toEqual({ intentId: 'in_1', status: 'confirmed', txHash: '0xdead' })
+      expect(fetchMock.mock.calls[0][0]).toBe(`${RELAYER_URL}/v1/intents/in_1`)
+    })
+
+    it('probeHealth is true only for an ok, kill-switch-off gateway with the chain RPC up', async () => {
+      vi.stubEnv('VITE_RELAYER_URL', RELAYER_URL)
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: 'ok', killSwitch: false, chains: { 137: { rpc: 'up' }, 80002: { rpc: 'down' } } }),
+      })
+      await expect(probeHealth(137)).resolves.toBe(true)
+      await expect(probeHealth(80002)).resolves.toBe(false)
+    })
+
+    it('probeHealth is false (never throws) on kill switch, error, or unset relayer', async () => {
+      vi.stubEnv('VITE_RELAYER_URL', RELAYER_URL)
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ status: 'ok', killSwitch: true }),
+      })
+      await expect(probeHealth(137)).resolves.toBe(false)
+
+      globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+      await expect(probeHealth(137)).resolves.toBe(false)
+
+      vi.stubEnv('VITE_RELAYER_URL', '')
+      await expect(probeHealth(137)).resolves.toBe(false)
+    })
+  })
+})

--- a/frontend/src/lib/relay/__tests__/useIntentAction.test.js
+++ b/frontend/src/lib/relay/__tests__/useIntentAction.test.js
@@ -1,0 +1,281 @@
+/**
+ * useIntentAction tests — the never-stranded rule and honest status machine (spec 035 FR-014/FR-018).
+ *
+ * intentClient is mocked at the module boundary (makeRelayer) so the hook's routing decisions are
+ * exercised directly: relayer unset → selfSubmit; RelayerUnavailable / PaymentUnsupportedOnChain →
+ * selfSubmit; and 'confirmed' is NEVER shown before a txHash-bearing confirmed relay status.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { PaymentUnsupportedOnChain, RelayerUnavailable } from '../errors'
+
+const h = vi.hoisted(() => ({
+  makeRelayer: vi.fn(),
+}))
+vi.mock('../intentClient', () => ({
+  makeRelayer: h.makeRelayer,
+}))
+
+import { useIntentAction, INTENT_STATUS, makeIntentActivityEntry } from '../useIntentAction'
+
+const SAMPLE_INTENT = {
+  intentClass: 'signer-attributed',
+  chainId: 137,
+  action: 'claimPayout',
+  uniquenessMarker: '0x' + 'aa'.repeat(32),
+  validBefore: Math.floor(Date.now() / 1000) + 3600,
+}
+
+/** A healthy relayer handle whose relay/poll behavior each test scripts. */
+function makeRelayerHandle({ relayIntent, pollStatus, probeHealth } = {}) {
+  return {
+    chainId: 137,
+    baseUrl: 'https://relayer.fairwins.example',
+    probeHealth: probeHealth || vi.fn().mockResolvedValue(true),
+    relayIntent: relayIntent || vi.fn(),
+    pollStatus: pollStatus || vi.fn(),
+  }
+}
+
+describe('useIntentAction', () => {
+  beforeEach(() => {
+    h.makeRelayer.mockReset()
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('throws at wiring time when selfSubmit is missing (never-stranded rule)', () => {
+    // React logs the render error before rethrowing — keep the test output clean.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() =>
+      renderHook(() => useIntentAction({ action: 'claimPayout', chainId: 137, buildIntent: async () => SAMPLE_INTENT }))
+    ).toThrow(/selfSubmit is required/)
+    consoleError.mockRestore()
+  })
+
+  it('falls back to selfSubmit when the relayer is unset, confirming only on the mined receipt', async () => {
+    h.makeRelayer.mockReturnValue(null) // VITE_RELAYER_URL unset
+    const buildIntent = vi.fn()
+    const selfSubmit = vi.fn().mockResolvedValue({ hash: '0xself' })
+    const { result } = renderHook(() =>
+      useIntentAction({ action: 'claimPayout', chainId: 137, buildIntent, selfSubmit })
+    )
+
+    let out
+    await act(async () => {
+      out = await result.current.run(7)
+    })
+
+    expect(selfSubmit).toHaveBeenCalledWith(7)
+    expect(buildIntent).not.toHaveBeenCalled() // no wasted signature when gasless is off
+    expect(out).toMatchObject({ via: 'self-submit', reason: 'relayer-unset', txHash: '0xself' })
+    expect(result.current.status).toBe(INTENT_STATUS.CONFIRMED)
+    expect(result.current.result.txHash).toBe('0xself')
+  })
+
+  it('falls back to selfSubmit when relayIntent throws RelayerUnavailable (429/503/timeout)', async () => {
+    const relayer = makeRelayerHandle({
+      relayIntent: vi.fn().mockRejectedValue(new RelayerUnavailable('busy', { code: 'backpressure', status: 429 })),
+    })
+    h.makeRelayer.mockReturnValue(relayer)
+    const selfSubmit = vi.fn().mockResolvedValue({ transactionHash: '0xfallback' })
+    const { result } = renderHook(() =>
+      useIntentAction({ action: 'claimPayout', chainId: 137, buildIntent: async () => SAMPLE_INTENT, selfSubmit })
+    )
+
+    await act(async () => {
+      await result.current.run()
+    })
+
+    expect(relayer.relayIntent).toHaveBeenCalled()
+    expect(selfSubmit).toHaveBeenCalledTimes(1)
+    expect(result.current.status).toBe(INTENT_STATUS.CONFIRMED)
+    expect(result.current.result).toMatchObject({ via: 'self-submit', reason: 'backpressure', txHash: '0xfallback' })
+  })
+
+  it('falls back to selfSubmit when the health probe fails, before requesting a signature (FR-016)', async () => {
+    const buildIntent = vi.fn()
+    const relayer = makeRelayerHandle({ probeHealth: vi.fn().mockResolvedValue(false) })
+    h.makeRelayer.mockReturnValue(relayer)
+    const selfSubmit = vi.fn().mockResolvedValue('0xdirect')
+    const { result } = renderHook(() =>
+      useIntentAction({ action: 'declareDraw', chainId: 137, buildIntent, selfSubmit })
+    )
+
+    await act(async () => {
+      await result.current.run()
+    })
+
+    expect(buildIntent).not.toHaveBeenCalled()
+    expect(selfSubmit).toHaveBeenCalled()
+    expect(result.current.result).toMatchObject({ via: 'self-submit', reason: 'relayer-unhealthy' })
+  })
+
+  it('falls back to selfSubmit when buildIntent throws PaymentUnsupportedOnChain (Mordor, FR-020)', async () => {
+    h.makeRelayer.mockReturnValue(makeRelayerHandle())
+    const buildIntent = vi.fn().mockRejectedValue(new PaymentUnsupportedOnChain('USC lacks EIP-3009', { chainId: 63 }))
+    const selfSubmit = vi.fn().mockResolvedValue({ hash: '0xown-gas' })
+    const { result } = renderHook(() =>
+      useIntentAction({ action: 'createWager', chainId: 63, buildIntent, selfSubmit })
+    )
+
+    await act(async () => {
+      await result.current.run()
+    })
+
+    expect(selfSubmit).toHaveBeenCalled()
+    expect(result.current.result).toMatchObject({ via: 'self-submit', reason: 'payment-unsupported', txHash: '0xown-gas' })
+  })
+
+  it("never shows 'confirmed' before a txHash-bearing confirmed status (FR-018/SC-007)", async () => {
+    // Manually-resolved poll promises make every intermediate state observable (no timer races).
+    const pollResolvers = []
+    const pollStatus = vi.fn(() => new Promise((resolve) => pollResolvers.push(resolve)))
+    const relayer = makeRelayerHandle({
+      relayIntent: vi.fn().mockResolvedValue({ intentId: 'in_1', status: 'submitted' }),
+      pollStatus,
+    })
+    h.makeRelayer.mockReturnValue(relayer)
+    const activity = []
+    const { result } = renderHook(() =>
+      useIntentAction({
+        action: 'claimPayout',
+        chainId: 137,
+        buildIntent: async () => SAMPLE_INTENT,
+        selfSubmit: vi.fn(),
+        onActivity: (entry) => activity.push(entry),
+        pollIntervalMs: 0,
+      })
+    )
+
+    let outPromise
+    act(() => {
+      outPromise = result.current.run()
+    })
+    // Relay accepted with status 'submitted' (no txHash) → honestly PENDING, not confirmed.
+    await waitFor(() => expect(result.current.status).toBe(INTENT_STATUS.PENDING))
+    await waitFor(() => expect(pollResolvers.length).toBe(1))
+
+    // Poll #1 still 'submitted' → stays pending.
+    await act(async () => {
+      pollResolvers[0]({ intentId: 'in_1', status: 'submitted' })
+    })
+    await waitFor(() => expect(pollResolvers.length).toBe(2))
+    expect(result.current.status).toBe(INTENT_STATUS.PENDING)
+
+    // Poll #2 claims 'confirmed' WITHOUT a txHash → must NOT render confirmed.
+    await act(async () => {
+      pollResolvers[1]({ intentId: 'in_1', status: 'confirmed' })
+    })
+    await waitFor(() => expect(pollResolvers.length).toBe(3))
+    expect(result.current.status).toBe(INTENT_STATUS.PENDING)
+
+    // Poll #3 carries the mined txHash → NOW it is confirmed.
+    let out
+    await act(async () => {
+      pollResolvers[2]({ intentId: 'in_1', status: 'confirmed', txHash: '0xmined' })
+      out = await outPromise
+    })
+    expect(result.current.status).toBe(INTENT_STATUS.CONFIRMED)
+    expect(out).toMatchObject({ via: 'relay', intentId: 'in_1', txHash: '0xmined' })
+
+    // Spec-031 entries at submitted → confirmed, in order, honest types.
+    expect(activity.map((e) => e.type)).toEqual(['intent-submitted', 'intent-confirmed'])
+    expect(activity[1].txHash).toBe('0xmined')
+    expect(activity.every((e) => e.domain === 'intents')).toBe(true)
+  })
+
+  it('marks the intent failed (keeping self-submit available) when the gateway reports failure', async () => {
+    const relayer = makeRelayerHandle({
+      relayIntent: vi.fn().mockResolvedValue({ intentId: 'in_2', status: 'submitted' }),
+      pollStatus: vi.fn().mockResolvedValue({ intentId: 'in_2', status: 'failed', reason: 'reverted' }),
+    })
+    h.makeRelayer.mockReturnValue(relayer)
+    const selfSubmit = vi.fn().mockResolvedValue({ hash: '0xretry' })
+    const activity = []
+    const { result } = renderHook(() =>
+      useIntentAction({
+        action: 'acceptWager',
+        chainId: 137,
+        buildIntent: async () => SAMPLE_INTENT,
+        selfSubmit,
+        onActivity: (entry) => activity.push(entry),
+        pollIntervalMs: 0,
+      })
+    )
+
+    await act(async () => {
+      await result.current.run()
+    })
+    expect(result.current.status).toBe(INTENT_STATUS.FAILED)
+    expect(result.current.error.message).toMatch(/reverted/)
+    expect(activity.map((e) => e.type)).toEqual(['intent-submitted', 'intent-failed'])
+
+    // The user can still choose "Pay my own gas" — never stranded.
+    await act(async () => {
+      await result.current.selfSubmitNow()
+    })
+    expect(selfSubmit).toHaveBeenCalled()
+    expect(result.current.status).toBe(INTENT_STATUS.CONFIRMED)
+  })
+
+  it('invalidate() sends invalidateNonce for a signed-but-unsubmitted intent (FR-006)', async () => {
+    const relayer = makeRelayerHandle({
+      relayIntent: vi.fn().mockRejectedValue(Object.assign(new Error('rejected'), { name: 'RelayRejected', code: 'expired' })),
+    })
+    h.makeRelayer.mockReturnValue(relayer)
+    const write = vi.fn().mockResolvedValue({ hash: '0xinv' })
+    const activity = []
+    const { result } = renderHook(() =>
+      useIntentAction({
+        action: 'claimPayout',
+        chainId: 137,
+        buildIntent: async () => SAMPLE_INTENT,
+        selfSubmit: vi.fn(),
+        onActivity: (entry) => activity.push(entry),
+      })
+    )
+
+    // Relay rejected (a validation verdict, not unavailability) → intent stays unsubmitted.
+    await act(async () => {
+      await result.current.run()
+    })
+    expect(result.current.status).toBe(INTENT_STATUS.FAILED)
+
+    await act(async () => {
+      await result.current.invalidate(write)
+    })
+    expect(write).toHaveBeenCalledWith(SAMPLE_INTENT.uniquenessMarker, expect.objectContaining({ uniquenessMarker: SAMPLE_INTENT.uniquenessMarker }))
+    expect(result.current.status).toBe(INTENT_STATUS.INVALIDATED)
+    expect(activity.some((e) => e.type === 'intent-invalidated')).toBe(true)
+
+    // Once invalidated there is nothing left to invalidate.
+    await expect(result.current.invalidate(write)).rejects.toThrow(/no unsubmitted intent/)
+  })
+
+  it('makeIntentActivityEntry produces spec-031-shaped entries', () => {
+    const entry = makeIntentActivityEntry('confirmed', {
+      action: 'purchaseTier',
+      chainId: 80002,
+      intentId: 'in_9',
+      txHash: '0xabc',
+      uniquenessMarker: '0x' + 'bb'.repeat(32),
+      nowMs: 1234,
+    })
+    expect(entry).toMatchObject({
+      id: `intent:0x${'bb'.repeat(32)}:confirmed`,
+      type: 'intent-confirmed',
+      domain: 'intents',
+      refId: '0x' + 'bb'.repeat(32),
+      severity: 'success',
+      actionable: false,
+      createdAt: 1234,
+      read: false,
+      chainId: 80002,
+      intentId: 'in_9',
+      txHash: '0xabc',
+    })
+    expect(typeof entry.message).toBe('string')
+  })
+})

--- a/frontend/src/lib/relay/errors.js
+++ b/frontend/src/lib/relay/errors.js
@@ -1,0 +1,59 @@
+/**
+ * Typed errors for the shared intent-relay client (specs 035 + 036).
+ *
+ * Callers branch on these classes (or their stable `code`) to enforce the never-stranded rule
+ * (spec 035 FR-014, spec 036 FR-016/SC-004): RelayerUnavailable and PaymentUnsupportedOnChain mean
+ * "fall back to self-submit" (identical on-chain result, user pays gas); RelayRejected means the
+ * gateway validated and refused the intent (no funds moved) — surface `code`/`reason` to the user.
+ */
+
+/** Base class so `err instanceof RelayError` catches every relay-client failure. */
+export class RelayError extends Error {
+  constructor(message, { code, cause } = {}) {
+    super(message)
+    this.name = 'RelayError'
+    this.code = code || 'relay_error'
+    if (cause !== undefined) this.cause = cause
+  }
+}
+
+/**
+ * The relayer cannot take the intent right now: unset/unreachable endpoint, timeout, 429 back-pressure
+ * or 503 (kill switch, screening outage, chain down). Never a validation verdict — the same intent may
+ * be self-submitted immediately (spec 036 relay-gateway-api.md 429/503 semantics).
+ */
+export class RelayerUnavailable extends RelayError {
+  constructor(message, { code, status, retryAfterSeconds, cause } = {}) {
+    super(message, { code: code || 'relayer_unavailable', cause })
+    this.name = 'RelayerUnavailable'
+    this.status = status ?? null
+    this.retryAfterSeconds = retryAfterSeconds ?? null
+  }
+}
+
+/**
+ * The gateway rejected the intent (4xx other than 429): invalid_signature, chain_mismatch,
+ * target_not_allowlisted, param_binding_mismatch, expired, not_yet_valid, fee_exceeds_cap,
+ * sanctioned_signer, duplicate_in_flight, … `code` carries the gateway's `error.code` verbatim.
+ */
+export class RelayRejected extends RelayError {
+  constructor(message, { code, status, reason, cause } = {}) {
+    super(message, { code: code || 'relay_rejected', cause })
+    this.name = 'RelayRejected'
+    this.status = status ?? null
+    this.reason = reason || message
+  }
+}
+
+/**
+ * Payment-class intents are impossible on this chain: the configured stablecoin has no EIP-3009
+ * `receiveWithAuthorization` (networks.js `stablecoin.domainVersion === null`, e.g. Mordor/ETC USC).
+ * Thrown BEFORE any wallet signature is requested (FR-020 pre-sign check) — the caller self-submits.
+ */
+export class PaymentUnsupportedOnChain extends RelayError {
+  constructor(message, { chainId, cause } = {}) {
+    super(message, { code: 'payment_unsupported_on_chain', cause })
+    this.name = 'PaymentUnsupportedOnChain'
+    this.chainId = chainId ?? null
+  }
+}

--- a/frontend/src/lib/relay/intentClient.js
+++ b/frontend/src/lib/relay/intentClient.js
@@ -1,0 +1,310 @@
+/**
+ * Shared intent-relay client (specs 035 + 036) — generalizes the dormant spec-034 prototypes
+ * (lib/pools/gasless.js + lib/pools/relayerClient.js) into the one client every gasless flow uses.
+ *
+ * The relayer is GAS INFRASTRUCTURE, not an app backend: when `VITE_RELAYER_URL` is unset,
+ * `makeRelayer()` returns null and every flow self-submits (the safe, zero-footprint default).
+ * The relayer is untrusted — it can censor, never steal: every consequential parameter is inside the
+ * signed EIP-712 struct, and the money leg is a recipient-bound EIP-3009 `receiveWithAuthorization`
+ * stapled to the action via `paymentNonce` (FR-007/FR-013).
+ *
+ * Error contract (see ./errors.js): RelayerUnavailable (429/503/network/timeout — self-submit),
+ * PaymentUnsupportedOnChain (FR-020 pre-sign domain check — self-submit),
+ * RelayRejected (gateway validation verdict — surface `code`/`reason`).
+ */
+import { ethers } from 'ethers'
+import {
+  INTENT_ACTIONS,
+  INTENT_TYPES,
+  RECEIVE_WITH_AUTHORIZATION_TYPES,
+  membershipManagerDomain,
+  stablecoinDomain,
+  wagerRegistryDomain,
+} from './intentTypes'
+import { PaymentUnsupportedOnChain, RelayRejected, RelayerUnavailable } from './errors'
+
+const DEFAULT_VALIDITY_SECONDS = 3600
+const RELAY_TIMEOUT_MS = 15000
+const HEALTH_BUDGET_MS = 2000
+
+/** The configured relay-gateway base URL, or '' when unset. Read at call time so tests can stub the env. */
+export function relayerBaseUrl() {
+  return (import.meta.env.VITE_RELAYER_URL || '').trim().replace(/\/$/, '')
+}
+
+/** A fresh random 32-byte nonce (2-D replay nonce / EIP-3009 nonce / uniquenessMarker). */
+export function randomNonce() {
+  return ethers.hexlify(ethers.randomBytes(32))
+}
+
+/** Serialize a uint-ish value (bigint/number/string) to a JSON-safe decimal string. */
+function toUintString(v) {
+  if (typeof v === 'bigint') return v.toString()
+  if (typeof v === 'number') return Math.trunc(v).toString()
+  return String(v)
+}
+
+/** Shallow-serialize signed params for the gateway body (bigints → decimal strings). */
+function serializeParams(params) {
+  const out = {}
+  for (const [key, value] of Object.entries(params || {})) {
+    out[key] = typeof value === 'bigint' ? value.toString() : value
+  }
+  return out
+}
+
+/** `fetch` with a bounded budget; any transport failure or timeout maps to RelayerUnavailable. */
+async function boundedFetch(url, options, timeoutMs) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(url, { ...options, signal: controller.signal })
+  } catch (e) {
+    throw new RelayerUnavailable(`Relayer unreachable: ${e?.message || e}`, {
+      code: e?.name === 'AbortError' ? 'timeout' : 'network_error',
+      cause: e,
+    })
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/** Best-effort JSON body (the gateway always sends JSON, but never trust a failing proxy). */
+async function readJson(res) {
+  try {
+    return await res.json()
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Sign one intent and build the gateway Intent body (spec 036 relay-gateway-api.md / spec 035
+ * data-model.md "Client-side: Intent"). ONE wallet interaction per leg: the action intent under the
+ * verifying contract's domain, plus — for payment-class actions — an EIP-3009
+ * `ReceiveWithAuthorization` under the stablecoin's own domain, its nonce stapled into the struct's
+ * `paymentNonce` so the relayer cannot pair the action with a different authorization (FR-007).
+ *
+ * FR-020 pre-sign check: payment-class on a chain whose stablecoin has `domainVersion: null` throws
+ * PaymentUnsupportedOnChain BEFORE any wallet prompt — the caller self-submits.
+ *
+ * @param {object} args
+ * @param {import('ethers').Signer} args.signer - wallet signer (must support signTypedData)
+ * @param {number} args.chainId
+ * @param {string} args.action - gateway action name (key of INTENT_ACTIONS)
+ * @param {string} args.targetContract - verifying contract (proxy) address on `chainId`
+ * @param {object} [args.params] - action struct fields EXCEPT the auto-filled actor field,
+ *   paymentNonce, nonce, validAfter, validBefore
+ * @param {{value: bigint|number|string}} [args.payment] - money leg (required for payment-class actions)
+ * @param {number} [args.validAfter=0] - earliest execution (unix seconds)
+ * @param {number} [args.validBefore] - expiry (unix seconds); defaults to now + validitySeconds
+ * @param {number} [args.validitySeconds=3600]
+ * @param {'sponsored'|'fee-netted'} [args.fundingMode='sponsored']
+ * @param {bigint|number|string} [args.maxFee] - bounded fee cap (fee-netted mode)
+ * @param {'wagerRegistry'|'membershipManager'} [args.verifier] - override for actions both contracts
+ *   expose (invalidateNonce); otherwise taken from INTENT_ACTIONS
+ * @param {number} [args.nowSeconds] - injectable clock for tests
+ * @returns {Promise<object>} the gateway Intent body (POST /v1/intents)
+ */
+export async function signIntent({
+  signer,
+  chainId,
+  action,
+  targetContract,
+  params = {},
+  payment,
+  validAfter = 0,
+  validBefore,
+  validitySeconds = DEFAULT_VALIDITY_SECONDS,
+  fundingMode = 'sponsored',
+  maxFee,
+  verifier,
+  nowSeconds,
+}) {
+  const meta = INTENT_ACTIONS[action]
+  if (!meta) throw new Error(`signIntent: unknown intent action '${action}'`)
+  if (!targetContract) throw new Error('signIntent: targetContract is required')
+  if (chainId == null) throw new Error('signIntent: chainId is required')
+
+  const verifierKind = verifier || meta.verifier
+  if (!verifierKind) throw new Error(`signIntent: action '${action}' needs an explicit verifier ('wagerRegistry' | 'membershipManager')`)
+  const domain =
+    verifierKind === 'membershipManager'
+      ? membershipManagerDomain(chainId, targetContract)
+      : wagerRegistryDomain(chainId, targetContract)
+
+  // FR-020: resolve the token domain BEFORE any wallet prompt — throws PaymentUnsupportedOnChain on
+  // chains whose stablecoin lacks EIP-3009 (Mordor/ETC USC), so the flow self-submits with zero
+  // wasted signatures.
+  const tokenDomain = meta.intentClass === 'payment' ? stablecoinDomain(chainId) : null
+
+  const from = await signer.getAddress()
+  const now = nowSeconds != null ? nowSeconds : Math.floor(Date.now() / 1000)
+  const before = validBefore != null ? validBefore : now + validitySeconds
+  const nonce = randomNonce()
+
+  const fields = INTENT_TYPES[meta.primaryType]
+  const hasField = (name) => fields.some((f) => f.name === name)
+
+  // The actor field is ALWAYS the wallet's own address — signer attribution is not caller-spoofable.
+  const message = { ...params, [meta.actorField]: from }
+
+  // Payment leg: sign the token's ReceiveWithAuthorization and staple its nonce into the struct.
+  // ONE marker for the whole payment intent (data-model.md: the uniquenessMarker IS the EIP-3009
+  // nonce): paymentNonce == struct nonce == uniquenessMarker. The registry's replay map and the
+  // token's authorizationState are separate state spaces, so sharing the value is safe — and the
+  // gateway enforces the equality (param_binding_mismatch otherwise).
+  let authorization = null
+  if (meta.intentClass === 'payment') {
+    if (payment == null || payment.value == null) throw new Error(`signIntent: action '${action}' is payment-class and requires payment.value`)
+    const paymentNonce = nonce
+    const authMessage = {
+      from,
+      to: targetContract,
+      value: toUintString(payment.value),
+      validAfter,
+      validBefore: before,
+      nonce: paymentNonce,
+    }
+    const sig = ethers.Signature.from(
+      await signer.signTypedData(tokenDomain, RECEIVE_WITH_AUTHORIZATION_TYPES, authMessage)
+    )
+    authorization = { ...authMessage, validAfter: toUintString(validAfter), validBefore: toUintString(before), v: sig.v, r: sig.r, s: sig.s }
+    if (hasField('paymentNonce')) message.paymentNonce = paymentNonce
+  }
+
+  message.nonce = nonce
+  if (hasField('validAfter')) message.validAfter = validAfter
+  message.validBefore = before
+
+  const signature = await signer.signTypedData(domain, { [meta.primaryType]: fields }, message)
+
+  const intent = {
+    intentClass: meta.intentClass,
+    chainId: Number(chainId),
+    targetContract,
+    action,
+    params: serializeParams(message),
+    signature,
+    validAfter,
+    validBefore: before,
+    uniquenessMarker: nonce,
+    fundingMode,
+  }
+  if (authorization) intent.authorization = authorization
+  if (maxFee != null) intent.maxFee = toUintString(maxFee)
+  return intent
+}
+
+/**
+ * POST the signed intent to the gateway (`POST /v1/intents`).
+ *
+ * @param {object} intent - the body built by signIntent
+ * @param {{baseUrl?: string, timeoutMs?: number}} [opts]
+ * @returns {Promise<{intentId: string, status: string, txHash?: string}>}
+ * @throws {RelayerUnavailable} on unset base URL, network error, timeout, 429 or 503 → self-submit
+ * @throws {RelayRejected} on any other non-2xx (gateway `error.code` preserved)
+ */
+export async function relayIntent(intent, { baseUrl, timeoutMs = RELAY_TIMEOUT_MS } = {}) {
+  const base = baseUrl != null ? baseUrl.replace(/\/$/, '') : relayerBaseUrl()
+  if (!base) throw new RelayerUnavailable('No relayer configured (VITE_RELAYER_URL unset)', { code: 'relayer_unset' })
+
+  const res = await boundedFetch(
+    `${base}/v1/intents`,
+    { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(intent) },
+    timeoutMs
+  )
+  const data = await readJson(res)
+
+  if (res.status === 429 || res.status === 503) {
+    const retryAfter = Number(res.headers?.get?.('Retry-After'))
+    throw new RelayerUnavailable(data?.error?.reason || `Relayer unavailable (HTTP ${res.status})`, {
+      code: data?.error?.code || (res.status === 429 ? 'backpressure' : 'unavailable'),
+      status: res.status,
+      retryAfterSeconds: Number.isFinite(retryAfter) ? retryAfter : null,
+    })
+  }
+  if (!res.ok) {
+    throw new RelayRejected(data?.error?.reason || `Relay rejected (HTTP ${res.status})`, {
+      code: data?.error?.code,
+      status: res.status,
+      reason: data?.error?.reason,
+    })
+  }
+  if (!data || typeof data.intentId !== 'string') {
+    throw new RelayerUnavailable('Relayer returned no intentId', { code: 'bad_response', status: res.status })
+  }
+  return { intentId: data.intentId, status: data.status, ...(data.txHash ? { txHash: data.txHash } : {}) }
+}
+
+/**
+ * Fetch relay status for an accepted intent (`GET /v1/intents/{id}`) — drives the honest status UI
+ * (`queued | submitted | confirmed | rejected | failed`; `confirmed` always carries `txHash`).
+ *
+ * @param {string} intentId
+ * @param {{baseUrl?: string, timeoutMs?: number}} [opts]
+ * @returns {Promise<{intentId: string, status: string, txHash?: string, reason?: string}>}
+ */
+export async function pollStatus(intentId, { baseUrl, timeoutMs = RELAY_TIMEOUT_MS } = {}) {
+  const base = baseUrl != null ? baseUrl.replace(/\/$/, '') : relayerBaseUrl()
+  if (!base) throw new RelayerUnavailable('No relayer configured (VITE_RELAYER_URL unset)', { code: 'relayer_unset' })
+
+  const res = await boundedFetch(`${base}/v1/intents/${encodeURIComponent(intentId)}`, { method: 'GET' }, timeoutMs)
+  const data = await readJson(res)
+  if (!res.ok || !data) {
+    throw new RelayerUnavailable(`Relayer status check failed (HTTP ${res.status})`, {
+      code: data?.error?.code || 'status_unavailable',
+      status: res.status,
+    })
+  }
+  return data
+}
+
+/**
+ * Probe `GET /healthz` within a bounded (~2s) budget. Returns true only when the gateway reports
+ * `status: 'ok'`, the kill switch is off, and — when the response itemizes chains — `chainId`'s RPC
+ * is up. Any failure, timeout, or unset relayer returns false (never throws): a failed probe routes
+ * the flow to self-submit BEFORE the user signs (FR-016).
+ *
+ * @param {number} chainId
+ * @param {{baseUrl?: string, budgetMs?: number}} [opts]
+ * @returns {Promise<boolean>}
+ */
+export async function probeHealth(chainId, { baseUrl, budgetMs = HEALTH_BUDGET_MS } = {}) {
+  const base = baseUrl != null ? baseUrl.replace(/\/$/, '') : relayerBaseUrl()
+  if (!base) return false
+  try {
+    const res = await boundedFetch(`${base}/healthz`, { method: 'GET' }, budgetMs)
+    if (!res.ok) return false
+    const data = await readJson(res)
+    if (!data || data.status !== 'ok' || data.killSwitch === true) return false
+    if (chainId != null && data.chains && data.chains[String(chainId)]) {
+      return data.chains[String(chainId)].rpc === 'up'
+    }
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Build a relayer handle bound to `chainId`, or null when gasless is disabled — the null return IS
+ * the never-stranded switch: every caller treats it as "self-submit" (spec 036 frontend-relay-client.md).
+ *
+ * @param {number} chainId
+ * @returns {null | {chainId: number, baseUrl: string,
+ *   relayIntent: (intent: object, opts?: object) => Promise<object>,
+ *   pollStatus: (intentId: string, opts?: object) => Promise<object>,
+ *   probeHealth: (opts?: object) => Promise<boolean>}}
+ */
+export function makeRelayer(chainId) {
+  const base = relayerBaseUrl()
+  if (!base) return null // gasless disabled → every flow self-submits (safe default)
+  return {
+    chainId: chainId != null ? Number(chainId) : null,
+    baseUrl: base,
+    relayIntent: (intent, opts = {}) => relayIntent(intent, { baseUrl: base, ...opts }),
+    pollStatus: (intentId, opts = {}) => pollStatus(intentId, { baseUrl: base, ...opts }),
+    probeHealth: (opts = {}) => probeHealth(chainId, { baseUrl: base, ...opts }),
+  }
+}

--- a/frontend/src/lib/relay/intentTypes.js
+++ b/frontend/src/lib/relay/intentTypes.js
@@ -1,0 +1,194 @@
+/**
+ * EIP-712 typed-data definitions for intent-based signatures (spec 035).
+ *
+ * One struct per action, mirroring specs/035-intent-based-payments/contracts/intent-eip712-schemas.md
+ * (CreateWagerIntent uses the complete field list from research.md §A3 — the schemas doc elides the
+ * middle fields with "…"). Every struct carries the common trailing fields
+ * `nonce / validAfter / validBefore` plus an actor address field that MUST equal the recovered signer;
+ * money-in structs additionally staple `paymentNonce` (== the EIP-3009 authorization nonce, FR-007).
+ *
+ * Domains are PER CONTRACT (name + version + chainId + verifyingContract) so a signature is valid only
+ * on the network and contract it was signed for (FR-005/FR-021). The payment leg is signed under the
+ * STABLECOIN's own domain (native Circle USDC version '2', bridged USDC.e '1'), driven by
+ * `stablecoin.domainVersion` in config/networks.js — null means the token lacks EIP-3009 and
+ * payment-class intents are unavailable on that chain (FR-020, e.g. Mordor/ETC USC).
+ */
+import { NETWORKS } from '../../config/networks'
+import { RECEIVE_WITH_AUTHORIZATION_TYPES } from '../pools/gasless'
+import { PaymentUnsupportedOnChain } from './errors'
+
+// Re-exported so relay callers need only this module for both signature legs (shape reused verbatim
+// from the spec-034 prototype in lib/pools/gasless.js — the token-side EIP-3009 struct is unchanged).
+export { RECEIVE_WITH_AUTHORIZATION_TYPES }
+
+/** Common trailing fields shared by every intent struct (schema: "Common trailing fields"). */
+const TRAILING = [
+  { name: 'nonce', type: 'bytes32' },
+  { name: 'validAfter', type: 'uint256' },
+  { name: 'validBefore', type: 'uint256' },
+]
+
+/** `{ wagerId, actor }` shape shared by most no-stake wager intents. */
+const WAGER_ACTOR = [
+  { name: 'wagerId', type: 'uint256' },
+  { name: 'actor', type: 'address' },
+]
+
+/**
+ * EIP-712 struct field lists, keyed by primary type. Pass as
+ * `{ [primaryType]: INTENT_TYPES[primaryType] }` to `signer.signTypedData` (no nested custom types).
+ */
+export const INTENT_TYPES = {
+  CreateWagerIntent: [
+    { name: 'creator', type: 'address' },
+    { name: 'opponent', type: 'address' },
+    { name: 'arbitrator', type: 'address' },
+    { name: 'token', type: 'address' },
+    { name: 'creatorStake', type: 'uint128' },
+    { name: 'opponentStake', type: 'uint128' },
+    { name: 'acceptDeadline', type: 'uint64' },
+    { name: 'resolveDeadline', type: 'uint64' },
+    { name: 'resolutionType', type: 'uint8' },
+    { name: 'conditionId', type: 'bytes32' },
+    { name: 'creatorIsYes', type: 'bool' },
+    { name: 'metadataHash', type: 'bytes32' },
+    { name: 'metadataUri', type: 'string' },
+    { name: 'termsVersionHash', type: 'bytes32' },
+    { name: 'paymentNonce', type: 'bytes32' },
+    ...TRAILING,
+  ],
+  AcceptWagerIntent: [
+    { name: 'wagerId', type: 'uint256' },
+    { name: 'taker', type: 'address' },
+    { name: 'paymentNonce', type: 'bytes32' },
+    ...TRAILING,
+  ],
+  ClaimPayoutIntent: [
+    { name: 'wagerId', type: 'uint256' },
+    { name: 'claimant', type: 'address' },
+    ...TRAILING,
+  ],
+  ClaimRefundIntent: [...WAGER_ACTOR, ...TRAILING],
+  DeclareDrawIntent: [...WAGER_ACTOR, ...TRAILING],
+  RevokeDrawIntent: [...WAGER_ACTOR, ...TRAILING],
+  CancelOpenIntent: [...WAGER_ACTOR, ...TRAILING],
+  DeclineIntent: [...WAGER_ACTOR, ...TRAILING],
+  DeclareWinnerIntent: [
+    { name: 'wagerId', type: 'uint256' },
+    { name: 'winner', type: 'address' },
+    { name: 'actor', type: 'address' },
+    ...TRAILING,
+  ],
+  PurchaseTierIntent: [
+    { name: 'role', type: 'bytes32' },
+    { name: 'tier', type: 'uint8' },
+    { name: 'acceptedTermsHash', type: 'bytes32' },
+    { name: 'member', type: 'address' },
+    { name: 'paymentNonce', type: 'bytes32' },
+    ...TRAILING,
+  ],
+  UpgradeTierIntent: [
+    { name: 'role', type: 'bytes32' },
+    { name: 'tier', type: 'uint8' },
+    { name: 'acceptedTermsHash', type: 'bytes32' },
+    { name: 'member', type: 'address' },
+    { name: 'paymentNonce', type: 'bytes32' },
+    ...TRAILING,
+  ],
+  ExtendMembershipIntent: [
+    { name: 'role', type: 'bytes32' },
+    { name: 'member', type: 'address' },
+    { name: 'paymentNonce', type: 'bytes32' },
+    ...TRAILING,
+  ],
+  RedeemVoucherIntent: [
+    { name: 'voucherId', type: 'uint256' },
+    { name: 'acceptedTermsHash', type: 'bytes32' },
+    { name: 'redeemer', type: 'address' },
+    ...TRAILING,
+  ],
+  // Gasless cancel of an unsubmitted intent (invalidateNonceWithSig, FR-006) — no validAfter: the
+  // cancel should be executable immediately, bounded only by validBefore.
+  InvalidateNonce: [
+    { name: 'signer', type: 'address' },
+    { name: 'nonce', type: 'bytes32' },
+    { name: 'validBefore', type: 'uint256' },
+  ],
+}
+
+/**
+ * Gateway `action` → typed-data + routing metadata:
+ *   primaryType  — key into INTENT_TYPES
+ *   verifier     — which FairWins EIP-712 domain verifies the intent ('wagerRegistry' | 'membershipManager';
+ *                  null = both contracts expose it, caller picks via signIntent's `verifier` option)
+ *   intentClass  — gateway Intent class ('payment' carries an EIP-3009 authorization; else 'signer-attributed')
+ *   actorField   — struct field that MUST equal the recovered signer (auto-filled by signIntent)
+ */
+export const INTENT_ACTIONS = {
+  createWager: { primaryType: 'CreateWagerIntent', verifier: 'wagerRegistry', intentClass: 'payment', actorField: 'creator' },
+  acceptWager: { primaryType: 'AcceptWagerIntent', verifier: 'wagerRegistry', intentClass: 'payment', actorField: 'taker' },
+  // Open-challenge accept: same AcceptWagerIntent, plus the separate claim-code proof signature
+  // (rebound to taker = signer) carried in params by the call site (schema §"Open-challenge accept").
+  acceptOpenWager: { primaryType: 'AcceptWagerIntent', verifier: 'wagerRegistry', intentClass: 'payment', actorField: 'taker' },
+  claimPayout: { primaryType: 'ClaimPayoutIntent', verifier: 'wagerRegistry', intentClass: 'signer-attributed', actorField: 'claimant' },
+  claimRefund: { primaryType: 'ClaimRefundIntent', verifier: 'wagerRegistry', intentClass: 'signer-attributed', actorField: 'actor' },
+  declareDraw: { primaryType: 'DeclareDrawIntent', verifier: 'wagerRegistry', intentClass: 'signer-attributed', actorField: 'actor' },
+  revokeDraw: { primaryType: 'RevokeDrawIntent', verifier: 'wagerRegistry', intentClass: 'signer-attributed', actorField: 'actor' },
+  cancelOpen: { primaryType: 'CancelOpenIntent', verifier: 'wagerRegistry', intentClass: 'signer-attributed', actorField: 'actor' },
+  declineWager: { primaryType: 'DeclineIntent', verifier: 'wagerRegistry', intentClass: 'signer-attributed', actorField: 'actor' },
+  declareWinner: { primaryType: 'DeclareWinnerIntent', verifier: 'wagerRegistry', intentClass: 'signer-attributed', actorField: 'actor' },
+  purchaseTier: { primaryType: 'PurchaseTierIntent', verifier: 'membershipManager', intentClass: 'payment', actorField: 'member' },
+  upgradeTier: { primaryType: 'UpgradeTierIntent', verifier: 'membershipManager', intentClass: 'payment', actorField: 'member' },
+  extendMembership: { primaryType: 'ExtendMembershipIntent', verifier: 'membershipManager', intentClass: 'payment', actorField: 'member' },
+  redeemVoucher: { primaryType: 'RedeemVoucherIntent', verifier: 'membershipManager', intentClass: 'signer-attributed', actorField: 'redeemer' },
+  invalidateNonce: { primaryType: 'InvalidateNonce', verifier: null, intentClass: 'signer-attributed', actorField: 'signer' },
+}
+
+/**
+ * EIP-712 domain for WagerRegistry intents (existing domain, WagerRegistry.sol — unchanged by the
+ * spec-035 upgrade so already-deployed verifier state stays valid).
+ * @param {number} chainId
+ * @param {string} verifyingContract - the wagerRegistry PROXY address for this chain
+ */
+export function wagerRegistryDomain(chainId, verifyingContract) {
+  return { name: 'FairWins WagerRegistry', version: '1', chainId: Number(chainId), verifyingContract }
+}
+
+/**
+ * EIP-712 domain for MembershipManager intents (added by the spec-035 upgrade via reinitializer(2)).
+ * @param {number} chainId
+ * @param {string} verifyingContract - the membershipManager PROXY address for this chain
+ */
+export function membershipManagerDomain(chainId, verifyingContract) {
+  return { name: 'FairWins MembershipManager', version: '1', chainId: Number(chainId), verifyingContract }
+}
+
+/**
+ * EIP-712 domain for the payment leg — the STABLECOIN's own domain, built from config/networks.js
+ * (`stablecoin.domainVersion`: native Circle USDC '2', bridged USDC.e '1'). This is the FR-020
+ * pre-sign check: a chain whose token lacks EIP-3009 (`domainVersion: null`, e.g. Mordor/ETC USC)
+ * throws PaymentUnsupportedOnChain BEFORE any wallet prompt, so the caller self-submits.
+ *
+ * Strict per-chain lookup (no default-network fallback) — a wrong-domain signature would burn the
+ * user's prompt on an authorization no token accepts.
+ *
+ * @param {number} chainId
+ * @returns {{name: string, version: string, chainId: number, verifyingContract: string}}
+ * @throws {PaymentUnsupportedOnChain} when the chain has no EIP-3009 stablecoin configured
+ */
+export function stablecoinDomain(chainId) {
+  const stablecoin = NETWORKS[chainId]?.stablecoin
+  if (!stablecoin || stablecoin.domainVersion == null) {
+    const symbol = stablecoin?.symbol || 'stablecoin'
+    throw new PaymentUnsupportedOnChain(
+      `Gasless payments are not available on chain ${chainId}: ${symbol} does not support EIP-3009 receiveWithAuthorization. Submit the transaction yourself (you pay gas).`,
+      { chainId: Number(chainId) }
+    )
+  }
+  return {
+    name: stablecoin.name,
+    version: stablecoin.domainVersion,
+    chainId: Number(chainId),
+    verifyingContract: stablecoin.address,
+  }
+}

--- a/frontend/src/lib/relay/useIntentAction.js
+++ b/frontend/src/lib/relay/useIntentAction.js
@@ -1,0 +1,318 @@
+/**
+ * useIntentAction — the enforcement point for the never-stranded rule (spec 035 FR-014, spec 036
+ * FR-016/SC-004). Wraps one action's gasless path (probe → sign → relay → poll) and TRANSPARENTLY
+ * falls back to the caller's self-submit path (identical on-chain result, user pays gas) whenever the
+ * relayer is unset, unhealthy, unavailable (429/503/network/timeout), or the chain cannot carry a
+ * payment-class intent (PaymentUnsupportedOnChain, FR-020). `selfSubmit` is therefore MANDATORY — the
+ * hook throws at wiring time if it is missing, so no call site can ship a gasless-only dead end.
+ *
+ * Honest status (FR-018/SC-007): the machine is
+ *   idle → signing → signed → submitting → pending → confirmed | failed | expired | invalidated
+ * plus the fallback leg `self-submitting → confirmed | self-submitted`. 'confirmed' is NEVER set
+ * before a txHash-bearing confirmed relay status or a mined self-submit receipt.
+ *
+ * Activity (spec 031): the provider's feed is poll-sourced with no push API, so lifecycle entries are
+ * emitted through the pluggable `onActivity(entry)` callback using the spec-031 ActivityEntry shape
+ * (`type ∈ intent-submitted|intent-confirmed|intent-failed|intent-expired|intent-invalidated`,
+ * `domain: 'intents'`) — wire it to an ActivitySource aux buffer or a toast, as the call site prefers.
+ */
+import { useCallback, useRef, useState } from 'react'
+import { makeRelayer } from './intentClient'
+import { PaymentUnsupportedOnChain, RelayerUnavailable } from './errors'
+
+/** Client lifecycle states (spec 035 data-model.md "Intent Status"). */
+export const INTENT_STATUS = {
+  IDLE: 'idle',
+  SIGNING: 'signing',
+  SIGNED: 'signed',
+  SUBMITTING: 'submitting',
+  PENDING: 'pending',
+  CONFIRMED: 'confirmed',
+  FAILED: 'failed',
+  EXPIRED: 'expired',
+  INVALIDATED: 'invalidated',
+  SELF_SUBMITTING: 'self-submitting',
+  SELF_SUBMITTED: 'self-submitted',
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 4000
+const DEFAULT_MAX_POLL_MS = 180000
+
+const ENTRY_SEVERITY = { confirmed: 'success', failed: 'error', expired: 'warning', invalidated: 'info', submitted: 'info' }
+
+/**
+ * Build a spec-031 ActivityEntry for an intent lifecycle transition (store-schema.md shape:
+ * id/type/message/severity/actionable/createdAt/read + domain/refId).
+ * @param {'submitted'|'confirmed'|'failed'|'expired'|'invalidated'} kind
+ * @param {{action: string, chainId?: number, intentId?: string, txHash?: string,
+ *   uniquenessMarker?: string, message?: string, nowMs?: number}} detail
+ * @returns {object} ActivityEntry
+ */
+export function makeIntentActivityEntry(kind, { action, chainId, intentId, txHash, uniquenessMarker, message, nowMs } = {}) {
+  const createdAt = nowMs != null ? nowMs : Date.now()
+  const refId = uniquenessMarker || intentId || `${action}:${createdAt}`
+  const defaultMessages = {
+    submitted: `Gasless ${action} submitted — waiting for on-chain confirmation`,
+    confirmed: `Gasless ${action} confirmed on-chain`,
+    failed: `Gasless ${action} failed`,
+    expired: `Gasless ${action} expired before execution`,
+    invalidated: `Gasless ${action} invalidated — it can never execute`,
+  }
+  return {
+    id: `intent:${refId}:${kind}`,
+    type: `intent-${kind}`,
+    domain: 'intents',
+    refId,
+    message: message || defaultMessages[kind] || `Gasless ${action}: ${kind}`,
+    severity: ENTRY_SEVERITY[kind] || 'info',
+    actionable: false,
+    createdAt,
+    read: false,
+    action,
+    ...(chainId != null ? { chainId } : {}),
+    ...(intentId ? { intentId } : {}),
+    ...(txHash ? { txHash } : {}),
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/** Extract a tx hash from whatever the caller's selfSubmit resolves to (receipt, tx, or raw hash). */
+function txHashOf(receipt) {
+  if (!receipt) return null
+  if (typeof receipt === 'string') return receipt
+  return receipt.hash || receipt.transactionHash || receipt.txHash || null
+}
+
+/**
+ * @param {object} args
+ * @param {string} args.action - gateway action name (documents the flow; stamped on activity entries)
+ * @param {number} [args.chainId] - active chain (relayer + activity scoping)
+ * @param {(...runArgs) => Promise<object>} args.buildIntent - signs and returns the gateway Intent
+ *   body (typically a thin wrapper around intentClient.signIntent). May throw
+ *   PaymentUnsupportedOnChain to route to self-submit (FR-020).
+ * @param {(...runArgs) => Promise<object|string>} args.selfSubmit - MANDATORY fallback: submits the
+ *   equivalent transaction from the user's own wallet and resolves with the MINED receipt (or its
+ *   hash). Missing ⇒ the hook throws (never-stranded).
+ * @param {(nonce: string, intent: object) => Promise<any>} [args.invalidateNonce] - default contract
+ *   write for invalidate() (e.g. `(nonce) => registry.invalidateNonce(nonce)`)
+ * @param {(entry: object) => void} [args.onActivity] - receives spec-031 ActivityEntry objects at
+ *   submitted/confirmed/failed/expired/invalidated transitions
+ * @param {number} [args.pollIntervalMs=4000]
+ * @param {number} [args.maxPollMs=180000] - polling budget; past it the intent stays 'pending'
+ *   (honest — the relayer may still land it) unless its validBefore has passed ('expired')
+ * @returns {{status: string, intent: object|null, result: object|null, error: Error|null,
+ *   run: (...args) => Promise<object>, invalidate: (write?: Function) => Promise<void>,
+ *   selfSubmitNow: (...args) => Promise<object>, reset: () => void}}
+ */
+export function useIntentAction({
+  action,
+  chainId,
+  buildIntent,
+  selfSubmit,
+  invalidateNonce,
+  onActivity,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+  maxPollMs = DEFAULT_MAX_POLL_MS,
+}) {
+  // Never-stranded rule: refuse to wire a gasless flow with no self-submit twin (FR-014).
+  if (typeof selfSubmit !== 'function') {
+    throw new Error(`useIntentAction(${action || 'unknown'}): selfSubmit is required — every gasless flow must have a self-submit fallback (never-stranded rule)`)
+  }
+  if (typeof buildIntent !== 'function') {
+    throw new Error(`useIntentAction(${action || 'unknown'}): buildIntent is required`)
+  }
+
+  const [status, setStatus] = useState(INTENT_STATUS.IDLE)
+  const [intent, setIntent] = useState(null)
+  const [result, setResult] = useState(null)
+  const [error, setError] = useState(null)
+  // The signed-but-not-yet-relayed intent, kept transient-only (data-model.md: a signed intent lives
+  // only in transient state with Invalidate + Self-submit actions). Cleared on confirm/invalidate.
+  const unsubmittedRef = useRef(null)
+
+  const emit = useCallback(
+    (kind, detail = {}) => {
+      if (typeof onActivity !== 'function') return
+      try {
+        onActivity(makeIntentActivityEntry(kind, { action, chainId, ...detail }))
+      } catch (e) {
+        console.warn('[useIntentAction] onActivity callback failed:', e?.message || e)
+      }
+    },
+    [onActivity, action, chainId]
+  )
+
+  /** Self-submit leg: only a mined, hash-bearing receipt may show 'confirmed'. */
+  const runSelfSubmit = useCallback(
+    async (reason, runArgs) => {
+      setStatus(INTENT_STATUS.SELF_SUBMITTING)
+      try {
+        const receipt = await selfSubmit(...runArgs)
+        const txHash = txHashOf(receipt)
+        unsubmittedRef.current = null
+        const res = { via: 'self-submit', reason, txHash }
+        setResult(res)
+        if (txHash) {
+          // A resolved wallet call with a receipt hash = mined → honest 'confirmed'.
+          setStatus(INTENT_STATUS.CONFIRMED)
+          emit('confirmed', { txHash, message: `${action} confirmed on-chain (self-submitted)` })
+        } else {
+          // No receipt to verify inclusion with — never claim 'confirmed' (FR-018/SC-007).
+          setStatus(INTENT_STATUS.SELF_SUBMITTED)
+        }
+        return res
+      } catch (e) {
+        setStatus(INTENT_STATUS.FAILED)
+        setError(e)
+        emit('failed', { message: `${action} failed: ${e?.message || e}` })
+        return { via: 'self-submit', reason, error: e }
+      }
+    },
+    [selfSubmit, emit, action]
+  )
+
+  /**
+   * Execute the action: probe → sign → relay → poll, self-submitting on any availability gap.
+   * Arguments are forwarded verbatim to buildIntent and (on fallback) selfSubmit.
+   */
+  const run = useCallback(
+    async (...runArgs) => {
+      setError(null)
+      setResult(null)
+      setIntent(null)
+
+      // Relayer unset → gasless disabled → self-submit (the dormant-safe default).
+      const relayer = makeRelayer(chainId)
+      if (!relayer) return runSelfSubmit('relayer-unset', runArgs)
+
+      // Failed health probe routes to self-submit BEFORE the user signs (FR-016).
+      const healthy = await relayer.probeHealth()
+      if (!healthy) return runSelfSubmit('relayer-unhealthy', runArgs)
+
+      setStatus(INTENT_STATUS.SIGNING)
+      let signed
+      try {
+        signed = await buildIntent(...runArgs)
+      } catch (e) {
+        if (e instanceof PaymentUnsupportedOnChain || e?.code === 'payment_unsupported_on_chain') {
+          return runSelfSubmit('payment-unsupported', runArgs)
+        }
+        setStatus(INTENT_STATUS.FAILED)
+        setError(e)
+        return { via: 'relay', error: e }
+      }
+      unsubmittedRef.current = signed
+      setIntent(signed)
+      setStatus(INTENT_STATUS.SIGNED)
+
+      setStatus(INTENT_STATUS.SUBMITTING)
+      let accepted
+      try {
+        accepted = await relayer.relayIntent(signed)
+      } catch (e) {
+        if (e instanceof RelayerUnavailable) return runSelfSubmit(e.code || 'relayer-unavailable', runArgs)
+        if (e instanceof PaymentUnsupportedOnChain || e?.code === 'payment_unsupported_on_chain') {
+          return runSelfSubmit('payment-unsupported', runArgs)
+        }
+        // A validation verdict (RelayRejected): the intent stays unsubmitted — Invalidate and
+        // self-submit remain available to the caller.
+        setStatus(INTENT_STATUS.FAILED)
+        setError(e)
+        emit('failed', { uniquenessMarker: signed.uniquenessMarker, message: `${action} rejected by relayer: ${e?.reason || e?.message}` })
+        return { via: 'relay', error: e }
+      }
+
+      emit('submitted', { intentId: accepted.intentId, uniquenessMarker: signed.uniquenessMarker })
+
+      // Only a txHash-bearing 'confirmed' may render as confirmed (FR-018/SC-007).
+      if (accepted.status === 'confirmed' && accepted.txHash) {
+        unsubmittedRef.current = null
+        const res = { via: 'relay', intentId: accepted.intentId, txHash: accepted.txHash }
+        setResult(res)
+        setStatus(INTENT_STATUS.CONFIRMED)
+        emit('confirmed', { intentId: accepted.intentId, txHash: accepted.txHash, uniquenessMarker: signed.uniquenessMarker })
+        return res
+      }
+
+      setStatus(INTENT_STATUS.PENDING)
+      const deadline = Date.now() + maxPollMs
+      let last = accepted
+      while (Date.now() <= deadline) {
+        try {
+          last = await relayer.pollStatus(accepted.intentId)
+        } catch {
+          last = null // transient status-check failure — keep polling within the budget
+        }
+        if (last && last.status === 'confirmed' && last.txHash) {
+          unsubmittedRef.current = null
+          const res = { via: 'relay', intentId: accepted.intentId, txHash: last.txHash }
+          setResult(res)
+          setStatus(INTENT_STATUS.CONFIRMED)
+          emit('confirmed', { intentId: accepted.intentId, txHash: last.txHash, uniquenessMarker: signed.uniquenessMarker })
+          return res
+        }
+        if (last && (last.status === 'failed' || last.status === 'rejected')) {
+          const e = new Error(last.reason || `Relayed ${action} ${last.status}`)
+          setStatus(INTENT_STATUS.FAILED)
+          setError(e)
+          emit('failed', { intentId: accepted.intentId, uniquenessMarker: signed.uniquenessMarker, message: e.message })
+          return { via: 'relay', intentId: accepted.intentId, error: e }
+        }
+        if (signed.validBefore && Date.now() / 1000 > Number(signed.validBefore)) {
+          setStatus(INTENT_STATUS.EXPIRED)
+          emit('expired', { intentId: accepted.intentId, uniquenessMarker: signed.uniquenessMarker })
+          return { via: 'relay', intentId: accepted.intentId, status: 'expired' }
+        }
+        await sleep(pollIntervalMs)
+      }
+      // Poll budget exhausted without a terminal status: stay honestly 'pending' unless expired.
+      if (signed.validBefore && Date.now() / 1000 > Number(signed.validBefore)) {
+        setStatus(INTENT_STATUS.EXPIRED)
+        emit('expired', { intentId: accepted.intentId, uniquenessMarker: signed.uniquenessMarker })
+        return { via: 'relay', intentId: accepted.intentId, status: 'expired' }
+      }
+      return { via: 'relay', intentId: accepted.intentId, status: 'pending' }
+    },
+    [chainId, buildIntent, runSelfSubmit, emit, action, pollIntervalMs, maxPollMs]
+  )
+
+  /**
+   * Invalidate the signed-but-unsubmitted intent (FR-006): sends `invalidateNonce(nonce)` (or the
+   * token's `cancelAuthorization` — supply it as `write`) so the intent can never execute.
+   * @param {(nonce: string, intent: object) => Promise<any>} [write] - overrides the hook-level
+   *   invalidateNonce contract write for this call (self-invalidation, user pays gas)
+   */
+  const invalidate = useCallback(
+    async (write) => {
+      const pending = unsubmittedRef.current
+      if (!pending) throw new Error('useIntentAction.invalidate: no unsubmitted intent to invalidate')
+      const writeFn = typeof write === 'function' ? write : invalidateNonce
+      if (typeof writeFn !== 'function') {
+        throw new Error('useIntentAction.invalidate: a contract write function is required (pass one or configure invalidateNonce)')
+      }
+      await writeFn(pending.uniquenessMarker, pending)
+      unsubmittedRef.current = null
+      setStatus(INTENT_STATUS.INVALIDATED)
+      emit('invalidated', { uniquenessMarker: pending.uniquenessMarker })
+    },
+    [invalidateNonce, emit]
+  )
+
+  /** Explicit user-chosen "Pay my own gas" escape hatch (e.g. from a signed/failed state). */
+  const selfSubmitNow = useCallback((...runArgs) => runSelfSubmit('user-choice', runArgs), [runSelfSubmit])
+
+  const reset = useCallback(() => {
+    unsubmittedRef.current = null
+    setStatus(INTENT_STATUS.IDLE)
+    setIntent(null)
+    setResult(null)
+    setError(null)
+  }, [])
+
+  return { status, intent, result, error, run, invalidate, selfSubmitNow, reset }
+}
+
+export default useIntentAction

--- a/scripts/deploy/check-storage-layout.js
+++ b/scripts/deploy/check-storage-layout.js
@@ -44,8 +44,31 @@ function loadDeployedImpl(deploymentsKey) {
   return null;
 }
 
+// Facet pairs sharing ONE proxy's storage (spec 035): the extension facet is delegatecalled from the
+// main facet's fallback, so its storage layout MUST be compatible with the main implementation's.
+// Validated by treating the facet as if it were an upgrade of the main implementation.
+const FACET_PAIRS = [
+  { main: "WagerRegistry", facet: "WagerRegistryIntents" },
+];
+
 async function main() {
   let failed = false;
+  for (const { main: mainName, facet: facetName } of FACET_PAIRS) {
+    try {
+      const MainFactory = await ethers.getContractFactory(mainName);
+      const FacetFactory = await ethers.getContractFactory(facetName);
+      // Main → facet: every sequential slot the main facet defines must line up in the extension
+      // (both inherit the same storage core; this catches any drift). The reverse direction is NOT
+      // validated: the extension additionally carries SignerIntentBase's ERC-7201 namespace, which
+      // the main facet legitimately does not declare — that namespace lives at a fixed
+      // keccak-derived slot that can never collide with sequential/gap slots.
+      await upgrades.validateUpgrade(MainFactory, FacetFactory, { kind: "uups" });
+      console.log(`✓ ${mainName} → ${facetName}: facet storage layouts are consistent`);
+    } catch (e) {
+      failed = true;
+      console.error(`✗ ${mainName} ⇄ ${facetName}: ${e.message}`);
+    }
+  }
   for (const { name, deploymentsKey } of UPGRADEABLE_CONTRACTS) {
     const Factory = await ethers.getContractFactory(name);
     const deployedImpl = loadDeployedImpl(deploymentsKey);

--- a/scripts/deploy/upgrade-gasless-intents.js
+++ b/scripts/deploy/upgrade-gasless-intents.js
@@ -1,0 +1,94 @@
+/**
+ * Spec 035 (gasless intents): upgrade the two live UUPS proxies IN PLACE and wire the intents facet.
+ *
+ *   1. WagerRegistry proxy → new implementation (actor-threaded internals + fallback→extension;
+ *      append-only storage: fee scalars + intentExtension, __gap 48→45). No reinitializer — the
+ *      EIP-712 domain was already set by the feature-024 upgrade.
+ *   2. Deploy the WagerRegistryIntents extension facet and point the proxy at it via
+ *      setIntentExtension (UPGRADER_ROLE — same authority as the upgrade itself).
+ *   3. MembershipManager proxy → new implementation (signer-attributed twins inline; append-only
+ *      storage: fee scalars, __gap 49→47), running `initializeIntents` (reinitializer(2)) during
+ *      the upgrade to set the "FairWins MembershipManager" EIP-712 domain.
+ *
+ *   GAS_PRICE_WEI=... npx hardhat run scripts/deploy/upgrade-gasless-intents.js --network <amoy|mordor|...>
+ *
+ * Storage safety: `npm run check:storage-layout` MUST be green first (CI-gating); upgradeProxy
+ * re-validates append-only compatibility against the deployed impl before anything goes on-chain.
+ * Requires the deployer to hold UPGRADER_ROLE on both proxies (floppy admin / .env fallback).
+ * Then: npm run sync:frontend-contracts:<net>, and optionally scripts/operations/set-fee-netting.js.
+ */
+const hre = require("hardhat");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+
+const { saveDeployment, getDeploymentFilename } = require("./lib/helpers");
+const { upgradeProxy } = require("./lib/upgradeable");
+
+async function main() {
+  const network = await ethers.provider.getNetwork();
+  const networkName = hre.network.name;
+  const [deployer] = await ethers.getSigners();
+  console.log(`Gasless-intents upgrade on ${networkName} (chainId ${Number(network.chainId)}) — deployer ${deployer.address}`);
+
+  const filename = getDeploymentFilename(network, "v2");
+  const filepath = path.join(process.cwd(), "deployments", filename);
+  if (!fs.existsSync(filepath)) throw new Error(`No deployment record at deployments/${filename}`);
+  const record = JSON.parse(fs.readFileSync(filepath, "utf8"));
+  const c = record.contracts || {};
+  if (!c.wagerRegistry || !ethers.isAddress(c.wagerRegistry)) {
+    throw new Error(`No wagerRegistry proxy in deployments/${filename} — this network is pre-UUPS (spec 025 migration required first).`);
+  }
+  if (!c.membershipManager || !ethers.isAddress(c.membershipManager)) {
+    throw new Error(`No membershipManager proxy in deployments/${filename} — spec 027 migration required first.`);
+  }
+
+  // 1) WagerRegistry: in-place upgrade (validates append-only storage against the deployed impl).
+  console.log(`\nUpgrading WagerRegistry proxy ${c.wagerRegistry}...`);
+  const regUpgrade = await upgradeProxy({ name: "WagerRegistry", proxyAddress: c.wagerRegistry });
+  c.wagerRegistryImpl = regUpgrade.implementation;
+
+  // 2) Deploy + wire the intents extension facet (twins + relocated batchExpireOpen/autoResolve*).
+  console.log("\nDeploying WagerRegistryIntents extension facet...");
+  const IntentsFactory = await ethers.getContractFactory("WagerRegistryIntents");
+  const intents = await IntentsFactory.deploy();
+  await intents.waitForDeployment();
+  const intentsAddress = await intents.getAddress();
+  console.log(`  ✓ WagerRegistryIntents facet: ${intentsAddress}`);
+
+  console.log("Pointing the proxy fallback at the facet (setIntentExtension)...");
+  await (await regUpgrade.contract.connect(deployer).setIntentExtension(intentsAddress)).wait();
+  c.wagerRegistryIntents = intentsAddress;
+
+  // 3) MembershipManager: in-place upgrade + one-time EIP-712 domain init (reinitializer(2)).
+  console.log(`\nUpgrading MembershipManager proxy ${c.membershipManager}...`);
+  const mgrUpgrade = await upgradeProxy({
+    name: "MembershipManager",
+    proxyAddress: c.membershipManager,
+    call: { fn: "initializeIntents", args: [] },
+  });
+  c.membershipManagerImpl = mgrUpgrade.implementation;
+
+  record.constructorArgs = record.constructorArgs || {};
+  Object.assign(record.constructorArgs, {
+    wagerRegistryImpl: [],
+    wagerRegistryIntents: [],
+    membershipManagerImpl: [],
+  });
+  record.gaslessIntentsUpgradedAt = new Date().toISOString();
+  saveDeployment(filename, record);
+
+  console.log("\n" + "=".repeat(60));
+  console.log("Appended to deployments/" + filename);
+  console.log("=".repeat(60));
+  console.log(`  wagerRegistryImpl (new)     ${c.wagerRegistryImpl}`);
+  console.log(`  wagerRegistryIntents (new)  ${c.wagerRegistryIntents}`);
+  console.log(`  membershipManagerImpl (new) ${c.membershipManagerImpl}`);
+  console.log(`\nNext: npm run sync:frontend-contracts${networkName === "mordor" ? "" : ":" + networkName}`);
+  console.log("Optional: enable fee netting via scripts/operations/set-fee-netting.js");
+}
+
+main().then(() => process.exit(0)).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/operations/set-fee-netting.js
+++ b/scripts/operations/set-fee-netting.js
@@ -1,0 +1,53 @@
+/**
+ * Spec 035 ops: configure atomic fee netting on the payment-carrying contracts (FR-015/FR-016).
+ *
+ * Fee netting makes the `…WithAuthorization` twins consume a SECOND, bounded EIP-3009 authorization
+ * from the signer and forward it on-chain to a segregated fee recipient — never the relayer hot key
+ * (spec 036 SC-015). Disabled (sponsored mode) by default.
+ *
+ *   FEE_ENABLED=true \
+ *   FEE_RECIPIENT=0x... \
+ *   FEE_MAX=1000000            # 1 USDC (6 decimals) per-tx ceiling \
+ *   npx hardhat run scripts/operations/set-fee-netting.js --network <net>
+ *
+ * Signed by the floppy-keystore admin (DEFAULT_ADMIN_ROLE on both proxies). Note the WagerRegistry
+ * setter lives on the intents facet — call it AT THE PROXY ADDRESS (served via the fallback).
+ */
+const hre = require("hardhat");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+
+const { getDeploymentFilename } = require("../deploy/lib/helpers");
+
+async function main() {
+  const network = await ethers.provider.getNetwork();
+  const [admin] = await ethers.getSigners();
+
+  const enabled = String(process.env.FEE_ENABLED || "false") === "true";
+  const recipient = process.env.FEE_RECIPIENT || ethers.ZeroAddress;
+  const cap = BigInt(process.env.FEE_MAX || "0");
+  if (enabled && (!ethers.isAddress(recipient) || recipient === ethers.ZeroAddress)) {
+    throw new Error("FEE_ENABLED=true requires a non-zero FEE_RECIPIENT (segregated sink — NOT the relayer hot key)");
+  }
+
+  const filename = getDeploymentFilename(network, "v2");
+  const record = JSON.parse(fs.readFileSync(path.join(process.cwd(), "deployments", filename), "utf8"));
+  const c = record.contracts || {};
+
+  console.log(`Fee netting on ${hre.network.name}: enabled=${enabled} recipient=${recipient} cap=${cap}`);
+
+  // WagerRegistry: setFeeNetting is served by the intents facet at the PROXY address.
+  const regIntents = await ethers.getContractAt("WagerRegistryIntents", c.wagerRegistry, admin);
+  await (await regIntents.setFeeNetting(enabled, recipient, cap)).wait();
+  console.log(`  ✓ WagerRegistry (${c.wagerRegistry})`);
+
+  const mgr = await ethers.getContractAt("MembershipManager", c.membershipManager, admin);
+  await (await mgr.setFeeNetting(enabled, recipient, cap)).wait();
+  console.log(`  ✓ MembershipManager (${c.membershipManager})`);
+}
+
+main().then(() => process.exit(0)).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/services/oz-relayer/README.md
+++ b/services/oz-relayer/README.md
@@ -1,0 +1,103 @@
+# OpenZeppelin Relayer — FairWins submission engine configuration (spec 036)
+
+This directory holds **configuration only** — the engine is the open-source
+[OpenZeppelin Relayer](https://github.com/OpenZeppelin/openzeppelin-relayer) (Rust, AGPL-3.0,
+**pin a 1.x release**), run as a container. It is *not* our code and must never be forked into
+this repo (AGPL containment: FairWins logic lives in the separately-licensed
+`services/relay-gateway/`, which talks to this engine only over its REST API — see plan.md,
+"AGPL-3.0 note").
+
+## The gateway / engine split
+
+| Concern | Owner |
+|---|---|
+| Recover + screen the **signer**, intent binding, dedup, quotas, spend caps, fee-netting, kill switch, origin-lock, audit | `services/relay-gateway/` (FairWins) |
+| Nonce lanes per `(chain, gas wallet)`, gas estimation + stuck-tx bumping, inclusion tracking, RPC failover, hot-key custody | **this engine** (configured here) |
+
+The engine only ever sees a built transaction `{to, value: "0", data, speed}` on
+`POST /api/v1/relayers/{relayerId}/transactions` — never a FairWins intent, never the signer.
+It can censor, it cannot steal (spec 036 FR-003).
+
+## Relayers (one per chain — `<name>-<chainId>`, matching the gateway's defaults)
+
+| id | chain | gas | notes |
+|---|---|---|---|
+| `polygon-137` | Polygon mainnet | EIP-1559 | `whitelist_receivers` pinned to the deployed WagerRegistry + MembershipManager proxies (defense-in-depth for FR-025) |
+| `amoy-80002` | Polygon Amoy | EIP-1559 | testnet |
+| `etc-61` | Ethereum Classic | **legacy type-0** | **`paused: true`** — no `deployments/*-chain61-v2.json` record exists yet, so there is no pinned target set; un-pause only after the ETC deployment lands |
+| `mordor-63` | Mordor | **legacy type-0** | testnet; ETC-family chains never adopted EIP-1559 |
+
+ETC-family specifics (research.md §2):
+
+- `eip1559_pricing: false` + no `eip1559` feature on the network entry → all pricing and
+  stuck-tx replacement use a single `gasPrice`, never `maxFeePerGas`.
+- **`batchMaxCount: 1` equivalent**: the public 61/63 endpoints (Caddy-fronted core-geth/besu)
+  mishandle batched JSON-RPC. The Rust engine issues sequential requests by default, but if a
+  batch option is ever enabled, keep it at 1 for these chains (tagged `no-batch` in
+  `config.json` as an operator reminder).
+- `gas_price_cap` is set high (2000 gwei) because the ETC legacy oracle suggests ~300 gwei
+  baseline; the cap bounds bump/replace escalation (FR-006).
+
+## Key provisioning (FR-017 / FR-019a)
+
+Signers reference **Google Cloud KMS** keys (`google_cloud_kms` signer type) — the hot gas key
+material never exists in env vars, config files, logs, or this repo. Provisioning:
+
+1. Create one secp256k1 signing key per chain in the `fairwins-relayer` key ring
+   (`gcloud kms keys create gas-key-polygon --keyring fairwins-relayer --purpose asym-signing ...`).
+2. Grant the engine's service account `cloudkms.signerVerifier` on those keys only
+   (least privilege).
+3. Fund each derived address with a **low-value, capped** gas balance (never from, or to, the
+   floppy-keystore admin keys). Rotation = create new key version, drain in-flight, re-point
+   `key_version`, defund the old address.
+
+For local dev only, swap a signer entry for the engine's `local` keystore type with a
+throwaway key — never a production key, never committed.
+
+## Webhook → gateway
+
+The `relay-gateway-webhook` notification posts transaction lifecycle updates
+(`pending|mined|confirmed|failed|...`) to the gateway's `POST /v1/engine/webhook`, which maps
+them onto intent statuses (never `confirmed` before mined — FR-006). `WEBHOOK_SIGNING_KEY` is
+the shared secret; the gateway checks it timing-safe (`WEBHOOK_SHARED_SECRET` on its side).
+
+## Running
+
+```bash
+docker run --rm -p 8080:8080 \
+  -v "$PWD/services/oz-relayer/config:/app/config:ro" \
+  -e GCP_PROJECT_ID=... \
+  -e GOOGLE_APPLICATION_CREDENTIALS_JSON=... \
+  -e WEBHOOK_SIGNING_KEY=... \
+  -e API_KEY=... \
+  -e REDIS_URL=redis://redis:6379 \
+  ghcr.io/openzeppelin/openzeppelin-relayer:v1.4.0   # PIN an exact 1.x tag
+```
+
+Or use `services/relay-gateway/docker-compose.yml`, which wires gateway + engine + Redis for
+local dev.
+
+## Assumptions made in `config.json` (verify against the pinned 1.x release at integration)
+
+1. **Schema**: `relayers[] / networks[] / signers[] / notifications[]` in one `config.json`,
+   with `policies.{eip1559_pricing, gas_price_cap, min_balance, whitelist_receivers}` — this
+   follows OpenZeppelin Relayer 1.x conventions as documented; exact field names can drift
+   between minor versions, so validate with the engine's config check on the pinned tag.
+2. **`${VAR:-default}` substitution** in `rpc_urls`/`url` values: if the pinned release does not
+   expand env placeholders in non-secret fields, replace them with literals at deploy time
+   (the defaults shown are the intended public-endpoint fallbacks).
+3. **Webhook auth**: the engine signs webhook payloads with `signing_key`. The gateway v1
+   authenticates a shared-secret header (`X-Webhook-Secret`/`Authorization: Bearer`); if the
+   pinned release only emits an HMAC signature header, add the small HMAC verifier in
+   `relay-gateway/src/engine/webhook.js` during integration (tracked as a Phase-1 integration
+   task — do not disable webhook auth).
+4. **Weighted RPC failover**: plain ordered `rpc_urls` arrays are used; if the pinned release
+   supports `{url, weight}` objects, weights may be added without other changes.
+5. `min_balance` doubles as the low-balance alert line (FR-018); `openzeppelin-monitor` is the
+   intended alerting add-on (plan.md) and is not configured here.
+
+## Fallback engine
+
+If AGPL-3.0 ever becomes a blocker, **rrelayer (MIT)** is the pre-vetted drop-in: it exposes an
+equivalent submit + webhook surface, and the gateway's engine client
+(`relay-gateway/src/engine/client.js`) is a thin adapter so the swap does not touch policy code.

--- a/services/oz-relayer/config/config.json
+++ b/services/oz-relayer/config/config.json
@@ -1,0 +1,212 @@
+{
+  "relayers": [
+    {
+      "id": "polygon-137",
+      "name": "FairWins Polygon (137)",
+      "network": "polygon",
+      "network_type": "evm",
+      "paused": false,
+      "signer_id": "gas-key-polygon",
+      "notification_id": "relay-gateway-webhook",
+      "policies": {
+        "eip1559_pricing": true,
+        "gas_price_cap": 1000000000000,
+        "min_balance": 500000000000000000,
+        "whitelist_receivers": [
+          "0x5023765809fDA93ab9F11B684fdb76521eD31774",
+          "0x00c3ef4e02Ef00Ad6eE955dF5022A22F6ea73dae"
+        ]
+      }
+    },
+    {
+      "id": "amoy-80002",
+      "name": "FairWins Amoy (80002)",
+      "network": "amoy",
+      "network_type": "evm",
+      "paused": false,
+      "signer_id": "gas-key-amoy",
+      "notification_id": "relay-gateway-webhook",
+      "policies": {
+        "eip1559_pricing": true,
+        "gas_price_cap": 500000000000,
+        "min_balance": 500000000000000000,
+        "whitelist_receivers": [
+          "0xA429CdaD3E1497e33BEA7D6FE7d6913fE880241b",
+          "0x89158f2E044C73c687dA12B7FA42b94F9A6D8465"
+        ]
+      }
+    },
+    {
+      "id": "etc-61",
+      "name": "FairWins Ethereum Classic (61)",
+      "network": "ethereum-classic",
+      "network_type": "evm",
+      "paused": true,
+      "signer_id": "gas-key-etc",
+      "notification_id": "relay-gateway-webhook",
+      "policies": {
+        "eip1559_pricing": false,
+        "gas_price_cap": 2000000000000,
+        "min_balance": 1000000000000000000
+      }
+    },
+    {
+      "id": "mordor-63",
+      "name": "FairWins Mordor (63)",
+      "network": "mordor",
+      "network_type": "evm",
+      "paused": false,
+      "signer_id": "gas-key-mordor",
+      "notification_id": "relay-gateway-webhook",
+      "policies": {
+        "eip1559_pricing": false,
+        "gas_price_cap": 2000000000000,
+        "min_balance": 1000000000000000000,
+        "whitelist_receivers": [
+          "0x3ccB144d8aa838e8d4D695867cC72e548117830C",
+          "0x68bCBA1055DAbe11b98Bb8425A16e648Ad65d541"
+        ]
+      }
+    }
+  ],
+  "networks": [
+    {
+      "network": "polygon",
+      "type": "evm",
+      "chain_id": 137,
+      "symbol": "POL",
+      "required_confirmations": 30,
+      "average_blocktime_ms": 2100,
+      "is_testnet": false,
+      "features": ["eip1559"],
+      "rpc_urls": [
+        "${RPC_URL_137_PRIMARY:-https://polygon-rpc.com}",
+        "${RPC_URL_137_SECONDARY:-https://polygon-bor-rpc.publicnode.com}"
+      ],
+      "explorer_urls": ["https://polygonscan.com"],
+      "tags": ["mainnet", "fairwins"]
+    },
+    {
+      "network": "amoy",
+      "type": "evm",
+      "chain_id": 80002,
+      "symbol": "POL",
+      "required_confirmations": 3,
+      "average_blocktime_ms": 2100,
+      "is_testnet": true,
+      "features": ["eip1559"],
+      "rpc_urls": [
+        "${RPC_URL_80002_PRIMARY:-https://rpc-amoy.polygon.technology}",
+        "${RPC_URL_80002_SECONDARY:-https://polygon-amoy-bor-rpc.publicnode.com}"
+      ],
+      "explorer_urls": ["https://amoy.polygonscan.com"],
+      "tags": ["testnet", "fairwins"]
+    },
+    {
+      "network": "ethereum-classic",
+      "type": "evm",
+      "chain_id": 61,
+      "symbol": "ETC",
+      "required_confirmations": 12,
+      "average_blocktime_ms": 13000,
+      "is_testnet": false,
+      "features": [],
+      "rpc_urls": [
+        "${RPC_URL_61_PRIMARY:-https://etc.rivet.link}",
+        "${RPC_URL_61_SECONDARY:-https://etc.etcdesktop.com}"
+      ],
+      "explorer_urls": ["https://etc.blockscout.com"],
+      "tags": ["mainnet", "fairwins", "legacy-gas", "no-batch"]
+    },
+    {
+      "network": "mordor",
+      "type": "evm",
+      "chain_id": 63,
+      "symbol": "METC",
+      "required_confirmations": 6,
+      "average_blocktime_ms": 13000,
+      "is_testnet": true,
+      "features": [],
+      "rpc_urls": [
+        "${RPC_URL_63_PRIMARY:-https://rpc.mordor.etccooperative.org}",
+        "${RPC_URL_63_SECONDARY:-https://geth-mordor.etc-network.info}"
+      ],
+      "explorer_urls": ["https://etc-mordor.blockscout.com"],
+      "tags": ["testnet", "fairwins", "legacy-gas", "no-batch"]
+    }
+  ],
+  "signers": [
+    {
+      "id": "gas-key-polygon",
+      "type": "google_cloud_kms",
+      "config": {
+        "service_account": {
+          "project_id": { "type": "env", "value": "GCP_PROJECT_ID" },
+          "credentials": { "type": "env", "value": "GOOGLE_APPLICATION_CREDENTIALS_JSON" }
+        },
+        "key": {
+          "location": "us-central1",
+          "key_ring_id": "fairwins-relayer",
+          "key_id": "gas-key-polygon",
+          "key_version": 1
+        }
+      }
+    },
+    {
+      "id": "gas-key-amoy",
+      "type": "google_cloud_kms",
+      "config": {
+        "service_account": {
+          "project_id": { "type": "env", "value": "GCP_PROJECT_ID" },
+          "credentials": { "type": "env", "value": "GOOGLE_APPLICATION_CREDENTIALS_JSON" }
+        },
+        "key": {
+          "location": "us-central1",
+          "key_ring_id": "fairwins-relayer",
+          "key_id": "gas-key-amoy",
+          "key_version": 1
+        }
+      }
+    },
+    {
+      "id": "gas-key-etc",
+      "type": "google_cloud_kms",
+      "config": {
+        "service_account": {
+          "project_id": { "type": "env", "value": "GCP_PROJECT_ID" },
+          "credentials": { "type": "env", "value": "GOOGLE_APPLICATION_CREDENTIALS_JSON" }
+        },
+        "key": {
+          "location": "us-central1",
+          "key_ring_id": "fairwins-relayer",
+          "key_id": "gas-key-etc",
+          "key_version": 1
+        }
+      }
+    },
+    {
+      "id": "gas-key-mordor",
+      "type": "google_cloud_kms",
+      "config": {
+        "service_account": {
+          "project_id": { "type": "env", "value": "GCP_PROJECT_ID" },
+          "credentials": { "type": "env", "value": "GOOGLE_APPLICATION_CREDENTIALS_JSON" }
+        },
+        "key": {
+          "location": "us-central1",
+          "key_ring_id": "fairwins-relayer",
+          "key_id": "gas-key-mordor",
+          "key_version": 1
+        }
+      }
+    }
+  ],
+  "notifications": [
+    {
+      "id": "relay-gateway-webhook",
+      "type": "webhook",
+      "url": "${GATEWAY_WEBHOOK_URL:-http://relay-gateway:8788/v1/engine/webhook}",
+      "signing_key": { "type": "env", "value": "WEBHOOK_SIGNING_KEY" }
+    }
+  ]
+}

--- a/services/relay-gateway/.env.example
+++ b/services/relay-gateway/.env.example
@@ -1,0 +1,41 @@
+# FairWins relay gateway — local/dev environment. NEVER commit a filled-in .env.
+# In production these come from Secret Manager / Cloud Run env (see README).
+
+# Chains served (default: the chains with deployments/ records). 61 (ETC mainnet) has no
+# deployment record yet — enabling it fails the FR-025 startup check by design.
+ENABLED_CHAIN_IDS=137,80002,63
+
+# >=2 endpoints per chain, comma-separated, failover order (FR-007). Defaults are public pairs.
+#RPC_URLS_137=https://polygon-rpc.com,https://polygon-bor-rpc.publicnode.com
+#RPC_URLS_80002=https://rpc-amoy.polygon.technology,https://polygon-amoy-bor-rpc.publicnode.com
+#RPC_URLS_63=https://rpc.mordor.etccooperative.org,https://geth-mordor.etc-network.info
+
+# Origin lock (FR-029): same secret the Cloudflare Transform Rule injects as X-Origin-Auth.
+# UNSET => lock disabled (dev only; production MUST set it).
+ORIGIN_AUTH_SECRET=
+
+# Engine (OpenZeppelin Relayer) — see ../oz-relayer/README.md
+ENGINE_URL=http://localhost:8080
+#ENGINE_API_KEY=
+# Engine relayer ids default to <name>-<chainId>: polygon-137, amoy-80002, etc-61, mordor-63
+#ENGINE_RELAYER_ID_137=polygon-137
+
+# Shared secret the engine presents on POST /v1/engine/webhook (X-Webhook-Secret).
+# UNSET => all webhooks rejected (fail closed).
+WEBHOOK_SHARED_SECRET=
+
+# Kill switch (FR-015): boot value; toggle at runtime with `kill -USR2 <pid>`.
+KILL_SWITCH=false
+
+# Quotas / caps (FR-009/FR-014/FR-018)
+#SIGNER_QUOTA_PER_MIN=12
+#GLOBAL_QUOTA_PER_MIN=120
+#MAX_QUEUE_DEPTH=100
+#GAS_SPEND_CAP_WEI_137=500000000000000000
+#SPEND_WINDOW_MS=3600000
+
+# healthz runway (observability only — the KEY never lives here)
+#GAS_WALLET_137=0x...
+#PEAK_BURN_WEI_PER_HR_137=50000000000000000
+
+#PORT=8788

--- a/services/relay-gateway/Dockerfile
+++ b/services/relay-gateway/Dockerfile
@@ -1,0 +1,30 @@
+# FairWins relay gateway (spec 036) — intent policy front-end for the OSS submission engine.
+#
+# BUILD CONTEXT = REPO ROOT (the image bakes in deployments/ for the FR-025 startup check):
+#   docker build -f services/relay-gateway/Dockerfile -t fairwins-relay-gateway .
+#
+# Holds NO keys: the gas hot key lives in the engine (Secret Manager); this container only
+# needs the origin-lock + webhook shared secrets injected at runtime (never baked in).
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY services/relay-gateway/package.json services/relay-gateway/package-lock.json* ./
+# Prefer the lockfile when present; fall back to a plain install for local builds.
+RUN if [ -f package-lock.json ]; then npm ci --omit=dev --no-audit --no-fund; \
+    else npm install --omit=dev --no-audit --no-fund; fi
+
+FROM node:20-alpine AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=deps /app/node_modules ./node_modules
+COPY services/relay-gateway/package.json ./
+COPY services/relay-gateway/src ./src
+# Version-pinned target set (FR-025): the deployments records are baked into the image so the
+# startup consistency check validates against the exact addresses this build was shipped with.
+COPY deployments ./deployments
+ENV DEPLOYMENTS_DIR=/app/deployments
+# Drop privileges: the node image ships a non-root `node` user.
+USER node
+EXPOSE 8788
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||8788)+'/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+CMD ["node", "src/server.js"]

--- a/services/relay-gateway/README.md
+++ b/services/relay-gateway/README.md
@@ -1,0 +1,113 @@
+# FairWins Relay Gateway (spec 036 — Intent Relayer Infrastructure)
+
+The policy front-end for gasless intent submission. Users sign spec-035 intents off-chain; this
+gateway recovers the **signer** from the signature, validates that the intent binds exactly what
+was signed, screens the signer against the on-chain sanctions guard (**fail-closed**), dedups,
+rate-limits and fee-gates — then hands a built call to the OSS submission engine
+([OpenZeppelin Relayer](../oz-relayer/), which owns nonces, gas bumping, inclusion tracking, RPC
+failover, and the hot key).
+
+This service is a **deliberate, documented, scoped exception** to the platform's no-backend
+directive (spec 036 FR-001/FR-004). It is optional and additive: with it stopped, killed, or
+censoring, every covered action still completes via self-submit with an identical on-chain
+result (FR-002 / SC-004).
+
+## Security posture
+
+- **Censor, not steal (untrusted-by-design).** The gateway holds no user funds, no contract
+  authority, and no client-asserted identity: the signer is *recovered* from the EIP-712 /
+  EIP-3009 signature, and the on-chain entrypoints re-verify everything. The worst this service
+  (or its operator) can do is refuse to pay gas.
+- **Fail-closed screening (FR-013).** Every intent's recovered signer is re-screened against the
+  on-chain `ISanctionsGuard.isAllowed` before any gas is spent. Sanctioned signer →
+  `403 sanctioned_signer`. Screening unavailable (RPC down, decode error) →
+  `503 screening_unavailable` — never "assume fine and submit". On-chain screening remains
+  authoritative; this is defense-in-depth so the relayer never pays gas for a wallet the guard
+  would reject.
+- **Hot-key containment (FR-017/FR-019a).** The gateway never touches the gas key — it lives in
+  the engine, KMS-held, low-value, spend-capped, segregated from the air-gapped floppy admin
+  keys. The gateway's own secrets are two shared-secret headers (origin lock + webhook), both
+  compared timing-safe over SHA-256 digests.
+- **Version-pinned targets (FR-025).** The per-chain target contracts are read from
+  `deployments/*-chain<ID>-v2.json` at startup, with a consistency check that exits non-zero on
+  any mismatch. Only allow-listed `(targetContract, action)` pairs are ever encoded.
+- **Honest status (FR-006).** `confirmed` is only ever reported after the engine's webhook says
+  mined/confirmed. Every terminal outcome emits an append-only audit event (JSON on stdout →
+  Cloud Logging → WORM sink, ≥5yr) linking intent → signer → txHash — never signatures or keys.
+- **Perimeter (FR-029).** Behind the same Cloudflare 451 geo-gate + origin-lock as the SPA; all
+  client routes require `X-Origin-Auth` (`/healthz` exempt for probes; `/v1/engine/webhook`
+  exempt because the engine calls in-network with its own shared secret).
+
+## API (contracts/relay-gateway-api.md)
+
+| Route | Purpose |
+|---|---|
+| `POST /v1/intents` | Submit a signed intent. `202 {intentId, status, txHash?}` on accept; `200` idempotent replay of a completed intent; errors always `{error:{code, reason}}` with the contract's exact codes (`invalid_signature`, `chain_mismatch`, `target_not_allowlisted`, `param_binding_mismatch`, `expired`, `not_yet_valid`, `fee_exceeds_cap`, `origin_denied`, `sanctioned_signer`, `duplicate_in_flight`, `quota_exceeded`, `backpressure`, `screening_unavailable`, `killswitch_active`, `chain_unavailable`, `payment_unsupported_on_chain`). |
+| `GET /v1/intents/:id` | Honest status: `queued \| submitted \| confirmed \| failed` (+`txHash`, `reason`). |
+| `POST /v1/engine/webhook` | Engine status callback (shared-secret; maps engine → intent status). |
+| `GET /healthz` | `{status, chains:{<id>:{rpc, gasWalletRunwayHrs}}, killSwitch}` — drives the client's self-submit fallback probe. |
+
+Validation pipeline (data-model.md): kill switch → parse → chain active → payment-class support
+→ target/action allow-list → signer recovery (EIP-712 for `signer-attributed`, EIP-3009
+authorization for `payment`) → param/window binding → dedup on `uniquenessMarker` → sanctions
+re-screen → per-signer/global quotas → bounded-queue back-pressure → per-chain gas spend cap →
+fee-netted `maxFee` check → encode `…WithSig`/`…WithAuthorization` calldata → engine submit.
+
+## Running
+
+```bash
+npm ci
+cp .env.example .env         # fill in secrets; never commit .env
+npm run dev                  # or: npm start
+npm test                     # vitest + supertest (all chain/engine access mocked via DI)
+```
+
+Full local stack (gateway + engine + redis): `docker compose up --build` (see
+`docker-compose.yml`; the image must be built from the **repo root** context so the
+`deployments/` records are baked in). Validation scenarios: `specs/036-relayer-infrastructure/quickstart.md`.
+
+Load test (CI-gating, FR-011): `k6 run load/k6-intents.js -e GATEWAY_URL=... -e INTENTS_FILE=...`
+— thresholds (p95 accept latency < 2s, hard-error rate < 1%) fail the run, and therefore CI.
+The intents file is a JSON array of pre-signed bodies (k6 cannot sign; generate a pool with
+`test/helpers.js#signedIntent` against a staging chain).
+
+## Environment variables
+
+| Var | Default | Purpose |
+|---|---|---|
+| `ENABLED_CHAIN_IDS` | `137,80002,63` | Chains served. `61` fails the startup check until an ETC deployment record exists (by design). |
+| `RPC_URLS_<id>` | public pair per chain | ≥2 read endpoints, comma-separated, failover order (FR-007). 61/63 automatically use `batchMaxCount: 1`. |
+| `ORIGIN_AUTH_SECRET` | *(unset = lock disabled, dev only)* | Origin-lock shared secret (`X-Origin-Auth`), same value the Cloudflare Transform Rule injects. |
+| `WEBHOOK_SHARED_SECRET` | *(unset = webhooks rejected)* | Engine webhook shared secret (fail closed). |
+| `ENGINE_URL` / `ENGINE_API_KEY` | `http://localhost:8080` / — | OpenZeppelin Relayer REST endpoint. |
+| `ENGINE_RELAYER_ID_<id>` | `<name>-<chainId>` | Engine relayer id per chain (`polygon-137`, `amoy-80002`, `etc-61`, `mordor-63`). |
+| `KILL_SWITCH` | `false` | Boot value; toggle at runtime with `kill -USR2 <pid>` (FR-015). |
+| `SIGNER_QUOTA_PER_MIN` / `GLOBAL_QUOTA_PER_MIN` | `12` / `120` | Per-signer / global quotas (FR-014). |
+| `MAX_QUEUE_DEPTH` | `100` | Bounded in-flight queue; past it → `429 backpressure` (FR-009). |
+| `GAS_SPEND_CAP_WEI_<id>` / `SPEND_WINDOW_MS` | `0.5e18` / `3600000` | Per-chain per-window estimated-gas spend cap (FR-014/FR-018). |
+| `FUNDING_MODE_<id>` | `sponsored` | Default funding mode per chain (`sponsored` \| `fee-netted`). |
+| `GAS_WALLET_<id>` / `PEAK_BURN_WEI_PER_HR_<id>` | — / `0.05e18` | Healthz runway reporting only — the key itself never lives here. |
+| `DEPLOYMENTS_DIR` | `../../deployments` (repo) / `/app/deployments` (image) | Version-pinned target records (FR-025). |
+| `PORT` | `8788` | HTTP port. |
+
+## Phase 1 vs Phase 2 (research.md §3)
+
+- **Phase 1 (this code, v1):** single instance (`--max-instances=1` on Cloud Run). Dedup,
+  quotas, spend counters, and the intent store are **in-process** — restart loss is benign
+  because the on-chain `uniquenessMarker` is single-use (a replay can never double-spend) and a
+  rate-limit reset is a momentary loosening.
+- **Phase 2 (horizontal scale):** move dedup/quota/spend to shared Redis (Memorystore Basic,
+  atomic `INCR`+TTL / `SET NX`) so limits are not multiplied by instance count and dedup holds
+  across instances (FR-012 / SC-012). The policy modules (`src/policy/*.js`) are factories with
+  narrow interfaces precisely so the Redis swap does not touch the pipeline.
+
+## v1 scope notes (honest limitations)
+
+- `payment` class is blocked on 61/63 (`503 payment_unsupported_on_chain`): live USC is
+  permit-only, no EIP-3009 (research.md §2). No-stake signer-attributed intents still relay there.
+- `createWager` and `declareWinner` are **not** allow-listed yet: spec 035 leaves the
+  `CreateArgs` struct open and defines no `DeclareWinnerIntent` typed struct. They stay on
+  self-submit until spec 035 pins them; adding one later is a single entry in
+  `src/intent/intentTypes.js`.
+- ETC mainnet (61) is configured but cannot be enabled until a `deployments/*-chain61-v2.json`
+  record exists — the startup consistency check refuses to serve an unpinned chain.

--- a/services/relay-gateway/docker-compose.yml
+++ b/services/relay-gateway/docker-compose.yml
@@ -1,0 +1,54 @@
+# FairWins relayer stack — local development wiring (spec 036).
+#
+#   relay-gateway  (this service; FairWins policy)  :8788
+#   oz-relayer     (OpenZeppelin Relayer engine)    :8080
+#   redis          (engine queue store; also the gateway's Phase-2 shared limiter/dedup store)
+#
+# Secrets come from a local `.env` (copy .env.example -> .env) — never commit `.env`.
+# Production runs the gateway on Cloud Run behind the Cloudflare 451 geo-gate + origin-lock;
+# this compose file is for local validation only (quickstart.md).
+#
+# Run from this directory:  docker compose up --build
+services:
+  relay-gateway:
+    build:
+      context: ../..                          # repo root: the image bakes in deployments/ (FR-025)
+      dockerfile: services/relay-gateway/Dockerfile
+    image: fairwins-relay-gateway:local
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      ENGINE_URL: http://oz-relayer:8080
+    ports:
+      - "${PORT:-8788}:${PORT:-8788}"
+    depends_on:
+      - oz-relayer
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp
+
+  oz-relayer:
+    # PIN an exact 1.x tag before relying on this (see ../oz-relayer/README.md).
+    image: ghcr.io/openzeppelin/openzeppelin-relayer:v1.4.0
+    restart: unless-stopped
+    volumes:
+      - ../oz-relayer/config:/app/config:ro
+    env_file:
+      - .env
+    environment:
+      REDIS_URL: redis://redis:6379
+      GATEWAY_WEBHOOK_URL: http://relay-gateway:8788/v1/engine/webhook
+    ports:
+      - "8080:8080"
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--save", "", "--appendonly", "no"]  # ephemeral by design: state is reconstructed from chain
+    ports:
+      - "6379:6379"

--- a/services/relay-gateway/load/k6-intents.js
+++ b/services/relay-gateway/load/k6-intents.js
@@ -1,0 +1,104 @@
+/**
+ * CI-gating k6 load test for the relay gateway (FR-011, SC-001/SC-002).
+ *
+ * Profiles (spec 036 capacity targets — tunable knobs, not ceilings):
+ *   sustained: >= 3 intents/sec/chain, held for SUSTAIN_DURATION
+ *   burst:     >= 20 intents/sec for 30s
+ *
+ * Thresholds FAIL the run (and therefore the CI pipeline — FR-026, no continue-on-error):
+ *   - p95 accept latency < 2s  (SC-002: p95 accept->broadcast < 2s; the HTTP accept path is the
+ *     gateway-side component of that budget)
+ *   - error rate: non-shed failures < 1%. 409/429 are EXPECTED shed/coalesce responses under
+ *     burst (FR-008/FR-009) and are not errors.
+ *
+ * Usage:
+ *   k6 run load/k6-intents.js \
+ *     -e GATEWAY_URL=http://localhost:8788 \
+ *     -e ORIGIN_AUTH_SECRET=... \
+ *     -e CHAIN_IDS=137,80002,63 \
+ *     -e INTENTS_FILE=./load/intents.json     # pre-signed intent bodies (see README)
+ *
+ * Intents must be PRE-SIGNED (k6 has no ethers): generate a pool of signed bodies against a
+ * staging chain with test/helpers.js (signedIntent) and dump them to INTENTS_FILE. Each VU
+ * mutates only the uniquenessMarker-bearing body it was assigned, so dedup coalescing is
+ * exercised deliberately by the duplicate scenario, not by accident.
+ */
+import http from 'k6/http'
+import { check } from 'k6'
+import { SharedArray } from 'k6/data'
+import { Rate, Trend } from 'k6/metrics'
+
+const GATEWAY_URL = __ENV.GATEWAY_URL || 'http://localhost:8788'
+const ORIGIN_AUTH_SECRET = __ENV.ORIGIN_AUTH_SECRET || ''
+const CHAIN_IDS = (__ENV.CHAIN_IDS || '137').split(',').map((s) => Number(s.trim()))
+const SUSTAINED_RPS_PER_CHAIN = Number(__ENV.SUSTAINED_RPS_PER_CHAIN || 3)
+const BURST_RPS = Number(__ENV.BURST_RPS || 20)
+const SUSTAIN_DURATION = __ENV.SUSTAIN_DURATION || '2m'
+
+const intents = new SharedArray('intents', () => {
+  // Pool of pre-signed intent bodies, one array entry per unique uniquenessMarker.
+  return JSON.parse(open(__ENV.INTENTS_FILE || './intents.json'))
+})
+
+const acceptLatency = new Trend('accept_latency', true)
+const hardErrors = new Rate('hard_errors') // anything that is not 202/200/409/429
+
+export const options = {
+  scenarios: {
+    sustained: {
+      executor: 'constant-arrival-rate',
+      rate: SUSTAINED_RPS_PER_CHAIN * CHAIN_IDS.length,
+      timeUnit: '1s',
+      duration: SUSTAIN_DURATION,
+      preAllocatedVUs: 20,
+      maxVUs: 100,
+      exec: 'submitIntent',
+    },
+    burst: {
+      executor: 'constant-arrival-rate',
+      rate: BURST_RPS,
+      timeUnit: '1s',
+      duration: '30s',
+      startTime: SUSTAIN_DURATION, // burst runs after the sustained phase
+      preAllocatedVUs: 40,
+      maxVUs: 200,
+      exec: 'submitIntent',
+    },
+  },
+  thresholds: {
+    // SC-002: p95 accept latency < 2s — a regression past this FAILS CI.
+    accept_latency: ['p(95)<2000'],
+    // Hard failure rate (5xx/4xx other than expected shed/coalesce) below 1%.
+    hard_errors: ['rate<0.01'],
+    // k6's own failed-request accounting (network errors, timeouts).
+    http_req_failed: ['rate<0.01'],
+  },
+}
+
+let cursor = 0
+
+export function submitIntent() {
+  // Round-robin the pre-signed pool; markers are unique per entry so each submission is a
+  // distinct intent (dedup is exercised by resubmitting an already-used index at the end).
+  const body = intents[(cursor += 1) % intents.length]
+
+  const res = http.post(`${GATEWAY_URL}/v1/intents`, JSON.stringify(body), {
+    headers: {
+      'Content-Type': 'application/json',
+      ...(ORIGIN_AUTH_SECRET ? { 'X-Origin-Auth': ORIGIN_AUTH_SECRET } : {}),
+    },
+    timeout: '10s',
+  })
+
+  acceptLatency.add(res.timings.duration)
+
+  const shedOrCoalesced = res.status === 409 || res.status === 429
+  const accepted = res.status === 202 || res.status === 200
+  hardErrors.add(!(accepted || shedOrCoalesced))
+
+  check(res, {
+    'accepted, coalesced, or explicitly shed': () => accepted || shedOrCoalesced,
+    'shed responses carry Retry-After': () =>
+      res.status !== 429 || res.headers['Retry-After'] !== undefined,
+  })
+}

--- a/services/relay-gateway/package-lock.json
+++ b/services/relay-gateway/package-lock.json
@@ -1,0 +1,2467 @@
+{
+  "name": "fairwins-relay-gateway",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fairwins-relay-gateway",
+      "version": "0.1.0",
+      "dependencies": {
+        "ethers": "^6.16.0",
+        "express": "^4.21.2",
+        "helmet": "^8.0.0"
+      },
+      "devDependencies": {
+        "supertest": "^7.0.0",
+        "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.17.0.tgz",
+      "integrity": "sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.11.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.21.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.138.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/services/relay-gateway/package.json
+++ b/services/relay-gateway/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "fairwins-relay-gateway",
+  "version": "0.1.0",
+  "private": true,
+  "description": "FairWins intent relay gateway (spec 036): policy front-end for the OSS submission engine. Recovers/screens the SIGNER, validates intent binding, dedups, rate-limits, then hands built calldata to OpenZeppelin Relayer. Untrusted-by-design: can censor, never steal.",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "dev": "node --watch src/server.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "load": "k6 run load/k6-intents.js",
+    "lint": "echo 'no standalone linter wired; relies on repo-level review' && exit 0"
+  },
+  "dependencies": {
+    "ethers": "^6.16.0",
+    "express": "^4.21.2",
+    "helmet": "^8.0.0"
+  },
+  "devDependencies": {
+    "supertest": "^7.0.0",
+    "vitest": "^4.0.18"
+  }
+}

--- a/services/relay-gateway/src/audit/log.js
+++ b/services/relay-gateway/src/audit/log.js
@@ -1,0 +1,34 @@
+/**
+ * Append-only audit events (FR-021, SC-009/SC-017) as structured JSON on stdout.
+ *
+ * In production stdout is captured by Cloud Logging and routed via a Log Router sink to a
+ * WORM-locked destination retained >=5 years (research.md §3). On-chain remains the permanent
+ * record of record; these events are the request-side intent -> signer -> txHash binding.
+ *
+ * MUST NEVER contain: the hot key (the gateway never has it), raw signatures, or any secret.
+ * The signer address and uniquenessMarker are on-chain-public values.
+ */
+
+const FORBIDDEN_KEYS = new Set(['signature', 'sig', 'intentSig', 'privateKey', 'key', 'secret', 'authorization'])
+
+/**
+ * @param {{sink?: (line: string) => void, now?: () => Date}} [opts]
+ * @returns {(fields: object) => void}
+ */
+export function createAuditLogger({ sink = (line) => process.stdout.write(line + '\n'), now = () => new Date() } = {}) {
+  return function audit(fields) {
+    const clean = {}
+    for (const [k, v] of Object.entries(fields)) {
+      if (FORBIDDEN_KEYS.has(k)) continue // hard guard: key material / signatures never hit the log
+      clean[k] = typeof v === 'bigint' ? v.toString() : v
+    }
+    const event = {
+      timestamp: now().toISOString(),
+      severity: 'INFO',
+      // Cloud-Logging-friendly: structured payload with a stable event name for the Log Router sink.
+      event: 'relay_audit',
+      ...clean,
+    }
+    sink(JSON.stringify(event))
+  }
+}

--- a/services/relay-gateway/src/config/chains.js
+++ b/services/relay-gateway/src/config/chains.js
@@ -1,0 +1,66 @@
+/**
+ * Static per-chain definitions for the relay gateway (spec 036 data-model.md "Chain Config").
+ *
+ * Dynamic values (RPC URLs, quotas, caps) are env-driven in ./index.js; this file holds the
+ * facts that are properties of the chain itself:
+ *
+ * - gasType:          'eip1559' on Polygon/Amoy; 'legacy' (type-0, single gasPrice) on ETC/Mordor —
+ *                     ETC never adopted EIP-1559 (research.md §2). The ENGINE prices gas; the
+ *                     gateway only needs this for its own estimates and the healthz surface.
+ * - paymentSupported: false on 61/63 — the live USC token is permit-only (NO EIP-3009), so the
+ *                     `payment` intent class is blocked there (503 payment_unsupported_on_chain)
+ *                     until an EIP-3009-capable USC exists (research.md §2).
+ * - noBatch:          61/63 endpoints return batch responses ethers v6 cannot decode; mirror the
+ *                     frontend's NO_BATCH_CHAIN_IDS workaround with batchMaxCount: 1.
+ * - tokenDomain:      EIP-712 domain (name/version) of the chain's EIP-3009 payment token, used to
+ *                     recover the signer of a `payment`-class authorization. Native USDC uses
+ *                     domain version "2". Overridable via TOKEN_DOMAIN_NAME_<id>/TOKEN_DOMAIN_VERSION_<id>.
+ * - defaultRpcUrls:   ≥2 independent public endpoints (FR-007), failover order; override with
+ *                     RPC_URLS_<chainId> (comma-separated).
+ */
+
+export const CHAIN_DEFS = {
+  137: {
+    chainId: 137,
+    name: 'polygon',
+    gasType: 'eip1559',
+    paymentSupported: true,
+    noBatch: false,
+    tokenDomain: { name: 'USD Coin', version: '2' },
+    defaultRpcUrls: ['https://polygon-rpc.com', 'https://polygon-bor-rpc.publicnode.com'],
+    // Fallbacks only — used when a live fee read fails; the engine owns real pricing.
+    gasPriceFallbackWei: 50_000_000_000n, // 50 gwei
+  },
+  80002: {
+    chainId: 80002,
+    name: 'amoy',
+    gasType: 'eip1559',
+    paymentSupported: true,
+    noBatch: false,
+    tokenDomain: { name: 'USDC', version: '2' },
+    defaultRpcUrls: ['https://rpc-amoy.polygon.technology', 'https://polygon-amoy-bor-rpc.publicnode.com'],
+    gasPriceFallbackWei: 30_000_000_000n,
+  },
+  61: {
+    chainId: 61,
+    name: 'etc',
+    gasType: 'legacy',
+    paymentSupported: false, // USC on ETC is permit-only; no EIP-3009 (research.md §2)
+    noBatch: true,
+    tokenDomain: null,
+    defaultRpcUrls: ['https://etc.rivet.link', 'https://etc.etcdesktop.com'],
+    gasPriceFallbackWei: 300_000_000_000n, // ~300 gwei legacy oracle suggestion (hardhat.config.js)
+  },
+  63: {
+    chainId: 63,
+    name: 'mordor',
+    gasType: 'legacy',
+    paymentSupported: false,
+    noBatch: true,
+    tokenDomain: null,
+    defaultRpcUrls: ['https://rpc.mordor.etccooperative.org', 'https://geth-mordor.etc-network.info'],
+    gasPriceFallbackWei: 300_000_000_000n,
+  },
+}
+
+export const SUPPORTED_CHAIN_IDS = Object.keys(CHAIN_DEFS).map(Number)

--- a/services/relay-gateway/src/config/index.js
+++ b/services/relay-gateway/src/config/index.js
@@ -1,0 +1,204 @@
+/**
+ * Relay-gateway configuration, loaded once at boot.
+ *
+ * Version-pinned target set (FR-025): the per-chain target contract addresses are read from
+ * the repo's `deployments/*-chain<ID>-v2.json` files — the platform's source of truth for
+ * on-chain addresses. Startup performs a consistency check: every enabled chain MUST have a
+ * deployment record with `wagerRegistry`, `membershipManager`, and `sanctionsGuard` addresses,
+ * or the process exits non-zero (fail loudly — never run against a stale/unknown target).
+ *
+ * Env:
+ *   ENABLED_CHAIN_IDS          comma list (default "137,80002,63" — 61 has no deployment record yet;
+ *                              enabling it without one fails the startup check by design)
+ *   RPC_URLS_<chainId>         comma list, failover order (default: built-in public pair, FR-007)
+ *   ORIGIN_AUTH_SECRET         origin-lock shared secret (X-Origin-Auth). Unset => lock DISABLED
+ *                              (dev only; production must set it — research.md §4 / SC-016)
+ *   WEBHOOK_SHARED_SECRET      engine webhook shared secret. Unset => webhook rejects everything (fail closed)
+ *   ENGINE_URL                 OpenZeppelin Relayer base URL (default http://localhost:8080)
+ *   ENGINE_API_KEY             optional bearer token for the engine API
+ *   ENGINE_RELAYER_ID_<id>     engine relayer id per chain (default "<name>-<chainId>", e.g. polygon-137)
+ *   KILL_SWITCH                'true' => boot with the kill switch active (FR-015)
+ *   SIGNER_QUOTA_PER_MIN       per-signer intents/min (default 12)
+ *   GLOBAL_QUOTA_PER_MIN       global intents/min (default 120)
+ *   MAX_QUEUE_DEPTH            bounded in-flight queue (default 100) — back-pressure past this (FR-009)
+ *   GAS_SPEND_CAP_WEI_<id>     per-chain per-window gas spend cap (default 0.5 native / hour, FR-014)
+ *   SPEND_WINDOW_MS            spend-cap window (default 3600000)
+ *   DEFAULT_GAS_LIMIT          fallback gas limit for estimates (default 300000)
+ *   GAS_WALLET_<id>            hot gas wallet address (healthz runway only; the KEY lives in the engine)
+ *   PEAK_BURN_WEI_PER_HR_<id>  runway divisor for healthz gasWalletRunwayHrs (default 0.05 native/hr)
+ *   PORT                       HTTP port (default 8788)
+ *
+ * The gateway NEVER holds the gas key — that is the engine's (Secret-Manager-held) concern.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { CHAIN_DEFS } from './chains.js'
+import { actionsForContract } from '../intent/intentTypes.js'
+
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const DEFAULT_DEPLOYMENTS_DIR = path.resolve(__dirname, '../../../../deployments')
+
+function opt(env, name, fallback) {
+  const v = env[name]
+  return v == null || String(v).trim() === '' ? fallback : String(v).trim()
+}
+
+function int(env, name, fallback) {
+  const v = opt(env, name, undefined)
+  if (v == null) return fallback
+  const n = Number.parseInt(v, 10)
+  if (!Number.isInteger(n) || n < 0) throw new Error(`[relay-gateway] invalid integer env ${name}=${v}`)
+  return n
+}
+
+function bigInt(env, name, fallback) {
+  const v = opt(env, name, undefined)
+  if (v == null) return fallback
+  try {
+    return BigInt(v)
+  } catch {
+    throw new Error(`[relay-gateway] invalid bigint env ${name}=${v}`)
+  }
+}
+
+/** Locate + parse the deployment record for a chain (source of truth for addresses). */
+function loadDeployment(deploymentsDir, chainId) {
+  let entries
+  try {
+    entries = fs.readdirSync(deploymentsDir)
+  } catch (e) {
+    throw new Error(`[relay-gateway] cannot read deployments dir ${deploymentsDir}: ${e.message}`)
+  }
+  const file = entries.find((f) => f.endsWith(`-chain${chainId}-v2.json`))
+  if (!file) return null
+  const parsed = JSON.parse(fs.readFileSync(path.join(deploymentsDir, file), 'utf8'))
+  return { file: path.join(deploymentsDir, file), ...parsed }
+}
+
+/**
+ * Build the validated config. Throws (=> non-zero exit at boot) on any inconsistency between
+ * the enabled chains and the deployments records — FR-025's startup consistency check.
+ * @param {NodeJS.ProcessEnv} [env]
+ * @param {{deploymentsDir?: string}} [opts]
+ */
+export function loadConfig(env = process.env, opts = {}) {
+  const deploymentsDir = opts.deploymentsDir || opt(env, 'DEPLOYMENTS_DIR', DEFAULT_DEPLOYMENTS_DIR)
+
+  const enabledChainIds = opt(env, 'ENABLED_CHAIN_IDS', '137,80002,63')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => {
+      const n = Number.parseInt(s, 10)
+      if (!Number.isInteger(n) || n <= 0) throw new Error(`[relay-gateway] invalid chainId in ENABLED_CHAIN_IDS: ${s}`)
+      return n
+    })
+  if (enabledChainIds.length === 0) throw new Error('[relay-gateway] ENABLED_CHAIN_IDS must list at least one chainId')
+
+  const chains = {}
+  for (const chainId of enabledChainIds) {
+    const def = CHAIN_DEFS[chainId]
+    if (!def) {
+      throw new Error(
+        `[relay-gateway] chainId ${chainId} is not a supported network (supported: ${Object.keys(CHAIN_DEFS).join(', ')})`
+      )
+    }
+
+    // --- FR-025 startup consistency check: pin targets to the recorded deployment ---
+    const deployment = loadDeployment(deploymentsDir, chainId)
+    if (!deployment) {
+      throw new Error(
+        `[relay-gateway] no deployment record (*-chain${chainId}-v2.json) in ${deploymentsDir} for enabled chain ${chainId}. ` +
+          'Refusing to start: target addresses must be version-pinned to deployments/ (FR-025).'
+      )
+    }
+    if (Number(deployment.chainId) !== chainId) {
+      throw new Error(`[relay-gateway] ${deployment.file} declares chainId ${deployment.chainId}, expected ${chainId}`)
+    }
+    const c = deployment.contracts || {}
+    for (const key of ['wagerRegistry', 'membershipManager', 'sanctionsGuard']) {
+      if (!ADDRESS_RE.test(c[key] || '')) {
+        throw new Error(
+          `[relay-gateway] deployment record for chain ${chainId} (${deployment.file}) is missing a valid "${key}" address — ` +
+            'cannot pin the target set (FR-025).'
+        )
+      }
+    }
+    if (def.paymentSupported && !ADDRESS_RE.test(deployment.paymentToken || '')) {
+      throw new Error(
+        `[relay-gateway] chain ${chainId} is payment-enabled but the deployment record has no paymentToken address`
+      )
+    }
+
+    // Version-pinned target map: address (lowercase) -> { key, allowedActions }
+    const targets = {
+      [c.wagerRegistry.toLowerCase()]: { key: 'wagerRegistry', address: c.wagerRegistry, allowedActions: actionsForContract('wagerRegistry') },
+      [c.membershipManager.toLowerCase()]: { key: 'membershipManager', address: c.membershipManager, allowedActions: actionsForContract('membershipManager') },
+    }
+
+    const rpcUrls = opt(env, `RPC_URLS_${chainId}`, def.defaultRpcUrls.join(','))
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+    if (rpcUrls.length === 0) throw new Error(`[relay-gateway] RPC_URLS_${chainId} must list at least one endpoint`)
+    if (rpcUrls.length < 2) {
+      // FR-007 wants >=2 independent endpoints; tolerate 1 for local dev but say so loudly.
+      console.warn(`[relay-gateway] WARN chain ${chainId}: only 1 RPC endpoint configured; FR-007 expects >=2 for failover`)
+    }
+
+    const gasWallet = opt(env, `GAS_WALLET_${chainId}`, null)
+    if (gasWallet && !ADDRESS_RE.test(gasWallet)) throw new Error(`[relay-gateway] GAS_WALLET_${chainId} is not an address`)
+
+    chains[chainId] = {
+      chainId,
+      name: def.name,
+      gasType: def.gasType,
+      noBatch: def.noBatch,
+      paymentSupported: def.paymentSupported,
+      tokenDomain: def.paymentSupported
+        ? {
+            name: opt(env, `TOKEN_DOMAIN_NAME_${chainId}`, def.tokenDomain.name),
+            version: opt(env, `TOKEN_DOMAIN_VERSION_${chainId}`, def.tokenDomain.version),
+          }
+        : null,
+      paymentToken: deployment.paymentToken || null,
+      sanctionsGuard: c.sanctionsGuard,
+      targets,
+      targetsByKey: { wagerRegistry: c.wagerRegistry, membershipManager: c.membershipManager },
+      rpcUrls,
+      fundingMode: opt(env, `FUNDING_MODE_${chainId}`, 'sponsored'), // 'sponsored' | 'fee-netted'
+      gasSpendCapWei: bigInt(env, `GAS_SPEND_CAP_WEI_${chainId}`, 500_000_000_000_000_000n), // 0.5 native / window
+      gasPriceFallbackWei: def.gasPriceFallbackWei,
+      gasWallet,
+      peakBurnWeiPerHour: bigInt(env, `PEAK_BURN_WEI_PER_HR_${chainId}`, 50_000_000_000_000_000n), // 0.05 native/hr
+      engineRelayerId: opt(env, `ENGINE_RELAYER_ID_${chainId}`, `${def.name}-${chainId}`),
+      deploymentFile: deployment.file,
+    }
+  }
+
+  return {
+    enabledChainIds,
+    chains,
+    port: int(env, 'PORT', 8788),
+    originAuthSecret: opt(env, 'ORIGIN_AUTH_SECRET', null),
+    webhookSecret: opt(env, 'WEBHOOK_SHARED_SECRET', null),
+    engine: {
+      url: opt(env, 'ENGINE_URL', 'http://localhost:8080'),
+      apiKey: opt(env, 'ENGINE_API_KEY', null),
+      timeoutMs: int(env, 'ENGINE_TIMEOUT_MS', 5000),
+      retries: int(env, 'ENGINE_RETRIES', 2),
+    },
+    killSwitch: opt(env, 'KILL_SWITCH', 'false').toLowerCase() === 'true',
+    quotas: {
+      signerPerWindow: int(env, 'SIGNER_QUOTA_PER_MIN', 12),
+      globalPerWindow: int(env, 'GLOBAL_QUOTA_PER_MIN', 120),
+      windowMs: int(env, 'QUOTA_WINDOW_MS', 60_000),
+    },
+    maxQueueDepth: int(env, 'MAX_QUEUE_DEPTH', 100),
+    spendWindowMs: int(env, 'SPEND_WINDOW_MS', 3_600_000),
+    defaultGasLimit: bigInt(env, 'DEFAULT_GAS_LIMIT', 300_000n),
+    rpcTimeoutMs: int(env, 'RPC_TIMEOUT_MS', 4000),
+  }
+}

--- a/services/relay-gateway/src/config/providers.js
+++ b/services/relay-gateway/src/config/providers.js
@@ -1,0 +1,61 @@
+/**
+ * Per-chain read providers with ordered failover (FR-007: >=2 independent endpoints, no single
+ * provider is a hard dependency). The gateway only READS (sanctions screen, gas estimate,
+ * health probe, balance) — all writes go through the engine, which has its own rpc_urls failover.
+ *
+ * ETC/Mordor (61/63): batchMaxCount: 1 — their Caddy-fronted endpoints return batch responses
+ * ethers v6 cannot decode (mirrors frontend/src/utils/rpcProvider.js NO_BATCH_CHAIN_IDS).
+ */
+import { ethers } from 'ethers'
+
+function withTimeout(promise, ms, label) {
+  let timer
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+  })
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
+}
+
+/**
+ * A minimal failover wrapper exposing only the read methods the gateway uses.
+ * Tries endpoints in configured order; first success wins; throws the last error if all fail.
+ */
+export function makeFailoverProvider(chainCfg, { timeoutMs = 4000 } = {}) {
+  const inner = chainCfg.rpcUrls.map(
+    (url) =>
+      new ethers.JsonRpcProvider(url, chainCfg.chainId, {
+        staticNetwork: ethers.Network.from(chainCfg.chainId),
+        ...(chainCfg.noBatch ? { batchMaxCount: 1 } : {}),
+      })
+  )
+
+  async function attempt(fnName, args) {
+    let lastErr
+    for (const provider of inner) {
+      try {
+        return await withTimeout(provider[fnName](...args), timeoutMs, `${fnName}@chain${chainCfg.chainId}`)
+      } catch (e) {
+        lastErr = e
+      }
+    }
+    throw lastErr ?? new Error(`no RPC endpoints configured for chain ${chainCfg.chainId}`)
+  }
+
+  return {
+    chainId: chainCfg.chainId,
+    call: (tx) => attempt('call', [tx]),
+    estimateGas: (tx) => attempt('estimateGas', [tx]),
+    getFeeData: () => attempt('getFeeData', []),
+    getBalance: (address) => attempt('getBalance', [address]),
+    getBlockNumber: () => attempt('getBlockNumber', []),
+  }
+}
+
+/** Build the default provider map { chainId -> failover provider }. Injectable in tests. */
+export function buildProviders(config) {
+  const providers = {}
+  for (const chainId of config.enabledChainIds) {
+    providers[chainId] = makeFailoverProvider(config.chains[chainId], { timeoutMs: config.rpcTimeoutMs })
+  }
+  return providers
+}

--- a/services/relay-gateway/src/engine/client.js
+++ b/services/relay-gateway/src/engine/client.js
@@ -1,0 +1,74 @@
+/**
+ * OpenZeppelin Relayer REST client (contracts/engine-integration.md).
+ *
+ * The engine sees ONLY a built transaction ({to, value, data, speed}) — never a FairWins intent
+ * or the recovered signer; all policy stays in the gateway. One engine `relayerId` exists per
+ * (chainId, gasWallet); the mapping lives in config.chains[chainId].engineRelayerId.
+ *
+ * Written as a thin adapter interface so the engine is swappable (rrelayer/MIT fallback exposes
+ * an equivalent submit + webhook surface) without touching policy.
+ */
+import { EngineUnavailableError } from '../errors.js'
+
+/**
+ * @param {{url: string, apiKey?: string|null, timeoutMs?: number, retries?: number, fetchImpl?: typeof fetch}} opts
+ */
+export function createEngineClient({ url, apiKey = null, timeoutMs = 5000, retries = 2, fetchImpl = fetch }) {
+  const base = url.replace(/\/+$/, '')
+
+  async function post(path, body) {
+    let lastErr
+    for (let attempt = 0; attempt <= retries; attempt += 1) {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), timeoutMs)
+      try {
+        const res = await fetchImpl(`${base}${path}`, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
+          },
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        })
+        if (res.status >= 500) {
+          lastErr = new EngineUnavailableError(`engine returned ${res.status}`)
+          continue // retry on engine-side errors
+        }
+        if (!res.ok) {
+          // 4xx from the engine is a hard error for this request (bad relayer id, paused, ...).
+          const text = await res.text().catch(() => '')
+          throw new EngineUnavailableError(`engine rejected submission (${res.status}): ${text.slice(0, 200)}`)
+        }
+        return await res.json()
+      } catch (e) {
+        if (e instanceof EngineUnavailableError && e.message.startsWith('engine rejected')) throw e
+        lastErr = e
+      } finally {
+        clearTimeout(timer)
+      }
+    }
+    throw new EngineUnavailableError(`engine unreachable after ${retries + 1} attempts`, lastErr)
+  }
+
+  return {
+    /**
+     * Submit a built transaction to the engine's lane for this chain.
+     * @param {{relayerId: string, to: string, data: string, speed?: string}} args
+     * @returns {Promise<{id: string, hash: string|null, status: string}>}
+     */
+    async submitTransaction({ relayerId, to, data, speed = 'fast' }) {
+      const json = await post(`/api/v1/relayers/${encodeURIComponent(relayerId)}/transactions`, {
+        to,
+        value: '0',
+        data,
+        speed,
+      })
+      // OZ Relayer 1.x wraps payloads as { success, data: {...} }; accept both shapes.
+      const tx = json?.data ?? json ?? {}
+      const id = tx.id ?? tx.transaction_id ?? null
+      if (!id) throw new EngineUnavailableError('engine response missing transaction id')
+      return { id: String(id), hash: tx.hash ?? null, status: tx.status ?? 'pending' }
+    },
+  }
+}

--- a/services/relay-gateway/src/engine/webhook.js
+++ b/services/relay-gateway/src/engine/webhook.js
@@ -1,0 +1,72 @@
+/**
+ * Engine -> gateway status webhook logic (contracts/engine-integration.md).
+ *
+ * Maps the engine's transaction lifecycle onto the Intent Status lifecycle
+ * (data-model.md): `confirmed` is surfaced ONLY on mined/confirmed — never on
+ * submit/pending — so the gateway can never report false success (FR-006).
+ *
+ *   engine status  -> intent status
+ *   pending/sent/submitted -> submitted
+ *   mined/confirmed        -> confirmed   (terminal; dedup marker -> completed)
+ *   failed/expired         -> failed      (terminal; dedup marker -> failed => retryable)
+ *   cancelled              -> failed
+ */
+const STATUS_MAP = {
+  pending: 'submitted',
+  sent: 'submitted',
+  submitted: 'submitted',
+  mined: 'confirmed',
+  confirmed: 'confirmed',
+  failed: 'failed',
+  expired: 'failed',
+  cancelled: 'failed',
+  canceled: 'failed',
+}
+
+export function mapEngineStatus(engineStatus) {
+  return STATUS_MAP[String(engineStatus ?? '').toLowerCase()] ?? null
+}
+
+/**
+ * Apply one engine webhook event. Pure of HTTP concerns (server.js owns auth + parsing).
+ * @returns {{ ok: boolean, code?: string, record?: object }}
+ */
+export function applyEngineEvent({ store, dedup, audit }, event) {
+  const engineTxId = event?.id != null ? String(event.id) : null
+  if (!engineTxId) return { ok: false, code: 'missing_id' }
+
+  const mapped = mapEngineStatus(event.status)
+  if (!mapped) return { ok: false, code: 'unknown_status' }
+
+  const record = store.getByEngineTxId(engineTxId)
+  if (!record) return { ok: false, code: 'unknown_transaction' }
+
+  // Don't regress a terminal state (late/duplicate webhook deliveries are expected).
+  if (record.status === 'confirmed' || record.status === 'failed') {
+    return { ok: true, record }
+  }
+
+  const txHash = event.hash ?? record.txHash ?? null
+  const reason = mapped === 'failed' ? (event.reason ?? event.status_reason ?? 'transaction failed on-chain') : null
+  store.setStatus(record.intentId, mapped, { txHash, reason })
+
+  if (mapped === 'confirmed') {
+    dedup.markCompleted(record.chainId, record.uniquenessMarker)
+  } else if (mapped === 'failed') {
+    // The on-chain nonce was not consumed; a fresh submission of the same marker is safe.
+    dedup.markFailed(record.chainId, record.uniquenessMarker)
+  }
+
+  audit({
+    signer: record.signer,
+    chainId: record.chainId,
+    action: record.action,
+    targetContract: record.targetContract,
+    uniquenessMarker: record.uniquenessMarker,
+    txHash,
+    outcome: mapped === 'submitted' ? 'submitted' : mapped,
+    ...(reason ? { reason } : {}),
+  })
+
+  return { ok: true, record }
+}

--- a/services/relay-gateway/src/errors.js
+++ b/services/relay-gateway/src/errors.js
@@ -1,0 +1,35 @@
+/**
+ * GatewayError — the single error type surfaced to clients.
+ *
+ * Error body shape is ALWAYS `{ error: { code, reason } }` (contracts/relay-gateway-api.md).
+ * `code` values are the exact enum from the API contract; `reason` is a specific,
+ * user-actionable sentence (spec 035 FR-019). Never leak internals or key material.
+ */
+export class GatewayError extends Error {
+  /**
+   * @param {number} status HTTP status
+   * @param {string} code   machine-readable error code from the API contract
+   * @param {string} reason user-actionable reason
+   * @param {{retryAfterSec?: number}} [opts]
+   */
+  constructor(status, code, reason, opts = {}) {
+    super(reason)
+    this.status = status
+    this.code = code
+    this.reason = reason
+    this.retryAfterSec = opts.retryAfterSec
+  }
+
+  toBody() {
+    return { error: { code: this.code, reason: this.reason } }
+  }
+}
+
+/** Engine unreachable / persistent non-2xx — mapped to 503 chain_unavailable at the route. */
+export class EngineUnavailableError extends Error {
+  constructor(message, cause) {
+    super(message)
+    this.name = 'EngineUnavailableError'
+    this.cause = cause
+  }
+}

--- a/services/relay-gateway/src/intent/intentTypes.js
+++ b/services/relay-gateway/src/intent/intentTypes.js
@@ -1,0 +1,384 @@
+/**
+ * Spec-035 intent type definitions — the ONE place where the EIP-712 structs
+ * (specs/035-intent-based-payments/contracts/intent-eip712-schemas.md) and the
+ * signer-attributed entrypoint ABI (…/withsig-entrypoints.md) live.
+ *
+ * Everything else (verification, encoding, tests, docs) derives from this module so a
+ * spec-035 schema change is a one-file edit.
+ *
+ * Notes / recorded assumptions:
+ * - The struct set below mirrors the DEPLOYED contracts (contracts/wagers/WagerRegistryIntents.sol,
+ *   contracts/access/MembershipManager.sol) — the on-chain typehashes are authoritative. This
+ *   includes fields the schemas doc elided: AcceptWagerIntent carries `paymentNonce` (it is a
+ *   money-in intent — the "common trailing fields" rule), CreateWagerIntent's "…" is the full
+ *   CreateArgs layout, and DeclareWinnerIntent backs declareWinnerWithSig.
+ * - Per data-model.md, for the `payment` class `uniquenessMarker` IS the EIP-3009 nonce; we also
+ *   require the intent-struct replay nonce to equal it (client signs both legs with one marker),
+ *   which keeps the request shape to a single `uniquenessMarker` field.
+ */
+import { ethers } from 'ethers'
+
+// ---------------------------------------------------------------------------
+// EIP-712 domains (per verifying contract; chainId + verifyingContract added at runtime)
+// ---------------------------------------------------------------------------
+
+export const CONTRACT_DOMAINS = {
+  wagerRegistry: { name: 'FairWins WagerRegistry', version: '1' },
+  membershipManager: { name: 'FairWins MembershipManager', version: '1' },
+}
+
+// ---------------------------------------------------------------------------
+// EIP-712 struct definitions (verbatim from intent-eip712-schemas.md)
+// ---------------------------------------------------------------------------
+
+const TAIL = [
+  { name: 'nonce', type: 'bytes32' },
+  { name: 'validAfter', type: 'uint256' },
+  { name: 'validBefore', type: 'uint256' },
+]
+
+export const INTENT_TYPES = {
+  CreateWagerIntent: [
+    { name: 'creator', type: 'address' },
+    { name: 'opponent', type: 'address' },
+    { name: 'arbitrator', type: 'address' },
+    { name: 'token', type: 'address' },
+    { name: 'creatorStake', type: 'uint128' },
+    { name: 'opponentStake', type: 'uint128' },
+    { name: 'acceptDeadline', type: 'uint64' },
+    { name: 'resolveDeadline', type: 'uint64' },
+    { name: 'resolutionType', type: 'uint8' },
+    { name: 'conditionId', type: 'bytes32' },
+    { name: 'creatorIsYes', type: 'bool' },
+    { name: 'metadataHash', type: 'bytes32' },
+    { name: 'metadataUri', type: 'string' },
+    { name: 'termsVersionHash', type: 'bytes32' },
+    { name: 'paymentNonce', type: 'bytes32' },
+    ...TAIL,
+  ],
+  AcceptWagerIntent: [
+    { name: 'wagerId', type: 'uint256' },
+    { name: 'taker', type: 'address' },
+    { name: 'paymentNonce', type: 'bytes32' },
+    ...TAIL,
+  ],
+  ClaimPayoutIntent: [
+    { name: 'wagerId', type: 'uint256' },
+    { name: 'claimant', type: 'address' },
+    ...TAIL,
+  ],
+  ClaimRefundIntent: [
+    { name: 'wagerId', type: 'uint256' },
+    { name: 'actor', type: 'address' },
+    ...TAIL,
+  ],
+  DeclareDrawIntent: [
+    { name: 'wagerId', type: 'uint256' },
+    { name: 'actor', type: 'address' },
+    ...TAIL,
+  ],
+  RevokeDrawIntent: [
+    { name: 'wagerId', type: 'uint256' },
+    { name: 'actor', type: 'address' },
+    ...TAIL,
+  ],
+  CancelOpenIntent: [
+    { name: 'wagerId', type: 'uint256' },
+    { name: 'actor', type: 'address' },
+    ...TAIL,
+  ],
+  DeclineIntent: [
+    { name: 'wagerId', type: 'uint256' },
+    { name: 'actor', type: 'address' },
+    ...TAIL,
+  ],
+  DeclareWinnerIntent: [
+    { name: 'wagerId', type: 'uint256' },
+    { name: 'winner', type: 'address' },
+    { name: 'actor', type: 'address' },
+    ...TAIL,
+  ],
+  PurchaseTierIntent: [
+    { name: 'role', type: 'bytes32' },
+    { name: 'tier', type: 'uint8' },
+    { name: 'acceptedTermsHash', type: 'bytes32' },
+    { name: 'member', type: 'address' },
+    { name: 'paymentNonce', type: 'bytes32' },
+    ...TAIL,
+  ],
+  UpgradeTierIntent: [
+    { name: 'role', type: 'bytes32' },
+    { name: 'tier', type: 'uint8' },
+    { name: 'acceptedTermsHash', type: 'bytes32' },
+    { name: 'member', type: 'address' },
+    { name: 'paymentNonce', type: 'bytes32' },
+    ...TAIL,
+  ],
+  ExtendMembershipIntent: [
+    { name: 'role', type: 'bytes32' },
+    { name: 'member', type: 'address' },
+    { name: 'paymentNonce', type: 'bytes32' },
+    ...TAIL,
+  ],
+  RedeemVoucherIntent: [
+    { name: 'voucherId', type: 'uint256' },
+    { name: 'acceptedTermsHash', type: 'bytes32' },
+    { name: 'redeemer', type: 'address' },
+    ...TAIL,
+  ],
+}
+
+// EIP-3009 payment-leg typed data (token's own domain — native USDC version "2").
+export const RECEIVE_WITH_AUTHORIZATION_TYPES = {
+  ReceiveWithAuthorization: [
+    { name: 'from', type: 'address' },
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'validAfter', type: 'uint256' },
+    { name: 'validBefore', type: 'uint256' },
+    { name: 'nonce', type: 'bytes32' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Signer-attributed entrypoint ABI (verbatim from withsig-entrypoints.md)
+// ---------------------------------------------------------------------------
+
+const AUTH_TUPLE = '(uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce,uint8 v,bytes32 r,bytes32 s)'
+const CREATE_ARGS_TUPLE =
+  '(address opponent,address arbitrator,address token,uint128 creatorStake,uint128 opponentStake,uint64 acceptDeadline,uint64 resolveDeadline,uint8 resolutionType,bytes32 conditionId,bool creatorIsYes,bytes32 metadataHash,string metadataUri,bytes32 termsVersionHash,bytes32 paymentNonce)'
+
+export const ENTRYPOINT_ABI = [
+  // WagerRegistry — no-stake …WithSig twins
+  'function claimPayoutWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes sig)',
+  'function claimRefundWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes sig)',
+  'function declareDrawWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes sig)',
+  'function revokeDrawWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes sig)',
+  'function cancelOpenWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes sig)',
+  'function declineWagerWithSig(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes sig)',
+  'function declareWinnerWithSig(uint256 wagerId, address winner, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes sig)',
+  // WagerRegistry — money-in …WithAuthorization twins (EIP-3009 pull attributed to signer)
+  `function createWagerWithAuthorization(${CREATE_ARGS_TUPLE} args, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes intentSig, ${AUTH_TUPLE} stakeAuth, ${AUTH_TUPLE} feeAuth) returns (uint256)`,
+  `function acceptWagerWithAuthorization(uint256 wagerId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes intentSig, ${AUTH_TUPLE} stakeAuth, ${AUTH_TUPLE} feeAuth)`,
+  `function acceptOpenWagerWithAuthorization(uint256 wagerId, address signer, bytes claimCodeSig, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes intentSig, ${AUTH_TUPLE} stakeAuth, ${AUTH_TUPLE} feeAuth)`,
+  // MembershipManager
+  `function purchaseTierWithAuthorization(bytes32 role, uint8 tier, bytes32 termsHash, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes intentSig, ${AUTH_TUPLE} priceAuth, ${AUTH_TUPLE} feeAuth)`,
+  `function upgradeTierWithAuthorization(bytes32 role, uint8 tier, bytes32 termsHash, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes intentSig, ${AUTH_TUPLE} priceAuth, ${AUTH_TUPLE} feeAuth)`,
+  `function extendMembershipWithAuthorization(bytes32 role, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes intentSig, ${AUTH_TUPLE} priceAuth, ${AUTH_TUPLE} feeAuth)`,
+  'function redeemVoucherWithSig(uint256 voucherId, bytes32 termsHash, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes sig)',
+]
+
+export const entrypointInterface = new ethers.Interface(ENTRYPOINT_ABI)
+
+/** Zeroed ERC3009Auth tuple — feeAuth is "ignored/empty" when fee-netting is off (spec 035). */
+export const EMPTY_AUTH = {
+  value: 0n,
+  validAfter: 0n,
+  validBefore: 0n,
+  nonce: ethers.ZeroHash,
+  v: 0,
+  r: ethers.ZeroHash,
+  s: ethers.ZeroHash,
+}
+
+const authTuple = (a) => [a.value, a.validAfter, a.validBefore, a.nonce, a.v, a.r, a.s]
+
+// ---------------------------------------------------------------------------
+// Action registry: canonical action name → class, contract, struct, encoder
+// ---------------------------------------------------------------------------
+//
+// `actorField` is the struct field that MUST equal the recovered signer (spec 035:
+// "an actor address field that MUST equal the recovered signer").
+// `params` lists the client-supplied action parameters (everything else is derived).
+// `buildMessage` produces the EIP-712 message we verify the signature against.
+// `encode` produces the calldata handed to the engine (Interface.encodeFunctionData).
+
+function withSigAction({ contract, typeName, actorField, fn, paramNames, buildArgs }) {
+  return {
+    intentClass: 'signer-attributed',
+    contract,
+    typeName,
+    actorField,
+    fn,
+    paramNames,
+    buildMessage: (params, signer, intent) => {
+      const msg = {}
+      for (const f of INTENT_TYPES[typeName]) {
+        if (f.name === actorField) msg[f.name] = signer
+        else if (f.name === 'nonce') msg[f.name] = intent.uniquenessMarker
+        else if (f.name === 'validAfter') msg[f.name] = intent.validAfter
+        else if (f.name === 'validBefore') msg[f.name] = intent.validBefore
+        else msg[f.name] = params[f.name]
+      }
+      return msg
+    },
+    encode: (params, signer, intent) =>
+      entrypointInterface.encodeFunctionData(fn, buildArgs(params, signer, intent)),
+  }
+}
+
+function withAuthAction({ contract, typeName, actorField, fn, paramNames, buildArgs }) {
+  return {
+    intentClass: 'payment',
+    contract,
+    typeName,
+    actorField,
+    fn,
+    paramNames,
+    buildMessage: (params, signer, intent) => {
+      const msg = {}
+      for (const f of INTENT_TYPES[typeName]) {
+        if (f.name === actorField) msg[f.name] = signer
+        else if (f.name === 'nonce') msg[f.name] = intent.uniquenessMarker
+        else if (f.name === 'paymentNonce') msg[f.name] = intent.authorization.nonce
+        else if (f.name === 'validAfter') msg[f.name] = intent.validAfter
+        else if (f.name === 'validBefore') msg[f.name] = intent.validBefore
+        else msg[f.name] = params[f.name]
+      }
+      return msg
+    },
+    encode: (params, signer, intent) =>
+      entrypointInterface.encodeFunctionData(fn, buildArgs(params, signer, intent)),
+  }
+}
+
+const sigArgs = (first) => (params, signer, intent) => [
+  params[first],
+  signer,
+  intent.uniquenessMarker,
+  intent.validAfter,
+  intent.validBefore,
+  intent.signature,
+]
+
+const stakeAuthOf = (intent) => authTuple({
+  value: intent.authorization.value,
+  validAfter: intent.authorization.validAfter,
+  validBefore: intent.authorization.validBefore,
+  nonce: intent.authorization.nonce,
+  v: intent.authorization.v,
+  r: intent.authorization.r,
+  s: intent.authorization.s,
+})
+
+const feeAuthOf = (intent) => authTuple(intent.feeAuthorization ?? EMPTY_AUTH)
+
+export const ACTIONS = {
+  // ---- WagerRegistry, no-stake ----
+  claimPayout: withSigAction({
+    contract: 'wagerRegistry', typeName: 'ClaimPayoutIntent', actorField: 'claimant',
+    fn: 'claimPayoutWithSig', paramNames: ['wagerId'], buildArgs: sigArgs('wagerId'),
+  }),
+  claimRefund: withSigAction({
+    contract: 'wagerRegistry', typeName: 'ClaimRefundIntent', actorField: 'actor',
+    fn: 'claimRefundWithSig', paramNames: ['wagerId'], buildArgs: sigArgs('wagerId'),
+  }),
+  declareDraw: withSigAction({
+    contract: 'wagerRegistry', typeName: 'DeclareDrawIntent', actorField: 'actor',
+    fn: 'declareDrawWithSig', paramNames: ['wagerId'], buildArgs: sigArgs('wagerId'),
+  }),
+  revokeDraw: withSigAction({
+    contract: 'wagerRegistry', typeName: 'RevokeDrawIntent', actorField: 'actor',
+    fn: 'revokeDrawWithSig', paramNames: ['wagerId'], buildArgs: sigArgs('wagerId'),
+  }),
+  cancelOpen: withSigAction({
+    contract: 'wagerRegistry', typeName: 'CancelOpenIntent', actorField: 'actor',
+    fn: 'cancelOpenWithSig', paramNames: ['wagerId'], buildArgs: sigArgs('wagerId'),
+  }),
+  declineWager: withSigAction({
+    contract: 'wagerRegistry', typeName: 'DeclineIntent', actorField: 'actor',
+    fn: 'declineWagerWithSig', paramNames: ['wagerId'], buildArgs: sigArgs('wagerId'),
+  }),
+  declareWinner: withSigAction({
+    contract: 'wagerRegistry', typeName: 'DeclareWinnerIntent', actorField: 'actor',
+    fn: 'declareWinnerWithSig', paramNames: ['wagerId', 'winner'],
+    buildArgs: (params, signer, intent) => [
+      params.wagerId, params.winner, signer, intent.uniquenessMarker,
+      intent.validAfter, intent.validBefore, intent.signature,
+    ],
+  }),
+
+  // ---- WagerRegistry, money-in (payment class) ----
+  createWager: withAuthAction({
+    contract: 'wagerRegistry', typeName: 'CreateWagerIntent', actorField: 'creator',
+    fn: 'createWagerWithAuthorization',
+    paramNames: [
+      'opponent', 'arbitrator', 'token', 'creatorStake', 'opponentStake', 'acceptDeadline',
+      'resolveDeadline', 'resolutionType', 'conditionId', 'creatorIsYes', 'metadataHash',
+      'metadataUri', 'termsVersionHash',
+    ],
+    buildArgs: (params, signer, intent) => [
+      [
+        params.opponent, params.arbitrator, params.token, params.creatorStake, params.opponentStake,
+        params.acceptDeadline, params.resolveDeadline, params.resolutionType, params.conditionId,
+        params.creatorIsYes, params.metadataHash, params.metadataUri, params.termsVersionHash,
+        intent.authorization.nonce, // paymentNonce — asserted on-chain against stakeAuth.nonce
+      ],
+      signer, intent.uniquenessMarker, intent.validAfter, intent.validBefore,
+      intent.signature, stakeAuthOf(intent), feeAuthOf(intent),
+    ],
+  }),
+  acceptWager: withAuthAction({
+    contract: 'wagerRegistry', typeName: 'AcceptWagerIntent', actorField: 'taker',
+    fn: 'acceptWagerWithAuthorization', paramNames: ['wagerId'],
+    buildArgs: (params, signer, intent) => [
+      params.wagerId, signer, intent.uniquenessMarker, intent.validAfter, intent.validBefore,
+      intent.signature, stakeAuthOf(intent), feeAuthOf(intent),
+    ],
+  }),
+  acceptOpenWager: withAuthAction({
+    contract: 'wagerRegistry', typeName: 'AcceptWagerIntent', actorField: 'taker',
+    fn: 'acceptOpenWagerWithAuthorization', paramNames: ['wagerId', 'claimCodeSig'],
+    buildArgs: (params, signer, intent) => [
+      params.wagerId, signer, params.claimCodeSig, intent.uniquenessMarker, intent.validAfter,
+      intent.validBefore, intent.signature, stakeAuthOf(intent), feeAuthOf(intent),
+    ],
+  }),
+
+  // ---- MembershipManager ----
+  purchaseTier: withAuthAction({
+    contract: 'membershipManager', typeName: 'PurchaseTierIntent', actorField: 'member',
+    fn: 'purchaseTierWithAuthorization', paramNames: ['role', 'tier', 'acceptedTermsHash'],
+    buildArgs: (params, signer, intent) => [
+      params.role, params.tier, params.acceptedTermsHash, signer, intent.uniquenessMarker,
+      intent.validAfter, intent.validBefore, intent.signature, stakeAuthOf(intent), feeAuthOf(intent),
+    ],
+  }),
+  upgradeTier: withAuthAction({
+    contract: 'membershipManager', typeName: 'UpgradeTierIntent', actorField: 'member',
+    fn: 'upgradeTierWithAuthorization', paramNames: ['role', 'tier', 'acceptedTermsHash'],
+    buildArgs: (params, signer, intent) => [
+      params.role, params.tier, params.acceptedTermsHash, signer, intent.uniquenessMarker,
+      intent.validAfter, intent.validBefore, intent.signature, stakeAuthOf(intent), feeAuthOf(intent),
+    ],
+  }),
+  extendMembership: withAuthAction({
+    contract: 'membershipManager', typeName: 'ExtendMembershipIntent', actorField: 'member',
+    fn: 'extendMembershipWithAuthorization', paramNames: ['role'],
+    buildArgs: (params, signer, intent) => [
+      params.role, signer, intent.uniquenessMarker, intent.validAfter, intent.validBefore,
+      intent.signature, stakeAuthOf(intent), feeAuthOf(intent),
+    ],
+  }),
+  redeemVoucher: withSigAction({
+    contract: 'membershipManager', typeName: 'RedeemVoucherIntent', actorField: 'redeemer',
+    fn: 'redeemVoucherWithSig', paramNames: ['voucherId', 'acceptedTermsHash'],
+    buildArgs: (params, signer, intent) => [
+      params.voucherId, params.acceptedTermsHash, signer, intent.uniquenessMarker,
+      intent.validAfter, intent.validBefore, intent.signature,
+    ],
+  }),
+}
+
+/** Allowed action names per target contract key — the version-pinned allow-list (FR-025). */
+export function actionsForContract(contractKey) {
+  return Object.entries(ACTIONS)
+    .filter(([, a]) => a.contract === contractKey)
+    .map(([name]) => name)
+}
+
+/** Single-type EIP-712 `types` object for an action's intent struct. */
+export function typesFor(action) {
+  const def = ACTIONS[action]
+  return { [def.typeName]: INTENT_TYPES[def.typeName] }
+}

--- a/services/relay-gateway/src/intent/store.js
+++ b/services/relay-gateway/src/intent/store.js
@@ -1,0 +1,97 @@
+/**
+ * In-memory intent store: intentId -> record, plus an engine-tx index for webhook resolution.
+ *
+ * Phase 1 (single instance): in-process Maps. Phase 2 (horizontal scale): move to shared Redis
+ * (Memorystore) — see research.md §3. Restart loss is benign: on-chain is the record of record
+ * and the uniquenessMarker is single-use on-chain, so a replay after restart cannot double-spend.
+ *
+ * Status lifecycle (data-model.md): queued -> submitted -> confirmed | failed.
+ * `confirmed` is ONLY ever set from an engine webhook reporting mined/confirmed (FR-006 —
+ * never report success before on-chain inclusion).
+ */
+import crypto from 'node:crypto'
+
+export function createIntentStore({ now = () => Date.now(), ttlMs = 24 * 3600 * 1000 } = {}) {
+  const byId = new Map()
+  const byEngineTxId = new Map()
+
+  function sweep() {
+    const cutoff = now() - ttlMs
+    for (const [id, rec] of byId) {
+      if (rec.updatedAt < cutoff && (rec.status === 'confirmed' || rec.status === 'failed')) {
+        byId.delete(id)
+        if (rec.engineTxId) byEngineTxId.delete(rec.engineTxId)
+      }
+    }
+  }
+
+  return {
+    create({ chainId, signer, action, targetContract, uniquenessMarker }) {
+      sweep()
+      const intentId = crypto.randomUUID()
+      const rec = {
+        intentId,
+        chainId,
+        signer,
+        action,
+        targetContract,
+        uniquenessMarker,
+        status: 'queued',
+        txHash: null,
+        engineTxId: null,
+        reason: null,
+        createdAt: now(),
+        updatedAt: now(),
+      }
+      byId.set(intentId, rec)
+      return rec
+    },
+
+    get(intentId) {
+      return byId.get(intentId) ?? null
+    },
+
+    getByEngineTxId(engineTxId) {
+      return byEngineTxId.get(engineTxId) ?? null
+    },
+
+    attachEngineTx(intentId, engineTxId, txHash) {
+      const rec = byId.get(intentId)
+      if (!rec) return null
+      rec.engineTxId = engineTxId
+      if (txHash) {
+        rec.txHash = txHash
+        rec.status = 'submitted'
+      }
+      rec.updatedAt = now()
+      if (engineTxId) byEngineTxId.set(engineTxId, rec)
+      return rec
+    },
+
+    setStatus(intentId, status, { txHash, reason } = {}) {
+      const rec = byId.get(intentId)
+      if (!rec) return null
+      rec.status = status
+      if (txHash) rec.txHash = txHash
+      if (reason) rec.reason = reason
+      rec.updatedAt = now()
+      return rec
+    },
+
+    /** Bounded-queue depth: intents accepted but not yet terminal (FR-009 back-pressure input). */
+    inFlightCount() {
+      let n = 0
+      for (const rec of byId.values()) {
+        if (rec.status === 'queued' || rec.status === 'submitted') n += 1
+      }
+      return n
+    },
+
+    remove(intentId) {
+      const rec = byId.get(intentId)
+      if (!rec) return
+      byId.delete(intentId)
+      if (rec.engineTxId) byEngineTxId.delete(rec.engineTxId)
+    },
+  }
+}

--- a/services/relay-gateway/src/intent/verify.js
+++ b/services/relay-gateway/src/intent/verify.js
@@ -1,0 +1,270 @@
+/**
+ * Intent parsing, signer recovery, and binding validation (data-model.md "Validation pipeline").
+ *
+ * The gateway NEVER trusts client-asserted identity: the signer is RECOVERED from the signature
+ * (EIP-712 typed data for the signer-attributed class; the EIP-3009 authorization for the payment
+ * class) and is the sole identity used for screening, quotas, and attribution (FR-002/FR-003).
+ *
+ * Network isolation (FR-024 / SC-014): the chainId is part of the EIP-712 domain, so a signature
+ * produced for chain A cannot recover to the claimed actor under chain B's domain. When the
+ * recovered address mismatches, we re-try recovery under every OTHER enabled chain's domain —
+ * if one of them matches, the intent was signed for a different network and we return the
+ * specific `chain_mismatch` instead of a generic `invalid_signature`.
+ */
+import { ethers } from 'ethers'
+import { GatewayError } from '../errors.js'
+import {
+  ACTIONS,
+  CONTRACT_DOMAINS,
+  RECEIVE_WITH_AUTHORIZATION_TYPES,
+  typesFor,
+} from './intentTypes.js'
+
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/
+const BYTES32_RE = /^0x[0-9a-fA-F]{64}$/
+const HEX_RE = /^0x[0-9a-fA-F]*$/
+
+const bad = (reason) => new GatewayError(400, 'bad_request', reason)
+
+function asAddress(label, v) {
+  if (typeof v !== 'string' || !ADDRESS_RE.test(v)) throw bad(`${label} must be a 20-byte hex address`)
+  return ethers.getAddress(v)
+}
+
+function asBytes32(label, v) {
+  if (typeof v !== 'string' || !BYTES32_RE.test(v)) throw bad(`${label} must be a 32-byte hex value`)
+  return v.toLowerCase()
+}
+
+function asUint(label, v) {
+  let n
+  try {
+    n = BigInt(typeof v === 'number' && Number.isInteger(v) ? v : String(v))
+  } catch {
+    throw bad(`${label} must be a non-negative integer`)
+  }
+  if (n < 0n) throw bad(`${label} must be a non-negative integer`)
+  return n
+}
+
+function asHexBytes(label, v) {
+  if (typeof v !== 'string' || !HEX_RE.test(v) || v.length % 2 !== 0) throw bad(`${label} must be 0x-prefixed hex bytes`)
+  return v
+}
+
+/** Parse + shape-validate the POST /v1/intents body. Throws GatewayError(400) on malformed input. */
+export function parseIntent(body) {
+  if (!body || typeof body !== 'object') throw bad('body must be a JSON object')
+
+  const intentClass = body.intentClass
+  if (intentClass !== 'payment' && intentClass !== 'signer-attributed') {
+    throw bad('intentClass must be "payment" or "signer-attributed"')
+  }
+
+  const chainId = Number(asUint('chainId', body.chainId))
+  const targetContract = asAddress('targetContract', body.targetContract)
+
+  if (typeof body.action !== 'string' || body.action.length === 0) throw bad('action must be a non-empty string')
+  const action = body.action
+
+  const params = body.params
+  if (!params || typeof params !== 'object') throw bad('params must be an object')
+
+  const validAfter = asUint('validAfter', body.validAfter ?? 0)
+  const validBefore = asUint('validBefore', body.validBefore ?? 0)
+  const uniquenessMarker = asBytes32('uniquenessMarker', body.uniquenessMarker)
+
+  const fundingMode = body.fundingMode ?? 'sponsored'
+  if (fundingMode !== 'sponsored' && fundingMode !== 'fee-netted') {
+    throw bad('fundingMode must be "sponsored" or "fee-netted"')
+  }
+  const maxFee = body.maxFee != null ? asUint('maxFee', body.maxFee) : null
+
+  const signature = asHexBytes('signature', body.signature)
+
+  let authorization = null
+  if (intentClass === 'payment') {
+    const a = body.authorization
+    if (!a || typeof a !== 'object') throw bad('payment intents require an authorization object (EIP-3009)')
+    authorization = {
+      from: asAddress('authorization.from', a.from),
+      to: asAddress('authorization.to', a.to),
+      value: asUint('authorization.value', a.value),
+      validAfter: asUint('authorization.validAfter', a.validAfter),
+      validBefore: asUint('authorization.validBefore', a.validBefore),
+      nonce: asBytes32('authorization.nonce', a.nonce),
+      v: Number(asUint('authorization.v', a.v)),
+      r: asBytes32('authorization.r', a.r),
+      s: asBytes32('authorization.s', a.s),
+    }
+    if (authorization.v > 255) throw bad('authorization.v out of range')
+  }
+
+  return {
+    intentClass,
+    chainId,
+    targetContract,
+    action,
+    params,
+    signature,
+    authorization,
+    validAfter,
+    validBefore,
+    uniquenessMarker,
+    fundingMode,
+    maxFee,
+  }
+}
+
+/** Normalize action params against the registry definition (rejects missing fields early). */
+function normalizeParams(actionDef, params) {
+  const out = {}
+  for (const name of actionDef.paramNames) {
+    if (params[name] == null) throw bad(`params.${name} is required for action`)
+    if (name === 'claimCodeSig') out[name] = asHexBytes(`params.${name}`, params[name])
+    else if (name === 'role' || name === 'acceptedTermsHash') out[name] = asBytes32(`params.${name}`, params[name])
+    else if (name === 'tier') out[name] = Number(asUint(`params.${name}`, params[name]))
+    else out[name] = asUint(`params.${name}`, params[name])
+  }
+  return out
+}
+
+function domainFor(chainCfg, contractKey) {
+  const d = CONTRACT_DOMAINS[contractKey]
+  return {
+    name: d.name,
+    version: d.version,
+    chainId: chainCfg.chainId,
+    verifyingContract: chainCfg.targetsByKey[contractKey],
+  }
+}
+
+function tryRecoverTyped(domain, types, message, signature) {
+  try {
+    return ethers.verifyTypedData(domain, types, message, signature)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Full verification for one intent against the addressed chain's config.
+ * Order: allow-list -> signer recovery + binding -> validity window.
+ * (chainId-active, payment-supported, dedup, screening, quotas, fee checks live in the route
+ * pipeline — see server.js.)
+ *
+ * @param {object} intent        parsed intent (parseIntent output)
+ * @param {object} chainCfg      config.chains[intent.chainId]
+ * @param {object} config        full gateway config (for cross-chain mismatch detection)
+ * @param {number} nowSec        current unix time
+ * @returns {{ signer: string, actionDef: object, params: object, calldata: string }}
+ */
+export function verifyIntent(intent, chainCfg, config, nowSec) {
+  // --- target + action allow-list (version-pinned, FR-025) ---
+  const target = chainCfg.targets[intent.targetContract.toLowerCase()]
+  if (!target) {
+    throw new GatewayError(400, 'target_not_allowlisted', 'targetContract is not in the version-pinned target set for this chain')
+  }
+  const actionDef = ACTIONS[intent.action]
+  if (!actionDef || actionDef.contract !== target.key || !target.allowedActions.includes(intent.action)) {
+    throw new GatewayError(400, 'target_not_allowlisted', `action "${intent.action}" is not allow-listed for this target contract`)
+  }
+  if (actionDef.intentClass !== intent.intentClass) {
+    throw new GatewayError(400, 'param_binding_mismatch', `action "${intent.action}" belongs to the ${actionDef.intentClass} intent class`)
+  }
+
+  const params = normalizeParams(actionDef, intent.params)
+
+  // --- signer recovery ---
+  let signer
+  if (intent.intentClass === 'payment') {
+    signer = recoverPaymentSigner(intent, chainCfg)
+    // Intent leg: the EIP-712 action struct must ALSO be signed by the same wallet — this is what
+    // binds params (role/tier/wagerId/...) to the money leg (FR-007/FR-013 in spec 035).
+    const domain = domainFor(chainCfg, actionDef.contract)
+    const message = actionDef.buildMessage(params, signer, intent)
+    const recovered = tryRecoverTyped(domain, typesFor(intent.action), message, intent.signature)
+    if (!recovered || recovered.toLowerCase() !== signer.toLowerCase()) {
+      throwSignatureError(intent, actionDef, params, signer, config, chainCfg)
+    }
+  } else {
+    // Signer-attributed: the actor field of the signed struct IS the signer; the client supplies
+    // it in params so the full message is reconstructible, and recovery must match it exactly.
+    const actor = asAddress(`params.${actionDef.actorField}`, intent.params[actionDef.actorField])
+    const domain = domainFor(chainCfg, actionDef.contract)
+    const message = actionDef.buildMessage(params, actor, intent)
+    const recovered = tryRecoverTyped(domain, typesFor(intent.action), message, intent.signature)
+    if (!recovered || recovered.toLowerCase() !== actor.toLowerCase()) {
+      throwSignatureError(intent, actionDef, params, actor, config, chainCfg)
+    }
+    signer = actor
+  }
+
+  // --- validity window (top-level fields are bound into the signed struct above) ---
+  if (intent.validBefore !== 0n && intent.validBefore <= BigInt(nowSec)) {
+    throw new GatewayError(400, 'expired', 'intent validBefore is in the past; sign a fresh intent')
+  }
+  if (intent.validAfter > BigInt(nowSec)) {
+    throw new GatewayError(400, 'not_yet_valid', 'intent validAfter is in the future')
+  }
+
+  // --- build the signer-attributed entrypoint calldata (engine sees only to/value/data) ---
+  const calldata = actionDef.encode(params, signer, intent)
+
+  return { signer, actionDef, params, calldata }
+}
+
+/** Recover the payment-class signer from the EIP-3009 authorization under the token's domain. */
+function recoverPaymentSigner(intent, chainCfg) {
+  const a = intent.authorization
+  // The authorization MUST pay the allow-listed target (binds funds to the contract, not the relayer).
+  if (a.to.toLowerCase() !== intent.targetContract.toLowerCase()) {
+    throw new GatewayError(400, 'param_binding_mismatch', 'authorization.to must equal targetContract')
+  }
+  // data-model.md: for the payment class the uniquenessMarker IS the EIP-3009 nonce.
+  if (a.nonce.toLowerCase() !== intent.uniquenessMarker.toLowerCase()) {
+    throw new GatewayError(400, 'param_binding_mismatch', 'uniquenessMarker must equal authorization.nonce for payment intents')
+  }
+  const domain = {
+    name: chainCfg.tokenDomain.name,
+    version: chainCfg.tokenDomain.version,
+    chainId: chainCfg.chainId,
+    verifyingContract: chainCfg.paymentToken,
+  }
+  const message = {
+    from: a.from,
+    to: a.to,
+    value: a.value,
+    validAfter: a.validAfter,
+    validBefore: a.validBefore,
+    nonce: a.nonce,
+  }
+  const sig = ethers.Signature.from({ v: a.v, r: a.r, s: a.s }).serialized
+  const recovered = tryRecoverTyped(domain, RECEIVE_WITH_AUTHORIZATION_TYPES, message, sig)
+  if (!recovered || recovered.toLowerCase() !== a.from.toLowerCase()) {
+    throw new GatewayError(400, 'invalid_signature', 'EIP-3009 authorization signature does not recover to authorization.from')
+  }
+  return recovered
+}
+
+/**
+ * Distinguish a wrong-network signature (chain_mismatch, SC-014) from a plain bad signature:
+ * re-try recovery under every other enabled chain's domain for the same contract key.
+ */
+function throwSignatureError(intent, actionDef, params, expectedActor, config, chainCfg) {
+  for (const otherId of config.enabledChainIds) {
+    if (otherId === chainCfg.chainId) continue
+    const other = config.chains[otherId]
+    const domain = domainFor(other, actionDef.contract)
+    const message = actionDef.buildMessage(params, expectedActor, intent)
+    const recovered = tryRecoverTyped(domain, typesFor(intent.action), message, intent.signature)
+    if (recovered && recovered.toLowerCase() === expectedActor.toLowerCase()) {
+      throw new GatewayError(
+        400,
+        'chain_mismatch',
+        `intent was signed for chain ${otherId}, not chain ${chainCfg.chainId}; intents never cross networks`
+      )
+    }
+  }
+  throw new GatewayError(400, 'invalid_signature', 'signature does not recover to the intent actor')
+}

--- a/services/relay-gateway/src/policy/backpressure.js
+++ b/services/relay-gateway/src/policy/backpressure.js
@@ -1,0 +1,16 @@
+/**
+ * Bounded-queue back-pressure (FR-009): when the in-flight depth reaches the configured bound,
+ * shed load explicitly with 429 backpressure + Retry-After instead of accepting unbounded work
+ * that then fails en masse. The client reacts by offering self-submit (FR-016).
+ */
+export function createBackpressure({ maxQueueDepth, depthFn, retryAfterSec = 15 }) {
+  return {
+    /** @returns {{allowed: true} | {allowed: false, retryAfterSec: number}} */
+    check() {
+      if (depthFn() >= maxQueueDepth) {
+        return { allowed: false, retryAfterSec }
+      }
+      return { allowed: true }
+    },
+  }
+}

--- a/services/relay-gateway/src/policy/dedup.js
+++ b/services/relay-gateway/src/policy/dedup.js
@@ -1,0 +1,74 @@
+/**
+ * Idempotent intent dedup on the uniquenessMarker (FR-008, SC-006).
+ *
+ * Keyed by `${chainId}:${uniquenessMarker}` (markers are per-network; FR-024 keeps networks
+ * isolated). States:
+ *   - in-flight  -> a concurrent duplicate is coalesced: 409 duplicate_in_flight
+ *   - completed  -> a repeat of a confirmed intent returns 200 with the ORIGINAL result,
+ *                   no second on-chain submission, no second gas spend
+ *   - failed     -> retryable: the on-chain nonce was never consumed, so a fresh attempt is safe
+ *
+ * The marker is reserved at the dedup step (before screening/quotas) so two concurrent identical
+ * requests can never both reach the engine; any later pipeline rejection releases the reservation.
+ *
+ * Phase 1: in-process Map (single instance). Phase 2: shared Redis (SET NX + TTL) so limits and
+ * dedup hold across instances — see research.md §3.
+ */
+export function createDedupStore({ now = () => Date.now(), ttlMs = 48 * 3600 * 1000 } = {}) {
+  /** @type {Map<string, {state: 'inflight'|'completed'|'failed', intentId: string, at: number}>} */
+  const entries = new Map()
+
+  const keyOf = (chainId, marker) => `${chainId}:${marker.toLowerCase()}`
+
+  function sweep() {
+    const cutoff = now() - ttlMs
+    for (const [k, e] of entries) {
+      if (e.at < cutoff && e.state !== 'inflight') entries.delete(k)
+    }
+  }
+
+  return {
+    /** Look up the marker without reserving. */
+    check(chainId, marker) {
+      const e = entries.get(keyOf(chainId, marker))
+      if (!e || e.state === 'failed') return { state: 'none' }
+      return { state: e.state, intentId: e.intentId }
+    },
+
+    /**
+     * Atomically reserve the marker for a new submission.
+     * @returns {{ok: true} | {ok: false, state: 'inflight'|'completed', intentId: string}}
+     */
+    reserve(chainId, marker, intentId) {
+      sweep()
+      const k = keyOf(chainId, marker)
+      const e = entries.get(k)
+      if (e && e.state !== 'failed') return { ok: false, state: e.state, intentId: e.intentId }
+      entries.set(k, { state: 'inflight', intentId, at: now() })
+      return { ok: true }
+    },
+
+    /** Release a reservation after a downstream rejection (marker never reached the engine). */
+    release(chainId, marker) {
+      entries.delete(keyOf(chainId, marker))
+    },
+
+    markCompleted(chainId, marker) {
+      const k = keyOf(chainId, marker)
+      const e = entries.get(k)
+      if (e) {
+        e.state = 'completed'
+        e.at = now()
+      }
+    },
+
+    markFailed(chainId, marker) {
+      const k = keyOf(chainId, marker)
+      const e = entries.get(k)
+      if (e) {
+        e.state = 'failed'
+        e.at = now()
+      }
+    },
+  }
+}

--- a/services/relay-gateway/src/policy/killswitch.js
+++ b/services/relay-gateway/src/policy/killswitch.js
@@ -1,0 +1,23 @@
+/**
+ * Global kill switch (FR-015): when active, POST /v1/intents returns 503 killswitch_active and
+ * all flows continue via self-submit (SC-004). Status polling and /healthz stay up so clients
+ * and operators can still observe state.
+ *
+ * Sources:
+ *  - boot: env KILL_SWITCH=true
+ *  - runtime: SIGUSR2 toggles it (wired in server.js bootstrap; `kill -USR2 <pid>`)
+ *  - tests/admin tooling: the returned setter
+ */
+export function createKillSwitch(initial = false) {
+  let active = Boolean(initial)
+  return {
+    isActive: () => active,
+    set(value) {
+      active = Boolean(value)
+    },
+    toggle() {
+      active = !active
+      return active
+    },
+  }
+}

--- a/services/relay-gateway/src/policy/quotas.js
+++ b/services/relay-gateway/src/policy/quotas.js
@@ -1,0 +1,90 @@
+/**
+ * Per-signer + global quotas and the per-chain per-window gas spend cap (FR-014, FR-018's
+ * per-window rate cap; SC-006 "no gas-wallet drain").
+ *
+ * Sliding-window counters over timestamps, with TTL cleanup on access. Phase 1: in-process
+ * (single instance). Phase 2: shared Redis atomic INCR+TTL so limits are NOT multiplied by
+ * instance count (FR-012, SC-012) — see research.md §3.
+ */
+
+export function createQuotas({ signerPerWindow, globalPerWindow, windowMs, now = () => Date.now() }) {
+  /** @type {Map<string, number[]>} signer -> accept timestamps */
+  const perSigner = new Map()
+  /** @type {number[]} */
+  let global = []
+
+  function prune(arr, cutoff) {
+    // Timestamps are appended in order; find the first still-live index.
+    let i = 0
+    while (i < arr.length && arr[i] <= cutoff) i += 1
+    return i > 0 ? arr.slice(i) : arr
+  }
+
+  function retryAfterSec(arr, cutoffMs) {
+    if (arr.length === 0) return 1
+    return Math.max(1, Math.ceil((arr[0] + cutoffMs - now()) / 1000))
+  }
+
+  return {
+    /**
+     * Count one acceptance attempt against the signer + global windows.
+     * @returns {{allowed: true} | {allowed: false, scope: 'signer'|'global', retryAfterSec: number}}
+     */
+    hit(signer) {
+      const t = now()
+      const cutoff = t - windowMs
+      const key = signer.toLowerCase()
+
+      let mine = prune(perSigner.get(key) ?? [], cutoff)
+      global = prune(global, cutoff)
+
+      if (mine.length >= signerPerWindow) {
+        perSigner.set(key, mine)
+        return { allowed: false, scope: 'signer', retryAfterSec: retryAfterSec(mine, windowMs) }
+      }
+      if (global.length >= globalPerWindow) {
+        return { allowed: false, scope: 'global', retryAfterSec: retryAfterSec(global, windowMs) }
+      }
+      mine = [...mine, t]
+      perSigner.set(key, mine)
+      global.push(t)
+
+      // TTL cleanup: drop empty signer buckets opportunistically to bound memory.
+      if (perSigner.size > 10_000) {
+        for (const [k, arr] of perSigner) {
+          if (prune(arr, cutoff).length === 0) perSigner.delete(k)
+        }
+      }
+      return { allowed: true }
+    },
+  }
+}
+
+/** Per-chain estimated-gas spend accumulator over a rolling window (FR-014 spend cap). */
+export function createSpendTracker({ chains, windowMs, now = () => Date.now() }) {
+  /** @type {Map<number, Array<{t: number, wei: bigint}>>} */
+  const spends = new Map()
+
+  return {
+    /**
+     * Try to add an estimated spend for a chain; refuses when the window cap would be exceeded.
+     * @returns {{allowed: true} | {allowed: false, retryAfterSec: number}}
+     */
+    tryAdd(chainId, estimatedWei) {
+      const cap = chains[chainId]?.gasSpendCapWei
+      if (cap == null) return { allowed: true }
+      const t = now()
+      const cutoff = t - windowMs
+      let arr = (spends.get(chainId) ?? []).filter((e) => e.t > cutoff)
+      const current = arr.reduce((acc, e) => acc + e.wei, 0n)
+      if (current + estimatedWei > cap) {
+        spends.set(chainId, arr)
+        const oldest = arr[0]?.t ?? t
+        return { allowed: false, retryAfterSec: Math.max(1, Math.ceil((oldest + windowMs - t) / 1000)) }
+      }
+      arr = [...arr, { t, wei: estimatedWei }]
+      spends.set(chainId, arr)
+      return { allowed: true }
+    },
+  }
+}

--- a/services/relay-gateway/src/policy/sanctions.js
+++ b/services/relay-gateway/src/policy/sanctions.js
@@ -1,0 +1,52 @@
+/**
+ * Sanctions re-screen of the RECOVERED SIGNER — fail-closed (FR-013, SC-005).
+ *
+ * Defense-in-depth duplicate of the contracts' own on-chain screen: the on-chain guard remains
+ * authoritative, but re-screening here means the relayer never even pays gas for a wallet the
+ * guard would reject, and never submits unscreened. Semantics:
+ *
+ *   - guard says not allowed             -> 403 sanctioned_signer
+ *   - screening cannot be performed      -> 503 screening_unavailable   (FAIL CLOSED — never
+ *     (RPC error, decode error, no guard)   "assume fine and submit")
+ *
+ * Uses ISanctionsGuard.isAllowed(address) (contracts/interfaces/ISanctionsGuard.sol), which is
+ * itself fail-closed over the Chainalysis oracle + deny-list.
+ */
+import { ethers } from 'ethers'
+import { GatewayError } from '../errors.js'
+
+export const SANCTIONS_GUARD_ABI = ['function isAllowed(address account) view returns (bool)']
+
+const iface = new ethers.Interface(SANCTIONS_GUARD_ABI)
+
+/**
+ * @param {{providers: Record<number, {call: Function}>, chains: Record<number, {sanctionsGuard: string}>}} deps
+ */
+export function createSanctionsScreen({ providers, chains }) {
+  return {
+    /**
+     * @param {number} chainId
+     * @param {string} signer recovered signer address
+     * @throws {GatewayError} 403 sanctioned_signer | 503 screening_unavailable
+     */
+    async screen(chainId, signer) {
+      const chain = chains[chainId]
+      const provider = providers[chainId]
+      if (!chain?.sanctionsGuard || !provider) {
+        throw new GatewayError(503, 'screening_unavailable', 'sanctions screening is required but not configured for this chain')
+      }
+      let allowed
+      try {
+        const data = iface.encodeFunctionData('isAllowed', [signer])
+        const result = await provider.call({ to: chain.sanctionsGuard, data })
+        ;[allowed] = iface.decodeFunctionResult('isAllowed', result)
+      } catch {
+        // Fail closed: an unreachable/erroring guard is NEVER treated as allowed (SC-005).
+        throw new GatewayError(503, 'screening_unavailable', 'sanctions screening could not be performed; try again or self-submit')
+      }
+      if (!allowed) {
+        throw new GatewayError(403, 'sanctioned_signer', 'signer failed sanctions screening')
+      }
+    },
+  }
+}

--- a/services/relay-gateway/src/server.js
+++ b/services/relay-gateway/src/server.js
@@ -1,0 +1,393 @@
+/**
+ * FairWins relay gateway — HTTP entrypoint (spec 036).
+ *
+ * The policy front-end for gasless intent submission: recovers + screens the SIGNER, validates
+ * intent binding, dedups, rate-limits and fee-gates, then hands built calldata to the OSS
+ * submission engine (OpenZeppelin Relayer) which owns nonces/gas/inclusion. Untrusted-by-design:
+ * this service can censor, never steal — every response leaves self-submit available (FR-002/FR-003).
+ *
+ * Routes (contracts/relay-gateway-api.md — implemented faithfully):
+ *   POST /v1/intents          submit a signed intent           (origin-locked)
+ *   GET  /v1/intents/:id      honest status                    (origin-locked)
+ *   POST /v1/engine/webhook   engine status callback           (shared-secret)
+ *   GET  /healthz             liveness/readiness               (origin-lock EXEMPT)
+ */
+import crypto from 'node:crypto'
+import express from 'express'
+import helmet from 'helmet'
+import { loadConfig } from './config/index.js'
+import { buildProviders } from './config/providers.js'
+import { parseIntent, verifyIntent } from './intent/verify.js'
+import { createIntentStore } from './intent/store.js'
+import { createSanctionsScreen } from './policy/sanctions.js'
+import { createDedupStore } from './policy/dedup.js'
+import { createQuotas, createSpendTracker } from './policy/quotas.js'
+import { createBackpressure } from './policy/backpressure.js'
+import { createKillSwitch } from './policy/killswitch.js'
+import { createEngineClient } from './engine/client.js'
+import { applyEngineEvent } from './engine/webhook.js'
+import { createAuditLogger } from './audit/log.js'
+import { GatewayError, EngineUnavailableError } from './errors.js'
+
+/** Constant-time secret comparison over fixed-length digests (no length leak). */
+function timingSafeEqual(a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string') return false
+  const da = crypto.createHash('sha256').update(a).digest()
+  const db = crypto.createHash('sha256').update(b).digest()
+  return crypto.timingSafeEqual(da, db)
+}
+
+/** Estimated gas cost in wei for spend-cap + fee-netting checks. Estimation failures fall back
+ * to configured defaults — the ENGINE owns real pricing; this is a policy-side bound only. */
+async function estimateCostWei(provider, chainCfg, { to, data }, defaultGasLimit) {
+  let gasLimit = defaultGasLimit
+  try {
+    if (provider?.estimateGas) gasLimit = BigInt(await provider.estimateGas({ to, data }))
+  } catch {
+    /* keep fallback */
+  }
+  let gasPrice = chainCfg.gasPriceFallbackWei
+  try {
+    if (provider?.getFeeData) {
+      const fee = await provider.getFeeData()
+      // Legacy chains (61/63) price on gasPrice only; EIP-1559 chains use maxFeePerGas.
+      const p = chainCfg.gasType === 'legacy' ? fee?.gasPrice : (fee?.maxFeePerGas ?? fee?.gasPrice)
+      if (p != null) gasPrice = BigInt(p)
+    }
+  } catch {
+    /* keep fallback */
+  }
+  return gasLimit * gasPrice
+}
+
+/**
+ * Build the Express app. All collaborators are injectable for tests
+ * ({providers, engineClient, now, killSwitch, auditSink}).
+ *
+ * @param {ReturnType<typeof loadConfig>} config
+ * @param {{
+ *   providers?: Record<number, object>,
+ *   engineClient?: {submitTransaction: Function},
+ *   now?: () => number,            // unix seconds
+ *   killSwitch?: ReturnType<typeof createKillSwitch>,
+ *   auditSink?: (line: string) => void,
+ * }} [deps]
+ */
+export function createApp(config, deps = {}) {
+  const providers = deps.providers ?? buildProviders(config)
+  const engineClient = deps.engineClient ?? createEngineClient(config.engine)
+  const now = deps.now ?? (() => Math.floor(Date.now() / 1000))
+  const killSwitch = deps.killSwitch ?? createKillSwitch(config.killSwitch)
+  const audit = createAuditLogger(deps.auditSink ? { sink: deps.auditSink } : {})
+
+  const nowMs = () => now() * 1000
+  const store = createIntentStore({ now: nowMs })
+  const dedup = createDedupStore({ now: nowMs })
+  const quotas = createQuotas({
+    signerPerWindow: config.quotas.signerPerWindow,
+    globalPerWindow: config.quotas.globalPerWindow,
+    windowMs: config.quotas.windowMs,
+    now: nowMs,
+  })
+  const spend = createSpendTracker({ chains: config.chains, windowMs: config.spendWindowMs, now: nowMs })
+  const backpressure = createBackpressure({
+    maxQueueDepth: config.maxQueueDepth,
+    // The current request's own record is already in the store when this runs — exclude it,
+    // the bound applies to work ALREADY in flight (FR-009).
+    depthFn: () => Math.max(0, store.inFlightCount() - 1),
+  })
+  const screen = createSanctionsScreen({ providers, chains: config.chains })
+
+  const app = express()
+  app.disable('x-powered-by')
+  app.use(helmet())
+  app.use(express.json({ limit: '32kb' })) // intents are small fixed-shape JSON; nothing large is legitimate
+
+  // ---- Origin-lock middleware (FR-029, SC-016): client-facing routes require X-Origin-Auth.
+  // The Cloudflare Transform Rule injects the header zone-wide; a direct *.run.app hit lacks it.
+  // Exempt: /healthz (probes) and /v1/engine/webhook — the engine calls from inside the private
+  // network (not through the edge) and authenticates with its own timing-safe shared secret.
+  app.use((req, res, next) => {
+    if (req.path === '/healthz' || req.path === '/v1/engine/webhook') return next()
+    if (!config.originAuthSecret) return next() // dev only; loudly warned at boot
+    const header = req.get('x-origin-auth')
+    if (!header || !timingSafeEqual(header, config.originAuthSecret)) {
+      res.status(403).json({ error: { code: 'origin_denied', reason: 'request did not arrive through the platform edge' } })
+      return
+    }
+    next()
+  })
+
+  // ---- GET /healthz (origin-lock exempt) --------------------------------------------------
+  app.get('/healthz', async (_req, res) => {
+    const chains = {}
+    await Promise.all(
+      config.enabledChainIds.map(async (chainId) => {
+        const chainCfg = config.chains[chainId]
+        const provider = providers[chainId]
+        let rpc = 'down'
+        try {
+          await provider.getBlockNumber()
+          rpc = 'up'
+        } catch {
+          rpc = 'down'
+        }
+        let gasWalletRunwayHrs = null
+        if (chainCfg.gasWallet && rpc === 'up') {
+          try {
+            const balance = BigInt(await provider.getBalance(chainCfg.gasWallet))
+            gasWalletRunwayHrs = Number(balance / chainCfg.peakBurnWeiPerHour)
+          } catch {
+            gasWalletRunwayHrs = null
+          }
+        }
+        chains[chainId] = { rpc, gasWalletRunwayHrs }
+      })
+    )
+    res.json({ status: 'ok', chains, killSwitch: killSwitch.isActive() })
+  })
+
+  // ---- POST /v1/intents --------------------------------------------------------------------
+  app.post('/v1/intents', async (req, res) => {
+    let reserved = null // {chainId, marker} released on any post-reservation rejection
+    try {
+      // Kill switch first: when active the gateway cleanly stops ACCEPTING intents (FR-015).
+      if (killSwitch.isActive()) {
+        throw new GatewayError(503, 'killswitch_active', 'relaying is temporarily disabled; use self-submit')
+      }
+
+      const intent = parseIntent(req.body)
+
+      // Chain active + matches config (FR-024).
+      const chainCfg = config.chains[intent.chainId]
+      if (!chainCfg) {
+        throw new GatewayError(400, 'chain_mismatch', `chainId ${intent.chainId} is not an active configured network`)
+      }
+
+      // Payment class on a chain without EIP-3009 (ETC/Mordor: USC is permit-only).
+      if (intent.intentClass === 'payment' && !chainCfg.paymentSupported) {
+        throw new GatewayError(
+          503,
+          'payment_unsupported_on_chain',
+          'gasless payment is not available on this network (token lacks EIP-3009); use self-submit'
+        )
+      }
+
+      // Allow-list -> signer recovery -> param binding -> validity window -> calldata.
+      const { signer, calldata } = verifyIntent(intent, chainCfg, config, now())
+
+      // Dedup by uniquenessMarker (FR-008): completed -> 200 original result; in-flight -> 409.
+      const existing = dedup.check(intent.chainId, intent.uniquenessMarker)
+      if (existing.state === 'completed') {
+        const original = store.get(existing.intentId)
+        res.status(200).json({
+          intentId: existing.intentId,
+          status: 'confirmed',
+          ...(original?.txHash ? { txHash: original.txHash } : {}),
+        })
+        return
+      }
+      if (existing.state === 'inflight') {
+        throw new GatewayError(409, 'duplicate_in_flight', 'an identical intent is already being relayed')
+      }
+
+      // Reserve the marker so concurrent duplicates coalesce from here on.
+      const record = store.create({
+        chainId: intent.chainId,
+        signer,
+        action: intent.action,
+        targetContract: intent.targetContract,
+        uniquenessMarker: intent.uniquenessMarker,
+      })
+      const reservation = dedup.reserve(intent.chainId, intent.uniquenessMarker, record.intentId)
+      if (!reservation.ok) {
+        store.remove(record.intentId)
+        if (reservation.state === 'completed') {
+          const original = store.get(reservation.intentId)
+          res.status(200).json({
+            intentId: reservation.intentId,
+            status: 'confirmed',
+            ...(original?.txHash ? { txHash: original.txHash } : {}),
+          })
+          return
+        }
+        throw new GatewayError(409, 'duplicate_in_flight', 'an identical intent is already being relayed')
+      }
+      reserved = { chainId: intent.chainId, marker: intent.uniquenessMarker, intentId: record.intentId }
+
+      // Sanctions re-screen of the RECOVERED signer — fail-closed (FR-013).
+      await screen.screen(intent.chainId, signer)
+
+      // Per-signer + global quotas (FR-014).
+      const q = quotas.hit(signer)
+      if (!q.allowed) {
+        throw new GatewayError(429, 'quota_exceeded', `${q.scope} relay quota exceeded; retry later or self-submit`, {
+          retryAfterSec: q.retryAfterSec,
+        })
+      }
+
+      // Bounded queue back-pressure (FR-009).
+      const bp = backpressure.check()
+      if (!bp.allowed) {
+        throw new GatewayError(429, 'backpressure', 'relayer is at capacity; retry later or self-submit', {
+          retryAfterSec: bp.retryAfterSec,
+        })
+      }
+
+      // Per-chain per-window gas spend cap (FR-014/FR-018) + fee-netted decline (FR-023).
+      const estimatedCostWei = await estimateCostWei(
+        providers[intent.chainId],
+        chainCfg,
+        { to: intent.targetContract, data: calldata },
+        config.defaultGasLimit
+      )
+      const fundingMode = intent.fundingMode ?? chainCfg.fundingMode
+      if (fundingMode === 'fee-netted') {
+        if (intent.maxFee == null || estimatedCostWei > intent.maxFee) {
+          throw new GatewayError(
+            402,
+            'fee_exceeds_cap',
+            `estimated gas cost ${estimatedCostWei} exceeds the intent's maxFee; no funds moved`
+          )
+        }
+      }
+      const sp = spend.tryAdd(intent.chainId, estimatedCostWei)
+      if (!sp.allowed) {
+        throw new GatewayError(429, 'quota_exceeded', 'per-chain gas spend cap reached for this window; retry later or self-submit', {
+          retryAfterSec: sp.retryAfterSec,
+        })
+      }
+
+      // Hand the built call to the engine (contracts/engine-integration.md).
+      let engineTx
+      try {
+        engineTx = await engineClient.submitTransaction({
+          relayerId: chainCfg.engineRelayerId,
+          to: intent.targetContract,
+          data: calldata,
+        })
+      } catch (e) {
+        if (e instanceof EngineUnavailableError) {
+          throw new GatewayError(503, 'chain_unavailable', 'submission engine unavailable; use self-submit')
+        }
+        throw e
+      }
+
+      store.attachEngineTx(record.intentId, engineTx.id, engineTx.hash)
+      const status = engineTx.hash ? 'submitted' : 'queued'
+      reserved = null // submission handed off; marker stays reserved until a terminal webhook
+
+      audit({
+        signer,
+        chainId: intent.chainId,
+        action: intent.action,
+        targetContract: intent.targetContract,
+        uniquenessMarker: intent.uniquenessMarker,
+        txHash: engineTx.hash ?? null,
+        outcome: status === 'submitted' ? 'submitted' : 'accepted',
+      })
+
+      res.status(202).json({
+        intentId: record.intentId,
+        status,
+        ...(engineTx.hash ? { txHash: engineTx.hash } : {}),
+      })
+    } catch (err) {
+      if (reserved) {
+        dedup.release(reserved.chainId, reserved.marker)
+        store.remove(reserved.intentId)
+      }
+      if (err instanceof GatewayError) {
+        // Terminal rejection -> audit record (FR-021): every outcome is reviewable.
+        const body = req.body ?? {}
+        audit({
+          // signer is omitted when rejection happened before recovery — never trust a client-asserted one
+          chainId: typeof body.chainId === 'number' ? body.chainId : undefined,
+          action: typeof body.action === 'string' ? body.action : undefined,
+          targetContract: typeof body.targetContract === 'string' ? body.targetContract : undefined,
+          uniquenessMarker: typeof body.uniquenessMarker === 'string' ? body.uniquenessMarker : undefined,
+          outcome: `rejected(${err.code})`,
+        })
+        if (err.retryAfterSec != null) res.set('Retry-After', String(err.retryAfterSec))
+        res.status(err.status).json(err.toBody())
+        return
+      }
+      console.error('[relay-gateway] unexpected error', err) // never leak internals to clients
+      res.status(500).json({ error: { code: 'internal', reason: 'internal error' } })
+    }
+  })
+
+  // ---- GET /v1/intents/:id -------------------------------------------------------------------
+  app.get('/v1/intents/:id', (req, res) => {
+    const rec = store.get(req.params.id)
+    if (!rec) {
+      res.status(404).json({ error: { code: 'not_found', reason: 'unknown intentId' } })
+      return
+    }
+    res.json({
+      intentId: rec.intentId,
+      status: rec.status,
+      ...(rec.txHash ? { txHash: rec.txHash } : {}),
+      ...(rec.reason ? { reason: rec.reason } : {}),
+    })
+  })
+
+  // ---- POST /v1/engine/webhook ----------------------------------------------------------------
+  app.post('/v1/engine/webhook', (req, res) => {
+    // Shared-secret auth, timing-safe. Fail closed: no configured secret => nothing is accepted.
+    const presented = req.get('x-webhook-secret') ?? (req.get('authorization') ?? '').replace(/^Bearer\s+/i, '')
+    if (!config.webhookSecret || !presented || !timingSafeEqual(presented, config.webhookSecret)) {
+      res.status(403).json({ error: { code: 'origin_denied', reason: 'invalid webhook credentials' } })
+      return
+    }
+    const result = applyEngineEvent({ store, dedup, audit }, req.body ?? {})
+    if (!result.ok) {
+      const status = result.code === 'unknown_transaction' ? 404 : 400
+      res.status(status).json({ error: { code: result.code, reason: 'webhook event not applicable' } })
+      return
+    }
+    res.json({ ok: true })
+  })
+
+  // JSON parse errors and other middleware failures.
+  // eslint-disable-next-line no-unused-vars
+  app.use((err, _req, res, _next) => {
+    if (err?.type === 'entity.too.large') {
+      res.status(413).json({ error: { code: 'too_large', reason: 'request body too large' } })
+      return
+    }
+    res.status(400).json({ error: { code: 'bad_request', reason: 'invalid request body' } })
+  })
+
+  return { app, killSwitch, store, dedup }
+}
+
+// ---- boot (only when run directly; tests import createApp) -----------------------------------
+const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`
+if (isMain) {
+  let config
+  try {
+    config = loadConfig() // throws on any deployments-pin inconsistency (FR-025) -> non-zero exit
+  } catch (e) {
+    console.error(String(e?.message ?? e))
+    process.exit(1)
+  }
+  if (!config.originAuthSecret) {
+    console.warn('[relay-gateway] WARN: ORIGIN_AUTH_SECRET unset — origin lock DISABLED (dev only; SC-016)')
+  }
+  if (!config.webhookSecret) {
+    console.warn('[relay-gateway] WARN: WEBHOOK_SHARED_SECRET unset — engine webhooks will be REJECTED')
+  }
+  const { app, killSwitch } = createApp(config)
+  // Runtime kill switch: `kill -USR2 <pid>` toggles accept/refuse (FR-015).
+  process.on('SIGUSR2', () => {
+    const active = killSwitch.toggle()
+    console.warn(`[relay-gateway] kill switch ${active ? 'ACTIVATED' : 'cleared'} via SIGUSR2`)
+  })
+  app.listen(config.port, () => {
+    console.log(
+      `[relay-gateway] listening on :${config.port} | chains=${config.enabledChainIds.join(',')} | ` +
+        `killSwitch=${killSwitch.isActive()} | originLock=${Boolean(config.originAuthSecret)}`
+    )
+  })
+}

--- a/services/relay-gateway/test/gateway.test.js
+++ b/services/relay-gateway/test/gateway.test.js
@@ -1,0 +1,403 @@
+/**
+ * Relay-gateway API tests (contracts/relay-gateway-api.md — routes, status codes, error codes).
+ * All chain/engine access is mocked via dependency injection; typed-data signing is real
+ * (ethers v6) against the version-pinned addresses from deployments/.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import request from 'supertest'
+import { ethers } from 'ethers'
+import { createApp } from '../src/server.js'
+import { createKillSwitch } from '../src/policy/killswitch.js'
+import { loadConfig } from '../src/config/index.js'
+import {
+  testConfig,
+  mockProviders,
+  mockEngine,
+  signedIntent,
+  signedPaymentIntent,
+  randomMarker,
+  wallet,
+  ORIGIN_SECRET,
+  WEBHOOK_SECRET,
+  TEST_NOW,
+  DEPLOYMENTS_DIR,
+} from './helpers.js'
+
+const now = () => TEST_NOW
+
+function build({ config = testConfig(), providers, engine = mockEngine(), killSwitch = createKillSwitch(false), auditLines = [] } = {}) {
+  const deps = {
+    providers: providers ?? mockProviders(config),
+    engineClient: engine,
+    now,
+    killSwitch,
+    auditSink: (line) => auditLines.push(JSON.parse(line)),
+  }
+  const { app, ...rest } = createApp(config, deps)
+  return { app, config, engine, killSwitch, auditLines, ...rest }
+}
+
+const post = (app, body) =>
+  request(app).post('/v1/intents').set('X-Origin-Auth', ORIGIN_SECRET).send(body)
+
+describe('config / startup consistency check (FR-025)', () => {
+  it('pins targets from deployments and fails loudly for a chain without a record', () => {
+    const config = testConfig()
+    expect(config.chains[137].targetsByKey.wagerRegistry).toBe('0x5023765809fDA93ab9F11B684fdb76521eD31774')
+    expect(config.chains[63].gasType).toBe('legacy')
+    expect(config.chains[63].paymentSupported).toBe(false)
+    // ETC mainnet (61) has no deployments record yet -> enabling it must throw.
+    expect(() =>
+      loadConfig({ ENABLED_CHAIN_IDS: '61' }, { deploymentsDir: DEPLOYMENTS_DIR })
+    ).toThrow(/no deployment record/)
+  })
+})
+
+describe('origin lock (FR-029, SC-016)', () => {
+  it('403 origin_denied without X-Origin-Auth; wrong secret also denied', async () => {
+    const { app, config } = build()
+    const intent = await signedIntent(config)
+    const r1 = await request(app).post('/v1/intents').send(intent)
+    expect(r1.status).toBe(403)
+    expect(r1.body.error.code).toBe('origin_denied')
+    const r2 = await request(app).post('/v1/intents').set('X-Origin-Auth', 'wrong').send(intent)
+    expect(r2.status).toBe(403)
+    expect(r2.body.error.code).toBe('origin_denied')
+  })
+
+  it('/healthz is origin-lock exempt', async () => {
+    const { app } = build()
+    const res = await request(app).get('/healthz')
+    expect(res.status).toBe(200)
+  })
+})
+
+describe('POST /v1/intents validation', () => {
+  let ctx
+  beforeEach(() => {
+    ctx = build()
+  })
+
+  it('accepts a valid signer-attributed intent -> 202 {intentId, status, txHash}', async () => {
+    const intent = await signedIntent(ctx.config)
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(202)
+    expect(res.body.intentId).toBeTruthy()
+    expect(res.body.status).toBe('submitted')
+    expect(res.body.txHash).toMatch(/^0x/)
+    // Engine got the encoded claimPayoutWithSig call for the pinned registry.
+    expect(ctx.engine.submissions).toHaveLength(1)
+    const { args } = ctx.engine.submissions[0]
+    expect(args.relayerId).toBe('polygon-137')
+    expect(args.to.toLowerCase()).toBe(ctx.config.chains[137].targetsByKey.wagerRegistry.toLowerCase())
+    expect(args.data.startsWith('0x')).toBe(true)
+  })
+
+  it('accepts a valid payment-class intent (EIP-3009 recovery) -> 202', async () => {
+    const intent = await signedPaymentIntent(ctx.config)
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(202)
+    expect(ctx.engine.submissions).toHaveLength(1)
+    expect(ctx.engine.submissions[0].args.to.toLowerCase()).toBe(
+      ctx.config.chains[137].targetsByKey.membershipManager.toLowerCase()
+    )
+  })
+
+  it('400 invalid_signature on a tampered signature', async () => {
+    const intent = await signedIntent(ctx.config)
+    // Flip a nibble inside `r` (not the trailing v byte — v=27 tampered to yParity 0 recovers the
+    // same address half the time, which made this assertion flaky).
+    const i = 10
+    intent.signature =
+      intent.signature.slice(0, i) + (intent.signature[i] === 'f' ? '0' : 'f') + intent.signature.slice(i + 1)
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('invalid_signature')
+    expect(ctx.engine.submissions).toHaveLength(0)
+  })
+
+  it('400 invalid_signature when the actor is not the signer', async () => {
+    const other = ethers.Wallet.createRandom()
+    const intent = await signedIntent(ctx.config)
+    intent.params.claimant = other.address // recovered != claimed actor
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('invalid_signature')
+  })
+
+  it('400 chain_mismatch for an unconfigured chainId', async () => {
+    const intent = await signedIntent(ctx.config)
+    intent.chainId = 999
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('chain_mismatch')
+  })
+
+  it('400 chain_mismatch when the intent was signed for another configured network (SC-014)', async () => {
+    // Signed under chain 137's domain, submitted as an 80002 intent against 80002's registry.
+    const intent = await signedIntent(ctx.config, { chainId: 80002, domainChainId: 137 })
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('chain_mismatch')
+    expect(ctx.engine.submissions).toHaveLength(0)
+  })
+
+  it('400 target_not_allowlisted for a non-pinned target contract', async () => {
+    const intent = await signedIntent(ctx.config)
+    intent.targetContract = ethers.Wallet.createRandom().address
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('target_not_allowlisted')
+  })
+
+  it('400 target_not_allowlisted for an unknown action name', async () => {
+    const intent = await signedIntent(ctx.config)
+    intent.action = 'mintUnicorn' // not a spec-035 action
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('target_not_allowlisted')
+  })
+
+  it('400 expired / 400 not_yet_valid on the validity window', async () => {
+    const expired = await signedIntent(ctx.config, { validBefore: TEST_NOW - 10 })
+    const r1 = await post(ctx.app, expired)
+    expect(r1.status).toBe(400)
+    expect(r1.body.error.code).toBe('expired')
+
+    const future = await signedIntent(ctx.config, { validAfter: TEST_NOW + 1000 })
+    const r2 = await post(ctx.app, future)
+    expect(r2.status).toBe(400)
+    expect(r2.body.error.code).toBe('not_yet_valid')
+  })
+
+  it('503 payment_unsupported_on_chain for the payment class on Mordor (63)', async () => {
+    const intent = {
+      intentClass: 'payment',
+      chainId: 63,
+      targetContract: ctx.config.chains[63].targetsByKey.membershipManager,
+      action: 'purchaseTier',
+      params: {},
+      signature: '0x00',
+      authorization: {
+        from: wallet.address, to: ctx.config.chains[63].targetsByKey.membershipManager,
+        value: '1', validAfter: 0, validBefore: TEST_NOW + 100, nonce: randomMarker(),
+        v: 27, r: randomMarker(), s: randomMarker(),
+      },
+      validAfter: 0,
+      validBefore: TEST_NOW + 100,
+      uniquenessMarker: randomMarker(),
+    }
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(503)
+    expect(res.body.error.code).toBe('payment_unsupported_on_chain')
+  })
+})
+
+describe('dedup idempotency (FR-008, SC-006)', () => {
+  it('in-flight duplicate -> 409 duplicate_in_flight; completed -> 200 with the ORIGINAL result', async () => {
+    const ctx = build()
+    const intent = await signedIntent(ctx.config)
+
+    const first = await post(ctx.app, intent)
+    expect(first.status).toBe(202)
+    const { intentId, txHash } = first.body
+
+    // Same marker while in flight -> coalesced, no second engine submission.
+    const dup = await post(ctx.app, intent)
+    expect(dup.status).toBe(409)
+    expect(dup.body.error.code).toBe('duplicate_in_flight')
+    expect(ctx.engine.submissions).toHaveLength(1)
+
+    // Engine reports mined -> intent confirmed; replay now returns the original result (200).
+    await request(ctx.app)
+      .post('/v1/engine/webhook')
+      .set('X-Webhook-Secret', WEBHOOK_SECRET)
+      .send({ id: 'engine-tx-1', hash: txHash, status: 'mined' })
+      .expect(200)
+
+    const replay = await post(ctx.app, intent)
+    expect(replay.status).toBe(200)
+    expect(replay.body).toMatchObject({ intentId, status: 'confirmed', txHash })
+    expect(ctx.engine.submissions).toHaveLength(1) // still exactly one on-chain submission
+  })
+
+  it('a failed submission releases the marker for a safe retry', async () => {
+    const ctx = build()
+    const intent = await signedIntent(ctx.config)
+    const first = await post(ctx.app, intent)
+    expect(first.status).toBe(202)
+    await request(ctx.app)
+      .post('/v1/engine/webhook')
+      .set('X-Webhook-Secret', WEBHOOK_SECRET)
+      .send({ id: 'engine-tx-1', status: 'failed', reason: 'out of gas' })
+      .expect(200)
+    const retry = await post(ctx.app, intent)
+    expect(retry.status).toBe(202)
+    expect(ctx.engine.submissions).toHaveLength(2)
+  })
+})
+
+describe('sanctions re-screen — fail-closed (FR-013, SC-005)', () => {
+  it('503 screening_unavailable when the guard RPC errors (fail closed, never submit)', async () => {
+    const config = testConfig()
+    const ctx = build({ config, providers: mockProviders(config, { screenError: true }) })
+    const res = await post(ctx.app, await signedIntent(config))
+    expect(res.status).toBe(503)
+    expect(res.body.error.code).toBe('screening_unavailable')
+    expect(ctx.engine.submissions).toHaveLength(0)
+  })
+
+  it('403 sanctioned_signer when the guard says not allowed', async () => {
+    const config = testConfig()
+    const ctx = build({ config, providers: mockProviders(config, { allowed: false }) })
+    const res = await post(ctx.app, await signedIntent(config))
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('sanctioned_signer')
+    expect(ctx.engine.submissions).toHaveLength(0)
+  })
+})
+
+describe('quotas + back-pressure (FR-009/FR-014)', () => {
+  it('429 quota_exceeded with Retry-After past the per-signer quota', async () => {
+    const config = testConfig({ SIGNER_QUOTA_PER_MIN: '2' })
+    const ctx = build({ config })
+    expect((await post(ctx.app, await signedIntent(config))).status).toBe(202)
+    expect((await post(ctx.app, await signedIntent(config))).status).toBe(202)
+    const third = await post(ctx.app, await signedIntent(config))
+    expect(third.status).toBe(429)
+    expect(third.body.error.code).toBe('quota_exceeded')
+    expect(Number(third.headers['retry-after'])).toBeGreaterThan(0)
+  })
+
+  it('429 backpressure when the bounded queue is full', async () => {
+    const config = testConfig({ MAX_QUEUE_DEPTH: '1' })
+    const ctx = build({ config })
+    expect((await post(ctx.app, await signedIntent(config))).status).toBe(202) // now in flight
+    const shed = await post(ctx.app, await signedIntent(config))
+    expect(shed.status).toBe(429)
+    expect(shed.body.error.code).toBe('backpressure')
+    expect(Number(shed.headers['retry-after'])).toBeGreaterThan(0)
+  })
+
+  it('402 fee_exceeds_cap in fee-netted mode when estimated gas > maxFee (FR-023)', async () => {
+    const ctx = build()
+    const intent = await signedIntent(ctx.config)
+    intent.fundingMode = 'fee-netted'
+    intent.maxFee = '1' // 1 wei; mock estimate is 100000 gas * 30 gwei
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(402)
+    expect(res.body.error.code).toBe('fee_exceeds_cap')
+    expect(ctx.engine.submissions).toHaveLength(0)
+  })
+})
+
+describe('kill switch (FR-015) + engine failure', () => {
+  it('503 killswitch_active while active; accepts again once cleared', async () => {
+    const ctx = build()
+    ctx.killSwitch.set(true)
+    const res = await post(ctx.app, await signedIntent(ctx.config))
+    expect(res.status).toBe(503)
+    expect(res.body.error.code).toBe('killswitch_active')
+    ctx.killSwitch.set(false)
+    expect((await post(ctx.app, await signedIntent(ctx.config))).status).toBe(202)
+  })
+
+  it('503 chain_unavailable when the engine is down, and the marker is released for retry', async () => {
+    const config = testConfig()
+    const down = mockEngine({ fail: true })
+    const ctx = build({ config, engine: down })
+    const intent = await signedIntent(config)
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(503)
+    expect(res.body.error.code).toBe('chain_unavailable')
+    // Same intent succeeds once the engine is back (fresh app shares nothing; use same app):
+    const ctx2 = build({ config })
+    expect((await post(ctx2.app, intent)).status).toBe(202)
+  })
+})
+
+describe('webhook + status lifecycle (FR-006: never confirmed before inclusion)', () => {
+  it('rejects a missing/wrong webhook secret (timing-safe shared secret)', async () => {
+    const { app } = build()
+    await request(app).post('/v1/engine/webhook').send({ id: 'x', status: 'mined' }).expect(403)
+    await request(app)
+      .post('/v1/engine/webhook')
+      .set('X-Webhook-Secret', 'wrong')
+      .send({ id: 'x', status: 'mined' })
+      .expect(403)
+  })
+
+  it('maps engine statuses honestly: pending -> submitted, mined -> confirmed, failed -> failed', async () => {
+    const ctx = build()
+    const intent = await signedIntent(ctx.config)
+    const accepted = await post(ctx.app, intent)
+    const { intentId } = accepted.body
+
+    // Engine says pending — status must NOT be confirmed.
+    await request(ctx.app)
+      .post('/v1/engine/webhook')
+      .set('X-Webhook-Secret', WEBHOOK_SECRET)
+      .send({ id: 'engine-tx-1', hash: accepted.body.txHash, status: 'pending' })
+      .expect(200)
+    let status = await request(ctx.app).get(`/v1/intents/${intentId}`).set('X-Origin-Auth', ORIGIN_SECRET)
+    expect(status.body.status).toBe('submitted')
+
+    // Only mined/confirmed flips it to confirmed.
+    await request(ctx.app)
+      .post('/v1/engine/webhook')
+      .set('X-Webhook-Secret', WEBHOOK_SECRET)
+      .send({ id: 'engine-tx-1', hash: accepted.body.txHash, status: 'mined' })
+      .expect(200)
+    status = await request(ctx.app).get(`/v1/intents/${intentId}`).set('X-Origin-Auth', ORIGIN_SECRET)
+    expect(status.body).toMatchObject({ intentId, status: 'confirmed', txHash: accepted.body.txHash })
+  })
+
+  it('unknown engine tx id -> 404; unknown intent id -> 404', async () => {
+    const { app } = build()
+    await request(app)
+      .post('/v1/engine/webhook')
+      .set('X-Webhook-Secret', WEBHOOK_SECRET)
+      .send({ id: 'nope', status: 'mined' })
+      .expect(404)
+    const res = await request(app).get('/v1/intents/does-not-exist').set('X-Origin-Auth', ORIGIN_SECRET)
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('GET /healthz shape', () => {
+  it('reports per-chain rpc state, runway, and kill switch', async () => {
+    const config = testConfig({ GAS_WALLET_137: '0x52502d049571C7893447b86c4d8B38e6184bF6e1' })
+    const providers = mockProviders(config)
+    providers[63] = { ...providers[63], getBlockNumber: async () => { throw new Error('down') } }
+    const { app } = build({ config, providers })
+    const res = await request(app).get('/healthz')
+    expect(res.status).toBe(200)
+    expect(res.body.status).toBe('ok')
+    expect(res.body.killSwitch).toBe(false)
+    expect(res.body.chains['137'].rpc).toBe('up')
+    expect(res.body.chains['137'].gasWalletRunwayHrs).toBeGreaterThan(0)
+    expect(res.body.chains['63'].rpc).toBe('down')
+    expect(res.body.chains['80002']).toEqual({ rpc: 'up', gasWalletRunwayHrs: null })
+  })
+})
+
+describe('audit trail (FR-021): no key material or signatures in events', () => {
+  it('emits intent -> signer -> txHash records and never logs the signature', async () => {
+    const auditLines = []
+    const ctx = build({ auditLines })
+    const intent = await signedIntent(ctx.config)
+    await post(ctx.app, intent).expect(202)
+    expect(auditLines.length).toBeGreaterThan(0)
+    const ev = auditLines.at(-1)
+    expect(ev).toMatchObject({
+      event: 'relay_audit',
+      signer: wallet.address,
+      chainId: 137,
+      action: 'claimPayout',
+      uniquenessMarker: intent.uniquenessMarker,
+    })
+    for (const line of auditLines) {
+      expect(JSON.stringify(line)).not.toContain(intent.signature)
+    }
+  })
+})

--- a/services/relay-gateway/test/helpers.js
+++ b/services/relay-gateway/test/helpers.js
@@ -1,0 +1,201 @@
+/**
+ * Test helpers: config against the REAL deployments/ records (the version-pinned target set),
+ * mock providers/engine (dependency injection), and typed-data signing utilities that mirror
+ * the spec-035 schemas exactly (via src/intent/intentTypes.js — one source of truth).
+ */
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { ethers } from 'ethers'
+import { loadConfig } from '../src/config/index.js'
+import { CONTRACT_DOMAINS, RECEIVE_WITH_AUTHORIZATION_TYPES, typesFor, ACTIONS } from '../src/intent/intentTypes.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+export const DEPLOYMENTS_DIR = path.resolve(__dirname, '../../../deployments')
+
+export const ORIGIN_SECRET = 'test-origin-secret'
+export const WEBHOOK_SECRET = 'test-webhook-secret'
+
+export const TEST_NOW = 1_800_000_000 // fixed unix seconds for deterministic windows
+
+export function testConfig(envOverrides = {}) {
+  return loadConfig(
+    {
+      ENABLED_CHAIN_IDS: '137,80002,63',
+      ORIGIN_AUTH_SECRET: ORIGIN_SECRET,
+      WEBHOOK_SHARED_SECRET: WEBHOOK_SECRET,
+      ENGINE_URL: 'http://engine.test.invalid',
+      ...envOverrides,
+    },
+    { deploymentsDir: DEPLOYMENTS_DIR }
+  )
+}
+
+const abi = ethers.AbiCoder.defaultAbiCoder()
+
+/**
+ * Mock read-provider. `allowed` controls the sanctions answer; `screenError` throws on call
+ * (fail-closed path); estimateGas/getFeeData resolve to stable numbers.
+ */
+export function mockProvider({ allowed = true, screenError = false, blockNumber = 1, balanceWei = 10n ** 18n } = {}) {
+  return {
+    async call() {
+      if (screenError) throw new Error('rpc unreachable')
+      return abi.encode(['bool'], [allowed])
+    },
+    async estimateGas() {
+      return 100_000n
+    },
+    async getFeeData() {
+      return { gasPrice: 30_000_000_000n, maxFeePerGas: 30_000_000_000n }
+    },
+    async getBlockNumber() {
+      if (screenError) throw new Error('rpc unreachable')
+      return blockNumber
+    },
+    async getBalance() {
+      return balanceWei
+    },
+  }
+}
+
+export function mockProviders(config, opts = {}) {
+  const providers = {}
+  for (const id of config.enabledChainIds) providers[id] = mockProvider(opts[id] ?? opts)
+  return providers
+}
+
+/** Mock engine client recording submissions; each returns a fresh id + hash. */
+export function mockEngine({ fail = false } = {}) {
+  const submissions = []
+  let n = 0
+  return {
+    submissions,
+    async submitTransaction(args) {
+      if (fail) {
+        const { EngineUnavailableError } = await import('../src/errors.js')
+        throw new EngineUnavailableError('engine down')
+      }
+      n += 1
+      const tx = { id: `engine-tx-${n}`, hash: `0x${String(n).padStart(64, '0')}`, status: 'pending' }
+      submissions.push({ args, tx })
+      return tx
+    },
+  }
+}
+
+export const wallet = new ethers.Wallet('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d') // hardhat #1
+
+export function randomMarker() {
+  return ethers.hexlify(ethers.randomBytes(32))
+}
+
+/**
+ * Build + sign a signer-attributed intent body (default: claimPayout on the given chain,
+ * against that chain's pinned WagerRegistry).
+ */
+export async function signedIntent(config, {
+  chainId = 137,
+  action = 'claimPayout',
+  signer = wallet,
+  params,
+  validAfter = 0,
+  validBefore = TEST_NOW + 3600,
+  marker = randomMarker(),
+  domainChainId, // sign under ANOTHER chain's domain to provoke chain_mismatch
+  targetContract,
+} = {}) {
+  const def = ACTIONS[action]
+  const chain = config.chains[chainId]
+  const domainChain = config.chains[domainChainId ?? chainId]
+  const verifyingContract = domainChain.targetsByKey[def.contract]
+  const domain = {
+    ...CONTRACT_DOMAINS[def.contract],
+    chainId: domainChainId ?? chainId,
+    verifyingContract,
+  }
+  const actorField = def.actorField
+  const baseParams = params ?? { wagerId: 1 }
+  const message = {
+    ...baseParams,
+    [actorField]: signer.address,
+    nonce: marker,
+    validAfter,
+    validBefore,
+  }
+  const signature = await signer.signTypedData(domain, typesFor(action), message)
+  return {
+    intentClass: 'signer-attributed',
+    chainId,
+    targetContract: targetContract ?? chain.targetsByKey[def.contract],
+    action,
+    params: { ...baseParams, [actorField]: signer.address },
+    signature,
+    validAfter,
+    validBefore,
+    uniquenessMarker: marker,
+    fundingMode: 'sponsored',
+  }
+}
+
+/** Build + sign a payment-class intent (default: purchaseTier on 137, both legs signed). */
+export async function signedPaymentIntent(config, {
+  chainId = 137,
+  action = 'purchaseTier',
+  signer = wallet,
+  value = 1_000_000n,
+  validAfter = 0,
+  validBefore = TEST_NOW + 3600,
+  marker = randomMarker(),
+} = {}) {
+  const def = ACTIONS[action]
+  const chain = config.chains[chainId]
+  const target = chain.targetsByKey[def.contract]
+
+  // Money leg: EIP-3009 ReceiveWithAuthorization under the token's own domain.
+  const tokenDomain = {
+    name: chain.tokenDomain.name,
+    version: chain.tokenDomain.version,
+    chainId,
+    verifyingContract: chain.paymentToken,
+  }
+  const auth = {
+    from: signer.address,
+    to: target,
+    value,
+    validAfter,
+    validBefore,
+    nonce: marker, // payment class: uniquenessMarker IS the EIP-3009 nonce (data-model.md)
+  }
+  const authSig = ethers.Signature.from(
+    await signer.signTypedData(tokenDomain, RECEIVE_WITH_AUTHORIZATION_TYPES, auth)
+  )
+
+  // Intent leg: the action struct under the contract's domain.
+  const role = ethers.id('POOL_PARTICIPANT_ROLE')
+  const termsHash = ethers.id('terms-v1')
+  const params = { role, tier: 1, acceptedTermsHash: termsHash }
+  const message = {
+    ...params,
+    member: signer.address,
+    paymentNonce: marker,
+    nonce: marker,
+    validAfter,
+    validBefore,
+  }
+  const domain = { ...CONTRACT_DOMAINS[def.contract], chainId, verifyingContract: target }
+  const signature = await signer.signTypedData(domain, typesFor(action), message)
+
+  return {
+    intentClass: 'payment',
+    chainId,
+    targetContract: target,
+    action,
+    params,
+    signature,
+    authorization: { ...auth, value: value.toString(), v: authSig.v, r: authSig.r, s: authSig.s },
+    validAfter,
+    validBefore,
+    uniquenessMarker: marker,
+    fundingMode: 'sponsored',
+  }
+}

--- a/test/helpers/proxy.js
+++ b/test/helpers/proxy.js
@@ -1,9 +1,33 @@
 const { ethers } = require("hardhat");
 
+/// Merge contract interfaces into one ABI fragment list (constructor/fallback dropped, duplicates
+/// deduped). Used to bind a single ethers.Contract to a proxy served by multiple facets (spec 035:
+/// WagerRegistry + WagerRegistryIntents behind one proxy address).
+function mergeAbis(...interfaces) {
+  const seen = new Set();
+  const fragments = [];
+  for (const iface of interfaces) {
+    for (const f of iface.fragments) {
+      if (f.type === "constructor" || f.type === "fallback" || f.type === "receive") continue;
+      const key = f.format("full");
+      if (!seen.has(key)) {
+        seen.add(key);
+        fragments.push(f);
+      }
+    }
+  }
+  return fragments;
+}
+
 /// Deploy WagerRegistry behind an ERC1967 UUPS proxy and return the contract bound to the proxy address.
 /// Mirrors production (the implementation's initializers are disabled by UUPSManaged; the proxy is
 /// initialized once). `initArgs` is the same ordered list the former constructor took:
 ///   [admin, membershipManager, polymarketAdapter, initialTokens]
+/// Since spec 035 the registry is two facets: the main implementation plus the WagerRegistryIntents
+/// extension (signer-attributed twins + relocated cold paths like batchExpireOpen/autoResolve*),
+/// reached through the main facet's fallback. This helper deploys BOTH, wires setIntentExtension
+/// (when a signer for `initArgs[0]` is available), and returns a contract carrying the MERGED ABI —
+/// exactly what integrators see at the proxy address.
 /// Manual proxy wiring (not the hardhat-upgrades plugin) keeps the large existing suite fast and free of the
 /// plugin's build-info coupling; the plugin's storage-layout/safety validation is exercised separately in
 /// test/upgradeable/ and via `npm run check:storage-layout`.
@@ -16,8 +40,21 @@ async function deployWagerRegistry(initArgs) {
   const Proxy = await ethers.getContractFactory("ERC1967Proxy");
   const proxy = await Proxy.deploy(await impl.getAddress(), initData);
   await proxy.waitForDeployment();
+  const proxyAddress = await proxy.getAddress();
 
-  return Impl.attach(await proxy.getAddress());
+  const IntentsImpl = await ethers.getContractFactory("WagerRegistryIntents");
+  const intentsImpl = await IntentsImpl.deploy();
+  await intentsImpl.waitForDeployment();
+
+  // Wire the extension facet as the admin (initArgs[0] holds UPGRADER_ROLE from initialize).
+  const signers = await ethers.getSigners();
+  const adminSigner = signers.find((s) => s.address === initArgs[0]);
+  if (adminSigner) {
+    const asAdmin = Impl.attach(proxyAddress).connect(adminSigner);
+    await asAdmin.setIntentExtension(await intentsImpl.getAddress());
+  }
+
+  return new ethers.Contract(proxyAddress, mergeAbis(Impl.interface, IntentsImpl.interface), signers[0]);
 }
 
 /// Deploy MembershipManager behind an ERC1967 UUPS proxy and return the contract bound to the proxy address
@@ -114,6 +151,7 @@ async function deployTokenFactoryV2({ adminSigner, sanctionsGuard = ethers.ZeroA
 }
 
 module.exports = {
+  mergeAbis,
   deployWagerRegistry,
   deployMembershipManager,
   deployTokenTemplates,

--- a/test/intent/MembershipIntents.test.js
+++ b/test/intent/MembershipIntents.test.js
@@ -1,0 +1,361 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time, loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+const { deployMembershipManager } = require("../helpers/proxy");
+
+// Spec 035 — signer-attributed (gasless) membership intents: purchase/upgrade/extend via a single
+// signature carrying an EIP-3009 price authorization, and voucher redemption via …WithSig. Also
+// covers the SignerIntentBase cross-contract isolation invariant (a nonce/signature is scoped to
+// one contract's EIP-712 domain).
+
+const Tier = { None: 0, Bronze: 1, Silver: 2, Gold: 3, Platinum: 4 };
+const WAGER_PARTICIPANT_ROLE = ethers.keccak256(ethers.toUtf8Bytes("WAGER_PARTICIPANT_ROLE"));
+const usdc = (n) => ethers.parseUnits(String(n), 6);
+const randomNonce = () => ethers.hexlify(ethers.randomBytes(32));
+
+const RECEIVE_WITH_AUTHORIZATION_TYPES = {
+  ReceiveWithAuthorization: [
+    { name: "from", type: "address" },
+    { name: "to", type: "address" },
+    { name: "value", type: "uint256" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+    { name: "nonce", type: "bytes32" },
+  ],
+};
+
+const PURCHASE_TIER_INTENT_TYPES = {
+  PurchaseTierIntent: [
+    { name: "role", type: "bytes32" },
+    { name: "tier", type: "uint8" },
+    { name: "acceptedTermsHash", type: "bytes32" },
+    { name: "member", type: "address" },
+    { name: "paymentNonce", type: "bytes32" },
+    { name: "nonce", type: "bytes32" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+  ],
+};
+
+const UPGRADE_TIER_INTENT_TYPES = {
+  UpgradeTierIntent: [
+    { name: "role", type: "bytes32" },
+    { name: "tier", type: "uint8" },
+    { name: "acceptedTermsHash", type: "bytes32" },
+    { name: "member", type: "address" },
+    { name: "paymentNonce", type: "bytes32" },
+    { name: "nonce", type: "bytes32" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+  ],
+};
+
+const EXTEND_MEMBERSHIP_INTENT_TYPES = {
+  ExtendMembershipIntent: [
+    { name: "role", type: "bytes32" },
+    { name: "member", type: "address" },
+    { name: "paymentNonce", type: "bytes32" },
+    { name: "nonce", type: "bytes32" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+  ],
+};
+
+const REDEEM_VOUCHER_INTENT_TYPES = {
+  RedeemVoucherIntent: [
+    { name: "voucherId", type: "uint256" },
+    { name: "acceptedTermsHash", type: "bytes32" },
+    { name: "redeemer", type: "address" },
+    { name: "nonce", type: "bytes32" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+  ],
+};
+
+const EMPTY_AUTH = { value: 0, validAfter: 0, validBefore: 0, nonce: ethers.ZeroHash, v: 0, r: ethers.ZeroHash, s: ethers.ZeroHash };
+
+describe("MembershipManager signer-attributed intents (spec 035)", function () {
+  async function deployFixture() {
+    const [admin, alice, bob, relayer, treasury, feeSink] = await ethers.getSigners();
+
+    const MockUSDC = await ethers.getContractFactory("MockUSDCPermit");
+    const usdcToken = await MockUSDC.deploy();
+    await usdcToken.waitForDeployment();
+
+    const mgr = await deployMembershipManager([admin.address, await usdcToken.getAddress(), treasury.address]);
+    const limits = { monthlyMarketCreation: 100, maxConcurrentMarkets: 10 };
+    await mgr.connect(admin).setTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze, usdc(50), 30, limits, true);
+    await mgr.connect(admin).setTier(WAGER_PARTICIPANT_ROLE, Tier.Silver, usdc(120), 30, limits, true);
+
+    const MockOracle = await ethers.getContractFactory("MockSanctionsOracle");
+    const oracle = await MockOracle.deploy();
+    const Guard = await ethers.getContractFactory("SanctionsGuard");
+    const guard = await Guard.deploy(admin.address, await oracle.getAddress());
+    await mgr.connect(admin).setSanctionsGuard(await guard.getAddress());
+
+    for (const u of [alice, bob]) {
+      await usdcToken.mint(u.address, usdc(10_000));
+      // Deliberately NO approvals — the gasless paths must not need one.
+    }
+
+    const chainId = (await ethers.provider.getNetwork()).chainId;
+    const mgrDomain = {
+      name: "FairWins MembershipManager",
+      version: "1",
+      chainId,
+      verifyingContract: await mgr.getAddress(),
+    };
+    const tokenDomain = {
+      name: "USD Coin",
+      version: "1",
+      chainId,
+      verifyingContract: await usdcToken.getAddress(),
+    };
+
+    return { mgr, usdcToken, guard, admin, alice, bob, relayer, treasury, feeSink, mgrDomain, tokenDomain, chainId };
+  }
+
+  async function signPriceAuth(fx, signer, value, to) {
+    const now = await time.latest();
+    const message = {
+      from: signer.address,
+      to: to ?? (await fx.mgr.getAddress()),
+      value,
+      validAfter: 0,
+      validBefore: now + 3600,
+      nonce: randomNonce(),
+    };
+    const sig = ethers.Signature.from(await signer.signTypedData(fx.tokenDomain, RECEIVE_WITH_AUTHORIZATION_TYPES, message));
+    return { value: message.value, validAfter: message.validAfter, validBefore: message.validBefore, nonce: message.nonce, v: sig.v, r: sig.r, s: sig.s };
+  }
+
+  async function signPurchase(fx, signer, { tier = Tier.Bronze, price = usdc(50), termsHash = ethers.id("terms-v1") } = {}) {
+    const now = await time.latest();
+    const priceAuth = await signPriceAuth(fx, signer, price);
+    const intent = { nonce: randomNonce(), validAfter: 0, validBefore: now + 3600 };
+    const sig = await signer.signTypedData(fx.mgrDomain, PURCHASE_TIER_INTENT_TYPES, {
+      role: WAGER_PARTICIPANT_ROLE,
+      tier,
+      acceptedTermsHash: termsHash,
+      member: signer.address,
+      paymentNonce: priceAuth.nonce,
+      ...intent,
+    });
+    return { tier, termsHash, priceAuth, intent, sig };
+  }
+
+  describe("purchaseTierWithAuthorization", function () {
+    it("purchases the tier for the signer with one signature, no approval, no native gas (SC-002)", async function () {
+      const fx = await loadFixture(deployFixture);
+      const p = await signPurchase(fx, fx.alice);
+      await expect(
+        fx.mgr.connect(fx.relayer).purchaseTierWithAuthorization(
+          WAGER_PARTICIPANT_ROLE, p.tier, p.termsHash, fx.alice.address,
+          p.intent.nonce, p.intent.validAfter, p.intent.validBefore, p.sig, p.priceAuth, EMPTY_AUTH
+        )
+      ).to.emit(fx.mgr, "MembershipPurchased");
+
+      expect(await fx.mgr.hasActiveRole(fx.alice.address, WAGER_PARTICIPANT_ROLE)).to.equal(true);
+      expect(await fx.mgr.getActiveTier(fx.alice.address, WAGER_PARTICIPANT_ROLE)).to.equal(Tier.Bronze);
+      // Terms recorded for the SIGNER (FR-039)
+      expect(await fx.mgr.memberTermsHash(fx.alice.address, WAGER_PARTICIPANT_ROLE)).to.equal(p.termsHash);
+    });
+
+    it("rejects replay and a substituted price authorization", async function () {
+      const fx = await loadFixture(deployFixture);
+      const p = await signPurchase(fx, fx.alice);
+      const submit = (auth) =>
+        fx.mgr.connect(fx.relayer).purchaseTierWithAuthorization(
+          WAGER_PARTICIPANT_ROLE, p.tier, p.termsHash, fx.alice.address,
+          p.intent.nonce, p.intent.validAfter, p.intent.validBefore, p.sig, auth, EMPTY_AUTH
+        );
+
+      const otherAuth = await signPriceAuth(fx, fx.alice, usdc(50));
+      // Substituted auth: its nonce differs from the signed paymentNonce → the digest no longer matches
+      await expect(submit(otherAuth)).to.be.revertedWithCustomError(fx.mgr, "InvalidIntentSignature");
+
+      await submit(p.priceAuth);
+      await expect(submit(p.priceAuth)).to.be.revertedWithCustomError(fx.mgr, "IntentReplayed");
+    });
+
+    it("screens the signer fail-closed", async function () {
+      const fx = await loadFixture(deployFixture);
+      await fx.guard.connect(fx.admin).setDenied(fx.alice.address, true, "ofac");
+      const p = await signPurchase(fx, fx.alice);
+      await expect(
+        fx.mgr.connect(fx.relayer).purchaseTierWithAuthorization(
+          WAGER_PARTICIPANT_ROLE, p.tier, p.termsHash, fx.alice.address,
+          p.intent.nonce, p.intent.validAfter, p.intent.validBefore, p.sig, p.priceAuth, EMPTY_AUTH
+        )
+      ).to.be.revertedWithCustomError(fx.guard, "SanctionedAddress").withArgs(fx.alice.address);
+    });
+
+    it("settles the bounded fee leg to the segregated recipient when netting is enabled", async function () {
+      const fx = await loadFixture(deployFixture);
+      await fx.mgr.connect(fx.admin).setFeeNetting(true, fx.feeSink.address, usdc(1));
+      const p = await signPurchase(fx, fx.alice);
+      const feeAuth = await signPriceAuth(fx, fx.alice, usdc(1) / 4n);
+      await fx.mgr.connect(fx.relayer).purchaseTierWithAuthorization(
+        WAGER_PARTICIPANT_ROLE, p.tier, p.termsHash, fx.alice.address,
+        p.intent.nonce, p.intent.validAfter, p.intent.validBefore, p.sig, p.priceAuth, feeAuth
+      );
+      expect(await fx.usdcToken.balanceOf(fx.feeSink.address)).to.equal(usdc(1) / 4n);
+    });
+  });
+
+  describe("upgradeTierWithAuthorization / extendMembershipWithAuthorization", function () {
+    async function bronzeMember(fx, user) {
+      const p = await signPurchase(fx, user);
+      await fx.mgr.connect(fx.relayer).purchaseTierWithAuthorization(
+        WAGER_PARTICIPANT_ROLE, p.tier, p.termsHash, user.address,
+        p.intent.nonce, p.intent.validAfter, p.intent.validBefore, p.sig, p.priceAuth, EMPTY_AUTH
+      );
+    }
+
+    it("upgrades to Silver pulling exactly the on-chain delta from the signer", async function () {
+      const fx = await loadFixture(deployFixture);
+      await bronzeMember(fx, fx.alice);
+      const now = await time.latest();
+
+      const priceAuth = await signPriceAuth(fx, fx.alice, usdc(70)); // 120 - 50 delta
+      const intent = { nonce: randomNonce(), validAfter: 0, validBefore: now + 3600 };
+      const sig = await fx.alice.signTypedData(fx.mgrDomain, UPGRADE_TIER_INTENT_TYPES, {
+        role: WAGER_PARTICIPANT_ROLE, tier: Tier.Silver, acceptedTermsHash: ethers.id("terms-v1"),
+        member: fx.alice.address, paymentNonce: priceAuth.nonce, ...intent,
+      });
+
+      await expect(
+        fx.mgr.connect(fx.relayer).upgradeTierWithAuthorization(
+          WAGER_PARTICIPANT_ROLE, Tier.Silver, ethers.id("terms-v1"), fx.alice.address,
+          intent.nonce, intent.validAfter, intent.validBefore, sig, priceAuth, EMPTY_AUTH
+        )
+      ).to.emit(fx.mgr, "MembershipUpgraded");
+      expect(await fx.mgr.getActiveTier(fx.alice.address, WAGER_PARTICIPANT_ROLE)).to.equal(Tier.Silver);
+    });
+
+    it("rejects an authorization that does not equal the on-chain delta (PaymentAuthMismatch)", async function () {
+      const fx = await loadFixture(deployFixture);
+      await bronzeMember(fx, fx.alice);
+      const now = await time.latest();
+
+      const priceAuth = await signPriceAuth(fx, fx.alice, usdc(60)); // wrong delta
+      const intent = { nonce: randomNonce(), validAfter: 0, validBefore: now + 3600 };
+      const sig = await fx.alice.signTypedData(fx.mgrDomain, UPGRADE_TIER_INTENT_TYPES, {
+        role: WAGER_PARTICIPANT_ROLE, tier: Tier.Silver, acceptedTermsHash: ethers.ZeroHash,
+        member: fx.alice.address, paymentNonce: priceAuth.nonce, ...intent,
+      });
+      await expect(
+        fx.mgr.connect(fx.relayer).upgradeTierWithAuthorization(
+          WAGER_PARTICIPANT_ROLE, Tier.Silver, ethers.ZeroHash, fx.alice.address,
+          intent.nonce, intent.validAfter, intent.validBefore, sig, priceAuth, EMPTY_AUTH
+        )
+      ).to.be.revertedWithCustomError(fx.mgr, "PaymentAuthMismatch");
+    });
+
+    it("extends membership from the signer's authorization", async function () {
+      const fx = await loadFixture(deployFixture);
+      await bronzeMember(fx, fx.alice);
+      const before = (await fx.mgr.getMembership(fx.alice.address, WAGER_PARTICIPANT_ROLE)).expiresAt;
+      const now = await time.latest();
+
+      const priceAuth = await signPriceAuth(fx, fx.alice, usdc(50));
+      const intent = { nonce: randomNonce(), validAfter: 0, validBefore: now + 3600 };
+      const sig = await fx.alice.signTypedData(fx.mgrDomain, EXTEND_MEMBERSHIP_INTENT_TYPES, {
+        role: WAGER_PARTICIPANT_ROLE, member: fx.alice.address, paymentNonce: priceAuth.nonce, ...intent,
+      });
+      await expect(
+        fx.mgr.connect(fx.relayer).extendMembershipWithAuthorization(
+          WAGER_PARTICIPANT_ROLE, fx.alice.address, intent.nonce, intent.validAfter, intent.validBefore, sig, priceAuth, EMPTY_AUTH
+        )
+      ).to.emit(fx.mgr, "MembershipExtended");
+      const after = (await fx.mgr.getMembership(fx.alice.address, WAGER_PARTICIPANT_ROLE)).expiresAt;
+      expect(after).to.equal(before + 30n * 86400n);
+    });
+  });
+
+  describe("redeemVoucherWithSig", function () {
+    async function voucherFixture() {
+      const fx = await deployFixture();
+      const Voucher = await ethers.getContractFactory("MembershipVoucher");
+      const voucher = await Voucher.deploy(fx.admin.address, await fx.mgr.getAddress());
+      await voucher.waitForDeployment();
+      await fx.mgr.connect(fx.admin).setVoucher(await voucher.getAddress());
+      return { ...fx, voucher };
+    }
+
+    it("redeems attributed to the signing voucher owner (no money leg)", async function () {
+      const fx = await voucherFixture();
+      // bob buys a voucher (self-submit mint path) and gifts it to alice
+      await fx.usdcToken.connect(fx.bob).approve(await fx.voucher.getAddress(), ethers.MaxUint256);
+      const tx = await fx.voucher.connect(fx.bob).mint(WAGER_PARTICIPANT_ROLE, Tier.Bronze);
+      const receipt = await tx.wait();
+      const ev = receipt.logs.map((l) => { try { return fx.voucher.interface.parseLog(l); } catch { return null; } })
+        .find((p) => p && p.name === "VoucherMinted");
+      const voucherId = ev.args[0];
+      await fx.voucher.connect(fx.bob).transferFrom(fx.bob.address, fx.alice.address, voucherId);
+
+      const now = await time.latest();
+      const intent = { nonce: randomNonce(), validAfter: 0, validBefore: now + 3600 };
+      const termsHash = ethers.id("terms-v1");
+      const sig = await fx.alice.signTypedData(fx.mgrDomain, REDEEM_VOUCHER_INTENT_TYPES, {
+        voucherId, acceptedTermsHash: termsHash, redeemer: fx.alice.address, ...intent,
+      });
+
+      await expect(
+        fx.mgr.connect(fx.relayer).redeemVoucherWithSig(voucherId, termsHash, fx.alice.address, intent.nonce, intent.validAfter, intent.validBefore, sig)
+      ).to.emit(fx.mgr, "MembershipRedeemed");
+      expect(await fx.mgr.hasActiveRole(fx.alice.address, WAGER_PARTICIPANT_ROLE)).to.equal(true);
+    });
+
+    it("rejects a signer who does not own the voucher", async function () {
+      const fx = await voucherFixture();
+      await fx.usdcToken.connect(fx.bob).approve(await fx.voucher.getAddress(), ethers.MaxUint256);
+      const tx = await fx.voucher.connect(fx.bob).mint(WAGER_PARTICIPANT_ROLE, Tier.Bronze);
+      const receipt = await tx.wait();
+      const ev = receipt.logs.map((l) => { try { return fx.voucher.interface.parseLog(l); } catch { return null; } })
+        .find((p) => p && p.name === "VoucherMinted");
+      const voucherId = ev.args[0];
+      await fx.voucher.connect(fx.bob).transferFrom(fx.bob.address, fx.alice.address, voucherId);
+
+      const now = await time.latest();
+      const intent = { nonce: randomNonce(), validAfter: 0, validBefore: now + 3600 };
+      const sig = await fx.bob.signTypedData(fx.mgrDomain, REDEEM_VOUCHER_INTENT_TYPES, {
+        voucherId, acceptedTermsHash: ethers.ZeroHash, redeemer: fx.bob.address, ...intent,
+      });
+      await expect(
+        fx.mgr.connect(fx.relayer).redeemVoucherWithSig(voucherId, ethers.ZeroHash, fx.bob.address, intent.nonce, intent.validAfter, intent.validBefore, sig)
+      ).to.be.revertedWithCustomError(fx.mgr, "NotVoucherOwner");
+    });
+  });
+
+  describe("cross-contract isolation (FR-005/FR-021)", function () {
+    it("the same nonce is independent per contract, and a signature for one contract is invalid on another", async function () {
+      const fx = await loadFixture(deployFixture);
+
+      // Deploy a SECOND MembershipManager — same code, different address ⇒ different domain.
+      const mgr2 = await deployMembershipManager([fx.admin.address, await fx.usdcToken.getAddress(), fx.treasury.address]);
+      const limits = { monthlyMarketCreation: 100, maxConcurrentMarkets: 10 };
+      await mgr2.connect(fx.admin).setTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze, usdc(50), 30, limits, true);
+
+      const p = await signPurchase(fx, fx.alice);
+      // Same signed payload replayed against mgr2: the domain separator differs → bad signature.
+      const priceAuth2 = await signPriceAuth(fx, fx.alice, usdc(50), await mgr2.getAddress());
+      await expect(
+        mgr2.connect(fx.relayer).purchaseTierWithAuthorization(
+          WAGER_PARTICIPANT_ROLE, p.tier, p.termsHash, fx.alice.address,
+          p.intent.nonce, p.intent.validAfter, p.intent.validBefore, p.sig, priceAuth2, EMPTY_AUTH
+        )
+      ).to.be.revertedWithCustomError(mgr2, "InvalidIntentSignature");
+
+      // The nonce consumed on mgr is still unused on mgr2 (per-contract nonce space).
+      await fx.mgr.connect(fx.relayer).purchaseTierWithAuthorization(
+        WAGER_PARTICIPANT_ROLE, p.tier, p.termsHash, fx.alice.address,
+        p.intent.nonce, p.intent.validAfter, p.intent.validBefore, p.sig, p.priceAuth, EMPTY_AUTH
+      );
+      expect(await fx.mgr.authorizationState(fx.alice.address, p.intent.nonce)).to.equal(true);
+      expect(await mgr2.authorizationState(fx.alice.address, p.intent.nonce)).to.equal(false);
+
+      expect(await fx.mgr.DOMAIN_SEPARATOR()).to.not.equal(await mgr2.DOMAIN_SEPARATOR());
+    });
+  });
+});

--- a/test/intent/WagerRegistryIntents.test.js
+++ b/test/intent/WagerRegistryIntents.test.js
@@ -1,0 +1,672 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time, loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+const { deployWagerRegistry, deployMembershipManager } = require("../helpers/proxy");
+
+// Spec 035 — signer-attributed (gasless) wager intents. A relayer (any third party) submits the
+// user's signed intent; the on-chain effect is attributed to the SIGNER: creator/opponent/winner
+// are the signers, stakes are pulled from the signers' balances via EIP-3009, and every
+// screening/membership/ownership/freeze check evaluates the signer (FR-002/FR-003/FR-007).
+
+const Tier = { None: 0, Bronze: 1, Silver: 2, Gold: 3, Platinum: 4 };
+const Resolution = { Either: 0, Creator: 1, Opponent: 2, ThirdParty: 3, Polymarket: 4 };
+const Status = { None: 0, Open: 1, Active: 2, Resolved: 3, Cancelled: 4, Refunded: 5, Draw: 6 };
+const WAGER_PARTICIPANT_ROLE = ethers.keccak256(ethers.toUtf8Bytes("WAGER_PARTICIPANT_ROLE"));
+const usdc = (n) => ethers.parseUnits(String(n), 6);
+const randomNonce = () => ethers.hexlify(ethers.randomBytes(32));
+
+const RECEIVE_WITH_AUTHORIZATION_TYPES = {
+  ReceiveWithAuthorization: [
+    { name: "from", type: "address" },
+    { name: "to", type: "address" },
+    { name: "value", type: "uint256" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+    { name: "nonce", type: "bytes32" },
+  ],
+};
+
+const CREATE_WAGER_INTENT_TYPES = {
+  CreateWagerIntent: [
+    { name: "creator", type: "address" },
+    { name: "opponent", type: "address" },
+    { name: "arbitrator", type: "address" },
+    { name: "token", type: "address" },
+    { name: "creatorStake", type: "uint128" },
+    { name: "opponentStake", type: "uint128" },
+    { name: "acceptDeadline", type: "uint64" },
+    { name: "resolveDeadline", type: "uint64" },
+    { name: "resolutionType", type: "uint8" },
+    { name: "conditionId", type: "bytes32" },
+    { name: "creatorIsYes", type: "bool" },
+    { name: "metadataHash", type: "bytes32" },
+    { name: "metadataUri", type: "string" },
+    { name: "termsVersionHash", type: "bytes32" },
+    { name: "paymentNonce", type: "bytes32" },
+    { name: "nonce", type: "bytes32" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+  ],
+};
+
+const ACCEPT_WAGER_INTENT_TYPES = {
+  AcceptWagerIntent: [
+    { name: "wagerId", type: "uint256" },
+    { name: "taker", type: "address" },
+    { name: "paymentNonce", type: "bytes32" },
+    { name: "nonce", type: "bytes32" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+  ],
+};
+
+const simpleIntentTypes = (structName, actorField) => ({
+  [structName]: [
+    { name: "wagerId", type: "uint256" },
+    { name: actorField, type: "address" },
+    { name: "nonce", type: "bytes32" },
+    { name: "validAfter", type: "uint256" },
+    { name: "validBefore", type: "uint256" },
+  ],
+});
+
+describe("WagerRegistry signer-attributed intents (spec 035)", function () {
+  async function deployFixture() {
+    const [admin, alice, bob, charlie, relayer, treasury, feeSink] = await ethers.getSigners();
+
+    // EIP-3009-capable stablecoin (MockUSDCPermit) — the gasless money leg requires it.
+    const MockUSDC = await ethers.getContractFactory("MockUSDCPermit");
+    const usdcToken = await MockUSDC.deploy();
+    await usdcToken.waitForDeployment();
+
+    const mgr = await deployMembershipManager([admin.address, await usdcToken.getAddress(), treasury.address]);
+    const limits = { monthlyMarketCreation: 100, maxConcurrentMarkets: 10 };
+    await mgr.connect(admin).setTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze, usdc(50), 30, limits, true);
+    await mgr.connect(admin).setTier(WAGER_PARTICIPANT_ROLE, Tier.Silver, usdc(120), 30, limits, true);
+
+    const MockOracle = await ethers.getContractFactory("MockSanctionsOracle");
+    const oracle = await MockOracle.deploy();
+    const Guard = await ethers.getContractFactory("SanctionsGuard");
+    const guard = await Guard.deploy(admin.address, await oracle.getAddress());
+
+    const reg = await deployWagerRegistry([
+      admin.address,
+      await mgr.getAddress(),
+      ethers.ZeroAddress,
+      [await usdcToken.getAddress()],
+    ]);
+    await mgr.connect(admin).setAuthorizedCaller(await reg.getAddress(), true);
+    await reg.connect(admin).setSanctionsGuard(await guard.getAddress());
+    await mgr.connect(admin).setSanctionsGuard(await guard.getAddress());
+
+    for (const u of [alice, bob, charlie]) {
+      await usdcToken.mint(u.address, usdc(10_000));
+      await usdcToken.connect(u).approve(await mgr.getAddress(), ethers.MaxUint256);
+      await mgr.connect(u).purchaseTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze);
+      // NOTE: deliberately NO approval to the registry — the gasless paths must not need one.
+    }
+
+    const chainId = (await ethers.provider.getNetwork()).chainId;
+    const regDomain = {
+      name: "FairWins WagerRegistry",
+      version: "1",
+      chainId,
+      verifyingContract: await reg.getAddress(),
+    };
+    const tokenDomain = {
+      name: "USD Coin",
+      version: "1", // MockUSDCPermit uses OZ's default domain version
+      chainId,
+      verifyingContract: await usdcToken.getAddress(),
+    };
+
+    return { reg, mgr, usdcToken, oracle, guard, admin, alice, bob, charlie, relayer, treasury, feeSink, regDomain, tokenDomain };
+  }
+
+  /** Sign an EIP-3009 receive authorization pulling `value` from `signer` into the registry. */
+  async function signStakeAuth(fx, signer, value, overrides = {}) {
+    const now = await time.latest();
+    const message = {
+      from: signer.address,
+      to: await fx.reg.getAddress(),
+      value,
+      validAfter: 0,
+      validBefore: now + 3600,
+      nonce: randomNonce(),
+      ...overrides,
+    };
+    const sig = ethers.Signature.from(
+      await signer.signTypedData(fx.tokenDomain, RECEIVE_WITH_AUTHORIZATION_TYPES, message)
+    );
+    return {
+      value: message.value,
+      validAfter: message.validAfter,
+      validBefore: message.validBefore,
+      nonce: message.nonce,
+      v: sig.v,
+      r: sig.r,
+      s: sig.s,
+    };
+  }
+
+  const EMPTY_AUTH = { value: 0, validAfter: 0, validBefore: 0, nonce: ethers.ZeroHash, v: 0, r: ethers.ZeroHash, s: ethers.ZeroHash };
+
+  /** Build + sign a CreateWagerIntent along with its stake authorization. */
+  async function signCreate(fx, creator, overrides = {}) {
+    const now = await time.latest();
+    const args = {
+      opponent: fx.bob.address,
+      arbitrator: ethers.ZeroAddress,
+      token: await fx.usdcToken.getAddress(),
+      creatorStake: usdc(10),
+      opponentStake: usdc(10),
+      acceptDeadline: now + 3600,
+      resolveDeadline: now + 86400,
+      resolutionType: Resolution.Either,
+      conditionId: ethers.ZeroHash,
+      creatorIsYes: false,
+      metadataHash: ethers.id("test"),
+      metadataUri: "ipfs://bafyIntentCid",
+      termsVersionHash: ethers.ZeroHash,
+      ...overrides.args,
+    };
+    const stakeAuth = await signStakeAuth(fx, creator, args.creatorStake);
+    args.paymentNonce = overrides.paymentNonce ?? stakeAuth.nonce;
+
+    const intent = {
+      nonce: randomNonce(),
+      validAfter: 0,
+      validBefore: now + 3600,
+      ...overrides.intent,
+    };
+    const message = {
+      creator: creator.address,
+      ...args,
+      nonce: intent.nonce,
+      validAfter: intent.validAfter,
+      validBefore: intent.validBefore,
+    };
+    const sig = await creator.signTypedData(fx.regDomain, CREATE_WAGER_INTENT_TYPES, message);
+    return { args, intent, sig, stakeAuth };
+  }
+
+  /** Full happy-path gasless create; returns the wagerId. */
+  async function gaslessCreate(fx, creator, overrides = {}, feeAuth = EMPTY_AUTH) {
+    const signed = await signCreate(fx, creator, overrides);
+    signed.signerAddress = creator.address;
+    const tx = await fx.reg
+      .connect(fx.relayer)
+      .createWagerWithAuthorization(
+        signed.args,
+        creator.address,
+        signed.intent.nonce,
+        signed.intent.validAfter,
+        signed.intent.validBefore,
+        signed.sig,
+        signed.stakeAuth,
+        feeAuth
+      );
+    const receipt = await tx.wait();
+    const ev = receipt.logs
+      .map((l) => { try { return fx.reg.interface.parseLog(l); } catch { return null; } })
+      .find((p) => p && p.name === "WagerCreated");
+    return { wagerId: Number(ev.args.wagerId), signed };
+  }
+
+  /** Sign an AcceptWagerIntent + stake auth for `taker` on `wagerId`. */
+  async function signAccept(fx, taker, wagerId, stakeValue, overrides = {}) {
+    const now = await time.latest();
+    const stakeAuth = await signStakeAuth(fx, taker, stakeValue, overrides.auth ?? {});
+    const intent = { nonce: randomNonce(), validAfter: 0, validBefore: now + 3600, ...overrides.intent };
+    const message = {
+      wagerId,
+      taker: taker.address,
+      paymentNonce: overrides.paymentNonce ?? stakeAuth.nonce,
+      nonce: intent.nonce,
+      validAfter: intent.validAfter,
+      validBefore: intent.validBefore,
+    };
+    const sig = await taker.signTypedData(fx.regDomain, ACCEPT_WAGER_INTENT_TYPES, message);
+    return { intent, sig, stakeAuth };
+  }
+
+  /** Sign a simple no-stake intent (ClaimPayoutIntent, DeclineIntent, …). */
+  async function signSimple(fx, signer, structName, actorField, wagerId, overrides = {}) {
+    const now = await time.latest();
+    const intent = { nonce: randomNonce(), validAfter: 0, validBefore: now + 3600, ...overrides };
+    const message = { wagerId, [actorField]: signer.address, nonce: intent.nonce, validAfter: intent.validAfter, validBefore: intent.validBefore };
+    const sig = await signer.signTypedData(fx.regDomain, simpleIntentTypes(structName, actorField), message);
+    return { intent, sig };
+  }
+
+  describe("createWagerWithAuthorization", function () {
+    it("creates the wager attributed to the signer, staking from the signer's balance (SC-001/SC-003)", async function () {
+      const fx = await loadFixture(deployFixture);
+      const before = await fx.usdcToken.balanceOf(fx.alice.address);
+      const { wagerId } = await gaslessCreate(fx, fx.alice);
+
+      const w = await fx.reg.getWager(wagerId);
+      expect(w.creator).to.equal(fx.alice.address); // attributed to the SIGNER, not the relayer
+      expect(w.opponent).to.equal(fx.bob.address);
+      expect(w.status).to.equal(Status.Open);
+      expect(await fx.usdcToken.balanceOf(fx.alice.address)).to.equal(before - usdc(10));
+      expect(await fx.usdcToken.balanceOf(await fx.reg.getAddress())).to.equal(usdc(10));
+    });
+
+    it("emits the same WagerCreated event as the self-submit twin (subgraph-compatible)", async function () {
+      const fx = await loadFixture(deployFixture);
+      const signed = await signCreate(fx, fx.alice);
+      await expect(
+        fx.reg.connect(fx.relayer).createWagerWithAuthorization(
+          signed.args, fx.alice.address, signed.intent.nonce, signed.intent.validAfter, signed.intent.validBefore, signed.sig, signed.stakeAuth, EMPTY_AUTH
+        )
+      )
+        .to.emit(fx.reg, "WagerCreated")
+        .withArgs(1, fx.alice.address, fx.bob.address, await fx.usdcToken.getAddress(), usdc(10), usdc(10), Resolution.Either, ethers.id("test"), "ipfs://bafyIntentCid");
+    });
+
+    it("rejects a replayed intent (SC-004)", async function () {
+      const fx = await loadFixture(deployFixture);
+      const signed = await signCreate(fx, fx.alice);
+      const submit = () =>
+        fx.reg.connect(fx.relayer).createWagerWithAuthorization(
+          signed.args, fx.alice.address, signed.intent.nonce, signed.intent.validAfter, signed.intent.validBefore, signed.sig, signed.stakeAuth, EMPTY_AUTH
+        );
+      await submit();
+      await expect(submit()).to.be.revertedWithCustomError(fx.reg, "IntentReplayed");
+    });
+
+    it("rejects an expired intent and a not-yet-valid intent", async function () {
+      const fx = await loadFixture(deployFixture);
+      const now = await time.latest();
+
+      const expired = await signCreate(fx, fx.alice, { intent: { validBefore: now - 1 } });
+      await expect(
+        fx.reg.connect(fx.relayer).createWagerWithAuthorization(
+          expired.args, fx.alice.address, expired.intent.nonce, expired.intent.validAfter, expired.intent.validBefore, expired.sig, expired.stakeAuth, EMPTY_AUTH
+        )
+      ).to.be.revertedWithCustomError(fx.reg, "IntentExpired");
+
+      const future = await signCreate(fx, fx.alice, { intent: { validAfter: now + 3000 } });
+      await expect(
+        fx.reg.connect(fx.relayer).createWagerWithAuthorization(
+          future.args, fx.alice.address, future.intent.nonce, future.intent.validAfter, future.intent.validBefore, future.sig, future.stakeAuth, EMPTY_AUTH
+        )
+      ).to.be.revertedWithCustomError(fx.reg, "IntentNotYetValid");
+    });
+
+    it("rejects a signature from anyone but the claimed signer", async function () {
+      const fx = await loadFixture(deployFixture);
+      const signed = await signCreate(fx, fx.alice);
+      await expect(
+        fx.reg.connect(fx.relayer).createWagerWithAuthorization(
+          signed.args, fx.charlie.address, // claims charlie, signed by alice
+          signed.intent.nonce, signed.intent.validAfter, signed.intent.validBefore, signed.sig, signed.stakeAuth, EMPTY_AUTH
+        )
+      ).to.be.revertedWithCustomError(fx.reg, "InvalidIntentSignature");
+    });
+
+    it("rejects a relayer substituting a different stake authorization (FR-007 binding)", async function () {
+      const fx = await loadFixture(deployFixture);
+      const signed = await signCreate(fx, fx.alice);
+      // A second, equally valid authorization from alice NOT bound into the intent:
+      const otherAuth = await signStakeAuth(fx, fx.alice, usdc(10));
+      await expect(
+        fx.reg.connect(fx.relayer).createWagerWithAuthorization(
+          signed.args, fx.alice.address, signed.intent.nonce, signed.intent.validAfter, signed.intent.validBefore, signed.sig, otherAuth, EMPTY_AUTH
+        )
+      ).to.be.revertedWithCustomError(fx.reg, "PaymentAuthMismatch");
+    });
+
+    it("rejects a tampered param (stake) — the intent binds exactly what was signed", async function () {
+      const fx = await loadFixture(deployFixture);
+      const signed = await signCreate(fx, fx.alice);
+      const tampered = { ...signed.args, creatorStake: usdc(1) }; // relayer tries to shrink the stake
+      await expect(
+        fx.reg.connect(fx.relayer).createWagerWithAuthorization(
+          tampered, fx.alice.address, signed.intent.nonce, signed.intent.validAfter, signed.intent.validBefore, signed.sig, signed.stakeAuth, EMPTY_AUTH
+        )
+      ).to.be.revertedWithCustomError(fx.reg, "InvalidIntentSignature");
+    });
+
+    it("screens the SIGNER fail-closed (sanctioned signer blocked, FR-003/FR-013)", async function () {
+      const fx = await loadFixture(deployFixture);
+      await fx.guard.connect(fx.admin).setDenied(fx.alice.address, true, "ofac");
+      const signed = await signCreate(fx, fx.alice);
+      await expect(
+        fx.reg.connect(fx.relayer).createWagerWithAuthorization(
+          signed.args, fx.alice.address, signed.intent.nonce, signed.intent.validAfter, signed.intent.validBefore, signed.sig, signed.stakeAuth, EMPTY_AUTH
+        )
+      ).to.be.revertedWithCustomError(fx.guard, "SanctionedAddress").withArgs(fx.alice.address);
+    });
+
+    it("blocks a frozen signer (freeze check evaluates the signer, not the relayer)", async function () {
+      const fx = await loadFixture(deployFixture);
+      await fx.reg.connect(fx.admin).freezeAccount(fx.alice.address, "test");
+      const signed = await signCreate(fx, fx.alice);
+      await expect(
+        fx.reg.connect(fx.relayer).createWagerWithAuthorization(
+          signed.args, fx.alice.address, signed.intent.nonce, signed.intent.validAfter, signed.intent.validBefore, signed.sig, signed.stakeAuth, EMPTY_AUTH
+        )
+      ).to.be.revertedWithCustomError(fx.reg, "AccountFrozenError").withArgs(fx.alice.address);
+    });
+
+    it("self-submit twin produces an identical on-chain result (SC-005)", async function () {
+      const fx = await loadFixture(deployFixture);
+      // Gasless create (id 1)
+      const { wagerId: gaslessId } = await gaslessCreate(fx, fx.alice);
+      // Self-submit create with identical params (id 2)
+      await fx.usdcToken.connect(fx.alice).approve(await fx.reg.getAddress(), ethers.MaxUint256);
+      const now = await time.latest();
+      await fx.reg.connect(fx.alice).createWager(
+        fx.bob.address, ethers.ZeroAddress, await fx.usdcToken.getAddress(),
+        usdc(10), usdc(10), now + 3600, now + 86400, Resolution.Either,
+        ethers.ZeroHash, false, ethers.id("test"), "ipfs://bafyIntentCid"
+      );
+      const a = await fx.reg.getWager(gaslessId);
+      const b = await fx.reg.getWager(gaslessId + 1);
+      expect(a.creator).to.equal(b.creator);
+      expect(a.opponent).to.equal(b.opponent);
+      expect(a.creatorStake).to.equal(b.creatorStake);
+      expect(a.status).to.equal(b.status);
+    });
+  });
+
+  describe("acceptWagerWithAuthorization", function () {
+    it("full gasless lifecycle: create + accept with zero registry approvals (SC-001)", async function () {
+      const fx = await loadFixture(deployFixture);
+      const { wagerId } = await gaslessCreate(fx, fx.alice);
+
+      const bobBefore = await fx.usdcToken.balanceOf(fx.bob.address);
+      const acc = await signAccept(fx, fx.bob, wagerId, usdc(10));
+      await expect(
+        fx.reg.connect(fx.relayer).acceptWagerWithAuthorization(
+          wagerId, fx.bob.address, acc.intent.nonce, acc.intent.validAfter, acc.intent.validBefore, acc.sig, acc.stakeAuth, EMPTY_AUTH
+        )
+      ).to.emit(fx.reg, "WagerAccepted").withArgs(wagerId, fx.bob.address);
+
+      const w = await fx.reg.getWager(wagerId);
+      expect(w.status).to.equal(Status.Active);
+      expect(w.opponent).to.equal(fx.bob.address);
+      expect(await fx.usdcToken.balanceOf(fx.bob.address)).to.equal(bobBefore - usdc(10));
+    });
+
+    it("only the named opponent's signature can accept (attribution, not submission, decides)", async function () {
+      const fx = await loadFixture(deployFixture);
+      const { wagerId } = await gaslessCreate(fx, fx.alice);
+      const acc = await signAccept(fx, fx.charlie, wagerId, usdc(10)); // charlie is not the opponent
+      await expect(
+        fx.reg.connect(fx.relayer).acceptWagerWithAuthorization(
+          wagerId, fx.charlie.address, acc.intent.nonce, acc.intent.validAfter, acc.intent.validBefore, acc.sig, acc.stakeAuth, EMPTY_AUTH
+        )
+      ).to.be.revertedWithCustomError(fx.reg, "NotOpponent");
+    });
+
+    it("rejects replay of the accept intent", async function () {
+      const fx = await loadFixture(deployFixture);
+      const { wagerId } = await gaslessCreate(fx, fx.alice);
+      const acc = await signAccept(fx, fx.bob, wagerId, usdc(10));
+      const submit = () =>
+        fx.reg.connect(fx.relayer).acceptWagerWithAuthorization(
+          wagerId, fx.bob.address, acc.intent.nonce, acc.intent.validAfter, acc.intent.validBefore, acc.sig, acc.stakeAuth, EMPTY_AUTH
+        );
+      await submit();
+      await expect(submit()).to.be.revertedWithCustomError(fx.reg, "IntentReplayed");
+    });
+  });
+
+  describe("fee netting (FR-015/FR-016)", function () {
+    it("consumes the bounded fee authorization and forwards it to the segregated recipient", async function () {
+      const fx = await loadFixture(deployFixture);
+      await fx.reg.connect(fx.admin).setFeeNetting(true, fx.feeSink.address, usdc(1));
+      expect(await fx.reg.feeNettingEnabled()).to.equal(true);
+
+      const feeAuth = await signStakeAuth(fx, fx.alice, usdc(1) / 2n); // 0.5 USDC fee
+      await gaslessCreate(fx, fx.alice, {}, feeAuth);
+      expect(await fx.usdcToken.balanceOf(fx.feeSink.address)).to.equal(usdc(1) / 2n);
+    });
+
+    it("declines a fee above the cap before any funds move", async function () {
+      const fx = await loadFixture(deployFixture);
+      await fx.reg.connect(fx.admin).setFeeNetting(true, fx.feeSink.address, usdc(1));
+      const balBefore = await fx.usdcToken.balanceOf(fx.alice.address);
+
+      const signed = await signCreate(fx, fx.alice);
+      const feeAuth = await signStakeAuth(fx, fx.alice, usdc(2)); // over the 1 USDC cap
+      await expect(
+        fx.reg.connect(fx.relayer).createWagerWithAuthorization(
+          signed.args, fx.alice.address, signed.intent.nonce, signed.intent.validAfter, signed.intent.validBefore, signed.sig, signed.stakeAuth, feeAuth
+        )
+      ).to.be.revertedWithCustomError(fx.reg, "FeeExceedsCap");
+      expect(await fx.usdcToken.balanceOf(fx.alice.address)).to.equal(balBefore); // atomic — nothing moved
+    });
+
+    it("ignores the fee leg when netting is disabled (sponsored mode)", async function () {
+      const fx = await loadFixture(deployFixture);
+      await gaslessCreate(fx, fx.alice, {}, EMPTY_AUTH);
+      expect(await fx.usdcToken.balanceOf(fx.feeSink.address)).to.equal(0);
+    });
+  });
+
+  describe("no-stake …WithSig twins", function () {
+    async function activeWager(fx) {
+      const { wagerId } = await gaslessCreate(fx, fx.alice);
+      const acc = await signAccept(fx, fx.bob, wagerId, usdc(10));
+      await fx.reg.connect(fx.relayer).acceptWagerWithAuthorization(
+        wagerId, fx.bob.address, acc.intent.nonce, acc.intent.validAfter, acc.intent.validBefore, acc.sig, acc.stakeAuth, EMPTY_AUTH
+      );
+      return wagerId;
+    }
+
+    it("declareWinnerWithSig resolves attributed to the signer; claimPayoutWithSig pays the winning signer (SC-009)", async function () {
+      const fx = await loadFixture(deployFixture);
+      const wagerId = await activeWager(fx);
+
+      // alice (Either-type participant) declares bob the winner via intent
+      const now = await time.latest();
+      const winIntent = { nonce: randomNonce(), validAfter: 0, validBefore: now + 3600 };
+      const winSig = await fx.alice.signTypedData(fx.regDomain, {
+        DeclareWinnerIntent: [
+          { name: "wagerId", type: "uint256" },
+          { name: "winner", type: "address" },
+          { name: "actor", type: "address" },
+          { name: "nonce", type: "bytes32" },
+          { name: "validAfter", type: "uint256" },
+          { name: "validBefore", type: "uint256" },
+        ],
+      }, { wagerId, winner: fx.bob.address, actor: fx.alice.address, ...winIntent });
+
+      await expect(
+        fx.reg.connect(fx.relayer).declareWinnerWithSig(wagerId, fx.bob.address, fx.alice.address, winIntent.nonce, winIntent.validAfter, winIntent.validBefore, winSig)
+      ).to.emit(fx.reg, "WagerResolved").withArgs(wagerId, fx.bob.address, fx.alice.address);
+
+      // bob claims the payout gaslessly — lands in bob's wallet
+      const bobBefore = await fx.usdcToken.balanceOf(fx.bob.address);
+      const claim = await signSimple(fx, fx.bob, "ClaimPayoutIntent", "claimant", wagerId);
+      await expect(
+        fx.reg.connect(fx.relayer).claimPayoutWithSig(wagerId, fx.bob.address, claim.intent.nonce, claim.intent.validAfter, claim.intent.validBefore, claim.sig)
+      ).to.emit(fx.reg, "PayoutClaimed").withArgs(wagerId, fx.bob.address, usdc(20));
+      expect(await fx.usdcToken.balanceOf(fx.bob.address)).to.equal(bobBefore + usdc(20));
+    });
+
+    it("a non-winner's signed claim reverts (ownership evaluated on the signer)", async function () {
+      const fx = await loadFixture(deployFixture);
+      const wagerId = await activeWager(fx);
+      await fx.reg.connect(fx.alice).declareWinner(wagerId, fx.bob.address);
+
+      const claim = await signSimple(fx, fx.alice, "ClaimPayoutIntent", "claimant", wagerId);
+      await expect(
+        fx.reg.connect(fx.relayer).claimPayoutWithSig(wagerId, fx.alice.address, claim.intent.nonce, claim.intent.validAfter, claim.intent.validBefore, claim.sig)
+      ).to.be.revertedWithCustomError(fx.reg, "NotWinner");
+    });
+
+    it("declineWagerWithSig refunds the creator, attributed to the signing opponent", async function () {
+      const fx = await loadFixture(deployFixture);
+      const { wagerId } = await gaslessCreate(fx, fx.alice);
+      const dec = await signSimple(fx, fx.bob, "DeclineIntent", "actor", wagerId);
+      await expect(
+        fx.reg.connect(fx.relayer).declineWagerWithSig(wagerId, fx.bob.address, dec.intent.nonce, dec.intent.validAfter, dec.intent.validBefore, dec.sig)
+      ).to.emit(fx.reg, "WagerDeclined").withArgs(wagerId, fx.bob.address);
+    });
+
+    it("cancelOpenWithSig only honors the creator's signature", async function () {
+      const fx = await loadFixture(deployFixture);
+      const { wagerId } = await gaslessCreate(fx, fx.alice);
+
+      const bad = await signSimple(fx, fx.bob, "CancelOpenIntent", "actor", wagerId);
+      await expect(
+        fx.reg.connect(fx.relayer).cancelOpenWithSig(wagerId, fx.bob.address, bad.intent.nonce, bad.intent.validAfter, bad.intent.validBefore, bad.sig)
+      ).to.be.revertedWithCustomError(fx.reg, "NotCreator");
+
+      const good = await signSimple(fx, fx.alice, "CancelOpenIntent", "actor", wagerId);
+      await expect(
+        fx.reg.connect(fx.relayer).cancelOpenWithSig(wagerId, fx.alice.address, good.intent.nonce, good.intent.validAfter, good.intent.validBefore, good.sig)
+      ).to.emit(fx.reg, "WagerCancelled").withArgs(wagerId);
+    });
+
+    it("declareDrawWithSig + revokeDrawWithSig drive the mutual-consent draw as the signers", async function () {
+      const fx = await loadFixture(deployFixture);
+      const wagerId = await activeWager(fx);
+
+      const p1 = await signSimple(fx, fx.alice, "DeclareDrawIntent", "actor", wagerId);
+      await expect(
+        fx.reg.connect(fx.relayer).declareDrawWithSig(wagerId, fx.alice.address, p1.intent.nonce, p1.intent.validAfter, p1.intent.validBefore, p1.sig)
+      ).to.emit(fx.reg, "DrawProposed").withArgs(wagerId, fx.alice.address);
+
+      const rv = await signSimple(fx, fx.alice, "RevokeDrawIntent", "actor", wagerId);
+      await expect(
+        fx.reg.connect(fx.relayer).revokeDrawWithSig(wagerId, fx.alice.address, rv.intent.nonce, rv.intent.validAfter, rv.intent.validBefore, rv.sig)
+      ).to.emit(fx.reg, "DrawRevoked").withArgs(wagerId, fx.alice.address);
+
+      // Propose again from both sides → settles as a draw
+      const p2 = await signSimple(fx, fx.alice, "DeclareDrawIntent", "actor", wagerId);
+      await fx.reg.connect(fx.relayer).declareDrawWithSig(wagerId, fx.alice.address, p2.intent.nonce, p2.intent.validAfter, p2.intent.validBefore, p2.sig);
+      const p3 = await signSimple(fx, fx.bob, "DeclareDrawIntent", "actor", wagerId);
+      await expect(
+        fx.reg.connect(fx.relayer).declareDrawWithSig(wagerId, fx.bob.address, p3.intent.nonce, p3.intent.validAfter, p3.intent.validBefore, p3.sig)
+      ).to.emit(fx.reg, "WagerDrawn").withArgs(wagerId, fx.alice.address, fx.bob.address, fx.bob.address);
+    });
+
+    it("claimRefundWithSig refunds the original creator after expiry", async function () {
+      const fx = await loadFixture(deployFixture);
+      const { wagerId } = await gaslessCreate(fx, fx.alice);
+      const w = await fx.reg.getWager(wagerId);
+      await time.increaseTo(Number(w.acceptDeadline) + 1);
+
+      const aliceBefore = await fx.usdcToken.balanceOf(fx.alice.address);
+      const rf = await signSimple(fx, fx.charlie, "ClaimRefundIntent", "actor", wagerId); // neutral third party drives it
+      await expect(
+        fx.reg.connect(fx.relayer).claimRefundWithSig(wagerId, fx.charlie.address, rf.intent.nonce, rf.intent.validAfter, rf.intent.validBefore, rf.sig)
+      ).to.emit(fx.reg, "WagerRefunded").withArgs(wagerId, fx.alice.address, ethers.ZeroAddress);
+      expect(await fx.usdcToken.balanceOf(fx.alice.address)).to.equal(aliceBefore + usdc(10));
+    });
+  });
+
+  describe("acceptOpenWagerWithAuthorization (open challenges)", function () {
+    it("accepts with claim-code proof rebound to the signing taker", async function () {
+      const fx = await loadFixture(deployFixture);
+      // Silver tier for alice to create an open challenge
+      await fx.mgr.connect(fx.admin).grantMembership(fx.alice.address, WAGER_PARTICIPANT_ROLE, Tier.Silver, 30);
+
+      // Claim authority = a fresh code-derived key
+      const claimKey = ethers.Wallet.createRandom().connect(ethers.provider);
+      const now = await time.latest();
+      await fx.usdcToken.connect(fx.alice).approve(await fx.reg.getAddress(), usdc(10));
+      const tx = await fx.reg.connect(fx.alice).createOpenWager(
+        claimKey.address, ethers.ZeroAddress, await fx.usdcToken.getAddress(), usdc(10),
+        now + 3600, now + 86400, Resolution.Either, ethers.ZeroHash, false, ethers.id("open"), "ipfs://open"
+      );
+      const receipt = await tx.wait();
+      const ev = receipt.logs.map((l) => { try { return fx.reg.interface.parseLog(l); } catch { return null; } })
+        .find((p) => p && p.name === "OpenWagerCreated");
+      const wagerId = Number(ev.args.wagerId);
+
+      // Claim-code proof bound to bob (the SIGNER, not the relayer)
+      const claimSig = await claimKey.signTypedData(fx.regDomain, {
+        OpenAccept: [
+          { name: "wagerId", type: "uint256" },
+          { name: "taker", type: "address" },
+        ],
+      }, { wagerId, taker: fx.bob.address });
+
+      const acc = await signAccept(fx, fx.bob, wagerId, usdc(10));
+      await expect(
+        fx.reg.connect(fx.relayer).acceptOpenWagerWithAuthorization(
+          wagerId, fx.bob.address, claimSig, acc.intent.nonce, acc.intent.validAfter, acc.intent.validBefore, acc.sig, acc.stakeAuth, EMPTY_AUTH
+        )
+      ).to.emit(fx.reg, "WagerAccepted").withArgs(wagerId, fx.bob.address);
+      expect((await fx.reg.getWager(wagerId)).opponent).to.equal(fx.bob.address);
+    });
+  });
+
+  describe("nonce invalidation (FR-006)", function () {
+    it("invalidateNonce burns an unused nonce so the signed intent can never execute", async function () {
+      const fx = await loadFixture(deployFixture);
+      const signed = await signCreate(fx, fx.alice);
+      await expect(fx.reg.connect(fx.alice).invalidateNonce(signed.intent.nonce))
+        .to.emit(fx.reg, "NonceInvalidated").withArgs(fx.alice.address, signed.intent.nonce);
+      expect(await fx.reg.authorizationState(fx.alice.address, signed.intent.nonce)).to.equal(true);
+
+      await expect(
+        fx.reg.connect(fx.relayer).createWagerWithAuthorization(
+          signed.args, fx.alice.address, signed.intent.nonce, signed.intent.validAfter, signed.intent.validBefore, signed.sig, signed.stakeAuth, EMPTY_AUTH
+        )
+      ).to.be.revertedWithCustomError(fx.reg, "IntentReplayed");
+    });
+
+    it("invalidateNonceWithSig lets a zero-native wallet cancel through the relayer", async function () {
+      const fx = await loadFixture(deployFixture);
+      const nonce = randomNonce();
+      const now = await time.latest();
+      const validBefore = now + 3600;
+      const sig = await fx.alice.signTypedData(fx.regDomain, {
+        InvalidateNonce: [
+          { name: "signer", type: "address" },
+          { name: "nonce", type: "bytes32" },
+          { name: "validBefore", type: "uint256" },
+        ],
+      }, { signer: fx.alice.address, nonce, validBefore });
+
+      await expect(fx.reg.connect(fx.relayer).invalidateNonceWithSig(fx.alice.address, nonce, validBefore, sig))
+        .to.emit(fx.reg, "NonceInvalidated").withArgs(fx.alice.address, nonce);
+    });
+
+    it("cancelAuthorization invalidates the payment leg in the stablecoin", async function () {
+      const fx = await loadFixture(deployFixture);
+      const signed = await signCreate(fx, fx.alice);
+      // Cancel the EIP-3009 authorization (payment leg) — the mock implements cancelAuthorization
+      const cancelSig = ethers.Signature.from(await fx.alice.signTypedData(fx.tokenDomain, {
+        CancelAuthorization: [
+          { name: "authorizer", type: "address" },
+          { name: "nonce", type: "bytes32" },
+        ],
+      }, { authorizer: fx.alice.address, nonce: signed.stakeAuth.nonce }));
+      await fx.usdcToken.connect(fx.relayer).cancelAuthorization(fx.alice.address, signed.stakeAuth.nonce, cancelSig.v, cancelSig.r, cancelSig.s);
+
+      await expect(
+        fx.reg.connect(fx.relayer).createWagerWithAuthorization(
+          signed.args, fx.alice.address, signed.intent.nonce, signed.intent.validAfter, signed.intent.validBefore, signed.sig, signed.stakeAuth, EMPTY_AUTH
+        )
+      ).to.be.revertedWithCustomError(fx.usdcToken, "AuthorizationUsed");
+    });
+  });
+
+  describe("facet wiring", function () {
+    it("intent selectors revert cleanly when no extension is set", async function () {
+      const fx = await loadFixture(deployFixture);
+      await fx.reg.connect(fx.admin).setIntentExtension(ethers.ZeroAddress);
+      const signed = await signCreate(fx, fx.alice);
+      await expect(
+        fx.reg.connect(fx.relayer).createWagerWithAuthorization(
+          signed.args, fx.alice.address, signed.intent.nonce, signed.intent.validAfter, signed.intent.validBefore, signed.sig, signed.stakeAuth, EMPTY_AUTH
+        )
+      ).to.be.revertedWithCustomError(fx.reg, "UnknownFunction");
+    });
+
+    it("setIntentExtension is UPGRADER_ROLE-gated", async function () {
+      const fx = await loadFixture(deployFixture);
+      await expect(fx.reg.connect(fx.alice).setIntentExtension(ethers.ZeroAddress))
+        .to.be.revertedWithCustomError(fx.reg, "AccessControlUnauthorizedAccount");
+    });
+  });
+});


### PR DESCRIPTION
# Gasless UX foundation — specs 035 (intent-based signatures) + 036 (relayer infrastructure)

Implements the platform-wide gasless flow: users authorize every core action with **one off-chain signature** (no ERC-20 approval, no native gas token); a relayer submits it, and the on-chain effect is always attributed to the **signer**. This is the foundation for future low-friction signing (e.g. passkeys) per the project goal.

## Spec 035 — contracts

- **`SignerIntentBase` mixin** (`contracts/upgradeable/`): EIP-712 `_verifyIntent`, ERC-7201-**namespaced** per-signer 2-D replay-nonce map (zero sequential slots — safe to add to live proxies), `invalidateNonce` / `invalidateNonceWithSig` (FR-006), EIP-3009 pull with on-chain `value`/`paymentNonce` binding (FR-007 — a relayer cannot substitute a different authorization), and bounded fee-netting settlement to a segregated recipient (FR-015/16).
- **WagerRegistry facet split** ⚠️ *architectural deviation from the plan, forced by measurement*: the deployed implementation is **24,460 of 24,576 bytes** — 116 bytes of headroom, so the ~10 planned twin entrypoints cannot ship in place. The registry is now **two facets behind the same proxy**:
  - `WagerRegistryCore` (abstract) — the single storage-layout definition + actor-threaded action bodies; both facets inherit it so layouts cannot drift (validated by the extended `check:storage-layout` gate).
  - `WagerRegistry` (main impl, 23.9 KB) — every pre-existing external unchanged + a `fallback()` that delegatecalls unknown selectors to the extension; `setIntentExtension` is `UPGRADER_ROLE`-gated (same authority class as an upgrade).
  - `WagerRegistryIntents` (extension impl, 19.7 KB) — `createWager`/`acceptWager`/`acceptOpenWager` **WithAuthorization** + 7 no-stake **WithSig** twins, `setFeeNetting`, and relocated cold paths (`batchExpireOpen`, `autoResolveFromPolymarket/Oracle` — same selectors at the proxy, unchanged behavior).
  - Callers still see **one contract**: one address, one merged ABI, one event stream, and the *existing* `FairWins WagerRegistry` EIP-712 domain (`address(this)` = proxy under delegatecall).
- **MembershipManager** (11 KB — twins fit inline per plan): `purchaseTier`/`upgradeTier`/`extendMembership` **WithAuthorization** + `redeemVoucherWithSig`; EIP-712 domain via `initializeIntents()` (`reinitializer(2)`); fee scalars (`__gap` 49→47).
- **Twin invariant**: every check — sanctions screen (fail-closed), membership gate, ownership, freeze — evaluates the recovered **signer**; the self-submit originals remain untouched as the never-stranded fallback.
- `MockUSDCPermit.cancelAuthorization` for payment-leg invalidation tests; `upgrade-gasless-intents.js` deploy script + `set-fee-netting.js` ops script.

## Spec 035 — frontend

- `frontend/src/lib/relay/`: `intentTypes` (EIP-712 structs — byte-identical to contract typehashes), `intentClient` (`signIntent`/`relayIntent`/`pollStatus`/`probeHealth`/`makeRelayer`; FR-020 stablecoin-domain pre-sign check via new `stablecoin.domainVersion` config), `useIntentAction` (never-stranded self-submit fallback on relayer unset/429/503/timeout/`payment_unsupported_on_chain`), `IntentStatus.jsx` (honest lifecycle, WCAG 2.1 AA — never "confirmed" before inclusion).

## Spec 036 — relayer (fully configured)

- **`services/relay-gateway/`** (Node 20 + ethers v6 + Express): full `POST /v1/intents` validation pipeline — signer recovery (never trusted from the body), chain/domain isolation, version-pinned target allow-list read from `deployments/` with a **fail-loud startup consistency check**, dedup/idempotency by uniqueness marker, **fail-closed on-chain sanctions re-screen of the signer**, per-signer + global quotas, gas-spend caps, bounded-queue back-pressure, fee-cap decline, kill switch, timing-safe origin lock; engine REST client + authenticated status webhook (no false success); WORM-ready structured audit log. Vitest suite (27), k6 CI-gating load profile, Dockerfile, docker-compose (gateway + engine + redis), Cloud Build step.
- **`services/oz-relayer/`**: OpenZeppelin Relayer engine config for Polygon 137 / Amoy 80002 / ETC 61 (paused) / Mordor 63 — legacy type-0 gas on ETC/Mordor, ≥2 RPC endpoints each, GCP KMS signer refs (hot key never in env/logs), receiver whitelists pinned to the deployed proxies, webhook back to the gateway.

## Verification

- **480 contract tests passing** (full suite), including 38 new intent tests: replay/expiry/tamper rejection, authorization-substitution rejection, fail-closed signer screening, frozen-signer block, fee-cap decline atomicity, self-submit twin equivalence, open-challenge claim-code rebinding, cross-contract nonce/domain isolation, payment-leg `cancelAuthorization`.
- **2,024 frontend tests passing** (incl. 27 new relay tests); **27 gateway tests passing** (3× for flake check); gateway boot smoke-tested (healthz, origin-lock 403, fail-loud unknown-chain start).
- `npm run check:storage-layout` green, now also validating main↔extension facet layout consistency.

## Deviations & follow-ups

- **Facet split** (above) — required by the 24 KB limit; documented in CLAUDE.md + `docs/developer-guide/gasless-intents.md`.
- `createOpenWagerWithAuthorization` deferred (not in the spec's ABI contract doc; open-challenge *accept* is covered).
- ZKWagerPool future-template `*For` creator actions (spec 035 US3, future clones only) deferred; pool join/vote/claim are already relayable.
- Frontend call-site migrations to `useIntentAction` (US1–US4 UI phases) land next — this PR ships the complete client/lib layer they consume.
- Rollout per plan: Amoy (full) → Mordor (no-stake only; USC lacks EIP-3009) → Polygon after the 025/027 UUPS migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwjCgm5kxqFUguv7d45mGu

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwjCgm5kxqFUguv7d45mGu)_