### PR TITLE
deploy(036): bump prod relayer to Tier-2 images (gateway tier2-807 + engine v1.5.0)

### DIFF
--- a/.openzeppelin/polygon.json
+++ b/.openzeppelin/polygon.json
@@ -15,6 +15,10 @@
       "address": "0x5806e76cA3c838524E7cF43db7625bdFBA0783a0",
       "txHash": "0x390496c320583dfb07d11134413d7af281798df4cc7847e72a2bb558bbafb6c5",
       "kind": "uups"
+    },
+    {
+      "address": "0x420aEC3c76859eB74ab21c769c16AcdAB221f723",
+      "kind": "uups"
     }
   ],
   "impls": {
@@ -1948,6 +1952,382 @@
           ]
         }
       }
+    },
+    "9b5e9b52724476e18ce7c10f8e1cdd8a0e640e77be6cce38d5c5f78d8d38a2e9": {
+      "address": "0x2ad0F9Fe788F35F8edbaCA35346Da22792c5d18e",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSManaged",
+            "src": "contracts/upgradeable/UUPSManaged.sol:46"
+          },
+          {
+            "label": "poolImpl",
+            "offset": 0,
+            "slot": "50",
+            "type": "t_address",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:59"
+          },
+          {
+            "label": "sanctionsGuard",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_contract(ISanctionsGuard)9081",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:63"
+          },
+          {
+            "label": "membershipManager",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_contract(IMembershipManager)9015",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:66"
+          },
+          {
+            "label": "screeningRequired",
+            "offset": 20,
+            "slot": "52",
+            "type": "t_bool",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:70"
+          },
+          {
+            "label": "poolCount",
+            "offset": 0,
+            "slot": "53",
+            "type": "t_uint256",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:73"
+          },
+          {
+            "label": "_pools",
+            "offset": 0,
+            "slot": "54",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:75"
+          },
+          {
+            "label": "poolAddressToId",
+            "offset": 0,
+            "slot": "55",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:78"
+          },
+          {
+            "label": "_phraseToPool",
+            "offset": 0,
+            "slot": "56",
+            "type": "t_mapping(t_bytes32,t_address)",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:81"
+          },
+          {
+            "label": "_poolToPhrase",
+            "offset": 0,
+            "slot": "57",
+            "type": "t_mapping(t_address,t_array(t_uint32)4_storage)",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:82"
+          },
+          {
+            "label": "allowedToken",
+            "offset": 0,
+            "slot": "58",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:86"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "59",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "WagerPoolFactory",
+            "src": "contracts/pools/WagerPoolFactory.sol:88"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_bytes32,t_bool))": {
+            "label": "mapping(address => mapping(bytes32 => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)26_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)36_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)26_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(EIP712Storage)363_storage": {
+            "label": "struct EIP712Upgradeable.EIP712Storage",
+            "members": [
+              {
+                "label": "_hashedName",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_hashedVersion",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "_version",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(InitializableStorage)147_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)300_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)26_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(SignerIntentStorage)4346_storage": {
+            "label": "struct SignerIntentBase.SignerIntentStorage",
+            "members": [
+              {
+                "label": "used",
+                "type": "t_mapping(t_address,t_mapping(t_bytes32,t_bool))",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_array(t_uint32)4_storage": {
+            "label": "uint32[4]",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IMembershipManager)9015": {
+            "label": "contract IMembershipManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ISanctionsGuard)9081": {
+            "label": "contract ISanctionsGuard",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_array(t_uint32)4_storage)": {
+            "label": "mapping(address => uint32[4])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_address)": {
+            "label": "mapping(bytes32 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_uint32": {
+            "label": "uint32",
+            "numberOfBytes": "4"
+          }
+        },
+        "namespaces": {
+          "erc7201:fairwins.storage.SignerIntentBase": [
+            {
+              "contract": "SignerIntentBase",
+              "label": "used",
+              "type": "t_mapping(t_address,t_mapping(t_bytes32,t_bool))",
+              "src": "contracts/upgradeable/SignerIntentBase.sol:33",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.EIP712": [
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedName",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:38",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedVersion",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:40",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_name",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:42",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_version",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:43",
+              "offset": 0,
+              "slot": "3"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol:43",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)26_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:62",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      },
+      "allAddresses": [
+        "0x2ad0F9Fe788F35F8edbaCA35346Da22792c5d18e",
+        "0x754d8aa4785Ec4bEE7c921f8d032D5E3a78d9308"
+      ]
     }
   }
 }

--- a/deployments/polygon-chain137-v2.json
+++ b/deployments/polygon-chain137-v2.json
@@ -26,7 +26,7 @@
     "umaAdapter": "0x8224433d099Af6cd30540A78421aBFd6e044E949",
     "wagerRegistryIntents": "0x8878C8d6822De61cA8886Ae1D8BDA60b61ca1d81",
     "wagerPoolFactory": "0x420aEC3c76859eB74ab21c769c16AcdAB221f723",
-    "wagerPoolFactoryImpl": "0x2ad0F9Fe788F35F8edbaCA35346Da22792c5d18e",
+    "wagerPoolFactoryImpl": "0x754d8aa4785Ec4bEE7c921f8d032D5E3a78d9308",
     "poolImpl": "0xB153e4456FaD1A7E96e35e14094Cf6964348BC40",
     "entryPoint": "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
     "accountFactory": "0xd519C25e9dEd0DAC586B764574100479CB318734",
@@ -82,5 +82,6 @@
     "altoExecutor": "0x7C6da19ae005D4F13BB8660Ac989c48aCcFE84F6",
     "altoImage": "ghcr.io/pimlicolabs/alto:v1.2.7",
     "altoNote": "EntryPoint v0.6; deploy-simulations-contract=false (v0.6 uses built-in simulateHandleOp). Executor key in Secret Manager alto-executor-key-137."
-  }
+  },
+  "tier2PoolIntentsUpgradedAt": "2026-07-06T13:05:14.888Z"
 }

--- a/services/oz-relayer/deploy/production/service.yaml
+++ b/services/oz-relayer/deploy/production/service.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
         # ---- ingress: FairWins policy gateway (public, port 8788) ----
         - name: gateway
-          image: us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway@sha256:d7548b53b9c9a2a424f52a29b39474d47548c41286409f926a58cbd0011943de
+          image: us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway:tier2-807
           ports:
             - name: http1
               containerPort: 8788
@@ -55,7 +55,7 @@ spec:
             limits: { cpu: "1", memory: 512Mi }
         # ---- sidecar: OZ Relayer engine (localhost:8080) ----
         - name: engine
-          image: us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-engine:multichain-v1.4.0
+          image: us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-engine:multichain-v1.5.0
           env:
             - name: IN_DOCKER
               value: "true"


### PR DESCRIPTION
As-built record for the Tier-2 gasless-pools relayer deploy. Both images are built + pushed to Artifact Registry; the live apply is the surgical image swap below (drift-free, prior revision kept for rollback).

```
gcloud run services update fairwins-relay-gateway --region us-central1 \
  --container gateway --image us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway:tier2-807 \
  --container engine  --image us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-engine:multichain-v1.5.0
```

**Engine v1.5.0** adds the WagerPoolFactory to `whitelist_receivers` (63 `0xac78B4Ed…`, 137 `0x420aEC3c…`). **Gateway tier2-807** carries the #807 pool-intent code.

⚠️ The Tier-2 SPA already auto-deployed on the #807 merge, so gasless **pool** actions hit a pre-Tier-2 gateway that rejects them until this applies. Tier 1 gasless + the CSP fix are already live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)