### PR TITLE
edge(041): ARM alto-bundler origin lock + 3 prod-found deploy fixes

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -32,7 +32,10 @@ steps:
       # relay gateway (SC-009). Baked in at build; passkeyConfig(137) is null without it, so passkey
       # accounts stay disabled on Polygon until this is set. EntryPoint v0.6; FairWins sponsors no gas.
       - '--build-arg'
-      - 'VITE_BUNDLER_URLS_POLYGON=https://fairwins-alto-bundler-266380754692.us-central1.run.app'
+      # Cloudflare-fronted edge host (origin-lock ARMED 2026-07-06). Cloudflare injects X-Origin-Auth on
+      # *.fairwins.app; the bare run.app URL now 403s (no header), so the SPA MUST use this host. CSP
+      # connect-src already allows it (frontend/nginx.conf).
+      - 'VITE_BUNDLER_URLS_POLYGON=https://bundler.fairwins.app'
       - '-t'
       - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/prediction-dao-research:$COMMIT_SHA'
       - '-t'

--- a/services/alto-bundler/README.md
+++ b/services/alto-bundler/README.md
@@ -16,8 +16,8 @@ browser ─▶ bundler.fairwins.app ─▶ Cloudflare (Transform Rule: +X-Origin
 
 | File | Purpose |
 |---|---|
-| `nginx/bundler.conf.template` | origin-lock map (`$origin_denied`) + `/healthz` exempt + proxy to `127.0.0.1:3000` |
-| `nginx/docker-entrypoint.sh` | derives `ORIGIN_LOCK_ENABLED` from whether `ORIGIN_LOCK_SECRET` is set (fail-open, never a 403-brick) |
+| `nginx/bundler.conf.template` | origin-lock map (`$origin_denied`, `map_hash_bucket_size 128`) + `/healthz` exempt + proxy to `127.0.0.1:3000` |
+| `nginx/docker-entrypoint.sh` | derives `ORIGIN_LOCK_ENABLED` from whether `ORIGIN_LOCK_SECRET` is set (fail-open, never a 403-brick); trims the secret |
 | `nginx/Dockerfile` | `nginx:1.27-alpine` + `envsubst` |
 | `cloudbuild.yaml` | manual/isolated rollout — build the nginx image + `gcloud run services replace` the full 2-container spec |
 | `deploy/service.yaml` | multi-container Cloud Run (nginx ingress + alto sidecar) — **alto env reconciled to live `alto:v1.2.7` / Polygon 137 (2026-07-06)** |
@@ -31,34 +31,42 @@ The origin lock is **fail-open by design**: no `ORIGIN_LOCK_SECRET` → `ORIGIN_
 traffic allowed. Mounting the Secret-Manager `origin-lock-secret` is the single switch that arms it, so
 you cannot half-configure it into a deny-everything state.
 
-## Rollout status + remaining steps
+## Rollout status
 
-Progress as of 2026-07-06:
-- ✅ nginx ingress image + `deploy/service.yaml` reconciled to the live `alto:v1.2.7` / Polygon 137 config.
-- ✅ Auto-deploy wired into the root `cloudbuild.yaml` — **merging brings up the 2-container service
-  LOCK-OFF** (fail-open): the nginx ingress goes live without breaking the working `run.app` URL.
-- ✅ `bundler.fairwins.app` CNAME created (Cloudflare-proxied).
-- ✅ Zone-wide `X-Origin-Auth` Transform Rule already in place (covers `*.fairwins.app`).
-- ⚠️ **`bundler.fairwins.app` does NOT route to the service yet.** It returns Google's HTML 404 (the GFE
-  doesn't recognize the Host), whereas the `run.app` URL returns alto's JSON 404. A bare CNAME→`*.run.app`
-  is insufficient — Cloud Run routes by Host. Fix with **either** a Cloudflare **Host-header override** to
-  the `*.run.app` origin (Origin Rule / Transform Rule → Rewrite Host), **or** a Cloud Run domain-mapping.
+**LIVE + origin-lock ARMED on Polygon 137 (2026-07-06).** 2-container service (nginx ingress + alto
+`v1.2.7` sidecar), SPA points at `bundler.fairwins.app`, Cloudflare Host-override routes it to the
+`*.run.app` origin and injects `X-Origin-Auth` zone-wide. Verified:
 
-### Arm the lock (only after the front door works)
+```sh
+# direct run.app (no Cloudflare header)         -> 403 (locked)
+curl -s -o /dev/null -w '%{http_code}\n' -X POST https://fairwins-alto-bundler-<hash>.run.app/ \
+  -H 'content-type: application/json' --data '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'
+# bundler.fairwins.app (Cloudflare injects header) -> 200 {"result":"0x89"}
+curl -s -X POST https://bundler.fairwins.app/ \
+  -H 'content-type: application/json' --data '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'
+```
 
-1. Confirm routing: `curl -s https://bundler.fairwins.app/` must return **alto's** JSON 404
-   (`{"message":"Route GET:/ not found",...}`), not Google's HTML 404.
-2. Point the SPA at the edge host: set `VITE_BUNDLER_URLS_POLYGON=https://bundler.fairwins.app` in the root
-   `cloudbuild.yaml` (currently the transitional `run.app` URL). CSP already allows both hosts, so no CSP change.
-3. Uncomment the `ORIGIN_LOCK_SECRET` env in `deploy/service.yaml` and merge (or run the manual config below).
-4. Verify:
-   ```sh
-   curl -sI https://bundler.fairwins.app/healthz                                            # 200 (health exempt)
-   curl -s -o /dev/null -w '%{http_code}\n' https://bundler.fairwins.app/                   # 200 (CF injects header)
-   curl -s -o /dev/null -w '%{http_code}\n' https://fairwins-alto-bundler-<hash>.run.app/   # 403 (no CF header — locked)
-   ```
+Use a **JSON-RPC POST** (`eth_chainId`) for external health checks — **not** `/healthz`: Cloud Run's GFE
+intercepts the startup-probe path `/healthz` and returns its own 404 for *external* requests (the internal
+probe hits nginx:8080 directly and passes fine). `curl https://bundler.fairwins.app/health` → `"OK"` also
+works (alto's own route, proxied).
 
-To roll the bundler alone (without a frontend build), run the manual config:
+### Deploy gotchas (all three cost a failed rollout — baked into the config now)
+
+1. **alto needs a `startupProbe`** — Cloud Run rejects the spec because nginx `depends_on` alto
+   (`container-dependencies`); the depended-upon container must declare one. TCP probe on `:3000`.
+2. **`map_hash_bucket_size 128`** in `bundler.conf.template` — the *armed* map key `"1:<64-hex secret>"`
+   is 66 bytes, over nginx's default 64-byte bucket, so **armed** nginx fails to boot (`could not build
+   map_hash`). Lock-off is fine (`"1:__unset__"` is short), which is why this only bites on arming.
+3. **The entrypoint trims `ORIGIN_LOCK_SECRET`** — Cloud Run injects Secret Manager values verbatim
+   including a trailing newline; nginx exact-matches, so an untrimmed secret 403s *every* Cloudflare
+   request (the Node relay-gateway trims, so it was unaffected — that's the tell).
+
+**Manual `services replace` caveat:** the `:latest` tag gets deduped/cached by Cloud Run, so a manual
+`gcloud run services replace` may keep the old image. Pin the digest (`alto-bundler-nginx@sha256:…`) for a
+one-off deploy. CI is unaffected — it seds `:latest`→`:$COMMIT_SHA` (a unique tag) before replacing.
+
+To roll the bundler alone (without a frontend build):
 ```sh
 gcloud builds submit . --config services/alto-bundler/cloudbuild.yaml
 ```

--- a/services/alto-bundler/deploy/service.yaml
+++ b/services/alto-bundler/deploy/service.yaml
@@ -36,19 +36,16 @@ spec:
           ports:
             - name: http1
               containerPort: 8080
-          # env: ORIGIN_LOCK_SECRET is intentionally OMITTED here so this merges LOCK-OFF (fail-open) —
-          # the 2-container ingress goes live without breaking anything while the front door is finished.
-          # ARM the lock ONLY AFTER both are true, or the bundler becomes unreachable:
-          #   (1) bundler.fairwins.app actually routes to this service — a bare CNAME→*.run.app returns a
-          #       Google 404 (Cloud Run doesn't recognize the Host); add a Cloudflare Host-header override
-          #       to the *.run.app origin, or a Cloud Run domain-mapping, until it returns alto's response.
-          #   (2) the SPA's VITE_BUNDLER_URLS_POLYGON points at https://bundler.fairwins.app (not the bare
-          #       run.app URL) — else the SPA hits run.app directly and the armed lock 403s it.
-          # Then arm by uncommenting:
-          #   env:
-          #     - name: ORIGIN_LOCK_SECRET
-          #       valueFrom:
-          #         secretKeyRef: { name: origin-lock-secret, key: latest }
+          env:
+            # Origin lock ARMED (2026-07-06): bundler.fairwins.app routes correctly (Cloudflare Host
+            # override to the *.run.app origin) and the SPA points at bundler.fairwins.app, so the header
+            # is present on every real request. Same secret Cloudflare injects as X-Origin-Auth zone-wide.
+            # Fail-open: drop this ref and the lock disables itself rather than 403-bricking the bundler.
+            - name: ORIGIN_LOCK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: origin-lock-secret
+                  key: latest
           resources:
             limits:
               cpu: "1"
@@ -91,3 +88,12 @@ spec:
             limits:
               cpu: "1"
               memory: 1Gi
+          # Required by Cloud Run because nginx `depends_on` alto (container-dependencies): the
+          # dependency ordering gates nginx startup on alto's port being live. TCP probe on alto's
+          # ALTO_PORT (3000); no HTTP health route exists on alto (GET / 404s).
+          startupProbe:
+            tcpSocket:
+              port: 3000
+            periodSeconds: 3
+            failureThreshold: 20
+            timeoutSeconds: 3

--- a/services/alto-bundler/nginx/bundler.conf.template
+++ b/services/alto-bundler/nginx/bundler.conf.template
@@ -10,6 +10,10 @@
 # $origin_denied = 1 => block (403). The secret is never written to logs. The bundler itself runs as a
 # localhost-only sidecar (alto binds 127.0.0.1:3000 in the same Cloud Run instance).
 
+# The armed map key is "1:<64-hex-char secret>" = 66 bytes, over nginx's default 64-byte hash bucket
+# (fine when lock-off — "1:__unset__" is short — but nginx fails to build the map when armed). Bump it.
+map_hash_bucket_size 128;
+
 map "${ORIGIN_LOCK_ENABLED}:$http_x_origin_auth" $origin_denied {
     default                      1;   # enforcement on + header missing/mismatch => deny
     "~^0:"                       0;   # enforcement off => allow everything

--- a/services/alto-bundler/nginx/docker-entrypoint.sh
+++ b/services/alto-bundler/nginx/docker-entrypoint.sh
@@ -7,6 +7,13 @@
 # arms enforcement — you can never half-configure it into a 403-everything brick.
 set -eu
 
+# Cloud Run injects Secret Manager values VERBATIM, including any trailing newline the secret file was
+# created with. nginx does an EXACT string match in the origin-lock map, so a stray newline (or space)
+# makes the ARMED lock 403 every request — the X-Origin-Auth header Cloudflare sends carries no newline.
+# The secret is `openssl rand -hex 32` (no internal whitespace), so stripping all whitespace is safe and
+# is a no-op for an already-clean value. (This is why the Node relay-gateway works but raw nginx didn't.)
+ORIGIN_LOCK_SECRET="$(printf '%s' "${ORIGIN_LOCK_SECRET:-}" | tr -d '[:space:]')"
+
 if [ -n "${ORIGIN_LOCK_SECRET:-}" ]; then
     export ORIGIN_LOCK_ENABLED=1
     echo "[bundler-nginx] origin lock ENABLED (X-Origin-Auth required)"


### PR DESCRIPTION
Arms the alto-bundler origin lock (spec 041 SC-009 / spec 036 FR-029) and lands three deploy fixes discovered by verifying against production. **Already verified live on Polygon 137** (manual `services replace`, rev `00006`); this PR makes CI reproduce that state and switches the SPA to the edge host.

## Verified
```
direct run.app POST (no CF header)          -> 403  (locked)
bundler.fairwins.app POST (CF injects hdr)  -> 200  {"result":"0x89"}
```

## Three bugs a lock-off merge would never have shown
1. **alto missing `startupProbe`** — Cloud Run rejects the whole spec because nginx `depends_on` alto (`container-dependencies`) and the depended-upon container must declare a probe. TCP probe on `:3000`. *(This failed the first 2-container `services replace`.)*
2. **`map_hash_bucket_size 128`** — the **armed** map key `"1:<64-hex secret>"` is 66 bytes, over nginx's default 64-byte bucket → armed nginx dies at boot (`could not build map_hash`). Lock-off is fine (`"1:__unset__"` is short), so it only bites on arming.
3. **Trim `ORIGIN_LOCK_SECRET`** — Cloud Run injects Secret Manager values verbatim incl. a trailing newline; nginx exact-matches, so an untrimmed secret **403s every Cloudflare request**. The Node relay-gateway trims → it worked → that mismatch was the tell.

## Also
- `service.yaml`: `ORIGIN_LOCK_SECRET` env **armed** (routing + SPA are ready).
- `cloudbuild.yaml`: `VITE_BUNDLER_URLS_POLYGON` → `https://bundler.fairwins.app` (the bare `run.app` URL now 403s; CSP `connect-src` already allows the edge host).
- `README`: armed status + use a **JSON-RPC POST** for external health checks (Cloud Run's GFE intercepts `/healthz` externally; the internal probe on nginx:8080 passes fine).

## Merge behavior
CI rebuilds the SPA (→ edge host) and `services replace`s the bundler (armed, all fixes, unique `:$COMMIT_SHA` tag) — reconciling the live manual revision. No behavior change from what's already running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)