### PR TITLE
Add PWA install prompt and automated update flow

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,8 +3,18 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/assets/logo_fairwins.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="FairWins - Open prediction markets where anyone can create, join, and resolve markets. Fair participation, transparent resolution, and privacy-preserving mechanisms for collective wisdom." />
+
+    <!-- Progressive Web App: manifest + install/standalone metadata -->
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#36B37E" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <!-- iOS standalone support (Safari ignores the manifest for home-screen installs) -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="FairWins" />
+    <link rel="apple-touch-icon" href="/assets/fairwins_no-text_logo.svg" />
     <title>FairWins - Prediction Markets for Friends</title>
     
     <!-- Preconnect to common external origins for better performance -->

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,6 +8,9 @@
 # so a new deploy is picked up promptly (never hard-cached at the edge or in the browser).
 map $uri $fw_cache_control {
     default                                                       "no-cache";
+    # The service worker must always revalidate — hard-caching sw.js (it ends in .js) would
+    # strand clients on a stale worker. Listed BEFORE the immutable asset rule so it wins.
+    "~*/sw\.js$"                                                  "no-cache";
     "~*\.(?:js|mjs|css|png|jpe?g|gif|ico|svg|woff2?|ttf|eot)$"     "public, max-age=31536000, immutable";
 }
 
