### PR TITLE
Polygon go-live — deploy + relayer + frontend cutover + gasless UX (Tier 1)

### DIFF
--- a/.openzeppelin/polygon.json
+++ b/.openzeppelin/polygon.json
@@ -1,0 +1,1483 @@
+{
+  "manifestVersion": "3.2",
+  "proxies": [
+    {
+      "address": "0xEfd1a880c6BfBf38A661A3F5fF6d5ECB296D557a",
+      "txHash": "0xc7f96e10b9525181c342c42a1a79c6fed46355681caad1b414fdd7fac57c20b1",
+      "kind": "uups"
+    },
+    {
+      "address": "0xE878b62887fC8A5F739B8Ce61bC19546A280Ef89",
+      "txHash": "0x36ca49e3080029d25e1ea0f48532d9cdc16aec5ddb21891ab64af8d90844b146",
+      "kind": "uups"
+    },
+    {
+      "address": "0x5806e76cA3c838524E7cF43db7625bdFBA0783a0",
+      "txHash": "0x390496c320583dfb07d11134413d7af281798df4cc7847e72a2bb558bbafb6c5",
+      "kind": "uups"
+    }
+  ],
+  "impls": {
+    "cbae87472cfe31070db52c60acd9231595dbe8281242adde99f85b7ab0ec2d4e": {
+      "address": "0x8018D8C85C1e22C785b384854e328b43158c0eCD",
+      "txHash": "0x443e63343efd87922ff3221621e82c0e273e098fe6b40884d61c32df1c4a9747",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSManaged",
+            "src": "contracts/upgradeable/UUPSManaged.sol:46"
+          },
+          {
+            "label": "_tiers",
+            "offset": 0,
+            "slot": "50",
+            "type": "t_mapping(t_bytes32,t_mapping(t_enum(Tier)17793,t_struct(TierConfig)17808_storage))",
+            "contract": "MembershipManager",
+            "src": "contracts/access/MembershipManager.sol:43"
+          },
+          {
+            "label": "_memberships",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_mapping(t_address,t_mapping(t_bytes32,t_struct(Membership)17820_storage))",
+            "contract": "MembershipManager",
+            "src": "contracts/access/MembershipManager.sol:44"
+          },
+          {
+            "label": "authorizedCallers",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "MembershipManager",
+            "src": "contracts/access/MembershipManager.sol:45"
+          },
+          {
+            "label": "paymentToken",
+            "offset": 0,
+            "slot": "53",
+            "type": "t_contract(IERC20)3586",
+            "contract": "MembershipManager",
+            "src": "contracts/access/MembershipManager.sol:47"
+          },
+          {
+            "label": "treasury",
+            "offset": 0,
+            "slot": "54",
+            "type": "t_address",
+            "contract": "MembershipManager",
+            "src": "contracts/access/MembershipManager.sol:48"
+          },
+          {
+            "label": "accruedFees",
+            "offset": 0,
+            "slot": "55",
+            "type": "t_uint128",
+            "contract": "MembershipManager",
+            "src": "contracts/access/MembershipManager.sol:49"
+          },
+          {
+            "label": "sanctionsGuard",
+            "offset": 0,
+            "slot": "56",
+            "type": "t_contract(ISanctionsGuard)18042",
+            "contract": "MembershipManager",
+            "src": "contracts/access/MembershipManager.sol:53"
+          },
+          {
+            "label": "memberTermsHash",
+            "offset": 0,
+            "slot": "57",
+            "type": "t_mapping(t_address,t_mapping(t_bytes32,t_bytes32))",
+            "contract": "MembershipManager",
+            "src": "contracts/access/MembershipManager.sol:57"
+          },
+          {
+            "label": "voucher",
+            "offset": 0,
+            "slot": "58",
+            "type": "t_address",
+            "contract": "MembershipManager",
+            "src": "contracts/access/MembershipManager.sol:61"
+          },
+          {
+            "label": "feeNettingEnabled",
+            "offset": 20,
+            "slot": "58",
+            "type": "t_bool",
+            "contract": "MembershipManager",
+            "src": "contracts/access/MembershipManager.sol:67"
+          },
+          {
+            "label": "gasFeeRecipient",
+            "offset": 0,
+            "slot": "59",
+            "type": "t_address",
+            "contract": "MembershipManager",
+            "src": "contracts/access/MembershipManager.sol:70"
+          },
+          {
+            "label": "maxGasFee",
+            "offset": 0,
+            "slot": "60",
+            "type": "t_uint256",
+            "contract": "MembershipManager",
+            "src": "contracts/access/MembershipManager.sol:72"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "61",
+            "type": "t_array(t_uint256)47_storage",
+            "contract": "MembershipManager",
+            "src": "contracts/access/MembershipManager.sol:79"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_bytes32,t_bool))": {
+            "label": "mapping(address => mapping(bytes32 => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)26_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)36_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)26_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(EIP712Storage)425_storage": {
+            "label": "struct EIP712Upgradeable.EIP712Storage",
+            "members": [
+              {
+                "label": "_hashedName",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_hashedVersion",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "_version",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(InitializableStorage)147_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)26_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(SignerIntentStorage)8319_storage": {
+            "label": "struct SignerIntentBase.SignerIntentStorage",
+            "members": [
+              {
+                "label": "used",
+                "type": "t_mapping(t_address,t_mapping(t_bytes32,t_bool))",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]",
+            "numberOfBytes": "1504"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_contract(IERC20)3586": {
+            "label": "contract IERC20",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ISanctionsGuard)18042": {
+            "label": "contract ISanctionsGuard",
+            "numberOfBytes": "20"
+          },
+          "t_enum(Tier)17793": {
+            "label": "enum IMembershipManager.Tier",
+            "members": [
+              "None",
+              "Bronze",
+              "Silver",
+              "Gold",
+              "Platinum"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_mapping(t_bytes32,t_bytes32))": {
+            "label": "mapping(address => mapping(bytes32 => bytes32))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_bytes32,t_struct(Membership)17820_storage))": {
+            "label": "mapping(address => mapping(bytes32 => struct IMembershipManager.Membership))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bytes32)": {
+            "label": "mapping(bytes32 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_mapping(t_enum(Tier)17793,t_struct(TierConfig)17808_storage))": {
+            "label": "mapping(bytes32 => mapping(enum IMembershipManager.Tier => struct IMembershipManager.TierConfig))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(Membership)17820_storage)": {
+            "label": "mapping(bytes32 => struct IMembershipManager.Membership)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_enum(Tier)17793,t_struct(TierConfig)17808_storage)": {
+            "label": "mapping(enum IMembershipManager.Tier => struct IMembershipManager.TierConfig)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Limits)17798_storage": {
+            "label": "struct IMembershipManager.Limits",
+            "members": [
+              {
+                "label": "monthlyMarketCreation",
+                "type": "t_uint32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "maxConcurrentMarkets",
+                "type": "t_uint32",
+                "offset": 4,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Membership)17820_storage": {
+            "label": "struct IMembershipManager.Membership",
+            "members": [
+              {
+                "label": "tier",
+                "type": "t_enum(Tier)17793",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "expiresAt",
+                "type": "t_uint64",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "monthCount",
+                "type": "t_uint32",
+                "offset": 9,
+                "slot": "0"
+              },
+              {
+                "label": "activeCount",
+                "type": "t_uint32",
+                "offset": 13,
+                "slot": "0"
+              },
+              {
+                "label": "monthAnchor",
+                "type": "t_uint64",
+                "offset": 17,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(TierConfig)17808_storage": {
+            "label": "struct IMembershipManager.TierConfig",
+            "members": [
+              {
+                "label": "priceUSDC",
+                "type": "t_uint128",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "durationDays",
+                "type": "t_uint32",
+                "offset": 16,
+                "slot": "0"
+              },
+              {
+                "label": "active",
+                "type": "t_bool",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "limits",
+                "type": "t_struct(Limits)17798_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint128": {
+            "label": "uint128",
+            "numberOfBytes": "16"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:fairwins.storage.SignerIntentBase": [
+            {
+              "contract": "SignerIntentBase",
+              "label": "used",
+              "type": "t_mapping(t_address,t_mapping(t_bytes32,t_bool))",
+              "src": "contracts/upgradeable/SignerIntentBase.sol:33",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.EIP712": [
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedName",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:38",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedVersion",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:40",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_name",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:42",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_version",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:43",
+              "offset": 0,
+              "slot": "3"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)26_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:62",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "c4ee497f899669580d6795ed664ec67c15ce040fec7ed29e3d85e11c9a109987": {
+      "address": "0x9c52C1ef4Bbe65CF19a5C26bebD4A22100964898",
+      "txHash": "0xbdbab6431149260e13c8f2675691b7c1af25acbf5bae423bbd4a06bbad248c67",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSManaged",
+            "src": "contracts/upgradeable/UUPSManaged.sol:46"
+          },
+          {
+            "label": "membershipManager",
+            "offset": 0,
+            "slot": "50",
+            "type": "t_contract(IMembershipManager)17940",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:59"
+          },
+          {
+            "label": "polymarketAdapter",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_contract(IOracleAdapter)19263",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:60"
+          },
+          {
+            "label": "sanctionsGuard",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_contract(ISanctionsGuard)18042",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:64"
+          },
+          {
+            "label": "oracleAdapters",
+            "offset": 0,
+            "slot": "53",
+            "type": "t_mapping(t_enum(ResolutionType)18512,t_contract(IOracleAdapter)19263)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:68"
+          },
+          {
+            "label": "_allowedTokens",
+            "offset": 0,
+            "slot": "54",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:70"
+          },
+          {
+            "label": "_wagers",
+            "offset": 0,
+            "slot": "55",
+            "type": "t_mapping(t_uint256,t_struct(Wager)18555_storage)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:71"
+          },
+          {
+            "label": "_frozen",
+            "offset": 0,
+            "slot": "56",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:72"
+          },
+          {
+            "label": "wagerTermsVersionHash",
+            "offset": 0,
+            "slot": "57",
+            "type": "t_mapping(t_uint256,t_bytes32)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:77"
+          },
+          {
+            "label": "_nextWagerId",
+            "offset": 0,
+            "slot": "58",
+            "type": "t_uint256",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:80"
+          },
+          {
+            "label": "_drawConsent",
+            "offset": 0,
+            "slot": "59",
+            "type": "t_mapping(t_uint256,t_uint8)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:88"
+          },
+          {
+            "label": "_userWagerIds",
+            "offset": 0,
+            "slot": "60",
+            "type": "t_mapping(t_address,t_struct(UintSet)14242_storage)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:96"
+          },
+          {
+            "label": "claimAuthority",
+            "offset": 0,
+            "slot": "61",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:101"
+          },
+          {
+            "label": "openWagerIdByClaim",
+            "offset": 0,
+            "slot": "62",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:104"
+          },
+          {
+            "label": "_feeNettingEnabled",
+            "offset": 0,
+            "slot": "63",
+            "type": "t_bool",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:112"
+          },
+          {
+            "label": "_gasFeeRecipient",
+            "offset": 1,
+            "slot": "63",
+            "type": "t_address",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:115"
+          },
+          {
+            "label": "_maxGasFee",
+            "offset": 0,
+            "slot": "64",
+            "type": "t_uint256",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:117"
+          },
+          {
+            "label": "intentExtension",
+            "offset": 0,
+            "slot": "65",
+            "type": "t_address",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:122"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "66",
+            "type": "t_array(t_uint256)45_storage",
+            "contract": "WagerRegistryCore",
+            "src": "contracts/wagers/WagerRegistryCore.sol:130"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)26_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)36_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)26_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(EIP712Storage)425_storage": {
+            "label": "struct EIP712Upgradeable.EIP712Storage",
+            "members": [
+              {
+                "label": "_hashedName",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_hashedVersion",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "_version",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(InitializableStorage)147_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)298_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)362_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)26_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)45_storage": {
+            "label": "uint256[45]",
+            "numberOfBytes": "1440"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_contract(IMembershipManager)17940": {
+            "label": "contract IMembershipManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IOracleAdapter)19263": {
+            "label": "contract IOracleAdapter",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ISanctionsGuard)18042": {
+            "label": "contract ISanctionsGuard",
+            "numberOfBytes": "20"
+          },
+          "t_enum(ResolutionType)18512": {
+            "label": "enum IWagerRegistryTypes.ResolutionType",
+            "members": [
+              "Either",
+              "Creator",
+              "Opponent",
+              "ThirdParty",
+              "Polymarket",
+              "ChainlinkDataFeed",
+              "ChainlinkFunctions",
+              "UMA"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_enum(Status)18520": {
+            "label": "enum IWagerRegistryTypes.Status",
+            "members": [
+              "None",
+              "Open",
+              "Active",
+              "Resolved",
+              "Cancelled",
+              "Refunded",
+              "Draw"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_struct(UintSet)14242_storage)": {
+            "label": "mapping(address => struct EnumerableSet.UintSet)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_enum(ResolutionType)18512,t_contract(IOracleAdapter)19263)": {
+            "label": "mapping(enum IWagerRegistryTypes.ResolutionType => contract IOracleAdapter)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_bytes32)": {
+            "label": "mapping(uint256 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Wager)18555_storage)": {
+            "label": "mapping(uint256 => struct IWagerRegistryTypes.Wager)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint8)": {
+            "label": "mapping(uint256 => uint8)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Set)13550_storage": {
+            "label": "struct EnumerableSet.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_positions",
+                "type": "t_mapping(t_bytes32,t_uint256)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(UintSet)14242_storage": {
+            "label": "struct EnumerableSet.UintSet",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)13550_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Wager)18555_storage": {
+            "label": "struct IWagerRegistryTypes.Wager",
+            "members": [
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "opponent",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "arbitrator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "token",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "creatorStake",
+                "type": "t_uint128",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "opponentStake",
+                "type": "t_uint128",
+                "offset": 16,
+                "slot": "4"
+              },
+              {
+                "label": "acceptDeadline",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "resolveDeadline",
+                "type": "t_uint64",
+                "offset": 8,
+                "slot": "5"
+              },
+              {
+                "label": "resolutionType",
+                "type": "t_enum(ResolutionType)18512",
+                "offset": 16,
+                "slot": "5"
+              },
+              {
+                "label": "status",
+                "type": "t_enum(Status)18520",
+                "offset": 17,
+                "slot": "5"
+              },
+              {
+                "label": "paid",
+                "type": "t_bool",
+                "offset": 18,
+                "slot": "5"
+              },
+              {
+                "label": "creatorIsYes",
+                "type": "t_bool",
+                "offset": 19,
+                "slot": "5"
+              },
+              {
+                "label": "winner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "metadataHash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "polymarketConditionId",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "metadataUri",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "9"
+              }
+            ],
+            "numberOfBytes": "320"
+          },
+          "t_uint128": {
+            "label": "uint128",
+            "numberOfBytes": "16"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.EIP712": [
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedName",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:38",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedVersion",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:40",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_name",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:42",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_version",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:43",
+              "offset": 0,
+              "slot": "3"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:43",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)26_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:62",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "9e8775cbafc8e8ef1cefdae06e110fc22d2aaacfa905fb6ca0b0931a6523937d": {
+      "address": "0xE819f7b672D81A8b78d40b1C99Fe5d646513D12C",
+      "txHash": "0x74cb6e9cc4ac4db21936e372d0347e66c49dcbf38dba1e1e41869e2ab9f4df19",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSManaged",
+            "src": "contracts/upgradeable/UUPSManaged.sol:46"
+          },
+          {
+            "label": "sanctionsGuard",
+            "offset": 0,
+            "slot": "50",
+            "type": "t_contract(ISanctionsGuard)22831",
+            "contract": "TokenFactory",
+            "src": "contracts/tokens/TokenFactory.sol:36"
+          },
+          {
+            "label": "openERC20Impl",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "TokenFactory",
+            "src": "contracts/tokens/TokenFactory.sol:39"
+          },
+          {
+            "label": "openERC721Impl",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_address",
+            "contract": "TokenFactory",
+            "src": "contracts/tokens/TokenFactory.sol:40"
+          },
+          {
+            "label": "restrictedERC20Impl",
+            "offset": 0,
+            "slot": "53",
+            "type": "t_address",
+            "contract": "TokenFactory",
+            "src": "contracts/tokens/TokenFactory.sol:41"
+          },
+          {
+            "label": "tokenCount",
+            "offset": 0,
+            "slot": "54",
+            "type": "t_uint256",
+            "contract": "TokenFactory",
+            "src": "contracts/tokens/TokenFactory.sol:44"
+          },
+          {
+            "label": "_tokens",
+            "offset": 0,
+            "slot": "55",
+            "type": "t_mapping(t_uint256,t_struct(TokenRecord)31504_storage)",
+            "contract": "TokenFactory",
+            "src": "contracts/tokens/TokenFactory.sol:46"
+          },
+          {
+            "label": "_issuerTokens",
+            "offset": 0,
+            "slot": "56",
+            "type": "t_mapping(t_address,t_array(t_uint256)dyn_storage)",
+            "contract": "TokenFactory",
+            "src": "contracts/tokens/TokenFactory.sol:47"
+          },
+          {
+            "label": "tokenAddressToId",
+            "offset": 0,
+            "slot": "57",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "TokenFactory",
+            "src": "contracts/tokens/TokenFactory.sol:50"
+          },
+          {
+            "label": "openERC20V2Impl",
+            "offset": 0,
+            "slot": "58",
+            "type": "t_address",
+            "contract": "TokenFactory",
+            "src": "contracts/tokens/TokenFactory.sol:56"
+          },
+          {
+            "label": "openERC721V2Impl",
+            "offset": 0,
+            "slot": "59",
+            "type": "t_address",
+            "contract": "TokenFactory",
+            "src": "contracts/tokens/TokenFactory.sol:57"
+          },
+          {
+            "label": "restrictedERC20V2Impl",
+            "offset": 0,
+            "slot": "60",
+            "type": "t_address",
+            "contract": "TokenFactory",
+            "src": "contracts/tokens/TokenFactory.sol:58"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "61",
+            "type": "t_array(t_uint256)47_storage",
+            "contract": "TokenFactory",
+            "src": "contracts/tokens/TokenFactory.sol:62"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)973_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)983_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)973_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)1258_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)2258_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)973_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]",
+            "numberOfBytes": "1504"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]",
+            "numberOfBytes": "32"
+          },
+          "t_contract(ISanctionsGuard)22831": {
+            "label": "contract ISanctionsGuard",
+            "numberOfBytes": "20"
+          },
+          "t_enum(TokenStandard)31468": {
+            "label": "enum ITokenFactory.TokenStandard",
+            "members": [
+              "OPEN_ERC20",
+              "OPEN_ERC721",
+              "RESTRICTED_ERC1404",
+              "PERMISSIONED_ERC3643"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_array(t_uint256)dyn_storage)": {
+            "label": "mapping(address => uint256[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(TokenRecord)31504_storage)": {
+            "label": "mapping(uint256 => struct ITokenFactory.TokenRecord)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(TokenRecord)31504_storage": {
+            "label": "struct ITokenFactory.TokenRecord",
+            "members": [
+              {
+                "label": "id",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "standard",
+                "type": "t_enum(TokenStandard)31468",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "tokenAddress",
+                "type": "t_address",
+                "offset": 1,
+                "slot": "1"
+              },
+              {
+                "label": "issuer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "symbol",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "metadataURI",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "isBurnable",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "isPausable",
+                "type": "t_bool",
+                "offset": 1,
+                "slot": "6"
+              },
+              {
+                "label": "suite",
+                "type": "t_struct(TrexSuiteRef)31478_storage",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "createdAt",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "11"
+              }
+            ],
+            "numberOfBytes": "384"
+          },
+          "t_struct(TrexSuiteRef)31478_storage": {
+            "label": "struct ITokenFactory.TrexSuiteRef",
+            "members": [
+              {
+                "label": "identityRegistry",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "compliance",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "claimTopicsRegistry",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "trustedIssuersRegistry",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:43",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)973_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:62",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/deployments/polygon-chain137-v2.json
+++ b/deployments/polygon-chain137-v2.json
@@ -24,7 +24,10 @@
     "chainlinkDataFeedAdapter": "0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23",
     "chainlinkFunctionsAdapter": "0x148C2E347a601AC1a680b17321529b0Ffc31AeFc",
     "umaAdapter": "0x8224433d099Af6cd30540A78421aBFd6e044E949",
-    "wagerRegistryIntents": "0x9e4338E12A30a98eaa0dE58b2c4d7B562f5eB438"
+    "wagerRegistryIntents": "0x9e4338E12A30a98eaa0dE58b2c4d7B562f5eB438",
+    "wagerPoolFactory": "0x420aEC3c76859eB74ab21c769c16AcdAB221f723",
+    "wagerPoolFactoryImpl": "0x2ad0F9Fe788F35F8edbaCA35346Da22792c5d18e",
+    "poolImpl": "0xd0b94a77DA7Aaa488343CF89978f1Bbf9E72E277"
   },
   "mocks": null,
   "constructorArgs": {
@@ -61,9 +64,12 @@
       "0x52502d049571C7893447b86c4d8B38e6184bF6e1",
       "0x5953f2538F613E05bAED8A5AeFa8e6622467AD3D"
     ],
-    "wagerRegistryIntents": []
+    "wagerRegistryIntents": [],
+    "wagerPoolFactoryImpl": [],
+    "poolImpl": []
   },
   "saltPrefix": "FairWins-P2P-v2.0-",
   "timestamp": "2026-07-05T20:05:10.649Z",
-  "gaslessIntentsUpgradedAt": "2026-07-05T20:10:24.755Z"
+  "gaslessIntentsUpgradedAt": "2026-07-05T20:10:24.755Z",
+  "wagerPoolsDeployedAt": "2026-07-05T21:15:07.971Z"
 }

--- a/deployments/polygon-chain137-v2.json
+++ b/deployments/polygon-chain137-v2.json
@@ -2,24 +2,68 @@
   "network": "polygon",
   "chainId": 137,
   "deployer": "0x52502d049571C7893447b86c4d8B38e6184bF6e1",
-  "treasury": "0x52502d049571C7893447b86c4d8B38e6184bF6e1",
+  "treasury": "0x1215185387E70a48b07D73AcB67002A073F18575",
   "paymentToken": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
   "wmatic": "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
   "polymarketCTF": "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045",
   "contracts": {
     "polymarketAdapter": "0x83688e9b8D4f085E3eF4619D91e0e6303cFcf0A4",
-    "membershipManager": "0x00c3ef4e02Ef00Ad6eE955dF5022A22F6ea73dae",
-    "wagerRegistry": "0x5023765809fDA93ab9F11B684fdb76521eD31774",
+    "membershipManager": "0xEfd1a880c6BfBf38A661A3F5fF6d5ECB296D557a",
+    "membershipManagerImpl": "0x8018D8C85C1e22C785b384854e328b43158c0eCD",
+    "membershipVoucher": "0xCB28DC438564672067a6f84131B5130e6Cf7ECC6",
+    "voucherBatchMinter": "0x4b50d24ca28CbDC029714e5830f7D16a0ebEDb0e",
+    "wagerRegistry": "0xE878b62887fC8A5F739B8Ce61bC19546A280Ef89",
+    "wagerRegistryImpl": "0x9c52C1ef4Bbe65CF19a5C26bebD4A22100964898",
     "keyRegistry": "0xcEFdeBba8E040c035c690ca9057cF22E73247c24",
     "sanctionsGuard": "0x2Dc53d91A189be71DfE96Ea9BCFCF6aDDA77BC76",
+    "tokenFactory": "0x5806e76cA3c838524E7cF43db7625bdFBA0783a0",
+    "tokenFactoryImpl": "0xE819f7b672D81A8b78d40b1C99Fe5d646513D12C",
+    "openERC20Impl": "0xd8E67C6C058a6D35E69c691B44b8D5f858591971",
+    "openERC721Impl": "0x02819fd0d338F4C3FC58E6d9aF299ACA75d624BB",
+    "restrictedERC20Impl": "0x0dD67E2af8Ad301a3B5308c2AD41CCb2220b0444",
     "chainlinkDataFeedAdapter": "0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23",
     "chainlinkFunctionsAdapter": "0x148C2E347a601AC1a680b17321529b0Ffc31AeFc",
-    "umaAdapter": "0x8224433d099Af6cd30540A78421aBFd6e044E949"
+    "umaAdapter": "0x8224433d099Af6cd30540A78421aBFd6e044E949",
+    "wagerRegistryIntents": "0x9e4338E12A30a98eaa0dE58b2c4d7B562f5eB438"
   },
   "mocks": null,
+  "constructorArgs": {
+    "membershipManagerImpl": [],
+    "membershipVoucher": [
+      "0x52502d049571C7893447b86c4d8B38e6184bF6e1",
+      "0xEfd1a880c6BfBf38A661A3F5fF6d5ECB296D557a"
+    ],
+    "voucherBatchMinter": [
+      "0xCB28DC438564672067a6f84131B5130e6Cf7ECC6"
+    ],
+    "wagerRegistryImpl": [],
+    "sanctionsGuard": [
+      "0x52502d049571C7893447b86c4d8B38e6184bF6e1",
+      "0x40C57923924B5c5c5455c48D93317139ADDaC8fb"
+    ],
+    "keyRegistry": [],
+    "tokenFactoryImpl": [],
+    "openERC20Impl": [],
+    "openERC721Impl": [],
+    "restrictedERC20Impl": [],
+    "polymarketAdapter": [
+      "0x52502d049571C7893447b86c4d8B38e6184bF6e1",
+      "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045"
+    ],
+    "chainlinkDataFeedAdapter": [
+      "0x52502d049571C7893447b86c4d8B38e6184bF6e1"
+    ],
+    "chainlinkFunctionsAdapter": [
+      "0x52502d049571C7893447b86c4d8B38e6184bF6e1",
+      "0xdc2AAF042Aeff2E68B3e8E33F19e4B9fA7C73F10"
+    ],
+    "umaAdapter": [
+      "0x52502d049571C7893447b86c4d8B38e6184bF6e1",
+      "0x5953f2538F613E05bAED8A5AeFa8e6622467AD3D"
+    ],
+    "wagerRegistryIntents": []
+  },
   "saltPrefix": "FairWins-P2P-v2.0-",
-  "timestamp": "2026-06-08T01:35:29.642Z",
-  "deployBlocks": {
-    "wagerRegistry": 88118344
-  }
+  "timestamp": "2026-07-05T20:05:10.649Z",
+  "gaslessIntentsUpgradedAt": "2026-07-05T20:10:24.755Z"
 }

--- a/frontend/src/components/fairwins/MarketAcceptanceModal.jsx
+++ b/frontend/src/components/fairwins/MarketAcceptanceModal.jsx
@@ -366,20 +366,12 @@ function MarketAcceptanceModal({
         )
       }
 
-      const currentAllowance = await tokenContract.allowance(account, contractAddress)
-      if (currentAllowance < stakeAmount) {
-        console.log('Approving stake token for WagerRegistry...')
-        const approveTx = await tokenContract.approve(contractAddress, stakeAmount)
-        await approveTx.wait()
-      }
-
-      let tx
-      console.log('Sending acceptWager transaction...')
-      const feeOverrides = await getFeeOverrides(signer.provider)
-      tx = await contract.acceptWager(marketId, feeOverrides)
-
-      setTxHash(tx.hash)
-      await tx.wait()
+      // Gasless-or-self-submit acceptance: the self-submit closure keeps the existing
+      // approve → acceptWager flow; the gasless path skips the approve (EIP-3009 pulls the
+      // acceptor's stake) and lets the relayer pay gas. Stake + token come from getWager above.
+      const result = await acceptWagerTx.run(marketId, stakeAmount, stakeTokenAddress)
+      if (result?.error) throw result.error
+      if (result?.txHash) setTxHash(result.txHash)
 
       setStep('success')
       if (onAccepted) onAccepted(marketId)
@@ -439,6 +431,39 @@ function MarketAcceptanceModal({
       setStep('error')
     }
   }
+
+  // Gasless acceptWager (spec 035/036): relayed where the relayer serves the chain and the stake
+  // token supports EIP-3009 (Polygon USDC), transparent self-submit otherwise (Mordor USC →
+  // auto self-submit). The payment leg authorizes the acceptor's stake via EIP-3009, so the gasless
+  // path skips the approve the self-submit closure performs. targetContract is pinned to this modal's
+  // own registry address so the relayed target can never diverge from the self-submit one.
+  const acceptWagerTx = useGaslessWrite('acceptWager', {
+    targetContract: contractAddress,
+    params: (wagerId) => ({ wagerId }),
+    payment: (wagerId, stakeAmount) => ({ value: stakeAmount }),
+    selfSubmit: async (wagerId, stakeAmount, stakeTokenAddress) => {
+      const contract = new ethers.Contract(contractAddress, contractABI, signer)
+      const tokenContract = new ethers.Contract(
+        stakeTokenAddress,
+        [
+          'function approve(address,uint256) returns (bool)',
+          'function allowance(address,address) view returns (uint256)',
+        ],
+        signer
+      )
+      const currentAllowance = await tokenContract.allowance(account, contractAddress)
+      if (currentAllowance < stakeAmount) {
+        console.log('Approving stake token for WagerRegistry...')
+        const approveTx = await tokenContract.approve(contractAddress, stakeAmount)
+        await approveTx.wait()
+      }
+      console.log('Sending acceptWager transaction...')
+      const feeOverrides = await getFeeOverrides(signer.provider)
+      const tx = await contract.acceptWager(wagerId, feeOverrides)
+      setTxHash(tx.hash)
+      return tx.wait()
+    },
+  })
 
   // Gasless declineWager (spec 035/036): relayed where the relayer serves the chain, transparent
   // self-submit otherwise. targetContract is pinned to this modal's own registry address so the

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -1953,6 +1953,60 @@ function ResolutionModal({
   )
   const isDrawSelected = selectedOutcome === DRAW
 
+  // Gasless declareDraw / declareWinner (spec 035/036): both are signer-attributed resolution
+  // actions (no payment), so they relay where the relayer serves the chain (user pays no gas) and
+  // transparently self-submit otherwise. The self-submit closures carry the existing fee overrides
+  // and receipt-status guards; the draw closure also inspects the WagerDrawn event to decide the
+  // proposed-vs-settled messaging (a receipt-only signal, so it lives where the receipt exists).
+  const declareDrawTx = useGaslessWrite('declareDraw', {
+    params: (wagerId) => ({ wagerId }),
+    selfSubmit: async (wagerId) => {
+      const registry = new ethers.Contract(
+        getContractAddressForChain('wagerRegistry', chainId),
+        WAGER_REGISTRY_ABI,
+        signer
+      )
+      const feeOverrides = await getFeeOverrides(signer.provider)
+      const tx = await registry.declareDraw(wagerId, feeOverrides)
+      const receipt = await tx.wait()
+      if (receipt && receipt.status === 0) {
+        throw new Error('Transaction reverted on-chain. Draw failed.')
+      }
+      if (!receipt) {
+        throw new Error('Transaction was dropped or replaced. Please try again.')
+      }
+      // A WagerDrawn event means the draw settled now; otherwise it's a pending
+      // proposal awaiting the counterparty's confirmation.
+      const settled = receipt.logs.some((l) => {
+        try { return registry.interface.parseLog(l)?.name === 'WagerDrawn' } catch { return false }
+      })
+      setDrawSettled(settled)
+      return receipt
+    },
+  })
+
+  const declareWinnerTx = useGaslessWrite('declareWinner', {
+    params: (wagerId, winner) => ({ wagerId, winner }),
+    selfSubmit: async (wagerId, winner) => {
+      const registry = new ethers.Contract(
+        getContractAddressForChain('wagerRegistry', chainId),
+        WAGER_REGISTRY_ABI,
+        signer
+      )
+      const feeOverrides = await getFeeOverrides(signer.provider)
+      const tx = await registry.declareWinner(wagerId, winner, feeOverrides)
+      const receipt = await tx.wait()
+      if (receipt && receipt.status === 0) {
+        throw new Error('Transaction reverted on-chain. Resolution failed.')
+      }
+      if (!receipt) {
+        throw new Error('Transaction was dropped or replaced. Please try again.')
+      }
+      console.log('Market resolution proposed:', receipt)
+      return receipt
+    },
+  })
+
   const handleSubmit = async () => {
     if (!selectedOutcome) {
       setError('Please select an outcome')
@@ -1986,26 +2040,13 @@ function ResolutionModal({
     )
 
     try {
-      const feeOverrides = await getFeeOverrides(signer.provider)
-
       // Draw: returns each party their own stake. For participant types the
       // first call only proposes (awaiting the counterparty); the second settles.
+      // The self-submit closure inspects the WagerDrawn event to set drawSettled.
       if (isDrawSelected) {
-        const tx = await registry.declareDraw(market.id, feeOverrides)
-        setTxHash(tx.hash)
-        const receipt = await tx.wait()
-        if (receipt && receipt.status === 0) {
-          throw new Error('Transaction reverted on-chain. Draw failed.')
-        }
-        if (!receipt) {
-          throw new Error('Transaction was dropped or replaced. Please try again.')
-        }
-        // A WagerDrawn event means the draw settled now; otherwise it's a pending
-        // proposal awaiting the counterparty's confirmation.
-        const settled = receipt.logs.some((l) => {
-          try { return registry.interface.parseLog(l)?.name === 'WagerDrawn' } catch { return false }
-        })
-        setDrawSettled(settled)
+        const result = await declareDrawTx.run(market.id)
+        if (result?.error) throw result.error
+        if (result?.txHash) setTxHash(result.txHash)
         setStep('success')
         return
       }
@@ -2023,19 +2064,10 @@ function ResolutionModal({
         notes: resolutionNotes,
       })
 
-      const tx = await registry.declareWinner(market.id, winner, feeOverrides)
-      setTxHash(tx.hash)
+      const result = await declareWinnerTx.run(market.id, winner)
+      if (result?.error) throw result.error
+      if (result?.txHash) setTxHash(result.txHash)
 
-      const receipt = await tx.wait()
-
-      if (receipt && receipt.status === 0) {
-        throw new Error('Transaction reverted on-chain. Resolution failed.')
-      }
-      if (!receipt) {
-        throw new Error('Transaction was dropped or replaced. Please try again.')
-      }
-
-      console.log('Market resolution proposed:', receipt)
       setStep('success')
     } catch (err) {
       console.error('Error resolving market:', err)

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -86,8 +86,8 @@ const POLYGON_CONTRACTS = {
   // Treasury / membership-sales recipient = chipprbots.eth (hardware wallet).
   treasury: '0x1215185387E70a48b07D73AcB67002A073F18575',
   // v2 core (populated by `npm run sync:frontend-contracts -- --network polygon --chainId 137`)
-  wagerRegistry: '0x5023765809fDA93ab9F11B684fdb76521eD31774',
-  membershipManager: '0x00c3ef4e02Ef00Ad6eE955dF5022A22F6ea73dae',
+  wagerRegistry: '0xE878b62887fC8A5F739B8Ce61bC19546A280Ef89',
+  membershipManager: '0xEfd1a880c6BfBf38A661A3F5fF6d5ECB296D557a',
   keyRegistry: '0xcEFdeBba8E040c035c690ca9057cF22E73247c24',
   sanctionsGuard: '0x2Dc53d91A189be71DfE96Ea9BCFCF6aDDA77BC76', // Spec 007 compliance guard
   polymarketAdapter: '0x83688e9b8D4f085E3eF4619D91e0e6303cFcf0A4', // tie-fix + admin-owner redeploy
@@ -97,6 +97,9 @@ const POLYGON_CONTRACTS = {
   chainlinkDataFeedAdapter: '0x7ae8220Dc02D0504EDCBa2C1B1AbA579AA3F0f23',
   chainlinkFunctionsAdapter: '0x148C2E347a601AC1a680b17321529b0Ffc31AeFc',
   umaAdapter: '0x8224433d099Af6cd30540A78421aBFd6e044E949',
+  membershipVoucher: '0xCB28DC438564672067a6f84131B5130e6Cf7ECC6',
+  voucherBatchMinter: '0x4b50d24ca28CbDC029714e5830f7D16a0ebEDb0e',
+  tokenFactory: '0x5806e76cA3c838524E7cF43db7625bdFBA0783a0',
 }
 
 const NETWORK_CONTRACTS = {
@@ -124,7 +127,7 @@ export const DEPLOYED_CONTRACTS =
 const DEPLOYMENT_BLOCKS_BY_CHAIN = {
   63: { friendGroupMarketFactory: 15658191, wagerRegistry: 0, membershipVoucher: 16404315, wagerPoolFactory: 16495564 },
   80002: { friendGroupMarketFactory: 0, wagerRegistry: 0, membershipVoucher: 40521024 },
-  137: { friendGroupMarketFactory: 0, wagerRegistry: 88118344, membershipVoucher: 0 },
+  137: { friendGroupMarketFactory: 0, wagerRegistry: 89717915, membershipVoucher: 89717915 },
 }
 
 export const DEPLOYMENT_BLOCKS =

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -100,6 +100,7 @@ const POLYGON_CONTRACTS = {
   membershipVoucher: '0xCB28DC438564672067a6f84131B5130e6Cf7ECC6',
   voucherBatchMinter: '0x4b50d24ca28CbDC029714e5830f7D16a0ebEDb0e',
   tokenFactory: '0x5806e76cA3c838524E7cF43db7625bdFBA0783a0',
+  wagerPoolFactory: '0x420aEC3c76859eB74ab21c769c16AcdAB221f723',
 }
 
 const NETWORK_CONTRACTS = {
@@ -127,7 +128,7 @@ export const DEPLOYED_CONTRACTS =
 const DEPLOYMENT_BLOCKS_BY_CHAIN = {
   63: { friendGroupMarketFactory: 15658191, wagerRegistry: 0, membershipVoucher: 16404315, wagerPoolFactory: 16495564 },
   80002: { friendGroupMarketFactory: 0, wagerRegistry: 0, membershipVoucher: 40521024 },
-  137: { friendGroupMarketFactory: 0, wagerRegistry: 89717915, membershipVoucher: 89717915 },
+  137: { friendGroupMarketFactory: 0, wagerRegistry: 89717915, membershipVoucher: 89717915, wagerPoolFactory: 89720731 },
 }
 
 export const DEPLOYMENT_BLOCKS =

--- a/frontend/src/hooks/useFriendMarketCreation.js
+++ b/frontend/src/hooks/useFriendMarketCreation.js
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import { ethers } from 'ethers'
 import { useWeb3 } from './useWeb3'
+import { useGaslessWrite } from '../lib/relay/useGaslessWrite'
 import { getContractAddress, getContractAddressForChain } from '../config/contracts'
 import { WAGER_REGISTRY_ABI } from '../abis/WagerRegistry'
 import { MEMBERSHIP_MANAGER_ABI } from '../abis/MembershipManager'
@@ -110,6 +111,32 @@ export const clearPendingTransaction = () => {
  */
 export function useFriendMarketCreation({ onMarketCreated } = {}) {
   const { signer } = useWeb3()
+
+  // Gasless createWager (spec 035/036): relayed where the relayer serves the chain and the stake token
+  // supports EIP-3009 (Polygon USDC); transparent self-submit otherwise (Mordor USC → auto self-submit).
+  // run() takes one context object carrying the exact values the self-submit flow already computed. The
+  // payment leg authorizes the creator's stake via EIP-3009, so the gasless path skips the approve the
+  // self-submit closure (ctx.performSelfSubmit) performs. Params mirror the CreateWagerIntent struct
+  // (creator is auto-filled from the signer).
+  const createWagerTx = useGaslessWrite('createWager', {
+    params: (ctx) => ({
+      opponent: ctx.opponent,
+      arbitrator: ctx.arbitrator,
+      token: ctx.stakeTokenAddress,
+      creatorStake: ctx.creatorStakeWei,
+      opponentStake: ctx.opponentStakeWei,
+      acceptDeadline: ctx.acceptDeadline,
+      resolveDeadline: ctx.resolveDeadline,
+      resolutionType: ctx.resolutionType,
+      conditionId: ctx.polymarketConditionId,
+      creatorIsYes: ctx.creatorIsYes,
+      metadataHash: ctx.metadataHash,
+      metadataUri: ctx.metadataReference,
+      termsVersionHash: ctx.termsVersionHash,
+    }),
+    payment: (ctx) => ({ value: ctx.creatorStakeWei }),
+    selfSubmit: (ctx) => ctx.performSelfSubmit(),
+  })
 
   const createFriendMarket = useCallback(async (data, modalSigner) => {
     const activeSigner = modalSigner || signer
@@ -328,44 +355,6 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
       }
       const metadataHash = ethers.keccak256(ethers.toUtf8Bytes(metadataReference))
 
-      // Approve stake token if needed. We approve the full uint256 max rather
-      // than the exact stake so (a) subsequent wagers don't need a fresh
-      // approval each time (the exact-stake approval left allowance at 0 after
-      // every wager) and (b) a stale read on a load-balanced RPC node can't
-      // under-approve. After approving we poll the allowance until the freshly
-      // mined approval is actually visible to the RPC — otherwise createWager's
-      // gas estimation can land on a node that still sees allowance 0, and the
-      // transferFrom reverts ("transfer amount exceeds allowance", surfaced as
-      // an opaque "missing revert data" by some wallet RPCs).
-      let currentAllowance = await stakeToken.allowance(userAddress, wagerRegistryAddress)
-      if (currentAllowance < creatorStakeWei) {
-        onProgress({ step: 'approve', message: 'Approving token spend...' })
-        const approveTx = await stakeToken.approve(wagerRegistryAddress, ethers.MaxUint256)
-        onProgress({ step: 'approve', message: 'Waiting for approval confirmation...', txHash: approveTx.hash })
-        await approveTx.wait()
-
-        // Wait until the approval is observable before continuing. Public RPCs
-        // are often load-balanced, so the node answering the next read/estimate
-        // may briefly lag the node that mined the approval.
-        for (let attempt = 0; attempt < 6; attempt++) {
-          currentAllowance = await stakeToken.allowance(userAddress, wagerRegistryAddress)
-          if (currentAllowance >= creatorStakeWei) break
-          await new Promise((resolve) => setTimeout(resolve, 1500 * (attempt + 1)))
-        }
-        if (currentAllowance < creatorStakeWei) {
-          throw new Error(
-            'Your token approval has not been confirmed yet. Please wait a few ' +
-            'seconds for it to finalize, then try creating the wager again.'
-          )
-        }
-      }
-
-      // Auto-cleanup expired Open wagers that still count toward the
-      // concurrent limit. Without this, acceptDeadline-expired wagers
-      // inflate activeCount and block new creation even when the user
-      // has fewer truly-active wagers than their tier allows.
-      await expireStaleWagers(registry, userAddress, onProgress)
-
       // Spec 007 (FR-056/FR-058): bind the in-force T&C version hash on-chain when the
       // registry supports it. legalDocs hashes are bare 64-hex → normalize to bytes32.
       // Falls back to plain createWager on older registries lacking the overload.
@@ -382,65 +371,138 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
         ...(useTerms ? [termsBytes32] : []),
       ]
 
-      // Simulate to catch reverts pre-wallet-prompt
-      try {
-        onProgress({ step: 'create', message: 'Validating transaction...' })
-        await registry[createMethod].staticCall(...createArgs)
-      } catch (simError) {
-        const reason = simError.reason || simError.shortMessage || simError.message || ''
-        throw new Error(translateRevert(reason))
-      }
+      // Self-submit leg: the existing approve → cleanup → simulate → estimate → send flow verbatim.
+      // The gasless path skips ALL of this — EIP-3009 pulls the stake (no approve) and the relayer
+      // estimates/pays gas. Captures the mined receipt so the shared code below can read WagerCreated.
+      let minedReceipt = null
+      const performSelfSubmit = async () => {
+        // Approve stake token if needed. We approve the full uint256 max rather
+        // than the exact stake so (a) subsequent wagers don't need a fresh
+        // approval each time (the exact-stake approval left allowance at 0 after
+        // every wager) and (b) a stale read on a load-balanced RPC node can't
+        // under-approve. After approving we poll the allowance until the freshly
+        // mined approval is actually visible to the RPC — otherwise createWager's
+        // gas estimation can land on a node that still sees allowance 0, and the
+        // transferFrom reverts ("transfer amount exceeds allowance", surfaced as
+        // an opaque "missing revert data" by some wallet RPCs).
+        let currentAllowance = await stakeToken.allowance(userAddress, wagerRegistryAddress)
+        if (currentAllowance < creatorStakeWei) {
+          onProgress({ step: 'approve', message: 'Approving token spend...' })
+          const approveTx = await stakeToken.approve(wagerRegistryAddress, ethers.MaxUint256)
+          onProgress({ step: 'approve', message: 'Waiting for approval confirmation...', txHash: approveTx.hash })
+          await approveTx.wait()
 
-      onProgress({ step: 'create', message: 'Please confirm in your wallet...' })
-      const feeOverrides = await getFeeOverrides(activeSigner.provider)
-
-      // Estimate gas explicitly with a short retry so a transient stale read on
-      // a load-balanced RPC doesn't surface a raw "missing revert data" error.
-      // The staticCall above already validated the args, so a failure here is
-      // almost always RPC lag rather than a genuine revert; fall back to a fixed
-      // limit after exhausting retries.
-      let gasLimit
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          const estimate = await registry[createMethod].estimateGas(...createArgs)
-          gasLimit = (estimate * 120n) / 100n // +20% headroom
-          break
-        } catch {
-          if (attempt === 2) {
-            gasLimit = 800000n // generous fallback; the staticCall already passed
-            break
+          // Wait until the approval is observable before continuing. Public RPCs
+          // are often load-balanced, so the node answering the next read/estimate
+          // may briefly lag the node that mined the approval.
+          for (let attempt = 0; attempt < 6; attempt++) {
+            currentAllowance = await stakeToken.allowance(userAddress, wagerRegistryAddress)
+            if (currentAllowance >= creatorStakeWei) break
+            await new Promise((resolve) => setTimeout(resolve, 1500 * (attempt + 1)))
           }
-          await new Promise((resolve) => setTimeout(resolve, 1500 * (attempt + 1)))
+          if (currentAllowance < creatorStakeWei) {
+            throw new Error(
+              'Your token approval has not been confirmed yet. Please wait a few ' +
+              'seconds for it to finalize, then try creating the wager again.'
+            )
+          }
         }
+
+        // Auto-cleanup expired Open wagers that still count toward the
+        // concurrent limit. Without this, acceptDeadline-expired wagers
+        // inflate activeCount and block new creation even when the user
+        // has fewer truly-active wagers than their tier allows.
+        await expireStaleWagers(registry, userAddress, onProgress)
+
+        // Simulate to catch reverts pre-wallet-prompt
+        try {
+          onProgress({ step: 'create', message: 'Validating transaction...' })
+          await registry[createMethod].staticCall(...createArgs)
+        } catch (simError) {
+          const reason = simError.reason || simError.shortMessage || simError.message || ''
+          throw new Error(translateRevert(reason))
+        }
+
+        onProgress({ step: 'create', message: 'Please confirm in your wallet...' })
+        const feeOverrides = await getFeeOverrides(activeSigner.provider)
+
+        // Estimate gas explicitly with a short retry so a transient stale read on
+        // a load-balanced RPC doesn't surface a raw "missing revert data" error.
+        // The staticCall above already validated the args, so a failure here is
+        // almost always RPC lag rather than a genuine revert; fall back to a fixed
+        // limit after exhausting retries.
+        let gasLimit
+        for (let attempt = 0; attempt < 3; attempt++) {
+          try {
+            const estimate = await registry[createMethod].estimateGas(...createArgs)
+            gasLimit = (estimate * 120n) / 100n // +20% headroom
+            break
+          } catch {
+            if (attempt === 2) {
+              gasLimit = 800000n // generous fallback; the staticCall already passed
+              break
+            }
+            await new Promise((resolve) => setTimeout(resolve, 1500 * (attempt + 1)))
+          }
+        }
+
+        const tx = await registry[createMethod](
+          ...createArgs,
+          { ...feeOverrides, gasLimit }
+        )
+        onProgress({ step: 'create', message: 'Waiting for confirmation...', txHash: tx.hash })
+        savePendingTransaction({ step: 'create', txHash: tx.hash, data: data.data })
+
+        minedReceipt = await tx.wait()
+        return minedReceipt
       }
 
-      const tx = await registry[createMethod](
-        ...createArgs,
-        { ...feeOverrides, gasLimit }
-      )
-      onProgress({ step: 'create', message: 'Waiting for confirmation...', txHash: tx.hash })
-      savePendingTransaction({ step: 'create', txHash: tx.hash, data: data.data })
+      // Gasless-or-self-submit send (spec 035/036). Params mirror the CreateWagerIntent struct; the
+      // creator is auto-filled from the signer. The relayer only serves EIP-3009 chains — everywhere
+      // else this transparently self-submits with identical on-chain effect.
+      const runResult = await createWagerTx.run({
+        opponent, arbitrator, stakeTokenAddress, creatorStakeWei, opponentStakeWei,
+        acceptDeadline, resolveDeadline, resolutionType, polymarketConditionId,
+        creatorIsYes, metadataHash, metadataReference,
+        termsVersionHash: termsBytes32 || ethers.ZeroHash,
+        performSelfSubmit,
+      })
+      if (runResult?.error) throw runResult.error
 
-      const receipt = await tx.wait()
-      if (!receipt || receipt.status === 0) {
+      // Only the self-submit leg guarantees a mined receipt in hand; treat a missing/failed one as a
+      // revert exactly as before. A relayed intent may still be pending (no receipt yet) — not a failure.
+      const selfSubmitted = runResult?.via === 'self-submit'
+      if (selfSubmitted && (!minedReceipt || minedReceipt.status === 0)) {
         clearPendingTransaction()
         throw new Error('Transaction reverted on-chain. The wager was not created.')
       }
       clearPendingTransaction()
 
-      // Parse WagerCreated event
-      let wagerId = null
-      for (const log of receipt.logs) {
+      // Resolve the receipt to read WagerCreated: self-submit captured it directly; the relayed path
+      // exposes only a txHash, so fetch it when available (still-queued intents have none yet).
+      let receipt = minedReceipt
+      if (!receipt && runResult?.txHash) {
         try {
-          const parsed = registry.interface.parseLog(log)
-          if (parsed?.name === 'WagerCreated') {
-            wagerId = parsed.args.wagerId.toString()
-            break
-          }
-        } catch { /* localStorage may be unavailable; ignore */ }
+          receipt = await activeSigner.provider.getTransactionReceipt(runResult.txHash)
+        } catch { /* relayer still landing it; wager id resolves once mined */ }
       }
 
-      onProgress({ step: 'complete', message: 'Wager created!', txHash: receipt.hash })
+      // Parse WagerCreated event
+      let wagerId = null
+      if (receipt) {
+        for (const log of receipt.logs) {
+          try {
+            const parsed = registry.interface.parseLog(log)
+            if (parsed?.name === 'WagerCreated') {
+              wagerId = parsed.args.wagerId.toString()
+              break
+            }
+          } catch { /* not a WagerRegistry log; ignore */ }
+        }
+      }
+
+      const txHash = receipt?.hash || runResult?.txHash || null
+      onProgress({ step: 'complete', message: 'Wager created!', txHash })
 
       const newMarket = {
         id: wagerId || `wager-${Date.now()}`,
@@ -469,12 +531,12 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
         tradingPeriod: Math.max(1, Math.ceil(tradingPeriodSeconds / 86400)).toString(),
         createdAt: new Date().toISOString(),
         status: 'pending',
-        txHash: receipt.hash,
+        txHash,
       }
 
       if (onMarketCreated) onMarketCreated(newMarket)
 
-      return { id: wagerId, txHash: receipt.hash, status: 'pending', ipfsCid, metadataHash }
+      return { id: wagerId, txHash, status: 'pending', ipfsCid, metadataHash }
     } catch (error) {
       console.error('Error creating wager:', error)
       if (error.code === 'ACTION_REJECTED' || error.code === 4001) {
@@ -485,7 +547,7 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
       }
       throw error
     }
-  }, [signer, onMarketCreated])
+  }, [signer, onMarketCreated, createWagerTx])
 
   return { createFriendMarket, loadPendingTransaction, clearPendingTransaction }
 }

--- a/frontend/src/hooks/useOpenChallengeAccept.js
+++ b/frontend/src/hooks/useOpenChallengeAccept.js
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react'
 import { ethers } from 'ethers'
 import { useWeb3 } from './useWeb3'
+import { useGaslessWrite } from '../lib/relay/useGaslessWrite'
 import { WAGER_REGISTRY_ABI } from '../abis/WagerRegistry'
 import { getContractAddressForChain, getContractAddress } from '../config/contracts'
 import { fetchEncryptedEnvelope, parseEncryptedIpfsReference } from '../utils/ipfsService'
@@ -31,6 +32,44 @@ export function useOpenChallengeAccept() {
   const { signer, account, chainId, provider } = useWeb3()
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState(null)
+
+  // Gasless acceptOpenWager (spec 035/036): relayed where the relayer serves the chain and the stake
+  // token supports EIP-3009 (Polygon USDC); transparent self-submit otherwise (Mordor USC → auto
+  // self-submit). This is AcceptWagerIntent PLUS the separate claim-code proof (signOpenAccept): the
+  // relay path carries the proof in params (the contract twin rebinds it to taker=signer, keeping the
+  // front-running defense under a relayer, FR-011); the self-submit path passes it straight to
+  // acceptOpenWager. The payment leg authorizes the taker's stake via EIP-3009, so the gasless path
+  // skips the approve the self-submit closure performs.
+  const acceptOpenWagerTx = useGaslessWrite('acceptOpenWager', {
+    params: (wagerId, claimCodeSig) => ({ wagerId, claimCodeSig }),
+    payment: (wagerId, claimCodeSig, stake) => ({ value: stake }),
+    selfSubmit: async (wagerId, claimCodeSig, stake, tokenAddr, registryAddr, symbol, onProgress = () => {}) => {
+      const registry = new ethers.Contract(registryAddr, WAGER_REGISTRY_ABI, signer)
+      const token = new ethers.Contract(tokenAddr, ERC20_ABI, signer)
+
+      // Approve the registry to escrow the stake (skip if already approved). Kept in the self-submit
+      // closure because the gasless path never approves — EIP-3009 pulls the stake instead.
+      const allowance = await token.allowance(account, registryAddr)
+      if (allowance < stake) {
+        onProgress({ step: 'approve', message: `Approve ${symbol} spending in your wallet…` })
+        const approveTx = await token.approve(registryAddr, ethers.MaxUint256)
+        await approveTx.wait()
+      }
+
+      // Pre-flight to surface a clear revert reason before the final wallet prompt.
+      try {
+        await registry.acceptOpenWager.staticCall(wagerId, claimCodeSig)
+      } catch (sim) {
+        throw new Error(translateAcceptRevert(sim.reason || sim.shortMessage || sim.message || ''))
+      }
+
+      onProgress({ step: 'accept', message: 'Confirm acceptance in your wallet…' })
+      const tx = await registry.acceptOpenWager(wagerId, claimCodeSig)
+      const receipt = await tx.wait()
+      if (!receipt || receipt.status === 0) throw new Error('Acceptance reverted on-chain.')
+      return receipt
+    },
+  })
 
   const resolveRegistry = useCallback(() => {
     const addr = chainId != null ? getContractAddressForChain('wagerRegistry', chainId) : getContractAddress('wagerRegistry')
@@ -157,16 +196,9 @@ export function useOpenChallengeAccept() {
         )
       }
 
-      // 2. Approve the registry to escrow your stake (skip if already approved). This is the step whose
-      //    absence caused the allowance revert — it must land before the staticCall and send below.
-      const allowance = await token.allowance(account, registryAddr)
-      if (allowance < stake) {
-        onProgress({ step: 'approve', message: `Approve ${symbol} spending in your wallet…` })
-        const approveTx = await token.approve(registryAddr, ethers.MaxUint256)
-        await approveTx.wait()
-      }
-
-      // 3. Sign the code-derived acceptance (bound to this taker, single-use).
+      // 2. Sign the code-derived acceptance (bound to this taker, single-use). Produced here — not
+      //    inside the send — because the relay path carries it through as an intent param (rebound to
+      //    taker=signer on-chain, FR-011), while self-submit passes it straight to acceptOpenWager.
       onProgress({ step: 'sign', message: 'Sign to authorize acceptance…' })
       const signature = await signOpenAccept(code, {
         wagerId,
@@ -175,25 +207,20 @@ export function useOpenChallengeAccept() {
         verifyingContract: registryAddr,
       })
 
-      // 4. Pre-flight to surface a clear revert reason before the final wallet prompt.
-      try {
-        await registry.acceptOpenWager.staticCall(wagerId, signature)
-      } catch (sim) {
-        throw new Error(translateAcceptRevert(sim.reason || sim.shortMessage || sim.message || ''))
-      }
-
-      onProgress({ step: 'accept', message: 'Confirm acceptance in your wallet…' })
-      const tx = await registry.acceptOpenWager(wagerId, signature)
-      const receipt = await tx.wait()
-      if (!receipt || receipt.status === 0) throw new Error('Acceptance reverted on-chain.')
-      return { txHash: receipt.hash }
+      // 3. Take it: relayed where the relayer serves the chain (gasless, skips the approve — EIP-3009
+      //    pulls the stake), transparent self-submit otherwise (approve → pre-flight → send). The
+      //    approval, whose absence caused the allowance revert, stays inside the self-submit closure
+      //    where a self-submitted accept still needs it.
+      const result = await acceptOpenWagerTx.run(wagerId, signature, stake, tokenAddr, registryAddr, symbol, onProgress)
+      if (result?.error) throw result.error
+      return { txHash: result?.txHash }
     } catch (e) {
       setError(e.message)
       throw e
     } finally {
       setBusy(false)
     }
-  }, [signer, account, resolveRegistry])
+  }, [signer, account, resolveRegistry, acceptOpenWagerTx])
 
   return { lookup, discover, accept, busy, error }
 }

--- a/frontend/src/hooks/usePurchaseFlow.js
+++ b/frontend/src/hooks/usePurchaseFlow.js
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback, useMemo } from 'react'
-import { purchaseRoleWithStablecoin, checkApprovalNeeded } from '../utils/blockchainService'
+import { purchaseRoleWithStablecoin, checkApprovalNeeded, resolveMembershipIntentParams } from '../utils/blockchainService'
 import { ensureKeyRegistered } from '../utils/keyRegistryService'
+import { useGaslessWrite } from '../lib/relay/useGaslessWrite'
 
 /**
  * Spec 022 — Membership Purchase Progress Indicator.
@@ -61,6 +62,30 @@ export function usePurchaseFlow(deps = {}) {
     else if (phase === 'confirmed') updateStep(step, { state: 'completed', txHash })
   }, [updateStep])
 
+  // Gasless seam (specs 035 + 036): relay the payment when a relayer is live, else self-submit via the
+  // existing approve+pay service call (never-stranded). The EIP-3009 `value` is the exact price the
+  // contract pulls (resolveMembershipIntentParams). Self-submit reads live params from paramsRef and
+  // reuses handleProgress so approve/pay step events fire identically on the fallback path.
+  const selfSubmitPurchase = () => purchaseFn(
+    paramsRef.current.signer, paramsRef.current.roleName, paramsRef.current.priceUSD,
+    paramsRef.current.tier, paramsRef.current.action, paramsRef.current.termsHash, handleProgress,
+  )
+  const purchaseTx = useGaslessWrite('purchaseTier', {
+    params: (ip) => ({ role: ip.roleHash, tier: ip.validTier, acceptedTermsHash: ip.acceptedTermsHash }),
+    payment: (ip) => ({ value: ip.price }),
+    selfSubmit: selfSubmitPurchase,
+  })
+  const upgradeTx = useGaslessWrite('upgradeTier', {
+    params: (ip) => ({ role: ip.roleHash, tier: ip.validTier, acceptedTermsHash: ip.acceptedTermsHash }),
+    payment: (ip) => ({ value: ip.price }),
+    selfSubmit: selfSubmitPurchase,
+  })
+  const extendTx = useGaslessWrite('extendMembership', {
+    params: (ip) => ({ role: ip.roleHash }),
+    payment: (ip) => ({ value: ip.price }),
+    selfSubmit: selfSubmitPurchase,
+  })
+
   // Mark the in-flight (or next pending) step as failed and attribute the reason.
   const markFailed = useCallback((reason) => {
     setSteps((prev) => {
@@ -81,9 +106,13 @@ export function usePurchaseFlow(deps = {}) {
     setStatus('running')
     try {
       if (fromSegment === 'purchase') {
-        const receipt = await purchaseFn(
-          p.signer, p.roleName, p.priceUSD, p.tier, p.action, p.termsHash, handleProgress,
-        )
+        // Resolve the exact intent params (price the contract pulls) and route the pay through the
+        // gasless seam; it self-submits (approve+pay) when no relayer is live. Same on-chain result.
+        const ip = await resolveMembershipIntentParams(p.signer, p.roleName, p.tier, p.action, p.termsHash)
+        const tx = p.action === 'upgrade' ? upgradeTx : (p.action === 'extend' ? extendTx : purchaseTx)
+        const result = await tx.run(ip)
+        if (result?.error) throw result.error
+        const receipt = result
         receiptRef.current = receipt
         // Defensively ensure approve (if present) + pay show completed.
         setSteps((prev) => prev.map((s) =>
@@ -113,7 +142,7 @@ export function usePurchaseFlow(deps = {}) {
       markFailed(err?.message || 'Step failed')
       setStatus('failed')
     }
-  }, [purchaseFn, registerKeyFn, handleProgress, updateStep, markFailed])
+  }, [registerKeyFn, updateStep, markFailed, purchaseTx, upgradeTx, extendTx])
 
   /**
    * Begin a fresh purchase flow. Builds the step list (omitting approval when not

--- a/frontend/src/hooks/useVouchers.js
+++ b/frontend/src/hooks/useVouchers.js
@@ -6,6 +6,7 @@ import { MEMBERSHIP_VOUCHER_ABI } from '../abis/MembershipVoucher'
 import { MEMBERSHIP_MANAGER_ABI } from '../abis/MembershipManager'
 import { VOUCHER_BATCH_MINTER_ABI } from '../abis/VoucherBatchMinter'
 import { ERC20_ABI } from '../abis/ERC20'
+import { useGaslessWrite } from '../lib/relay/useGaslessWrite'
 
 /**
  * useVouchers — buy and redeem membership voucher NFTs (spec 026).
@@ -42,6 +43,19 @@ export function useVouchers() {
     setError(null)
     setLastTxHash(null)
   }, [])
+
+  // Gasless seam (specs 035 + 036): relay the redeem when a relayer is live, else self-submit the
+  // MembershipManager.redeemVoucher call (never-stranded). Signer-attributed (no payment) — the
+  // redeemer is the connected wallet, auto-filled by signIntent, so it's omitted from params.
+  const voucherTx = useGaslessWrite('redeemVoucher', {
+    params: (tokenId, termsHash) => ({ voucherId: tokenId, acceptedTermsHash: termsHash || ethers.ZeroHash }),
+    selfSubmit: async (tokenId, termsHash) => {
+      const manager = new ethers.Contract(managerAddress, MEMBERSHIP_MANAGER_ABI, signer)
+      const tx = await manager.redeemVoucher(tokenId, termsHash || ethers.ZeroHash)
+      setLastTxHash(tx.hash)
+      return tx.wait()
+    },
+  })
 
   /**
    * Buy `quantity` vouchers of `(roleHash, tierId)` and send them to `recipient` (defaults to the buyer).
@@ -164,19 +178,18 @@ export function useVouchers() {
       setError(null)
       setLastTxHash(null)
       try {
-        const manager = new ethers.Contract(managerAddress, MEMBERSHIP_MANAGER_ABI, signer)
-        const tx = await manager.redeemVoucher(tokenId, termsHash || ethers.ZeroHash)
-        setLastTxHash(tx.hash)
-        await tx.wait()
+        const result = await voucherTx.run(tokenId, termsHash)
+        if (result?.error) throw result.error
+        setLastTxHash(result.txHash || lastTxHash)
         setStatus('success')
-        return { txHash: tx.hash }
+        return { txHash: result.txHash || lastTxHash }
       } catch (e) {
         setStatus('error')
         setError(e?.shortMessage || e?.message || 'Redemption failed.')
         throw e
       }
     },
-    [signer, voucherAvailable, managerAddress]
+    [signer, voucherAvailable, voucherTx, lastTxHash]
   )
 
   /**

--- a/frontend/src/test/MarketAcceptanceModal.test.jsx
+++ b/frontend/src/test/MarketAcceptanceModal.test.jsx
@@ -26,6 +26,17 @@ vi.mock('../hooks/useEncryption', () => ({
   }))
 }))
 
+// The gasless accept/decline wiring (useGaslessWrite) imports useWeb3 from the direct module, not
+// the ../hooks barrel these tests mock — stub it so the component renders without a WalletProvider.
+vi.mock('../hooks/useWeb3', () => ({
+  useWeb3: () => ({
+    signer: { provider: { getBalance: vi.fn() } },
+    chainId: 137,
+    isCorrectNetwork: true,
+    switchNetwork: vi.fn()
+  })
+}))
+
 import { useWallet, useWeb3 } from '../hooks'
 import { useEncryption } from '../hooks/useEncryption'
 

--- a/frontend/src/test/blockchainService.intentParams.test.js
+++ b/frontend/src/test/blockchainService.intentParams.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Focused unit test for resolveMembershipIntentParams (specs 035 + 036): the read-only helper that
+// resolves the exact EIP-712 intent params (esp. the USDC `price` the contract pulls) for a gasless
+// membership payment. We stub the contract resolver and the MembershipManager reads so no real chain
+// call happens, while keeping the rest of ethers real (keccak256/toUtf8Bytes drive ROLE_NAME_TO_HASH
+// at module load; ZeroHash is the no-terms sentinel).
+const { resolverMock, mmMock } = vi.hoisted(() => ({
+  resolverMock: vi.fn(),
+  mmMock: {},
+}))
+
+vi.mock('../config/contracts', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, getContractAddressForChain: resolverMock }
+})
+
+vi.mock('ethers', async () => {
+  const real = await vi.importActual('ethers')
+  // `new ethers.Contract(addr, abi, signer)` must return our MembershipManager stub.
+  function FakeContract() {
+    return mmMock
+  }
+  return { ...real, ethers: { ...real.ethers, Contract: FakeContract } }
+})
+
+import { resolveMembershipIntentParams, getRoleHash } from '../utils/blockchainService'
+import { ethers } from 'ethers'
+
+const MM_ADDR = '0x00c3ef4e02Ef00Ad6eE955dF5022A22F6ea73dae'
+const ROLE = 'WAGER_PARTICIPANT'
+
+const makeSigner = (chainId = 137, address = '0x0000000000000000000000000000000000000001') => ({
+  getAddress: async () => address,
+  provider: { getNetwork: async () => ({ chainId: BigInt(chainId) }) },
+})
+
+describe('resolveMembershipIntentParams', () => {
+  beforeEach(() => {
+    resolverMock.mockReset()
+    resolverMock.mockReturnValue(MM_ADDR)
+    // priceUSDC scales with the tier so upgrade deltas are checkable: tier N → N * 10 USDC (6 decimals).
+    mmMock.getTierConfig = vi.fn(async (_role, tier) => ({ priceUSDC: BigInt(Number(tier)) * 10_000_000n }))
+    mmMock.getMembership = vi.fn(async () => ({ tier: 1 }))
+  })
+
+  it('resolves purchase price from the target tier config', async () => {
+    const res = await resolveMembershipIntentParams(makeSigner(), ROLE, 2, 'purchase', null)
+    expect(res.roleHash).toBe(getRoleHash(ROLE))
+    expect(res.validTier).toBe(2)
+    expect(res.price).toBe(20_000_000n) // getTierConfig(role, 2).priceUSDC
+    expect(res.acceptedTermsHash).toBe(ethers.ZeroHash)
+    expect(mmMock.getTierConfig).toHaveBeenCalledWith(getRoleHash(ROLE), 2)
+  })
+
+  it('resolves extend price from the passed (current) tier config', async () => {
+    const res = await resolveMembershipIntentParams(makeSigner(), ROLE, 3, 'extend', null)
+    expect(res.price).toBe(30_000_000n)
+    expect(res.validTier).toBe(3)
+    expect(mmMock.getMembership).not.toHaveBeenCalled() // extend never reads current membership
+  })
+
+  it('resolves upgrade price as the tier delta (new - current)', async () => {
+    mmMock.getMembership = vi.fn(async () => ({ tier: 1 })) // current Bronze
+    const res = await resolveMembershipIntentParams(makeSigner(), ROLE, 4, 'upgrade', null)
+    // getTierConfig(role, 4) - getTierConfig(role, 1) = 40 - 10 USDC
+    expect(res.price).toBe(30_000_000n)
+    expect(mmMock.getMembership).toHaveBeenCalled()
+  })
+
+  it('clamps out-of-range tiers to Bronze (1) and reads the config for the clamped tier', async () => {
+    const res = await resolveMembershipIntentParams(makeSigner(), ROLE, 9, 'purchase', null)
+    expect(res.validTier).toBe(1)
+    expect(res.price).toBe(10_000_000n)
+    expect(mmMock.getTierConfig).toHaveBeenCalledWith(getRoleHash(ROLE), 1)
+  })
+
+  it('normalizes a bare 64-hex terms hash to a 0x-prefixed bytes32', async () => {
+    const bare = 'ab'.repeat(32)
+    const res = await resolveMembershipIntentParams(makeSigner(), ROLE, 1, 'purchase', bare)
+    expect(res.acceptedTermsHash).toBe('0x' + bare)
+  })
+
+  it('passes through an already 0x-prefixed terms hash unchanged', async () => {
+    const withPrefix = '0x' + 'cd'.repeat(32)
+    const res = await resolveMembershipIntentParams(makeSigner(), ROLE, 1, 'purchase', withPrefix)
+    expect(res.acceptedTermsHash).toBe(withPrefix)
+  })
+
+  it('uses ZeroHash for a malformed / empty terms hash', async () => {
+    const res = await resolveMembershipIntentParams(makeSigner(), ROLE, 1, 'purchase', 'not-a-hash')
+    expect(res.acceptedTermsHash).toBe(ethers.ZeroHash)
+  })
+
+  it('throws on a missing signer', async () => {
+    await expect(resolveMembershipIntentParams(null, ROLE, 1, 'purchase', null)).rejects.toThrow(/wallet not connected/i)
+  })
+
+  it('throws on an unknown role', async () => {
+    await expect(resolveMembershipIntentParams(makeSigner(), 'NOPE', 1, 'purchase', null)).rejects.toThrow(/unknown role/i)
+  })
+
+  it('throws when no MembershipManager is configured on the chain', async () => {
+    resolverMock.mockReturnValue(undefined)
+    await expect(resolveMembershipIntentParams(makeSigner(), ROLE, 1, 'purchase', null)).rejects.toThrow(/no membership contract/i)
+  })
+})

--- a/frontend/src/test/useOpenChallengeAccept.test.jsx
+++ b/frontend/src/test/useOpenChallengeAccept.test.jsx
@@ -11,7 +11,7 @@ const ACCOUNT = '0x3333333333333333333333333333333333333333'
 const STAKE = 10_000_000n // 10 USDC (6 decimals)
 
 const { state, calls } = vi.hoisted(() => ({
-  state: { allowance: 0n, balance: 100_000_000n, wagerId: 0n, throwLookup: false, metadataUri: '' },
+  state: { allowance: 0n, balance: 100_000_000n, wagerId: 0n, throwLookup: false, metadataUri: '', acceptArgs: null },
   calls: [],
 }))
 
@@ -45,8 +45,9 @@ vi.mock('ethers', async () => {
   const real = await vi.importActual('ethers')
   function FakeContract(address) {
     if (address === REGISTRY) {
-      const acceptOpenWager = (..._a) => {
+      const acceptOpenWager = (...a) => {
         calls.push('accept')
+        state.acceptArgs = a
         return Promise.resolve({ wait: () => Promise.resolve({ status: 1, hash: '0xtxhash' }) })
       }
       acceptOpenWager.staticCall = () => Promise.resolve()
@@ -91,6 +92,7 @@ describe('useOpenChallengeAccept.accept (funding flow)', () => {
     calls.length = 0
     state.allowance = 0n
     state.balance = 100_000_000n
+    state.acceptArgs = null
   })
 
   it('approves the registry BEFORE sending acceptOpenWager when allowance is short', async () => {
@@ -105,6 +107,17 @@ describe('useOpenChallengeAccept.accept (funding flow)', () => {
     expect(calls).toEqual(['approve', 'accept'])
     // Steps are surfaced for the UI checklist.
     expect(steps).toEqual(expect.arrayContaining(['check', 'approve', 'sign', 'accept']))
+  })
+
+  it('routes the send through the gasless seam, threading the claim-code proof to acceptOpenWager', async () => {
+    // With no relayer configured (VITE_RELAYER_URL unset in tests) useGaslessWrite self-submits, so
+    // acceptOpenWager(wagerId, claimCodeSig) must still receive the code-derived signature verbatim —
+    // the same proof the relay path would carry in its intent params (rebound to taker=signer on-chain).
+    const { result } = renderHook(() => useOpenChallengeAccept())
+    await act(async () => {
+      await result.current.accept('river tiger kite zoo', 4n)
+    })
+    expect(state.acceptArgs).toEqual([4n, '0xsignature'])
   })
 
   it('skips approval when the existing allowance already covers the stake', async () => {

--- a/frontend/src/test/usePurchaseFlow.test.js
+++ b/frontend/src/test/usePurchaseFlow.test.js
@@ -6,14 +6,44 @@ import { renderHook, act, waitFor } from '@testing-library/react'
 vi.mock('../utils/blockchainService', () => ({
   purchaseRoleWithStablecoin: vi.fn(),
   checkApprovalNeeded: vi.fn(),
+  resolveMembershipIntentParams: vi.fn(),
 }))
 vi.mock('../utils/keyRegistryService', () => ({
   ensureKeyRegistered: vi.fn(),
 }))
 
+// Specs 035 + 036: the hook now routes the pay through useGaslessWrite. With no relayer configured
+// (test default) the real seam self-submits anyway, but useGaslessWrite calls useWeb3() which throws
+// outside a WalletProvider — so mock it to run the caller's selfSubmit directly. selfSubmit is the
+// existing purchaseFn (approve+pay) call, so the step-machine assertions are unchanged. The
+// self-submit leg returns errors in `result.error` (never throws), matching useIntentAction.
+vi.mock('../lib/relay/useGaslessWrite', () => ({
+  useGaslessWrite: (_action, cfg) => ({
+    run: async (...args) => {
+      try {
+        const receipt = await cfg.selfSubmit(...args)
+        return { via: 'self-submit', receipt, txHash: receipt?.hash ?? receipt?.transactionHash }
+      } catch (error) {
+        return { via: 'self-submit', error }
+      }
+    },
+    status: 'idle', intent: null, result: null, error: null,
+    invalidate: vi.fn(), selfSubmitNow: vi.fn(), reset: vi.fn(),
+  }),
+}))
+
 import { usePurchaseFlow } from '../hooks/usePurchaseFlow'
-import { purchaseRoleWithStablecoin, checkApprovalNeeded } from '../utils/blockchainService'
+import { purchaseRoleWithStablecoin, checkApprovalNeeded, resolveMembershipIntentParams } from '../utils/blockchainService'
 import { ensureKeyRegistered } from '../utils/keyRegistryService'
+
+// A resolved intent-params object; its exact contents don't matter to the step machine (the mocked
+// gasless seam forwards straight to selfSubmit), only that it resolves so the purchase segment proceeds.
+const INTENT_PARAMS = {
+  roleHash: '0x' + '11'.repeat(32),
+  validTier: 1,
+  price: 2000000n,
+  acceptedTermsHash: '0x' + '00'.repeat(32),
+}
 
 const baseParams = (overrides = {}) => ({
   signer: { getAddress: async () => '0xabc' },
@@ -31,6 +61,7 @@ const baseParams = (overrides = {}) => ({
 describe('usePurchaseFlow — step list construction (FR-009)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    resolveMembershipIntentParams.mockResolvedValue(INTENT_PARAMS)
     purchaseRoleWithStablecoin.mockResolvedValue({ hash: '0xpay' })
     ensureKeyRegistered.mockResolvedValue(true)
   })
@@ -75,6 +106,7 @@ describe('usePurchaseFlow — step list construction (FR-009)', () => {
 describe('usePurchaseFlow — happy path & progress (US2)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    resolveMembershipIntentParams.mockResolvedValue(INTENT_PARAMS)
     checkApprovalNeeded.mockResolvedValue(false)
     ensureKeyRegistered.mockResolvedValue(true)
   })
@@ -112,6 +144,7 @@ describe('usePurchaseFlow — happy path & progress (US2)', () => {
 describe('usePurchaseFlow — failure attribution & recovery (US3)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    resolveMembershipIntentParams.mockResolvedValue(INTENT_PARAMS)
     checkApprovalNeeded.mockResolvedValue(false)
   })
 

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -1395,6 +1395,67 @@ export async function purchaseRoleWithStablecoin(signer, roleName, priceUSD, tie
 }
 
 /**
+ * Specs 035 + 036: resolve the exact EIP-712 intent parameters for a membership
+ * payment action (purchase / upgrade / extend) so a gasless relay can authorize
+ * the precise USDC amount the contract will pull. Read-only — issues no wallet
+ * prompt and moves no funds. The returned `price` is the exact `receiveWithAuthorization`
+ * value; it MUST match what MembershipManager charges (any mismatch is rejected).
+ *
+ * Mirrors the price/terms resolution in {@link purchaseRoleWithStablecoin}:
+ *   - purchase & extend: price = getTierConfig(role, validTier).priceUSDC
+ *   - upgrade:           price = getTierConfig(role, newTier).priceUSDC
+ *                                - getTierConfig(role, currentTier).priceUSDC
+ *   - terms:             normalize to a 0x-prefixed bytes32, or ZeroHash when none
+ *
+ * @param {ethers.Signer} signer - Connected wallet signer (its provider is read for the chain + tiers)
+ * @param {string} roleName - Name of the role being purchased/upgraded/extended
+ * @param {number} tier - Target membership tier (1=Bronze..4=Platinum), clamped to [1,4]
+ * @param {string} [action='purchase'] - 'purchase' (default), 'upgrade', or 'extend'
+ * @param {string|null} [termsHash=null] - accepted T&C version hash (bare 64-hex or 0x-prefixed)
+ * @returns {Promise<{roleHash: string, validTier: number, price: bigint, acceptedTermsHash: string}>}
+ */
+export async function resolveMembershipIntentParams(signer, roleName, tier = MembershipTier.BRONZE, action = 'purchase', termsHash = null) {
+  if (!signer) throw new Error('Wallet not connected')
+  const roleHash = getRoleHash(roleName)
+  if (!roleHash) throw new Error(`Unknown role: ${roleName}`)
+  const validTier = [1, 2, 3, 4].includes(tier) ? tier : MembershipTier.BRONZE
+
+  // Resolve the MembershipManager for the wallet's CURRENT chain (matches purchaseRoleWithStablecoin).
+  let walletChainId = null
+  try {
+    walletChainId = Number((await signer.provider.getNetwork()).chainId)
+  } catch { /* provider without a network; fall back to build-time chain */ }
+  const mmAddress = getContractAddressForChain('membershipManager', walletChainId)
+  if (!mmAddress) {
+    throw new Error(`No membership contract is configured on the connected network (chain ${walletChainId ?? 'unknown'}).`)
+  }
+
+  const mm = new ethers.Contract(mmAddress, MEMBERSHIP_MANAGER_ABI, signer)
+  const userAddress = await signer.getAddress()
+
+  // Determine the price the contract will charge (exact — this becomes the EIP-3009 value).
+  let price
+  if (action === 'upgrade') {
+    const membership = await mm.getMembership(userAddress, roleHash)
+    const currentCfg = await mm.getTierConfig(roleHash, membership.tier)
+    const newCfg = await mm.getTierConfig(roleHash, validTier)
+    price = newCfg.priceUSDC - currentCfg.priceUSDC
+  } else {
+    const tierCfg = await mm.getTierConfig(roleHash, validTier)
+    price = tierCfg.priceUSDC
+  }
+
+  // Normalize the accepted-terms hash exactly as purchaseRoleWithStablecoin does (bare 64-hex → 0x…).
+  const normTerms = typeof termsHash === 'string'
+    ? (termsHash.startsWith('0x') ? termsHash : '0x' + termsHash)
+    : null
+  const hasTerms = normTerms !== null && /^0x[0-9a-fA-F]{64}$/.test(normTerms)
+  const acceptedTermsHash = hasTerms ? normTerms : ethers.ZeroHash
+
+  return { roleHash, validTier, price, acceptedTermsHash }
+}
+
+/**
  * Spec 022: read-only pre-flight to decide whether the membership purchase will
  * require a separate ERC-20 approval prompt. Lets the progress indicator build the
  * exact step list up front and OMIT the approval step entirely when the member

--- a/scripts/deploy/seed-pool-tiers.js
+++ b/scripts/deploy/seed-pool-tiers.js
@@ -1,0 +1,90 @@
+/**
+ * Seed POOL_PARTICIPANT_ROLE membership tiers (spec 034 gated pools).
+ *
+ * Pools on value-bearing networks are sanctions-screened AND membership-gated: the WagerPoolFactory
+ * calls `membershipManager.checkCanCreate(user, POOL_PARTICIPANT_ROLE)` on create/join, which returns
+ * false unless the wallet holds an active POOL_PARTICIPANT_ROLE membership. The contract forbids $0
+ * tiers (`_purchaseTier` reverts `PriceZero`), so the compliance gate is a PAID, self-served membership
+ * screened for sanctions on purchase — mirroring the 1v1 WAGER_PARTICIPANT ladder (the chosen config).
+ *
+ * This seeds the SAME 4-tier ladder (2/8/25/100, 30-day, identical limits) for POOL_PARTICIPANT_ROLE
+ * on the MembershipManager recorded in deployments/<net>-chain<id>-v2.json. Idempotent-ish: setTier is
+ * an upsert, safe to re-run. Run BEFORE deploy-wager-pool-factory.js with POOL_ENABLE_MEMBERSHIP=1.
+ *
+ * Usage:
+ *   POLYGON_RPC_URL=... npx hardhat run scripts/deploy/seed-pool-tiers.js --network polygon
+ */
+const hre = require("hardhat");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+const { WAGER_PARTICIPANT_TIERS } = require("./lib/constants");
+
+const POOL_PARTICIPANT_ROLE = ethers.keccak256(ethers.toUtf8Bytes("POOL_PARTICIPANT_ROLE"));
+
+// Tier price is authored in 18-decimal ethers (whole dollars); scale to the payment token's decimals.
+function toTokenUnits(price18, decimals) {
+  return price18 / 10n ** BigInt(18 - decimals);
+}
+
+async function main() {
+  const net = hre.network.name;
+  const { chainId } = await ethers.provider.getNetwork();
+  const [deployer] = await ethers.getSigners();
+
+  const filename = `${net}-chain${chainId}-v2.json`;
+  const filepath = path.join(process.cwd(), "deployments", filename);
+  if (!fs.existsSync(filepath)) throw new Error(`No deployment record at deployments/${filename}`);
+  const record = JSON.parse(fs.readFileSync(filepath, "utf8"));
+  const contracts = record.contracts || record;
+  const mmAddr = contracts.membershipManager;
+  if (!mmAddr || !ethers.isAddress(mmAddr)) throw new Error(`No membershipManager in deployments/${filename}`);
+
+  console.log("=".repeat(60));
+  console.log("Seed POOL_PARTICIPANT_ROLE tiers (spec 034 gated pools)");
+  console.log("=".repeat(60));
+  console.log(`Network:            ${net} (chainId ${chainId})`);
+  console.log(`Deployer/admin:     ${deployer.address}`);
+  console.log(`MembershipManager:  ${mmAddr}`);
+  console.log(`POOL_PARTICIPANT_ROLE: ${POOL_PARTICIPANT_ROLE}`);
+
+  const mm = await ethers.getContractAt("MembershipManager", mmAddr, deployer);
+
+  // Payment-token decimals (prices scale to the stablecoin's own decimals; USDC = 6).
+  const paymentToken = await mm.paymentToken();
+  const erc20 = await ethers.getContractAt(
+    ["function decimals() view returns (uint8)"],
+    paymentToken
+  );
+  const decimals = Number(await erc20.decimals());
+  console.log(`Payment token:      ${paymentToken} (decimals ${decimals})\n`);
+
+  const tierNames = ["NONE", "BRONZE", "SILVER", "GOLD", "PLATINUM"];
+  for (const cfg of WAGER_PARTICIPANT_TIERS) {
+    const priceUSDC = toTokenUnits(cfg.price, decimals);
+    const limits = {
+      monthlyMarketCreation:
+        cfg.limits.monthlyMarketCreation > 2n ** 32n - 1n ? 0 : Number(cfg.limits.monthlyMarketCreation),
+      maxConcurrentMarkets:
+        cfg.limits.maxConcurrentMarkets > 2n ** 32n - 1n ? 0 : Number(cfg.limits.maxConcurrentMarkets),
+    };
+    console.log(
+      `  POOL ${tierNames[cfg.tier]}: ${ethers.formatUnits(priceUSDC, decimals)} ` +
+        `(${limits.monthlyMarketCreation || "∞"}/mo, ${limits.maxConcurrentMarkets || "∞"} concurrent, 30-day)`
+    );
+    const tx = await mm.setTier(POOL_PARTICIPANT_ROLE, cfg.tier, priceUSDC, 30, limits, true);
+    await tx.wait();
+  }
+
+  // Verify one tier round-trips.
+  const bronze = await mm.getTierConfig(POOL_PARTICIPANT_ROLE, 1);
+  console.log(`\n  ✓ Verified BRONZE on-chain: price=${ethers.formatUnits(bronze.priceUSDC, decimals)}, active=${bronze.active}`);
+  console.log("\nDone. Next: deploy the factory with POOL_ENABLE_MEMBERSHIP=1 (screeningRequired defaults true on mainnet).");
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/services/oz-relayer/deploy/production/README.md
+++ b/services/oz-relayer/deploy/production/README.md
@@ -1,0 +1,21 @@
+# Production relayer — as-built (multichain: Mordor 63 + Polygon 137)
+
+This is the **live** 3-container Cloud Run relayer (`fairwins-relay-gateway`, us-central1),
+serving both chains from one service. It supersedes the single-chain snapshot in `../mordor/`.
+
+- **config.json** — OZ engine config baked into `fairwins-relay-engine:multichain-v1.4.0`
+  (`COPY config /app/config`). Two relayers (`mordor-63`, `polygon-137`), two KMS signers
+  (`gas-key-mordor`, `gas-key-polygon`), two networks. Secrets arrive via env at runtime.
+- **service.yaml** — the Cloud Run service (gateway :8788 + engine :8080 + redis). Gateway
+  `ENABLED_CHAIN_IDS=63,137`; per-chain `GAS_WALLET_*` / `RPC_URLS_*` / `ENGINE_RELAYER_ID_*`.
+
+## Gas wallets (hot; KMS-held keys, never floppy)
+- Mordor  (63):  `0xf505d95F62bEE94437C112d3D64ee7Df0Fa973aC`  (KMS `gas-key-mordor`)
+- Polygon (137): `0x3BB28b184b8a748dE22aBD076634F85adADA82db`  (KMS `gas-key-polygon`)
+
+## Polygon go-live (2026-07-05)
+KMS `gas-key-polygon` (HSM secp256k1) → gas wallet above; funded 10 POL from deployer
+`0x52502d…` (tx `0x780fd70dd50770a50b8647f887eac3165e89f103bc2f4730397d2bb1fdc1eacf`).
+Whitelisted receivers = Polygon `wagerRegistry` `0xE878b628…` + `membershipManager` `0xEfd1a880…`.
+Polygon USDC supports EIP-3009 → payment intents relay here (unlike Mordor). Verified live:
+`/status` → both chains `rpc:up`, Polygon runway ~200h.

--- a/services/oz-relayer/deploy/production/config.json
+++ b/services/oz-relayer/deploy/production/config.json
@@ -1,0 +1,123 @@
+{
+  "relayers": [
+    {
+      "id": "mordor-63",
+      "name": "FairWins Mordor (63)",
+      "network": "mordor",
+      "network_type": "evm",
+      "paused": false,
+      "signer_id": "gas-key-mordor",
+      "notification_id": "relay-gateway-webhook",
+      "policies": {
+        "eip1559_pricing": false,
+        "gas_price_cap": 2000000000000,
+        "min_balance": 1000000000000000000,
+        "whitelist_receivers": [
+          "0x3ccB144d8aa838e8d4D695867cC72e548117830C",
+          "0x68bCBA1055DAbe11b98Bb8425A16e648Ad65d541"
+        ]
+      }
+    },
+    {
+      "id": "polygon-137",
+      "name": "FairWins Polygon (137)",
+      "network": "polygon",
+      "network_type": "evm",
+      "paused": false,
+      "signer_id": "gas-key-polygon",
+      "notification_id": "relay-gateway-webhook",
+      "policies": {
+        "eip1559_pricing": true,
+        "gas_price_cap": 1500000000000,
+        "min_balance": 500000000000000000,
+        "whitelist_receivers": [
+          "0xE878b62887fC8A5F739B8Ce61bC19546A280Ef89",
+          "0xEfd1a880c6BfBf38A661A3F5fF6d5ECB296D557a"
+        ]
+      }
+    }
+  ],
+  "notifications": [
+    {
+      "id": "relay-gateway-webhook",
+      "type": "webhook",
+      "url": "http://localhost:8788/v1/engine/webhook",
+      "signing_key": { "type": "env", "value": "WEBHOOK_SIGNING_KEY" }
+    }
+  ],
+  "signers": [
+    {
+      "id": "gas-key-mordor",
+      "type": "google_cloud_kms",
+      "config": {
+        "service_account": {
+          "project_id": "chippr-bots-site-wp",
+          "private_key_id": { "type": "env", "value": "GCP_PRIVATE_KEY_ID" },
+          "private_key": { "type": "env", "value": "GCP_PRIVATE_KEY" },
+          "client_email": { "type": "env", "value": "GCP_CLIENT_EMAIL" },
+          "client_id": "105464822134406954574"
+        },
+        "key": {
+          "location": "us-central1",
+          "key_ring_id": "fairwins-relayer",
+          "key_id": "gas-key-mordor",
+          "key_version": 1
+        }
+      }
+    },
+    {
+      "id": "gas-key-polygon",
+      "type": "google_cloud_kms",
+      "config": {
+        "service_account": {
+          "project_id": "chippr-bots-site-wp",
+          "private_key_id": { "type": "env", "value": "GCP_PRIVATE_KEY_ID" },
+          "private_key": { "type": "env", "value": "GCP_PRIVATE_KEY" },
+          "client_email": { "type": "env", "value": "GCP_CLIENT_EMAIL" },
+          "client_id": "105464822134406954574"
+        },
+        "key": {
+          "location": "us-central1",
+          "key_ring_id": "fairwins-relayer",
+          "key_id": "gas-key-polygon",
+          "key_version": 1
+        }
+      }
+    }
+  ],
+  "networks": [
+    {
+      "network": "mordor",
+      "type": "evm",
+      "chain_id": 63,
+      "symbol": "METC",
+      "required_confirmations": 6,
+      "average_blocktime_ms": 13000,
+      "is_testnet": true,
+      "features": [],
+      "rpc_urls": [
+        "https://rpc.mordor.etccooperative.org",
+        "https://geth-mordor.etc-network.info"
+      ],
+      "explorer_urls": ["https://etc-mordor.blockscout.com"],
+      "tags": ["testnet", "fairwins", "legacy-gas", "no-batch"]
+    },
+    {
+      "network": "polygon",
+      "type": "evm",
+      "chain_id": 137,
+      "symbol": "POL",
+      "required_confirmations": 5,
+      "average_blocktime_ms": 2000,
+      "is_testnet": false,
+      "features": [],
+      "rpc_urls": [
+        "https://polygon-bor-rpc.publicnode.com",
+        "https://polygon.llamarpc.com"
+      ],
+      "explorer_urls": ["https://polygonscan.com"],
+      "tags": ["mainnet", "fairwins", "eip1559", "eip3009"]
+    }
+  ],
+  "plugins": []
+}

--- a/services/oz-relayer/deploy/production/service.yaml
+++ b/services/oz-relayer/deploy/production/service.yaml
@@ -1,0 +1,105 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: fairwins-relay-gateway
+  labels:
+    cloud.googleapis.com/location: us-central1
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "1"
+        run.googleapis.com/cpu-throttling: "false"
+        run.googleapis.com/startup-cpu-boost: "true"
+        run.googleapis.com/container-dependencies: '{"gateway":["engine"],"engine":["redis"]}'
+    spec:
+      serviceAccountName: fairwins-relay-engine@chippr-bots-site-wp.iam.gserviceaccount.com
+      containers:
+        # ---- ingress: FairWins policy gateway (public, port 8788) ----
+        - name: gateway
+          image: us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway@sha256:d7548b53b9c9a2a424f52a29b39474d47548c41286409f926a58cbd0011943de
+          ports:
+            - name: http1
+              containerPort: 8788
+          env:
+            # PORT is injected by Cloud Run from containerPort (8788) — must not be set here.
+            - name: ENABLED_CHAIN_IDS
+              value: "63,137"
+            - name: ALLOWED_ORIGINS
+              value: "https://fairwins.app"
+            - name: ENGINE_URL
+              value: "http://localhost:8080"
+            - name: ENGINE_RELAYER_ID_63
+              value: "mordor-63"
+            - name: GAS_WALLET_63
+              value: "0xf505d95F62bEE94437C112d3D64ee7Df0Fa973aC"
+            - name: RPC_URLS_63
+              value: "https://rpc.mordor.etccooperative.org,https://geth-mordor.etc-network.info"
+            - name: ENGINE_RELAYER_ID_137
+              value: "polygon-137"
+            - name: GAS_WALLET_137
+              value: "0x3BB28b184b8a748dE22aBD076634F85adADA82db"
+            - name: RPC_URLS_137
+              value: "https://polygon-bor-rpc.publicnode.com,https://polygon.llamarpc.com"
+            - name: ORIGIN_AUTH_SECRET
+              valueFrom:
+                secretKeyRef: { name: origin-lock-secret, key: latest }
+            - name: WEBHOOK_SHARED_SECRET
+              valueFrom:
+                secretKeyRef: { name: relay-webhook-secret, key: "2" }
+            - name: ENGINE_API_KEY
+              valueFrom:
+                secretKeyRef: { name: relay-engine-api-key, key: "2" }
+          resources:
+            limits: { cpu: "1", memory: 512Mi }
+        # ---- sidecar: OZ Relayer engine (localhost:8080) ----
+        - name: engine
+          image: us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-engine:multichain-v1.4.0
+          env:
+            - name: IN_DOCKER
+              value: "true"
+            - name: APP_PORT
+              value: "8080"
+            - name: METRICS_ENABLED
+              value: "false"
+            - name: LOG_LEVEL
+              value: "info"
+            - name: REDIS_URL
+              value: "redis://localhost:6379"
+            - name: GCP_PRIVATE_KEY_ID
+              value: "4f206bc79b3f42976c9c49a30d485e3b304b750f"
+            - name: GCP_CLIENT_EMAIL
+              value: "fairwins-relay-engine@chippr-bots-site-wp.iam.gserviceaccount.com"
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef: { name: relay-engine-api-key, key: "2" }
+            - name: WEBHOOK_SIGNING_KEY
+              valueFrom:
+                secretKeyRef: { name: relay-webhook-secret, key: "2" }
+            - name: GCP_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef: { name: relay-engine-gcp-private-key, key: latest }
+          startupProbe:
+            tcpSocket: { port: 8080 }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 30
+          resources:
+            limits: { cpu: 800m, memory: 512Mi }
+        # ---- sidecar: ephemeral redis (localhost:6379) ----
+        - name: redis
+          image: redis:7-alpine
+          args: ["redis-server", "--save", "", "--appendonly", "no"]
+          startupProbe:
+            tcpSocket: { port: 6379 }
+            initialDelaySeconds: 2
+            periodSeconds: 3
+            timeoutSeconds: 2
+            failureThreshold: 20
+          resources:
+            limits: { cpu: 200m, memory: 256Mi }
+  traffic:
+    - percent: 100
+      latestRevision: true


### PR DESCRIPTION
## Polygon mainnet go-live — deploy + gasless relayer + frontend cutover + gasless UX (Tier 1)

End-to-end Polygon (chainId 137) launch. Deployer/admin `0x52502d…`; **payout/treasury =
chipprbots.eth → `0x1215185387E70a48b07D73AcB67002A073F18575`** (baked into `initialize`, verified on-chain).

### 1. Contracts — deployed + **source-verified** on Polygonscan
| Contract | Address |
|---|---|
| MembershipManager (UUPS) | `0xEfd1a880c6BfBf38A661A3F5fF6d5ECB296D557a` |
| WagerRegistry (UUPS) | `0xE878b62887fC8A5F739B8Ce61bC19546A280Ef89` |
| WagerRegistryIntents facet | `0x9e4338E12A30a98eaa0dE58b2c4d7B562f5eB438` |
| **WagerPoolFactory (UUPS)** | `0x420aEC3c76859eB74ab21c769c16AcdAB221f723` |
| MembershipVoucher / VoucherBatchMinter | `0xCB28DC43…` / `0x4b50d24c…` |
| SanctionsGuard / KeyRegistry / TokenFactory | `0x2Dc53d91…` / `0xcEFdeBba…` / `0x5806e76c…` |
| Polymarket / Chainlink×2 / UMA adapters | reused CREATE2 |

Pools ship with **gated sanctions compliance**: `screeningRequired=true` + membershipManager wired;
a paid, sanctions-screened `POOL_PARTICIPANT_ROLE` membership (2/8/25/100 USDC, 30-day, mirroring 1v1).
All contracts verified (incl. the ones `verify.js` skips — intents facet, factory, pool template).

### 2. Gasless relayer — Polygon added to the live multichain service
KMS `gas-key-polygon` → gas wallet `0x3BB28b18…`, **funded 10 POL** (tx `0x780fd70d…`). Engine
`multichain-v1.4.0` (Polygon does EIP-1559 + EIP-3009 → payment intents relay); `relay.fairwins.app/status`
→ both chains `rpc:up`. As-built manifests in `services/oz-relayer/deploy/production/`.

### 3. Frontend cutover — Polygon default → live contracts
Synced `POLYGON_CONTRACTS` + treasury + `DEPLOYMENT_BLOCKS[137]` to the new deploy.

### 4. Gasless UX — Tier 1 (4 → 14 relayable actions)
Wired 10 more actions through `useGaslessWrite` (never-stranded: each self-submits when the relayer or
the chain's EIP-3009 token is absent — behaviour unchanged where gasless can't run; no contract/relayer
changes, every action already had a twin + whitelisted target):
- **Payment (EIP-3009 leg replaces the approve tx):** createWager, acceptWager, acceptOpenWager,
  purchaseTier, upgradeTier, extendMembership
- **Signer-attributed:** declareDraw, declareWinner, redeemVoucher
- New `resolveMembershipIntentParams` computes the exact price the contract pulls; fixed a pre-existing
  red test from #803 (MarketAcceptanceModal's barrel-only useWeb3 mock). **Full frontend suite 2079/2079** (UTC).

### Deferred → Tier 2 (separate PR after this merges)
Pool gasless (dynamic clone addresses need factory-provenance authorization), plus `createOpenWager`
twin + long-tail (vouchers/keyRegistry). Design scoped; not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
