### PR TITLE
feat(041): Oracle-settled open challenges (Polymarket)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/040-my-wagers-refinements"
+  "feature_directory": "specs/041-oracle-open-challenges"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,5 +104,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/040-my-wagers-refinements/plan.md
+at specs/041-oracle-open-challenges/plan.md
 <!-- SPECKIT END -->

--- a/docs/developer-guide/oracle-open-challenges.md
+++ b/docs/developer-guide/oracle-open-challenges.md
@@ -1,0 +1,52 @@
+# Oracle-Settled Open Challenges (spec 041)
+
+Open challenges (spec 024) with **Polymarket as the settlement source**: the creator
+links a live Polymarket market at creation, picks a side, and shares the four-word
+claim code; the taker gets the opposite side and the wager settles automatically via
+`autoResolveFromPolymarket`. **No contract changes** — `createOpenWager` already
+validates oracle linkage on-chain (`_checkOracleLinkage`: non-zero condition id,
+adapter configured, condition *unresolved*), and the post-accept resolution path is
+identical to named-opponent oracle wagers. The lifecycle proof lives in
+`test/integration/oracle/WagerRegistry_PolymarketOpenChallenge.test.js`.
+
+## Frontend pieces
+
+| Piece | File | Notes |
+|---|---|---|
+| Create flow | `frontend/src/components/fairwins/OracleOpenChallengeModal.jsx` | Picker-first: `PolymarketBrowser` (inline) → side picker → stake → derived timeline. Gated on `capabilities.polymarketSidebets` + `isOracleModelExposed(Polymarket)`. |
+| Claimant view | `frontend/src/components/fairwins/TakeChallengePanel.jsx` | Bet summary (stake/payout for all open challenges) + oracle block: question, taker's side, "Settled automatically by Polymarket" badge, live context, accept gate. |
+| Shared result panel | `frontend/src/components/fairwins/ClaimCodeResultPanel.jsx` | Extracted from `OpenChallengeModal` — one code/QR/deep-link/vault-backup UX for both create flows. Don't fork it. |
+| Timeline derivation | `frontend/src/lib/openChallenge/oracleTimeline.js` | Pure. `accept = min(marketEnd, now+30d−1h)`, `resolve = min(marketEnd+7d, now+180d−1h)`, 1h minimum lead. Derived values can never fail the contract's `_checkDeadlines`. |
+| Live market fetch | `frontend/src/hooks/usePolymarketMarket.js` | One Gamma market by `condition_ids`; normalized via `normaliseGammaMarket`; errors degrade, never gate. |
+
+## The sealed `oracle` terms block
+
+`useOpenChallengeCreate` seals (code-keyed envelope, spec 024 format unchanged):
+
+```json
+{
+  "description": "…human-readable, names market + side + Polymarket…",
+  "createdAt": "<ISO>",
+  "oracle": {
+    "source": "polymarket", "conditionId": "0x…", "question": "…",
+    "outcomes": ["Yes", "No"], "creatorSide": 0, "endDate": "<ISO>", "slug": "…"
+  }
+}
+```
+
+It exists so a code-holder can read the bet when the Gamma API is down (FR-014).
+Never put the market reference in on-chain plaintext — it would break the spec-024
+indistinguishability of code-gated challenges.
+
+## Chain-authoritative display rule (Constitution III)
+
+The on-chain wager fields — `resolutionType`, `polymarketConditionId`, `creatorIsYes`
+— are the **only** authority for what is bet. The sealed `oracle` block is display
+metadata: the claimant view cross-checks `terms.oracle.conditionId` against
+`wager.polymarketConditionId` and, on mismatch, flags the stored description and
+falls back to live data. Side labels index the adapter's outcome ordering:
+**index 0 = YES = `creatorIsYes: true`**; the taker always holds the opposite.
+
+Accept gating is app-level honesty (the contract cannot query the oracle at accept):
+a closed market warns; only a *positively known* public outcome (closed + ~certain
+price) disables accept. Unreachable live data discloses itself and never blocks.

--- a/frontend/src/components/fairwins/ClaimCodeResultPanel.jsx
+++ b/frontend/src/components/fairwins/ClaimCodeResultPanel.jsx
@@ -1,0 +1,146 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useOpenChallengeCodeVault } from '../../hooks/useOpenChallengeCodeVault'
+import WagerQRCode from '../ui/WagerQRCode'
+import InfoTip from '../ui/InfoTip'
+import { buildTakeChallengeUrl } from '../../utils/claimCode/deepLink.js'
+
+const CopyIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+    <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+  </svg>
+)
+
+const CheckIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden="true">
+    <path d="M20 6L9 17l-5-5" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+)
+
+/**
+ * Post-create claim-code result (spec 041 extraction of the feature-024 UI, byte-for-byte
+ * behavior): shows the four-word code ONCE with copy, QR / take-challenge deep link, the
+ * save-it-now warning, and the encrypted device-local backup (auto-saved when possible,
+ * manual fallback otherwise). Shared by the user-defined and oracle-settled open-challenge
+ * create flows so the security-relevant UX cannot drift between them.
+ *
+ * `backupMeta` ({ description, stake }) labels the vault entry for later recovery.
+ */
+export default function ClaimCodeResultPanel({ result, backupMeta = {}, onDone }) {
+  const [copied, setCopied] = useState(false)
+  const { saveCode, canUse: canBackup } = useOpenChallengeCodeVault()
+  const [backupState, setBackupState] = useState('idle') // idle | saving | saved | error
+  const [backupError, setBackupError] = useState(null)
+  const autoBackupStarted = useRef(false)
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(result.code)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch { /* clipboard unavailable */ }
+  }, [result])
+
+  const handleSaveBackup = useCallback(async () => {
+    if (!result) return
+    setBackupError(null)
+    setBackupState('saving')
+    try {
+      await saveCode({
+        code: result.code,
+        wagerId: result.wagerId != null ? String(result.wagerId) : null,
+        description: backupMeta.description || '',
+        stake: backupMeta.stake,
+      })
+      setBackupState('saved')
+    } catch (err) {
+      setBackupState('error')
+      setBackupError(err?.message || 'Could not save the backup.')
+    }
+  }, [result, saveCode, backupMeta.description, backupMeta.stake])
+
+  // Save the share words locally without the user having to do anything (testing feedback):
+  // as soon as the challenge exists, write the encrypted device backup automatically. If it
+  // can't complete (no wallet, signature declined), the manual save button below is the fallback.
+  useEffect(() => {
+    if (!result || !canBackup || autoBackupStarted.current) return
+    autoBackupStarted.current = true
+    handleSaveBackup()
+  }, [result, canBackup, handleSaveBackup])
+
+  if (!result) return null
+
+  return (
+    <div className="fm-success">
+      <div className="fm-success-icon" aria-hidden="true">&#127881;</div>
+      <h3>Open challenge created</h3>
+      <p className="fm-success-desc">Share this four-word code with whoever you want to take the other side.</p>
+
+      <div className="oc-code-display">
+        <code className="oc-code">{result.code}</code>
+        <button
+          type="button"
+          className="oc-copy-btn"
+          onClick={handleCopy}
+          title={copied ? 'Copied' : 'Copy code'}
+          aria-label={copied ? 'Copied' : 'Copy code'}
+        >
+          {copied ? <CheckIcon /> : <CopyIcon />}
+        </button>
+      </div>
+
+      <div className="oc-qr">
+        <WagerQRCode value={buildTakeChallengeUrl(result.code)} size={180} ariaLabel="QR code to take this challenge" />
+        <span className="oc-qr-caption">Scan to take this challenge — opens the app with the code filled in</span>
+      </div>
+
+      <div className="oc-notice oc-notice--warn" role="alert">
+        <strong>Save this code now.</strong> It's the only way to take, read, or re-read this challenge — we
+        don't store it server-side. Anyone with the code can take the other side.
+      </div>
+
+      {/* Encrypted backup (recovery) — saved automatically, stored only on this device, readable only with this wallet. */}
+      <div className="oc-backup">
+        {backupState === 'saved' ? (
+          <p className="oc-backup-ok" role="status">
+            <span aria-hidden="true">&#128274;</span> Encrypted backup saved to this device. Recover it
+            anytime from the <strong>Recover codes</strong> tab with this wallet.
+          </p>
+        ) : backupState === 'saving' ? (
+          <p className="oc-backup-ok" role="status">
+            <span aria-hidden="true">&#128274;</span> Saving an encrypted backup to this device…
+          </p>
+        ) : (
+          <>
+            <span className="fm-label-row">
+              <button
+                type="button"
+                className="fm-btn-secondary"
+                onClick={handleSaveBackup}
+                disabled={!canBackup}
+              >
+                Save encrypted backup to this device
+              </button>
+              <InfoTip label="About: Encrypted backup">
+                {canBackup
+                  ? 'Stores an encrypted copy of the code on this device so you can recover it later if you forget it. Readable only with this wallet.'
+                  : 'Connect your wallet to save a recoverable encrypted copy of this code.'}
+              </InfoTip>
+            </span>
+            {backupState === 'error' && backupError && (
+              <div className="fm-error-banner" role="alert">{backupError}</div>
+            )}
+          </>
+        )}
+      </div>
+      <p className="fm-hint">
+        The four words resist casual guessing, but a determined attacker with specialized hardware could
+        brute-force them. Use it for friendly stakes and share it only with the people you intend to.
+      </p>
+
+      <div className="fm-success-actions">
+        <button type="button" className="fm-btn-primary fm-success-done" onClick={onDone}>Done</button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/fairwins/Dashboard.jsx
+++ b/frontend/src/components/fairwins/Dashboard.jsx
@@ -9,6 +9,7 @@ import { SHOW_ALL_ORACLE_MODELS } from '../../constants/wagerDefaults'
 import { isCardVisible, subscribe as subscribeQuickAccess } from '../../utils/quickAccessPreference'
 import FriendMarketsModal from './FriendMarketsModal'
 import OpenChallengeModal from './OpenChallengeModal'
+import OracleOpenChallengeModal from './OracleOpenChallengeModal'
 import GroupPoolModal from './GroupPoolModal'
 import UnifiedLookupModal from './UnifiedLookupModal'
 import { parseTakeChallengeParams } from '../../utils/claimCode/deepLink.js'
@@ -152,6 +153,21 @@ function QuickActions({ onAction, actionNeededCount = 0 }) {
       ),
       title: 'Open Challenge',
       description: 'Post without naming an opponent — share a four-word code to create or take'
+    },
+    {
+      id: 'oracle-open-challenge',
+      category: 'create',
+      tag: 'Oracle settles',
+      icon: (
+        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+          <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+          <path d="M7 11V7a5 5 0 0 1 9.9-1" />
+          <circle cx="12" cy="16" r="1" />
+          <path d="M19 2l1 2 2 1-2 1-1 2-1-2-2-1 2-1z" />
+        </svg>
+      ),
+      title: 'Oracle Open Challenge',
+      description: 'Pick a Polymarket market, share a code — Polymarket settles it automatically'
     },
     {
       id: 'create-pool',
@@ -530,6 +546,7 @@ function Dashboard() {
   // Modal state
   const [showCreateWager, setShowCreateWager] = useState(false)
   const [showOpenChallenge, setShowOpenChallenge] = useState(false)
+  const [showOracleOpenChallenge, setShowOracleOpenChallenge] = useState(false)
   const [showGroupPool, setShowGroupPool] = useState(false)
   // Unified phrase lookup (spec 037): one entry point for taking a challenge or joining a pool.
   const [showUnifiedLookup, setShowUnifiedLookup] = useState(false)
@@ -603,6 +620,9 @@ function Dashboard() {
         break
       case 'open-challenge':
         setShowOpenChallenge(true)
+        break
+      case 'oracle-open-challenge':
+        setShowOracleOpenChallenge(true)
         break
       case 'create-pool':
         setShowGroupPool(true)
@@ -764,6 +784,13 @@ function Dashboard() {
           setShowOpenChallenge(false)
           showModal(<PremiumPurchaseModal onClose={hideModal} />, { title: '', size: 'large', closable: false })
         }}
+      />
+
+      {/* Oracle Open Challenge (spec 041) — code-gated open challenge settled by a linked Polymarket market. */}
+      <OracleOpenChallengeModal
+        key={showOracleOpenChallenge ? 'ooc-open' : 'ooc-closed'}
+        isOpen={showOracleOpenChallenge}
+        onClose={() => setShowOracleOpenChallenge(false)}
       />
 
       {/* Unified phrase lookup (spec 037) — one entry point: enter four words to take a challenge or join a pool. */}

--- a/frontend/src/components/fairwins/OpenChallengeModal.jsx
+++ b/frontend/src/components/fairwins/OpenChallengeModal.jsx
@@ -1,13 +1,11 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { isAddress } from 'ethers'
 import { useOpenChallengeCreate, OPEN_RESOLUTION_TYPES } from '../../hooks/useOpenChallengeCreate'
-import { useOpenChallengeCodeVault } from '../../hooks/useOpenChallengeCodeVault'
 import { useWeb3 } from '../../hooks/useWeb3'
-import WagerQRCode from '../ui/WagerQRCode'
 import AddressInput from '../ui/AddressInput'
 import AddressBookButton from '../ui/AddressBookButton'
 import QRScanner from '../ui/QRScanner'
-import { buildTakeChallengeUrl } from '../../utils/claimCode/deepLink.js'
+import ClaimCodeResultPanel from './ClaimCodeResultPanel'
 import DeadlineTimeline from './DeadlineTimeline'
 import { toDatetimeLocal, fromDatetimeLocal, formatTimelineSpan, HOUR_MS, DAY_MS } from './wagerTimeline'
 import PillSelect from '../ui/PillSelect'
@@ -25,19 +23,6 @@ const RESOLVE_MAX_GAP_MS = 90 * DAY_MS
 const CloseIcon = () => (
   <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
     <path d="M15 5L5 15M5 5L15 15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-  </svg>
-)
-
-const CopyIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-    <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
-  </svg>
-)
-
-const CheckIcon = () => (
-  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden="true">
-    <path d="M20 6L9 17l-5-5" strokeLinecap="round" strokeLinejoin="round" />
   </svg>
 )
 
@@ -117,12 +102,6 @@ function MakerPanel({ onClose }) {
   const [error, setError] = useState(null)
   const [progress, setProgress] = useState(null)
   const [result, setResult] = useState(null)
-  const [copied, setCopied] = useState(false)
-  // Encrypted, device-local code backup (feature 024 follow-up) so a forgotten code can be recovered.
-  const { saveCode, canUse: canBackup } = useOpenChallengeCodeVault()
-  const [backupState, setBackupState] = useState('idle') // idle | saving | saved | error
-  const [backupError, setBackupError] = useState(null)
-  const autoBackupStarted = useRef(false)
 
   const isThirdParty = Number(resolutionType) === OPEN_RESOLUTION_TYPES.ThirdParty
   const arbitratorAddr = arbitratorResolved || arbitrator
@@ -193,114 +172,13 @@ function MakerPanel({ onClose }) {
     }
   }, [createOpenChallenge, description, stake, resolutionType, isThirdParty, arbitratorAddr, acceptMs, resolveMs])
 
-  const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(result.code)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch { /* clipboard unavailable */ }
-  }, [result])
-
-  const handleSaveBackup = useCallback(async () => {
-    if (!result) return
-    setBackupError(null)
-    setBackupState('saving')
-    try {
-      await saveCode({
-        code: result.code,
-        wagerId: result.wagerId != null ? String(result.wagerId) : null,
-        description: description.trim(),
-        stake,
-      })
-      setBackupState('saved')
-    } catch (err) {
-      setBackupState('error')
-      setBackupError(err?.message || 'Could not save the backup.')
-    }
-  }, [result, saveCode, description, stake])
-
-  // Save the share words locally without the user having to do anything (testing feedback):
-  // as soon as the challenge exists, write the encrypted device backup automatically. If it
-  // can't complete (no wallet, signature declined), the manual save button below is the fallback.
-  useEffect(() => {
-    if (!result || !canBackup || autoBackupStarted.current) return
-    autoBackupStarted.current = true
-    handleSaveBackup()
-  }, [result, canBackup, handleSaveBackup])
-
   if (result) {
     return (
-      <div className="fm-success">
-        <div className="fm-success-icon" aria-hidden="true">&#127881;</div>
-        <h3>Open challenge created</h3>
-        <p className="fm-success-desc">Share this four-word code with whoever you want to take the other side.</p>
-
-        <div className="oc-code-display">
-          <code className="oc-code">{result.code}</code>
-          <button
-            type="button"
-            className="oc-copy-btn"
-            onClick={handleCopy}
-            title={copied ? 'Copied' : 'Copy code'}
-            aria-label={copied ? 'Copied' : 'Copy code'}
-          >
-            {copied ? <CheckIcon /> : <CopyIcon />}
-          </button>
-        </div>
-
-        <div className="oc-qr">
-          <WagerQRCode value={buildTakeChallengeUrl(result.code)} size={180} ariaLabel="QR code to take this challenge" />
-          <span className="oc-qr-caption">Scan to take this challenge — opens the app with the code filled in</span>
-        </div>
-
-        <div className="oc-notice oc-notice--warn" role="alert">
-          <strong>Save this code now.</strong> It's the only way to take, read, or re-read this challenge — we
-          don't store it server-side. Anyone with the code can take the other side.
-        </div>
-
-        {/* Encrypted backup (recovery) — saved automatically, stored only on this device, readable only with this wallet. */}
-        <div className="oc-backup">
-          {backupState === 'saved' ? (
-            <p className="oc-backup-ok" role="status">
-              <span aria-hidden="true">&#128274;</span> Encrypted backup saved to this device. Recover it
-              anytime from the <strong>Recover codes</strong> tab with this wallet.
-            </p>
-          ) : backupState === 'saving' ? (
-            <p className="oc-backup-ok" role="status">
-              <span aria-hidden="true">&#128274;</span> Saving an encrypted backup to this device…
-            </p>
-          ) : (
-            <>
-              <span className="fm-label-row">
-                <button
-                  type="button"
-                  className="fm-btn-secondary"
-                  onClick={handleSaveBackup}
-                  disabled={!canBackup}
-                >
-                  Save encrypted backup to this device
-                </button>
-                <InfoTip label="About: Encrypted backup">
-                  {canBackup
-                    ? 'Stores an encrypted copy of the code on this device so you can recover it later if you forget it. Readable only with this wallet.'
-                    : 'Connect your wallet to save a recoverable encrypted copy of this code.'}
-                </InfoTip>
-              </span>
-              {backupState === 'error' && backupError && (
-                <div className="fm-error-banner" role="alert">{backupError}</div>
-              )}
-            </>
-          )}
-        </div>
-        <p className="fm-hint">
-          The four words resist casual guessing, but a determined attacker with specialized hardware could
-          brute-force them. Use it for friendly stakes and share it only with the people you intend to.
-        </p>
-
-        <div className="fm-success-actions">
-          <button type="button" className="fm-btn-primary fm-success-done" onClick={onClose}>Done</button>
-        </div>
-      </div>
+      <ClaimCodeResultPanel
+        result={result}
+        backupMeta={{ description: description.trim(), stake }}
+        onDone={onClose}
+      />
     )
   }
 

--- a/frontend/src/components/fairwins/OracleOpenChallengeModal.css
+++ b/frontend/src/components/fairwins/OracleOpenChallengeModal.css
@@ -1,0 +1,26 @@
+/* Oracle Open Challenge modal (spec 041) — section-specific styles layered over the
+   shared fm-* / OpenChallengeModal.css base. Keep additions minimal: the flow reuses
+   fm-polymarket-selected, fm-side-picker, oc-deadlines, etc. */
+
+/* Live price chip inside a side button (text + number, not color-only). */
+.ooc-side-price {
+  display: block;
+  font-size: 0.78rem;
+  opacity: 0.75;
+  margin-top: 2px;
+}
+
+/* Refused-market notice sits above the picker so the reason is read before re-picking. */
+.ooc-ineligible {
+  margin-bottom: 10px;
+}
+
+/* Derived timeline: visually the same tiles as oc-deadlines, but flagged read-only. */
+.ooc-derived-timeline {
+  cursor: default;
+}
+
+.ooc-timeline-provenance {
+  display: block;
+  margin-top: 6px;
+}

--- a/frontend/src/components/fairwins/OracleOpenChallengeModal.css
+++ b/frontend/src/components/fairwins/OracleOpenChallengeModal.css
@@ -24,3 +24,11 @@
   display: block;
   margin-top: 6px;
 }
+
+/* Keep the inline picker usable inside the modal on small screens: the feed scrolls
+   within its own region instead of stretching the whole sheet (US3). */
+#ooc-market-picker {
+  max-height: min(52vh, 460px);
+  overflow-y: auto;
+  border-radius: 12px;
+}