@@ -21,6 +24,13 @@ server {
     # Handle SPA routing - all routes should serve index.html
     location / {
         try_files $uri $uri/ /index.html;
+    }
+
+    # Serve the PWA manifest with the correct media type regardless of the bundled
+    # mime.types version. No `add_header` here on purpose — an empty-of-add_header
+    # location still inherits every server-level security header (see note below).
+    location = /manifest.webmanifest {
+        default_type application/manifest+json;
     }
 
     # --- Headers (server level only) ------------------------------------------------------

--- a/frontend/nginx.conf.template
+++ b/frontend/nginx.conf.template
@@ -80,6 +80,21 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # Service worker: exact-match location wins over the .js rule below, so sw.js is
+    # never hard-cached — a stale worker would strand clients on old assets.
+    location = /sw.js {
+        if ($origin_denied) { return 403; }
+        add_header Cache-Control "no-cache";
+    }
+
+    # PWA manifest: pin the media type (independent of the bundled mime.types) and
+    # keep it revalidated so install metadata updates promptly.
+    location = /manifest.webmanifest {
+        if ($origin_denied) { return 403; }
+        default_type application/manifest+json;
+        add_header Cache-Control "no-cache";
+    }
+
     # Cache static assets
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         if ($origin_denied) { return 403; }

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,0 +1,28 @@
+{
+  "name": "FairWins — Prediction Markets for Friends",
+  "short_name": "FairWins",
+  "description": "Open prediction markets where anyone can create, join, and resolve markets. Fair participation, transparent resolution, and privacy-preserving mechanisms for collective wisdom.",
+  "id": "/",
+  "start_url": "/?source=pwa",
+  "scope": "/",
+  "display": "standalone",
+  "display_override": ["standalone", "minimal-ui", "browser"],
+  "orientation": "portrait-primary",
+  "background_color": "#0E141B",
+  "theme_color": "#36B37E",
+  "categories": ["finance", "social"],
+  "icons": [
+    {
+      "src": "/assets/fairwins_no-text_logo.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/assets/fairwins_no-text_logo.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,46 @@
+/* FairWins service worker.
+ *
+ * Kept intentionally minimal: its job is to make the app a real, installable PWA
+ * (Chromium's install criteria historically want a registered service worker with
+ * a fetch handler) — NOT to aggressively cache. Aggressive caching of a web3 app
+ * risks serving stale JS bundles against live on-chain state, so we only pre-cache
+ * a tiny app-shell for an offline fallback and pass everything else straight to the
+ * network. Bump CACHE_VERSION to invalidate the shell cache on deploy.
+ */
+const CACHE_VERSION = 'fairwins-shell-v1'
+const OFFLINE_URLS = ['/', '/index.html', '/manifest.webmanifest']
+
+self.addEventListener('install', (event) => {
+  // Take over as soon as the new worker is ready so users aren't stuck on an old one.
+  self.skipWaiting()
+  event.waitUntil(
+    caches.open(CACHE_VERSION).then((cache) => cache.addAll(OFFLINE_URLS).catch(() => undefined))
+  )
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) => Promise.all(keys.filter((k) => k !== CACHE_VERSION).map((k) => caches.delete(k))))
+      .then(() => self.clients.claim())
+  )
+})
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event
+  // Only handle GET navigations for the offline fallback; everything else is network-only.
+  if (request.method !== 'GET') return
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request).catch(() =>
+        caches.match(request).then((cached) => cached || caches.match('/index.html'))
+      )
+    )
+    return
+  }
+
+  // Non-navigation GETs: try network, fall back to any cached shell asset if offline.
+  event.respondWith(fetch(request).catch(() => caches.match(request)))
+})

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -11,11 +11,22 @@ const CACHE_VERSION = 'fairwins-shell-v1'
 const OFFLINE_URLS = ['/', '/index.html', '/manifest.webmanifest']
 
 self.addEventListener('install', (event) => {
-  // Take over as soon as the new worker is ready so users aren't stuck on an old one.
-  self.skipWaiting()
+  // NOTE: we deliberately do NOT call skipWaiting() here. On a fresh install there is
+  // no controlling worker, so the new worker activates immediately anyway. On an UPDATE
+  // the old worker keeps controlling open tabs and the new one parks in `waiting` until
+  // the user approves the update (the app posts SKIP_WAITING). This gives a controlled,
+  // user-driven update flow instead of swapping bundles out from under a live session.
   event.waitUntil(
     caches.open(CACHE_VERSION).then((cache) => cache.addAll(OFFLINE_URLS).catch(() => undefined))
   )
+})
+
+// The page posts { type: 'SKIP_WAITING' } when the user clicks "Update now"; that
+// promotes this waiting worker to active, which fires `controllerchange` on the client.
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting()
+  }
 })
 
 self.addEventListener('activate', (event) => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,6 +33,7 @@ import DevelopmentWarningBanner from './components/ui/DevelopmentWarningBanner'
 import DevelopmentWarningModal from './components/ui/DevelopmentWarningModal'
 import StateManagementDemo from './components/StateManagementDemo'
 import { ComponentExamples } from './components/ui'
+import PwaInstallPrompt from './components/pwa/PwaInstallPrompt'
 
 function AppLayout() {
   return (
@@ -78,6 +79,9 @@ function AppContent() {
 
       {/* Modal system */}
       <ModalSystem />
+
+      {/* PWA install bottom-sheet — shown to non-standalone visitors who haven't opted out */}
+      <PwaInstallPrompt />
 
       {/* Network error banner */}
       {networkError && isConnected && (

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,6 +34,7 @@ import DevelopmentWarningModal from './components/ui/DevelopmentWarningModal'
 import StateManagementDemo from './components/StateManagementDemo'
 import { ComponentExamples } from './components/ui'
 import PwaInstallPrompt from './components/pwa/PwaInstallPrompt'
+import PwaUpdateNotification from './components/pwa/PwaUpdateNotification'
 
 function AppLayout() {
   return (
@@ -82,6 +83,9 @@ function AppContent() {
 
       {/* PWA install bottom-sheet — shown to non-standalone visitors who haven't opted out */}
       <PwaInstallPrompt />
+
+      {/* PWA update toast — routes to the Software Update section when a new version is ready */}
+      <PwaUpdateNotification />
 
       {/* Network error banner */}
       {networkError && isConnected && (

--- a/frontend/src/components/pwa/PwaInstallPrompt.css
+++ b/frontend/src/components/pwa/PwaInstallPrompt.css
@@ -1,0 +1,170 @@
+/* PWA install bottom-sheet — centered card on desktop, sheet rising from the bottom
+   on mobile. Self-contained styling that reads the shared theme CSS variables so it
+   tracks light/dark + platform themes. Mirrors the CpBottomSheet interaction model. */
+
+.pwa-install-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.pwa-install-sheet {
+  position: relative;
+  width: 100%;
+  max-width: 460px;
+  max-height: 92vh;
+  overflow-y: auto;
+  background: var(--bg-primary, #fff);
+  color: var(--text-primary, #111);
+  border: 1px solid var(--border-color, rgba(0, 0, 0, 0.12));
+  border-radius: var(--radius-lg, 14px);
+  padding: 1.25rem 1.25rem 1.4rem;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.28);
+  animation: pwaSheetUp 0.2s ease-out;
+}
+
+@keyframes pwaSheetUp {
+  from { opacity: 0; transform: translateY(16px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.pwa-install-handle { display: none; }
+
+.pwa-install-close {
+  position: absolute;
+  top: 0.65rem;
+  right: 0.65rem;
+  width: 34px;
+  height: 34px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 999px;
+  background: var(--bg-secondary, rgba(0, 0, 0, 0.05));
+  color: var(--text-secondary, #555);
+  cursor: pointer;
+}
+.pwa-install-close:hover { background: var(--bg-tertiary, rgba(0, 0, 0, 0.1)); }
+
+.pwa-install-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  margin: 0.2rem 2rem 0.9rem 0;
+}
+
+.pwa-install-icon {
+  flex: 0 0 auto;
+  width: 48px;
+  height: 48px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--brand-primary, #36B37E) 14%, transparent);
+  overflow: hidden;
+}
+.pwa-install-icon img { display: block; width: 40px; height: 40px; }
+
+.pwa-install-title {
+  margin: 0 0 0.25rem;
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.pwa-install-desc {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  color: var(--text-secondary, #555);
+}
+
+/* iOS manual steps */
+.pwa-install-ios-steps {
+  margin: 0 0 1rem;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--text-primary, #111);
+}
+.pwa-install-ios-steps li { line-height: 1.5; }
+.pwa-install-ios-share {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  margin: 0 0.3rem;
+  color: var(--brand-primary, #36B37E);
+}
+
+/* Primary install CTA (Chromium / desktop) */
+.pwa-install-cta {
+  width: 100%;
+  padding: 0.8rem 1rem;
+  margin-bottom: 0.85rem;
+  border: none;
+  border-radius: 10px;
+  background: var(--brand-primary, #36B37E);
+  color: #fff;
+  font-size: 0.98rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter 0.15s ease;
+}
+.pwa-install-cta:hover { filter: brightness(1.05); }
+.pwa-install-cta:active { filter: brightness(0.96); }
+
+.pwa-install-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.pwa-install-secondary,
+.pwa-install-dont-show {
+  border: none;
+  background: none;
+  padding: 0.35rem 0.15rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+.pwa-install-secondary { color: var(--text-primary, #111); font-weight: 500; }
+.pwa-install-secondary:hover { text-decoration: underline; }
+.pwa-install-dont-show { color: var(--text-secondary, #777); }
+.pwa-install-dont-show:hover { color: var(--text-primary, #111); text-decoration: underline; }
+
+/* Mobile: dock to the bottom as a sheet with a grab handle. */
+@media (max-width: 768px) {
+  .pwa-install-backdrop {
+    align-items: flex-end;
+    padding: 0;
+  }
+  .pwa-install-sheet {
+    max-width: 100%;
+    max-height: 95vh;
+    border-radius: 20px 20px 0 0;
+    padding-bottom: calc(1.4rem + env(safe-area-inset-bottom, 0px));
+  }
+  .pwa-install-handle {
+    display: block;
+    width: 40px;
+    height: 4px;
+    border-radius: 999px;
+    background: var(--border-color, rgba(0, 0, 0, 0.2));
+    margin: 0 auto 0.9rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pwa-install-sheet { animation: none; }
+}

--- a/frontend/src/components/pwa/PwaInstallPrompt.jsx
+++ b/frontend/src/components/pwa/PwaInstallPrompt.jsx
@@ -1,0 +1,154 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { usePwaInstall } from '../../hooks/usePwaInstall'
+import './PwaInstallPrompt.css'
+
+// Small delay before the sheet rises, so it doesn't slam up the instant the page paints.
+const SHOW_DELAY_MS = 1200
+
+/**
+ * PwaInstallPrompt — a bottom-sheet (mobile) / centered card (desktop) that invites
+ * the visitor to install FairWins as an app when they're browsing in a normal tab.
+ *
+ * Visibility rules (all must hold):
+ *   - not already running standalone / installed,
+ *   - the user hasn't permanently opted out ("Don't show again" → Preferences toggle),
+ *   - the user hasn't dismissed it for this session,
+ *   - AND either a native install prompt is available (Chromium) or we're on iOS
+ *     Safari (which needs manual Add-to-Home-Screen instructions).
+ */
+export default function PwaInstallPrompt() {
+  const {
+    isStandalone,
+    isIos,
+    canPrompt,
+    hidden,
+    snoozed,
+    promptInstall,
+    dismissForSession,
+    setHidden,
+  } = usePwaInstall()
+
+  const [ready, setReady] = useState(false)
+  const panelRef = useRef(null)
+
+  const eligible = useMemo(
+    () => !isStandalone && !hidden && !snoozed && (canPrompt || isIos),
+    [isStandalone, hidden, snoozed, canPrompt, isIos]
+  )
+
+  // Delay the reveal slightly once eligible; reset on cleanup so a later
+  // eligibility flip re-arms the delay rather than showing instantly.
+  useEffect(() => {
+    if (!eligible) return undefined
+    const t = setTimeout(() => setReady(true), SHOW_DELAY_MS)
+    return () => {
+      clearTimeout(t)
+      setReady(false)
+    }
+  }, [eligible])
+
+  const open = eligible && ready
+
+  // Escape closes (session-dismiss); lock background scroll; move focus into the sheet.
+  useEffect(() => {
+    if (!open) return undefined
+    const onKey = (e) => {
+      if (e.key === 'Escape') dismissForSession()
+    }
+    document.addEventListener('keydown', onKey)
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    panelRef.current?.focus()
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.body.style.overflow = prevOverflow
+    }
+  }, [open, dismissForSession])
+
+  if (!open) return null
+
+  const handleInstall = async () => {
+    const outcome = await promptInstall()
+    // Whether accepted or dismissed, don't nag again this session.
+    if (outcome !== 'unavailable') dismissForSession()
+  }
+
+  const handleDontShowAgain = () => {
+    setHidden(true)
+  }
+
+  return (
+    <div
+      className="pwa-install-backdrop"
+      role="presentation"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) dismissForSession()
+      }}
+    >
+      <div
+        ref={panelRef}
+        className="pwa-install-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="pwa-install-title"
+        aria-describedby="pwa-install-desc"
+        tabIndex={-1}
+      >
+        <div className="pwa-install-handle" aria-hidden="true" />
+
+        <button
+          type="button"
+          className="pwa-install-close"
+          onClick={dismissForSession}
+          aria-label="Dismiss install prompt"
+        >
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+            <path d="M6 6l12 12M18 6L6 18" strokeLinecap="round" />
+          </svg>
+        </button>
+
+        <div className="pwa-install-head">
+          <span className="pwa-install-icon" aria-hidden="true">
+            <img src="/assets/fairwins_no-text_logo.svg" alt="" width="40" height="40" />
+          </span>
+          <div>
+            <h3 id="pwa-install-title" className="pwa-install-title">Install FairWins</h3>
+            <p id="pwa-install-desc" className="pwa-install-desc">
+              Install the app on your device to easily access it anytime. No app store.
+              No download. No hassle.
+            </p>
+          </div>
+        </div>
+
+        {isIos && !canPrompt ? (
+          <ol className="pwa-install-ios-steps" aria-label="How to install on iOS">
+            <li>
+              Tap the Share icon
+              <span className="pwa-install-ios-share" aria-hidden="true">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                  <path d="M12 3v12M8 7l4-4 4 4" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M5 12v7a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-7" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </span>
+              in the toolbar
+            </li>
+            <li>Select <strong>Add to Home Screen</strong></li>
+          </ol>
+        ) : (
+          <button type="button" className="pwa-install-cta" onClick={handleInstall}>
+            Install
+          </button>
+        )}
+
+        <div className="pwa-install-actions">
+          <button type="button" className="pwa-install-secondary" onClick={dismissForSession}>
+            Continue in browser
+          </button>
+          <button type="button" className="pwa-install-dont-show" onClick={handleDontShowAgain}>
+            Don&apos;t show again
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/pwa/PwaUpdateNotification.css
+++ b/frontend/src/components/pwa/PwaUpdateNotification.css
@@ -1,0 +1,97 @@
+/* PWA "update available" toast — a compact, dismissible card pinned bottom-center that
+   routes the user to the Software Update section in Preferences. Theme-variable driven so
+   it tracks light/dark. Sits above app chrome but below modal overlays. */
+
+.pwa-update-toast {
+  position: fixed;
+  left: 50%;
+  bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+  transform: translateX(-50%);
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: calc(100% - 2rem);
+  max-width: 440px;
+  padding: 0.75rem 0.85rem;
+  background: var(--bg-primary, #fff);
+  color: var(--text-primary, #111);
+  border: 1px solid var(--border-color, rgba(0, 0, 0, 0.12));
+  border-radius: 12px;
+  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.24);
+  animation: pwaToastUp 0.2s ease-out;
+}
+
+@keyframes pwaToastUp {
+  from { opacity: 0; transform: translate(-50%, 12px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}
+
+.pwa-update-toast-icon {
+  flex: 0 0 auto;
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--brand-primary, #36B37E) 16%, transparent);
+  color: var(--brand-primary, #36B37E);
+}
+
+.pwa-update-toast-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.pwa-update-toast-text strong { font-size: 0.92rem; font-weight: 600; }
+.pwa-update-toast-text span {
+  font-size: 0.82rem;
+  color: var(--text-secondary, #666);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pwa-update-toast-actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.pwa-update-toast-cta {
+  padding: 0.45rem 0.8rem;
+  border: none;
+  border-radius: 8px;
+  background: var(--brand-primary, #36B37E);
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter 0.15s ease;
+}
+.pwa-update-toast-cta:hover { filter: brightness(1.05); }
+.pwa-update-toast-cta:active { filter: brightness(0.96); }
+
+.pwa-update-toast-dismiss {
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 8px;
+  background: none;
+  color: var(--text-secondary, #777);
+  cursor: pointer;
+}
+.pwa-update-toast-dismiss:hover {
+  background: var(--bg-secondary, rgba(0, 0, 0, 0.06));
+  color: var(--text-primary, #111);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pwa-update-toast { animation: none; }
+}

--- a/frontend/src/components/pwa/PwaUpdateNotification.jsx
+++ b/frontend/src/components/pwa/PwaUpdateNotification.jsx
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { usePwaUpdate } from '../../hooks/usePwaUpdate'
+import './PwaUpdateNotification.css'
+
+/**
+ * PwaUpdateNotification — a small, dismissible toast shown when a newer version of the
+ * installed app is ready. It doesn't apply the update itself; it routes the user to the
+ * Software Update section of their wallet Preferences, where they confirm and install.
+ */
+export default function PwaUpdateNotification() {
+  const { updateReady } = usePwaUpdate()
+  const [dismissed, setDismissed] = useState(false)
+  const navigate = useNavigate()
+
+  if (!updateReady || dismissed) return null
+
+  const goToUpdate = () => {
+    navigate('/wallet?tab=preferences#pwa-update')
+    setDismissed(true)
+  }
+
+  return (
+    <div className="pwa-update-toast" role="status" aria-live="polite">
+      <span className="pwa-update-toast-icon" aria-hidden="true">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+          <path d="M21 12a9 9 0 1 1-2.64-6.36" strokeLinecap="round" />
+          <path d="M21 3v5h-5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </span>
+      <div className="pwa-update-toast-text">
+        <strong>Update available</strong>
+        <span>A new version of FairWins is ready to install.</span>
+      </div>
+      <div className="pwa-update-toast-actions">
+        <button type="button" className="pwa-update-toast-cta" onClick={goToUpdate}>
+          View update
+        </button>
+        <button
+          type="button"
+          className="pwa-update-toast-dismiss"
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss update notification"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+            <path d="M6 6l12 12M18 6L6 18" strokeLinecap="round" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/pwa/__tests__/PwaInstallPrompt.test.jsx
+++ b/frontend/src/components/pwa/__tests__/PwaInstallPrompt.test.jsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+import PwaInstallPrompt from '../PwaInstallPrompt'
+import { isInstallPromptHidden } from '../../../lib/pwa/installPreference'
+
+// Fire a fake Chromium beforeinstallprompt event and return the userChoice control.
+function fireBeforeInstallPrompt(outcome = 'accepted') {
+  const event = new Event('beforeinstallprompt')
+  event.prompt = vi.fn()
+  event.userChoice = Promise.resolve({ outcome })
+  act(() => {
+    window.dispatchEvent(event)
+  })
+  return event
+}
+
+// Advance past the reveal delay (SHOW_DELAY_MS = 1200).
+function revealSheet() {
+  act(() => {
+    vi.advanceTimersByTime(1300)
+  })
+}
+
+describe('PwaInstallPrompt', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders nothing until an install prompt is available', () => {
+    render(<PwaInstallPrompt />)
+    revealSheet()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('shows the install sheet after the delay once installable', () => {
+    render(<PwaInstallPrompt />)
+    fireBeforeInstallPrompt()
+    // Not shown immediately...
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    revealSheet()
+    // ...shown after the delay.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('Install FairWins')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Install' })).toBeInTheDocument()
+  })
+
+  it('triggers the native prompt and dismisses on Install', async () => {
+    render(<PwaInstallPrompt />)
+    const event = fireBeforeInstallPrompt('accepted')
+    revealSheet()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Install' }))
+    expect(event.prompt).toHaveBeenCalledTimes(1)
+
+    // After the choice resolves, the sheet is dismissed for the session.
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('"Don\'t show again" persists the opt-out and hides the sheet', () => {
+    render(<PwaInstallPrompt />)
+    fireBeforeInstallPrompt()
+    revealSheet()
+
+    fireEvent.click(screen.getByRole('button', { name: /don't show again/i }))
+    expect(isInstallPromptHidden()).toBe(true)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('"Continue in browser" dismisses for the session without persisting opt-out', () => {
+    render(<PwaInstallPrompt />)
+    fireBeforeInstallPrompt()
+    revealSheet()
+
+    fireEvent.click(screen.getByRole('button', { name: /continue in browser/i }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    // Not a permanent opt-out.
+    expect(isInstallPromptHidden()).toBe(false)
+  })
+
+  it('does not show when the user has permanently opted out', () => {
+    localStorage.setItem('fw_global_prefs', JSON.stringify({ pwaInstallPromptHidden: true }))
+    render(<PwaInstallPrompt />)
+    fireBeforeInstallPrompt()
+    revealSheet()
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/pwa/__tests__/PwaUpdateNotification.test.jsx
+++ b/frontend/src/components/pwa/__tests__/PwaUpdateNotification.test.jsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import PwaUpdateNotification from '../PwaUpdateNotification'
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+let updateReady = false
+vi.mock('../../../hooks/usePwaUpdate', () => ({
+  usePwaUpdate: () => ({ updateReady, applyUpdate: vi.fn(), checkForUpdate: vi.fn() }),
+}))
+
+function renderToast() {
+  return render(
+    <MemoryRouter>
+      <PwaUpdateNotification />
+    </MemoryRouter>
+  )
+}
+
+describe('PwaUpdateNotification', () => {
+  beforeEach(() => {
+    navigateMock.mockClear()
+    updateReady = false
+  })
+
+  it('renders nothing when no update is ready', () => {
+    renderToast()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('shows the toast when an update is ready', () => {
+    updateReady = true
+    renderToast()
+    expect(screen.getByText('Update available')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'View update' })).toBeInTheDocument()
+  })
+
+  it('routes to the Software Update section in Preferences on click', () => {
+    updateReady = true
+    renderToast()
+    fireEvent.click(screen.getByRole('button', { name: 'View update' }))
+    expect(navigateMock).toHaveBeenCalledWith('/wallet?tab=preferences#pwa-update')
+    // Dismissed after navigating.
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('can be dismissed', () => {
+    updateReady = true
+    renderToast()
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/hooks/usePwaInstall.js
+++ b/frontend/src/hooks/usePwaInstall.js
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react'
+import {
+  isInstallPromptHidden,
+  isInstallPromptSnoozed,
+  setInstallPromptHidden,
+  snoozeInstallPromptForSession,
+  subscribeInstallPref,
+} from '../lib/pwa/installPreference'
+
+/** Is the app currently running as an installed/standalone PWA? */
+function detectStandalone() {
+  if (typeof window === 'undefined') return false
+  const displayModeStandalone =
+    typeof window.matchMedia === 'function' &&
+    (window.matchMedia('(display-mode: standalone)').matches ||
+      window.matchMedia('(display-mode: minimal-ui)').matches ||
+      window.matchMedia('(display-mode: fullscreen)').matches)
+  // iOS Safari exposes navigator.standalone instead of the display-mode media query.
+  const iosStandalone = window.navigator.standalone === true
+  return Boolean(displayModeStandalone || iosStandalone)
+}
+
+/** iOS Safari never fires `beforeinstallprompt`; installs are manual (Share → Add to Home Screen). */
+function detectIos() {
+  if (typeof window === 'undefined') return false
+  const ua = window.navigator.userAgent || ''
+  const isIosDevice =
+    /iphone|ipad|ipod/i.test(ua) ||
+    // iPadOS 13+ reports as a Mac; disambiguate by touch support.
+    (/Macintosh/.test(ua) && typeof document !== 'undefined' && 'ontouchend' in document)
+  // Exclude in-app browsers that can't add to home screen anyway (Chrome/Firefox on iOS
+  // use CriOS/FxiOS and cannot install; only real Safari can).
+  const isSafari = !/CriOS|FxiOS|EdgiOS|OPiOS/i.test(ua)
+  return isIosDevice && isSafari
+}
+
+// External-store glue so `hidden` stays in sync with the Preferences toggle.
+const subscribeHidden = (cb) => subscribeInstallPref(cb)
+const getHiddenSnapshot = () => isInstallPromptHidden()
+const getHiddenServerSnapshot = () => false
+
+/**
+ * usePwaInstall — browser-agnostic PWA install state.
+ *
+ * Captures the deferred `beforeinstallprompt` event (Chromium) so we can trigger
+ * the native install dialog from our own UI, detects iOS (manual-install path) and
+ * standalone mode, and exposes the persistent "don't show again" preference plus a
+ * per-session snooze.
+ *
+ * @returns {{
+ *   isStandalone: boolean,   // already running as an installed app
+ *   isIos: boolean,          // iOS Safari — show manual Add-to-Home-Screen steps
+ *   canPrompt: boolean,      // a native install prompt is available to trigger
+ *   isInstalled: boolean,    // an install completed during this session
+ *   hidden: boolean,         // user permanently opted out ("don't show again")
+ *   snoozed: boolean,        // dismissed for this session only
+ *   promptInstall: () => Promise<'accepted'|'dismissed'|'unavailable'>,
+ *   dismissForSession: () => void,
+ *   setHidden: (v: boolean) => void,
+ * }}
+ */
+export function usePwaInstall() {
+  const [deferredPrompt, setDeferredPrompt] = useState(null)
+  const [isStandalone, setIsStandalone] = useState(detectStandalone)
+  const [isInstalled, setIsInstalled] = useState(false)
+  const [isIos] = useState(detectIos)
+  const [snoozed, setSnoozed] = useState(isInstallPromptSnoozed)
+
+  const hidden = useSyncExternalStore(subscribeHidden, getHiddenSnapshot, getHiddenServerSnapshot)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+
+    const onBeforeInstallPrompt = (e) => {
+      // Prevent Chromium's default mini-infobar so we can present our own bottom-sheet.
+      e.preventDefault()
+      setDeferredPrompt(e)
+    }
+    const onAppInstalled = () => {
+      setDeferredPrompt(null)
+      setIsInstalled(true)
+      setIsStandalone(true)
+    }
+
+    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+    window.addEventListener('appinstalled', onAppInstalled)
+
+    // Track live display-mode changes (e.g. user installs then launches standalone).
+    let mql
+    const onDisplayChange = () => setIsStandalone(detectStandalone())
+    if (typeof window.matchMedia === 'function') {
+      mql = window.matchMedia('(display-mode: standalone)')
+      mql.addEventListener?.('change', onDisplayChange)
+    }
+
+    // Keep the per-session snooze in sync if another surface sets it.
+    const unsubscribe = subscribeInstallPref(() => setSnoozed(isInstallPromptSnoozed()))
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt)
+      window.removeEventListener('appinstalled', onAppInstalled)
+      mql?.removeEventListener?.('change', onDisplayChange)
+      unsubscribe()
+    }
+  }, [])
+
+  const promptInstall = useCallback(async () => {
+    if (!deferredPrompt) return 'unavailable'
+    deferredPrompt.prompt()
+    try {
+      const { outcome } = await deferredPrompt.userChoice
+      // A deferred prompt can only be used once; drop it regardless of outcome.
+      setDeferredPrompt(null)
+      return outcome === 'accepted' ? 'accepted' : 'dismissed'
+    } catch {
+      setDeferredPrompt(null)
+      return 'dismissed'
+    }
+  }, [deferredPrompt])
+
+  const dismissForSession = useCallback(() => {
+    snoozeInstallPromptForSession()
+    setSnoozed(true)
+  }, [])
+
+  const setHidden = useCallback((value) => {
+    setInstallPromptHidden(value)
+  }, [])
+
+  return {
+    isStandalone,
+    isIos,
+    canPrompt: Boolean(deferredPrompt),
+    isInstalled,
+    hidden,
+    snoozed,
+    promptInstall,
+    dismissForSession,
+    setHidden,
+  }
+}

--- a/frontend/src/hooks/usePwaUpdate.js
+++ b/frontend/src/hooks/usePwaUpdate.js
@@ -1,0 +1,23 @@
+import { useCallback, useSyncExternalStore } from 'react'
+import {
+  subscribe,
+  getUpdateReadySnapshot,
+  applyUpdate as applyUpdateImpl,
+  checkForUpdate as checkForUpdateImpl,
+} from '../lib/pwa/serviceWorkerUpdate'
+
+/**
+ * usePwaUpdate — reactive access to the service-worker update state.
+ *
+ * @returns {{
+ *   updateReady: boolean,                 // a new version is installed and waiting
+ *   applyUpdate: () => boolean,           // activate it (reloads on takeover)
+ *   checkForUpdate: () => Promise<void>,  // manually poll for a new version
+ * }}
+ */
+export function usePwaUpdate() {
+  const updateReady = useSyncExternalStore(subscribe, getUpdateReadySnapshot, () => false)
+  const applyUpdate = useCallback(() => applyUpdateImpl(), [])
+  const checkForUpdate = useCallback(() => checkForUpdateImpl(), [])
+  return { updateReady, applyUpdate, checkForUpdate }
+}

--- a/frontend/src/lib/pwa/__tests__/installPreference.test.js
+++ b/frontend/src/lib/pwa/__tests__/installPreference.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  INSTALL_PROMPT_HIDDEN_KEY,
+  isInstallPromptHidden,
+  setInstallPromptHidden,
+  isInstallPromptSnoozed,
+  snoozeInstallPromptForSession,
+  subscribeInstallPref,
+} from '../installPreference'
+
+describe('installPreference', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('defaults to not hidden and not snoozed', () => {
+    expect(isInstallPromptHidden()).toBe(false)
+    expect(isInstallPromptSnoozed()).toBe(false)
+  })
+
+  it('persists the permanent hidden flag to localStorage', () => {
+    setInstallPromptHidden(true)
+    expect(isInstallPromptHidden()).toBe(true)
+    // Stored under the global prefs bucket, not wallet-scoped.
+    const bucket = JSON.parse(localStorage.getItem('fw_global_prefs'))
+    expect(bucket[INSTALL_PROMPT_HIDDEN_KEY]).toBe(true)
+
+    setInstallPromptHidden(false)
+    expect(isInstallPromptHidden()).toBe(false)
+  })
+
+  it('snoozes only for the session (sessionStorage, not localStorage)', () => {
+    snoozeInstallPromptForSession()
+    expect(isInstallPromptSnoozed()).toBe(true)
+    expect(localStorage.getItem('fw_global_prefs')).toBeNull()
+  })
+
+  it('notifies subscribers when the hidden flag changes', () => {
+    const cb = vi.fn()
+    const unsubscribe = subscribeInstallPref(cb)
+    setInstallPromptHidden(true)
+    expect(cb).toHaveBeenCalledTimes(1)
+    unsubscribe()
+    setInstallPromptHidden(false)
+    expect(cb).toHaveBeenCalledTimes(1)
+  })
+
+  it('notifies subscribers when snoozed', () => {
+    const cb = vi.fn()
+    const unsubscribe = subscribeInstallPref(cb)
+    snoozeInstallPromptForSession()
+    expect(cb).toHaveBeenCalledTimes(1)
+    unsubscribe()
+  })
+})

--- a/frontend/src/lib/pwa/__tests__/serviceWorkerUpdate.test.js
+++ b/frontend/src/lib/pwa/__tests__/serviceWorkerUpdate.test.js
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  registerServiceWorker,
+  subscribe,
+  getUpdateReadySnapshot,
+  applyUpdate,
+  checkForUpdate,
+  __resetForTests,
+} from '../serviceWorkerUpdate'
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+function makeWorker() {
+  const listeners = {}
+  return {
+    state: 'installing',
+    postMessage: vi.fn(),
+    addEventListener: (type, cb) => { listeners[type] = cb },
+    setState(next) {
+      this.state = next
+      listeners.statechange?.()
+    },
+  }
+}
+
+function makeRegistration() {
+  const listeners = {}
+  return {
+    waiting: null,
+    installing: null,
+    update: vi.fn().mockResolvedValue(undefined),
+    addEventListener: (type, cb) => { listeners[type] = cb },
+    fire: (type) => listeners[type]?.(),
+  }
+}
+
+function installFakeServiceWorker({ hasController = true } = {}) {
+  const registration = makeRegistration()
+  const swListeners = {}
+  const serviceWorker = {
+    controller: hasController ? {} : null,
+    register: vi.fn().mockResolvedValue(registration),
+    addEventListener: (type, cb) => { swListeners[type] = cb },
+    fire: (type) => swListeners[type]?.(),
+  }
+  Object.defineProperty(navigator, 'serviceWorker', {
+    configurable: true,
+    value: serviceWorker,
+  })
+  return { registration, serviceWorker }
+}
+
+// Drive registerServiceWorker through the window 'load' handler and let register() resolve.
+async function boot() {
+  registerServiceWorker()
+  window.dispatchEvent(new Event('load'))
+  await flush()
+}
+
+describe('serviceWorkerUpdate', () => {
+  let reloadSpy
+  let originalLocation
+
+  beforeEach(() => {
+    __resetForTests()
+    reloadSpy = vi.fn()
+    // jsdom's location.reload is non-configurable, so swap the whole location object.
+    originalLocation = window.location
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, hash: '', reload: reloadSpy },
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    })
+    delete navigator.serviceWorker
+    vi.restoreAllMocks()
+  })
+
+  it('flags an update when a new worker installs behind an existing controller', async () => {
+    const { registration } = installFakeServiceWorker({ hasController: true })
+    const cb = vi.fn()
+    subscribe(cb)
+
+    await boot()
+    expect(getUpdateReadySnapshot()).toBe(false)
+
+    // Browser finds a new worker → it installs.
+    const worker = makeWorker()
+    registration.installing = worker
+    registration.fire('updatefound')
+    worker.setState('installed')
+
+    expect(getUpdateReadySnapshot()).toBe(true)
+    expect(cb).toHaveBeenCalled()
+  })
+
+  it('does NOT flag an update on the first install (no existing controller)', async () => {
+    const { registration } = installFakeServiceWorker({ hasController: false })
+    await boot()
+
+    const worker = makeWorker()
+    registration.installing = worker
+    registration.fire('updatefound')
+    worker.setState('installed')
+
+    expect(getUpdateReadySnapshot()).toBe(false)
+  })
+
+  it('applyUpdate posts SKIP_WAITING and reloads once the new worker takes control', async () => {
+    const { registration, serviceWorker } = installFakeServiceWorker({ hasController: true })
+    await boot()
+
+    const worker = makeWorker()
+    registration.installing = worker
+    registration.fire('updatefound')
+    worker.setState('installed')
+
+    expect(applyUpdate()).toBe(true)
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'SKIP_WAITING' })
+
+    // The new worker activates → controllerchange → reload (user-approved).
+    serviceWorker.fire('controllerchange')
+    expect(reloadSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reload on controllerchange that the user did not trigger', async () => {
+    const { serviceWorker } = installFakeServiceWorker({ hasController: true })
+    await boot()
+
+    // First-ever activation fires controllerchange without any applyUpdate() call.
+    serviceWorker.fire('controllerchange')
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('applyUpdate returns false when no update is waiting', async () => {
+    installFakeServiceWorker({ hasController: true })
+    await boot()
+    expect(applyUpdate()).toBe(false)
+  })
+
+  it('checkForUpdate polls the registration', async () => {
+    const { registration } = installFakeServiceWorker({ hasController: true })
+    await boot()
+    await checkForUpdate()
+    expect(registration.update).toHaveBeenCalled()
+  })
+
+  it('picks up a worker that was already waiting at registration time', async () => {
+    const { registration } = installFakeServiceWorker({ hasController: true })
+    registration.waiting = makeWorker()
+    await boot()
+    expect(getUpdateReadySnapshot()).toBe(true)
+  })
+})

--- a/frontend/src/lib/pwa/installPreference.js
+++ b/frontend/src/lib/pwa/installPreference.js
@@ -1,0 +1,79 @@
+/**
+ * Device-wide preference for the PWA install prompt.
+ *
+ * This is deliberately NOT tied to a wallet address: a first-time visitor who
+ * has never connected a wallet still needs to see (and be able to permanently
+ * dismiss) the install bottom-sheet. So we persist it via the global-preference
+ * helpers (localStorage, keyed per browser/device) rather than the wallet-scoped
+ * user-preference store.
+ *
+ * Two levels of "don't bother me":
+ *   - HIDDEN (persistent, this module): user chose "Don't show again". Survives
+ *     reloads and is the flag surfaced/toggle-able in the wallet Preferences tab.
+ *   - SNOOZED (per session, sessionStorage): user tapped "Continue in browser" or
+ *     closed the sheet. Cleared when the tab/session ends.
+ *
+ * A tiny pub/sub (custom event) lets the bottom-sheet and the Preferences toggle
+ * react to each other's changes within the same tab without a shared React
+ * context. `storage` events cover cross-tab sync for free.
+ */
+import { getGlobalPreference, saveGlobalPreference } from '../../utils/userStorage'
+
+export const INSTALL_PROMPT_HIDDEN_KEY = 'pwaInstallPromptHidden'
+const SESSION_SNOOZE_KEY = 'fw_pwa_install_snoozed'
+const CHANGE_EVENT = 'fw:pwa-install-pref-change'
+
+/** True when the user has permanently opted out of the install prompt. */
+export function isInstallPromptHidden() {
+  return getGlobalPreference(INSTALL_PROMPT_HIDDEN_KEY, false) === true
+}
+
+/** Persist the permanent opt-out flag and notify subscribers. */
+export function setInstallPromptHidden(hidden) {
+  saveGlobalPreference(INSTALL_PROMPT_HIDDEN_KEY, Boolean(hidden))
+  notify()
+}
+
+/** True when the prompt has been dismissed for the current browser session only. */
+export function isInstallPromptSnoozed() {
+  try {
+    return sessionStorage.getItem(SESSION_SNOOZE_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+/** Dismiss the prompt for the rest of this session (does not persist across reloads). */
+export function snoozeInstallPromptForSession() {
+  try {
+    sessionStorage.setItem(SESSION_SNOOZE_KEY, '1')
+  } catch {
+    // sessionStorage may be unavailable (private mode / SSR); non-fatal.
+  }
+  notify()
+}
+
+function notify() {
+  try {
+    window.dispatchEvent(new CustomEvent(CHANGE_EVENT))
+  } catch {
+    // window may be absent in non-DOM environments; non-fatal.
+  }
+}
+
+/**
+ * Subscribe to preference changes (in-tab custom event + cross-tab storage event).
+ * Returns an unsubscribe function.
+ */
+export function subscribeInstallPref(callback) {
+  const onStorage = (e) => {
+    // Only react to the global-prefs bucket (and the coarse `null` all-cleared case).
+    if (e.key === null || e.key === 'fw_global_prefs') callback()
+  }
+  window.addEventListener(CHANGE_EVENT, callback)
+  window.addEventListener('storage', onStorage)
+  return () => {
+    window.removeEventListener(CHANGE_EVENT, callback)
+    window.removeEventListener('storage', onStorage)
+  }
+}

--- a/frontend/src/lib/pwa/serviceWorkerUpdate.js
+++ b/frontend/src/lib/pwa/serviceWorkerUpdate.js
@@ -1,0 +1,131 @@
+/**
+ * Service-worker update lifecycle for the FairWins PWA.
+ *
+ * Registers the worker, watches for a newer version in the background, and exposes a
+ * small external store so React can surface an "update available" notification and let
+ * the user apply it on their terms.
+ *
+ * Flow:
+ *   1. registerServiceWorker() runs once at startup (production only).
+ *   2. The browser (and our periodic poll) fetches /sw.js; a byte-different worker
+ *      installs and parks in `waiting` behind the current controller.
+ *   3. We detect the waiting worker and flip `updateReady` → the app shows a prompt.
+ *   4. applyUpdate() posts SKIP_WAITING to the waiting worker; when it takes control
+ *      `controllerchange` fires and we reload once so the new bundle is live.
+ *
+ * The reload is gated on `userTriggeredUpdate` so the first-ever activation (which also
+ * fires controllerchange via clients.claim()) never reloads the page unexpectedly.
+ */
+
+// How often to poll for a new worker while the app is open (1 hour).
+const CHECK_INTERVAL_MS = 60 * 60 * 1000
+
+let registration = null
+let waitingWorker = null
+let updateReady = false
+let userTriggeredUpdate = false
+let reloading = false
+const listeners = new Set()
+
+function emit() {
+  listeners.forEach((l) => l())
+}
+
+function markUpdateReady(worker) {
+  waitingWorker = worker || waitingWorker
+  if (!updateReady) {
+    updateReady = true
+    emit()
+  }
+}
+
+/** Subscribe to update-state changes. Returns an unsubscribe function. */
+export function subscribe(callback) {
+  listeners.add(callback)
+  return () => listeners.delete(callback)
+}
+
+/** useSyncExternalStore snapshot: is a new version installed and waiting? */
+export function getUpdateReadySnapshot() {
+  return updateReady
+}
+
+// A worker reaching `installed` while a controller already exists means it's an update
+// waiting behind the running version (as opposed to the very first install).
+function watchInstalling(worker) {
+  if (!worker) return
+  worker.addEventListener('statechange', () => {
+    if (worker.state === 'installed' && navigator.serviceWorker.controller) {
+      markUpdateReady(worker)
+    }
+  })
+}
+
+/**
+ * Register the service worker and wire up background update detection.
+ * No-op where service workers are unavailable.
+ */
+export function registerServiceWorker() {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') return
+  if (!('serviceWorker' in navigator)) return
+
+  window.addEventListener('load', async () => {
+    try {
+      registration = await navigator.serviceWorker.register('/sw.js')
+
+      // A newer worker may already be waiting from a previous visit/tab.
+      if (registration.waiting && navigator.serviceWorker.controller) {
+        markUpdateReady(registration.waiting)
+      }
+
+      registration.addEventListener('updatefound', () => {
+        watchInstalling(registration.installing)
+      })
+
+      // Reload exactly once, and only for a user-approved update.
+      navigator.serviceWorker.addEventListener('controllerchange', () => {
+        if (!userTriggeredUpdate || reloading) return
+        reloading = true
+        window.location.reload()
+      })
+
+      // Background freshness: poll periodically and whenever the tab regains focus.
+      const check = () => {
+        registration?.update().catch(() => {})
+      }
+      setInterval(check, CHECK_INTERVAL_MS)
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') check()
+      })
+    } catch (error) {
+      console.warn('Service worker registration failed:', error)
+    }
+  })
+}
+
+/**
+ * Apply a waiting update: promote the new worker and let controllerchange reload us.
+ * @returns {boolean} true if an update was pending and has been triggered.
+ */
+export function applyUpdate() {
+  if (!waitingWorker) return false
+  userTriggeredUpdate = true
+  waitingWorker.postMessage({ type: 'SKIP_WAITING' })
+  return true
+}
+
+/** Manually poll for a new worker (e.g. a "Check for updates" button). */
+export function checkForUpdate() {
+  if (!registration) return Promise.resolve()
+  return registration.update().catch(() => {})
+}
+
+// Test-only: reset module singletons between cases.
+export function __resetForTests() {
+  registration = null
+  waitingWorker = null
+  updateReady = false
+  userTriggeredUpdate = false
+  reloading = false
+  listeners.clear()
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -52,3 +52,14 @@ createRoot(document.getElementById('root')).render(
 requestAnimationFrame(() => {
   validateTheme()
 })
+
+// Register the PWA service worker so the app is installable and works offline.
+// Dev is skipped: Vite serves modules the SW would otherwise intercept, and a stale
+// cache during HMR is a debugging footgun. Registration failures are non-fatal.
+if ('serviceWorker' in navigator && import.meta.env.PROD) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch((error) => {
+      console.warn('Service worker registration failed:', error)
+    })
+  })
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -16,6 +16,7 @@ import {
 } from './contexts'
 import ErrorBoundary from './components/ui/ErrorBoundary'
 import { validateTheme } from './utils/validateTheme'
+import { registerServiceWorker } from './lib/pwa/serviceWorkerUpdate'
 
 // Create query client for wagmi
 const queryClient = new QueryClient()
@@ -53,13 +54,10 @@ requestAnimationFrame(() => {
   validateTheme()
 })
 
-// Register the PWA service worker so the app is installable and works offline.
+// Register the PWA service worker so the app is installable, works offline, and can
+// surface a user-approved update when a new version ships (see serviceWorkerUpdate.js).
 // Dev is skipped: Vite serves modules the SW would otherwise intercept, and a stale
 // cache during HMR is a debugging footgun. Registration failures are non-fatal.
-if ('serviceWorker' in navigator && import.meta.env.PROD) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch((error) => {
-      console.warn('Service worker registration failed:', error)
-    })
-  })
+if (import.meta.env.PROD) {
+  registerServiceWorker()
 }

--- a/frontend/src/pages/WalletPage.css
+++ b/frontend/src/pages/WalletPage.css
@@ -1189,3 +1189,21 @@
 .polymarket-category-option input[type="checkbox"] {
   accent-color: #2d9cdb;
 }
+
+/* PWA install preference toggle (Preferences tab) */
+.pwa-pref-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0.75rem 0 1rem;
+  font-size: 0.92rem;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.pwa-pref-toggle input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--brand-primary, #36B37E);
+  cursor: pointer;
+}

--- a/frontend/src/pages/WalletPage.css
+++ b/frontend/src/pages/WalletPage.css
@@ -1207,3 +1207,27 @@
   accent-color: var(--brand-primary, #36B37E);
   cursor: pointer;
 }
+
+/* Software Update section (Preferences tab) */
+.pwa-update-status {
+  margin: 0.5rem 0 0.85rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary, rgba(0, 0, 0, 0.03));
+  color: var(--text-secondary);
+}
+
+.pwa-update-status.is-available {
+  border-color: color-mix(in srgb, var(--brand-primary, #36B37E) 45%, transparent);
+  background: color-mix(in srgb, var(--brand-primary, #36B37E) 12%, transparent);
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.pwa-update-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useWallet, useWalletConnection, useWalletRoles } from '../hooks'
 import { useEncryption } from '../hooks/useEncryption'
 import { useUserPreferences } from '../hooks/useUserPreferences'
+import { usePwaInstall } from '../hooks/usePwaInstall'
 import { useChainTokens } from '../hooks/useChainTokens'
 import { useModal } from '../hooks/useUI'
 import { ROLES, ROLE_INFO } from '../contexts/RoleContext'
@@ -67,6 +68,14 @@ function WalletPage() {
   const { preferences, setPolymarketCategories } = useUserPreferences()
   const { capabilities } = useChainTokens()
   const polymarketSidebetsEnabled = Boolean(capabilities?.polymarketSidebets)
+  const {
+    isStandalone: pwaStandalone,
+    canPrompt: pwaCanPrompt,
+    isIos: pwaIsIos,
+    hidden: pwaPromptHidden,
+    setHidden: setPwaPromptHidden,
+    promptInstall: pwaPromptInstall,
+  } = usePwaInstall()
   const navigate = useNavigate()
   const [activeTab, setActiveTab] = useState('account')
   // On phones the section nav is a slide-over drawer that overlays the content,
@@ -453,6 +462,48 @@ function WalletPage() {
 
                 {activeTab === 'preferences' && (
                   <div className="preferences-section" role="tabpanel">
+                    <div className="section">
+                      <h3>Install App</h3>
+                      <p className="section-description">
+                        FairWins is a progressive web app you can install to your device for
+                        quick, full-screen access — no app store, no download.
+                      </p>
+
+                      {pwaStandalone ? (
+                        <div className="key-status" role="note">
+                          FairWins is already installed and running as an app on this device.
+                        </div>
+                      ) : (
+                        <>
+                          <label className="pwa-pref-toggle">
+                            <input
+                              type="checkbox"
+                              checked={!pwaPromptHidden}
+                              onChange={(e) => setPwaPromptHidden(!e.target.checked)}
+                            />
+                            <span>Show the install prompt when I visit in a browser</span>
+                          </label>
+
+                          {pwaCanPrompt && (
+                            <button
+                              type="button"
+                              className="key-action-btn primary"
+                              onClick={pwaPromptInstall}
+                            >
+                              Install now
+                            </button>
+                          )}
+
+                          {pwaIsIos && !pwaCanPrompt && (
+                            <p className="section-description">
+                              On iOS, open the Share menu in Safari and choose{' '}
+                              <strong>Add to Home Screen</strong> to install.
+                            </p>
+                          )}
+                        </>
+                      )}
+                    </div>
+
                     <div className="section">
                       <h3>Polymarket Categories</h3>
                       <p className="section-description">

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -1,9 +1,10 @@
 import { useState, useCallback, useEffect, useMemo } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useWallet, useWalletConnection, useWalletRoles } from '../hooks'
 import { useEncryption } from '../hooks/useEncryption'
 import { useUserPreferences } from '../hooks/useUserPreferences'
 import { usePwaInstall } from '../hooks/usePwaInstall'
+import { usePwaUpdate } from '../hooks/usePwaUpdate'
 import { useChainTokens } from '../hooks/useChainTokens'
 import { useModal } from '../hooks/useUI'
 import { ROLES, ROLE_INFO } from '../contexts/RoleContext'
@@ -76,8 +77,15 @@ function WalletPage() {
     setHidden: setPwaPromptHidden,
     promptInstall: pwaPromptInstall,
   } = usePwaInstall()
+  const { updateReady: pwaUpdateReady, applyUpdate: pwaApplyUpdate, checkForUpdate: pwaCheckForUpdate } = usePwaUpdate()
+  const [pwaChecking, setPwaChecking] = useState(false)
   const navigate = useNavigate()
-  const [activeTab, setActiveTab] = useState('account')
+  const [searchParams] = useSearchParams()
+  // Allow deep-linking straight to a section (e.g. the update toast → ?tab=preferences).
+  const [activeTab, setActiveTab] = useState(() => {
+    const requested = searchParams.get('tab')
+    return WALLET_TABS.some((t) => t.id === requested) ? requested : 'account'
+  })
   // On phones the section nav is a slide-over drawer that overlays the content,
   // so it starts closed; on wider screens it stays docked open like a portal.
   const [isMobile, setIsMobile] = useState(
@@ -209,6 +217,25 @@ function WalletPage() {
     setActiveTab(id)
     if (isMobile) setSidebarOpen(false)
   }, [isMobile])
+
+  const handleCheckForUpdate = useCallback(async () => {
+    setPwaChecking(true)
+    try {
+      await pwaCheckForUpdate()
+    } finally {
+      setPwaChecking(false)
+    }
+  }, [pwaCheckForUpdate])
+
+  // When routed here from the update toast (#pwa-update), reveal the section.
+  useEffect(() => {
+    if (activeTab !== 'preferences') return
+    if (typeof window === 'undefined' || window.location.hash !== '#pwa-update') return
+    const id = window.setTimeout(() => {
+      document.getElementById('pwa-update')?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }, 50)
+    return () => window.clearTimeout(id)
+  }, [activeTab])
 
   const selectedPolymarketCategories = useMemo(
     () => preferences?.polymarketCategories || [],
@@ -502,6 +529,44 @@ function WalletPage() {
                           )}
                         </>
                       )}
+                    </div>
+
+                    <div className="section" id="pwa-update">
+                      <h3>Software Update</h3>
+                      <p className="section-description">
+                        FairWins checks for new versions automatically in the background.
+                        When an update is ready you can install it here — it takes a moment
+                        and reloads the app.
+                      </p>
+
+                      <div
+                        className={`pwa-update-status ${pwaUpdateReady ? 'is-available' : 'is-current'}`}
+                        role="status"
+                      >
+                        {pwaUpdateReady
+                          ? 'A new version is available.'
+                          : "You're running the latest version."}
+                      </div>
+
+                      <div className="pwa-update-buttons">
+                        {pwaUpdateReady && (
+                          <button
+                            type="button"
+                            className="key-action-btn primary"
+                            onClick={pwaApplyUpdate}
+                          >
+                            Update now
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          className="key-action-btn secondary"
+                          onClick={handleCheckForUpdate}
+                          disabled={pwaChecking}
+                        >
+                          {pwaChecking ? 'Checking…' : 'Check for updates'}
+                        </button>
+                      </div>
                     </div>
 
                     <div className="section">


### PR DESCRIPTION
## Summary

Makes FairWins an installable progressive web app and closes the loop on the app lifecycle: prompt visitors to **install**, then keep the installed app **up to date** with a controlled, user-approved update flow.

1. **Install** — when a visitor arrives and the app is **not** running standalone, a bottom-sheet (mobile) / centered card (desktop) invites them to install. They can install, continue in the browser (session dismiss), or opt out permanently with **Don't show again**. The show/hide preference is also in the wallet **Preferences** tab.
2. **Update** — the app checks for a new version in the background. When one is ready, a dismissible toast routes the user to the **Software Update** section of Preferences, where they click **Update now** to activate the new version and reload.

## What changed

**PWA plumbing**
- `frontend/public/manifest.webmanifest` — web app manifest (name, icons, `display: standalone`, theme/background colors).
- `frontend/public/sw.js` — minimal service worker (app-shell offline fallback, network-first). It does **not** `skipWaiting()` on install; a new version parks in `waiting` and only activates when the page posts `SKIP_WAITING`, so a live session is never swapped out from under the user.
- `frontend/index.html` — manifest link, `theme-color`, iOS `apple-mobile-web-app-*` / `apple-touch-icon` tags, `viewport-fit=cover`.
- `frontend/src/main.jsx` — registers the worker in production via the update lib.

**Install UX**
- `frontend/src/hooks/usePwaInstall.js` — captures the Chromium `beforeinstallprompt` event, detects standalone + iOS Safari (manual Add-to-Home-Screen path), exposes install/dismiss.
- `frontend/src/components/pwa/PwaInstallPrompt.{jsx,css}` — the install sheet/card. Rendered globally from `App.jsx`.
- `frontend/src/lib/pwa/installPreference.js` — **device-wide** preference store (not wallet-scoped) so anonymous first-time visitors can permanently dismiss; persistent "Don't show again" + per-session snooze, with a small pub/sub keeping the sheet and the Preferences toggle in sync.

**Update flow**
- `frontend/src/lib/pwa/serviceWorkerUpdate.js` — registers the worker, polls for a new version in the background (hourly + on tab focus), detects the waiting worker, and exposes an external store. `applyUpdate()` posts `SKIP_WAITING` and reloads once on `controllerchange` — gated on a user-triggered flag so the first-ever activation never reloads unexpectedly.
- `frontend/src/hooks/usePwaUpdate.js` — reactive `updateReady` / `applyUpdate` / `checkForUpdate`.
- `frontend/src/components/pwa/PwaUpdateNotification.{jsx,css}` — the "Update available" toast; routes to the Software Update section. Rendered globally from `App.jsx`.

**Preferences tab**
- `frontend/src/pages/WalletPage.{jsx,css}` — "Install App" section (toggle + "Install now" + iOS guidance) and "Software Update" section (status, "Update now", "Check for updates"). Deep-linkable via `?tab=preferences#pwa-update`.

**nginx**
- `nginx.conf` / `nginx.conf.template` — serve the manifest with `application/manifest+json` and keep `sw.js` revalidated (`no-cache`) instead of hard-cached, so a new worker is never stranded behind an immutable cache. CSP unchanged (manifest and SVG icons are same-origin).

## Testing

- `npm run test:frontend` — full suite green (**257 files / 2185 tests**), including new coverage:
  - `installPreference.test.js` — persistence, session snooze, pub/sub.
  - `PwaInstallPrompt.test.jsx` — reveal delay, native prompt trigger, "Continue in browser" vs "Don't show again", suppression when opted out.
  - `serviceWorkerUpdate.test.js` — update detection behind an existing controller, no false-positive on first install, `applyUpdate` → `SKIP_WAITING` → single reload, no reload on non-user-triggered `controllerchange`, `checkForUpdate` polling, already-waiting worker.
  - `PwaUpdateNotification.test.jsx` — visibility, routing to the update section, dismiss.
- `npm run build` — production build succeeds; `manifest.webmanifest` and `sw.js` ship in `dist/`.
- Verified visually in Chromium: desktop card + mobile bottom-sheet for install, and the update toast in light/dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)