### PR TITLE
edge(041): reconcile alto-bundler sidecar to live v1.2.7 + auto-deploy (lock-off)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -66,6 +66,33 @@ steps:
       - 'managed'
       - '--allow-unauthenticated'
 
+  # --- Alto ERC-4337 bundler origin-lock ingress (spec 041 SC-009) --------------------------------
+  # The bundler is a MULTI-container service (nginx origin-lock ingress + alto sidecar), so it is
+  # rolled out with `gcloud run services replace` of the full 2-container spec — a single-container
+  # `gcloud run deploy` (like the SPA step above) would drop the alto sidecar. Build the nginx image,
+  # then replace the service pinned to this commit. The alto sidecar env is reconciled to live in
+  # services/alto-bundler/deploy/service.yaml; the origin lock arms itself iff ORIGIN_LOCK_SECRET is
+  # present (fail-open). NOTE: this redeploys the bundler on every main merge — acceptable for a
+  # low-traffic bundler with a Secret-Manager executor key; add a path-filtered trigger later to scope it.
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/alto-bundler-nginx:$COMMIT_SHA'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/alto-bundler-nginx:latest'
+      - 'services/alto-bundler/nginx'
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', '--all-tags', 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/alto-bundler-nginx']
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: bash
+    args:
+      - '-c'
+      - |
+        sed "s|alto-bundler-nginx:latest|alto-bundler-nginx:$COMMIT_SHA|" \
+          services/alto-bundler/deploy/service.yaml > /workspace/alto-bundler.rendered.yaml
+        gcloud run services replace /workspace/alto-bundler.rendered.yaml --region us-central1 --quiet
+
   # --- Relay gateway (spec 036) — NOT built or deployed here -----------------------------------
   # The production relayer is a 3-CONTAINER Cloud Run service (policy gateway + from-source OZ
   # Relayer engine + redis) wired to a KMS-signed gas key. A single-container `gcloud run deploy`

