### PR TITLE
feat(036): gasless relayer — build-from-source engine + Mordor deployment + hardening

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,6 +33,10 @@ LICENSE
 # Smart contracts and blockchain
 contracts
 deployments
+# ...but the relay-gateway image (services/relay-gateway/Dockerfile) bakes the deployment
+# records for its FR-025 version-pinned target check. Re-include them (last match wins; harmless
+# to the SPA build, which doesn't COPY them).
+!deployments
 artifacts
 cache
 typechain-types

--- a/.openzeppelin/unknown-63.json
+++ b/.openzeppelin/unknown-63.json
@@ -56,7 +56,7 @@
             "label": "membershipManager",
             "offset": 0,
             "slot": "50",
-            "type": "t_contract(IMembershipManager)13808",
+            "type": "t_contract(IMembershipManager)22674",
             "contract": "WagerRegistry",
             "src": "contracts/wagers/WagerRegistry.sol:47"
           },
@@ -64,7 +64,7 @@
             "label": "polymarketAdapter",
             "offset": 0,
             "slot": "51",
-            "type": "t_contract(IOracleAdapter)14452",
+            "type": "t_contract(IOracleAdapter)24742",
             "contract": "WagerRegistry",
             "src": "contracts/wagers/WagerRegistry.sol:48"
           },
@@ -72,7 +72,7 @@
             "label": "sanctionsGuard",
             "offset": 0,
             "slot": "52",
-            "type": "t_contract(ISanctionsGuard)13874",
+            "type": "t_contract(ISanctionsGuard)22831",
             "contract": "WagerRegistry",
             "src": "contracts/wagers/WagerRegistry.sol:52"
           },
@@ -80,7 +80,7 @@
             "label": "oracleAdapters",
             "offset": 0,
             "slot": "53",
-            "type": "t_mapping(t_enum(ResolutionType)13886,t_contract(IOracleAdapter)14452)",
+            "type": "t_mapping(t_enum(ResolutionType)22843,t_contract(IOracleAdapter)24742)",
             "contract": "WagerRegistry",
             "src": "contracts/wagers/WagerRegistry.sol:56"
           },
@@ -96,7 +96,7 @@
             "label": "_wagers",
             "offset": 0,
             "slot": "55",
-            "type": "t_mapping(t_uint256,t_struct(Wager)13929_storage)",
+            "type": "t_mapping(t_uint256,t_struct(Wager)22886_storage)",
             "contract": "WagerRegistry",
             "src": "contracts/wagers/WagerRegistry.sol:59"
           },
@@ -136,7 +136,7 @@
             "label": "_userWagerIds",
             "offset": 0,
             "slot": "60",
-            "type": "t_mapping(t_address,t_struct(UintSet)11394_storage)",
+            "type": "t_mapping(t_address,t_struct(UintSet)18699_storage)",
             "contract": "WagerRegistry",
             "src": "contracts/wagers/WagerRegistry.sol:84"
           },
@@ -182,7 +182,7 @@
             "label": "mapping(address => bool)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_bytes32,t_struct(RoleData)26_storage)": {
+          "t_mapping(t_bytes32,t_struct(RoleData)973_storage)": {
             "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
             "numberOfBytes": "32"
           },
@@ -190,19 +190,19 @@
             "label": "string",
             "numberOfBytes": "32"
           },
