### PR TITLE
Group wallet section tabs by function

### DIFF
--- a/frontend/src/components/ui/PortalNav.css
+++ b/frontend/src/components/ui/PortalNav.css
@@ -38,6 +38,24 @@
   padding: 8px;
 }
 
+/* Group heading for the grouped rail (Admin / Finance / Tools / Apps). Purely
+   presentational — the tabs beneath it stay part of the single tablist. */
+.portal-nav-group-label {
+  padding: 12px 12px 4px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary, var(--color-text-secondary, #8895A1));
+}
+
+/* First heading hugs the top; later ones get breathing room from the group above. */
+.portal-nav-group-label:not(:first-child) {
+  margin-top: 10px;
+  border-top: 1px solid var(--border-color, var(--color-border, #e5e7eb));
+  padding-top: 12px;
+}
+
 .portal-nav-item {
   display: flex;
   align-items: center;

--- a/frontend/src/components/ui/PortalNav.jsx
+++ b/frontend/src/components/ui/PortalNav.jsx
@@ -3,12 +3,31 @@
  * down the left side as an accessible vertical tablist. Shared by My Account
  * (WalletPage) and the Admin Panel so both read like a portal.
  *
- * Items: [{ id, label }]. The active item is reflected with aria-selected and
- * an accent border. Pair with role="tabpanel" content keyed off the same id.
+ * Flat form: pass `items` = [{ id, label }].
+ * Grouped form: pass `groups` = [{ label, items: [{ id, label }] }] to break the
+ * rail into labelled sections (e.g. Admin / Finance / Tools / Apps). The group
+ * labels are presentational headers; every entry stays a tab in the one tablist
+ * so keyboard/tablist semantics are unchanged. The active item is reflected with
+ * aria-selected and an accent border. Pair with role="tabpanel" content keyed
+ * off the same id.
  */
+import { Fragment } from 'react'
 import './PortalNav.css'
 
-export default function PortalNav({ items, activeId, onSelect, ariaLabel }) {
+export default function PortalNav({ items, groups, activeId, onSelect, ariaLabel }) {
+  const renderItem = (item) => (
+    <button
+      key={item.id}
+      type="button"
+      role="tab"
+      aria-selected={item.id === activeId}
+      className={`portal-nav-item ${item.id === activeId ? 'active' : ''}`}
+      onClick={() => onSelect(item.id)}
+    >
+      {item.label}
+    </button>
+  )
+
   return (
     <nav
       className="portal-nav"
@@ -16,18 +35,16 @@ export default function PortalNav({ items, activeId, onSelect, ariaLabel }) {
       aria-orientation="vertical"
       aria-label={ariaLabel}
     >
-      {items.map((item) => (
-        <button
-          key={item.id}
-          type="button"
-          role="tab"
-          aria-selected={item.id === activeId}
-          className={`portal-nav-item ${item.id === activeId ? 'active' : ''}`}
-          onClick={() => onSelect(item.id)}
-        >
-          {item.label}
-        </button>
-      ))}
+      {groups
+        ? groups.map((group) => (
+            <Fragment key={group.label}>
+              <span className="portal-nav-group-label" role="presentation">
+                {group.label}
+              </span>
+              {group.items.map(renderItem)}
+            </Fragment>
+          ))
+        : items.map(renderItem)}
     </nav>
   )
 }

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -26,21 +26,45 @@ import LoadingScreen from '../components/ui/LoadingScreen'
 import { getWalletLabel, getWalletIcon } from '../utils/walletLabel'
 import './WalletPage.css'
 
-// My Account sections, shown via the WalletTabMenu kebab menu.
-const WALLET_TABS = [
-  { id: 'account', label: 'Account' },
-  { id: 'paytransfer', label: 'Pay & Transfer' },
-  { id: 'addressbook', label: 'Address Book' },
-  { id: 'backup', label: 'Backup' },
-  { id: 'membership', label: 'Membership' },
-  { id: 'network', label: 'Network' },
-  { id: 'security', label: 'Security' },
-  { id: 'preferences', label: 'Preferences' },
-  { id: 'reports', label: 'Reporting' },
-  { id: 'tokens', label: 'Tokens' },
-  { id: 'clearpath', label: 'ClearPath' },
-  { id: 'trade', label: 'Trade' },
+// My Account sections, grouped by function so the section rail stays legible as
+// the number of tabs grows. Each group renders a heading in PortalNav; the tabs
+// themselves stay a single tablist. WALLET_TABS is the flat projection used for
+// deep-link/alias resolution and for looking up the active tab's label.
+const WALLET_TAB_GROUPS = [
+  {
+    label: 'Admin',
+    items: [
+      { id: 'account', label: 'Account' },
+      { id: 'membership', label: 'Membership' },
+      { id: 'network', label: 'Network' },
+      { id: 'preferences', label: 'Preferences' },
+      { id: 'security', label: 'Security' },
+    ],
+  },
+  {
+    label: 'Finance',
+    items: [
+      { id: 'trade', label: 'Trade' },
+      { id: 'paytransfer', label: 'Pay & Transfer' },
+    ],
+  },
+  {
+    label: 'Tools',
+    items: [
+      { id: 'addressbook', label: 'Address Book' },
+      { id: 'backup', label: 'Backup' },
+      { id: 'reports', label: 'Reporting' },
+    ],
+  },
+  {
+    label: 'Apps',
+    items: [
+      { id: 'clearpath', label: 'ClearPath' },
+      { id: 'tokens', label: 'Token Mint' },
+    ],
+  },
 ]
+const WALLET_TABS = WALLET_TAB_GROUPS.flatMap((group) => group.items)
 
 // Legacy deep-link aliases → canonical tab ids (the Swap tab is now "Trade").
 const TAB_ALIASES = { swap: 'trade' }
@@ -330,7 +354,7 @@ function WalletPage() {
                   <span className="status-dot connected" aria-hidden="true"></span>
                 </div>
                 <PortalNav
-                  items={WALLET_TABS}
+                  groups={WALLET_TAB_GROUPS}
                   activeId={activeTab}
                   onSelect={handleSelectTab}
                   ariaLabel="Account sections"

--- a/frontend/src/test/PortalNav.test.jsx
+++ b/frontend/src/test/PortalNav.test.jsx
@@ -39,3 +39,47 @@ describe('PortalNav (vertical sidebar tabs)', () => {
     expect(await axe(container)).toHaveNoViolations()
   })
 })
+
+const GROUPS = [
+  { label: 'Admin', items: [{ id: 'account', label: 'Account' }] },
+  {
+    label: 'Finance',
+    items: [
+      { id: 'trade', label: 'Trade' },
+      { id: 'paytransfer', label: 'Pay & Transfer' },
+    ],
+  },
+]
+
+describe('PortalNav (grouped rail)', () => {
+  it('renders a group heading for each group with its tabs beneath', () => {
+    render(<PortalNav groups={GROUPS} activeId="account" onSelect={vi.fn()} ariaLabel="Account sections" />)
+    expect(screen.getByText('Admin')).toBeInTheDocument()
+    expect(screen.getByText('Finance')).toBeInTheDocument()
+    for (const group of GROUPS) {
+      for (const item of group.items) {
+        expect(screen.getByRole('tab', { name: item.label })).toBeInTheDocument()
+      }
+    }
+  })
+
+  it('keeps every grouped entry inside the single tablist', () => {
+    render(<PortalNav groups={GROUPS} activeId="account" onSelect={vi.fn()} ariaLabel="Account sections" />)
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs).toHaveLength(3)
+  })
+
+  it('calls onSelect with the item id when a grouped tab is clicked', () => {
+    const onSelect = vi.fn()
+    render(<PortalNav groups={GROUPS} activeId="account" onSelect={onSelect} ariaLabel="Account sections" />)
+    fireEvent.click(screen.getByRole('tab', { name: 'Pay & Transfer' }))
+    expect(onSelect).toHaveBeenCalledWith('paytransfer')
+  })
+
+  it('has no axe violations when grouped', async () => {
+    const { container } = render(
+      <PortalNav groups={GROUPS} activeId="account" onSelect={vi.fn()} ariaLabel="Account sections" />
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})


### PR DESCRIPTION
## Summary

The My Account section rail (`WalletPage`) had grown to a dozen flat tabs, which was getting hard to scan. This groups them visually in the side nav by function:

- **Admin** — Account, Membership, Network, Preferences, Security
- **Finance** — Trade, Pay & Transfer
- **Tools** — Address Book, Backup, Reporting
- **Apps** — ClearPath, Token Mint

("Earn" and "Vaults" from the requested Finance grouping don't exist as tabs yet, so they're omitted for now — the group is ready to receive them when they land.)

## Changes

- **`PortalNav`** gains an optional `groups` prop (`[{ label, items }]`). When provided, it renders a presentational heading per group while keeping every entry a `role="tab"` inside the single `role="tablist"` — keyboard navigation and `aria-selected` semantics are unchanged. The existing flat `items` path (used by the Admin Panel) is untouched.
- **`WalletPage`** defines `WALLET_TAB_GROUPS` and derives the flat `WALLET_TABS` from it, so deep-link/alias resolution and the active-tab-label lookup keep working. The Tokens tab is relabelled **"Token Mint"** to match its panel (spec 028) and the requested Apps grouping.
- **`PortalNav.css`** styles the group headings (uppercase, subtle divider between groups).

## Testing

- `PortalNav.test.jsx` — added grouped-rail tests (headings render, all entries stay in one tablist, click dispatches the id, no axe violations).
- `PortalNav.test.jsx` + `WalletPage.test.jsx` pass (16 tests), including accessibility checks.
- Lint: 0 errors on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGt3MzxsvfTcq9z1sqzyc8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGt3MzxsvfTcq9z1sqzyc8)_