--- a/services/alto-bundler/README.md
+++ b/services/alto-bundler/README.md
@@ -19,47 +19,49 @@ browser ─▶ bundler.fairwins.app ─▶ Cloudflare (Transform Rule: +X-Origin
 | `nginx/bundler.conf.template` | origin-lock map (`$origin_denied`) + `/healthz` exempt + proxy to `127.0.0.1:3000` |
 | `nginx/docker-entrypoint.sh` | derives `ORIGIN_LOCK_ENABLED` from whether `ORIGIN_LOCK_SECRET` is set (fail-open, never a 403-brick) |
 | `nginx/Dockerfile` | `nginx:1.27-alpine` + `envsubst` |
-| `cloudbuild.yaml` | build/push `alto-bundler-nginx` |
-| `deploy/service.yaml` | multi-container Cloud Run (nginx ingress + alto sidecar) — **alto env must be reconciled from the live service first** |
+| `cloudbuild.yaml` | manual/isolated rollout — build the nginx image + `gcloud run services replace` the full 2-container spec |
+| `deploy/service.yaml` | multi-container Cloud Run (nginx ingress + alto sidecar) — **alto env reconciled to live `alto:v1.2.7` / Polygon 137 (2026-07-06)** |
+
+**Auto-deploy:** the root `cloudbuild.yaml` (fired by the `^main$` Cloud Build trigger on every merge)
+builds `alto-bundler-nginx:$COMMIT_SHA` and `gcloud run services replace`s this service — so merging a
+change here rolls the bundler out automatically. (It redeploys on *every* main merge; add a
+`--included-files services/alto-bundler/**` trigger later if you want to scope it.)
 
 The origin lock is **fail-open by design**: no `ORIGIN_LOCK_SECRET` → `ORIGIN_LOCK_ENABLED=0` → all
 traffic allowed. Mounting the Secret-Manager `origin-lock-secret` is the single switch that arms it, so
 you cannot half-configure it into a deny-everything state.
 
-## Staged rollout (never break the live bundler)
+## Rollout status + remaining steps
 
-Because the SPA currently calls the bare `run.app` URL, and passkey is OFF until the bundler is wired,
-roll out in this order so nothing 403s before its front door exists:
+Progress as of 2026-07-06:
+- ✅ nginx ingress image + `deploy/service.yaml` reconciled to the live `alto:v1.2.7` / Polygon 137 config.
+- ✅ Auto-deploy wired into the root `cloudbuild.yaml` — **merging brings up the 2-container service
+  LOCK-OFF** (fail-open): the nginx ingress goes live without breaking the working `run.app` URL.
+- ✅ `bundler.fairwins.app` CNAME created (Cloudflare-proxied).
+- ✅ Zone-wide `X-Origin-Auth` Transform Rule already in place (covers `*.fairwins.app`).
+- ⚠️ **`bundler.fairwins.app` does NOT route to the service yet.** It returns Google's HTML 404 (the GFE
+  doesn't recognize the Host), whereas the `run.app` URL returns alto's JSON 404. A bare CNAME→`*.run.app`
+  is insufficient — Cloud Run routes by Host. Fix with **either** a Cloudflare **Host-header override** to
+  the `*.run.app` origin (Origin Rule / Transform Rule → Rewrite Host), **or** a Cloud Run domain-mapping.
 
-1. **Build the ingress image**
+### Arm the lock (only after the front door works)
+
+1. Confirm routing: `curl -s https://bundler.fairwins.app/` must return **alto's** JSON 404
+   (`{"message":"Route GET:/ not found",...}`), not Google's HTML 404.
+2. Point the SPA at the edge host: set `VITE_BUNDLER_URLS_POLYGON=https://bundler.fairwins.app` in the root
+   `cloudbuild.yaml` (currently the transitional `run.app` URL). CSP already allows both hosts, so no CSP change.
+3. Uncomment the `ORIGIN_LOCK_SECRET` env in `deploy/service.yaml` and merge (or run the manual config below).
+4. Verify:
    ```sh
-   gcloud builds submit services/alto-bundler --config services/alto-bundler/cloudbuild.yaml
+   curl -sI https://bundler.fairwins.app/healthz                                            # 200 (health exempt)
+   curl -s -o /dev/null -w '%{http_code}\n' https://bundler.fairwins.app/                   # 200 (CF injects header)
+   curl -s -o /dev/null -w '%{http_code}\n' https://fairwins-alto-bundler-<hash>.run.app/   # 403 (no CF header — locked)
    ```
-2. **Reconcile alto's env** into `deploy/service.yaml` from the live service (do NOT guess it):
-   ```sh
-   gcloud run services describe fairwins-alto-bundler --region us-central1 --format export
-   ```
-   Copy the live `ALTO_*` env + the executor/utility key secret refs into the `alto` container block.
-3. **Deploy the sidecar with the lock OFF** (omit `ORIGIN_LOCK_SECRET`) — behaviour-neutral; the bundler
-   keeps working on the `run.app` URL while gaining the nginx ingress:
-   ```sh
-   gcloud run services replace services/alto-bundler/deploy/service.yaml --region us-central1
-   ```
-4. **Cloudflare (dashboard — needs CF access; no API creds in this repo):**
-   - Add `bundler` CNAME → the Cloud Run service (or map the custom domain:
-     `gcloud run domain-mappings create --service fairwins-alto-bundler --domain bundler.fairwins.app --region us-central1`).
-   - Confirm the existing zone-wide Transform Rule injecting `X-Origin-Auth: <origin-lock-secret>`
-     covers `bundler.fairwins.app` (it is scoped to `*.fairwins.app`, so it should already apply —
-     verify with `curl -sI https://bundler.fairwins.app/healthz`).
-5. **Arm the lock:** add the `ORIGIN_LOCK_SECRET` secret ref (already in `service.yaml`) and redeploy.
-   Verify: a request **without** the header now 403s, a Cloudflare-proxied request 200s.
-   ```sh
-   curl -sI https://bundler.fairwins.app/healthz          # 200 (health is exempt)
-   curl -s -o /dev/null -w '%{http_code}\n' https://fairwins-alto-bundler-<hash>.run.app/   # 403 (no CF header)
-   ```
-6. **Point the SPA at the edge host:** set `VITE_BUNDLER_URLS_POLYGON=https://bundler.fairwins.app` in
-   `cloudbuild.yaml` and redeploy the SPA. The SPA CSP already allows both `bundler.fairwins.app` and the
-   transitional `run.app` host (`frontend/nginx.conf*` connect-src), so no CSP change is needed.
+
+To roll the bundler alone (without a frontend build), run the manual config:
+```sh
+gcloud builds submit . --config services/alto-bundler/cloudbuild.yaml
+```
 
 ## Rollback
 

--- a/services/alto-bundler/cloudbuild.yaml
+++ b/services/alto-bundler/cloudbuild.yaml
@@ -1,18 +1,29 @@
-# Build + push the origin-lock nginx ingress image for the alto bundler.
-#   gcloud builds submit services/alto-bundler --config services/alto-bundler/cloudbuild.yaml
-# Then apply services/alto-bundler/deploy/service.yaml (see README) to roll out the multi-container
-# service (nginx ingress + alto sidecar).
+# Manual / isolated rollout of the alto bundler origin-lock ingress (builds the nginx image AND
+# replaces the multi-container Cloud Run service). Auto-deploy on merge is handled by the ROOT
+# cloudbuild.yaml; use this to redeploy the bundler alone without a frontend build:
+#
+#   gcloud builds submit . --config services/alto-bundler/cloudbuild.yaml
+#
+# Run from the REPO ROOT (context needs services/alto-bundler/deploy/service.yaml + nginx/). Applied via
+# `gcloud run services replace` — a single-container `gcloud run deploy` would drop the alto sidecar.
 steps:
   - name: gcr.io/cloud-builders/docker
     args:
       - build
       - -t
-      - us-central1-docker.pkg.dev/$PROJECT_ID/fairwins/alto-bundler-nginx:$SHORT_SHA
+      - us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/alto-bundler-nginx:$SHORT_SHA
       - -t
-      - us-central1-docker.pkg.dev/$PROJECT_ID/fairwins/alto-bundler-nginx:latest
-      - nginx
-images:
-  - us-central1-docker.pkg.dev/$PROJECT_ID/fairwins/alto-bundler-nginx:$SHORT_SHA
-  - us-central1-docker.pkg.dev/$PROJECT_ID/fairwins/alto-bundler-nginx:latest
+      - us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/alto-bundler-nginx:latest
+      - services/alto-bundler/nginx
+  - name: gcr.io/cloud-builders/docker
+    args: [push, --all-tags, us-central1-docker.pkg.dev/$PROJECT_ID/cloud-run-source-deploy/alto-bundler-nginx]
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        sed "s|alto-bundler-nginx:latest|alto-bundler-nginx:$SHORT_SHA|" \
+          services/alto-bundler/deploy/service.yaml > /workspace/alto-bundler.rendered.yaml
+        gcloud run services replace /workspace/alto-bundler.rendered.yaml --region us-central1 --quiet
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/services/alto-bundler/deploy/service.yaml
+++ b/services/alto-bundler/deploy/service.yaml
@@ -1,14 +1,14 @@
 # Cloud Run multi-container service: origin-lock nginx ingress + alto ERC-4337 bundler sidecar.
 # Spec 041 SC-009 / spec 036 FR-029: put the bundler behind the same origin lock as the SPA + gateway.
 #
-# INGRESS container = nginx (the only one with a `ports:` entry, receives all traffic on 8080).
+# INGRESS container = nginx (the only one with a `ports:` entry — receives all traffic on 8080).
 # SIDECAR  container = alto  (localhost-only; nginx proxies to 127.0.0.1:3000).
 #
-# ⚠️  The `alto` container's env below is the DOCUMENTED baseline (spec 041 + project memory). Before
-#     first apply, RECONCILE it against the currently-live service so no runtime setting is lost:
-#         gcloud run services describe fairwins-alto-bundler --region us-central1 --format export
-#     Copy the live ALTO_* env + the executor-key secret ref into the alto container here, then apply.
-#     (The README walks through this — it is the one step that must not be guessed.)
+# The `alto` container below is RECONCILED to the live service (`fairwins-alto-bundler`, alto v1.2.7,
+# Polygon 137) as of 2026-07-06 — image, all ALTO_* env, and the executor-key secret ref match what
+# was running standalone, so flipping to this 2-container spec changes ONLY the ingress path, never the
+# bundler's runtime. Applied via `gcloud run services replace` (a single-container `gcloud run deploy`
+# would drop the alto sidecar).
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
@@ -17,31 +17,38 @@ metadata:
     app: fairwins-alto-bundler
   annotations:
     run.googleapis.com/launch-stage: BETA          # multi-container (sidecars) is BETA-gated
-    run.googleapis.com/ingress: all                # Cloudflare fronts it; origin lock is the gate
+    run.googleapis.com/ingress: all                # Cloudflare fronts it; the origin lock is the gate
 spec:
   template:
     metadata:
       annotations:
         run.googleapis.com/container-dependencies: '{"nginx":["alto"]}'  # start alto before nginx
         autoscaling.knative.dev/minScale: "1"      # keep one warm (executor nonce continuity)
-        autoscaling.knative.dev/maxScale: "3"
+        autoscaling.knative.dev/maxScale: "2"
+        run.googleapis.com/cpu-throttling: "false"     # bundler must keep processing between requests
+        run.googleapis.com/startup-cpu-boost: "true"
     spec:
+      serviceAccountName: 266380754692-compute@developer.gserviceaccount.com
       containers:
-        # ---- Ingress: origin-lock nginx ----
+        # ---- Ingress: origin-lock nginx (validates Cloudflare's X-Origin-Auth) ----
         - name: nginx
-          image: us-central1-docker.pkg.dev/chippr-bots-site-wp/fairwins/alto-bundler-nginx:latest
+          image: us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/alto-bundler-nginx:latest
           ports:
             - name: http1
               containerPort: 8080
-          env:
-            # Arms the origin lock (docker-entrypoint derives ORIGIN_LOCK_ENABLED). Same secret Cloudflare
-            # injects as X-Origin-Auth zone-wide. OMIT this on the first (pre-Cloudflare) rollout so the
-            # bundler stays open until bundler.fairwins.app is fronted, then add it to arm enforcement.
-            - name: ORIGIN_LOCK_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: origin-lock-secret
-                  key: latest
+          # env: ORIGIN_LOCK_SECRET is intentionally OMITTED here so this merges LOCK-OFF (fail-open) —
+          # the 2-container ingress goes live without breaking anything while the front door is finished.
+          # ARM the lock ONLY AFTER both are true, or the bundler becomes unreachable:
+          #   (1) bundler.fairwins.app actually routes to this service — a bare CNAME→*.run.app returns a
+          #       Google 404 (Cloud Run doesn't recognize the Host); add a Cloudflare Host-header override
+          #       to the *.run.app origin, or a Cloud Run domain-mapping, until it returns alto's response.
+          #   (2) the SPA's VITE_BUNDLER_URLS_POLYGON points at https://bundler.fairwins.app (not the bare
+          #       run.app URL) — else the SPA hits run.app directly and the armed lock 403s it.
+          # Then arm by uncommenting:
+          #   env:
+          #     - name: ORIGIN_LOCK_SECRET
+          #       valueFrom:
+          #         secretKeyRef: { name: origin-lock-secret, key: latest }
           resources:
             limits:
               cpu: "1"
@@ -52,21 +59,35 @@ spec:
               port: 8080
             failureThreshold: 10
             periodSeconds: 3
-        # ---- Sidecar: alto bundler (localhost only) ----
+        # ---- Sidecar: alto bundler (localhost only; reconciled to live v1.2.7 / Polygon 137) ----
         - name: alto
-          image: ghcr.io/pimlicolabs/alto:v1.2.7
-          # RECONCILE from the live service (see header). Documented baseline:
+          image: us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/alto:v1.2.7
           env:
-            - name: ALTO_PORT
-              value: "3000"
             - name: ALTO_ENTRYPOINTS
               value: "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"   # EntryPoint v0.6
+            - name: ALTO_RPC_URL
+              value: "https://polygon-bor-rpc.publicnode.com"
+            - name: ALTO_SAFE_MODE
+              value: "false"
+            - name: ALTO_PORT
+              value: "3000"
+            - name: ALTO_API_VERSION
+              value: "v1,v2"
+            - name: ALTO_NETWORK_NAME
+              value: "polygon"
             - name: ALTO_DEPLOY_SIMULATIONS_CONTRACT
               value: "false"   # v0.6 has built-in simulation; the sim contract fails EIP-170 on Polygon
-            # - name: ALTO_RPC_URL            # <-- copy from the live service
-            # - name: ALTO_EXECUTOR_PRIVATE_KEYS   # <-- from Secret Manager (executor gas key)
-            # - name: ALTO_UTILITY_PRIVATE_KEY     # <-- from Secret Manager
+            - name: ALTO_EXECUTOR_PRIVATE_KEYS
+              valueFrom:
+                secretKeyRef:
+                  name: alto-executor-key-137
+                  key: latest
+            - name: ALTO_UTILITY_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: alto-executor-key-137
+                  key: latest
           resources:
             limits:
               cpu: "1"
-              memory: 512Mi
+              memory: 1Gi


### PR DESCRIPTION
Reconciles the #808 origin-lock nginx sidecar to the **actually-running** alto bundler and wires it to deploy on merge.

## What changed
- **`deploy/service.yaml`** — alto sidecar reconciled EXACTLY to live `fairwins-alto-bundler`: image `alto:v1.2.7` (from `cloud-run-source-deploy`, not ghcr), all 9 `ALTO_*` env vars, the `alto-executor-key-137` secret ref, 1Gi, the compute service account, cpu-throttling off. The 2-container flip (nginx ingress :8080 + alto sidecar :3000) changes only the ingress path — the bundler runtime is byte-identical to what runs today.
- **Root `cloudbuild.yaml`** — builds `alto-bundler-nginx:$COMMIT_SHA` and `gcloud run services replace`s the full 2-container spec on every `main` merge (the only merge trigger). A single-container `gcloud run deploy` would clobber the alto sidecar, so it uses `services replace` like the gateway.
- **`services/alto-bundler/cloudbuild.yaml`** — self-contained manual rollout (build + replace), fixed to the existing `cloud-run-source-deploy` AR repo.

## ⚠️ Ships LOCK-OFF on purpose
`bundler.fairwins.app` **does not route to the service yet** — it returns Google's GFE HTML 404 (Cloud Run doesn't recognize the Host; a bare CNAME→`*.run.app` is insufficient), whereas the `run.app` URL returns **alto's** JSON 404. Arming the origin lock now — while the SPA still targets `run.app` — would make the bundler unreachable.

**Merging is safe:** it deploys the 2-container ingress fail-open; `run.app` keeps working. **To arm the lock** (steps in the README): (1) add a Cloudflare Host-override to the `*.run.app` origin (or a Cloud Run domain-mapping) so `bundler.fairwins.app` returns alto's response; (2) switch the SPA's `VITE_BUNDLER_URLS_POLYGON` to `bundler.fairwins.app`; (3) uncomment `ORIGIN_LOCK_SECRET` in `service.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)