-          "t_struct(AccessControlStorage)36_storage": {
+          "t_struct(AccessControlStorage)983_storage": {
             "label": "struct AccessControlUpgradeable.AccessControlStorage",
             "members": [
               {
                 "label": "_roles",
-                "type": "t_mapping(t_bytes32,t_struct(RoleData)26_storage)",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)973_storage)",
                 "offset": 0,
                 "slot": "0"
               }
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(EIP712Storage)425_storage": {
+          "t_struct(EIP712Storage)2321_storage": {
             "label": "struct EIP712Upgradeable.EIP712Storage",
             "members": [
               {
@@ -232,7 +232,7 @@
             ],
             "numberOfBytes": "128"
           },
-          "t_struct(InitializableStorage)147_storage": {
+          "t_struct(InitializableStorage)1258_storage": {
             "label": "struct Initializable.InitializableStorage",
             "members": [
               {
@@ -250,7 +250,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(PausableStorage)298_storage": {
+          "t_struct(PausableStorage)2194_storage": {
             "label": "struct PausableUpgradeable.PausableStorage",
             "members": [
               {
@@ -262,7 +262,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(ReentrancyGuardStorage)362_storage": {
+          "t_struct(ReentrancyGuardStorage)2258_storage": {
             "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
             "members": [
               {
@@ -274,7 +274,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(RoleData)26_storage": {
+          "t_struct(RoleData)973_storage": {
             "label": "struct AccessControlUpgradeable.RoleData",
             "members": [
               {
@@ -312,19 +312,19 @@
             "label": "uint256[50]",
             "numberOfBytes": "1600"
           },
-          "t_contract(IMembershipManager)13808": {
+          "t_contract(IMembershipManager)22674": {
             "label": "contract IMembershipManager",
             "numberOfBytes": "20"
           },
-          "t_contract(IOracleAdapter)14452": {
+          "t_contract(IOracleAdapter)24742": {
             "label": "contract IOracleAdapter",
             "numberOfBytes": "20"
           },
-          "t_contract(ISanctionsGuard)13874": {
+          "t_contract(ISanctionsGuard)22831": {
             "label": "contract ISanctionsGuard",
             "numberOfBytes": "20"
           },
-          "t_enum(ResolutionType)13886": {
+          "t_enum(ResolutionType)22843": {
             "label": "enum IWagerRegistry.ResolutionType",
             "members": [
               "Either",
@@ -338,7 +338,7 @@
             ],
             "numberOfBytes": "1"
           },
-          "t_enum(Status)13894": {
+          "t_enum(Status)22851": {
             "label": "enum IWagerRegistry.Status",
             "members": [
               "None",
@@ -351,7 +351,7 @@
             ],
             "numberOfBytes": "1"
           },
-          "t_mapping(t_address,t_struct(UintSet)11394_storage)": {
+          "t_mapping(t_address,t_struct(UintSet)18699_storage)": {
             "label": "mapping(address => struct EnumerableSet.UintSet)",
             "numberOfBytes": "32"
           },
@@ -363,7 +363,7 @@
             "label": "mapping(bytes32 => uint256)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_enum(ResolutionType)13886,t_contract(IOracleAdapter)14452)": {
+          "t_mapping(t_enum(ResolutionType)22843,t_contract(IOracleAdapter)24742)": {
             "label": "mapping(enum IWagerRegistry.ResolutionType => contract IOracleAdapter)",
             "numberOfBytes": "32"
           },
@@ -375,7 +375,7 @@
             "label": "mapping(uint256 => bytes32)",
             "numberOfBytes": "32"
           },
-          "t_mapping(t_uint256,t_struct(Wager)13929_storage)": {
+          "t_mapping(t_uint256,t_struct(Wager)22886_storage)": {
             "label": "mapping(uint256 => struct IWagerRegistry.Wager)",
             "numberOfBytes": "32"
           },
@@ -383,7 +383,7 @@
             "label": "mapping(uint256 => uint8)",
             "numberOfBytes": "32"
           },
-          "t_struct(Set)10702_storage": {
+          "t_struct(Set)18007_storage": {
             "label": "struct EnumerableSet.Set",
             "members": [
               {
@@ -401,19 +401,19 @@
             ],
             "numberOfBytes": "64"
           },
-          "t_struct(UintSet)11394_storage": {
+          "t_struct(UintSet)18699_storage": {
             "label": "struct EnumerableSet.UintSet",
             "members": [
               {
                 "label": "_inner",
-                "type": "t_struct(Set)10702_storage",
+                "type": "t_struct(Set)18007_storage",
                 "offset": 0,
                 "slot": "0"
               }
             ],
             "numberOfBytes": "64"
           },
-          "t_struct(Wager)13929_storage": {
+          "t_struct(Wager)22886_storage": {
             "label": "struct IWagerRegistry.Wager",
             "members": [
               {
@@ -466,13 +466,13 @@
               },
               {
                 "label": "resolutionType",
-                "type": "t_enum(ResolutionType)13886",
+                "type": "t_enum(ResolutionType)22843",
                 "offset": 16,
                 "slot": "5"
               },
               {
                 "label": "status",
-                "type": "t_enum(Status)13894",
+                "type": "t_enum(Status)22851",
                 "offset": 17,
                 "slot": "5"
               },
@@ -583,7 +583,7 @@
             {
               "contract": "AccessControlUpgradeable",
               "label": "_roles",
-              "type": "t_mapping(t_bytes32,t_struct(RoleData)26_storage)",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)973_storage)",
               "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:62",
               "offset": 0,
               "slot": "0"
@@ -2461,6 +2461,610 @@
           }
         },
         "namespaces": {
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:43",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)26_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:62",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "c4ee497f899669580d6795ed664ec67c15ce040fec7ed29e3d85e11c9a109987": {
+      "address": "0x9FfE701be18Ff033706f2df19cd8730F5CB884B2",
+      "txHash": "0x8f2990cce9da763986c63338f7550ac68653cec9a1bd52a0a72d4fce0a2e1727",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSManaged",
+            "src": "contracts/upgradeable/UUPSManaged.sol:46"
+          },
+          {
+            "label": "membershipManager",
+            "offset": 0,
+            "slot": "50",
+            "type": "t_contract(IMembershipManager)17940",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:59"
+          },
+          {
+            "label": "polymarketAdapter",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_contract(IOracleAdapter)19263",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:60"
+          },
+          {
+            "label": "sanctionsGuard",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_contract(ISanctionsGuard)18042",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:64"
+          },
+          {
+            "label": "oracleAdapters",
+            "offset": 0,
+            "slot": "53",
+            "type": "t_mapping(t_enum(ResolutionType)18512,t_contract(IOracleAdapter)19263)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:68"
+          },
+          {
+            "label": "_allowedTokens",
+            "offset": 0,
+            "slot": "54",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:70"
+          },
+          {
+            "label": "_wagers",
+            "offset": 0,
+            "slot": "55",
+            "type": "t_mapping(t_uint256,t_struct(Wager)18555_storage)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:71"
+          },
+          {
+            "label": "_frozen",
+            "offset": 0,
+            "slot": "56",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:72"
+          },
+          {
+            "label": "wagerTermsVersionHash",
+            "offset": 0,
+            "slot": "57",
+            "type": "t_mapping(t_uint256,t_bytes32)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:77"
+          },
+          {
+            "label": "_nextWagerId",
+            "offset": 0,
+            "slot": "58",
+            "type": "t_uint256",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:80"
+          },
+          {
+            "label": "_drawConsent",
+            "offset": 0,
+            "slot": "59",
+            "type": "t_mapping(t_uint256,t_uint8)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:88"
+          },
+          {
+            "label": "_userWagerIds",
+            "offset": 0,
+            "slot": "60",
+            "type": "t_mapping(t_address,t_struct(UintSet)14242_storage)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:96"
+          },
+          {
+            "label": "claimAuthority",
+            "offset": 0,
+            "slot": "61",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:101"
+          },
+          {
+            "label": "openWagerIdByClaim",
+            "offset": 0,
+            "slot": "62",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:104"
+          },
+          {
+            "label": "_feeNettingEnabled",
+            "offset": 0,
+            "slot": "63",
+            "type": "t_bool",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:112"
+          },
+          {
+            "label": "_gasFeeRecipient",
+            "offset": 1,
+            "slot": "63",
+            "type": "t_address",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:115"
+          },
+          {
+            "label": "_maxGasFee",
+            "offset": 0,
+            "slot": "64",
+            "type": "t_uint256",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:117"
+          },
+          {
+            "label": "intentExtension",
+            "offset": 0,
+            "slot": "65",
+            "type": "t_address",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:122"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "66",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:130"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)26_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)36_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)26_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(EIP712Storage)425_storage": {
+            "label": "struct EIP712Upgradeable.EIP712Storage",
+            "members": [
+              {
+                "label": "_hashedName",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_hashedVersion",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "_version",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(InitializableStorage)147_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)298_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)362_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)26_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_contract(IMembershipManager)17940": {
+            "label": "contract IMembershipManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IOracleAdapter)19263": {
+            "label": "contract IOracleAdapter",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ISanctionsGuard)18042": {
+            "label": "contract ISanctionsGuard",
+            "numberOfBytes": "20"
+          },
+          "t_enum(ResolutionType)18512": {
+            "label": "enum IWagerRegistryTypes.ResolutionType",
+            "members": [
+              "Either",
+              "Creator",
+              "Opponent",
+              "ThirdParty",
+              "Polymarket",
+              "ChainlinkDataFeed",
+              "ChainlinkFunctions",
+              "UMA"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(Status)18520": {
+            "label": "enum IWagerRegistryTypes.Status",
+            "members": [
+              "None",
+              "Open",
+              "Active",
+              "Resolved",
+              "Cancelled",
+              "Refunded",
+              "Draw"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_struct(UintSet)14242_storage)": {
+            "label": "mapping(address => struct EnumerableSet.UintSet)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_enum(ResolutionType)18512,t_contract(IOracleAdapter)19263)": {
+            "label": "mapping(enum IWagerRegistryTypes.ResolutionType => contract IOracleAdapter)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_bytes32)": {
+            "label": "mapping(uint256 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Wager)18555_storage)": {
+            "label": "mapping(uint256 => struct IWagerRegistryTypes.Wager)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint8)": {
+            "label": "mapping(uint256 => uint8)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Set)13550_storage": {
+            "label": "struct EnumerableSet.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_positions",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(UintSet)14242_storage": {
+            "label": "struct EnumerableSet.UintSet",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)13550_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Wager)18555_storage": {
+            "label": "struct IWagerRegistryTypes.Wager",
+            "members": [
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "opponent",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "arbitrator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "creatorStake",
+                "type": "t_uint128",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "opponentStake",
+                "type": "t_uint128",
+                "offset": 16,
+                "slot": "4"
+              },
+              {
+                "label": "acceptDeadline",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "resolveDeadline",
+                "type": "t_uint64",
+                "offset": 8,
+                "slot": "5"
+              },
+              {
+                "label": "resolutionType",
+                "type": "t_enum(ResolutionType)18512",
+                "offset": 16,
+                "slot": "5"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(Status)18520",
+                "offset": 17,
+                "slot": "5"
+              },
+              {
+                "label": "paid",
+                "type": "t_bool",
+                "offset": 18,
+                "slot": "5"
+              },
+              {
+                "label": "creatorIsYes",
+                "type": "t_bool",
+                "offset": 19,
+                "slot": "5"
+              },
+              {
+                "label": "winner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "metadataHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "polymarketConditionId",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "metadataUri",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "9"
+              }
+            ],
+            "numberOfBytes": "320"
+          },
+          "t_uint128": {
+            "label": "uint128",
+            "numberOfBytes": "16"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.EIP712": [
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedName",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:38",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedVersion",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:40",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_name",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:42",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_version",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:43",
+              "offset": 0,
+              "slot": "3"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
           "erc7201:openzeppelin.storage.ReentrancyGuard": [
             {
               "contract": "ReentrancyGuardUpgradeable",

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ ARG VITE_IPFS_GATEWAY
 # v2 WagerRegistry subgraph (Spec 017 / #707) — public, build-time only.
 ARG VITE_SUBGRAPH_URL
 ARG VITE_WAGER_SOURCE
+# Gasless relayer base URL (spec 036). Unset => gasless disabled, everything self-submits.
+ARG VITE_RELAYER_URL
 
 # Set environment variables from build args
 ENV VITE_WALLETCONNECT_PROJECT_ID=${VITE_WALLETCONNECT_PROJECT_ID}
@@ -32,6 +34,7 @@ ENV VITE_RPC_URL=${VITE_RPC_URL}
 ENV VITE_IPFS_GATEWAY=${VITE_IPFS_GATEWAY}
 ENV VITE_SUBGRAPH_URL=${VITE_SUBGRAPH_URL}
 ENV VITE_WAGER_SOURCE=${VITE_WAGER_SOURCE}
+ENV VITE_RELAYER_URL=${VITE_RELAYER_URL}
 
 # Build the application
 RUN npm run build

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,6 +10,9 @@ steps:
       - '--build-arg'
       - 'VITE_APP_URL=https://fairwins.app'
       - '--build-arg'
+      # Gasless relayer (spec 036). The SPA probes this and self-submits if it's down (never-stranded).
+      - 'VITE_RELAYER_URL=https://relay.fairwins.app'
+      - '--build-arg'
       - 'VITE_NETWORK_ID=80002'
       - '--build-arg'
       - 'VITE_RPC_URL=https://rpc-amoy.polygon.technology'
@@ -58,51 +61,16 @@ steps:
       - 'managed'
       - '--allow-unauthenticated'
 
-  # --- Relay gateway (spec 036) ---------------------------------------------------------------
-  # Build from the REPO ROOT context so deployments/ is baked into the image (the FR-025
-  # startup consistency check pins target addresses to those records).
-  - name: 'gcr.io/cloud-builders/docker'
-    args:
-      - 'build'
-      - '-f'
-      - 'services/relay-gateway/Dockerfile'
-      - '-t'
-      - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway:$COMMIT_SHA'
-      - '-t'
-      - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway:latest'
-      - '.'
-
-  - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', '--all-tags', 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway']
-
-  # Deploy the relay gateway to Cloud Run (Phase 1: single instance — in-process dedup/quota
-  # state stays correct; see services/relay-gateway/README.md "Phase 1 vs Phase 2").
-  # Secrets (ORIGIN_AUTH_SECRET, WEBHOOK_SHARED_SECRET) are configured on the Cloud Run service
-  # from Secret Manager — like ORIGIN_LOCK_SECRET above, they are intentionally NOT set here so
-  # deploys don't fail before the secrets exist. Once created, wire them declaratively with:
-  #   - '--update-secrets'
-  #   - 'ORIGIN_AUTH_SECRET=origin-lock-secret:latest,WEBHOOK_SHARED_SECRET=relay-webhook-secret:latest'
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-    entrypoint: gcloud
-    args:
-      - 'run'
-      - 'deploy'
-      - 'fairwins-relay-gateway'
-      - '--image'
-      - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway:$COMMIT_SHA'
-      - '--region'
-      - 'us-central1'
-      - '--platform'
-      - 'managed'
-      - '--allow-unauthenticated'
-      - '--max-instances'
-      - '1'
+  # --- Relay gateway (spec 036) — NOT built or deployed here -----------------------------------
+  # The production relayer is a 3-CONTAINER Cloud Run service (policy gateway + from-source OZ
+  # Relayer engine + redis) wired to a KMS-signed gas key. A single-container `gcloud run deploy`
+  # from CI would CLOBBER it (drop the engine + redis sidecars), so the relayer is managed
+  # OUT-OF-BAND (built from source, deployed via `gcloud run services replace`). See
+  # docs/architecture/relayer-infrastructure.md and docs/runbooks/relayer-mordor-deploy.md.
 
 images:
   - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/prediction-dao-research:$COMMIT_SHA'
   - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/prediction-dao-research:latest'
-  - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway:$COMMIT_SHA'
-  - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway:latest'
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/deployments/mordor-chain63-v2.json
+++ b/deployments/mordor-chain63-v2.json
@@ -11,7 +11,7 @@
     "membershipManagerImpl": "0x7D38F7Ef26f7E2409d5C04a62c1d9A3Ec002A49e",
     "membershipVoucher": "0xf514e0e342A898E4681bf51590B672aEC5620401",
     "wagerRegistry": "0x3ccB144d8aa838e8d4D695867cC72e548117830C",
-    "wagerRegistryImpl": "0xa7cf596DA0523371F422E04350A922Ff544fD164",
+    "wagerRegistryImpl": "0x9FfE701be18Ff033706f2df19cd8730F5CB884B2",
     "keyRegistry": "0xcEFdeBba8E040c035c690ca9057cF22E73247c24",
     "sanctionsGuard": "0xdF41355dD5E47FCA4eE2F2205af4C70Dab8C13B3",
     "voucherBatchMinter": "0xc26F02da923263e2c9CFB722006e0B8Da2F952B2",
@@ -33,7 +33,8 @@
     "zkWagerPoolFactoryImpl": "0xd3e851FDDa9D5796D503daFd34b2403D7336d9fD",
     "poolImpl": "0xd0b94a77DA7Aaa488343CF89978f1Bbf9E72E277",
     "wagerPoolFactory": "0xac78B4EdeF96e74a2653028dF93A26acFCfC613F",
-    "wagerPoolFactoryImpl": "0xD69a175a0a2CD0564A62384a0687A2908DDf632c"
+    "wagerPoolFactoryImpl": "0xD69a175a0a2CD0564A62384a0687A2908DDf632c",
+    "wagerRegistryIntents": "0x81a9c5904A109F0b7bC6329ba6F2be2de5B6abB1"
   },
   "mocks": {
     "mockSanctionsOracle": "0xa5F0bB3a63C55721078be5ee80653E9cB0927D9E"
@@ -65,7 +66,8 @@
     "backupPointerRegistry": [],
     "zkWagerPoolFactoryImpl": [],
     "poolImpl": [],
-    "wagerPoolFactoryImpl": []
+    "wagerPoolFactoryImpl": [],
+    "wagerRegistryIntents": []
   },
   "saltPrefix": "FairWins-P2P-v2.0-",
   "timestamp": "2026-06-21T03:31:32.666Z",
@@ -85,5 +87,6 @@
   "semaphoreSelfDeployedAt": "2026-07-01T00:03:56.515Z",
   "zkWagerPoolsDeployedAt": "2026-07-01T00:06:05.668Z",
   "wagerPoolsDeployedAt": "2026-07-04T15:27:55.875Z",
-  "poolTemplateResyncedAt": "2026-07-04T21:47:07.000Z"
+  "poolTemplateResyncedAt": "2026-07-04T21:47:07.000Z",
+  "gaslessIntentsUpgradedAt": "2026-07-05T17:35:37.300Z"
 }

--- a/docs/architecture/relayer-infrastructure.md
+++ b/docs/architecture/relayer-infrastructure.md
@@ -1,0 +1,215 @@
+# Gasless Intent Relayer — Infrastructure Architecture (spec 036)
+
+The relayer is **optional gas infrastructure**. It lets a user sign a spec-035 intent off-chain and
+have a hosted service pay the gas to submit it — but it can only ever **censor, never steal**, and
+every covered action keeps a **self-submit fallback**. So the worst failure of everything below is
+"the user pays their own gas," never a stuck or stolen wager.
+
+> **Deployed footprint (Mordor / ETC testnet, chain 63):** one Cloud Run service,
+> `fairwins-relay-gateway`, running **three sidecar containers** (policy gateway + OZ Relayer engine
+> + ephemeral Redis). This is the sanctioned exception to the platform's no-backend rule — see
+> [../developer-guide/gasless-intents.md](../developer-guide/gasless-intents.md) and the runbook
+> [../runbooks/relayer-mordor-deploy.md](../runbooks/relayer-mordor-deploy.md).
+
+---
+
+## 1. System context — where the relayer sits
+
+```mermaid
+flowchart TB
+    subgraph client["Browser (fairwins.app SPA)"]
+        UI["Action UI<br/>(claim / accept / …)"]
+        RELAY["lib/relay/intentClient.js<br/>probe → sign → relay → poll"]
+        WALLET["Wallet<br/>(EIP-712 signature)"]
+    end
+
+    subgraph edge["Cloudflare edge"]
+        CF["451 geo-gate + origin-lock<br/>injects X-Origin-Auth"]
+    end
+
+    subgraph gcp["GCP · Cloud Run service: fairwins-relay-gateway (1 instance)"]
+        GW["relay-gateway<br/>:8788 (ingress)<br/>policy + audit"]
+        ENG["oz-relayer engine<br/>:8080 (sidecar)<br/>nonce · gas · submit"]
+        RDS["redis :6379<br/>(sidecar, ephemeral)"]
+    end
+
+    subgraph chain["Ethereum Classic — Mordor (63)"]
+        REG["WagerRegistry + MembershipManager<br/>…WithSig entrypoints"]
+        GUARD["SanctionsGuard"]
+    end
+
+    KMS["Cloud KMS (HSM)<br/>gas-key-mordor → 0xf505…"]
+
+    UI --> RELAY
+    RELAY -- "GET /status (probe)" --> CF
+    RELAY -- "POST /v1/intents" --> CF
+    RELAY -. "signature request" .-> WALLET
+    WALLET -. "signed intent" .-> RELAY
+    CF -->|"X-Origin-Auth"| GW
+    GW <-->|"screen signer (fail-closed)"| GUARD
+    GW -->|"built tx {to,data}"| ENG
+    ENG <-->|"REST + Redis"| RDS
+    ENG -->|"sign (no key material leaves KMS)"| KMS
+    ENG -->|"legacy type-0 tx"| REG
+    ENG -. "webhook: X-Signature HMAC" .-> GW
+
+    RELAY == "self-submit fallback<br/>(probe fail / kill switch / error)" ==> WALLET
+    WALLET == "user-paid tx" ==> REG
+
+    classDef fallback stroke-dasharray:5 5;
+```
+
+**Read it as two paths.** The **relayed path** (solid): the SPA probes `/status`, has the wallet sign
+the intent, POSTs it through Cloudflare to the gateway; the gateway recovers + screens the signer,
+builds the exact call, and hands it to the engine, which signs with the KMS key and submits. The
+**self-submit path** (thick dashed): on any probe failure, kill switch, or relay error the SPA
+silently has the user submit the same action themselves — identical on-chain result (FR-016 / SC-004).
+
+---
+
+## 2. Deployment topology — one Cloud Run service, three containers
+
+Redis is **ephemeral by design** (nonce/queue state is reconstructed from chain), and Phase 1 is
+**single-instance** (one nonce-lane owner, in-process dedup/quota). That makes co-locating all three
+containers in one Cloud Run instance — talking over `localhost` — the simplest correct topology: no
+VPC connector, no Memorystore, no cross-service auth.
+
+```mermaid
+flowchart LR
+    subgraph svc["Cloud Run: fairwins-relay-gateway · us-central1 · min=max=1 · CPU always-on"]
+        direction TB
+        G["gateway (ingress :8788)<br/>run as fairwins-relay-engine SA"]
+        E["engine :8080"]
+        R["redis :6379"]
+        R -->|"depends on"| E -->|"depends on"| G
+        G <-->|"http localhost:8080"| E
+        E <-->|"localhost:6379"| R
+    end
+
+    subgraph sm["Secret Manager"]
+        S1["origin-lock-secret"]
+        S2["relay-webhook-secret"]
+        S3["relay-engine-api-key"]
+        S4["relay-engine-gcp-private-key"]
+    end
+
+    subgraph kms["Cloud KMS · keyring fairwins-relayer"]
+        K["gas-key-mordor<br/>HSM secp256k1"]
+    end
+
+    IMG["Artifact Registry<br/>fairwins-relay-gateway:…<br/>fairwins-relay-engine-base:v1.4.0<br/>fairwins-relay-engine:mordor-v1.4.0"]
+    GASW["Mordor gas wallet 0xf505…<br/>(3 METC)"]
+
+    S1 -. "ORIGIN_AUTH_SECRET" .-> G
+    S2 -. "WEBHOOK_SHARED_SECRET" .-> G
+    S3 -. "ENGINE_API_KEY / API_KEY" .-> G
+    S2 -. "WEBHOOK_SIGNING_KEY" .-> E
+    S3 -. "API_KEY" .-> E
+    S4 -. "GCP_PRIVATE_KEY" .-> E
+    E -->|"cloudkms.signerVerifier"| K
+    K -. "derives" .-> GASW
+    IMG -. "images" .-> svc
+```
+
+The whole service runs as the least-privilege **`fairwins-relay-engine`** service account, which holds
+only `cloudkms.signerVerifier` on the one gas key plus `secretAccessor` on the four secrets. The gas
+key never leaves KMS; its **public** key derives the funded address `0xf505…`.
+
+> **Known limitation — exported SA key for the KMS signer.** OZ Relayer **v1.4.0**'s Cloud-KMS signer
+> authenticates with an explicit service-account key (`service_account.private_key` etc., stored as the
+> `relay-engine-gcp-private-key` secret) — it does **not** support keyless ADC / Workload Identity, even
+> though the pod already runs *as* that same SA. So we mint one exported key for the least-privilege
+> engine SA (it can only `signerVerifier` + `secretAccessor` — no data access), keep it only in Secret
+> Manager, and never bake it into the image. **Follow-up:** drop the key and switch to ADC once the
+> engine supports it (evaluate on the next engine bump); rotate the key on any SA change.
+
+---
+
+## 3. Intent lifecycle — request → confirmed
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as SPA (intentClient)
+    participant W as Wallet
+    participant GW as relay-gateway
+    participant EN as oz-relayer engine
+    participant K as Cloud KMS
+    participant CH as Mordor (63)
+
+    U->>GW: GET /status (bounded ~2s probe)
+    alt gateway unhealthy / kill switch / chain down
+        GW-->>U: not ok
+        Note over U,W: SELF-SUBMIT — user signs + sends the tx themselves. Done.
+    else healthy
+        GW-->>U: {status:ok, chains:{63:{rpc:up}}}
+        U->>W: request EIP-712 signature (intent)
+        W-->>U: signed intent
+        U->>GW: POST /v1/intents  (X-Origin-Auth)
+        GW->>GW: recover signer · bind params · dedup · quotas · spend cap
+        GW->>CH: SanctionsGuard.isAllowed(signer)  (fail-closed)
+        GW->>EN: POST /transactions {to,data,speed}
+        EN->>K: sign (secp256k1, legacy type-0)
+        K-->>EN: signature
+        EN->>CH: submit raw tx (gas paid by 0xf505…)
+        GW-->>U: 202 {intentId, status:queued}
+        EN-->>GW: webhook mined/confirmed<br/>(X-Signature = HMAC-SHA256(body, secret))
+        GW->>GW: verify HMAC (timing-safe) · map to status
+        U->>GW: GET /v1/intents/{id}
+        GW-->>U: {status:confirmed, txHash}
+    end
+```
+
+Status is **honest**: the gateway only reports `confirmed` after the engine's webhook says mined
+(FR-006). Money-in intents are **rejected on ETC** (`503 payment_unsupported_on_chain`) because live
+USDC there has no EIP-3009 — those flows self-submit; only no-stake (signer-attributed) actions relay.
+
+---
+
+## 4. Trust & security boundaries
+
+| Component | Holds | Can do | **Cannot** do |
+|---|---|---|---|
+| `relay-gateway` | two shared secrets (origin, webhook) | refuse/accept intents, screen, rate-limit | sign, move funds, forge a signer (it is *recovered*) |
+| `oz-relayer` engine | KMS **handle** (not the key) | sign gas txs to allow-listed receivers, submit | exceed `gas_price_cap`, pay non-whitelisted receivers, spend user funds |
+| Cloud KMS (HSM) | the secp256k1 gas key | produce signatures | export the private key |
+| gas wallet `0xf505…` | ~3 METC | pay gas | anything else (no contract authority) |
+| Cloudflare | origin-lock secret | gate + inject `X-Origin-Auth` | read intents' meaning |
+
+Compromise bound of the **entire hosted stack** = the testnet gas balance + the ability to *censor*
+(refuse to relay). No user funds, no contract admin, no floppy-keystore key is reachable from here.
+On-chain entrypoints re-verify every signature and re-screen every actor regardless.
+
+---
+
+## 5. GCP resource inventory (Mordor)
+
+| Kind | Name | Notes |
+|---|---|---|
+| Cloud Run service | `fairwins-relay-gateway` | 3 containers, `us-central1`, min=max=1, CPU always-on, public ingress |
+| Service account | `fairwins-relay-engine@…` | runs the service; `signerVerifier` + `secretAccessor` only |
+| KMS keyring / key | `fairwins-relayer` / `gas-key-mordor` | **HSM** secp256k1 (software rejects the curve) |
+| Gas wallet | `0xf505d95F62bEE94437C112d3D64ee7Df0Fa973aC` | derived from the KMS public key; funded 3 METC |
+| Secrets | `origin-lock-secret`, `relay-webhook-secret`, `relay-engine-api-key`, `relay-engine-gcp-private-key` | injected as env at runtime |
+| Artifact Registry | `fairwins-relay-gateway`, `fairwins-relay-engine-base:v1.4.0`, `fairwins-relay-engine:mordor-v1.4.0` | engine base is **built from source** (see below) |
+
+---
+
+## 6. Build-from-source & integration truths
+
+The OZ Relayer publishes **no pre-built image** — it is built from `Dockerfile.production` at a pinned
+tag (`v1.4.0`) and hosted in our Artifact Registry; we layer only our config (AGPL-safe: unmodified
+upstream, never forked into the repo). Things the spec assumed that turned out otherwise, all now
+reflected in the config/code:
+
+- **KMS signer needs an explicit service-account key** (no ADC/attached-SA path in v1.4.0).
+- The engine **does not expand `${VAR}`** in `config.json` → RPC + webhook URLs are literal.
+- Webhook auth is **`X-Signature: base64(HMAC-SHA256(body, signing_key))`**, verified by the gateway
+  over the raw body (`services/relay-gateway/src/server.js`).
+- `/healthz` is **intercepted by Google's GFE on every `*.run.app`** → external probes use **`/status`**.
+
+## 7. Operate it
+
+- Deploy / redeploy: [../runbooks/relayer-mordor-deploy.md](../runbooks/relayer-mordor-deploy.md)
+- Incidents, kill switch, key rotation, funding: [../runbooks/relayer-operations.md](../runbooks/relayer-operations.md)
+- Protocol / intent semantics: [../developer-guide/gasless-intents.md](../developer-guide/gasless-intents.md)

--- a/docs/runbooks/relayer-mordor-deploy.md
+++ b/docs/runbooks/relayer-mordor-deploy.md
@@ -1,0 +1,197 @@
+# Runbook: Deploy the Intent Relayer to Mordor (spec 036, full stack)
+
+First real bring-up of the gasless relayer, scoped to **Mordor (ETC testnet, chain 63)** only —
+the Mordor→Polygon sequence's testnet leg. Everything here is **optional gas infrastructure**: with
+it absent or killed, every covered action still self-submits (never-stranded rule), so a mistake
+here degrades to "users pay their own gas", never lost funds.
+
+**Targets:** relays **WagerRegistry + MembershipManager** `…WithSig` intents (the engine's
+`whitelist_receivers` for `mordor-63` pin `0x3ccB…` + `0x68bC…`). It does **not** relay spec-034
+**pool** clones — those aren't in the version-pinned target set. Gasless pools are separate work.
+
+**ETC caveats (baked into config):** legacy type-0 gas (no EIP-1559), `batchMaxCount:1`, and
+**payment/EIP-3009 (money-in) intents are blocked** on 63 — only signer-attributed (no-stake)
+actions relay; join/stake self-submits. Chain 61 stays `paused`.
+
+Project `chippr-bots-site-wp`, region/KMS location `us-central1` (matches
+`services/oz-relayer/config/config.json`).
+
+---
+
+> ### ⚑ AS BUILT (2026-07-05) — read before following the steps below
+> This runbook was drafted before integration; the deploy that actually shipped corrected several
+> assumptions. The authoritative picture is
+> [../architecture/relayer-infrastructure.md](../architecture/relayer-infrastructure.md). Deltas from
+> the steps below:
+> - **Engine image is built from source** — OZ Relayer publishes no pullable image (§6 of the arch
+>   doc). Build `Dockerfile.production` @`v1.4.0` → `fairwins-relay-engine-base:v1.4.0` in AR.
+> - **KMS signer needs an explicit SA key** (no ADC) → secret `relay-engine-gcp-private-key`; the
+>   config `service_account` uses `private_key`/`client_email`/`private_key_id`.
+> - **One Cloud Run service, 3 sidecar containers** (gateway+engine+redis over localhost) — *not* a
+>   separate internal engine service; no Memorystore/VPC (Redis is an ephemeral sidecar).
+> - **Config must use literal RPC/webhook URLs** (engine doesn't expand `${VAR}`) and `plugins: []`.
+> - **Gateway verifies the engine's `X-Signature` HMAC**; the external health path is **`/status`**
+>   (`/healthz` is GFE-intercepted on `*.run.app`).
+> - KMS secp256k1 must be **HSM** protection; `PORT` is reserved on the ingress container.
+
+## 0. Prerequisites (BLOCKER: interactive)
+
+```bash
+gcloud auth login                                   # both cached tokens are expired; interactive
+gcloud config set project chippr-bots-site-wp
+gcloud services enable secretmanager.googleapis.com cloudkms.googleapis.com \
+  run.googleapis.com artifactregistry.googleapis.com redis.googleapis.com vpcaccess.googleapis.com
+```
+
+Confirm the two identities we reference (fill their real emails into the steps below):
+
+```bash
+gcloud run services describe fairwins-relay-gateway --region=us-central1 \
+  --format='value(spec.template.spec.serviceAccountName)' 2>/dev/null   # gateway runtime SA (may not exist yet)
+gcloud iam service-accounts list --format='table(email)'                # look for a relay/run SA
+```
+
+If no dedicated engine SA exists, create one (least privilege — KMS signer only):
+
+```bash
+gcloud iam service-accounts create fairwins-relay-engine \
+  --display-name="FairWins relay engine (KMS gas signer)"
+# => fairwins-relay-engine@chippr-bots-site-wp.iam.gserviceaccount.com   (ENGINE_SA below)
+```
+
+## 1. Secrets (Secret Manager)
+
+```bash
+# Origin lock — SHARED with the SPA's spec-007 origin lock; it very likely already exists.
+gcloud secrets describe origin-lock-secret >/dev/null 2>&1 \
+  && echo "origin-lock-secret exists (reuse)" \
+  || { openssl rand -hex 32 | gcloud secrets create origin-lock-secret --data-file=- ; }
+
+# Shared gateway<->engine webhook secret (WEBHOOK_SHARED_SECRET / WEBHOOK_SIGNING_KEY — same value).
+openssl rand -hex 32 | gcloud secrets create relay-webhook-secret --data-file=-
+
+# Engine REST API key (gateway sends it as ENGINE_API_KEY; engine checks it as API_KEY).
+openssl rand -hex 32 | gcloud secrets create relay-engine-api-key --data-file=-
+```
+
+Grant each runtime SA `roles/secretmanager.secretAccessor` on exactly the secrets it reads
+(gateway: origin-lock-secret, relay-webhook-secret, relay-engine-api-key; engine:
+relay-webhook-secret, relay-engine-api-key).
+
+## 2. KMS gas key + derived address
+
+```bash
+gcloud kms keyrings create fairwins-relayer --location=us-central1 2>/dev/null || true
+gcloud kms keys create gas-key-mordor \
+  --keyring=fairwins-relayer --location=us-central1 \
+  --purpose=asymmetric-signing \
+  --default-algorithm=ec-sign-secp256k1-sha256 \
+  --protection-level=hsm          # 'software' if HSM secp256k1 is unavailable in the project
+
+gcloud kms keys add-iam-policy-binding gas-key-mordor \
+  --keyring=fairwins-relayer --location=us-central1 \
+  --member="serviceAccount:${ENGINE_SA}" --role="roles/cloudkms.signerVerifier"
+
+# Derive the Ethereum gas-wallet address to fund (KMS never exposes the private key):
+gcloud kms keys versions get-public-key 1 --key=gas-key-mordor \
+  --keyring=fairwins-relayer --location=us-central1 --output-file=/tmp/gas-key-mordor.pem
+GAS_ADDR=$(node scripts/operations/relayer/kms-gas-address.js /tmp/gas-key-mordor.pem)
+echo "Fund this Mordor gas wallet: $GAS_ADDR"
+```
+
+## 3. Fund the gas wallet (Mordor test METC)
+
+Send low-value test METC to `$GAS_ADDR` — cover the engine `min_balance` (1 METC) plus headroom
+(~5 METC). Use a Mordor faucet, or send from the pool deployer `0x52502d049571C7893447b86c4d8B38e6184bF6e1`
+(holds Mordor ETC). **Never** fund from or to the floppy admin keys (SC-015). Verify:
+
+```bash
+# via the repo's mordor RPC / hardhat, or:
+cast balance $GAS_ADDR --rpc-url https://rpc.mordor.etccooperative.org
+```
+
+## 4. Engine (oz-relayer) → Cloud Run (internal)
+
+```bash
+AR=us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research
+# Build the config-baked engine image (Dockerfile pins the upstream 1.x tag):
+gcloud builds submit services/oz-relayer \
+  --tag=$AR/fairwins-relay-engine:$(git rev-parse --short HEAD)
+```
+
+**DECISION — engine state store.** The engine keeps nonce lanes + in-flight tracking. Pick one:
+- **Memorystore Redis** (Basic, 1 GB, us-central1) + a Serverless VPC connector — durable across
+  restarts; ~\$35/mo. Production-correct.
+- **In-memory** (`REDIS_URL` unset, single instance) — cheapest; nonce state re-syncs from chain on
+  restart. Acceptable for Mordor validation. Start here, add Memorystore before Polygon.
+
+Deploy internal-only, single always-on instance (Phase 1 — one lane owner per chain):
+
+```bash
+gcloud run deploy fairwins-relay-engine \
+  --image=$AR/fairwins-relay-engine:$(git rev-parse --short HEAD) \
+  --region=us-central1 --platform=managed \
+  --ingress=internal --no-allow-unauthenticated \
+  --service-account=$ENGINE_SA \
+  --min-instances=1 --max-instances=1 --no-cpu-throttling \
+  --set-env-vars=GCP_PROJECT_ID=chippr-bots-site-wp,GATEWAY_WEBHOOK_URL=https://<GATEWAY_URL>/v1/engine/webhook \
+  --update-secrets=WEBHOOK_SIGNING_KEY=relay-webhook-secret:latest,API_KEY=relay-engine-api-key:latest
+  # + REDIS_URL=redis://<memorystore-ip>:6379 and --vpc-connector=<conn> if using Memorystore
+```
+
+> **Verify against the pinned engine release** (README "Assumptions"): (a) Cloud KMS signer via the
+> attached SA / ADC vs. an explicit `GOOGLE_APPLICATION_CREDENTIALS_JSON` (mint a SA-key secret only
+> if ADC is unsupported); (b) `${VAR:-default}` expansion in config — replace with literals if the
+> tag doesn't expand them; (c) webhook auth header shape (add the HMAC verifier in
+> `relay-gateway/src/engine/webhook.js` if it signs rather than shared-secrets). Config-check on the
+> pinned tag before trusting it.
+
+Capture the engine URL → `ENGINE_URL` for the gateway.
+
+## 5. Gateway → Cloud Run (via cloudbuild)
+
+Wire the secrets that `cloudbuild.yaml` intentionally left un-set (see its inline note), and pin the
+gateway to Mordor. Deploy:
+
+```bash
+gcloud run deploy fairwins-relay-gateway \
+  --image=$AR/fairwins-relay-gateway:latest \
+  --region=us-central1 --platform=managed --allow-unauthenticated --max-instances=1 \
+  --set-env-vars=ENABLED_CHAIN_IDS=63,ENGINE_URL=<ENGINE_URL>,ENGINE_RELAYER_ID_63=mordor-63,GAS_WALLET_63=$GAS_ADDR \
+  --update-secrets=ORIGIN_AUTH_SECRET=origin-lock-secret:latest,WEBHOOK_SHARED_SECRET=relay-webhook-secret:latest,ENGINE_API_KEY=relay-engine-api-key:latest
+```
+
+Then make it declarative: uncomment the `--update-secrets` block in `cloudbuild.yaml` (it names
+`origin-lock-secret` + `relay-webhook-secret`; add `ENGINE_API_KEY`) so future CI deploys keep the
+wiring. `ENABLED_CHAIN_IDS=63` means the gateway boots only Mordor and skips 137/80002 (each needs
+its own funded key before enabling).
+
+## 6. Perimeter (Cloudflare origin lock)
+
+Map a hostname to the gateway (e.g. `relay.fairwins.app`) and add the Transform Rule injecting
+`X-Origin-Auth: <origin-lock-secret>` per `infra/cloudflare/origin-lock.md`. `/healthz` and
+`/v1/engine/webhook` are exempt by design.
+
+## 7. Frontend cutover
+
+Set `VITE_RELAYER_URL=https://relay.fairwins.app` (baked at SPA build — cloudbuild) and redeploy the
+SPA. The client health-probes `/healthz`; if the gateway is down/killed it silently self-submits.
+
+## 8. Validate
+
+```bash
+curl -s https://relay.fairwins.app/healthz | jq     # chains.63.rpc ok, gasWalletRunwayHrs, killSwitch:false
+```
+
+Then sign one Mordor no-stake intent (`services/relay-gateway/test/helpers.js#signedIntent`) and
+`POST /v1/intents` → expect `202 {intentId, status}` → poll `GET /v1/intents/:id` → `confirmed` +
+`txHash` on `etc-mordor.blockscout.com`. Confirm a money-in intent returns
+`503 payment_unsupported_on_chain` (expected on ETC). Toggle the kill switch and confirm the client
+falls back to self-submit.
+
+## Rollback / stop
+
+- Kill switch: `KILL_SWITCH=true` on the gateway (redeploy) → `503 killswitch_active` → clients
+  self-submit. In-flight engine txs still track to inclusion.
+- Full stop: delete/scale the Cloud Run services to 0; drain the gas wallet. Contract `pause()`
+  (GUARDIAN_ROLE) is independent of the relayer.

--- a/docs/runbooks/relayer-mordor-deploy.md
+++ b/docs/runbooks/relayer-mordor-deploy.md
@@ -30,9 +30,17 @@ Project `chippr-bots-site-wp`, region/KMS location `us-central1` (matches
 > - **One Cloud Run service, 3 sidecar containers** (gateway+engine+redis over localhost) — *not* a
 >   separate internal engine service; no Memorystore/VPC (Redis is an ephemeral sidecar).
 > - **Config must use literal RPC/webhook URLs** (engine doesn't expand `${VAR}`) and `plugins: []`.
-> - **Gateway verifies the engine's `X-Signature` HMAC**; the external health path is **`/status`**
->   (`/healthz` is GFE-intercepted on `*.run.app`).
+> - **Gateway verifies the engine's `X-Signature` HMAC** over a **nested** body — the engine wraps every
+>   update as `{ id: <notificationId>, event, payload, timestamp }` and the tx `id`/`hash`/`status` live
+>   INSIDE `payload` (flattened for `payload_type:"transaction"`, under `payload.transaction` for
+>   `"transaction_failure"`); the outer `id` is the *notification* id, not the tx id. `normalizeEngineEvent`
+>   handles both this and the flat shape. The external health path is **`/status`** (`/healthz` is
+>   GFE-intercepted on `*.run.app`).
 > - KMS secp256k1 must be **HSM** protection; `PORT` is reserved on the ingress container.
+> - **The target registry MUST already expose the gasless-intent facet.** The relayer only submits
+>   `…WithSig` calls, which revert on a pre-intents `WagerRegistry`. Confirm the proxy is upgraded
+>   (`intentExtension()` returns the facet, `DOMAIN_SEPARATOR()` does not revert) — for Mordor this was
+>   `scripts/deploy/upgrade-gasless-intents.js` (impl `0x9FfE…`, facet `0x81a9…`; see the deploy record).
 
 ## 0. Prerequisites (BLOCKER: interactive)
 
@@ -61,17 +69,28 @@ gcloud iam service-accounts create fairwins-relay-engine \
 
 ## 1. Secrets (Secret Manager)
 
+> ⚠️ **Strip the trailing newline.** `openssl rand -hex 32` emits a `\n`, and `gcloud secrets … --data-file=-`
+> stores stdin **verbatim, including that newline**. The engine (Rust) uses the raw secret bytes for both
+> the Bearer API key and the webhook HMAC key, so a stray `\n` silently breaks auth in two different ways:
+> the HTTP layer trims it off the `Authorization` header (→ engine 401 → gateway `503 chain_unavailable`),
+> while the gateway's config loader `.trim()`s the webhook secret but the engine does not (→ HMAC key
+> mismatch → every status webhook rejected → intents hang at `queued`). **Always pipe through `tr -d '\n'`.**
+
 ```bash
 # Origin lock — SHARED with the SPA's spec-007 origin lock; it very likely already exists.
 gcloud secrets describe origin-lock-secret >/dev/null 2>&1 \
   && echo "origin-lock-secret exists (reuse)" \
-  || { openssl rand -hex 32 | gcloud secrets create origin-lock-secret --data-file=- ; }
+  || { openssl rand -hex 32 | tr -d '\n' | gcloud secrets create origin-lock-secret --data-file=- ; }
 
 # Shared gateway<->engine webhook secret (WEBHOOK_SHARED_SECRET / WEBHOOK_SIGNING_KEY — same value).
-openssl rand -hex 32 | gcloud secrets create relay-webhook-secret --data-file=-
+openssl rand -hex 32 | tr -d '\n' | gcloud secrets create relay-webhook-secret --data-file=-
 
 # Engine REST API key (gateway sends it as ENGINE_API_KEY; engine checks it as API_KEY).
-openssl rand -hex 32 | gcloud secrets create relay-engine-api-key --data-file=-
+openssl rand -hex 32 | tr -d '\n' | gcloud secrets create relay-engine-api-key --data-file=-
+
+# Already created a secret WITH a newline? Add a clean version + pin the service.yaml refs to it:
+#   gcloud secrets versions access latest --secret=NAME | tr -d '\n' \
+#     | gcloud secrets versions add NAME --data-file=-
 ```
 
 Grant each runtime SA `roles/secretmanager.secretAccessor` on exactly the secrets it reads
@@ -111,6 +130,13 @@ cast balance $GAS_ADDR --rpc-url https://rpc.mordor.etccooperative.org
 ```
 
 ## 4. Engine (oz-relayer) → Cloud Run (internal)
+
+> **As-built shortcut.** Steps 4–5 below are the *illustrative* two-separate-services path. What is
+> actually live is a **single Cloud Run service with three sidecar containers** (gateway + engine +
+> redis), captured verbatim in **`services/oz-relayer/deploy/mordor/service.yaml`** with the engine
+> config in **`services/oz-relayer/deploy/mordor/config.json`**. To reproduce the live topology, build
+> the two images (below), then `gcloud run services replace services/oz-relayer/deploy/mordor/service.yaml
+> --region=us-central1`. Read steps 4–5 for the *why* behind each field.
 
 ```bash
 AR=us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research

--- a/frontend/src/lib/relay/__tests__/intentClient.test.js
+++ b/frontend/src/lib/relay/__tests__/intentClient.test.js
@@ -306,6 +306,9 @@ describe('intent relay client', () => {
       })
       await expect(probeHealth(137)).resolves.toBe(true)
       await expect(probeHealth(80002)).resolves.toBe(false)
+      // Chain the relayer doesn't serve (absent from the map) must probe FALSE so the caller
+      // self-submits instead of signing and then hard-failing on chain_mismatch (never-stranded).
+      await expect(probeHealth(63)).resolves.toBe(false)
     })
 
     it('probeHealth is false (never throws) on kill switch, error, or unset relayer', async () => {

--- a/frontend/src/lib/relay/intentClient.js
+++ b/frontend/src/lib/relay/intentClient.js
@@ -261,10 +261,14 @@ export async function pollStatus(intentId, { baseUrl, timeoutMs = RELAY_TIMEOUT_
 }
 
 /**
- * Probe `GET /healthz` within a bounded (~2s) budget. Returns true only when the gateway reports
+ * Probe `GET /status` within a bounded (~2s) budget. Returns true only when the gateway reports
  * `status: 'ok'`, the kill switch is off, and — when the response itemizes chains — `chainId`'s RPC
  * is up. Any failure, timeout, or unset relayer returns false (never throws): a failed probe routes
  * the flow to self-submit BEFORE the user signs (FR-016).
+ *
+ * NOTE: the path is `/status`, not `/healthz` — Google's GFE intercepts the literal `/healthz` on
+ * Cloud Run (*.run.app), so it never reaches the gateway. `/status` is the same handler at a
+ * non-reserved path.
  *
  * @param {number} chainId
  * @param {{baseUrl?: string, budgetMs?: number}} [opts]
@@ -274,12 +278,17 @@ export async function probeHealth(chainId, { baseUrl, budgetMs = HEALTH_BUDGET_M
   const base = baseUrl != null ? baseUrl.replace(/\/$/, '') : relayerBaseUrl()
   if (!base) return false
   try {
-    const res = await boundedFetch(`${base}/healthz`, { method: 'GET' }, budgetMs)
+    const res = await boundedFetch(`${base}/status`, { method: 'GET' }, budgetMs)
     if (!res.ok) return false
     const data = await readJson(res)
     if (!data || data.status !== 'ok' || data.killSwitch === true) return false
-    if (chainId != null && data.chains && data.chains[String(chainId)]) {
-      return data.chains[String(chainId)].rpc === 'up'
+    // A caller that names a chain the relayer doesn't serve (absent from the map) must fall back to
+    // self-submit — returning true here would prompt a signature and then hard-fail on chain_mismatch,
+    // stranding the action (never-stranded, FR-002/FR-003). Only chainId==null (caller doesn't care)
+    // trusts the top-level status.
+    if (chainId != null) {
+      const c = data.chains && data.chains[String(chainId)]
+      return !!c && c.rpc === 'up'
     }
     return true
   } catch {

--- a/scripts/operations/relayer/fund-gas-wallet.js
+++ b/scripts/operations/relayer/fund-gas-wallet.js
@@ -1,0 +1,47 @@
+/**
+ * Ops: fund a relayer gas wallet (spec 036) from the network deployer.
+ *
+ * The engine's hot gas key lives in Cloud KMS; its derived address (see
+ * scripts/operations/relayer/kms-gas-address.js) must hold a low-value, capped gas balance. This
+ * tops it up from the hardhat network signer (the deployer / PRIVATE_KEY). NEVER fund from or to
+ * the floppy admin keys (SC-015) — the deployer is a low-value operational key.
+ *
+ *   RELAYER_GAS_ADDRESS=0x... FUND_AMOUNT_ETH=3 GAS_PRICE_WEI=100000000000 \
+ *     npx hardhat run scripts/operations/relayer/fund-gas-wallet.js --network mordor
+ */
+const { ethers } = require("hardhat");
+
+async function main() {
+  const to = process.env.RELAYER_GAS_ADDRESS;
+  const amountEth = process.env.FUND_AMOUNT_ETH || "3";
+  if (!to || !ethers.isAddress(to)) throw new Error(`Set RELAYER_GAS_ADDRESS to the gas wallet (got: ${to})`);
+
+  const [deployer] = await ethers.getSigners();
+  const net = await ethers.provider.getNetwork();
+  const amount = ethers.parseEther(amountEth);
+  const buffer = ethers.parseEther("0.2"); // keep gas for the deployer itself
+
+  const balDeployer = await ethers.provider.getBalance(deployer.address);
+  const balTarget = await ethers.provider.getBalance(to);
+  console.log(`Network:  ${net.name || "?"} (chainId ${Number(net.chainId)})`);
+  console.log(`From:     ${deployer.address}  (${ethers.formatEther(balDeployer)})`);
+  console.log(`To (gas): ${to}  (${ethers.formatEther(balTarget)})`);
+  console.log(`Amount:   ${amountEth}`);
+
+  if (balDeployer < amount + buffer) {
+    throw new Error(
+      `Deployer balance ${ethers.formatEther(balDeployer)} < amount ${amountEth} + 0.2 buffer. ` +
+        `Lower FUND_AMOUNT_ETH or top up the deployer.`
+    );
+  }
+
+  const txReq = { to, value: amount };
+  if (process.env.GAS_PRICE_WEI) txReq.gasPrice = BigInt(process.env.GAS_PRICE_WEI); // legacy type-0 for ETC/Mordor
+  const tx = await deployer.sendTransaction(txReq);
+  console.log(`\nSent ${amountEth} in tx ${tx.hash} — waiting...`);
+  const rcpt = await tx.wait();
+  console.log(`  ✓ mined in block ${rcpt.blockNumber}`);
+  console.log(`  gas wallet now: ${ethers.formatEther(await ethers.provider.getBalance(to))}`);
+}
+
+main().then(() => process.exit(0)).catch((e) => { console.error(e.message || e); process.exit(1); });

--- a/scripts/operations/relayer/kms-gas-address.js
+++ b/scripts/operations/relayer/kms-gas-address.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Derive the Ethereum gas-wallet address for a GCP KMS secp256k1 signing key (spec 036 engine).
+ *
+ * The oz-relayer engine signs with a Cloud KMS key (`services/oz-relayer/config/config.json` →
+ * signers[].config.key). KMS never exposes the private key, so the funded address is derived from
+ * the key's PUBLIC key. This script takes that public key (PEM, as emitted by
+ * `gcloud kms keys versions get-public-key`) and prints the checksummed 0x address to fund.
+ *
+ * Usage:
+ *   gcloud kms keys versions get-public-key 1 \
+ *     --key=gas-key-mordor --keyring=fairwins-relayer --location=us-central1 \
+ *     --project=chippr-bots-site-wp --output-file=/tmp/gas-key-mordor.pem
+ *   node scripts/operations/relayer/kms-gas-address.js /tmp/gas-key-mordor.pem
+ *
+ * Or pipe the PEM on stdin:
+ *   gcloud kms keys versions get-public-key 1 --key=... | node scripts/operations/relayer/kms-gas-address.js
+ *
+ * secp256k1 SubjectPublicKeyInfo (SPKI) ends with the uncompressed EC point `04 || X(32) || Y(32)`
+ * (the BIT STRING payload after its `00` unused-bits octet), i.e. the last 65 DER bytes. The
+ * Ethereum address is keccak256(X||Y)[-20:], which ethers computes from that 65-byte point.
+ */
+const fs = require("fs");
+const { ethers } = require("ethers");
+
+function readInput() {
+  const argPath = process.argv[2];
+  if (argPath && argPath !== "-") return fs.readFileSync(argPath, "utf8");
+  return fs.readFileSync(0, "utf8"); // stdin
+}
+
+function pemToUncompressedPoint(pem) {
+  const b64 = pem
+    .replace(/-----BEGIN [^-]+-----/g, "")
+    .replace(/-----END [^-]+-----/g, "")
+    .replace(/\s+/g, "");
+  if (!b64) throw new Error("No PEM body found — expected a `-----BEGIN PUBLIC KEY-----` block.");
+  const der = Buffer.from(b64, "base64");
+  const point = der.subarray(der.length - 65); // 04 || X(32) || Y(32)
+  if (point.length !== 65 || point[0] !== 0x04) {
+    throw new Error(
+      `Not a secp256k1 uncompressed SPKI public key (got ${point.length} trailing bytes, ` +
+        `leading 0x${point[0]?.toString(16)}). Confirm the key algorithm is EC_SIGN_SECP256K1_SHA256.`
+    );
+  }
+  return "0x" + point.toString("hex");
+}
+
+function main() {
+  const pem = readInput();
+  const point = pemToUncompressedPoint(pem);
+  const address = ethers.computeAddress(point);
+  // Address on stdout (scriptable); context on stderr.
+  process.stderr.write(`uncompressed pubkey: ${point}\n`);
+  process.stdout.write(address + "\n");
+}
+
+main();

--- a/services/oz-relayer/Dockerfile
+++ b/services/oz-relayer/Dockerfile
@@ -1,0 +1,18 @@
+# Config-baked FairWins engine image (spec 036).
+#
+# The OZ Relayer publishes NO pullable image (ghcr returns 403 on every tag) — it is BUILT FROM SOURCE
+# at a pinned tag and hosted in our Artifact Registry, then this image layers ONLY our config on top
+# (AGPL-safe: unmodified upstream, never forked into this repo). Engine reads /app/config/config.json
+# when IN_DOCKER=true. Full procedure: docs/architecture/relayer-infrastructure.md §6 and
+# docs/runbooks/relayer-mordor-deploy.md.
+#
+# Build the base ONCE (Rust; BuildKit for the cargo cache mounts):
+#   git clone --depth 1 --branch v1.4.0 https://github.com/OpenZeppelin/openzeppelin-relayer ozr
+#   gcloud builds submit ozr \
+#     --config <build using Dockerfile.production, DOCKER_BUILDKIT=1, machineType E2_HIGHCPU_8, timeout 3600s> \
+#     # -> <AR>/fairwins-relay-engine-base:v1.4.0
+FROM us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-engine-base:v1.4.0
+
+# Config only (relayers/networks/signers/notifications). No secrets, no keys — those arrive at
+# runtime via env / Secret Manager and Cloud KMS (see the runbook).
+COPY config /app/config

--- a/services/oz-relayer/deploy/mordor/config.json
+++ b/services/oz-relayer/deploy/mordor/config.json
@@ -1,0 +1,70 @@
+{
+  "relayers": [
+    {
+      "id": "mordor-63",
+      "name": "FairWins Mordor (63)",
+      "network": "mordor",
+      "network_type": "evm",
+      "paused": false,
+      "signer_id": "gas-key-mordor",
+      "notification_id": "relay-gateway-webhook",
+      "policies": {
+        "eip1559_pricing": false,
+        "gas_price_cap": 2000000000000,
+        "min_balance": 1000000000000000000,
+        "whitelist_receivers": [
+          "0x3ccB144d8aa838e8d4D695867cC72e548117830C",
+          "0x68bCBA1055DAbe11b98Bb8425A16e648Ad65d541"
+        ]
+      }
+    }
+  ],
+  "notifications": [
+    {
+      "id": "relay-gateway-webhook",
+      "type": "webhook",
+      "url": "http://localhost:8788/v1/engine/webhook",
+      "signing_key": { "type": "env", "value": "WEBHOOK_SIGNING_KEY" }
+    }
+  ],
+  "signers": [
+    {
+      "id": "gas-key-mordor",
+      "type": "google_cloud_kms",
+      "config": {
+        "service_account": {
+          "project_id": "chippr-bots-site-wp",
+          "private_key_id": { "type": "env", "value": "GCP_PRIVATE_KEY_ID" },
+          "private_key": { "type": "env", "value": "GCP_PRIVATE_KEY" },
+          "client_email": { "type": "env", "value": "GCP_CLIENT_EMAIL" },
+          "client_id": "105464822134406954574"
+        },
+        "key": {
+          "location": "us-central1",
+          "key_ring_id": "fairwins-relayer",
+          "key_id": "gas-key-mordor",
+          "key_version": 1
+        }
+      }
+    }
+  ],
+  "networks": [
+    {
+      "network": "mordor",
+      "type": "evm",
+      "chain_id": 63,
+      "symbol": "METC",
+      "required_confirmations": 6,
+      "average_blocktime_ms": 13000,
+      "is_testnet": true,
+      "features": [],
+      "rpc_urls": [
+        "https://rpc.mordor.etccooperative.org",
+        "https://geth-mordor.etc-network.info"
+      ],
+      "explorer_urls": ["https://etc-mordor.blockscout.com"],
+      "tags": ["testnet", "fairwins", "legacy-gas", "no-batch"]
+    }
+  ],
+  "plugins": []
+}

--- a/services/oz-relayer/deploy/mordor/service.yaml
+++ b/services/oz-relayer/deploy/mordor/service.yaml
@@ -1,0 +1,112 @@
+# As-built Cloud Run manifest for the Mordor (chain 63) gasless relayer — ONE service, THREE
+# sidecar containers over localhost: gateway (public ingress :8788) -> engine (OZ Relayer :8080)
+# -> redis (:6379). This is the real production shape; the runbook's step 4/5 `gcloud run deploy`
+# lines are an illustrative single-service sketch — apply THIS instead:
+#
+#   gcloud run services replace services/oz-relayer/deploy/mordor/service.yaml --region=us-central1
+#
+# Pinning notes:
+#   - The gateway image is pinned by DIGEST (immutability). Re-resolve after every gateway rebuild:
+#       gcloud artifacts docker images describe .../fairwins-relay-gateway:mordor --format='value(image_summary.digest)'
+#   - relay-webhook-secret / relay-engine-api-key are pinned to version "2" ONLY because their v1
+#     values carried a trailing newline (see runbook §1). A fresh deploy that creates the secrets with
+#     `tr -d '\n'` can use `key: latest` for all three.
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: fairwins-relay-gateway
+  labels:
+    cloud.googleapis.com/location: us-central1
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "1"
+        run.googleapis.com/cpu-throttling: "false"
+        run.googleapis.com/startup-cpu-boost: "true"
+        run.googleapis.com/container-dependencies: '{"gateway":["engine"],"engine":["redis"]}'
+    spec:
+      serviceAccountName: fairwins-relay-engine@chippr-bots-site-wp.iam.gserviceaccount.com
+      containers:
+        # ---- ingress: FairWins policy gateway (public, port 8788) ----
+        - name: gateway
+          image: us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway@sha256:f08dd77c7c9cfe9f510adccabcfb6ffab9243910c378a37841c6bef8a822ad18
+          ports:
+            - name: http1
+              containerPort: 8788
+          env:
+            # PORT is injected by Cloud Run from containerPort (8788) — must not be set here.
+            - name: ENABLED_CHAIN_IDS
+              value: "63"
+            - name: ALLOWED_ORIGINS
+              value: "https://fairwins.app"
+            - name: ENGINE_URL
+              value: "http://localhost:8080"
+            - name: ENGINE_RELAYER_ID_63
+              value: "mordor-63"
+            - name: GAS_WALLET_63
+              value: "0xf505d95F62bEE94437C112d3D64ee7Df0Fa973aC"
+            - name: RPC_URLS_63
+              value: "https://rpc.mordor.etccooperative.org,https://geth-mordor.etc-network.info"
+            - name: ORIGIN_AUTH_SECRET
+              valueFrom:
+                secretKeyRef: { name: origin-lock-secret, key: latest }
+            - name: WEBHOOK_SHARED_SECRET
+              valueFrom:
+                secretKeyRef: { name: relay-webhook-secret, key: "2" }
+            - name: ENGINE_API_KEY
+              valueFrom:
+                secretKeyRef: { name: relay-engine-api-key, key: "2" }
+          resources:
+            limits: { cpu: "1", memory: 512Mi }
+        # ---- sidecar: OZ Relayer engine (localhost:8080) ----
+        - name: engine
+          image: us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-engine:mordor-v1.4.0
+          env:
+            - name: IN_DOCKER
+              value: "true"
+            - name: APP_PORT
+              value: "8080"
+            - name: METRICS_ENABLED
+              value: "false"
+            - name: LOG_LEVEL
+              value: "info"
+            - name: REDIS_URL
+              value: "redis://localhost:6379"
+            - name: GCP_PRIVATE_KEY_ID
+              value: "4f206bc79b3f42976c9c49a30d485e3b304b750f"
+            - name: GCP_CLIENT_EMAIL
+              value: "fairwins-relay-engine@chippr-bots-site-wp.iam.gserviceaccount.com"
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef: { name: relay-engine-api-key, key: "2" }
+            - name: WEBHOOK_SIGNING_KEY
+              valueFrom:
+                secretKeyRef: { name: relay-webhook-secret, key: "2" }
+            - name: GCP_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef: { name: relay-engine-gcp-private-key, key: latest }
+          startupProbe:
+            tcpSocket: { port: 8080 }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 30
+          resources:
+            limits: { cpu: 800m, memory: 512Mi }
+        # ---- sidecar: ephemeral redis (localhost:6379) ----
+        - name: redis
+          image: redis:7-alpine
+          args: ["redis-server", "--save", "", "--appendonly", "no"]
+          startupProbe:
+            tcpSocket: { port: 6379 }
+            initialDelaySeconds: 2
+            periodSeconds: 3
+            timeoutSeconds: 2
+            failureThreshold: 20
+          resources:
+            limits: { cpu: 200m, memory: 256Mi }
+  traffic:
+    - percent: 100
+      latestRevision: true

--- a/services/relay-gateway/src/config/index.js
+++ b/services/relay-gateway/src/config/index.js
@@ -184,6 +184,13 @@ export function loadConfig(env = process.env, opts = {}) {
     port: int(env, 'PORT', 8788),
     originAuthSecret: opt(env, 'ORIGIN_AUTH_SECRET', null),
     webhookSecret: opt(env, 'WEBHOOK_SHARED_SECRET', null),
+    // Browser origins allowed to call the gateway cross-origin (CORS). The SPA lives on a different
+    // host than the relay subdomain (fairwins.app -> relay.fairwins.app), so it needs an explicit
+    // allow-list. Comma-separated; unset => no CORS headers (same-origin / server-to-server only).
+    allowedOrigins: opt(env, 'ALLOWED_ORIGINS', '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean),
     engine: {
       url: opt(env, 'ENGINE_URL', 'http://localhost:8080'),
       apiKey: opt(env, 'ENGINE_API_KEY', null),
@@ -200,5 +207,8 @@ export function loadConfig(env = process.env, opts = {}) {
     spendWindowMs: int(env, 'SPEND_WINDOW_MS', 3_600_000),
     defaultGasLimit: bigInt(env, 'DEFAULT_GAS_LIMIT', 300_000n),
     rpcTimeoutMs: int(env, 'RPC_TIMEOUT_MS', 4000),
+    // /healthz + /status cache window: caps upstream RPC fan-out from the origin-lock-exempt health
+    // route so it can't be looped to amplify load onto the operator's public RPCs.
+    healthCacheMs: int(env, 'HEALTH_CACHE_MS', 5000),
   }
 }

--- a/services/relay-gateway/src/engine/webhook.js
+++ b/services/relay-gateway/src/engine/webhook.js
@@ -28,14 +28,32 @@ export function mapEngineStatus(engineStatus) {
 }
 
 /**
+ * Normalize an engine webhook body to { id, status, hash, reason }. The real OZ Relayer wraps every
+ * tx update as `{ id: <notificationId>, event, payload, timestamp }` — the TRANSACTION fields (its own
+ * id/hash/status) live INSIDE `payload`: flattened for `payload_type: "transaction"`, nested under
+ * `payload.transaction` (+ `failure_reason`) for `"transaction_failure"`. NB the outer `event.id` is
+ * the notification id, NOT the tx id. Also accepts a flat `{ id, status, hash }` (the shape
+ * engine-integration.md originally assumed / the unit tests use) so both are handled.
+ */
+export function normalizeEngineEvent(event) {
+  const p = event?.payload
+  if (p && typeof p === 'object') {
+    const tx = p.payload_type === 'transaction_failure' ? (p.transaction ?? {}) : p
+    return { id: tx.id, status: tx.status, hash: tx.hash, reason: p.failure_reason ?? tx.status_reason ?? p.reason }
+  }
+  return { id: event?.id, status: event?.status, hash: event?.hash, reason: event?.reason ?? event?.status_reason }
+}
+
+/**
  * Apply one engine webhook event. Pure of HTTP concerns (server.js owns auth + parsing).
  * @returns {{ ok: boolean, code?: string, record?: object }}
  */
 export function applyEngineEvent({ store, dedup, audit }, event) {
-  const engineTxId = event?.id != null ? String(event.id) : null
+  const n = normalizeEngineEvent(event)
+  const engineTxId = n.id != null ? String(n.id) : null
   if (!engineTxId) return { ok: false, code: 'missing_id' }
 
-  const mapped = mapEngineStatus(event.status)
+  const mapped = mapEngineStatus(n.status)
   if (!mapped) return { ok: false, code: 'unknown_status' }
 
   const record = store.getByEngineTxId(engineTxId)
@@ -46,8 +64,8 @@ export function applyEngineEvent({ store, dedup, audit }, event) {
     return { ok: true, record }
   }
 
-  const txHash = event.hash ?? record.txHash ?? null
-  const reason = mapped === 'failed' ? (event.reason ?? event.status_reason ?? 'transaction failed on-chain') : null
+  const txHash = n.hash ?? record.txHash ?? null
+  const reason = mapped === 'failed' ? (n.reason ?? 'transaction failed on-chain') : null
   store.setStatus(record.intentId, mapped, { txHash, reason })
 
   if (mapped === 'confirmed') {

--- a/services/relay-gateway/src/server.js
+++ b/services/relay-gateway/src/server.js
@@ -101,14 +101,32 @@ export function createApp(config, deps = {}) {
   const app = express()
   app.disable('x-powered-by')
   app.use(helmet())
-  app.use(express.json({ limit: '32kb' })) // intents are small fixed-shape JSON; nothing large is legitimate
+
+  // ---- CORS: the SPA calls the gateway cross-origin (fairwins.app -> relay.fairwins.app). Echo an
+  // allow-listed Origin and answer preflight BEFORE the origin lock — browsers cannot attach
+  // X-Origin-Auth (Cloudflare injects it in transit) and preflight OPTIONS carry no credentials.
+  app.use((req, res, next) => {
+    const origin = req.get('origin')
+    if (origin && config.allowedOrigins.includes(origin)) {
+      res.setHeader('Access-Control-Allow-Origin', origin)
+      res.setHeader('Vary', 'Origin')
+      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
+      res.setHeader('Access-Control-Max-Age', '600')
+    }
+    if (req.method === 'OPTIONS') return res.status(204).end()
+    next()
+  })
+  // Capture the raw body so the engine-webhook route can verify the HMAC over the exact bytes
+  // the engine signed (re-serializing could reorder keys and break the signature).
+  app.use(express.json({ limit: '32kb', verify: (req, _res, buf) => { req.rawBody = buf } })) // intents are small fixed-shape JSON; nothing large is legitimate
 
   // ---- Origin-lock middleware (FR-029, SC-016): client-facing routes require X-Origin-Auth.
   // The Cloudflare Transform Rule injects the header zone-wide; a direct *.run.app hit lacks it.
   // Exempt: /healthz (probes) and /v1/engine/webhook — the engine calls from inside the private
   // network (not through the edge) and authenticates with its own timing-safe shared secret.
   app.use((req, res, next) => {
-    if (req.path === '/healthz' || req.path === '/v1/engine/webhook') return next()
+    if (req.path === '/healthz' || req.path === '/status' || req.path === '/v1/engine/webhook') return next()
     if (!config.originAuthSecret) return next() // dev only; loudly warned at boot
     const header = req.get('x-origin-auth')
     if (!header || !timingSafeEqual(header, config.originAuthSecret)) {
@@ -118,8 +136,20 @@ export function createApp(config, deps = {}) {
     next()
   })
 
-  // ---- GET /healthz (origin-lock exempt) --------------------------------------------------
-  app.get('/healthz', async (_req, res) => {
+  // ---- GET /healthz + /status (origin-lock exempt) ----------------------------------------
+  // Google's GFE intercepts the literal `/healthz` on *.run.app (it never reaches the container),
+  // so `/status` is the externally reachable alias used by the client self-submit probe and the
+  // Cloudflare-fronted URL. `/healthz` stays for the in-container Docker HEALTHCHECK / TCP probe.
+  //
+  // Because /status is origin-lock exempt AND (unlike /healthz) not GFE-intercepted, it is reachable
+  // unauthenticated on the raw *.run.app URL. Two hardenings so that exposure can't be abused:
+  //  1. The upstream RPC fan-out (getBlockNumber + getBalance per chain) is CACHED for a short window
+  //     and de-duped across concurrent callers — a client looping GET can't amplify load onto the
+  //     operator's public RPCs (at most one fan-out per HEALTH_CACHE_MS regardless of request rate).
+  //  2. gasWalletRunwayHrs is operator telemetry (burn rate + time-to-empty) the SPA probe never reads;
+  //     it is disclosed ONLY to callers that present a valid X-Origin-Auth (i.e. arrived via the trusted
+  //     edge, or the lock is disabled in dev). Public callers see only per-chain rpc up/down.
+  const computeHealthChains = async () => {
     const chains = {}
     await Promise.all(
       config.enabledChainIds.map(async (chainId) => {
@@ -144,8 +174,48 @@ export function createApp(config, deps = {}) {
         chains[chainId] = { rpc, gasWalletRunwayHrs }
       })
     )
+    return chains
+  }
+  let healthCache = { at: 0, chains: null }
+  let healthInflight = null
+  const refreshHealth = () => {
+    if (!healthInflight) {
+      healthInflight = computeHealthChains().then(
+        (chains) => {
+          healthCache = { at: Date.now(), chains }
+          healthInflight = null
+          return chains
+        },
+        (err) => {
+          healthInflight = null
+          throw err
+        }
+      )
+    }
+    return healthInflight
+  }
+  const edgeAuthorized = (req) => {
+    if (!config.originAuthSecret) return true // lock disabled (dev) — nothing to protect
+    const header = req.get('x-origin-auth')
+    return !!header && timingSafeEqual(header, config.originAuthSecret)
+  }
+  const healthHandler = async (req, res) => {
+    if (!healthCache.chains || Date.now() - healthCache.at >= config.healthCacheMs) {
+      try {
+        await refreshHealth()
+      } catch {
+        // upstream RPC hiccup — serve the last good snapshot (or empty on cold start) rather than 500
+      }
+    }
+    const disclose = edgeAuthorized(req)
+    const chains = {}
+    for (const [id, c] of Object.entries(healthCache.chains || {})) {
+      chains[id] = disclose ? c : { rpc: c.rpc }
+    }
     res.json({ status: 'ok', chains, killSwitch: killSwitch.isActive() })
-  })
+  }
+  app.get('/healthz', healthHandler)
+  app.get('/status', healthHandler)
 
   // ---- POST /v1/intents --------------------------------------------------------------------
   app.post('/v1/intents', async (req, res) => {
@@ -334,9 +404,15 @@ export function createApp(config, deps = {}) {
 
   // ---- POST /v1/engine/webhook ----------------------------------------------------------------
   app.post('/v1/engine/webhook', (req, res) => {
-    // Shared-secret auth, timing-safe. Fail closed: no configured secret => nothing is accepted.
-    const presented = req.get('x-webhook-secret') ?? (req.get('authorization') ?? '').replace(/^Bearer\s+/i, '')
-    if (!config.webhookSecret || !presented || !timingSafeEqual(presented, config.webhookSecret)) {
+    // Engine authenticity: the OZ Relayer signs each webhook as `X-Signature:
+    // base64(HMAC-SHA256(rawBody, signing_key))` (services/oz-relayer — notification signing_key ===
+    // our WEBHOOK_SHARED_SECRET). Verify timing-safe over the exact received bytes. Fail closed:
+    // no configured secret, no header, or mismatch => nothing is accepted.
+    const presented = req.get('x-signature') ?? ''
+    const expected = config.webhookSecret
+      ? crypto.createHmac('sha256', config.webhookSecret).update(req.rawBody ?? Buffer.alloc(0)).digest('base64')
+      : ''
+    if (!config.webhookSecret || !presented || !timingSafeEqual(presented, expected)) {
       res.status(403).json({ error: { code: 'origin_denied', reason: 'invalid webhook credentials' } })
       return
     }

--- a/services/relay-gateway/src/server.js
+++ b/services/relay-gateway/src/server.js
@@ -338,6 +338,9 @@ export function createApp(config, deps = {}) {
         })
       } catch (e) {
         if (e instanceof EngineUnavailableError) {
+          // Surface WHY the engine was unavailable (auth, non-2xx, timeout) — the client only ever
+          // sees the generic 503, so without this an engine outage is invisible in the logs.
+          console.error('[relay-gateway] engine submission failed:', e.message, e.cause ? `| cause: ${e.cause?.message ?? e.cause}` : '')
           throw new GatewayError(503, 'chain_unavailable', 'submission engine unavailable; use self-submit')
         }
         throw e

--- a/services/relay-gateway/test/gateway.test.js
+++ b/services/relay-gateway/test/gateway.test.js
@@ -358,6 +358,25 @@ describe('webhook + status lifecycle (FR-006: never confirmed before inclusion)'
     expect(status.body).toMatchObject({ intentId, status: 'confirmed', txHash: accepted.body.txHash })
   })
 
+  it('accepts the REAL OZ engine nested payload (tx fields under payload; outer id ignored)', async () => {
+    const ctx = build()
+    const intent = await signedIntent(ctx.config)
+    const accepted = await post(ctx.app, intent)
+    const { intentId } = accepted.body
+
+    // The engine wraps updates as { id: <notificationId>, event, payload: {...}, timestamp }; the
+    // transaction id/hash/status live INSIDE payload (payload_type "transaction"). The outer id is the
+    // notification id and must NOT be used to look up the intent.
+    await postWebhook(ctx.app, {
+      id: 'notif-xyz',
+      event: 'transaction_update',
+      timestamp: '2026-01-01T00:00:00Z',
+      payload: { payload_type: 'transaction', id: 'engine-tx-1', hash: accepted.body.txHash, status: 'mined' },
+    }).expect(200)
+    const status = await request(ctx.app).get(`/v1/intents/${intentId}`).set('X-Origin-Auth', ORIGIN_SECRET)
+    expect(status.body).toMatchObject({ intentId, status: 'confirmed', txHash: accepted.body.txHash })
+  })
+
   it('unknown engine tx id -> 404; unknown intent id -> 404', async () => {
     const { app } = build()
     await postWebhook(app, { id: 'nope', status: 'mined' }).expect(404)

--- a/services/relay-gateway/test/gateway.test.js
+++ b/services/relay-gateway/test/gateway.test.js
@@ -4,6 +4,7 @@
  * (ethers v6) against the version-pinned addresses from deployments/.
  */
 import { describe, it, expect, beforeEach } from 'vitest'
+import crypto from 'node:crypto'
 import request from 'supertest'
 import { ethers } from 'ethers'
 import { createApp } from '../src/server.js'
@@ -40,6 +41,15 @@ function build({ config = testConfig(), providers, engine = mockEngine(), killSw
 const post = (app, body) =>
   request(app).post('/v1/intents').set('X-Origin-Auth', ORIGIN_SECRET).send(body)
 
+// The engine authenticates each webhook with `X-Signature: base64(HMAC-SHA256(rawBody, secret))`
+// (secret === WEBHOOK_SECRET). supertest serializes the body with JSON.stringify, which is the exact
+// byte string the gateway HMACs over.
+const postWebhook = (app, body, { secret = WEBHOOK_SECRET, sign = true } = {}) => {
+  const req = request(app).post('/v1/engine/webhook')
+  if (sign) req.set('X-Signature', crypto.createHmac('sha256', secret).update(JSON.stringify(body)).digest('base64'))
+  return req.send(body)
+}
+
 describe('config / startup consistency check (FR-025)', () => {
   it('pins targets from deployments and fails loudly for a chain without a record', () => {
     const config = testConfig()
@@ -69,6 +79,22 @@ describe('origin lock (FR-029, SC-016)', () => {
     const { app } = build()
     const res = await request(app).get('/healthz')
     expect(res.status).toBe(200)
+  })
+})
+
+describe('CORS (cross-origin SPA -> relay subdomain)', () => {
+  it('answers preflight and echoes an allow-listed Origin; ignores others', async () => {
+    const { app } = build({ config: testConfig({ ALLOWED_ORIGINS: 'https://fairwins.app' }) })
+    const pre = await request(app).options('/v1/intents').set('Origin', 'https://fairwins.app')
+    expect(pre.status).toBe(204)
+    expect(pre.headers['access-control-allow-origin']).toBe('https://fairwins.app')
+    expect(pre.headers['access-control-allow-methods']).toContain('POST')
+
+    const status = await request(app).get('/status').set('Origin', 'https://fairwins.app')
+    expect(status.headers['access-control-allow-origin']).toBe('https://fairwins.app')
+
+    const evil = await request(app).get('/status').set('Origin', 'https://evil.example')
+    expect(evil.headers['access-control-allow-origin']).toBeUndefined()
   })
 })
 
@@ -209,11 +235,7 @@ describe('dedup idempotency (FR-008, SC-006)', () => {
     expect(ctx.engine.submissions).toHaveLength(1)
 
     // Engine reports mined -> intent confirmed; replay now returns the original result (200).
-    await request(ctx.app)
-      .post('/v1/engine/webhook')
-      .set('X-Webhook-Secret', WEBHOOK_SECRET)
-      .send({ id: 'engine-tx-1', hash: txHash, status: 'mined' })
-      .expect(200)
+    await postWebhook(ctx.app, { id: 'engine-tx-1', hash: txHash, status: 'mined' }).expect(200)
 
     const replay = await post(ctx.app, intent)
     expect(replay.status).toBe(200)
@@ -226,11 +248,7 @@ describe('dedup idempotency (FR-008, SC-006)', () => {
     const intent = await signedIntent(ctx.config)
     const first = await post(ctx.app, intent)
     expect(first.status).toBe(202)
-    await request(ctx.app)
-      .post('/v1/engine/webhook')
-      .set('X-Webhook-Secret', WEBHOOK_SECRET)
-      .send({ id: 'engine-tx-1', status: 'failed', reason: 'out of gas' })
-      .expect(200)
+    await postWebhook(ctx.app, { id: 'engine-tx-1', status: 'failed', reason: 'out of gas' }).expect(200)
     const retry = await post(ctx.app, intent)
     expect(retry.status).toBe(202)
     expect(ctx.engine.submissions).toHaveLength(2)
@@ -317,14 +335,10 @@ describe('kill switch (FR-015) + engine failure', () => {
 })
 
 describe('webhook + status lifecycle (FR-006: never confirmed before inclusion)', () => {
-  it('rejects a missing/wrong webhook secret (timing-safe shared secret)', async () => {
+  it('rejects a missing/wrong webhook signature (timing-safe HMAC)', async () => {
     const { app } = build()
-    await request(app).post('/v1/engine/webhook').send({ id: 'x', status: 'mined' }).expect(403)
-    await request(app)
-      .post('/v1/engine/webhook')
-      .set('X-Webhook-Secret', 'wrong')
-      .send({ id: 'x', status: 'mined' })
-      .expect(403)
+    await postWebhook(app, { id: 'x', status: 'mined' }, { sign: false }).expect(403)
+    await postWebhook(app, { id: 'x', status: 'mined' }, { secret: 'wrong' }).expect(403)
   })
 
   it('maps engine statuses honestly: pending -> submitted, mined -> confirmed, failed -> failed', async () => {
@@ -334,50 +348,57 @@ describe('webhook + status lifecycle (FR-006: never confirmed before inclusion)'
     const { intentId } = accepted.body
 
     // Engine says pending — status must NOT be confirmed.
-    await request(ctx.app)
-      .post('/v1/engine/webhook')
-      .set('X-Webhook-Secret', WEBHOOK_SECRET)
-      .send({ id: 'engine-tx-1', hash: accepted.body.txHash, status: 'pending' })
-      .expect(200)
+    await postWebhook(ctx.app, { id: 'engine-tx-1', hash: accepted.body.txHash, status: 'pending' }).expect(200)
     let status = await request(ctx.app).get(`/v1/intents/${intentId}`).set('X-Origin-Auth', ORIGIN_SECRET)
     expect(status.body.status).toBe('submitted')
 
     // Only mined/confirmed flips it to confirmed.
-    await request(ctx.app)
-      .post('/v1/engine/webhook')
-      .set('X-Webhook-Secret', WEBHOOK_SECRET)
-      .send({ id: 'engine-tx-1', hash: accepted.body.txHash, status: 'mined' })
-      .expect(200)
+    await postWebhook(ctx.app, { id: 'engine-tx-1', hash: accepted.body.txHash, status: 'mined' }).expect(200)
     status = await request(ctx.app).get(`/v1/intents/${intentId}`).set('X-Origin-Auth', ORIGIN_SECRET)
     expect(status.body).toMatchObject({ intentId, status: 'confirmed', txHash: accepted.body.txHash })
   })
 
   it('unknown engine tx id -> 404; unknown intent id -> 404', async () => {
     const { app } = build()
-    await request(app)
-      .post('/v1/engine/webhook')
-      .set('X-Webhook-Secret', WEBHOOK_SECRET)
-      .send({ id: 'nope', status: 'mined' })
-      .expect(404)
+    await postWebhook(app, { id: 'nope', status: 'mined' }).expect(404)
     const res = await request(app).get('/v1/intents/does-not-exist').set('X-Origin-Auth', ORIGIN_SECRET)
     expect(res.status).toBe(404)
   })
 })
 
-describe('GET /healthz shape', () => {
-  it('reports per-chain rpc state, runway, and kill switch', async () => {
+describe('GET /healthz + /status (cached, gated telemetry)', () => {
+  it('discloses gas runway only to edge-authenticated callers; public view is rpc-only', async () => {
     const config = testConfig({ GAS_WALLET_137: '0x52502d049571C7893447b86c4d8B38e6184bF6e1' })
     const providers = mockProviders(config)
     providers[63] = { ...providers[63], getBlockNumber: async () => { throw new Error('down') } }
     const { app } = build({ config, providers })
-    const res = await request(app).get('/healthz')
-    expect(res.status).toBe(200)
-    expect(res.body.status).toBe('ok')
-    expect(res.body.killSwitch).toBe(false)
-    expect(res.body.chains['137'].rpc).toBe('up')
-    expect(res.body.chains['137'].gasWalletRunwayHrs).toBeGreaterThan(0)
-    expect(res.body.chains['63'].rpc).toBe('down')
-    expect(res.body.chains['80002']).toEqual({ rpc: 'up', gasWalletRunwayHrs: null })
+
+    // Public caller (no X-Origin-Auth) — rpc up/down only, NO gas-runway telemetry leaked.
+    const pub = await request(app).get('/status')
+    expect(pub.status).toBe(200)
+    expect(pub.body.status).toBe('ok')
+    expect(pub.body.killSwitch).toBe(false)
+    expect(pub.body.chains['137']).toEqual({ rpc: 'up' })
+    expect(pub.body.chains['137'].gasWalletRunwayHrs).toBeUndefined()
+    expect(pub.body.chains['63']).toEqual({ rpc: 'down' })
+    expect(pub.body.chains['80002']).toEqual({ rpc: 'up' })
+
+    // Edge/operator caller (valid X-Origin-Auth) — runway disclosed.
+    const auth = await request(app).get('/status').set('X-Origin-Auth', ORIGIN_SECRET)
+    expect(auth.body.chains['137'].gasWalletRunwayHrs).toBeGreaterThan(0)
+    expect(auth.body.chains['80002']).toEqual({ rpc: 'up', gasWalletRunwayHrs: null })
+  })
+
+  it('caches the RPC fan-out so a request loop cannot amplify upstream load', async () => {
+    const config = testConfig()
+    let blockCalls = 0
+    const providers = mockProviders(config)
+    providers[63] = { ...providers[63], getBlockNumber: async () => { blockCalls += 1; return 1 } }
+    const { app } = build({ config, providers })
+    await request(app).get('/status')
+    await request(app).get('/status')
+    await request(app).get('/status')
+    expect(blockCalls).toBe(1) // three hits, one fan-out within the cache window
   })
 })
 


### PR DESCRIPTION
## Spec 036 — Gasless Intent Relayer: build-from-source engine + Mordor deployment (proven end-to-end)

Stands up the optional gasless relayer end-to-end on **Mordor (ETC testnet, chain 63)** and hardens it
for real integration. The relayer is **optional gas infrastructure** — every covered action keeps a
self-submit fallback, so the worst failure here is "users pay their own gas," never a stuck wager.

**✅ Proven live on Mordor.** A signer-attributed `cancelOpen` intent was signed by a user wallet, POSTed
through `https://relay.fairwins.app`, validated + policy-checked by the gateway, KMS-signed and submitted
by the relayer's gas wallet, and mined on-chain (`0xc1ac7d…`, `0x5d3a14…`) — the **user paid zero gas**.
The gateway reported the honest lifecycle `queued → submitted → confirmed` via the engine status webhook.

### What shipped
- **Engine is built from source.** OpenZeppelin Relayer publishes no pullable image, so `v1.4.0` is
  built from `Dockerfile.production` → Artifact Registry, and `services/oz-relayer/Dockerfile` layers
  only our config on that base (AGPL-safe; never forked into the repo).
- **Webhook authenticity + payload shape (real integration fixes).** The engine signs webhooks as
  `X-Signature: base64(HMAC-SHA256(rawBody, signing_key))` (not the shared-secret header we assumed) and
  the body is **nested** — `{ id, event, payload, timestamp }` with the tx id/hash/status inside
  `payload` (the outer `id` is the *notification* id). Added the timing-safe HMAC verifier + raw-body
  capture, and `normalizeEngineEvent` which maps both the nested and flat shapes so status reaches
  `confirmed` instead of hanging at `queued`.
- **`/status` health alias + hardening.** Google's GFE intercepts the literal `/healthz` on every
  `*.run.app`, so the health handler is also served at `/status` (frontend probe points there). A
  pre-commit adversarial review then made `/status` **cached + de-duped** (unauth RPC-fanout DoS), and
  **gated `gasWalletRunwayHrs`** behind `X-Origin-Auth` (public sees `rpc` up/down only).
- **CORS + never-stranded probe.** The SPA (`fairwins.app`) calls the relay subdomain cross-origin, so
  the gateway emits a strict allow-listed CORS response and answers preflight before the origin lock;
  and `probeHealth` returns `false` for any chain absent from `/status` (self-submit, never sign-then-strand).
- **Cutover wiring.** `cloudbuild.yaml` bakes `VITE_RELAYER_URL` into the SPA build (via `Dockerfile`),
  and the single-container gateway build/deploy is **removed** from CI — the production relayer is a
  3-container Cloud Run service and a `gcloud run deploy` from CI would clobber it.
- **As-built deploy artifacts.** The live topology (one Cloud Run service, three sidecar containers:
  gateway + OZ engine + redis) is committed at `services/oz-relayer/deploy/mordor/{service.yaml,config.json}`.
- **Ops + docs.** `scripts/operations/relayer/{kms-gas-address,fund-gas-wallet}.js`;
  `docs/architecture/relayer-infrastructure.md`; `docs/runbooks/relayer-mordor-deploy.md` (now including
  the secret-newline trap, the registry-must-expose-intents prereq, and the nested webhook shape).

### On-chain prerequisite (done for Mordor)
The relayer only submits `…WithSig` calls, which revert on a pre-intents `WagerRegistry`. The Mordor
proxy was UUPS-upgraded to expose the gasless-intent facet — main impl `0x9FfE…`, facet `0x81a9…`
(`intentExtension()` wired, `DOMAIN_SEPARATOR()` no longer reverts). Recorded in
`deployments/mordor-chain63-v2.json` + `.openzeppelin/unknown-63.json`.

### Deployment status (Mordor, chain 63)
Live + validated: gateway at `https://relay.fairwins.app` (Cloudflare origin-locked), signing from an
**HSM secp256k1 Cloud KMS** key (`0xf505…`, funded METC). Relays **WagerRegistry + MembershipManager**
intents (not pools); payment/EIP-3009 intents self-submit on ETC by design (legacy gas, batch size 1).

### Not in this PR — the frontend "last mile"
The relayer client library (`useIntentAction`, `intentClient`, `IntentStatus`) is complete and tested,
but is **not yet wired into the pool/wager write flows** — every user write is still a direct self-submit
today (see the note atop `frontend/src/hooks/usePools.js`). Turning on the gasless UX for users is a
separate frontend change: route each write through `useIntentAction` (buildIntent + selfSubmit twin) and
surface `IntentStatus`. Baking `VITE_RELAYER_URL` is safe but dormant until that wiring lands.

### Also tracked
- Reconcile the canonical 4-chain `services/oz-relayer/config/config.json` to the v1.4.0 schema.
- Engine uses an exported KMS SA key (OZ-Relayer v1.4.0 has no ADC) — switch to ADC on the next engine bump.
- Domain-mapping cert won't auto-renew while Cloudflare-proxied — handle before 2026-10-03.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
