### PR TITLE
Mobile push notifications with per-category delivery preferences

### DIFF
--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -38,6 +38,51 @@ self.addEventListener('activate', (event) => {
   )
 })
 
+// Activity notifications. When the running PWA raises a system
+// notification for a 'push'-mode activity entry (via registration.showNotification),
+// tapping it must focus the app and deep-link to that entry. The entry's router
+// link ({ to, state }) rides along in notification.data; we hand it to a focused
+// client (the ActivityNotificationBridge performs the in-app navigation) or, if
+// no window is open, open one at the link's path.
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+  const link = (event.notification.data && event.notification.data.link) || null
+  const targetPath = (link && link.to) || '/app'
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
+      for (const client of clientList) {
+        if ('focus' in client) {
+          client.focus()
+          client.postMessage({ type: 'ACTIVITY_NAVIGATE', link: link || { to: targetPath } })
+          return undefined
+        }
+      }
+      return self.clients.openWindow ? self.clients.openWindow(targetPath) : undefined
+    })
+  )
+})
+
+// Forward-compat: real server-initiated Web Push. There is no push backend today
+// (notifications are derived client-side), but wiring this listener now means a
+// future backend can deliver push without another service-worker change.
+self.addEventListener('push', (event) => {
+  let payload = {}
+  try {
+    payload = event.data ? event.data.json() : {}
+  } catch {
+    payload = {}
+  }
+  const title = payload.title || 'FairWins'
+  const options = {
+    body: payload.body || payload.message || 'New activity',
+    icon: '/assets/fairwins_no-text_logo.svg',
+    badge: '/assets/fairwins_no-text_logo.svg',
+    tag: payload.tag || 'fairwins-activity',
+    data: { link: payload.link || null },
+  }
+  event.waitUntil(self.registration.showNotification(title, options))
+})
+
 self.addEventListener('fetch', (event) => {
   const { request } = event
   // Only handle GET navigations for the offline fallback; everything else is network-only.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,6 +24,7 @@ import PoolPage from './pages/PoolPage'
 import { TermsPage, RiskPage, PrivacyPage } from './pages/legal/LegalDocPage'
 import EntryGate from './components/compliance/EntryGate'
 import { ActivityProvider } from './contexts/ActivityProvider.jsx'
+import ActivityNotificationBridge from './components/notifications/ActivityNotificationBridge'
 
 //admin
 import AdminPanel from './components/AdminPanel'
@@ -42,6 +43,8 @@ function AppLayout() {
        below consume it (wagers + DAO/token/membership sources); landing pages never poll. */
     <ActivityProvider>
       <Header appMode />
+      {/* Spec 041: route a tapped push notification into in-app navigation. */}
+      <ActivityNotificationBridge />
       {/* Spec 007 (US4): client-side eligibility notice gate before any app content. */}
       <EntryGate />
       <Outlet />

--- a/frontend/src/components/account/NotificationPreferencesPanel.css
+++ b/frontend/src/components/account/NotificationPreferencesPanel.css
@@ -1,0 +1,183 @@
+/* NotificationPreferencesPanel — notification delivery controls on the
+   Preferences tab (mobile push / in-app / silent per category). Reuses the
+   PreferencesPanel switch look for the master toggle and adds a segmented
+   three-way control per category. */
+
+.notif-pref-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.notif-pref-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.notif-pref-hint {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+/* Master mobile-push toggle */
+.notif-pref-master {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-top: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.notif-pref-master-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.notif-pref-master-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.notif-pref-master-sub {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.notif-pref-switch {
+  position: relative;
+  width: 44px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: var(--border-color);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background var(--transition-base, 0.2s ease);
+}
+
+.notif-pref-switch::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--text-muted, var(--text-secondary));
+  transition: transform var(--transition-base, 0.2s ease), background var(--transition-base, 0.2s ease);
+}
+
+.notif-pref-switch.on {
+  background: var(--brand-primary);
+}
+
+.notif-pref-switch.on::after {
+  transform: translateX(20px);
+  background: #fff;
+}
+
+.notif-pref-switch:focus-visible {
+  outline: 2px solid var(--brand-primary);
+  outline-offset: 2px;
+}
+
+.notif-pref-switch:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Per-category rows */
+.notif-pref-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.notif-pref-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--border-color);
+  flex-wrap: wrap;
+}
+
+.notif-pref-row:last-child {
+  border-bottom: none;
+}
+
+.notif-pref-row-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+  flex: 1 1 12rem;
+}
+
+.notif-pref-row-label {
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.notif-pref-row-desc {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.notif-pref-row-warn {
+  font-size: 0.75rem;
+  color: var(--color-warning, #b45309);
+}
+
+/* Segmented three-way control (Push / In-app / Silent) */
+.notif-pref-segmented {
+  display: inline-flex;
+  flex-shrink: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--surface-secondary, var(--border-color));
+}
+
+.notif-pref-seg {
+  appearance: none;
+  border: none;
+  background: transparent;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background var(--transition-base, 0.2s ease), color var(--transition-base, 0.2s ease);
+}
+
+.notif-pref-seg + .notif-pref-seg {
+  border-left: 1px solid var(--border-color);
+}
+
+.notif-pref-seg:hover {
+  color: var(--text-primary);
+}
+
+.notif-pref-seg.selected {
+  background: var(--brand-primary);
+  color: #fff;
+  font-weight: 600;
+}
+
+.notif-pref-seg:focus-visible {
+  outline: 2px solid var(--brand-primary);
+  outline-offset: -2px;
+}

--- a/frontend/src/components/account/NotificationPreferencesPanel.jsx
+++ b/frontend/src/components/account/NotificationPreferencesPanel.jsx
@@ -1,0 +1,124 @@
+import { useNotificationPreferences } from '../../hooks/useNotificationPreferences'
+import {
+  NOTIFICATION_CATEGORIES,
+  DELIVERY_MODES,
+} from '../../lib/notifications/deliveryPreferences'
+import { isPushSupported } from '../../lib/notifications/pushDelivery'
+import './NotificationPreferencesPanel.css'
+
+const MODE_LABELS = {
+  push: 'Push',
+  app: 'In-app',
+  silent: 'Silent',
+}
+
+const MODE_HINTS = {
+  push: 'Phone notification + in-app',
+  app: 'In-app toast + activity feed',
+  silent: 'Activity feed only',
+}
+
+/**
+ * NotificationPreferencesPanel — the "Notifications" area of the Preferences tab
+ * (My Account / Wallet). Lets a user (1) enable mobile push and (2) choose, per
+ * notification category, whether it's pushed to the device, shown in-app only,
+ * or kept silent (feed only). Device-scoped (a phone's push permission is
+ * per-device), so no wallet is required. Persisted via
+ * lib/notifications/deliveryPreferences.js.
+ */
+function NotificationPreferencesPanel() {
+  const { prefs, permission, setMode, enablePush, disablePush } = useNotificationPreferences()
+  const supported = isPushSupported()
+  const blocked = permission === 'denied'
+  const pushOn = prefs.pushEnabled && permission === 'granted'
+
+  const handleTogglePush = async () => {
+    if (pushOn) {
+      disablePush()
+    } else {
+      await enablePush()
+    }
+  }
+
+  return (
+    <div className="notif-pref-panel">
+      <h3 className="notif-pref-title">Notifications</h3>
+      <p className="notif-pref-hint">
+        Choose how each kind of update reaches you. Turn on mobile push to get
+        device notifications for new activity while FairWins is open.
+      </p>
+
+      <div className="notif-pref-master">
+        <div className="notif-pref-master-text">
+          <span className="notif-pref-master-label" id="notif-pref-push-label">
+            Mobile push notifications
+          </span>
+          <span className="notif-pref-master-sub">
+            {!supported
+              ? 'This browser cannot show system notifications.'
+              : blocked
+                ? 'Notifications are blocked in your browser settings — allow them for this site to enable push.'
+                : pushOn
+                  ? 'On — Push categories notify this device while the app is open.'
+                  : 'Off — enable to receive Push-category alerts on this device.'}
+          </span>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={pushOn}
+          aria-labelledby="notif-pref-push-label"
+          className={`notif-pref-switch ${pushOn ? 'on' : ''}`}
+          disabled={!supported || blocked}
+          onClick={handleTogglePush}
+        >
+          <span className="sr-only">{pushOn ? 'Mobile push on' : 'Mobile push off'}</span>
+        </button>
+      </div>
+
+      <ul className="notif-pref-list">
+        {NOTIFICATION_CATEGORIES.map((category) => {
+          const current = prefs.modes[category.domain] || 'app'
+          const groupLabelId = `notif-pref-cat-${category.domain}`
+          return (
+            <li key={category.domain} className="notif-pref-row">
+              <div className="notif-pref-row-text">
+                <span className="notif-pref-row-label" id={groupLabelId}>{category.label}</span>
+                <span className="notif-pref-row-desc">{category.description}</span>
+                {current === 'push' && !pushOn && (
+                  <span className="notif-pref-row-warn">
+                    Enable mobile push above to receive these on your device.
+                  </span>
+                )}
+              </div>
+              <div
+                className="notif-pref-segmented"
+                role="radiogroup"
+                aria-labelledby={groupLabelId}
+              >
+                {DELIVERY_MODES.map((mode) => {
+                  const selected = current === mode
+                  return (
+                    <button
+                      key={mode}
+                      type="button"
+                      role="radio"
+                      aria-checked={selected}
+                      title={MODE_HINTS[mode]}
+                      className={`notif-pref-seg ${selected ? 'selected' : ''}`}
+                      onClick={() => setMode(category.domain, mode)}
+                    >
+                      {MODE_LABELS[mode]}
+                    </button>
+                  )
+                })}
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+export default NotificationPreferencesPanel

--- a/frontend/src/components/fairwins/Dashboard.jsx
+++ b/frontend/src/components/fairwins/Dashboard.jsx
@@ -569,23 +569,22 @@ function Dashboard() {
   // Friend markets from shared context (single fetch, no duplication)
   const { friendMarkets } = useFriendMarkets()
 
-  // Feed → wager navigation (spec 012 T018/FR-004). The activity feed
-  // navigates to /app with { openWagerId } in router state. Stash the id and
-  // open My Wagers during render (React's "adjust state while rendering"
-  // pattern — guarded, so it settles after one extra render), then consume
-  // the router state in an effect so a refresh or back-navigation doesn't
-  // re-open the modal.
-  const routeWagerId = location.state?.openWagerId == null
-    ? null
-    : String(location.state.openWagerId)
-  if (routeWagerId != null && initialWagerId !== routeWagerId) {
-    setInitialWagerId(routeWagerId)
-    setShowMyWagers(true)
-  }
+  // Feed → wager navigation (spec 012 T018/FR-004). The activity feed navigates
+  // to /app with { openWagerId } in router state. Consume it in a SINGLE effect:
+  // open My Wagers on that wager, then immediately clear the history state so the
+  // modal's visibility is driven purely by component state, never the live
+  // history entry. Doing the open + clear render-safely in one effect (rather
+  // than a render-phase setState plus a deferred clearing navigate) keeps Back
+  // and click-away deterministic: pressing Back pops history without re-firing
+  // the modal, and closing never races a not-yet-cleared state (the bug where
+  // testers saw an error on back/away after accepting from a notification).
   useEffect(() => {
-    if (routeWagerId == null) return
+    const openWagerId = location.state?.openWagerId
+    if (openWagerId == null) return
+    setInitialWagerId(String(openWagerId))
+    setShowMyWagers(true)
     navigate(location.pathname, { replace: true, state: {} })
-  }, [routeWagerId, location.pathname, navigate])
+  }, [location.state, location.pathname, navigate])
 
   // Shared-phrase deep link (feature 024 / spec 037): a shared QR / link of the form
   // /app?oc=take&code=<four words> now opens the unified phrase lookup, pre-filled and auto-resolved,

--- a/frontend/src/components/fairwins/MarketAcceptanceModal.jsx
+++ b/frontend/src/components/fairwins/MarketAcceptanceModal.jsx
@@ -137,6 +137,11 @@ function MarketAcceptanceModal({
   const [envelopeLoading, setEnvelopeLoading] = useState(false)
 
   useEffect(() => {
+    // Guard against setState-after-unmount: navigating away (e.g. Back from a
+    // notification-launched accept screen) can unmount this modal while the IPFS
+    // fetch is still in flight. `alive` is cleared on cleanup so the awaited
+    // result is dropped instead of writing into a torn-down component.
+    let alive = true
     const resolveEnvelope = async () => {
       if (!marketData?.isEncrypted) return
 
@@ -145,7 +150,7 @@ function MarketAcceptanceModal({
         try {
           const parsed = JSON.parse(marketData.rawDescription)
           if (parsed.version && parsed.algorithm && parsed.content) {
-            setResolvedEnvelope(parsed)
+            if (alive) setResolvedEnvelope(parsed)
             return
           }
         } catch {
@@ -157,19 +162,20 @@ function MarketAcceptanceModal({
       const cid = marketData.ipfsCid
       if (cid) {
         try {
-          setEnvelopeLoading(true)
+          if (alive) setEnvelopeLoading(true)
           const envelope = await fetchEncryptedEnvelope(cid)
-          setResolvedEnvelope(envelope)
+          if (alive) setResolvedEnvelope(envelope)
         } catch (err) {
           console.error('Failed to fetch encrypted envelope from IPFS:', err)
         } finally {
-          setEnvelopeLoading(false)
+          if (alive) setEnvelopeLoading(false)
         }
       }
     }
 
     setResolvedEnvelope(null)
     resolveEnvelope()
+    return () => { alive = false }
   }, [marketData?.isEncrypted, marketData?.rawDescription, marketData?.ipfsCid])
 
   // Legacy fallback: decrypt using shared creator signature from old invitation URLs

--- a/frontend/src/components/notifications/ActivityNotificationBridge.jsx
+++ b/frontend/src/components/notifications/ActivityNotificationBridge.jsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+/**
+ * Bridges a tapped system notification (raised for 'push'-mode activity)
+ * into in-app navigation. public/sw.js#notificationclick focuses this window and
+ * postMessages the entry's router link ({ to, state } — e.g. state.openWagerId);
+ * we perform the navigation here, inside the router. Renders nothing.
+ */
+function ActivityNotificationBridge() {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return undefined
+    const handler = (event) => {
+      const data = event.data
+      if (!data || data.type !== 'ACTIVITY_NAVIGATE' || !data.link?.to) return
+      navigate(data.link.to, data.link.state ? { state: data.link.state } : undefined)
+    }
+    navigator.serviceWorker.addEventListener('message', handler)
+    return () => navigator.serviceWorker.removeEventListener('message', handler)
+  }, [navigate])
+
+  return null
+}
+
+export default ActivityNotificationBridge

--- a/frontend/src/contexts/ActivityProvider.jsx
+++ b/frontend/src/contexts/ActivityProvider.jsx
@@ -16,6 +16,8 @@ import { useNotification } from '../hooks/useUI'
 import { activitySources } from '../data/notifications/sources'
 import { defaultStore, loadStore, saveStore, appendEntries, markRead, setSourceSlice } from '../data/notifications/activityStore'
 import { detectAll, countActionNeeded } from '../data/notifications/activityEngine'
+import { resolveDelivery } from '../lib/notifications/deliveryPreferences'
+import { showSystemNotification } from '../lib/notifications/pushDelivery'
 
 const MAX_TOASTS_PER_CYCLE = 3
 const TOAST_DURATION_MS = 6000
@@ -101,11 +103,21 @@ export function ActivityProvider({ children, sources = activitySources }) {
       const isCatchUp = firstPollRef.current
       firstPollRef.current = false
       if (!isCatchUp && added.length > 0) {
-        for (const entry of added.slice(0, MAX_TOASTS_PER_CYCLE)) {
+        // Route each fresh entry by its domain's delivery mode (per-device
+        // preference): 'silent' → feed only (already persisted above);
+        // 'app' → in-app toast; 'push' → in-app toast + a system notification on
+        // this device. The toast cap applies to non-silent entries; system
+        // notifications are capped the same way so a busy cycle can't spam.
+        const toastable = added.filter((e) => resolveDelivery(e.domain || 'wagers') !== 'silent')
+        for (const entry of toastable.slice(0, MAX_TOASTS_PER_CYCLE)) {
           showNotification(entry.message, entry.severity, TOAST_DURATION_MS)
         }
-        if (added.length > MAX_TOASTS_PER_CYCLE) {
-          showNotification(`+${added.length - MAX_TOASTS_PER_CYCLE} more updates in activity`, 'info', TOAST_DURATION_MS)
+        if (toastable.length > MAX_TOASTS_PER_CYCLE) {
+          showNotification(`+${toastable.length - MAX_TOASTS_PER_CYCLE} more updates in activity`, 'info', TOAST_DURATION_MS)
+        }
+        const pushable = added.filter((e) => resolveDelivery(e.domain || 'wagers') === 'push')
+        for (const entry of pushable.slice(0, MAX_TOASTS_PER_CYCLE)) {
+          showSystemNotification(entry)
         }
       }
       if (anyFailure && !failureNoticedRef.current) {

--- a/frontend/src/hooks/useNotificationPreferences.js
+++ b/frontend/src/hooks/useNotificationPreferences.js
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  getNotificationPrefs,
+  setDeliveryMode,
+  setPushEnabled,
+  subscribe,
+} from '../lib/notifications/deliveryPreferences'
+import { ensurePushPermission, getPermissionState } from '../lib/notifications/pushDelivery'
+
+/**
+ * React binding for the device-scoped notification delivery preferences
+ * (lib/notifications/deliveryPreferences.js). Re-renders when preferences change
+ * from anywhere — the Preferences panel and the delivery path share one source
+ * of truth. Enabling push is user-gesture-driven: it requests the browser
+ * permission and only persists the master flag if the user actually grants it.
+ */
+export function useNotificationPreferences() {
+  const [prefs, setPrefs] = useState(getNotificationPrefs)
+  const [permission, setPermission] = useState(getPermissionState)
+
+  useEffect(() => {
+    const sync = () => {
+      setPrefs(getNotificationPrefs())
+      setPermission(getPermissionState())
+    }
+    const unsubscribe = subscribe(sync)
+    // Catch any change that landed between the initial render and this effect.
+    sync()
+    return unsubscribe
+  }, [])
+
+  const setMode = useCallback((domain, mode) => {
+    setDeliveryMode(domain, mode)
+  }, [])
+
+  const enablePush = useCallback(async () => {
+    const granted = await ensurePushPermission()
+    setPushEnabled(granted)
+    setPermission(getPermissionState())
+    return granted
+  }, [])
+
+  const disablePush = useCallback(() => {
+    setPushEnabled(false)
+  }, [])
+
+  return { prefs, permission, setMode, enablePush, disablePush }
+}
+
+export default useNotificationPreferences

--- a/frontend/src/lib/notifications/deliveryPreferences.js
+++ b/frontend/src/lib/notifications/deliveryPreferences.js
@@ -1,0 +1,163 @@
+/**
+ * Per-device notification delivery preferences.
+ *
+ * FairWins notifications are derived client-side by the ActivityProvider poll
+ * loop (spec 031). Each notification belongs to a domain (wagers, dao, token,
+ * membership, pools). This module lets a user pick, per domain, how that
+ * domain's notifications are DELIVERED:
+ *
+ *   - 'push'   → raise a real OS/phone notification (Web Notifications API via
+ *                the service worker) AND an in-app toast + feed entry.
+ *   - 'app'    → in-app toast + feed entry only (the historical default).
+ *   - 'silent' → feed entry only; no toast, no system notification.
+ *
+ * A master `pushEnabled` flag gates whether any 'push'-mode domain actually
+ * raises a system notification — it only flips true once the user has granted
+ * the browser notification permission (see pushDelivery.js). With it off, a
+ * 'push' domain degrades to 'app' delivery (never silently dropped).
+ *
+ * Follows the qrColorPreference.js / quickAccessPreference.js device-scoped
+ * pattern: plain-JSON localStorage, graceful fallbacks, never throws, in-memory
+ * listeners so the Preferences UI and the delivery path stay in sync within a
+ * session even when storage is unavailable (private browsing / quota).
+ */
+
+const DELIVERY_PREF_KEY = 'fairwins_notif_delivery_v1'
+
+/** Delivery modes, most-intrusive first. */
+export const DELIVERY_MODES = ['push', 'app', 'silent']
+
+/**
+ * User-facing notification categories, keyed by the entry `domain` the
+ * ActivityProvider stamps (see data/notifications/domains.js). Order is the
+ * order rendered in the Preferences panel. Keeping this list here — rather than
+ * deriving from DOMAIN_META — means the panel only ever shows domains that
+ * actually produce feed entries, and each gets a human description.
+ */
+export const NOTIFICATION_CATEGORIES = [
+  { domain: 'wagers', label: 'Wagers', description: 'Accept, resolve, claim, refund, and deadline reminders' },
+  { domain: 'pools', label: 'Wager Pools', description: 'Pool closed, resolved, cancelled, and members joining' },
+  { domain: 'membership', label: 'Membership', description: 'Renewals, upgrades, and redeemable vouchers' },
+  { domain: 'dao', label: 'Governance', description: 'Proposals to vote on, queue, or execute' },
+  { domain: 'token', label: 'Token admin', description: 'Role changes and pause/unpause events' },
+]
+
+const KNOWN_DOMAINS = NOTIFICATION_CATEGORIES.map((c) => c.domain)
+
+/** The historical behavior — toast + feed — so an unconfigured install is unchanged. */
+export const DEFAULT_MODE = 'app'
+
+const listeners = new Set()
+
+function notify() {
+  listeners.forEach((listener) => {
+    try {
+      listener()
+    } catch (error) {
+      console.warn('Error in notification delivery preference listener:', error)
+    }
+  })
+}
+
+function readRaw() {
+  try {
+    const saved = localStorage.getItem(DELIVERY_PREF_KEY)
+    if (!saved) return {}
+    const parsed = JSON.parse(saved)
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch (error) {
+    console.warn('Error reading notification delivery preferences:', error)
+    return {}
+  }
+}
+
+function writeRaw(value) {
+  try {
+    localStorage.setItem(DELIVERY_PREF_KEY, JSON.stringify(value))
+  } catch (error) {
+    // Private browsing / quota: fall back to session-only state; listeners still
+    // fire below so the current session stays consistent.
+    console.warn('Error saving notification delivery preferences:', error)
+  }
+}
+
+/**
+ * Full, normalized preferences for this device — every known domain resolved to
+ * a valid mode, plus the master push flag. Safe to call on every render.
+ * @returns {{ pushEnabled: boolean, modes: Record<string, 'push'|'app'|'silent'> }}
+ */
+export function getNotificationPrefs() {
+  const raw = readRaw()
+  const savedModes = raw && typeof raw.modes === 'object' && raw.modes ? raw.modes : {}
+  const modes = {}
+  for (const domain of KNOWN_DOMAINS) {
+    const mode = savedModes[domain]
+    modes[domain] = DELIVERY_MODES.includes(mode) ? mode : DEFAULT_MODE
+  }
+  return { pushEnabled: raw.pushEnabled === true, modes }
+}
+
+/**
+ * The configured delivery mode for a domain (falls back to DEFAULT_MODE for an
+ * unknown/unconfigured domain, so a new domain is never accidentally silenced).
+ * @param {string} domain
+ * @returns {'push'|'app'|'silent'}
+ */
+export function getDeliveryMode(domain) {
+  const mode = getNotificationPrefs().modes[domain]
+  return mode || DEFAULT_MODE
+}
+
+/**
+ * Persist the delivery mode for a domain. No-op for an unknown mode.
+ * @param {string} domain
+ * @param {'push'|'app'|'silent'} mode
+ */
+export function setDeliveryMode(domain, mode) {
+  if (!DELIVERY_MODES.includes(mode)) return
+  const raw = readRaw()
+  const modes = { ...(raw.modes && typeof raw.modes === 'object' ? raw.modes : {}), [domain]: mode }
+  writeRaw({ ...raw, modes })
+  notify()
+}
+
+/** Whether the user has opted into (and been granted) mobile push. */
+export function isPushEnabled() {
+  return getNotificationPrefs().pushEnabled
+}
+
+/**
+ * Set the master mobile-push flag. Only flip this true once the browser
+ * notification permission is actually granted (pushDelivery.js#ensurePushPermission).
+ * @param {boolean} enabled
+ */
+export function setPushEnabled(enabled) {
+  const raw = readRaw()
+  writeRaw({ ...raw, pushEnabled: enabled === true })
+  notify()
+}
+
+/**
+ * Resolve how an entry of the given domain should actually be delivered right
+ * now, collapsing the master push flag: a 'push' domain degrades to 'app' when
+ * push is disabled so nothing is ever silently dropped.
+ * @param {string} domain
+ * @returns {'push'|'app'|'silent'}
+ */
+export function resolveDelivery(domain) {
+  const { pushEnabled, modes } = getNotificationPrefs()
+  const mode = modes[domain] || DEFAULT_MODE
+  if (mode === 'push' && !pushEnabled) return 'app'
+  return mode
+}
+
+/**
+ * Subscribe to preference changes (e.g. the Preferences panel updating what the
+ * delivery path does). Returns an unsubscribe function.
+ * @param {() => void} listener
+ * @returns {() => void} unsubscribe
+ */
+export function subscribe(listener) {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}

--- a/frontend/src/lib/notifications/pushDelivery.js
+++ b/frontend/src/lib/notifications/pushDelivery.js
@@ -1,0 +1,108 @@
+/**
+ * Client-side "mobile push" delivery via the Web Notifications API.
+ *
+ * There is no notification backend (spec 031 derives everything client-side), so
+ * "push" here means: while the installed PWA is running — including backgrounded
+ * on a phone — the ActivityProvider poll loop raises a real OS notification
+ * (tray / lock screen) for domains the user set to 'push'. Tapping it focuses the
+ * app and deep-links to the entry (handled by public/sw.js#notificationclick).
+ *
+ * We prefer the ServiceWorkerRegistration.showNotification() path (works
+ * backgrounded and supports actions/tags) and fall back to the `new Notification`
+ * constructor where no SW controls the page. All calls are permission- and
+ * feature-guarded and never throw — a failure degrades silently to the in-app
+ * toast that always accompanies a push-mode entry.
+ *
+ * This module is deliberately backend-agnostic: if a real Web Push service is
+ * added later, subscribeToPush() below is the single seam to extend (register a
+ * PushSubscription with the backend) without touching the UI or delivery path.
+ */
+
+const NOTIFICATION_TAG_PREFIX = 'fairwins-activity'
+
+/** Whether this environment can show system notifications at all. */
+export function isPushSupported() {
+  return typeof window !== 'undefined' && 'Notification' in window
+}
+
+/**
+ * Current browser permission for notifications.
+ * @returns {'granted'|'denied'|'default'|'unsupported'}
+ */
+export function getPermissionState() {
+  if (!isPushSupported()) return 'unsupported'
+  return Notification.permission
+}
+
+/**
+ * Request notification permission if not already decided. Resolves to true only
+ * when permission ends up granted. Safe to call from a user gesture (the browser
+ * requires one for the prompt).
+ * @returns {Promise<boolean>}
+ */
+export async function ensurePushPermission() {
+  if (!isPushSupported()) return false
+  if (Notification.permission === 'granted') return true
+  if (Notification.permission === 'denied') return false
+  try {
+    const result = await Notification.requestPermission()
+    return result === 'granted'
+  } catch (error) {
+    console.warn('[pushDelivery] permission request failed:', error)
+    return false
+  }
+}
+
+/**
+ * Raise a system notification for an activity entry. No-op unless permission is
+ * granted. Best-effort: prefers the service-worker registration (backgrounded
+ * delivery), falls back to the page-level Notification constructor.
+ * @param {{ id?: string, message: string, domain?: string, severity?: string, link?: object }} entry
+ * @returns {Promise<boolean>} whether a notification was shown
+ */
+export async function showSystemNotification(entry) {
+  if (!isPushSupported() || Notification.permission !== 'granted' || !entry) return false
+
+  const title = 'FairWins'
+  const options = {
+    body: entry.message || 'New activity',
+    // Tag by entry id so a re-detected entry replaces rather than stacks.
+    tag: entry.id ? `${NOTIFICATION_TAG_PREFIX}:${entry.id}` : NOTIFICATION_TAG_PREFIX,
+    icon: '/assets/fairwins_no-text_logo.svg',
+    badge: '/assets/fairwins_no-text_logo.svg',
+    // Carried through to sw.js#notificationclick for deep-link navigation.
+    data: { link: entry.link || null, domain: entry.domain || null, entryId: entry.id || null },
+  }
+
+  try {
+    if ('serviceWorker' in navigator && navigator.serviceWorker.ready) {
+      const registration = await navigator.serviceWorker.ready
+      if (registration && typeof registration.showNotification === 'function') {
+        await registration.showNotification(title, options)
+        return true
+      }
+    }
+  } catch (error) {
+    // Fall through to the constructor path below.
+    console.warn('[pushDelivery] SW notification failed, falling back:', error)
+  }
+
+  try {
+    const shown = new Notification(title, options)
+    return Boolean(shown)
+  } catch (error) {
+    console.warn('[pushDelivery] Notification constructor failed:', error)
+    return false
+  }
+}
+
+/**
+ * Backend seam (currently a no-op). If a real Web Push service is added, this is
+ * where the page would `registration.pushManager.subscribe({ applicationServerKey })`
+ * and POST the PushSubscription to the backend. Kept here so the UI/preferences
+ * never need to change when server push lands.
+ * @returns {Promise<null>}
+ */
+export async function subscribeToPush() {
+  return null
+}

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -14,6 +14,7 @@ import PayTransferPanel from '../components/wallet/PayTransferPanel'
 import TokensPanel from '../components/tokens/TokensPanel'
 import ClearPathPanel from '../components/clearpath/ClearPathPanel'
 import AccountDashboard from '../components/account/AccountDashboard'
+import NotificationPreferencesPanel from '../components/account/NotificationPreferencesPanel'
 import AddressBookPanel from '../components/account/AddressBookPanel'
 import BackupPanel from '../components/account/BackupPanel'
 import RecoveryCodesPanel from '../components/account/RecoveryCodesPanel'
@@ -525,6 +526,10 @@ function WalletPage() {
 
                 {activeTab === 'preferences' && (
                   <div className="preferences-section" role="tabpanel">
+                    <div className="section">
+                      <NotificationPreferencesPanel />
+                    </div>
+
                     <div className="section">
                       <h3>Install App</h3>
                       <p className="section-description">

--- a/frontend/src/test/ActivityProvider.delivery.test.jsx
+++ b/frontend/src/test/ActivityProvider.delivery.test.jsx
@@ -1,0 +1,95 @@
+/**
+ * ActivityProvider delivery-routing tests. Verifies per-domain delivery modes
+ * route a fresh entry to a toast (app), a toast + system notification (push),
+ * or nothing beyond the feed (silent), and that push degrades to app-toast when
+ * the master push flag is off.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { ActivityProvider } from '../contexts/ActivityProvider'
+import { setDeliveryMode, setPushEnabled } from '../lib/notifications/deliveryPreferences'
+
+const NOW = 1765432100000
+const ACC = '0xAAA0000000000000000000000000000000000aaa'
+
+const h = vi.hoisted(() => ({
+  wallet: { account: '', chainId: 0 },
+  showNotification: vi.fn(),
+  showSystem: vi.fn(),
+}))
+vi.mock('../hooks/useWalletManagement', () => ({ useWallet: () => h.wallet }))
+vi.mock('../hooks/useUI', () => ({ useNotification: () => ({ showNotification: h.showNotification }) }))
+vi.mock('../lib/notifications/pushDelivery', () => ({
+  showSystemNotification: (...args) => h.showSystem(...args),
+}))
+
+function entry(id, domain) {
+  return { id, domain, refId: id, type: 't', message: `msg-${id}`, severity: 'info', actionable: false, createdAt: NOW, read: false }
+}
+// call 1 = catch-up (feed-only, empty); call 2 = live poll emitting `entries`.
+function twoPhaseSource(entries) {
+  let call = 0
+  return {
+    key: 'wagers',
+    label: 'Wagers',
+    detect: vi.fn(async () => {
+      call += 1
+      return { ok: true, entries: call === 1 ? [] : entries, nextSnapshots: {}, nextAux: {}, currentIds: [], actionNeededById: {} }
+    }),
+  }
+}
+const tick = (ms) => act(async () => { await vi.advanceTimersByTimeAsync(ms) })
+
+beforeEach(() => {
+  localStorage.clear()
+  h.wallet = { account: ACC, chainId: 137 }
+  h.showNotification.mockReset()
+  h.showSystem.mockReset()
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+})
+afterEach(() => vi.useRealTimers())
+
+describe('ActivityProvider delivery routing', () => {
+  it('push domain (master on): toasts AND raises a system notification', async () => {
+    setDeliveryMode('wagers', 'push')
+    setPushEnabled(true)
+    const src = twoPhaseSource([entry('w1', 'wagers')])
+    render(<ActivityProvider sources={[src]} />)
+    await tick(0) // catch-up
+    await tick(30_000) // live
+    expect(h.showNotification).toHaveBeenCalledWith('msg-w1', 'info', 6000)
+    expect(h.showSystem).toHaveBeenCalledTimes(1)
+    expect(h.showSystem).toHaveBeenCalledWith(expect.objectContaining({ id: 'w1', domain: 'wagers' }))
+  })
+
+  it('silent domain: no toast and no system notification', async () => {
+    setDeliveryMode('wagers', 'silent')
+    const src = twoPhaseSource([entry('w1', 'wagers')])
+    render(<ActivityProvider sources={[src]} />)
+    await tick(0)
+    await tick(30_000)
+    expect(h.showNotification).not.toHaveBeenCalled()
+    expect(h.showSystem).not.toHaveBeenCalled()
+  })
+
+  it('push domain with master off: degrades to an app toast, no system notification', async () => {
+    setDeliveryMode('wagers', 'push')
+    setPushEnabled(false)
+    const src = twoPhaseSource([entry('w1', 'wagers')])
+    render(<ActivityProvider sources={[src]} />)
+    await tick(0)
+    await tick(30_000)
+    expect(h.showNotification).toHaveBeenCalledWith('msg-w1', 'info', 6000)
+    expect(h.showSystem).not.toHaveBeenCalled()
+  })
+
+  it('default (unconfigured) domain: app toast, no system notification', async () => {
+    const src = twoPhaseSource([entry('w1', 'wagers')])
+    render(<ActivityProvider sources={[src]} />)
+    await tick(0)
+    await tick(30_000)
+    expect(h.showNotification).toHaveBeenCalledWith('msg-w1', 'info', 6000)
+    expect(h.showSystem).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/test/NotificationPreferencesPanel.test.jsx
+++ b/frontend/src/test/NotificationPreferencesPanel.test.jsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import userEvent from '@testing-library/user-event'
+import NotificationPreferencesPanel from '../components/account/NotificationPreferencesPanel'
+import { NOTIFICATION_CATEGORIES, getNotificationPrefs } from '../lib/notifications/deliveryPreferences'
+
+// A permission-granted Notification stub so the master push toggle is operable.
+function stubNotification(permission = 'granted', requestResult = 'granted') {
+  const stub = vi.fn()
+  stub.permission = permission
+  // Mirror real browser behavior: granting the prompt updates Notification.permission.
+  stub.requestPermission = vi.fn().mockImplementation(async () => {
+    stub.permission = requestResult
+    return requestResult
+  })
+  vi.stubGlobal('Notification', stub)
+}
+
+describe('NotificationPreferencesPanel', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    stubNotification('granted', 'granted')
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders a category row per notification domain, defaulting to In-app', () => {
+    render(<NotificationPreferencesPanel />)
+    for (const category of NOTIFICATION_CATEGORIES) {
+      const group = screen.getByRole('radiogroup', { name: category.label })
+      const inApp = within(group).getByRole('radio', { name: 'In-app' })
+      expect(inApp).toHaveAttribute('aria-checked', 'true')
+    }
+  })
+
+  it('selecting Silent for a category persists the mode', async () => {
+    const user = userEvent.setup()
+    render(<NotificationPreferencesPanel />)
+    const wagers = screen.getByRole('radiogroup', { name: 'Wagers' })
+    await user.click(within(wagers).getByRole('radio', { name: 'Silent' }))
+    expect(within(wagers).getByRole('radio', { name: 'Silent' })).toHaveAttribute('aria-checked', 'true')
+    expect(getNotificationPrefs().modes.wagers).toBe('silent')
+  })
+
+  it('enabling mobile push requests permission and flips the master switch on', async () => {
+    const user = userEvent.setup()
+    Notification.permission = 'default'
+    render(<NotificationPreferencesPanel />)
+    const master = screen.getByRole('switch', { name: /mobile push/i })
+    expect(master).toHaveAttribute('aria-checked', 'false')
+    await user.click(master)
+    expect(Notification.requestPermission).toHaveBeenCalled()
+    expect(master).toHaveAttribute('aria-checked', 'true')
+    expect(getNotificationPrefs().pushEnabled).toBe(true)
+  })
+
+  it('shows a warning when a category is Push while master push is off', async () => {
+    const user = userEvent.setup()
+    render(<NotificationPreferencesPanel />) // push off by default
+    const dao = screen.getByRole('radiogroup', { name: 'Governance' })
+    await user.click(within(dao).getByRole('radio', { name: 'Push' }))
+    expect(screen.getByText(/enable mobile push above/i)).toBeInTheDocument()
+  })
+
+  it('disables the master switch when notifications are blocked', () => {
+    Notification.permission = 'denied'
+    render(<NotificationPreferencesPanel />)
+    expect(screen.getByRole('switch', { name: /mobile push/i })).toBeDisabled()
+  })
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<NotificationPreferencesPanel />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/deliveryPreferences.test.js
+++ b/frontend/src/test/deliveryPreferences.test.js
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for the notification delivery preference model.
+ * Device-scoped localStorage, three delivery modes, master push gating.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  NOTIFICATION_CATEGORIES,
+  DELIVERY_MODES,
+  DEFAULT_MODE,
+  getNotificationPrefs,
+  getDeliveryMode,
+  setDeliveryMode,
+  isPushEnabled,
+  setPushEnabled,
+  resolveDelivery,
+  subscribe,
+} from '../lib/notifications/deliveryPreferences'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('deliveryPreferences model', () => {
+  it('defaults every known category to in-app, push off', () => {
+    const prefs = getNotificationPrefs()
+    expect(prefs.pushEnabled).toBe(false)
+    for (const { domain } of NOTIFICATION_CATEGORIES) {
+      expect(prefs.modes[domain]).toBe(DEFAULT_MODE)
+      expect(DEFAULT_MODE).toBe('app')
+    }
+  })
+
+  it('persists and reads back a per-domain mode', () => {
+    setDeliveryMode('wagers', 'silent')
+    expect(getDeliveryMode('wagers')).toBe('silent')
+    // Survives a fresh read from storage.
+    expect(getNotificationPrefs().modes.wagers).toBe('silent')
+  })
+
+  it('ignores an invalid mode', () => {
+    setDeliveryMode('wagers', 'bogus')
+    expect(getDeliveryMode('wagers')).toBe(DEFAULT_MODE)
+  })
+
+  it('falls back to the default for an unknown domain (never silences a new domain)', () => {
+    expect(getDeliveryMode('brand-new-domain')).toBe(DEFAULT_MODE)
+  })
+
+  it('toggles the master push flag', () => {
+    expect(isPushEnabled()).toBe(false)
+    setPushEnabled(true)
+    expect(isPushEnabled()).toBe(true)
+    setPushEnabled(false)
+    expect(isPushEnabled()).toBe(false)
+  })
+
+  it('resolveDelivery collapses push→app when master push is off (never dropped)', () => {
+    setDeliveryMode('wagers', 'push')
+    expect(resolveDelivery('wagers')).toBe('app') // push off → degrades to app
+    setPushEnabled(true)
+    expect(resolveDelivery('wagers')).toBe('push') // push on → honored
+  })
+
+  it('resolveDelivery keeps silent regardless of the master flag', () => {
+    setDeliveryMode('dao', 'silent')
+    setPushEnabled(true)
+    expect(resolveDelivery('dao')).toBe('silent')
+  })
+
+  it('notifies subscribers on change and stops after unsubscribe', () => {
+    const listener = vi.fn()
+    const unsubscribe = subscribe(listener)
+    setDeliveryMode('pools', 'push')
+    expect(listener).toHaveBeenCalledTimes(1)
+    setPushEnabled(true)
+    expect(listener).toHaveBeenCalledTimes(2)
+    unsubscribe()
+    setDeliveryMode('pools', 'app')
+    expect(listener).toHaveBeenCalledTimes(2)
+  })
+
+  it('exposes exactly the three delivery modes', () => {
+    expect(DELIVERY_MODES).toEqual(['push', 'app', 'silent'])
+  })
+})

--- a/frontend/src/test/feedNavigation.test.jsx
+++ b/frontend/src/test/feedNavigation.test.jsx
@@ -211,6 +211,29 @@ describe('Feed → wager navigation (spec 012 T018, FR-004/FR-016)', () => {
     ).toBeInTheDocument()
   })
 
+  it('closing the wager modal after a feed open does not reopen it (regression: back/click-away error)', async () => {
+    await renderDashboard(
+      [{ pathname: '/app', state: { openWagerId: '42' } }],
+      [wager42()]
+    )
+
+    // Opened on the wager detail view via router state.
+    await screen.findByRole('button', { name: /back to list/i })
+
+    // Click away (the modal close). Previously the router state was consumed via
+    // a render-phase setState + deferred navigate, so closing raced a not-yet-
+    // cleared state and reopened the modal / threw. It must now close and stay
+    // closed — the state was cleared atomically in the open effect.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /close modal/i }))
+    })
+
+    expect(screen.queryByRole('button', { name: /back to list/i })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('heading', { level: 3, name: /feed target wager/i })
+    ).not.toBeInTheDocument()
+  })
+
   it('marks the wager read when opened via router state (FR-004)', async () => {
     await renderDashboard(
       [{ pathname: '/app', state: { openWagerId: '42' } }],


### PR DESCRIPTION
## Summary

Adds mobile (device) push notifications for FairWins activity and lets users control, **per notification category**, whether each is **pushed to the device**, shown **in-app only**, or kept **silent** (activity feed only). Also fixes a tester-reported error that occurred when navigating back / clicking away after opening a wager from a notification.

FairWins notifications are derived entirely client-side (spec 031 polls on-chain state in the browser — there is no notification backend). "Push" therefore raises real OS notifications via the **Web Notifications API + service worker** while the PWA is running, with a self-contained fallback and **no backend dependency**. The service-worker `push` / `notificationclick` handlers are wired **backend-ready**, so a future Web Push service can plug in without any UI changes.

## Delivery preferences

- **New device-scoped model** (`lib/notifications/deliveryPreferences.js`): three modes — `push` / `app` / `silent` — per category, gated by a master push flag that only flips true once the browser notification permission is granted. A `push` category **degrades to an in-app toast when the master flag is off**, so nothing is ever silently dropped.
- **`pushDelivery.js`**: user-gesture permission request + system-notification delivery through the service-worker registration (falls back to the `Notification` constructor), all feature/permission-guarded and non-throwing.
- **New "Notifications" area on the Preferences tab** of *My Account / Wallet* (`NotificationPreferencesPanel`) — an accessible master toggle plus a three-way segmented control per category (Wagers, Wager Pools, Membership, Governance, Token admin).
- **`ActivityProvider`** routes each fresh entry by its domain's delivery mode: `silent` → feed only; `app` → toast; `push` → toast + a system notification on the device (both capped per cycle).
- **`sw.js`** gains a `notificationclick` handler (focus the app + deep-link to the entry) and a forward-compat `push` handler; `ActivityNotificationBridge` performs the in-app navigation from a tapped notification.

## Bug fix — back / click-away error after accepting from a notification

`Dashboard` consumed the feed's `{ openWagerId }` router state via a **render-phase `setState`** plus a deferred clearing `navigate`, so the accept modal's visibility desynced from browser history — pressing Back or clicking away could re-fire `setState` during render and trip the top-level `ErrorBoundary`. This is now consumed **and cleared atomically in a single effect**, matching the sibling router-state effect already in the file. Also hardened `MarketAcceptanceModal`'s async IPFS envelope fetch against setState-after-unmount when navigating away mid-fetch.

## Scope note

Because notifications are generated client-side, device notifications fire when new activity is detected **while the app is open** (foregrounded/visible). True delivery when the app is fully closed would require a server-side chain monitor + Web Push backend; the SW handlers are structured so that can be added later without reworking the UI or preferences.

## Testing

- `npm run build` — passes
- New unit/component/integration tests, all green:
  - `deliveryPreferences.test.js` — model (modes, master gating, push→app degrade, subscribers)
  - `NotificationPreferencesPanel.test.jsx` — panel behavior + accessibility (axe)
  - `ActivityProvider.delivery.test.jsx` — per-domain delivery routing
  - `feedNavigation.test.jsx` — regression: close-after-open from a notification does not reopen/error
- Affected existing suites (ActivityProvider, PreferencesPanel, WalletPage, account/*, NotificationBell) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhbJFQY2GXNE9U2vR8tzc5)_