### PR TITLE
feat(034/036): Tier 2 gasless group pools — factory-forwarder relayer path

### DIFF
--- a/.openzeppelin/unknown-63.json
+++ b/.openzeppelin/unknown-63.json
@@ -2253,7 +2253,7 @@
             "label": "sanctionsGuard",
             "offset": 0,
             "slot": "51",
-            "type": "t_contract(ISanctionsGuard)9004",
+            "type": "t_contract(ISanctionsGuard)22128",
             "contract": "WagerPoolFactory",
             "src": "contracts/pools/WagerPoolFactory.sol:47"
           },
@@ -2261,7 +2261,7 @@
             "label": "membershipManager",
             "offset": 0,
             "slot": "52",
-            "type": "t_contract(IMembershipManager)8938",
+            "type": "t_contract(IMembershipManager)22026",
             "contract": "WagerPoolFactory",
             "src": "contracts/pools/WagerPoolFactory.sol:50"
           },
@@ -2381,7 +2381,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(ReentrancyGuardStorage)300_storage": {
+          "t_struct(ReentrancyGuardStorage)362_storage": {
             "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
             "members": [
               {
@@ -2431,11 +2431,11 @@
             "label": "uint32[4]",
             "numberOfBytes": "32"
           },
-          "t_contract(IMembershipManager)8938": {
+          "t_contract(IMembershipManager)22026": {
             "label": "contract IMembershipManager",
             "numberOfBytes": "20"
           },
-          "t_contract(ISanctionsGuard)9004": {
+          "t_contract(ISanctionsGuard)22128": {
             "label": "contract ISanctionsGuard",
             "numberOfBytes": "20"
           },
@@ -3063,6 +3063,379 @@
               "src": "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol:21",
               "offset": 0,
               "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:43",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)26_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:62",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
+    },
+    "9b5e9b52724476e18ce7c10f8e1cdd8a0e640e77be6cce38d5c5f78d8d38a2e9": {
+      "address": "0xfB6F9F7EfD86a220eE1aD7906278247051B25430",
+      "txHash": "0xa84a0c64648d83b5338930a1ac37e1665ab48f8173bf77fa68aa354e09fc0d15",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSManaged",
+            "src": "contracts/upgradeable/UUPSManaged.sol:46"
+          },
+          {
+            "label": "poolImpl",
+            "offset": 0,
+            "slot": "50",
+            "type": "t_address",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:59"
+          },
+          {
+            "label": "sanctionsGuard",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_contract(ISanctionsGuard)9081",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:63"
+          },
+          {
+            "label": "membershipManager",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_contract(IMembershipManager)9015",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:66"
+          },
+          {
+            "label": "screeningRequired",
+            "offset": 20,
+            "slot": "52",
+            "type": "t_bool",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:70"
+          },
+          {
+            "label": "poolCount",
+            "offset": 0,
+            "slot": "53",
+            "type": "t_uint256",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:73"
+          },
+          {
+            "label": "_pools",
+            "offset": 0,
+            "slot": "54",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:75"
+          },
+          {
+            "label": "poolAddressToId",
+            "offset": 0,
+            "slot": "55",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:78"
+          },
+          {
+            "label": "_phraseToPool",
+            "offset": 0,
+            "slot": "56",
+            "type": "t_mapping(t_bytes32,t_address)",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:81"
+          },
+          {
+            "label": "_poolToPhrase",
+            "offset": 0,
+            "slot": "57",
+            "type": "t_mapping(t_address,t_array(t_uint32)4_storage)",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:82"
+          },
+          {
+            "label": "allowedToken",
+            "offset": 0,
+            "slot": "58",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:86"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "59",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:88"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_bytes32,t_bool))": {
+            "label": "mapping(address => mapping(bytes32 => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)26_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)36_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)26_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(EIP712Storage)363_storage": {
+            "label": "struct EIP712Upgradeable.EIP712Storage",
+            "members": [
+              {
+                "label": "_hashedName",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_hashedVersion",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "_version",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(InitializableStorage)147_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)300_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)26_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(SignerIntentStorage)4346_storage": {
+            "label": "struct SignerIntentBase.SignerIntentStorage",
+            "members": [
+              {
+                "label": "used",
+                "type": "t_mapping(t_address,t_mapping(t_bytes32,t_bool))",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint32)4_storage": {
+            "label": "uint32[4]",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IMembershipManager)9015": {
+            "label": "contract IMembershipManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ISanctionsGuard)9081": {
+            "label": "contract ISanctionsGuard",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_array(t_uint32)4_storage)": {
+            "label": "mapping(address => uint32[4])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_address)": {
+            "label": "mapping(bytes32 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:fairwins.storage.SignerIntentBase": [
+            {
+              "contract": "SignerIntentBase",
+              "label": "used",
+              "type": "t_mapping(t_address,t_mapping(t_bytes32,t_bool))",
+              "src": "contracts/upgradeable/SignerIntentBase.sol:33",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.EIP712": [
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedName",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:38",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedVersion",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:40",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_name",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:42",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_version",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:43",
+              "offset": 0,
+              "slot": "3"
             }
           ],
           "erc7201:openzeppelin.storage.ReentrancyGuard": [

--- a/contracts/pools/WagerPoolFactory.sol
+++ b/contracts/pools/WagerPoolFactory.sol
@@ -5,10 +5,19 @@ import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/ut
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 
 import {UUPSManaged} from "../upgradeable/UUPSManaged.sol";
+import {SignerIntentBase} from "../upgradeable/SignerIntentBase.sol";
 import {ISanctionsGuard} from "../interfaces/ISanctionsGuard.sol";
 import {IMembershipManager} from "../interfaces/IMembershipManager.sol";
 import {IWagerPoolFactory} from "./interfaces/IWagerPoolFactory.sol";
+import {IWagerPool, PayoutEntry} from "./interfaces/IWagerPool.sol";
 import {WagerPool} from "./WagerPool.sol";
+
+/// @notice Minimal surface for the pool's inherited {SignerIntentBase.invalidateNonceWithSig}, which
+///         {IWagerPool} does not re-declare. Lets the factory forward a gasless FR-006 nonce
+///         cancellation to a clone the same way it forwards the …WithSig action twins.
+interface IPoolIntentCancel {
+    function invalidateNonceWithSig(address signer, bytes32 nonce, uint256 validBefore, bytes calldata sig) external;
+}
 
 /// @title WagerPoolFactory — authority & registry for group-wager pools (spec 034, address-based)
 /// @notice The single upgradeable, state-bearing contract that clones isolated {WagerPool} instances. It
@@ -24,7 +33,7 @@ import {WagerPool} from "./WagerPool.sol";
 ///         and create/join revert otherwise (FR-021a). It also serves the pools' compliance callbacks
 ///         via {screen}/{requireMembership}. Timing mirrors the 1v1/oracle {WagerRegistry}: two absolute
 ///         deadlines (`acceptDeadline`, `resolveDeadline`), bounded + ordered by {_checkDeadlines}.
-contract WagerPoolFactory is IWagerPoolFactory, UUPSManaged, ReentrancyGuardUpgradeable {
+contract WagerPoolFactory is IWagerPoolFactory, UUPSManaged, ReentrancyGuardUpgradeable, SignerIntentBase {
     /// @notice Membership role gating pool participation, distinct from `WAGER_PARTICIPANT_ROLE`
     ///         (FR-021b).
     bytes32 public constant POOL_PARTICIPANT_ROLE = keccak256("POOL_PARTICIPANT_ROLE");
@@ -36,6 +45,13 @@ contract WagerPoolFactory is IWagerPoolFactory, UUPSManaged, ReentrancyGuardUpgr
     ///         identically (30-day accept horizon, 180-day resolve horizon).
     uint64 public constant MAX_ACCEPT_WINDOW = 30 days;
     uint64 public constant MAX_RESOLVE_WINDOW = 180 days;
+
+    /// @notice EIP-712 typehash for the gasless {createPoolWithSig} intent (spec 035/036 Tier 2). The
+    ///         factory verifies this against its OWN domain ("FairWins WagerPoolFactory"/"1"); the pool
+    ///         clones each verify the six actor twins against their own per-clone domain.
+    bytes32 private constant CREATE_POOL_TYPEHASH = keccak256(
+        "CreatePool(address creator,address token,uint256 buyIn,uint32 maxMembers,uint16 thresholdBips,uint64 acceptDeadline,uint64 resolveDeadline,bytes32 nonce,uint256 validAfter,uint256 validBefore)"
+    );
 
     // ---- Append-only storage (never insert/reorder/remove above __gap) ----
 
@@ -78,6 +94,9 @@ contract WagerPoolFactory is IWagerPoolFactory, UUPSManaged, ReentrancyGuardUpgr
     error MembershipNotConfigured();
     error MembershipDenied();
     error UnknownPhrase();
+    /// @notice A relayer forwarder was called with a `pool` this factory did not create (FR-025 on-chain
+    ///         provenance). Ids start at 1, so `poolAddressToId == 0` means unknown.
+    error UnknownPool();
 
     /// @notice Initialize the factory proxy.
     function initialize(
@@ -97,6 +116,17 @@ contract WagerPoolFactory is IWagerPoolFactory, UUPSManaged, ReentrancyGuardUpgr
         sanctionsGuard = ISanctionsGuard(sanctionsGuard_);
         membershipManager = IMembershipManager(membershipManager_);
         screeningRequired = screeningRequired_;
+        __EIP712_init("FairWins WagerPoolFactory", "1");
+    }
+
+    /// @notice Reinitializer that wires the factory's EIP-712 intent domain for an already-deployed proxy
+    ///         (spec 035/036 Tier 2). Fresh deploys get the domain in {initialize}; this in-place upgrade
+    ///         path (`upgradeToAndCall(initializeIntents)`) brings the domain to a live factory whose
+    ///         original `initialize` predates {SignerIntentBase}. Idempotent-by-version: `reinitializer(2)`
+    ///         runs exactly once. No sequential storage is added — {SignerIntentBase}/{EIP712Upgradeable}
+    ///         are ERC-7201 namespaced — so the layout stays append-only.
+    function initializeIntents() external reinitializer(2) {
+        __EIP712_init("FairWins WagerPoolFactory", "1");
     }
 
     // ---------------------------------------------------------------------
@@ -109,9 +139,51 @@ contract WagerPoolFactory is IWagerPoolFactory, UUPSManaged, ReentrancyGuardUpgr
         nonReentrant
         returns (uint256 poolId, address pool)
     {
+        return _createPool(p, msg.sender);
+    }
+
+    /// @notice Gasless {createPool} (spec 035/036 Tier 2): the pool is created for and attributed to the
+    ///         recovered EIP-712 `signer` — screened as the creator — never the relayer that submits it
+    ///         (FR-002). The factory verifies the intent against its OWN domain and burns the single-use
+    ///         nonce (FR-026/FR-027) before any pool exists; a bad/expired/replayed intent moves no funds
+    ///         and creates nothing. The self-submit {createPool} remains the primary path (FR-014). Only
+    ///         pools whose factory carries this method are gaslessly creatable.
+    function createPoolWithSig(
+        CreatePoolParams calldata p,
+        address signer,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata sig
+    ) external nonReentrant returns (uint256 poolId, address pool) {
+        bytes32 structHash = keccak256(
+            abi.encode(
+                CREATE_POOL_TYPEHASH,
+                signer,
+                p.token,
+                p.buyIn,
+                p.maxMembers,
+                p.thresholdBips,
+                p.acceptDeadline,
+                p.resolveDeadline,
+                nonce,
+                validAfter,
+                validBefore
+            )
+        );
+        _verifyIntent(structHash, signer, nonce, validAfter, validBefore, sig);
+        return _createPool(p, signer);
+    }
+
+    /// @dev Shared create path. `creator` is `msg.sender` for self-submit and the recovered signer for
+    ///      the gasless twin; screening/attribution/events all key on it (FR-002/FR-021).
+    function _createPool(CreatePoolParams calldata p, address creator)
+        internal
+        returns (uint256 poolId, address pool)
+    {
         // Screen the creator on the real wallet, before any pool exists (FR-021).
-        screen(msg.sender);
-        requireMembership(msg.sender);
+        screen(creator);
+        requireMembership(creator);
 
         if (
             p.token == address(0) || p.buyIn == 0 || p.maxMembers < 2 || p.maxMembers > MAX_MEMBERS_CAP
@@ -127,7 +199,7 @@ contract WagerPoolFactory is IWagerPoolFactory, UUPSManaged, ReentrancyGuardUpgr
         pool = Clones.clone(poolImpl);
 
         WagerPool(pool).initialize(
-            p.token, msg.sender, p.buyIn, p.maxMembers, p.thresholdBips, p.acceptDeadline, p.resolveDeadline
+            p.token, creator, p.buyIn, p.maxMembers, p.thresholdBips, p.acceptDeadline, p.resolveDeadline
         );
 
         uint32[4] memory wordIndices = _assignPhrase(poolId, pool);
@@ -138,7 +210,7 @@ contract WagerPoolFactory is IWagerPoolFactory, UUPSManaged, ReentrancyGuardUpgr
         emit PoolCreated(
             poolId,
             pool,
-            msg.sender,
+            creator,
             wordIndices,
             p.token,
             p.buyIn,
@@ -228,6 +300,150 @@ contract WagerPoolFactory is IWagerPoolFactory, UUPSManaged, ReentrancyGuardUpgr
             return;
         }
         if (!m.checkCanCreate(account, POOL_PARTICIPANT_ROLE)) revert MembershipDenied();
+    }
+
+    // ---------------------------------------------------------------------
+    // Relayer forwarders (spec 035/036 Tier 2) — route a clone's gasless twin through the STABLE
+    // factory address so ONLY the factory is whitelisted at the relayer engine (FR-025 defense-in-depth).
+    // Clones are dynamic ERC-1167 addresses the engine cannot pre-pin; forwarding here keeps the engine's
+    // receiver whitelist static AND enforces pool provenance ON-CHAIN (`poolAddressToId[pool] != 0`), so a
+    // compromised relayer/gateway can still only reach pools this factory created — never an arbitrary
+    // contract. These are PURE PASS-THROUGHS: each clone independently verifies the member's EIP-712
+    // signature against its own per-clone domain (SignerIntentBase); the factory adds no trust, only the
+    // address anchor. The self-submit + direct-to-clone paths remain available (FR-014, never-stranded).
+    // ---------------------------------------------------------------------
+
+    /// @dev On-chain provenance guard shared by every forwarder (FR-025). Ids start at 1, so a zero id
+    ///      means the address is not a pool this factory minted.
+    function _requirePool(address pool) internal view {
+        if (poolAddressToId[pool] == 0) revert UnknownPool();
+    }
+
+    /// @notice Forward a member's gasless close-joining intent to `pool` (creator action).
+    function closeJoiningWithSigFor(
+        address pool,
+        address signer,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata sig
+    ) external {
+        _requirePool(pool);
+        IWagerPool(pool).closeJoiningWithSig(signer, nonce, validAfter, validBefore, sig);
+    }
+
+    /// @notice Forward a member's gasless cancel intent to `pool` (creator action, while JoiningOpen).
+    function cancelWithSigFor(
+        address pool,
+        address signer,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata sig
+    ) external {
+        _requirePool(pool);
+        IWagerPool(pool).cancelWithSig(signer, nonce, validAfter, validBefore, sig);
+    }
+
+    /// @notice Forward a creator's gasless propose-outcome intent (full payout matrix) to `pool`.
+    function proposeOutcomeWithSigFor(
+        address pool,
+        PayoutEntry[] calldata entries,
+        address signer,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata sig
+    ) external {
+        _requirePool(pool);
+        IWagerPool(pool).proposeOutcomeWithSig(entries, signer, nonce, validAfter, validBefore, sig);
+    }
+
+    /// @notice Forward a member's gasless approve-outcome intent to `pool`. `proposalId` is pinned in the
+    ///         signed struct so a relayer cannot retarget the approval to a revised matrix (anti-rug).
+    function approveWithSigFor(
+        address pool,
+        bytes32 proposalId,
+        address signer,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata sig
+    ) external {
+        _requirePool(pool);
+        IWagerPool(pool).approveWithSig(proposalId, signer, nonce, validAfter, validBefore, sig);
+    }
+
+    /// @notice Forward a winner's gasless claim intent to `pool`. Funds go to the signer-chosen
+    ///         `recipient`; the clone binds the payout to `entries[index].winner == signer` — a relayer
+    ///         can never redirect the payout to itself. The strongest gasless case: a winner with zero gas.
+    function claimWithSigFor(
+        address pool,
+        PayoutEntry[] calldata entries,
+        uint256 index,
+        address recipient,
+        address signer,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata sig
+    ) external {
+        _requirePool(pool);
+        IWagerPool(pool).claimWithSig(entries, index, recipient, signer, nonce, validAfter, validBefore, sig);
+    }
+
+    /// @notice Forward a member's gasless refund intent to `pool` (cancelled, or unresolved past the
+    ///         resolve deadline). The buy-in returns to the signer, never the relayer.
+    function refundWithSigFor(
+        address pool,
+        address signer,
+        bytes32 nonce,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes calldata sig
+    ) external {
+        _requirePool(pool);
+        IWagerPool(pool).refundWithSig(signer, nonce, validAfter, validBefore, sig);
+    }
+
+    /// @notice Forward a member's gasless join (EIP-3009 payment authorization) to `pool`. The token
+    ///         itself enforces the authorization's `to` is the caller — here the pool clone — so USDC
+    ///         moves from `from` into the pool escrow; the factory never custodies funds. This is the one
+    ///         payment-class pool forwarder (unavailable where the stablecoin lacks EIP-3009, e.g. Mordor).
+    function joinWithAuthorizationFor(
+        address pool,
+        address from,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        _requirePool(pool);
+        IWagerPool(pool).joinWithAuthorization(from, value, validAfter, validBefore, nonce, v, r, s);
+    }
+
+    /// @notice Forward the permissionless keeper poke to `pool` (closes joining once acceptDeadline
+    ///         passes). No signature — the action is caller-independent; forwarding just lets the relayer
+    ///         submit it via the whitelisted factory instead of the un-pinned clone address.
+    function pokeDeadlineFor(address pool) external {
+        _requirePool(pool);
+        IWagerPool(pool).pokeDeadline();
+    }
+
+    /// @notice Forward a member's gasless FR-006 nonce cancellation to `pool`, so a signed-but-unsubmitted
+    ///         pool intent can be revoked without holding gas.
+    function invalidateNonceWithSigFor(
+        address pool,
+        address signer,
+        bytes32 nonce,
+        uint256 validBefore,
+        bytes calldata sig
+    ) external {
+        _requirePool(pool);
+        IPoolIntentCancel(pool).invalidateNonceWithSig(signer, nonce, validBefore, sig);
     }
 
     // ---------------------------------------------------------------------

--- a/deployments/mordor-chain63-v2.json
+++ b/deployments/mordor-chain63-v2.json
@@ -33,7 +33,7 @@
     "zkWagerPoolFactoryImpl": "0xd3e851FDDa9D5796D503daFd34b2403D7336d9fD",
     "poolImpl": "0xd0b94a77DA7Aaa488343CF89978f1Bbf9E72E277",
     "wagerPoolFactory": "0xac78B4EdeF96e74a2653028dF93A26acFCfC613F",
-    "wagerPoolFactoryImpl": "0xD69a175a0a2CD0564A62384a0687A2908DDf632c",
+    "wagerPoolFactoryImpl": "0xfB6F9F7EfD86a220eE1aD7906278247051B25430",
     "wagerRegistryIntents": "0x81a9c5904A109F0b7bC6329ba6F2be2de5B6abB1"
   },
   "mocks": {
@@ -88,5 +88,6 @@
   "zkWagerPoolsDeployedAt": "2026-07-01T00:06:05.668Z",
   "wagerPoolsDeployedAt": "2026-07-04T15:27:55.875Z",
   "poolTemplateResyncedAt": "2026-07-04T21:47:07.000Z",
-  "gaslessIntentsUpgradedAt": "2026-07-05T17:35:37.300Z"
+  "gaslessIntentsUpgradedAt": "2026-07-05T17:35:37.300Z",
+  "tier2PoolIntentsUpgradedAt": "2026-07-06T04:32:38.208Z"
 }

--- a/frontend/src/hooks/usePools.js
+++ b/frontend/src/hooks/usePools.js
@@ -19,6 +19,42 @@ import { phraseToIndices, resolvePool, indicesToPhrase } from '../lib/pools/gate
 import { deriveNickname } from '../lib/pools/nickname'
 import { payoutMatrixHash } from '../lib/pools/payout'
 import { recordJoinedPool } from '../lib/lookup/myWagersSources'
+import { useGaslessWrite } from '../lib/relay/useGaslessWrite'
+
+/** Fetch a receipt by hash, retrying briefly for relay/RPC lag (self-submit resolves on the first try). */
+async function waitReceipt(signer, txHash, tries = 8, delayMs = 1500) {
+  if (!txHash) return null
+  for (let i = 0; i < tries; i += 1) {
+    const r = await signer.provider.getTransactionReceipt(txHash)
+    if (r) return r
+    await new Promise((res) => setTimeout(res, delayMs))
+  }
+  return null
+}
+
+/** Parse the PoolCreated event from a create receipt into the hook's return shape. */
+function parsePoolCreated(receipt, factory, account) {
+  const ev = (receipt?.logs || [])
+    .map((l) => {
+      try {
+        return factory.interface.parseLog(l)
+      } catch {
+        return null
+      }
+    })
+    .find((e) => e && e.name === 'PoolCreated')
+  const wordIndices = ev ? ev.args.wordIndices.map((x) => Number(x)) : null
+  // Record the pool device-locally so My Wagers can always list it, even when the subgraph for this
+  // chain is lagging or absent (tester feedback: pools must be easy to locate again).
+  if (ev && account) recordJoinedPool(account, ev.args.pool)
+  return {
+    poolId: ev ? ev.args.poolId : null,
+    pool: ev ? ev.args.pool : null,
+    wordIndices,
+    phrase: wordIndices ? indicesToPhrase(wordIndices) : null,
+    txHash: receipt?.hash ?? null,
+  }
+}
 
 function requiredApprovals(frozenDenominator, thresholdBips) {
   if (frozenDenominator <= 0) return 0
@@ -120,6 +156,81 @@ export function usePools() {
     return { signer, chainId: Number(net.chainId), account }
   }, [signer])
 
+  // ---- Gasless seams (spec 035/036 Tier 2, factory-forwarder) ----
+  // Each pool write routes through the relayer when one is live and transparently self-submits otherwise
+  // (never-stranded, FR-014). The `selfSubmit` closure IS the original EOA path; `params` shapes the
+  // signed intent. Target resolves to the WagerPoolFactory (the action verifier key); the pool clone
+  // rides in params and — for the six actor twins — is the EIP-712 verifyingContract (domain/target
+  // split), so only the factory is ever the tx target. Behaviour-neutral on chains the relayer doesn't
+  // serve (Mordor's stablecoin lacks EIP-3009 → join self-submits; unset relayer → all self-submit).
+  const poolCreateTx = useGaslessWrite('poolCreate', {
+    params: (form, ctx) => ({
+      token: ctx.params.token,
+      buyIn: ctx.params.buyIn,
+      maxMembers: ctx.params.maxMembers,
+      thresholdBips: ctx.params.thresholdBips,
+      acceptDeadline: ctx.params.acceptDeadline,
+      resolveDeadline: ctx.params.resolveDeadline,
+    }),
+    selfSubmit: async (form, ctx) => ctx.factory.createPool(ctx.params).then((tx) => tx.wait()),
+  })
+  const joinTx = useGaslessWrite('poolJoin', {
+    params: (poolAddress) => ({ pool: poolAddress }),
+    payment: (poolAddress, summary) => ({ value: summary.buyIn }),
+    selfSubmit: async (poolAddress, summary, account) => {
+      const { signer: s } = await requireSigner()
+      const token = new ethers.Contract(summary.tokenAddress, ERC20_ABI, s)
+      const allowance = await token.allowance(account, poolAddress)
+      if (allowance < summary.buyIn) await (await token.approve(poolAddress, summary.buyIn)).wait()
+      return (await getPool(poolAddress, s).join()).wait()
+    },
+  })
+  const closeJoiningTx = useGaslessWrite('poolCloseJoining', {
+    params: (poolAddress) => ({ pool: poolAddress }),
+    selfSubmit: async (poolAddress) => {
+      const { signer: s } = await requireSigner()
+      return (await getPool(poolAddress, s).closeJoining()).wait()
+    },
+  })
+  const cancelTx = useGaslessWrite('poolCancel', {
+    params: (poolAddress) => ({ pool: poolAddress }),
+    selfSubmit: async (poolAddress) => {
+      const { signer: s } = await requireSigner()
+      return (await getPool(poolAddress, s).cancel()).wait()
+    },
+  })
+  const proposeTx = useGaslessWrite('poolProposeOutcome', {
+    params: (poolAddress, entries) => ({ pool: poolAddress, entries, proposalId: payoutMatrixHash(entries) }),
+    selfSubmit: async (poolAddress, entries) => {
+      const { signer: s } = await requireSigner()
+      return (await getPool(poolAddress, s).proposeOutcome(entries)).wait()
+    },
+  })
+  const approveTx = useGaslessWrite('poolApprove', {
+    params: (poolAddress, proposalId) => ({ pool: poolAddress, proposalId }),
+    selfSubmit: async (poolAddress, proposalId, step) => {
+      const { signer: s } = await requireSigner()
+      step?.('Confirm the approval in your wallet…')
+      const tx = await getPool(poolAddress, s).approve()
+      step?.('Submitting your approval on-chain…')
+      return tx.wait()
+    },
+  })
+  const claimTx = useGaslessWrite('poolClaim', {
+    params: (poolAddress, entries, index, recipient) => ({ pool: poolAddress, entries, index, recipient }),
+    selfSubmit: async (poolAddress, entries, index, recipient) => {
+      const { signer: s } = await requireSigner()
+      return (await getPool(poolAddress, s).claim(entries, index, recipient)).wait()
+    },
+  })
+  const refundTx = useGaslessWrite('poolRefund', {
+    params: (poolAddress) => ({ pool: poolAddress }),
+    selfSubmit: async (poolAddress) => {
+      const { signer: s } = await requireSigner()
+      return (await getPool(poolAddress, s).refund()).wait()
+    },
+  })
+
   /**
    * Create a pool. `form`: { buyIn, maxMembers, thresholdPct, token?, acceptDeadline, resolveDeadline,
    * joinDays?, resolutionDays? }. The create UI passes exact instants from the shared DeadlineTimeline —
@@ -156,35 +267,20 @@ export function usePools() {
         acceptDeadline,
         resolveDeadline,
       }
-      const tx = await factory.createPool(params)
-      const receipt = await tx.wait()
-      const ev = receipt.logs
-        .map((l) => {
-          try {
-            return factory.interface.parseLog(l)
-          } catch {
-            return null
-          }
-        })
-        .find((e) => e && e.name === 'PoolCreated')
-      const wordIndices = ev ? ev.args.wordIndices.map((x) => Number(x)) : null
-      // Record the pool device-locally so My Wagers can always list it, even when the subgraph for this
-      // chain is lagging or absent (tester feedback: pools must be easy to locate again).
-      if (ev) recordJoinedPool(account, ev.args.pool)
+      // Gasless when a relayer is live (createPoolWithSig, attributed to the signer), else self-submit.
+      const result = await poolCreateTx.run(form, { factory, params, account })
+      if (result?.error) throw result.error
+      // run() surfaces only a txHash; re-read the receipt to recover the pool address + share phrase
+      // (the PoolCreated event) uniformly across the relay and self-submit paths.
+      const receipt = await waitReceipt(s, result.txHash)
       setStatus('idle')
-      return {
-        poolId: ev ? ev.args.poolId : null,
-        pool: ev ? ev.args.pool : null,
-        wordIndices,
-        phrase: wordIndices ? indicesToPhrase(wordIndices) : null,
-        txHash: receipt.hash,
-      }
+      return parsePoolCreated(receipt, factory, account)
     } catch (e) {
       setStatus('error')
       setError(e?.shortMessage || e?.message || String(e))
       throw e
     }
-  }, [requireSigner])
+  }, [requireSigner, poolCreateTx])
 
   /** Resolve a four-word phrase to a pool summary, or null if it maps to no pool. */
   const resolvePhrase = useCallback(async (phrase, lang = 'en') => {
@@ -205,32 +301,29 @@ export function usePools() {
     return summarizePool(getPool(address, s), account)
   }, [requireSigner])
 
-  /** Join a pool: approve the buy-in, then join with your wallet (no identity/proof). */
+  /**
+   * Join a pool. Gasless via EIP-3009 (joinWithAuthorization → the factory forwarder) where the chain's
+   * stablecoin supports it AND a relayer is live; otherwise the classic approve-then-join self-submit
+   * (also the fallback on Mordor, whose stablecoin lacks EIP-3009). One signature vs two txs when gasless.
+   */
   const joinPool = useCallback(async (poolAddress) => {
     setStatus('joining')
     setError(null)
     try {
       const { signer: s, account } = await requireSigner()
-      const pool = getPool(poolAddress, s)
-      const summary = await summarizePool(pool, account)
-      const token = new ethers.Contract(summary.tokenAddress, ERC20_ABI, s)
-      const allowance = await token.allowance(account, poolAddress)
-      if (allowance < summary.buyIn) {
-        const approveTx = await token.approve(poolAddress, summary.buyIn)
-        await approveTx.wait()
-      }
-      const tx = await pool.join()
-      const receipt = await tx.wait()
+      const summary = await summarizePool(getPool(poolAddress, s), account)
+      const result = await joinTx.run(poolAddress, summary, account)
+      if (result?.error) throw result.error
       // Record the join device-locally so EVERY join path makes the pool findable in My Wagers.
       recordJoinedPool(account, poolAddress)
       setStatus('idle')
-      return { txHash: receipt.hash }
+      return { txHash: result.txHash }
     } catch (e) {
       setStatus('error')
       setError(e?.shortMessage || e?.message || String(e))
       throw e
     }
-  }, [requireSigner])
+  }, [requireSigner, joinTx])
 
   /**
    * The pool roster: member wallet addresses from `Joined(address)` events, each with a deterministic
@@ -286,38 +379,38 @@ export function usePools() {
     }
   }, [requireSigner])
 
-  /** Creator: close joining early (freezes the denominator). */
+  /** Creator: close joining early (freezes the denominator). Gasless when a relayer is live. */
   const closeJoining = useCallback(async (poolAddress) => {
-    const { signer: s } = await requireSigner()
-    const tx = await getPool(poolAddress, s).closeJoining()
-    return (await tx.wait()).hash
-  }, [requireSigner])
+    const result = await closeJoiningTx.run(poolAddress)
+    if (result?.error) throw result.error
+    return result.txHash
+  }, [closeJoiningTx])
 
-  /** Anyone: close joining once the accept deadline has passed. */
+  /** Anyone: close joining once the accept deadline has passed (permissionless keeper — self-submit). */
   const pokeDeadline = useCallback(async (poolAddress) => {
     const { signer: s } = await requireSigner()
     const tx = await getPool(poolAddress, s).pokeDeadline()
     return (await tx.wait()).hash
   }, [requireSigner])
 
-  /** Creator: cancel a pool before it fills (members can then refund). */
+  /** Creator: cancel a pool before it fills (members can then refund). Gasless when a relayer is live. */
   const cancelPool = useCallback(async (poolAddress) => {
-    const { signer: s } = await requireSigner()
-    const tx = await getPool(poolAddress, s).cancel()
-    return (await tx.wait()).hash
-  }, [requireSigner])
+    const result = await cancelTx.run(poolAddress)
+    if (result?.error) throw result.error
+    return result.txHash
+  }, [cancelTx])
 
   /**
    * Creator: propose (or revise) the payout outcome by committing the FULL payout matrix. The contract
    * validates it on-chain (non-empty, non-zero winners, amounts sum to the exact escrow) and emits it, so
    * every member can read the split from the chain before approving. `entries` is a `{winner, amount}[]`
-   * array; the on-chain `proposalId` = keccak256(abi.encode(entries)).
+   * array; the on-chain `proposalId` = keccak256(abi.encode(entries)). Gasless when a relayer is live.
    */
   const proposeOutcome = useCallback(async (poolAddress, entries) => {
-    const { signer: s } = await requireSigner()
-    const tx = await getPool(poolAddress, s).proposeOutcome(entries)
-    return (await tx.wait()).hash
-  }, [requireSigner])
+    const result = await proposeTx.run(poolAddress, entries)
+    if (result?.error) throw result.error
+    return result.txHash
+  }, [proposeTx])
 
   /**
    * Member: approve the current proposal with your wallet (one approval per member per proposal). Plain
@@ -329,23 +422,22 @@ export function usePools() {
     setError(null)
     try {
       const { signer: s } = await requireSigner()
-      const pool = getPool(poolAddress, s)
-      const proposalId = await pool.currentProposalId()
+      // Pin the CURRENT proposalId the member is approving — approveWithSig binds it so a relayer can
+      // never retarget the approval to a matrix the member never saw (anti-rug).
+      const proposalId = await getPool(poolAddress, s).currentProposalId()
       if (!proposalId || proposalId === ethers.ZeroHash) {
         throw new Error('There is no proposed payout to approve yet.')
       }
-      step('Confirm the approval in your wallet…')
-      const tx = await pool.approve()
-      step('Submitting your approval on-chain…')
-      const hash = (await tx.wait()).hash
+      const result = await approveTx.run(poolAddress, proposalId, step)
+      if (result?.error) throw result.error
       setStatus('idle')
-      return hash
+      return result.txHash
     } catch (e) {
       setStatus('error')
       setError(e?.shortMessage || e?.message || String(e))
       throw e
     }
-  }, [requireSigner])
+  }, [requireSigner, approveTx])
 
   /**
    * Winner: claim a share to `recipient`. `entries` is the payout-matrix preimage (shared by the creator);
@@ -355,35 +447,34 @@ export function usePools() {
     setStatus('claiming')
     setError(null)
     try {
-      const { signer: s } = await requireSigner()
-      const pool = getPool(poolAddress, s)
-      const tx = await pool.claim(entries, index, recipient)
-      const hash = (await tx.wait()).hash
+      // Strongest gasless case: a winner holding zero gas. claimWithSig binds (index, recipient) to the
+      // signer, so the relayer can never redirect the payout to itself.
+      const result = await claimTx.run(poolAddress, entries, index, recipient)
+      if (result?.error) throw result.error
       setStatus('idle')
-      return hash
+      return result.txHash
     } catch (e) {
       setStatus('error')
       setError(e?.shortMessage || e?.message || String(e))
       throw e
     }
-  }, [requireSigner])
+  }, [claimTx])
 
-  /** Member: recover the buy-in after a timeout or cancellation. */
+  /** Member: recover the buy-in after a timeout or cancellation. Gasless (a stranded member has no gas). */
   const refund = useCallback(async (poolAddress) => {
     setStatus('refunding')
     setError(null)
     try {
-      const { signer: s } = await requireSigner()
-      const tx = await getPool(poolAddress, s).refund()
-      const hash = (await tx.wait()).hash
+      const result = await refundTx.run(poolAddress)
+      if (result?.error) throw result.error
       setStatus('idle')
-      return hash
+      return result.txHash
     } catch (e) {
       setStatus('error')
       setError(e?.shortMessage || e?.message || String(e))
       throw e
     }
-  }, [requireSigner])
+  }, [refundTx])
 
   return {
     status,

--- a/frontend/src/hooks/usePools.js
+++ b/frontend/src/hooks/usePools.js
@@ -271,10 +271,15 @@ export function usePools() {
       const result = await poolCreateTx.run(form, { factory, params, account })
       if (result?.error) throw result.error
       // run() surfaces only a txHash; re-read the receipt to recover the pool address + share phrase
-      // (the PoolCreated event) uniformly across the relay and self-submit paths.
-      const receipt = await waitReceipt(s, result.txHash)
+      // (the PoolCreated event) uniformly across the relay and self-submit paths. A relayed tx can lag
+      // well behind its ACK, so poll generously (~90s) — losing the receipt means losing the pool's
+      // address + share phrase + the device-local record, while the escrow has already succeeded.
+      const receipt = await waitReceipt(s, result.txHash, 45, 2000)
       setStatus('idle')
-      return parsePoolCreated(receipt, factory, account)
+      const parsed = parsePoolCreated(receipt, factory, account)
+      // Never drop the txHash even if the receipt hasn't landed in time — the UI needs it to show a
+      // pending pool the user can recover, not an all-null result that reads as a failure.
+      return { ...parsed, txHash: parsed.txHash ?? result.txHash ?? null }
     } catch (e) {
       setStatus('error')
       setError(e?.shortMessage || e?.message || String(e))

--- a/frontend/src/lib/relay/__tests__/poolIntents.test.js
+++ b/frontend/src/lib/relay/__tests__/poolIntents.test.js
@@ -1,0 +1,156 @@
+/**
+ * Tier-2 group-pool intent tests (spec 035/036, factory-forwarder).
+ *
+ * Covers the pool-specific machinery layered onto signIntent:
+ *  - the three-place byte-identical typehash rule (client structs == on-chain typehashes, CLAUDE.md);
+ *  - the domain/target SPLIT: the six actor twins sign under the CLONE's domain but target the factory,
+ *    createPool signs under the FACTORY's domain;
+ *  - pool join (authOnly): no intent struct, the EIP-3009 authorization is the whole intent and its
+ *    `to` is the clone (not the factory).
+ */
+import { describe, it, expect } from 'vitest'
+import { ethers } from 'ethers'
+import { signIntent } from '../intentClient'
+import { INTENT_TYPES, wagerPoolDomain, wagerPoolFactoryDomain } from '../intentTypes'
+
+const FACTORY = ethers.getAddress('0x' + 'fa'.repeat(20))
+const POOL = ethers.getAddress('0x' + 'c1'.repeat(20))
+
+/** EIP-712 encodeType for a flat struct (no nested custom types) — the on-chain typehash preimage. */
+const encodeType = (name, fields) => `${name}(${fields.map((f) => `${f.type} ${f.name}`).join(',')})`
+
+// The canonical typehash strings from contracts/pools/WagerPool.sol + WagerPoolFactory.sol. If a client
+// struct drifts from these, relays silently fail signature recovery — so pin them here.
+const CONTRACT_TYPEHASHES = {
+  ApproveOutcome: 'ApproveOutcome(address member,bytes32 proposalId,bytes32 nonce,uint256 validAfter,uint256 validBefore)',
+  ClaimShare: 'ClaimShare(address winner,uint256 index,address recipient,bytes32 nonce,uint256 validAfter,uint256 validBefore)',
+  ProposeOutcome: 'ProposeOutcome(address creator,bytes32 proposalId,bytes32 nonce,uint256 validAfter,uint256 validBefore)',
+  CloseJoining: 'CloseJoining(address creator,bytes32 nonce,uint256 validAfter,uint256 validBefore)',
+  Cancel: 'Cancel(address creator,bytes32 nonce,uint256 validAfter,uint256 validBefore)',
+  Refund: 'Refund(address member,bytes32 nonce,uint256 validAfter,uint256 validBefore)',
+  CreatePool:
+    'CreatePool(address creator,address token,uint256 buyIn,uint32 maxMembers,uint16 thresholdBips,uint64 acceptDeadline,uint64 resolveDeadline,bytes32 nonce,uint256 validAfter,uint256 validBefore)',
+}
+
+function makeSigner(address = '0x00000000000000000000000000000000000000bb') {
+  const calls = []
+  return {
+    calls,
+    getAddress: async () => address,
+    signTypedData: async (domain, types, message) => {
+      calls.push({ domain, types, message })
+      return '0x' + '11'.repeat(32) + '22'.repeat(32) + '1b'
+    },
+  }
+}
+
+describe('Tier-2 pool intents', () => {
+  describe('three-place typehash parity (client == contract)', () => {
+    for (const [name, expected] of Object.entries(CONTRACT_TYPEHASHES)) {
+      it(`${name} struct matches the on-chain typehash`, () => {
+        expect(INTENT_TYPES[name]).toBeDefined()
+        expect(encodeType(name, INTENT_TYPES[name])).toBe(expected)
+      })
+    }
+  })
+
+  describe('domain/target split', () => {
+    it('poolApprove — signs under the CLONE domain, targets the FACTORY', async () => {
+      const signer = makeSigner()
+      const proposalId = '0x' + 'ab'.repeat(32)
+      const intent = await signIntent({
+        signer,
+        chainId: 137,
+        action: 'poolApprove',
+        targetContract: FACTORY,
+        params: { pool: POOL, proposalId },
+        nowSeconds: 1_000_000,
+      })
+      // Body targets the factory (the pinned + whitelisted address).
+      expect(intent.targetContract).toBe(FACTORY)
+      expect(intent.intentClass).toBe('signer-attributed')
+      expect(intent.params.pool).toBe(POOL)
+      expect(intent.params.proposalId).toBe(proposalId)
+      // ...but the single wallet prompt is under the CLONE's domain.
+      expect(signer.calls).toHaveLength(1)
+      expect(signer.calls[0].domain).toEqual(wagerPoolDomain(137, POOL))
+      expect(Object.keys(signer.calls[0].types)).toEqual(['ApproveOutcome'])
+      expect(signer.calls[0].message.member).toBe(await signer.getAddress())
+    })
+
+    it('poolCreate — signs under the FACTORY domain (no clone exists yet)', async () => {
+      const signer = makeSigner()
+      const intent = await signIntent({
+        signer,
+        chainId: 137,
+        action: 'poolCreate',
+        targetContract: FACTORY,
+        params: {
+          token: '0x0000000000000000000000000000000000000dead',
+          buyIn: 10_000_000n,
+          maxMembers: 5,
+          thresholdBips: 6000,
+          acceptDeadline: 2_000_000,
+          resolveDeadline: 3_000_000,
+        },
+        nowSeconds: 1_000_000,
+      })
+      expect(intent.targetContract).toBe(FACTORY)
+      expect(signer.calls[0].domain).toEqual(wagerPoolFactoryDomain(137, FACTORY))
+      expect(signer.calls[0].message.creator).toBe(await signer.getAddress())
+      expect(intent.params.buyIn).toBe('10000000') // JSON-safe
+    })
+  })
+
+  describe('pool join (authOnly)', () => {
+    it('carries only the EIP-3009 authorization (to = clone), no intent struct', async () => {
+      const signer = makeSigner()
+      const intent = await signIntent({
+        signer,
+        chainId: 137,
+        action: 'poolJoin',
+        targetContract: FACTORY,
+        params: { pool: POOL },
+        payment: { value: 10_000_000n },
+        nowSeconds: 1_000_000,
+      })
+      expect(intent.intentClass).toBe('payment')
+      expect(intent.targetContract).toBe(FACTORY)
+      expect(intent.signature).toBe('0x') // no intent-struct signature
+      expect(intent.params).toEqual({ pool: POOL }) // raw params only
+      // Exactly one wallet prompt: the token's ReceiveWithAuthorization, paying INTO the clone.
+      expect(signer.calls).toHaveLength(1)
+      expect(signer.calls[0].message.to).toBe(POOL)
+      expect(intent.authorization.to).toBe(POOL)
+      expect(intent.authorization.nonce).toBe(intent.uniquenessMarker)
+    })
+  })
+
+  describe('frontend↔contract signature parity (real wallet)', () => {
+    it('poolClaim recovers to the signer under the CLONE domain + ClaimShare struct', async () => {
+      const wallet = new ethers.Wallet('0x' + '11'.repeat(32))
+      const recipient = '0x0000000000000000000000000000000000005555'
+      const intent = await signIntent({
+        signer: wallet,
+        chainId: 137,
+        action: 'poolClaim',
+        targetContract: FACTORY,
+        params: { pool: POOL, index: 0, recipient },
+        nowSeconds: 1_000_000,
+        validitySeconds: 600,
+      })
+      const domain = wagerPoolDomain(137, POOL)
+      const types = { ClaimShare: INTENT_TYPES.ClaimShare }
+      const message = {
+        winner: wallet.address,
+        index: 0,
+        recipient,
+        nonce: intent.uniquenessMarker,
+        validAfter: 0,
+        validBefore: 1_000_600,
+      }
+      const recovered = ethers.verifyTypedData(domain, types, message, intent.signature)
+      expect(recovered).toBe(wallet.address)
+    })
+  })
+})

--- a/frontend/src/lib/relay/intentClient.js
+++ b/frontend/src/lib/relay/intentClient.js
@@ -19,6 +19,8 @@ import {
   RECEIVE_WITH_AUTHORIZATION_TYPES,
   membershipManagerDomain,
   stablecoinDomain,
+  wagerPoolDomain,
+  wagerPoolFactoryDomain,
   wagerRegistryDomain,
 } from './intentTypes'
 import { PaymentUnsupportedOnChain, RelayRejected, RelayerUnavailable } from './errors'
@@ -44,13 +46,30 @@ function toUintString(v) {
   return String(v)
 }
 
-/** Shallow-serialize signed params for the gateway body (bigints → decimal strings). */
+/** Serialize signed params for the gateway body — DEEP (bigints → decimal strings), so nested arrays
+ *  like a pool payout matrix ([{ winner, amount: bigint }]) survive JSON.stringify. */
 function serializeParams(params) {
-  const out = {}
-  for (const [key, value] of Object.entries(params || {})) {
-    out[key] = typeof value === 'bigint' ? value.toString() : value
+  const conv = (v) => {
+    if (typeof v === 'bigint') return v.toString()
+    if (Array.isArray(v)) return v.map(conv)
+    if (v && typeof v === 'object') return Object.fromEntries(Object.entries(v).map(([k, x]) => [k, conv(x)]))
+    return v
   }
-  return out
+  return conv(params || {})
+}
+
+/** Resolve an intent's EIP-712 domain by verifier/domain key (the pool split adds wagerPool[Factory]). */
+function buildIntentDomain(kind, chainId, verifyingContract) {
+  switch (kind) {
+    case 'membershipManager':
+      return membershipManagerDomain(chainId, verifyingContract)
+    case 'wagerPool':
+      return wagerPoolDomain(chainId, verifyingContract)
+    case 'wagerPoolFactory':
+      return wagerPoolFactoryDomain(chainId, verifyingContract)
+    default:
+      return wagerRegistryDomain(chainId, verifyingContract)
+  }
 }
 
 /** `fetch` with a bounded budget; any transport failure or timeout maps to RelayerUnavailable. */
@@ -127,11 +146,19 @@ export async function signIntent({
   if (chainId == null) throw new Error('signIntent: chainId is required')
 
   const verifierKind = verifier || meta.verifier
-  if (!verifierKind) throw new Error(`signIntent: action '${action}' needs an explicit verifier ('wagerRegistry' | 'membershipManager')`)
-  const domain =
-    verifierKind === 'membershipManager'
-      ? membershipManagerDomain(chainId, targetContract)
-      : wagerRegistryDomain(chainId, targetContract)
+  if (!verifierKind) throw new Error(`signIntent: action '${action}' needs an explicit verifier`)
+
+  // Pool join (`authOnly`) carries no signer-attributed intent struct — the EIP-3009 authorization IS
+  // the whole intent (attribution + binding), so there is no action-domain signature to build.
+  const isAuthOnly = !!meta.authOnly
+
+  // Domain/target SPLIT (Tier-2 pools): the intent TARGET is `targetContract` (the factory, pinned +
+  // whitelisted at the engine), but the signature may verify under a DIFFERENT contract's domain — the
+  // CLONE for the six actor twins (verifyingContract = params[verifyingContractParam]), the FACTORY for
+  // createPool, else the target itself. Non-pool actions keep the original behavior (domain == target).
+  const domainKind = meta.domainVerifier || verifierKind
+  const domainVerifyingContract = meta.verifyingContractParam ? params[meta.verifyingContractParam] : targetContract
+  const domain = isAuthOnly ? null : buildIntentDomain(domainKind, chainId, domainVerifyingContract)
 
   // FR-020: resolve the token domain BEFORE any wallet prompt — throws PaymentUnsupportedOnChain on
   // chains whose stablecoin lacks EIP-3009 (Mordor/ETC USC), so the flow self-submits with zero
@@ -143,11 +170,11 @@ export async function signIntent({
   const before = validBefore != null ? validBefore : now + validitySeconds
   const nonce = randomNonce()
 
-  const fields = INTENT_TYPES[meta.primaryType]
+  const fields = isAuthOnly ? [] : INTENT_TYPES[meta.primaryType]
   const hasField = (name) => fields.some((f) => f.name === name)
 
   // The actor field is ALWAYS the wallet's own address — signer attribution is not caller-spoofable.
-  const message = { ...params, [meta.actorField]: from }
+  const message = isAuthOnly ? {} : { ...params, [meta.actorField]: from }
 
   // Payment leg: sign the token's ReceiveWithAuthorization and staple its nonce into the struct.
   // ONE marker for the whole payment intent (data-model.md: the uniquenessMarker IS the EIP-3009
@@ -160,7 +187,9 @@ export async function signIntent({
     const paymentNonce = nonce
     const authMessage = {
       from,
-      to: targetContract,
+      // Money is bound to the pinned target by default; for a pool join it flows into the CLONE
+      // (`authToParam: 'pool'`), which the token enforces is the caller so a relayer can't redirect it.
+      to: meta.authToParam ? params[meta.authToParam] : targetContract,
       value: toUintString(payment.value),
       validAfter,
       validBefore: before,
@@ -173,18 +202,23 @@ export async function signIntent({
     if (hasField('paymentNonce')) message.paymentNonce = paymentNonce
   }
 
-  message.nonce = nonce
-  if (hasField('validAfter')) message.validAfter = validAfter
-  message.validBefore = before
+  if (!isAuthOnly) {
+    message.nonce = nonce
+    if (hasField('validAfter')) message.validAfter = validAfter
+    message.validBefore = before
+  }
 
-  const signature = await signer.signTypedData(domain, { [meta.primaryType]: fields }, message)
+  const signature = isAuthOnly
+    ? '0x'
+    : await signer.signTypedData(domain, { [meta.primaryType]: fields }, message)
 
   const intent = {
     intentClass: meta.intentClass,
     chainId: Number(chainId),
     targetContract,
     action,
-    params: serializeParams(message),
+    // authOnly: the body params are the raw action params (e.g. { pool }); no struct fields to emit.
+    params: serializeParams(isAuthOnly ? params : message),
     signature,
     validAfter,
     validBefore: before,

--- a/frontend/src/lib/relay/intentTypes.js
+++ b/frontend/src/lib/relay/intentTypes.js
@@ -114,6 +114,48 @@ export const INTENT_TYPES = {
     { name: 'nonce', type: 'bytes32' },
     { name: 'validBefore', type: 'uint256' },
   ],
+
+  // ---- Tier-2 group pools (spec 035/036) ----
+  // Byte-identical to the on-chain typehashes: the six actor twins verify against the CLONE's domain,
+  // CreatePool against the FACTORY's. `pool`/`entries` ride in intent.params (calldata), NOT the struct.
+  ApproveOutcome: [
+    { name: 'member', type: 'address' },
+    { name: 'proposalId', type: 'bytes32' },
+    ...TRAILING,
+  ],
+  ClaimShare: [
+    { name: 'winner', type: 'address' },
+    { name: 'index', type: 'uint256' },
+    { name: 'recipient', type: 'address' },
+    ...TRAILING,
+  ],
+  ProposeOutcome: [
+    { name: 'creator', type: 'address' },
+    { name: 'proposalId', type: 'bytes32' },
+    ...TRAILING,
+  ],
+  CloseJoining: [
+    { name: 'creator', type: 'address' },
+    ...TRAILING,
+  ],
+  Cancel: [
+    { name: 'creator', type: 'address' },
+    ...TRAILING,
+  ],
+  Refund: [
+    { name: 'member', type: 'address' },
+    ...TRAILING,
+  ],
+  CreatePool: [
+    { name: 'creator', type: 'address' },
+    { name: 'token', type: 'address' },
+    { name: 'buyIn', type: 'uint256' },
+    { name: 'maxMembers', type: 'uint32' },
+    { name: 'thresholdBips', type: 'uint16' },
+    { name: 'acceptDeadline', type: 'uint64' },
+    { name: 'resolveDeadline', type: 'uint64' },
+    ...TRAILING,
+  ],
 }
 
 /**
@@ -142,6 +184,22 @@ export const INTENT_ACTIONS = {
   extendMembership: { primaryType: 'ExtendMembershipIntent', verifier: 'membershipManager', intentClass: 'payment', actorField: 'member' },
   redeemVoucher: { primaryType: 'RedeemVoucherIntent', verifier: 'membershipManager', intentClass: 'signer-attributed', actorField: 'redeemer' },
   invalidateNonce: { primaryType: 'InvalidateNonce', verifier: null, intentClass: 'signer-attributed', actorField: 'signer' },
+
+  // ---- Tier-2 group pools (spec 035/036, factory-forwarder) ----
+  // `verifier` = the getContractAddressForChain KEY that resolves the intent TARGET (the factory, whose
+  //   forwarder the relayer calls — the only whitelisted pool address). `domainVerifier` = the EIP-712
+  //   domain the signature is verified under; `verifyingContractParam` names the param holding the
+  //   verifyingContract (the CLONE) — the domain/target SPLIT. The six actor twins sign under the clone;
+  //   createPool signs under the factory. `authOnly` (poolJoin) = no intent struct, the EIP-3009
+  //   authorization is the whole intent; `authToParam` binds the money to the clone, not the factory.
+  poolCloseJoining: { primaryType: 'CloseJoining', verifier: 'wagerPoolFactory', domainVerifier: 'wagerPool', verifyingContractParam: 'pool', intentClass: 'signer-attributed', actorField: 'creator' },
+  poolCancel: { primaryType: 'Cancel', verifier: 'wagerPoolFactory', domainVerifier: 'wagerPool', verifyingContractParam: 'pool', intentClass: 'signer-attributed', actorField: 'creator' },
+  poolRefund: { primaryType: 'Refund', verifier: 'wagerPoolFactory', domainVerifier: 'wagerPool', verifyingContractParam: 'pool', intentClass: 'signer-attributed', actorField: 'member' },
+  poolApprove: { primaryType: 'ApproveOutcome', verifier: 'wagerPoolFactory', domainVerifier: 'wagerPool', verifyingContractParam: 'pool', intentClass: 'signer-attributed', actorField: 'member' },
+  poolProposeOutcome: { primaryType: 'ProposeOutcome', verifier: 'wagerPoolFactory', domainVerifier: 'wagerPool', verifyingContractParam: 'pool', intentClass: 'signer-attributed', actorField: 'creator' },
+  poolClaim: { primaryType: 'ClaimShare', verifier: 'wagerPoolFactory', domainVerifier: 'wagerPool', verifyingContractParam: 'pool', intentClass: 'signer-attributed', actorField: 'winner' },
+  poolCreate: { primaryType: 'CreatePool', verifier: 'wagerPoolFactory', domainVerifier: 'wagerPoolFactory', intentClass: 'signer-attributed', actorField: 'creator' },
+  poolJoin: { verifier: 'wagerPoolFactory', intentClass: 'payment', authOnly: true, authToParam: 'pool' },
 }
 
 /**
@@ -161,6 +219,27 @@ export function wagerRegistryDomain(chainId, verifyingContract) {
  */
 export function membershipManagerDomain(chainId, verifyingContract) {
   return { name: 'FairWins MembershipManager', version: '1', chainId: Number(chainId), verifyingContract }
+}
+
+/**
+ * EIP-712 domain for a WagerPool CLONE (spec 034/035). verifyingContract is the pool clone's own
+ * address — each clone is its own SignerIntentBase domain, so the six actor twins are verified there
+ * even though the relayer submits through the factory forwarder.
+ * @param {number} chainId
+ * @param {string} verifyingContract - the pool CLONE address
+ */
+export function wagerPoolDomain(chainId, verifyingContract) {
+  return { name: 'FairWins WagerPool', version: '1', chainId: Number(chainId), verifyingContract }
+}
+
+/**
+ * EIP-712 domain for the WagerPoolFactory (spec 035/036 Tier 2 — createPoolWithSig). verifyingContract
+ * is the factory PROXY address for this chain.
+ * @param {number} chainId
+ * @param {string} verifyingContract - the wagerPoolFactory PROXY address
+ */
+export function wagerPoolFactoryDomain(chainId, verifyingContract) {
+  return { name: 'FairWins WagerPoolFactory', version: '1', chainId: Number(chainId), verifyingContract }
 }
 
 /**

--- a/scripts/deploy/upgrade-pool-factory-intents.js
+++ b/scripts/deploy/upgrade-pool-factory-intents.js
@@ -1,0 +1,77 @@
+/**
+ * Spec 035/036 Tier 2 (gasless group pools): upgrade the live WagerPoolFactory UUPS proxy IN PLACE,
+ * adding the factory-forwarder relayer surface — createPoolWithSig + the nine …WithSigFor / …For
+ * forwarders + SignerIntentBase. Runs `initializeIntents` (reinitializer(2)) during the upgrade to set
+ * the "FairWins WagerPoolFactory" EIP-712 domain that createPoolWithSig verifies against.
+ *
+ *   GAS_PRICE_WEI=... npx hardhat run scripts/deploy/upgrade-pool-factory-intents.js --network <mordor|polygon>
+ *
+ * Storage safety: APPEND-ONLY (SignerIntentBase is ERC-7201 namespaced — zero sequential slots, __gap
+ * untouched). `npm run check:storage-layout` MUST be green first (CI-gating); upgradeProxy re-validates
+ * append-only compatibility against the deployed impl before anything goes on-chain. Requires the
+ * deployer to hold the proxy's upgrade authority (floppy admin / .env fallback).
+ * Then: npm run sync:frontend-contracts:<net> (refresh the factory ABI) and commit the updated
+ * deployments/ record + .openzeppelin manifest.
+ */
+const hre = require("hardhat");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+
+const { saveDeployment, getDeploymentFilename } = require("./lib/helpers");
+const { upgradeProxy } = require("./lib/upgradeable");
+
+async function main() {
+  const network = await ethers.provider.getNetwork();
+  const networkName = hre.network.name;
+  const [deployer] = await ethers.getSigners();
+  console.log(
+    `Tier-2 pool-factory upgrade on ${networkName} (chainId ${Number(network.chainId)}) — deployer ${deployer.address}`
+  );
+
+  const filename = getDeploymentFilename(network, "v2");
+  const filepath = path.join(process.cwd(), "deployments", filename);
+  if (!fs.existsSync(filepath)) throw new Error(`No deployment record at deployments/${filename}`);
+  const record = JSON.parse(fs.readFileSync(filepath, "utf8"));
+  const c = record.contracts || {};
+  if (!c.wagerPoolFactory || !ethers.isAddress(c.wagerPoolFactory)) {
+    throw new Error(
+      `No wagerPoolFactory proxy in deployments/${filename} — deploy it first (deploy-wager-pool-factory.js).`
+    );
+  }
+
+  console.log(`\nUpgrading WagerPoolFactory proxy ${c.wagerPoolFactory}...`);
+  const upgrade = await upgradeProxy({
+    name: "WagerPoolFactory",
+    proxyAddress: c.wagerPoolFactory,
+    call: { fn: "initializeIntents", args: [] },
+  });
+  c.wagerPoolFactoryImpl = upgrade.implementation;
+
+  // Sanity: the factory's EIP-712 domain must now be live (createPoolWithSig verifies against it), and
+  // the forwarder surface reachable. A non-zero DOMAIN_SEPARATOR confirms initializeIntents ran.
+  const factory = await ethers.getContractAt("WagerPoolFactory", c.wagerPoolFactory);
+  const sep = await factory.DOMAIN_SEPARATOR();
+  if (!sep || sep === ethers.ZeroHash) throw new Error("DOMAIN_SEPARATOR is zero — initializeIntents did not run");
+  console.log(`  ✓ EIP-712 domain wired (DOMAIN_SEPARATOR ${sep.slice(0, 10)}…)`);
+
+  record.constructorArgs = record.constructorArgs || {};
+  record.constructorArgs.wagerPoolFactoryImpl = [];
+  record.tier2PoolIntentsUpgradedAt = new Date().toISOString();
+  saveDeployment(filename, record);
+
+  console.log("\n" + "=".repeat(60));
+  console.log("Appended to deployments/" + filename);
+  console.log("=".repeat(60));
+  console.log(`  wagerPoolFactory (proxy)    ${c.wagerPoolFactory}`);
+  console.log(`  wagerPoolFactoryImpl (new)  ${c.wagerPoolFactoryImpl}`);
+  console.log(`\nNext: npm run sync:frontend-contracts${networkName === "mordor" ? "" : ":" + networkName}`);
+  console.log("Then add the factory to the relayer engine whitelist + redeploy the gateway (see PR).");
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/services/oz-relayer/config/config.json
+++ b/services/oz-relayer/config/config.json
@@ -1,56 +1,6 @@
 {
   "relayers": [
     {
-      "id": "polygon-137",
-      "name": "FairWins Polygon (137)",
-      "network": "polygon",
-      "network_type": "evm",
-      "paused": false,
-      "signer_id": "gas-key-polygon",
-      "notification_id": "relay-gateway-webhook",
-      "policies": {
-        "eip1559_pricing": true,
-        "gas_price_cap": 1000000000000,
-        "min_balance": 500000000000000000,
-        "whitelist_receivers": [
-          "0x5023765809fDA93ab9F11B684fdb76521eD31774",
-          "0x00c3ef4e02Ef00Ad6eE955dF5022A22F6ea73dae"
-        ]
-      }
-    },
-    {
-      "id": "amoy-80002",
-      "name": "FairWins Amoy (80002)",
-      "network": "amoy",
-      "network_type": "evm",
-      "paused": false,
-      "signer_id": "gas-key-amoy",
-      "notification_id": "relay-gateway-webhook",
-      "policies": {
-        "eip1559_pricing": true,
-        "gas_price_cap": 500000000000,
-        "min_balance": 500000000000000000,
-        "whitelist_receivers": [
-          "0xA429CdaD3E1497e33BEA7D6FE7d6913fE880241b",
-          "0x89158f2E044C73c687dA12B7FA42b94F9A6D8465"
-        ]
-      }
-    },
-    {
-      "id": "etc-61",
-      "name": "FairWins Ethereum Classic (61)",
-      "network": "ethereum-classic",
-      "network_type": "evm",
-      "paused": true,
-      "signer_id": "gas-key-etc",
-      "notification_id": "relay-gateway-webhook",
-      "policies": {
-        "eip1559_pricing": false,
-        "gas_price_cap": 2000000000000,
-        "min_balance": 1000000000000000000
-      }
-    },
-    {
       "id": "mordor-63",
       "name": "FairWins Mordor (63)",
       "network": "mordor",
@@ -64,60 +14,80 @@
         "min_balance": 1000000000000000000,
         "whitelist_receivers": [
           "0x3ccB144d8aa838e8d4D695867cC72e548117830C",
-          "0x68bCBA1055DAbe11b98Bb8425A16e648Ad65d541"
+          "0x68bCBA1055DAbe11b98Bb8425A16e648Ad65d541",
+          "0xac78B4EdeF96e74a2653028dF93A26acFCfC613F"
+        ]
+      }
+    },
+    {
+      "id": "polygon-137",
+      "name": "FairWins Polygon (137)",
+      "network": "polygon",
+      "network_type": "evm",
+      "paused": false,
+      "signer_id": "gas-key-polygon",
+      "notification_id": "relay-gateway-webhook",
+      "policies": {
+        "eip1559_pricing": true,
+        "gas_price_cap": 1500000000000,
+        "min_balance": 500000000000000000,
+        "whitelist_receivers": [
+          "0xE878b62887fC8A5F739B8Ce61bC19546A280Ef89",
+          "0xEfd1a880c6BfBf38A661A3F5fF6d5ECB296D557a",
+          "0x420aEC3c76859eB74ab21c769c16AcdAB221f723"
         ]
       }
     }
   ],
+  "notifications": [
+    {
+      "id": "relay-gateway-webhook",
+      "type": "webhook",
+      "url": "http://localhost:8788/v1/engine/webhook",
+      "signing_key": { "type": "env", "value": "WEBHOOK_SIGNING_KEY" }
+    }
+  ],
+  "signers": [
+    {
+      "id": "gas-key-mordor",
+      "type": "google_cloud_kms",
+      "config": {
+        "service_account": {
+          "project_id": "chippr-bots-site-wp",
+          "private_key_id": { "type": "env", "value": "GCP_PRIVATE_KEY_ID" },
+          "private_key": { "type": "env", "value": "GCP_PRIVATE_KEY" },
+          "client_email": { "type": "env", "value": "GCP_CLIENT_EMAIL" },
+          "client_id": "105464822134406954574"
+        },
+        "key": {
+          "location": "us-central1",
+          "key_ring_id": "fairwins-relayer",
+          "key_id": "gas-key-mordor",
+          "key_version": 1
+        }
+      }
+    },
+    {
+      "id": "gas-key-polygon",
+      "type": "google_cloud_kms",
+      "config": {
+        "service_account": {
+          "project_id": "chippr-bots-site-wp",
+          "private_key_id": { "type": "env", "value": "GCP_PRIVATE_KEY_ID" },
+          "private_key": { "type": "env", "value": "GCP_PRIVATE_KEY" },
+          "client_email": { "type": "env", "value": "GCP_CLIENT_EMAIL" },
+          "client_id": "105464822134406954574"
+        },
+        "key": {
+          "location": "us-central1",
+          "key_ring_id": "fairwins-relayer",
+          "key_id": "gas-key-polygon",
+          "key_version": 1
+        }
+      }
+    }
+  ],
   "networks": [
-    {
-      "network": "polygon",
-      "type": "evm",
-      "chain_id": 137,
-      "symbol": "POL",
-      "required_confirmations": 30,
-      "average_blocktime_ms": 2100,
-      "is_testnet": false,
-      "features": ["eip1559"],
-      "rpc_urls": [
-        "${RPC_URL_137_PRIMARY:-https://polygon-rpc.com}",
-        "${RPC_URL_137_SECONDARY:-https://polygon-bor-rpc.publicnode.com}"
-      ],
-      "explorer_urls": ["https://polygonscan.com"],
-      "tags": ["mainnet", "fairwins"]
-    },
-    {
-      "network": "amoy",
-      "type": "evm",
-      "chain_id": 80002,
-      "symbol": "POL",
-      "required_confirmations": 3,
-      "average_blocktime_ms": 2100,
-      "is_testnet": true,
-      "features": ["eip1559"],
-      "rpc_urls": [
-        "${RPC_URL_80002_PRIMARY:-https://rpc-amoy.polygon.technology}",
-        "${RPC_URL_80002_SECONDARY:-https://polygon-amoy-bor-rpc.publicnode.com}"
-      ],
-      "explorer_urls": ["https://amoy.polygonscan.com"],
-      "tags": ["testnet", "fairwins"]
-    },
-    {
-      "network": "ethereum-classic",
-      "type": "evm",
-      "chain_id": 61,
-      "symbol": "ETC",
-      "required_confirmations": 12,
-      "average_blocktime_ms": 13000,
-      "is_testnet": false,
-      "features": [],
-      "rpc_urls": [
-        "${RPC_URL_61_PRIMARY:-https://etc.rivet.link}",
-        "${RPC_URL_61_SECONDARY:-https://etc.etcdesktop.com}"
-      ],
-      "explorer_urls": ["https://etc.blockscout.com"],
-      "tags": ["mainnet", "fairwins", "legacy-gas", "no-batch"]
-    },
     {
       "network": "mordor",
       "type": "evm",
@@ -128,85 +98,28 @@
       "is_testnet": true,
       "features": [],
       "rpc_urls": [
-        "${RPC_URL_63_PRIMARY:-https://rpc.mordor.etccooperative.org}",
-        "${RPC_URL_63_SECONDARY:-https://geth-mordor.etc-network.info}"
+        "https://rpc.mordor.etccooperative.org",
+        "https://geth-mordor.etc-network.info"
       ],
       "explorer_urls": ["https://etc-mordor.blockscout.com"],
       "tags": ["testnet", "fairwins", "legacy-gas", "no-batch"]
+    },
+    {
+      "network": "polygon",
+      "type": "evm",
+      "chain_id": 137,
+      "symbol": "POL",
+      "required_confirmations": 5,
+      "average_blocktime_ms": 2000,
+      "is_testnet": false,
+      "features": [],
+      "rpc_urls": [
+        "https://polygon-bor-rpc.publicnode.com",
+        "https://polygon.llamarpc.com"
+      ],
+      "explorer_urls": ["https://polygonscan.com"],
+      "tags": ["mainnet", "fairwins", "eip1559", "eip3009"]
     }
   ],
-  "signers": [
-    {
-      "id": "gas-key-polygon",
-      "type": "google_cloud_kms",
-      "config": {
-        "service_account": {
-          "project_id": { "type": "env", "value": "GCP_PROJECT_ID" },
-          "credentials": { "type": "env", "value": "GOOGLE_APPLICATION_CREDENTIALS_JSON" }
-        },
-        "key": {
-          "location": "us-central1",
-          "key_ring_id": "fairwins-relayer",
-          "key_id": "gas-key-polygon",
-          "key_version": 1
-        }
-      }
-    },
-    {
-      "id": "gas-key-amoy",
-      "type": "google_cloud_kms",
-      "config": {
-        "service_account": {
-          "project_id": { "type": "env", "value": "GCP_PROJECT_ID" },
-          "credentials": { "type": "env", "value": "GOOGLE_APPLICATION_CREDENTIALS_JSON" }
-        },
-        "key": {
-          "location": "us-central1",
-          "key_ring_id": "fairwins-relayer",
-          "key_id": "gas-key-amoy",
-          "key_version": 1
-        }
-      }
-    },
-    {
-      "id": "gas-key-etc",
-      "type": "google_cloud_kms",
-      "config": {
-        "service_account": {
-          "project_id": { "type": "env", "value": "GCP_PROJECT_ID" },
-          "credentials": { "type": "env", "value": "GOOGLE_APPLICATION_CREDENTIALS_JSON" }
-        },
-        "key": {
-          "location": "us-central1",
-          "key_ring_id": "fairwins-relayer",
-          "key_id": "gas-key-etc",
-          "key_version": 1
-        }
-      }
-    },
-    {
-      "id": "gas-key-mordor",
-      "type": "google_cloud_kms",
-      "config": {
-        "service_account": {
-          "project_id": { "type": "env", "value": "GCP_PROJECT_ID" },
-          "credentials": { "type": "env", "value": "GOOGLE_APPLICATION_CREDENTIALS_JSON" }
-        },
-        "key": {
-          "location": "us-central1",
-          "key_ring_id": "fairwins-relayer",
-          "key_id": "gas-key-mordor",
-          "key_version": 1
-        }
-      }
-    }
-  ],
-  "notifications": [
-    {
-      "id": "relay-gateway-webhook",
-      "type": "webhook",
-      "url": "${GATEWAY_WEBHOOK_URL:-http://relay-gateway:8788/v1/engine/webhook}",
-      "signing_key": { "type": "env", "value": "WEBHOOK_SIGNING_KEY" }
-    }
-  ]
+  "plugins": []
 }

--- a/services/oz-relayer/deploy/production/config.json
+++ b/services/oz-relayer/deploy/production/config.json
@@ -14,7 +14,8 @@
         "min_balance": 1000000000000000000,
         "whitelist_receivers": [
           "0x3ccB144d8aa838e8d4D695867cC72e548117830C",
-          "0x68bCBA1055DAbe11b98Bb8425A16e648Ad65d541"
+          "0x68bCBA1055DAbe11b98Bb8425A16e648Ad65d541",
+          "0xac78B4EdeF96e74a2653028dF93A26acFCfC613F"
         ]
       }
     },
@@ -32,7 +33,8 @@
         "min_balance": 500000000000000000,
         "whitelist_receivers": [
           "0xE878b62887fC8A5F739B8Ce61bC19546A280Ef89",
-          "0xEfd1a880c6BfBf38A661A3F5fF6d5ECB296D557a"
+          "0xEfd1a880c6BfBf38A661A3F5fF6d5ECB296D557a",
+          "0x420aEC3c76859eB74ab21c769c16AcdAB221f723"
         ]
       }
     }

--- a/services/relay-gateway/src/config/index.js
+++ b/services/relay-gateway/src/config/index.js
@@ -137,6 +137,20 @@ export function loadConfig(env = process.env, opts = {}) {
       [c.wagerRegistry.toLowerCase()]: { key: 'wagerRegistry', address: c.wagerRegistry, allowedActions: actionsForContract('wagerRegistry') },
       [c.membershipManager.toLowerCase()]: { key: 'membershipManager', address: c.membershipManager, allowedActions: actionsForContract('membershipManager') },
     }
+    const targetsByKey = { wagerRegistry: c.wagerRegistry, membershipManager: c.membershipManager }
+
+    // Tier-2 group pools (spec 035/036) are OPTIONAL per chain: only pin the WagerPoolFactory where the
+    // deployment record has one (Mordor/Polygon), so chains without pools still boot (pool actions there
+    // just self-submit). The factory is the only pool target the engine whitelists — clones are reached
+    // via its forwarders and proven on-chain (poolAddressToId), so no clone address is ever pinned.
+    if (ADDRESS_RE.test(c.wagerPoolFactory || '')) {
+      targets[c.wagerPoolFactory.toLowerCase()] = {
+        key: 'wagerPoolFactory',
+        address: c.wagerPoolFactory,
+        allowedActions: actionsForContract('wagerPoolFactory'),
+      }
+      targetsByKey.wagerPoolFactory = c.wagerPoolFactory
+    }
 
     const rpcUrls = opt(env, `RPC_URLS_${chainId}`, def.defaultRpcUrls.join(','))
       .split(',')
@@ -166,7 +180,7 @@ export function loadConfig(env = process.env, opts = {}) {
       paymentToken: deployment.paymentToken || null,
       sanctionsGuard: c.sanctionsGuard,
       targets,
-      targetsByKey: { wagerRegistry: c.wagerRegistry, membershipManager: c.membershipManager },
+      targetsByKey,
       rpcUrls,
       fundingMode: opt(env, `FUNDING_MODE_${chainId}`, 'sponsored'), // 'sponsored' | 'fee-netted'
       gasSpendCapWei: bigInt(env, `GAS_SPEND_CAP_WEI_${chainId}`, 500_000_000_000_000_000n), // 0.5 native / window

--- a/services/relay-gateway/src/intent/intentTypes.js
+++ b/services/relay-gateway/src/intent/intentTypes.js
@@ -17,6 +17,7 @@
  *   which keeps the request shape to a single `uniquenessMarker` field.
  */
 import { ethers } from 'ethers'
+import { GatewayError } from '../errors.js'
 
 // ---------------------------------------------------------------------------
 // EIP-712 domains (per verifying contract; chainId + verifyingContract added at runtime)
@@ -25,6 +26,12 @@ import { ethers } from 'ethers'
 export const CONTRACT_DOMAINS = {
   wagerRegistry: { name: 'FairWins WagerRegistry', version: '1' },
   membershipManager: { name: 'FairWins MembershipManager', version: '1' },
+  // Tier-2 group pools (spec 035/036). The FACTORY verifies createPoolWithSig against its own domain;
+  // the CLONE verifies the six actor twins against a per-clone domain (verifyingContract = the clone),
+  // so pool signer-attributed actions target the factory but recover under `wagerPool` with the pool
+  // address as verifyingContract (the domain/target split — see ACTIONS + verify.js).
+  wagerPool: { name: 'FairWins WagerPool', version: '1' },
+  wagerPoolFactory: { name: 'FairWins WagerPoolFactory', version: '1' },
 }
 
 // ---------------------------------------------------------------------------
@@ -126,6 +133,48 @@ export const INTENT_TYPES = {
     { name: 'redeemer', type: 'address' },
     ...TAIL,
   ],
+
+  // ---- Tier-2 group pools (spec 035/036) ----
+  // Byte-identical to the on-chain typehashes: the six actor twins verify against the CLONE's domain
+  // (contracts/pools/WagerPool.sol), CreatePool against the FACTORY's domain (WagerPoolFactory.sol).
+  ApproveOutcome: [
+    { name: 'member', type: 'address' },
+    { name: 'proposalId', type: 'bytes32' },
+    ...TAIL,
+  ],
+  ClaimShare: [
+    { name: 'winner', type: 'address' },
+    { name: 'index', type: 'uint256' },
+    { name: 'recipient', type: 'address' },
+    ...TAIL,
+  ],
+  ProposeOutcome: [
+    { name: 'creator', type: 'address' },
+    { name: 'proposalId', type: 'bytes32' },
+    ...TAIL,
+  ],
+  CloseJoining: [
+    { name: 'creator', type: 'address' },
+    ...TAIL,
+  ],
+  Cancel: [
+    { name: 'creator', type: 'address' },
+    ...TAIL,
+  ],
+  Refund: [
+    { name: 'member', type: 'address' },
+    ...TAIL,
+  ],
+  CreatePool: [
+    { name: 'creator', type: 'address' },
+    { name: 'token', type: 'address' },
+    { name: 'buyIn', type: 'uint256' },
+    { name: 'maxMembers', type: 'uint32' },
+    { name: 'thresholdBips', type: 'uint16' },
+    { name: 'acceptDeadline', type: 'uint64' },
+    { name: 'resolveDeadline', type: 'uint64' },
+    ...TAIL,
+  ],
 }
 
 // EIP-3009 payment-leg typed data (token's own domain — native USDC version "2").
@@ -147,6 +196,10 @@ export const RECEIVE_WITH_AUTHORIZATION_TYPES = {
 const AUTH_TUPLE = '(uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce,uint8 v,bytes32 r,bytes32 s)'
 const CREATE_ARGS_TUPLE =
   '(address opponent,address arbitrator,address token,uint128 creatorStake,uint128 opponentStake,uint64 acceptDeadline,uint64 resolveDeadline,uint8 resolutionType,bytes32 conditionId,bool creatorIsYes,bytes32 metadataHash,string metadataUri,bytes32 termsVersionHash,bytes32 paymentNonce)'
+// Tier-2 pool tuples: WagerPoolFactory.CreatePoolParams and WagerPool.PayoutEntry[].
+const POOL_CREATE_PARAMS_TUPLE =
+  '(address token,uint256 buyIn,uint32 maxMembers,uint16 thresholdBips,uint64 acceptDeadline,uint64 resolveDeadline)'
+const POOL_ENTRIES_TUPLE = '(address winner,uint256 amount)[]'
 
 export const ENTRYPOINT_ABI = [
   // WagerRegistry — no-stake …WithSig twins
@@ -166,6 +219,16 @@ export const ENTRYPOINT_ABI = [
   `function upgradeTierWithAuthorization(bytes32 role, uint8 tier, bytes32 termsHash, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes intentSig, ${AUTH_TUPLE} priceAuth, ${AUTH_TUPLE} feeAuth)`,
   `function extendMembershipWithAuthorization(bytes32 role, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes intentSig, ${AUTH_TUPLE} priceAuth, ${AUTH_TUPLE} feeAuth)`,
   'function redeemVoucherWithSig(uint256 voucherId, bytes32 termsHash, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes sig)',
+  // WagerPoolFactory — Tier-2 forwarders (route a clone's twin through the whitelisted factory).
+  // Each checks poolAddressToId[pool] != 0 on-chain, then calls the clone twin (pure pass-through).
+  `function createPoolWithSig(${POOL_CREATE_PARAMS_TUPLE} p, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes sig) returns (uint256, address)`,
+  `function joinWithAuthorizationFor(address pool, address from, uint256 value, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s)`,
+  'function closeJoiningWithSigFor(address pool, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes sig)',
+  'function cancelWithSigFor(address pool, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes sig)',
+  `function proposeOutcomeWithSigFor(address pool, ${POOL_ENTRIES_TUPLE} entries, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes sig)`,
+  'function approveWithSigFor(address pool, bytes32 proposalId, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes sig)',
+  `function claimWithSigFor(address pool, ${POOL_ENTRIES_TUPLE} entries, uint256 index, address recipient, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes sig)`,
+  'function refundWithSigFor(address pool, address signer, bytes32 nonce, uint256 validAfter, uint256 validBefore, bytes sig)',
 ]
 
 export const entrypointInterface = new ethers.Interface(ENTRYPOINT_ABI)
@@ -250,6 +313,59 @@ const sigArgs = (first) => (params, signer, intent) => [
   intent.validBefore,
   intent.signature,
 ]
+
+// ---- Tier-2 pool action helpers (spec 035/036) ----------------------------
+//
+// The domain/target SPLIT: a pool signer-attributed action TARGETS the factory (`contract`, pinned +
+// engine-whitelisted) but its EIP-712 signature is verified under the CLONE's domain
+// (`domainContract: 'wagerPool'`, `verifyingContractParam: 'pool'`). `provenanceParam: 'pool'` tells
+// verify.js to eth_call factory.poolAddressToId(pool) != 0 before trusting a dynamic clone address.
+// `pool` is a calldata + domain input, NOT an EIP-712 struct field, so buildMessage never emits it.
+
+function poolBuildMessage(typeName, actorField) {
+  return (params, signer, intent) => {
+    const msg = {}
+    for (const f of INTENT_TYPES[typeName]) {
+      if (f.name === actorField) msg[f.name] = signer
+      else if (f.name === 'nonce') msg[f.name] = intent.uniquenessMarker
+      else if (f.name === 'validAfter') msg[f.name] = intent.validAfter
+      else if (f.name === 'validBefore') msg[f.name] = intent.validBefore
+      else msg[f.name] = params[f.name]
+    }
+    return msg
+  }
+}
+
+/**
+ * A pool signer-attributed forwarder: verified under the clone domain, submitted via the factory.
+ * `extraParams` are the calldata args BETWEEN `pool` and `signer` (e.g. proposalId, entries, index).
+ * `buildExtraArgs(params)` returns those same values in forwarder order.
+ */
+function poolSigAction({ typeName, actorField, fn, extraParams = [], buildExtraArgs = () => [], verifyParams }) {
+  return {
+    intentClass: 'signer-attributed',
+    contract: 'wagerPoolFactory',
+    domainContract: 'wagerPool',
+    verifyingContractParam: 'pool',
+    provenanceParam: 'pool',
+    typeName,
+    actorField,
+    fn,
+    paramNames: ['pool', ...extraParams],
+    verifyParams,
+    buildMessage: poolBuildMessage(typeName, actorField),
+    encode: (params, signer, intent) =>
+      entrypointInterface.encodeFunctionData(fn, [
+        params.pool,
+        ...buildExtraArgs(params),
+        signer,
+        intent.uniquenessMarker,
+        intent.validAfter,
+        intent.validBefore,
+        intent.signature,
+      ]),
+  }
+}
 
 const stakeAuthOf = (intent) => authTuple({
   value: intent.authorization.value,
@@ -368,6 +484,78 @@ export const ACTIONS = {
       intent.validAfter, intent.validBefore, intent.signature,
     ],
   }),
+
+  // ---- Tier-2 group pools (spec 035/036) ----
+  // Signer-attributed: verified under the clone domain, forwarded through the whitelisted factory.
+  poolCloseJoining: poolSigAction({ typeName: 'CloseJoining', actorField: 'creator', fn: 'closeJoiningWithSigFor' }),
+  poolCancel: poolSigAction({ typeName: 'Cancel', actorField: 'creator', fn: 'cancelWithSigFor' }),
+  poolRefund: poolSigAction({ typeName: 'Refund', actorField: 'member', fn: 'refundWithSigFor' }),
+  poolApprove: poolSigAction({
+    typeName: 'ApproveOutcome', actorField: 'member', fn: 'approveWithSigFor',
+    extraParams: ['proposalId'], buildExtraArgs: (p) => [p.proposalId],
+  }),
+  poolProposeOutcome: poolSigAction({
+    // proposalId is signed in the struct; entries is the calldata preimage the contract re-hashes.
+    typeName: 'ProposeOutcome', actorField: 'creator', fn: 'proposeOutcomeWithSigFor',
+    extraParams: ['entries', 'proposalId'], buildExtraArgs: (p) => [p.entries],
+    // The signed proposalId MUST be the hash of the revealed matrix (the contract asserts the same),
+    // so a mismatched pair is rejected before the engine wastes a submission.
+    verifyParams: (p) => {
+      const got = ethers.keccak256(
+        ethers.AbiCoder.defaultAbiCoder().encode(
+          ['tuple(address winner,uint256 amount)[]'],
+          [p.entries.map((e) => ({ winner: e.winner, amount: e.amount }))]
+        )
+      )
+      if (got.toLowerCase() !== String(p.proposalId).toLowerCase()) {
+        throw new GatewayError(400, 'param_binding_mismatch', 'proposalId must equal keccak256(entries)')
+      }
+    },
+  }),
+  poolClaim: poolSigAction({
+    typeName: 'ClaimShare', actorField: 'winner', fn: 'claimWithSigFor',
+    extraParams: ['entries', 'index', 'recipient'], buildExtraArgs: (p) => [p.entries, p.index, p.recipient],
+  }),
+
+  // createPool is verified under the FACTORY's own domain (no clone exists yet); attributed to `creator`.
+  poolCreate: {
+    intentClass: 'signer-attributed',
+    contract: 'wagerPoolFactory',
+    domainContract: 'wagerPoolFactory',
+    typeName: 'CreatePool',
+    actorField: 'creator',
+    fn: 'createPoolWithSig',
+    paramNames: ['token', 'buyIn', 'maxMembers', 'thresholdBips', 'acceptDeadline', 'resolveDeadline'],
+    buildMessage: poolBuildMessage('CreatePool', 'creator'),
+    encode: (params, signer, intent) =>
+      entrypointInterface.encodeFunctionData('createPoolWithSig', [
+        [params.token, params.buyIn, params.maxMembers, params.thresholdBips, params.acceptDeadline, params.resolveDeadline],
+        signer,
+        intent.uniquenessMarker,
+        intent.validAfter,
+        intent.validBefore,
+        intent.signature,
+      ]),
+  },
+
+  // Payment (EIP-3009): attribution comes SOLELY from the token authorization — no separate intent
+  // struct. `authOnly` skips the intent-leg recovery; `authToParam: 'pool'` binds the money to the
+  // clone (not the factory). The token enforces to == caller (the clone) so a relayer can't redirect.
+  poolJoin: {
+    intentClass: 'payment',
+    contract: 'wagerPoolFactory',
+    authOnly: true,
+    authToParam: 'pool',
+    provenanceParam: 'pool',
+    fn: 'joinWithAuthorizationFor',
+    paramNames: ['pool'],
+    encode: (params, signer, intent) => {
+      const a = intent.authorization
+      return entrypointInterface.encodeFunctionData('joinWithAuthorizationFor', [
+        params.pool, a.from, a.value, a.validAfter, a.validBefore, a.nonce, a.v, a.r, a.s,
+      ])
+    },
+  },
 }
 
 /** Allowed action names per target contract key — the version-pinned allow-list (FR-025). */

--- a/services/relay-gateway/src/intent/verify.js
+++ b/services/relay-gateway/src/intent/verify.js
@@ -116,26 +116,120 @@ export function parseIntent(body) {
   }
 }
 
+function asBool(label, v) {
+  if (typeof v === 'boolean') return v
+  if (v === 'true') return true
+  if (v === 'false') return false
+  throw bad(`${label} must be a boolean`)
+}
+
+function asString(label, v) {
+  if (typeof v !== 'string') throw bad(`${label} must be a string`)
+  return v
+}
+
+/** A pool payout matrix: non-empty array of { winner: address, amount: uint256 } (spec 034). */
+function asPayoutEntries(label, v) {
+  if (!Array.isArray(v) || v.length === 0) throw bad(`${label} must be a non-empty array`)
+  return v.map((e, i) => {
+    if (!e || typeof e !== 'object') throw bad(`${label}[${i}] must be an object`)
+    return {
+      winner: asAddress(`${label}[${i}].winner`, e.winner),
+      amount: asUint(`${label}[${i}].amount`, e.amount),
+    }
+  })
+}
+
+// Param name -> canonical type. Coercion is DRIVEN BY TYPE, not name: an address stays a checksummed
+// address, a bool stays a bool, a string stays a string. (The prior name-list coerced everything not
+// explicitly special-cased through asUint, which silently corrupted address/bool/string/array params —
+// e.g. createWager's metadataUri/creatorIsYes and declareWinner's winner.)
+const PARAM_TYPES = {
+  // WagerRegistry
+  wagerId: 'uint256', winner: 'address', opponent: 'address', arbitrator: 'address',
+  token: 'address', creatorStake: 'uint128', opponentStake: 'uint128',
+  acceptDeadline: 'uint64', resolveDeadline: 'uint64', resolutionType: 'uint8',
+  conditionId: 'bytes32', creatorIsYes: 'bool', metadataHash: 'bytes32',
+  metadataUri: 'string', termsVersionHash: 'bytes32', claimCodeSig: 'bytes',
+  // MembershipManager
+  role: 'bytes32', tier: 'uint8', acceptedTermsHash: 'bytes32', voucherId: 'uint256',
+  // Tier-2 pools
+  pool: 'address', proposalId: 'bytes32', entries: 'entries', index: 'uint256',
+  recipient: 'address', buyIn: 'uint256', maxMembers: 'uint32', thresholdBips: 'uint16',
+}
+
+function coerceParam(type, label, v) {
+  switch (type) {
+    case 'address': return asAddress(label, v)
+    case 'bool': return asBool(label, v)
+    case 'bytes32': return asBytes32(label, v)
+    case 'bytes': return asHexBytes(label, v)
+    case 'string': return asString(label, v)
+    case 'entries': return asPayoutEntries(label, v)
+    case 'uint8':
+    case 'uint16':
+    case 'uint32':
+    case 'uint64':
+    case 'uint128':
+    case 'uint256':
+      return asUint(label, v)
+    default:
+      throw bad(`${label} has unsupported type ${type}`)
+  }
+}
+
 /** Normalize action params against the registry definition (rejects missing fields early). */
 function normalizeParams(actionDef, params) {
   const out = {}
   for (const name of actionDef.paramNames) {
     if (params[name] == null) throw bad(`params.${name} is required for action`)
-    if (name === 'claimCodeSig') out[name] = asHexBytes(`params.${name}`, params[name])
-    else if (name === 'role' || name === 'acceptedTermsHash') out[name] = asBytes32(`params.${name}`, params[name])
-    else if (name === 'tier') out[name] = Number(asUint(`params.${name}`, params[name]))
-    else out[name] = asUint(`params.${name}`, params[name])
+    const type = PARAM_TYPES[name]
+    if (!type) throw bad(`params.${name} has no registered type`)
+    out[name] = coerceParam(type, `params.${name}`, params[name])
   }
   return out
 }
 
-function domainFor(chainCfg, contractKey) {
+function domainFor(chainCfg, contractKey, verifyingContract) {
   const d = CONTRACT_DOMAINS[contractKey]
   return {
     name: d.name,
     version: d.version,
     chainId: chainCfg.chainId,
-    verifyingContract: chainCfg.targetsByKey[contractKey],
+    // Tier-2 pool signer actions verify under the CLONE's domain: verifyingContract is the pool
+    // address (from params), not the pinned target-by-key. Everything else uses the pinned target.
+    verifyingContract: verifyingContract ?? chainCfg.targetsByKey[contractKey],
+  }
+}
+
+const FACTORY_IFACE = new ethers.Interface(['function poolAddressToId(address) view returns (uint256)'])
+
+/**
+ * On-chain provenance for a dynamic pool clone (Tier 2). Clones are ERC-1167 addresses the gateway
+ * cannot pre-pin, so instead of an allow-list we ask the pinned factory: `poolAddressToId(pool) != 0`
+ * (ids start at 1). This mirrors the factory forwarders' own `_requirePool` guard, so the gateway
+ * never accepts a target the contract would reject. Fail modes: a genuine non-pool → 400 (hard reject,
+ * do not retry); an RPC/provider failure → 503 (retryable → the client self-submits, never-stranded).
+ */
+async function checkPoolProvenance(provider, factoryAddress, pool) {
+  if (!provider || !factoryAddress) {
+    throw new GatewayError(503, 'chain_unavailable', 'cannot verify pool provenance without a read provider; self-submit')
+  }
+  let ret
+  try {
+    const data = FACTORY_IFACE.encodeFunctionData('poolAddressToId', [pool])
+    ret = await provider.call({ to: factoryAddress, data })
+  } catch {
+    throw new GatewayError(503, 'chain_unavailable', 'pool provenance check failed (RPC error); retry or self-submit')
+  }
+  let id
+  try {
+    ;[id] = FACTORY_IFACE.decodeFunctionResult('poolAddressToId', ret)
+  } catch {
+    id = 0n
+  }
+  if (id === 0n) {
+    throw new GatewayError(400, 'target_not_allowlisted', 'pool was not created by the pinned WagerPoolFactory')
   }
 }
 
@@ -203,17 +297,35 @@ export async function verifyIntent(intent, chainCfg, config, nowSec, provider = 
 
   const params = normalizeParams(actionDef, intent.params)
 
+  // Action-specific cross-param invariants (e.g. proposalId == keccak256(entries)) — a cheap
+  // pre-check that mirrors an on-chain assertion, so a doomed intent is rejected before the engine.
+  actionDef.verifyParams?.(params)
+
+  // Dynamic-clone provenance (Tier 2): the pinned target is the FACTORY; the acted-on pool is a
+  // clone proven on-chain via factory.poolAddressToId, not an allow-list.
+  if (actionDef.provenanceParam) {
+    await checkPoolProvenance(provider, chainCfg.targetsByKey[actionDef.contract], params[actionDef.provenanceParam])
+  }
+
+  // EIP-712 domain: name/version from `domainContract` (defaults to the target), verifyingContract
+  // from `verifyingContractParam` when set (the clone address) else the pinned target (the split).
+  const domainKey = actionDef.domainContract ?? actionDef.contract
+  const verifyingContract = actionDef.verifyingContractParam ? params[actionDef.verifyingContractParam] : undefined
+
   // --- signer recovery ---
   let signer
   if (intent.intentClass === 'payment') {
-    signer = recoverPaymentSigner(intent, chainCfg)
-    // Intent leg: the EIP-712 action struct must ALSO be signed by the same wallet — this is what
-    // binds params (role/tier/wagerId/...) to the money leg (FR-007/FR-013 in spec 035).
-    const domain = domainFor(chainCfg, actionDef.contract)
-    const message = actionDef.buildMessage(params, signer, intent)
-    const recovered = tryRecoverTyped(domain, typesFor(intent.action), message, intent.signature)
-    if (!recovered || recovered.toLowerCase() !== signer.toLowerCase()) {
-      throwSignatureError(intent, actionDef, params, signer, config, chainCfg)
+    signer = recoverPaymentSigner(intent, chainCfg, actionDef, params)
+    // Money-only forwarders (pool join) carry NO intent struct — the EIP-3009 authorization IS the
+    // attribution + binding. Otherwise the EIP-712 action struct must ALSO be signed by the same
+    // wallet, binding params (role/tier/wagerId/...) to the money leg (FR-007/FR-013).
+    if (!actionDef.authOnly) {
+      const domain = domainFor(chainCfg, domainKey, verifyingContract)
+      const message = actionDef.buildMessage(params, signer, intent)
+      const recovered = tryRecoverTyped(domain, typesFor(intent.action), message, intent.signature)
+      if (!recovered || recovered.toLowerCase() !== signer.toLowerCase()) {
+        throwSignatureError(intent, actionDef, params, signer, config, chainCfg, domainKey, verifyingContract)
+      }
     }
   } else {
     // Signer-attributed: the actor field of the signed struct IS the signer; the client supplies
@@ -221,13 +333,13 @@ export async function verifyIntent(intent, chainCfg, config, nowSec, provider = 
     // Contract accounts (spec 041 passkey smart wallets) cannot ECDSA-recover to their own
     // address — on mismatch, fall back to asking the actor contract via ERC-1271.
     const actor = asAddress(`params.${actionDef.actorField}`, intent.params[actionDef.actorField])
-    const domain = domainFor(chainCfg, actionDef.contract)
+    const domain = domainFor(chainCfg, domainKey, verifyingContract)
     const message = actionDef.buildMessage(params, actor, intent)
     const recovered = tryRecoverTyped(domain, typesFor(intent.action), message, intent.signature)
     if (!recovered || recovered.toLowerCase() !== actor.toLowerCase()) {
       const digest = ethers.TypedDataEncoder.hash(domain, typesFor(intent.action), message)
       const okVia1271 = await isValidErc1271Signature(provider, actor, digest, intent.signature)
-      if (!okVia1271) throwSignatureError(intent, actionDef, params, actor, config, chainCfg)
+      if (!okVia1271) throwSignatureError(intent, actionDef, params, actor, config, chainCfg, domainKey, verifyingContract)
     }
     signer = actor
   }
@@ -247,11 +359,14 @@ export async function verifyIntent(intent, chainCfg, config, nowSec, provider = 
 }
 
 /** Recover the payment-class signer from the EIP-3009 authorization under the token's domain. */
-function recoverPaymentSigner(intent, chainCfg) {
+function recoverPaymentSigner(intent, chainCfg, actionDef, params) {
   const a = intent.authorization
-  // The authorization MUST pay the allow-listed target (binds funds to the contract, not the relayer).
-  if (a.to.toLowerCase() !== intent.targetContract.toLowerCase()) {
-    throw new GatewayError(400, 'param_binding_mismatch', 'authorization.to must equal targetContract')
+  // The authorization MUST pay the bound recipient (binds funds to the contract, not the relayer).
+  // Normally that is the pinned targetContract; for a pool join the money goes into the CLONE
+  // (`authToParam: 'pool'`), which the token enforces is the caller, so a relayer can't redirect it.
+  const expectedTo = actionDef?.authToParam ? params[actionDef.authToParam] : intent.targetContract
+  if (a.to.toLowerCase() !== String(expectedTo).toLowerCase()) {
+    throw new GatewayError(400, 'param_binding_mismatch', 'authorization.to must equal the bound payment recipient')
   }
   // data-model.md: for the payment class the uniquenessMarker IS the EIP-3009 nonce.
   if (a.nonce.toLowerCase() !== intent.uniquenessMarker.toLowerCase()) {
@@ -283,11 +398,11 @@ function recoverPaymentSigner(intent, chainCfg) {
  * Distinguish a wrong-network signature (chain_mismatch, SC-014) from a plain bad signature:
  * re-try recovery under every other enabled chain's domain for the same contract key.
  */
-function throwSignatureError(intent, actionDef, params, expectedActor, config, chainCfg) {
+function throwSignatureError(intent, actionDef, params, expectedActor, config, chainCfg, domainKey, verifyingContract) {
   for (const otherId of config.enabledChainIds) {
     if (otherId === chainCfg.chainId) continue
     const other = config.chains[otherId]
-    const domain = domainFor(other, actionDef.contract)
+    const domain = domainFor(other, domainKey ?? actionDef.contract, verifyingContract)
     const message = actionDef.buildMessage(params, expectedActor, intent)
     const recovered = tryRecoverTyped(domain, typesFor(intent.action), message, intent.signature)
     if (recovered && recovered.toLowerCase() === expectedActor.toLowerCase()) {

--- a/services/relay-gateway/src/intent/verify.js
+++ b/services/relay-gateway/src/intent/verify.js
@@ -226,7 +226,11 @@ async function checkPoolProvenance(provider, factoryAddress, pool) {
   try {
     ;[id] = FACTORY_IFACE.decodeFunctionResult('poolAddressToId', ret)
   } catch {
-    id = 0n
+    // A malformed/empty response (e.g. '0x' from a flaky node or a call to a non-contract) is a
+    // PROVIDER failure, not proof the pool is fake — treat it as retryable so the client self-submits
+    // (never-stranded), matching this function's contract. Only a cleanly-decoded id === 0 below is a
+    // genuine non-pool (hard 400).
+    throw new GatewayError(503, 'chain_unavailable', 'pool provenance response malformed (RPC issue); retry or self-submit')
   }
   if (id === 0n) {
     throw new GatewayError(400, 'target_not_allowlisted', 'pool was not created by the pinned WagerPoolFactory')

--- a/services/relay-gateway/test/gateway.test.js
+++ b/services/relay-gateway/test/gateway.test.js
@@ -339,6 +339,17 @@ describe('Tier-2 group pools (spec 035/036 — factory-forwarder)', () => {
     expect(ctx503.engine.submissions).toHaveLength(0)
   })
 
+  it('provenance — a malformed/empty (0x) provenance response is 503 (self-submit), not a hard 400', async () => {
+    // A flaky node returning '0x' fails to decode; that is a provider failure, not proof the pool is
+    // forged, so it must be retryable (client self-submits, never-stranded) — never a hard reject.
+    const ctxBad = build({ providers: mockProviders(testConfig(), { poolIdRaw: '0x' }) })
+    const intent = await signedPoolIntent(ctxBad.config, { action: 'poolApprove', params: { proposalId: poolMatrixHash(entries) } })
+    const res = await post(ctxBad.app, intent)
+    expect(res.status).toBe(503)
+    expect(res.body.error.code).toBe('chain_unavailable')
+    expect(ctxBad.engine.submissions).toHaveLength(0)
+  })
+
   it('targeting the clone directly is rejected — only the factory is pinned', async () => {
     const intent = await signedPoolIntent(ctx.config, { action: 'poolApprove', params: { proposalId: poolMatrixHash(entries) } })
     intent.targetContract = POOL_ADDRESS // clone address is not in the pinned target set

--- a/services/relay-gateway/test/gateway.test.js
+++ b/services/relay-gateway/test/gateway.test.js
@@ -16,6 +16,10 @@ import {
   mockEngine,
   signedIntent,
   signedPaymentIntent,
+  signedPoolIntent,
+  signedPoolJoinIntent,
+  poolMatrixHash,
+  POOL_ADDRESS,
   randomMarker,
   wallet,
   ORIGIN_SECRET,
@@ -23,6 +27,7 @@ import {
   TEST_NOW,
   DEPLOYMENTS_DIR,
 } from './helpers.js'
+import { entrypointInterface } from '../src/intent/intentTypes.js'
 
 const now = () => TEST_NOW
 
@@ -216,6 +221,141 @@ describe('POST /v1/intents validation', () => {
     const res = await post(ctx.app, intent)
     expect(res.status).toBe(503)
     expect(res.body.error.code).toBe('payment_unsupported_on_chain')
+  })
+})
+
+describe('Tier-2 group pools (spec 035/036 — factory-forwarder)', () => {
+  let ctx
+  const entries = [
+    { winner: wallet.address, amount: 15_000_000n },
+    { winner: '0x2222222222222222222222222222222222222222', amount: 5_000_000n },
+  ]
+
+  beforeEach(() => {
+    ctx = build()
+  })
+
+  const factoryOf = (chainId = 137) => ctx.config.chains[chainId].targetsByKey.wagerPoolFactory
+
+  it('poolApprove — verified under the CLONE domain, submitted to the FACTORY with pool as arg 0', async () => {
+    const proposalId = poolMatrixHash(entries)
+    const intent = await signedPoolIntent(ctx.config, { action: 'poolApprove', params: { proposalId } })
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(202)
+    expect(ctx.engine.submissions).toHaveLength(1)
+    const { args } = ctx.engine.submissions[0]
+    // tx.to is the whitelisted FACTORY, never the dynamic clone.
+    expect(args.to.toLowerCase()).toBe(factoryOf().toLowerCase())
+    const decoded = entrypointInterface.decodeFunctionData('approveWithSigFor', args.data)
+    expect(decoded[0].toLowerCase()).toBe(POOL_ADDRESS.toLowerCase()) // pool
+    expect(decoded[1].toLowerCase()).toBe(proposalId.toLowerCase()) // proposalId
+    expect(decoded[2].toLowerCase()).toBe(wallet.address.toLowerCase()) // signer
+  })
+
+  it('poolClaim — binds entries/index/recipient, forwarded to the factory', async () => {
+    const intent = await signedPoolIntent(ctx.config, {
+      action: 'poolClaim',
+      params: { entries, index: 0, recipient: wallet.address },
+    })
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(202)
+    const decoded = entrypointInterface.decodeFunctionData('claimWithSigFor', ctx.engine.submissions[0].args.data)
+    expect(decoded[0].toLowerCase()).toBe(POOL_ADDRESS.toLowerCase())
+    expect(decoded[2]).toBe(0n) // index
+    expect(decoded[3].toLowerCase()).toBe(wallet.address.toLowerCase()) // recipient
+  })
+
+  it('poolProposeOutcome — accepts a matching proposalId, rejects a mismatched one', async () => {
+    const good = await signedPoolIntent(ctx.config, {
+      action: 'poolProposeOutcome',
+      params: { entries, proposalId: poolMatrixHash(entries) },
+    })
+    expect((await post(ctx.app, good)).status).toBe(202)
+
+    const bad = await signedPoolIntent(ctx.config, {
+      action: 'poolProposeOutcome',
+      params: { entries, proposalId: ethers.ZeroHash }, // != keccak256(entries)
+    })
+    const res = await post(ctx.app, bad)
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('param_binding_mismatch')
+  })
+
+  it('poolCreate — verified under the FACTORY domain (no clone yet), attributed to the signer', async () => {
+    const intent = await signedPoolIntent(ctx.config, {
+      action: 'poolCreate',
+      params: {
+        token: ctx.config.chains[137].paymentToken,
+        buyIn: 10_000_000n,
+        maxMembers: 5,
+        thresholdBips: 6000,
+        acceptDeadline: TEST_NOW + 7 * 86400,
+        resolveDeadline: TEST_NOW + 14 * 86400,
+      },
+    })
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(202)
+    const { args } = ctx.engine.submissions[0]
+    expect(args.to.toLowerCase()).toBe(factoryOf().toLowerCase())
+    const decoded = entrypointInterface.decodeFunctionData('createPoolWithSig', args.data)
+    expect(decoded[1].toLowerCase()).toBe(wallet.address.toLowerCase()) // signer == creator
+  })
+
+  it('poolJoin — EIP-3009 into the clone, forwarded via the factory (authorization.to == pool)', async () => {
+    const intent = await signedPoolJoinIntent(ctx.config, { value: 10_000_000n })
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(202)
+    const { args } = ctx.engine.submissions[0]
+    expect(args.to.toLowerCase()).toBe(factoryOf().toLowerCase())
+    const decoded = entrypointInterface.decodeFunctionData('joinWithAuthorizationFor', args.data)
+    expect(decoded[0].toLowerCase()).toBe(POOL_ADDRESS.toLowerCase()) // pool
+    expect(decoded[1].toLowerCase()).toBe(wallet.address.toLowerCase()) // from
+    expect(decoded[2]).toBe(10_000_000n) // value
+  })
+
+  it('poolJoin — 400 param_binding_mismatch when authorization.to is not the pool', async () => {
+    const intent = await signedPoolJoinIntent(ctx.config, {})
+    intent.authorization.to = ethers.Wallet.createRandom().address // redirect the money
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('param_binding_mismatch')
+    expect(ctx.engine.submissions).toHaveLength(0)
+  })
+
+  it('provenance — 400 target_not_allowlisted for a pool the factory did not create (poolAddressToId == 0)', async () => {
+    const ctx0 = build({ providers: mockProviders(testConfig(), { poolId: 0n }) })
+    const intent = await signedPoolIntent(ctx0.config, { action: 'poolApprove', params: { proposalId: poolMatrixHash(entries) } })
+    const res = await post(ctx0.app, intent)
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('target_not_allowlisted')
+    expect(ctx0.engine.submissions).toHaveLength(0)
+  })
+
+  it('provenance — 503 (self-submit) when the provenance eth_call fails', async () => {
+    const ctx503 = build({ providers: mockProviders(testConfig(), { screenError: true }) })
+    const intent = await signedPoolIntent(ctx503.config, { action: 'poolApprove', params: { proposalId: poolMatrixHash(entries) } })
+    const res = await post(ctx503.app, intent)
+    expect(res.status).toBe(503)
+    expect(ctx503.engine.submissions).toHaveLength(0)
+  })
+
+  it('targeting the clone directly is rejected — only the factory is pinned', async () => {
+    const intent = await signedPoolIntent(ctx.config, { action: 'poolApprove', params: { proposalId: poolMatrixHash(entries) } })
+    intent.targetContract = POOL_ADDRESS // clone address is not in the pinned target set
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('target_not_allowlisted')
+  })
+
+  it('signer-attributed pool actions work on Mordor (63), which pins the factory but has no EIP-3009', async () => {
+    const intent = await signedPoolIntent(ctx.config, {
+      chainId: 63,
+      action: 'poolClaim',
+      params: { entries, index: 0, recipient: wallet.address },
+    })
+    const res = await post(ctx.app, intent)
+    expect(res.status).toBe(202)
+    expect(ctx.engine.submissions[0].args.relayerId).toBe('mordor-63')
   })
 })
 

--- a/services/relay-gateway/test/helpers.js
+++ b/services/relay-gateway/test/helpers.js
@@ -60,11 +60,16 @@ export function mockProvider({
   // Tier-2 pool provenance: WagerPoolFactory.poolAddressToId(address) answer. Default 1 (nonzero =>
   // recognized clone). Set 0 to simulate an unknown/forged pool address (400 target_not_allowlisted).
   poolId = 1n,
+  // When set, the provenance call returns this RAW hex verbatim (e.g. '0x' to simulate a
+  // malformed/empty node response). Overrides `poolId` — used to assert the decode-failure path
+  // maps to a retryable 503 (never-stranded), not a hard 400.
+  poolIdRaw = null,
 } = {}) {
   return {
     async call(tx) {
       if (screenError) throw new Error('rpc unreachable')
       if (tx?.data?.startsWith(POOL_ID_SELECTOR)) {
+        if (poolIdRaw != null) return poolIdRaw
         return abi.encode(['uint256'], [poolId])
       }
       if (tx?.data?.startsWith('0x1626ba7e')) {

--- a/services/relay-gateway/test/helpers.js
+++ b/services/relay-gateway/test/helpers.js
@@ -7,7 +7,18 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { ethers } from 'ethers'
 import { loadConfig } from '../src/config/index.js'
-import { CONTRACT_DOMAINS, RECEIVE_WITH_AUTHORIZATION_TYPES, typesFor, ACTIONS } from '../src/intent/intentTypes.js'
+import { CONTRACT_DOMAINS, RECEIVE_WITH_AUTHORIZATION_TYPES, typesFor, ACTIONS, INTENT_TYPES } from '../src/intent/intentTypes.js'
+
+// Selector for WagerPoolFactory.poolAddressToId(address) — the Tier-2 provenance eth_call.
+const POOL_ID_SELECTOR = ethers.id('poolAddressToId(address)').slice(0, 10)
+
+/** Recursively convert BigInts to decimal strings so a body survives JSON.stringify (mirrors the client). */
+function jsonSafe(v) {
+  if (typeof v === 'bigint') return v.toString()
+  if (Array.isArray(v)) return v.map(jsonSafe)
+  if (v && typeof v === 'object') return Object.fromEntries(Object.entries(v).map(([k, x]) => [k, jsonSafe(x)]))
+  return v
+}
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 export const DEPLOYMENTS_DIR = path.resolve(__dirname, '../../../deployments')
@@ -46,10 +57,16 @@ export function mockProvider({
   // (selector 0x1626ba7e) on those addresses answer accordingly; addresses
   // not in the map behave like codeless accounts (eth_call returns '0x').
   erc1271 = {},
+  // Tier-2 pool provenance: WagerPoolFactory.poolAddressToId(address) answer. Default 1 (nonzero =>
+  // recognized clone). Set 0 to simulate an unknown/forged pool address (400 target_not_allowlisted).
+  poolId = 1n,
 } = {}) {
   return {
     async call(tx) {
       if (screenError) throw new Error('rpc unreachable')
+      if (tx?.data?.startsWith(POOL_ID_SELECTOR)) {
+        return abi.encode(['uint256'], [poolId])
+      }
       if (tx?.data?.startsWith('0x1626ba7e')) {
         const mode = erc1271[tx.to?.toLowerCase()]
         if (mode === 'magic') return '0x1626ba7e' + '0'.repeat(56)
@@ -218,4 +235,99 @@ export async function signedPaymentIntent(config, {
     uniquenessMarker: marker,
     fundingMode: 'sponsored',
   }
+}
+
+// A stand-in pool clone address for provenance-mocked tests (mockProvider answers poolAddressToId).
+export const POOL_ADDRESS = '0x1111111111111111111111111111111111111111'
+
+/**
+ * Build + sign a Tier-2 pool signer-attributed intent. Targets the factory, but signs under the CLONE's
+ * domain (verifyingContract = `pool`) for the six actor twins, or the FACTORY's domain for poolCreate.
+ * `params` supplies the action-specific struct/calldata fields (proposalId, entries, index, recipient,
+ * or the createPool tuple); the actor field is filled with the signer.
+ */
+export async function signedPoolIntent(config, {
+  chainId = 137,
+  action = 'poolApprove',
+  signer = wallet,
+  pool = POOL_ADDRESS,
+  params = {},
+  validAfter = 0,
+  validBefore = TEST_NOW + 3600,
+  marker = randomMarker(),
+  domainChainId,
+} = {}) {
+  const def = ACTIONS[action]
+  const chain = config.chains[chainId]
+  const domainCId = domainChainId ?? chainId
+  const usesCloneDomain = def.verifyingContractParam === 'pool'
+  const verifyingContract = usesCloneDomain ? pool : config.chains[domainCId].targetsByKey[def.contract]
+  const domain = { ...CONTRACT_DOMAINS[def.domainContract ?? def.contract], chainId: domainCId, verifyingContract }
+  const actor = signer.address
+  const message = {}
+  for (const f of INTENT_TYPES[def.typeName]) {
+    if (f.name === def.actorField) message[f.name] = actor
+    else if (f.name === 'nonce') message[f.name] = marker
+    else if (f.name === 'validAfter') message[f.name] = validAfter
+    else if (f.name === 'validBefore') message[f.name] = validBefore
+    else message[f.name] = params[f.name]
+  }
+  const signature = await signer.signTypedData(domain, typesFor(action), message)
+  const outParams = { ...params, [def.actorField]: actor }
+  if (usesCloneDomain) outParams.pool = pool
+  return {
+    intentClass: 'signer-attributed',
+    chainId,
+    targetContract: chain.targetsByKey[def.contract],
+    action,
+    // The wire body is JSON, so BigInts (entries amounts, buyIn) travel as decimal strings — exactly
+    // as the frontend serializes them; the gateway coerces them back via asUint before re-hashing.
+    params: jsonSafe(outParams),
+    signature,
+    validAfter,
+    validBefore,
+    uniquenessMarker: marker,
+    fundingMode: 'sponsored',
+  }
+}
+
+/** Build + sign a Tier-2 gasless pool JOIN (EIP-3009 into the clone; no separate intent struct). */
+export async function signedPoolJoinIntent(config, {
+  chainId = 137,
+  signer = wallet,
+  pool = POOL_ADDRESS,
+  value = 1_000_000n,
+  validAfter = 0,
+  validBefore = TEST_NOW + 3600,
+  marker = randomMarker(),
+} = {}) {
+  const chain = config.chains[chainId]
+  const tokenDomain = {
+    name: chain.tokenDomain.name,
+    version: chain.tokenDomain.version,
+    chainId,
+    verifyingContract: chain.paymentToken,
+  }
+  const auth = { from: signer.address, to: pool, value, validAfter, validBefore, nonce: marker }
+  const authSig = ethers.Signature.from(await signer.signTypedData(tokenDomain, RECEIVE_WITH_AUTHORIZATION_TYPES, auth))
+  return {
+    intentClass: 'payment',
+    chainId,
+    targetContract: chain.targetsByKey.wagerPoolFactory,
+    action: 'poolJoin',
+    params: { pool },
+    signature: '0x',
+    authorization: { ...auth, value: value.toString(), v: authSig.v, r: authSig.r, s: authSig.s },
+    validAfter,
+    validBefore,
+    uniquenessMarker: marker,
+    fundingMode: 'sponsored',
+  }
+}
+
+/** keccak256(abi.encode(PayoutEntry[])) — the pool proposalId / lockedOutcome. */
+export function poolMatrixHash(entries) {
+  return ethers.keccak256(
+    abi.encode(['tuple(address winner,uint256 amount)[]'], [entries.map((e) => ({ winner: e.winner, amount: e.amount }))])
+  )
 }

--- a/test/helpers/wagerpool.js
+++ b/test/helpers/wagerpool.js
@@ -175,6 +175,94 @@ const signCancel = (pool, signer, opts) =>
 const signRefund = (pool, signer, opts) =>
   signIntent(pool, signer, 'Refund', [{ name: 'member', type: 'address' }, ...TAIL], { member: signer.address }, opts);
 
+// ---------------------------------------------------------------------------
+// Factory-domain intent signing (spec 035/036 Tier 2 — createPoolWithSig)
+// ---------------------------------------------------------------------------
+
+/**
+ * Sign a CreatePool intent against the FACTORY's own EIP-712 domain
+ * ("FairWins WagerPoolFactory"/"1"). Fields must match CREATE_POOL_TYPEHASH exactly.
+ * `params` is a CreatePoolParams-shaped object.
+ */
+async function signCreatePool(factory, signer, params, opts = {}) {
+  const { chainId } = await ethers.provider.getNetwork();
+  const now = (await ethers.provider.getBlock('latest')).timestamp;
+  const window = opts.window ?? 3600;
+  const nonce = opts.nonce ?? randNonce();
+  const validAfter = opts.validAfter ?? now - 60;
+  const validBefore = opts.validBefore ?? now + window;
+  const domain = {
+    name: 'FairWins WagerPoolFactory',
+    version: '1',
+    chainId: Number(chainId),
+    verifyingContract: await factory.getAddress(),
+  };
+  const types = {
+    CreatePool: [
+      { name: 'creator', type: 'address' },
+      { name: 'token', type: 'address' },
+      { name: 'buyIn', type: 'uint256' },
+      { name: 'maxMembers', type: 'uint32' },
+      { name: 'thresholdBips', type: 'uint16' },
+      { name: 'acceptDeadline', type: 'uint64' },
+      { name: 'resolveDeadline', type: 'uint64' },
+      ...TAIL,
+    ],
+  };
+  const message = {
+    creator: signer.address,
+    token: params.token,
+    buyIn: params.buyIn,
+    maxMembers: params.maxMembers,
+    thresholdBips: params.thresholdBips,
+    acceptDeadline: params.acceptDeadline,
+    resolveDeadline: params.resolveDeadline,
+    nonce,
+    validAfter,
+    validBefore,
+  };
+  const sig = await signer.signTypedData(domain, types, message);
+  return { sig, nonce, validAfter, validBefore };
+}
+
+/**
+ * Sign an EIP-3009 ReceiveWithAuthorization for a MockUSDCPermit-style token (the gasless join leg).
+ * Returns split { v, r, s } plus the window/nonce so callers can splat into joinWithAuthorization[For].
+ */
+async function signReceiveAuth(token, from, to, value, opts = {}) {
+  const { chainId } = await ethers.provider.getNetwork();
+  const now = (await ethers.provider.getBlock('latest')).timestamp;
+  const nonce = opts.nonce ?? randNonce();
+  const validAfter = opts.validAfter ?? 0;
+  const validBefore = opts.validBefore ?? now + (opts.window ?? 3600);
+  const domain = {
+    name: 'USD Coin',
+    version: '1',
+    chainId: Number(chainId),
+    verifyingContract: await token.getAddress(),
+  };
+  const types = {
+    ReceiveWithAuthorization: [
+      { name: 'from', type: 'address' },
+      { name: 'to', type: 'address' },
+      { name: 'value', type: 'uint256' },
+      { name: 'validAfter', type: 'uint256' },
+      { name: 'validBefore', type: 'uint256' },
+      { name: 'nonce', type: 'bytes32' },
+    ],
+  };
+  const sig = await from.signTypedData(domain, types, {
+    from: from.address,
+    to,
+    value,
+    validAfter,
+    validBefore,
+    nonce,
+  });
+  const { v, r, s } = ethers.Signature.from(sig);
+  return { v, r, s, nonce, validAfter, validBefore };
+}
+
 module.exports = {
   ZERO,
   usdc,
@@ -192,4 +280,6 @@ module.exports = {
   signClose,
   signCancel,
   signRefund,
+  signCreatePool,
+  signReceiveAuth,
 };

--- a/test/pools/WagerPoolFactory.forwarders.test.js
+++ b/test/pools/WagerPoolFactory.forwarders.test.js
@@ -1,0 +1,374 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+const { time } = require('@nomicfoundation/hardhat-network-helpers');
+const { anyValue } = require('@nomicfoundation/hardhat-chai-matchers/withArgs');
+const {
+  deployPoolFactory,
+  deployToken,
+  defaultParams,
+  createPool,
+  matrixHash,
+  usdc,
+  randNonce,
+  signApprove,
+  signClaim,
+  signPropose,
+  signClose,
+  signCancel,
+  signRefund,
+  signCreatePool,
+  signReceiveAuth,
+} = require('../helpers/wagerpool');
+
+// Tier-2 gasless pools (spec 035/036): the WagerPoolFactory routes a clone's …WithSig / …WithAuthorization
+// twin through the STABLE factory address so only the factory is whitelisted at the relayer engine
+// (FR-025). Each forwarder enforces pool provenance ON-CHAIN (poolAddressToId != 0) then passes through to
+// the clone, which independently verifies the member's EIP-712 signature against its own per-clone domain.
+// The clone twins themselves are exhaustively covered by WagerPool.withsig.test.js; here we prove: (1) the
+// provenance guard rejects non-pools, (2) each forwarder actually forwards + attributes to the SIGNER not
+// the relayer, (3) clone-side guards still bubble up through the forwarder, and (4) the new factory-verified
+// createPoolWithSig behaves like an intent (attribution, replay, expiry, wrong-signer, screening).
+
+describe('WagerPoolFactory — relayer forwarders (Tier 2)', function () {
+  let admin, creator, m2, m3, outsider, relayer, factory, token;
+
+  beforeEach(async function () {
+    [admin, creator, m2, m3, outsider, relayer] = await ethers.getSigners();
+    ({ factory } = await deployPoolFactory({ admin: admin.address }));
+    token = await deployToken([creator, m2, m3, outsider, relayer]);
+  });
+
+  // --- state builders ------------------------------------------------------
+  async function makePool(overrides = {}) {
+    const params = await defaultParams(token, { maxMembers: 2, thresholdBips: 10000, ...overrides });
+    const { pool } = await createPool(factory, creator, params);
+    return pool;
+  }
+  async function joinAs(pool, signer) {
+    await token.connect(signer).approve(await pool.getAddress(), await pool.buyIn());
+    return pool.connect(signer).join();
+  }
+  function evenSplit() {
+    return [
+      { winner: creator.address, amount: usdc(15) },
+      { winner: m2.address, amount: usdc(5) },
+    ];
+  }
+  async function openWithMembers() {
+    const pool = await makePool({ maxMembers: 5 });
+    await joinAs(pool, creator);
+    await joinAs(pool, m2);
+    return pool; // JoiningOpen, 2 members
+  }
+  async function closedPool() {
+    const pool = await makePool({ maxMembers: 2, thresholdBips: 10000 });
+    await joinAs(pool, creator);
+    await joinAs(pool, m2); // auto-close on full, escrow 20
+    return pool;
+  }
+  async function proposedPool() {
+    const pool = await closedPool();
+    const entries = evenSplit();
+    const pid = matrixHash(entries);
+    await pool.connect(creator).proposeOutcome(entries);
+    return { pool, entries, pid };
+  }
+  async function resolvedPool() {
+    const { pool, entries, pid } = await proposedPool();
+    await pool.connect(creator).approve();
+    await pool.connect(m2).approve(); // locks (100% threshold)
+    return { pool, entries, pid };
+  }
+
+  const addr = (c) => c.getAddress();
+
+  // =========================================================================
+  // 1. On-chain provenance guard — every forwarder rejects a non-pool target
+  // =========================================================================
+  describe('provenance guard (UnknownPool)', function () {
+    it('rejects a target this factory never created', async function () {
+      const fake = outsider.address; // never registered → poolAddressToId == 0
+      const n = randNonce();
+      const now = await time.latest();
+      const va = 0;
+      const vb = now + 3600;
+      const emptySig = '0x';
+
+      await expect(factory.closeJoiningWithSigFor(fake, m2.address, n, va, vb, emptySig)).to.be.revertedWithCustomError(
+        factory,
+        'UnknownPool'
+      );
+      await expect(factory.cancelWithSigFor(fake, m2.address, n, va, vb, emptySig)).to.be.revertedWithCustomError(
+        factory,
+        'UnknownPool'
+      );
+      await expect(
+        factory.proposeOutcomeWithSigFor(fake, evenSplit(), m2.address, n, va, vb, emptySig)
+      ).to.be.revertedWithCustomError(factory, 'UnknownPool');
+      await expect(
+        factory.approveWithSigFor(fake, ethers.ZeroHash, m2.address, n, va, vb, emptySig)
+      ).to.be.revertedWithCustomError(factory, 'UnknownPool');
+      await expect(
+        factory.claimWithSigFor(fake, evenSplit(), 0, outsider.address, m2.address, n, va, vb, emptySig)
+      ).to.be.revertedWithCustomError(factory, 'UnknownPool');
+      await expect(factory.refundWithSigFor(fake, m2.address, n, va, vb, emptySig)).to.be.revertedWithCustomError(
+        factory,
+        'UnknownPool'
+      );
+      await expect(
+        factory.joinWithAuthorizationFor(fake, m2.address, usdc(10), va, vb, n, 27, ethers.ZeroHash, ethers.ZeroHash)
+      ).to.be.revertedWithCustomError(factory, 'UnknownPool');
+      await expect(factory.pokeDeadlineFor(fake)).to.be.revertedWithCustomError(factory, 'UnknownPool');
+      await expect(
+        factory.invalidateNonceWithSigFor(fake, m2.address, n, vb, emptySig)
+      ).to.be.revertedWithCustomError(factory, 'UnknownPool');
+    });
+
+    it('accepts a real pool (guard passes, clone-side verification runs)', async function () {
+      const pool = await openWithMembers();
+      // Bad signature at the clone → NOT UnknownPool (guard passed), but the clone rejects it.
+      const s = await signClose(pool, outsider); // outsider is not creator; sig is valid but wrong role bubbles
+      await expect(
+        factory.connect(relayer).closeJoiningWithSigFor(await addr(pool), outsider.address, s.nonce, s.validAfter, s.validBefore, s.sig)
+      ).to.be.revertedWithCustomError(pool, 'NotCreator');
+    });
+  });
+
+  // =========================================================================
+  // 2. Signer-attributed forwarders — relayer submits, signer is attributed
+  // =========================================================================
+  describe('signer-attributed forwarders (relayer submits, signer attributed)', function () {
+    it('closeJoiningWithSigFor — creator signs, relayer closes via factory', async function () {
+      const pool = await openWithMembers();
+      const s = await signClose(pool, creator);
+      await factory
+        .connect(relayer)
+        .closeJoiningWithSigFor(await addr(pool), creator.address, s.nonce, s.validAfter, s.validBefore, s.sig);
+      expect(await pool.state()).to.equal(1); // JoiningClosed
+    });
+
+    it('cancelWithSigFor — creator signs, relayer cancels via factory', async function () {
+      const pool = await openWithMembers();
+      const s = await signCancel(pool, creator);
+      await factory
+        .connect(relayer)
+        .cancelWithSigFor(await addr(pool), creator.address, s.nonce, s.validAfter, s.validBefore, s.sig);
+      expect(await pool.state()).to.equal(3); // Cancelled
+    });
+
+    it('proposeOutcomeWithSigFor — creator signs matrix, relayer proposes via factory', async function () {
+      const pool = await closedPool();
+      const entries = evenSplit();
+      const pid = matrixHash(entries);
+      const s = await signPropose(pool, creator, pid);
+      await expect(
+        factory
+          .connect(relayer)
+          .proposeOutcomeWithSigFor(await addr(pool), entries, creator.address, s.nonce, s.validAfter, s.validBefore, s.sig)
+      )
+        .to.emit(pool, 'OutcomeProposed')
+        .withArgs(pid, anyValue);
+    });
+
+    it('approveWithSigFor — member signs, relayer approves via factory (proposalId pinned)', async function () {
+      const { pool, pid } = await proposedPool();
+      const s = await signApprove(pool, m2, pid);
+      await expect(
+        factory
+          .connect(relayer)
+          .approveWithSigFor(await addr(pool), pid, m2.address, s.nonce, s.validAfter, s.validBefore, s.sig)
+      )
+        .to.emit(pool, 'Approved')
+        .withArgs(pid, m2.address);
+    });
+
+    it('claimWithSigFor — winner signs, funds go to signer-chosen recipient, never the relayer', async function () {
+      const { pool, entries } = await resolvedPool();
+      const before = await token.balanceOf(outsider.address);
+      const relBefore = await token.balanceOf(relayer.address);
+      // creator is entries[0].winner (15 USDC), recipient = outsider
+      const s = await signClaim(pool, creator, 0, outsider.address);
+      await factory
+        .connect(relayer)
+        .claimWithSigFor(await addr(pool), entries, 0, outsider.address, creator.address, s.nonce, s.validAfter, s.validBefore, s.sig);
+      expect(await token.balanceOf(outsider.address)).to.equal(before + usdc(15));
+      expect(await token.balanceOf(relayer.address)).to.equal(relBefore); // relayer never receives funds
+    });
+
+    it('refundWithSigFor — member signs, buy-in returns to signer via factory', async function () {
+      const pool = await openWithMembers();
+      await pool.connect(creator).cancel(); // now refundable
+      const before = await token.balanceOf(m2.address);
+      const s = await signRefund(pool, m2);
+      await factory
+        .connect(relayer)
+        .refundWithSigFor(await addr(pool), m2.address, s.nonce, s.validAfter, s.validBefore, s.sig);
+      expect(await token.balanceOf(m2.address)).to.equal(before + usdc(10));
+    });
+
+    it('invalidateNonceWithSigFor — member cancels an unused nonce on the clone via factory', async function () {
+      const pool = await openWithMembers();
+      const nonce = randNonce();
+      const now = await time.latest();
+      const validBefore = now + 3600;
+      // Sign an InvalidateNonce intent against the CLONE domain.
+      const domain = {
+        name: 'FairWins WagerPool',
+        version: '1',
+        chainId: Number((await ethers.provider.getNetwork()).chainId),
+        verifyingContract: await addr(pool),
+      };
+      const types = {
+        InvalidateNonce: [
+          { name: 'signer', type: 'address' },
+          { name: 'nonce', type: 'bytes32' },
+          { name: 'validBefore', type: 'uint256' },
+        ],
+      };
+      const sig = await m2.signTypedData(domain, types, { signer: m2.address, nonce, validBefore });
+      expect(await pool.authorizationState(m2.address, nonce)).to.equal(false);
+      await factory.connect(relayer).invalidateNonceWithSigFor(await addr(pool), m2.address, nonce, validBefore, sig);
+      expect(await pool.authorizationState(m2.address, nonce)).to.equal(true);
+    });
+  });
+
+  // =========================================================================
+  // 3. Payment + keeper forwarders
+  // =========================================================================
+  describe('payment + keeper forwarders', function () {
+    it('joinWithAuthorizationFor — member signs EIP-3009, relayer joins via factory, escrow funded', async function () {
+      const pool = await makePool({ maxMembers: 5 });
+      const buyIn = await pool.buyIn();
+      const poolAddr = await addr(pool);
+      const auth = await signReceiveAuth(token, m3, poolAddr, buyIn);
+      const escrowBefore = await token.balanceOf(poolAddr);
+      await factory
+        .connect(relayer)
+        .joinWithAuthorizationFor(poolAddr, m3.address, buyIn, auth.validAfter, auth.validBefore, auth.nonce, auth.v, auth.r, auth.s);
+      expect(await token.balanceOf(poolAddr)).to.equal(escrowBefore + buyIn);
+      expect(await pool.memberCount()).to.equal(1n);
+    });
+
+    it('pokeDeadlineFor — relayer closes joining after acceptDeadline via factory', async function () {
+      const pool = await openWithMembers();
+      const acceptDeadline = await pool.acceptDeadline();
+      await time.increaseTo(acceptDeadline + 1n);
+      await factory.connect(relayer).pokeDeadlineFor(await addr(pool));
+      expect(await pool.state()).to.equal(1); // JoiningClosed
+    });
+  });
+
+  // =========================================================================
+  // 4. createPoolWithSig — factory-verified intent (attribution + guards)
+  // =========================================================================
+  describe('createPoolWithSig', function () {
+    it('creates a pool attributed to the SIGNER, submitted by the relayer', async function () {
+      const params = await defaultParams(token, { maxMembers: 3 });
+      const s = await signCreatePool(factory, m2, params); // m2 is the intended creator
+      const rc = await (
+        await factory
+          .connect(relayer)
+          .createPoolWithSig(params, m2.address, s.nonce, s.validAfter, s.validBefore, s.sig)
+      ).wait();
+      const ev = rc.logs
+        .map((l) => {
+          try {
+            return factory.interface.parseLog(l);
+          } catch {
+            return null;
+          }
+        })
+        .find((e) => e && e.name === 'PoolCreated');
+      expect(ev.args.creator).to.equal(m2.address); // attributed to signer, not relayer
+      const pool = await ethers.getContractAt('WagerPool', ev.args.pool);
+      expect(await pool.creator()).to.equal(m2.address);
+      expect(await factory.poolAddressToId(ev.args.pool)).to.equal(ev.args.poolId);
+    });
+
+    it('rejects a replayed nonce (IntentReplayed)', async function () {
+      const params = await defaultParams(token, { maxMembers: 3 });
+      const s = await signCreatePool(factory, m2, params);
+      await factory.connect(relayer).createPoolWithSig(params, m2.address, s.nonce, s.validAfter, s.validBefore, s.sig);
+      // Re-sign an identical intent reusing the SAME nonce → replay.
+      const s2 = await signCreatePool(factory, m2, params, { nonce: s.nonce });
+      await expect(
+        factory.connect(relayer).createPoolWithSig(params, m2.address, s2.nonce, s2.validAfter, s2.validBefore, s2.sig)
+      ).to.be.revertedWithCustomError(factory, 'IntentReplayed');
+    });
+
+    it('rejects an expired intent (IntentExpired)', async function () {
+      const params = await defaultParams(token, { maxMembers: 3 });
+      const now = await time.latest();
+      const s = await signCreatePool(factory, m2, params, { validBefore: now - 1, validAfter: 0 });
+      await expect(
+        factory.connect(relayer).createPoolWithSig(params, m2.address, s.nonce, s.validAfter, s.validBefore, s.sig)
+      ).to.be.revertedWithCustomError(factory, 'IntentExpired');
+    });
+
+    it('rejects a not-yet-valid intent (IntentNotYetValid)', async function () {
+      const params = await defaultParams(token, { maxMembers: 3 });
+      const now = await time.latest();
+      const s = await signCreatePool(factory, m2, params, { validAfter: now + 3600, validBefore: now + 7200 });
+      await expect(
+        factory.connect(relayer).createPoolWithSig(params, m2.address, s.nonce, s.validAfter, s.validBefore, s.sig)
+      ).to.be.revertedWithCustomError(factory, 'IntentNotYetValid');
+    });
+
+    it('rejects a signature that does not recover the claimed signer (InvalidIntentSignature)', async function () {
+      const params = await defaultParams(token, { maxMembers: 3 });
+      const s = await signCreatePool(factory, m3, params); // signed by m3
+      await expect(
+        // ...but claims m2 as the signer
+        factory.connect(relayer).createPoolWithSig(params, m2.address, s.nonce, s.validAfter, s.validBefore, s.sig)
+      ).to.be.revertedWithCustomError(factory, 'InvalidIntentSignature');
+    });
+
+    it('rejects tampered params (signature no longer recovers signer)', async function () {
+      const params = await defaultParams(token, { maxMembers: 3 });
+      const s = await signCreatePool(factory, m2, params);
+      const tampered = { ...params, buyIn: usdc(999) }; // relayer bumps the buy-in
+      await expect(
+        factory.connect(relayer).createPoolWithSig(tampered, m2.address, s.nonce, s.validAfter, s.validBefore, s.sig)
+      ).to.be.revertedWithCustomError(factory, 'InvalidIntentSignature');
+    });
+  });
+
+  // =========================================================================
+  // 5. createPoolWithSig screens the SIGNER (compliance on the real wallet, FR-021)
+  // =========================================================================
+  describe('createPoolWithSig screening (FR-021)', function () {
+    it('screens the signer (not the relayer) when screening is required', async function () {
+      // Deploy a screening-required factory with a sanctions guard that blocks m2.
+      const Guard = await ethers.getContractFactory('MockPoolSanctions');
+      const guard = await Guard.deploy();
+      await guard.waitForDeployment();
+      const Membership = await ethers.getContractFactory('MockPoolMembership');
+      const membership = await Membership.deploy();
+      await membership.waitForDeployment(); // setAllowed defaults true
+
+      const { factory: sfactory } = await deployPoolFactory({
+        admin: admin.address,
+        screeningRequired: true,
+        sanctionsGuard: await guard.getAddress(),
+        membershipManager: await membership.getAddress(),
+      });
+      await sfactory.connect(admin).setAllowedToken(await token.getAddress(), true);
+
+      const params = await defaultParams(token, { maxMembers: 3 });
+
+      // Block the SIGNER (m2). Even though the relayer is clean, the create must revert.
+      await guard.setDenied(m2.address, true);
+      const s = await signCreatePool(sfactory, m2, params);
+      await expect(
+        sfactory.connect(relayer).createPoolWithSig(params, m2.address, s.nonce, s.validAfter, s.validBefore, s.sig)
+      ).to.be.revertedWithCustomError(guard, 'SanctionedAddress'); // sanctions guard blocks m2
+
+      // Unblock m2 → same intent now succeeds (fresh nonce).
+      await guard.setDenied(m2.address, false);
+      const s2 = await signCreatePool(sfactory, m2, params);
+      await expect(
+        sfactory.connect(relayer).createPoolWithSig(params, m2.address, s2.nonce, s2.validAfter, s2.validBefore, s2.sig)
+      ).to.emit(sfactory, 'PoolCreated');
+    });
+  });
+});


### PR DESCRIPTION
## Tier 2 gasless group pools (Design A: factory-forwarder)

Every WagerPool actor action is now gaslessly relayable, routed through the **stable WagerPoolFactory** so the relayer engine whitelists only the factory (FR-025). Clone provenance is enforced **on-chain** (`poolAddressToId != 0`) — a compromised relayer/gateway can still only reach pools this factory created.

### Layers
- **Contract** — `WagerPoolFactory` gains `SignerIntentBase` + `createPoolWithSig` + 9 forwarders (`{close,cancel,propose,approve,claim,refund}WithSigFor`, `joinWithAuthorizationFor`, `pokeDeadlineFor`, `invalidateNonceWithSigFor`). UUPS **append-only** (storage-gated); `initializeIntents` reinitializer wires the factory EIP-712 domain. +11 KB headroom.
- **Gateway** — 8 pool actions with the **domain/target split** (clone domain, factory target), `poolAddressToId` provenance `eth_call`, `authorization.to == pool` for join. Also **fixes a latent `normalizeParams` bug** that corrupted address/bool/string params (repairs `createWager`/`declareWinner`).
- **Client** — 8 pool intent actions + domain/target split + `authOnly` join; three-place typehash parity locked by test.
- **Engine** — factory added to `whitelist_receivers` (137 + 63); **reconciled the drifted build-context config** from the production snapshot (it had stale Polygon whitelist addresses).
- **Frontend** — all 8 `usePools` actions via `useGaslessWrite` with a self-submit fallback (never-stranded); `createPool` re-reads its receipt for the `PoolCreated` return.

### Tests
69 contract pool · 45 gateway (10 new pool) · 11 client pool · 60 frontend — all green. Storage-layout gate passes.

### Deploy (follow-up, ordered)
factory upgrade Mordor→Polygon (`upgradeProxy` call:`initializeIntents`) → engine rebuild+replace → gateway redeploy → **frontend last** (SPA already points at the live relayer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)