### PR TITLE
fix(041): clarify Oracle Open Challenge is a peer-to-peer wager

### DIFF
--- a/frontend/src/components/fairwins/OracleOpenChallengeModal.css
+++ b/frontend/src/components/fairwins/OracleOpenChallengeModal.css
@@ -2,22 +2,27 @@
    shared fm-* / OpenChallengeModal.css base. Keep additions minimal: the flow reuses
    fm-polymarket-selected, fm-side-picker, oc-deadlines, etc. */
 
-/* Live price chip inside a side button (text + number, not color-only). */
-.ooc-side-price {
-  display: block;
-  font-size: 0.78rem;
-  opacity: 0.75;
-  margin-top: 2px;
-}
-
 /* Refused-market notice sits above the picker so the reason is read before re-picking. */
 .ooc-ineligible {
   margin-bottom: 10px;
 }
 
-/* Derived timeline: visually the same tiles as oc-deadlines, but flagged read-only. */
-.ooc-derived-timeline {
-  cursor: default;
+/* Deep link to the linked market on Polymarket, so takers/makers can review or wager
+   the same event at the source (the challenge here is a peer-to-peer bet, not a
+   Polymarket trade). */
+.ooc-polymarket-link {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  margin-top: 6px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--brand-primary, #36B37E);
+  text-decoration: none;
+}
+
+.ooc-polymarket-link:hover {
+  text-decoration: underline;
 }
 
 .ooc-timeline-provenance {

--- a/frontend/src/components/fairwins/OracleOpenChallengeModal.jsx
+++ b/frontend/src/components/fairwins/OracleOpenChallengeModal.jsx
@@ -52,12 +52,13 @@ function OracleOpenChallengeModal({ isOpen, onClose }) {
               <h2 id="oracle-open-challenge-title">Oracle Open Challenge</h2>
             </div>
             <p className="fm-subtitle">
-              Pick a Polymarket market, share a code — Polymarket settles it
+              Bet head-to-head with whoever takes your code — Polymarket only settles the result
               <InfoTip label="About oracle open challenges">
-                No opponent named up front and nobody judges the outcome: whoever you share the
-                four-word code with can take the other side, and the linked Polymarket market&apos;s
-                public resolution settles the bet automatically. Equal stakes. The event sets the
-                timeline. Creating one requires a Silver membership or above.
+                This is a peer-to-peer wager: you&apos;re betting another person, not Polymarket.
+                Whoever you share the four-word code with takes the other side, and the linked
+                Polymarket market&apos;s public resolution just decides who was right — the stakes
+                are escrowed between the two of you. Equal stakes. The event sets the timeline.
+                Creating one requires a Silver membership or above.
               </InfoTip>
             </p>
           </div>
@@ -230,6 +231,16 @@ function OracleMakerPanel({ onClose }) {
                 )}
               </div>
               <code className="fm-polymarket-cid">{market.conditionId}</code>
+              {market.slug && (
+                <a
+                  className="ooc-polymarket-link"
+                  href={`https://polymarket.com/event/${market.slug}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  View on Polymarket &#8599;
+                </a>
+              )}
             </div>
             <button type="button" className="fm-link-btn" onClick={clearMarket} disabled={busy}>
               Change
@@ -263,7 +274,6 @@ function OracleMakerPanel({ onClose }) {
             <div className="fm-side-picker">
               {['0', '1'].map((idx) => {
                 const name = sideName(idx)
-                const price = market.outcomes?.[Number(idx)]?.price
                 const active = side === idx
                 return (
                   <button
@@ -275,9 +285,6 @@ function OracleMakerPanel({ onClose }) {
                     aria-pressed={active}
                   >
                     <span className="fm-side-btn-label">I&apos;m taking {name}</span>
-                    {price != null && (
-                      <span className="ooc-side-price">{Math.round(price * 100)}&cent; now</span>
-                    )}
                   </button>
                 )
               })}
@@ -326,16 +333,6 @@ function OracleMakerPanel({ onClose }) {
                   closes (capped at 30 days), and it settles once Polymarket resolves the market.
                 </InfoTip>
               </span>
-              <div className="oc-deadlines ooc-derived-timeline" aria-label="Challenge time constraints (derived from the event)">
-                <div className="oc-deadline">
-                  <span className="oc-deadline-label">Takeable until</span>
-                  <span className="oc-deadline-value">{formatDateTime(timeline.acceptDeadlineMs)}</span>
-                </div>
-                <div className="oc-deadline">
-                  <span className="oc-deadline-label">Settles by</span>
-                  <span className="oc-deadline-value">{formatDateTime(timeline.resolveDeadlineMs)}</span>
-                </div>
-              </div>
               <span className="fm-hint ooc-timeline-provenance">
                 {timeline.acceptCapped
                   ? 'This event ends more than 30 days out, so the challenge closes for takers after the 30-day maximum — settlement still follows the event.'
@@ -363,14 +360,6 @@ function formatDate(iso) {
     return new Date(iso).toLocaleDateString([], { dateStyle: 'medium' })
   } catch {
     return String(iso)
-  }
-}
-
-function formatDateTime(ms) {
-  try {
-    return new Date(ms).toLocaleString([], { dateStyle: 'medium', timeStyle: 'short' })
-  } catch {
-    return ''
   }
 }
 

--- a/frontend/src/test/claimCode/OracleOpenChallengeModal.test.jsx
+++ b/frontend/src/test/claimCode/OracleOpenChallengeModal.test.jsx
@@ -74,7 +74,7 @@ describe('OracleOpenChallengeModal (spec 041, US1)', () => {
     expect(screen.queryByText(/your side of the bet/i)).toBeNull()
   })
 
-  it('picking a market reveals side picker (market outcome labels + prices), stake, and the derived read-only timeline', () => {
+  it('picking a market reveals side picker (market outcome labels, no per-side prices), stake, and a Polymarket deep link', () => {
     render(<OracleOpenChallengeModal isOpen onClose={() => {}} />)
     fireEvent.click(screen.getByRole('button', { name: /pick eligible/i }))
 
@@ -82,17 +82,23 @@ describe('OracleOpenChallengeModal (spec 041, US1)', () => {
     expect(screen.getByText('Will ETH flip BTC?')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /change/i })).toBeInTheDocument()
 
-    // Side picker: two aria-pressed buttons carrying the market's own labels + live prices.
+    // Deep link out to the source market on Polymarket.
+    const pmLink = screen.getByRole('link', { name: /view on polymarket/i })
+    expect(pmLink).toHaveAttribute('href', expect.stringContaining('polymarket.com/event/'))
+
+    // Side picker: two aria-pressed buttons carrying the market's own labels. Per-side
+    // prices are intentionally omitted so they can't be mistaken for the cost of a side.
     const yesBtn = screen.getByRole('button', { name: /taking yes/i })
     const noBtn = screen.getByRole('button', { name: /taking no/i })
     expect(yesBtn).toHaveAttribute('aria-pressed', 'false')
-    expect(yesBtn).toHaveTextContent(/62¢/)
-    expect(noBtn).toHaveTextContent(/38¢/)
+    expect(yesBtn).not.toHaveTextContent(/¢/)
+    expect(noBtn).not.toHaveTextContent(/¢/)
 
-    // Derived timeline is presented as coming from the event, with no date inputs.
+    // Derived timeline is presented as coming from the event, with no date inputs and no
+    // empty deadline tiles.
     expect(screen.getByText(/timeline — set by the event/i)).toBeInTheDocument()
-    expect(screen.getByText('Takeable until')).toBeInTheDocument()
-    expect(screen.getByText('Settles by')).toBeInTheDocument()
+    expect(screen.queryByText('Takeable until')).toBeNull()
+    expect(screen.queryByText('Settles by')).toBeNull()
     expect(document.querySelector('input[type="datetime-local"]')).toBeNull()
 
     // Taker side is spelled out once a side is picked.


### PR DESCRIPTION
## Summary

The Oracle Open Challenge create flow read as though the user were betting **against Polymarket**. In fact it's a **peer-to-peer wager** — you bet whoever takes your code, and Polymarket's public resolution only decides who was right. This PR makes that clear and cleans up two things on the same screen that added confusion.

Addresses UI feedback on the create-challenge sheet (screenshot: "Oracle Open Challenge").

## Changes

- **Clarify it's person-vs-person, not vs Polymarket.** The subtitle now reads _"Bet head-to-head with whoever takes your code — Polymarket only settles the result"_, and the info tooltip spells out that the stakes are escrowed between the two participants.
- **Remove the per-side price under each side button.** The `N¢ now` chip under _"I'm taking Yes / No"_ could be mistaken for the cost of picking that side, so it's gone. Market odds are still shown as context in the linked-market card.
- **Add a "View on Polymarket ↗" deep link** in the linked-market card (`https://polymarket.com/event/<slug>`) so users can review — or place a wager on — the same event at the source.
- **Remove the void below "Timeline — set by the event."** The two derived deadline tiles used `--fm-*` CSS variables that are never defined, so they fell back to white-on-white and rendered as an empty gap in light mode. They're removed; the plain-language provenance hint already describes the timeline (takeable until the market closes, settled after Polymarket resolves it).

## Testing

- Updated `OracleOpenChallengeModal.test.jsx` to assert no per-side `¢` prices, no deadline tiles, and a present Polymarket deep link.
- `vitest run src/test/claimCode/OracleOpenChallengeModal.test.jsx` — 11 passed
- `vitest run src/test/Dashboard.test.jsx` — 27 passed
- `eslint` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KVAgC9GhXATryTbEbXYQB

---
_Generated by [Claude Code](https://claude.ai/code/session_012KVAgC9GhXATryTbEbXYQB)_