### PR TITLE
feat(wallet): Pay & Transfer section — gasless stablecoin + native transfers

### DIFF
--- a/frontend/src/components/wallet/PayTransfer.css
+++ b/frontend/src/components/wallet/PayTransfer.css
@@ -1,0 +1,305 @@
+/* Pay & Transfer wallet section — theme-aware, maps onto the shared app CSS variables. */
+
+.pt-root {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.pt-intro {
+  color: var(--color-text-secondary, var(--text-secondary, #6b7280));
+  font-size: 0.95rem;
+  margin: 0 0 0.25rem;
+}
+
+/* Tabs */
+.pt-tabs {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--color-border, var(--border-color, #e5e7eb));
+}
+.pt-tab {
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--color-text-secondary, var(--text-secondary, #6b7280));
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.6rem 1rem;
+}
+.pt-tab.active {
+  color: var(--color-primary, var(--brand-primary, #6d28d9));
+  border-bottom-color: var(--color-primary, var(--brand-primary, #6d28d9));
+}
+.pt-tab:focus-visible {
+  outline: 2px solid var(--color-primary, #6d28d9);
+  outline-offset: -2px;
+}
+
+/* Form */
+.pt-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+.pt-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.pt-label {
+  color: var(--color-primary, var(--brand-primary, #6d28d9));
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+.pt-hint {
+  color: var(--color-text-tertiary, var(--text-muted, #9ca3af));
+  font-size: 0.8rem;
+}
+
+/* Asset toggle */
+.pt-assets {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+}
+.pt-asset {
+  border: 1px solid var(--color-border, var(--border-color, #e5e7eb));
+  border-radius: 12px;
+  background: var(--color-surface, var(--surface-color, #fff));
+  padding: 0.75rem 0.9rem;
+  cursor: pointer;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.pt-asset.active {
+  border-color: var(--color-primary, #6d28d9);
+  box-shadow: 0 0 0 1px var(--color-primary, #6d28d9) inset;
+}
+.pt-asset-sym {
+  font-weight: 700;
+  color: var(--color-text, var(--text-primary, #111827));
+}
+.pt-asset-bal {
+  font-size: 0.8rem;
+  color: var(--color-text-secondary, var(--text-secondary, #6b7280));
+}
+
+/* Amount input row */
+.pt-amount-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid var(--color-border, var(--border-color, #e5e7eb));
+  border-radius: 10px;
+  padding: 0.1rem 0.75rem;
+  background: var(--color-surface, var(--surface-color, #fff));
+}
+.pt-amount-input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--color-text, var(--text-primary, #111827));
+  font-size: 1.25rem;
+  padding: 0.6rem 0;
+  min-width: 0;
+}
+.pt-amount-input:focus {
+  outline: none;
+}
+.pt-amount-sym {
+  font-weight: 700;
+  color: var(--color-text-secondary, var(--text-secondary, #6b7280));
+}
+.pt-max {
+  appearance: none;
+  border: 1px solid var(--color-border, #e5e7eb);
+  background: transparent;
+  border-radius: 8px;
+  color: var(--color-primary, #6d28d9);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.2rem 0.5rem;
+}
+
+/* From (read-only) */
+.pt-from {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--tm-mono, ui-monospace, monospace);
+  color: var(--color-text-secondary, var(--text-secondary, #6b7280));
+  font-size: 0.9rem;
+}
+
+/* Badges */
+.pt-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.2rem 0.6rem;
+  width: fit-content;
+}
+.pt-badge-gasless {
+  background: color-mix(in srgb, var(--color-success, #16a34a) 15%, transparent);
+  color: var(--color-success, #16a34a);
+}
+.pt-badge-fee {
+  background: var(--color-surface-secondary, #f3f4f6);
+  color: var(--color-text-secondary, #6b7280);
+}
+
+/* Notices */
+.pt-notice {
+  border-radius: 10px;
+  padding: 0.7rem 0.9rem;
+  font-size: 0.9rem;
+}
+.pt-notice-error {
+  background: color-mix(in srgb, var(--color-error, #dc2626) 12%, transparent);
+  color: var(--color-error, #dc2626);
+}
+.pt-notice-warn {
+  background: color-mix(in srgb, #d97706 14%, transparent);
+  color: #b45309;
+}
+.pt-notice-success {
+  background: color-mix(in srgb, var(--color-success, #16a34a) 12%, transparent);
+  color: var(--color-success, #16a34a);
+}
+
+/* Buttons */
+.pt-actions {
+  display: flex;
+  gap: 0.6rem;
+}
+.pt-btn {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 700;
+  padding: 0.85rem 1.5rem;
+  flex: 1;
+}
+.pt-btn-primary {
+  background: var(--color-primary, var(--brand-primary, #6d28d9));
+  color: #fff;
+}
+.pt-btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.pt-btn-secondary {
+  background: transparent;
+  border: 1px solid var(--color-border, #e5e7eb);
+  color: var(--color-text, var(--text-primary, #111827));
+}
+
+/* Preview summary */
+.pt-preview {
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 12px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  background: var(--color-surface-secondary, #f9fafb);
+}
+.pt-preview-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.9rem;
+}
+.pt-preview-row .k {
+  color: var(--color-text-secondary, #6b7280);
+}
+.pt-preview-row .v {
+  color: var(--color-text, #111827);
+  font-weight: 600;
+  text-align: right;
+  word-break: break-all;
+}
+.pt-preview-amount {
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: var(--color-primary, #6d28d9);
+}
+
+/* Activity list */
+.pt-activity {
+  display: flex;
+  flex-direction: column;
+}
+.pt-activity-empty {
+  color: var(--color-text-secondary, #6b7280);
+  padding: 1.5rem 0.25rem;
+  text-align: center;
+}
+.pt-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.9rem 0.25rem;
+  border-bottom: 1px solid var(--color-border, #eee);
+}
+.pt-item-body {
+  min-width: 0;
+  flex: 1;
+}
+.pt-item-status {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-text-secondary, #6b7280);
+  text-transform: capitalize;
+}
+.pt-item-amount {
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--color-primary, #6d28d9);
+  margin: 0.05rem 0;
+}
+.pt-item-route {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-width: 0;
+  color: var(--color-text, #374151);
+  font-size: 0.95rem;
+}
+.pt-item-route code {
+  font-family: var(--tm-mono, ui-monospace, monospace);
+  font-size: 0.85rem;
+}
+.pt-item-arrow {
+  color: var(--color-text-tertiary, #9ca3af);
+}
+.pt-item-date {
+  font-size: 0.8rem;
+  color: var(--color-text-tertiary, #9ca3af);
+  margin-top: 0.15rem;
+}
+.pt-status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+.pt-status-dot.in_process { background: #d97706; }
+.pt-status-dot.complete { background: var(--color-success, #16a34a); }
+.pt-status-dot.failed { background: var(--color-error, #dc2626); }
+.pt-item-link {
+  color: var(--color-primary, #6d28d9);
+  font-size: 1.2rem;
+  text-decoration: none;
+}

--- a/frontend/src/components/wallet/PayTransferPanel.jsx
+++ b/frontend/src/components/wallet/PayTransferPanel.jsx
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+import TransferForm from './TransferForm'
+import TransferActivityList from './TransferActivityList'
+import './PayTransfer.css'
+
+const TABS = [
+  { id: 'transfer', label: 'Transfer' },
+  { id: 'activity', label: 'Activity' },
+]
+
+/**
+ * Pay & Transfer — wallet section for sending the active chain's stablecoin (gasless) or native token to
+ * any address, plus an Activity log of transfers sent from this device. Two tabs mirror the reference
+ * "Transfer Money" design (Transfer / Activity).
+ */
+export default function PayTransferPanel() {
+  const [tab, setTab] = useState('transfer')
+
+  return (
+    <div className="pt-root">
+      <p className="pt-intro">
+        Send stablecoins and native tokens to any wallet or ENS name. Stablecoin transfers are gasless where
+        the rails are available.
+      </p>
+
+      <div className="pt-tabs" role="tablist" aria-label="Pay & Transfer">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            role="tab"
+            aria-selected={tab === t.id}
+            className={`pt-tab ${tab === t.id ? 'active' : ''}`}
+            onClick={() => setTab(t.id)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'transfer' && (
+        <div role="tabpanel" aria-label="Transfer">
+          <TransferForm onSent={() => setTab('activity')} />
+        </div>
+      )}
+      {tab === 'activity' && (
+        <div role="tabpanel" aria-label="Activity">
+          <TransferActivityList />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/wallet/TransferActivityList.jsx
+++ b/frontend/src/components/wallet/TransferActivityList.jsx
@@ -1,0 +1,75 @@
+import { useMemo } from 'react'
+import { useTransferActivity } from '../../hooks/useTransferActivity'
+import { getNetwork } from '../../config/networks'
+import { TRANSFER_STATUS } from '../../lib/transfer/transferStore'
+
+const short = (a) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '')
+
+const STATUS_LABEL = {
+  [TRANSFER_STATUS.IN_PROCESS]: 'In process',
+  [TRANSFER_STATUS.COMPLETE]: 'Complete',
+  [TRANSFER_STATUS.FAILED]: 'Failed',
+}
+
+function formatDate(ts) {
+  try {
+    return new Date(ts).toLocaleDateString(undefined, { year: 'numeric', month: '2-digit', day: '2-digit' })
+  } catch {
+    return ''
+  }
+}
+
+function explorerTxUrl(chainId, txHash) {
+  if (!txHash || String(txHash).length !== 66) return null // only real tx hashes (not userOp/intent ids)
+  const base = getNetwork(chainId)?.explorer?.baseUrl
+  return base ? `${base}/tx/${txHash}` : null
+}
+
+/**
+ * Activity tab — the transfers this browser has sent, newest first, with truthful status. Mirrors the
+ * reference design: status label, amount, from → to, date, and a deep link to the on-chain transaction
+ * once it is known.
+ */
+export default function TransferActivityList() {
+  const { transfers } = useTransferActivity()
+
+  const rows = useMemo(() => transfers, [transfers])
+
+  if (rows.length === 0) {
+    return (
+      <div className="pt-activity">
+        <p className="pt-activity-empty">No transfers yet. Payments you send from this device will appear here.</p>
+      </div>
+    )
+  }
+
+  return (
+    <ul className="pt-activity" aria-label="Transfer activity">
+      {rows.map((r) => {
+        const url = explorerTxUrl(r.chainId, r.txHash)
+        return (
+          <li key={r.id} className="pt-item">
+            <span className={`pt-status-dot ${r.status}`} aria-hidden="true" />
+            <div className="pt-item-body">
+              <div className="pt-item-status">{STATUS_LABEL[r.status] || r.status}</div>
+              <div className="pt-item-amount">{r.amount} {r.symbol}</div>
+              <div className="pt-item-route">
+                <span>{short(r.from)}</span>
+                <span className="pt-item-arrow" aria-hidden="true">➡</span>
+                <span>{short(r.to)}</span>
+              </div>
+              <div className="pt-item-date">
+                {formatDate(r.createdAt)}
+                {r.route === 'gasless' ? ' · gasless' : ''}
+                {r.status === TRANSFER_STATUS.FAILED && r.error ? ` · ${r.error}` : ''}
+              </div>
+            </div>
+            {url && (
+              <a className="pt-item-link" href={url} target="_blank" rel="noopener noreferrer" aria-label="View on block explorer">›</a>
+            )}
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/frontend/src/components/wallet/TransferForm.jsx
+++ b/frontend/src/components/wallet/TransferForm.jsx
@@ -1,0 +1,230 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import AddressInput from '../ui/AddressInput'
+import BlockiesAvatar from '../ui/BlockiesAvatar'
+import { useTransfer, TRANSFER_KIND } from '../../hooks/useTransfer'
+import { useWallet } from '../../hooks/useWalletManagement'
+import { useAddressScreening } from '../../hooks/useAddressScreening'
+import { useNotification } from '../../hooks/useUI'
+
+const short = (a) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '')
+
+/**
+ * Transfer tab — send the active chain's stablecoin or native token to any address/ENS name.
+ * Reuses the standard AddressInput (ENS + address book) for recipient entry and surfaces gasless status
+ * honestly. Two-step: fill → Preview → Send, mirroring the reference "Preview" affordance.
+ */
+export default function TransferForm({ onSent }) {
+  const {
+    send, status, error, quoteGasless, meta, balanceOf, refreshBalances, tokens, isPasskey,
+  } = useTransfer()
+  const { address } = useWallet()
+  const { screenOne } = useAddressScreening()
+  const { showNotification } = useNotification()
+
+  const [kind, setKind] = useState(TRANSFER_KIND.STABLE)
+  const [toRaw, setToRaw] = useState('')
+  const [toResolved, setToResolved] = useState('')
+  const [amount, setAmount] = useState('')
+  const [previewing, setPreviewing] = useState(false)
+  const [screening, setScreening] = useState(null) // null | 'clear' | 'restricted' | 'uncertain'
+  const [formError, setFormError] = useState(null)
+
+  const busy = status === 'signing' || status === 'submitting' || status === 'pending'
+  const m = meta(kind)
+  const gasless = quoteGasless(kind)
+  const bal = balanceOf(kind)
+  const stableUnavailable = kind === TRANSFER_KIND.STABLE && !tokens.stableAddress
+
+  useEffect(() => { refreshBalances() }, [refreshBalances])
+
+  // If the network has no stablecoin, default the picker to native so the form stays usable.
+  useEffect(() => {
+    if (stableUnavailable) setKind(TRANSFER_KIND.NATIVE)
+  }, [stableUnavailable])
+
+  // Advisory sanctions pre-check on the resolved recipient (fail-closed on 'restricted').
+  useEffect(() => {
+    let cancelled = false
+    if (!toResolved) { setScreening(null); return }
+    setScreening(null)
+    Promise.resolve(screenOne(toResolved))
+      .then((s) => { if (!cancelled) setScreening(s) })
+      .catch(() => { if (!cancelled) setScreening('uncertain') })
+    return () => { cancelled = true }
+  }, [toResolved, screenOne])
+
+  const amountValid = useMemo(() => {
+    const n = Number(amount)
+    return Number.isFinite(n) && n > 0
+  }, [amount])
+
+  const overBalance = useMemo(() => {
+    if (bal == null || !amountValid) return false
+    return Number(amount) > Number(bal)
+  }, [bal, amount, amountValid])
+
+  const canPreview = Boolean(toResolved) && amountValid && !overBalance && screening !== 'restricted' && !busy
+
+  const handleMax = useCallback(() => {
+    if (bal != null) setAmount(String(bal))
+  }, [bal])
+
+  const resetForm = useCallback(() => {
+    setToRaw(''); setToResolved(''); setAmount(''); setPreviewing(false); setScreening(null); setFormError(null)
+  }, [])
+
+  const handleSend = useCallback(async () => {
+    setFormError(null)
+    try {
+      const res = await send({ kind, to: toResolved, amount })
+      showNotification(
+        `Sent ${amount} ${m.symbol} to ${short(toResolved)}${res.route === 'gasless' ? ' (gasless)' : ''}.`,
+        'success'
+      )
+      resetForm()
+      onSent?.(res)
+    } catch (err) {
+      setFormError(err?.shortMessage || err?.message || 'Transfer failed.')
+    }
+  }, [send, kind, toResolved, amount, m.symbol, showNotification, resetForm, onSent])
+
+  return (
+    <div className="pt-form">
+      {/* Asset selector */}
+      <div className="pt-field">
+        <span className="pt-label">Asset</span>
+        <div className="pt-assets" role="radiogroup" aria-label="Asset to send">
+          <button
+            type="button"
+            role="radio"
+            aria-checked={kind === TRANSFER_KIND.STABLE}
+            className={`pt-asset ${kind === TRANSFER_KIND.STABLE ? 'active' : ''}`}
+            onClick={() => setKind(TRANSFER_KIND.STABLE)}
+            disabled={stableUnavailable || busy}
+          >
+            <span className="pt-asset-sym">{tokens.stable}</span>
+            <span className="pt-asset-bal">
+              {stableUnavailable ? 'Not on this network' : `Balance: ${balanceOf(TRANSFER_KIND.STABLE) ?? '…'}`}
+            </span>
+          </button>
+          <button
+            type="button"
+            role="radio"
+            aria-checked={kind === TRANSFER_KIND.NATIVE}
+            className={`pt-asset ${kind === TRANSFER_KIND.NATIVE ? 'active' : ''}`}
+            onClick={() => setKind(TRANSFER_KIND.NATIVE)}
+            disabled={busy}
+          >
+            <span className="pt-asset-sym">{tokens.native}</span>
+            <span className="pt-asset-bal">Balance: {balanceOf(TRANSFER_KIND.NATIVE) ?? '…'}</span>
+          </button>
+        </div>
+        {gasless ? (
+          <span className="pt-badge pt-badge-gasless">⚡ Gasless{isPasskey ? ' · sponsored' : ''}</span>
+        ) : (
+          <span className="pt-badge pt-badge-fee">Network fee applies</span>
+        )}
+      </div>
+
+      {!previewing ? (
+        <>
+          {/* From — the connected account, read-only */}
+          <div className="pt-field">
+            <span className="pt-label">From</span>
+            <div className="pt-from">
+              <BlockiesAvatar address={address} size={20} />
+              <span>{short(address)}</span>
+            </div>
+          </div>
+
+          {/* To — reuses the standard address entry component (ENS + address book) */}
+          <div className="pt-field">
+            <label className="pt-label" htmlFor="pt-to">To</label>
+            <AddressInput
+              id="pt-to"
+              value={toRaw}
+              onChange={(e) => setToRaw(e.target.value)}
+              onResolvedChange={(addr) => setToResolved(addr || '')}
+              enableAddressBook
+              chainId={tokens.chainId}
+              placeholder="0x… or ENS name (e.g., vitalik.eth)"
+              disabled={busy}
+            />
+            {screening === 'restricted' && (
+              <div className="pt-notice pt-notice-error" role="alert">
+                This address is flagged by sanctions screening. Transfers to it are blocked.
+              </div>
+            )}
+            {screening === 'uncertain' && toResolved && (
+              <span className="pt-hint">Screening unavailable — proceed with care.</span>
+            )}
+          </div>
+
+          {/* Amount */}
+          <div className="pt-field">
+            <label className="pt-label" htmlFor="pt-amount">Amount</label>
+            <div className="pt-amount-row">
+              <input
+                id="pt-amount"
+                className="pt-amount-input"
+                inputMode="decimal"
+                type="text"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value.replace(/[^0-9.]/g, ''))}
+                placeholder="0.00"
+                disabled={busy}
+                aria-describedby="pt-amount-hint"
+              />
+              <button type="button" className="pt-max" onClick={handleMax} disabled={bal == null || busy}>MAX</button>
+              <span className="pt-amount-sym">{m.symbol}</span>
+            </div>
+            <span className="pt-hint" id="pt-amount-hint">
+              {bal != null ? `Balance: ${bal} ${m.symbol}` : 'Loading balance…'}
+              {overBalance && ' · exceeds balance'}
+            </span>
+          </div>
+
+          {(error || formError) && (
+            <div className="pt-notice pt-notice-error" role="alert">{formError || error}</div>
+          )}
+
+          <div className="pt-actions">
+            <button
+              type="button"
+              className="pt-btn pt-btn-primary"
+              onClick={() => setPreviewing(true)}
+              disabled={!canPreview}
+            >
+              Preview
+            </button>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="pt-preview" aria-live="polite">
+            <div className="pt-preview-amount">{amount} {m.symbol}</div>
+            <div className="pt-preview-row"><span className="k">To</span><span className="v">{short(toResolved)}</span></div>
+            <div className="pt-preview-row"><span className="k">Network</span><span className="v">{tokens.networkName}</span></div>
+            <div className="pt-preview-row">
+              <span className="k">Fee</span>
+              <span className="v">{gasless ? 'Gasless — no network fee' : `You pay the ${tokens.native} network fee`}</span>
+            </div>
+          </div>
+
+          {(error || formError) && (
+            <div className="pt-notice pt-notice-error" role="alert">{formError || error}</div>
+          )}
+
+          <div className="pt-actions">
+            <button type="button" className="pt-btn pt-btn-secondary" onClick={() => setPreviewing(false)} disabled={busy}>
+              Back
+            </button>
+            <button type="button" className="pt-btn pt-btn-primary" onClick={handleSend} disabled={busy}>
+              {busy ? (status === 'signing' ? 'Confirm in wallet…' : 'Sending…') : 'Send'}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/index.js
+++ b/frontend/src/hooks/index.js
@@ -108,3 +108,7 @@ export {
   useLazyMarketMetadata
 } from './useIpfs'
 
+
+// Pay & Transfer (wallet stablecoin/native send + activity)
+export { useTransfer, TRANSFER_KIND } from './useTransfer'
+export { useTransferActivity } from './useTransferActivity'

--- a/frontend/src/hooks/useTransfer.js
+++ b/frontend/src/hooks/useTransfer.js
@@ -1,0 +1,234 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { ethers } from 'ethers'
+import { useWallet } from './useWalletManagement'
+import { useChainTokens } from './useChainTokens'
+import { getNetwork } from '../config/networks'
+import {
+  TRANSFER_ABI,
+  signTransferAuthorization,
+  getTransferRelayer,
+  relayGaslessTransfer,
+} from '../lib/transfer/eip3009Transfer'
+import { recordTransfer, updateTransfer, TRANSFER_STATUS } from '../lib/transfer/transferStore'
+
+/**
+ * useTransfer — the send engine behind the Pay & Transfer wallet section.
+ *
+ * Two asset kinds, one honest routing table:
+ *
+ *   stablecoin, passkey session   → gasless via the smart-account batch (sendCalls → ERC-4337 UserOp/relay)
+ *   stablecoin, classic + relayer → gasless via EIP-3009 transferWithAuthorization (token-native)
+ *   stablecoin, classic, no relay → self-submit token.transfer (sender pays gas)  [never-stranded fallback]
+ *   native, passkey session       → gasless via the smart-account batch
+ *   native, classic               → standard network-fee transfer
+ *
+ * "All stablecoin transfers are gasless" holds wherever the rails exist (a live relayer, or a passkey smart
+ * account); where they don't, the transfer still goes through by self-submit rather than being blocked — and
+ * the UI says so truthfully via `quoteGasless`.
+ */
+
+export const TRANSFER_KIND = Object.freeze({ NATIVE: 'native', STABLE: 'stable' })
+
+const ERC20_IFACE = new ethers.Interface(TRANSFER_ABI)
+
+export function useTransfer() {
+  const { address, chainId, signer, provider, loginMethod, sendCalls } = useWallet()
+  const tokens = useChainTokens()
+  const isPasskey = loginMethod === 'passkey'
+
+  const [status, setStatus] = useState('idle') // idle | signing | submitting | pending | success | error
+  const [error, setError] = useState(null)
+  const [lastResult, setLastResult] = useState(null)
+  const [nativeBalance, setNativeBalance] = useState(null)
+  const [stableBalance, setStableBalance] = useState(null)
+
+  const stableDomainVersion = getNetwork(chainId)?.stablecoin?.domainVersion ?? null
+  // A stablecoin transfer is gasless when a passkey smart account sponsors it, or when the token supports
+  // EIP-3009 AND a relayer is configured to submit the signed authorization.
+  const hasRelayer = Boolean(getTransferRelayer())
+  const stableGasless = isPasskey || (stableDomainVersion != null && hasRelayer)
+
+  /** Whether a given kind will be gasless for the current session (drives the UI badge, honestly). */
+  const quoteGasless = useCallback(
+    (kind) => (kind === TRANSFER_KIND.STABLE ? stableGasless : isPasskey),
+    [stableGasless, isPasskey]
+  )
+
+  const meta = useCallback(
+    (kind) =>
+      kind === TRANSFER_KIND.STABLE
+        ? { symbol: tokens.stable, name: tokens.stableName, decimals: tokens.stableDecimals, address: tokens.stableAddress }
+        : { symbol: tokens.native, name: tokens.nativeName, decimals: tokens.nativeDecimals, address: null },
+    [tokens]
+  )
+
+  // Balances for the two supported assets. Native comes from the provider; the stablecoin needs its own
+  // (6-decimal) read since the shared getTokenBalance formats with 18.
+  const refreshBalances = useCallback(async () => {
+    if (!provider || !address) {
+      setNativeBalance(null)
+      setStableBalance(null)
+      return
+    }
+    try {
+      const nat = await provider.getBalance(address)
+      setNativeBalance(ethers.formatUnits(nat, tokens.nativeDecimals))
+    } catch {
+      setNativeBalance(null)
+    }
+    if (tokens.stableAddress) {
+      try {
+        const erc20 = new ethers.Contract(tokens.stableAddress, TRANSFER_ABI, provider)
+        const bal = await erc20.balanceOf(address)
+        setStableBalance(ethers.formatUnits(bal, tokens.stableDecimals))
+      } catch {
+        setStableBalance(null)
+      }
+    } else {
+      setStableBalance(null)
+    }
+  }, [provider, address, tokens.stableAddress, tokens.stableDecimals, tokens.nativeDecimals])
+
+  useEffect(() => {
+    refreshBalances()
+  }, [refreshBalances])
+
+  const balanceOf = useCallback(
+    (kind) => (kind === TRANSFER_KIND.STABLE ? stableBalance : nativeBalance),
+    [stableBalance, nativeBalance]
+  )
+
+  const reset = useCallback(() => {
+    setStatus('idle')
+    setError(null)
+    setLastResult(null)
+  }, [])
+
+  /**
+   * Send a transfer. `to` must be a resolved 0x address; `amount` is a human-readable decimal string.
+   * Returns { txHash?, route } on success and records the attempt to the Activity log with truthful status.
+   */
+  const send = useCallback(
+    async ({ kind, to, amount }) => {
+      if (!signer && !isPasskey) throw new Error('Wallet not connected.')
+      if (!ethers.isAddress(to)) throw new Error('Enter a valid recipient address.')
+      const m = meta(kind)
+      let value
+      try {
+        value = ethers.parseUnits(String(amount), m.decimals)
+      } catch {
+        throw new Error('Enter a valid amount.')
+      }
+      if (value <= 0n) throw new Error('Enter an amount greater than zero.')
+      if (kind === TRANSFER_KIND.STABLE && !m.address) {
+        throw new Error(`No ${m.symbol || 'stablecoin'} is configured on this network.`)
+      }
+
+      const gasless = quoteGasless(kind)
+      const entry = recordTransfer(address, {
+        chainId,
+        kind,
+        symbol: m.symbol,
+        decimals: m.decimals,
+        amount: String(amount),
+        from: address,
+        to,
+        route: gasless ? 'gasless' : kind === TRANSFER_KIND.STABLE ? 'self' : 'direct',
+      })
+
+      setError(null)
+      setStatus('signing')
+      try {
+        let txHash = null
+        let route = entry.route
+
+        if (isPasskey) {
+          // One ceremony, sponsored by the smart account. Native = value move; stable = ERC-20 transfer call.
+          const calls =
+            kind === TRANSFER_KIND.STABLE
+              ? [{ target: m.address, data: ERC20_IFACE.encodeFunctionData('transfer', [to, value]), value: 0n }]
+              : [{ target: to, data: '0x', value }]
+          setStatus('submitting')
+          const res = await sendCalls(calls)
+          txHash = res?.txHash ?? res?.userOpHash ?? res?.intentId ?? null
+          route = 'gasless' // smart-account batch is sponsored (bundler/relay) regardless of inner route
+        } else if (kind === TRANSFER_KIND.STABLE && stableDomainVersion != null && hasRelayer) {
+          // Classic EOA, gasless: sign an EIP-3009 authorization; a relayer submits + pays gas.
+          const auth = await signTransferAuthorization({
+            signer,
+            token: m.address,
+            tokenName: m.name || 'USD Coin',
+            tokenVersion: stableDomainVersion,
+            chainId,
+            to,
+            value,
+          })
+          setStatus('submitting')
+          try {
+            const relayed = await relayGaslessTransfer(getTransferRelayer(), auth, { token: m.address, chainId })
+            txHash = relayed.txHash
+            route = 'gasless'
+          } catch (relayErr) {
+            // Never stranded: fall back to a self-submitted transfer (sender pays gas).
+            console.warn('[useTransfer] relayer failed, self-submitting:', relayErr?.message)
+            const erc20 = new ethers.Contract(m.address, TRANSFER_ABI, signer)
+            const tx = await erc20.transfer(to, value)
+            const receipt = await tx.wait()
+            txHash = receipt?.hash ?? tx.hash
+            route = 'self'
+          }
+        } else if (kind === TRANSFER_KIND.STABLE) {
+          // Classic EOA, no gasless rail on this chain: plain ERC-20 transfer.
+          setStatus('submitting')
+          const erc20 = new ethers.Contract(m.address, TRANSFER_ABI, signer)
+          const tx = await erc20.transfer(to, value)
+          const receipt = await tx.wait()
+          txHash = receipt?.hash ?? tx.hash
+          route = 'self'
+        } else {
+          // Native, classic EOA: standard network-fee transfer.
+          setStatus('submitting')
+          const tx = await signer.sendTransaction({ to, value })
+          const receipt = await tx.wait()
+          txHash = receipt?.hash ?? tx.hash
+          route = 'direct'
+        }
+
+        updateTransfer(address, entry.id, { status: TRANSFER_STATUS.COMPLETE, txHash, route })
+        setStatus('success')
+        const result = { txHash, route, id: entry.id }
+        setLastResult(result)
+        refreshBalances()
+        return result
+      } catch (err) {
+        const message = err?.shortMessage || err?.message || 'Transfer failed.'
+        updateTransfer(address, entry.id, { status: TRANSFER_STATUS.FAILED, error: message })
+        setError(message)
+        setStatus('error')
+        throw err
+      }
+    },
+    [signer, isPasskey, meta, quoteGasless, address, chainId, sendCalls, stableDomainVersion, hasRelayer, refreshBalances]
+  )
+
+  return useMemo(
+    () => ({
+      status,
+      error,
+      lastResult,
+      send,
+      reset,
+      quoteGasless,
+      meta,
+      balanceOf,
+      refreshBalances,
+      nativeBalance,
+      stableBalance,
+      tokens,
+      isPasskey,
+    }),
+    [status, error, lastResult, send, reset, quoteGasless, meta, balanceOf, refreshBalances, nativeBalance, stableBalance, tokens, isPasskey]
+  )
+}
+
+export default useTransfer

--- a/frontend/src/hooks/useTransferActivity.js
+++ b/frontend/src/hooks/useTransferActivity.js
@@ -1,0 +1,30 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useWallet } from './useWalletManagement'
+import { listTransfers, subscribeTransfers } from '../lib/transfer/transferStore'
+
+/**
+ * useTransferActivity — reactive view of the local Pay & Transfer history for the active address, scoped to
+ * the active chain. Re-reads on any store change (same-tab custom event or cross-tab `storage`) so a
+ * transfer initiated on the Transfer tab appears on the Activity tab immediately.
+ *
+ * @param {object} [opts]
+ * @param {boolean} [opts.allChains=false] - when true, ignore the chain filter and show every network.
+ */
+export function useTransferActivity({ allChains = false } = {}) {
+  const { address, chainId } = useWallet()
+  const [transfers, setTransfers] = useState([])
+
+  const refresh = useCallback(() => {
+    setTransfers(listTransfers(address, allChains ? undefined : chainId))
+  }, [address, chainId, allChains])
+
+  useEffect(() => {
+    refresh()
+    const unsubscribe = subscribeTransfers(refresh)
+    return unsubscribe
+  }, [refresh])
+
+  return { transfers, refresh }
+}
+
+export default useTransferActivity

--- a/frontend/src/lib/transfer/eip3009Transfer.js
+++ b/frontend/src/lib/transfer/eip3009Transfer.js
@@ -1,0 +1,129 @@
+/**
+ * Gasless peer-to-peer stablecoin transfer via EIP-3009 `transferWithAuthorization`
+ * (Pay & Transfer, wallet feature). WITHOUT an app backend.
+ *
+ * This is the P2P sibling of the pool-join flow in `lib/pools/gasless.js`. A pool join signs
+ * `ReceiveWithAuthorization` because the pool contract is BOTH caller and recipient; a wallet-to-wallet
+ * payment signs `TransferWithAuthorization`, which lets ANY relayer submit `token.transferWithAuthorization`
+ * and pay gas while the value moves `from → to`. The authorization binds amount + recipient and is
+ * replay-protected by the token's own nonce, so the relayer is untrusted (it can censor, never steal or
+ * redirect). When no relayer is configured, the sender transfers normally (paying gas) — gasless is purely
+ * additive (the never-stranded rule, spec 035/036).
+ *
+ * The FairWins relay-gateway (services/relay-gateway) is a version-pinned allow-list for wager/membership
+ * actions only, so it cannot relay an arbitrary token transfer. This path therefore targets the STABLECOIN
+ * contract directly under the token's own EIP-712 domain (native Circle USDC version '2', bridged USDC.e
+ * '1'), driven by `stablecoin.domainVersion` in config/networks.js — `null` means the token lacks EIP-3009
+ * and this whole path is skipped in favour of a plain `transfer` (e.g. Mordor/ETC USC).
+ */
+import { ethers } from 'ethers'
+
+/** EIP-3009 typed-data for a wallet-to-wallet payment (arbitrary recipient submits via a relayer). */
+export const TRANSFER_WITH_AUTHORIZATION_TYPES = {
+  TransferWithAuthorization: [
+    { name: 'from', type: 'address' },
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'validAfter', type: 'uint256' },
+    { name: 'validBefore', type: 'uint256' },
+    { name: 'nonce', type: 'bytes32' },
+  ],
+}
+
+/** Minimal ABI for the self-submit fallback + the relayed authorization call. */
+export const TRANSFER_ABI = [
+  'function transfer(address to, uint256 value) returns (bool)',
+  'function balanceOf(address account) view returns (uint256)',
+  'function transferWithAuthorization(address from, address to, uint256 value, uint256 validAfter, uint256 validBefore, bytes32 nonce, uint8 v, bytes32 r, bytes32 s)',
+]
+
+/**
+ * Produce a signed EIP-3009 authorization that lets a relayer move `value` from the sender to `to`.
+ * @param {object} opts
+ * @param {import('ethers').Signer} opts.signer - the sender's signer.
+ * @param {string} opts.token - stablecoin contract address (the EIP-712 verifying contract).
+ * @param {string} [opts.tokenName='USD Coin'] - token EIP-712 domain name.
+ * @param {string} [opts.tokenVersion='2'] - token EIP-712 domain version (Circle USDC '2', USDC.e '1').
+ * @param {number} opts.chainId
+ * @param {string} opts.to - recipient address.
+ * @param {bigint|string} opts.value - amount in the token's base units.
+ * @param {number} [opts.nowSeconds] - override "now" (tests); defaults to wall-clock seconds.
+ * @param {number} [opts.validitySeconds=3600] - window from now during which the authorization is valid.
+ * @returns {Promise<object>} { from, to, value, validAfter, validBefore, nonce, v, r, s }
+ */
+export async function signTransferAuthorization({
+  signer,
+  token,
+  tokenName = 'USD Coin',
+  tokenVersion = '2',
+  chainId,
+  to,
+  value,
+  nowSeconds,
+  validitySeconds = 3600,
+}) {
+  const from = await signer.getAddress()
+  const now = nowSeconds != null ? nowSeconds : Math.floor(Date.now() / 1000)
+  const nonce = ethers.hexlify(ethers.randomBytes(32))
+  const domain = { name: tokenName, version: tokenVersion, chainId: Number(chainId), verifyingContract: token }
+  const message = {
+    from,
+    to,
+    value: value.toString(),
+    // A small backdate absorbs clock skew between the signer and the relayer's node.
+    validAfter: 0,
+    validBefore: now + validitySeconds,
+    nonce,
+  }
+  const sig = ethers.Signature.from(
+    await signer.signTypedData(domain, TRANSFER_WITH_AUTHORIZATION_TYPES, message)
+  )
+  return { from, to, value, validAfter: 0, validBefore: message.validBefore, nonce, v: sig.v, r: sig.r, s: sig.s }
+}
+
+/**
+ * Resolve the pluggable transfer relayer. Returns a function
+ * `(authorization, { token, chainId }) => Promise<{ txHash }>` when `VITE_TRANSFER_RELAYER_URL` is set,
+ * else `null` so the caller self-submits. Kept intentionally thin: the endpoint receives only the token
+ * address and the token-scoped authorization (no FairWins identity), matching the "can censor, cannot
+ * steal" bound.
+ */
+export function getTransferRelayer() {
+  const url = import.meta.env?.VITE_TRANSFER_RELAYER_URL
+  if (!url) return null
+  return async (authorization, { token, chainId }) => {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        token,
+        chainId,
+        authorization: {
+          ...authorization,
+          value: authorization.value.toString(),
+        },
+      }),
+    })
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '')
+      throw new Error(`Transfer relayer rejected the authorization (${res.status})${detail ? `: ${detail}` : ''}`)
+    }
+    const json = await res.json()
+    const txHash = json?.txHash ?? json?.transactionHash ?? json?.hash
+    if (!txHash) throw new Error('Transfer relayer response missing a transaction hash')
+    return { txHash }
+  }
+}
+
+/**
+ * Relay a gasless transfer through a pluggable relayer. `relayer` is
+ * `(authorization, { token, chainId }) => Promise<{ txHash }>`. A missing relayer throws a clear error so
+ * the UI falls back to a normal (gas-paying) transfer. The context is identity-free — only the token +
+ * chain travel alongside the token-scoped authorization.
+ */
+export async function relayGaslessTransfer(relayer, authorization, { token, chainId }) {
+  if (typeof relayer !== 'function') {
+    throw new Error('No gasless relayer configured. Send normally (you pay gas), or configure a relayer.')
+  }
+  return relayer(authorization, { token, chainId })
+}

--- a/frontend/src/lib/transfer/transferStore.js
+++ b/frontend/src/lib/transfer/transferStore.js
@@ -1,0 +1,132 @@
+/**
+ * Local, per-address history for the Pay & Transfer wallet feature.
+ *
+ * A wallet-to-wallet payment is a self-contained action with no on-chain "my transfers" index we can
+ * cheaply query (a stablecoin `transfer`/`transferWithAuthorization` is an ordinary ERC-20 Transfer event
+ * among millions), so the Activity tab is backed by a small localStorage log the sender appends to when it
+ * initiates a transfer. This is intentionally honest about scope: it records transfers THIS browser sent,
+ * with truthful status transitions (in process → complete/failed), mirroring the reference design. It is
+ * NOT a chain-of-record — the on-chain transaction is — and it never blocks a transfer if storage fails.
+ *
+ * Scoped by lowercased sender address so switching accounts shows the right history; each record also
+ * carries its chainId so the list can note the network.
+ */
+
+const STORAGE_KEY = 'fairwins.transfers.v1'
+const EVENT = 'fairwins:transfers-changed'
+const MAX_PER_ADDRESS = 100
+
+export const TRANSFER_STATUS = Object.freeze({
+  IN_PROCESS: 'in_process',
+  COMPLETE: 'complete',
+  FAILED: 'failed',
+})
+
+function safeParse(raw) {
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+function readAll() {
+  if (typeof localStorage === 'undefined') return {}
+  return safeParse(localStorage.getItem(STORAGE_KEY))
+}
+
+function writeAll(all) {
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(all))
+    // Notify same-tab listeners (the native `storage` event only fires cross-tab).
+    if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+      window.dispatchEvent(new CustomEvent(EVENT))
+    }
+  } catch {
+    // Storage full / disabled — history is best-effort and must never break a transfer.
+  }
+}
+
+function keyFor(address) {
+  return (address || '').toLowerCase()
+}
+
+function makeId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') return crypto.randomUUID()
+  return `t_${Date.now().toString(36)}_${Math.floor(Math.random() * 1e9).toString(36)}`
+}
+
+/**
+ * Append a new transfer record and return it (with generated id + timestamps).
+ * @param {string} address - the sender address the history is scoped to.
+ * @param {object} entry - { chainId, kind, symbol, decimals, amount, from, to, status, route, txHash?, error? }
+ */
+export function recordTransfer(address, entry) {
+  const now = Date.now()
+  const record = {
+    id: makeId(),
+    createdAt: now,
+    updatedAt: now,
+    status: TRANSFER_STATUS.IN_PROCESS,
+    txHash: null,
+    error: null,
+    ...entry,
+  }
+  const all = readAll()
+  const k = keyFor(address)
+  const list = Array.isArray(all[k]) ? all[k] : []
+  all[k] = [record, ...list].slice(0, MAX_PER_ADDRESS)
+  writeAll(all)
+  return record
+}
+
+/**
+ * Patch an existing record (e.g. flip status to complete/failed, attach a txHash). No-op if not found.
+ */
+export function updateTransfer(address, id, patch) {
+  const all = readAll()
+  const k = keyFor(address)
+  const list = Array.isArray(all[k]) ? all[k] : []
+  let changed = false
+  all[k] = list.map((r) => {
+    if (r.id !== id) return r
+    changed = true
+    return { ...r, ...patch, updatedAt: Date.now() }
+  })
+  if (changed) writeAll(all)
+}
+
+/**
+ * List transfers for an address, newest first. Optionally filter to a chainId.
+ */
+export function listTransfers(address, chainId) {
+  const all = readAll()
+  const list = all[keyFor(address)]
+  if (!Array.isArray(list)) return []
+  const rows = chainId == null ? list : list.filter((r) => Number(r.chainId) === Number(chainId))
+  return [...rows].sort((a, b) => b.createdAt - a.createdAt)
+}
+
+/** Subscribe to same-tab + cross-tab changes. Returns an unsubscribe function. */
+export function subscribeTransfers(listener) {
+  if (typeof window === 'undefined') return () => {}
+  const onLocal = () => listener()
+  const onStorage = (e) => {
+    if (!e || e.key === null || e.key === STORAGE_KEY) listener()
+  }
+  window.addEventListener(EVENT, onLocal)
+  window.addEventListener('storage', onStorage)
+  return () => {
+    window.removeEventListener(EVENT, onLocal)
+    window.removeEventListener('storage', onStorage)
+  }
+}
+
+/** Test/util seam: wipe all stored transfer history. */
+export function __clearTransfers() {
+  if (typeof localStorage === 'undefined') return
+  localStorage.removeItem(STORAGE_KEY)
+}

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -8,6 +8,7 @@ import { useModal } from '../hooks/useUI'
 import { ROLES, ROLE_INFO } from '../contexts/RoleContext'
 import { hasRegisteredKey, ensureKeyRegistered } from '../utils/keyRegistryService'
 import SwapPanel from '../components/fairwins/SwapPanel'
+import PayTransferPanel from '../components/wallet/PayTransferPanel'
 import TokensPanel from '../components/tokens/TokensPanel'
 import ClearPathPanel from '../components/clearpath/ClearPathPanel'
 import AccountDashboard from '../components/account/AccountDashboard'
@@ -26,6 +27,7 @@ import './WalletPage.css'
 // My Account sections, shown via the WalletTabMenu kebab menu.
 const WALLET_TABS = [
   { id: 'account', label: 'Account' },
+  { id: 'paytransfer', label: 'Pay & Transfer' },
   { id: 'addressbook', label: 'Address Book' },
   { id: 'backup', label: 'Backup' },
   { id: 'membership', label: 'Membership' },
@@ -332,6 +334,12 @@ function WalletPage() {
                         <button onClick={handleNavigateToAdmin} className="admin-panel-btn">Role Management</button>
                       </div>
                     )}
+                  </div>
+                )}
+
+                {activeTab === 'paytransfer' && (
+                  <div className="paytransfer-section" role="tabpanel">
+                    <PayTransferPanel />
                   </div>
                 )}
 

--- a/frontend/src/test/TransferForm.test.jsx
+++ b/frontend/src/test/TransferForm.test.jsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// Mock the standard address input to a plain field that resolves whatever is typed — keeps the test off
+// the ENS network path while still exercising the resolved-address wiring.
+vi.mock('../components/ui/AddressInput', () => ({
+  default: ({ id, value, onChange, onResolvedChange, placeholder, disabled }) => (
+    <input
+      id={id}
+      aria-label="To"
+      value={value}
+      placeholder={placeholder}
+      disabled={disabled}
+      onChange={(e) => { onChange(e); onResolvedChange(e.target.value) }}
+    />
+  ),
+}))
+vi.mock('../components/ui/BlockiesAvatar', () => ({ default: () => <span data-testid="blockie" /> }))
+
+const send = vi.fn().mockResolvedValue({ txHash: '0xhash', route: 'gasless', id: 't1' })
+const showNotification = vi.fn()
+
+vi.mock('../hooks/useWalletManagement', () => ({
+  useWallet: () => ({ address: '0xAaAa000000000000000000000000000000000001' }),
+}))
+vi.mock('../hooks/useAddressScreening', () => ({
+  useAddressScreening: () => ({ screenOne: vi.fn().mockResolvedValue('clear') }),
+}))
+vi.mock('../hooks/useUI', () => ({ useNotification: () => ({ showNotification }) }))
+
+let gasless = true
+vi.mock('../hooks/useTransfer', async () => {
+  const actual = await vi.importActual('../hooks/useTransfer')
+  return {
+    ...actual,
+    useTransfer: () => ({
+      send,
+      status: 'idle',
+      error: null,
+      quoteGasless: () => gasless,
+      meta: (kind) => (kind === 'stable'
+        ? { symbol: 'USDC', name: 'USD Coin', decimals: 6, address: '0xtoken' }
+        : { symbol: 'MATIC', name: 'MATIC', decimals: 18, address: null }),
+      balanceOf: (kind) => (kind === 'stable' ? '100' : '5'),
+      refreshBalances: vi.fn(),
+      tokens: { stable: 'USDC', native: 'MATIC', stableAddress: '0xtoken', chainId: 137, networkName: 'Polygon' },
+      isPasskey: true,
+    }),
+  }
+})
+
+import TransferForm from '../components/wallet/TransferForm'
+
+describe('TransferForm', () => {
+  beforeEach(() => { send.mockClear(); showNotification.mockClear(); gasless = true })
+
+  it('shows a gasless badge for the stablecoin and previews then sends to the resolved recipient', async () => {
+    const user = userEvent.setup()
+    render(<TransferForm />)
+
+    // Gasless badge visible (USDC selected by default)
+    expect(screen.getByText(/gasless/i)).toBeInTheDocument()
+
+    await user.type(screen.getByLabelText('To'), '0xBbBb000000000000000000000000000000000002')
+    await user.type(screen.getByLabelText('Amount'), '10')
+
+    const preview = screen.getByRole('button', { name: 'Preview' })
+    await waitFor(() => expect(preview).toBeEnabled())
+    await user.click(preview)
+
+    // Preview summary appears
+    expect(screen.getByText('10 USDC')).toBeInTheDocument()
+    expect(screen.getByText(/no network fee/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Send' }))
+    await waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+    expect(send).toHaveBeenCalledWith({
+      kind: 'stable',
+      to: '0xBbBb000000000000000000000000000000000002',
+      amount: '10',
+    })
+    await waitFor(() => expect(showNotification).toHaveBeenCalled())
+  })
+
+  it('blocks Preview when the amount exceeds the balance', async () => {
+    const user = userEvent.setup()
+    render(<TransferForm />)
+    await user.type(screen.getByLabelText('To'), '0xBbBb000000000000000000000000000000000002')
+    await user.type(screen.getByLabelText('Amount'), '999') // balance is 100
+    expect(screen.getByRole('button', { name: 'Preview' })).toBeDisabled()
+    expect(screen.getByText(/exceeds balance/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/transferEip3009.test.js
+++ b/frontend/src/test/transferEip3009.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest'
+import { ethers } from 'ethers'
+import {
+  signTransferAuthorization,
+  relayGaslessTransfer,
+  TRANSFER_WITH_AUTHORIZATION_TYPES,
+} from '../lib/transfer/eip3009Transfer'
+
+// Pay & Transfer gasless leg (no backend): the sender signs an EIP-3009 TransferWithAuthorization; a
+// third-party relayer submits token.transferWithAuthorization and pays gas. We verify the signature
+// recovers to the sender (so the token will accept it) and that relaying is gated on a configured relayer.
+
+describe('Pay & Transfer — EIP-3009 transferWithAuthorization', () => {
+  it('signs an authorization that recovers to the sender', async () => {
+    // Fixed key (Wallet.createRandom's mnemonic path hits an ethers/jsdom crypto quirk under vitest).
+    const wallet = new ethers.Wallet('0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d')
+    const token = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359' // Polygon native USDC
+    const to = '0x00000000000000000000000000000000000000aa'
+    const auth = await signTransferAuthorization({
+      signer: wallet,
+      token,
+      tokenName: 'USD Coin',
+      tokenVersion: '2',
+      chainId: 137,
+      to,
+      value: ethers.parseUnits('25', 6),
+      nowSeconds: 1_000_000,
+      validitySeconds: 3600,
+    })
+
+    const domain = { name: 'USD Coin', version: '2', chainId: 137, verifyingContract: token }
+    const recovered = ethers.verifyTypedData(
+      domain,
+      TRANSFER_WITH_AUTHORIZATION_TYPES,
+      {
+        from: auth.from,
+        to: auth.to,
+        value: auth.value.toString(),
+        validAfter: auth.validAfter,
+        validBefore: auth.validBefore,
+        nonce: auth.nonce,
+      },
+      ethers.Signature.from({ v: auth.v, r: auth.r, s: auth.s })
+    )
+    expect(recovered).toBe(wallet.address)
+    expect(auth.from).toBe(wallet.address)
+    expect(auth.to).toBe(to)
+    expect(auth.validBefore).toBe(1_000_000 + 3600)
+  })
+
+  it('relays through a configured relayer, and errors clearly without one', async () => {
+    const relayer = vi.fn().mockResolvedValue({ txHash: '0xabc' })
+    const res = await relayGaslessTransfer(relayer, { from: '0x1', to: '0x2' }, { token: '0xtok', chainId: 137 })
+    expect(res.txHash).toBe('0xabc')
+    expect(relayer).toHaveBeenCalledWith({ from: '0x1', to: '0x2' }, { token: '0xtok', chainId: 137 })
+    // Identity-free: only token + chain travel with the authorization, no FairWins identity.
+    expect(relayer.mock.calls[0][1]).not.toHaveProperty('identityCommitment')
+
+    await expect(relayGaslessTransfer(null, {}, {})).rejects.toThrow(/no gasless relayer/i)
+  })
+})

--- a/frontend/src/test/transferStore.test.js
+++ b/frontend/src/test/transferStore.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  recordTransfer,
+  updateTransfer,
+  listTransfers,
+  subscribeTransfers,
+  __clearTransfers,
+  TRANSFER_STATUS,
+} from '../lib/transfer/transferStore'
+
+const A = '0xAaAa000000000000000000000000000000000001'
+const B = '0xBbBb000000000000000000000000000000000002'
+
+describe('Pay & Transfer — local activity store', () => {
+  beforeEach(() => __clearTransfers())
+
+  it('records a transfer with defaults and lists it newest-first, scoped by address', () => {
+    const r1 = recordTransfer(A, { chainId: 137, kind: 'stable', symbol: 'USDC', amount: '10', from: A, to: B })
+    const r2 = recordTransfer(A, { chainId: 137, kind: 'native', symbol: 'MATIC', amount: '1', from: A, to: B })
+    expect(r1.status).toBe(TRANSFER_STATUS.IN_PROCESS)
+    expect(r1.id).toBeTruthy()
+
+    const forA = listTransfers(A)
+    expect(forA.map((r) => r.id)).toEqual([r2.id, r1.id]) // newest first
+    expect(listTransfers(B)).toEqual([]) // scoped by sender
+  })
+
+  it('filters by chainId', () => {
+    recordTransfer(A, { chainId: 137, kind: 'stable', symbol: 'USDC', amount: '10', from: A, to: B })
+    recordTransfer(A, { chainId: 80002, kind: 'stable', symbol: 'USDC', amount: '5', from: A, to: B })
+    expect(listTransfers(A, 137)).toHaveLength(1)
+    expect(listTransfers(A, 80002)).toHaveLength(1)
+    expect(listTransfers(A)).toHaveLength(2)
+  })
+
+  it('updates status + txHash and notifies subscribers', () => {
+    const listener = vi.fn()
+    const unsub = subscribeTransfers(listener)
+    const rec = recordTransfer(A, { chainId: 137, kind: 'stable', symbol: 'USDC', amount: '10', from: A, to: B })
+    updateTransfer(A, rec.id, { status: TRANSFER_STATUS.COMPLETE, txHash: '0xdead' })
+
+    const [row] = listTransfers(A)
+    expect(row.status).toBe(TRANSFER_STATUS.COMPLETE)
+    expect(row.txHash).toBe('0xdead')
+    expect(listener).toHaveBeenCalled() // record + update both fire
+    unsub()
+  })
+
+  it('is case-insensitive on the sender address', () => {
+    recordTransfer(A.toUpperCase(), { chainId: 137, kind: 'native', symbol: 'MATIC', amount: '1', from: A, to: B })
+    expect(listTransfers(A.toLowerCase())).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a **Pay & Transfer** section to the wallet (My Account → Pay & Transfer), building on the recently-merged passkey smart-account rails (spec 041). It has two tabs — **Transfer** and **Activity** — mirroring the reference "Transfer Money" design.

### Transfer tab
- Send the active chain's **stablecoin** or **native token** to any address or ENS name.
- Recipient entry reuses the **standard `AddressInput`** (ENS resolution + address-book picker); symbols/decimals come from `useChainTokens`; the recipient gets an advisory **sanctions pre-check** (`useAddressScreening`, fail-closed on a flagged address).
- **Stablecoin transfers are gasless**:
  - **Passkey smart-account sessions** → routed through `sendCalls` (ERC-4337, sponsored by the account) as an `execute(token, transfer(to, value))` batch.
  - **Classic EOA sessions** → sign an **EIP-3009 `transferWithAuthorization`** under the token's own EIP-712 domain; a pluggable relayer (`VITE_TRANSFER_RELAYER_URL`) submits it and pays gas.
  - Both keep a **self-submit fallback** (the never-stranded rule): if no relay rail exists on the chain, the transfer still goes through by plain `transfer` and the UI says "network fee applies" rather than blocking it.
- **Native transfers** go gasless via the smart account, or as a standard network-fee transfer for classic wallets.
- Two-step **Preview → Send**, with balance/amount validation and a MAX button.

### Activity tab
- Local, per-address history (localStorage) rendered like the reference design: **status** (In process / Complete / Failed), **amount**, **from → to**, **date**, plus an explorer deep-link once the tx hash is known. Status transitions are truthful (in process → complete/failed) and history is scoped by sender + chain.

## Why the token-native EIP-3009 path
The FairWins relay-gateway (`services/relay-gateway`) is a version-pinned allow-list for wager/membership actions only, so it cannot relay an arbitrary wallet-to-wallet transfer. The gasless stablecoin path therefore targets the **stablecoin contract's own** EIP-3009 domain (`stablecoin.domainVersion`: Circle USDC `2`, USDC.e `1`; `null` ⇒ no EIP-3009, e.g. Mordor/ETC USC → self-submit). This mirrors the existing pool-join gasless pattern in `lib/pools/gasless.js`.

## Changes
**New**
- `frontend/src/lib/transfer/eip3009Transfer.js` — `TransferWithAuthorization` signing + pluggable relayer.
- `frontend/src/lib/transfer/transferStore.js` — per-address transfer activity log (localStorage, reactive).
- `frontend/src/hooks/useTransfer.js` — send engine + routing table + balances.
- `frontend/src/hooks/useTransferActivity.js` — reactive activity view.
- `frontend/src/components/wallet/PayTransferPanel.jsx`, `TransferForm.jsx`, `TransferActivityList.jsx`, `PayTransfer.css`.

**Modified**
- `frontend/src/pages/WalletPage.jsx` — new "Pay & Transfer" section tab.
- `frontend/src/hooks/index.js` — barrel exports.

## Testing
- `transferEip3009.test.js` — EIP-3009 signature recovers to the sender; relay gating (configured vs missing relayer).
- `transferStore.test.js` — record/list/update/subscribe roundtrip, chain + address scoping.
- `TransferForm.test.jsx` — gasless badge, Preview→Send with the resolved recipient, balance-guard.
- All 16 tests pass; existing `WalletPage` tests unchanged; `npm run build` and `eslint` are clean (no new error-level lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZM6hbezQpxVrGQsgn87dN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZM6hbezQpxVrGQsgn87dN)_