--- a/frontend/src/components/fairwins/OracleOpenChallengeModal.jsx
+++ b/frontend/src/components/fairwins/OracleOpenChallengeModal.jsx
@@ -1,0 +1,377 @@
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useOpenChallengeCreate, OPEN_RESOLUTION_TYPES } from '../../hooks/useOpenChallengeCreate'
+import { useChainTokens } from '../../hooks/useChainTokens'
+import { ResolutionType, isOracleModelExposed } from '../../constants/wagerDefaults'
+import PolymarketBrowser from './PolymarketBrowser'
+import ClaimCodeResultPanel from './ClaimCodeResultPanel'
+import InfoTip from '../ui/InfoTip'
+import {
+  deriveOracleChallengeTimeline,
+} from '../../lib/openChallenge/oracleTimeline'
+import './FriendMarketsModal.css'
+import './OpenChallengeModal.css'
+import './OracleOpenChallengeModal.css'
+
+const CloseIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+    <path d="M15 5L5 15M5 5L15 15" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+  </svg>
+)
+
+/**
+ * Oracle Open Challenge modal (spec 041) — post a code-gated open challenge settled
+ * automatically by a linked Polymarket market. Picker-first flow: browse/search a market,
+ * pick your side, set the equal stake — the EVENT defines the timeline (accept until the
+ * market closes, settle after it resolves; both capped to the contract windows). Reuses
+ * the feature-024 claim-code machinery unchanged (ClaimCodeResultPanel).
+ */
+function OracleOpenChallengeModal({ isOpen, onClose }) {
+  useEffect(() => {
+    if (!isOpen) return
+    const onKey = (e) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+  const handleBackdrop = (e) => { if (e.target === e.currentTarget) onClose() }
+
+  return (
+    <div
+      className="friend-markets-modal-backdrop"
+      onClick={handleBackdrop}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="oracle-open-challenge-title"
+    >
+      <div className="friend-markets-modal" onClick={(e) => e.stopPropagation()}>
+        <header className="fm-header">
+          <div className="fm-header-content">
+            <div className="fm-brand">
+              <span className="fm-brand-icon" aria-hidden="true">&#128302;</span>
+              <h2 id="oracle-open-challenge-title">Oracle Open Challenge</h2>
+            </div>
+            <p className="fm-subtitle">
+              Pick a Polymarket market, share a code — Polymarket settles it
+              <InfoTip label="About oracle open challenges">
+                No opponent named up front and nobody judges the outcome: whoever you share the
+                four-word code with can take the other side, and the linked Polymarket market&apos;s
+                public resolution settles the bet automatically. Equal stakes. The event sets the
+                timeline. Creating one requires a Silver membership or above.
+              </InfoTip>
+            </p>
+          </div>
+          <button className="fm-close-btn" onClick={onClose} aria-label="Close modal">
+            <CloseIcon />
+          </button>
+        </header>
+
+        <div className="fm-content">
+          <div className="fm-panel">
+            <OracleMakerPanel onClose={onClose} />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Maker — pick market → pick side → stake → create (timeline derived, not edited)
+// ---------------------------------------------------------------------------
+function OracleMakerPanel({ onClose }) {
+  const { createOpenChallenge, busy } = useOpenChallengeCreate()
+  const { capabilities } = useChainTokens()
+  const polymarketAvailable =
+    Boolean(capabilities?.polymarketSidebets) && isOracleModelExposed(ResolutionType.Polymarket)
+
+  const [market, setMarket] = useState(null)
+  const [side, setSide] = useState('') // '' | '0' | '1' — outcome index; 0 = YES side
+  const [stake, setStake] = useState('10.00')
+  // Mount-time "now" anchors the derived timeline so it doesn't drift while the form is open.
+  const [nowMs] = useState(() => Date.now())
+  const [ineligible, setIneligible] = useState(null) // { question, reason } for a refused pick
+  const [error, setError] = useState(null)
+  const [progress, setProgress] = useState(null)
+  const [result, setResult] = useState(null)
+
+  const timeline = useMemo(
+    () => (market ? deriveOracleChallengeTimeline(market.endDate, nowMs) : null),
+    [market, nowMs]
+  )
+
+  const handleSelectMarket = useCallback((m) => {
+    setError(null)
+    const t = deriveOracleChallengeTimeline(m?.endDate, Date.now())
+    if (!t.eligible) {
+      // Refuse the pick, keep the picker open, and say why (FR-003).
+      setIneligible({ question: m?.question || 'That market', reason: t.reason })
+      return
+    }
+    setIneligible(null)
+    setMarket(m)
+    setSide('')
+  }, [])
+
+  const clearMarket = useCallback(() => {
+    setMarket(null)
+    setSide('')
+    setError(null)
+  }, [])
+
+  const sideName = (idx) =>
+    market?.outcomes?.[Number(idx)]?.name || (String(idx) === '0' ? 'YES' : 'NO')
+
+  const composedDescription = market && side !== ''
+    ? `${market.question} — creator takes ${sideName(side)} · settled automatically by Polymarket`
+    : ''
+
+  const canCreate = Boolean(
+    market && timeline?.eligible && side !== '' && Number(stake) > 0 && !busy
+  )
+
+  const handleCreate = useCallback(async (e) => {
+    e?.preventDefault?.()
+    if (!market || !timeline?.eligible || side === '') return
+    setError(null)
+    try {
+      const res = await createOpenChallenge(
+        {
+          description: composedDescription,
+          stake,
+          resolutionType: OPEN_RESOLUTION_TYPES.Polymarket,
+          oracleConditionId: market.conditionId,
+          creatorIsYes: side === '0',
+          acceptDeadline: Math.floor(timeline.acceptDeadlineMs / 1000),
+          resolveDeadline: Math.floor(timeline.resolveDeadlineMs / 1000),
+          // Sealed (code-keyed) market metadata so a code-holder can read the bet
+          // even when live market data is unreachable (D4/FR-014).
+          oracleMeta: {
+            source: 'polymarket',
+            conditionId: market.conditionId,
+            question: market.question,
+            outcomes: [sideName(0), sideName(1)],
+            creatorSide: Number(side),
+            endDate: market.endDate,
+            slug: market.slug || null,
+          },
+        },
+        (p) => setProgress(p)
+      )
+      setResult(res)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setProgress(null)
+    }
+  }, [createOpenChallenge, market, timeline, side, stake, composedDescription]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (result) {
+    return (
+      <ClaimCodeResultPanel
+        result={result}
+        backupMeta={{ description: composedDescription, stake }}
+        onDone={onClose}
+      />
+    )
+  }
+
+  // Locked state: consistent with the existing oracle flow's gating (FR-004) —
+  // the section explains itself instead of silently disappearing.
+  if (!polymarketAvailable) {
+    return (
+      <div className="fm-form">
+        <div className="oc-notice oc-notice--warn" role="alert">
+          Polymarket settlement isn&apos;t available on this network. Switch to a
+          Polymarket-enabled network to post an oracle open challenge, or use a
+          regular open challenge instead.
+        </div>
+        <div className="fm-success-actions">
+          <button type="button" className="fm-btn-secondary" onClick={onClose}>Close</button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <form className="fm-form" onSubmit={handleCreate}>
+      <div className="fm-form-group fm-form-full">
+        <span className="fm-label-row">
+          <label htmlFor="ooc-market-picker">
+            Linked Polymarket market <span className="fm-required">*</span>
+          </label>
+          <InfoTip label="About: Linked Polymarket market">
+            Browse popular markets by category or search for an event. The challenge settles
+            automatically from that market&apos;s public resolution — you just pick a side and
+            share the code.
+          </InfoTip>
+        </span>
+
+        {ineligible && (
+          <div className="oc-notice oc-notice--warn ooc-ineligible" role="alert">
+            <strong>{ineligible.question}</strong> can&apos;t back an open challenge: {ineligible.reason}
+          </div>
+        )}
+
+        {market ? (
+          <div className="fm-polymarket-selected">
+            <div className="fm-polymarket-selected-body">
+              <strong>{market.question}</strong>
+              <div className="fm-polymarket-meta">
+                {market.endDate && (
+                  <span>Event ends {formatDate(market.endDate)}</span>
+                )}
+                {market.outcomes?.length > 0 && (
+                  <span>
+                    {market.outcomes
+                      .map((o) => `${o.name}${o.price != null ? ` ${Math.round(o.price * 100)}¢` : ''}`)
+                      .join(' · ')}
+                  </span>
+                )}
+              </div>
+              <code className="fm-polymarket-cid">{market.conditionId}</code>
+            </div>
+            <button type="button" className="fm-link-btn" onClick={clearMarket} disabled={busy}>
+              Change
+            </button>
+          </div>
+        ) : (
+          <div id="ooc-market-picker">
+            <PolymarketBrowser
+              variant="inline"
+              showFilters
+              limit={20}
+              selectedConditionId={market?.conditionId}
+              onSelectMarket={handleSelectMarket}
+            />
+          </div>
+        )}
+      </div>
+
+      {market && (
+        <>
+          {/* Side picker — same convention as the 1v1 oracle flow: outcome index 0 is the
+              YES side (creatorIsYes = true); the taker always holds the opposite. */}
+          <div className="fm-form-group fm-form-full">
+            <span className="fm-label-row">
+              <label>Your side of the bet <span className="fm-required">*</span></label>
+              <InfoTip label="About: Your side of the bet">
+                Pick the outcome you&apos;re backing. Whoever takes your code gets the other side —
+                the code is the only thing you need to share.
+              </InfoTip>
+            </span>
+            <div className="fm-side-picker">
+              {['0', '1'].map((idx) => {
+                const name = sideName(idx)
+                const price = market.outcomes?.[Number(idx)]?.price
+                const active = side === idx
+                return (
+                  <button
+                    key={idx}
+                    type="button"
+                    className={`fm-side-btn ${active ? 'active' : ''}`}
+                    onClick={() => setSide(idx)}
+                    disabled={busy}
+                    aria-pressed={active}
+                  >
+                    <span className="fm-side-btn-label">I&apos;m taking {name}</span>
+                    {price != null && (
+                      <span className="ooc-side-price">{Math.round(price * 100)}&cent; now</span>
+                    )}
+                  </button>
+                )
+              })}
+            </div>
+            {side !== '' && (
+              <span className="fm-hint">
+                Whoever takes your code will be taking <strong>{sideName(side === '0' ? 1 : 0)}</strong>.
+              </span>
+            )}
+          </div>
+
+          <div className="fm-form-group fm-form-full">
+            <span className="fm-label-row">
+              <label htmlFor="ooc-stake">Stake — each side <span className="fm-required">*</span></label>
+              <InfoTip label="About: Stake — each side">
+                Enter the amount in USD. Open challenges are equal-stakes — check the market&apos;s
+                current prices above to judge the bet; only USDC is supported on this network.
+              </InfoTip>
+            </span>
+            <div className="fm-stake-input-wrapper fm-stake-row">
+              <span className="fm-stake-prefix">$</span>
+              <input
+                id="ooc-stake" type="number" inputMode="decimal" min="0" step="0.01"
+                placeholder="10.00" className="fm-stake-usd"
+                value={stake}
+                onChange={(e) => setStake(e.target.value)}
+                onBlur={() => {
+                  const n = Number(stake)
+                  if (stake !== '' && Number.isFinite(n) && n > 0) setStake(n.toFixed(2))
+                }}
+                disabled={busy}
+              />
+              <select id="ooc-stake-token" aria-label="Stake Token" className="fm-token-select fm-stake-token-inline" disabled={busy} value="USDC" onChange={() => {}}>
+                <option value="USDC">&#128181; USDC</option>
+              </select>
+            </div>
+          </div>
+
+          {/* Derived timeline — read-only by design (spec: "the event defines the timelines"). */}
+          {timeline?.eligible && (
+            <div className="fm-form-group fm-form-full">
+              <span className="fm-label-row">
+                <label>Timeline — set by the event</label>
+                <InfoTip label="About: Timeline — set by the event">
+                  You don&apos;t pick dates here: the challenge stays takeable until the market
+                  closes (capped at 30 days), and it settles once Polymarket resolves the market.
+                </InfoTip>
+              </span>
+              <div className="oc-deadlines ooc-derived-timeline" aria-label="Challenge time constraints (derived from the event)">
+                <div className="oc-deadline">
+                  <span className="oc-deadline-label">Takeable until</span>
+                  <span className="oc-deadline-value">{formatDateTime(timeline.acceptDeadlineMs)}</span>
+                </div>
+                <div className="oc-deadline">
+                  <span className="oc-deadline-label">Settles by</span>
+                  <span className="oc-deadline-value">{formatDateTime(timeline.resolveDeadlineMs)}</span>
+                </div>
+              </div>
+              <span className="fm-hint ooc-timeline-provenance">
+                {timeline.acceptCapped
+                  ? 'This event ends more than 30 days out, so the challenge closes for takers after the 30-day maximum — settlement still follows the event.'
+                  : 'From the linked event: takeable until the market closes, settled after Polymarket resolves it.'}
+              </span>
+            </div>
+          )}
+        </>
+      )}
+
+      {progress && <p className="fm-hint" role="status">{progress.message}</p>}
+      {error && <div className="fm-error-banner" role="alert">{error}</div>}
+
+      <div className="fm-success-actions">
+        <button type="submit" className="fm-btn-primary" disabled={!canCreate}>
+          {busy ? 'Creating…' : 'Create & generate code'}
+        </button>
+      </div>
+    </form>
+  )
+}
+
+function formatDate(iso) {
+  try {
+    return new Date(iso).toLocaleDateString([], { dateStyle: 'medium' })
+  } catch {
+    return String(iso)
+  }
+}
+
+function formatDateTime(ms) {
+  try {
+    return new Date(ms).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short' })
+  } catch {
+    return ''
+  }
+}
+
+export default OracleOpenChallengeModal

--- a/frontend/src/components/fairwins/TakeChallengePanel.css
+++ b/frontend/src/components/fairwins/TakeChallengePanel.css
@@ -1,0 +1,85 @@
+/* Take-a-challenge bet summary additions (spec 041). Meaning is carried by text +
+   icon, never color alone (WCAG); layered over FriendMarketsModal/OpenChallengeModal css. */
+
+.tc-stake {
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 0.95rem;
+}
+
+.tc-oracle {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.tc-oracle-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 1rem;
+}
+
+.tc-oracle-badge-icon {
+  font-size: 1.15rem;
+}
+
+.tc-oracle-explain {
+  margin: 0;
+  font-size: 0.85rem;
+  opacity: 0.8;
+}
+
+.tc-oracle-question {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 1rem;
+}
+
+.tc-oracle-question-fallback {
+  font-size: 0.9rem;
+  opacity: 0.85;
+}
+
+.tc-oracle-link {
+  font-size: 0.82rem;
+  text-decoration: underline;
+  width: fit-content;
+}
+
+.tc-oracle-sides {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  font-size: 0.95rem;
+}
+
+.tc-oracle-sides-sep {
+  opacity: 0.5;
+}
+
+.tc-oracle-live {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: baseline;
+  font-size: 0.85rem;
+  opacity: 0.9;
+}
+
+.tc-oracle-live-degraded,
+.tc-oracle-live-loading {
+  font-style: italic;
+  opacity: 0.8;
+}
+
+.tc-oracle-live-status.is-closed {
+  font-weight: 600;
+}

--- a/frontend/src/components/fairwins/TakeChallengePanel.jsx
+++ b/frontend/src/components/fairwins/TakeChallengePanel.jsx
@@ -1,9 +1,13 @@
 import { useState, useCallback, useContext } from 'react'
 import { useOpenChallengeAccept } from '../../hooks/useOpenChallengeAccept'
+import { usePolymarketMarket } from '../../hooks/usePolymarketMarket'
+import { useChainTokens } from '../../hooks/useChainTokens'
+import { ResolutionType } from '../../constants/wagerDefaults'
 import { UIContext } from '../../contexts/UIContext'
 import InfoTip from '../ui/InfoTip'
 import './FriendMarketsModal.css'
 import './OpenChallengeModal.css'
+import './TakeChallengePanel.css'
 
 /**
  * Take-a-challenge presentation (spec 037, US1) — extracted verbatim from OpenChallengeModal's
@@ -22,6 +26,17 @@ export default function TakeChallengePanel({ code, match, onClose, onBuyMembersh
   const [txHash, setTxHash] = useState(null)
   const [error, setError] = useState(null)
   const found = match
+
+  // Oracle-settled open challenges (spec 041): the on-chain fields are authoritative for
+  // WHAT is bet (market linkage + side); live Gamma data is a disclosure layer on top.
+  const wager = found?.wager
+  const isPolymarket = Number(wager?.resolutionType ?? 0) === ResolutionType.Polymarket
+  const conditionId = wager?.polymarketConditionId
+  const live = usePolymarketMarket(conditionId, { enabled: isPolymarket })
+  // Accept gate (D8/FR-015): block only on a positively-known public outcome; a merely
+  // closed market warns but stays acceptable; unreachable live data never gates.
+  const resolvedOutcomeName = isPolymarket ? publiclyResolvedOutcome(live.market) : null
+  const blockedResolved = Boolean(resolvedOutcomeName)
 
   const handleAccept = useCallback(async () => {
     setError(null)
@@ -71,6 +86,17 @@ export default function TakeChallengePanel({ code, match, onClose, onBuyMembersh
         )}
       </div>
 
+      {/* What you'd be agreeing to — one view, no navigation (spec 041 FR-012). */}
+      <ChallengeStake wager={found.wager} />
+      {isPolymarket && (
+        <OracleBetSummary
+          wager={found.wager}
+          terms={found.terms}
+          live={live}
+          resolvedOutcomeName={resolvedOutcomeName}
+        />
+      )}
+
       <ChallengeDeadlines wager={found.wager} />
 
       {found.needsMembership ? (
@@ -93,9 +119,16 @@ export default function TakeChallengePanel({ code, match, onClose, onBuyMembersh
           </ol>
           {progress && <p className="fm-hint" role="status">{progress.message}</p>}
           {error && <div className="fm-error-banner" role="alert">{error}</div>}
+          {blockedResolved && (
+            <div className="oc-notice oc-notice--warn" role="alert">
+              This market has already resolved{resolvedOutcomeName ? <> (<strong>{resolvedOutcomeName}</strong>)</> : null} —
+              the outcome is public, so this challenge can no longer be taken fairly. It will expire and the
+              creator&apos;s stake will be refundable.
+            </div>
+          )}
           <div className="fm-success-actions">
             <span className="fm-label-row">
-              <button type="button" className="fm-btn-primary" onClick={handleAccept} disabled={busy}>{busy ? (progress ? `${stepLabel(progress.step)}…` : 'Accepting…') : 'Accept challenge'}</button>
+              <button type="button" className="fm-btn-primary" onClick={handleAccept} disabled={busy || blockedResolved}>{busy ? (progress ? `${stepLabel(progress.step)}…` : 'Accepting…') : 'Accept challenge'}</button>
               <InfoTip label="About accepting">
                 Accepting binds you as the opponent and escrows your equal stake. Save your code to re-read the terms later.
               </InfoTip>
@@ -124,6 +157,167 @@ function stepClass(current, step) {
 
 function stepLabel(step) {
   return STEP_LABELS[step] || 'Accepting'
+}
+
+/** Stake + payout line for every open challenge (spec 041 FR-012) — open challenges are
+ *  equal-stakes in the chain stablecoin, so the on-chain opponentStake is the taker's stake. */
+function ChallengeStake({ wager }) {
+  const { stable, stableDecimals } = useChainTokens()
+  const amount = formatStake(wager?.opponentStake, stableDecimals)
+  const payout = formatStake(
+    wager?.opponentStake != null && wager?.creatorStake != null
+      ? BigInt(wager.opponentStake) + BigInt(wager.creatorStake)
+      : null,
+    stableDecimals
+  )
+  if (!amount) return null
+  return (
+    <div className="tc-stake" aria-label="Stake and payout">
+      <span className="tc-stake-line">
+        You stake <strong>{amount} {stable}</strong> — winner takes <strong>{payout} {stable}</strong>
+      </span>
+    </div>
+  )
+}
+
+/**
+ * Oracle bet summary (spec 041, US2): the market question, the side the TAKER gets,
+ * an unmistakable "settled by Polymarket" badge, and live market context. On-chain
+ * `creatorIsYes`/`polymarketConditionId` are authoritative; the sealed terms' oracle
+ * block is display metadata and is cross-checked before being trusted (honest state).
+ */
+function OracleBetSummary({ wager, terms, live, resolvedOutcomeName }) {
+  const conditionId = wager?.polymarketConditionId
+  const creatorIsYes = Boolean(wager?.creatorIsYes)
+  const { market, isLoading, error } = live
+
+  const sealed = terms && typeof terms === 'object' ? terms.oracle : null
+  const integrity = !sealed
+    ? 'unverifiable'
+    : hexEquals(sealed.conditionId, conditionId) ? 'ok' : 'mismatch'
+  const trusted = integrity === 'ok' ? sealed : null
+
+  // Best-available display data: verified sealed metadata first (works offline), then live.
+  const question = trusted?.question || market?.question || null
+  const labels = normalizeOutcomeLabels(trusted?.outcomes) || normalizeOutcomeLabels(market?.outcomes?.map((o) => o.name)) || ['YES', 'NO']
+  const takerLabel = labels[creatorIsYes ? 1 : 0]
+  const creatorLabel = labels[creatorIsYes ? 0 : 1]
+  const slug = trusted?.slug || market?.slug || null
+  const marketClosed = Boolean(market && (market.closed || (market.endDate && Date.parse(market.endDate) < Date.now())))
+
+  return (
+    <div className="tc-oracle" aria-label="How this bet settles">
+      {/* Settlement source — always shown, live or degraded (FR-013/SC-005). */}
+      <div className="tc-oracle-badge">
+        <span className="tc-oracle-badge-icon" aria-hidden="true">&#128302;</span>
+        <span className="tc-oracle-badge-text">Settled automatically by <strong>Polymarket</strong></span>
+      </div>
+      <p className="tc-oracle-explain">
+        The winner is decided by the linked public Polymarket market&apos;s resolution — neither you,
+        the creator, nor anyone else in the app judges the outcome.
+      </p>
+
+      <div className="tc-oracle-question">
+        {question ? (
+          <strong>{question}</strong>
+        ) : (
+          <span className="tc-oracle-question-fallback">
+            Market details unavailable — linked market <code>{shortenHex(conditionId)}</code>
+          </span>
+        )}
+        {slug && (
+          <a
+            className="tc-oracle-link"
+            href={`https://polymarket.com/market/${slug}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            View on Polymarket
+          </a>
+        )}
+      </div>
+
+      <div className="tc-oracle-sides">
+        <span>You take: <strong>{takerLabel}</strong></span>
+        <span className="tc-oracle-sides-sep" aria-hidden="true">·</span>
+        <span>Creator holds: {creatorLabel}</span>
+      </div>
+
+      {integrity === 'mismatch' && (
+        <div className="oc-notice oc-notice--warn" role="alert">
+          The stored description doesn&apos;t match the market this challenge is actually linked to
+          on-chain. Trust the on-chain linkage shown here — not the description text.
+        </div>
+      )}
+
+      {/* Live market context (FR-014): odds/status when reachable, disclosed degradation when not. */}
+      <div className="tc-oracle-live" role="status">
+        {isLoading ? (
+          <span className="tc-oracle-live-loading">Checking the live market…</span>
+        ) : error ? (
+          <span className="tc-oracle-live-degraded">
+            Live market info unavailable right now — the bet terms above are binding.
+          </span>
+        ) : market ? (
+          <>
+            <span className="tc-oracle-live-prices">
+              Now: {market.outcomes
+                .map((o) => `${o.name}${o.price != null ? ` ${Math.round(o.price * 100)}¢` : ''}`)
+                .join(' · ')}
+            </span>
+            <span className={`tc-oracle-live-status ${marketClosed ? 'is-closed' : 'is-open'}`}>
+              {marketClosed ? 'Market closed' : 'Market open'}
+            </span>
+          </>
+        ) : null}
+      </div>
+
+      {marketClosed && !resolvedOutcomeName && (
+        <div className="oc-notice oc-notice--warn" role="alert">
+          This market has already closed. The outcome may be decided soon — make sure you still
+          want to take this bet.
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** A live market whose outcome is already public: closed with a near-certain price.
+ *  Returns that outcome's name, or null. Deliberately conservative — only a positively
+ *  known result blocks acceptance (D8); stale/ambiguous data merely warns. */
+function publiclyResolvedOutcome(market) {
+  if (!market || market.closed !== true) return null
+  const winner = (market.outcomes || []).find((o) => o.price != null && o.price >= 0.999)
+  return winner ? winner.name : null
+}
+
+function normalizeOutcomeLabels(list) {
+  if (!Array.isArray(list) || list.length < 2) return null
+  const a = String(list[0] ?? '').trim()
+  const b = String(list[1] ?? '').trim()
+  return a && b ? [a, b] : null
+}
+
+function hexEquals(a, b) {
+  if (!a || !b) return false
+  return String(a).toLowerCase() === String(b).toLowerCase()
+}
+
+function shortenHex(h) {
+  const s = String(h || '')
+  return s.length > 14 ? `${s.slice(0, 10)}…${s.slice(-4)}` : s
+}
+
+function formatStake(value, decimals = 6) {
+  if (value == null) return ''
+  let n
+  try {
+    n = Number(BigInt(value)) / 10 ** decimals
+  } catch {
+    return ''
+  }
+  if (!Number.isFinite(n) || n <= 0) return ''
+  return n.toLocaleString([], { maximumFractionDigits: 2 })
 }
 
 /** Show an open challenge's accept/resolve deadlines (feature 024). Reads the on-chain wager struct. */

--- a/frontend/src/components/fairwins/TakeChallengePanel.jsx
+++ b/frontend/src/components/fairwins/TakeChallengePanel.jsx
@@ -190,6 +190,9 @@ function OracleBetSummary({ wager, terms, live, resolvedOutcomeName }) {
   const conditionId = wager?.polymarketConditionId
   const creatorIsYes = Boolean(wager?.creatorIsYes)
   const { market, isLoading, error } = live
+  // Mount-anchored clock: render must stay pure, and "has the event passed" doesn't
+  // need to tick while the panel is open.
+  const [nowMs] = useState(() => Date.now())
 
   const sealed = terms && typeof terms === 'object' ? terms.oracle : null
   const integrity = !sealed
@@ -203,7 +206,7 @@ function OracleBetSummary({ wager, terms, live, resolvedOutcomeName }) {
   const takerLabel = labels[creatorIsYes ? 1 : 0]
   const creatorLabel = labels[creatorIsYes ? 0 : 1]
   const slug = trusted?.slug || market?.slug || null
-  const marketClosed = Boolean(market && (market.closed || (market.endDate && Date.parse(market.endDate) < Date.now())))
+  const marketClosed = Boolean(market && (market.closed || (market.endDate && Date.parse(market.endDate) < nowMs)))
 
   return (
     <div className="tc-oracle" aria-label="How this bet settles">

--- a/frontend/src/constants/quickAccessCards.js
+++ b/frontend/src/constants/quickAccessCards.js
@@ -11,6 +11,7 @@ export const QUICK_ACCESS_CARDS = [
   { id: 'create-1v1-oracle', label: 'Oracle Settles (1v1)' },
   { id: 'create-offer', label: 'Make an Offer' },
   { id: 'open-challenge', label: 'Open Challenge' },
+  { id: 'oracle-open-challenge', label: 'Oracle Open Challenge' },
   { id: 'create-pool', label: 'Group Pool' },
   { id: 'enter-phrase', label: 'Enter a Phrase' },
   { id: 'my-wagers', label: 'My Wagers' },

--- a/frontend/src/hooks/useOpenChallengeCreate.js
+++ b/frontend/src/hooks/useOpenChallengeCreate.js
@@ -66,8 +66,18 @@ export function useOpenChallengeCreate() {
       onProgress({ step: 'upload', message: 'Encrypting and uploading terms…' })
       const termsDoc = getCurrentDocument('terms')
       const termsVersion = termsDoc ? { id: termsDoc.id, hash: termsDoc.hash } : null
+      // Oracle-settled challenges (spec 041) seal the market metadata alongside the
+      // description so a code-holder can read the bet (question, outcome labels, side)
+      // even when live market data is unreachable. The on-chain fields
+      // (resolutionType / polymarketConditionId / creatorIsYes) stay authoritative —
+      // the claimant view cross-checks this block against them. Never on-chain plaintext:
+      // a public market reference would break code-gated indistinguishability (spec 024).
       const envelope = encryptEnvelopeCode(
-        { description: form.description || 'Open challenge', createdAt: undefined },
+        {
+          description: form.description || 'Open challenge',
+          createdAt: new Date().toISOString(),
+          ...(form.oracleMeta ? { oracle: form.oracleMeta } : {}),
+        },
         symKey,
         termsVersion
       )
@@ -143,6 +153,12 @@ export function translateOpenCreateRevert(reason) {
   if (r.includes('BadDeadlines')) return 'The accept/resolve deadlines are outside the allowed window.'
   if (r.includes('NotAllowedToken')) return 'That stake token is not allowed.'
   if (r.includes('ZeroStake')) return 'Enter a stake greater than zero.'
+  // Oracle-linked open challenges (spec 041).
+  if (r.includes('ConditionAlreadyResolved')) return 'That market has already resolved — pick a market that is still live.'
+  if (r.includes('PolymarketRequired')) return 'Pick a Polymarket market to link this challenge to.'
+  if (r.includes('PolymarketDisallowed')) return 'A market can only be linked when the challenge is oracle-settled.'
+  if (r.includes('AdapterNotSet') || r.includes('OracleAdapterNotSet')) return 'Polymarket settlement isn’t available on this network yet.'
+  if (r.includes('OracleConditionRequired')) return 'Pick an oracle condition to link this challenge to.'
   return reason || 'Could not create the open challenge. Please try again.'
 }
 

--- a/frontend/src/hooks/usePolymarketMarket.js
+++ b/frontend/src/hooks/usePolymarketMarket.js
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useChainId } from 'wagmi'
+import { getNetwork, getCurrentChainId } from '../config/networks'
+import { normaliseGammaMarket } from './usePolymarketSearch'
+import logger from '../utils/logger'
+
+const DEFAULT_GAMMA_BASE = 'https://gamma-api.polymarket.com'
+const ZERO_HASH = '0x0000000000000000000000000000000000000000000000000000000000000000'
+
+function apiBaseFor(chainId) {
+  const network = getNetwork(chainId)
+  const base = network?.polymarket?.gammaApiUrl || DEFAULT_GAMMA_BASE
+  return base.replace(/\/$/, '')
+}
+
+/** A usable condition id: non-empty and not the zero hash (non-oracle wagers store zero). */
+function isRealConditionId(conditionId) {
+  if (!conditionId) return false
+  const s = String(conditionId)
+  return s !== ZERO_HASH && /^0x[0-9a-fA-F]+$/.test(s)
+}
+
+/**
+ * Fetch a single Polymarket market by condition id from the Gamma API (spec 041, FR-014).
+ * Used by the claimant view for live odds/status and by the create flow for a freshness
+ * re-check. One fetch per (conditionId, chainId) mount plus manual refresh() — no polling.
+ *
+ * Never throws into render: failures land in `error` and the caller shows the disclosed
+ * "live market info unavailable" state (the bound challenge terms never depend on this).
+ */
+export function usePolymarketMarket(conditionId, { enabled = true } = {}) {
+  const wagmiChainId = useChainId()
+  const chainId = wagmiChainId || getCurrentChainId()
+  const apiBase = apiBaseFor(chainId)
+
+  const active = enabled && isRealConditionId(conditionId)
+
+  const [market, setMarket] = useState(null)
+  const [isLoading, setIsLoading] = useState(active)
+  const [error, setError] = useState(null)
+  const abortRef = useRef(null)
+
+  const fetchMarket = useCallback(async () => {
+    if (!active) {
+      setMarket(null)
+      setIsLoading(false)
+      setError(null)
+      return
+    }
+    if (abortRef.current) abortRef.current.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    setIsLoading(true)
+    setError(null)
+    try {
+      const url = `${apiBase}/markets?condition_ids=${encodeURIComponent(String(conditionId))}&limit=1`
+      const res = await fetch(url, { headers: { Accept: 'application/json' }, signal: controller.signal })
+      if (!res.ok) throw new Error(`Market lookup failed (${res.status})`)
+      const data = await res.json()
+      const raw = Array.isArray(data) ? data[0] : Array.isArray(data?.data) ? data.data[0] : null
+      if (!raw) throw new Error('Market not found')
+      setMarket(normaliseGammaMarket(raw))
+    } catch (err) {
+      if (err?.name === 'AbortError') return
+      logger.warn?.('[usePolymarketMarket] failed:', err)
+      setMarket(null)
+      setError(err?.message || 'Live market info unavailable')
+    } finally {
+      if (!controller.signal.aborted) setIsLoading(false)
+    }
+  }, [active, apiBase, conditionId])
+
+  useEffect(() => {
+    fetchMarket()
+    return () => { if (abortRef.current) abortRef.current.abort() }
+  }, [fetchMarket])
+
+  return { market, isLoading, error, refresh: fetchMarket }
+}
+
+export default usePolymarketMarket

--- a/frontend/src/lib/openChallenge/oracleTimeline.js
+++ b/frontend/src/lib/openChallenge/oracleTimeline.js
@@ -1,0 +1,66 @@
+// Event-derived timeline for oracle-settled open challenges (spec 041, FR-007/FR-003).
+// "The event defines the timelines": the creator never hand-picks dates — the linked
+// Polymarket market's end date drives both deadlines, clamped to stay strictly inside
+// the contract bounds (WagerRegistryCore: MAX_ACCEPT_WINDOW = 30d, MAX_RESOLVE_WINDOW
+// = 180d) so a derived value can never revert _checkDeadlines while the tx is pending.
+
+const HOUR_MS = 60 * 60 * 1000
+const DAY_MS = 24 * HOUR_MS
+
+/** Markets ending sooner than this are not offered — nobody could realistically share
+ *  a code and have it taken in time (parity with the 1v1 oracle flow's 1-hour floor). */
+export const MIN_LEAD_MS = HOUR_MS
+
+/** Contract MAX_ACCEPT_WINDOW (30 days) minus a tx-safety margin. */
+export const ACCEPT_CAP_MS = 30 * DAY_MS - HOUR_MS
+
+/** Time allowed after the market's scheduled end for Polymarket to resolve and for
+ *  anyone to call autoResolveFromPolymarket. */
+export const SETTLE_BUFFER_MS = 7 * DAY_MS
+
+/** Contract MAX_RESOLVE_WINDOW (180 days) minus a tx-safety margin. */
+export const RESOLVE_CAP_MS = 180 * DAY_MS - HOUR_MS
+
+/**
+ * Derive the accept/settle deadlines for an oracle open challenge from the linked
+ * market's scheduled end. Pure and clock-injected (callers anchor `nowMs` at mount).
+ *
+ * Returns:
+ *   {
+ *     eligible: boolean,
+ *     reason: string|null,            // set iff !eligible
+ *     acceptDeadlineMs: number|null,  // min(marketEnd, now + ACCEPT_CAP_MS)
+ *     resolveDeadlineMs: number|null, // min(marketEnd + SETTLE_BUFFER_MS, now + RESOLVE_CAP_MS)
+ *     acceptCapped: boolean,          // the 30-day cap shortened the accept window
+ *   }
+ *
+ * Invariants for every eligible result: now < accept < resolve, accept ≤ now + 30d,
+ * resolve ≤ now + 180d (see contracts/timeline-derivation.md).
+ */
+export function deriveOracleChallengeTimeline(marketEndIso, nowMs = Date.now()) {
+  const ineligible = (reason) => ({
+    eligible: false,
+    reason,
+    acceptDeadlineMs: null,
+    resolveDeadlineMs: null,
+    acceptCapped: false,
+  })
+
+  if (!marketEndIso) return ineligible('This market has no scheduled end date.')
+  const endMs = Date.parse(marketEndIso)
+  if (!Number.isFinite(endMs)) return ineligible('This market has no readable end date.')
+  if (endMs < nowMs + MIN_LEAD_MS) {
+    return ineligible('This market ends too soon to share a challenge for it.')
+  }
+
+  const acceptCapMs = nowMs + ACCEPT_CAP_MS
+  const acceptCapped = acceptCapMs < endMs
+  const acceptDeadlineMs = acceptCapped ? acceptCapMs : endMs
+  // marketEnd ≥ acceptDeadline and the buffer/caps preserve the gap, so
+  // resolve > accept holds by construction.
+  const resolveDeadlineMs = Math.min(endMs + SETTLE_BUFFER_MS, nowMs + RESOLVE_CAP_MS)
+
+  return { eligible: true, reason: null, acceptDeadlineMs, resolveDeadlineMs, acceptCapped }
+}
+
+export default deriveOracleChallengeTimeline

--- a/frontend/src/test/Dashboard.test.jsx
+++ b/frontend/src/test/Dashboard.test.jsx
@@ -20,6 +20,12 @@ vi.mock('../components/fairwins/FriendMarketsModal', () => ({
 
 // Stub the unified phrase lookup (spec 037) so we assert the Dashboard wiring — the "Enter a Phrase"
 // quick action and the ?oc=take&code= deep-link reroute — without its resolver/hook internals.
+// Stub the oracle open challenge modal (spec 041) to assert the Dashboard card wiring
+// without the picker/create internals (covered by OracleOpenChallengeModal.test.jsx).
+vi.mock('../components/fairwins/OracleOpenChallengeModal', () => ({
+  default: ({ isOpen }) => isOpen ? <div data-testid="oracle-open-challenge-modal" /> : null,
+}))
+
 vi.mock('../components/fairwins/UnifiedLookupModal', () => ({
   default: ({ isOpen, initialPhrase, autoResolve }) => isOpen ? (
     <div data-testid="unified-modal" data-phrase={initialPhrase} data-auto={String(autoResolve)} />
@@ -348,7 +354,8 @@ describe('Dashboard Component', () => {
 
     it('shows a recoverable empty state pointing at Preferences when every card is hidden', () => {
       const allCardIds = [
-        'create-1v1-friends', 'create-1v1-oracle', 'create-offer', 'open-challenge', 'create-pool',
+        'create-1v1-friends', 'create-1v1-oracle', 'create-offer', 'open-challenge',
+        'oracle-open-challenge', 'create-pool',
         'enter-phrase', 'my-wagers', 'scan-qr', 'share-account',
       ]
       allCardIds.forEach((id) => setCardVisible(id, false))
@@ -377,6 +384,38 @@ describe('Dashboard Component', () => {
       const toggle = screen.getByRole('button', { name: /How P2P Wagers Work/i })
         || screen.getByText('How P2P Wagers Work').closest('button')
       expect(toggle).toHaveAttribute('aria-expanded')
+    })
+  })
+
+  describe('Oracle Open Challenge entry (spec 041)', () => {
+    it('renders the card with its oracle-settles description', () => {
+      renderWithProviders(<Dashboard />)
+      expect(screen.getByText('Oracle Open Challenge')).toBeInTheDocument()
+      expect(screen.getByText(/share a code — Polymarket settles it automatically/i)).toBeInTheDocument()
+    })
+
+    it('clicking the card opens the oracle open challenge modal (not the 1v1 flow)', () => {
+      renderWithProviders(<Dashboard />)
+      expect(screen.queryByTestId('oracle-open-challenge-modal')).toBeNull()
+      fireEvent.click(screen.getByText('Oracle Open Challenge'))
+      expect(screen.getByTestId('oracle-open-challenge-modal')).toBeInTheDocument()
+      expect(screen.queryByTestId('friend-modal')).toBeNull()
+    })
+
+    it('the card is toggleable via quick-access preferences like any other (spec 038 US5)', () => {
+      setCardVisible('oracle-open-challenge', false)
+      renderWithProviders(<Dashboard />)
+      expect(screen.queryByText('Oracle Open Challenge')).toBeNull()
+      setCardVisible('oracle-open-challenge', true)
+    })
+
+    it('the user-defined Open Challenge card still opens its own modal unchanged (FR-018)', () => {
+      renderWithProviders(<Dashboard />)
+      fireEvent.click(screen.getByText('Open Challenge'))
+      // The user-defined modal renders its own dialog header (not the oracle stub);
+      // the card itself is an h4, the modal title an h2.
+      expect(screen.queryByTestId('oracle-open-challenge-modal')).toBeNull()
+      expect(screen.getByRole('heading', { level: 2, name: 'Open Challenge' })).toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/test/PreferencesPanel.test.jsx
+++ b/frontend/src/test/PreferencesPanel.test.jsx
@@ -11,9 +11,9 @@ describe('PreferencesPanel (spec 038 US5)', () => {
     localStorage.clear()
   })
 
-  it('lists all 9 quick access cards, each visible by default', () => {
+  it('lists all 10 quick access cards, each visible by default', () => {
     render(<PreferencesPanel />)
-    expect(QUICK_ACCESS_CARDS).toHaveLength(9)
+    expect(QUICK_ACCESS_CARDS).toHaveLength(10) // +oracle-open-challenge (spec 041)
     QUICK_ACCESS_CARDS.forEach((card) => {
       const toggle = screen.getByRole('switch', { name: card.label })
       expect(toggle).toHaveAttribute('aria-checked', 'true')

--- a/frontend/src/test/accessibility.test.jsx
+++ b/frontend/src/test/accessibility.test.jsx
@@ -291,3 +291,104 @@ describe('OpenChallengeModal Accessibility (feature 024, WCAG 2.1 AA)', () => {
     expect(screen.getByText('Open Challenge')).toBeInTheDocument()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Spec 041 — oracle open challenge surfaces (WCAG 2.1 AA, Constitution V).
+// vi.mock calls are hoisted, so these stubs coexist with the sections above.
+// ---------------------------------------------------------------------------
+vi.mock('../components/fairwins/PolymarketBrowser', () => ({
+  default: ({ onSelectMarket }) => (
+    <div>
+      <button
+        type="button"
+        onClick={() => onSelectMarket({
+          id: 'm1',
+          slug: 'will-eth-flip-btc',
+          question: 'Will ETH flip BTC?',
+          conditionId: '0xc0ffee',
+          endDate: new Date(Date.now() + 10 * 24 * 3600 * 1000).toISOString(),
+          active: true,
+          closed: false,
+          outcomes: [{ name: 'Yes', price: 0.62 }, { name: 'No', price: 0.38 }],
+        })}
+      >
+        pick market
+      </button>
+    </div>
+  ),
+}))
+vi.mock('../hooks/useChainTokens', () => ({
+  useChainTokens: () => ({ capabilities: { polymarketSidebets: true }, stable: 'USDC', stableDecimals: 6 }),
+}))
+vi.mock('../hooks/usePolymarketMarket', () => ({
+  usePolymarketMarket: () => ({
+    market: {
+      id: 'm1',
+      slug: 'will-eth-flip-btc',
+      question: 'Will ETH flip BTC?',
+      conditionId: '0xc0ffee',
+      endDate: '2026-12-31T00:00:00Z',
+      active: true,
+      closed: false,
+      outcomes: [{ name: 'Yes', price: 0.62 }, { name: 'No', price: 0.38 }],
+    },
+    isLoading: false,
+    error: null,
+    refresh: () => {},
+  }),
+}))
+
+import OracleOpenChallengeModal from '../components/fairwins/OracleOpenChallengeModal'
+import TakeChallengePanel from '../components/fairwins/TakeChallengePanel'
+
+describe('Oracle open challenge accessibility (spec 041)', () => {
+  it('has no axe violations on the market-picker step', async () => {
+    const { container } = render(<OracleOpenChallengeModal isOpen onClose={() => {}} />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('has no axe violations on the configure step (side picker + stake + derived timeline)', async () => {
+    const { container } = render(<OracleOpenChallengeModal isOpen onClose={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: /pick market/i }))
+    fireEvent.click(screen.getByRole('button', { name: /taking yes/i }))
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+
+  it('has no axe violations on the claimant oracle bet summary', async () => {
+    const { container } = render(
+      <TakeChallengePanel
+        code="river tiger kite zoo"
+        match={{
+          wagerId: 1n,
+          wager: {
+            resolutionType: 4n,
+            polymarketConditionId: '0xc0ffee',
+            creatorIsYes: true,
+            creatorStake: 10_000_000n,
+            opponentStake: 10_000_000n,
+            acceptDeadline: BigInt(Math.floor(Date.now() / 1000) + 3600),
+            resolveDeadline: BigInt(Math.floor(Date.now() / 1000) + 86400),
+          },
+          terms: {
+            description: 'Will ETH flip BTC? — creator takes Yes · settled automatically by Polymarket',
+            oracle: {
+              source: 'polymarket',
+              conditionId: '0xc0ffee',
+              question: 'Will ETH flip BTC?',
+              outcomes: ['Yes', 'No'],
+              creatorSide: 0,
+              slug: 'will-eth-flip-btc',
+            },
+          },
+          termsUnavailable: false,
+          needsMembership: false,
+        }}
+        onClose={() => {}}
+      />
+    )
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/claimCode/OpenChallengeModal.test.jsx
+++ b/frontend/src/test/claimCode/OpenChallengeModal.test.jsx
@@ -162,3 +162,54 @@ describe('OpenChallengeModal explainers behind info icons (spec 039 US1)', () =>
     expect(screen.getByRole('note')).toHaveTextContent(/encrypted copy/i)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Spec 041 foundational changes: oracle-aware revert translation and the sealed
+// `oracle` metadata block (the claimant reads the bet even with live data down).
+// ---------------------------------------------------------------------------
+import { translateOpenCreateRevert } from '../../hooks/useOpenChallengeCreate'
+import { deriveFromCode } from '../../utils/claimCode/deriveFromCode.js'
+import { generateCode } from '../../utils/claimCode/wordlist.js'
+import { encryptEnvelopeCode, decryptEnvelopeCode } from '../../utils/crypto/envelopeEncryption.js'
+
+describe('Oracle open challenges — create-hook foundations (spec 041)', () => {
+  it('translates the oracle-linkage reverts to actionable messages (FR-008)', () => {
+    expect(translateOpenCreateRevert('ConditionAlreadyResolved()')).toMatch(/already resolved/i)
+    expect(translateOpenCreateRevert('PolymarketRequired()')).toMatch(/pick a polymarket market/i)
+    expect(translateOpenCreateRevert('PolymarketDisallowed()')).toMatch(/oracle-settled/i)
+    expect(translateOpenCreateRevert('AdapterNotSet()')).toMatch(/available on this network/i)
+    // Existing translations are untouched.
+    expect(translateOpenCreateRevert('InsufficientMembershipTier()')).toMatch(/silver/i)
+  })
+
+  it('a sealed payload with an oracle block round-trips through the code envelope (D4/FR-014)', () => {
+    const code = generateCode()
+    const { symKey } = deriveFromCode(code)
+    const plaintext = {
+      description: '"Will ETH flip BTC?" — creator takes Yes',
+      createdAt: '2026-07-05T00:00:00.000Z',
+      oracle: {
+        source: 'polymarket',
+        conditionId: '0xabc123',
+        question: 'Will ETH flip BTC?',
+        outcomes: ['Yes', 'No'],
+        creatorSide: 0,
+        endDate: '2026-12-31T00:00:00Z',
+        slug: 'will-eth-flip-btc',
+      },
+    }
+    const envelope = encryptEnvelopeCode(plaintext, symKey)
+    const { symKey: rederived } = deriveFromCode(code)
+    expect(decryptEnvelopeCode(envelope, rederived)).toEqual(plaintext)
+  })
+
+  it('legacy payloads without an oracle block still round-trip unchanged (FR-018 of 024)', () => {
+    const code = generateCode()
+    const { symKey } = deriveFromCode(code)
+    const plaintext = { description: 'Plain user-defined challenge', createdAt: undefined }
+    const envelope = encryptEnvelopeCode(plaintext, symKey)
+    const recovered = decryptEnvelopeCode(envelope, symKey)
+    expect(recovered.description).toBe('Plain user-defined challenge')
+    expect(recovered.oracle).toBeUndefined()
+  })
+})

--- a/frontend/src/test/claimCode/OracleOpenChallengeModal.test.jsx
+++ b/frontend/src/test/claimCode/OracleOpenChallengeModal.test.jsx
@@ -155,3 +155,56 @@ describe('OracleOpenChallengeModal (spec 041, US1)', () => {
     expect(screen.getByRole('button', { name: /change/i })).toBeInTheDocument()
   })
 })
+
+// ---------------------------------------------------------------------------
+// US3 — fast discovery & effortless sharing (SC-001). Feed internals (grouping,
+// category chips, retry, a11y) are covered by PolymarketBrowser.test.jsx; here we
+// pin the modal-level interaction budget and state transitions.
+// ---------------------------------------------------------------------------
+describe('OracleOpenChallengeModal — discovery speed & sharing (spec 041, US3)', () => {
+  beforeEach(() => {
+    createOpenChallenge.mockReset()
+    capsHolder.capabilities = { polymarketSidebets: true }
+  })
+
+  it('the picker is browsable with zero input the moment the section opens', () => {
+    render(<OracleOpenChallengeModal isOpen onClose={() => {}} />)
+    expect(screen.getByTestId('pm-browser')).toBeInTheDocument()
+    // No search/typing is required before markets are pickable.
+    expect(screen.getByRole('button', { name: /pick eligible/i })).toBeInTheDocument()
+  })
+
+  it('feed → side picked takes at most 3 interactions (SC-001)', () => {
+    render(<OracleOpenChallengeModal isOpen onClose={() => {}} />)
+    // 1: pick a market from the feed; 2: pick a side. (3rd would be a category/search refinement.)
+    fireEvent.click(screen.getByRole('button', { name: /pick eligible/i }))
+    fireEvent.click(screen.getByRole('button', { name: /taking yes/i }))
+    expect(screen.getByRole('button', { name: /taking yes/i })).toHaveAttribute('aria-pressed', 'true')
+    // Stake is pre-filled, so the create button is already enabled after 2 interactions.
+    expect(screen.getByRole('button', { name: /create & generate code/i })).toBeEnabled()
+  })
+
+  it('a refused (too-soon) pick does not strand the flow — the next valid pick clears the notice', () => {
+    render(<OracleOpenChallengeModal isOpen onClose={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: /pick soon/i }))
+    expect(screen.getByRole('alert')).toHaveTextContent(/too soon/i)
+    fireEvent.click(screen.getByRole('button', { name: /pick eligible/i }))
+    expect(screen.queryByText(/too soon/i)).toBeNull()
+    expect(screen.getByText('Will ETH flip BTC?')).toBeInTheDocument()
+  })
+
+  it('after create, the share tools are immediately at hand: copy, QR deep link, device backup (FR-010)', async () => {
+    createOpenChallenge.mockResolvedValue({ code: 'river tiger kite zoo', wagerId: 3n, txHash: '0x1' })
+    render(<OracleOpenChallengeModal isOpen onClose={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: /pick eligible/i }))
+    fireEvent.click(screen.getByRole('button', { name: /taking no/i }))
+    fireEvent.click(screen.getByRole('button', { name: /create & generate code/i }))
+
+    expect(await screen.findByText('river tiger kite zoo')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /copy code/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/qr code to take this challenge/i)).toBeInTheDocument()
+    // The retention warning tells the sharer the code is also how the bet is READ later.
+    expect(screen.getByText(/only way to take, read, or re-read/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /save encrypted backup/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/claimCode/OracleOpenChallengeModal.test.jsx
+++ b/frontend/src/test/claimCode/OracleOpenChallengeModal.test.jsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+// Mock the create flow (no chain/IPFS) — same approach as OpenChallengeModal.test.jsx.
+const createOpenChallenge = vi.fn()
+vi.mock('../../hooks/useOpenChallengeCreate', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, useOpenChallengeCreate: () => ({ createOpenChallenge, busy: false, error: null }) }
+})
+
+// Chain capability gate — flip per-test via this holder.
+const capsHolder = { capabilities: { polymarketSidebets: true } }
+vi.mock('../../hooks/useChainTokens', () => ({
+  useChainTokens: () => capsHolder,
+}))
+
+// Stub the market browser: the modal's contract with it is onSelectMarket(normalizedMarket).
+// The browser's own feed/filter behavior is covered by PolymarketBrowser.test.jsx.
+const FAR_END = new Date(Date.now() + 10 * 24 * 3600 * 1000).toISOString()
+const SOON_END = new Date(Date.now() + 10 * 60 * 1000).toISOString() // < 1h lead → ineligible
+const eligibleMarket = {
+  id: 'm1',
+  slug: 'will-eth-flip-btc',
+  question: 'Will ETH flip BTC?',
+  conditionId: '0xc0ffee',
+  endDate: FAR_END,
+  active: true,
+  closed: false,
+  outcomes: [{ name: 'Yes', price: 0.62 }, { name: 'No', price: 0.38 }],
+}
+const soonMarket = { ...eligibleMarket, id: 'm2', question: 'Ends in minutes?', conditionId: '0xsoon', endDate: SOON_END }
+vi.mock('../../components/fairwins/PolymarketBrowser', () => ({
+  default: ({ onSelectMarket }) => (
+    <div data-testid="pm-browser">
+      <button type="button" onClick={() => onSelectMarket(eligibleMarket)}>pick eligible</button>
+      <button type="button" onClick={() => onSelectMarket(soonMarket)}>pick soon</button>
+    </div>
+  ),
+}))
+
+import OracleOpenChallengeModal from '../../components/fairwins/OracleOpenChallengeModal'
+import { OPEN_RESOLUTION_TYPES } from '../../hooks/useOpenChallengeCreate'
+
+describe('OracleOpenChallengeModal (spec 041, US1)', () => {
+  beforeEach(() => {
+    createOpenChallenge.mockReset()
+    capsHolder.capabilities = { polymarketSidebets: true }
+  })
+
+  it('renders nothing when closed', () => {
+    const { container } = render(<OracleOpenChallengeModal isOpen={false} onClose={() => {}} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('opens straight into the market picker — no side/stake until a market is picked', () => {
+    render(<OracleOpenChallengeModal isOpen onClose={() => {}} />)
+    expect(screen.getByTestId('pm-browser')).toBeInTheDocument()
+    expect(screen.queryByText(/your side of the bet/i)).toBeNull()
+    expect(screen.getByRole('button', { name: /create & generate code/i })).toBeDisabled()
+  })
+
+  it('shows a locked explanation (not a silent blank) on chains without Polymarket support (FR-004)', () => {
+    capsHolder.capabilities = { polymarketSidebets: false }
+    render(<OracleOpenChallengeModal isOpen onClose={() => {}} />)
+    expect(screen.getByRole('alert')).toHaveTextContent(/isn't available on this network/i)
+    expect(screen.queryByTestId('pm-browser')).toBeNull()
+  })
+
+  it('refuses a market that ends too soon, keeps the picker open, and says why (FR-003)', () => {
+    render(<OracleOpenChallengeModal isOpen onClose={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: /pick soon/i }))
+    expect(screen.getByRole('alert')).toHaveTextContent(/too soon/i)
+    expect(screen.getByTestId('pm-browser')).toBeInTheDocument()
+    expect(screen.queryByText(/your side of the bet/i)).toBeNull()
+  })
+
+  it('picking a market reveals side picker (market outcome labels + prices), stake, and the derived read-only timeline', () => {
+    render(<OracleOpenChallengeModal isOpen onClose={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: /pick eligible/i }))
+
+    // Selected-market summary with a change affordance back to the picker.
+    expect(screen.getByText('Will ETH flip BTC?')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /change/i })).toBeInTheDocument()
+
+    // Side picker: two aria-pressed buttons carrying the market's own labels + live prices.
+    const yesBtn = screen.getByRole('button', { name: /taking yes/i })
+    const noBtn = screen.getByRole('button', { name: /taking no/i })
+    expect(yesBtn).toHaveAttribute('aria-pressed', 'false')
+    expect(yesBtn).toHaveTextContent(/62¢/)
+    expect(noBtn).toHaveTextContent(/38¢/)
+
+    // Derived timeline is presented as coming from the event, with no date inputs.
+    expect(screen.getByText(/timeline — set by the event/i)).toBeInTheDocument()
+    expect(screen.getByText('Takeable until')).toBeInTheDocument()
+    expect(screen.getByText('Settles by')).toBeInTheDocument()
+    expect(document.querySelector('input[type="datetime-local"]')).toBeNull()
+
+    // Taker side is spelled out once a side is picked.
+    fireEvent.click(yesBtn)
+    expect(yesBtn).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByText(/whoever takes your code will be taking/i)).toHaveTextContent(/No/)
+  })
+
+  it('submits resolutionType=Polymarket with the market linkage, side, derived deadlines, and sealed oracleMeta (FR-005..FR-010)', async () => {
+    createOpenChallenge.mockResolvedValue({ code: 'river tiger kite zoo', wagerId: 7n, txHash: '0xabc' })
+    render(<OracleOpenChallengeModal isOpen onClose={() => {}} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /pick eligible/i }))
+    const createBtn = screen.getByRole('button', { name: /create & generate code/i })
+    expect(createBtn).toBeDisabled() // no side picked yet
+    fireEvent.click(screen.getByRole('button', { name: /taking no/i }))
+    expect(createBtn).toBeEnabled()
+    fireEvent.click(createBtn)
+
+    await waitFor(() => expect(createOpenChallenge).toHaveBeenCalled())
+    const form = createOpenChallenge.mock.calls[0][0]
+
+    expect(form.resolutionType).toBe(OPEN_RESOLUTION_TYPES.Polymarket)
+    expect(form.oracleConditionId).toBe('0xc0ffee')
+    expect(form.creatorIsYes).toBe(false) // picked the index-1 (NO) side
+    // Deadlines derive from the event: accept == market end (within the 30-day cap),
+    // settle after it — both in unix seconds.
+    const endSecs = Math.floor(Date.parse(FAR_END) / 1000)
+    expect(form.acceptDeadline).toBe(endSecs)
+    expect(form.resolveDeadline).toBeGreaterThan(form.acceptDeadline)
+    // The sealed metadata makes the bet readable to code-holders even offline (D4).
+    expect(form.oracleMeta).toMatchObject({
+      source: 'polymarket',
+      conditionId: '0xc0ffee',
+      question: 'Will ETH flip BTC?',
+      outcomes: ['Yes', 'No'],
+      creatorSide: 1,
+      slug: 'will-eth-flip-btc',
+    })
+    // The description names the market, the side, and Polymarket as the settler.
+    expect(form.description).toMatch(/Will ETH flip BTC\?/)
+    expect(form.description).toMatch(/takes No/i)
+    expect(form.description).toMatch(/Polymarket/)
+
+    // Success → shared claim-code result panel (code shown once + QR).
+    expect(await screen.findByText('river tiger kite zoo')).toBeInTheDocument()
+    expect(screen.getByText(/save this code now/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/qr code to take this challenge/i)).toBeInTheDocument()
+  })
+
+  it('surfaces a translated create failure and stays on the form', async () => {
+    createOpenChallenge.mockRejectedValue(new Error('That market has already resolved — pick a market that is still live.'))
+    render(<OracleOpenChallengeModal isOpen onClose={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: /pick eligible/i }))
+    fireEvent.click(screen.getByRole('button', { name: /taking yes/i }))
+    fireEvent.click(screen.getByRole('button', { name: /create & generate code/i }))
+
+    expect(await screen.findByText(/already resolved/i)).toBeInTheDocument()
+    // Still on the form — the Change affordance lets the creator re-pick (FR-008).
+    expect(screen.getByRole('button', { name: /change/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/claimCode/TakeChallengePanel.oracle.test.jsx
+++ b/frontend/src/test/claimCode/TakeChallengePanel.oracle.test.jsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// The accept flow itself is resolution-type agnostic (FR-016) — mock it out.
+const accept = vi.fn()
+vi.mock('../../hooks/useOpenChallengeAccept', () => ({
+  useOpenChallengeAccept: () => ({ accept, busy: false }),
+}))
+
+// Live market data holder — each test sets what the Gamma lookup "returns".
+const liveHolder = { market: null, isLoading: false, error: null, refresh: vi.fn() }
+vi.mock('../../hooks/usePolymarketMarket', () => ({
+  usePolymarketMarket: () => liveHolder,
+}))
+
+// Open challenges stake the chain stablecoin.
+vi.mock('../../hooks/useChainTokens', () => ({
+  useChainTokens: () => ({ stable: 'USDC', stableDecimals: 6 }),
+}))
+
+import TakeChallengePanel from '../../components/fairwins/TakeChallengePanel'
+
+const CONDITION = '0xc0ffee00000000000000000000000000000000000000000000000000000000ab'
+
+const oracleWager = (over = {}) => ({
+  resolutionType: 4n, // Polymarket
+  polymarketConditionId: CONDITION,
+  creatorIsYes: true,
+  creatorStake: 10_000_000n, // 10 USDC
+  opponentStake: 10_000_000n,
+  acceptDeadline: BigInt(Math.floor(Date.now() / 1000) + 3600),
+  resolveDeadline: BigInt(Math.floor(Date.now() / 1000) + 86400),
+  ...over,
+})
+
+const sealedTerms = (over = {}) => ({
+  description: 'Will ETH flip BTC? — creator takes Yes · settled automatically by Polymarket',
+  createdAt: '2026-07-05T00:00:00.000Z',
+  oracle: {
+    source: 'polymarket',
+    conditionId: CONDITION,
+    question: 'Will ETH flip BTC?',
+    outcomes: ['Yes', 'No'],
+    creatorSide: 0,
+    endDate: '2026-12-31T00:00:00Z',
+    slug: 'will-eth-flip-btc',
+    ...over,
+  },
+})
+
+const liveMarket = (over = {}) => ({
+  id: 'm1',
+  slug: 'will-eth-flip-btc',
+  question: 'Will ETH flip BTC?',
+  conditionId: CONDITION,
+  endDate: '2026-12-31T00:00:00Z',
+  active: true,
+  closed: false,
+  outcomes: [{ name: 'Yes', price: 0.62 }, { name: 'No', price: 0.38 }],
+  ...over,
+})
+
+function renderPanel({ wager = oracleWager(), terms = sealedTerms(), termsUnavailable = false, needsMembership = false } = {}) {
+  return render(
+    <TakeChallengePanel
+      code="river tiger kite zoo"
+      match={{ wagerId: 1n, wager, terms, termsUnavailable, needsMembership }}
+      onClose={() => {}}
+    />
+  )
+}
+
+describe('TakeChallengePanel — oracle bet summary (spec 041, US2)', () => {
+  beforeEach(() => {
+    accept.mockReset()
+    Object.assign(liveHolder, { market: null, isLoading: false, error: null })
+  })
+
+  it('shows the complete bet on one view: question, YOUR side, stake, payout, deadlines (SC-004)', () => {
+    liveHolder.market = liveMarket()
+    renderPanel()
+
+    expect(screen.getByText('Will ETH flip BTC?')).toBeInTheDocument()
+    // Creator took YES → the taker gets NO, spelled out.
+    expect(screen.getByText(/you take:/i).parentElement).toHaveTextContent(/No/)
+    expect(screen.getByText(/creator holds:/i).parentElement).toHaveTextContent(/Yes/)
+    // Stake + payout from the on-chain equal stakes.
+    expect(screen.getByLabelText(/stake and payout/i)).toHaveTextContent(/10 USDC/)
+    expect(screen.getByLabelText(/stake and payout/i)).toHaveTextContent(/20 USDC/)
+    // Deadlines (existing block still renders).
+    expect(screen.getByText(/take by/i)).toBeInTheDocument()
+    expect(screen.getByText(/resolve by/i)).toBeInTheDocument()
+    // Live context row with prices + open status.
+    expect(screen.getByRole('status')).toHaveTextContent(/Yes 62¢ · No 38¢/)
+    expect(screen.getByRole('status')).toHaveTextContent(/market open/i)
+    // Public market link from the sealed slug.
+    expect(screen.getByRole('link', { name: /view on polymarket/i }))
+      .toHaveAttribute('href', 'https://polymarket.com/market/will-eth-flip-btc')
+  })
+
+  it('names Polymarket as the settlement source with a plain-language explanation — live AND degraded (FR-013/SC-005)', () => {
+    const badge = () => screen.getByText(/settled automatically by/i, { selector: '.tc-oracle-badge-text' })
+    liveHolder.market = liveMarket()
+    const live = renderPanel()
+    expect(badge()).toHaveTextContent(/Polymarket/)
+    expect(screen.getByText(/neither you, the creator, nor anyone else/i)).toBeInTheDocument()
+    live.unmount()
+
+    Object.assign(liveHolder, { market: null, error: 'down' })
+    renderPanel()
+    expect(badge()).toHaveTextContent(/Polymarket/)
+  })
+
+  it('degraded state: sealed terms still render the bet, unavailability is disclosed, accept stays enabled (FR-014)', () => {
+    Object.assign(liveHolder, { market: null, error: 'network down' })
+    renderPanel()
+
+    expect(screen.getByText('Will ETH flip BTC?')).toBeInTheDocument()
+    expect(screen.getByText(/live market info unavailable/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /accept challenge/i })).toBeEnabled()
+  })
+
+  it('side labels follow on-chain creatorIsYes in both directions (D6)', () => {
+    liveHolder.market = liveMarket()
+    const a = renderPanel({ wager: oracleWager({ creatorIsYes: false }) })
+    expect(screen.getByText(/you take:/i).parentElement).toHaveTextContent(/Yes/)
+    a.unmount()
+
+    renderPanel({ wager: oracleWager({ creatorIsYes: true }) })
+    expect(screen.getByText(/you take:/i).parentElement).toHaveTextContent(/No/)
+  })
+
+  it('flags a sealed oracle block that does not match the on-chain linkage (honest state)', () => {
+    liveHolder.market = liveMarket()
+    renderPanel({ terms: sealedTerms({ conditionId: '0x' + 'ab'.repeat(32) }) })
+    expect(screen.getByText(/doesn't match the market this challenge is actually linked to/i)).toBeInTheDocument()
+  })
+
+  it('renders from live data alone for a legacy bundle without an oracle block (no false warning)', () => {
+    liveHolder.market = liveMarket()
+    renderPanel({ terms: { description: 'legacy' } })
+    expect(screen.getByText('Will ETH flip BTC?')).toBeInTheDocument()
+    expect(screen.queryByText(/doesn't match the market/i)).toBeNull()
+  })
+
+  it('warns (but does not block) when the market has closed without a public outcome (FR-015)', () => {
+    liveHolder.market = liveMarket({ closed: true, outcomes: [{ name: 'Yes', price: 0.7 }, { name: 'No', price: 0.3 }] })
+    renderPanel()
+    expect(screen.getByText(/already closed/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /accept challenge/i })).toBeEnabled()
+  })
+
+  it('blocks acceptance with an explanation when the outcome is already public (FR-015/D8)', () => {
+    liveHolder.market = liveMarket({ closed: true, outcomes: [{ name: 'Yes', price: 1 }, { name: 'No', price: 0 }] })
+    renderPanel()
+    const btn = screen.getByRole('button', { name: /accept challenge/i })
+    expect(btn).toBeDisabled()
+    expect(screen.getByText(/can no longer be taken fairly/i)).toBeInTheDocument()
+    expect(screen.getByText(/can no longer be taken fairly/i).parentElement).toHaveTextContent(/Yes/)
+  })
+
+  it('non-oracle challenges are unchanged apart from the new stake/payout line (FR-018)', () => {
+    renderPanel({
+      wager: oracleWager({ resolutionType: 0n, polymarketConditionId: '0x' + '0'.repeat(64) }),
+      terms: { description: 'plain user-defined bet' },
+    })
+    expect(screen.queryByText(/settled automatically by/i)).toBeNull()
+    expect(screen.queryByRole('status')).toBeNull()
+    expect(screen.getByLabelText(/stake and payout/i)).toHaveTextContent(/10 USDC/)
+    expect(screen.getByRole('button', { name: /accept challenge/i })).toBeEnabled()
+  })
+})

--- a/frontend/src/test/oracleTimeline.test.js
+++ b/frontend/src/test/oracleTimeline.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import {
+  deriveOracleChallengeTimeline,
+  MIN_LEAD_MS,
+  ACCEPT_CAP_MS,
+  SETTLE_BUFFER_MS,
+  RESOLVE_CAP_MS,
+} from '../lib/openChallenge/oracleTimeline'
+
+const HOUR = 60 * 60 * 1000
+const DAY = 24 * HOUR
+const NOW = Date.parse('2026-07-05T12:00:00Z')
+
+const iso = (ms) => new Date(ms).toISOString()
+
+describe('deriveOracleChallengeTimeline (spec 041, FR-007/FR-003, SC-003)', () => {
+  it('is ineligible without an end date', () => {
+    for (const bad of [null, undefined, '']) {
+      const r = deriveOracleChallengeTimeline(bad, NOW)
+      expect(r.eligible).toBe(false)
+      expect(r.reason).toMatch(/end date/i)
+      expect(r.acceptDeadlineMs).toBeNull()
+      expect(r.resolveDeadlineMs).toBeNull()
+    }
+  })
+
+  it('is ineligible with a garbage end date', () => {
+    const r = deriveOracleChallengeTimeline('not-a-date', NOW)
+    expect(r.eligible).toBe(false)
+    expect(r.reason).toMatch(/end date/i)
+  })
+
+  it('is ineligible when the market ends inside the minimum lead time', () => {
+    const past = deriveOracleChallengeTimeline(iso(NOW - DAY), NOW)
+    expect(past.eligible).toBe(false)
+
+    const tooSoon = deriveOracleChallengeTimeline(iso(NOW + MIN_LEAD_MS - 1), NOW)
+    expect(tooSoon.eligible).toBe(false)
+    expect(tooSoon.reason).toMatch(/too soon/i)
+
+    const justEnough = deriveOracleChallengeTimeline(iso(NOW + MIN_LEAD_MS + 1000), NOW)
+    expect(justEnough.eligible).toBe(true)
+  })
+
+  it('uses the market end as the accept deadline when inside the 30-day cap', () => {
+    const end = NOW + 5 * DAY
+    const r = deriveOracleChallengeTimeline(iso(end), NOW)
+    expect(r.eligible).toBe(true)
+    expect(r.acceptCapped).toBe(false)
+    expect(r.acceptDeadlineMs).toBe(end)
+    expect(r.resolveDeadlineMs).toBe(end + SETTLE_BUFFER_MS)
+  })
+
+  it('caps the accept deadline at 30 days minus margin for far-future events, and discloses it', () => {
+    const end = NOW + 90 * DAY
+    const r = deriveOracleChallengeTimeline(iso(end), NOW)
+    expect(r.eligible).toBe(true)
+    expect(r.acceptCapped).toBe(true)
+    expect(r.acceptDeadlineMs).toBe(NOW + ACCEPT_CAP_MS)
+    // Settlement still tracks the event (end + buffer), within the resolve cap.
+    expect(r.resolveDeadlineMs).toBe(end + SETTLE_BUFFER_MS)
+  })
+
+  it('caps the resolve deadline at 180 days minus margin for very far events', () => {
+    const end = NOW + 179 * DAY
+    const r = deriveOracleChallengeTimeline(iso(end), NOW)
+    expect(r.eligible).toBe(true)
+    expect(r.resolveDeadlineMs).toBe(NOW + RESOLVE_CAP_MS)
+  })
+
+  it('holds the contract-safety invariants for every eligible output', () => {
+    // Sweep a wide range of end dates: from just past the lead floor to past both caps.
+    const ends = [
+      NOW + MIN_LEAD_MS + 1000,
+      NOW + 6 * HOUR,
+      NOW + 2 * DAY,
+      NOW + 29 * DAY,
+      NOW + 30 * DAY,
+      NOW + 31 * DAY,
+      NOW + 100 * DAY,
+      NOW + 179 * DAY,
+      NOW + 400 * DAY,
+    ]
+    for (const end of ends) {
+      const r = deriveOracleChallengeTimeline(iso(end), NOW)
+      expect(r.eligible).toBe(true)
+      expect(r.acceptDeadlineMs).toBeGreaterThan(NOW)
+      expect(r.resolveDeadlineMs).toBeGreaterThan(r.acceptDeadlineMs)
+      expect(r.acceptDeadlineMs).toBeLessThanOrEqual(NOW + 30 * DAY)
+      expect(r.resolveDeadlineMs).toBeLessThanOrEqual(NOW + 180 * DAY)
+      // The challenge is never takeable after the event closes (SC-003).
+      expect(r.acceptDeadlineMs).toBeLessThanOrEqual(end)
+    }
+  })
+
+  it('is deterministic for an injected clock (no internal Date.now reads)', () => {
+    const end = iso(NOW + 10 * DAY)
+    const a = deriveOracleChallengeTimeline(end, NOW)
+    const b = deriveOracleChallengeTimeline(end, NOW)
+    expect(a).toEqual(b)
+  })
+})

--- a/frontend/src/test/useOpenChallengeAccept.test.jsx
+++ b/frontend/src/test/useOpenChallengeAccept.test.jsx
@@ -11,7 +11,7 @@ const ACCOUNT = '0x3333333333333333333333333333333333333333'
 const STAKE = 10_000_000n // 10 USDC (6 decimals)
 
 const { state, calls } = vi.hoisted(() => ({
-  state: { allowance: 0n, balance: 100_000_000n, wagerId: 0n, throwLookup: false },
+  state: { allowance: 0n, balance: 100_000_000n, wagerId: 0n, throwLookup: false, metadataUri: '' },
   calls: [],
 }))
 
@@ -54,7 +54,12 @@ vi.mock('ethers', async () => {
         openWagerIdForClaim: () => state.throwLookup
           ? Promise.reject(new Error('rpc down'))
           : Promise.resolve(state.wagerId),
-        getWager: () => Promise.resolve({ token: TOKEN, opponentStake: STAKE, creator: '0xCreator', metadataUri: '' }),
+        getWager: () => Promise.resolve({
+          token: TOKEN, opponentStake: STAKE, creatorStake: STAKE, creator: '0xCreator',
+          metadataUri: state.metadataUri,
+          // Oracle linkage fields (spec 041) — already part of the on-chain struct.
+          resolutionType: 4n, polymarketConditionId: '0xc0ffee', creatorIsYes: true,
+        }),
         acceptOpenWager,
       }
     }
@@ -156,5 +161,38 @@ describe('useOpenChallengeAccept.lookup (structured outcome)', () => {
     await act(async () => { res = await result.current.lookup('river tiger kite zoo') })
     expect(res.status).toBe('errored')
     expect(res.error).toBeInstanceOf(Error)
+  })
+})
+
+// Spec 041: the lookup payload must carry the on-chain oracle linkage untouched, and a
+// sealed terms bundle with an `oracle` block must reach the caller — the claimant view
+// (TakeChallengePanel) renders the bet from exactly these fields. Accept is unchanged.
+describe('useOpenChallengeAccept.lookup (oracle open challenges, spec 041)', () => {
+  beforeEach(() => { calls.length = 0; state.wagerId = 7n; state.throwLookup = false; state.metadataUri = 'ipfs-enc://cid' })
+
+  it('passes through resolutionType/polymarketConditionId/creatorIsYes and the sealed oracle block', async () => {
+    const { parseEncryptedIpfsReference, fetchEncryptedEnvelope } = await import('../utils/ipfsService')
+    const { decryptEnvelopeCode, isCodeEnvelope } = await import('../utils/crypto/envelopeEncryption.js')
+    parseEncryptedIpfsReference.mockReturnValue({ isIpfs: true, cid: 'cid' })
+    fetchEncryptedEnvelope.mockResolvedValue({ sealed: true })
+    isCodeEnvelope.mockReturnValue(true)
+    decryptEnvelopeCode.mockReturnValue({
+      description: 'Will ETH flip BTC? — creator takes Yes · settled automatically by Polymarket',
+      oracle: { source: 'polymarket', conditionId: '0xc0ffee', question: 'Will ETH flip BTC?', outcomes: ['Yes', 'No'], creatorSide: 0 },
+    })
+
+    const { result } = renderHook(() => useOpenChallengeAccept())
+    let res
+    await act(async () => { res = await result.current.lookup('river tiger kite zoo') })
+
+    expect(res.status).toBe('matched')
+    const { wager, terms, termsUnavailable } = res.payload
+    expect(termsUnavailable).toBe(false)
+    expect(wager.resolutionType).toBe(4n)
+    expect(wager.polymarketConditionId).toBe('0xc0ffee')
+    expect(wager.creatorIsYes).toBe(true)
+    expect(terms.oracle).toMatchObject({ source: 'polymarket', conditionId: '0xc0ffee', outcomes: ['Yes', 'No'] })
+    // Read-only — no approval/acceptance sent by a lookup.
+    expect(calls).toEqual([])
   })
 })

--- a/frontend/src/test/usePolymarketMarket.test.jsx
+++ b/frontend/src/test/usePolymarketMarket.test.jsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { usePolymarketMarket } from '../hooks/usePolymarketMarket'
+import { installGammaFetch, urlHas } from './helpers/mockGammaFetch'
+
+const ZERO_HASH = '0x0000000000000000000000000000000000000000000000000000000000000000'
+
+// Raw Gamma market shape (outcomes/outcomePrices are JSON strings on the wire).
+const rawMarket = (over = {}) => ({
+  id: 'm1',
+  question: 'Will it happen?',
+  conditionId: '0xabc123',
+  slug: 'will-it-happen',
+  endDate: '2026-12-31T00:00:00Z',
+  volume: 12345,
+  active: true,
+  closed: false,
+  outcomes: JSON.stringify(['Yes', 'No']),
+  outcomePrices: JSON.stringify(['0.62', '0.38']),
+  ...over,
+})
+
+describe('usePolymarketMarket (spec 041, FR-014)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('fetches by condition id and returns the normalized market shape', async () => {
+    const fetchMock = installGammaFetch([
+      { match: urlHas('/markets?condition_ids=0xabc123'), json: [rawMarket()] },
+    ])
+
+    const { result } = renderHook(() => usePolymarketMarket('0xabc123'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain('condition_ids=0xabc123')
+    expect(result.current.error).toBeNull()
+    expect(result.current.market).toMatchObject({
+      conditionId: '0xabc123',
+      question: 'Will it happen?',
+      slug: 'will-it-happen',
+      closed: false,
+      outcomes: [
+        { name: 'Yes', price: 0.62 },
+        { name: 'No', price: 0.38 },
+      ],
+    })
+  })
+
+  it('reports an error (market null) when the market is not found', async () => {
+    installGammaFetch([{ match: urlHas('/markets'), json: [] }])
+
+    const { result } = renderHook(() => usePolymarketMarket('0xdeadbeef'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.market).toBeNull()
+    expect(result.current.error).toBeTruthy()
+  })
+
+  it('reports an error on a non-OK response and on network failure — never throws', async () => {
+    installGammaFetch([{ match: urlHas('/markets'), ok: false, status: 503 }])
+    const bad = renderHook(() => usePolymarketMarket('0xabc123'))
+    await waitFor(() => expect(bad.result.current.isLoading).toBe(false))
+    expect(bad.result.current.market).toBeNull()
+    expect(bad.result.current.error).toMatch(/503/)
+    bad.unmount()
+
+    installGammaFetch([{ match: urlHas('/markets'), error: new Error('network down') }])
+    const failed = renderHook(() => usePolymarketMarket('0xdef456'))
+    await waitFor(() => expect(failed.result.current.isLoading).toBe(false))
+    expect(failed.result.current.market).toBeNull()
+    expect(failed.result.current.error).toBeTruthy()
+  })
+
+  it('skips the fetch entirely for falsy or zero-hash condition ids, and when disabled', async () => {
+    const fetchMock = installGammaFetch([{ match: () => true, json: [rawMarket()] }])
+
+    const none = renderHook(() => usePolymarketMarket(null))
+    const zero = renderHook(() => usePolymarketMarket(ZERO_HASH))
+    const off = renderHook(() => usePolymarketMarket('0xabc123', { enabled: false }))
+    await waitFor(() => {
+      expect(none.result.current.isLoading).toBe(false)
+      expect(zero.result.current.isLoading).toBe(false)
+      expect(off.result.current.isLoading).toBe(false)
+    })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    for (const r of [none, zero, off]) {
+      expect(r.result.current.market).toBeNull()
+      expect(r.result.current.error).toBeNull()
+    }
+  })
+
+  it('refresh() refetches on demand', async () => {
+    const fetchMock = installGammaFetch([
+      { match: urlHas('/markets'), json: [rawMarket({ outcomePrices: JSON.stringify(['0.7', '0.3']) })] },
+    ])
+
+    const { result } = renderHook(() => usePolymarketMarket('0xabc123'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => { await result.current.refresh() })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(result.current.market.outcomes[0].price).toBe(0.7)
+  })
+})

--- a/specs/041-oracle-open-challenges/checklists/requirements.md
+++ b/specs/041-oracle-open-challenges/checklists/requirements.md
@@ -1,0 +1,47 @@
+# Specification Quality Checklist: Oracle-Settled Open Challenges (Polymarket)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-05
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Ambiguities were resolved with documented defaults instead of
+  clarification markers, because clear precedents exist in the codebase and prior
+  specs (see Assumptions):
+  - Oracle scope → Polymarket only in v1 (matches the platform's current oracle
+    exposure default and the user's description).
+  - Timeline control → derived from the event, shown but not hand-edited (user's
+    description: "the event defines the timelines"), capped by existing platform
+    bounds.
+  - Side selection → creator explicitly picks a side of a binary market; taker
+    gets the opposite (required for any oracle-settled two-party wager).
+- "Polymarket" appears in requirements as the *product-level oracle source* the
+  user mandated — a business requirement, not an implementation choice.
+- Ready for `/speckit-plan` (or `/speckit-clarify` if the defaults above should be
+  revisited).

--- a/specs/041-oracle-open-challenges/contracts/claimant-view.md
+++ b/specs/041-oracle-open-challenges/contracts/claimant-view.md
@@ -1,0 +1,54 @@
+# Module Contract: Claimant View — Oracle Bet Summary
+
+**Component**: `TakeChallengePanel.jsx` (extended). Lookup plumbing
+(`UnifiedLookupModal` → `useOpenChallengeAccept.lookup`) is reused unchanged — the
+`getWager` struct already returns `resolutionType`, `polymarketConditionId`,
+`creatorIsYes`, and stakes.
+
+## Rendering contract (when `Number(wager.resolutionType) === ResolutionType.Polymarket`)
+
+Between the decrypted terms and the deadlines block, render an **oracle bet summary**:
+
+1. **Bet statement** (single view, no navigation — FR-012/SC-004):
+   - Market question — from verified `terms.oracle.question`, else live market, else
+     "market details unavailable" fallback with the on-chain condition id shortened.
+   - "You take: **{takerSideLabel}**" and "Creator holds: {creatorSideLabel}" — labels
+     from `terms.oracle.outcomes` (verified) or live market outcomes; side assignment
+     ALWAYS from on-chain `creatorIsYes` (taker = opposite).
+   - Stake and payout: "You stake {stake} — winner takes {2×stake}" from on-chain
+     `opponentStake` + token decimals/symbol.
+2. **Settlement source (FR-013 / SC-005)**: a distinct badge — glyph + text
+   "Settled automatically by **Polymarket**" — plus one plain-language sentence:
+   the linked public market's resolution decides the winner; neither participant (nor
+   any arbitrator) judges the outcome. Link to the public market page when `slug` is
+   known. Rendered in BOTH live and degraded states.
+3. **Live market context (FR-014)**: via `usePolymarketMarket(wager.polymarketConditionId)` —
+   current prices per outcome, open/closed status, end date. While loading: skeleton row
+   (never blocks the bound terms). On error: "Live market info unavailable right now —
+   the bet terms above are binding" notice; accept stays enabled.
+4. **Integrity (Constitution III)**: if `terms.oracle` exists and
+   `terms.oracle.conditionId !== wager.polymarketConditionId` (case-insensitive hex
+   compare) → show a warning that the stored description does not match the on-chain
+   market linkage, and prefer live-market data for display. Missing `terms.oracle`
+   (legacy bundle) → `unverifiable`: fall back to live data without a warning.
+5. **Accept gate (FR-015, D8)**:
+   - Live market `closed === true` or past `endDate` (but no outcome known) → prominent
+     warning above the accept button; accept remains possible.
+   - Live data shows a resolved outcome → accept button disabled with explanation
+     ("This market has already resolved — this challenge can no longer be taken
+     fairly.").
+   - Live data unreachable → no gate beyond the on-chain accept deadline (disclosed).
+6. **Non-oracle challenges** (`Either`/`ThirdParty`): rendering unchanged from today,
+   except the bet summary's stake/payout line is also added (small, uniform
+   improvement; existing tests updated accordingly).
+
+## Accessibility
+
+Badge conveys meaning by text + glyph (not color alone); live-status updates use
+`role="status"`; the disabled accept state has an explanatory adjacent text node, not
+just `disabled`.
+
+## Accept flow
+
+`useOpenChallengeAccept.accept` is resolution-type agnostic and unchanged; the only new
+behavior is the app-level gate above (a UI predicate, not a hook change).

--- a/specs/041-oracle-open-challenges/contracts/create-flow.md
+++ b/specs/041-oracle-open-challenges/contracts/create-flow.md
@@ -1,0 +1,82 @@
+# Module Contract: Oracle Open Challenge — Create Flow
+
+**Components**: `OracleOpenChallengeModal.jsx` (new), `ClaimCodeResultPanel.jsx`
+(extracted), `useOpenChallengeCreate.js` (extended)
+
+## OracleOpenChallengeModal
+
+```jsx
+<OracleOpenChallengeModal isOpen={bool} onClose={fn} />
+```
+
+Behavior contract:
+
+1. **Gating**: renders nothing useful on chains without `capabilities.polymarketSidebets`
+   or when `!isOracleModelExposed(ResolutionType.Polymarket)`; Dashboard also hides/locks
+   the entry card (see FR-004). `PolymarketBrowser` self-gates as a second layer.
+2. **Discovery step**: `PolymarketBrowser variant="inline" showFilters limit={20}
+   onSelectMarket={...} selectedConditionId={...}` — default feed with no input,
+   category chips, debounced search, event grouping (all existing behavior).
+   Markets failing `deriveOracleChallengeTimeline(...).eligible` (ends < 1h out,
+   closed, unparseable end) are not selectable; the card shows the reason.
+3. **Configure step** (market selected): shows question + image + endDate + live prices;
+   side picker = two labelled buttons from `market.outcomes[].name` (fallback Yes/No)
+   with prices, `aria-pressed`, keyboard operable; stake input identical to
+   `OpenChallengeModal` (USDC, `> 0`, 2-dp normalize on blur); derived timeline rendered
+   read-only ("Takeable until … · settles by …", sourced from the event; discloses when
+   the 30-day cap shortened it). No editable date inputs.
+4. **Create**: calls `createOpenChallenge` (below) with
+   `resolutionType: ResolutionType.Polymarket`, `oracleConditionId: market.conditionId`,
+   `creatorIsYes: side === 0`, derived deadlines (ms → hook converts), auto-composed
+   `description`, and `oracleMeta` for the sealed block. Progress states mirror
+   `OpenChallengeModal` (`onProgress` messages), errors surface translated reverts.
+5. **Result**: renders `ClaimCodeResultPanel` (below) — behavior identical to the
+   user-defined flow (code shown once, copy, QR, deep link, auto vault backup).
+
+## ClaimCodeResultPanel (extraction — no behavior change)
+
+```jsx
+<ClaimCodeResultPanel result={{ code, wagerId, txHash }} onDone={fn} />
+```
+
+Extracted from `OpenChallengeModal`'s post-create UI. MUST preserve: one-time code
+display, copy-with-confirmation, `WagerQRCode` + `buildTakeChallengeUrl` deep link,
+`useOpenChallengeCodeVault` auto-backup with `idle|saving|saved|error` states.
+`OpenChallengeModal` switches to this component; its existing tests stay green.
+
+## useOpenChallengeCreate (extension)
+
+Accepted form fields (existing + new semantics):
+
+```js
+createOpenChallenge({
+  description,            // auto-composed by the oracle modal
+  stake, token?,
+  acceptDeadline, resolveDeadline,   // unix seconds (derived, not hand-picked)
+  resolutionType,          // 4 (Polymarket) for this flow — already supported
+  oracleConditionId,       // market.conditionId — already threaded to the contract
+  creatorIsYes,            // side === 0 — already threaded to the contract
+  oracleMeta?,             // NEW: { source, conditionId, question, outcomes,
+                           //        creatorSide, endDate, slug } — sealed, never on-chain plaintext
+}, onProgress)
+```
+
+Contract:
+
+- When `oracleMeta` is present, the sealed plaintext becomes
+  `{ description, createdAt: <ISO now>, oracle: oracleMeta }`; otherwise the payload is
+  unchanged (`{ description, createdAt }`) — user-defined flow byte-compatible.
+- `translateOpenCreateRevert` gains mappings: `PolymarketRequired` → "Pick a market to
+  link…", `AdapterNotSet` → "Polymarket settlement isn't available on this network…",
+  `ConditionAlreadyResolved` → "That market has already resolved — pick a live one.",
+  `PolymarketDisallowed` → internal-consistency message. (FR-008 UX; the revert itself
+  is the on-chain re-validation.)
+- Return shape unchanged: `{ code, wagerId, txHash }`.
+
+## Dashboard wiring
+
+- `quickAccessCards.js`: add `{ id: 'oracle-open-challenge', label: 'Oracle Open
+  Challenge', … }`.
+- `Dashboard.jsx`: card in `createActions` (capability-aware like `create-1v1-oracle`),
+  `handleQuickAction('oracle-open-challenge')` → open the new modal; modal instance
+  alongside `OpenChallengeModal`. Existing cards/flows untouched.

--- a/specs/041-oracle-open-challenges/contracts/polymarket-market-hook.md
+++ b/specs/041-oracle-open-challenges/contracts/polymarket-market-hook.md
@@ -1,0 +1,34 @@
+# Module Contract: usePolymarketMarket
+
+**File**: `frontend/src/hooks/usePolymarketMarket.js` (new)
+
+## Signature
+
+```js
+const { market, isLoading, error, refresh } = usePolymarketMarket(conditionId, {
+  enabled = true,   // skip fetch entirely (e.g. non-oracle challenge, gated chain)
+} = {})
+```
+
+## Contract
+
+- Fetches `GET {gammaBase}/markets?condition_ids=<conditionId>&limit=1` where
+  `gammaBase` comes from the active network config exactly as `usePolymarketSearch`
+  resolves it (`getNetwork(chainId)?.polymarket?.gammaApiUrl` with the public default).
+- Normalizes the first result with `normaliseGammaMarket` (exported from
+  `usePolymarketSearch.js` as part of this feature) → the LinkedMarket shape
+  (`outcomes: [{ name, price }]`, `endDate`, `active`, `closed`, `slug`, …).
+- `conditionId` falsy, zero-hash, or `enabled: false` → no fetch,
+  `{ market: null, isLoading: false, error: null }`.
+- Not found / non-OK / network failure → `{ market: null, error }` (message safe to
+  display); NEVER throws into render. No retry storm: single fetch per
+  (conditionId, chainId) mount + manual `refresh()`.
+- No polling in v1 (claimant view is short-lived); `refresh` allows explicit re-check.
+- Aborts in-flight request on unmount/param change (same AbortController discipline as
+  the search hook).
+
+## Consumers
+
+- `TakeChallengePanel` (claimant live context + accept gate)
+- `OracleOpenChallengeModal` (optional freshness re-check of the selected market before
+  submit; selection data itself comes from the browser feed)

--- a/specs/041-oracle-open-challenges/contracts/timeline-derivation.md
+++ b/specs/041-oracle-open-challenges/contracts/timeline-derivation.md
@@ -1,0 +1,45 @@
+# Module Contract: deriveOracleChallengeTimeline
+
+**File**: `frontend/src/lib/openChallenge/oracleTimeline.js` (new, pure — no React)
+
+## Signature
+
+```js
+deriveOracleChallengeTimeline(marketEndIso, nowMs = Date.now()) => {
+  eligible: boolean,
+  reason: string | null,        // set iff !eligible
+  acceptDeadlineMs: number|null,
+  resolveDeadlineMs: number|null,
+  acceptCapped: boolean,        // 30-day cap shortened the accept window
+}
+```
+
+## Constants (exported for tests/UI copy)
+
+| Name | Value | Source |
+|---|---|---|
+| `MIN_LEAD_MS` | 1 hour | existing oracle-flow minimum ("at least 1 hour from now") |
+| `ACCEPT_CAP_MS` | 30 days − 1 hour | contract `MAX_ACCEPT_WINDOW` (30d) minus tx-safety margin |
+| `SETTLE_BUFFER_MS` | 7 days | time for market resolution + `autoResolveFromPolymarket` call |
+| `RESOLVE_CAP_MS` | 180 days − 1 hour | contract `MAX_RESOLVE_WINDOW` (180d) minus margin |
+
+## Rules
+
+1. Unparseable/absent `marketEndIso` → `{ eligible: false, reason }`.
+2. `marketEnd < now + MIN_LEAD_MS` → ineligible ("ends too soon to share a challenge").
+3. `acceptDeadlineMs = min(marketEnd, now + ACCEPT_CAP_MS)`;
+   `acceptCapped = (now + ACCEPT_CAP_MS) < marketEnd`.
+4. `resolveDeadlineMs = min(marketEnd + SETTLE_BUFFER_MS, now + RESOLVE_CAP_MS)`.
+5. Invariants (MUST hold for every eligible output; unit-tested):
+   `now < acceptDeadlineMs < resolveDeadlineMs`,
+   `acceptDeadlineMs ≤ now + 30d`, `resolveDeadlineMs ≤ now + 180d`
+   (i.e. the contract's `_checkDeadlines` can never revert on derived values).
+6. Deterministic: no internal clock reads — `nowMs` injected (testable, and the modal
+   anchors it at mount like `OpenChallengeModal` does).
+
+## Consumers
+
+- `PolymarketBrowser`-fed selection filter in `OracleOpenChallengeModal` (ineligible
+  markets unselectable, reason shown)
+- Derived-timeline display (read-only) + `createOpenChallenge` deadline args
+- Vitest: `frontend/src/test/oracleTimeline.test.js`

--- a/specs/041-oracle-open-challenges/data-model.md
+++ b/specs/041-oracle-open-challenges/data-model.md
@@ -1,0 +1,86 @@
+# Data Model: Oracle-Settled Open Challenges (Polymarket)
+
+**Feature**: 041 | **Date**: 2026-07-05 | **Plan**: [plan.md](./plan.md)
+
+No new on-chain state and no new persisted stores. This feature composes existing
+on-chain wager fields with one extended off-chain sealed payload and a handful of
+client-side view models.
+
+## On-chain (existing fields, newly exercised — read-only for this feature)
+
+**Wager** (`WagerRegistry.getWager`, fields already in the deployed struct/ABI):
+
+| Field | Type | Use in this feature |
+|---|---|---|
+| `resolutionType` | enum (4 = Polymarket) | Discriminates an oracle open challenge in the claimant view |
+| `polymarketConditionId` | bytes32 | Authoritative market linkage; key for live lookup; cross-check vs sealed metadata |
+| `creatorIsYes` | bool | Authoritative side assignment; claimant side = opposite |
+| `creatorStake` / `opponentStake` | uint128 | Equal stakes; drives stake + payout display |
+| `acceptDeadline` / `resolveDeadline` | uint64 | Derived timeline (already displayed) |
+| `metadataUri` / `metadataHash` | string / bytes32 | Code-keyed sealed terms envelope reference (spec 024, unchanged mechanics) |
+
+Constraints enforced on-chain at creation (existing): non-zero conditionId, adapter
+configured, condition unresolved, deadlines within `MAX_ACCEPT_WINDOW` (30d) /
+`MAX_RESOLVE_WINDOW` (180d), equal stakes, Silver+ creator, no self-resolution types.
+
+## Sealed terms payload (extended — code-keyed envelope, IPFS)
+
+`SealedOpenChallengeTerms` — plaintext sealed by `encryptEnvelopeCode` (spec 024
+envelope format unchanged; this only extends the JSON inside):
+
+| Field | Type | Rules |
+|---|---|---|
+| `description` | string | Auto-composed for oracle challenges: market question + creator's side (human-readable standalone) |
+| `createdAt` | ISO string | Now populated at creation |
+| `oracle` | object \| absent | Present only for oracle-settled challenges |
+| `oracle.source` | `"polymarket"` | Settlement source label key |
+| `oracle.conditionId` | hex string | MUST equal on-chain `polymarketConditionId`; claimant view flags mismatch and does not trust the bundle |
+| `oracle.question` | string | Market question for offline display |
+| `oracle.outcomes` | string[2] | Outcome labels, index-aligned with adapter ordering (0 = YES side) |
+| `oracle.creatorSide` | 0 \| 1 | Creator's outcome index; MUST agree with on-chain `creatorIsYes` (0 ⇄ true) |
+| `oracle.endDate` | ISO string | Market's scheduled end (timeline provenance display) |
+| `oracle.slug` | string | Polymarket slug (deep link to the public market page) |
+
+Backward compatibility: bundles without `oracle` render exactly as today
+(user-defined challenges, pre-041 challenges).
+
+## Client-side view models (in-memory only)
+
+**LinkedMarket** — normalized Gamma market (existing `normaliseGammaMarket` shape,
+now also produced by `usePolymarketMarket(conditionId)`):
+`{ id, slug, question, label, description, conditionId, endDate, volume, liquidity,
+active, closed, image, outcomes: [{ name, price }] }`
+
+**DerivedTimeline** — output of `deriveOracleChallengeTimeline(marketEndIso, nowMs)`:
+
+| Field | Type | Rules |
+|---|---|---|
+| `eligible` | boolean | false when market end < now + 1h (MIN_LEAD) or unparseable |
+| `reason` | string \| null | Ineligibility explanation for UI |
+| `acceptDeadlineMs` | number | `min(marketEnd, now + 30d − 1h)`; always > now when eligible |
+| `resolveDeadlineMs` | number | `min(marketEnd + 7d, now + 180d − 1h)`; always > acceptDeadlineMs |
+| `acceptCapped` | boolean | true when the 30-day cap shortened the accept window (UI discloses) |
+
+**OracleChallengeDraft** — create-modal state:
+`{ market: LinkedMarket, side: 0|1, stake: string, timeline: DerivedTimeline }` →
+submitted to `useOpenChallengeCreate` as
+`{ description (auto), stake, resolutionType: 4, oracleConditionId: market.conditionId,
+creatorIsYes: side === 0, acceptDeadline, resolveDeadline, oracleMeta (sealed block) }`.
+
+**ClaimantOracleSummary** — derived in `TakeChallengePanel` for `resolutionType === 4`:
+
+| Field | Source | Notes |
+|---|---|---|
+| `question`, `outcomes`, `slug` | sealed `terms.oracle` (verified) → live market fallback | Either source may be missing; view renders best available and discloses |
+| `takerSide` / `creatorSide` labels | on-chain `creatorIsYes` + outcome labels | On-chain bool is authoritative |
+| `stake`, `payout` | on-chain `opponentStake` (payout = 2× stake) | Formatted in token units |
+| `live` | `usePolymarketMarket` | `{ market, isLoading, error }`; drives odds/status row |
+| `integrity` | comparison | `'ok' \| 'mismatch' \| 'unverifiable'` (no sealed oracle block) |
+| `acceptGate` | live + deadlines | `'open' \| 'warn-closed' \| 'blocked-resolved'` (D8) |
+
+## State transitions
+
+No new ones. The wager lifecycle is unchanged from spec 024 / existing oracle wagers:
+Open → (accept) Active → (autoResolveFromPolymarket) Resolved/Draw → claimed; or
+Open → cancelled/expired → refund. This feature only changes *how a wager enters*
+Open (with oracle linkage) and *what code-holders see*.

--- a/specs/041-oracle-open-challenges/plan.md
+++ b/specs/041-oracle-open-challenges/plan.md
@@ -1,0 +1,113 @@
+# Implementation Plan: [FEATURE]
+
+**Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
+
+**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+
+**Note**: This template is filled in by the `/speckit-plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+[Extract from feature spec: primary requirement + technical approach from research]
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]
+
+**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]
+
+**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]
+
+**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]
+
+**Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
+
+**Project Type**: [e.g., library/cli/web-service/mobile-app/compiler/desktop-app or NEEDS CLARIFICATION]
+
+**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]
+
+**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]
+
+**Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+[Gates determined based on constitution file]
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit-plan command output)
+├── research.md          # Phase 0 output (/speckit-plan command)
+├── data-model.md        # Phase 1 output (/speckit-plan command)
+├── quickstart.md        # Phase 1 output (/speckit-plan command)
+├── contracts/           # Phase 1 output (/speckit-plan command)
+└── tasks.md             # Phase 2 output (/speckit-tasks command - NOT created by /speckit-plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+# [REMOVE IF UNUSED] Option 1: Single project (DEFAULT)
+src/
+├── models/
+├── services/
+├── cli/
+└── lib/
+
+tests/
+├── contract/
+├── integration/
+└── unit/
+
+# [REMOVE IF UNUSED] Option 2: Web application (when "frontend" + "backend" detected)
+backend/
+├── src/
+│   ├── models/
+│   ├── services/
+│   └── api/
+└── tests/
+
+frontend/
+├── src/
+│   ├── components/
+│   ├── pages/
+│   └── services/
+└── tests/
+
+# [REMOVE IF UNUSED] Option 3: Mobile + API (when "iOS/Android" detected)
+api/
+└── [same as backend above]
+
+ios/ or android/
+└── [platform-specific structure: feature modules, UI flows, platform tests]
+```
+
+**Structure Decision**: [Document the selected structure and reference the real
+directories captured above]
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/041-oracle-open-challenges/plan.md
+++ b/specs/041-oracle-open-challenges/plan.md
@@ -1,113 +1,175 @@
-# Implementation Plan: [FEATURE]
+# Implementation Plan: Oracle-Settled Open Challenges (Polymarket)
 
-**Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
+**Branch**: `claude/oracle-settled-challenges-p3iwl9` | **Date**: 2026-07-05 | **Spec**: [spec.md](./spec.md)
 
-**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
-
-**Note**: This template is filled in by the `/speckit-plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+**Input**: Feature specification from `specs/041-oracle-open-challenges/spec.md`
 
 ## Summary
 
-[Extract from feature spec: primary requirement + technical approach from research]
+Add a new **Oracle Open Challenge** section: the creator picks a live Polymarket market
+through the existing `PolymarketBrowser` discovery UX, picks a side, sets an equal stake,
+and posts a code-gated open challenge whose accept/settle deadlines are **derived from the
+market's own schedule**. The claim-code machinery (spec 024) is reused unchanged; the
+claimant view (`TakeChallengePanel`) gains a clear bet summary with Polymarket unmistakably
+identified as the automatic settlement source, including live market context.
+
+**This is a frontend-only feature — zero Solidity changes.** `WagerRegistry.createOpenWager`
+already accepts and validates oracle linkage (`_checkOracleLinkage` requires a non-zero
+`oracleConditionId`, a configured `polymarketAdapter`, and an *unresolved* condition —
+`WagerRegistryCore.sol:217-230`), stores `creatorIsYes` + `polymarketConditionId`, and the
+post-accept resolution path (`autoResolveFromPolymarket`, `WagerRegistryIntents.sol:226-245`)
+is origin-independent. Even the frontend create hook (`useOpenChallengeCreate`) already
+threads `oracleConditionId`/`creatorIsYes` through to the contract. What's missing is:
+(1) a create UI that collects a market + side, (2) event-derived timeline computation,
+(3) oracle metadata sealed into the terms bundle for the claimant, (4) the claimant-view
+bet summary + Polymarket identification + live market context, (5) oracle-aware revert
+translation, and (6) tests — including contract-level JS tests proving the open + Polymarket
+path end-to-end (none exist today).
 
 ## Technical Context
 
-<!--
-  ACTION REQUIRED: Replace the content in this section with the technical details
-  for the project. The structure here is presented in advisory capacity to guide
-  the iteration process.
--->
+**Language/Version**: JavaScript (ES2022), React 18 function components + hooks; Solidity
+untouched (Hardhat JS tests only)
 
-**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]
+**Primary Dependencies**: React, Vite; `ethers` v6 (registry calls, keccak); existing app
+modules — `useOpenChallengeCreate` / `useOpenChallengeAccept` / code vault (spec 024),
+`PolymarketBrowser` + `usePolymarketSearch` (Gamma API, spec 013), `UnifiedLookupModal` /
+`TakeChallengePanel` (spec 037), `DeadlineTimeline` + `wagerTimeline.js` (spec 038),
+`ChainCapabilityGate` / `useChainTokens` capability gating, `wagerDefaults.js`
+(`ResolutionType`, `isOracleModelExposed`, `toDateTimeLocal`)
 
-**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]
+**Storage**: No new persistence. Sealed terms envelope (IPFS, code-keyed — spec 024) gains
+an optional `oracle` block; on-chain wager struct fields already exist
+(`resolutionType`, `polymarketConditionId`, `creatorIsYes`)
 
-**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]
+**Testing**: Vitest (`npm run test:frontend`) for UI/hooks/pure helpers; Hardhat
+(`npm test`) for new contract-level integration tests of the open + Polymarket lifecycle
+(using `MockPolymarketCTF` + `PolymarketOracleAdapter` + `deployWagerRegistry` fixture)
 
-**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]
+**Target Platform**: Web (mobile-first PWA), `/app` dashboard; active only on chains with
+the `polymarketSidebets` capability (Polygon mainnet, Amoy testnet today)
 
-**Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
+**Project Type**: Web application — `frontend/` plus `test/` (contract JS tests); no
+`contracts/` source changes
 
-**Project Type**: [e.g., library/cli/web-service/mobile-app/compiler/desktop-app or NEEDS CLARIFICATION]
+**Performance Goals**: Discovery reuses PolymarketBrowser's existing debounced search
+(325 ms) and cached feeds — default feed/search visible < 2 s typical (SC-002); claimant
+view renders bound terms immediately and layers live market data in without blocking accept
 
-**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]
+**Constraints**: WCAG 2.1 AA (side picker and share tools are real buttons with labels;
+oracle badge conveyed by text + icon, not color alone); honest state (bound on-chain fields
+are authoritative; terms-bundle market info is cross-checked against
+`wager.polymarketConditionId`; live data unavailability is disclosed, never faked); strict
+per-chain gating (`polymarketSidebets`); no hardcoded addresses/ABIs (generated sync
+artifacts only)
 
-**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]
-
-**Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
+**Scale/Scope**: One new modal (create flow), one claimant-view section, ~2 new hooks/libs
+(single-market fetch, timeline derivation), one shared result-panel extraction, dashboard
+card wiring, ~6 new/extended frontend test files + 1 new contract test file
 
 ## Constitution Check
 
-*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
 
-[Gates determined based on constitution file]
+- **I. Security-First Smart Contracts (NON-NEGOTIABLE)** — **Pass (no contract changes).**
+  Zero Solidity edits; Slither/Medusa scope unchanged. The feature *exercises* an existing
+  oracle-resolution path, which is a highest-risk surface, so the plan adds contract-level
+  JS lifecycle tests (create-open-with-Polymarket → code accept → auto-resolve win/tie →
+  claim; creation reverts for resolved condition / missing adapter / zero conditionId)
+  to prove the deployed logic under the new usage pattern before the UI ships it.
+- **II. Test-First & Comprehensive Coverage (NON-NEGOTIABLE)** — **Pass.** New pure helpers
+  (`deriveOracleChallengeTimeline`, terms-bundle oracle block build/verify) get Vitest unit
+  tests written alongside; component tests for the new create modal, the claimant oracle
+  summary (live, degraded, closed/resolved states), and dashboard wiring; the contract
+  integration tests above cover resolution/claim/refund/timeout edges for the new path.
+- **III. Honest State, No Mocks in Shipped Paths** — **Pass.** The claimant view renders
+  the on-chain-bound side/condition as authoritative, cross-checks sealed market metadata
+  against `wager.polymarketConditionId` (mismatch → flagged, not trusted), shows a truthful
+  "live market info unavailable" state instead of stale/fake odds, and blocks accept when
+  the market already shows a public outcome. Deadlines shown come from the values actually
+  submitted on-chain. No mock data outside test scopes.
+- **IV. Fail Loudly in CI** — **Pass.** No `continue-on-error`; all new tests gate the
+  pipeline (frontend + Hardhat suites).
+- **V. Accessible, Consistent Frontend** — **Pass.** Reuses the shared `fm-*` modal system,
+  `PillSelect`/`InfoTip`/`DeadlineTimeline` components; side picker is a labelled button
+  group (`aria-pressed`); oracle source identified by text + glyph; axe/Lighthouse audits
+  unchanged in CI. Addresses/ABIs come from generated sync artifacts
+  (`getContractAddressForChain`, `abis/WagerRegistry.js`).
+
+**Result: PASS — no violations, Complexity Tracking not required.**
 
 ## Project Structure
 
 ### Documentation (this feature)
 
 ```text
-specs/[###-feature]/
-├── plan.md              # This file (/speckit-plan command output)
-├── research.md          # Phase 0 output (/speckit-plan command)
-├── data-model.md        # Phase 1 output (/speckit-plan command)
-├── quickstart.md        # Phase 1 output (/speckit-plan command)
-├── contracts/           # Phase 1 output (/speckit-plan command)
-└── tasks.md             # Phase 2 output (/speckit-tasks command - NOT created by /speckit-plan)
+specs/041-oracle-open-challenges/
+├── plan.md              # This file (/speckit-plan output)
+├── research.md          # Phase 0 output — decisions D1–D9
+├── data-model.md        # Phase 1 output — entities & view models
+├── quickstart.md        # Phase 1 output — validation scenarios
+├── contracts/           # Phase 1 output — module interface contracts
+│   ├── create-flow.md
+│   ├── claimant-view.md
+│   ├── polymarket-market-hook.md
+│   └── timeline-derivation.md
+├── checklists/
+│   └── requirements.md  # Created by /speckit-specify (all pass)
+└── tasks.md             # Phase 2 output (/speckit-tasks — NOT created here)
 ```
 
 ### Source Code (repository root)
-<!--
-  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
-  for this feature. Delete unused options and expand the chosen structure with
-  real paths (e.g., apps/admin, packages/something). The delivered plan must
-  not include Option labels.
--->
 
 ```text
-# [REMOVE IF UNUSED] Option 1: Single project (DEFAULT)
-src/
-├── models/
-├── services/
-├── cli/
-└── lib/
+frontend/src/
+├── components/fairwins/
+│   ├── OracleOpenChallengeModal.jsx   # NEW: pick market → pick side → stake →
+│   │                                  #      derived timeline → create → code result
+│   ├── OracleOpenChallengeModal.css   # NEW: section-specific styles (fm-* base reused)
+│   ├── ClaimCodeResultPanel.jsx       # NEW (extraction): code display + copy/QR/deep-link
+│   │                                  #      + vault backup, shared with OpenChallengeModal
+│   ├── OpenChallengeModal.jsx         # EDIT: use extracted ClaimCodeResultPanel (no
+│   │                                  #      behavior change to the user-defined flow)
+│   ├── TakeChallengePanel.jsx         # EDIT: bet summary (stake/payout) + oracle
+│   │                                  #      settlement block + live market context +
+│   │                                  #      closed/resolved warning-or-block
+│   ├── PolymarketBrowser.jsx          # (reuse inline variant unchanged)
+│   └── Dashboard.jsx                  # EDIT: new quick-action card + modal instance +
+│                                      #      handleQuickAction case (capability-gated)
+├── hooks/
+│   ├── useOpenChallengeCreate.js      # EDIT: seal oracle block into terms payload;
+│   │                                  #      oracle-aware revert translation
+│   ├── useOpenChallengeAccept.js      # (reuse; lookup already returns oracle fields)
+│   ├── usePolymarketMarket.js         # NEW: single market by conditionId (Gamma),
+│   │                                  #      polling-free fetch + refresh, normalized shape
+│   └── usePolymarketSearch.js         # EDIT: export normaliseGammaMarket for reuse
+├── lib/openChallenge/
+│   └── oracleTimeline.js              # NEW: deriveOracleChallengeTimeline(endDate, now)
+│                                      #      → eligibility + capped accept/settle deadlines
+├── constants/
+│   └── quickAccessCards.js            # EDIT: add 'oracle-open-challenge' card id
+└── test/
+    ├── claimCode/OracleOpenChallengeModal.test.jsx  # NEW
+    ├── claimCode/TakeChallengePanel.oracle.test.jsx # NEW
+    ├── oracleTimeline.test.js                       # NEW (pure helper)
+    ├── usePolymarketMarket.test.jsx                 # NEW
+    ├── claimCode/OpenChallengeModal.test.jsx        # EXTEND (result-panel extraction intact)
+    ├── useOpenChallengeAccept.test.jsx              # EXTEND (oracle fields in lookup payload)
+    └── Dashboard.test.jsx                           # EXTEND (card + gating)
 
-tests/
-├── contract/
-├── integration/
-└── unit/
-
-# [REMOVE IF UNUSED] Option 2: Web application (when "frontend" + "backend" detected)
-backend/
-├── src/
-│   ├── models/
-│   ├── services/
-│   └── api/
-└── tests/
-
-frontend/
-├── src/
-│   ├── components/
-│   ├── pages/
-│   └── services/
-└── tests/
-
-# [REMOVE IF UNUSED] Option 3: Mobile + API (when "iOS/Android" detected)
-api/
-└── [same as backend above]
-
-ios/ or android/
-└── [platform-specific structure: feature modules, UI flows, platform tests]
+test/
+└── integration/oracle/
+    └── WagerRegistry_PolymarketOpenChallenge.test.js # NEW: open+Polymarket lifecycle
+                                                      #      (no Solidity changes)
 ```
 
-**Structure Decision**: [Document the selected structure and reference the real
-directories captured above]
+**Structure Decision**: Web-application layout, `frontend/` only for product code plus a
+new Hardhat integration test under `test/integration/oracle/`. The create flow is a **new
+modal** (not a mode inside `OpenChallengeModal`) because its form is market-driven
+(picker + side + derived timeline) rather than description-driven (free text + editable
+timeline); the shared claim-code result experience is extracted once into
+`ClaimCodeResultPanel` and reused by both.
 
 ## Complexity Tracking
 
-> **Fill ONLY if Constitution Check has violations that must be justified**
-
-| Violation | Why Needed | Simpler Alternative Rejected Because |
-|-----------|------------|-------------------------------------|
-| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
-| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |
+No constitution violations — table not required.

--- a/specs/041-oracle-open-challenges/quickstart.md
+++ b/specs/041-oracle-open-challenges/quickstart.md
@@ -1,0 +1,90 @@
+# Quickstart: Validating Oracle-Settled Open Challenges
+
+**Feature**: 041 | **Plan**: [plan.md](./plan.md) | **Contracts**: [contracts/](./contracts/)
+
+## Prerequisites
+
+- `npm install` at repo root (Hardhat + frontend workspaces)
+- No deployments needed — all validation runs against local Hardhat fixtures and the
+  Vitest suite. Manual UX checks use the dev server on a Polymarket-capable network
+  (Polygon Amoy) with a Silver+ test membership.
+
+## 1. Contract-path equivalence (no Solidity changes — prove the existing path)
+
+```bash
+npm run compile
+npx hardhat test test/integration/oracle/WagerRegistry_PolymarketOpenChallenge.test.js
+```
+
+Expected:
+
+- `createOpenWager(..., ResolutionType.Polymarket, conditionId, creatorIsYes, ...)`
+  succeeds for an unresolved mock condition and emits `OpenWagerCreated` +
+  `PolymarketLinked` (D1).
+- Creation **reverts** with `PolymarketRequired` (zero conditionId),
+  `ConditionAlreadyResolved` (pre-resolved condition), `AdapterNotSet` (registry
+  deployed without adapter), and still rejects `Creator`/`Opponent` types (SC-008 gate,
+  FR-008).
+- A code-holder accepts via `acceptOpenWager`; then `autoResolveFromPolymarket` settles
+  YES-win, NO-win, and tie→draw identically to the named-opponent suite
+  (`WagerRegistry_Polymarket.test.js`) — winner claims payout (SC-006, FR-017).
+- An untaken oracle open challenge expires → creator refund (edge case parity).
+
+Regression (SC-007):
+
+```bash
+npm test           # full contract suite — existing open-challenge + oracle suites unchanged
+```
+
+## 2. Frontend units & components
+
+```bash
+npm run test:frontend
+```
+
+Expected new/extended suites green:
+
+- `oracleTimeline.test.js` — caps/buffer/invariants per
+  [timeline-derivation.md](./contracts/timeline-derivation.md) (SC-003).
+- `claimCode/OracleOpenChallengeModal.test.jsx` — picker→side→stake→create submits
+  `resolutionType=4`, `oracleConditionId`, `creatorIsYes`, derived deadlines, sealed
+  `oracle` block; ineligible markets unselectable; capability + `VITE_ORACLE_MODELS`
+  gating (FR-001..FR-011).
+- `claimCode/TakeChallengePanel.oracle.test.jsx` — bet summary, Polymarket badge in
+  live AND degraded states, mismatch flag, closed-warn / resolved-block accept gate
+  (FR-012..FR-016, SC-004/SC-005).
+- `usePolymarketMarket.test.jsx` — fetch/normalize/error/disabled contract.
+- `claimCode/OpenChallengeModal.test.jsx` — still green after `ClaimCodeResultPanel`
+  extraction (FR-018).
+- `Dashboard.test.jsx` — new card wiring + gating (FR-004).
+
+## 3. Manual end-to-end (dev server)
+
+```bash
+npm run frontend    # on Polygon Amoy with a Silver+ membership wallet
+```
+
+1. Dashboard → **Oracle Open Challenge** card (visible only on Polymarket-capable
+   chains) → default feed shows popular markets with no input (US3/SC-001).
+2. Filter by a category, pick a market → choose a side (labels + live prices) → enter
+   stake → confirm the displayed timeline is derived from the event (capped case: pick
+   a far-future market and check the disclosure) → create.
+3. Save the shown four-word code; verify copy / QR / take-challenge link render (FR-010).
+4. In a second browser/wallet (any active membership tier): unified lookup → enter the
+   code → verify the single-view bet summary: question, YOUR side, stake, payout,
+   deadlines, **"Settled automatically by Polymarket"** badge + explanation, live odds
+   row (SC-004/SC-005).
+5. Kill network access to `gamma-api.polymarket.com` (devtools offline for that origin)
+   → reload lookup → bound terms still render with the "live market info unavailable"
+   notice; accept still enabled (FR-014).
+6. Accept with the second wallet → wager appears in My Wagers for both; manual draw
+   controls disabled ("resolves from an oracle") as with existing oracle wagers.
+
+## 4. Lint & a11y gates
+
+```bash
+npm run lint --workspace frontend   # zero errors (build-blocking)
+```
+
+Axe/Lighthouse CI audits must stay green — the new side picker/badge use labelled
+buttons, `aria-pressed`, `role="status"`, text+glyph (not color-only) semantics.

--- a/specs/041-oracle-open-challenges/research.md
+++ b/specs/041-oracle-open-challenges/research.md
@@ -1,0 +1,223 @@
+# Research & Decisions: Oracle-Settled Open Challenges (Polymarket)
+
+**Feature**: 041 | **Date**: 2026-07-05 | **Spec**: [spec.md](./spec.md)
+
+Phase 0 findings from code exploration. All spec assumptions verified against the
+codebase; no NEEDS CLARIFICATION items remained after the spec phase.
+
+## D1 — No contract changes; prove the path with tests instead
+
+**Decision**: Ship with zero Solidity edits. Add a contract-level JS integration suite
+(`test/integration/oracle/WagerRegistry_PolymarketOpenChallenge.test.js`) covering the
+open + Polymarket lifecycle.
+
+**Rationale**: `createOpenWager` already validates oracle linkage at creation via
+`_checkOracleLinkage` (`contracts/wagers/WagerRegistryCore.sol:217-230`): for
+`ResolutionType.Polymarket` it requires a non-zero `oracleConditionId`
+(`PolymarketRequired`), a configured adapter (`AdapterNotSet`), and an **unresolved**
+condition (`ConditionAlreadyResolved` — this is FR-008's create-time re-validation,
+enforced on-chain, not just in the app). It stores `creatorIsYes` and
+`polymarketConditionId` (`WagerRegistry.sol:287,289`) and emits `PolymarketLinked`
+(`:306`). Post-accept, `autoResolveFromPolymarket`
+(`contracts/wagers/WagerRegistryIntents.sol:226-245`) reads only wager state
+(`status`, `resolutionType`, `polymarketConditionId`, `creatorIsYes` via
+`_settleOracleWin`, `WagerRegistryCore.sol:559-567`) — it has no open-vs-named branch,
+so an accepted open challenge resolves identically to a named-opponent oracle wager
+(FR-017). However, **no existing test creates an open wager with an oracle type**
+(`test/WagerRegistry.openChallenge.test.js` covers Either/ThirdParty only;
+`test/integration/oracle/WagerRegistry_Polymarket.test.js` uses `createWager`), and the
+constitution treats oracle-resolution paths as highest-risk — so the new usage pattern
+gets dedicated lifecycle tests before the UI ships it.
+
+**Alternatives considered**: Adding a contract-side "market schedule" validation
+(accept deadline ≤ market end) — rejected: the chain cannot know Polymarket schedules;
+the derivation is a UX concern (D3), and the existing deadline bounds
+(`_checkDeadlines`, `WagerRegistryCore.sol:207-212`) already cap windows.
+
+## D2 — New `OracleOpenChallengeModal`, shared `ClaimCodeResultPanel` extraction
+
+**Decision**: Build the section as a new modal component that composes the existing
+`PolymarketBrowser` (`variant="inline"`) + a side picker + stake + derived-timeline
+summary, and extract the post-create claim-code result experience (code display, copy,
+QR, take-challenge deep link, vault backup) out of `OpenChallengeModal.jsx` into a
+shared `ClaimCodeResultPanel` used by both modals.
+
+**Rationale**: The user asked for a **new section**, and the two create forms diverge
+fundamentally: user-defined challenges are description-driven with a hand-edited
+`DeadlineTimeline`; oracle challenges are market-driven with a derived, read-only
+timeline (spec: "the event defines the timelines"). Forcing both into one modal would
+bury the exciting picker-first flow behind mode switches. The code-result screen,
+however, is identical by spec (FR-010 — reuse claim-code machinery unchanged), so it is
+extracted once rather than duplicated. `OpenChallengeModal`'s user-defined behavior is
+untouched (FR-018), verified by its existing tests.
+
+**Alternatives considered**: (a) Adding oracle tabs to `OpenChallengeModal` à la
+`FriendMarketsModal` — rejected: FriendMarketsModal's tab complexity is what makes it
+hard to keep "fast and fun"; (b) duplicating the result UI — rejected: two drift-prone
+copies of security-relevant UX (code shown once, backup prompts).
+
+## D3 — Event-derived timeline: rules and bounds
+
+**Decision**: New pure helper `deriveOracleChallengeTimeline(marketEndIso, nowMs)` in
+`frontend/src/lib/openChallenge/oracleTimeline.js`:
+
+- `MIN_LEAD_MS = 1 hour` — markets ending sooner are **ineligible** (not selectable),
+  matching the existing oracle wager flow's "at least 1 hour from now" floor.
+- `acceptDeadline = min(marketEnd, now + ACCEPT_CAP)` with `ACCEPT_CAP = 30 days − 1 hour`
+  (safety margin under the contract's `MAX_ACCEPT_WINDOW = 30 days`,
+  `WagerRegistryCore.sol:46`, so the tx can't straddle the bound while pending).
+  When capped, the UI states the challenge closes for takers before the event ends.
+- `resolveDeadline = min(marketEnd + SETTLE_BUFFER, now + RESOLVE_CAP)` with
+  `SETTLE_BUFFER = 7 days` (time for Polymarket's resolution + anyone to call
+  `autoResolveFromPolymarket`) and `RESOLVE_CAP = 180 days − 1 hour` (under
+  `MAX_RESOLVE_WINDOW = 180 days`, `WagerRegistryCore.sol:47`). Invariant
+  `resolveDeadline > acceptDeadline` is guaranteed by construction
+  (`marketEnd ≥ acceptDeadline` and buffer > 0; when both are capped the caps preserve
+  the gap).
+- Returns `{ eligible, reason, acceptDeadlineMs, resolveDeadlineMs, acceptCapped }` so
+  the UI can render the derived timeline and per-market ineligibility honestly.
+
+**Rationale**: Spec FR-007 ("takeable until the event closes, capped") and FR-003
+(minimum lead). Accepting right up to market close is intentionally different from the
+1v1 flow's `getMidpointAcceptanceDeadline` (`wagerDefaults.js:269-276`): an open
+challenge's whole point is maximum time for a code-holder to take it. Late acceptance
+close to event end is equal-stakes and both-sides-symmetric, and D8 blocks accepting a
+market that already shows a public outcome.
+
+**Alternatives considered**: Midpoint acceptance (1v1 parity) — rejected: shrinks the
+sharing window for no symmetry benefit; creator-editable deadlines — rejected by the
+user's framing ("the event defines the timelines") and spec Assumptions.
+
+## D4 — Terms bundle gains a sealed `oracle` block; on-chain fields stay authoritative
+
+**Decision**: Extend the code-keyed sealed payload built in `useOpenChallengeCreate`
+(today exactly `{ description, createdAt }`, `useOpenChallengeCreate.js:69-73`) with an
+optional block:
+
+```json
+{
+  "description": "…auto-composed, human-readable…",
+  "createdAt": "<ISO>",
+  "oracle": {
+    "source": "polymarket",
+    "conditionId": "0x…",
+    "question": "…",
+    "outcomes": ["Yes", "No"],
+    "creatorSide": 0,
+    "endDate": "<ISO>",
+    "slug": "…"
+  }
+}
+```
+
+The claimant view treats on-chain `wager.resolutionType` / `wager.polymarketConditionId`
+/ `wager.creatorIsYes` as **authoritative** and uses the sealed `oracle` block only for
+human-readable display (question, outcome labels). If
+`terms.oracle.conditionId !== wager.polymarketConditionId`, the view flags the stored
+description as not matching the on-chain linkage instead of trusting it. The
+`description` field is auto-composed (market question + creator's side) so even a
+legacy/plain reader of the terms sees a meaningful sentence.
+
+**Rationale**: FR-012/FR-014 require the claimant to understand the bet even when the
+Gamma API is down — the question and outcome labels must therefore be stored with the
+challenge, and the code-keyed envelope is the existing place confidential terms live
+(FR-010: reuse machinery; envelope format `encryptEnvelopeCode` is shape-agnostic).
+Constitution III (honest state) dictates the chain-vs-bundle precedence and the mismatch
+flag. Backward compatible: old bundles simply lack `oracle`, and user-defined challenges
+continue to seal `{ description, createdAt }`.
+
+**Alternatives considered**: Fetch-only market display (no sealed metadata) — rejected:
+violates FR-014's degraded state; plaintext market metadata in `metadataUri` — rejected:
+would leak which market a code-gated challenge references, weakening the spec-024
+indistinguishability property (FR-008 of 024).
+
+## D5 — Live market context via a new `usePolymarketMarket(conditionId)` hook
+
+**Decision**: Add a small hook that fetches one market by condition id from the Gamma
+API (`GET {gammaBase}/markets?condition_ids=<id>`), normalizes it with the existing
+`normaliseGammaMarket` (exported from `usePolymarketSearch.js`), and returns
+`{ market, isLoading, error, refresh }`. Used by `TakeChallengePanel` (claimant) and the
+create-flow review step (price display parity).
+
+**Rationale**: No single-market-by-conditionId fetch exists today (search/browse only).
+The claimant holds only on-chain fields + sealed metadata; live odds/status (FR-014,
+US2-3) need a direct lookup. Reusing `normaliseGammaMarket` keeps one market shape
+(`outcomes: [{name, price}]`, `endDate`, `closed`, `active`) everywhere. Errors degrade
+to the sealed-metadata view with the disclosed "live market info unavailable" notice —
+never a blocking spinner.
+
+**Alternatives considered**: Reusing `usePolymarketSearch` with the question text —
+rejected: ambiguous matches, wasteful; subgraph indexing of market state — rejected:
+Gamma is already the app's market-data source and the subgraph doesn't index Polymarket.
+
+## D6 — Side semantics: outcome index 0 = YES = `creatorIsYes: true`
+
+**Decision**: The side picker renders both outcome labels from
+`market.outcomes[].name` (fallback Yes/No) with current prices; the chosen index maps to
+the contract exactly as the 1v1 flow does: index 0 → `creatorIsYes = true`, index 1 →
+`false` (`FriendMarketsModal.jsx:963-972`). The claimant is always shown **their** side:
+`outcomes[creatorIsYes ? 1 : 0]`.
+
+**Rationale**: Matches `PolymarketOracleAdapter` outcome ordering already relied on by
+the named-opponent flow and by `_settleOracleWin`
+(`winner = outcome == creatorIsYes ? creator : opponent`,
+`WagerRegistryCore.sol:560`). One convention, no translation layer.
+
+**Alternatives considered**: Storing outcome names on-chain — impossible without
+contract changes; free-side text — rejected, binary markets only (spec Assumptions).
+
+## D7 — Entry point + gating
+
+**Decision**: New quick-access card id `oracle-open-challenge` in
+`constants/quickAccessCards.js`, a card in Dashboard's `createActions`, a
+`handleQuickAction` case opening the new modal, gated on the `polymarketSidebets`
+capability (`useChainTokens().capabilities`) with the same locked/unavailable treatment
+the oracle 1v1 card uses; `PolymarketBrowser` additionally self-gates (returns null on
+unsupported chains). The section also respects `isOracleModelExposed(Polymarket)`
+(`VITE_ORACLE_MODELS`, default `polymarket-only`).
+
+**Rationale**: FR-001/FR-004; identical gating semantics to the existing oracle flow
+means no new capability plumbing. The Polymarket dashboard feed's
+`handlePolymarketCardClick` continues to open the 1v1 flow (unchanged scope); a
+follow-up could offer a choice, but YAGNI for v1.
+
+## D8 — Closed/resolved market at claim time: warn, and block when outcome is public
+
+**Decision**: In the claimant view, when live data is reachable: if the linked market is
+`closed` (or past `endDate`) show a prominent warning; if it already reports a resolved
+outcome (adapter/Gamma shows a winner), **disable accept in the app** with an
+explanation. When live data is unreachable, show the derived schedule + the degraded
+notice and keep accept enabled (per FR-014) — the accept deadline itself (≤ market end,
+D3) is the primary guard.
+
+**Rationale**: FR-015 and US2-5. The contract cannot re-check the oracle at accept
+(acceptOpenWager is resolution-type agnostic — `useOpenChallengeAccept.js:126-196`
+mirrors this), so this is deliberately an app-level honesty measure, documented as such.
+Blocking only on a *public, positively known* outcome avoids false lockouts from stale
+data; the derived accept deadline already makes the window small.
+
+**Alternatives considered**: Contract-level accept guard querying the adapter —
+rejected: contract change, gas cost, and Amoy/Polygon adapter timing quirks for a
+window the deadline already bounds.
+
+## D9 — Test strategy
+
+**Decision**:
+- **Contract (Hardhat, new file)** `test/integration/oracle/WagerRegistry_PolymarketOpenChallenge.test.js`,
+  modeled on `WagerRegistry_Polymarket.test.js` fixtures (`MockPolymarketCTF` →
+  `PolymarketOracleAdapter` → `deployWagerRegistry` with adapter as 3rd init arg):
+  create-open-with-Polymarket happy path (event `PolymarketLinked`), code-based accept,
+  `autoResolveFromPolymarket` YES-win / NO-win / tie→draw / unresolved-revert, payout
+  claim, expiry refund of an untaken oracle challenge, and creation reverts:
+  zero conditionId (`PolymarketRequired`), resolved condition
+  (`ConditionAlreadyResolved`), self-resolution types still barred.
+- **Frontend (Vitest)**: unit tests for `deriveOracleChallengeTimeline` (caps, buffer,
+  ineligibility, invariants) and the terms `oracle` block build/verify; component tests
+  for `OracleOpenChallengeModal` (picker→side→stake→derived timeline→create args:
+  `resolutionType=4`, conditionId, creatorIsYes, sealed oracle block),
+  `TakeChallengePanel` oracle summary (live / degraded / closed / resolved / mismatch
+  states, Polymarket named in all), `ClaimCodeResultPanel` extraction (OpenChallengeModal
+  tests still green), `usePolymarketMarket`, and Dashboard card gating.
+
+**Rationale**: Constitution II; SC-006/SC-007 (equivalence + zero regression) map
+directly onto the contract equivalence tests and the untouched existing suites.

--- a/specs/041-oracle-open-challenges/spec.md
+++ b/specs/041-oracle-open-challenges/spec.md
@@ -1,0 +1,372 @@
+# Feature Specification: Oracle-Settled Open Challenges (Polymarket)
+
+**Feature Branch**: `claude/oracle-settled-challenges-p3iwl9`
+
+**Created**: 2026-07-05
+
+**Status**: Draft
+
+**Input**: User description: "Create a new 'Oracle-Settled Open Challenges' section: open challenges (creator defines the event and stake, then shares a claim code) are currently restricted to user-defined events only. Extend the open-challenge model to oracle-settled wagers using Polymarket as the oracle source. The creator picks a Polymarket event via an intuitive, fast event-discovery interface (like the existing 'oracle settles' section), sets the stake, and the chosen event's own timeline drives the wager deadlines (accept/resolve). The goal is an exciting, interactive way to quickly pick an oracle event and share the challenge code. The claimant who opens the code must see the bet details clearly and understandably, and it must be unmistakable that Polymarket is the oracle/settlement source."
+
+## Overview
+
+Open challenges (feature 024) let a creator post a code-gated wager with no named
+opponent: whoever holds the four-word claim code can read the terms and take the
+other side. Today the app restricts open challenges to **user-defined resolution**
+only — "either side submits the outcome" or "a named arbitrator decides" — even
+though the underlying wager system already permits oracle-settled open challenges.
+That leaves out the most trustless combination the platform offers: *a challenge
+anyone can take, settled automatically by a public prediction market*.
+
+This feature adds a new **Oracle-Settled Open Challenges** section. The creator:
+
+1. **Picks a real-world event** from Polymarket through the same fast, interactive
+   discovery experience used by the existing "an oracle settles it" wager flow —
+   trending markets, category chips (Politics, Sports, Crypto, …), and instant
+   search, grouped by event.
+2. **Picks their side** of the market's binary outcome (e.g. YES/NO) and **sets the
+   stake** (equal stakes, as all open challenges require).
+3. **Gets the timelines for free** — the chosen event's own schedule drives the
+   wager deadlines: the challenge stays takeable until the event closes, and the
+   settlement deadline follows the event's expected resolution. The creator does
+   not hand-pick dates; the event defines the timeline.
+4. **Shares the four-word claim code** exactly as with any open challenge (copy,
+   QR, deep link).
+
+The claimant who enters the code sees the bet plainly and completely — the market
+question, which side they are taking (the opposite of the creator's), the stake
+and potential payout, the timeline, and the market's live state — with **Polymarket
+unmistakably presented as the oracle/settlement source**: nobody judges the outcome;
+the linked market's public resolution settles the wager automatically.
+
+The existing user-defined open-challenge flow is untouched; this is a parallel,
+additive entry point that reuses the same claim-code machinery, membership gates,
+and escrow rules.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Pick a Polymarket event and post an oracle-settled open challenge (Priority: P1)
+
+A Silver+ member opens the new Oracle-Settled Open Challenges section, browses
+trending Polymarket markets (or filters by category / searches by keyword), taps a
+market, picks the side they believe in, enters a stake, sees the timeline the event
+implies, and creates the challenge. They receive the four-word claim code with the
+familiar share tools (copy, QR, take-challenge link) and send it to a friend or a
+group.
+
+**Why this priority**: This is the headline capability — without the creation path
+there is no feature. It delivers standalone value: a shareable, oracle-settled
+challenge that needs no arbitrator and no trust between strangers.
+
+**Independent Test**: As a Silver+ member on a Polymarket-capable network, create an
+oracle open challenge end-to-end from the new section (browse → pick market → pick
+side → stake → create) and confirm: the stake is escrowed, a four-word code is
+issued, the challenge records the linked market and the creator's side, and the
+accept/resolve deadlines are consistent with the event's schedule.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Silver+ member in the new section, **When** they browse without
+   typing anything, **Then** they see a list of currently popular, still-open
+   Polymarket markets they can immediately pick from.
+2. **Given** the member types a search term or taps a category chip, **When**
+   results return, **Then** only markets that are active, unresolved, and ending in
+   the future are offered for selection.
+3. **Given** a selected market, **When** the member reviews the challenge before
+   creating, **Then** they see the market question, the side they picked, the equal
+   stake, and the derived accept/settle timeline — and the timeline is presented as
+   coming from the event, not as a free-form choice.
+4. **Given** the member confirms creation, **When** the challenge is created,
+   **Then** their stake is escrowed, the market linkage and chosen side are bound to
+   the wager, and the four-word claim code is displayed once with copy / QR /
+   deep-link sharing and the existing device-local code backup.
+5. **Given** a member below the Silver tier, **When** they attempt to create an
+   oracle open challenge, **Then** they are refused and prompted to upgrade, exactly
+   as with user-defined open challenges.
+
+---
+
+### User Story 2 - Claimant opens the code and clearly understands the bet before taking it (Priority: P1)
+
+Someone receives the four-word code (message, QR, or link), enters it in the app's
+code lookup, and lands on the challenge view. Before accepting, they can see at a
+glance: the exact market question, which side **they** would take, how much they
+stake and how much they'd win, when the challenge expires and when the bet settles,
+and — prominently — that **Polymarket settles this bet automatically** (no person
+decides the outcome). They accept, and from then on the wager behaves exactly like
+any accepted oracle-resolved wager: it settles from the linked market's public
+resolution and the winner claims the payout.
+
+**Why this priority**: The claim experience is half the feature's promise. A code
+recipient is often a first-time or casual user; if they cannot understand what they
+are agreeing to — or don't realize an external oracle settles it — the feature fails
+its trust and clarity goals. Ships together with Story 1.
+
+**Independent Test**: With a code from Story 1, as a different member: enter the
+code, verify every element of the bet summary is present and correct (question,
+claimant's side, stakes, payout, deadlines, Polymarket-as-oracle indication), accept,
+then drive the linked market to resolution (test double) and confirm automatic
+settlement and payout claim work identically to an existing oracle-resolved wager.
+
+**Acceptance Scenarios**:
+
+1. **Given** a person holding the correct code, **When** they look it up, **Then**
+   the challenge view shows the market question, the side the claimant takes (the
+   opposite of the creator's), the stake amount, the total potential payout, and
+   the accept/settle deadlines in plain language.
+2. **Given** the challenge view, **When** the claimant reads how the bet resolves,
+   **Then** Polymarket is explicitly and prominently identified as the settlement
+   source, with a plain-language explanation that the outcome is decided by the
+   public market's resolution, not by either participant.
+3. **Given** the Polymarket market data is reachable, **When** the claimant views
+   the challenge, **Then** they also see the market's live context (such as current
+   odds/pricing and status) so they can judge the bet before taking it.
+4. **Given** the market data is temporarily unreachable, **When** the claimant views
+   the challenge, **Then** the bound bet terms (question, side, stake, deadlines,
+   oracle source) still render from stored challenge data with a clear notice that
+   live market info is unavailable — and acceptance is still possible.
+5. **Given** the linked market has already closed or resolved by the time the code
+   is used, **When** the claimant views the challenge, **Then** they are clearly
+   warned (or blocked, if the outcome is already public) rather than being allowed
+   to unknowingly take a decided bet.
+6. **Given** an accepted oracle open challenge, **When** the linked market resolves,
+   **Then** settlement, payout claim, draw/refund behavior are identical to an
+   existing named-opponent oracle wager (no new resolution rules).
+
+---
+
+### User Story 3 - Fast, exciting discovery and effortless sharing (Priority: P2)
+
+A creator wants to go from "I have a hot take" to "code sent to the group chat" in
+under a minute. The section opens straight into an inviting, browsable feed of
+popular markets; category chips and search respond quickly; picking a market takes
+one tap; and after creation the share tools (copy, QR, deep link) are immediately at
+hand.
+
+**Why this priority**: The user goal explicitly calls for "an exciting interactive
+way to quickly pick an oracle and share the code." Story 1 makes it *possible*;
+this story makes it *fast and fun* — the speed and polish targets that make the
+section feel like a feed you want to play with rather than a form you fill in.
+
+**Independent Test**: Time a member (who knows what they want to bet on) going from
+opening the section to holding a shareable code; verify the interaction targets in
+the Success Criteria (search latency, steps to select, share affordances) are met.
+
+**Acceptance Scenarios**:
+
+1. **Given** the section is opened, **When** no filters are applied, **Then**
+   popular pickable markets render without requiring any input first.
+2. **Given** a category chip is tapped or a search term typed, **When** results
+   update, **Then** stale results are never shown as fresh, and typical updates feel
+   immediate (see SC-002).
+3. **Given** a market whose event groups several related markets, **When** it is
+   browsed, **Then** the group presents as one expandable entry so the list stays
+   scannable.
+4. **Given** a created challenge, **When** the code screen is shown, **Then** copy,
+   QR, and take-challenge deep link are all available without further navigation,
+   and the code is backed up per the existing open-challenge code backup behavior.
+
+---
+
+### Edge Cases
+
+- **Linked market ends beyond the maximum acceptance window**: the challenge's
+  accept deadline is capped at the platform's maximum acceptance window (30 days)
+  even if the event ends later; the creator is shown the effective (capped) window
+  before creating. The settle deadline still tracks the event's expected resolution
+  (within the platform's maximum resolve window).
+- **Linked market ends too soon**: markets ending inside the platform's minimum
+  lead time are not offered for selection (a challenge nobody could realistically
+  take is not creatable).
+- **Market closes or resolves between selection and creation**: creation re-checks
+  the market's state; a market that is no longer open for linkage is refused with a
+  clear message and the creator is returned to the picker.
+- **Market resolves early (event decided before its scheduled end)**: the claimant
+  view surfaces live market status; a market already showing a public outcome
+  blocks acceptance (US2 scenario 5) so no one unknowingly takes a decided bet. If
+  it slips through (data lag), settlement still pays per the market's resolution —
+  identical to existing oracle wagers.
+- **Skewed odds, equal stakes**: open challenges are equal-stakes by rule, even when
+  the market prices one side at 80¢. The claimant view shows live odds precisely so
+  a code-holder can decline an unfavorable bet; sharing the code does not obligate
+  anyone.
+- **Network without Polymarket support**: the section is hidden or shown locked
+  with an explanation on chains where Polymarket settlement is not available,
+  mirroring how the existing oracle wager flow gates itself.
+- **Polymarket discovery service unreachable at creation time**: the picker shows a
+  clear error/retry state; creation is impossible without a verifiable live market
+  (no free-text fallback in this section — that's what user-defined open challenges
+  are for).
+- **No one accepts before the accept deadline**: standard open-challenge expiry —
+  the creator's stake becomes refundable, identical to feature 024.
+- **Creator loses the code / wrong code entered / non-member taker / sanctions**:
+  all inherited unchanged from feature 024 (code backup vault, code-not-found
+  handling, membership prompt at accept, sanctions screening).
+- **Settlement never arrives (market disputed/delayed past the settle deadline)**:
+  the existing oracle-wager deadline/refund behavior applies unchanged; this
+  feature adds no new settlement rules.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Section & discovery
+
+- **FR-001**: The app MUST offer a new, clearly named entry point for creating
+  **oracle-settled open challenges**, separate from (and not replacing) the existing
+  user-defined open-challenge flow.
+- **FR-002**: The section MUST let the creator discover Polymarket markets through
+  the same interaction model as the existing oracle wager flow: a no-input default
+  feed of popular markets, category filter chips, and keyword search, with related
+  markets grouped by event.
+- **FR-003**: Only markets that are active, unresolved, and ending in the future
+  MUST be selectable; markets ending inside the platform's minimum lead time MUST
+  be excluded from selection.
+- **FR-004**: The section MUST be available only on networks where Polymarket
+  settlement is supported, and MUST present a clear locked/unavailable state
+  elsewhere (consistent with the existing oracle flow's gating).
+
+#### Creating the challenge
+
+- **FR-005**: The creator MUST explicitly choose their side of the linked market's
+  binary outcome, with both sides shown using the market's own outcome labels; the
+  taker's side is always the opposite.
+- **FR-006**: The creator MUST set a stake, and the challenge MUST be equal-stakes
+  (both sides stake the same amount), inheriting the open-challenge rule.
+- **FR-007**: The challenge's deadlines MUST be derived from the linked event, not
+  hand-entered: the acceptance deadline follows the market's close (capped at the
+  platform's maximum acceptance window), and the settlement deadline follows the
+  market's expected resolution (within the platform's maximum resolve window). The
+  derived timeline MUST be displayed to the creator before creation, presented as
+  coming from the event.
+- **FR-008**: At the moment of creation the system MUST re-validate that the linked
+  market is still open for linkage and MUST refuse creation with a clear message if
+  it is not.
+- **FR-009**: Creation MUST bind the linked market's identity and the creator's
+  chosen side to the wager such that settlement can only follow that market's
+  public resolution.
+- **FR-010**: Creation MUST reuse the existing open-challenge claim-code machinery
+  unchanged: a four-word code shown once, code-derived readability of terms,
+  active-uniqueness of the code, device-local encrypted code backup, and copy / QR /
+  take-challenge deep-link sharing.
+- **FR-011**: Oracle open-challenge creation MUST enforce the same creator gates as
+  user-defined open challenges (Silver-and-above membership tier, sanctions
+  screening, membership limits, allowed stake token).
+
+#### Claimant experience
+
+- **FR-012**: Entering the correct claim code MUST take the holder to a challenge
+  view that presents, without further navigation: the market question, the side the
+  claimant would take, the stake amount, the total potential payout, the acceptance
+  deadline, and the expected settlement timeline — all in plain language.
+- **FR-013**: The challenge view MUST unmistakably identify Polymarket as the
+  oracle/settlement source, both visually (a distinct, consistent oracle indicator)
+  and in plain words (the outcome is settled automatically from the public market's
+  resolution; neither participant decides).
+- **FR-014**: When live market data is reachable, the challenge view MUST show the
+  linked market's current context (at minimum: current price/odds and open/closed
+  status). When unreachable, the view MUST still render the bound bet terms from
+  stored challenge data with a clear "live market info unavailable" notice, and
+  acceptance MUST remain possible.
+- **FR-015**: If the linked market is already closed or already shows a public
+  outcome when the code is used, the claimant MUST be clearly warned before
+  accepting; if the outcome is already public, acceptance MUST be prevented in the
+  app.
+- **FR-016**: Accepting MUST enforce all existing open-challenge accept-time
+  protections unchanged (code proof, first-taker-wins, membership required for all
+  takers, sanctions screening, creator cannot self-accept).
+
+#### Settlement & compatibility
+
+- **FR-017**: After acceptance, the wager MUST behave identically to an existing
+  oracle-resolved wager: settlement follows the linked market's public resolution
+  automatically, and payout, draw, refund, and claim flows are unchanged.
+- **FR-018**: The existing user-defined open-challenge flow (either-side and
+  third-party arbitrator resolution) MUST remain available and unchanged.
+- **FR-019**: All existing wager flows (named-opponent, user-defined open
+  challenges, group pools) MUST continue to pass their existing tests unchanged;
+  this feature is additive.
+
+### Key Entities
+
+- **Oracle Open Challenge**: An open challenge (code-gated, no named counterparty,
+  equal stakes) whose resolution is bound at creation to a specific Polymarket
+  market and a chosen side. Becomes an ordinary accepted oracle-resolved wager once
+  a code-holder takes it.
+- **Linked Market**: The Polymarket market chosen by the creator — identified
+  durably (so settlement is verifiable) and described richly (question, outcome
+  labels, schedule, live pricing) for display. Its schedule is the source of the
+  challenge's derived timeline; its public resolution is the sole settlement input.
+- **Side Assignment**: The creator's chosen outcome of the linked market; the
+  taker automatically holds the opposite outcome. Both are displayed using the
+  market's own outcome labels.
+- **Derived Timeline**: The accept-by and settle-by deadlines computed from the
+  linked market's schedule (with platform caps), shown to the creator before
+  creation and to every code-holder afterward.
+- **Claim Code** *(existing, unchanged)*: The four-word secret from feature 024 —
+  discovery, accept authorization, and terms readability, shared out-of-band.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A member who knows what they want to bet on can go from opening the
+  section to holding a shareable claim code in under 2 minutes, with market
+  selection itself taking no more than 3 interactions from the default feed
+  (filter/search → pick market → pick side).
+- **SC-002**: Market discovery feels immediate: under typical conditions, the
+  default feed and search/filter results render within 2 seconds of the action.
+- **SC-003**: 100% of created oracle open challenges have timelines consistent with
+  their linked event: the challenge cannot be accepted after the event's close (or
+  the platform cap, whichever is earlier), and the settlement deadline allows for
+  the event's expected resolution.
+- **SC-004**: 100% of code-holders see the complete bet summary (market question,
+  their side, stake, payout, deadlines, settlement source) on a single view with no
+  additional navigation, in both live-data and degraded (market data unavailable)
+  states.
+- **SC-005**: In moderated usability checks, at least 90% of first-time code
+  recipients can correctly answer "who decides who wins?" (answer: Polymarket's
+  public market resolution — nobody in the app) after viewing the challenge, and
+  100% of challenge views name Polymarket as the settlement source.
+- **SC-006**: 100% of accepted oracle open challenges settle through the same
+  automatic path as existing oracle wagers, with no manual intervention and no new
+  settlement rules — verified by equivalence tests against the existing oracle
+  wager flow.
+- **SC-007**: Zero regressions: existing user-defined open-challenge, named-opponent,
+  and oracle wager test suites pass unchanged.
+- **SC-008**: 100% of attempts to create against a market that is closed, resolved,
+  or ending too soon are refused with an actionable message (no silent failures, no
+  challenges created against dead markets).
+
+## Assumptions
+
+- **Polymarket is the only oracle source for this section in v1.** The platform's
+  oracle exposure already defaults to Polymarket only; Chainlink/UMA variants of
+  oracle open challenges are out of scope here and can follow the same pattern
+  later.
+- **The underlying wager system already supports oracle-settled open challenges.**
+  Feature 024 deliberately permitted oracle resolution for open challenges at the
+  contract level and barred only single-party self-resolution; the current
+  restriction to user-defined resolution is an app-level limitation. This feature
+  is expected to require **no changes to the deployed wager contracts**.
+- **Timelines are derived, not hand-edited.** "The event defines the timelines" is
+  taken literally: the creator sees the derived accept/settle deadlines but does
+  not pick dates in this flow. Platform bounds (maximum 30-day acceptance window,
+  maximum resolve window, minimum lead time) cap the derivation, and the effective
+  deadlines are always shown before creation.
+- **Binary markets only.** Selectable markets are those with a two-outcome
+  structure (YES/NO or equivalent two-sided outcomes); multi-outcome events are
+  represented through their individual binary markets, as in the existing oracle
+  flow's event grouping.
+- **Equal stakes despite market odds is accepted and disclosed.** Open challenges
+  are equal-stakes by rule; the live odds display exists so both parties can judge
+  the bet, and an unfavorable code can simply go untaken until it expires.
+- **Claim-code security model is inherited unchanged from feature 024**, including
+  its documented v1 residual risks and the membership/sanctions gates at create and
+  accept.
+- **Networks**: applies where Polymarket settlement is configured (Polygon mainnet
+  and the Amoy testnet today); other networks show the gated/unavailable state.
+- **Claimant clarity relies on challenge-bound data first, live data second.** The
+  bet's bound terms (question, side, stake, deadlines, oracle source) must never
+  depend on the discovery service being up; live pricing/status is an enhancement
+  layered on top.

--- a/specs/041-oracle-open-challenges/tasks.md
+++ b/specs/041-oracle-open-challenges/tasks.md
@@ -213,17 +213,17 @@ grouped events stay scannable; share tools at hand — SC-001/SC-002 interaction
 hand in under 2 minutes, ≤ 3 interactions from feed to side-picked market; feed/search
 under ~2 s typical.
 
-- [ ] T022 [US3] Discovery polish in `OracleOpenChallengeModal.jsx` +
+- [X] T022 [US3] Discovery polish in `OracleOpenChallengeModal.jsx` +
       `OracleOpenChallengeModal.css`: default feed opens expanded with popular markets
       (no input required), event-grouped rows expand inline, ineligible-market reason
       copy is friendly ("ends too soon…"), selection → configure step transition is a
       single tap, and an `InfoTip` explains the section ("Polymarket settles it — you
       just pick a side and share the code").
-- [ ] T023 [US3] Share-readiness pass on `ClaimCodeResultPanel.jsx`: copy / QR /
+- [X] T023 [US3] Share-readiness pass on `ClaimCodeResultPanel.jsx`: copy / QR /
       take-challenge deep link and vault-backup states visible without scrolling on
       mobile-width viewport; code-retention prompt copy mentions the taker needs the
       code to read the bet (parity with FR-010; no new mechanics).
-- [ ] T024 [P] [US3] Extend `frontend/src/test/claimCode/OracleOpenChallengeModal.test.jsx`
+- [X] T024 [P] [US3] Extend `frontend/src/test/claimCode/OracleOpenChallengeModal.test.jsx`
       for US3 acceptance: feed renders with zero input, grouped event expands, ≤ 3
       interactions from feed to side selection (assert step transitions), stale-result
       guard (loading state shown while switching filters).
@@ -232,18 +232,18 @@ under ~2 s typical.
 
 ## Phase 6: Polish & Cross-Cutting
 
-- [ ] T025 [P] Accessibility audit additions in
+- [X] T025 [P] Accessibility audit additions in
       `frontend/src/test/accessibility.test.jsx`: axe checks over
       `OracleOpenChallengeModal` (both steps) and the oracle-summary
       `TakeChallengePanel` state (WCAG 2.1 AA — Constitution V).
-- [ ] T026 [P] Update `docs/` developer notes: brief section in the wagers/oracle
+- [X] T026 [P] Update `docs/` developer notes: brief section in the wagers/oracle
       developer guide (e.g. `docs/developer-guide/` alongside existing guides) covering
       the sealed `oracle` terms block, timeline-derivation constants, and the
       chain-authoritative display rule (D4).
-- [ ] T027 Full verification sweep per quickstart: `npm run compile`, `npm test`,
+- [X] T027 Full verification sweep per quickstart: `npm run compile`, `npm test`,
       `npm run test:frontend`, frontend lint — all green with zero regressions
       (SC-007); compare against the T001 baseline.
-- [ ] T028 Manual quickstart §3 walkthrough on Amoy (create → share → second-wallet
+- [ ] T028 (PENDING — needs a wallet on Amoy; see PR description) Manual quickstart §3 walkthrough on Amoy (create → share → second-wallet
       claim view incl. degraded state → accept) and record outcomes in the PR
       description (SC-001/SC-004/SC-005 evidence).
 

--- a/specs/041-oracle-open-challenges/tasks.md
+++ b/specs/041-oracle-open-challenges/tasks.md
@@ -27,7 +27,7 @@ Web app: product code under `frontend/src/`, contract JS tests under `test/`
 
 **Purpose**: Anchor the zero-regression guarantee (SC-007) before any edits.
 
-- [ ] T001 Record a green baseline: run `npm test` (contract suite) and
+- [X] T001 Record a green baseline: run `npm test` (contract suite) and
       `npm run test:frontend`; note current pass counts in the PR description or
       commit message so SC-007 regressions are attributable. No file changes.
 
@@ -40,7 +40,7 @@ Web app: product code under `frontend/src/`, contract JS tests under `test/`
 **⚠️ CRITICAL**: T002 is the constitutional risk gate (oracle-resolution path); the
 shared helpers/hooks (T003–T009) block both US1 and US2.
 
-- [ ] T002 [P] Contract lifecycle proof (D1, FR-017, SC-006, SC-008): create
+- [X] T002 [P] Contract lifecycle proof (D1, FR-017, SC-006, SC-008): create
       `test/integration/oracle/WagerRegistry_PolymarketOpenChallenge.test.js` modeled
       on `test/integration/oracle/WagerRegistry_Polymarket.test.js` fixtures
       (`MockPolymarketCTF` → `PolymarketOracleAdapter` → `deployWagerRegistry` from
@@ -55,42 +55,42 @@ shared helpers/hooks (T003–T009) block both US1 and US2.
       then `autoResolveFromPolymarket` settles YES-win, NO-win, tie→draw, and reverts
       `ConditionNotResolved` when unresolved; winner claims payout; (d) untaken oracle
       open challenge expires → creator refund.
-- [ ] T003 [P] Create `frontend/src/lib/openChallenge/oracleTimeline.js` per
+- [X] T003 [P] Create `frontend/src/lib/openChallenge/oracleTimeline.js` per
       contracts/timeline-derivation.md: export `deriveOracleChallengeTimeline(marketEndIso, nowMs)`
       and constants `MIN_LEAD_MS` (1h), `ACCEPT_CAP_MS` (30d−1h), `SETTLE_BUFFER_MS`
       (7d), `RESOLVE_CAP_MS` (180d−1h); pure, injected clock, returns
       `{ eligible, reason, acceptDeadlineMs, resolveDeadlineMs, acceptCapped }`.
-- [ ] T004 [P] Create `frontend/src/test/oracleTimeline.test.js`: eligibility floor,
+- [X] T004 [P] Create `frontend/src/test/oracleTimeline.test.js`: eligibility floor,
       cap behavior (`acceptCapped`), settle buffer, invariants
       `now < accept < resolve ≤ now+180d` across near/far/absent/garbage end dates
       (SC-003).
-- [ ] T005 [P] Export `normaliseGammaMarket` from
+- [X] T005 [P] Export `normaliseGammaMarket` from
       `frontend/src/hooks/usePolymarketSearch.js` (named export; no behavior change —
       existing search/browse hooks keep using it internally).
-- [ ] T006 Create `frontend/src/hooks/usePolymarketMarket.js` per
+- [X] T006 Create `frontend/src/hooks/usePolymarketMarket.js` per
       contracts/polymarket-market-hook.md: fetch
       `{gammaBase}/markets?condition_ids=<id>&limit=1` (gamma base resolved like
       `usePolymarketSearch`), normalize via `normaliseGammaMarket`, return
       `{ market, isLoading, error, refresh }`; no fetch when conditionId is
       falsy/ZeroHash or `enabled:false`; AbortController on unmount/param change;
       never throws into render. (Depends on T005.)
-- [ ] T007 [P] Create `frontend/src/test/usePolymarketMarket.test.jsx`: success
+- [X] T007 [P] Create `frontend/src/test/usePolymarketMarket.test.jsx`: success
       normalization, not-found, network error → `{market:null, error}`, disabled/zero
       conditionId skips fetch, `refresh()` refetches.
-- [ ] T008 Extract `ClaimCodeResultPanel` per contracts/create-flow.md: new
+- [X] T008 Extract `ClaimCodeResultPanel` per contracts/create-flow.md: new
       `frontend/src/components/fairwins/ClaimCodeResultPanel.jsx` carrying the
       post-create result UI currently inside
       `frontend/src/components/fairwins/OpenChallengeModal.jsx` (one-time code display,
       copy-with-check, `WagerQRCode` + `buildTakeChallengeUrl` deep link,
       `useOpenChallengeCodeVault` auto-backup states); rewire `OpenChallengeModal.jsx`
       to render it with zero user-visible behavior change (FR-018).
-- [ ] T009 Extend `frontend/src/hooks/useOpenChallengeCreate.js` per
+- [X] T009 Extend `frontend/src/hooks/useOpenChallengeCreate.js` per
       contracts/create-flow.md: accept optional `form.oracleMeta`; seal
       `{ description, createdAt: <ISO now>, oracle: oracleMeta }` when present
       (unchanged payload otherwise); add oracle revert translations to
       `translateOpenCreateRevert` (`PolymarketRequired`, `AdapterNotSet`,
       `ConditionAlreadyResolved`, `PolymarketDisallowed`).
-- [ ] T010 Extend `frontend/src/test/claimCode/OpenChallengeModal.test.jsx` (and add
+- [X] T010 Extend `frontend/src/test/claimCode/OpenChallengeModal.test.jsx` (and add
       hook-level assertions there or in a sibling test) to cover: result-panel
       extraction leaves the user-defined flow identical, sealed payload includes
       `createdAt` + `oracle` block only when `oracleMeta` given, and the new revert

--- a/specs/041-oracle-open-challenges/tasks.md
+++ b/specs/041-oracle-open-challenges/tasks.md
@@ -109,7 +109,7 @@ sees the event-derived timeline, creates, and gets the shareable four-word code.
 end-to-end from the new section; verify escrow, code issuance, on-chain market linkage
 + side, and deadlines consistent with the event (quickstart §3 steps 1–3).
 
-- [ ] T011 [US1] Create `frontend/src/components/fairwins/OracleOpenChallengeModal.jsx`
+- [X] T011 [US1] Create `frontend/src/components/fairwins/OracleOpenChallengeModal.jsx`
       per contracts/create-flow.md — structure + discovery step: `fm-*` modal shell
       (mirror `OpenChallengeModal.jsx` header/close/backdrop/Escape patterns), gating
       (`useChainTokens().capabilities.polymarketSidebets` +
@@ -119,7 +119,7 @@ end-to-end from the new section; verify escrow, code issuance, on-chain market l
       onSelectMarket selectedConditionId>`; selecting a market runs
       `deriveOracleChallengeTimeline(market.endDate, nowMs)` (mount-anchored `nowMs`)
       and refuses ineligible markets with the returned `reason` displayed.
-- [ ] T012 [US1] Add the configure step to `OracleOpenChallengeModal.jsx`: selected
+- [X] T012 [US1] Add the configure step to `OracleOpenChallengeModal.jsx`: selected
       market summary (question, image, end date, live outcome prices); side picker —
       two labelled buttons from `market.outcomes[].name` (fallback Yes/No) with prices,
       `aria-pressed`, index 0 → `creatorIsYes: true` (D6); stake input identical to
@@ -127,29 +127,29 @@ end-to-end from the new section; verify escrow, code issuance, on-chain market l
       timeline summary ("Takeable until … · settles by …", provenance "from the
       event", disclosure when `acceptCapped`); "change market" affordance back to the
       picker.
-- [ ] T013 [US1] Wire submit in `OracleOpenChallengeModal.jsx`: compose `description`
+- [X] T013 [US1] Wire submit in `OracleOpenChallengeModal.jsx`: compose `description`
       (market question + chosen side label), call `createOpenChallenge({ description,
       stake, resolutionType: ResolutionType.Polymarket, oracleConditionId:
       market.conditionId, creatorIsYes, acceptDeadline, resolveDeadline, oracleMeta })`
       with progress states; on success render `ClaimCodeResultPanel`; surface
       translated reverts (incl. `ConditionAlreadyResolved` → back to picker per
       FR-008).
-- [ ] T014 [P] [US1] Create `frontend/src/components/fairwins/OracleOpenChallengeModal.css`
+- [X] T014 [P] [US1] Create `frontend/src/components/fairwins/OracleOpenChallengeModal.css`
       (section-specific styles over the shared `fm-*`/`OpenChallengeModal.css` base;
       side-picker buttons meet contrast + focus-visible requirements).
-- [ ] T015 [US1] Dashboard entry point: add `oracle-open-challenge` to
+- [X] T015 [US1] Dashboard entry point: add `oracle-open-challenge` to
       `frontend/src/constants/quickAccessCards.js`; in
       `frontend/src/components/fairwins/Dashboard.jsx` add the card to `createActions`
       (capability-aware like `create-1v1-oracle`), a `handleQuickAction` case opening
       the new modal, and the `<OracleOpenChallengeModal>` instance beside
       `<OpenChallengeModal>` (FR-001, FR-004).
-- [ ] T016 [P] [US1] Create `frontend/src/test/claimCode/OracleOpenChallengeModal.test.jsx`:
+- [X] T016 [P] [US1] Create `frontend/src/test/claimCode/OracleOpenChallengeModal.test.jsx`:
       renders feed with no input; ineligible market unselectable with reason; side/stake
       step gates create button; submit passes `resolutionType=4`, conditionId,
       `creatorIsYes` per side, derived deadlines, and `oracleMeta` (mock
       `useOpenChallengeCreate`); success shows the code result panel; hidden/locked
       when capability or oracle-model exposure is off.
-- [ ] T017 [P] [US1] Extend `frontend/src/test/Dashboard.test.jsx`: new card appears
+- [X] T017 [P] [US1] Extend `frontend/src/test/Dashboard.test.jsx`: new card appears
       (and is gated by `polymarketSidebets`), quick action opens the oracle modal, the
       existing `open-challenge` card still opens the user-defined modal.
 

--- a/specs/041-oracle-open-challenges/tasks.md
+++ b/specs/041-oracle-open-challenges/tasks.md
@@ -169,7 +169,7 @@ closed/resolved markets.
 single-view summary in live, degraded (Gamma offline), closed, and resolved states;
 accept and confirm standard oracle settlement (quickstart §3.4–3.6).
 
-- [ ] T018 [US2] Extend `frontend/src/components/fairwins/TakeChallengePanel.jsx` per
+- [X] T018 [US2] Extend `frontend/src/components/fairwins/TakeChallengePanel.jsx` per
       contracts/claimant-view.md — bet summary + oracle block: for
       `Number(wager.resolutionType) === ResolutionType.Polymarket`, render between the
       terms `<pre>` and `<ChallengeDeadlines>`: market question (verified
@@ -180,7 +180,7 @@ accept and confirm standard oracle settlement (quickstart §3.4–3.6).
       line renders for non-oracle challenges too). Include the integrity check:
       `terms.oracle.conditionId` vs `wager.polymarketConditionId` mismatch → warning +
       prefer live data (Constitution III).
-- [ ] T019 [US2] Add the settlement-source badge + live context to
+- [X] T019 [US2] Add the settlement-source badge + live context to
       `TakeChallengePanel.jsx`: distinct text+glyph badge "Settled automatically by
       Polymarket" with the plain-language explanation (shown in live AND degraded
       states), public market link when slug known; wire
@@ -189,13 +189,13 @@ accept and confirm standard oracle settlement (quickstart §3.4–3.6).
       unavailable" on error with accept still enabled); accept gate per D8 —
       closed/past-end → prominent warning, publicly resolved outcome → accept button
       disabled with adjacent explanation (FR-013..FR-015).
-- [ ] T020 [P] [US2] Create `frontend/src/test/claimCode/TakeChallengePanel.oracle.test.jsx`:
+- [X] T020 [P] [US2] Create `frontend/src/test/claimCode/TakeChallengePanel.oracle.test.jsx`:
       full summary fields present on one view (SC-004); Polymarket named in live and
       degraded states (SC-005); side labels follow `creatorIsYes` both ways; integrity
       mismatch warning; closed-market warning vs resolved-market accept block;
       non-oracle challenge unchanged except stake/payout line; a11y roles
       (`role="status"`, button semantics).
-- [ ] T021 [P] [US2] Extend `frontend/src/test/useOpenChallengeAccept.test.jsx`:
+- [X] T021 [P] [US2] Extend `frontend/src/test/useOpenChallengeAccept.test.jsx`:
       lookup payload passes through `resolutionType`, `polymarketConditionId`,
       `creatorIsYes` untouched, and decrypted terms with an `oracle` block reach the
       caller (accept flow itself unchanged — FR-016).

--- a/specs/041-oracle-open-challenges/tasks.md
+++ b/specs/041-oracle-open-challenges/tasks.md
@@ -1,0 +1,281 @@
+# Tasks: Oracle-Settled Open Challenges (Polymarket)
+
+**Input**: Design documents from `/specs/041-oracle-open-challenges/`
+
+**Prerequisites**: plan.md, spec.md, research.md (D1–D9), data-model.md, contracts/
+
+**Tests**: INCLUDED — Constitution Principle II (test-first) is non-negotiable, and the
+plan's Constitution Check commits to contract-level lifecycle tests for the
+previously-untested `createOpenWager` + Polymarket path before the UI ships it.
+
+**Organization**: Grouped by user story; US1 (create) and US2 (claimant) are the joint
+MVP, US3 (discovery/share polish) layers on top.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1 (create flow), US2 (claimant clarity), US3 (fast discovery & sharing)
+
+## Path Conventions
+
+Web app: product code under `frontend/src/`, contract JS tests under `test/`
+(no Solidity changes — `contracts/` source is untouched).
+
+---
+
+## Phase 1: Setup (Baseline)
+
+**Purpose**: Anchor the zero-regression guarantee (SC-007) before any edits.
+
+- [ ] T001 Record a green baseline: run `npm test` (contract suite) and
+      `npm run test:frontend`; note current pass counts in the PR description or
+      commit message so SC-007 regressions are attributable. No file changes.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Risk gate + shared modules every story builds on.
+
+**⚠️ CRITICAL**: T002 is the constitutional risk gate (oracle-resolution path); the
+shared helpers/hooks (T003–T009) block both US1 and US2.
+
+- [ ] T002 [P] Contract lifecycle proof (D1, FR-017, SC-006, SC-008): create
+      `test/integration/oracle/WagerRegistry_PolymarketOpenChallenge.test.js` modeled
+      on `test/integration/oracle/WagerRegistry_Polymarket.test.js` fixtures
+      (`MockPolymarketCTF` → `PolymarketOracleAdapter` → `deployWagerRegistry` from
+      `test/helpers/proxy.js` with the adapter as 3rd init arg) and the code-based
+      accept helpers from `test/WagerRegistry.openChallenge.test.js`. Cover:
+      (a) `createOpenWager(..., Polymarket, conditionId, creatorIsYes, ...)` succeeds
+      for an unresolved condition, emits `OpenWagerCreated` + `PolymarketLinked`;
+      (b) creation reverts: zero conditionId (`PolymarketRequired`), pre-resolved
+      condition (`ConditionAlreadyResolved`), registry without adapter
+      (`AdapterNotSet`), and `Creator`/`Opponent` types still revert
+      (`OpenResolutionTypeNotAllowed`); (c) code-holder accepts via `acceptOpenWager`,
+      then `autoResolveFromPolymarket` settles YES-win, NO-win, tie→draw, and reverts
+      `ConditionNotResolved` when unresolved; winner claims payout; (d) untaken oracle
+      open challenge expires → creator refund.
+- [ ] T003 [P] Create `frontend/src/lib/openChallenge/oracleTimeline.js` per
+      contracts/timeline-derivation.md: export `deriveOracleChallengeTimeline(marketEndIso, nowMs)`
+      and constants `MIN_LEAD_MS` (1h), `ACCEPT_CAP_MS` (30d−1h), `SETTLE_BUFFER_MS`
+      (7d), `RESOLVE_CAP_MS` (180d−1h); pure, injected clock, returns
+      `{ eligible, reason, acceptDeadlineMs, resolveDeadlineMs, acceptCapped }`.
+- [ ] T004 [P] Create `frontend/src/test/oracleTimeline.test.js`: eligibility floor,
+      cap behavior (`acceptCapped`), settle buffer, invariants
+      `now < accept < resolve ≤ now+180d` across near/far/absent/garbage end dates
+      (SC-003).
+- [ ] T005 [P] Export `normaliseGammaMarket` from
+      `frontend/src/hooks/usePolymarketSearch.js` (named export; no behavior change —
+      existing search/browse hooks keep using it internally).
+- [ ] T006 Create `frontend/src/hooks/usePolymarketMarket.js` per
+      contracts/polymarket-market-hook.md: fetch
+      `{gammaBase}/markets?condition_ids=<id>&limit=1` (gamma base resolved like
+      `usePolymarketSearch`), normalize via `normaliseGammaMarket`, return
+      `{ market, isLoading, error, refresh }`; no fetch when conditionId is
+      falsy/ZeroHash or `enabled:false`; AbortController on unmount/param change;
+      never throws into render. (Depends on T005.)
+- [ ] T007 [P] Create `frontend/src/test/usePolymarketMarket.test.jsx`: success
+      normalization, not-found, network error → `{market:null, error}`, disabled/zero
+      conditionId skips fetch, `refresh()` refetches.
+- [ ] T008 Extract `ClaimCodeResultPanel` per contracts/create-flow.md: new
+      `frontend/src/components/fairwins/ClaimCodeResultPanel.jsx` carrying the
+      post-create result UI currently inside
+      `frontend/src/components/fairwins/OpenChallengeModal.jsx` (one-time code display,
+      copy-with-check, `WagerQRCode` + `buildTakeChallengeUrl` deep link,
+      `useOpenChallengeCodeVault` auto-backup states); rewire `OpenChallengeModal.jsx`
+      to render it with zero user-visible behavior change (FR-018).
+- [ ] T009 Extend `frontend/src/hooks/useOpenChallengeCreate.js` per
+      contracts/create-flow.md: accept optional `form.oracleMeta`; seal
+      `{ description, createdAt: <ISO now>, oracle: oracleMeta }` when present
+      (unchanged payload otherwise); add oracle revert translations to
+      `translateOpenCreateRevert` (`PolymarketRequired`, `AdapterNotSet`,
+      `ConditionAlreadyResolved`, `PolymarketDisallowed`).
+- [ ] T010 Extend `frontend/src/test/claimCode/OpenChallengeModal.test.jsx` (and add
+      hook-level assertions there or in a sibling test) to cover: result-panel
+      extraction leaves the user-defined flow identical, sealed payload includes
+      `createdAt` + `oracle` block only when `oracleMeta` given, and the new revert
+      translations map to friendly messages. (Depends on T008–T009.)
+
+**Checkpoint**: Foundation ready — `npm test` + `npm run test:frontend` green.
+
+---
+
+## Phase 3: User Story 1 — Pick a Polymarket event and post an oracle-settled open challenge (Priority: P1) 🎯 MVP
+
+**Goal**: Silver+ member browses/searches Polymarket markets, picks a side and stake,
+sees the event-derived timeline, creates, and gets the shareable four-word code.
+
+**Independent Test**: On a Polymarket-capable chain, create an oracle open challenge
+end-to-end from the new section; verify escrow, code issuance, on-chain market linkage
++ side, and deadlines consistent with the event (quickstart §3 steps 1–3).
+
+- [ ] T011 [US1] Create `frontend/src/components/fairwins/OracleOpenChallengeModal.jsx`
+      per contracts/create-flow.md — structure + discovery step: `fm-*` modal shell
+      (mirror `OpenChallengeModal.jsx` header/close/backdrop/Escape patterns), gating
+      (`useChainTokens().capabilities.polymarketSidebets` +
+      `isOracleModelExposed(ResolutionType.Polymarket)` from
+      `frontend/src/constants/wagerDefaults.js`), embedded
+      `<PolymarketBrowser variant="inline" showFilters limit={20}
+      onSelectMarket selectedConditionId>`; selecting a market runs
+      `deriveOracleChallengeTimeline(market.endDate, nowMs)` (mount-anchored `nowMs`)
+      and refuses ineligible markets with the returned `reason` displayed.
+- [ ] T012 [US1] Add the configure step to `OracleOpenChallengeModal.jsx`: selected
+      market summary (question, image, end date, live outcome prices); side picker —
+      two labelled buttons from `market.outcomes[].name` (fallback Yes/No) with prices,
+      `aria-pressed`, index 0 → `creatorIsYes: true` (D6); stake input identical to
+      OpenChallengeModal's (USDC select, `> 0`, 2-dp blur normalize); read-only derived
+      timeline summary ("Takeable until … · settles by …", provenance "from the
+      event", disclosure when `acceptCapped`); "change market" affordance back to the
+      picker.
+- [ ] T013 [US1] Wire submit in `OracleOpenChallengeModal.jsx`: compose `description`
+      (market question + chosen side label), call `createOpenChallenge({ description,
+      stake, resolutionType: ResolutionType.Polymarket, oracleConditionId:
+      market.conditionId, creatorIsYes, acceptDeadline, resolveDeadline, oracleMeta })`
+      with progress states; on success render `ClaimCodeResultPanel`; surface
+      translated reverts (incl. `ConditionAlreadyResolved` → back to picker per
+      FR-008).
+- [ ] T014 [P] [US1] Create `frontend/src/components/fairwins/OracleOpenChallengeModal.css`
+      (section-specific styles over the shared `fm-*`/`OpenChallengeModal.css` base;
+      side-picker buttons meet contrast + focus-visible requirements).
+- [ ] T015 [US1] Dashboard entry point: add `oracle-open-challenge` to
+      `frontend/src/constants/quickAccessCards.js`; in
+      `frontend/src/components/fairwins/Dashboard.jsx` add the card to `createActions`
+      (capability-aware like `create-1v1-oracle`), a `handleQuickAction` case opening
+      the new modal, and the `<OracleOpenChallengeModal>` instance beside
+      `<OpenChallengeModal>` (FR-001, FR-004).
+- [ ] T016 [P] [US1] Create `frontend/src/test/claimCode/OracleOpenChallengeModal.test.jsx`:
+      renders feed with no input; ineligible market unselectable with reason; side/stake
+      step gates create button; submit passes `resolutionType=4`, conditionId,
+      `creatorIsYes` per side, derived deadlines, and `oracleMeta` (mock
+      `useOpenChallengeCreate`); success shows the code result panel; hidden/locked
+      when capability or oracle-model exposure is off.
+- [ ] T017 [P] [US1] Extend `frontend/src/test/Dashboard.test.jsx`: new card appears
+      (and is gated by `polymarketSidebets`), quick action opens the oracle modal, the
+      existing `open-challenge` card still opens the user-defined modal.
+
+**Checkpoint**: US1 independently testable — create flow works end-to-end against a
+mocked create hook in tests and real Amoy manually (quickstart §3.1–3.3).
+
+---
+
+## Phase 4: User Story 2 — Claimant opens the code and clearly understands the bet (Priority: P1) 🎯 MVP
+
+**Goal**: A code-holder sees the full bet summary — question, THEIR side, stake,
+payout, deadlines — with Polymarket unmistakably identified as the automatic settlement
+source, live market context when reachable, and honest warnings/blocks around
+closed/resolved markets.
+
+**Independent Test**: With a code from US1, look it up as another member and verify the
+single-view summary in live, degraded (Gamma offline), closed, and resolved states;
+accept and confirm standard oracle settlement (quickstart §3.4–3.6).
+
+- [ ] T018 [US2] Extend `frontend/src/components/fairwins/TakeChallengePanel.jsx` per
+      contracts/claimant-view.md — bet summary + oracle block: for
+      `Number(wager.resolutionType) === ResolutionType.Polymarket`, render between the
+      terms `<pre>` and `<ChallengeDeadlines>`: market question (verified
+      `terms.oracle` → live → shortened conditionId fallback), "You take
+      {takerSideLabel} / Creator holds {creatorSideLabel}" driven by on-chain
+      `creatorIsYes` (labels from verified terms or live outcomes), and the
+      stake/payout line from on-chain `opponentStake` + token metadata (stake/payout
+      line renders for non-oracle challenges too). Include the integrity check:
+      `terms.oracle.conditionId` vs `wager.polymarketConditionId` mismatch → warning +
+      prefer live data (Constitution III).
+- [ ] T019 [US2] Add the settlement-source badge + live context to
+      `TakeChallengePanel.jsx`: distinct text+glyph badge "Settled automatically by
+      Polymarket" with the plain-language explanation (shown in live AND degraded
+      states), public market link when slug known; wire
+      `usePolymarketMarket(wager.polymarketConditionId)` for current prices/status
+      (`role="status"`, skeleton while loading, disclosed "live market info
+      unavailable" on error with accept still enabled); accept gate per D8 —
+      closed/past-end → prominent warning, publicly resolved outcome → accept button
+      disabled with adjacent explanation (FR-013..FR-015).
+- [ ] T020 [P] [US2] Create `frontend/src/test/claimCode/TakeChallengePanel.oracle.test.jsx`:
+      full summary fields present on one view (SC-004); Polymarket named in live and
+      degraded states (SC-005); side labels follow `creatorIsYes` both ways; integrity
+      mismatch warning; closed-market warning vs resolved-market accept block;
+      non-oracle challenge unchanged except stake/payout line; a11y roles
+      (`role="status"`, button semantics).
+- [ ] T021 [P] [US2] Extend `frontend/src/test/useOpenChallengeAccept.test.jsx`:
+      lookup payload passes through `resolutionType`, `polymarketConditionId`,
+      `creatorIsYes` untouched, and decrypted terms with an `oracle` block reach the
+      caller (accept flow itself unchanged — FR-016).
+
+**Checkpoint**: US1+US2 together = MVP (quickstart §2–§3 fully green).
+
+---
+
+## Phase 5: User Story 3 — Fast, exciting discovery and effortless sharing (Priority: P2)
+
+**Goal**: Section opens straight into a browsable feed; filters/search feel immediate;
+grouped events stay scannable; share tools at hand — SC-001/SC-002 interaction targets.
+
+**Independent Test**: Timed walkthrough per quickstart §3.1–3.3: open section → code in
+hand in under 2 minutes, ≤ 3 interactions from feed to side-picked market; feed/search
+under ~2 s typical.
+
+- [ ] T022 [US3] Discovery polish in `OracleOpenChallengeModal.jsx` +
+      `OracleOpenChallengeModal.css`: default feed opens expanded with popular markets
+      (no input required), event-grouped rows expand inline, ineligible-market reason
+      copy is friendly ("ends too soon…"), selection → configure step transition is a
+      single tap, and an `InfoTip` explains the section ("Polymarket settles it — you
+      just pick a side and share the code").
+- [ ] T023 [US3] Share-readiness pass on `ClaimCodeResultPanel.jsx`: copy / QR /
+      take-challenge deep link and vault-backup states visible without scrolling on
+      mobile-width viewport; code-retention prompt copy mentions the taker needs the
+      code to read the bet (parity with FR-010; no new mechanics).
+- [ ] T024 [P] [US3] Extend `frontend/src/test/claimCode/OracleOpenChallengeModal.test.jsx`
+      for US3 acceptance: feed renders with zero input, grouped event expands, ≤ 3
+      interactions from feed to side selection (assert step transitions), stale-result
+      guard (loading state shown while switching filters).
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T025 [P] Accessibility audit additions in
+      `frontend/src/test/accessibility.test.jsx`: axe checks over
+      `OracleOpenChallengeModal` (both steps) and the oracle-summary
+      `TakeChallengePanel` state (WCAG 2.1 AA — Constitution V).
+- [ ] T026 [P] Update `docs/` developer notes: brief section in the wagers/oracle
+      developer guide (e.g. `docs/developer-guide/` alongside existing guides) covering
+      the sealed `oracle` terms block, timeline-derivation constants, and the
+      chain-authoritative display rule (D4).
+- [ ] T027 Full verification sweep per quickstart: `npm run compile`, `npm test`,
+      `npm run test:frontend`, frontend lint — all green with zero regressions
+      (SC-007); compare against the T001 baseline.
+- [ ] T028 Manual quickstart §3 walkthrough on Amoy (create → share → second-wallet
+      claim view incl. degraded state → accept) and record outcomes in the PR
+      description (SC-001/SC-004/SC-005 evidence).
+
+---
+
+## Dependencies
+
+```text
+Phase 1 (T001)
+  └─► Phase 2: T002 ∥ (T003→T004) ∥ (T005→T006→T007) ∥ (T008→T009→T010)
+        └─► Phase 3 (US1): T011→T012→T013; T014 ∥; T015 after T011; T016/T017 after T013/T015
+              └─► Phase 4 (US2): T018→T019; T020/T021 after T019   [needs T006, T009 sealing]
+                    └─► Phase 5 (US3): T022→T023; T024 after T022  [polish over US1 UI]
+                          └─► Phase 6: T025–T028
+```
+
+- US2 depends on Foundational (T006 hook, T009 sealed block) and benefits from US1 for
+  end-to-end data, but its component tests run against fixture wagers — implementable
+  in parallel with US1 after Phase 2 if desired.
+- T002 (contract proof) has no frontend dependents and can run fully in parallel.
+
+## Parallel Execution Examples
+
+- **Phase 2**: T002, T003+T004, T005→T006+T007, T008→T009→T010 are four independent
+  tracks (different files).
+- **US1**: T014 (CSS) and T016/T017 (tests) parallel to late implementation tasks.
+- **US2**: T020 and T021 in parallel once T019 lands.
+
+## Implementation Strategy
+
+**MVP = Phase 2 + US1 + US2** (create + claim are one promise; US1 alone already
+demos end-to-end with the existing lookup showing terms + deadlines). Ship order:
+foundation risk-gate first (T002 proves the chain path), shared modules, then US1 and
+US2 (parallelizable), US3 polish, final sweep. Each checkpoint leaves the branch green
+(`npm test` + `npm run test:frontend`).

--- a/test/integration/oracle/WagerRegistry_PolymarketOpenChallenge.test.js
+++ b/test/integration/oracle/WagerRegistry_PolymarketOpenChallenge.test.js
@@ -1,0 +1,274 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time, loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+const { deployWagerRegistry, deployMembershipManager } = require("../../helpers/proxy");
+
+// Spec 041 — oracle-settled OPEN challenges (Polymarket). No Solidity changes: this
+// suite proves the deployed path end-to-end under the new usage pattern (constitution
+// Principle I treats oracle-resolution paths as highest-risk, and no prior test created
+// an open wager with an oracle resolution type). Equivalence target: an accepted oracle
+// open challenge behaves identically to the named-opponent Polymarket suite
+// (test/integration/oracle/WagerRegistry_Polymarket.test.js).
+
+const Tier = { None: 0, Bronze: 1, Silver: 2 };
+const Resolution = {
+  Either: 0, Creator: 1, Opponent: 2, ThirdParty: 3, Polymarket: 4,
+  ChainlinkDataFeed: 5, ChainlinkFunctions: 6, UMA: 7,
+};
+const Status = { None: 0, Open: 1, Active: 2, Resolved: 3, Cancelled: 4, Refunded: 5, Draw: 6 };
+const WAGER_PARTICIPANT_ROLE = ethers.keccak256(ethers.toUtf8Bytes("WAGER_PARTICIPANT_ROLE"));
+const usdc = (n) => ethers.parseUnits(String(n), 6);
+
+describe("WagerRegistry — oracle-settled open challenges (041, Polymarket)", function () {
+  async function deployFixture() {
+    const [admin, silverCreator, taker, otherTaker, treasury] = await ethers.getSigners();
+
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    const usdcToken = await MockERC20.deploy("USD Coin", "USDC", 0);
+
+    const Ctf = await ethers.getContractFactory("MockPolymarketCTF");
+    const ctf = await Ctf.deploy();
+    const PolymarketAdapter = await ethers.getContractFactory("PolymarketOracleAdapter");
+    const pmAdapter = await PolymarketAdapter.deploy(admin.address, await ctf.getAddress());
+
+    const mgr = await deployMembershipManager([admin.address, await usdcToken.getAddress(), treasury.address]);
+    const limits = { monthlyMarketCreation: 100, maxConcurrentMarkets: 20 };
+    await mgr.connect(admin).setTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze, usdc(50), 30, limits, true);
+    await mgr.connect(admin).setTier(WAGER_PARTICIPANT_ROLE, Tier.Silver, usdc(100), 30, limits, true);
+
+    const reg = await deployWagerRegistry([
+      admin.address, await mgr.getAddress(), await pmAdapter.getAddress(),
+      [await usdcToken.getAddress()],
+    ]);
+    await mgr.connect(admin).setAuthorizedCaller(await reg.getAddress(), true);
+
+    for (const u of [silverCreator, taker, otherTaker]) {
+      await usdcToken.mint(u.address, usdc(10_000));
+      await usdcToken.connect(u).approve(await mgr.getAddress(), ethers.MaxUint256);
+      await usdcToken.connect(u).approve(await reg.getAddress(), ethers.MaxUint256);
+    }
+    await mgr.connect(silverCreator).purchaseTier(WAGER_PARTICIPANT_ROLE, Tier.Silver);
+    await mgr.connect(taker).purchaseTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze);
+    await mgr.connect(otherTaker).purchaseTier(WAGER_PARTICIPANT_ROLE, Tier.Bronze);
+
+    return { reg, mgr, usdcToken, ctf, pmAdapter, admin, silverCreator, taker, otherTaker };
+  }
+
+  /** Prepare a fresh (unresolved) CTF condition and return its id. */
+  async function prepareCondition(fx) {
+    const oracle = fx.admin.address;
+    const questionId = ethers.id("open-q-" + Math.random());
+    const conditionId = await fx.ctf.getConditionId(oracle, questionId, 2);
+    await fx.ctf.prepareCondition(oracle, questionId, 2);
+    return conditionId;
+  }
+
+  // The code-derived claim key (production derives it from the four-word code).
+  function newClaimKey() {
+    return ethers.Wallet.createRandom();
+  }
+
+  async function signOpenAccept(claimKey, regAddr, wagerId, takerAddr) {
+    const { chainId } = await ethers.provider.getNetwork();
+    const domain = { name: "FairWins WagerRegistry", version: "1", chainId, verifyingContract: regAddr };
+    const types = { OpenAccept: [{ name: "wagerId", type: "uint256" }, { name: "taker", type: "address" }] };
+    return claimKey.signTypedData(domain, types, { wagerId, taker: takerAddr });
+  }
+
+  /** Create an oracle-settled open challenge; returns { wagerId, key }. */
+  async function createOracleOpen(fx, conditionId, overrides = {}) {
+    const now = await time.latest();
+    const key = overrides.key || newClaimKey();
+    const p = {
+      stake: usdc(10),
+      acceptDeadline: now + 3600,
+      resolveDeadline: now + 86400,
+      resolutionType: Resolution.Polymarket,
+      creatorIsYes: true,
+      ...overrides,
+    };
+    const tx = await fx.reg.connect(fx.silverCreator).createOpenWager(
+      key.address, ethers.ZeroAddress, await fx.usdcToken.getAddress(),
+      p.stake, p.acceptDeadline, p.resolveDeadline, p.resolutionType,
+      conditionId, p.creatorIsYes, ethers.id("oracle-open-terms"), "ipfs://bafyOracleOpen"
+    );
+    const rc = await tx.wait();
+    const ev = rc.logs.map((l) => { try { return fx.reg.interface.parseLog(l); } catch { return null; } })
+      .find((p2) => p2 && p2.name === "OpenWagerCreated");
+    return { wagerId: Number(ev.args.wagerId), key, tx };
+  }
+
+  async function acceptWithCode(fx, wagerId, key, taker) {
+    const sig = await signOpenAccept(key, await fx.reg.getAddress(), wagerId, taker.address);
+    return fx.reg.connect(taker).acceptOpenWager(wagerId, sig);
+  }
+
+  describe("creation (FR-008/FR-009 — on-chain linkage validation)", () => {
+    it("links an unresolved Polymarket condition and emits OpenWagerCreated + PolymarketLinked", async () => {
+      const fx = await loadFixture(deployFixture);
+      const conditionId = await prepareCondition(fx);
+      const { wagerId, tx } = await createOracleOpen(fx, conditionId, { creatorIsYes: true });
+
+      await expect(tx).to.emit(fx.reg, "PolymarketLinked").withArgs(wagerId, conditionId, true);
+      const w = await fx.reg.getWager(wagerId);
+      expect(w.status).to.equal(Status.Open);
+      expect(w.opponent).to.equal(ethers.ZeroAddress);
+      expect(w.resolutionType).to.equal(Resolution.Polymarket);
+      expect(w.polymarketConditionId).to.equal(conditionId);
+      expect(w.creatorIsYes).to.equal(true);
+      expect(w.creatorStake).to.equal(usdc(10));
+      expect(w.opponentStake).to.equal(usdc(10)); // equal stakes by construction
+      expect(await fx.reg.isOpenChallenge(wagerId)).to.equal(true);
+    });
+
+    it("reverts PolymarketRequired for a zero condition id", async () => {
+      const fx = await loadFixture(deployFixture);
+      await expect(createOracleOpen(fx, ethers.ZeroHash))
+        .to.be.revertedWithCustomError(fx.reg, "PolymarketRequired");
+    });
+
+    it("reverts ConditionAlreadyResolved for a market whose outcome is already public", async () => {
+      const fx = await loadFixture(deployFixture);
+      const conditionId = await prepareCondition(fx);
+      await fx.ctf.resolveCondition(conditionId, [1, 0]);
+      await expect(createOracleOpen(fx, conditionId))
+        .to.be.revertedWithCustomError(fx.reg, "ConditionAlreadyResolved");
+    });
+
+    it("reverts AdapterNotSet when the registry has no Polymarket adapter", async () => {
+      const fx = await loadFixture(deployFixture);
+      const { admin, silverCreator, usdcToken, mgr } = fx;
+      const bare = await deployWagerRegistry([
+        admin.address, await mgr.getAddress(), ethers.ZeroAddress,
+        [await usdcToken.getAddress()],
+      ]);
+      await mgr.connect(admin).setAuthorizedCaller(await bare.getAddress(), true);
+      await usdcToken.connect(silverCreator).approve(await bare.getAddress(), ethers.MaxUint256);
+
+      const now = await time.latest();
+      await expect(bare.connect(silverCreator).createOpenWager(
+        newClaimKey().address, ethers.ZeroAddress, await usdcToken.getAddress(),
+        usdc(10), now + 3600, now + 86400, Resolution.Polymarket,
+        ethers.id("some-condition"), true, ethers.id("t"), ""
+      )).to.be.revertedWithCustomError(bare, "AdapterNotSet");
+    });
+
+    it("still bars single-party self-resolution on open challenges (FR-016a of 024)", async () => {
+      const fx = await loadFixture(deployFixture);
+      await expect(createOracleOpen(fx, ethers.ZeroHash, { resolutionType: Resolution.Creator }))
+        .to.be.revertedWithCustomError(fx.reg, "OpenResolutionTypeNotAllowed");
+      await expect(createOracleOpen(fx, ethers.ZeroHash, { resolutionType: Resolution.Opponent }))
+        .to.be.revertedWithCustomError(fx.reg, "OpenResolutionTypeNotAllowed");
+    });
+  });
+
+  describe("accept → auto-resolve → claim (FR-016/FR-017 — equivalence with named-opponent oracle wagers)", () => {
+    it("YES outcome: creator (creatorIsYes=true) wins and claims 2× stake", async () => {
+      const fx = await loadFixture(deployFixture);
+      const conditionId = await prepareCondition(fx);
+      const { wagerId, key } = await createOracleOpen(fx, conditionId, { creatorIsYes: true });
+
+      await acceptWithCode(fx, wagerId, key, fx.taker);
+      expect((await fx.reg.getWager(wagerId)).status).to.equal(Status.Active);
+      expect((await fx.reg.getWager(wagerId)).opponent).to.equal(fx.taker.address);
+
+      await fx.ctf.resolveCondition(conditionId, [1, 0]); // YES wins
+      // Anyone may trigger the auto-resolve — same as named-opponent oracle wagers.
+      await fx.reg.connect(fx.otherTaker).autoResolveFromPolymarket(wagerId);
+
+      const w = await fx.reg.getWager(wagerId);
+      expect(w.status).to.equal(Status.Resolved);
+      expect(w.winner).to.equal(fx.silverCreator.address);
+
+      const before = await fx.usdcToken.balanceOf(fx.silverCreator.address);
+      await fx.reg.connect(fx.silverCreator).claimPayout(wagerId);
+      expect((await fx.usdcToken.balanceOf(fx.silverCreator.address)) - before).to.equal(usdc(20));
+    });
+
+    it("NO outcome: the code-holding taker (opposite side) wins", async () => {
+      const fx = await loadFixture(deployFixture);
+      const conditionId = await prepareCondition(fx);
+      const { wagerId, key } = await createOracleOpen(fx, conditionId, { creatorIsYes: true });
+      await acceptWithCode(fx, wagerId, key, fx.taker);
+
+      await fx.ctf.resolveCondition(conditionId, [0, 1]); // NO wins
+      await fx.reg.connect(fx.otherTaker).autoResolveFromPolymarket(wagerId);
+
+      const w = await fx.reg.getWager(wagerId);
+      expect(w.status).to.equal(Status.Resolved);
+      expect(w.winner).to.equal(fx.taker.address);
+
+      const before = await fx.usdcToken.balanceOf(fx.taker.address);
+      await fx.reg.connect(fx.taker).claimPayout(wagerId);
+      expect((await fx.usdcToken.balanceOf(fx.taker.address)) - before).to.equal(usdc(20));
+    });
+
+    it("TIE (invalid market): settles a DRAW and returns both stakes", async () => {
+      const fx = await loadFixture(deployFixture);
+      const conditionId = await prepareCondition(fx);
+      const { wagerId, key } = await createOracleOpen(fx, conditionId, { creatorIsYes: true });
+      await acceptWithCode(fx, wagerId, key, fx.taker);
+
+      await fx.ctf.resolveCondition(conditionId, [1, 1]); // 50/50 tie
+      const cBefore = await fx.usdcToken.balanceOf(fx.silverCreator.address);
+      const tBefore = await fx.usdcToken.balanceOf(fx.taker.address);
+      await expect(fx.reg.connect(fx.otherTaker).autoResolveFromPolymarket(wagerId))
+        .to.emit(fx.reg, "WagerDrawn");
+
+      expect((await fx.reg.getWager(wagerId)).status).to.equal(Status.Draw);
+      expect((await fx.usdcToken.balanceOf(fx.silverCreator.address)) - cBefore).to.equal(usdc(10));
+      expect((await fx.usdcToken.balanceOf(fx.taker.address)) - tBefore).to.equal(usdc(10));
+    });
+
+    it("UNRESOLVED market: auto-resolve reverts ConditionNotResolved (no premature settle)", async () => {
+      const fx = await loadFixture(deployFixture);
+      const conditionId = await prepareCondition(fx);
+      const { wagerId, key } = await createOracleOpen(fx, conditionId);
+      await acceptWithCode(fx, wagerId, key, fx.taker);
+
+      await expect(fx.reg.connect(fx.otherTaker).autoResolveFromPolymarket(wagerId))
+        .to.be.revertedWithCustomError(fx.reg, "ConditionNotResolved");
+    });
+
+    it("only the first code-holder binds; a second acceptance is cleanly refused", async () => {
+      const fx = await loadFixture(deployFixture);
+      const conditionId = await prepareCondition(fx);
+      const { wagerId, key } = await createOracleOpen(fx, conditionId);
+
+      await acceptWithCode(fx, wagerId, key, fx.taker);
+      await expect(acceptWithCode(fx, wagerId, key, fx.otherTaker)).to.be.reverted;
+      expect((await fx.reg.getWager(wagerId)).opponent).to.equal(fx.taker.address);
+    });
+  });
+
+  describe("lifecycle edges", () => {
+    it("an untaken oracle open challenge expires → creator refund, code slot freed", async () => {
+      const fx = await loadFixture(deployFixture);
+      const conditionId = await prepareCondition(fx);
+      const { wagerId, key } = await createOracleOpen(fx, conditionId);
+
+      const w = await fx.reg.getWager(wagerId);
+      await time.increaseTo(Number(w.acceptDeadline) + 1);
+
+      const before = await fx.usdcToken.balanceOf(fx.silverCreator.address);
+      await fx.reg.connect(fx.silverCreator).claimRefund(wagerId);
+      expect((await fx.reg.getWager(wagerId)).status).to.equal(Status.Refunded);
+      expect((await fx.usdcToken.balanceOf(fx.silverCreator.address)) - before).to.equal(usdc(10));
+      expect(await fx.reg.openWagerIdForClaim(key.address)).to.equal(0n);
+    });
+
+    it("the market resolving while the challenge is still Open does not break expiry/refund", async () => {
+      // The claimant-side app blocks taking a publicly-decided market (D8); on-chain, an
+      // untaken challenge whose market resolved simply expires and refunds as usual.
+      const fx = await loadFixture(deployFixture);
+      const conditionId = await prepareCondition(fx);
+      const { wagerId } = await createOracleOpen(fx, conditionId);
+
+      await fx.ctf.resolveCondition(conditionId, [1, 0]);
+      const w = await fx.reg.getWager(wagerId);
+      await time.increaseTo(Number(w.acceptDeadline) + 1);
+      await fx.reg.connect(fx.silverCreator).claimRefund(wagerId);
+      expect((await fx.reg.getWager(wagerId)).status).to.equal(Status.Refunded);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds feature **041 — Oracle-Settled Open Challenges**: a new section where a creator picks a Polymarket market through the same fast discovery UX as the existing oracle wager flow, picks a side and a stake, and posts a code-gated **open challenge** settled automatically by Polymarket. The linked event's own schedule derives the accept/settle deadlines ("the event defines the timelines"). The claim-code flow (spec 024) is reused unchanged, and the claimant view presents the bet plainly with Polymarket unmistakably identified as the settlement source.

**Zero Solidity changes.** `WagerRegistry.createOpenWager` already validates oracle linkage at creation (`_checkOracleLinkage`: non-zero condition id, adapter configured, condition unresolved) and `autoResolveFromPolymarket` is origin-independent — the "user-defined only" restriction lived purely in the frontend. A new contract-level lifecycle suite proves the previously-untested open+Polymarket path end-to-end.

## What's in the change

- **Create flow** — `OracleOpenChallengeModal`: inline `PolymarketBrowser` picker (trending/categories/search), side picker with the market's own outcome labels + live prices, equal-stake input, and a **read-only event-derived timeline** (`deriveOracleChallengeTimeline`: accept = market close capped at 30d−1h, settle = close + 7d within 180d−1h, 1h minimum lead — derived values can never revert `_checkDeadlines`). Dashboard gains a toggleable "Oracle Open Challenge" quick-access card; locked explanation on chains without `polymarketSidebets`.
- **Claimant view** — `TakeChallengePanel` now shows stake + winner-takes payout (all open challenges) and, for oracle challenges: the market question, **the taker's side** (opposite of on-chain `creatorIsYes`), a "Settled automatically by Polymarket" badge with plain-language explanation (live *and* degraded states), live prices/status via new `usePolymarketMarket`, and a public market link. Honest-state rules: the sealed metadata is cross-checked against `wager.polymarketConditionId` (mismatch flagged); closed market warns; a publicly-resolved outcome disables accept; unreachable live data discloses itself and never gates.
- **Sealed terms** — `useOpenChallengeCreate` seals an `oracle` block ({question, outcomes, side, endDate, slug}) into the code-keyed envelope so a code-holder can read the bet even when the Gamma API is down; never on-chain plaintext (preserves spec-024 indistinguishability). Plus oracle revert translations (`ConditionAlreadyResolved`, `PolymarketRequired`, `AdapterNotSet`, …).
- **Shared result panel** — `ClaimCodeResultPanel` extracted from `OpenChallengeModal` (code shown once / copy / QR / deep link / device vault backup) so both create flows share one security-relevant UX; the user-defined flow is behaviorally unchanged.
- **Docs** — `docs/developer-guide/oracle-open-challenges.md` (sealed block format, timeline constants, chain-authoritative display rule).

## Spec Kit workflow (complete)

- [x] `/speckit-specify` — spec.md + requirements checklist (all pass)
- [x] `/speckit-plan` — plan.md (constitution check PASS), research.md (D1–D9), data-model.md, contracts/, quickstart.md
- [x] `/speckit-tasks` — 28 tasks, 6 phases
- [x] `/speckit-implement` — 27/28 tasks complete (T028 below)

## Verification (SC-007 baseline → final)

- Contract suite: **608 passing** (includes 12 new lifecycle tests in `test/integration/oracle/WagerRegistry_PolymarketOpenChallenge.test.js`: linkage-validation reverts, code accept, YES/NO/tie auto-resolve equivalence, payout, expiry refund)
- Frontend suite: **2,062 passing** (new: `oracleTimeline`, `usePolymarketMarket`, `OracleOpenChallengeModal` incl. US3 interaction budget, `TakeChallengePanel.oracle`, Dashboard wiring, axe checks for the new surfaces)
- Frontend lint: **0 errors** (the earlier CI failure was a `Date.now()`-in-render purity error at `b03209d`, fixed in `c807f48`)

## Outstanding

- **T028 (manual)**: quickstart §3 walkthrough on Amoy with a Silver+ wallet (create → share → second-wallet claim view incl. degraded state → accept). Needs a funded test wallet, so it couldn't be exercised from this environment — everything it covers is unit/integration tested, but the on-network pass should happen before merge or as part of QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BZvW5prkrcniQGCnDMkovG