### PR TITLE
feat(036): wire gasless UX into the no-fund wager write flows

### DIFF
--- a/frontend/src/components/fairwins/MarketAcceptanceModal.jsx
+++ b/frontend/src/components/fairwins/MarketAcceptanceModal.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { ethers } from 'ethers'
 import { useWallet, useWeb3 } from '../../hooks'
+import { useGaslessWrite } from '../../lib/relay/useGaslessWrite'
 import { useEncryption } from '../../hooks/useEncryption'
 import { fetchEncryptedEnvelope } from '../../utils/ipfsService'
 import {
@@ -439,6 +440,20 @@ function MarketAcceptanceModal({
     }
   }
 
+  // Gasless declineWager (spec 035/036): relayed where the relayer serves the chain, transparent
+  // self-submit otherwise. targetContract is pinned to this modal's own registry address so the
+  // relayed target can never diverge from the self-submit one.
+  const declineWagerTx = useGaslessWrite('declineWager', {
+    targetContract: contractAddress,
+    params: (wagerId) => ({ wagerId }),
+    selfSubmit: async (wagerId) => {
+      const contract = new ethers.Contract(contractAddress, contractABI, signer)
+      const tx = await contract.declineWager(wagerId)
+      setTxHash(tx.hash)
+      return tx.wait()
+    },
+  })
+
   const handleDecline = async () => {
     if (!signer) {
       setError('Please connect your wallet')
@@ -458,14 +473,9 @@ function MarketAcceptanceModal({
     setError(null)
 
     try {
-      const contract = new ethers.Contract(
-        contractAddress,
-        contractABI,
-        signer
-      )
-      const tx = await contract.declineWager(marketId)
-      setTxHash(tx.hash)
-      await tx.wait()
+      const result = await declineWagerTx.run(marketId)
+      if (result?.error) throw result.error
+      if (result?.txHash) setTxHash(result.txHash)
       setStep('declined')
     } catch (err) {
       let errorMessage = 'Failed to decline the offer.'

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -9,6 +9,7 @@ import { useFriendMarkets } from '../../contexts/FriendMarketsContext.js'
 import { WagerStatus as MarketStatus, DisputeStatus, WAGER_DEFAULTS, MyWagersDensity, MyWagersView } from '../../constants/wagerDefaults'
 import { getContractAddressForChain } from '../../config/contracts'
 import { getNetwork } from '../../config/networks'
+import { useGaslessWrite } from '../../lib/relay/useGaslessWrite'
 import { WAGER_REGISTRY_ABI } from '../../abis/WagerRegistry'
 import { getFeeOverrides } from '../../utils/feeOverrides'
 import { getTransactionUrl } from '../../config/blockExplorer'
@@ -752,6 +753,21 @@ function MyMarketsModal({
   const [claimingId, setClaimingId] = useState(null)
   const [claimError, setClaimError] = useState(null)
 
+  // Gasless claimPayout (spec 035/036): relayed where the relayer serves the chain (user pays no gas),
+  // transparent self-submit otherwise. One in-flight claim at a time (claimingId), so one hook suffices.
+  const claimPayoutTx = useGaslessWrite('claimPayout', {
+    params: (wagerId) => ({ wagerId }),
+    selfSubmit: async (wagerId) => {
+      const registry = new ethers.Contract(
+        getContractAddressForChain('wagerRegistry', chainId),
+        WAGER_REGISTRY_ABI,
+        signer
+      )
+      const tx = await registry.claimPayout(wagerId)
+      return tx.wait()
+    },
+  })
+
   const handleClaimPayout = useCallback(async (market) => {
     if (!signer) return
     const id = String(market.id)
@@ -769,17 +785,12 @@ function MyMarketsModal({
     setClaimError(null)
 
     try {
-      const registry = new ethers.Contract(
-        getContractAddressForChain('wagerRegistry', chainId),
-        WAGER_REGISTRY_ABI,
-        signer
-      )
-      const tx = await registry.claimPayout(market.wagerId ?? market.id)
-      await tx.wait()
+      const result = await claimPayoutTx.run(market.wagerId ?? market.id)
+      if (result?.error) throw result.error
       // Pull fresh on-chain data so the claimed wager flips to paid (which
       // hides the Claim affordances) and clear its unread activity.
       markWagerRead?.(id)
-      fireToast('Winnings claimed 🎉')
+      fireToast(result?.txHash ? 'Winnings claimed 🎉' : 'Claim submitted — confirming…')
       await refreshFriendMarkets?.()
     } catch (err) {
       const reason = err?.reason || err?.shortMessage || err?.data?.message || err?.message || ''
@@ -800,7 +811,7 @@ function MyMarketsModal({
     } finally {
       setClaimingId(null)
     }
-  }, [signer, isCorrectNetwork, switchNetwork, chainId, markWagerRead, refreshFriendMarkets, fireToast])
+  }, [signer, isCorrectNetwork, switchNetwork, markWagerRead, refreshFriendMarkets, fireToast, claimPayoutTx])
 
   // Participant reclaims their stake on a wager that ran past its resolution
   // window without a winner being declared (the "refundable" state). Mirrors
@@ -810,6 +821,20 @@ function MyMarketsModal({
   // handled separately by handleClearExpired's "Reclaim & Clear".
   const [refundingId, setRefundingId] = useState(null)
   const [refundError, setRefundError] = useState(null)
+
+  // Gasless claimRefund for the list row (spec 035/036); one in-flight refund at a time (refundingId).
+  const claimRefundRowTx = useGaslessWrite('claimRefund', {
+    params: (wagerId) => ({ wagerId }),
+    selfSubmit: async (wagerId) => {
+      const registry = new ethers.Contract(
+        getContractAddressForChain('wagerRegistry', chainId),
+        WAGER_REGISTRY_ABI,
+        signer
+      )
+      const tx = await registry.claimRefund(wagerId)
+      return tx.wait()
+    },
+  })
 
   const handleClaimRefund = useCallback(async (market) => {
     if (!signer) return
@@ -828,17 +853,12 @@ function MyMarketsModal({
     setRefundError(null)
 
     try {
-      const registry = new ethers.Contract(
-        getContractAddressForChain('wagerRegistry', chainId),
-        WAGER_REGISTRY_ABI,
-        signer
-      )
-      const tx = await registry.claimRefund(market.wagerId ?? market.id)
-      await tx.wait()
+      const result = await claimRefundRowTx.run(market.wagerId ?? market.id)
+      if (result?.error) throw result.error
       // Pull fresh on-chain data so the refunded wager leaves the list and clear
       // its unread activity.
       markWagerRead?.(id)
-      fireToast('Refund claimed')
+      fireToast(result?.txHash ? 'Refund claimed' : 'Refund submitted — confirming…')
       await refreshFriendMarkets?.()
     } catch (err) {
       const reason = err?.reason || err?.shortMessage || err?.data?.message || err?.message || ''
@@ -857,7 +877,7 @@ function MyMarketsModal({
     } finally {
       setRefundingId(null)
     }
-  }, [signer, isCorrectNetwork, switchNetwork, chainId, markWagerRead, refreshFriendMarkets, fireToast])
+  }, [signer, isCorrectNetwork, switchNetwork, markWagerRead, refreshFriendMarkets, fireToast, claimRefundRowTx])
 
   if (!isOpen) return null
 
@@ -1392,6 +1412,22 @@ function MarketDetailView({
   const [withdrawSuccess, setWithdrawSuccess] = useState(false)
   const [withdrawTxHash, setWithdrawTxHash] = useState(null)
 
+  // Gasless cancelOpen (spec 035/036): relayed where the relayer serves the chain (user pays no gas),
+  // otherwise a transparent self-submit — identical on-chain result, and the UI below is unchanged.
+  const cancelOpenTx = useGaslessWrite('cancelOpen', {
+    params: (wagerId) => ({ wagerId }),
+    selfSubmit: async (wagerId) => {
+      const contract = new ethers.Contract(
+        getContractAddressForChain('wagerRegistry', chainId),
+        WAGER_REGISTRY_ABI,
+        signer
+      )
+      const tx = await contract.cancelOpen(wagerId)
+      setWithdrawTxHash(tx.hash)
+      return tx.wait()
+    },
+  })
+
   const handleWithdraw = async () => {
     if (!signer) return
 
@@ -1408,16 +1444,17 @@ function MarketDetailView({
     setWithdrawError(null)
 
     try {
-      const contract = new ethers.Contract(
-        getContractAddressForChain('wagerRegistry', chainId),
-        WAGER_REGISTRY_ABI,
-        signer
-      )
-      const tx = await contract.cancelOpen(market.wagerId ?? market.id)
-      setWithdrawTxHash(tx.hash)
-      await tx.wait()
-      setWithdrawSuccess(true)
-      onWithdraw?.(market)
+      const result = await cancelOpenTx.run(market.wagerId ?? market.id)
+      if (result?.error) throw result.error
+      if (result?.txHash) {
+        setWithdrawTxHash(result.txHash)
+        setWithdrawSuccess(true)
+        onWithdraw?.(market)
+      } else {
+        // Relay accepted but not yet mined within the poll budget (rare on Mordor) — stay honest: no
+        // false success. A refresh will show it withdrawn, or the idempotent retry reverts NotOpen.
+        setWithdrawError('Still processing — check back in a moment.')
+      }
     } catch (err) {
       const reason = err?.reason || err?.data?.message || err?.message || ''
       if (reason.includes('user rejected') || reason.includes('ACTION_REJECTED')) {
@@ -1446,6 +1483,21 @@ function MarketDetailView({
   const showRefundButton = isParticipant && signer &&
     status === MarketStatus.PENDING_RESOLUTION && !refundSuccess
 
+  // Gasless claimRefund (spec 035/036): relayed where available, transparent self-submit otherwise.
+  const claimRefundTx = useGaslessWrite('claimRefund', {
+    params: (wagerId) => ({ wagerId }),
+    selfSubmit: async (wagerId) => {
+      const registry = new ethers.Contract(
+        getContractAddressForChain('wagerRegistry', chainId),
+        WAGER_REGISTRY_ABI,
+        signer
+      )
+      const tx = await registry.claimRefund(wagerId)
+      setRefundTxHash(tx.hash)
+      return tx.wait()
+    },
+  })
+
   const handleClaimRefund = async () => {
     if (!signer) return
 
@@ -1462,16 +1514,15 @@ function MarketDetailView({
     setRefundError(null)
 
     try {
-      const registry = new ethers.Contract(
-        getContractAddressForChain('wagerRegistry', chainId),
-        WAGER_REGISTRY_ABI,
-        signer
-      )
-      const tx = await registry.claimRefund(market.wagerId ?? market.id)
-      setRefundTxHash(tx.hash)
-      await tx.wait()
-      setRefundSuccess(true)
-      onRefunded?.(market)
+      const result = await claimRefundTx.run(market.wagerId ?? market.id)
+      if (result?.error) throw result.error
+      if (result?.txHash) {
+        setRefundTxHash(result.txHash)
+        setRefundSuccess(true)
+        onRefunded?.(market)
+      } else {
+        setRefundError('Still processing — check back in a moment.')
+      }
     } catch (err) {
       const reason = err?.reason || err?.shortMessage || err?.message || ''
       if (err?.code === 'ACTION_REJECTED' || err?.code === 4001 ||

--- a/frontend/src/lib/relay/__tests__/intentClient.test.js
+++ b/frontend/src/lib/relay/__tests__/intentClient.test.js
@@ -8,6 +8,7 @@
  * src/test/setup.js; we override it per test.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ethers } from 'ethers'
 import { makeRelayer, signIntent, relayIntent, pollStatus, probeHealth, randomNonce } from '../intentClient'
 import { PaymentUnsupportedOnChain, RelayRejected, RelayerUnavailable } from '../errors'
 import { stablecoinDomain, wagerRegistryDomain, membershipManagerDomain } from '../intentTypes'
@@ -131,6 +132,42 @@ describe('intent relay client', () => {
       expect(Object.keys(call.types)).toEqual(['ClaimPayoutIntent'])
       expect(call.message.claimant).toBe(SIGNER_ADDRESS)
       expect(call.message.nonce).toBe(intent.uniquenessMarker)
+    })
+
+    it('produces a real signature that recovers to the signer under the contract EIP-712 domain (frontend↔contract parity)', async () => {
+      // Not a mock signer: a real ethers wallet signs, and we recover under the LITERAL domain +
+      // struct the on-chain WagerRegistry intents facet verifies against — the same domain the live
+      // Mordor relay E2E accepted. This is the guard that the frontend's intentTypes never drift from
+      // the contract typehashes (the "three byte-identical places" invariant, per CLAUDE.md).
+      // Fixed key (createRandom's mnemonic entropy is stubbed in the test env); any valid key works.
+      const wallet = new ethers.Wallet('0x' + '11'.repeat(32))
+      const intent = await signIntent({
+        signer: wallet,
+        chainId: 63,
+        action: 'cancelOpen',
+        targetContract: REGISTRY,
+        params: { wagerId: 7n },
+        nowSeconds: 1_000_000,
+        validitySeconds: 600,
+      })
+      const domain = { name: 'FairWins WagerRegistry', version: '1', chainId: 63, verifyingContract: REGISTRY }
+      const types = {
+        CancelOpenIntent: [
+          { name: 'wagerId', type: 'uint256' },
+          { name: 'actor', type: 'address' },
+          { name: 'nonce', type: 'bytes32' },
+          { name: 'validAfter', type: 'uint256' },
+          { name: 'validBefore', type: 'uint256' },
+        ],
+      }
+      const message = {
+        wagerId: intent.params.wagerId,
+        actor: wallet.address,
+        nonce: intent.uniquenessMarker,
+        validAfter: intent.validAfter,
+        validBefore: intent.validBefore,
+      }
+      expect(ethers.verifyTypedData(domain, types, message, intent.signature)).toBe(wallet.address)
     })
 
     it('staples the EIP-3009 authorization to a payment-class intent (paymentNonce binding, FR-007)', async () => {

--- a/frontend/src/lib/relay/__tests__/useGaslessWrite.test.js
+++ b/frontend/src/lib/relay/__tests__/useGaslessWrite.test.js
@@ -1,0 +1,102 @@
+/**
+ * useGaslessWrite tests — the reusable call-site seam. useIntentAction (the state machine) and
+ * intentClient.signIntent are mocked at the module boundary, so these assert only the helper's own
+ * job: resolve the EIP-712 verifying contract from the action's verifier, shape params from run()
+ * args, and pass a correct config through to useIntentAction (incl. the payment leg for payment-class
+ * actions). The routing/never-stranded behaviour is covered by useIntentAction's own suite.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const h = vi.hoisted(() => ({
+  useIntentAction: vi.fn((cfg) => ({ __cfg: cfg, status: 'idle', run: vi.fn() })),
+  signIntent: vi.fn(async (args) => ({ __signed: args })),
+  getContractAddressForChain: vi.fn((name, cid) => `0xADDR_${name}_${cid}`),
+  useWeb3: vi.fn(() => ({ signer: { getAddress: async () => '0xSIGNER' }, chainId: 63 })),
+}))
+vi.mock('../useIntentAction', () => ({ useIntentAction: h.useIntentAction }))
+vi.mock('../intentClient', () => ({ signIntent: h.signIntent }))
+vi.mock('../../../config/contracts', () => ({ getContractAddressForChain: h.getContractAddressForChain }))
+vi.mock('../../../hooks/useWeb3', () => ({ useWeb3: h.useWeb3 }))
+
+import { useGaslessWrite } from '../useGaslessWrite'
+
+describe('useGaslessWrite', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('passes action/chainId/selfSubmit through to useIntentAction', () => {
+    const selfSubmit = vi.fn()
+    renderHook(() => useGaslessWrite('cancelOpen', { params: (id) => ({ wagerId: id }), selfSubmit }))
+    const cfg = h.useIntentAction.mock.calls[0][0]
+    expect(cfg.action).toBe('cancelOpen')
+    expect(cfg.chainId).toBe(63)
+    expect(cfg.selfSubmit).toBe(selfSubmit)
+    expect(typeof cfg.buildIntent).toBe('function')
+  })
+
+  it('buildIntent signs with the resolved wagerRegistry target + shaped params (signer-attributed, no payment)', async () => {
+    renderHook(() => useGaslessWrite('cancelOpen', { params: (id) => ({ wagerId: id }), selfSubmit: vi.fn() }))
+    const cfg = h.useIntentAction.mock.calls[0][0]
+    await cfg.buildIntent(42)
+    expect(h.getContractAddressForChain).toHaveBeenCalledWith('wagerRegistry', 63)
+    expect(h.signIntent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'cancelOpen',
+        chainId: 63,
+        targetContract: '0xADDR_wagerRegistry_63',
+        params: { wagerId: 42 },
+      })
+    )
+    expect(h.signIntent.mock.calls[0][0].payment).toBeUndefined()
+  })
+
+  it('forwards payment.value + targets membershipManager for a payment-class action', async () => {
+    renderHook(() =>
+      useGaslessWrite('purchaseTier', {
+        params: (role, tier, terms) => ({ role, tier, acceptedTermsHash: terms }),
+        payment: (_role, _tier, _terms, price) => ({ value: price }),
+        selfSubmit: vi.fn(),
+      })
+    )
+    const cfg = h.useIntentAction.mock.calls[0][0]
+    await cfg.buildIntent('0xROLE', 2, '0xTERMS', 5000000n)
+    expect(h.getContractAddressForChain).toHaveBeenCalledWith('membershipManager', 63)
+    expect(h.signIntent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'purchaseTier',
+        targetContract: '0xADDR_membershipManager_63',
+        params: { role: '0xROLE', tier: 2, acceptedTermsHash: '0xTERMS' },
+        payment: { value: 5000000n },
+      })
+    )
+  })
+
+  it('honors an explicit targetContract override (never resolves from the verifier)', async () => {
+    renderHook(() =>
+      useGaslessWrite('declineWager', {
+        targetContract: '0xMODAL_REGISTRY',
+        params: (id) => ({ wagerId: id }),
+        selfSubmit: vi.fn(),
+      })
+    )
+    const cfg = h.useIntentAction.mock.calls[0][0]
+    await cfg.buildIntent(9)
+    expect(h.getContractAddressForChain).not.toHaveBeenCalled()
+    expect(h.signIntent).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'declineWager', targetContract: '0xMODAL_REGISTRY', params: { wagerId: 9 } })
+    )
+  })
+
+  it('tolerates an unconfigured chain (getContractAddressForChain throws) → null target, no crash', () => {
+    h.getContractAddressForChain.mockImplementationOnce(() => {
+      throw new Error('no address for chain')
+    })
+    const { result } = renderHook(() => useGaslessWrite('cancelOpen', { params: (id) => ({ wagerId: id }), selfSubmit: vi.fn() }))
+    // render must not throw; the hook still returns a useIntentAction handle
+    expect(result.current).toBeTruthy()
+    const cfg = h.useIntentAction.mock.calls[0][0]
+    expect(cfg.action).toBe('cancelOpen')
+  })
+})

--- a/frontend/src/lib/relay/useGaslessWrite.js
+++ b/frontend/src/lib/relay/useGaslessWrite.js
@@ -1,0 +1,73 @@
+import { useMemo } from 'react'
+import { useWeb3 } from '../../hooks/useWeb3'
+import { getContractAddressForChain } from '../../config/contracts'
+import { signIntent } from './intentClient'
+import { INTENT_ACTIONS } from './intentTypes'
+import { useIntentAction } from './useIntentAction'
+
+/**
+ * useGaslessWrite — the one-line seam every call site uses to route an on-chain write through the
+ * gasless relayer WITH a transparent self-submit fallback (spec 035/036 never-stranded rule; the
+ * actual state machine lives in {@link useIntentAction}). It resolves the signer + chainId from the
+ * wallet context and the EIP-712 verifying contract from the action's `verifier`, so a caller supplies
+ * only two things: how to shape the intent params from the run() arguments, and how to self-submit the
+ * equivalent wallet transaction.
+ *
+ * Chain behaviour is automatic and safe:
+ *   - relayer URL unset, or the chain absent from the relayer's `/status` → self-submit (probeHealth).
+ *   - payment-class action on a chain whose stablecoin lacks EIP-3009 (Mordor/ETC) → `signIntent`
+ *     throws PaymentUnsupportedOnChain BEFORE any wallet prompt → self-submit.
+ * So wiring a call site here never changes its behaviour on chains the relayer doesn't (yet) serve —
+ * it stays a plain self-submit — and lights up gasless only where the relayer is live.
+ *
+ * @param {string} action - an INTENT_ACTIONS key (e.g. 'cancelOpen', 'claimPayout', 'redeemVoucher').
+ * @param {object} cfg
+ * @param {(...runArgs: any[]) => object} [cfg.params] - maps run() args → the intent struct params,
+ *   minus the fields signIntent auto-fills (actor/nonce/validAfter/validBefore/paymentNonce). Omit for
+ *   a no-param action. Receives the exact args passed to `run(...)`.
+ * @param {(...runArgs: any[]) => {value: bigint|string}} [cfg.payment] - payment-class only: the USDC
+ *   amount to authorize (ReceiveWithAuthorization value). Ignored for signer-attributed actions.
+ * @param {(...runArgs: any[]) => Promise<object|string>} cfg.selfSubmit - MANDATORY: the existing
+ *   wallet write, resolving with the mined receipt (or its hash). Receives the same run() args.
+ * @param {(entry: object) => void} [cfg.onActivity] - spec-031 ActivityEntry sink (optional).
+ * @param {string} [cfg.targetContract] - override the EIP-712 verifying contract. Defaults to the
+ *   action verifier's address via getContractAddressForChain; pass this when the call site already
+ *   holds the exact proxy address (so the relayed target can never diverge from the self-submit one).
+ * @param {object} [cfg.rest] - forwarded to useIntentAction (pollIntervalMs, maxPollMs, invalidateNonce).
+ * @returns {ReturnType<typeof useIntentAction>} { status, intent, result, error, run, invalidate,
+ *   selfSubmitNow, reset }
+ */
+export function useGaslessWrite(action, { params, payment, selfSubmit, onActivity, targetContract: targetOverride, ...rest } = {}) {
+  const { signer, chainId } = useWeb3()
+  const verifier = INTENT_ACTIONS[action]?.verifier
+
+  // The EIP-712 verifying contract is the action's target proxy (wagerRegistry | membershipManager).
+  const targetContract = useMemo(() => {
+    if (targetOverride) return targetOverride
+    if (chainId == null || !verifier) return null
+    try {
+      return getContractAddressForChain(verifier, chainId)
+    } catch {
+      return null // chain not configured for this contract — buildIntent will surface it; probe self-submits first
+    }
+  }, [targetOverride, verifier, chainId])
+
+  return useIntentAction({
+    action,
+    chainId,
+    buildIntent: (...runArgs) =>
+      signIntent({
+        signer,
+        chainId,
+        action,
+        targetContract,
+        params: typeof params === 'function' ? params(...runArgs) : params || {},
+        ...(typeof payment === 'function' ? { payment: payment(...runArgs) } : {}),
+      }),
+    selfSubmit,
+    onActivity,
+    ...rest,
+  })
+}
+
+export default useGaslessWrite


### PR DESCRIPTION
## Spec 036 — Wire gasless UX into the no-fund wager write flows

Follow-up to #802 (the relayer infra, proven E2E on Mordor). That PR shipped the relayer client
library (`useIntentAction`, `intentClient`) but nothing called it — every write still self-submitted.
This PR routes the **signer-attributed (no-fund) WagerRegistry writes** through the relayer, so they go
**gasless where the relayer serves the chain** (Mordor today) and stay a plain self-submit everywhere
else. Pages are otherwise unchanged.

### The seam
`useGaslessWrite(action, { params, selfSubmit, targetContract? })` — resolves the signer + chainId from
the wallet context and the EIP-712 verifying contract from the action's `verifier` (or an explicit
override), and wraps `useIntentAction`. A call site keeps its existing handler and swaps only the final
send: `const result = await tx.run(...)` with the existing `ethers` write as the `selfSubmit` twin.

Safety is automatic (never-stranded rule): relayer URL unset, or the chain absent from the relayer's
`/status`, → self-submit before any wallet prompt; payment-class actions on a chain whose stablecoin
lacks EIP-3009 → `PaymentUnsupportedOnChain` → self-submit. So wiring a site never changes its behaviour
on chains the relayer doesn't serve.

### Wired (gasless on Mordor, self-submit elsewhere)
`cancelOpen`, `claimRefund` (detail view + list row), `claimPayout`, `declineWager`.

### Parity guard
A new test signs a real `cancelOpen` intent via `signIntent` and asserts it **recovers to the signer
under the literal `FairWins WagerRegistry` domain** the live Mordor relay accepted — a regression guard
for the "three byte-identical intentTypes copies" invariant (CLAUDE.md), catching any frontend↔contract
EIP-712 drift.

### Deferred (still self-submit — no behaviour change)
- `declareDraw` / `declareWinner` — need receipt-log parsing (WagerDrawn settle-vs-propose) and a
  pre-sign `getWager` winner lookup; wrapping their send naively would drop that logic.
- `redeemVoucher` — signer-attributed, but pending confirmation that the **Mordor MembershipManager**
  exposes the intents facet (wiring it before that risks the relay reverting where self-submit would
  succeed — a stranding).
- Payment-class (`createWager` / `acceptWager` / `acceptOpenWager` / `purchaseTier` / `upgradeTier` /
  `extendMembership`) — EIP-3009; self-submit on ETC by design, light up when the Polygon relayer lands.

### Tests
`useGaslessWrite` (5) + `intentClient` parity (+1) added; `MyMarketsModal` (44) and
`MarketAcceptanceModal` (14) remain green. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
