### PR TITLE
Safe multisig custody (043): spec + implementation (US1–US2, US4–US6, US3 core)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/042-clearpath-multi-network"
+  "feature_directory": "specs/043-safe-multisig-custody"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,5 +104,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/042-clearpath-multi-network/plan.md
+at specs/043-safe-multisig-custody/plan.md
 <!-- SPECKIT END -->

--- a/contracts/custody/SafeProposalHub.sol
+++ b/contracts/custody/SafeProposalHub.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title SafeProposalHub
+/// @notice Events-only broadcaster of Safe multisig transaction preimages, for serverless co-owner discovery
+///         (spec 043, Safe multisig custody). A proposer emits the full parameters of a Safe transaction so
+///         other owners can find it, recompute its hash, and approve it on-chain — with no hosted Safe
+///         Transaction Service and no app backend.
+/// @dev Value-free and authority-free: holds no funds, has no state, and can neither approve nor execute any
+///      Safe transaction. Integrity does NOT depend on this contract — co-owner clients MUST recompute
+///      `Safe.getTransactionHash(...)` from the emitted parameters and reject anything that does not equal the
+///      `safeTxHash` before calling `Safe.approveHash`. A malicious or malformed `propose` can therefore only
+///      waste the proposer's own gas; it cannot cause an incorrect approval. No external calls, no arithmetic,
+///      no roles — CEI is trivial and reentrancy is impossible. Uses no OpenZeppelin, so it compiles on
+///      pre-Cancun targets (e.g. ETC/Mordor) as well. Cloned in shape from `BackupPointerRegistry`.
+contract SafeProposalHub {
+    /// @dev Generous bound on the broadcast calldata blob, capping per-proposal event size.
+    uint256 private constant MAX_DATA_LENGTH = 8192;
+
+    /// @notice Broadcast a proposed Safe transaction's full preimage.
+    /// @param safe       The Safe the proposal targets.
+    /// @param proposer   `msg.sender` (informational; SHOULD be an owner, not enforced here).
+    /// @param safeTxHash Proposer-supplied hash; clients MUST recompute and verify it.
+    /// @param to         Target of the Safe transaction.
+    /// @param value      Native value.
+    /// @param data       Calldata (non-indexed so it is decodable from logs).
+    /// @param operation  0 = CALL, 1 = DELEGATECALL.
+    /// @param nonce      The Safe nonce the proposal is built against.
+    event Proposed(
+        address indexed safe,
+        address indexed proposer,
+        bytes32 indexed safeTxHash,
+        address to,
+        uint256 value,
+        bytes data,
+        uint8 operation,
+        uint256 nonce
+    );
+
+    /// @notice Advisory signal that a proposer no longer intends to pursue a proposal. The Safe nonce remains
+    ///         the real arbiter of supersession; this is a UX hint only.
+    event Cancelled(address indexed safe, address indexed proposer, bytes32 indexed safeTxHash);
+
+    error InvalidOperation();
+    error DataTooLong();
+
+    /// @notice Emit a proposal preimage for discovery. Emits `Proposed`; writes no state, calls nothing.
+    function propose(
+        address safe,
+        address to,
+        uint256 value,
+        bytes calldata data,
+        uint8 operation,
+        uint256 nonce,
+        bytes32 safeTxHash
+    ) external {
+        if (operation > 1) revert InvalidOperation();
+        if (data.length > MAX_DATA_LENGTH) revert DataTooLong();
+        emit Proposed(safe, msg.sender, safeTxHash, to, value, data, operation, nonce);
+    }
+
+    /// @notice Signal cancellation of a previously broadcast proposal. Advisory; emits `Cancelled` only.
+    function cancel(address safe, bytes32 safeTxHash) external {
+        emit Cancelled(safe, msg.sender, safeTxHash);
+    }
+}

--- a/docs/developer-guide/safe-custody.md
+++ b/docs/developer-guide/safe-custody.md
@@ -1,0 +1,90 @@
+# Safe Multisig Custody (spec 043)
+
+Custody brings the [Safe](https://safe.global) (v1.4.1) multisignature vault pattern — as deployed by the
+Ethereum Classic Cooperative — into FairWins. Members create or load a shared vault, then propose / approve /
+execute vault transactions under a configurable threshold, and can **operate as** the vault across the app's
+money-moving surfaces. It lives under **My Wallet → Finance → Custody**, split into **On chain** (the multisig)
+and **Off chain** (a disabled placeholder).
+
+Spec/plan/tasks: [`specs/043-safe-multisig-custody/`](../../specs/043-safe-multisig-custody/).
+
+## Design in one paragraph
+
+Everything is **on-chain and serverless** — no hosted Safe Transaction Service, no app backend (unlike
+`etclabscore/web-core`, which self-hosts the full Safe backend). Approvals and execution use the Safe's own
+primitives: each owner calls `approveHash` on-chain, and any owner then calls `execTransaction` with
+**pre-validated signatures** (`v=1`, `r=owner`) once the threshold is met. Discovery of a pending transaction's
+preimage is served by a tiny, immutable, **events-only** helper contract, `SafeProposalHub`, with a signed
+EIP-712 payload link/QR as the never-stranded fallback. Integrity never depends on the hub: co-owner clients
+recompute the Safe tx hash from the emitted parameters and reject anything that doesn't match.
+
+## Contracts & addresses
+
+- **`contracts/custody/SafeProposalHub.sol`** — events-only broadcaster (no funds, no state, no authority).
+  Deploy per network with [`scripts/deploy/custody/deploy-safe-proposal-hub.js`](../../scripts/deploy/custody/deploy-safe-proposal-hub.js);
+  see the [runbook](../runbooks/safe-proposal-hub-deploy.md). Recorded under `safeProposalHub` in `deployments/`.
+- **Safe v1.4.1** contracts are **external** deployments. Their canonical addresses are **identical** across
+  Ethereum Classic (61), Mordor (63), and Polygon (137) and live in
+  [`frontend/src/config/safeContracts.js`](../../frontend/src/config/safeContracts.js) — they are NOT synced
+  by `sync:frontend-contracts` (which only fills our own deployments). `getSafeContracts(chainId)` returns
+  `undefined` on unsupported chains, which the UI renders as "unavailable on this network".
+
+## Frontend map
+
+| Concern | Location |
+|--------|----------|
+| Safe/factory/MultiSend/hub ABIs | `frontend/src/abis/{Safe,SafeProxyFactory,MultiSendCallOnly,SafeProposalHub}.js` |
+| Tx encoders (hash, pre-validated sigs, MultiSend, governance) | `frontend/src/lib/custody/vaultTransaction.js` |
+| Create / load / predict-address | `frontend/src/lib/custody/safeVault.js` |
+| Proposal broadcast/read + verify + payload fallback | `frontend/src/lib/custody/proposalHub.js` |
+| Proposal status state machine | `frontend/src/lib/custody/proposalStatus.js` |
+| Shared vault proposal reader | `frontend/src/lib/custody/vaultProposalReads.js` |
+| Vault references (backed up) | `frontend/src/lib/custody/vaultReferences.js` |
+| Vault list/create/load hook | `frontend/src/hooks/useCustodyVaults.js` |
+| Proposal queue hook | `frontend/src/hooks/useVaultProposals.js` |
+| Active identity ("operate as") | `frontend/src/contexts/CustodyContext.{js,jsx}` + `frontend/src/hooks/{useCustody,useActiveAccount}.js` |
+| Submit seam (personal send vs. vault proposal) | `frontend/src/lib/custody/submitAsActiveAccount.js` |
+| UI | `frontend/src/components/custody/*` (mounted from `pages/WalletPage.jsx`) |
+
+## On-chain-only transaction flow
+
+1. **Build** a `SafeTx` (`buildSafeTx`) at the current `Safe.nonce()`.
+2. **Hash** it (`computeSafeTxHash`) — an EIP-712 hash over the `SafeTx` type with domain `{chainId,
+   verifyingContract: safe}`. This is proven byte-for-byte equal to the Safe's on-chain `getTransactionHash`
+   (see `vaultTransaction.test.js`).
+3. **Broadcast** the preimage via `SafeProposalHub.propose(...)` and record the proposer's approval with
+   `Safe.approveHash(hash)`.
+4. **Co-owners** discover it from the hub's `Proposed` events, recompute + verify the hash, and call
+   `approveHash`.
+5. **Execute** with `execTransaction` and a pre-validated signature bundle (owners sorted ascending) once
+   approvals ≥ threshold.
+
+## "Operate as" the vault
+
+`CustodyContext` holds the active identity (`personal` | `vault`), resetting to personal on account change.
+`useActiveAccount().submit({to,value,data,batch})` is the single seam every money-moving surface routes
+through: in personal mode it sends via the connected signer; in vault mode it builds a `SafeTx` (batching
+`approve + action` via MultiSendCallOnly when needed), broadcasts it, and records the proposer's approval —
+returning a **pending proposal**, never an immediate execution. Not-yet-approved actions surface **only** in
+the vault queue (FR-022b). A persistent `OperateAsIndicator` banner shows the active identity app-wide with a
+switch-back control. Wired surfaces today: **Pay & Transfer** and **wager creation**; the remaining chokepoints
+(Membership, Token Mint, ClearPath, Trade/Swap, wager accept + claim routing) are tracked in
+[`tasks.md`](../../specs/043-safe-multisig-custody/tasks.md).
+
+**Inbound vs. outbound (FR-022c):** receiving funds and triggering **refunds** to the vault need no threshold;
+only outbound movements do. The one exception is a **vault-won wager payout claim** — `WagerRegistry` binds the
+claimer to the winner and its gasless twins are `ecrecover`-only (no EIP-1271), so that claim is a
+threshold-approved vault transaction.
+
+## Backup & notifications
+
+- **Backup (spec 032):** vault references + labels ride the app-wide encrypted backup via one `syncedObjects`
+  entry; labels are client-side only, never on-chain.
+- **Notifications (spec 031):** `custodySource` emits "approval-needed" (actionable), "executed", and
+  "governance-changed" entries, controllable as the **Custody** category (push/app/silent).
+
+## Networks
+
+Launch targets **Mordor (63)** and **Polygon (137)**. **Ethereum Classic mainnet (61)** is contract-ready (the
+canonical Safe addresses already resolve) but requires an app-level ETC network block in `frontend/src/config/`
+first — see the follow-ups in [`plan.md`](../../specs/043-safe-multisig-custody/plan.md).

--- a/docs/runbooks/safe-proposal-hub-deploy.md
+++ b/docs/runbooks/safe-proposal-hub-deploy.md
@@ -1,0 +1,62 @@
+# Runbook: Deploying the SafeProposalHub (spec 043)
+
+How to deploy the `SafeProposalHub` — the small, immutable, **events-only** helper that Custody uses for
+serverless discovery of pending Safe transactions. Background:
+[developer-guide/safe-custody.md](../developer-guide/safe-custody.md).
+
+> **Why this is low-risk.** The hub holds **no funds**, has **no state**, and has **no authority over any
+> Safe** — it only emits a proposer-supplied preimage. A malformed/malicious `propose` can waste only the
+> proposer's own gas; co-owner clients recompute and verify the Safe tx hash before approving. It is
+> nonetheless a `contracts/` change and passes Slither + the smart-contract security review in CI.
+
+## Key facts
+
+- **Contract:** `contracts/custody/SafeProposalHub.sol` (immutable; not upgradeable; no storage-layout gating).
+- **Deploy key:** `safeProposalHub` (address) + `deployBlocks.safeProposalHub` in
+  `deployments/<network>-chain<id>-v2.json`.
+- **Networks:** Mordor (63) and Polygon (137) at launch. ETC mainnet (61) once the app gains an ETC network
+  block.
+- **Deterministic:** deployed via the shared CREATE2 helper (`generateSalt` + `deployDeterministic`), so the
+  address matches what a fresh full deploy would produce.
+- **Signer:** only the deploy transaction signs (no admin, no roles). Uses the standard deployer key.
+
+## Deploy steps
+
+1. **Compile & test** locally:
+   ```bash
+   npm run compile
+   npx hardhat test test/custody/SafeProposalHub.test.js
+   ```
+2. **Deploy** to the target network (records the address + deploy block into the existing deployment file,
+   without disturbing any other field):
+   ```bash
+   npx hardhat run scripts/deploy/custody/deploy-safe-proposal-hub.js --network mordor
+   # or: --network polygon
+   ```
+   Re-running is safe — it no-ops if the recorded address already has bytecode.
+3. **Sync** the address into the frontend config:
+   ```bash
+   npm run sync:frontend-contracts -- --network mordor --chainId 63
+   # or: --network polygon --chainId 137
+   ```
+   This fills `safeProposalHub` in the matching `*_CONTRACTS` block in `frontend/src/config/contracts.js`.
+4. **Verify** (optional, block explorer):
+   ```bash
+   npx hardhat verify --network mordor <deployed-address>
+   ```
+
+## Verification
+
+- `deployments/<network>-chain<id>-v2.json` now has `contracts.safeProposalHub` **and**
+  `deployBlocks.safeProposalHub`. **Both are required** — the frontend refuses to scan from genesis, so
+  Custody's proposal queue and the notification source stay inert until the deploy block is recorded.
+- In the app on that network, **My Wallet → Finance → Custody → On chain** no longer shows "unavailable", and a
+  vault owner can propose → approve → execute a transaction.
+
+## Rollback / notes
+
+- There is nothing to roll back on-chain (immutable, value-free). To disable Custody on a network, remove the
+  `safeProposalHub` entry from that network's config; the UI degrades to "unavailable" and no proposals are
+  read.
+- The hub is **optional infrastructure**: where it is absent, the signed EIP-712 payload link/QR discovery
+  path still lets co-owners approve and execute (never-stranded). Approvals and execution never depend on it.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,6 +25,7 @@ import { TermsPage, RiskPage, PrivacyPage } from './pages/legal/LegalDocPage'
 import EntryGate from './components/compliance/EntryGate'
 import { ActivityProvider } from './contexts/ActivityProvider.jsx'
 import ActivityNotificationBridge from './components/notifications/ActivityNotificationBridge'
+import OperateAsIndicator from './components/custody/OperateAsIndicator'
 
 //admin
 import AdminPanel from './components/AdminPanel'
@@ -43,6 +44,8 @@ function AppLayout() {
        below consume it (wagers + DAO/token/membership sources); landing pages never poll. */
     <ActivityProvider>
       <Header appMode />
+      {/* Spec 043 (US3): persistent banner while operating as a vault, with switch-back. */}
+      <OperateAsIndicator />
       {/* Spec 041: route a tapped push notification into in-app navigation. */}
       <ActivityNotificationBridge />
       {/* Spec 007 (US4): client-side eligibility notice gate before any app content. */}

--- a/frontend/src/abis/MultiSendCallOnly.js
+++ b/frontend/src/abis/MultiSendCallOnly.js
@@ -1,0 +1,11 @@
+// Spec 043 — MultiSendCallOnly (v1.4.1) ABI, hand-maintained. Batches multiple inner transactions into one
+// Safe transaction executed with operation = 1 (delegatecall to MultiSendCallOnly). "CallOnly" restricts the
+// inner transactions to CALL (no nested delegatecall) — the smaller-attack-surface choice for the common
+// "approve + action" batch (e.g. ERC-20 approve then createWager).
+//
+// Each inner transaction is packed as: operation(1 byte = 0x00) ‖ to(20) ‖ value(32) ‖ dataLength(32) ‖ data,
+// and all are concatenated into the single `transactions` bytes argument.
+
+export const MULTI_SEND_CALL_ONLY_ABI = ['function multiSend(bytes transactions) payable']
+
+export default MULTI_SEND_CALL_ONLY_ABI

--- a/frontend/src/abis/Safe.js
+++ b/frontend/src/abis/Safe.js
@@ -1,0 +1,35 @@
+// Spec 043 — Safe (v1.4.1) multisig ABI, hand-maintained (the repo does not auto-generate frontend ABIs; the
+// sync script only fills addresses). Only the methods/events the custody feature uses are included. These are
+// the canonical Safe v1.4.1 selectors; refresh from the official artifact if the targeted version changes.
+//
+// On-chain-only flow (no Safe Transaction Service): compute getTransactionHash → each owner approveHash →
+// any owner execTransaction with pre-validated signatures once threshold approvals exist.
+
+export const SAFE_ABI = [
+  // --- reads ---
+  'function getOwners() view returns (address[])',
+  'function getThreshold() view returns (uint256)',
+  'function nonce() view returns (uint256)',
+  'function isOwner(address owner) view returns (bool)',
+  'function VERSION() view returns (string)',
+  'function domainSeparator() view returns (bytes32)',
+  'function approvedHashes(address owner, bytes32 hash) view returns (uint256)',
+  'function getTransactionHash(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 _nonce) view returns (bytes32)',
+  // --- writes ---
+  'function approveHash(bytes32 hashToApprove)',
+  'function execTransaction(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures) payable returns (bool success)',
+  // --- governance (each is an ordinary Safe transaction targeting the Safe itself) ---
+  'function addOwnerWithThreshold(address owner, uint256 _threshold)',
+  'function removeOwner(address prevOwner, address owner, uint256 _threshold)',
+  'function swapOwner(address prevOwner, address oldOwner, address newOwner)',
+  'function changeThreshold(uint256 _threshold)',
+  // --- events ---
+  'event ApproveHash(bytes32 indexed approvedHash, address indexed owner)',
+  'event ExecutionSuccess(bytes32 indexed txHash, uint256 payment)',
+  'event ExecutionFailure(bytes32 indexed txHash, uint256 payment)',
+  'event AddedOwner(address indexed owner)',
+  'event RemovedOwner(address indexed owner)',
+  'event ChangedThreshold(uint256 threshold)',
+]
+
+export default SAFE_ABI

--- a/frontend/src/abis/SafeProposalHub.js
+++ b/frontend/src/abis/SafeProposalHub.js
@@ -1,0 +1,13 @@
+// Spec 043 — SafeProposalHub ABI, hand-maintained. Events-only broadcaster of Safe transaction preimages for
+// serverless co-owner discovery. Holds no funds and no authority; integrity is enforced by clients recomputing
+// the Safe transaction hash from the emitted params before approving. Refresh from the compiled artifact after
+// contract changes. Address is filled per-network by `npm run sync:frontend-contracts` (key: safeProposalHub).
+
+export const SAFE_PROPOSAL_HUB_ABI = [
+  'function propose(address safe, address to, uint256 value, bytes data, uint8 operation, uint256 nonce, bytes32 safeTxHash)',
+  'function cancel(address safe, bytes32 safeTxHash)',
+  'event Proposed(address indexed safe, address indexed proposer, bytes32 indexed safeTxHash, address to, uint256 value, bytes data, uint8 operation, uint256 nonce)',
+  'event Cancelled(address indexed safe, address indexed proposer, bytes32 indexed safeTxHash)',
+]
+
+export default SAFE_PROPOSAL_HUB_ABI

--- a/frontend/src/abis/SafeProxyFactory.js
+++ b/frontend/src/abis/SafeProxyFactory.js
@@ -1,0 +1,16 @@
+// Spec 043 — SafeProxyFactory (v1.4.1) ABI, hand-maintained. Used to deploy a new Safe vault: the initializer
+// is an ABI-encoded call to Safe.setup(owners, threshold, to, data, fallbackHandler, paymentToken, payment,
+// paymentReceiver). The resulting proxy address is deterministic (CREATE2) and previewable off-chain.
+
+export const SAFE_PROXY_FACTORY_ABI = [
+  'function createProxyWithNonce(address _singleton, bytes initializer, uint256 saltNonce) returns (address proxy)',
+  'function proxyCreationCode() view returns (bytes)',
+  'event ProxyCreation(address indexed proxy, address singleton)',
+]
+
+// The Safe singleton `setup` initializer (encoded and passed as `initializer` above).
+export const SAFE_SETUP_ABI = [
+  'function setup(address[] _owners, uint256 _threshold, address to, bytes data, address fallbackHandler, address paymentToken, uint256 payment, address paymentReceiver)',
+]
+
+export default SAFE_PROXY_FACTORY_ABI

--- a/frontend/src/components/clearpath/ExternalDaoView.jsx
+++ b/frontend/src/components/clearpath/ExternalDaoView.jsx
@@ -3,6 +3,7 @@ import { ethers } from 'ethers'
 import { getNetwork } from '../../config/networks'
 import { useNotification } from '../../hooks/useUI'
 import { useAddressScreening } from '../../hooks/useAddressScreening'
+import { useActiveAccount } from '../../hooks/useActiveAccount'
 import { DAO_FRAMEWORK_LABEL, PROPOSAL_STATE_LABEL, VOTE_SUPPORT } from '../../abis/externalDAORegistry'
 import { getConnector, detectFramework } from './connectors'
 import { fetchDaoProposals } from './daoDataSource'
@@ -107,6 +108,8 @@ function CopyableId({ id }) {
 export default function ExternalDaoView({ record, reader, signer, account, chainId, usdcAddress, onBack }) {
   const { showNotification } = useNotification()
   const { screenOne } = useAddressScreening()
+  // Spec 043 (US3, FR-022a): acting on a DAO while operating as a vault becomes a threshold-gated vault proposal.
+  const { isVault: operatingAsVault, canActAsVault, submit: submitAsActive } = useActiveAccount()
   const net = getNetwork(chainId)
   const explorerBase = (net?.explorer?.baseUrl || '').replace(/\/$/, '')
 
@@ -245,6 +248,12 @@ export default function ExternalDaoView({ record, reader, signer, account, chain
     try {
       showNotification(`${label}: confirm in your wallet…`, 'info', 0)
       const tx = await makeTx()
+      // Spec 043 (US3): in vault mode makeTx returns a pending proposal (no on-chain tx to await).
+      if (tx?.kind === 'proposed' || tx?.proposed) {
+        showNotification(`${label} proposed to your vault — awaiting co-owner approval.`, 'success')
+        await loadProposals()
+        return true
+      }
       showNotification(`${label} submitted — awaiting confirmation…`, 'info', 0)
       await tx.wait(1, CONFIRM_TIMEOUT_MS)
       showNotification(`${label} confirmed${tx?.hash ? ` · tx ${short(tx.hash)}` : ''}.`, 'success')
@@ -262,6 +271,20 @@ export default function ExternalDaoView({ record, reader, signer, account, chain
     } finally {
       setBusy(false)
     }
+  }
+
+  // Spec 043 (US3): build the tx factory for a management action — a normal signer call in personal mode, or
+  // a threshold-gated vault proposal (via the connector's `encode`) when operating as a vault.
+  const managedTx = (action, encodeArgs, personalFn) => async () => {
+    if (operatingAsVault) {
+      if (!canActAsVault) throw new Error("Switch to the vault's network to act as the vault.")
+      if (typeof connector.encode !== 'function') {
+        throw new Error('This DAO framework does not support acting as a vault yet.')
+      }
+      const { to, data } = connector.encode(record.dao, action, encodeArgs)
+      return submitAsActive({ to, value: 0n, data })
+    }
+    return personalFn()
   }
 
   return (
@@ -418,12 +441,12 @@ export default function ExternalDaoView({ record, reader, signer, account, chain
               <div className="cp-row-actions" style={{ marginTop: '0.6rem' }}>
                 {canVote && (
                   <>
-                    <button type="button" className="cp-btn cp-btn-primary" disabled={busy} onClick={() => run('Vote For', () => connector.castVote(signer, record.dao, p.id, VOTE_SUPPORT.For))}>Vote For</button>
-                    <button type="button" className="cp-btn" disabled={busy} onClick={() => run('Vote Against', () => connector.castVote(signer, record.dao, p.id, VOTE_SUPPORT.Against))}>Against</button>
-                    <button type="button" className="cp-btn" disabled={busy} onClick={() => run('Vote Abstain', () => connector.castVote(signer, record.dao, p.id, VOTE_SUPPORT.Abstain))}>Abstain</button>
+                    <button type="button" className="cp-btn cp-btn-primary" disabled={busy} onClick={() => run('Vote For', managedTx('castVote', { proposalId: p.id, support: VOTE_SUPPORT.For }, () => connector.castVote(signer, record.dao, p.id, VOTE_SUPPORT.For)))}>Vote For</button>
+                    <button type="button" className="cp-btn" disabled={busy} onClick={() => run('Vote Against', managedTx('castVote', { proposalId: p.id, support: VOTE_SUPPORT.Against }, () => connector.castVote(signer, record.dao, p.id, VOTE_SUPPORT.Against)))}>Against</button>
+                    <button type="button" className="cp-btn" disabled={busy} onClick={() => run('Vote Abstain', managedTx('castVote', { proposalId: p.id, support: VOTE_SUPPORT.Abstain }, () => connector.castVote(signer, record.dao, p.id, VOTE_SUPPORT.Abstain)))}>Abstain</button>
                   </>
                 )}
-                {p.state === 4 && <button type="button" className="cp-btn cp-btn-primary" disabled={busy} onClick={() => run('Queue', () => connector.queue(signer, record.dao, p))}>Queue</button>}
+                {p.state === 4 && <button type="button" className="cp-btn cp-btn-primary" disabled={busy} onClick={() => run('Queue', managedTx('queue', { p }, () => connector.queue(signer, record.dao, p)))}>Queue</button>}
                 {p.state === 5 && (
                   <button
                     type="button"
@@ -431,7 +454,7 @@ export default function ExternalDaoView({ record, reader, signer, account, chain
                     disabled={busy || !executeReady}
                     aria-disabled={busy || !executeReady}
                     title={executeReady ? undefined : 'Waiting for the timelock delay to elapse'}
-                    onClick={() => run('Execute', () => connector.execute(signer, record.dao, p))}
+                    onClick={() => run('Execute', managedTx('execute', { p }, () => connector.execute(signer, record.dao, p)))}
                   >
                     Execute
                   </button>

--- a/frontend/src/components/clearpath/__tests__/ExternalDaoView.notifications.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ExternalDaoView.notifications.test.jsx
@@ -71,6 +71,10 @@ vi.mock('../../../config/networks', () => ({
 }))
 // ProposalBuilder → CpAddressField → AddressBookButton → useWallet would throw without a provider.
 vi.mock('../../../hooks/useAddressBook', () => ({ useAddressBook: () => ({ search: () => [] }) }))
+// Spec 043: default the active identity to personal mode for these tests.
+vi.mock('../../../hooks/useActiveAccount', () => ({
+  useActiveAccount: () => ({ isVault: false, canActAsVault: false, identity: { mode: 'personal' }, submit: vi.fn(), operateAsPersonal: vi.fn() }),
+}))
 vi.mock('../../../hooks/useAddressScreening', () => ({
   useAddressScreening: () => ({ getStatus: () => 'clear', screen: vi.fn(), screenOne: () => Promise.resolve(h.screenStatus) }),
 }))

--- a/frontend/src/components/clearpath/connectors/governorBravo.js
+++ b/frontend/src/components/clearpath/connectors/governorBravo.js
@@ -234,6 +234,18 @@ export async function detectTreasuryFunding() {
   return null
 }
 
+// Spec 043 (US3, FR-022a): encode a management action's calldata (to the governor) so it can be proposed as a
+// vault transaction when operating as a Safe. Bravo queue/execute take only the proposal id. Returns {to,data}.
+export function encodeManagementAction(governor, action, args) {
+  const iface = new ethers.Interface(BRAVO_WRITE_ABI)
+  let data
+  if (action === 'castVote') data = iface.encodeFunctionData('castVote', [args.proposalId, args.support])
+  else if (action === 'queue') data = iface.encodeFunctionData('queue', [args.p.id])
+  else if (action === 'execute') data = iface.encodeFunctionData('execute', [args.p.id])
+  else throw new Error(`Unsupported vault governance action: ${action}`)
+  return { to: governor, data }
+}
+
 /** The pluggable connector object (framework 1). */
 export const governorBravoConnector = {
   framework: 1,
@@ -250,5 +262,6 @@ export const governorBravoConnector = {
   queue,
   execute,
   propose,
+  encode: encodeManagementAction,
   explainTxError,
 }

--- a/frontend/src/components/clearpath/connectors/ozGovernor.js
+++ b/frontend/src/components/clearpath/connectors/ozGovernor.js
@@ -382,6 +382,18 @@ export function proposeAction(signer, governor, { targets, values, calldatas, de
   return writeContract(signer, governor).propose(targets, values, calldatas, description)
 }
 
+// Spec 043 (US3, FR-022a): encode a management action's calldata (to the governor) so it can be proposed as a
+// vault transaction when operating as a Safe. Returns { to, data }.
+export function encodeManagementAction(governor, action, args) {
+  const iface = new ethers.Interface(GOVERNOR_WRITE_ABI)
+  let data
+  if (action === 'castVote') data = iface.encodeFunctionData('castVote', [args.proposalId, args.support])
+  else if (action === 'queue') data = iface.encodeFunctionData('queue', [args.p.targets, args.p.values, args.p.calldatas, args.p.descriptionHash])
+  else if (action === 'execute') data = iface.encodeFunctionData('execute', [args.p.targets, args.p.values, args.p.calldatas, args.p.descriptionHash])
+  else throw new Error(`Unsupported vault governance action: ${action}`)
+  return { to: governor, data }
+}
+
 // --- Spec 042: pluggable connector object (framework 0 = OpenZeppelin Governor) ---
 // One implementation of the shared connector interface (specs/042 contracts/connector-interface.md) so the
 // ClearPath UI, daoDataSource, and daoSource stay framework-agnostic. It wraps the functions above; adding a
@@ -403,5 +415,6 @@ export const ozGovernorConnector = {
   queue: queueProposal,
   execute: executeProposal,
   propose: proposeAction,
+  encode: encodeManagementAction,
   explainTxError,
 }

--- a/frontend/src/components/custody/CreateVaultWizard.jsx
+++ b/frontend/src/components/custody/CreateVaultWizard.jsx
@@ -2,7 +2,7 @@
 // deploy. Validation mirrors validateVaultConfig (FR-005). Presentational; all chain work is delegated to the
 // injected callbacks so the component is unit-testable.
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { validateVaultConfig } from '../../lib/custody/safeVault'
 
 export default function CreateVaultWizard({ connectedAddress, onCreate, onPreview, onDone }) {
@@ -21,6 +21,12 @@ export default function CreateVaultWizard({ connectedAddress, onCreate, onPrevie
     } catch (e) {
       return e.message
     }
+  }, [owners, threshold])
+
+  // A previewed address is only valid for the exact owners+threshold it was computed from; clear it whenever
+  // the config changes so the user never sees a stale address that won't match what "Create vault" deploys.
+  useEffect(() => {
+    setPredicted(null)
   }, [owners, threshold])
 
   const cleanedOwners = () => owners.map((o) => o.trim()).filter(Boolean)

--- a/frontend/src/components/custody/CreateVaultWizard.jsx
+++ b/frontend/src/components/custody/CreateVaultWizard.jsx
@@ -1,0 +1,132 @@
+// Spec 043 (US1) — create a new Safe vault: choose owners + threshold, preview the deterministic address, and
+// deploy. Validation mirrors validateVaultConfig (FR-005). Presentational; all chain work is delegated to the
+// injected callbacks so the component is unit-testable.
+
+import { useState, useMemo } from 'react'
+import { validateVaultConfig } from '../../lib/custody/safeVault'
+
+export default function CreateVaultWizard({ connectedAddress, onCreate, onPreview, onDone }) {
+  const [owners, setOwners] = useState([connectedAddress || ''])
+  const [threshold, setThreshold] = useState(1)
+  const [label, setLabel] = useState('')
+  const [predicted, setPredicted] = useState(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState(null)
+
+  const validationError = useMemo(() => {
+    const cleaned = owners.map((o) => o.trim()).filter(Boolean)
+    try {
+      validateVaultConfig(cleaned, threshold)
+      return null
+    } catch (e) {
+      return e.message
+    }
+  }, [owners, threshold])
+
+  const cleanedOwners = () => owners.map((o) => o.trim()).filter(Boolean)
+  const nextSaltNonce = () => Date.now()
+
+  const updateOwner = (i, val) => setOwners((prev) => prev.map((o, idx) => (idx === i ? val : o)))
+  const addOwner = () => setOwners((prev) => [...prev, ''])
+  const removeOwner = (i) => setOwners((prev) => prev.filter((_, idx) => idx !== i))
+
+  const handlePreview = async () => {
+    setError(null)
+    setBusy(true)
+    try {
+      const addr = await onPreview({ owners: cleanedOwners(), threshold, saltNonce: previewNonce })
+      setPredicted(addr)
+    } catch (e) {
+      setError(e?.message || 'Could not preview the vault address')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  // A stable salt for this wizard instance so preview and create resolve to the same address.
+  const [previewNonce] = useState(() => nextSaltNonce())
+
+  const handleCreate = async () => {
+    setError(null)
+    setBusy(true)
+    try {
+      await onCreate({ owners: cleanedOwners(), threshold, saltNonce: previewNonce, label })
+      onDone?.()
+    } catch (e) {
+      setError(e?.message || 'Vault creation failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <form className="custody-create" onSubmit={(e) => e.preventDefault()} aria-label="Create a vault">
+      <fieldset>
+        <legend>Owners</legend>
+        {owners.map((owner, i) => (
+          <div className="custody-owner-row" key={i}>
+            <label className="sr-only" htmlFor={`owner-${i}`}>{`Owner ${i + 1} address`}</label>
+            <input
+              id={`owner-${i}`}
+              type="text"
+              inputMode="text"
+              placeholder="0x…"
+              value={owner}
+              onChange={(e) => updateOwner(i, e.target.value)}
+            />
+            {owners.length > 1 && (
+              <button type="button" onClick={() => removeOwner(i)} aria-label={`Remove owner ${i + 1}`}>
+                Remove
+              </button>
+            )}
+          </div>
+        ))}
+        <button type="button" onClick={addOwner}>
+          Add owner
+        </button>
+      </fieldset>
+
+      <div className="custody-field">
+        <label htmlFor="vault-threshold">Approvals required (threshold)</label>
+        <input
+          id="vault-threshold"
+          type="number"
+          min={1}
+          max={Math.max(1, cleanedOwners().length)}
+          value={threshold}
+          onChange={(e) => setThreshold(Number(e.target.value))}
+        />
+      </div>
+
+      <div className="custody-field">
+        <label htmlFor="vault-label">Label (private, on this device)</label>
+        <input id="vault-label" type="text" value={label} onChange={(e) => setLabel(e.target.value)} />
+      </div>
+
+      {validationError && (
+        <p className="custody-error" role="alert">
+          {validationError}
+        </p>
+      )}
+      {error && (
+        <p className="custody-error" role="alert">
+          {error}
+        </p>
+      )}
+      {predicted && (
+        <p className="custody-predicted" role="status">
+          Vault address will be <code>{predicted}</code>
+        </p>
+      )}
+
+      <div className="custody-actions">
+        <button type="button" onClick={handlePreview} disabled={!!validationError || busy}>
+          Preview address
+        </button>
+        <button type="button" onClick={handleCreate} disabled={!!validationError || busy}>
+          {busy ? 'Working…' : 'Create vault'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/components/custody/Custody.css
+++ b/frontend/src/components/custody/Custody.css
@@ -138,6 +138,82 @@
   word-break: break-all;
 }
 
+.custody-vault-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.custody-proposal-list {
+  list-style: none;
+  margin: 0.25rem 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.custody-proposal-row {
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.25));
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.custody-proposal-main {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.custody-proposal-hash,
+.custody-proposal-facts {
+  font-size: 0.8125rem;
+  color: var(--text-muted, #6b7280);
+  word-break: break-all;
+}
+
+.custody-proposal-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.custody-status {
+  text-transform: capitalize;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.0625rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+}
+
+.custody-status--pending {
+  color: #b45309;
+}
+.custody-status--ready {
+  color: #047857;
+}
+.custody-status--executed {
+  color: #4f46e5;
+}
+.custody-status--failed,
+.custody-status--superseded {
+  color: #6b7280;
+}
+
+.custody-link {
+  background: none;
+  border: none;
+  color: var(--accent-color, #4f46e5);
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;

--- a/frontend/src/components/custody/Custody.css
+++ b/frontend/src/components/custody/Custody.css
@@ -1,0 +1,40 @@
+/* Spec 043 — Custody surface styles. Mirrors the app's existing section spacing/typography tokens. */
+
+.custody-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.custody-heading {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.custody-subsection {
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.25));
+  border-radius: 0.5rem;
+  padding: 1rem 1.25rem;
+}
+
+.custody-subsection-title {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+}
+
+.custody-subsection--disabled {
+  opacity: 0.55;
+}
+
+.custody-hint {
+  color: var(--text-muted, #6b7280);
+  font-size: 0.875rem;
+  margin: 0.25rem 0 0;
+}
+
+.custody-unavailable,
+.custody-onchain-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}

--- a/frontend/src/components/custody/Custody.css
+++ b/frontend/src/components/custody/Custody.css
@@ -38,3 +38,114 @@
   flex-direction: column;
   gap: 0.25rem;
 }
+
+.custody-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+
+.custody-onchain-body {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@media (min-width: 720px) {
+  .custody-onchain-body {
+    grid-template-columns: minmax(0, 18rem) minmax(0, 1fr);
+  }
+}
+
+.custody-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin: 0.5rem 0;
+}
+
+.custody-owner-row {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.375rem;
+}
+
+.custody-owner-row input {
+  flex: 1;
+}
+
+.custody-vault-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.custody-vault-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.125rem;
+  width: 100%;
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.25));
+  border-radius: 0.375rem;
+  background: transparent;
+  cursor: pointer;
+}
+
+.custody-vault-item.is-selected {
+  border-color: var(--accent-color, #4f46e5);
+}
+
+.custody-vault-addr,
+.custody-vault-meta {
+  font-size: 0.8125rem;
+  color: var(--text-muted, #6b7280);
+}
+
+.custody-vault-facts {
+  display: grid;
+  gap: 0.375rem;
+  margin: 0.5rem 0;
+}
+
+.custody-vault-facts dt {
+  font-size: 0.8125rem;
+  color: var(--text-muted, #6b7280);
+}
+
+.custody-owner-addresses {
+  list-style: none;
+  margin: 0.25rem 0 0.75rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  word-break: break-all;
+}
+
+.custody-error {
+  color: var(--error-color, #dc2626);
+  font-size: 0.875rem;
+}
+
+.custody-predicted code {
+  word-break: break-all;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/frontend/src/components/custody/Custody.css
+++ b/frontend/src/components/custody/Custody.css
@@ -214,6 +214,29 @@
   padding: 0;
 }
 
+.custody-operateas {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 1rem;
+  background: var(--accent-soft, rgba(79, 70, 229, 0.12));
+  border-bottom: 1px solid var(--accent-color, #4f46e5);
+  font-size: 0.875rem;
+}
+
+.custody-operateas-text code {
+  word-break: break-all;
+}
+
+.custody-operateas-warn {
+  color: var(--error-color, #dc2626);
+}
+
+.custody-operateas-switch {
+  margin-left: auto;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;

--- a/frontend/src/components/custody/CustodyPanel.jsx
+++ b/frontend/src/components/custody/CustodyPanel.jsx
@@ -1,36 +1,72 @@
-// Spec 043 — Custody surface shell. Lives under My Wallet → Finance → Custody with two sub-sections:
-// "On chain" (Safe multisig; filled in by later tasks) and "Off chain" (reserved, disabled). Gated by Safe
-// availability: on a network without a configured Safe deployment, the On chain section shows an honest
-// "unavailable on this network" state rather than a broken UI (FR-030).
+// Spec 043 — Custody surface. Lives under My Wallet → Finance → Custody with two sub-sections: "On chain"
+// (Safe multisig) and "Off chain" (reserved, disabled). Gated by Safe availability: on a network without a
+// configured Safe deployment, the On chain section shows an honest "unavailable on this network" state (FR-030).
 
+import { useState } from 'react'
 import { useWallet } from '../../hooks'
+import { useCustodyVaults } from '../../hooks/useCustodyVaults'
 import { isCustodySupported, CUSTODY_SUPPORTED_CHAIN_IDS } from '../../config/safeContracts'
+import VaultList from './VaultList'
+import VaultDetail from './VaultDetail'
+import CreateVaultWizard from './CreateVaultWizard'
+import LoadVaultForm from './LoadVaultForm'
 import './Custody.css'
 
-function OnChainSection({ chainId }) {
-  const supported = isCustodySupported(chainId)
-  if (!supported) {
-    return (
-      <div className="custody-unavailable" role="status">
-        <p>Custody is not available on this network.</p>
-        <p className="custody-hint">
-          Switch to a supported network to create or manage a multisig vault.
-        </p>
-      </div>
-    )
-  }
-  // Vault list / create / load are wired in by subsequent custody tasks (US1+). The shell renders the
-  // onboarding empty state so the section is usable and testable on its own.
+function OnChainSection() {
+  const { address } = useWallet()
+  const {
+    vaults,
+    activeVault,
+    activeAddress,
+    selectVault,
+    loading,
+    error,
+    loadByAddress,
+    createVault,
+    previewVaultAddress,
+    forget,
+  } = useCustodyVaults()
+  const [mode, setMode] = useState(null) // null | 'create' | 'load'
+
   return (
-    <div className="custody-onchain-empty" role="region" aria-label="On-chain vaults">
-      <p>No vaults yet.</p>
-      <p className="custody-hint">Create a new multisig vault or load an existing one by address.</p>
+    <div className="custody-onchain" role="region" aria-label="On-chain vaults">
+      <div className="custody-actions">
+        <button type="button" onClick={() => setMode(mode === 'create' ? null : 'create')}>
+          Create vault
+        </button>
+        <button type="button" onClick={() => setMode(mode === 'load' ? null : 'load')}>
+          Load existing
+        </button>
+      </div>
+
+      {mode === 'create' && (
+        <CreateVaultWizard
+          connectedAddress={address}
+          onCreate={createVault}
+          onPreview={previewVaultAddress}
+          onDone={() => setMode(null)}
+        />
+      )}
+      {mode === 'load' && <LoadVaultForm onLoad={loadByAddress} onDone={() => setMode(null)} />}
+
+      {loading && <p className="custody-hint">Loading vaults…</p>}
+      {error && (
+        <p className="custody-error" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="custody-onchain-body">
+        <VaultList vaults={vaults} activeAddress={activeAddress} onSelect={selectVault} />
+        {activeVault && <VaultDetail vault={activeVault} onForget={forget} />}
+      </div>
     </div>
   )
 }
 
 export default function CustodyPanel() {
   const { chainId } = useWallet()
+  const supported = isCustodySupported(chainId)
 
   return (
     <div className="custody-panel">
@@ -40,7 +76,16 @@ export default function CustodyPanel() {
         <h3 id="custody-onchain-title" className="custody-subsection-title">
           On chain
         </h3>
-        <OnChainSection chainId={chainId} />
+        {supported ? (
+          <OnChainSection />
+        ) : (
+          <div className="custody-unavailable" role="status">
+            <p>Custody is not available on this network.</p>
+            <p className="custody-hint">
+              Switch to a supported network to create or manage a multisig vault.
+            </p>
+          </div>
+        )}
       </section>
 
       <section

--- a/frontend/src/components/custody/CustodyPanel.jsx
+++ b/frontend/src/components/custody/CustodyPanel.jsx
@@ -8,6 +8,7 @@ import { useCustodyVaults } from '../../hooks/useCustodyVaults'
 import { isCustodySupported, CUSTODY_SUPPORTED_CHAIN_IDS } from '../../config/safeContracts'
 import VaultList from './VaultList'
 import VaultDetail from './VaultDetail'
+import VaultProposalsPanel from './VaultProposalsPanel'
 import CreateVaultWizard from './CreateVaultWizard'
 import LoadVaultForm from './LoadVaultForm'
 import './Custody.css'
@@ -58,7 +59,12 @@ function OnChainSection() {
 
       <div className="custody-onchain-body">
         <VaultList vaults={vaults} activeAddress={activeAddress} onSelect={selectVault} />
-        {activeVault && <VaultDetail vault={activeVault} onForget={forget} />}
+        {activeVault && (
+          <div className="custody-vault-column">
+            <VaultDetail vault={activeVault} onForget={forget} />
+            <VaultProposalsPanel vault={activeVault} />
+          </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/components/custody/CustodyPanel.jsx
+++ b/frontend/src/components/custody/CustodyPanel.jsx
@@ -1,0 +1,60 @@
+// Spec 043 — Custody surface shell. Lives under My Wallet → Finance → Custody with two sub-sections:
+// "On chain" (Safe multisig; filled in by later tasks) and "Off chain" (reserved, disabled). Gated by Safe
+// availability: on a network without a configured Safe deployment, the On chain section shows an honest
+// "unavailable on this network" state rather than a broken UI (FR-030).
+
+import { useWallet } from '../../hooks'
+import { isCustodySupported, CUSTODY_SUPPORTED_CHAIN_IDS } from '../../config/safeContracts'
+import './Custody.css'
+
+function OnChainSection({ chainId }) {
+  const supported = isCustodySupported(chainId)
+  if (!supported) {
+    return (
+      <div className="custody-unavailable" role="status">
+        <p>Custody is not available on this network.</p>
+        <p className="custody-hint">
+          Switch to a supported network to create or manage a multisig vault.
+        </p>
+      </div>
+    )
+  }
+  // Vault list / create / load are wired in by subsequent custody tasks (US1+). The shell renders the
+  // onboarding empty state so the section is usable and testable on its own.
+  return (
+    <div className="custody-onchain-empty" role="region" aria-label="On-chain vaults">
+      <p>No vaults yet.</p>
+      <p className="custody-hint">Create a new multisig vault or load an existing one by address.</p>
+    </div>
+  )
+}
+
+export default function CustodyPanel() {
+  const { chainId } = useWallet()
+
+  return (
+    <div className="custody-panel">
+      <h2 className="custody-heading">Custody</h2>
+
+      <section className="custody-subsection" aria-labelledby="custody-onchain-title">
+        <h3 id="custody-onchain-title" className="custody-subsection-title">
+          On chain
+        </h3>
+        <OnChainSection chainId={chainId} />
+      </section>
+
+      <section
+        className="custody-subsection custody-subsection--disabled"
+        aria-labelledby="custody-offchain-title"
+        aria-disabled="true"
+      >
+        <h3 id="custody-offchain-title" className="custody-subsection-title">
+          Off chain
+        </h3>
+        <p className="custody-hint">Off-chain custody is coming later.</p>
+      </section>
+    </div>
+  )
+}
+
+export { CUSTODY_SUPPORTED_CHAIN_IDS }

--- a/frontend/src/components/custody/CustodyPanel.jsx
+++ b/frontend/src/components/custody/CustodyPanel.jsx
@@ -4,6 +4,7 @@
 
 import { useState } from 'react'
 import { useWallet } from '../../hooks'
+import { useCustody } from '../../hooks/useCustody'
 import { useCustodyVaults } from '../../hooks/useCustodyVaults'
 import { isCustodySupported, CUSTODY_SUPPORTED_CHAIN_IDS } from '../../config/safeContracts'
 import VaultList from './VaultList'
@@ -15,6 +16,7 @@ import './Custody.css'
 
 function OnChainSection() {
   const { address } = useWallet()
+  const { active, operateAsVault } = useCustody()
   const {
     vaults,
     activeVault,
@@ -61,7 +63,12 @@ function OnChainSection() {
         <VaultList vaults={vaults} activeAddress={activeAddress} onSelect={selectVault} />
         {activeVault && (
           <div className="custody-vault-column">
-            <VaultDetail vault={activeVault} onForget={forget} />
+            <VaultDetail
+              vault={activeVault}
+              onForget={forget}
+              onOperateAs={operateAsVault}
+              isActiveIdentity={active.mode === 'vault' && active.vaultAddress === activeVault.address}
+            />
             <VaultProposalsPanel vault={activeVault} />
           </div>
         )}

--- a/frontend/src/components/custody/LoadVaultForm.jsx
+++ b/frontend/src/components/custody/LoadVaultForm.jsx
@@ -1,0 +1,64 @@
+// Spec 043 (US1) — load an existing vault by address. Distinguishes "not a contract", "not a Safe", and a
+// real Safe (owned vs view-only is derived after load). Delegates the chain read to onLoad.
+
+import { useState } from 'react'
+
+export default function LoadVaultForm({ onLoad, onDone }) {
+  const [address, setAddress] = useState('')
+  const [label, setLabel] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState(null)
+  const [result, setResult] = useState(null)
+
+  const handleLoad = async () => {
+    setError(null)
+    setResult(null)
+    setBusy(true)
+    try {
+      const vault = await onLoad(address.trim(), label)
+      setResult(vault)
+      onDone?.(vault)
+    } catch (e) {
+      setError(e?.message || 'Could not load that address')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <form className="custody-load" onSubmit={(e) => e.preventDefault()} aria-label="Load a vault by address">
+      <div className="custody-field">
+        <label htmlFor="load-address">Vault address</label>
+        <input
+          id="load-address"
+          type="text"
+          placeholder="0x…"
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+        />
+      </div>
+      <div className="custody-field">
+        <label htmlFor="load-label">Label (private, on this device)</label>
+        <input id="load-label" type="text" value={label} onChange={(e) => setLabel(e.target.value)} />
+      </div>
+
+      {error && (
+        <p className="custody-error" role="alert">
+          {error}
+        </p>
+      )}
+      {result?.isSafe && (
+        <p className="custody-predicted" role="status">
+          Loaded {result.owner ? 'a vault you co-own' : 'a view-only vault'} with {result.owners.length}{' '}
+          owners and a {result.threshold}-of-{result.owners.length} threshold.
+        </p>
+      )}
+
+      <div className="custody-actions">
+        <button type="button" onClick={handleLoad} disabled={!address.trim() || busy}>
+          {busy ? 'Loading…' : 'Load vault'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/components/custody/OperateAsIndicator.jsx
+++ b/frontend/src/components/custody/OperateAsIndicator.jsx
@@ -1,0 +1,29 @@
+// Spec 043 (US3, FR-020/FR-023) — a persistent, app-wide banner shown whenever the member is operating as a
+// vault, with a one-click switch back to the personal wallet. Renders nothing in personal mode.
+
+import { useActiveAccount } from '../../hooks/useActiveAccount'
+import './Custody.css'
+
+function shorten(addr) {
+  return addr ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : ''
+}
+
+export default function OperateAsIndicator() {
+  const { isVault, identity, canActAsVault, operateAsPersonal } = useActiveAccount()
+  if (!isVault) return null
+
+  return (
+    <div className="custody-operateas" role="status" aria-live="polite">
+      <span className="custody-operateas-text">
+        Operating as <strong>{identity.label || 'vault'}</strong>{' '}
+        <code>{shorten(identity.vaultAddress)}</code>
+        {!canActAsVault && (
+          <span className="custody-operateas-warn"> — switch to network {identity.chainId} to act</span>
+        )}
+      </span>
+      <button type="button" className="custody-operateas-switch" onClick={operateAsPersonal}>
+        Switch back to personal wallet
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/custody/OwnersThresholdPanel.jsx
+++ b/frontend/src/components/custody/OwnersThresholdPanel.jsx
@@ -1,0 +1,133 @@
+// Spec 043 (US4, FR-018/019) — vault governance: add/remove an owner or change the threshold. Each is an
+// ordinary vault transaction targeting the Safe itself, proposed through the same queue as any other action
+// (onPropose === useVaultProposals.propose). Presentational; the encoding is delegated to vaultTransaction's
+// governance builders. Owners only (FR-016).
+
+import { useState, useMemo } from 'react'
+import { getAddress } from 'ethers'
+import {
+  buildAddOwner,
+  buildRemoveOwner,
+  buildChangeThreshold,
+  prevOwnerOf,
+} from '../../lib/custody/vaultTransaction'
+
+const isAddr = (v) => {
+  try {
+    getAddress(v)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export default function OwnersThresholdPanel({ vault, onPropose, busy }) {
+  const [mode, setMode] = useState(null) // null | 'add' | 'remove' | 'threshold'
+  const [newOwner, setNewOwner] = useState('')
+  const [removeTarget, setRemoveTarget] = useState('')
+  const [threshold, setThreshold] = useState(vault?.threshold ?? 1)
+  const [error, setError] = useState(null)
+
+  const owners = useMemo(() => vault?.owners || [], [vault?.owners])
+
+  const validation = useMemo(() => {
+    if (mode === 'add') {
+      if (!isAddr(newOwner.trim())) return 'Enter a valid owner address'
+      if (owners.some((o) => o.toLowerCase() === newOwner.trim().toLowerCase())) return 'Already an owner'
+      const max = owners.length + 1
+      if (threshold < 1 || threshold > max) return `Threshold must be between 1 and ${max}`
+    } else if (mode === 'remove') {
+      if (!removeTarget) return 'Select an owner to remove'
+      if (owners.length <= 1) return 'A vault must keep at least one owner'
+      const max = owners.length - 1
+      if (threshold < 1 || threshold > max) return `Threshold must be between 1 and ${max}`
+    } else if (mode === 'threshold') {
+      if (threshold < 1 || threshold > owners.length) return `Threshold must be between 1 and ${owners.length}`
+    }
+    return null
+  }, [mode, newOwner, removeTarget, threshold, owners])
+
+  if (!vault?.owner) return null // view-only members can't propose governance
+
+  const submit = async () => {
+    setError(null)
+    try {
+      let tx
+      if (mode === 'add') {
+        tx = buildAddOwner(vault.address, newOwner.trim(), threshold, 0)
+      } else if (mode === 'remove') {
+        const prev = prevOwnerOf(owners, removeTarget)
+        tx = buildRemoveOwner(vault.address, prev, removeTarget, threshold, 0)
+      } else if (mode === 'threshold') {
+        tx = buildChangeThreshold(vault.address, threshold, 0)
+      }
+      // propose() recomputes the nonce; we only pass the target + encoded call.
+      await onPropose({ to: tx.to, value: 0n, data: tx.data })
+      setMode(null)
+      setNewOwner('')
+      setRemoveTarget('')
+    } catch (e) {
+      setError(e?.message || 'Could not create the governance proposal')
+    }
+  }
+
+  return (
+    <div className="custody-governance" role="region" aria-label="Vault governance">
+      <h5>Governance</h5>
+      <div className="custody-actions">
+        <button type="button" onClick={() => setMode(mode === 'add' ? null : 'add')}>Add owner</button>
+        <button type="button" onClick={() => setMode(mode === 'remove' ? null : 'remove')}>Remove owner</button>
+        <button type="button" onClick={() => setMode(mode === 'threshold' ? null : 'threshold')}>
+          Change threshold
+        </button>
+      </div>
+
+      {mode === 'add' && (
+        <div className="custody-field">
+          <label htmlFor="gov-new-owner">New owner address</label>
+          <input id="gov-new-owner" type="text" placeholder="0x…" value={newOwner} onChange={(e) => setNewOwner(e.target.value)} />
+        </div>
+      )}
+
+      {mode === 'remove' && (
+        <div className="custody-field">
+          <label htmlFor="gov-remove-owner">Owner to remove</label>
+          <select id="gov-remove-owner" value={removeTarget} onChange={(e) => setRemoveTarget(e.target.value)}>
+            <option value="">Select…</option>
+            {owners.map((o) => (
+              <option key={o} value={o}>
+                {o}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {mode && (
+        <div className="custody-field">
+          <label htmlFor="gov-threshold">New threshold (approvals required)</label>
+          <input id="gov-threshold" type="number" min={1} value={threshold} onChange={(e) => setThreshold(Number(e.target.value))} />
+        </div>
+      )}
+
+      {mode && validation && (
+        <p className="custody-error" role="alert">
+          {validation}
+        </p>
+      )}
+      {error && (
+        <p className="custody-error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {mode && (
+        <div className="custody-actions">
+          <button type="button" onClick={submit} disabled={!!validation || busy}>
+            Propose {mode === 'threshold' ? 'threshold change' : mode === 'add' ? 'add owner' : 'remove owner'}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/custody/ProposalQueue.jsx
+++ b/frontend/src/components/custody/ProposalQueue.jsx
@@ -1,0 +1,93 @@
+// Spec 043 (US2) — the vault's pending queue + history with approve/execute actions. Non-owners see state
+// but no action buttons (FR-016). Blocked states are surfaced honestly (approvals remaining; not-ready).
+
+import { STATUS } from '../../lib/custody/proposalStatus'
+import { approvalsRemaining } from '../../lib/custody/proposalStatus'
+
+function shortHash(h) {
+  return h ? `${h.slice(0, 10)}…${h.slice(-6)}` : ''
+}
+
+function ProposalRow({ p, isOwner, hasApproved, onApprove, onExecute, onCancel, busy }) {
+  const remaining = approvalsRemaining(p.approvals, p.threshold)
+  return (
+    <li className="custody-proposal-row">
+      <div className="custody-proposal-main">
+        <span className={`custody-status custody-status--${p.status}`}>{p.status}</span>
+        <span className="custody-proposal-meta">
+          {p.approvals}/{p.threshold} approvals
+          {p.status === STATUS.PENDING && remaining > 0 ? ` · ${remaining} more needed` : ''}
+        </span>
+        <code className="custody-proposal-hash">{shortHash(p.safeTxHash)}</code>
+      </div>
+      <div className="custody-proposal-facts">
+        <span>to <code>{p.to}</code></span>
+        <span>nonce {String(p.nonce)}</span>
+      </div>
+      {isOwner && (
+        <div className="custody-actions">
+          {p.status === STATUS.PENDING && (
+            <button type="button" onClick={() => onApprove(p.safeTxHash)} disabled={busy || hasApproved}>
+              {hasApproved ? 'Approved' : 'Approve'}
+            </button>
+          )}
+          {p.status === STATUS.READY && (
+            <button type="button" onClick={() => onExecute(p)} disabled={busy}>
+              Execute
+            </button>
+          )}
+          {(p.status === STATUS.PENDING || p.status === STATUS.READY) && onCancel && (
+            <button type="button" className="custody-link" onClick={() => onCancel(p.safeTxHash)} disabled={busy}>
+              Cancel
+            </button>
+          )}
+        </div>
+      )}
+    </li>
+  )
+}
+
+export default function ProposalQueue({ queue, history, isOwner, connectedAddress, onApprove, onExecute, onCancel, busy }) {
+  const approvedByMe = (p) =>
+    !!connectedAddress && (p.approvers || []).some((a) => a.toLowerCase() === connectedAddress.toLowerCase())
+
+  return (
+    <div className="custody-proposals" role="region" aria-label="Vault proposals">
+      <h5>Pending queue</h5>
+      {queue.length === 0 ? (
+        <p className="custody-hint" role="status">
+          No pending transactions.
+        </p>
+      ) : (
+        <ul className="custody-proposal-list">
+          {queue.map((p) => (
+            <ProposalRow
+              key={p.safeTxHash}
+              p={p}
+              isOwner={isOwner}
+              hasApproved={approvedByMe(p)}
+              onApprove={onApprove}
+              onExecute={onExecute}
+              onCancel={onCancel}
+              busy={busy}
+            />
+          ))}
+        </ul>
+      )}
+
+      {history.length > 0 && (
+        <>
+          <h5>History</h5>
+          <ul className="custody-proposal-list custody-proposal-list--history">
+            {history.map((p) => (
+              <li key={p.safeTxHash} className="custody-proposal-row">
+                <span className={`custody-status custody-status--${p.status}`}>{p.status}</span>
+                <code className="custody-proposal-hash">{shortHash(p.safeTxHash)}</code>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/custody/ProposeTransactionForm.jsx
+++ b/frontend/src/components/custody/ProposeTransactionForm.jsx
@@ -1,0 +1,114 @@
+// Spec 043 (US2) — propose a transfer from the vault: native asset or an ERC-20. Builds {to,value,data} and
+// hands it to onPropose (which creates the vault proposal). Presentational; encoding is local + pure.
+
+import { useState, useMemo } from 'react'
+import { buildTransferPayload } from '../../lib/custody/transfers'
+
+export default function ProposeTransactionForm({ onPropose, onDone }) {
+  const [assetType, setAssetType] = useState('native') // 'native' | 'token'
+  const [recipient, setRecipient] = useState('')
+  const [amount, setAmount] = useState('')
+  const [tokenAddress, setTokenAddress] = useState('')
+  const [decimals, setDecimals] = useState('18')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState(null)
+
+  const validationError = useMemo(() => {
+    try {
+      if (!recipient.trim() || !amount.trim()) return 'Recipient and amount are required'
+      buildTransferPayload({
+        recipient: recipient.trim(),
+        amount,
+        tokenAddress: assetType === 'token' ? tokenAddress.trim() : null,
+        decimals,
+      })
+      return null
+    } catch (e) {
+      return e.message
+    }
+  }, [recipient, amount, tokenAddress, decimals, assetType])
+
+  const submit = async () => {
+    setError(null)
+    setBusy(true)
+    try {
+      const payload = buildTransferPayload({
+        recipient: recipient.trim(),
+        amount,
+        tokenAddress: assetType === 'token' ? tokenAddress.trim() : null,
+        decimals,
+      })
+      await onPropose(payload)
+      onDone?.()
+    } catch (e) {
+      setError(e?.message || 'Could not create the proposal')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <form className="custody-propose" onSubmit={(e) => e.preventDefault()} aria-label="Propose a transfer">
+      <fieldset>
+        <legend>Asset</legend>
+        <label>
+          <input
+            type="radio"
+            name="asset"
+            checked={assetType === 'native'}
+            onChange={() => setAssetType('native')}
+          />
+          Native
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="asset"
+            checked={assetType === 'token'}
+            onChange={() => setAssetType('token')}
+          />
+          Token (ERC-20)
+        </label>
+      </fieldset>
+
+      {assetType === 'token' && (
+        <>
+          <div className="custody-field">
+            <label htmlFor="propose-token">Token address</label>
+            <input id="propose-token" type="text" placeholder="0x…" value={tokenAddress} onChange={(e) => setTokenAddress(e.target.value)} />
+          </div>
+          <div className="custody-field">
+            <label htmlFor="propose-decimals">Token decimals</label>
+            <input id="propose-decimals" type="number" min={0} max={36} value={decimals} onChange={(e) => setDecimals(e.target.value)} />
+          </div>
+        </>
+      )}
+
+      <div className="custody-field">
+        <label htmlFor="propose-recipient">Recipient</label>
+        <input id="propose-recipient" type="text" placeholder="0x…" value={recipient} onChange={(e) => setRecipient(e.target.value)} />
+      </div>
+      <div className="custody-field">
+        <label htmlFor="propose-amount">Amount</label>
+        <input id="propose-amount" type="text" inputMode="decimal" value={amount} onChange={(e) => setAmount(e.target.value)} />
+      </div>
+
+      {validationError && (
+        <p className="custody-error" role="alert">
+          {validationError}
+        </p>
+      )}
+      {error && (
+        <p className="custody-error" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="custody-actions">
+        <button type="button" onClick={submit} disabled={!!validationError || busy}>
+          {busy ? 'Proposing…' : 'Propose transfer'}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/components/custody/VaultDetail.jsx
+++ b/frontend/src/components/custody/VaultDetail.jsx
@@ -1,0 +1,67 @@
+// Spec 043 (US1) — a single vault's live on-chain state: address, network, owners, threshold, balance.
+// Honest state: everything shown here is read from chain (owners/threshold/nonce) or is a local label.
+
+export default function VaultDetail({ vault, onForget }) {
+  if (!vault) return null
+  if (vault.isSafe === false) {
+    return (
+      <div className="custody-vault-detail" role="region" aria-label="Vault detail">
+        <h4>{vault.label || 'Vault'}</h4>
+        <p className="custody-error" role="alert">
+          Could not read a Safe at <code>{vault.address}</code> on this network.
+        </p>
+        {onForget && (
+          <button type="button" onClick={() => onForget(vault.address)}>
+            Remove from list
+          </button>
+        )}
+      </div>
+    )
+  }
+  return (
+    <div className="custody-vault-detail" role="region" aria-label="Vault detail">
+      <h4>{vault.label || 'Vault'}</h4>
+      <dl className="custody-vault-facts">
+        <div>
+          <dt>Address</dt>
+          <dd>
+            <code>{vault.address}</code>
+          </dd>
+        </div>
+        <div>
+          <dt>Network</dt>
+          <dd>{vault.chainId}</dd>
+        </div>
+        <div>
+          <dt>Threshold</dt>
+          <dd>
+            {vault.threshold} of {vault.owners?.length} owners
+          </dd>
+        </div>
+        <div>
+          <dt>Your role</dt>
+          <dd>{vault.owner ? 'Owner (can propose & approve)' : 'View-only'}</dd>
+        </div>
+        {vault.version && (
+          <div>
+            <dt>Safe version</dt>
+            <dd>{vault.version}</dd>
+          </div>
+        )}
+      </dl>
+      <h5>Owners</h5>
+      <ul className="custody-owner-addresses">
+        {(vault.owners || []).map((o) => (
+          <li key={o}>
+            <code>{o}</code>
+          </li>
+        ))}
+      </ul>
+      {onForget && (
+        <button type="button" onClick={() => onForget(vault.address)}>
+          Remove from list
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/custody/VaultDetail.jsx
+++ b/frontend/src/components/custody/VaultDetail.jsx
@@ -1,7 +1,7 @@
 // Spec 043 (US1) — a single vault's live on-chain state: address, network, owners, threshold, balance.
 // Honest state: everything shown here is read from chain (owners/threshold/nonce) or is a local label.
 
-export default function VaultDetail({ vault, onForget }) {
+export default function VaultDetail({ vault, onForget, onOperateAs, isActiveIdentity }) {
   if (!vault) return null
   if (vault.isSafe === false) {
     return (
@@ -57,11 +57,18 @@ export default function VaultDetail({ vault, onForget }) {
           </li>
         ))}
       </ul>
-      {onForget && (
-        <button type="button" onClick={() => onForget(vault.address)}>
-          Remove from list
-        </button>
-      )}
+      <div className="custody-actions">
+        {vault.owner && onOperateAs && (
+          <button type="button" onClick={() => onOperateAs(vault)} disabled={isActiveIdentity}>
+            {isActiveIdentity ? 'Operating as this vault' : 'Operate as this vault'}
+          </button>
+        )}
+        {onForget && (
+          <button type="button" className="custody-link" onClick={() => onForget(vault.address)}>
+            Remove from list
+          </button>
+        )}
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/custody/VaultList.jsx
+++ b/frontend/src/components/custody/VaultList.jsx
@@ -1,0 +1,43 @@
+// Spec 043 (US1) — the member's vaults on the active network, with selection (FR-007).
+
+export default function VaultList({ vaults, activeAddress, onSelect }) {
+  if (!vaults?.length) {
+    return (
+      <p className="custody-hint" role="status">
+        No vaults yet on this network.
+      </p>
+    )
+  }
+  return (
+    <ul className="custody-vault-list" aria-label="Your vaults">
+      {vaults.map((v) => {
+        const selected = v.address === activeAddress
+        const label = v.label || 'Unnamed vault'
+        return (
+          <li key={`${v.chainId}:${v.address}`}>
+            <button
+              type="button"
+              className={`custody-vault-item${selected ? ' is-selected' : ''}`}
+              aria-current={selected ? 'true' : undefined}
+              onClick={() => onSelect(v.address)}
+            >
+              <span className="custody-vault-label">{label}</span>
+              <span className="custody-vault-addr">{shorten(v.address)}</span>
+              {v.isSafe && (
+                <span className="custody-vault-meta">
+                  {v.threshold}-of-{v.owners.length}
+                  {v.owner ? ' · owner' : ' · view-only'}
+                </span>
+              )}
+              {v.isSafe === false && <span className="custody-vault-meta custody-error">unreadable</span>}
+            </button>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+function shorten(addr) {
+  return addr ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : ''
+}

--- a/frontend/src/components/custody/VaultProposalsPanel.jsx
+++ b/frontend/src/components/custody/VaultProposalsPanel.jsx
@@ -1,0 +1,79 @@
+// Spec 043 (US2) — container wiring useVaultProposals to the propose form + queue for the active vault.
+// Handles the owner/view-only split (FR-016) and the network-mismatch prompt (edge case).
+
+import { useState } from 'react'
+import { useWallet } from '../../hooks'
+import { useVaultProposals } from '../../hooks/useVaultProposals'
+import ProposeTransactionForm from './ProposeTransactionForm'
+import ProposalQueue from './ProposalQueue'
+
+export default function VaultProposalsPanel({ vault }) {
+  const { address, chainId, switchNetwork } = useWallet()
+  const { queue, history, loading, error, propose, approve, execute, cancel } = useVaultProposals(vault)
+  const [showPropose, setShowPropose] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [actionError, setActionError] = useState(null)
+
+  if (!vault?.isSafe) return null
+
+  // Acting on a vault requires being on its network (approvals/execution are chain-scoped).
+  if (Number(chainId) !== Number(vault.chainId)) {
+    return (
+      <div className="custody-proposals" role="region" aria-label="Vault proposals">
+        <p className="custody-error" role="alert">
+          This vault is on network {vault.chainId}. Switch networks to view and act on its transactions.
+        </p>
+        {switchNetwork && (
+          <button type="button" onClick={() => switchNetwork(vault.chainId)}>
+            Switch to network {vault.chainId}
+          </button>
+        )}
+      </div>
+    )
+  }
+
+  const run = (fn) => async (...args) => {
+    setActionError(null)
+    setBusy(true)
+    try {
+      await fn(...args)
+    } catch (e) {
+      setActionError(e?.message || 'Action failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="custody-vault-proposals">
+      {vault.owner && (
+        <div className="custody-actions">
+          <button type="button" onClick={() => setShowPropose((s) => !s)}>
+            {showPropose ? 'Close' : 'New transfer'}
+          </button>
+        </div>
+      )}
+      {vault.owner && showPropose && (
+        <ProposeTransactionForm onPropose={run(propose)} onDone={() => setShowPropose(false)} />
+      )}
+
+      {loading && <p className="custody-hint">Loading transactions…</p>}
+      {(error || actionError) && (
+        <p className="custody-error" role="alert">
+          {error || actionError}
+        </p>
+      )}
+
+      <ProposalQueue
+        queue={queue}
+        history={history}
+        isOwner={!!vault.owner}
+        connectedAddress={address}
+        onApprove={run(approve)}
+        onExecute={run(execute)}
+        onCancel={run(cancel)}
+        busy={busy}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/custody/VaultProposalsPanel.jsx
+++ b/frontend/src/components/custody/VaultProposalsPanel.jsx
@@ -6,6 +6,7 @@ import { useWallet } from '../../hooks'
 import { useVaultProposals } from '../../hooks/useVaultProposals'
 import ProposeTransactionForm from './ProposeTransactionForm'
 import ProposalQueue from './ProposalQueue'
+import OwnersThresholdPanel from './OwnersThresholdPanel'
 
 export default function VaultProposalsPanel({ vault }) {
   const { address, chainId, switchNetwork } = useWallet()
@@ -56,6 +57,8 @@ export default function VaultProposalsPanel({ vault }) {
       {vault.owner && showPropose && (
         <ProposeTransactionForm onPropose={run(propose)} onDone={() => setShowPropose(false)} />
       )}
+
+      <OwnersThresholdPanel vault={vault} onPropose={run(propose)} busy={busy} />
 
       {loading && <p className="custody-hint">Loading transactions…</p>}
       {(error || actionError) && (

--- a/frontend/src/components/fairwins/MarketAcceptanceModal.jsx
+++ b/frontend/src/components/fairwins/MarketAcceptanceModal.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { ethers } from 'ethers'
 import { useWallet, useWeb3 } from '../../hooks'
+import { useActiveAccount } from '../../hooks/useActiveAccount'
 import { useGaslessWrite } from '../../lib/relay/useGaslessWrite'
 import { useEncryption } from '../../hooks/useEncryption'
 import { fetchEncryptedEnvelope } from '../../utils/ipfsService'
@@ -80,6 +81,8 @@ function MarketAcceptanceModal({
 }) {
   const { isConnected, account } = useWallet()
   const { signer, isCorrectNetwork, switchNetwork, chainId } = useWeb3()
+  // Spec 043 (US3): accepting a wager while operating as a vault becomes a threshold-gated vault proposal.
+  const { isVault: operatingAsVault, canActAsVault, submit: submitAsActive } = useActiveAccount()
   const {
     decryptMetadata,
     canUserDecrypt,
@@ -357,6 +360,25 @@ function MarketAcceptanceModal({
         ],
         signer
       )
+
+      // Spec 043 (US3, FR-021): accepting AS a vault → batch [approve, acceptWager] as a threshold-gated
+      // vault proposal (the Safe is the opponent; stake pulled from the vault). Only in the vault queue until
+      // co-owners approve + execute (FR-022b). Skips the personal balance check — execution enforces it.
+      if (operatingAsVault) {
+        if (!canActAsVault) throw new Error("Switch to the vault's network to accept as the vault.")
+        const approveData = tokenContract.interface.encodeFunctionData('approve', [contractAddress, stakeAmount])
+        const acceptData = contract.interface.encodeFunctionData('acceptWager', [marketId])
+        const res = await submitAsActive({
+          batch: [
+            { to: stakeTokenAddress, value: 0n, data: approveData },
+            { to: contractAddress, value: 0n, data: acceptData },
+          ],
+        })
+        if (res?.safeTxHash) setTxHash(res.safeTxHash)
+        setStep('success')
+        if (onAccepted) onAccepted(marketId)
+        return
+      }
 
       const balance = await tokenContract.balanceOf(account)
       let tokenSymbol = marketData?.stakeTokenSymbol || 'tokens'

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { ethers } from 'ethers'
 import { useWallet, useWeb3 } from '../../hooks'
+import { useActiveAccount } from '../../hooks/useActiveAccount'
 import { useLazyMarketDecryption } from '../../hooks/useEncryption'
 import { useLazyIpfsEnvelope } from '../../hooks/useIpfs'
 import { useWagerActivityOptional } from '../../hooks/useWagerActivity'
@@ -49,6 +50,9 @@ function MyMarketsModal({
 }) {
   const { isConnected, account, chainId } = useWallet()
   const { signer, isCorrectNetwork, switchNetwork } = useWeb3()
+  // Spec 043 (US3, FR-022c): a vault-won payout claim is a threshold-gated vault transaction (the registry
+  // binds the claimer to the winner). Refunds stay single-owner and need no change.
+  const { isVault: operatingAsVault, canActAsVault, submit: submitAsActive } = useActiveAccount()
 
   // Wager activity watcher (spec 012). Optional: the modal must keep working
   // when rendered outside WagerActivityProvider (legacy trees, tests).
@@ -785,7 +789,18 @@ function MyMarketsModal({
     setClaimError(null)
 
     try {
-      const result = await claimPayoutTx.run(market.wagerId ?? market.id)
+      const wagerId = market.wagerId ?? market.id
+      // Spec 043 (FR-022c): claiming as a vault → threshold-gated proposal calling claimPayout FROM the Safe.
+      if (operatingAsVault) {
+        if (!canActAsVault) throw new Error("Switch to the vault's network to claim as the vault.")
+        const registryAddr = getContractAddressForChain('wagerRegistry', chainId)
+        const data = new ethers.Interface(WAGER_REGISTRY_ABI).encodeFunctionData('claimPayout', [wagerId])
+        await submitAsActive({ to: registryAddr, value: 0n, data })
+        markWagerRead?.(id)
+        fireToast('Vault claim proposed — awaiting co-owner approval')
+        return
+      }
+      const result = await claimPayoutTx.run(wagerId)
       if (result?.error) throw result.error
       // Pull fresh on-chain data so the claimed wager flips to paid (which
       // hides the Claim affordances) and clear its unread activity.
@@ -811,7 +826,7 @@ function MyMarketsModal({
     } finally {
       setClaimingId(null)
     }
-  }, [signer, isCorrectNetwork, switchNetwork, markWagerRead, refreshFriendMarkets, fireToast, claimPayoutTx])
+  }, [signer, isCorrectNetwork, switchNetwork, markWagerRead, refreshFriendMarkets, fireToast, claimPayoutTx, operatingAsVault, canActAsVault, submitAsActive, chainId])
 
   // Participant reclaims their stake on a wager that ran past its resolution
   // window without a winner being declared (the "refundable" state). Mirrors

--- a/frontend/src/components/tokens/useTokenFactory.js
+++ b/frontend/src/components/tokens/useTokenFactory.js
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { ethers } from 'ethers'
 import { useWallet } from '../../hooks/useWalletManagement'
+import { useActiveAccount } from '../../hooks/useActiveAccount'
 import { getContractAddressForChain } from '../../config/contracts'
 import {
   TOKEN_FACTORY_ABI,
@@ -35,6 +36,8 @@ export function v1AbiForStandard(standard) {
  */
 export function useTokenFactory() {
   const { account, signer, provider, chainId, isConnected } = useWallet()
+  // Spec 043 (US3): creating a token while operating as a vault becomes a threshold-gated vault proposal.
+  const { isVault: operatingAsVault, canActAsVault, submit: submitAsActive } = useActiveAccount()
 
   const factoryAddress = getContractAddressForChain('tokenFactory', chainId)
   const isSupported = ethers.isAddress(factoryAddress || '')
@@ -235,7 +238,7 @@ export function useTokenFactory() {
 
   // Shared write wrapper: enforces support + signer, tracks honest tx state, returns the created token address.
   const runCreate = useCallback(
-    async (fn) => {
+    async (method, args) => {
       if (!isSupported) throw new Error('Token issuance is not available on this network.')
       if (!signer) throw new Error('Connect a wallet to create a token.')
       setStatus('creating')
@@ -243,7 +246,16 @@ export function useTokenFactory() {
       setLastTxHash(null)
       try {
         const factory = new ethers.Contract(factoryAddress, TOKEN_FACTORY_ABI, signer)
-        const tx = await fn(factory)
+        // Spec 043 (US3, FR-022a): create AS a vault → propose the factory call as a threshold-gated vault
+        // transaction (the Safe becomes the token issuer). Only in the vault queue until executed.
+        if (operatingAsVault) {
+          if (!canActAsVault) throw new Error("Switch to the vault's network to create a token as the vault.")
+          const data = factory.interface.encodeFunctionData(method, args)
+          const res = await submitAsActive({ to: factoryAddress, value: 0n, data })
+          setStatus('success')
+          return { proposed: true, safeTxHash: res.safeTxHash }
+        }
+        const tx = await factory[method](...args)
         setLastTxHash(tx.hash)
         const receipt = await tx.wait()
         // Pull the deployed token address from the TokenCreated event (only finalized after confirmation).
@@ -269,61 +281,57 @@ export function useTokenFactory() {
         throw e
       }
     },
-    [isSupported, factoryAddress, signer]
+    [isSupported, factoryAddress, signer, operatingAsVault, canActAsVault, submitAsActive]
   )
 
   const createOpenERC20 = useCallback(
-    ({ name, symbol, decimals, initialSupply, metadataURI = '', burnable = false, pausable = false }) =>
-      runCreate((factory) => {
-        const supply = ethers.parseUnits(String(initialSupply || '0'), Number(decimals))
-        return factory.createOpenERC20(name, symbol, Number(decimals), supply, metadataURI, burnable, pausable)
-      }),
+    ({ name, symbol, decimals, initialSupply, metadataURI = '', burnable = false, pausable = false }) => {
+      const supply = ethers.parseUnits(String(initialSupply || '0'), Number(decimals))
+      return runCreate('createOpenERC20', [name, symbol, Number(decimals), supply, metadataURI, burnable, pausable])
+    },
     [runCreate]
   )
 
   const createOpenERC721 = useCallback(
     ({ name, symbol, baseURI = '', burnable = false }) =>
-      runCreate((factory) => factory.createOpenERC721(name, symbol, baseURI, burnable)),
+      runCreate('createOpenERC721', [name, symbol, baseURI, burnable]),
     [runCreate]
   )
 
   const createRestrictedERC20 = useCallback(
-    ({ name, symbol, decimals, initialSupply, metadataURI = '', initialEligible = [] }) =>
-      runCreate((factory) => {
-        const supply = ethers.parseUnits(String(initialSupply || '0'), Number(decimals))
-        const eligible = initialEligible.filter((a) => ethers.isAddress(a))
-        return factory.createRestrictedERC20(name, symbol, Number(decimals), supply, metadataURI, eligible)
-      }),
+    ({ name, symbol, decimals, initialSupply, metadataURI = '', initialEligible = [] }) => {
+      const supply = ethers.parseUnits(String(initialSupply || '0'), Number(decimals))
+      const eligible = initialEligible.filter((a) => ethers.isAddress(a))
+      return runCreate('createRestrictedERC20', [name, symbol, Number(decimals), supply, metadataURI, eligible])
+    },
     [runCreate]
   )
 
   // --- v2 create (role-based + optional cap; cap '' or 0 ⇒ uncapped) ---
 
   const createOpenERC20V2 = useCallback(
-    ({ name, symbol, decimals, initialSupply, cap = '0', metadataURI = '' }) =>
-      runCreate((factory) => {
-        const d = Number(decimals)
-        const supply = ethers.parseUnits(String(initialSupply || '0'), d)
-        const capWei = ethers.parseUnits(String(cap || '0'), d) // 0 ⇒ uncapped (contract stores max)
-        return factory.createOpenERC20V2(name, symbol, d, supply, capWei, metadataURI)
-      }),
+    ({ name, symbol, decimals, initialSupply, cap = '0', metadataURI = '' }) => {
+      const d = Number(decimals)
+      const supply = ethers.parseUnits(String(initialSupply || '0'), d)
+      const capWei = ethers.parseUnits(String(cap || '0'), d) // 0 ⇒ uncapped (contract stores max)
+      return runCreate('createOpenERC20V2', [name, symbol, d, supply, capWei, metadataURI])
+    },
     [runCreate]
   )
 
   const createOpenERC721V2 = useCallback(
-    ({ name, symbol, baseURI = '' }) => runCreate((factory) => factory.createOpenERC721V2(name, symbol, baseURI)),
+    ({ name, symbol, baseURI = '' }) => runCreate('createOpenERC721V2', [name, symbol, baseURI]),
     [runCreate]
   )
 
   const createRestrictedERC20V2 = useCallback(
-    ({ name, symbol, decimals, initialSupply, cap = '0', metadataURI = '', initialEligible = [] }) =>
-      runCreate((factory) => {
-        const d = Number(decimals)
-        const supply = ethers.parseUnits(String(initialSupply || '0'), d)
-        const capWei = ethers.parseUnits(String(cap || '0'), d)
-        const eligible = initialEligible.filter((a) => ethers.isAddress(a))
-        return factory.createRestrictedERC20V2(name, symbol, d, supply, capWei, metadataURI, eligible)
-      }),
+    ({ name, symbol, decimals, initialSupply, cap = '0', metadataURI = '', initialEligible = [] }) => {
+      const d = Number(decimals)
+      const supply = ethers.parseUnits(String(initialSupply || '0'), d)
+      const capWei = ethers.parseUnits(String(cap || '0'), d)
+      const eligible = initialEligible.filter((a) => ethers.isAddress(a))
+      return runCreate('createRestrictedERC20V2', [name, symbol, d, supply, capWei, metadataURI, eligible])
+    },
     [runCreate]
   )
 

--- a/frontend/src/config/safeContracts.js
+++ b/frontend/src/config/safeContracts.js
@@ -1,0 +1,45 @@
+// Spec 043 — canonical Safe v1.4.1 contract addresses per supported chain, hand-maintained. Safe contracts are
+// EXTERNAL deployments (not ours), so they are NOT synced by `sync:frontend-contracts` (which only fills our
+// own deployment addresses). v1.4.1 was deployed through the per-chain Safe Singleton Factory, so the
+// `canonical` addresses below are IDENTICAL across Ethereum Classic (61), Mordor (63), and Polygon (137) —
+// all verified live on-chain (see specs/043-safe-multisig-custody/research.md, Decision 1).
+//
+// Custody is offered ONLY on chains present here; `getSafeContracts` returns undefined otherwise so the UI can
+// show "unavailable on this network" (FR-030). The SafeProposalHub address (OUR contract) is resolved
+// separately via getContractAddressForChain('safeProposalHub', chainId).
+
+// Same canonical v1.4.1 address set on every chain the Safe Singleton Factory reached.
+const SAFE_V1_4_1 = {
+  singleton: '0x41675C099F32341bf84BFc5382aF534df5C7461a', // Safe (L1) singleton
+  singletonL2: '0x29fcB43b46531BcA003ddC8FCB67FFE91900C762', // SafeL2 singleton (richer events for indexing)
+  proxyFactory: '0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67',
+  fallbackHandler: '0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99', // CompatibilityFallbackHandler (EIP-1271)
+  multiSendCallOnly: '0x9641d764fc13c8B624c04430C7356C1C7C8102e2',
+  version: '1.4.1',
+}
+
+// chainId → Safe contract set. Add 61 (ETC mainnet) here once the app gains an ETC network block; the address
+// set is already correct (identical canonical addresses).
+export const SAFE_CONTRACTS = {
+  63: SAFE_V1_4_1, // Mordor (Ethereum Classic testnet)
+  137: SAFE_V1_4_1, // Polygon
+}
+
+/** Supported custody chain ids (those with a Safe deployment configured above). */
+export const CUSTODY_SUPPORTED_CHAIN_IDS = Object.keys(SAFE_CONTRACTS).map((id) => Number(id))
+
+/**
+ * Resolve the Safe v1.4.1 contract set for a chain, or `undefined` when Custody is unavailable there.
+ * @param {number|string|null|undefined} chainId
+ */
+export function getSafeContracts(chainId) {
+  if (chainId == null) return undefined
+  return SAFE_CONTRACTS[Number(chainId)]
+}
+
+/** Whether Custody's on-chain multisig features are available on the given chain. */
+export function isCustodySupported(chainId) {
+  return getSafeContracts(chainId) !== undefined
+}
+
+export default SAFE_CONTRACTS

--- a/frontend/src/contexts/CustodyContext.js
+++ b/frontend/src/contexts/CustodyContext.js
@@ -1,0 +1,8 @@
+// Spec 043 (US3) — the active-identity context object. Kept in a plain .js file (matching DexContext) so the
+// provider .jsx only exports a component (react-refresh) and the hook lives under hooks/.
+
+import { createContext } from 'react'
+
+export const CustodyContext = createContext(null)
+
+export default CustodyContext

--- a/frontend/src/contexts/CustodyContext.jsx
+++ b/frontend/src/contexts/CustodyContext.jsx
@@ -1,0 +1,46 @@
+// Spec 043 (US3) — the active-identity provider. A member operates either as their personal wallet (default)
+// or "as" one of their vaults. This is a per-session choice (not persisted) and always resets to personal when
+// the connected account changes. Authorization still keys off the connected wallet address; the active
+// identity only changes where prepared actions are *sent* (personal send vs. threshold-gated vault proposal).
+
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import { useWallet } from '../hooks'
+import { CustodyContext } from './CustodyContext'
+
+export function CustodyProvider({ children }) {
+  const { address } = useWallet()
+  const [active, setActive] = useState({ mode: 'personal' })
+  const prevAddress = useRef(address)
+
+  // Reset to the personal wallet whenever the connected account actually changes or disconnects. This is a
+  // deliberate external-sync effect (identity must not carry across accounts); guarded by a ref so it only
+  // fires on a real change.
+  useEffect(() => {
+    if (prevAddress.current !== address) {
+      prevAddress.current = address
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional reset on account change
+      setActive({ mode: 'personal' })
+    }
+  }, [address])
+
+  const operateAsVault = useCallback((vault) => {
+    if (!vault?.address || vault.chainId == null) return
+    setActive({
+      mode: 'vault',
+      vaultAddress: vault.address,
+      chainId: Number(vault.chainId),
+      label: vault.label || '',
+    })
+  }, [])
+
+  const operateAsPersonal = useCallback(() => setActive({ mode: 'personal' }), [])
+
+  const value = useMemo(
+    () => ({ active, operateAsVault, operateAsPersonal }),
+    [active, operateAsVault, operateAsPersonal],
+  )
+
+  return <CustodyContext.Provider value={value}>{children}</CustodyContext.Provider>
+}
+
+export default CustodyProvider

--- a/frontend/src/contexts/DexContext.jsx
+++ b/frontend/src/contexts/DexContext.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 import { ethers } from 'ethers'
 import { useChainId } from 'wagmi'
 import { useWallet } from '../hooks/useWalletManagement'
+import { useActiveAccount } from '../hooks/useActiveAccount'
 import { FEE_TIERS, DEFAULT_SLIPPAGE } from '../constants/dex'
 import { getNetwork, getCurrentChainId } from '../config/networks'
 import { ERC20_ABI } from '../abis/ERC20'
@@ -23,6 +24,8 @@ const ZERO = '0x0000000000000000000000000000000000000000'
  */
 export function DexProvider({ children }) {
   const { provider, signer, address, isConnected } = useWallet()
+  // Spec 043 (US3): swapping while operating as a vault becomes a threshold-gated vault proposal.
+  const { isVault: operatingAsVault, canActAsVault, identity: activeIdentity, submit: submitAsActive } = useActiveAccount()
   const wagmiChainId = useChainId()
   const chainId = wagmiChainId || getCurrentChainId()
   const network = getNetwork(chainId)
@@ -376,6 +379,31 @@ export function DexProvider({ children }) {
       const amountInWei = ethers.parseUnits(amountIn, decIn)
       const minAmountOutWei = quote.minimumReceivedWei
 
+      // Spec 043 (US3, FR-022a): swap AS a vault → batch [approve, exactInputSingle] with recipient = the
+      // vault, proposed as a threshold-gated vault transaction. Only in the vault queue until executed.
+      if (operatingAsVault) {
+        if (!canActAsVault) throw new Error("Switch to the vault's network to swap as the vault.")
+        const erc20 = new ethers.Interface(ERC20_ABI)
+        const approveData = erc20.encodeFunctionData('approve', [addresses.SWAP_ROUTER_02, amountInWei])
+        const vaultParams = {
+          tokenIn,
+          tokenOut,
+          fee: quote.feeTier,
+          recipient: activeIdentity.vaultAddress,
+          amountIn: amountInWei,
+          amountOutMinimum: minAmountOutWei,
+          sqrtPriceLimitX96: 0,
+        }
+        const swapData = contracts.swapRouter.interface.encodeFunctionData('exactInputSingle', [vaultParams])
+        const res = await submitAsActive({
+          batch: [
+            { to: tokenIn, value: 0n, data: approveData },
+            { to: addresses.SWAP_ROUTER_02, value: 0n, data: swapData },
+          ],
+        })
+        return { proposed: true, safeTxHash: res.safeTxHash }
+      }
+
       const tokenInContract = new ethers.Contract(tokenIn, ERC20_ABI, signer)
       const allowance = await tokenInContract.allowance(address, addresses.SWAP_ROUTER_02)
 
@@ -409,7 +437,7 @@ export function DexProvider({ children }) {
     } finally {
       setLoading(false)
     }
-  }, [signer, contracts, address, getBestQuote, fetchBalances, decimalsOf, addresses])
+  }, [signer, contracts, address, getBestQuote, fetchBalances, decimalsOf, addresses, operatingAsVault, canActAsVault, activeIdentity, submitAsActive])
 
   const value = {
     balances,

--- a/frontend/src/contexts/index.js
+++ b/frontend/src/contexts/index.js
@@ -28,3 +28,7 @@ export { FriendMarketsProvider } from './FriendMarketsContext.jsx'
 // Role constants and context (roles are managed in WalletProvider, but RoleContext exported for test compatibility)
 export { RoleContext, ROLES, ROLE_INFO, ADMIN_ROLES, isAdminRole, getRoleName } from './RoleContext.js'
 
+// Spec 043: active-identity ("operate as" a vault) context. Provider here; the useCustody hook lives under
+// hooks/ (mirroring DexContext) so this .jsx exports only a component.
+export { CustodyProvider } from './CustodyContext.jsx'
+

--- a/frontend/src/data/notifications/domains.js
+++ b/frontend/src/data/notifications/domains.js
@@ -9,6 +9,8 @@ export const DOMAIN_META = {
   token: { label: 'Token' },
   membership: { label: 'Membership' },
   pools: { label: 'Pool' },
+  // Spec 043 custody (Safe multisig vault) events.
+  custody: { label: 'Custody' },
   // Spec 035 intent lifecycle entries (emitted via useIntentAction's onActivity callback).
   intents: { label: 'Gasless' },
 }

--- a/frontend/src/data/notifications/sources/custodySource.js
+++ b/frontend/src/data/notifications/sources/custodySource.js
@@ -1,0 +1,106 @@
+/**
+ * Custody activity source (spec 043, US6 / spec 031). Snapshot-diffs each vault the member belongs to on the
+ * active network: a pending proposal that needs the member's approval (action: approve), a proposal newly
+ * executed, and an owners/threshold governance change. Pure snapshot-diff (first-sight = baseline). No hooks;
+ * read-only provider. No-ops until the SafeProposalHub is deployed + its block recorded (never scans genesis).
+ */
+import { ethers } from 'ethers'
+import { getProvider } from '../../../utils/blockchainService'
+import { getContractAddressForChain, getDeploymentBlockForChain } from '../../../config/contracts'
+import { getSafeContracts } from '../../../config/safeContracts'
+import { loadVaultReferences } from '../../../lib/custody/vaultReferences'
+import { readVaultProposalState } from '../../../lib/custody/vaultProposalReads'
+import { STATUS } from '../../../lib/custody/proposalStatus'
+
+const EMPTY = { ok: true, entries: [], nextSnapshots: {}, currentIds: [], actionNeededById: {} }
+
+export const custodySource = {
+  key: 'custody',
+  label: 'Custody',
+  async detect({ account, chainId, nowMs, prior }) {
+    if (!account || !getSafeContracts(chainId)) return EMPTY
+    const hubAddress = getContractAddressForChain('safeProposalHub', chainId)
+    const fromBlock = getDeploymentBlockForChain('safeProposalHub', chainId)
+    // Until the hub is deployed + its block recorded, there is nothing to read (and we never scan genesis).
+    if (!hubAddress || !ethers.isAddress(hubAddress) || !fromBlock) return EMPTY
+
+    const refs = loadVaultReferences(account).filter((r) => r.chainId === Number(chainId))
+    if (refs.length === 0) return EMPTY
+
+    let provider
+    try {
+      provider = getProvider(chainId)
+    } catch {
+      return { ok: false }
+    }
+
+    const entries = []
+    const currentIds = []
+    const actionNeededById = {}
+    const nextSnapshots = { ...(prior.snapshots || {}) }
+    const accountLc = String(account).toLowerCase()
+    let anyOk = false
+
+    const mk = (vaultAddr, type, message, severity, actionable) => ({
+      id: `custody:${vaultAddr}:${type}:${nowMs}`,
+      domain: 'custody',
+      refId: vaultAddr,
+      type,
+      message,
+      severity,
+      actionable,
+      link: { to: '/wallet', state: { tab: 'custody', vault: vaultAddr } },
+      createdAt: nowMs,
+      read: false,
+    })
+
+    for (const ref of refs) {
+      const vaultAddr = ref.address
+      const sid = `custody:${vaultAddr}`
+      currentIds.push(sid)
+      let state
+      try {
+        state = await readVaultProposalState({ safeAddress: vaultAddr, hubAddress, chainId, provider, fromBlock })
+        anyOk = true
+      } catch {
+        // Can't read this vault — keep its prior snapshot so we don't lose the baseline.
+        if (prior.snapshots?.[sid]) nextSnapshots[sid] = prior.snapshots[sid]
+        continue
+      }
+
+      const isOwner = state.owners.some((o) => o.toLowerCase() === accountLc)
+      // Pending proposals that still need THIS member's approval.
+      const needMe = state.proposals
+        .filter((p) => p.status === STATUS.PENDING && isOwner && !p.approvers.some((a) => a.toLowerCase() === accountLc))
+        .map((p) => String(p.safeTxHash).toLowerCase())
+        .sort()
+      const executedCount = state.proposals.filter((p) => p.status === STATUS.EXECUTED).length
+      const label = ref.label || 'vault'
+      const govKey = `${state.owners.length}:${state.threshold}`
+
+      const prev = prior.snapshots?.[sid]
+      nextSnapshots[sid] = { needMe, executedCount, govKey, snappedAt: nowMs }
+
+      if (needMe.length > 0) actionNeededById[sid] = 'approve'
+
+      if (prev) {
+        const prevNeed = new Set(prev.needMe || [])
+        if (needMe.some((h) => !prevNeed.has(h))) {
+          entries.push(mk(vaultAddr, 'approval-needed', `A transaction on “${label}” needs your approval`, 'warning', true))
+        }
+        if (executedCount > (prev.executedCount || 0)) {
+          entries.push(mk(vaultAddr, 'executed', `A transaction on “${label}” was executed`, 'success', false))
+        }
+        if (prev.govKey && prev.govKey !== govKey) {
+          entries.push(mk(vaultAddr, 'governance-changed', `The owners or threshold on “${label}” changed`, 'info', false))
+        }
+      }
+    }
+
+    // If every vault read failed, report not-ok so the engine retains the prior slice.
+    if (!anyOk && refs.length > 0) return { ok: false }
+    return { ok: true, entries, nextSnapshots, currentIds, actionNeededById }
+  },
+}
+
+export default custodySource

--- a/frontend/src/data/notifications/sources/index.js
+++ b/frontend/src/data/notifications/sources/index.js
@@ -10,7 +10,8 @@ import { daoSource } from './daoSource'
 import { tokenSource } from './tokenSource'
 import { membershipSource } from './membershipSource'
 import { poolsSource } from './poolsSource'
+import { custodySource } from './custodySource'
 
-export const activitySources = [wagerSource, daoSource, tokenSource, membershipSource, poolsSource]
+export const activitySources = [wagerSource, daoSource, tokenSource, membershipSource, poolsSource, custodySource]
 
 export default activitySources

--- a/frontend/src/hooks/useActiveAccount.js
+++ b/frontend/src/hooks/useActiveAccount.js
@@ -2,7 +2,7 @@
 // In personal mode submit sends via the connected signer; in vault mode it creates a threshold-gated proposal.
 
 import { useCallback, useContext } from 'react'
-import { useWallet } from '.'
+import { useWallet } from './useWalletManagement'
 import { CustodyContext } from '../contexts/CustodyContext'
 import { getSafeContracts } from '../config/safeContracts'
 import { getContractAddressForChain } from '../config/contracts'

--- a/frontend/src/hooks/useActiveAccount.js
+++ b/frontend/src/hooks/useActiveAccount.js
@@ -1,15 +1,23 @@
 // Spec 043 (US3) — expose the active identity and a single submit() that every money-moving surface can call.
 // In personal mode submit sends via the connected signer; in vault mode it creates a threshold-gated proposal.
 
-import { useCallback } from 'react'
+import { useCallback, useContext } from 'react'
 import { useWallet } from '.'
-import { useCustody } from './useCustody'
+import { CustodyContext } from '../contexts/CustodyContext'
 import { getSafeContracts } from '../config/safeContracts'
 import { getContractAddressForChain } from '../config/contracts'
 import { submitAsActiveAccount } from '../lib/custody/submitAsActiveAccount'
 
+const PERSONAL = { mode: 'personal' }
+const NOOP = () => {}
+
 export function useActiveAccount() {
-  const { active, operateAsPersonal } = useCustody()
+  // Read the context directly and degrade to personal mode when no CustodyProvider is mounted. Operate-as is
+  // an optional overlay (the provider is always present at runtime), so broad consumers like useTransfer and
+  // useFriendMarketCreation must not hard-crash when it is absent (e.g. in isolated component tests).
+  const custody = useContext(CustodyContext)
+  const active = custody?.active ?? PERSONAL
+  const operateAsPersonal = custody?.operateAsPersonal ?? NOOP
   const { chainId, signer, provider } = useWallet()
   const isVault = active.mode === 'vault'
 

--- a/frontend/src/hooks/useActiveAccount.js
+++ b/frontend/src/hooks/useActiveAccount.js
@@ -1,0 +1,40 @@
+// Spec 043 (US3) — expose the active identity and a single submit() that every money-moving surface can call.
+// In personal mode submit sends via the connected signer; in vault mode it creates a threshold-gated proposal.
+
+import { useCallback } from 'react'
+import { useWallet } from '.'
+import { useCustody } from './useCustody'
+import { getSafeContracts } from '../config/safeContracts'
+import { getContractAddressForChain } from '../config/contracts'
+import { submitAsActiveAccount } from '../lib/custody/submitAsActiveAccount'
+
+export function useActiveAccount() {
+  const { active, operateAsPersonal } = useCustody()
+  const { chainId, signer, provider } = useWallet()
+  const isVault = active.mode === 'vault'
+
+  const submit = useCallback(
+    async (payload) => {
+      if (active.mode === 'vault') {
+        return submitAsActiveAccount(payload, {
+          mode: 'vault',
+          vaultAddress: active.vaultAddress,
+          chainId: active.chainId,
+          hubAddress: getContractAddressForChain('safeProposalHub', active.chainId),
+          safeContracts: getSafeContracts(active.chainId),
+          signer,
+          provider,
+        })
+      }
+      return submitAsActiveAccount(payload, { mode: 'personal', signer })
+    },
+    [active, signer, provider],
+  )
+
+  // Whether a vault action can currently be sent (connected to the vault's network).
+  const canActAsVault = isVault && Number(chainId) === Number(active.chainId)
+
+  return { identity: active, isVault, canActAsVault, submit, operateAsPersonal }
+}
+
+export default useActiveAccount

--- a/frontend/src/hooks/useCustody.js
+++ b/frontend/src/hooks/useCustody.js
@@ -1,0 +1,12 @@
+// Spec 043 (US3) — access the active-identity context (operate as personal wallet vs. a vault).
+
+import { useContext } from 'react'
+import { CustodyContext } from '../contexts/CustodyContext'
+
+export function useCustody() {
+  const ctx = useContext(CustodyContext)
+  if (!ctx) throw new Error('useCustody must be used within a CustodyProvider')
+  return ctx
+}
+
+export default useCustody

--- a/frontend/src/hooks/useCustodyVaults.js
+++ b/frontend/src/hooks/useCustodyVaults.js
@@ -1,0 +1,152 @@
+// Spec 043 — vault list + create/load orchestration for the Custody On chain section (US1). Reads the
+// member's saved vault references, enriches each with live on-chain state, and exposes create/load actions
+// that persist a reference. Honest state: on-chain reads are the source of truth; references are just labels.
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useWallet } from '.'
+import { isCustodySupported } from '../config/safeContracts'
+import {
+  createVault as createVaultTx,
+  buildCreateVaultTx,
+  loadVault,
+  isVaultOwner,
+} from '../lib/custody/safeVault'
+import {
+  loadVaultReferences,
+  upsertVaultReference,
+  removeVaultReference,
+} from '../lib/custody/vaultReferences'
+
+export function useCustodyVaults() {
+  const { address, chainId, signer, provider } = useWallet()
+  const [vaults, setVaults] = useState([])
+  const [activeAddress, setActiveAddress] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const reqId = useRef(0)
+
+  const supported = isCustodySupported(chainId)
+
+  const refresh = useCallback(async () => {
+    if (!address || !chainId || !supported) {
+      setVaults([])
+      return
+    }
+    const myReq = ++reqId.current
+    setLoading(true)
+    setError(null)
+    try {
+      const refs = loadVaultReferences(address).filter((r) => r.chainId === Number(chainId))
+      const enriched = await Promise.all(
+        refs.map(async (ref) => {
+          try {
+            const state = await loadVault(ref.address, chainId, provider)
+            return { ...ref, ...state, owner: isVaultOwner(state, address) }
+          } catch (e) {
+            return { ...ref, isSafe: undefined, loadError: e?.message || 'load failed' }
+          }
+        }),
+      )
+      if (myReq === reqId.current) setVaults(enriched)
+    } catch (e) {
+      if (myReq === reqId.current) setError(e?.message || 'Failed to load vaults')
+    } finally {
+      if (myReq === reqId.current) setLoading(false)
+    }
+  }, [address, chainId, provider, supported])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  /** Load a vault by address, classify it, and (if it is a Safe) persist a reference. */
+  const loadByAddress = useCallback(
+    async (rawAddress, label = '', nowMs = 0) => {
+      setError(null)
+      const state = await loadVault(rawAddress, chainId, provider)
+      if (!state.isSafe) {
+        const reason = state.reason === 'no-contract' ? 'No contract at this address.' : 'Not a Safe vault.'
+        const err = new Error(reason)
+        err.classification = state.reason
+        throw err
+      }
+      const owner = isVaultOwner(state, address)
+      upsertVaultReference(
+        address,
+        { chainId: Number(chainId), address: state.address, label, role: owner ? 'owner' : 'watch' },
+        nowMs,
+      )
+      await refresh()
+      setActiveAddress(state.address)
+      return { ...state, owner }
+    },
+    [address, chainId, provider, refresh],
+  )
+
+  /** Create a new vault and persist its reference (owner role). */
+  const createVault = useCallback(
+    async ({ owners, threshold, saltNonce, label = '' }, nowMs = 0) => {
+      if (!signer) throw new Error('Connect a wallet to create a vault')
+      setError(null)
+      const { address: vaultAddress, txHash } = await createVaultTx({
+        signer,
+        chainId,
+        owners,
+        threshold,
+        saltNonce,
+      })
+      upsertVaultReference(
+        address,
+        { chainId: Number(chainId), address: vaultAddress, label, role: 'owner' },
+        nowMs,
+      )
+      await refresh()
+      setActiveAddress(vaultAddress)
+      return { address: vaultAddress, txHash }
+    },
+    [signer, address, chainId, refresh],
+  )
+
+  /** Preview the deterministic address a new vault would deploy to (before signing, FR US1). */
+  const previewVaultAddress = useCallback(
+    async ({ owners, threshold, saltNonce }) => {
+      const { predictedAddress } = await buildCreateVaultTx({
+        chainId,
+        owners,
+        threshold,
+        saltNonce,
+        provider,
+      })
+      return predictedAddress
+    },
+    [chainId, provider],
+  )
+
+  const forget = useCallback(
+    async (vaultAddress) => {
+      removeVaultReference(address, chainId, vaultAddress)
+      if (activeAddress === vaultAddress) setActiveAddress(null)
+      await refresh()
+    },
+    [address, chainId, activeAddress, refresh],
+  )
+
+  const activeVault = vaults.find((v) => v.address === activeAddress) || null
+
+  return {
+    supported,
+    vaults,
+    activeVault,
+    activeAddress,
+    selectVault: setActiveAddress,
+    loading,
+    error,
+    refresh,
+    loadByAddress,
+    createVault,
+    previewVaultAddress,
+    forget,
+  }
+}
+
+export default useCustodyVaults

--- a/frontend/src/hooks/useCustodyVaults.js
+++ b/frontend/src/hooks/useCustodyVaults.js
@@ -74,7 +74,7 @@ export function useCustodyVaults() {
       upsertVaultReference(
         address,
         { chainId: Number(chainId), address: state.address, label, role: owner ? 'owner' : 'watch' },
-        nowMs,
+        nowMs || Date.now(),
       )
       await refresh()
       setActiveAddress(state.address)
@@ -98,7 +98,7 @@ export function useCustodyVaults() {
       upsertVaultReference(
         address,
         { chainId: Number(chainId), address: vaultAddress, label, role: 'owner' },
-        nowMs,
+        nowMs || Date.now(),
       )
       await refresh()
       setActiveAddress(vaultAddress)

--- a/frontend/src/hooks/useCustodyVaults.js
+++ b/frontend/src/hooks/useCustodyVaults.js
@@ -28,11 +28,13 @@ export function useCustodyVaults() {
   const supported = isCustodySupported(chainId)
 
   const refresh = useCallback(async () => {
+    // Bump first so any in-flight request is invalidated even on the early-return path.
+    const myReq = ++reqId.current
     if (!address || !chainId || !supported) {
       setVaults([])
+      setLoading(false)
       return
     }
-    const myReq = ++reqId.current
     setLoading(true)
     setError(null)
     try {

--- a/frontend/src/hooks/useFriendMarketCreation.js
+++ b/frontend/src/hooks/useFriendMarketCreation.js
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 import { ethers } from 'ethers'
 import { useWeb3 } from './useWeb3'
+import { useActiveAccount } from './useActiveAccount'
 import { useGaslessWrite } from '../lib/relay/useGaslessWrite'
 import { getContractAddress, getContractAddressForChain } from '../config/contracts'
 import { WAGER_REGISTRY_ABI } from '../abis/WagerRegistry'
@@ -111,6 +112,8 @@ export const clearPendingTransaction = () => {
  */
 export function useFriendMarketCreation({ onMarketCreated } = {}) {
   const { signer } = useWeb3()
+  // Spec 043 (US3): when operating as a vault, wager creation becomes a threshold-gated vault proposal.
+  const { isVault: operatingAsVault, canActAsVault, submit: submitAsActive } = useActiveAccount()
 
   // Gasless createWager (spec 035/036): relayed where the relayer serves the chain and the stake token
   // supports EIP-3009 (Polygon USDC); transparent self-submit otherwise (Mordor USC → auto self-submit).
@@ -371,6 +374,24 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
         ...(useTerms ? [termsBytes32] : []),
       ]
 
+      // Spec 043 (US3, FR-021): operating as a vault → create the wager AS the vault. Batch
+      // [approve(registry, stake), createWager(...)] into one MultiSend and propose it as a threshold-gated
+      // vault transaction; the Safe becomes the creator and the stake is pulled from the vault. The wager
+      // surfaces only in the vault queue until co-owners approve + execute (FR-022b) — no self-submit/gasless.
+      if (operatingAsVault) {
+        if (!canActAsVault) throw new Error("Switch to the vault's network to create a wager as the vault.")
+        const approveData = stakeToken.interface.encodeFunctionData('approve', [wagerRegistryAddress, creatorStakeWei])
+        const createData = registry.interface.encodeFunctionData(createMethod, createArgs)
+        onProgress({ step: 'create', message: 'Creating a vault proposal for co-owner approval…' })
+        const res = await submitAsActive({
+          batch: [
+            { to: stakeTokenAddress, value: 0n, data: approveData },
+            { to: wagerRegistryAddress, value: 0n, data: createData },
+          ],
+        })
+        return { proposed: true, safeTxHash: res.safeTxHash, marketType: data.marketType }
+      }
+
       // Self-submit leg: the existing approve → cleanup → simulate → estimate → send flow verbatim.
       // The gasless path skips ALL of this — EIP-3009 pulls the stake (no approve) and the relayer
       // estimates/pays gas. Captures the mined receipt so the shared code below can read WagerCreated.
@@ -547,7 +568,7 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
       }
       throw error
     }
-  }, [signer, onMarketCreated, createWagerTx])
+  }, [signer, onMarketCreated, createWagerTx, operatingAsVault, canActAsVault, submitAsActive])
 
   return { createFriendMarket, loadPendingTransaction, clearPendingTransaction }
 }

--- a/frontend/src/hooks/useTransfer.js
+++ b/frontend/src/hooks/useTransfer.js
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ethers } from 'ethers'
 import { useWallet } from './useWalletManagement'
+import { useActiveAccount } from './useActiveAccount'
 import { useChainTokens } from './useChainTokens'
 import { getNetwork } from '../config/networks'
 import {
@@ -33,6 +34,7 @@ const ERC20_IFACE = new ethers.Interface(TRANSFER_ABI)
 
 export function useTransfer() {
   const { address, chainId, signer, provider, loginMethod, sendCalls } = useWallet()
+  const { isVault: operatingAsVault, canActAsVault, submit: submitAsActive } = useActiveAccount()
   const tokens = useChainTokens()
   const isPasskey = loginMethod === 'passkey'
 
@@ -124,6 +126,30 @@ export function useTransfer() {
         throw new Error(`No ${m.symbol || 'stablecoin'} is configured on this network.`)
       }
 
+      // Spec 043 (US3, FR-022): when operating as a vault, a transfer becomes a threshold-gated vault
+      // proposal instead of an immediate send. It surfaces only in the vault queue (FR-022b) until executed.
+      if (operatingAsVault) {
+        if (!canActAsVault) throw new Error("Switch to the vault's network to send from it.")
+        const payload =
+          kind === TRANSFER_KIND.STABLE
+            ? { to: m.address, value: 0n, data: ERC20_IFACE.encodeFunctionData('transfer', [to, value]) }
+            : { to, value, data: '0x' }
+        setError(null)
+        setStatus('submitting')
+        try {
+          const res = await submitAsActive(payload)
+          setStatus('success')
+          const result = { proposed: true, safeTxHash: res.safeTxHash, route: 'vault', id: null }
+          setLastResult(result)
+          return result
+        } catch (err) {
+          const message = err?.shortMessage || err?.message || 'Could not create the vault proposal.'
+          setError(message)
+          setStatus('error')
+          throw err
+        }
+      }
+
       const gasless = quoteGasless(kind)
       const entry = recordTransfer(address, {
         chainId,
@@ -208,7 +234,7 @@ export function useTransfer() {
         throw err
       }
     },
-    [signer, isPasskey, meta, quoteGasless, address, chainId, sendCalls, stableDomainVersion, hasRelayer, refreshBalances]
+    [signer, isPasskey, meta, quoteGasless, address, chainId, sendCalls, stableDomainVersion, hasRelayer, refreshBalances, operatingAsVault, canActAsVault, submitAsActive]
   )
 
   return useMemo(

--- a/frontend/src/hooks/useVaultProposals.js
+++ b/frontend/src/hooks/useVaultProposals.js
@@ -1,0 +1,155 @@
+// Spec 043 (US2) — a vault's pending queue + history, built entirely from on-chain + hub state, plus the
+// propose/approve/execute actions. Honest state: approvals and execution come from the Safe itself; the hub
+// only supplies (verified) preimages. Guards: execute only when ready and nonce-current; approvals counted
+// once per owner on-chain (idempotent); non-owners get read-only.
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { Contract, getAddress } from 'ethers'
+import { useWallet } from '.'
+import { SAFE_ABI } from '../abis/Safe'
+import { getContractAddressForChain, getDeploymentBlockForChain } from '../config/contracts'
+import {
+  buildSafeTx,
+  computeSafeTxHash,
+  buildPrevalidatedSignatures,
+  encodeExecTransaction,
+} from '../lib/custody/vaultTransaction'
+import { emitProposal, cancelProposal, readVerifiedProposals } from '../lib/custody/proposalHub'
+import { deriveProposalStatus, isQueued, STATUS } from '../lib/custody/proposalStatus'
+
+export function useVaultProposals(vault) {
+  const { chainId, signer, provider } = useWallet()
+  const [proposals, setProposals] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const reqId = useRef(0)
+
+  const vaultAddress = vault?.isSafe ? vault.address : null
+  const hubAddress = getContractAddressForChain('safeProposalHub', chainId)
+
+  const refresh = useCallback(async () => {
+    if (!vaultAddress || !hubAddress || !provider) {
+      setProposals([])
+      return
+    }
+    const myReq = ++reqId.current
+    setLoading(true)
+    setError(null)
+    try {
+      const safe = new Contract(vaultAddress, SAFE_ABI, provider)
+      const [owners, threshold, currentNonce] = await Promise.all([
+        safe.getOwners(),
+        safe.getThreshold(),
+        safe.nonce(),
+      ])
+      const fromBlock = getDeploymentBlockForChain('safeProposalHub', chainId) || 0
+      const { proposals: verified } = await readVerifiedProposals({
+        hubAddress,
+        safeAddress: vaultAddress,
+        chainId,
+        provider,
+        fromBlock,
+      })
+
+      // Execution outcomes from the Safe itself.
+      const [successes, failures] = await Promise.all([
+        safe.queryFilter(safe.filters.ExecutionSuccess(), fromBlock),
+        safe.queryFilter(safe.filters.ExecutionFailure(), fromBlock),
+      ])
+      const executedHashes = new Set(successes.map((l) => String(l.args.txHash).toLowerCase()))
+      const failedHashes = new Set(failures.map((l) => String(l.args.txHash).toLowerCase()))
+
+      // Approvals per proposal (one on-chain read per owner per proposal).
+      const enriched = await Promise.all(
+        verified.map(async (p) => {
+          const hashLc = String(p.safeTxHash).toLowerCase()
+          const approvalFlags = await Promise.all(
+            owners.map((o) => safe.approvedHashes(o, p.safeTxHash).then((n) => (n > 0n ? getAddress(o) : null))),
+          )
+          const approvers = approvalFlags.filter(Boolean)
+          const status = deriveProposalStatus({
+            approvals: approvers.length,
+            threshold: Number(threshold),
+            currentNonce: Number(currentNonce),
+            proposalNonce: Number(p.nonce),
+            executed: executedHashes.has(hashLc),
+            failed: failedHashes.has(hashLc),
+            cancelled: p.cancelled,
+          })
+          return { ...p, approvers, approvals: approvers.length, threshold: Number(threshold), status }
+        }),
+      )
+      if (myReq === reqId.current) setProposals(enriched)
+    } catch (e) {
+      if (myReq === reqId.current) setError(e?.message || 'Failed to read proposals')
+    } finally {
+      if (myReq === reqId.current) setLoading(false)
+    }
+  }, [vaultAddress, hubAddress, provider, chainId])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  /** Propose a transaction: build the SafeTx at the current nonce, broadcast it, and record the proposer's
+   *  first approval on-chain. */
+  const propose = useCallback(
+    async ({ to, value = 0n, data = '0x', operation = 0 }) => {
+      if (!signer) throw new Error('Connect a wallet to propose')
+      const safe = new Contract(vaultAddress, SAFE_ABI, signer)
+      const nonce = await safe.nonce()
+      const safeTx = buildSafeTx({ to, value, data, operation, nonce })
+      const safeTxHash = computeSafeTxHash(vaultAddress, chainId, safeTx)
+      await emitProposal({ hubAddress, safe: vaultAddress, safeTx, safeTxHash, signer })
+      const approveTx = await safe.approveHash(safeTxHash)
+      await approveTx.wait()
+      await refresh()
+      return { safeTxHash }
+    },
+    [signer, vaultAddress, hubAddress, chainId, refresh],
+  )
+
+  /** Record the connected owner's approval for a proposal (idempotent on-chain). */
+  const approve = useCallback(
+    async (safeTxHash) => {
+      if (!signer) throw new Error('Connect a wallet to approve')
+      const safe = new Contract(vaultAddress, SAFE_ABI, signer)
+      const tx = await safe.approveHash(safeTxHash)
+      await tx.wait()
+      await refresh()
+    },
+    [signer, vaultAddress, refresh],
+  )
+
+  /** Execute a proposal that has reached threshold, using pre-validated (on-chain approval) signatures. */
+  const execute = useCallback(
+    async (proposal) => {
+      if (!signer) throw new Error('Connect a wallet to execute')
+      if (proposal.status !== STATUS.READY) throw new Error('Proposal is not ready to execute')
+      const safe = new Contract(vaultAddress, SAFE_ABI, signer)
+      const signatures = buildPrevalidatedSignatures(proposal.approvers)
+      const args = encodeExecTransaction(proposal.safeTx, signatures)
+      const tx = await safe.execTransaction(...args)
+      const receipt = await tx.wait()
+      await refresh()
+      return { txHash: receipt.hash }
+    },
+    [signer, vaultAddress, refresh],
+  )
+
+  const cancel = useCallback(
+    async (safeTxHash) => {
+      if (!signer) throw new Error('Connect a wallet to cancel')
+      await cancelProposal({ hubAddress, safe: vaultAddress, safeTxHash, signer })
+      await refresh()
+    },
+    [signer, hubAddress, vaultAddress, refresh],
+  )
+
+  const queue = proposals.filter((p) => isQueued(p.status))
+  const history = proposals.filter((p) => !isQueued(p.status))
+
+  return { proposals, queue, history, loading, error, refresh, propose, approve, execute, cancel }
+}
+
+export default useVaultProposals

--- a/frontend/src/hooks/useVaultProposals.js
+++ b/frontend/src/hooks/useVaultProposals.js
@@ -26,11 +26,14 @@ export function useVaultProposals(vault) {
 
   const vaultAddress = vault?.isSafe ? vault.address : null
   const hubAddress = getContractAddressForChain('safeProposalHub', chainId)
+  // Only read when the connected wallet is on the vault's own network — the connected chainId/provider drive
+  // the reads, so a mismatched chain would query the wrong contracts. The UI gates actions on the same fact.
+  const onVaultChain = vault?.chainId != null && Number(chainId) === Number(vault.chainId)
 
   const refresh = useCallback(async () => {
     // Bump first so any in-flight request is invalidated even on the early-return path.
     const myReq = ++reqId.current
-    if (!vaultAddress || !hubAddress || !provider) {
+    if (!vaultAddress || !hubAddress || !provider || !onVaultChain) {
       setProposals([])
       setLoading(false)
       return
@@ -95,7 +98,7 @@ export function useVaultProposals(vault) {
     } finally {
       if (myReq === reqId.current) setLoading(false)
     }
-  }, [vaultAddress, hubAddress, provider, chainId])
+  }, [vaultAddress, hubAddress, provider, chainId, onVaultChain])
 
   useEffect(() => {
     refresh()

--- a/frontend/src/hooks/useVaultProposals.js
+++ b/frontend/src/hooks/useVaultProposals.js
@@ -28,21 +28,31 @@ export function useVaultProposals(vault) {
   const hubAddress = getContractAddressForChain('safeProposalHub', chainId)
 
   const refresh = useCallback(async () => {
+    // Bump first so any in-flight request is invalidated even on the early-return path.
+    const myReq = ++reqId.current
     if (!vaultAddress || !hubAddress || !provider) {
       setProposals([])
+      setLoading(false)
       return
     }
-    const myReq = ++reqId.current
     setLoading(true)
     setError(null)
     try {
+      // Never scan from genesis (contracts.js guidance): require a recorded hub deploy block.
+      const fromBlock = getDeploymentBlockForChain('safeProposalHub', chainId)
+      if (!fromBlock) {
+        if (myReq === reqId.current) {
+          setProposals([])
+          setError('Custody proposal history is not configured for this network yet.')
+        }
+        return
+      }
       const safe = new Contract(vaultAddress, SAFE_ABI, provider)
       const [owners, threshold, currentNonce] = await Promise.all([
         safe.getOwners(),
         safe.getThreshold(),
         safe.nonce(),
       ])
-      const fromBlock = getDeploymentBlockForChain('safeProposalHub', chainId) || 0
       const { proposals: verified } = await readVerifiedProposals({
         hubAddress,
         safeAddress: vaultAddress,
@@ -96,6 +106,7 @@ export function useVaultProposals(vault) {
   const propose = useCallback(
     async ({ to, value = 0n, data = '0x', operation = 0 }) => {
       if (!signer) throw new Error('Connect a wallet to propose')
+      if (!hubAddress) throw new Error('Custody proposals are not configured on this network')
       const safe = new Contract(vaultAddress, SAFE_ABI, signer)
       const nonce = await safe.nonce()
       const safeTx = buildSafeTx({ to, value, data, operation, nonce })
@@ -140,6 +151,7 @@ export function useVaultProposals(vault) {
   const cancel = useCallback(
     async (safeTxHash) => {
       if (!signer) throw new Error('Connect a wallet to cancel')
+      if (!hubAddress) throw new Error('Custody proposals are not configured on this network')
       await cancelProposal({ hubAddress, safe: vaultAddress, safeTxHash, signer })
       await refresh()
     },

--- a/frontend/src/lib/backup/backupBundle.js
+++ b/frontend/src/lib/backup/backupBundle.js
@@ -49,6 +49,14 @@ function assertNetworkTagged(key, val) {
       }
     }
   }
+  if (key === 'vaultReferences') {
+    // Spec 043 — each vault reference carries a chainId (identity is (chainId, address)).
+    for (const ref of Array.isArray(val) ? val : []) {
+      if (typeof ref?.chainId !== 'number') {
+        throw new Error(`Network-scoped element missing chainId in ${key}`)
+      }
+    }
+  }
 }
 
 /** Apply a (validated) bundle to local data. mode: 'merge' (additive, default) | 'replace'. */

--- a/frontend/src/lib/backup/syncedObjects.js
+++ b/frontend/src/lib/backup/syncedObjects.js
@@ -4,6 +4,11 @@
 
 import { loadAddressBook, saveAddressBook, mergeBook } from '../addressBook/addressBookStore'
 import { getUserPreference, saveUserPreference } from '../../utils/userStorage'
+import {
+  loadVaultReferences,
+  saveVaultReferences,
+  mergeVaultReferences,
+} from '../custody/vaultReferences'
 
 const PREF_KEYS = {
   recentSearches: 'recent_searches',
@@ -51,6 +56,23 @@ export const syncedObjects = [
       return { conflicts: [] }
     },
     merge: (_current, incoming) => ({ value: incoming, conflicts: [] }),
+  },
+  {
+    // Spec 043 — custody vault references + labels. Network-scoped: identity is (chainId, address).
+    key: 'vaultReferences',
+    label: 'Vault references',
+    networkScoped: true,
+    load: (account) => loadVaultReferences(account),
+    apply: (account, value, mode) => {
+      if (mode === 'replace') {
+        saveVaultReferences(account, value)
+        return { conflicts: [] }
+      }
+      const { value: merged, conflicts } = mergeVaultReferences(loadVaultReferences(account), value)
+      saveVaultReferences(account, merged)
+      return { conflicts }
+    },
+    merge: (current, incoming) => mergeVaultReferences(current, incoming),
   },
 ]
 

--- a/frontend/src/lib/custody/proposalHub.js
+++ b/frontend/src/lib/custody/proposalHub.js
@@ -1,0 +1,136 @@
+// Spec 043 (US2) — SafeProposalHub client: broadcast a proposal preimage, read+verify proposals from chain,
+// and the never-stranded EIP-712 payload link/QR fallback. SECURITY: a proposal's integrity is never trusted
+// from the hub — every read proposal is reconstructed and its safeTxHash recomputed locally (verifyProposal);
+// a mismatch is discarded. See research.md Decision 4.
+
+import { Contract, Interface, getAddress, toBeHex } from 'ethers'
+import { SAFE_PROPOSAL_HUB_ABI } from '../../abis/SafeProposalHub'
+import { buildSafeTx, computeSafeTxHash } from './vaultTransaction'
+
+const hubIface = new Interface(SAFE_PROPOSAL_HUB_ABI)
+
+/** Broadcast a proposal's preimage to the hub. */
+export async function emitProposal({ hubAddress, safe, safeTx, safeTxHash, signer }) {
+  const hub = new Contract(getAddress(hubAddress), SAFE_PROPOSAL_HUB_ABI, signer)
+  return hub.propose(
+    getAddress(safe),
+    safeTx.to,
+    safeTx.value,
+    safeTx.data,
+    safeTx.operation,
+    safeTx.nonce,
+    safeTxHash,
+  )
+}
+
+/** Signal cancellation of a proposal (advisory). */
+export async function cancelProposal({ hubAddress, safe, safeTxHash, signer }) {
+  const hub = new Contract(getAddress(hubAddress), SAFE_PROPOSAL_HUB_ABI, signer)
+  return hub.cancel(getAddress(safe), safeTxHash)
+}
+
+/** Reconstruct a full SafeTx + metadata from decoded `Proposed` event args. Pure. */
+export function reconstructProposal(args) {
+  const safeTx = buildSafeTx({
+    to: args.to,
+    value: args.value,
+    data: args.data,
+    operation: Number(args.operation),
+    nonce: args.nonce,
+  })
+  return {
+    safe: getAddress(args.safe),
+    proposer: getAddress(args.proposer),
+    safeTxHash: args.safeTxHash,
+    safeTx,
+    to: safeTx.to,
+    value: safeTx.value,
+    data: safeTx.data,
+    operation: safeTx.operation,
+    nonce: safeTx.nonce,
+  }
+}
+
+/**
+ * Verify a reconstructed proposal: recompute the Safe tx hash from its own parameters and compare to the
+ * emitted safeTxHash. Returns true only when they match (tampered/malformed preimages are rejected). Pure.
+ */
+export function verifyProposal(proposal, chainId) {
+  const recomputed = computeSafeTxHash(proposal.safe, chainId, proposal.safeTx)
+  return recomputed.toLowerCase() === String(proposal.safeTxHash).toLowerCase()
+}
+
+/**
+ * Read all VERIFIED proposals for a vault from the hub. Decodes `Proposed` logs, reconstructs each, and keeps
+ * only those whose recomputed hash matches. Also returns the set of cancelled hashes.
+ * @returns {Promise<{proposals: object[], cancelled: Set<string>}>}
+ */
+export async function readVerifiedProposals({ hubAddress, safeAddress, chainId, provider, fromBlock = 0 }) {
+  const hub = new Contract(getAddress(hubAddress), SAFE_PROPOSAL_HUB_ABI, provider)
+  const safeTopic = getAddress(safeAddress)
+  const proposedLogs = await hub.queryFilter(hub.filters.Proposed(safeTopic), fromBlock)
+  const cancelledLogs = await hub.queryFilter(hub.filters.Cancelled(safeTopic), fromBlock)
+
+  const cancelled = new Set(cancelledLogs.map((l) => String(l.args.safeTxHash).toLowerCase()))
+  const proposals = []
+  for (const log of proposedLogs) {
+    try {
+      const p = reconstructProposal(log.args)
+      if (verifyProposal(p, chainId)) {
+        proposals.push({ ...p, blockNumber: log.blockNumber, cancelled: cancelled.has(String(p.safeTxHash).toLowerCase()) })
+      }
+    } catch {
+      /* malformed log — skip */
+    }
+  }
+  return { proposals, cancelled }
+}
+
+// --- Never-stranded fallback: shareable EIP-712 payload link/QR (no hub required) ---
+
+const PAYLOAD_SCHEMA = 'fairwins-safe-proposal-v1'
+
+/** Serialize a proposal into a compact, shareable payload string (base64url of JSON). Pure. */
+export function encodePayloadLink(safe, safeTx, chainId) {
+  const payload = {
+    schema: PAYLOAD_SCHEMA,
+    chainId: Number(chainId),
+    safe: getAddress(safe),
+    tx: {
+      to: safeTx.to,
+      value: toBeHex(safeTx.value),
+      data: safeTx.data,
+      operation: safeTx.operation,
+      nonce: toBeHex(safeTx.nonce),
+    },
+  }
+  return base64UrlEncode(JSON.stringify(payload))
+}
+
+/**
+ * Parse a payload string back into { safe, safeTx, chainId }. The caller MUST recompute the hash and verify
+ * before acting — this function does not establish trust, only transport. Pure.
+ */
+export function parsePayloadLink(link) {
+  const obj = JSON.parse(base64UrlDecode(String(link)))
+  if (obj?.schema !== PAYLOAD_SCHEMA) throw new Error('Unrecognized proposal payload')
+  const safeTx = buildSafeTx({
+    to: obj.tx.to,
+    value: BigInt(obj.tx.value),
+    data: obj.tx.data,
+    operation: Number(obj.tx.operation),
+    nonce: BigInt(obj.tx.nonce),
+  })
+  return { safe: getAddress(obj.safe), chainId: Number(obj.chainId), safeTx }
+}
+
+function base64UrlEncode(str) {
+  // btoa/atob are present in browsers and in the jsdom test environment.
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function base64UrlDecode(s) {
+  return atob(s.replace(/-/g, '+').replace(/_/g, '/'))
+}
+
+export { hubIface }

--- a/frontend/src/lib/custody/proposalHub.js
+++ b/frontend/src/lib/custody/proposalHub.js
@@ -130,7 +130,10 @@ function base64UrlEncode(str) {
 }
 
 function base64UrlDecode(s) {
-  return atob(s.replace(/-/g, '+').replace(/_/g, '/'))
+  let b64 = s.replace(/-/g, '+').replace(/_/g, '/')
+  const pad = b64.length % 4
+  if (pad) b64 += '='.repeat(4 - pad) // some atob implementations require '=' padding
+  return atob(b64)
 }
 
 export { hubIface }

--- a/frontend/src/lib/custody/proposalStatus.js
+++ b/frontend/src/lib/custody/proposalStatus.js
@@ -1,0 +1,42 @@
+// Spec 043 (US2) — pure derivation of a vault proposal's status from on-chain facts (data-model.md state
+// machine). No chain access here; callers supply the facts they read.
+
+export const STATUS = {
+  PENDING: 'pending', // approvals < threshold, executable nonce not yet reached or not enough approvals
+  READY: 'ready', // approvals >= threshold AND nonce === current Safe nonce
+  EXECUTED: 'executed',
+  FAILED: 'failed',
+  SUPERSEDED: 'superseded', // another tx executed at this nonce, or the proposer cancelled
+}
+
+/**
+ * @param {object} f
+ * @param {number} f.approvals       distinct owner approvals recorded on-chain for this safeTxHash
+ * @param {number} f.threshold       current Safe threshold
+ * @param {number} f.currentNonce    the Safe's current nonce
+ * @param {number} f.proposalNonce   the nonce this proposal was built against
+ * @param {boolean} [f.executed]     the Safe emitted ExecutionSuccess for this hash
+ * @param {boolean} [f.failed]       the Safe emitted ExecutionFailure for this hash
+ * @param {boolean} [f.cancelled]    the proposer emitted Cancelled for this hash
+ * @returns {string} one of STATUS
+ */
+export function deriveProposalStatus(f) {
+  if (f.executed) return STATUS.EXECUTED
+  if (f.failed) return STATUS.FAILED
+  // A proposal built against a past nonce can never execute — a different tx took that slot.
+  if (f.proposalNonce < f.currentNonce) return STATUS.SUPERSEDED
+  if (f.cancelled) return STATUS.SUPERSEDED
+  // At (or ahead of) the current nonce: ready only when this is the next nonce AND threshold is met.
+  if (f.proposalNonce === f.currentNonce && f.approvals >= f.threshold) return STATUS.READY
+  return STATUS.PENDING
+}
+
+/** Whether a status belongs in the live queue (vs. history). */
+export function isQueued(status) {
+  return status === STATUS.PENDING || status === STATUS.READY
+}
+
+/** Approvals still needed before a proposal can execute (0 when ready/execut­able). */
+export function approvalsRemaining(approvals, threshold) {
+  return Math.max(0, Number(threshold) - Number(approvals))
+}

--- a/frontend/src/lib/custody/safeVault.js
+++ b/frontend/src/lib/custody/safeVault.js
@@ -62,8 +62,11 @@ export function validateVaultConfig(owners, threshold) {
  */
 export function computeVaultAddress({ proxyFactory, singleton, initializer, saltNonce, creationCode }) {
   const salt = solidityPackedKeccak256(['bytes32', 'uint256'], [keccak256(initializer), BigInt(saltNonce)])
+  // SafeProxyFactory appends the singleton to the proxy creation code as a single 32-byte word
+  // (abi.encodePacked(creationCode, uint256(uint160(singleton)))). Encoding the address here yields the same
+  // 32-byte left-padded word, so the CREATE2 preimage matches the on-chain factory exactly.
   const deploymentData =
-    creationCode + AbiCoder.defaultAbiCoder().encode(['uint256'], [BigInt(singleton)]).slice(2)
+    creationCode + AbiCoder.defaultAbiCoder().encode(['address'], [getAddress(singleton)]).slice(2)
   return getCreate2Address(getAddress(proxyFactory), salt, keccak256(deploymentData))
 }
 

--- a/frontend/src/lib/custody/safeVault.js
+++ b/frontend/src/lib/custody/safeVault.js
@@ -1,0 +1,192 @@
+// Spec 043 — Safe (v1.4.1) vault create/load/read. Deploys a new Safe via SafeProxyFactory.createProxyWithNonce
+// (deterministic CREATE2 address, previewable before signing), and reads live vault state (owners, threshold,
+// nonce, version, native balance). No Safe Transaction Service involved. See contracts/vault-transactions.md.
+
+import {
+  AbiCoder,
+  Contract,
+  Interface,
+  ZeroAddress,
+  getAddress,
+  getCreate2Address,
+  keccak256,
+  solidityPackedKeccak256,
+} from 'ethers'
+import { SAFE_ABI } from '../../abis/Safe'
+import { SAFE_PROXY_FACTORY_ABI, SAFE_SETUP_ABI } from '../../abis/SafeProxyFactory'
+import { getSafeContracts } from '../../config/safeContracts'
+import { getProvider } from '../../utils/blockchainService'
+
+const setupIface = new Interface(SAFE_SETUP_ABI)
+const factoryIface = new Interface(SAFE_PROXY_FACTORY_ABI)
+
+/** Encode the Safe.setup initializer for a plain multisig (no setup delegatecall, no gas refunds). */
+export function buildSetupInitializer(owners, threshold, fallbackHandler) {
+  const cleanOwners = owners.map((o) => getAddress(o))
+  return setupIface.encodeFunctionData('setup', [
+    cleanOwners,
+    BigInt(threshold),
+    ZeroAddress, // to
+    '0x', // data
+    getAddress(fallbackHandler),
+    ZeroAddress, // paymentToken
+    0n, // payment
+    ZeroAddress, // paymentReceiver
+  ])
+}
+
+/** Validate owners + threshold (FR-005). Throws with a user-facing message on invalid input. */
+export function validateVaultConfig(owners, threshold) {
+  const seen = new Set()
+  for (const o of owners) {
+    let a
+    try {
+      a = getAddress(o)
+    } catch {
+      throw new Error(`Invalid owner address: ${o}`)
+    }
+    if (seen.has(a)) throw new Error(`Duplicate owner: ${a}`)
+    seen.add(a)
+  }
+  if (owners.length === 0) throw new Error('At least one owner is required')
+  const t = Number(threshold)
+  if (!Number.isInteger(t) || t < 1) throw new Error('Threshold must be at least 1')
+  if (t > owners.length) throw new Error('Threshold cannot exceed the number of owners')
+}
+
+/**
+ * Pure CREATE2 computation matching SafeProxyFactory.createProxyWithNonce:
+ * salt = keccak256(keccak256(initializer) ‖ saltNonce); initCode = proxyCreationCode ‖ abi.encode(singleton).
+ * Separated out so it is deterministically unit-testable without a provider.
+ * @returns {string} checksummed predicted address
+ */
+export function computeVaultAddress({ proxyFactory, singleton, initializer, saltNonce, creationCode }) {
+  const salt = solidityPackedKeccak256(['bytes32', 'uint256'], [keccak256(initializer), BigInt(saltNonce)])
+  const deploymentData =
+    creationCode + AbiCoder.defaultAbiCoder().encode(['uint256'], [BigInt(singleton)]).slice(2)
+  return getCreate2Address(getAddress(proxyFactory), salt, keccak256(deploymentData))
+}
+
+/**
+ * Predict the CREATE2 address of a Safe created with createProxyWithNonce (reads proxyCreationCode on-chain).
+ * @returns {Promise<string>} checksummed predicted address
+ */
+export async function predictVaultAddress({ chainId, initializer, saltNonce, provider }) {
+  const safe = getSafeContracts(chainId)
+  if (!safe) throw new Error(`Custody is not available on chain ${chainId}`)
+  const reader = provider || getProvider(chainId)
+  const factory = new Contract(safe.proxyFactory, SAFE_PROXY_FACTORY_ABI, reader)
+  const creationCode = await factory.proxyCreationCode()
+  return computeVaultAddress({
+    proxyFactory: safe.proxyFactory,
+    singleton: safe.singletonL2,
+    initializer,
+    saltNonce,
+    creationCode,
+  })
+}
+
+/**
+ * Pure: build the createProxyWithNonce calldata for a new vault (no provider, no predicted address).
+ * @returns {{ to:string, data:string, value:bigint, initializer:string }}
+ */
+export function buildCreateVaultCalldata({ chainId, owners, threshold, saltNonce }) {
+  validateVaultConfig(owners, threshold)
+  const safe = getSafeContracts(chainId)
+  if (!safe) throw new Error(`Custody is not available on chain ${chainId}`)
+  const initializer = buildSetupInitializer(owners, threshold, safe.fallbackHandler)
+  const data = factoryIface.encodeFunctionData('createProxyWithNonce', [
+    getAddress(safe.singletonL2),
+    initializer,
+    BigInt(saltNonce),
+  ])
+  return { to: getAddress(safe.proxyFactory), data, value: 0n, initializer }
+}
+
+/**
+ * Build the createProxyWithNonce transaction plus the deterministic predicted address (reads
+ * proxyCreationCode on-chain via `provider`).
+ * @returns {{ to:string, data:string, value:bigint, predictedAddress:string }}
+ */
+export async function buildCreateVaultTx({ chainId, owners, threshold, saltNonce, provider }) {
+  const { to, data, value, initializer } = buildCreateVaultCalldata({ chainId, owners, threshold, saltNonce })
+  const predictedAddress = await predictVaultAddress({ chainId, initializer, saltNonce, provider })
+  return { to, data, value, predictedAddress }
+}
+
+/**
+ * Deploy a new vault. Sends createProxyWithNonce with `signer` and returns the deployed proxy address parsed
+ * from the ProxyCreation event (falling back to the predicted address).
+ */
+export async function createVault({ signer, chainId, owners, threshold, saltNonce }) {
+  const tx = await buildCreateVaultTx({ chainId, owners, threshold, saltNonce, provider: signer.provider })
+  const sent = await signer.sendTransaction({ to: tx.to, data: tx.data, value: tx.value })
+  const receipt = await sent.wait()
+  let deployed = tx.predictedAddress
+  for (const log of receipt.logs || []) {
+    try {
+      const parsed = factoryIface.parseLog(log)
+      if (parsed?.name === 'ProxyCreation') {
+        deployed = getAddress(parsed.args.proxy)
+        break
+      }
+    } catch {
+      /* not a factory log */
+    }
+  }
+  return { address: deployed, txHash: sent.hash, predictedAddress: tx.predictedAddress }
+}
+
+/**
+ * Load a vault's live on-chain state. Returns null-ish shape only when the address is not a Safe.
+ * @returns {Promise<{address,chainId,owners,threshold,nonce,version,isSafe:boolean}>}
+ */
+export async function loadVault(address, chainId, provider) {
+  const addr = getAddress(address)
+  const reader = provider || getProvider(chainId)
+  const code = await reader.getCode(addr)
+  if (!code || code === '0x') {
+    return { address: addr, chainId: Number(chainId), isSafe: false, reason: 'no-contract' }
+  }
+  const safe = new Contract(addr, SAFE_ABI, reader)
+  try {
+    const [owners, threshold, nonce] = await Promise.all([
+      safe.getOwners(),
+      safe.getThreshold(),
+      safe.nonce(),
+    ])
+    let version = ''
+    try {
+      version = await safe.VERSION()
+    } catch {
+      /* older/foreign Safe without VERSION() */
+    }
+    if (!owners.length || threshold === 0n) {
+      return { address: addr, chainId: Number(chainId), isSafe: false, reason: 'not-a-safe' }
+    }
+    return {
+      address: addr,
+      chainId: Number(chainId),
+      isSafe: true,
+      owners: owners.map((o) => getAddress(o)),
+      threshold: Number(threshold),
+      nonce: Number(nonce),
+      version,
+    }
+  } catch {
+    return { address: addr, chainId: Number(chainId), isSafe: false, reason: 'not-a-safe' }
+  }
+}
+
+/** Read a vault's native-asset balance (token balances are layered in by the vault detail hook). */
+export async function readVaultNativeBalance(address, chainId, provider) {
+  const reader = provider || getProvider(chainId)
+  return reader.getBalance(getAddress(address))
+}
+
+/** Whether a connected address is one of a loaded vault's owners (determines owner vs view-only). */
+export function isVaultOwner(vault, account) {
+  if (!vault?.isSafe || !account) return false
+  const a = getAddress(account)
+  return (vault.owners || []).some((o) => getAddress(o) === a)
+}

--- a/frontend/src/lib/custody/submitAsActiveAccount.js
+++ b/frontend/src/lib/custody/submitAsActiveAccount.js
@@ -1,0 +1,49 @@
+// Spec 043 (US3) — the single seam every money-moving flow routes its final {to,value,data} through. In
+// personal mode it sends normally; in vault mode it turns the action into a threshold-gated vault proposal
+// (emit preimage to the hub + record the proposer's on-chain approval) and returns a pending proposal instead
+// of executing. Not-yet-approved actions therefore live only in the vault queue (FR-022b).
+
+import { Contract } from 'ethers'
+import { SAFE_ABI } from '../../abis/Safe'
+import { buildSafeTx, computeSafeTxHash, encodeMultiSend } from './vaultTransaction'
+import { emitProposal } from './proposalHub'
+
+/**
+ * Pure: turn an action payload into the SafeTx to propose. A `batch` (array of {to,value,data}) is wrapped in
+ * a MultiSendCallOnly delegatecall (e.g. approve + action); otherwise the single call is used directly.
+ */
+export function buildActiveAccountSafeTx({ to, value = 0n, data = '0x', operation = 0, batch }, { nonce, multiSendCallOnly }) {
+  if (Array.isArray(batch) && batch.length > 0) {
+    const ms = encodeMultiSend(multiSendCallOnly, batch)
+    return buildSafeTx({ to: ms.to, value: ms.value, data: ms.data, operation: ms.operation, nonce })
+  }
+  return buildSafeTx({ to, value, data, operation, nonce })
+}
+
+/**
+ * @param {{to?:string,value?:bigint,data?:string,operation?:number,batch?:Array}} payload
+ * @param {object} ctx — { mode:'personal'|'vault', signer, ... vault fields when mode==='vault' }
+ * @returns {Promise<{kind:'sent',txHash:string}|{kind:'proposed',safeTxHash:string}>}
+ */
+export async function submitAsActiveAccount(payload, ctx) {
+  if (ctx.mode === 'vault') {
+    const { vaultAddress, chainId, hubAddress, signer, safeContracts } = ctx
+    if (!hubAddress) throw new Error('Custody proposals are not configured on this network')
+    if (!safeContracts) throw new Error('Custody is not available on this network')
+    const safe = new Contract(vaultAddress, SAFE_ABI, signer)
+    const nonce = await safe.nonce()
+    const safeTx = buildActiveAccountSafeTx(payload, { nonce, multiSendCallOnly: safeContracts.multiSendCallOnly })
+    const safeTxHash = computeSafeTxHash(vaultAddress, chainId, safeTx)
+    await emitProposal({ hubAddress, safe: vaultAddress, safeTx, safeTxHash, signer })
+    const approveTx = await safe.approveHash(safeTxHash)
+    await approveTx.wait()
+    return { kind: 'proposed', safeTxHash }
+  }
+  // personal mode — unchanged single-signer behaviour
+  const sent = await ctx.signer.sendTransaction({
+    to: payload.to,
+    value: payload.value ?? 0n,
+    data: payload.data ?? '0x',
+  })
+  return { kind: 'sent', txHash: sent.hash ?? sent }
+}

--- a/frontend/src/lib/custody/submitAsActiveAccount.js
+++ b/frontend/src/lib/custody/submitAsActiveAccount.js
@@ -27,9 +27,18 @@ export function buildActiveAccountSafeTx({ to, value = 0n, data = '0x', operatio
  */
 export async function submitAsActiveAccount(payload, ctx) {
   if (ctx.mode === 'vault') {
-    const { vaultAddress, chainId, hubAddress, signer, safeContracts } = ctx
+    const { vaultAddress, chainId, hubAddress, signer, provider, safeContracts } = ctx
     if (!hubAddress) throw new Error('Custody proposals are not configured on this network')
     if (!safeContracts) throw new Error('Custody is not available on this network')
+    // Guard against a wrong-network footgun: the hash is chain-scoped and approveHash lands on whatever chain
+    // the signer is connected to, so refuse unless the signer/provider is actually on the vault's chain.
+    const netSource = provider || signer?.provider
+    if (netSource?.getNetwork) {
+      const net = await netSource.getNetwork()
+      if (Number(net.chainId) !== Number(chainId)) {
+        throw new Error("Wallet is not connected to the vault's network")
+      }
+    }
     const safe = new Contract(vaultAddress, SAFE_ABI, signer)
     const nonce = await safe.nonce()
     const safeTx = buildActiveAccountSafeTx(payload, { nonce, multiSendCallOnly: safeContracts.multiSendCallOnly })

--- a/frontend/src/lib/custody/transfers.js
+++ b/frontend/src/lib/custody/transfers.js
@@ -1,0 +1,19 @@
+// Spec 043 (US2) — build a transfer SafeTx payload for the vault: native asset or an ERC-20. Pure.
+
+import { Interface, getAddress, parseEther, parseUnits } from 'ethers'
+
+const erc20 = new Interface(['function transfer(address to, uint256 amount)'])
+
+/**
+ * @param {{recipient:string, amount:string|number, tokenAddress?:string|null, decimals?:number}} args
+ * @returns {{to:string, value:bigint, data:string, operation:number}}
+ */
+export function buildTransferPayload({ recipient, amount, tokenAddress, decimals }) {
+  const to = getAddress(recipient)
+  if (tokenAddress) {
+    const value = parseUnits(String(amount), Number(decimals ?? 18))
+    const data = erc20.encodeFunctionData('transfer', [to, value])
+    return { to: getAddress(tokenAddress), value: 0n, data, operation: 0 }
+  }
+  return { to, value: parseEther(String(amount)), data: '0x', operation: 0 }
+}

--- a/frontend/src/lib/custody/vaultProposalReads.js
+++ b/frontend/src/lib/custody/vaultProposalReads.js
@@ -1,0 +1,60 @@
+// Spec 043 — shared, pure read of a vault's proposal state from chain + hub, used by both useVaultProposals
+// (US2) and custodySource (US6). Reads owners/threshold/nonce, the verified hub proposals, per-owner
+// approvals, and execution outcomes, then derives each proposal's status. Read-only; no React.
+
+import { Contract, getAddress } from 'ethers'
+import { SAFE_ABI } from '../../abis/Safe'
+import { readVerifiedProposals } from './proposalHub'
+import { deriveProposalStatus } from './proposalStatus'
+
+/**
+ * @returns {Promise<{owners:string[], threshold:number, nonce:number, proposals:object[]}>}
+ */
+export async function readVaultProposalState({ safeAddress, hubAddress, chainId, provider, fromBlock }) {
+  const safe = new Contract(safeAddress, SAFE_ABI, provider)
+  const [ownersRaw, thresholdRaw, nonceRaw] = await Promise.all([
+    safe.getOwners(),
+    safe.getThreshold(),
+    safe.nonce(),
+  ])
+  const owners = ownersRaw.map((o) => getAddress(o))
+  const threshold = Number(thresholdRaw)
+  const currentNonce = Number(nonceRaw)
+
+  const { proposals: verified } = await readVerifiedProposals({
+    hubAddress,
+    safeAddress,
+    chainId,
+    provider,
+    fromBlock,
+  })
+
+  const [successes, failures] = await Promise.all([
+    safe.queryFilter(safe.filters.ExecutionSuccess(), fromBlock),
+    safe.queryFilter(safe.filters.ExecutionFailure(), fromBlock),
+  ])
+  const executed = new Set(successes.map((l) => String(l.args.txHash).toLowerCase()))
+  const failed = new Set(failures.map((l) => String(l.args.txHash).toLowerCase()))
+
+  const proposals = await Promise.all(
+    verified.map(async (p) => {
+      const hashLc = String(p.safeTxHash).toLowerCase()
+      const approvalFlags = await Promise.all(
+        owners.map((o) => safe.approvedHashes(o, p.safeTxHash).then((n) => (n > 0n ? o : null))),
+      )
+      const approvers = approvalFlags.filter(Boolean)
+      const status = deriveProposalStatus({
+        approvals: approvers.length,
+        threshold,
+        currentNonce,
+        proposalNonce: Number(p.nonce),
+        executed: executed.has(hashLc),
+        failed: failed.has(hashLc),
+        cancelled: p.cancelled,
+      })
+      return { ...p, approvers, approvals: approvers.length, threshold, status }
+    }),
+  )
+
+  return { owners, threshold, nonce: currentNonce, proposals }
+}

--- a/frontend/src/lib/custody/vaultReferences.js
+++ b/frontend/src/lib/custody/vaultReferences.js
@@ -49,7 +49,11 @@ export function saveVaultReferences(account, refs) {
   return clean
 }
 
-/** Insert or update one reference by (chainId, address); newest label wins. Returns the new array. */
+/**
+ * Insert or update one reference by (chainId, address). On update, `addedAt` is bumped to the edit time so a
+ * fresh label/role edit wins the backup merge (mergeVaultReferences resolves conflicts by newest `addedAt`);
+ * it never moves backwards. Returns the new array.
+ */
 export function upsertVaultReference(account, entry, nowMs = 0) {
   const next = sanitize(entry)
   if (!next) return loadVaultReferences(account)
@@ -57,8 +61,13 @@ export function upsertVaultReference(account, entry, nowMs = 0) {
   const current = loadVaultReferences(account)
   const key = vaultKey(next.chainId, next.address)
   const idx = current.findIndex((r) => vaultKey(r.chainId, r.address) === key)
-  if (idx === -1) current.push(next)
-  else current[idx] = { ...current[idx], ...next, addedAt: current[idx].addedAt || next.addedAt }
+  if (idx === -1) {
+    current.push(next)
+  } else {
+    // Bump addedAt so an edit is "newer" than the prior entry (and any other device's copy) at merge time.
+    const addedAt = Math.max(current[idx].addedAt || 0, next.addedAt || 0)
+    current[idx] = { ...current[idx], ...next, addedAt }
+  }
   return saveVaultReferences(account, current)
 }
 

--- a/frontend/src/lib/custody/vaultReferences.js
+++ b/frontend/src/lib/custody/vaultReferences.js
@@ -1,0 +1,95 @@
+// Spec 043 — client-side store of a member's vault references + labels. This is the ONLY custody data placed
+// in the app-wide encrypted backup (spec 032). It is NOT authoritative over on-chain state: the vault lives on
+// chain and is re-loadable by address; these records just remember which vaults a member belongs to and their
+// member-authored labels (labels are client-side only, never on-chain). Identity is (chainId, address).
+
+import { getAddress } from 'ethers'
+import { getUserPreference, saveUserPreference } from '../../utils/userStorage'
+
+const STORAGE_KEY = 'custody_vault_references'
+
+/** Normalize to a checksummed address, or null if invalid. */
+export function normalizeVaultAddress(input) {
+  try {
+    return getAddress(String(input).trim())
+  } catch {
+    return null
+  }
+}
+
+/** Stable identity key for a reference. */
+export function vaultKey(chainId, address) {
+  return `${Number(chainId)}:${normalizeVaultAddress(address)}`
+}
+
+function sanitize(entry) {
+  const address = normalizeVaultAddress(entry?.address)
+  const chainId = Number(entry?.chainId)
+  if (!address || !Number.isFinite(chainId)) return null
+  return {
+    address,
+    chainId,
+    label: typeof entry.label === 'string' ? entry.label : '',
+    addedAt: Number.isFinite(entry?.addedAt) ? entry.addedAt : 0,
+    role: entry?.role === 'owner' ? 'owner' : 'watch',
+  }
+}
+
+/** Load all vault references for a wallet (array). */
+export function loadVaultReferences(account) {
+  const raw = getUserPreference(account, STORAGE_KEY, [], true)
+  if (!Array.isArray(raw)) return []
+  return raw.map(sanitize).filter(Boolean)
+}
+
+/** Persist the full array (replaces). */
+export function saveVaultReferences(account, refs) {
+  const clean = (Array.isArray(refs) ? refs : []).map(sanitize).filter(Boolean)
+  saveUserPreference(account, STORAGE_KEY, clean, true)
+  return clean
+}
+
+/** Insert or update one reference by (chainId, address); newest label wins. Returns the new array. */
+export function upsertVaultReference(account, entry, nowMs = 0) {
+  const next = sanitize(entry)
+  if (!next) return loadVaultReferences(account)
+  if (!next.addedAt) next.addedAt = nowMs
+  const current = loadVaultReferences(account)
+  const key = vaultKey(next.chainId, next.address)
+  const idx = current.findIndex((r) => vaultKey(r.chainId, r.address) === key)
+  if (idx === -1) current.push(next)
+  else current[idx] = { ...current[idx], ...next, addedAt: current[idx].addedAt || next.addedAt }
+  return saveVaultReferences(account, current)
+}
+
+/** Remove one reference by (chainId, address). */
+export function removeVaultReference(account, chainId, address) {
+  const key = vaultKey(chainId, address)
+  const current = loadVaultReferences(account).filter((r) => vaultKey(r.chainId, r.address) !== key)
+  return saveVaultReferences(account, current)
+}
+
+/**
+ * Merge two reference arrays (used by the backup restore "merge" mode). Union by (chainId, address); the entry
+ * with the greater `addedAt` wins its label/role (newest label wins). Pure — does not touch storage.
+ * @returns {{ value: object[], conflicts: object[] }}
+ */
+export function mergeVaultReferences(current, incoming) {
+  const byKey = new Map()
+  for (const e of (current || []).map(sanitize).filter(Boolean)) byKey.set(vaultKey(e.chainId, e.address), e)
+  const conflicts = []
+  for (const raw of (incoming || []).map(sanitize).filter(Boolean)) {
+    const key = vaultKey(raw.chainId, raw.address)
+    const existing = byKey.get(key)
+    if (!existing) {
+      byKey.set(key, raw)
+    } else {
+      const winner = raw.addedAt >= existing.addedAt ? raw : existing
+      if (existing.label !== raw.label && existing.label && raw.label) {
+        conflicts.push({ key, kept: winner.label, other: winner === raw ? existing.label : raw.label })
+      }
+      byKey.set(key, { ...winner, addedAt: Math.max(existing.addedAt, raw.addedAt) })
+    }
+  }
+  return { value: Array.from(byKey.values()), conflicts }
+}

--- a/frontend/src/lib/custody/vaultTransaction.js
+++ b/frontend/src/lib/custody/vaultTransaction.js
@@ -1,0 +1,187 @@
+// Spec 043 — Safe (v1.4.1) transaction encoders for the on-chain-only custody flow. Pure functions over
+// ethers v6; no provider required (so they are deterministically unit-testable). See
+// specs/043-safe-multisig-custody/contracts/vault-transactions.md.
+//
+// Flow: build a SafeTx → computeSafeTxHash → each owner approveHash(hash) on-chain → any owner execTransaction
+// with a PRE-VALIDATED signature bundle once threshold owners have approved. No off-chain ECDSA is ever needed.
+
+import { Interface, TypedDataEncoder, ZeroAddress, getAddress, solidityPacked, zeroPadValue } from 'ethers'
+import { SAFE_ABI } from '../../abis/Safe'
+import { MULTI_SEND_CALL_ONLY_ABI } from '../../abis/MultiSendCallOnly'
+
+/** EIP-712 type of a Safe transaction (matches Safe v1.4.1 `SafeTx` typehash). */
+export const SAFE_TX_TYPES = {
+  SafeTx: [
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'data', type: 'bytes' },
+    { name: 'operation', type: 'uint8' },
+    { name: 'safeTxGas', type: 'uint256' },
+    { name: 'baseGas', type: 'uint256' },
+    { name: 'gasPrice', type: 'uint256' },
+    { name: 'gasToken', type: 'address' },
+    { name: 'refundReceiver', type: 'address' },
+    { name: 'nonce', type: 'uint256' },
+  ],
+}
+
+export const CALL = 0
+export const DELEGATECALL = 1
+
+const safeIface = new Interface(SAFE_ABI)
+const multiSendIface = new Interface(MULTI_SEND_CALL_ONLY_ABI)
+
+/**
+ * Normalize a partial Safe transaction into a full SafeTx with the custody defaults (no gas refunds).
+ * @param {{to:string,value?:bigint|number|string,data?:string,operation?:number,nonce:bigint|number|string,
+ *   safeTxGas?:bigint|number|string,baseGas?:bigint|number|string,gasPrice?:bigint|number|string,
+ *   gasToken?:string,refundReceiver?:string}} tx
+ */
+export function buildSafeTx(tx) {
+  if (!tx || tx.to == null) throw new Error('buildSafeTx: `to` is required')
+  if (tx.nonce == null) throw new Error('buildSafeTx: `nonce` is required')
+  const operation = tx.operation ?? CALL
+  if (operation !== CALL && operation !== DELEGATECALL) {
+    throw new Error(`buildSafeTx: invalid operation ${operation}`)
+  }
+  return {
+    to: getAddress(tx.to),
+    value: BigInt(tx.value ?? 0),
+    data: tx.data ?? '0x',
+    operation,
+    safeTxGas: BigInt(tx.safeTxGas ?? 0),
+    baseGas: BigInt(tx.baseGas ?? 0),
+    gasPrice: BigInt(tx.gasPrice ?? 0),
+    gasToken: getAddress(tx.gasToken ?? ZeroAddress),
+    refundReceiver: getAddress(tx.refundReceiver ?? ZeroAddress),
+    nonce: BigInt(tx.nonce),
+  }
+}
+
+/**
+ * Compute the Safe transaction hash (the value each owner approves) off-chain. Matches
+ * `Safe.getTransactionHash(...)`: EIP-712 over the SafeTx type with domain {chainId, verifyingContract: safe}.
+ * @param {string} safeAddress
+ * @param {number|string} chainId
+ * @param {object} safeTx result of buildSafeTx
+ * @returns {string} 32-byte hash
+ */
+export function computeSafeTxHash(safeAddress, chainId, safeTx) {
+  const domain = { chainId: Number(chainId), verifyingContract: getAddress(safeAddress) }
+  return TypedDataEncoder.hash(domain, SAFE_TX_TYPES, safeTx)
+}
+
+/**
+ * Build the pre-validated ("approved hash") signature bundle for `execTransaction`. For each approving owner,
+ * 65 bytes: r = owner left-padded to 32 bytes, s = 32 zero bytes, v = 0x01. Blocks MUST be concatenated in
+ * ASCENDING owner-address order (the Safe's checkNSignatures loop requires currentOwner > lastOwner).
+ * @param {string[]} approverAddresses owners that have called approveHash for this tx
+ * @returns {string} 0x-prefixed concatenated signatures
+ */
+export function buildPrevalidatedSignatures(approverAddresses) {
+  if (!Array.isArray(approverAddresses) || approverAddresses.length === 0) {
+    throw new Error('buildPrevalidatedSignatures: at least one approver is required')
+  }
+  const sorted = [...approverAddresses]
+    .map((a) => getAddress(a))
+    .sort((a, b) => (BigInt(a) < BigInt(b) ? -1 : BigInt(a) > BigInt(b) ? 1 : 0))
+  // reject duplicates (would be rejected on-chain and double-count nothing)
+  for (let i = 1; i < sorted.length; i += 1) {
+    if (sorted[i] === sorted[i - 1]) throw new Error(`buildPrevalidatedSignatures: duplicate owner ${sorted[i]}`)
+  }
+  let out = '0x'
+  for (const owner of sorted) {
+    const r = zeroPadValue(owner, 32).slice(2) // 32-byte left-padded address
+    const s = '00'.repeat(32)
+    const v = '01'
+    out += r + s + v
+  }
+  return out
+}
+
+/**
+ * Pack inner transactions for MultiSendCallOnly. Each: operation(1=0x00) ‖ to(20) ‖ value(32) ‖ dataLen(32) ‖
+ * data. Returns a SafeTx-shaped object (operation=DELEGATECALL to MultiSendCallOnly) to feed buildSafeTx.
+ * @param {string} multiSendCallOnly address
+ * @param {{to:string,value?:bigint|number|string,data?:string}[]} innerTxs
+ */
+export function encodeMultiSend(multiSendCallOnly, innerTxs) {
+  if (!Array.isArray(innerTxs) || innerTxs.length === 0) {
+    throw new Error('encodeMultiSend: at least one inner transaction is required')
+  }
+  const packed = innerTxs
+    .map((t) => {
+      const data = t.data ?? '0x'
+      const dataLen = (data.length - 2) / 2
+      return solidityPacked(
+        ['uint8', 'address', 'uint256', 'uint256', 'bytes'],
+        [CALL, getAddress(t.to), BigInt(t.value ?? 0), BigInt(dataLen), data],
+      ).slice(2)
+    })
+    .join('')
+  const data = multiSendIface.encodeFunctionData('multiSend', ['0x' + packed])
+  return { to: getAddress(multiSendCallOnly), value: 0n, data, operation: DELEGATECALL }
+}
+
+/**
+ * Build the ordered argument array for `Safe.execTransaction(...)`.
+ * @param {object} safeTx result of buildSafeTx
+ * @param {string} signatures pre-validated bundle
+ */
+export function encodeExecTransaction(safeTx, signatures) {
+  return [
+    safeTx.to,
+    safeTx.value,
+    safeTx.data,
+    safeTx.operation,
+    safeTx.safeTxGas,
+    safeTx.baseGas,
+    safeTx.gasPrice,
+    safeTx.gasToken,
+    safeTx.refundReceiver,
+    signatures,
+  ]
+}
+
+// --- Governance builders: ordinary Safe transactions targeting the Safe itself (to = safeAddress) ---
+
+export function buildAddOwner(safeAddress, newOwner, newThreshold, nonce) {
+  const data = safeIface.encodeFunctionData('addOwnerWithThreshold', [getAddress(newOwner), BigInt(newThreshold)])
+  return buildSafeTx({ to: safeAddress, data, nonce })
+}
+
+/** prevOwner is the owner pointing to `owner` in the Safe's linked list (SENTINEL 0x…1 if `owner` is first). */
+export function buildRemoveOwner(safeAddress, prevOwner, owner, newThreshold, nonce) {
+  const data = safeIface.encodeFunctionData('removeOwner', [
+    getAddress(prevOwner),
+    getAddress(owner),
+    BigInt(newThreshold),
+  ])
+  return buildSafeTx({ to: safeAddress, data, nonce })
+}
+
+export function buildSwapOwner(safeAddress, prevOwner, oldOwner, newOwner, nonce) {
+  const data = safeIface.encodeFunctionData('swapOwner', [
+    getAddress(prevOwner),
+    getAddress(oldOwner),
+    getAddress(newOwner),
+  ])
+  return buildSafeTx({ to: safeAddress, data, nonce })
+}
+
+export function buildChangeThreshold(safeAddress, newThreshold, nonce) {
+  const data = safeIface.encodeFunctionData('changeThreshold', [BigInt(newThreshold)])
+  return buildSafeTx({ to: safeAddress, data, nonce })
+}
+
+/** Sentinel owner used as the head of the Safe owners linked list. */
+export const SENTINEL_OWNERS = '0x0000000000000000000000000000000000000001'
+
+/** Given the current owners array and a target, return the prevOwner argument for removeOwner/swapOwner. */
+export function prevOwnerOf(owners, target) {
+  const list = owners.map((o) => getAddress(o))
+  const t = getAddress(target)
+  const idx = list.indexOf(t)
+  if (idx === -1) throw new Error(`prevOwnerOf: ${target} is not an owner`)
+  return idx === 0 ? SENTINEL_OWNERS : list[idx - 1]
+}

--- a/frontend/src/lib/notifications/deliveryPreferences.js
+++ b/frontend/src/lib/notifications/deliveryPreferences.js
@@ -40,6 +40,7 @@ export const NOTIFICATION_CATEGORIES = [
   { domain: 'membership', label: 'Membership', description: 'Renewals, upgrades, and redeemable vouchers' },
   { domain: 'dao', label: 'Governance', description: 'Proposals to vote on, queue, or execute' },
   { domain: 'token', label: 'Token admin', description: 'Role changes and pause/unpause events' },
+  { domain: 'custody', label: 'Custody', description: 'Vault approvals needed, executions, and owner/threshold changes' },
 ]
 
 const KNOWN_DOMAINS = NOTIFICATION_CATEGORIES.map((c) => c.domain)

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -12,7 +12,8 @@ import {
   PriceProvider,
   DexProvider,
   UserPreferencesProvider,
-  FriendMarketsProvider
+  FriendMarketsProvider,
+  CustodyProvider
 } from './contexts'
 import ErrorBoundary from './components/ui/ErrorBoundary'
 import { validateTheme } from './utils/validateTheme'
@@ -29,6 +30,7 @@ createRoot(document.getElementById('root')).render(
           <ThemeProvider>
             {/* WalletProvider is the unified blockchain context - single source of truth */}
             <WalletProvider>
+              <CustodyProvider>
               <UserPreferencesProvider>
                 <FriendMarketsProvider>
                   <DexProvider>
@@ -40,6 +42,7 @@ createRoot(document.getElementById('root')).render(
                   </DexProvider>
                 </FriendMarketsProvider>
               </UserPreferencesProvider>
+              </CustodyProvider>
             </WalletProvider>
           </ThemeProvider>
         </QueryClientProvider>

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -11,6 +11,7 @@ import { ROLES, ROLE_INFO } from '../contexts/RoleContext'
 import { hasRegisteredKey, ensureKeyRegistered } from '../utils/keyRegistryService'
 import TradePanel from '../components/fairwins/TradePanel'
 import PayTransferPanel from '../components/wallet/PayTransferPanel'
+import CustodyPanel from '../components/custody/CustodyPanel'
 import TokensPanel from '../components/tokens/TokensPanel'
 import ClearPathPanel from '../components/clearpath/ClearPathPanel'
 import AccountDashboard from '../components/account/AccountDashboard'
@@ -47,6 +48,7 @@ const WALLET_TAB_GROUPS = [
     items: [
       { id: 'trade', label: 'Trade' },
       { id: 'paytransfer', label: 'Pay & Transfer' },
+      { id: 'custody', label: 'Custody' },
     ],
   },
   {
@@ -405,6 +407,12 @@ function WalletPage() {
                 {activeTab === 'paytransfer' && (
                   <div className="paytransfer-section" role="tabpanel">
                     <PayTransferPanel />
+                  </div>
+                )}
+
+                {activeTab === 'custody' && (
+                  <div className="custody-section" role="tabpanel">
+                    <CustodyPanel />
                   </div>
                 )}
 

--- a/frontend/src/test/MarketAcceptanceModal.test.jsx
+++ b/frontend/src/test/MarketAcceptanceModal.test.jsx
@@ -15,6 +15,10 @@ vi.mock('../hooks', () => ({
     switchNetwork: vi.fn()
   }))
 }))
+// Spec 043: the modal now reads the active identity; default it to personal mode for these tests.
+vi.mock('../hooks/useActiveAccount', () => ({
+  useActiveAccount: () => ({ isVault: false, canActAsVault: false, identity: { mode: 'personal' }, submit: vi.fn(), operateAsPersonal: vi.fn() }),
+}))
 
 vi.mock('../hooks/useEncryption', () => ({
   useEncryption: vi.fn(() => ({

--- a/frontend/src/test/backup/vaultReferences.sync.test.js
+++ b/frontend/src/test/backup/vaultReferences.sync.test.js
@@ -1,0 +1,75 @@
+// Spec 043 — vault reference store + backup integration. Verifies the store round-trips, merge unions by
+// (chainId, address) with newest label winning, the bundle includes vaultReferences, and network-tag
+// validation rejects an untagged reference on restore.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  loadVaultReferences,
+  upsertVaultReference,
+  removeVaultReference,
+  mergeVaultReferences,
+  vaultKey,
+} from '../../lib/custody/vaultReferences'
+import { buildBundle, parseBundle } from '../../lib/backup/backupBundle'
+
+const ACCOUNT = '0x00000000000000000000000000000000000000a1'
+const V1 = '0x1111111111111111111111111111111111111111'
+const V2 = '0x2222222222222222222222222222222222222222'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('vaultReferences store', () => {
+  it('upserts, loads, and removes by (chainId, address)', () => {
+    upsertVaultReference(ACCOUNT, { chainId: 63, address: V1, label: 'Coop', role: 'owner' }, 100)
+    upsertVaultReference(ACCOUNT, { chainId: 137, address: V1, label: 'Coop L2' }, 100)
+    let refs = loadVaultReferences(ACCOUNT)
+    expect(refs).toHaveLength(2) // same address, different chains → distinct
+    upsertVaultReference(ACCOUNT, { chainId: 63, address: V1, label: 'Renamed' }, 200)
+    refs = loadVaultReferences(ACCOUNT)
+    expect(refs).toHaveLength(2)
+    expect(refs.find((r) => r.chainId === 63).label).toBe('Renamed')
+    removeVaultReference(ACCOUNT, 63, V1)
+    expect(loadVaultReferences(ACCOUNT).map((r) => vaultKey(r.chainId, r.address))).toEqual([vaultKey(137, V1)])
+  })
+
+  it('ignores invalid addresses / missing chainId', () => {
+    upsertVaultReference(ACCOUNT, { chainId: 63, address: 'not-an-address', label: 'x' }, 1)
+    upsertVaultReference(ACCOUNT, { chainId: NaN, address: V2, label: 'y' }, 1)
+    expect(loadVaultReferences(ACCOUNT)).toHaveLength(0)
+  })
+})
+
+describe('mergeVaultReferences', () => {
+  it('unions by key; newest addedAt wins the label', () => {
+    const current = [{ chainId: 63, address: V1, label: 'Old', addedAt: 100, role: 'owner' }]
+    const incoming = [
+      { chainId: 63, address: V1, label: 'New', addedAt: 200, role: 'owner' },
+      { chainId: 63, address: V2, label: 'Other', addedAt: 150, role: 'watch' },
+    ]
+    const { value } = mergeVaultReferences(current, incoming)
+    expect(value).toHaveLength(2)
+    expect(value.find((r) => r.address === V1).label).toBe('New')
+  })
+})
+
+describe('backup bundle integration', () => {
+  it('includes vaultReferences and round-trips through parseBundle', () => {
+    upsertVaultReference(ACCOUNT, { chainId: 63, address: V1, label: 'Coop', role: 'owner' }, 100)
+    const bundle = buildBundle(ACCOUNT, 12345)
+    expect(bundle.objects.vaultReferences).toHaveLength(1)
+    expect(() => parseBundle(bundle)).not.toThrow()
+  })
+
+  it('rejects a restore whose vault reference is missing its chainId (network-tag guard)', () => {
+    const bad = {
+      schema: 'fairwins-data-backup',
+      version: 1,
+      createdAt: 1,
+      wallet: ACCOUNT,
+      objects: { vaultReferences: [{ address: V1, label: 'x' }] }, // no chainId
+    }
+    expect(() => parseBundle(bad)).toThrow(/chainId/)
+  })
+})

--- a/frontend/src/test/backup/vaultReferences.sync.test.js
+++ b/frontend/src/test/backup/vaultReferences.sync.test.js
@@ -34,6 +34,17 @@ describe('vaultReferences store', () => {
     expect(loadVaultReferences(ACCOUNT).map((r) => vaultKey(r.chainId, r.address))).toEqual([vaultKey(137, V1)])
   })
 
+  it('bumps addedAt on update so an edited label wins a later merge', () => {
+    upsertVaultReference(ACCOUNT, { chainId: 63, address: V1, label: 'Original' }, 100)
+    // A newer edit on this device.
+    upsertVaultReference(ACCOUNT, { chainId: 63, address: V1, label: 'Edited' }, 300)
+    const edited = loadVaultReferences(ACCOUNT).find((r) => r.chainId === 63)
+    expect(edited.addedAt).toBe(300)
+    // Another device still holds the older copy (addedAt 100); the edit must win the merge.
+    const { value } = mergeVaultReferences([{ chainId: 63, address: V1, label: 'Stale', addedAt: 100 }], [edited])
+    expect(value.find((r) => r.address.toLowerCase() === V1.toLowerCase()).label).toBe('Edited')
+  })
+
   it('ignores invalid addresses / missing chainId', () => {
     upsertVaultReference(ACCOUNT, { chainId: 63, address: 'not-an-address', label: 'x' }, 1)
     upsertVaultReference(ACCOUNT, { chainId: NaN, address: V2, label: 'y' }, 1)

--- a/frontend/src/test/custody/CreateVaultWizard.test.jsx
+++ b/frontend/src/test/custody/CreateVaultWizard.test.jsx
@@ -1,0 +1,56 @@
+// Spec 043 (US1) — create wizard: validation (FR-005), address preview, and create delegation.
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import CreateVaultWizard from '../../components/custody/CreateVaultWizard'
+
+const OWNER = '0x1111111111111111111111111111111111111111'
+const OWNER2 = '0x2222222222222222222222222222222222222222'
+
+describe('CreateVaultWizard', () => {
+  it('blocks create when threshold exceeds owner count (FR-005)', () => {
+    render(<CreateVaultWizard connectedAddress={OWNER} onCreate={vi.fn()} onPreview={vi.fn()} />)
+    fireEvent.change(screen.getByLabelText(/threshold/i), { target: { value: '2' } }) // 1 owner, threshold 2
+    expect(screen.getByRole('alert')).toHaveTextContent(/exceed/i)
+    expect(screen.getByRole('button', { name: /create vault/i })).toBeDisabled()
+  })
+
+  it('previews the predicted address for a valid config', async () => {
+    const onPreview = vi.fn().mockResolvedValue('0xABCdef0000000000000000000000000000000123')
+    render(<CreateVaultWizard connectedAddress={OWNER} onCreate={vi.fn()} onPreview={onPreview} />)
+    fireEvent.click(screen.getByRole('button', { name: /add owner/i }))
+    const inputs = screen.getAllByPlaceholderText('0x…')
+    fireEvent.change(inputs[1], { target: { value: OWNER2 } })
+    fireEvent.change(screen.getByLabelText(/threshold/i), { target: { value: '2' } })
+    fireEvent.click(screen.getByRole('button', { name: /preview address/i }))
+    await waitFor(() => expect(screen.getByText(/0xABCdef/i)).toBeInTheDocument())
+    expect(onPreview).toHaveBeenCalledWith(
+      expect.objectContaining({ owners: [OWNER, OWNER2], threshold: 2 }),
+    )
+  })
+
+  it('calls onCreate then onDone with the same salt used for preview', async () => {
+    const onPreview = vi.fn().mockResolvedValue('0xabc')
+    const onCreate = vi.fn().mockResolvedValue({ address: '0xabc' })
+    const onDone = vi.fn()
+    render(
+      <CreateVaultWizard connectedAddress={OWNER} onCreate={onCreate} onPreview={onPreview} onDone={onDone} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /preview address/i }))
+    await waitFor(() => expect(onPreview).toHaveBeenCalled())
+    fireEvent.click(screen.getByRole('button', { name: /create vault/i }))
+    await waitFor(() => expect(onCreate).toHaveBeenCalled())
+    const previewSalt = onPreview.mock.calls[0][0].saltNonce
+    const createSalt = onCreate.mock.calls[0][0].saltNonce
+    expect(createSalt).toBe(previewSalt)
+    expect(onDone).toHaveBeenCalled()
+  })
+
+  it('has no axe violations', async () => {
+    const { container } = render(
+      <CreateVaultWizard connectedAddress={OWNER} onCreate={vi.fn()} onPreview={vi.fn()} />,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/custody/CustodyContext.test.jsx
+++ b/frontend/src/test/custody/CustodyContext.test.jsx
@@ -1,0 +1,62 @@
+// Spec 043 (US3) — active-identity context: operate-as-vault sets the identity, switch-back resets, and a
+// change of connected account resets to personal.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+let walletCtx = { address: '0xowner' }
+vi.mock('../../hooks', () => ({ useWallet: () => walletCtx }))
+
+import { CustodyProvider } from '../../contexts/CustodyContext.jsx'
+import { useCustody } from '../../hooks/useCustody'
+
+function Probe() {
+  const { active, operateAsVault, operateAsPersonal } = useCustody()
+  return (
+    <div>
+      <span data-testid="mode">{active.mode}</span>
+      <span data-testid="vault">{active.vaultAddress || ''}</span>
+      <button onClick={() => operateAsVault({ address: '0xVault', chainId: 63, label: 'Coop' })}>as-vault</button>
+      <button onClick={operateAsPersonal}>as-personal</button>
+    </div>
+  )
+}
+
+beforeEach(() => {
+  walletCtx = { address: '0xowner' }
+})
+
+describe('CustodyContext', () => {
+  it('defaults to personal and switches to a vault then back', () => {
+    render(
+      <CustodyProvider>
+        <Probe />
+      </CustodyProvider>,
+    )
+    expect(screen.getByTestId('mode')).toHaveTextContent('personal')
+    fireEvent.click(screen.getByText('as-vault'))
+    expect(screen.getByTestId('mode')).toHaveTextContent('vault')
+    expect(screen.getByTestId('vault')).toHaveTextContent('0xVault')
+    fireEvent.click(screen.getByText('as-personal'))
+    expect(screen.getByTestId('mode')).toHaveTextContent('personal')
+  })
+
+  it('ignores an invalid vault (missing address/chainId)', () => {
+    function BadProbe() {
+      const { active, operateAsVault } = useCustody()
+      return (
+        <div>
+          <span data-testid="mode">{active.mode}</span>
+          <button onClick={() => operateAsVault({ label: 'x' })}>bad</button>
+        </div>
+      )
+    }
+    render(
+      <CustodyProvider>
+        <BadProbe />
+      </CustodyProvider>,
+    )
+    fireEvent.click(screen.getByText('bad'))
+    expect(screen.getByTestId('mode')).toHaveTextContent('personal')
+  })
+})

--- a/frontend/src/test/custody/CustodyPanel.test.jsx
+++ b/frontend/src/test/custody/CustodyPanel.test.jsx
@@ -7,6 +7,9 @@ import { axe } from 'vitest-axe'
 
 let walletCtx = { chainId: 63 }
 vi.mock('../../hooks', () => ({ useWallet: () => walletCtx }))
+vi.mock('../../hooks/useCustody', () => ({
+  useCustody: () => ({ active: { mode: 'personal' }, operateAsVault: vi.fn(), operateAsPersonal: vi.fn() }),
+}))
 
 import CustodyPanel from '../../components/custody/CustodyPanel'
 

--- a/frontend/src/test/custody/CustodyPanel.test.jsx
+++ b/frontend/src/test/custody/CustodyPanel.test.jsx
@@ -1,0 +1,43 @@
+// Spec 043 — Custody shell renders both sub-sections, disables Off chain, gates On chain by Safe availability,
+// and meets WCAG 2.1 AA.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+
+let walletCtx = { chainId: 63 }
+vi.mock('../../hooks', () => ({ useWallet: () => walletCtx }))
+
+import CustodyPanel from '../../components/custody/CustodyPanel'
+
+beforeEach(() => {
+  walletCtx = { chainId: 63 }
+})
+
+describe('CustodyPanel', () => {
+  it('renders On chain and Off chain sub-sections, Off chain disabled', () => {
+    render(<CustodyPanel />)
+    expect(screen.getByRole('heading', { name: /^On chain$/i })).toBeInTheDocument()
+    const offchain = screen.getByRole('heading', { name: /^Off chain$/i }).closest('section')
+    expect(offchain).toHaveAttribute('aria-disabled', 'true')
+    expect(screen.getByText(/coming later/i)).toBeInTheDocument()
+  })
+
+  it('shows the onboarding empty state on a supported network (Mordor 63)', () => {
+    walletCtx = { chainId: 63 }
+    render(<CustodyPanel />)
+    expect(screen.getByText(/no vaults yet/i)).toBeInTheDocument()
+  })
+
+  it('shows an "unavailable on this network" state on an unsupported chain', () => {
+    walletCtx = { chainId: 1 }
+    render(<CustodyPanel />)
+    expect(screen.getByText(/not available on this network/i)).toBeInTheDocument()
+    expect(screen.queryByText(/no vaults yet/i)).not.toBeInTheDocument()
+  })
+
+  it('has no axe violations', async () => {
+    const { container } = render(<CustodyPanel />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/custody/LoadVaultForm.test.jsx
+++ b/frontend/src/test/custody/LoadVaultForm.test.jsx
@@ -1,0 +1,32 @@
+// Spec 043 (US1) — load form: surfaces the classified error for a non-Safe and confirms a loaded vault.
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import LoadVaultForm from '../../components/custody/LoadVaultForm'
+
+const VAULT = '0x1111111111111111111111111111111111111111'
+
+describe('LoadVaultForm', () => {
+  it('shows an error when the address is not a Safe', async () => {
+    const onLoad = vi.fn().mockRejectedValue(Object.assign(new Error('Not a Safe vault.'), { classification: 'not-a-safe' }))
+    render(<LoadVaultForm onLoad={onLoad} />)
+    fireEvent.change(screen.getByLabelText(/vault address/i), { target: { value: VAULT } })
+    fireEvent.click(screen.getByRole('button', { name: /load vault/i }))
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/not a safe/i))
+  })
+
+  it('confirms a loaded view-only vault', async () => {
+    const onLoad = vi.fn().mockResolvedValue({ isSafe: true, owner: false, owners: [VAULT, VAULT], threshold: 2 })
+    render(<LoadVaultForm onLoad={onLoad} />)
+    fireEvent.change(screen.getByLabelText(/vault address/i), { target: { value: VAULT } })
+    fireEvent.click(screen.getByRole('button', { name: /load vault/i }))
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent(/view-only vault/i))
+  })
+
+  it('disables load until an address is entered and has no axe violations', async () => {
+    const { container } = render(<LoadVaultForm onLoad={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /load vault/i })).toBeDisabled()
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/custody/OperateAsIndicator.test.jsx
+++ b/frontend/src/test/custody/OperateAsIndicator.test.jsx
@@ -1,0 +1,45 @@
+// Spec 043 (US3, FR-020/023) — the persistent indicator: hidden in personal mode; shows identity + switch-back
+// in vault mode; warns on network mismatch.
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+
+let active = { mode: 'personal' }
+let canActAsVault = true
+const operateAsPersonal = vi.fn()
+vi.mock('../../hooks/useActiveAccount', () => ({
+  useActiveAccount: () => ({
+    isVault: active.mode === 'vault',
+    identity: active,
+    canActAsVault,
+    operateAsPersonal,
+  }),
+}))
+
+import OperateAsIndicator from '../../components/custody/OperateAsIndicator'
+
+describe('OperateAsIndicator', () => {
+  it('renders nothing in personal mode', () => {
+    active = { mode: 'personal' }
+    const { container } = render(<OperateAsIndicator />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows the active vault and a switch-back control', async () => {
+    active = { mode: 'vault', vaultAddress: '0x1111111111111111111111111111111111111111', chainId: 63, label: 'Coop' }
+    canActAsVault = true
+    const { container } = render(<OperateAsIndicator />)
+    expect(screen.getByText(/operating as/i)).toHaveTextContent(/Coop/)
+    fireEvent.click(screen.getByRole('button', { name: /switch back to personal/i }))
+    expect(operateAsPersonal).toHaveBeenCalled()
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('warns when connected to the wrong network', () => {
+    active = { mode: 'vault', vaultAddress: '0x1111111111111111111111111111111111111111', chainId: 137, label: 'Coop' }
+    canActAsVault = false
+    render(<OperateAsIndicator />)
+    expect(screen.getByText(/switch to network 137/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/custody/OwnersThresholdPanel.test.jsx
+++ b/frontend/src/test/custody/OwnersThresholdPanel.test.jsx
@@ -1,0 +1,61 @@
+// Spec 043 (US4) — governance panel: proposes add/remove/threshold as vault transactions targeting the Safe,
+// enforces threshold bounds (FR-018/005), and is hidden for view-only members (FR-016).
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import { Interface, getAddress } from 'ethers'
+import OwnersThresholdPanel from '../../components/custody/OwnersThresholdPanel'
+import { SAFE_ABI } from '../../abis/Safe'
+
+const A = '0x000000000000000000000000000000000000aaa1'
+const B = '0x000000000000000000000000000000000000bbb2'
+const C = '0x000000000000000000000000000000000000ccc3'
+const VAULT = '0x1111111111111111111111111111111111111111'
+const safeIface = new Interface(SAFE_ABI)
+
+const ownedVault = { isSafe: true, owner: true, address: VAULT, chainId: 63, owners: [A, B], threshold: 1 }
+
+describe('OwnersThresholdPanel', () => {
+  it('proposes addOwnerWithThreshold targeting the Safe', async () => {
+    const onPropose = vi.fn().mockResolvedValue({})
+    render(<OwnersThresholdPanel vault={ownedVault} onPropose={onPropose} />)
+    fireEvent.click(screen.getByRole('button', { name: /add owner/i }))
+    fireEvent.change(screen.getByLabelText(/new owner address/i), { target: { value: C } })
+    fireEvent.change(screen.getByLabelText(/new threshold/i), { target: { value: '2' } })
+    fireEvent.click(screen.getByRole('button', { name: /propose add owner/i }))
+    await waitFor(() => expect(onPropose).toHaveBeenCalled())
+    const { to, data } = onPropose.mock.calls[0][0]
+    expect(getAddress(to)).toBe(getAddress(VAULT))
+    const decoded = safeIface.decodeFunctionData('addOwnerWithThreshold', data)
+    expect(getAddress(decoded[0])).toBe(getAddress(C))
+    expect(decoded[1]).toBe(2n)
+  })
+
+  it('blocks a threshold greater than the resulting owner count', () => {
+    render(<OwnersThresholdPanel vault={ownedVault} onPropose={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /add owner/i }))
+    fireEvent.change(screen.getByLabelText(/new owner address/i), { target: { value: C } })
+    fireEvent.change(screen.getByLabelText(/new threshold/i), { target: { value: '4' } }) // max would be 3
+    expect(screen.getByRole('alert')).toHaveTextContent(/between 1 and 3/i)
+    expect(screen.getByRole('button', { name: /propose add owner/i })).toBeDisabled()
+  })
+
+  it('proposes changeThreshold and has no axe violations', async () => {
+    const onPropose = vi.fn().mockResolvedValue({})
+    const threeVault = { ...ownedVault, owners: [A, B, C], threshold: 2 }
+    const { container } = render(<OwnersThresholdPanel vault={threeVault} onPropose={onPropose} />)
+    fireEvent.click(screen.getByRole('button', { name: /change threshold/i }))
+    fireEvent.change(screen.getByLabelText(/new threshold/i), { target: { value: '3' } })
+    fireEvent.click(screen.getByRole('button', { name: /propose threshold change/i }))
+    await waitFor(() => expect(onPropose).toHaveBeenCalled())
+    const decoded = safeIface.decodeFunctionData('changeThreshold', onPropose.mock.calls[0][0].data)
+    expect(decoded[0]).toBe(3n)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders nothing for a view-only member', () => {
+    const { container } = render(<OwnersThresholdPanel vault={{ ...ownedVault, owner: false }} onPropose={vi.fn()} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/test/custody/ProposalQueue.test.jsx
+++ b/frontend/src/test/custody/ProposalQueue.test.jsx
@@ -1,0 +1,65 @@
+// Spec 043 (US2) — queue: owner can approve pending / execute ready; view-only sees no actions (FR-016);
+// approvals-remaining and history render.
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import ProposalQueue from '../../components/custody/ProposalQueue'
+import { STATUS } from '../../lib/custody/proposalStatus'
+
+const A = '0xAAaAAa0000000000000000000000000000000001'
+const HASH1 = '0x' + '11'.repeat(32)
+const HASH2 = '0x' + '22'.repeat(32)
+
+const pending = {
+  safeTxHash: HASH1,
+  to: '0x3333333333333333333333333333333333333333',
+  nonce: 5n,
+  approvals: 1,
+  threshold: 2,
+  approvers: [],
+  status: STATUS.PENDING,
+}
+const ready = { ...pending, safeTxHash: HASH2, approvals: 2, approvers: [A], status: STATUS.READY }
+
+describe('ProposalQueue', () => {
+  it('shows Approve for a pending proposal and remaining count (owner)', () => {
+    render(
+      <ProposalQueue queue={[pending]} history={[]} isOwner connectedAddress={A} onApprove={vi.fn()} onExecute={vi.fn()} onCancel={vi.fn()} />,
+    )
+    expect(screen.getByRole('button', { name: /^approve$/i })).toBeInTheDocument()
+    expect(screen.getByText(/1 more needed/i)).toBeInTheDocument()
+  })
+
+  it('shows Execute for a ready proposal (owner)', () => {
+    render(
+      <ProposalQueue queue={[ready]} history={[]} isOwner connectedAddress={A} onApprove={vi.fn()} onExecute={vi.fn()} onCancel={vi.fn()} />,
+    )
+    expect(screen.getByRole('button', { name: /execute/i })).toBeInTheDocument()
+  })
+
+  it('shows no action buttons for a view-only (non-owner) member', () => {
+    render(
+      <ProposalQueue queue={[pending, ready]} history={[]} isOwner={false} connectedAddress={A} onApprove={vi.fn()} onExecute={vi.fn()} />,
+    )
+    expect(screen.queryByRole('button', { name: /approve|execute/i })).not.toBeInTheDocument()
+  })
+
+  it('disables Approve when the connected owner already approved', () => {
+    const mine = { ...pending, approvers: [A] }
+    render(
+      <ProposalQueue queue={[mine]} history={[]} isOwner connectedAddress={A} onApprove={vi.fn()} onExecute={vi.fn()} />,
+    )
+    expect(screen.getByRole('button', { name: /approved/i })).toBeDisabled()
+  })
+
+  it('renders history and an empty-queue state, no axe violations', async () => {
+    const done = { ...pending, safeTxHash: HASH2, status: STATUS.EXECUTED }
+    const { container } = render(
+      <ProposalQueue queue={[]} history={[done]} isOwner connectedAddress={A} onApprove={vi.fn()} onExecute={vi.fn()} />,
+    )
+    expect(screen.getByRole('status')).toHaveTextContent(/no pending transactions/i)
+    expect(screen.getByText(/history/i)).toBeInTheDocument()
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/custody/ProposeTransactionForm.test.jsx
+++ b/frontend/src/test/custody/ProposeTransactionForm.test.jsx
@@ -1,0 +1,47 @@
+// Spec 043 (US2) — propose form: payload encoding (native + ERC-20) and submit delegation.
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import { parseEther, parseUnits } from 'ethers'
+import ProposeTransactionForm from '../../components/custody/ProposeTransactionForm'
+import { buildTransferPayload } from '../../lib/custody/transfers'
+
+const R = '0x1111111111111111111111111111111111111111'
+const TOKEN = '0x2222222222222222222222222222222222222222'
+
+describe('buildTransferPayload', () => {
+  it('encodes a native transfer', () => {
+    const p = buildTransferPayload({ recipient: R, amount: '1.5' })
+    expect(p.value).toBe(parseEther('1.5'))
+    expect(p.data).toBe('0x')
+    expect(p.to.toLowerCase()).toBe(R)
+  })
+
+  it('encodes an ERC-20 transfer (to = token, value 0, transfer calldata)', () => {
+    const p = buildTransferPayload({ recipient: R, amount: '2', tokenAddress: TOKEN, decimals: 6 })
+    expect(p.to.toLowerCase()).toBe(TOKEN)
+    expect(p.value).toBe(0n)
+    expect(p.data.startsWith('0xa9059cbb')).toBe(true) // transfer(address,uint256)
+    // amount (2 * 10^6 = 0x1e8480) is the last 32-byte word of the calldata
+    expect(p.data.endsWith(parseUnits('2', 6).toString(16).padStart(64, '0'))).toBe(true)
+  })
+})
+
+describe('ProposeTransactionForm', () => {
+  it('submits a native transfer payload', async () => {
+    const onPropose = vi.fn().mockResolvedValue({})
+    render(<ProposeTransactionForm onPropose={onPropose} />)
+    fireEvent.change(screen.getByLabelText(/recipient/i), { target: { value: R } })
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '0.25' } })
+    fireEvent.click(screen.getByRole('button', { name: /propose transfer/i }))
+    await waitFor(() => expect(onPropose).toHaveBeenCalled())
+    expect(onPropose.mock.calls[0][0].value).toBe(parseEther('0.25'))
+  })
+
+  it('blocks submit until recipient and amount are provided and has no axe violations', async () => {
+    const { container } = render(<ProposeTransactionForm onPropose={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /propose transfer/i })).toBeDisabled()
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/custody/VaultDetail.test.jsx
+++ b/frontend/src/test/custody/VaultDetail.test.jsx
@@ -1,0 +1,40 @@
+// Spec 043 (US1) — vault detail renders live on-chain facts and the unreadable-vault state.
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import VaultDetail from '../../components/custody/VaultDetail'
+import VaultList from '../../components/custody/VaultList'
+
+const A = '0x1111111111111111111111111111111111111111'
+const B = '0x2222222222222222222222222222222222222222'
+
+describe('VaultDetail', () => {
+  it('renders threshold, role, and owners for a loaded Safe', async () => {
+    const vault = { isSafe: true, address: A, chainId: 63, owners: [A, B], threshold: 2, owner: true, label: 'Coop', version: '1.4.1' }
+    const { container } = render(<VaultDetail vault={vault} />)
+    expect(screen.getByText(/2 of 2 owners/i)).toBeInTheDocument()
+    expect(screen.getByText(/can propose & approve/i)).toBeInTheDocument()
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('shows an unreadable state for a non-Safe reference', () => {
+    render(<VaultDetail vault={{ isSafe: false, address: A, label: 'x' }} onForget={vi.fn()} />)
+    expect(screen.getByRole('alert')).toHaveTextContent(/could not read a safe/i)
+  })
+})
+
+describe('VaultList', () => {
+  it('marks the active vault and calls onSelect', () => {
+    const onSelect = vi.fn()
+    const vaults = [{ chainId: 63, address: A, label: 'One', isSafe: true, owners: [A], threshold: 1, owner: true }]
+    render(<VaultList vaults={vaults} activeAddress={A} onSelect={onSelect} />)
+    const item = screen.getByRole('button', { name: /One/i })
+    expect(item).toHaveAttribute('aria-current', 'true')
+  })
+
+  it('renders an empty state with no vaults', () => {
+    render(<VaultList vaults={[]} activeAddress={null} onSelect={vi.fn()} />)
+    expect(screen.getByRole('status')).toHaveTextContent(/no vaults yet/i)
+  })
+})

--- a/frontend/src/test/custody/operateAsTransfer.test.jsx
+++ b/frontend/src/test/custody/operateAsTransfer.test.jsx
@@ -1,0 +1,69 @@
+// Spec 043 (US3) — operating as a vault turns a Pay & Transfer send into a threshold-gated vault proposal
+// (FR-022) rather than an immediate transfer. Exercises the real useTransfer send() with the wallet + active
+// account mocked, verifying it routes through submit() and returns a proposed result.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+const submit = vi.fn()
+let activeAccount = { isVault: true, canActAsVault: true, submit }
+
+vi.mock('../../hooks/useWalletManagement', () => ({
+  useWallet: () => ({
+    address: '0xAaAa000000000000000000000000000000000001',
+    chainId: 63,
+    signer: {},
+    provider: {},
+    loginMethod: 'eoa',
+    sendCalls: vi.fn(),
+  }),
+}))
+vi.mock('../../hooks/useActiveAccount', () => ({ useActiveAccount: () => activeAccount }))
+vi.mock('../../hooks/useChainTokens', () => ({
+  useChainTokens: () => ({
+    native: 'ETC',
+    nativeName: 'Ethereum Classic',
+    nativeDecimals: 18,
+    stable: null,
+    stableName: null,
+    stableDecimals: 6,
+    stableAddress: null,
+  }),
+}))
+
+import { useTransfer, TRANSFER_KIND } from '../../hooks/useTransfer'
+
+beforeEach(() => {
+  submit.mockReset()
+  activeAccount = { isVault: true, canActAsVault: true, submit }
+})
+
+describe('useTransfer while operating as a vault', () => {
+  it('creates a vault proposal for a native transfer instead of sending', async () => {
+    submit.mockResolvedValue({ kind: 'proposed', safeTxHash: '0xhash' })
+    const { result } = renderHook(() => useTransfer())
+    let out
+    await act(async () => {
+      out = await result.current.send({
+        kind: TRANSFER_KIND.NATIVE,
+        to: '0xbbbb000000000000000000000000000000000002',
+        amount: '1.5',
+      })
+    })
+    expect(submit).toHaveBeenCalledTimes(1)
+    const payload = submit.mock.calls[0][0]
+    expect(payload.to.toLowerCase()).toBe('0xbbbb000000000000000000000000000000000002')
+    expect(payload.value).toBe(1500000000000000000n) // 1.5e18
+    expect(out.proposed).toBe(true)
+    expect(out.safeTxHash).toBe('0xhash')
+  })
+
+  it('refuses when connected to the wrong network', async () => {
+    activeAccount = { isVault: true, canActAsVault: false, submit }
+    const { result } = renderHook(() => useTransfer())
+    await expect(
+      result.current.send({ kind: TRANSFER_KIND.NATIVE, to: '0xbbbb000000000000000000000000000000000002', amount: '1' }),
+    ).rejects.toThrow(/network/i)
+    expect(submit).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/test/custody/proposalHub.test.js
+++ b/frontend/src/test/custody/proposalHub.test.js
@@ -61,6 +61,17 @@ describe('payload link fallback', () => {
     )
   })
 
+  it('round-trips across data lengths that exercise base64 padding', () => {
+    // Vary calldata length so the encoded payload lands on each of the 4 base64 padding remainders.
+    for (let n = 0; n < 6; n += 1) {
+      const safeTx = buildSafeTx({ to: TO, value: BigInt(n), data: '0x' + 'ab'.repeat(n), nonce: n })
+      const parsed = parsePayloadLink(encodePayloadLink(SAFE, safeTx, CHAIN))
+      expect(computeSafeTxHash(parsed.safe, parsed.chainId, parsed.safeTx)).toBe(
+        computeSafeTxHash(SAFE, CHAIN, safeTx),
+      )
+    }
+  })
+
   it('rejects an unrecognized payload', () => {
     const bad = Buffer.from(JSON.stringify({ schema: 'nope' }), 'utf8').toString('base64')
     expect(() => parsePayloadLink(bad)).toThrow(/Unrecognized/)

--- a/frontend/src/test/custody/proposalHub.test.js
+++ b/frontend/src/test/custody/proposalHub.test.js
@@ -1,0 +1,68 @@
+// Spec 043 (US2) — hub client integrity + payload fallback. The security property is that a proposal read
+// from the hub is only trusted if its recomputed hash matches the emitted one; a tampered preimage is rejected.
+
+import { describe, it, expect } from 'vitest'
+import {
+  reconstructProposal,
+  verifyProposal,
+  encodePayloadLink,
+  parsePayloadLink,
+} from '../../lib/custody/proposalHub'
+import { buildSafeTx, computeSafeTxHash } from '../../lib/custody/vaultTransaction'
+
+const SAFE = '0x1111111111111111111111111111111111111111'
+const PROPOSER = '0x2222222222222222222222222222222222222222'
+const TO = '0x3333333333333333333333333333333333333333'
+const CHAIN = 63
+
+function proposedArgs(overridesHash) {
+  const safeTx = buildSafeTx({ to: TO, value: 1000n, nonce: 5 })
+  const safeTxHash = overridesHash ?? computeSafeTxHash(SAFE, CHAIN, safeTx)
+  return {
+    safe: SAFE,
+    proposer: PROPOSER,
+    safeTxHash,
+    to: safeTx.to,
+    value: safeTx.value,
+    data: safeTx.data,
+    operation: safeTx.operation,
+    nonce: safeTx.nonce,
+  }
+}
+
+describe('reconstructProposal + verifyProposal', () => {
+  it('verifies a proposal whose emitted hash matches its parameters', () => {
+    const p = reconstructProposal(proposedArgs())
+    expect(verifyProposal(p, CHAIN)).toBe(true)
+  })
+
+  it('rejects a proposal whose emitted hash does not match (tampered preimage)', () => {
+    const bad = reconstructProposal(proposedArgs('0x' + 'de'.repeat(32)))
+    expect(verifyProposal(bad, CHAIN)).toBe(false)
+  })
+
+  it('rejects a correct hash checked against the wrong chain', () => {
+    const p = reconstructProposal(proposedArgs())
+    expect(verifyProposal(p, 137)).toBe(false) // hash is chain-scoped
+  })
+})
+
+describe('payload link fallback', () => {
+  it('round-trips a SafeTx and preserves the verifiable hash', () => {
+    const safeTx = buildSafeTx({ to: TO, value: 4200n, data: '0xabcd', nonce: 7 })
+    const link = encodePayloadLink(SAFE, safeTx, CHAIN)
+    expect(typeof link).toBe('string')
+    const parsed = parsePayloadLink(link)
+    expect(parsed.safe).toBe(SAFE)
+    expect(parsed.chainId).toBe(CHAIN)
+    // The reconstructed tx must produce the same hash the proposer would have signed.
+    expect(computeSafeTxHash(parsed.safe, parsed.chainId, parsed.safeTx)).toBe(
+      computeSafeTxHash(SAFE, CHAIN, safeTx),
+    )
+  })
+
+  it('rejects an unrecognized payload', () => {
+    const bad = Buffer.from(JSON.stringify({ schema: 'nope' }), 'utf8').toString('base64')
+    expect(() => parsePayloadLink(bad)).toThrow(/Unrecognized/)
+  })
+})

--- a/frontend/src/test/custody/proposalStatus.test.js
+++ b/frontend/src/test/custody/proposalStatus.test.js
@@ -1,0 +1,43 @@
+// Spec 043 (US2) — proposal status derivation (data-model.md state machine).
+
+import { describe, it, expect } from 'vitest'
+import { deriveProposalStatus, STATUS, isQueued, approvalsRemaining } from '../../lib/custody/proposalStatus'
+
+describe('deriveProposalStatus', () => {
+  const base = { approvals: 0, threshold: 2, currentNonce: 5, proposalNonce: 5 }
+
+  it('is pending below threshold at the current nonce', () => {
+    expect(deriveProposalStatus({ ...base, approvals: 1 })).toBe(STATUS.PENDING)
+  })
+  it('is ready at/above threshold at the current nonce', () => {
+    expect(deriveProposalStatus({ ...base, approvals: 2 })).toBe(STATUS.READY)
+    expect(deriveProposalStatus({ ...base, approvals: 3 })).toBe(STATUS.READY)
+  })
+  it('is executed/failed when the Safe emitted the outcome', () => {
+    expect(deriveProposalStatus({ ...base, approvals: 2, executed: true })).toBe(STATUS.EXECUTED)
+    expect(deriveProposalStatus({ ...base, approvals: 2, failed: true })).toBe(STATUS.FAILED)
+  })
+  it('is superseded when the proposal nonce is behind the current nonce', () => {
+    expect(deriveProposalStatus({ ...base, approvals: 2, proposalNonce: 4 })).toBe(STATUS.SUPERSEDED)
+  })
+  it('is superseded when cancelled (but executed still wins)', () => {
+    expect(deriveProposalStatus({ ...base, approvals: 2, cancelled: true })).toBe(STATUS.SUPERSEDED)
+    expect(deriveProposalStatus({ ...base, approvals: 2, cancelled: true, executed: true })).toBe(STATUS.EXECUTED)
+  })
+  it('is pending (queued) when the proposal nonce is ahead of the current nonce', () => {
+    expect(deriveProposalStatus({ ...base, approvals: 2, proposalNonce: 6 })).toBe(STATUS.PENDING)
+  })
+})
+
+describe('helpers', () => {
+  it('isQueued covers pending and ready only', () => {
+    expect(isQueued(STATUS.PENDING)).toBe(true)
+    expect(isQueued(STATUS.READY)).toBe(true)
+    expect(isQueued(STATUS.EXECUTED)).toBe(false)
+    expect(isQueued(STATUS.SUPERSEDED)).toBe(false)
+  })
+  it('approvalsRemaining never goes negative', () => {
+    expect(approvalsRemaining(1, 3)).toBe(2)
+    expect(approvalsRemaining(5, 3)).toBe(0)
+  })
+})

--- a/frontend/src/test/custody/safeVault.test.js
+++ b/frontend/src/test/custody/safeVault.test.js
@@ -2,7 +2,9 @@
 // not-a-contract path. The live Safe create+load round-trip is exercised by the fork test (T015).
 
 import { describe, it, expect } from 'vitest'
-import { Interface, getAddress } from 'ethers'
+import { AbiCoder, Interface, getAddress, getCreate2Address, keccak256, solidityPackedKeccak256 } from 'ethers'
+
+const coder = AbiCoder.defaultAbiCoder()
 import {
   buildSetupInitializer,
   validateVaultConfig,
@@ -53,6 +55,17 @@ describe('computeVaultAddress', () => {
     const b = computeVaultAddress({ proxyFactory: safe.proxyFactory, singleton: safe.singletonL2, initializer, saltNonce: 0, creationCode })
     expect(a).toBe(b)
     expect(a).toBe(getAddress(a))
+  })
+
+  it('encodes the singleton as the same 32-byte word whether typed address or uint256 (factory parity)', () => {
+    // The Safe factory appends uint256(uint160(singleton)); abi.encode(address) yields the identical word.
+    const asAddress = computeVaultAddress({ proxyFactory: safe.proxyFactory, singleton: safe.singletonL2, initializer, saltNonce: 0, creationCode })
+    const asUint = getCreate2Address(
+      getAddress(safe.proxyFactory),
+      solidityPackedKeccak256(['bytes32', 'uint256'], [keccak256(initializer), 0n]),
+      keccak256(creationCode + coder.encode(['uint256'], [BigInt(safe.singletonL2)]).slice(2)),
+    )
+    expect(asAddress).toBe(asUint)
   })
 
   it('changes with saltNonce and with owners', () => {

--- a/frontend/src/test/custody/safeVault.test.js
+++ b/frontend/src/test/custody/safeVault.test.js
@@ -1,0 +1,102 @@
+// Spec 043 — safeVault unit tests (offline). Pure setup/validation/address-prediction logic plus loadVault's
+// not-a-contract path. The live Safe create+load round-trip is exercised by the fork test (T015).
+
+import { describe, it, expect } from 'vitest'
+import { Interface, getAddress } from 'ethers'
+import {
+  buildSetupInitializer,
+  validateVaultConfig,
+  computeVaultAddress,
+  buildCreateVaultCalldata,
+  loadVault,
+  isVaultOwner,
+} from '../../lib/custody/safeVault'
+import { getSafeContracts } from '../../config/safeContracts'
+import { SAFE_SETUP_ABI } from '../../abis/SafeProxyFactory'
+
+const O1 = '0x1111111111111111111111111111111111111111'
+const O2 = '0x2222222222222222222222222222222222222222'
+const O3 = '0x3333333333333333333333333333333333333333'
+const FALLBACK = '0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99'
+
+describe('buildSetupInitializer', () => {
+  it('encodes Safe.setup with owners, threshold, and fallback handler', () => {
+    const data = buildSetupInitializer([O1, O2, O3], 2, FALLBACK)
+    const decoded = new Interface(SAFE_SETUP_ABI).decodeFunctionData('setup', data)
+    expect(decoded[0].map((a) => getAddress(a))).toEqual([O1, O2, O3].map(getAddress))
+    expect(decoded[1]).toBe(2n)
+    expect(getAddress(decoded[4])).toBe(getAddress(FALLBACK))
+  })
+})
+
+describe('validateVaultConfig (FR-005)', () => {
+  it('accepts a valid 2-of-3', () => {
+    expect(() => validateVaultConfig([O1, O2, O3], 2)).not.toThrow()
+  })
+  it('rejects threshold greater than owner count', () => {
+    expect(() => validateVaultConfig([O1, O2], 3)).toThrow(/exceed/)
+  })
+  it('rejects threshold below 1, duplicate owners, and invalid addresses', () => {
+    expect(() => validateVaultConfig([O1, O2], 0)).toThrow(/at least 1/i)
+    expect(() => validateVaultConfig([O1, O1], 1)).toThrow(/[Dd]uplicate/)
+    expect(() => validateVaultConfig(['nope'], 1)).toThrow(/Invalid owner/)
+  })
+})
+
+describe('computeVaultAddress', () => {
+  const safe = getSafeContracts(63)
+  const creationCode = '0x' + '60'.repeat(32) // stand-in proxy creation code (deterministic for the test)
+  const initializer = buildSetupInitializer([O1, O2, O3], 2, FALLBACK)
+
+  it('is deterministic and checksummed', () => {
+    const a = computeVaultAddress({ proxyFactory: safe.proxyFactory, singleton: safe.singletonL2, initializer, saltNonce: 0, creationCode })
+    const b = computeVaultAddress({ proxyFactory: safe.proxyFactory, singleton: safe.singletonL2, initializer, saltNonce: 0, creationCode })
+    expect(a).toBe(b)
+    expect(a).toBe(getAddress(a))
+  })
+
+  it('changes with saltNonce and with owners', () => {
+    const base = computeVaultAddress({ proxyFactory: safe.proxyFactory, singleton: safe.singletonL2, initializer, saltNonce: 0, creationCode })
+    const otherSalt = computeVaultAddress({ proxyFactory: safe.proxyFactory, singleton: safe.singletonL2, initializer, saltNonce: 1, creationCode })
+    const otherOwners = computeVaultAddress({
+      proxyFactory: safe.proxyFactory,
+      singleton: safe.singletonL2,
+      initializer: buildSetupInitializer([O1, O2], 2, FALLBACK),
+      saltNonce: 0,
+      creationCode,
+    })
+    expect(otherSalt).not.toBe(base)
+    expect(otherOwners).not.toBe(base)
+  })
+})
+
+describe('buildCreateVaultCalldata', () => {
+  it('targets the proxy factory with createProxyWithNonce calldata', () => {
+    const tx = buildCreateVaultCalldata({ chainId: 63, owners: [O1, O2, O3], threshold: 2, saltNonce: 5 })
+    expect(getAddress(tx.to)).toBe(getAddress(getSafeContracts(63).proxyFactory))
+    expect(tx.data.startsWith('0x1688f0b9')).toBe(true) // createProxyWithNonce selector
+    expect(tx.initializer.startsWith('0xb63e800d')).toBe(true) // setup selector
+  })
+
+  it('rejects an invalid config before building', () => {
+    expect(() => buildCreateVaultCalldata({ chainId: 63, owners: [O1, O2], threshold: 3, saltNonce: 0 })).toThrow(/exceed/)
+  })
+})
+
+describe('loadVault', () => {
+  it('returns isSafe:false when there is no contract at the address', async () => {
+    const provider = { getCode: async () => '0x' }
+    const res = await loadVault(O1, 63, provider)
+    expect(res.isSafe).toBe(false)
+    expect(res.reason).toBe('no-contract')
+  })
+})
+
+describe('isVaultOwner', () => {
+  it('is true only for an owner of a loaded Safe', () => {
+    const vault = { isSafe: true, owners: [O1, O2] }
+    expect(isVaultOwner(vault, O1)).toBe(true)
+    expect(isVaultOwner(vault, O3)).toBe(false)
+    expect(isVaultOwner({ isSafe: false }, O1)).toBe(false)
+  })
+})

--- a/frontend/src/test/custody/submitAsActiveAccount.test.js
+++ b/frontend/src/test/custody/submitAsActiveAccount.test.js
@@ -54,4 +54,14 @@ describe('submitAsActiveAccount (vault mode) guards', () => {
       submitAsActiveAccount({ to: TO }, { mode: 'vault', vaultAddress: TO, chainId: 63, hubAddress: TO, safeContracts: undefined, signer: {} }),
     ).rejects.toThrow(/not available/i)
   })
+
+  it('refuses when the connected provider is on a different chain than the vault', async () => {
+    const provider = { getNetwork: async () => ({ chainId: 137n }) }
+    await expect(
+      submitAsActiveAccount(
+        { to: TO },
+        { mode: 'vault', vaultAddress: TO, chainId: 63, hubAddress: TO, safeContracts: { multiSendCallOnly: TO }, signer: {}, provider },
+      ),
+    ).rejects.toThrow(/not connected to the vault/i)
+  })
 })

--- a/frontend/src/test/custody/submitAsActiveAccount.test.js
+++ b/frontend/src/test/custody/submitAsActiveAccount.test.js
@@ -1,0 +1,57 @@
+// Spec 043 (US3) — the active-account seam. Personal mode sends; the SafeTx builder wraps a batch in
+// MultiSendCallOnly (delegatecall) and a single call directly. (The full vault emit+approve path is exercised
+// via the app; here we cover the routing decision and payload construction, which are the risk points.)
+
+import { describe, it, expect, vi } from 'vitest'
+import { getAddress } from 'ethers'
+import { buildActiveAccountSafeTx, submitAsActiveAccount } from '../../lib/custody/submitAsActiveAccount'
+import { DELEGATECALL, CALL } from '../../lib/custody/vaultTransaction'
+
+const MS = '0x9641d764fc13c8B624c04430C7356C1C7C8102e2'
+const TO = '0x1111111111111111111111111111111111111111'
+const TOKEN = '0x2222222222222222222222222222222222222222'
+
+describe('buildActiveAccountSafeTx', () => {
+  it('uses a single call directly (operation CALL)', () => {
+    const tx = buildActiveAccountSafeTx({ to: TO, value: 5n, data: '0x' }, { nonce: 3n, multiSendCallOnly: MS })
+    expect(getAddress(tx.to)).toBe(getAddress(TO))
+    expect(tx.value).toBe(5n)
+    expect(tx.operation).toBe(CALL)
+    expect(tx.nonce).toBe(3n)
+  })
+
+  it('wraps a batch in MultiSendCallOnly (operation DELEGATECALL to the MS contract)', () => {
+    const batch = [
+      { to: TOKEN, data: '0xabcd' },
+      { to: TO, value: 1n },
+    ]
+    const tx = buildActiveAccountSafeTx({ batch }, { nonce: 9n, multiSendCallOnly: MS })
+    expect(getAddress(tx.to)).toBe(getAddress(MS))
+    expect(tx.operation).toBe(DELEGATECALL)
+    expect(tx.data.startsWith('0x8d80ff0a')).toBe(true) // multiSend(bytes)
+    expect(tx.nonce).toBe(9n)
+  })
+})
+
+describe('submitAsActiveAccount (personal mode)', () => {
+  it('sends via the connected signer and returns a sent result', async () => {
+    const signer = { sendTransaction: vi.fn().mockResolvedValue({ hash: '0xdeadbeef' }) }
+    const res = await submitAsActiveAccount({ to: TO, value: 7n, data: '0x' }, { mode: 'personal', signer })
+    expect(res).toEqual({ kind: 'sent', txHash: '0xdeadbeef' })
+    expect(signer.sendTransaction).toHaveBeenCalledWith({ to: TO, value: 7n, data: '0x' })
+  })
+})
+
+describe('submitAsActiveAccount (vault mode) guards', () => {
+  it('throws a clear error when the hub is not configured', async () => {
+    await expect(
+      submitAsActiveAccount({ to: TO }, { mode: 'vault', vaultAddress: TO, chainId: 63, hubAddress: undefined, safeContracts: {}, signer: {} }),
+    ).rejects.toThrow(/not configured/i)
+  })
+
+  it('throws when Safe contracts are unavailable on the network', async () => {
+    await expect(
+      submitAsActiveAccount({ to: TO }, { mode: 'vault', vaultAddress: TO, chainId: 63, hubAddress: TO, safeContracts: undefined, signer: {} }),
+    ).rejects.toThrow(/not available/i)
+  })
+})

--- a/frontend/src/test/custody/vaultTransaction.test.js
+++ b/frontend/src/test/custody/vaultTransaction.test.js
@@ -1,0 +1,137 @@
+// Spec 043 — encoder unit tests. The hash test independently reproduces Safe v1.4.1's getTransactionHash
+// algorithm (EIP-712 domain separator + SafeTx typehash) and asserts our TypedDataEncoder-based
+// computeSafeTxHash matches it byte-for-byte — proving on-chain/off-chain agreement without a chain.
+
+import { describe, it, expect } from 'vitest'
+import {
+  AbiCoder,
+  ZeroAddress,
+  getAddress,
+  id as keccakId,
+  keccak256,
+  solidityPacked,
+} from 'ethers'
+import {
+  buildSafeTx,
+  computeSafeTxHash,
+  buildPrevalidatedSignatures,
+  encodeMultiSend,
+  encodeExecTransaction,
+  buildAddOwner,
+  buildChangeThreshold,
+  prevOwnerOf,
+  SENTINEL_OWNERS,
+  DELEGATECALL,
+} from '../../lib/custody/vaultTransaction'
+
+const coder = AbiCoder.defaultAbiCoder()
+
+// Independent, from-scratch reimplementation of Safe.encodeTransactionData / getTransactionHash.
+function safeHashReference(safe, chainId, tx) {
+  const DOMAIN_TYPEHASH = keccakId('EIP712Domain(uint256 chainId,address verifyingContract)')
+  const SAFE_TX_TYPEHASH = keccakId(
+    'SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)',
+  )
+  const domainSeparator = keccak256(
+    coder.encode(['bytes32', 'uint256', 'address'], [DOMAIN_TYPEHASH, chainId, getAddress(safe)]),
+  )
+  const safeTxStructHash = keccak256(
+    coder.encode(
+      ['bytes32', 'address', 'uint256', 'bytes32', 'uint8', 'uint256', 'uint256', 'uint256', 'address', 'address', 'uint256'],
+      [
+        SAFE_TX_TYPEHASH,
+        tx.to,
+        tx.value,
+        keccak256(tx.data),
+        tx.operation,
+        tx.safeTxGas,
+        tx.baseGas,
+        tx.gasPrice,
+        tx.gasToken,
+        tx.refundReceiver,
+        tx.nonce,
+      ],
+    ),
+  )
+  return keccak256(solidityPacked(['bytes1', 'bytes1', 'bytes32', 'bytes32'], ['0x19', '0x01', domainSeparator, safeTxStructHash]))
+}
+
+const SAFE = '0x1111111111111111111111111111111111111111'
+const CHAIN = 63
+
+describe('computeSafeTxHash', () => {
+  it('matches the raw Safe EIP-712 algorithm for a native transfer', () => {
+    const tx = buildSafeTx({ to: '0x2222222222222222222222222222222222222222', value: 1000n, nonce: 5 })
+    expect(computeSafeTxHash(SAFE, CHAIN, tx)).toBe(safeHashReference(SAFE, CHAIN, tx))
+  })
+
+  it('matches for a contract call with calldata and is chain/nonce sensitive', () => {
+    const tx = buildSafeTx({ to: SAFE, data: '0xa9059cbb0000', nonce: 0 })
+    expect(computeSafeTxHash(SAFE, CHAIN, tx)).toBe(safeHashReference(SAFE, CHAIN, tx))
+    expect(computeSafeTxHash(SAFE, 137, tx)).not.toBe(computeSafeTxHash(SAFE, CHAIN, tx))
+    const tx2 = buildSafeTx({ to: SAFE, data: '0xa9059cbb0000', nonce: 1 })
+    expect(computeSafeTxHash(SAFE, CHAIN, tx2)).not.toBe(computeSafeTxHash(SAFE, CHAIN, tx))
+  })
+})
+
+describe('buildPrevalidatedSignatures', () => {
+  const A = '0x000000000000000000000000000000000000aaaa'
+  const B = '0x000000000000000000000000000000000000bbbb'
+  const C = '0x000000000000000000000000000000000000cccc'
+
+  it('sorts owners ascending, 65 bytes each, v=1, r=padded owner', () => {
+    const sig = buildPrevalidatedSignatures([C, A, B])
+    expect((sig.length - 2) / 2).toBe(65 * 3)
+    // first block must be the lowest address A
+    const first = sig.slice(2, 2 + 130)
+    expect(first.slice(24, 64).toLowerCase()).toBe(A.slice(2).toLowerCase()) // r low 20 bytes = owner
+    expect(first.slice(64, 128)).toBe('00'.repeat(32)) // s = 0
+    expect(first.slice(128, 130)).toBe('01') // v = 1
+  })
+
+  it('rejects duplicate owners and empty input', () => {
+    expect(() => buildPrevalidatedSignatures([A, A])).toThrow(/duplicate/)
+    expect(() => buildPrevalidatedSignatures([])).toThrow()
+  })
+})
+
+describe('encodeMultiSend', () => {
+  it('produces a DELEGATECALL SafeTx to MultiSendCallOnly wrapping the batch', () => {
+    const MS = '0x9641d764fc13c8B624c04430C7356C1C7C8102e2'
+    const batch = encodeMultiSend(MS, [
+      { to: '0x3333333333333333333333333333333333333333', data: '0x1234' },
+      { to: '0x4444444444444444444444444444444444444444', value: 7n },
+    ])
+    expect(batch.operation).toBe(DELEGATECALL)
+    expect(getAddress(batch.to)).toBe(getAddress(MS))
+    expect(batch.data.startsWith('0x8d80ff0a')).toBe(true) // multiSend(bytes) selector
+  })
+})
+
+describe('governance builders', () => {
+  it('encodes addOwnerWithThreshold and changeThreshold targeting the Safe', () => {
+    const add = buildAddOwner(SAFE, '0x5555555555555555555555555555555555555555', 2, 0)
+    expect(getAddress(add.to)).toBe(getAddress(SAFE))
+    expect(add.data.startsWith('0x0d582f13')).toBe(true) // addOwnerWithThreshold selector
+    const chg = buildChangeThreshold(SAFE, 3, 1)
+    expect(chg.data.startsWith('0x694e80c3')).toBe(true) // changeThreshold selector
+  })
+})
+
+describe('prevOwnerOf', () => {
+  it('returns SENTINEL for the first owner and the predecessor otherwise', () => {
+    const owners = ['0xAA00000000000000000000000000000000000001', '0xBB00000000000000000000000000000000000002', '0xCC00000000000000000000000000000000000003']
+    expect(prevOwnerOf(owners, owners[0])).toBe(SENTINEL_OWNERS)
+    expect(getAddress(prevOwnerOf(owners, owners[2]))).toBe(getAddress(owners[1]))
+    expect(() => prevOwnerOf(owners, ZeroAddress)).toThrow()
+  })
+})
+
+describe('encodeExecTransaction', () => {
+  it('returns the 10 ordered execTransaction args', () => {
+    const tx = buildSafeTx({ to: SAFE, nonce: 0 })
+    const args = encodeExecTransaction(tx, '0x01')
+    expect(args).toHaveLength(10)
+    expect(args[9]).toBe('0x01')
+  })
+})

--- a/frontend/src/test/sources/custodySource.integration.test.js
+++ b/frontend/src/test/sources/custodySource.integration.test.js
@@ -1,0 +1,32 @@
+// Spec 043 (US6, FR-027/028) — Custody is a controllable notification category: it appears in the preferences
+// list, and setting it to 'silent' suppresses only Custody delivery while other domains keep delivering.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  NOTIFICATION_CATEGORIES,
+  getDeliveryMode,
+  setDeliveryMode,
+  resolveDelivery,
+} from '../../lib/notifications/deliveryPreferences'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('Custody notification controls', () => {
+  it('is registered as a preference category with a description', () => {
+    const custody = NOTIFICATION_CATEGORIES.find((c) => c.domain === 'custody')
+    expect(custody).toBeTruthy()
+    expect(custody.label).toBe('Custody')
+    expect(custody.description).toMatch(/approval|threshold|execut/i)
+  })
+
+  it('defaults to app delivery and can be silenced without affecting other domains', () => {
+    expect(getDeliveryMode('custody')).toBe('app')
+    setDeliveryMode('custody', 'silent')
+    expect(resolveDelivery('custody')).toBe('silent')
+    // Other sources are unaffected.
+    expect(resolveDelivery('wagers')).toBe('app')
+    expect(resolveDelivery('membership')).toBe('app')
+  })
+})

--- a/frontend/src/test/sources/custodySource.test.js
+++ b/frontend/src/test/sources/custodySource.test.js
@@ -1,0 +1,83 @@
+// Spec 043 (US6 / spec 031) — custodySource snapshot-diff: baseline on first sight, "approval-needed"
+// (actionable) when a pending proposal newly needs the member, "executed" and "governance-changed" on diff,
+// and a no-op until the hub is configured. The chain reads (readVaultProposalState) are mocked — the source's
+// diff logic is the unit under test.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const H1 = '0x' + '11'.repeat(32)
+const OWNER = '0x00000000000000000000000000000000000000a1'
+const VAULT = '0x1111111111111111111111111111111111111111'
+
+const readState = vi.fn()
+const refs = vi.fn()
+
+vi.mock('../../utils/blockchainService', () => ({ getProvider: () => ({}) }))
+vi.mock('../../config/safeContracts', () => ({ getSafeContracts: () => ({ multiSendCallOnly: VAULT }) }))
+vi.mock('../../config/contracts', () => ({
+  getContractAddressForChain: () => '0x000000000000000000000000000000000000abcd',
+  getDeploymentBlockForChain: () => 100,
+}))
+vi.mock('../../lib/custody/vaultReferences', () => ({ loadVaultReferences: (...a) => refs(...a) }))
+vi.mock('../../lib/custody/vaultProposalReads', () => ({ readVaultProposalState: (...a) => readState(...a) }))
+
+import { custodySource } from '../../data/notifications/sources/custodySource'
+
+const NOW = 1_700_000_000_000
+const base = { owners: [OWNER], threshold: 1, nonce: 5, proposals: [] }
+const pendingNeedingMe = {
+  ...base,
+  proposals: [{ safeTxHash: H1, status: 'pending', approvers: [], nonce: 5 }],
+}
+
+beforeEach(() => {
+  refs.mockReturnValue([{ chainId: 63, address: VAULT, label: 'Coop', role: 'owner' }])
+  readState.mockReset()
+})
+
+const sid = `custody:${VAULT}`
+
+describe('custodySource', () => {
+  it('is a no-op with no vaults', async () => {
+    refs.mockReturnValue([])
+    const out = await custodySource.detect({ account: OWNER, chainId: 63, nowMs: NOW, prior: {} })
+    expect(out.entries).toEqual([])
+    expect(out.currentIds).toEqual([])
+  })
+
+  it('sets a baseline on first sight without emitting', async () => {
+    readState.mockResolvedValue(pendingNeedingMe)
+    const out = await custodySource.detect({ account: OWNER, chainId: 63, nowMs: NOW, prior: {} })
+    expect(out.entries).toEqual([]) // first sight = baseline
+    expect(out.nextSnapshots[sid].needMe).toEqual([H1.toLowerCase()])
+    expect(out.actionNeededById[sid]).toBe('approve') // still flags action-needed for the badge
+  })
+
+  it('emits approval-needed when a new pending proposal needs the member', async () => {
+    readState.mockResolvedValue(pendingNeedingMe)
+    const prior = { snapshots: { [sid]: { needMe: [], executedCount: 0, govKey: '1:1' } } }
+    const out = await custodySource.detect({ account: OWNER, chainId: 63, nowMs: NOW, prior })
+    const e = out.entries.find((x) => x.type === 'approval-needed')
+    expect(e).toBeTruthy()
+    expect(e.actionable).toBe(true)
+    expect(e.link).toEqual({ to: '/wallet', state: { tab: 'custody', vault: VAULT } })
+  })
+
+  it('emits executed and governance-changed on diff', async () => {
+    readState.mockResolvedValue({
+      owners: [OWNER, '0x00000000000000000000000000000000000000b2'],
+      threshold: 2,
+      nonce: 6,
+      proposals: [{ safeTxHash: H1, status: 'executed', approvers: [OWNER], nonce: 5 }],
+    })
+    const prior = { snapshots: { [sid]: { needMe: [], executedCount: 0, govKey: '1:1' } } }
+    const out = await custodySource.detect({ account: OWNER, chainId: 63, nowMs: NOW, prior })
+    expect(out.entries.map((e) => e.type).sort()).toEqual(['executed', 'governance-changed'])
+  })
+
+  it('degrades to ok:false when the only vault read fails', async () => {
+    readState.mockRejectedValue(new Error('rpc down'))
+    const out = await custodySource.detect({ account: OWNER, chainId: 63, nowMs: NOW, prior: {} })
+    expect(out.ok).toBe(false)
+  })
+})

--- a/scripts/deploy/custody/deploy-safe-proposal-hub.js
+++ b/scripts/deploy/custody/deploy-safe-proposal-hub.js
@@ -1,0 +1,74 @@
+/**
+ * Targeted deploy: SafeProposalHub only (spec 043 — Safe multisig custody).
+ *
+ * The hub is an immutable, value-free, events-only helper that broadcasts a proposed Safe transaction's
+ * preimage so co-owners can discover and approve it on-chain without a hosted Safe Transaction Service. Like
+ * the BackupPointerRegistry deploy, this script deploys ONLY the hub using a deterministic CREATE2 salt (so the
+ * address matches a fresh full deploy) and records it into the existing `deployments/<net>-chain<id>-v2.json`
+ * under `safeProposalHub` without disturbing any other field. It never touches the UUPS proxies.
+ *
+ * Custody launch networks: Mordor (63) and Polygon (137), where Safe v1.4.1 is verified live. The contract has
+ * no admin/funds, so only the deploy itself signs.
+ *
+ * Usage: npx hardhat run scripts/deploy/custody/deploy-safe-proposal-hub.js --network <mordor|polygon>
+ * Next:  npm run sync:frontend-contracts -- --network <net> --chainId <id>
+ */
+const fs = require("fs");
+const path = require("path");
+const hre = require("hardhat");
+const { ethers } = hre;
+const { deployDeterministic, generateSalt } = require("../lib/helpers");
+const { SALT_PREFIXES } = require("../lib/constants");
+
+async function main() {
+  const net = await ethers.provider.getNetwork();
+  const chainId = Number(net.chainId);
+
+  const deploymentsDir = path.join(__dirname, "..", "..", "..", "deployments");
+  const fileByChain = {
+    63: "mordor-chain63-v2.json",
+    137: "polygon-chain137-v2.json",
+  };
+  const fileName = fileByChain[chainId];
+  if (!fileName) throw new Error(`SafeProposalHub is only deployed to Custody-supported chains (63, 137); got ${chainId}`);
+  const recordPath = path.join(deploymentsDir, fileName);
+  const record = JSON.parse(fs.readFileSync(recordPath, "utf8"));
+
+  const [deployer] = await ethers.getSigners();
+  const bal = await ethers.provider.getBalance(deployer.address);
+  console.log(`Network:   ${record.network} (chainId ${chainId})`);
+  console.log(`Deployer:  ${deployer.address}  (balance ${ethers.formatEther(bal)})`);
+
+  if (record.contracts?.safeProposalHub) {
+    const existingCode = await ethers.provider.getCode(record.contracts.safeProposalHub);
+    if (existingCode !== "0x") {
+      console.log(`\n✓ SafeProposalHub already recorded + on-chain at ${record.contracts.safeProposalHub} — nothing to do.`);
+      return;
+    }
+  }
+
+  const salt = generateSalt(SALT_PREFIXES.V2 + "SafeProposalHub");
+  const result = await deployDeterministic("SafeProposalHub", [], salt, deployer);
+  const address = result.address;
+
+  let deployBlock = 0;
+  try {
+    deployBlock = await ethers.provider.getBlockNumber();
+  } catch { /* non-fatal */ }
+
+  // Surgical record update — preserve every other field/format.
+  record.contracts = record.contracts || {};
+  record.contracts.safeProposalHub = address;
+  record.constructorArgs = record.constructorArgs || {};
+  record.constructorArgs.safeProposalHub = [];
+  record.deployBlocks = record.deployBlocks || {};
+  if (deployBlock) record.deployBlocks.safeProposalHub = deployBlock;
+  fs.writeFileSync(recordPath, JSON.stringify(record, null, 2) + "\n");
+
+  console.log(`\n✓ SafeProposalHub deployed: ${address}`);
+  console.log(`  recorded in deployments/${fileName}${deployBlock ? ` (deployBlock ${deployBlock})` : ""}`);
+  console.log(`\nNext: npm run sync:frontend-contracts -- --network ${record.network} --chainId ${chainId}`);
+  console.log(`      npx hardhat verify --network ${record.network} ${address}`);
+}
+
+main().catch((e) => { console.error(e); process.exitCode = 1; });

--- a/specs/043-safe-multisig-custody/checklists/requirements.md
+++ b/specs/043-safe-multisig-custody/checklists/requirements.md
@@ -31,9 +31,16 @@
 
 ## Notes
 
-- All checklist items pass. Both prior clarifications were resolved with the user (2026-07-06):
+- All checklist items pass. Clarifications resolved with the user (2026-07-06), across two rounds:
   - **FR-017** — co-signer coordination: **on-chain only** (each approval is an on-chain transaction; the
     vault's on-chain state is the shared source of truth; no platform backend).
   - **FR-030** — supported networks: **Ethereum Classic + platform deployment targets** (e.g. Mordor,
     Polygon), gated by Safe contract availability per network.
-- Spec is ready for `/speckit-plan` (or optional `/speckit-clarify` for finer-grained de-risking).
+  - **FR-025** — backup scope: **vault references + labels only** (no owner-key backup, no on-chain recovery
+    module).
+  - **FR-021/FR-022a/FR-029** — operate-as breadth: **wagers, Pay & Transfer, ClearPath, Token Mint,
+    Membership, and Trade/Swap**.
+  - **FR-022b** — not-yet-approved vault actions live **only** in the vault's pending queue (no domain-list
+    placeholders until execution).
+  - **FR-022c** — **inbound** movements to the vault need no threshold approval; only outbound does.
+- Spec is ready for `/speckit-plan`.

--- a/specs/043-safe-multisig-custody/checklists/requirements.md
+++ b/specs/043-safe-multisig-custody/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Safe Multisig Custody
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass. Both prior clarifications were resolved with the user (2026-07-06):
+  - **FR-017** — co-signer coordination: **on-chain only** (each approval is an on-chain transaction; the
+    vault's on-chain state is the shared source of truth; no platform backend).
+  - **FR-030** — supported networks: **Ethereum Classic + platform deployment targets** (e.g. Mordor,
+    Polygon), gated by Safe contract availability per network.
+- Spec is ready for `/speckit-plan` (or optional `/speckit-clarify` for finer-grained de-risking).

--- a/specs/043-safe-multisig-custody/contracts/SafeProposalHub.md
+++ b/specs/043-safe-multisig-custody/contracts/SafeProposalHub.md
@@ -1,0 +1,80 @@
+# Contract: `SafeProposalHub`
+
+**Location**: `contracts/custody/SafeProposalHub.sol` · **Type**: immutable, stateless, **events-only** helper.
+Holds no funds, custodies nothing, has **no authority over any Safe**. Its only purpose is to broadcast a
+proposed Safe transaction's **preimage** on-chain so co-owners can discover and verify it without a backend.
+
+Integrity does not depend on the hub: co-owner clients recompute `Safe.getTransactionHash(...)` from the
+emitted params and reject anything that does not match `safeTxHash` before calling `Safe.approveHash`. A
+malicious or malformed `propose` therefore cannot cause an incorrect approval — it can only waste the
+proposer's own gas.
+
+## Interface
+
+```solidity
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.20;
+
+/// @notice Events-only broadcaster of Safe transaction preimages for serverless co-owner discovery.
+/// @dev No state, no funds, no authority. Integrity is enforced by owners recomputing the hash off-chain.
+interface ISafeProposalHub {
+    /// @param safe        The Safe the proposal targets.
+    /// @param proposer    msg.sender (informational; SHOULD be an owner, not enforced).
+    /// @param safeTxHash  Proposer-supplied hash; clients MUST recompute and verify it.
+    /// @param to          Target of the Safe transaction.
+    /// @param value       Native value.
+    /// @param data        Calldata (non-indexed so it is decodable from logs).
+    /// @param operation   0 = CALL, 1 = DELEGATECALL.
+    /// @param nonce       Safe nonce the proposal is built against.
+    event Proposed(
+        address indexed safe,
+        address indexed proposer,
+        bytes32 indexed safeTxHash,
+        address to,
+        uint256 value,
+        bytes data,
+        uint8 operation,
+        uint256 nonce
+    );
+
+    /// @notice Signal that a proposer no longer intends to pursue a proposal (advisory; the Safe nonce is the
+    ///         real arbiter of supersession).
+    event Cancelled(address indexed safe, address indexed proposer, bytes32 indexed safeTxHash);
+
+    function propose(
+        address safe,
+        address to,
+        uint256 value,
+        bytes calldata data,
+        uint8 operation,
+        uint256 nonce,
+        bytes32 safeTxHash
+    ) external;
+
+    function cancel(address safe, bytes32 safeTxHash) external;
+}
+```
+
+## Behavior
+
+- `propose(...)` emits `Proposed(safe, msg.sender, safeTxHash, to, value, data, operation, nonce)` and returns.
+  No storage writes, no external calls (checks-effects-interactions is trivially satisfied). Reentrancy is
+  not possible.
+- `cancel(...)` emits `Cancelled(safe, msg.sender, safeTxHash)`.
+- The contract MAY optionally require `operation <= 1` (reject invalid enum) — the only input validation.
+
+## Security review notes (Constitution I)
+
+- Attack surface is limited to emitting attacker-controlled log data; there is no value or authority to steal.
+- The hub cannot approve, execute, or alter any Safe transaction.
+- Must still pass **Slither** and the smart-contract security agent review, and carry unit tests; target
+  EthTrust-SL **L2**. Non-upgradeable and stateless → **no storage-layout gating** applies.
+
+## Deployment
+
+- One immutable instance per supported chain (Mordor 63, Polygon 137 at launch; ETC 61 when the app adds an
+  ETC network block). Deployed by `scripts/deploy/custody/deploy-safe-proposal-hub.js`, recorded in
+  `deployments/<network>-chain<id>-v2.json` under key `safeProposalHub`, then synced into
+  `frontend/src/config/contracts.js` via `npm run sync:frontend-contracts`.
+- The hub is **optional infrastructure**: where it is absent, the client falls back to the signed EIP-712
+  payload link/QR discovery path (never-stranded). Approvals and execution never depend on the hub.

--- a/specs/043-safe-multisig-custody/contracts/SafeProposalHub.md
+++ b/specs/043-safe-multisig-custody/contracts/SafeProposalHub.md
@@ -12,8 +12,8 @@ proposer's own gas.
 ## Interface
 
 ```solidity
-// SPDX-License-Identifier: LGPL-3.0-only
-pragma solidity ^0.8.20;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
 
 /// @notice Events-only broadcaster of Safe transaction preimages for serverless co-owner discovery.
 /// @dev No state, no funds, no authority. Integrity is enforced by owners recomputing the hash off-chain.

--- a/specs/043-safe-multisig-custody/contracts/frontend-integration.md
+++ b/specs/043-safe-multisig-custody/contracts/frontend-integration.md
@@ -1,0 +1,88 @@
+# Contract: Frontend Integration Seams
+
+Exact seams this feature plugs into, with the interface each new module must satisfy. These mirror existing,
+documented patterns so no engine edits are needed.
+
+## 1. WalletPage — Custody tab (Finance group)
+
+`frontend/src/pages/WalletPage.jsx`: add `{ id: 'custody', label: 'Custody' }` to the **Finance** group's
+`items` in `WALLET_TAB_GROUPS` (after `paytransfer`), and a render branch:
+```jsx
+{activeTab === 'custody' && (
+  <div className="custody-section" role="tabpanel"><CustodyPanel /></div>
+)}
+```
+`CustodyPanel` renders two sub-sections: **On chain** (multisig UI) and **Off chain** (rendered disabled with
+"coming later" copy). Deep-link `?tab=custody` and notification `link.state = { tab: 'custody' }` resolve via
+existing `WALLET_TABS` logic.
+
+## 2. Notification activity source (spec 031)
+
+`frontend/src/data/notifications/sources/custodySource.js` implements the source contract:
+```js
+export const custodySource = {
+  key: 'custody',
+  label: 'Custody',
+  async detect({ account, chainId, nowMs, prior }) {
+    // read the member's vaults (from vaultReferences) on chainId; for each, diff:
+    //   Safe.nonce(), approvedHashes, ApproveHash/ExecutionSuccess/ExecutionFailure logs,
+    //   SafeProposalHub.Proposed logs, incoming/outgoing transfers
+    // → { entries, nextSnapshots, currentIds, actionNeededById, ok, partial }
+    // entries: { id, domain:'custody', refId, type, message, severity, actionable,
+    //            link:{ to:'/wallet', state:{ tab:'custody', vault } }, createdAt, read }
+  },
+}
+```
+Register in `frontend/src/data/notifications/sources/index.js`:
+`export const activitySources = [wagerSource, daoSource, tokenSource, membershipSource, poolsSource, custodySource]`.
+Add `custody` to `DOMAIN_META` (`frontend/src/data/notifications/domains.js`) and to `NOTIFICATION_CATEGORIES`
+(`frontend/src/lib/notifications/deliveryPreferences.js`) as `{ domain:'custody', label:'Custody', description }`
+so per-source on/off (`push`/`app`/`silent`) works (FR-027, FR-028).
+
+## 3. Encrypted backup synced object (spec 032)
+
+`frontend/src/lib/backup/syncedObjects.js`: append
+```js
+{
+  key: 'vaultReferences',
+  label: 'Vault References',
+  networkScoped: true,
+  load(account) { /* read {chainId,address,label,addedAt,role}[] from local store */ },
+  apply(account, value, mode) { /* merge|replace into local store */ },
+  merge(current, incoming) { /* union by (chainId,address); newest label wins */ },
+}
+```
+Extend `assertNetworkTagged` in `frontend/src/lib/backup/backupBundle.js` to validate the `chainId` tag on
+`vaultReferences`. No changes to `useDataBackup`, `BackupPanel`, backup crypto, or the pointer registry
+(FR-025, FR-026). Labels are client-side only, never on-chain.
+
+## 4. Active identity context + indicator
+
+`frontend/src/contexts/CustodyContext.jsx` provides `{ activeIdentity, setActiveIdentity, submit }` where
+`activeIdentity = { mode:'personal'|'vault', vaultAddress?, chainId }`. `OperateAsIndicator.jsx` renders a
+persistent, WCAG-AA banner/switcher visible app-wide showing the active identity (FR-020) with a "switch back"
+control (FR-023). `useActiveAccount()` exposes `submit(tx)` → `submitAsActiveAccount(tx, ctx)`.
+
+## 5. Chokepoint rerouting (staged)
+
+Each fund-moving chokepoint routes its final `{to, value, data}` through `useActiveAccount().submit(...)` when
+`mode === 'vault'`, otherwise keeps today's path.
+
+| Priority | Chokepoint | File |
+|----------|-----------|------|
+| **P1** | Pay & Transfer send | `frontend/src/hooks/useTransfer.js` (`send`) |
+| **P1** | Wager create (+ accept) | `frontend/src/hooks/useFriendMarketCreation.js`, `useOpenChallengeAccept.js` |
+| **P2** | Membership purchase | `frontend/src/hooks/usePurchaseFlow.js` |
+| **P2** | Token Mint | `frontend/src/components/tokens/useTokenFactory.js` |
+| **P2** | ClearPath governance | `frontend/src/components/clearpath/connectors/{ozGovernor,governorBravo}.js` |
+| **P2** | Trade / Swap | `frontend/src/contexts/DexContext.jsx` (`swap`) |
+
+In vault mode these calls return a **pending proposal** (not an executed tx); the UI directs the member to the
+Custody queue for co-owner approval. Not-yet-approved actions appear **only** in the vault queue (FR-022b).
+
+## 6. Config
+
+`frontend/src/config/safeContracts.js` (NEW): `{ [chainId]: { safe, safeL2, proxyFactory, fallbackHandler,
+multiSendCallOnly } }` for 63 and 137 (and 61 when added), plus `getSafeContracts(chainId)` returning
+`undefined` on unsupported chains → Custody shows "unavailable on this network" (FR-030). `safeProposalHub`
+address is added to the `MORDOR_CONTRACTS` / `POLYGON_CONTRACTS` blocks in `contracts.js` (synced).

--- a/specs/043-safe-multisig-custody/contracts/vault-transactions.md
+++ b/specs/043-safe-multisig-custody/contracts/vault-transactions.md
@@ -1,0 +1,85 @@
+# Contract: Client-side Vault Transaction Encoders
+
+These are **client library contracts** (function signatures the frontend implements in `frontend/src/lib/custody/`),
+not Solidity. They wrap the external Safe v1.4.1 ABIs. Addresses come from `frontend/src/config/safeContracts.js`
+(canonical Safe addresses) and `getContractAddressForChain('safeProposalHub', chainId)`.
+
+## Safe v1.4.1 ABI surface used (hand-maintained in `frontend/src/abis/`)
+
+**`Safe`** (read): `getOwners() → address[]`, `getThreshold() → uint256`, `nonce() → uint256`,
+`isOwner(address) → bool`, `VERSION() → string`, `approvedHashes(address,bytes32) → uint256`,
+`getTransactionHash(address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,uint256) → bytes32`.
+**`Safe`** (write): `approveHash(bytes32)`,
+`execTransaction(address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,bytes) → bool`,
+governance: `addOwnerWithThreshold(address,uint256)`, `removeOwner(address,address,uint256)`,
+`swapOwner(address,address,address)`, `changeThreshold(uint256)`.
+Events: `ApproveHash(bytes32,address)`, `ExecutionSuccess(bytes32,uint256)`, `ExecutionFailure(bytes32,uint256)`.
+
+**`SafeProxyFactory`**: `createProxyWithNonce(address,bytes,uint256) → address`, event
+`ProxyCreation(address,address)`. **`Safe.setup`** initializer:
+`setup(address[],uint256,address,bytes,address,address,uint256,address)`.
+
+**`MultiSendCallOnly`**: `multiSend(bytes transactions)` where each inner tx is packed
+`operation(1 byte=0x00) ‖ to(20) ‖ value(32) ‖ dataLength(32) ‖ data`.
+
+## `safeVault.js`
+
+```
+createVault({ owners, threshold, saltNonce, chainId, signer }) → { predictedAddress, tx }
+    // builds Safe.setup initializer (fallbackHandler = CompatibilityFallbackHandler, payment fields 0)
+    // returns predicted CREATE2 address + the createProxyWithNonce tx
+loadVault(address, chainId, provider) → Vault      // reads owners/threshold/nonce/version/balances; validates Safe
+readVaultState(address, chainId, provider) → Vault // refresh
+```
+
+## `vaultTransaction.js`
+
+```
+buildSafeTx({ to, value, data, operation=0, nonce }) → SafeTx
+computeSafeTxHash(safeAddress, safeTx, chainId, provider) → bytes32   // via Safe.getTransactionHash
+buildPrevalidatedSignatures(approverAddresses) → bytes
+    // 65 bytes/owner: r = left-padded owner (32) ‖ s = 0x00*32 ‖ v = 0x01; SORTED ascending by owner address
+encodeMultiSend(innerTxs[]) → { to: MultiSendCallOnly, value: 0, data, operation: 1 }
+    // batch e.g. [approve(registry, stake), createWager(...)] into one Safe transaction
+encodeExecTransaction(safeTx, signatures) → txRequest    // Safe.execTransaction args
+// Governance helpers → SafeTx targeting the Safe itself:
+buildAddOwner(newOwner, newThreshold) | buildRemoveOwner(prevOwner, owner, newThreshold)
+  | buildSwapOwner(prevOwner, oldOwner, newOwner) | buildChangeThreshold(newThreshold)
+```
+
+**Rules**: `s` bytes are ignored by the Safe for `v==1`; ordering by ascending owner address is **mandatory**
+(the Safe's `checkNSignatures` loop requires `currentOwner > lastOwner`). `nonce` must equal `Safe.nonce()` at
+execution or the call reverts.
+
+## `proposalHub.js`
+
+```
+emitProposal({ hub, safe, safeTx, safeTxHash, signer }) → tx     // SafeProposalHub.propose(...)
+readProposals(hub, safeAddress, provider) → Proposal[]           // decode Proposed logs, recompute+verify hash
+cancelProposal({ hub, safe, safeTxHash, signer }) → tx
+// Fallback (never-stranded, no hub required):
+encodePayloadLink(safe, safeTx, chainId) → string                // signed EIP-712 SafeTx JSON → link/QR
+parsePayloadLink(link) → { safe, safeTx, chainId }               // import; client recomputes+verifies hash
+```
+
+## `submitAsActiveAccount.js`
+
+```
+submitAsActiveAccount({ to, value, data, operation, batch }, ctx) → Result
+    // ctx from CustodyContext: { mode, vaultAddress, chainId, signer, provider }
+    // mode==='personal' → signer.sendTransaction / existing path; returns { kind:'sent', txHash }
+    // mode==='vault'    → build SafeTx (batch via MultiSendCallOnly if provided), compute hash,
+    //                     emitProposal + proposer approveHash; returns { kind:'proposed', safeTxHash }
+```
+
+## Wager / Membership routing when operating as a vault
+
+- **Create wager (vault)**: MultiSend batch `[ERC20.approve(wagerRegistry, stake), wagerRegistry.createWager(...)]`
+  as one Safe transaction (`operation = 1` to `MultiSendCallOnly`). Creator becomes the Safe address.
+- **Accept wager (vault)**: batch `[approve, acceptWager(id)]`; the Safe must be the named `opponent`.
+- **Claim payout (vault won)**: `execTransaction` calling `wagerRegistry.claimPayout(id)` **from the Safe** —
+  threshold-gated (see research Decision 7; the registry binds `msg.sender == winner`).
+- **Refund (vault)**: `wagerRegistry.claimRefund(id)` — caller-agnostic; any single owner may call it directly
+  (no Safe transaction, no threshold) since funds route to the recorded participant.
+- **Membership / Token Mint / ClearPath / Swap (vault)**: encode the target contract call as the SafeTx `data`
+  (with a preceding `approve` in a MultiSend batch where the action pulls an ERC-20).

--- a/specs/043-safe-multisig-custody/data-model.md
+++ b/specs/043-safe-multisig-custody/data-model.md
@@ -1,0 +1,122 @@
+# Phase 1 Data Model: Safe Multisig Custody
+
+Source of truth is on-chain wherever possible. Client-side records are caches/labels only and are never
+authoritative over chain state (Constitution III). "Stored" below means client `localStorage` + encrypted
+backup unless noted.
+
+## Entity: Vault (Safe)
+
+The shared on-chain account. **Authoritative on-chain**; the client only caches display fields.
+
+| Field | Type | Source | Notes |
+|-------|------|--------|-------|
+| `address` | address | chain | The Safe proxy address; identity of the vault |
+| `chainId` | number | client | Network the vault lives on (network-scoped) |
+| `owners` | address[] | `Safe.getOwners()` | Live |
+| `threshold` | number | `Safe.getThreshold()` | 1 ≤ threshold ≤ owners.length |
+| `nonce` | number | `Safe.nonce()` | Next transaction nonce |
+| `version` | string | `Safe.VERSION()` | Expect `1.4.1` |
+| `balances` | {token, amount}[] | chain/RPC | Native + supported tokens |
+| `fallbackHandler` | address | setup config | `CompatibilityFallbackHandler` (EIP-1271) |
+
+**Validation**: creation requires `1 ≤ threshold ≤ owners.length`, `owners` non-empty, all owners distinct and
+valid addresses (FR-005). A load-by-address must resolve non-empty bytecode implementing the Safe interface,
+else surfaced as "not a vault at this address" (edge case).
+
+## Entity: Vault Reference / Label (client, backed up)
+
+A member's record that they are associated with a vault, plus a friendly name. **The only Custody data in the
+encrypted backup** (FR-025). Not authoritative.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `address` | address | Vault address |
+| `chainId` | number | Network scope (drives `assertNetworkTagged`) |
+| `label` | string | Member-authored two-word-or-free nickname; client-side only, never on-chain |
+| `addedAt` | number | Timestamp |
+| `role` | enum | `owner` \| `watch` — whether the member controls an owner address (derived; cached) |
+
+Backup integration: one entry in `frontend/src/lib/backup/syncedObjects.js`
+(`{ key: 'vaultReferences', networkScoped: true, load, apply, merge }`); `merge` unions by `(chainId, address)`,
+newest `label` wins. `assertNetworkTagged` extended so restore validates the `chainId` tag.
+
+## Entity: Vault Transaction (Proposal)
+
+A proposed action from a vault and the **sole representation of a not-yet-approved vault-originated action**
+(FR-022b). Preimage lives in `SafeProposalHub` events + local cache; approval state is on-chain.
+
+| Field | Type | Source | Notes |
+|-------|------|--------|-------|
+| `safeTxHash` | bytes32 | computed | `getTransactionHash(...)`; the key |
+| `safe` | address | hub event | Originating vault |
+| `to` | address | hub event | Target |
+| `value` | uint256 | hub event | Native value (0 for token/ERC-20 actions) |
+| `data` | bytes | hub event | Calldata (e.g. `transfer`, `createWager`, MultiSend batch) |
+| `operation` | 0\|1 | hub event | 0 = CALL, 1 = DELEGATECALL (MultiSend batches) |
+| `nonce` | uint256 | hub event | Must equal `Safe.nonce()` to be executable |
+| `type` | enum | derived from `to`/`data` | `transfer` \| `wagerStake` \| `wagerAccept` \| `governance` \| `clearpath` \| `tokenMint` \| `membership` \| `swap` \| `raw` |
+| `approvals` | address[] | `approvedHashes(owner, hash)` per owner | Live on-chain |
+| `status` | enum | derived | see state machine |
+| `proposer` | address | hub event | Owner who proposed |
+
+**Derived status**:
+- `pending` — approvals < threshold AND `nonce == Safe.nonce()`
+- `ready` — approvals ≥ threshold AND `nonce == Safe.nonce()`
+- `executed` — the Safe emitted `ExecutionSuccess` for `safeTxHash`
+- `failed` — the Safe emitted `ExecutionFailure` for `safeTxHash`
+- `superseded` — a different transaction executed at this `nonce` (this one can never execute; Safe nonces are
+  strictly sequential), or the proposer emitted a `cancel`
+
+**State transitions**:
+```
+propose ──▶ pending ──(approvals reach threshold)──▶ ready ──(execTransaction)──▶ executed | failed
+   │                                                    │
+   └──────────────── superseded ◀───────────────────────┘   (another tx executes at same nonce, or cancel)
+```
+
+**Validation / rules**:
+- Duplicate approval by the same owner is idempotent (`approvedHashes` is 0/1) — never double-counts (FR-013).
+- Execution blocked unless `approvals ≥ threshold` and `nonce == Safe.nonce()` (FR-012, FR-013).
+- Owner-set/threshold changes evaluate against the **current** owners/threshold at execution time (edge case:
+  owner removed mid-flight).
+- Governance transactions (`type = governance`) target the Safe itself (`addOwnerWithThreshold`,
+  `removeOwner`, `swapOwner`, `changeThreshold`) and require threshold approval like any other (FR-018).
+
+## Entity: Approval
+
+An owner's on-chain endorsement of a `safeTxHash`. Not a separate stored object — it is the
+`approvedHashes[owner][safeTxHash] == 1` on-chain fact plus the `ApproveHash` event. Counts once per owner.
+
+## Entity: Active Identity (client, session)
+
+Which identity the member is currently operating as. **Not backed up** (a per-session/device choice).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `mode` | enum | `personal` \| `vault` |
+| `vaultAddress` | address? | Set when `mode = vault`; must be a vault the member owns |
+| `chainId` | number | Must match the active network |
+
+**Rules**: switching to `vault` requires the connected wallet to be an owner of that vault (FR-020); on network
+switch away from the vault's chain, the indicator prompts/reverts (edge case: network mismatch). All
+authorization still keys off the connected `address` for signing; the vault identity only changes the
+*destination* of prepared actions.
+
+## Entity: Custody Notification Event (spec 031 activity source)
+
+Derived feed entries. Emitted by `custodySource.detect(...)` via snapshot-diff; shape per the spec-031 source
+contract.
+
+| `type` | Trigger |
+|--------|---------|
+| `proposalCreated` | New `Proposed` for a vault the member owns |
+| `approvalNeeded` | `pending` proposal the member (as owner) has not yet approved — `actionable: true` |
+| `approvalAdded` | An `ApproveHash` by another owner |
+| `readyToExecute` | Proposal reached threshold |
+| `executed` / `failed` | `ExecutionSuccess` / `ExecutionFailure` |
+| `governanceChanged` | Owner/threshold change executed |
+| `fundsIn` / `fundsOut` | Incoming/outgoing vault transfers |
+
+Entry fields follow the existing sources: `{ id, domain: 'custody', refId: safeTxHash|address, type, message,
+severity, actionable, link: { to: '/wallet', state: { tab: 'custody', vault } }, createdAt, read }`.
+Per-source delivery control via `NOTIFICATION_CATEGORIES` (`domain: 'custody'`) and `DOMAIN_META`.

--- a/specs/043-safe-multisig-custody/plan.md
+++ b/specs/043-safe-multisig-custody/plan.md
@@ -170,12 +170,13 @@ submit chokepoints reroute through one place.
 
 These are tracked outside this PR and are intended for a separate session/PR:
 
-- **Finish US3 operate-as** — wire the remaining money-moving chokepoints (Membership `usePurchaseFlow`,
-  Token Mint `useTokenFactory`, ClearPath governance connectors, Trade/Swap `DexContext`), the wager **accept**
-  path, and the vault-won-payout **claim routing** (FR-022c), plus the "view/act on the vault's wagers"
-  plumbing those depend on (T035, T039 remainder, T040, T041, T042). The `submitAsActiveAccount` seam and the
-  `OperateAsIndicator` are already in place; each chokepoint reroutes its final `{to,value,data}` through
-  `useActiveAccount().submit` in vault mode.
+- **US3 operate-as** — wired surfaces: Pay & Transfer, wager **create** + **accept**, vault-won payout **claim**
+  routing (FR-022c), **Trade/Swap** (`DexContext`), **Token Mint** (`useTokenFactory`), and **ClearPath**
+  governance (castVote/queue/execute via connector `encode`). **Remaining: Membership purchase**
+  (`usePurchaseFlow`) — its stake goes through the deep `purchaseRoleWithStablecoin` service layer and a vault
+  buying its own membership is the most niche operate-as case; deferred as a focused follow-up. The wager
+  claim UI routes correctly but is only reachable once a "view the vault's wagers" list is added (the wager
+  list is keyed to the connected address today).
 - **Ethereum Classic mainnet (61)** — Custody is contract-ready (the canonical Safe v1.4.1 addresses already
   resolve for 61 in `safeContracts.js` shape), but the app has **no `61` network block** today
   (`frontend/src/config/contracts.js` / `networks.js`). Adding an ETC network entry (RPC, chain + token config)

--- a/specs/043-safe-multisig-custody/plan.md
+++ b/specs/043-safe-multisig-custody/plan.md
@@ -1,0 +1,167 @@
+# Implementation Plan: Safe Multisig Custody
+
+**Branch**: `claude/fairwins-safe-multisig-custody-322ady` | **Date**: 2026-07-06 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/043-safe-multisig-custody/spec.md`
+
+## Summary
+
+Bring the Safe (v1.4.1) multisignature vault pattern into FairWins as a **Custody** area under **My Wallet →
+Finance**, with **On chain** (multisig) and **Off chain** (disabled placeholder) sub-sections. Members create
+or load Safe vaults, and propose / approve / execute vault transactions using an **entirely on-chain** flow —
+`approveHash` + `execTransaction` with pre-validated signatures — with **no hosted Safe Transaction Service and
+no app backend**. Pending-transaction discovery is served by a tiny, events-only on-chain **`SafeProposalHub`**
+helper (censorship-resistant, serverless) with a signed EIP-712 payload link/QR as the never-stranded fallback.
+An **active-identity ("operate as") seam** lets a member act as a vault across the app's money-moving surfaces
+(wagers, Pay & Transfer, ClearPath, Token Mint, Membership, Trade/Swap): each such action becomes a
+threshold-gated Safe transaction. Vault references + labels ride the existing encrypted backup (spec 032);
+vault events register as a new **Custody** activity source in the notification system (spec 031).
+
+## Technical Context
+
+**Language/Version**: Solidity `^0.8.x` (Hardhat) for the one new helper contract; JavaScript/JSX (React 18 +
+Vite) for the frontend, using **ethers v6** (the codebase's contract layer) atop wagmi v3 / viem v2 connection
+state. Vitest for frontend tests; Hardhat (Mocha/Chai) for contract tests.
+
+**Primary Dependencies**: Existing app stack only. Interact with Safe via **hand-maintained minimal ABIs** in
+`frontend/src/abis/` (`Safe`, `SafeProxyFactory`, `MultiSendCallOnly`, and the new `SafeProposalHub`) called
+through ethers v6 — **no new runtime Safe SDK** (`@safe-global/protocol-kit` is rejected below). Canonical Safe
+addresses are configuration, not a dependency.
+
+**Storage**:
+- On-chain: existing Safe v1.4.1 singletons/factory/handler/MultiSend (external, immutable); one new
+  events-only `SafeProposalHub` (holds no funds, no state beyond events); the vault itself is the source of
+  truth for owners/threshold/nonce/approvedHashes.
+- Client-side: vault references + labels in the same `localStorage`-then-encrypted-backup path used by the
+  address book (spec 032 `syncedObjects`); proposal preimages cached locally by the proposer and rediscovered
+  from `SafeProposalHub` events by co-owners.
+
+**Testing**: Vitest unit/component/a11y (`vitest-axe`) under `frontend/src/test/{custody,sources,backup}`;
+Hardhat unit + integration for `SafeProposalHub` and the vault-transaction encoders under `test/`; fork tests
+against Mordor/Polygon Safe deployments for the create/approve/execute round-trip.
+
+**Target Platform**: PWA (browsers, desktop/mobile) on Mordor (63) and Polygon (137) at launch; Ethereum
+Classic mainnet (61) ready at the contract level (addresses verified) but gated on an app-level ETC network
+block (prerequisite, see Constraints).
+
+**Project Type**: Web application (existing `frontend/` + `contracts/` monorepo).
+
+**Performance Goals**: UI interactions ≤ standard app expectations; vault state reads batched to keep the
+Custody panel responsive (initial vault load < 2s on a healthy RPC). No new latency-critical path — approvals
+and execution are user-initiated on-chain transactions.
+
+**Constraints**:
+- **On-chain only / no app backend** (FR-017): approvals and execution use Safe primitives; discovery uses the
+  on-chain hub + never-stranded EIP-712 payload fallback. No hosted Safe Transaction Service, Client Gateway,
+  or Config Service (unlike etclabscore/web-core, which self-hosts that stack).
+- **Networks gated by Safe availability** (FR-030): Custody renders only where the Safe factory + `SafeProposalHub`
+  resolve for the active chain; otherwise it shows "unavailable on this network." Launch = Mordor (63) +
+  Polygon (137). **ETC mainnet (61) requires adding an ETC entry to the app's network config** (`contracts.js`
+  has no `61` block today) — treated as a prerequisite, not part of this feature's core.
+- **Safe as signer cannot use the gasless intent twins**: `WagerRegistry`/`MembershipManager` `…WithSig` /
+  `…WithAuthorization` verify EOA signatures via `ecrecover` only (no EIP-1271), so a vault must self-submit
+  every action via `execTransaction`. This is consistent with the on-chain-only decision.
+
+**Scale/Scope**: ~1 new tiny contract; ~1 Custody page/panel tree; 1 activity source; 1 synced-object entry;
+1 active-identity context + a shared `submitAsActiveAccount` seam wired into 7 existing submit chokepoints
+(staged by priority). Six prioritized user stories from the spec.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment |
+|-----------|------------|
+| **I. Security-First Smart Contracts (NON-NEGOTIABLE)** | One new contract, `SafeProposalHub`, is **events-only**: it holds no funds, custodies nothing, and grants no authority over any Safe (it merely emits a proposer-supplied preimage; integrity is enforced by owners recomputing `getTransactionHash` before approving). It follows checks-effects-interactions trivially (no state, no external calls), and MUST pass Slither + the smart-contract security agent review and target EthTrust-SL L2. All *authority* stays in the audited Safe v1.4.1 contracts. **Fund custody is delegated to Safe, not re-rolled.** Vault-transaction encoding (pre-validated signatures, MultiSend batching) is client-side and covered by fork tests. ✅ within principle. |
+| **II. Test-First & Coverage (NON-NEGOTIABLE)** | `SafeProposalHub` gets unit + integration tests; the client vault-tx encoders (hash, pre-validated sig ordering, MultiSend) get unit tests + a Mordor/Polygon fork test for the full create→approve→execute round-trip (resolution/claim/refund paths for vault-owned wagers included). Frontend logic (identity switch, proposal lifecycle, source detection, backup round-trip) gets Vitest coverage. ✅ |
+| **III. Honest State, No Mocks** | All vault state (owners, threshold, nonce, approvals, balances) read live from chain; pending proposals reflect real on-chain `approvedHashes`. Not-yet-approved actions exist **only** as pending vault-queue entries (FR-022b) — never surfaced as active wagers/transfers until executed, so no implied finality. Network-scoped vault refs carry `chainId`. **One honest-state reconciliation** required in the spec re: vault-won wager payout claims — see Complexity Tracking. ✅ (with reconciliation) |
+| **IV. Fail Loudly in CI** | No `continue-on-error` added. New Hardhat tests, Vitest tests, Slither, and a11y audits gate the pipeline. Storage-layout gating N/A (`SafeProposalHub` is non-upgradeable, stateless). ✅ |
+| **V. Accessible, Consistent Frontend** | Custody reuses `PortalNav` tab semantics, existing panel patterns, and the notification-preference surface; new UI meets WCAG 2.1 AA with `vitest-axe` coverage. Safe addresses come from config (the sync-artifact convention), never hand-copied into components. ✅ |
+| **Additional: new core tech** | No new runtime dependency (hand-rolled ABIs + ethers v6). Rejecting `@safe-global/protocol-kit` documented in research.md. ✅ |
+| **Additional: key management** | No private keys handled; owners sign with their own connected wallets. No secrets. ✅ |
+
+**Gate result**: PASS (one spec reconciliation logged in Complexity Tracking; no unjustified violations).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/043-safe-multisig-custody/
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions + rationale (Safe version, discovery, seam, deps)
+├── data-model.md        # Phase 1 — entities, fields, state transitions
+├── quickstart.md        # Phase 1 — runnable validation scenarios
+├── contracts/           # Phase 1 — SafeProposalHub interface + client vault-tx & UI/source/backup contracts
+│   ├── SafeProposalHub.md
+│   ├── vault-transactions.md
+│   └── frontend-integration.md
+├── checklists/
+│   └── requirements.md  # (from /speckit-specify)
+└── tasks.md             # Phase 2 — /speckit-tasks (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+contracts/
+└── custody/
+    └── SafeProposalHub.sol          # NEW: events-only proposal preimage broadcaster (immutable, no funds)
+
+test/
+├── custody/
+│   └── SafeProposalHub.test.js      # NEW: unit
+├── integration/
+│   └── safe-vault-lifecycle.test.js # NEW: create→approve→execute (+ vault-owned wager) via encoders
+└── fork/
+    └── safe-mordor-polygon.fork.js  # NEW: against live Safe v1.4.1 deployments
+
+scripts/deploy/
+└── custody/deploy-safe-proposal-hub.js  # NEW: deploy + record in deployments/, then sync:frontend-contracts
+
+frontend/src/
+├── config/
+│   ├── contracts.js                 # EDIT: add safeProposalHub key to MORDOR/POLYGON blocks (synced)
+│   └── safeContracts.js             # NEW: canonical Safe v1.4.1 addresses per supported chainId + lookup
+├── abis/
+│   ├── Safe.js, SafeProxyFactory.js, MultiSendCallOnly.js, SafeProposalHub.js   # NEW hand-maintained ABIs
+├── contexts/
+│   └── CustodyContext.jsx           # NEW: active identity (personal vs vault), operate-as state + indicator
+├── lib/custody/
+│   ├── safeVault.js                 # NEW: read owners/threshold/nonce/balances; create/load
+│   ├── vaultTransaction.js          # NEW: build SafeTx, getTransactionHash, pre-validated sig, MultiSend batch
+│   ├── proposalHub.js               # NEW: emit/read Proposed events; EIP-712 payload link/QR fallback
+│   └── submitAsActiveAccount.js     # NEW: shared seam — personal send vs vault proposal
+├── hooks/
+│   ├── useCustodyVaults.js          # NEW: vault list, load-by-address, refresh
+│   ├── useVaultProposals.js         # NEW: pending queue + history from chain + hub
+│   └── useActiveAccount.js          # NEW: read/switch active identity; expose submit seam
+├── components/custody/
+│   ├── CustodyPanel.jsx             # NEW: On chain / Off chain sub-sections
+│   ├── VaultList.jsx, VaultDetail.jsx, CreateVaultWizard.jsx, LoadVaultForm.jsx
+│   ├── ProposalQueue.jsx, ProposalDetail.jsx, ProposeTransactionForm.jsx
+│   ├── OwnersThresholdPanel.jsx     # governance (add/remove owner, change threshold)
+│   └── OperateAsIndicator.jsx       # NEW: persistent app-wide active-identity banner/switcher
+├── pages/WalletPage.jsx             # EDIT: add {id:'custody', label:'Custody'} to Finance group + panel
+├── data/notifications/sources/
+│   ├── custodySource.js             # NEW: activity source (spec 031)
+│   └── index.js                     # EDIT: register custodySource
+├── lib/notifications/deliveryPreferences.js  # EDIT: add 'custody' to NOTIFICATION_CATEGORIES
+├── data/notifications/domains.js    # EDIT: add custody to DOMAIN_META
+├── lib/backup/syncedObjects.js      # EDIT: add vaultReferences synced object (networkScoped)
+└── lib/backup/backupBundle.js       # EDIT: extend assertNetworkTagged for vaultReferences
+```
+
+**Structure Decision**: Reuse the existing web-app monorepo. Contracts stay under `contracts/custody/`; all
+UI/logic under `frontend/src`, integrating through the documented spec-031 (activity source), spec-032
+(`syncedObjects`), and WalletPage tab-group seams rather than parallel mechanisms. The active-identity concept
+is genuinely new and is isolated in `CustodyContext` + a single `submitAsActiveAccount` seam so the 7 existing
+submit chokepoints reroute through one place.
+
+## Complexity Tracking
+
+| Item | Why Needed | Simpler Alternative Rejected Because |
+|------|-----------|--------------------------------------|
+| **New contract `SafeProposalHub`** (events-only) | On-chain-only discovery of a pending transaction's preimage without a hosted backend; the chain otherwise reveals only the 32-byte hash before execution | *Pure off-chain payload sharing* (link/QR) alone was de-prioritized by the user as the primary mechanism; it remains the never-stranded fallback. *Reusing the encrypted-sync store* was rejected in clarification (on-chain-only). The hub is the minimal on-chain-native answer; it holds no funds and grants no authority, so its risk is far below routing custody through new stateful code. |
+| **Active-identity ("operate as") seam** touching 7 chokepoints | Spec (US3, FR-020–022c) requires acting as the vault across all money-moving surfaces | No existing delegation/impersonation concept exists; a per-call `modalSigner` swap can't represent a *contract* account that signs via threshold approvals. A single shared `submitAsActiveAccount` seam is the smallest change that covers all chokepoints; wiring is **staged by priority** (P1: Transfer + Wager; P2: Membership, ClearPath, Token Mint, Trade). |
+| **Spec reconciliation — vault-won wager payout claims (FR-022c)** | `WagerRegistry.claimPayout` requires `msg.sender == w.winner` and its gasless twin is EOA-`ecrecover` only (no EIP-1271). A vault that *wins* a wager can only claim by an `execTransaction` **from** the Safe → a threshold-gated action | FR-022c's "inbound needs no approval" holds for plain ERC-20 receipts and for `claimRefund` (caller-agnostic — any owner triggers it, funds route to the vault). It **cannot** hold for wager *payout* claims without a contract change (add EIP-1271 intent support), which is out of scope for v1. Spec FR-022c is reconciled to scope "no-approval inbound" to receipts + refunds, and to note payout-claims for a vault-won wager are a threshold Safe transaction. Recorded here and reflected in the spec. |

--- a/specs/043-safe-multisig-custody/plan.md
+++ b/specs/043-safe-multisig-custody/plan.md
@@ -165,3 +165,21 @@ submit chokepoints reroute through one place.
 | **New contract `SafeProposalHub`** (events-only) | On-chain-only discovery of a pending transaction's preimage without a hosted backend; the chain otherwise reveals only the 32-byte hash before execution | *Pure off-chain payload sharing* (link/QR) alone was de-prioritized by the user as the primary mechanism; it remains the never-stranded fallback. *Reusing the encrypted-sync store* was rejected in clarification (on-chain-only). The hub is the minimal on-chain-native answer; it holds no funds and grants no authority, so its risk is far below routing custody through new stateful code. |
 | **Active-identity ("operate as") seam** touching 7 chokepoints | Spec (US3, FR-020–022c) requires acting as the vault across all money-moving surfaces | No existing delegation/impersonation concept exists; a per-call `modalSigner` swap can't represent a *contract* account that signs via threshold approvals. A single shared `submitAsActiveAccount` seam is the smallest change that covers all chokepoints; wiring is **staged by priority** (P1: Transfer + Wager; P2: Membership, ClearPath, Token Mint, Trade). |
 | **Spec reconciliation — vault-won wager payout claims (FR-022c)** | `WagerRegistry.claimPayout` requires `msg.sender == w.winner` and its gasless twin is EOA-`ecrecover` only (no EIP-1271). A vault that *wins* a wager can only claim by an `execTransaction` **from** the Safe → a threshold-gated action | FR-022c's "inbound needs no approval" holds for plain ERC-20 receipts and for `claimRefund` (caller-agnostic — any owner triggers it, funds route to the vault). It **cannot** hold for wager *payout* claims without a contract change (add EIP-1271 intent support), which is out of scope for v1. Spec FR-022c is reconciled to scope "no-approval inbound" to receipts + refunds, and to note payout-claims for a vault-won wager are a threshold Safe transaction. Recorded here and reflected in the spec. |
+
+## Follow-ups (post-landing)
+
+These are tracked outside this PR and are intended for a separate session/PR:
+
+- **Finish US3 operate-as** — wire the remaining money-moving chokepoints (Membership `usePurchaseFlow`,
+  Token Mint `useTokenFactory`, ClearPath governance connectors, Trade/Swap `DexContext`), the wager **accept**
+  path, and the vault-won-payout **claim routing** (FR-022c), plus the "view/act on the vault's wagers"
+  plumbing those depend on (T035, T039 remainder, T040, T041, T042). The `submitAsActiveAccount` seam and the
+  `OperateAsIndicator` are already in place; each chokepoint reroutes its final `{to,value,data}` through
+  `useActiveAccount().submit` in vault mode.
+- **Ethereum Classic mainnet (61)** — Custody is contract-ready (the canonical Safe v1.4.1 addresses already
+  resolve for 61 in `safeContracts.js` shape), but the app has **no `61` network block** today
+  (`frontend/src/config/contracts.js` / `networks.js`). Adding an ETC network entry (RPC, chain + token config)
+  is a **prerequisite** — after which deploying a `SafeProposalHub` to ETC and syncing lights up Custody there
+  with the same address set. This is config-only and out of scope for this feature.
+- **Live-network tasks** — deploy the hub to Mordor/Polygon (T008/T058) and run the fork tests against the live
+  Safe v1.4.1 deployments (T015/T025/T044); these require funded wallets and a fork RPC.

--- a/specs/043-safe-multisig-custody/quickstart.md
+++ b/specs/043-safe-multisig-custody/quickstart.md
@@ -1,0 +1,85 @@
+# Quickstart & Validation: Safe Multisig Custody
+
+Runnable scenarios proving the feature end-to-end. See [data-model.md](./data-model.md),
+[contracts/](./contracts/), and the spec's acceptance scenarios for detail. This is a validation guide, not
+implementation.
+
+## Prerequisites
+
+- Repo installed (`npm install`) and frontend deps (`cd frontend && npm install`).
+- Access to Mordor (63) and/or Polygon (137) RPC; a funded test wallet (or two/three for multi-owner tests).
+- Safe v1.4.1 is already live on Mordor/Polygon (see research.md) — nothing to deploy for Safe itself.
+- `SafeProposalHub` deployed to the target chain and synced:
+  `npx hardhat run scripts/deploy/custody/deploy-safe-proposal-hub.js --network mordor` then
+  `npm run sync:frontend-contracts -- --network mordor --chainId 63`.
+
+## Automated checks
+
+```bash
+npm run compile
+npm test                     # includes test/custody/SafeProposalHub.test.js
+npm run test:fork            # test/fork/safe-mordor-polygon.fork.js — create→approve→execute round-trip
+npx slither contracts/custody/SafeProposalHub.sol
+npm run test:frontend        # Vitest: custody lib/hooks/components, custodySource, backup round-trip, a11y
+```
+Expected: all green; Slither reports no new high/critical; `vitest-axe` passes for Custody UI.
+
+## Scenario 1 — Create & view a vault (US1 / FR-004–008)
+
+1. `npm run frontend`; connect a wallet on Mordor; open **My Wallet → Finance → Custody → On chain**.
+2. Create vault with 3 owners, threshold 2. Confirm the predicted address is shown before signing; sign the
+   `createProxyWithNonce` tx.
+3. **Expected**: after mining, the vault appears with the correct address, 3 owners, threshold 2, and zero
+   balance — all read from chain. A `vaultReferences` entry with your label is stored.
+4. In a fresh browser profile, **Load** the same vault by address. **Expected**: identical owners/threshold
+   read live. Setting an invalid threshold (e.g. 4 for 3 owners) is blocked with a clear message.
+
+## Scenario 2 — Propose, approve, execute a transfer (US2 / FR-009–016)
+
+1. Fund the vault with a supported ERC-20. As owner A, **Propose** a transfer of that token to an address.
+2. **Expected**: proposal shows in the vault's pending queue, status `pending`, "1 of 2 approvals". A
+   `Proposed` event is emitted to `SafeProposalHub`; owner A's `approveHash` is recorded.
+3. As owner B (different browser/wallet), open Custody — the pending proposal is **discovered from chain**
+   (hub event; hash recomputed and verified). Approve it.
+4. **Expected**: status flips to `ready`. Any owner clicks Execute → `execTransaction` with pre-validated
+   signatures (sorted ascending by owner) succeeds; balance moves; proposal moves to history as `executed`.
+5. Negative checks: executing at `pending` is blocked; owner B approving twice does not reach 3 (idempotent);
+   a second proposal at the same nonce becomes `superseded` once one executes.
+
+## Scenario 3 — Operate as the vault: wager + transfer (US3 / FR-020–024)
+
+1. With a vault you own, toggle **operate as** that vault. **Expected**: a persistent indicator shows the vault
+   as the active identity across the app.
+2. Go to **Create Wager**, build a wager. **Expected**: instead of an immediate tx, a **pending vault
+   transaction** is created (MultiSend `approve + createWager`) and appears **only** in the Custody queue — no
+   placeholder in My Wagers. After co-owners approve to threshold and it executes, the wager becomes active
+   with the vault as creator.
+3. Go to **Pay & Transfer**, send from the vault. **Expected**: creates a pending vault transaction subject to
+   threshold, not an immediate send.
+4. Switch back to personal wallet. **Expected**: subsequent actions are single-signer; indicator updates.
+5. **Inbound check** (FR-022c): trigger a refund owed to the vault → succeeds via a single owner, no threshold.
+   A vault-**won** payout claim → correctly requires a threshold Safe transaction (documented exception).
+
+## Scenario 4 — Governance (US4 / FR-018–019)
+
+1. Propose "add owner D, threshold 3". Approve to threshold; execute.
+2. **Expected**: vault now shows 4 owners, threshold 3, read live; the next transaction requires 3 approvals.
+   Proposing a threshold above the resulting owner count is blocked.
+
+## Scenario 5 — Backup & restore (US5 / FR-025–026)
+
+1. Add two vaults with custom labels. Run **Backup** (Tools → Backup).
+2. Restore in a fresh browser profile with the same wallet. **Expected**: both vaults and labels reappear in
+   Custody. The IPFS bundle is unreadable without the wallet (encrypted); no key material is in the bundle.
+
+## Scenario 6 — Notifications (US6 / FR-027–028)
+
+1. With Custody notifications enabled, have a co-owner propose a transaction needing your approval.
+2. **Expected**: a "needs your action" entry appears in the activity feed and deep-links to the Custody vault.
+3. Set the **Custody** source to `silent` in Notification Preferences. **Expected**: new vault events stop
+   surfacing while other sources still work.
+
+## Network gating (FR-030)
+
+Switch to an unsupported network (no Safe / hub resolved). **Expected**: Custody shows "unavailable on this
+network" rather than a broken UI. The **Off chain** sub-section is always visible but disabled.

--- a/specs/043-safe-multisig-custody/research.md
+++ b/specs/043-safe-multisig-custody/research.md
@@ -1,0 +1,173 @@
+# Phase 0 Research: Safe Multisig Custody
+
+All contract-presence claims were verified by live `eth_getCode` against public ETC mainnet
+(`https://etc.rivet.link`) and Mordor (`https://rpc.mordor.etccooperative.org`, `eth_chainId` = `0x3f` = 63)
+RPCs, cross-referenced with `@safe-global/safe-deployments`.
+
+## Decision 1 — Safe contract version: **v1.4.1 (canonical addresses)**
+
+**Decision**: Target **Safe v1.4.1**, whose `canonical` deployment addresses are **identical across ETC (61),
+Mordor (63), and Polygon (137)** because v1.4.1 was deployed through the per-chain Safe Singleton Factory
+(`0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7`).
+
+Verified live addresses (non-empty bytecode on ETC + Mordor; canonical also on Polygon):
+
+| Contract | Address (all three chains) |
+|----------|----------------------------|
+| `Safe` (L1) singleton | `0x41675C099F32341bf84BFc5382aF534df5C7461a` |
+| `SafeL2` singleton | `0x29fcB43b46531BcA003ddC8FCB67FFE91900C762` |
+| `SafeProxyFactory` | `0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67` |
+| `CompatibilityFallbackHandler` | `0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99` |
+| `MultiSend` | `0x38869bf66a61cF6bDB996A6aE40D5853Fd43B526` |
+| `MultiSendCallOnly` | `0x9641d764fc13c8B624c04430C7356C1C7C8102e2` |
+
+**Rationale**: One address set across every target chain drastically simplifies config, testing, and the
+multi-network story (FR-030). Use the **`SafeL2`** singleton for new vaults (richer events for our
+`useVaultProposals` indexing) with the version-matched `CompatibilityFallbackHandler` so EIP-1271 / token
+receiver hooks work.
+
+**Alternatives considered**:
+- *v1.3.0 (eip155 variant)*: also live on ETC/Mordor, but its addresses **differ per chain** (ETC/Mordor use
+  the `eip155` set at `0x69f4D1…2938` / factory `0xC22834…910BC`; Polygon uses `canonical`). Rejected — more
+  config surface, no benefit. The well-known cross-chain v1.3.0 `canonical` addresses are **not** on ETC
+  (verified: canonical factory `0xa6B71E…6AB2` returns `0x` on ETC).
+
+**Action before relying on it**: verify deployed bytecode hash of the L2 singleton + MultiSend against
+`safe-deployments` `deployedBytecode` during implementation (the L1 singleton `0x69f4…` and v1.3.0 MultiSend
+came from JSON only and are not used by this plan).
+
+## Decision 2 — No hosted backend; drive Safe contracts directly
+
+**Decision**: Do **not** stand up or depend on any Safe Transaction Service / Client Gateway / Config Service.
+Drive the Safe contracts directly for create, read, approve, and execute.
+
+**Rationale**: FR-017 mandates on-chain-only coordination with no app backend. Note that **etclabscore/web-core
+does *not* avoid a backend** — it is a fork of the Safe{Wallet} frontend that self-hosts the full Safe backend
+stack (`etclabscore/safe-transaction-service`, `safe-client-gateway`, `safe-config-service`) pointed at ETC.
+Replicating that contradicts our constitution ("no app backend", "honest state") and the user's clarified
+choice. We therefore use the reference only for *chain wiring intent*, not its architecture.
+
+## Decision 3 — Vault creation and the on-chain transaction flow
+
+**Create a vault** (one transaction, deterministic address):
+`SafeProxyFactory.createProxyWithNonce(singleton, initializer, saltNonce)` where
+`initializer = Safe.setup(owners, threshold, 0, 0x, CompatibilityFallbackHandler, 0, 0, 0)`
+(`paymentToken=0`, `payment=0`, no setup delegatecall). Emits `ProxyCreation(proxy, singleton)`. The address is
+previewable off-chain via CREATE2 so the UI can show it before deploying.
+
+**Propose / approve / execute (on-chain only)**:
+1. **Compute** `safeTxHash = Safe.getTransactionHash(to, value, data, operation, safeTxGas=0, baseGas=0,
+   gasPrice=0, gasToken=0, refundReceiver=0, nonce = Safe.nonce())`.
+2. **Approve**: each owner calls `Safe.approveHash(safeTxHash)` on-chain (emits
+   `ApproveHash(bytes32 indexed, address indexed)`; sets `approvedHashes[owner][hash]=1`; **no revocation** — an
+   approved hash is permanent, like a stored signature).
+3. **Execute** (anyone, once ≥ threshold approvals): `Safe.execTransaction(...)` with a **pre-validated
+   signature bundle** — 65 bytes per approving owner, `v = 1`:
+   `r = owner address left-padded to 32 bytes`, `s = 32 zero bytes`, `v = 0x01`; blocks **concatenated in
+   ascending owner-address order**. For `v==1` the Safe accepts the signature iff `msg.sender == owner` **or**
+   `approvedHashes[owner][hash] != 0` — so no off-chain ECDSA is ever needed.
+
+**Reads** for state/queue: `getOwners()`, `getThreshold()`, `nonce()`, `isOwner(address)`,
+`approvedHashes(owner, hash)`.
+
+**Rationale**: This is the canonical serverless Safe flow. It satisfies "on-chain only," is inherently
+never-stranded (any owner can execute once threshold approvals exist), and needs no shared signature store.
+
+**Batching (approve + createWager, etc.)**: encode a `MultiSendCallOnly.multiSend(bytes)` batch and execute it
+as a single Safe transaction with `operation = 1` (delegatecall to `MultiSendCallOnly`). `MultiSendCallOnly`
+(not `MultiSend`) is chosen so the batch's inner transactions are restricted to `CALL` (no nested
+delegatecall) — smaller attack surface for the common approve+action pattern.
+
+## Decision 4 — Preimage discovery: **on-chain `SafeProposalHub` (primary) + EIP-712 payload link/QR (fallback)**
+
+**Problem**: With on-chain-only approvals, a co-owner needs the full transaction **preimage**
+(`to, value, data, operation, nonce`) to recompute and approve the correct hash. On-chain, the Safe reveals
+only the 32-byte hash (via `ApproveHash`) until the params appear in `execTransaction` calldata at execution —
+too late.
+
+**Decision**:
+- **Primary — `SafeProposalHub`**: a tiny, immutable, **events-only** helper contract. The proposer calls
+  `propose(safe, to, value, data, operation, nonce, safeTxHash)` which does nothing but
+  `emit Proposed(indexed safe, indexed proposer, safeTxHash, to, value, data, operation, nonce)` (and a
+  `cancel`/status event as needed). Co-owner clients index `Proposed` for their vaults, **recompute
+  `getTransactionHash` from the emitted params, verify it equals `safeTxHash`**, then `approveHash`. Integrity
+  is free — a tampered preimage yields a different hash and is rejected by the owner's own client.
+- **Fallback — signed EIP-712 payload**: the proposer can always share the serialized `SafeTx` (EIP-712 typed
+  JSON) as a link / QR / file; the co-owner imports, verifies the hash, and approves. This works even on a
+  chain where the hub is not deployed → **never-stranded**.
+
+**Rationale**: Keeps discovery **on-chain and serverless** (matches the clarified on-chain-only choice and "no
+app backend") while the hub carries **no funds and no authority over any Safe** — it cannot move money or
+approve anything; it only echoes data the proposer supplies. This mirrors the codebase's established
+"optional on-chain infra + never-stranded self path" pattern (spec 036 relayer). The fallback guarantees the
+feature works with zero infrastructure.
+
+**Alternatives considered**:
+- *Off-chain payload sharing only*: simplest/no contract, but de-prioritized by the user as the *primary*
+  mechanism; retained as the fallback.
+- *Reuse encrypted-sync store for preimages*: rejected in clarification (on-chain-only, no shared store).
+- *Safe Module that approves on behalf while logging*: rejected — modules bypass the threshold check; unsafe.
+
+## Decision 5 — No new runtime Safe SDK; hand-rolled ABIs + ethers v6
+
+**Decision**: Interact with Safe using **hand-maintained minimal ABIs** (`Safe`, `SafeProxyFactory`,
+`MultiSendCallOnly`, `SafeProposalHub`) in `frontend/src/abis/`, called through **ethers v6** (already the
+codebase's contract layer). Canonical Safe addresses live in a new `frontend/src/config/safeContracts.js`
+keyed by chainId; `SafeProposalHub` addresses are synced into the existing `*_CONTRACTS` blocks by
+`sync:frontend-contracts` like every other deployed contract.
+
+**Rationale**: Constitution requires justifying new core tech and prefers the smallest change. `@safe-global/protocol-kit`
+is heavyweight and its defaults assume the Transaction Service we are explicitly not running; the Safe ABIs we
+need are tiny and stable. Hand-rolled ABIs match the repo convention (ABIs are hand-maintained;
+`sync:frontend-contracts` only updates address string literals, not ABIs).
+
+**Alternatives considered**: `@safe-global/protocol-kit` / `safe-core-sdk` (rejected: new heavy dependency,
+backend-oriented defaults), `@safe-global/safe-deployments` at runtime (rejected: we only need a handful of
+fixed addresses — use it as a *dev-time reference* to author the config, not a runtime import).
+
+## Decision 6 — "Operate as" the vault: a single `submitAsActiveAccount` seam
+
+**Decision**: Introduce a `CustodyContext` holding the **active identity** (personal wallet vs. a chosen vault)
+and a persistent `OperateAsIndicator`. All fund-moving flows route their final `{to, value, data, operation?}`
+through one shared `submitAsActiveAccount(tx)`:
+- **Personal mode** → existing behavior (`signer.sendTransaction` / `contract.method(...)` /
+  `useGaslessWrite`).
+- **Vault mode** → build the SafeTx, compute the hash, `propose` (emit to hub) + proposer `approveHash`, and
+  return a **pending proposal** (no immediate execution). The action materializes only after threshold approval
+  + execution (FR-022b).
+
+**Rationale**: The frontend has **no existing act-as concept** — identity is always the connected wagmi
+address, and authorization "always keys off `address`." A vault is a *contract* account that "signs" via
+threshold on-chain approvals, so a per-call `modalSigner` swap can't represent it. A single seam is the
+smallest change that satisfies "all money-moving surfaces" and keeps the 7 heterogeneous chokepoints
+(wager create/accept, Pay & Transfer, Membership, Token Mint, ClearPath governance, Trade/Swap) rerouting
+through one audited place. **Staged by priority**: P1 wires Transfer + Wager; P2 wires Membership, ClearPath,
+Token Mint, Trade.
+
+## Decision 7 — Inbound vs. outbound; the wager-payout reconciliation
+
+**Facts** (verified in `contracts/wagers/`):
+- `claimRefund` is **caller-agnostic** (`notFrozen(msg.sender)` only; funds route to recorded
+  creator/opponent). → A vault's refunds need **no** threshold; any owner triggers them. ✅ FR-022c.
+- Plain ERC-20 receipts into the vault need nothing. ✅ FR-022c.
+- `claimPayout` requires **`msg.sender == w.winner`**, and `claimPayoutWithSig` recovers an **EOA** signer
+  (`ecrecover`, no EIP-1271). → A vault that *wins* a wager can claim **only** via `execTransaction` from the
+  Safe, i.e. a **threshold-gated** action.
+
+**Decision**: Scope FR-022c's "inbound needs no approval" to **receipts + refunds**. **Vault-won wager payout
+claims are a threshold Safe transaction** in v1 (documented, honest). A future option — add EIP-1271 intent
+verification to `WagerRegistryIntents` so a relayer can execute a Safe-signed claim — is **out of scope**.
+
+**Rationale**: Honest-state principle forbids implying the chain will let a single owner pull a payout when the
+registry binds the caller to the winner. The reconciliation is reflected in spec FR-022c.
+
+## Decision 8 — Networks at launch
+
+**Decision**: Enable Custody on **Mordor (63)** and **Polygon (137)** at launch — the intersection of
+app-supported chains and verified Safe v1.4.1 deployments. Deploy `SafeProposalHub` to each. **Ethereum Classic
+mainnet (61)** is the origin target and its Safe addresses are verified ready, but the app's `contracts.js` has
+**no `61` block today**; adding an ETC network entry (RPC, chain config, token config) is a **prerequisite**
+tracked separately, after which Custody + a hub deploy light it up with the same address set.
+
+**Rationale**: Matches the CLAUDE.md launch sequence (Mordor → Polygon) and avoids coupling this feature to a
+broader ETC-network onboarding effort while keeping the door open (config-only) per FR-030.

--- a/specs/043-safe-multisig-custody/spec.md
+++ b/specs/043-safe-multisig-custody/spec.md
@@ -236,8 +236,10 @@ confirm no new vault notifications arrive.
   was removed reflects the current owner set and threshold when evaluated for execution.
 - **Insufficient vault balance**: proposing or executing a transfer that exceeds the vault's balance is
   surfaced honestly and cannot silently succeed.
-- **Inbound funds while below threshold**: receiving funds into the vault, or an owner claiming winnings owed
-  to the vault, succeeds without threshold approval because it does not remove funds from the vault.
+- **Inbound funds while below threshold**: receiving funds into the vault, or an owner triggering a refund owed
+  to the vault, succeeds without threshold approval because it does not remove funds from the vault. (A
+  vault-won wager *payout* claim is the documented exception in FR-022c — the wager contract binds the claimer,
+  so it is a threshold-approved vault transaction.)
 - **Not-yet-approved vault action**: a vault-originated wager/payment/DAO action that has not reached
   threshold exists only as a pending vault-queue entry and does not appear in domain lists (e.g. My Wagers) or
   affect balances until it executes.
@@ -325,10 +327,13 @@ confirm no new vault notifications arrive.
   entry in the vault's pending transaction queue; it MUST NOT appear as a pending placeholder in
   domain-specific lists (e.g. My Wagers, transfer activity) or affect balances until the vault transaction
   executes.
-- **FR-022c**: Movements of funds **into** the vault — receiving funds, or an owner claiming/collecting funds
-  owed to the vault address (e.g. a vault-created wager's winnings) — MUST NOT require threshold approval and
-  MAY be triggered by any single owner; only movements that take funds **out** of the vault require threshold
-  approval.
+- **FR-022c**: Movements of funds **into** the vault — receiving funds, or an owner triggering a **refund**
+  owed to the vault address — MUST NOT require threshold approval and MAY be triggered by any single owner;
+  only movements that take funds **out** of the vault require threshold approval. **Exception (honest-state
+  reconciliation, see plan.md research Decision 7):** claiming a **vault-won wager payout** is bound by the
+  wager contract to the winner as `msg.sender` and therefore MUST be executed as a threshold-approved vault
+  transaction in v1 — it cannot be a single-owner action without a contract change (adding EIP-1271 intent
+  verification), which is out of scope. Plain ERC-20 receipts and refunds remain approval-free.
 - **FR-023**: Members MUST be able to switch back to their personal wallet at any time, after which actions
   are single-signer again.
 - **FR-024**: Vault-originated actions (wagers, payments, and the surfaces in FR-022a) MUST be subject to the
@@ -417,8 +422,10 @@ confirm no new vault notifications arrive.
   non-fund-moving surfaces are unaffected.
 - **Backup is references only**: The encrypted backup stores vault references and labels only; there is no
   owner-key backup and no on-chain recovery/guardian module in scope.
-- **Inbound is unrestricted**: Only outbound movements (funds leaving the vault) are threshold-gated;
-  receiving or claiming funds to the vault address is single-owner and needs no approval.
+- **Inbound is unrestricted (with one exception)**: Only outbound movements (funds leaving the vault) are
+  threshold-gated; receiving funds and triggering refunds to the vault address is single-owner and needs no
+  approval. The lone exception is a vault-won wager payout claim, which the wager contract binds to the winner
+  as caller and so must be a threshold-approved vault transaction (FR-022c, plan research Decision 7).
 - **Established multisig standard**: "Vault" refers to the widely deployed Safe multisignature pattern (as
   used by the Ethereum Classic Cooperative and mirrored by the referenced `etclabscore/web-core`), so that
   vaults created or loaded here are interoperable with that ecosystem rather than a bespoke scheme.

--- a/specs/043-safe-multisig-custody/spec.md
+++ b/specs/043-safe-multisig-custody/spec.md
@@ -24,7 +24,8 @@ Custody presents two sub-sections: **On chain** (the multisig functionality) and
 platform's existing **encrypted backup and recovery** so a member never loses track of the vaults
 they belong to. Vault activity flows into the platform's **notification and activity system** with
 per-source controls, and Custody controls surface in the places a member already works — wager
-creation and Pay & Transfer — through an **"operate as" the vault** switch.
+creation, Pay & Transfer, ClearPath, Token Mint, Membership, and Trade/Swap — through an
+**"operate as" the vault** switch.
 
 ## Clarifications
 
@@ -38,6 +39,21 @@ creation and Pay & Transfer — through an **"operate as" the vault** switch.
 - Q: Which networks should Custody support at launch? → A: **Ethereum Classic plus the platform's existing
   deployment targets** (e.g. Mordor testnet, Polygon), each gated by the availability of the Safe multisig
   contracts on that network. Custody is only offered on networks where those contracts are deployed.
+- Q: What does "backup and recovery of the Safe wallet" cover? → A: **Vault references and labels only.** The
+  app-wide encrypted backup stores the list of vaults a member belongs to plus their local labels/metadata.
+  The vault itself lives on-chain and is re-loadable by address; no key material is backed up and no on-chain
+  recovery module is introduced.
+- Q: How broad is "operate as the vault" for v1? → A: **Wagers, Pay & Transfer, plus ClearPath DAO actions,
+  Token Mint, and Membership purchase, and Trade/Swap.** Operate-as-vault applies across all of these
+  money-moving surfaces; each such action becomes a vault transaction subject to the vault's threshold.
+- Q: Where does a not-yet-approved vault action (wager/payment/other) appear in the UI before it reaches
+  threshold? → A: **In the vault's pending transaction queue only.** It is a single entry in the vault queue
+  and only materializes as a real wager/transfer/etc. once the vault transaction executes on-chain — it is not
+  separately shown as a "pending" placeholder in domain-specific lists (e.g. My Wagers).
+- Q: Does moving funds INTO the vault (e.g. claiming a vault-created wager's winnings to the vault address)
+  require threshold approval? → A: **No.** Any single owner may trigger a claim or receipt of funds to the
+  vault address without threshold approval, because the destination is the vault itself. Only movements that
+  take funds OUT of the vault require threshold approval.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -102,10 +118,13 @@ becomes executable at 2 approvals, execute it, and verify the balance change and
 
 While using the app as a normal member, a member can switch to **operate as** one of their vaults. In that
 mode, actions that move or commit money are prepared as vault transactions requiring co-owner approval rather
-than as single-signer actions. Specifically, the member can **create a wager as the vault** (co-owners
-approve the stake before it is committed) and **send a payment as the vault** from the **Pay & Transfer**
-section. A persistent, clearly visible indicator shows which identity (personal wallet vs. a named vault) is
-currently active, and the member can switch back at any time.
+than as single-signer actions. This applies across every money-moving surface: **creating a wager**,
+**sending a payment** in **Pay & Transfer**, **ClearPath DAO actions**, **Token Mint**, **Membership
+purchase**, and **Trade/Swap**. In each case the action becomes an entry in the vault's pending queue and
+only takes effect once approved to threshold and executed. A persistent, clearly visible indicator shows
+which identity (personal wallet vs. a named vault) is currently active, and the member can switch back at any
+time. A not-yet-approved action is represented **only** as an entry in the vault's pending queue — it does
+not appear as a separate pending placeholder in the domain-specific lists (e.g. My Wagers) until it executes.
 
 **Why this priority**: This is what makes custody useful inside FairWins rather than a standalone tool. It is
 P2 because Stories 1–2 already deliver a governable vault; "operate as" extends that value into the product's
@@ -120,11 +139,16 @@ Transfer as the vault and confirm it becomes a pending vault transaction.
 1. **Given** a member who owns a vault, **When** they choose "operate as" that vault, **Then** a persistent
    indicator shows the vault as the active identity across the app.
 2. **Given** operate-as-vault is active, **When** the member creates a wager, **Then** the wager's stake is
-   sourced from the vault and requires co-owner approval before the wager becomes active.
+   sourced from the vault, the action appears as an entry in the vault's pending queue, and it requires
+   co-owner approval to threshold before the wager becomes active — with no separate placeholder in My Wagers
+   until it executes.
 3. **Given** operate-as-vault is active, **When** the member sends a payment in Pay & Transfer, **Then** the
    payment is created as a pending vault transaction subject to the vault's threshold rather than sent
    immediately.
-4. **Given** operate-as-vault is active, **When** the member switches back to their personal wallet, **Then**
+4. **Given** operate-as-vault is active, **When** the member initiates a ClearPath DAO action, a Token Mint, a
+   Membership purchase, or a Trade/Swap, **Then** that action likewise becomes a threshold-gated entry in the
+   vault's pending queue rather than a single-signer action.
+5. **Given** operate-as-vault is active, **When** the member switches back to their personal wallet, **Then**
    subsequent actions are single-signer again and the indicator updates.
 
 ---
@@ -212,6 +236,11 @@ confirm no new vault notifications arrive.
   was removed reflects the current owner set and threshold when evaluated for execution.
 - **Insufficient vault balance**: proposing or executing a transfer that exceeds the vault's balance is
   surfaced honestly and cannot silently succeed.
+- **Inbound funds while below threshold**: receiving funds into the vault, or an owner claiming winnings owed
+  to the vault, succeeds without threshold approval because it does not remove funds from the vault.
+- **Not-yet-approved vault action**: a vault-originated wager/payment/DAO action that has not reached
+  threshold exists only as a pending vault-queue entry and does not appear in domain lists (e.g. My Wagers) or
+  affect balances until it executes.
 - **Network mismatch**: acting on a vault while connected to a different network than the vault is deployed on
   is prevented or clearly prompts a network switch.
 - **Sanctions / membership gates**: vault-originated wagers and payments are subject to the same eligibility
@@ -289,16 +318,29 @@ confirm no new vault notifications arrive.
   require co-owner approval to threshold before the wager becomes active.
 - **FR-022**: While operating as a vault, sending a payment in the **Pay & Transfer** section MUST create a
   pending vault transaction subject to the vault's threshold rather than an immediate single-signer send.
+- **FR-022a**: Operate-as-vault MUST also cover the app's other money-moving surfaces — **ClearPath DAO
+  actions**, **Token Mint**, **Membership purchase**, and **Trade/Swap** — such that each such action, while
+  operating as the vault, becomes a threshold-gated vault transaction rather than a single-signer action.
+- **FR-022b**: A vault-originated action that has not reached threshold MUST be represented **only** as an
+  entry in the vault's pending transaction queue; it MUST NOT appear as a pending placeholder in
+  domain-specific lists (e.g. My Wagers, transfer activity) or affect balances until the vault transaction
+  executes.
+- **FR-022c**: Movements of funds **into** the vault — receiving funds, or an owner claiming/collecting funds
+  owed to the vault address (e.g. a vault-created wager's winnings) — MUST NOT require threshold approval and
+  MAY be triggered by any single owner; only movements that take funds **out** of the vault require threshold
+  approval.
 - **FR-023**: Members MUST be able to switch back to their personal wallet at any time, after which actions
   are single-signer again.
-- **FR-024**: Vault-originated wagers and payments MUST be subject to the same eligibility and compliance
-  checks (e.g. sanctions screening, membership roles) applied to personal-wallet actions.
+- **FR-024**: Vault-originated actions (wagers, payments, and the surfaces in FR-022a) MUST be subject to the
+  same eligibility and compliance checks (e.g. sanctions screening, membership roles) applied to
+  personal-wallet actions.
 
 **Backup & recovery**
 
 - **FR-025**: A member's vault references and member-authored labels/metadata MUST be included in the
   platform's existing app-wide **encrypted backup and recovery**, restorable with only control of the
-  member's wallet.
+  member's wallet. The backup scope is references and labels **only** — no owner key material is stored and no
+  on-chain recovery module is introduced (the vault itself lives on-chain and is re-loadable by address).
 - **FR-026**: Backed-up vault data MUST NOT be readable by anyone other than the member, even when stored in a
   publicly readable location.
 
@@ -311,8 +353,9 @@ confirm no new vault notifications arrive.
   other notification sources, including enabling/disabling the Custody source, without affecting other
   sources.
 - **FR-029**: Custody control surfaces MUST be integrated into the relevant existing surfaces across the app
-  (at minimum: the wager creation flow and the Pay & Transfer section for "operate as," and the notification
-  preferences surface), consistent with the app's established navigation and accessibility conventions.
+  (at minimum: the wager creation flow, the Pay & Transfer section, ClearPath DAO actions, Token Mint,
+  Membership purchase, and Trade/Swap for "operate as," plus the notification preferences surface),
+  consistent with the app's established navigation and accessibility conventions.
 
 **Scope & networks**
 
@@ -327,10 +370,12 @@ confirm no new vault notifications arrive.
   set of owner addresses, approval threshold, balances. Lives on-chain; the source of truth is the chain.
 - **Vault Reference / Label**: A member's local record that they are associated with a given vault, plus a
   human-friendly name and metadata. Included in encrypted backup; never authoritative over on-chain state.
-- **Vault Transaction (Proposal)**: A proposed movement or governance action from a vault. Attributes:
-  originating vault, type (transfer, wager stake, governance change), parameters (recipient/amount/asset or
-  owner/threshold change), collected approvals, status (pending, ready, executed, rejected/replaced), and
-  history placement.
+- **Vault Transaction (Proposal)**: A proposed movement or governance action from a vault, and the sole
+  representation of a not-yet-approved vault-originated action. Attributes: originating vault, type (transfer,
+  wager stake, ClearPath/DAO action, Token Mint, Membership purchase, Trade/Swap, governance change),
+  parameters (recipient/amount/asset or owner/threshold change), collected approvals, status (pending, ready,
+  executed, rejected/replaced), and history placement. Inbound movements to the vault are not modeled as
+  threshold-gated proposals.
 - **Approval**: An owner's endorsement of a specific vault transaction; counts once per owner toward the
   threshold.
 - **Active Identity**: The identity a member is currently operating as — their personal wallet or a specific
@@ -348,9 +393,10 @@ confirm no new vault notifications arrive.
   owner approvals — verified across normal, duplicate-approval, and concurrent-execution cases (0 violations).
 - **SC-003**: A member can load an existing vault by address and see its owners, threshold, and balances match
   independent on-chain inspection 100% of the time.
-- **SC-004**: A member operating "as a vault" can, from an ordinary wager-creation or Pay & Transfer flow,
-  produce a co-owner-approved fund movement without leaving those flows, and 90% of test users correctly
-  identify which identity is active from the on-screen indicator.
+- **SC-004**: A member operating "as a vault" can, from any supported money-moving flow (wager creation, Pay
+  & Transfer, ClearPath DAO actions, Token Mint, Membership purchase, or Trade/Swap), produce a
+  co-owner-approved fund movement without leaving that flow, and 90% of test users correctly identify which
+  identity is active from the on-screen indicator.
 - **SC-005**: After backing up and restoring on a fresh device/browser, 100% of a member's previously known
   vaults and labels reappear in Custody.
 - **SC-006**: When a co-owner proposes a transaction needing the member's approval, a "needs your action"
@@ -363,8 +409,16 @@ confirm no new vault notifications arrive.
 ## Assumptions
 
 - **Reuse of existing platform infrastructure**: The feature reuses the platform's existing encrypted
-  backup/recovery (spec 032), notification & activity system (spec 031), sanctions/membership gating, and
-  wager/transfer flows rather than introducing parallel mechanisms.
+  backup/recovery (spec 032), notification & activity system (spec 031), sanctions/membership gating, and the
+  existing wager/transfer/ClearPath/Token Mint/Membership/Trade flows rather than introducing parallel
+  mechanisms.
+- **Operate-as breadth**: Operate-as-vault covers all of the app's money-moving surfaces — wager creation,
+  Pay & Transfer, ClearPath DAO actions, Token Mint, Membership purchase, and Trade/Swap. Read-only or
+  non-fund-moving surfaces are unaffected.
+- **Backup is references only**: The encrypted backup stores vault references and labels only; there is no
+  owner-key backup and no on-chain recovery/guardian module in scope.
+- **Inbound is unrestricted**: Only outbound movements (funds leaving the vault) are threshold-gated;
+  receiving or claiming funds to the vault address is single-owner and needs no approval.
 - **Established multisig standard**: "Vault" refers to the widely deployed Safe multisignature pattern (as
   used by the Ethereum Classic Cooperative and mirrored by the referenced `etclabscore/web-core`), so that
   vaults created or loaded here are interoperable with that ecosystem rather than a bespoke scheme.
@@ -387,6 +441,7 @@ confirm no new vault notifications arrive.
 
 - Encrypted backup & recovery (spec 032) for FR-025/FR-026.
 - Platform notification & activity system (spec 031) for FR-027/FR-028.
-- Existing wager creation and Pay & Transfer flows for FR-021/FR-022.
+- Existing wager creation, Pay & Transfer, ClearPath, Token Mint, Membership, and Trade/Swap flows for
+  FR-021/FR-022/FR-022a.
 - Existing sanctions/membership eligibility checks for FR-024.
 - Availability of the Safe multisig contracts on each in-scope network (FR-030).

--- a/specs/043-safe-multisig-custody/spec.md
+++ b/specs/043-safe-multisig-custody/spec.md
@@ -1,0 +1,392 @@
+# Feature Specification: Safe Multisig Custody
+
+**Feature Branch**: `043-safe-multisig-custody`
+
+**Created**: 2026-07-06
+
+**Status**: Draft
+
+**Input**: User description: "Several years back Ethereum Classic Cooperative deployed Safe multisigs on ETC and we should support this pattern within the FairWins app. The goal is to replicate as much of the functionality of creating and managing vault transactions. This feature should appear in the 'My Wallet' view in the 'Finance' section and be labeled 'Custody'. The Custody section will have two sections, 'On chain' and 'Off chain' (disabled for now). The On chain section will be where the multisig functionality will live. Backup of the Safe wallet should use the app-wide encrypted backup and recovery. The app should give the option to 'operate as' the multisig so a user can create a wager transaction with the multisig and have others approve, or send from the multisig in the 'Transfer & Pay' section. All appropriate wallet events should be wired into the 'Notification' system and have appropriate controls. All control surfaces should be integrated into appropriate surfaces across the app. Reference https://github.com/etclabscore/web-core"
+
+## Overview
+
+FairWins members today act on-chain as a single wallet: one address, one signer, one point of
+failure. Many real communities — the Ethereum Classic Cooperative among them — instead hold and
+move funds through a **shared multisignature vault (a "Safe")**, where several owners must jointly
+approve any movement of money. This feature brings that pattern into FairWins so a group can create,
+fund, and govern a shared vault, and then **use that vault throughout the app** — placing wagers as
+the vault, sending payments as the vault — with every fund movement requiring a configurable number
+of co-owner approvals.
+
+Custody lives in the member's **My Wallet** view under the **Finance** section, labeled **Custody**.
+Custody presents two sub-sections: **On chain** (the multisig functionality) and **Off chain**
+(reserved and shown disabled for now). References to the members' vaults are protected by the
+platform's existing **encrypted backup and recovery** so a member never loses track of the vaults
+they belong to. Vault activity flows into the platform's **notification and activity system** with
+per-source controls, and Custody controls surface in the places a member already works — wager
+creation and Pay & Transfer — through an **"operate as" the vault** switch.
+
+## Clarifications
+
+### Session 2026-07-06
+
+- Q: How do co-owners discover a pending vault transaction and contribute their approvals, given the
+  platform's "no app backend" principle? → A: **On-chain only.** Each owner submits an on-chain approval
+  transaction (and pays gas) so the chain itself is the shared source of truth for a transaction's proposals
+  and collected approvals. No platform-operated or off-chain shared store is required; the vault's on-chain
+  state is read to discover pending transactions and their approval progress.
+- Q: Which networks should Custody support at launch? → A: **Ethereum Classic plus the platform's existing
+  deployment targets** (e.g. Mordor testnet, Polygon), each gated by the availability of the Safe multisig
+  contracts on that network. Custody is only offered on networks where those contracts are deployed.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Create or load an on-chain vault (Priority: P1)
+
+A member opens **My Wallet → Finance → Custody → On chain** and either creates a new shared vault by
+choosing its co-owners and how many of them must approve a transaction (the "threshold"), or loads a
+vault that already exists on-chain by entering its address. Once created or loaded, the vault is shown
+with its address, network, current balance(s), the list of owners, and the approval threshold.
+
+**Why this priority**: Without the ability to establish and see a vault, nothing else in the feature is
+reachable. This is the minimum viable slice — it lets a group stand up the shared vault the Ethereum
+Classic Cooperative pattern is built around and confirm it is theirs.
+
+**Independent Test**: Create a vault with 3 owners and a 2-of-3 threshold on a supported network, confirm
+it appears in Custody with the correct owners, threshold, address, and balance; separately, load a
+pre-existing vault by address and confirm the same details render from on-chain state.
+
+**Acceptance Scenarios**:
+
+1. **Given** a connected member on a supported network, **When** they create a vault with a chosen set of
+   owner addresses and a threshold, **Then** the vault is deployed on-chain and displayed in Custody with
+   those exact owners, threshold, address, and current balance.
+2. **Given** a member who knows an existing vault address they co-own, **When** they load it by address,
+   **Then** Custody shows the vault's live owners, threshold, and balances read from the chain.
+3. **Given** a threshold greater than the number of owners, **When** the member tries to create the vault,
+   **Then** creation is blocked with a clear explanation.
+4. **Given** a member belonging to more than one vault, **When** they open Custody, **Then** they can see
+   and switch between all of their vaults.
+
+---
+
+### User Story 2 - Propose, approve, and execute a vault transaction (Priority: P1)
+
+A vault owner proposes a transaction from the vault (for example, sending funds to an address). Other
+owners see the pending transaction, review its details, and approve it. Once the number of approvals meets
+the threshold, any owner can execute it and the funds move on-chain. Executed and rejected transactions are
+retained in a per-vault history.
+
+**Why this priority**: This is the core of "creating and managing vault transactions." A vault that cannot
+move money under multi-party approval is not a multisig. Together with Story 1 it is the complete MVP.
+
+**Independent Test**: With a 2-of-3 vault, have owner A propose a transfer, owner B approve it, confirm it
+becomes executable at 2 approvals, execute it, and verify the balance change and the history entry.
+
+**Acceptance Scenarios**:
+
+1. **Given** an owner of a 2-of-3 vault, **When** they propose a transfer, **Then** the transaction appears
+   in the vault's pending queue with its details and a 1-of-2-remaining approval status.
+2. **Given** a pending transaction below threshold, **When** a second owner approves it, **Then** its status
+   updates to "ready to execute."
+3. **Given** a transaction that has met threshold, **When** any owner executes it, **Then** the funds move
+   on-chain and the transaction moves from the queue to history as executed.
+4. **Given** a pending transaction, **When** an owner rejects it or the vault owners approve a replacement,
+   **Then** the queue reflects the rejection/replacement and the superseded transaction cannot be executed.
+5. **Given** a member who is not an owner of the vault, **When** they view it, **Then** they can see state
+   but cannot propose, approve, or execute.
+
+---
+
+### User Story 3 - Operate as the vault across the app (Priority: P2)
+
+While using the app as a normal member, a member can switch to **operate as** one of their vaults. In that
+mode, actions that move or commit money are prepared as vault transactions requiring co-owner approval rather
+than as single-signer actions. Specifically, the member can **create a wager as the vault** (co-owners
+approve the stake before it is committed) and **send a payment as the vault** from the **Pay & Transfer**
+section. A persistent, clearly visible indicator shows which identity (personal wallet vs. a named vault) is
+currently active, and the member can switch back at any time.
+
+**Why this priority**: This is what makes custody useful inside FairWins rather than a standalone tool. It is
+P2 because Stories 1–2 already deliver a governable vault; "operate as" extends that value into the product's
+primary flows.
+
+**Independent Test**: Switch to operate as a vault, create a wager whose stake is drawn from the vault,
+confirm co-owners must approve before the wager is active, and separately initiate a payment from Pay &
+Transfer as the vault and confirm it becomes a pending vault transaction.
+
+**Acceptance Scenarios**:
+
+1. **Given** a member who owns a vault, **When** they choose "operate as" that vault, **Then** a persistent
+   indicator shows the vault as the active identity across the app.
+2. **Given** operate-as-vault is active, **When** the member creates a wager, **Then** the wager's stake is
+   sourced from the vault and requires co-owner approval before the wager becomes active.
+3. **Given** operate-as-vault is active, **When** the member sends a payment in Pay & Transfer, **Then** the
+   payment is created as a pending vault transaction subject to the vault's threshold rather than sent
+   immediately.
+4. **Given** operate-as-vault is active, **When** the member switches back to their personal wallet, **Then**
+   subsequent actions are single-signer again and the indicator updates.
+
+---
+
+### User Story 4 - Manage vault ownership and threshold (Priority: P2)
+
+An owner changes the vault's governance: adding an owner, removing an owner, or changing the approval
+threshold. Because these changes affect who controls the money, each is itself a vault transaction that must
+be proposed and approved to threshold before it takes effect.
+
+**Why this priority**: Real vaults evolve — people join and leave the group. This is required for long-lived
+use but not for a first demonstration of value, so it sits at P2.
+
+**Independent Test**: Propose adding a fourth owner to a 2-of-3 vault, approve it to threshold, execute it,
+and confirm the owner set and any threshold change are reflected in Custody and enforced on the next
+transaction.
+
+**Acceptance Scenarios**:
+
+1. **Given** an owner, **When** they propose adding or removing an owner or changing the threshold, **Then**
+   the change enters the pending queue as a governance transaction requiring threshold approval.
+2. **Given** an approved governance change, **When** it is executed, **Then** the vault's owners/threshold
+   update on-chain and Custody reflects the new configuration.
+3. **Given** a proposed threshold that would exceed the resulting number of owners, **When** an owner tries
+   to propose it, **Then** it is blocked with a clear explanation.
+
+---
+
+### User Story 5 - Backup and recovery of vault references (Priority: P2)
+
+A member's list of vaults (and the local labels/metadata they've given them) is included in the platform's
+existing encrypted backup, and is restored when the member restores their data on a new device or browser —
+without exposing that data publicly and without requiring anything beyond control of their wallet.
+
+**Why this priority**: Losing track of which vaults a member belongs to is a serious continuity problem, but
+vaults themselves live on-chain and can be re-loaded by address, so this augments rather than gates the core
+value.
+
+**Independent Test**: Add two vaults with custom labels, run the app-wide backup, restore on a fresh
+browser/profile, and confirm both vaults and their labels reappear in Custody.
+
+**Acceptance Scenarios**:
+
+1. **Given** a member with one or more vaults, **When** they perform the app-wide encrypted backup, **Then**
+   their vault references and labels are included in that encrypted backup.
+2. **Given** a member on a new device who restores their backup, **When** they open Custody, **Then** their
+   previously known vaults and labels reappear.
+3. **Given** the encrypted backup is stored in a publicly readable location, **When** anyone other than the
+   member inspects it, **Then** the vault references are not readable.
+
+---
+
+### User Story 6 - Vault event notifications and controls (Priority: P3)
+
+Vault events the member cares about — a new transaction proposed on a vault they own, an approval added, a
+transaction ready to execute, a transaction executed, a governance change, incoming/outgoing funds — appear
+in the platform's notification and activity feed. The member can control these notifications through the same
+preference surface used for other notification sources, including turning the Custody source on or off.
+
+**Why this priority**: Notifications make multi-party coordination practical (owners need to know when their
+approval is needed), but the feature is usable without them at first, so P3.
+
+**Independent Test**: With notifications enabled, have a co-owner propose a transaction and confirm a "needs
+your approval" entry appears in the member's activity feed; then disable the Custody notification source and
+confirm no new vault notifications arrive.
+
+**Acceptance Scenarios**:
+
+1. **Given** a member who owns a vault with notifications enabled, **When** a co-owner proposes a transaction
+   needing that member's approval, **Then** a "needs your action" entry appears in the activity feed.
+2. **Given** a vault transaction is executed, **When** the member next sees the feed, **Then** an executed
+   entry is present.
+3. **Given** the member disables the Custody notification source, **When** subsequent vault events occur,
+   **Then** no new Custody notifications are surfaced while other sources continue to work.
+
+---
+
+### Edge Cases
+
+- **Threshold not yet met at execution**: attempting to execute a transaction that has fewer approvals than
+  the threshold is blocked with a clear reason.
+- **Duplicate approval**: the same owner approving the same transaction twice does not double-count toward
+  threshold.
+- **Owner removed mid-flight**: a pending transaction whose approvals were partly gathered before an owner
+  was removed reflects the current owner set and threshold when evaluated for execution.
+- **Insufficient vault balance**: proposing or executing a transfer that exceeds the vault's balance is
+  surfaced honestly and cannot silently succeed.
+- **Network mismatch**: acting on a vault while connected to a different network than the vault is deployed on
+  is prevented or clearly prompts a network switch.
+- **Sanctions / membership gates**: vault-originated wagers and payments are subject to the same eligibility
+  checks (sanctions screening, membership roles) the platform applies to personal-wallet actions.
+- **Operate-as with no owned vault**: a member who owns no vault sees Custody in an empty/onboarding state and
+  the "operate as" control is unavailable or clearly guides them to create a vault.
+- **Off chain sub-section**: the Off chain sub-section is visible but disabled, and communicates that it is
+  coming later rather than appearing broken.
+- **Loading an address that is not a vault / not one the member owns**: the app distinguishes "not a vault at
+  this address," "a vault you can view but not sign for," and "a vault you own."
+- **Concurrent execution**: two owners executing the same ready transaction at nearly the same moment results
+  in one on-chain execution, not two, with honest feedback to the second.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Placement & navigation**
+
+- **FR-001**: The app MUST present a **Custody** entry within the **Finance** section of the **My Wallet**
+  view.
+- **FR-002**: Custody MUST contain exactly two sub-sections labeled **On chain** and **Off chain**, with
+  **Off chain** shown in a disabled state that communicates it is reserved for later.
+- **FR-003**: All multisig functionality MUST live under the **On chain** sub-section.
+
+**Vault lifecycle**
+
+- **FR-004**: Members MUST be able to create a new multisignature vault by specifying its set of owner
+  addresses and its approval threshold on a supported network.
+- **FR-005**: The system MUST prevent creating or configuring a vault with a threshold greater than its
+  number of owners, or a threshold of zero.
+- **FR-006**: Members MUST be able to load an existing vault by its address and view its live on-chain state
+  (owners, threshold, balances, address, network).
+- **FR-007**: The system MUST display all vaults a member is associated with and allow switching between
+  them.
+- **FR-008**: Vault state shown to the member MUST reflect real on-chain state and MUST NOT imply a
+  configuration or balance the chain has not confirmed.
+
+**Transactions & approvals**
+
+- **FR-009**: A vault owner MUST be able to propose a transaction from the vault (at minimum, transferring the
+  network's native asset and supported tokens to a chosen recipient).
+- **FR-010**: Owners MUST be able to review a pending transaction's details (recipient, amount, asset,
+  purpose) and approve it.
+- **FR-011**: The system MUST track approvals per transaction and indicate how many approvals remain before
+  the threshold is met.
+- **FR-012**: A transaction MUST become executable only once its approvals meet or exceed the vault's
+  threshold, and any owner MUST be able to execute an executable transaction.
+- **FR-013**: The system MUST prevent execution of a transaction that has not met threshold, prevent a single
+  owner's approval from counting more than once, and prevent double execution of the same transaction.
+- **FR-014**: Owners MUST be able to reject or replace a pending transaction, and the queue MUST reflect the
+  resulting state.
+- **FR-015**: Each vault MUST retain a history of executed and rejected/replaced transactions viewable by its
+  members.
+- **FR-016**: Only owners of a vault MUST be able to propose, approve, execute, reject, or replace its
+  transactions; non-owners MAY view state only.
+- **FR-017**: Co-owners MUST discover pending transactions and their approval progress by reading the vault's
+  on-chain state, and MUST contribute their approvals by submitting an on-chain approval transaction. The
+  feature MUST NOT depend on a platform-operated or off-chain shared store to coordinate proposals or
+  approvals (on-chain only, honoring the "no app backend" and "never-stranded" principles).
+
+**Governance**
+
+- **FR-018**: Members MUST be able to propose adding an owner, removing an owner, and changing the threshold,
+  each processed as a vault transaction requiring threshold approval before it takes effect.
+- **FR-019**: After a governance change executes, the vault's displayed owners/threshold MUST reflect the new
+  configuration and the new configuration MUST govern subsequent transactions.
+
+**Operate-as-vault integration**
+
+- **FR-020**: Members who own a vault MUST be able to switch to **operate as** that vault, and a persistent,
+  clearly visible indicator MUST show which identity (personal wallet vs. a named vault) is currently active
+  across the app.
+- **FR-021**: While operating as a vault, creating a **wager** MUST source the stake from the vault and
+  require co-owner approval to threshold before the wager becomes active.
+- **FR-022**: While operating as a vault, sending a payment in the **Pay & Transfer** section MUST create a
+  pending vault transaction subject to the vault's threshold rather than an immediate single-signer send.
+- **FR-023**: Members MUST be able to switch back to their personal wallet at any time, after which actions
+  are single-signer again.
+- **FR-024**: Vault-originated wagers and payments MUST be subject to the same eligibility and compliance
+  checks (e.g. sanctions screening, membership roles) applied to personal-wallet actions.
+
+**Backup & recovery**
+
+- **FR-025**: A member's vault references and member-authored labels/metadata MUST be included in the
+  platform's existing app-wide **encrypted backup and recovery**, restorable with only control of the
+  member's wallet.
+- **FR-026**: Backed-up vault data MUST NOT be readable by anyone other than the member, even when stored in a
+  publicly readable location.
+
+**Notifications & control surfaces**
+
+- **FR-027**: Vault events (proposed, approved, ready-to-execute, executed, rejected/replaced, governance
+  change, incoming/outgoing funds) MUST be surfaced through the platform's notification and activity system,
+  registered as a distinct **Custody** activity source.
+- **FR-028**: The member MUST be able to control Custody notifications through the same preference surface as
+  other notification sources, including enabling/disabling the Custody source, without affecting other
+  sources.
+- **FR-029**: Custody control surfaces MUST be integrated into the relevant existing surfaces across the app
+  (at minimum: the wager creation flow and the Pay & Transfer section for "operate as," and the notification
+  preferences surface), consistent with the app's established navigation and accessibility conventions.
+
+**Scope & networks**
+
+- **FR-030**: The feature MUST support **Ethereum Classic** plus the platform's existing deployment targets
+  (e.g. Mordor testnet, Polygon), and MUST offer Custody only on networks where the Safe multisig contracts
+  are already deployed; on unsupported networks Custody MUST clearly indicate it is unavailable rather than
+  appearing broken.
+
+### Key Entities *(include if data involved)*
+
+- **Vault (Safe)**: A shared on-chain account governed by multiple owners. Key attributes: address, network,
+  set of owner addresses, approval threshold, balances. Lives on-chain; the source of truth is the chain.
+- **Vault Reference / Label**: A member's local record that they are associated with a given vault, plus a
+  human-friendly name and metadata. Included in encrypted backup; never authoritative over on-chain state.
+- **Vault Transaction (Proposal)**: A proposed movement or governance action from a vault. Attributes:
+  originating vault, type (transfer, wager stake, governance change), parameters (recipient/amount/asset or
+  owner/threshold change), collected approvals, status (pending, ready, executed, rejected/replaced), and
+  history placement.
+- **Approval**: An owner's endorsement of a specific vault transaction; counts once per owner toward the
+  threshold.
+- **Active Identity**: The identity a member is currently operating as — their personal wallet or a specific
+  vault — governing whether actions are single-signer or vault-governed.
+- **Custody Notification Event**: An activity-feed entry derived from a vault event, subject to Custody-source
+  preference controls.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A member can create a new multisig vault (choosing owners and threshold) and see it correctly
+  reflected in Custody in under 3 minutes without external documentation.
+- **SC-002**: For a vault requiring N approvals, no transaction ever moves funds with fewer than N distinct
+  owner approvals — verified across normal, duplicate-approval, and concurrent-execution cases (0 violations).
+- **SC-003**: A member can load an existing vault by address and see its owners, threshold, and balances match
+  independent on-chain inspection 100% of the time.
+- **SC-004**: A member operating "as a vault" can, from an ordinary wager-creation or Pay & Transfer flow,
+  produce a co-owner-approved fund movement without leaving those flows, and 90% of test users correctly
+  identify which identity is active from the on-screen indicator.
+- **SC-005**: After backing up and restoring on a fresh device/browser, 100% of a member's previously known
+  vaults and labels reappear in Custody.
+- **SC-006**: When a co-owner proposes a transaction needing the member's approval, a "needs your action"
+  notification appears in the member's activity feed, and disabling the Custody source suppresses subsequent
+  vault notifications without affecting other sources (verified on/off).
+- **SC-007**: Owners are notified of a pending transaction needing their approval promptly enough that a
+  typical 2-of-3 transfer can be proposed, approved, and executed by a distributed group within a single
+  working session.
+
+## Assumptions
+
+- **Reuse of existing platform infrastructure**: The feature reuses the platform's existing encrypted
+  backup/recovery (spec 032), notification & activity system (spec 031), sanctions/membership gating, and
+  wager/transfer flows rather than introducing parallel mechanisms.
+- **Established multisig standard**: "Vault" refers to the widely deployed Safe multisignature pattern (as
+  used by the Ethereum Classic Cooperative and mirrored by the referenced `etclabscore/web-core`), so that
+  vaults created or loaded here are interoperable with that ecosystem rather than a bespoke scheme.
+- **Both create and load**: Members can both create new vaults and load/import existing ones by address.
+- **Owner = signer**: A vault owner is any address in the owner set; the member can only propose/approve/
+  execute for vaults whose owner set includes an address they control.
+- **No app backend / on-chain coordination**: Consistent with the platform's principles, the feature does not
+  rely on a platform-operated backend. Proposals and approvals are coordinated entirely on-chain — the vault's
+  on-chain state is the shared source of truth, and each approval is an on-chain transaction (owners pay gas
+  per approval). This is inherently "never-stranded."
+- **Off chain deferred**: The Off chain sub-section is intentionally out of scope for this feature beyond
+  appearing as a disabled placeholder.
+- **Native + supported tokens**: Vault transfers cover the network's native asset and the tokens the platform
+  already supports; arbitrary contract-call composition beyond transfers/wagers/governance is out of scope for
+  the first version.
+- **Networks**: Ethereum Classic plus the platform's existing deployment targets (e.g. Mordor testnet,
+  Polygon), each gated by Safe multisig contract availability on that network.
+
+## Dependencies
+
+- Encrypted backup & recovery (spec 032) for FR-025/FR-026.
+- Platform notification & activity system (spec 031) for FR-027/FR-028.
+- Existing wager creation and Pay & Transfer flows for FR-021/FR-022.
+- Existing sanctions/membership eligibility checks for FR-024.
+- Availability of the Safe multisig contracts on each in-scope network (FR-030).

--- a/specs/043-safe-multisig-custody/tasks.md
+++ b/specs/043-safe-multisig-custody/tasks.md
@@ -70,19 +70,19 @@ chain; load a pre-existing vault by address and see the same live state (quickst
 
 ### Tests for User Story 1
 
-- [ ] T014 [P] [US1] Write `frontend/src/test/custody/safeVault.test.js` — createVault initializer/predicted-address, loadVault parses owners/threshold/version, threshold>owners rejected (FR-005)
+- [X] T014 [P] [US1] Write `frontend/src/test/custody/safeVault.test.js` — createVault initializer/predicted-address, loadVault parses owners/threshold/version, threshold>owners rejected (FR-005)
 - [ ] T015 [P] [US1] Write `test/fork/safe-mordor-polygon.fork.js` create+load leg — deploy a 2-of-3 Safe via `SafeProxyFactory` and read back owners/threshold (fork test against live Safe v1.4.1)
 
 ### Implementation for User Story 1
 
 - [X] T016 [P] [US1] Implement `frontend/src/lib/custody/vaultReferences.js` — local store of `{chainId,address,label,addedAt,role}[]` with load/save/upsert (data-model.md)
-- [ ] T017 [US1] Implement `frontend/src/lib/custody/safeVault.js` — `createVault`, `loadVault`, `readVaultState` (owners/threshold/nonce/version/balances; validates the address is a Safe) per `contracts/vault-transactions.md`
-- [ ] T018 [US1] Implement `frontend/src/hooks/useCustodyVaults.js` — vault list from `vaultReferences`, load-by-address, refresh, active-vault selection
-- [ ] T019 [P] [US1] Build `frontend/src/components/custody/CreateVaultWizard.jsx` — owners + threshold inputs, live validation (FR-005), predicted address shown before signing
-- [ ] T020 [P] [US1] Build `frontend/src/components/custody/LoadVaultForm.jsx` — load by address; distinguish "not a vault", "view-only (not an owner)", and "owned" (edge cases)
-- [ ] T021 [P] [US1] Build `frontend/src/components/custody/VaultList.jsx` and `VaultDetail.jsx` — address, network, owners, threshold, balances; switch between multiple vaults (FR-007)
-- [ ] T022 [US1] Wire CreateVaultWizard/LoadVaultForm/VaultList/VaultDetail into the On chain sub-section of `CustodyPanel.jsx`, persisting references with labels on create/load
-- [ ] T023 [US1] Write `frontend/src/test/custody/CreateVaultWizard.test.jsx`, `LoadVaultForm.test.jsx`, `VaultDetail.test.jsx` (+ axe), covering the empty/onboarding state
+- [X] T017 [US1] Implement `frontend/src/lib/custody/safeVault.js` — `createVault`, `loadVault`, `readVaultState` (owners/threshold/nonce/version/balances; validates the address is a Safe) per `contracts/vault-transactions.md`
+- [X] T018 [US1] Implement `frontend/src/hooks/useCustodyVaults.js` — vault list from `vaultReferences`, load-by-address, refresh, active-vault selection
+- [X] T019 [P] [US1] Build `frontend/src/components/custody/CreateVaultWizard.jsx` — owners + threshold inputs, live validation (FR-005), predicted address shown before signing
+- [X] T020 [P] [US1] Build `frontend/src/components/custody/LoadVaultForm.jsx` — load by address; distinguish "not a vault", "view-only (not an owner)", and "owned" (edge cases)
+- [X] T021 [P] [US1] Build `frontend/src/components/custody/VaultList.jsx` and `VaultDetail.jsx` — address, network, owners, threshold, balances; switch between multiple vaults (FR-007)
+- [X] T022 [US1] Wire CreateVaultWizard/LoadVaultForm/VaultList/VaultDetail into the On chain sub-section of `CustodyPanel.jsx`, persisting references with labels on create/load
+- [X] T023 [US1] Write `frontend/src/test/custody/CreateVaultWizard.test.jsx`, `LoadVaultForm.test.jsx`, `VaultDetail.test.jsx` (+ axe), covering the empty/onboarding state
 
 **Checkpoint**: MVP — a member can create/load vaults and see honest on-chain state.
 

--- a/specs/043-safe-multisig-custody/tasks.md
+++ b/specs/043-safe-multisig-custody/tasks.md
@@ -196,14 +196,14 @@ entry appears; setting Custody to `silent` stops new entries (quickstart Scenari
 
 ### Tests for User Story 6
 
-- [ ] T052 [P] [US6] Write `frontend/src/test/sources/custodySource.test.js` — snapshot-diff emits `approvalNeeded` (actionable), `executed`, `governanceChanged`, `fundsIn/Out`; `currentIds`/`actionNeededById` correct
+- [X] T052 [P] [US6] Write `frontend/src/test/sources/custodySource.test.js` — snapshot-diff emits `approvalNeeded` (actionable), `executed`, `governanceChanged`, `fundsIn/Out`; `currentIds`/`actionNeededById` correct
 
 ### Implementation for User Story 6
 
-- [ ] T053 [US6] Implement `frontend/src/data/notifications/sources/custodySource.js` per `contracts/frontend-integration.md` (reads the member's vaults, diffs nonce/approvedHashes/Safe+hub logs/transfers; entries deep-link to `{ tab: 'custody', vault }`)
-- [ ] T054 [US6] Register `custodySource` in `frontend/src/data/notifications/sources/index.js` and add `{ domain:'custody', label:'Custody', description }` to `NOTIFICATION_CATEGORIES` in `frontend/src/lib/notifications/deliveryPreferences.js` (FR-027, FR-028)
-- [ ] T055 [US6] Confirm the notification tap navigates to the Custody tab via `ActivityNotificationBridge` (link.state), no engine change expected
-- [ ] T056 [US6] Write `frontend/src/test/sources/custodySource.integration.test.js` verifying `silent` suppresses only Custody while other sources still deliver
+- [X] T053 [US6] Implement `frontend/src/data/notifications/sources/custodySource.js` per `contracts/frontend-integration.md` (reads the member's vaults, diffs nonce/approvedHashes/Safe+hub logs/transfers; entries deep-link to `{ tab: 'custody', vault }`)
+- [X] T054 [US6] Register `custodySource` in `frontend/src/data/notifications/sources/index.js` and add `{ domain:'custody', label:'Custody', description }` to `NOTIFICATION_CATEGORIES` in `frontend/src/lib/notifications/deliveryPreferences.js` (FR-027, FR-028)
+- [X] T055 [US6] Confirm the notification tap navigates to the Custody tab via `ActivityNotificationBridge` (link.state), no engine change expected
+- [X] T056 [US6] Write `frontend/src/test/sources/custodySource.integration.test.js` verifying `silent` suppresses only Custody while other sources still deliver
 
 **Checkpoint**: Owners are notified when their approval is needed; controls work.
 

--- a/specs/043-safe-multisig-custody/tasks.md
+++ b/specs/043-safe-multisig-custody/tasks.md
@@ -175,7 +175,7 @@ confirm new config governs the next transaction (quickstart Scenario 4).
 
 ### Tests for User Story 5
 
-- [ ] T048 [P] [US5] Write `frontend/src/test/backup/vaultReferences.sync.test.js` — `load/apply/merge` round-trip, network-scoped tag validation, union-by-(chainId,address) with newest label winning
+- [X] T048 [P] [US5] Write `frontend/src/test/backup/vaultReferences.sync.test.js` — `load/apply/merge` round-trip, network-scoped tag validation, union-by-(chainId,address) with newest label winning
 
 ### Implementation for User Story 5
 

--- a/specs/043-safe-multisig-custody/tasks.md
+++ b/specs/043-safe-multisig-custody/tasks.md
@@ -32,10 +32,10 @@ Web-app monorepo (per plan.md): contracts under `contracts/`, tests under `test/
 
 **Purpose**: Scaffolding and external Safe wiring that every later phase reuses.
 
-- [ ] T001 [P] Add hand-maintained Safe v1.4.1 ABIs in `frontend/src/abis/Safe.js`, `frontend/src/abis/SafeProxyFactory.js`, `frontend/src/abis/MultiSendCallOnly.js` (only the methods/events in `contracts/vault-transactions.md`)
-- [ ] T002 [P] Create `frontend/src/config/safeContracts.js` with the verified canonical v1.4.1 addresses for chainId 63 and 137 (`safe`, `safeL2`, `proxyFactory`, `fallbackHandler`, `multiSendCallOnly`) plus `getSafeContracts(chainId)` returning `undefined` on unsupported chains (research.md Decision 1 & 8)
-- [ ] T003 [P] Create feature directories: `contracts/custody/`, `test/custody/`, `frontend/src/lib/custody/`, `frontend/src/components/custody/`, and a `frontend/src/components/custody/Custody.css` scaffold
-- [ ] T004 [P] Add a `custody` entry to `frontend/src/data/notifications/domains.js` `DOMAIN_META` (label "Custody") so the domain resolves early (used by US6, harmless now)
+- [X] T001 [P] Add hand-maintained Safe v1.4.1 ABIs in `frontend/src/abis/Safe.js`, `frontend/src/abis/SafeProxyFactory.js`, `frontend/src/abis/MultiSendCallOnly.js` (only the methods/events in `contracts/vault-transactions.md`)
+- [X] T002 [P] Create `frontend/src/config/safeContracts.js` with the verified canonical v1.4.1 addresses for chainId 63 and 137 (`safe`, `safeL2`, `proxyFactory`, `fallbackHandler`, `multiSendCallOnly`) plus `getSafeContracts(chainId)` returning `undefined` on unsupported chains (research.md Decision 1 & 8)
+- [X] T003 [P] Create feature directories: `contracts/custody/`, `test/custody/`, `frontend/src/lib/custody/`, `frontend/src/components/custody/`, and a `frontend/src/components/custody/Custody.css` scaffold
+- [X] T004 [P] Add a `custody` entry to `frontend/src/data/notifications/domains.js` `DOMAIN_META` (label "Custody") so the domain resolves early (used by US6, harmless now)
 
 ---
 
@@ -46,15 +46,15 @@ shell. **No user story can be completed until this phase is done.**
 
 **⚠️ CRITICAL**: Blocks all user stories.
 
-- [ ] T005 Implement `contracts/custody/SafeProposalHub.sol` — events-only broadcaster per `contracts/SafeProposalHub.md` (`propose`, `cancel`, `Proposed`, `Cancelled`; optional `operation <= 1` guard; no state, no funds)
-- [ ] T006 [P] Write `test/custody/SafeProposalHub.test.js` FIRST (assert events emitted with exact args, no state writes, invalid operation reverts) and confirm it fails before T005 is wired
-- [ ] T007 Create `scripts/deploy/custody/deploy-safe-proposal-hub.js` (deploy, record under `safeProposalHub` in `deployments/<network>-chain<id>-v2.json`)
+- [X] T005 Implement `contracts/custody/SafeProposalHub.sol` — events-only broadcaster per `contracts/SafeProposalHub.md` (`propose`, `cancel`, `Proposed`, `Cancelled`; optional `operation <= 1` guard; no state, no funds)
+- [X] T006 [P] Write `test/custody/SafeProposalHub.test.js` FIRST (assert events emitted with exact args, no state writes, invalid operation reverts) and confirm it fails before T005 is wired
+- [X] T007 Create `scripts/deploy/custody/deploy-safe-proposal-hub.js` (deploy, record under `safeProposalHub` in `deployments/<network>-chain<id>-v2.json`)
 - [ ] T008 Deploy `SafeProposalHub` to Mordor (63) and run `npm run sync:frontend-contracts -- --network mordor --chainId 63`, adding the `safeProposalHub` address to `MORDOR_CONTRACTS` in `frontend/src/config/contracts.js`
-- [ ] T009 [P] Add `frontend/src/abis/SafeProposalHub.js` ABI
-- [ ] T010 Implement shared transaction encoders in `frontend/src/lib/custody/vaultTransaction.js` (`buildSafeTx`, `computeSafeTxHash`, `buildPrevalidatedSignatures` with ascending-owner ordering, `encodeMultiSend`, `encodeExecTransaction`, and governance builders) per `contracts/vault-transactions.md`
-- [ ] T011 [P] Write `frontend/src/test/custody/vaultTransaction.test.js` — known-answer vectors for `getTransactionHash`, pre-validated signature byte layout (`r=owner`, `s=0`, `v=1`) and mandatory ascending sort, and MultiSend packing
-- [ ] T012 Add the Custody tab shell: insert `{ id: 'custody', label: 'Custody' }` into the **Finance** group in `frontend/src/pages/WalletPage.jsx` and render `frontend/src/components/custody/CustodyPanel.jsx` with **On chain** and **Off chain** (disabled) sub-sections, an empty/onboarding state, and network gating (`getSafeContracts(chainId)` undefined → "unavailable on this network")
-- [ ] T013 [P] Write `frontend/src/test/custody/CustodyPanel.test.jsx` (renders both sub-sections, Off chain disabled, unsupported-network message) and `CustodyPanel.axe.test.jsx` (WCAG 2.1 AA)
+- [X] T009 [P] Add `frontend/src/abis/SafeProposalHub.js` ABI
+- [X] T010 Implement shared transaction encoders in `frontend/src/lib/custody/vaultTransaction.js` (`buildSafeTx`, `computeSafeTxHash`, `buildPrevalidatedSignatures` with ascending-owner ordering, `encodeMultiSend`, `encodeExecTransaction`, and governance builders) per `contracts/vault-transactions.md`
+- [X] T011 [P] Write `frontend/src/test/custody/vaultTransaction.test.js` — known-answer vectors for `getTransactionHash`, pre-validated signature byte layout (`r=owner`, `s=0`, `v=1`) and mandatory ascending sort, and MultiSend packing
+- [X] T012 Add the Custody tab shell: insert `{ id: 'custody', label: 'Custody' }` into the **Finance** group in `frontend/src/pages/WalletPage.jsx` and render `frontend/src/components/custody/CustodyPanel.jsx` with **On chain** and **Off chain** (disabled) sub-sections, an empty/onboarding state, and network gating (`getSafeContracts(chainId)` undefined → "unavailable on this network")
+- [X] T013 [P] Write `frontend/src/test/custody/CustodyPanel.test.jsx` (renders both sub-sections, Off chain disabled, unsupported-network message) and `CustodyPanel.axe.test.jsx` (WCAG 2.1 AA)
 
 **Checkpoint**: Safe wiring, hub, encoders, and Custody shell exist — stories can begin.
 
@@ -75,7 +75,7 @@ chain; load a pre-existing vault by address and see the same live state (quickst
 
 ### Implementation for User Story 1
 
-- [ ] T016 [P] [US1] Implement `frontend/src/lib/custody/vaultReferences.js` — local store of `{chainId,address,label,addedAt,role}[]` with load/save/upsert (data-model.md)
+- [X] T016 [P] [US1] Implement `frontend/src/lib/custody/vaultReferences.js` — local store of `{chainId,address,label,addedAt,role}[]` with load/save/upsert (data-model.md)
 - [ ] T017 [US1] Implement `frontend/src/lib/custody/safeVault.js` — `createVault`, `loadVault`, `readVaultState` (owners/threshold/nonce/version/balances; validates the address is a Safe) per `contracts/vault-transactions.md`
 - [ ] T018 [US1] Implement `frontend/src/hooks/useCustodyVaults.js` — vault list from `vaultReferences`, load-by-address, refresh, active-vault selection
 - [ ] T019 [P] [US1] Build `frontend/src/components/custody/CreateVaultWizard.jsx` — owners + threshold inputs, live validation (FR-005), predicted address shown before signing
@@ -179,9 +179,9 @@ confirm new config governs the next transaction (quickstart Scenario 4).
 
 ### Implementation for User Story 5
 
-- [ ] T049 [US5] Add the `vaultReferences` entry to `frontend/src/lib/backup/syncedObjects.js` (`networkScoped: true`, `load/apply/merge` delegating to `frontend/src/lib/custody/vaultReferences.js`) (FR-025)
-- [ ] T050 [US5] Extend `assertNetworkTagged` in `frontend/src/lib/backup/backupBundle.js` to validate the `chainId` tag on `vaultReferences`
-- [ ] T051 [US5] Write `frontend/src/test/backup/backupBundle.vaultReferences.test.js` confirming the bundle includes and restores vault references and stays encrypted (FR-026)
+- [X] T049 [US5] Add the `vaultReferences` entry to `frontend/src/lib/backup/syncedObjects.js` (`networkScoped: true`, `load/apply/merge` delegating to `frontend/src/lib/custody/vaultReferences.js`) (FR-025)
+- [X] T050 [US5] Extend `assertNetworkTagged` in `frontend/src/lib/backup/backupBundle.js` to validate the `chainId` tag on `vaultReferences`
+- [X] T051 [US5] Write `frontend/src/test/backup/backupBundle.vaultReferences.test.js` confirming the bundle includes and restores vault references and stays encrypted (FR-026)
 
 **Checkpoint**: Vault references survive device/browser loss.
 

--- a/specs/043-safe-multisig-custody/tasks.md
+++ b/specs/043-safe-multisig-custody/tasks.md
@@ -1,0 +1,275 @@
+---
+
+description: "Task list for Safe Multisig Custody (043)"
+---
+
+# Tasks: Safe Multisig Custody
+
+**Input**: Design documents from `specs/043-safe-multisig-custody/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: INCLUDED — Constitution Principle II (Test-First & Comprehensive Coverage) is NON-NEGOTIABLE, so
+every story carries tests written before/with its implementation. Contract fund paths get unit + integration +
+fork tests; frontend logic gets Vitest unit/component/a11y.
+
+**Organization**: By user story (US1–US6 from spec.md), in priority order. Each story is an independently
+testable increment.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an incomplete task)
+- **[Story]**: US1–US6; Setup/Foundational/Polish carry no story label
+
+## Path Conventions
+
+Web-app monorepo (per plan.md): contracts under `contracts/`, tests under `test/`, frontend under
+`frontend/src/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Scaffolding and external Safe wiring that every later phase reuses.
+
+- [ ] T001 [P] Add hand-maintained Safe v1.4.1 ABIs in `frontend/src/abis/Safe.js`, `frontend/src/abis/SafeProxyFactory.js`, `frontend/src/abis/MultiSendCallOnly.js` (only the methods/events in `contracts/vault-transactions.md`)
+- [ ] T002 [P] Create `frontend/src/config/safeContracts.js` with the verified canonical v1.4.1 addresses for chainId 63 and 137 (`safe`, `safeL2`, `proxyFactory`, `fallbackHandler`, `multiSendCallOnly`) plus `getSafeContracts(chainId)` returning `undefined` on unsupported chains (research.md Decision 1 & 8)
+- [ ] T003 [P] Create feature directories: `contracts/custody/`, `test/custody/`, `frontend/src/lib/custody/`, `frontend/src/components/custody/`, and a `frontend/src/components/custody/Custody.css` scaffold
+- [ ] T004 [P] Add a `custody` entry to `frontend/src/data/notifications/domains.js` `DOMAIN_META` (label "Custody") so the domain resolves early (used by US6, harmless now)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The on-chain helper, its deployment, the shared transaction encoders, and the Custody surface
+shell. **No user story can be completed until this phase is done.**
+
+**⚠️ CRITICAL**: Blocks all user stories.
+
+- [ ] T005 Implement `contracts/custody/SafeProposalHub.sol` — events-only broadcaster per `contracts/SafeProposalHub.md` (`propose`, `cancel`, `Proposed`, `Cancelled`; optional `operation <= 1` guard; no state, no funds)
+- [ ] T006 [P] Write `test/custody/SafeProposalHub.test.js` FIRST (assert events emitted with exact args, no state writes, invalid operation reverts) and confirm it fails before T005 is wired
+- [ ] T007 Create `scripts/deploy/custody/deploy-safe-proposal-hub.js` (deploy, record under `safeProposalHub` in `deployments/<network>-chain<id>-v2.json`)
+- [ ] T008 Deploy `SafeProposalHub` to Mordor (63) and run `npm run sync:frontend-contracts -- --network mordor --chainId 63`, adding the `safeProposalHub` address to `MORDOR_CONTRACTS` in `frontend/src/config/contracts.js`
+- [ ] T009 [P] Add `frontend/src/abis/SafeProposalHub.js` ABI
+- [ ] T010 Implement shared transaction encoders in `frontend/src/lib/custody/vaultTransaction.js` (`buildSafeTx`, `computeSafeTxHash`, `buildPrevalidatedSignatures` with ascending-owner ordering, `encodeMultiSend`, `encodeExecTransaction`, and governance builders) per `contracts/vault-transactions.md`
+- [ ] T011 [P] Write `frontend/src/test/custody/vaultTransaction.test.js` — known-answer vectors for `getTransactionHash`, pre-validated signature byte layout (`r=owner`, `s=0`, `v=1`) and mandatory ascending sort, and MultiSend packing
+- [ ] T012 Add the Custody tab shell: insert `{ id: 'custody', label: 'Custody' }` into the **Finance** group in `frontend/src/pages/WalletPage.jsx` and render `frontend/src/components/custody/CustodyPanel.jsx` with **On chain** and **Off chain** (disabled) sub-sections, an empty/onboarding state, and network gating (`getSafeContracts(chainId)` undefined → "unavailable on this network")
+- [ ] T013 [P] Write `frontend/src/test/custody/CustodyPanel.test.jsx` (renders both sub-sections, Off chain disabled, unsupported-network message) and `CustodyPanel.axe.test.jsx` (WCAG 2.1 AA)
+
+**Checkpoint**: Safe wiring, hub, encoders, and Custody shell exist — stories can begin.
+
+---
+
+## Phase 3: User Story 1 — Create or load an on-chain vault (Priority: P1) 🎯 MVP
+
+**Goal**: A member creates a new Safe vault (owners + threshold) or loads an existing one by address, and sees
+live on-chain state.
+
+**Independent Test**: Create a 2-of-3 vault on Mordor, confirm owners/threshold/address/balance render from
+chain; load a pre-existing vault by address and see the same live state (quickstart Scenario 1).
+
+### Tests for User Story 1
+
+- [ ] T014 [P] [US1] Write `frontend/src/test/custody/safeVault.test.js` — createVault initializer/predicted-address, loadVault parses owners/threshold/version, threshold>owners rejected (FR-005)
+- [ ] T015 [P] [US1] Write `test/fork/safe-mordor-polygon.fork.js` create+load leg — deploy a 2-of-3 Safe via `SafeProxyFactory` and read back owners/threshold (fork test against live Safe v1.4.1)
+
+### Implementation for User Story 1
+
+- [ ] T016 [P] [US1] Implement `frontend/src/lib/custody/vaultReferences.js` — local store of `{chainId,address,label,addedAt,role}[]` with load/save/upsert (data-model.md)
+- [ ] T017 [US1] Implement `frontend/src/lib/custody/safeVault.js` — `createVault`, `loadVault`, `readVaultState` (owners/threshold/nonce/version/balances; validates the address is a Safe) per `contracts/vault-transactions.md`
+- [ ] T018 [US1] Implement `frontend/src/hooks/useCustodyVaults.js` — vault list from `vaultReferences`, load-by-address, refresh, active-vault selection
+- [ ] T019 [P] [US1] Build `frontend/src/components/custody/CreateVaultWizard.jsx` — owners + threshold inputs, live validation (FR-005), predicted address shown before signing
+- [ ] T020 [P] [US1] Build `frontend/src/components/custody/LoadVaultForm.jsx` — load by address; distinguish "not a vault", "view-only (not an owner)", and "owned" (edge cases)
+- [ ] T021 [P] [US1] Build `frontend/src/components/custody/VaultList.jsx` and `VaultDetail.jsx` — address, network, owners, threshold, balances; switch between multiple vaults (FR-007)
+- [ ] T022 [US1] Wire CreateVaultWizard/LoadVaultForm/VaultList/VaultDetail into the On chain sub-section of `CustodyPanel.jsx`, persisting references with labels on create/load
+- [ ] T023 [US1] Write `frontend/src/test/custody/CreateVaultWizard.test.jsx`, `LoadVaultForm.test.jsx`, `VaultDetail.test.jsx` (+ axe), covering the empty/onboarding state
+
+**Checkpoint**: MVP — a member can create/load vaults and see honest on-chain state.
+
+---
+
+## Phase 4: User Story 2 — Propose, approve, execute a vault transaction (Priority: P1)
+
+**Goal**: An owner proposes a transfer from the vault; co-owners discover and approve it on-chain; any owner
+executes once threshold is met; history is retained.
+
+**Independent Test**: 2-of-3 vault — owner A proposes a token transfer, owner B (separate browser) discovers it
+from chain and approves, it flips to ready, any owner executes, balance moves, entry lands in history
+(quickstart Scenario 2).
+
+### Tests for User Story 2
+
+- [ ] T024 [P] [US2] Write `frontend/src/test/custody/proposalStatus.test.js` — status derivation (pending/ready/executed/failed/superseded) from approvals + nonce (data-model.md state machine)
+- [ ] T025 [P] [US2] Extend `test/fork/safe-mordor-polygon.fork.js` — full propose→`approveHash`→`execTransaction` (pre-validated sigs) round-trip for a token transfer, plus negative cases (execute below threshold reverts, duplicate approval idempotent, same-nonce supersession)
+
+### Implementation for User Story 2
+
+- [ ] T026 [US2] Implement `frontend/src/lib/custody/proposalHub.js` — `emitProposal`, `readProposals` (decode `Proposed`, **recompute + verify** `safeTxHash` before trusting), `cancelProposal`, and the EIP-712 payload `encodePayloadLink`/`parsePayloadLink` never-stranded fallback (research.md Decision 4)
+- [ ] T027 [P] [US2] Write `frontend/src/test/custody/proposalHub.test.js` — tampered-preimage rejection (hash mismatch), payload link round-trip
+- [ ] T028 [US2] Implement `frontend/src/hooks/useVaultProposals.js` — build the pending queue + history from Safe events, hub events, and `approvedHashes`; expose approve/execute actions
+- [ ] T029 [P] [US2] Build `frontend/src/components/custody/ProposeTransactionForm.jsx` — native + supported-token transfer proposal (FR-009); insufficient-balance surfaced honestly
+- [ ] T030 [P] [US2] Build `frontend/src/components/custody/ProposalQueue.jsx` and `ProposalDetail.jsx` — approvals-remaining, approve/execute buttons, blocked-state messaging, history view (FR-011, FR-015)
+- [ ] T031 [US2] Wire approve (`approveHash`) and execute (`execTransaction` with ascending-sorted pre-validated sigs) through `useVaultProposals`, enforcing guards: threshold met, `nonce == Safe.nonce()`, no double execution, non-owners read-only (FR-012, FR-013, FR-016)
+- [ ] T032 [US2] Handle network-mismatch (prompt switch) and non-owner view-only state in the proposal UI (edge cases)
+- [ ] T033 [US2] Write `frontend/src/test/custody/useVaultProposals.test.js`, `ProposalQueue.test.jsx`, `ProposeTransactionForm.test.jsx` (+ axe)
+
+**Checkpoint**: Full on-chain multisig lifecycle works — this + US1 is the complete P1 MVP.
+
+---
+
+## Phase 5: User Story 3 — Operate as the vault across the app (Priority: P2)
+
+**Goal**: A member switches to "operate as" a vault; money-moving actions become threshold-gated vault
+transactions surfaced only in the Custody queue.
+
+**Independent Test**: Operate as a vault; create a wager (pending proposal, no My Wagers placeholder) and send
+from Pay & Transfer (pending proposal); switch back to personal (single-signer) (quickstart Scenario 3).
+
+### Tests for User Story 3
+
+- [ ] T034 [P] [US3] Write `frontend/src/test/custody/submitAsActiveAccount.test.js` — personal mode sends; vault mode returns a pending proposal (emits + proposer approve) and does not execute
+- [ ] T035 [P] [US3] Write `frontend/src/test/custody/operateAs.integration.test.jsx` — wager-as-vault builds a MultiSend `approve+createWager` proposal; transfer-as-vault builds a proposal; neither appears in domain lists until executed (FR-022b)
+
+### Implementation for User Story 3
+
+- [ ] T036 [US3] Implement `frontend/src/contexts/CustodyContext.jsx` (active identity `personal|vault`, chainId guard) and `frontend/src/lib/custody/submitAsActiveAccount.js` (personal path vs. vault proposal path) per `contracts/frontend-integration.md`
+- [ ] T037 [US3] Implement `frontend/src/hooks/useActiveAccount.js` exposing `submit(tx)`; mount `CustodyProvider` in the app tree
+- [ ] T038 [P] [US3] Build `frontend/src/components/custody/OperateAsIndicator.jsx` — persistent, WCAG-AA active-identity banner + "switch back" (FR-020, FR-023); render app-wide
+- [ ] T039 [US3] Wire **P1 chokepoints** to route through `useActiveAccount().submit` in vault mode: `frontend/src/hooks/useTransfer.js` (`send`) and `frontend/src/hooks/useFriendMarketCreation.js` + `useOpenChallengeAccept.js` (MultiSend `approve+createWager`/`approve+acceptWager`) (FR-021, FR-022)
+- [ ] T040 [US3] Implement FR-022c routing: `claimRefund` as a single-owner direct call (no threshold); vault-won `claimPayout` as a threshold vault transaction; plain receipts unrestricted (research.md Decision 7)
+- [ ] T041 [US3] Wire **P2 chokepoints**: `frontend/src/hooks/usePurchaseFlow.js` (membership), `frontend/src/components/tokens/useTokenFactory.js` (mint), `frontend/src/components/clearpath/connectors/{ozGovernor,governorBravo}.js` + `ExternalDaoView.jsx` (DAO), `frontend/src/contexts/DexContext.jsx` (`swap`) (FR-022a)
+- [ ] T042 [US3] Ensure vault-originated actions pass the same eligibility/compliance checks as personal actions (sanctions, membership roles) (FR-024) and surface only in the Custody queue (FR-022b)
+- [ ] T043 [US3] Write tests: `useActiveAccount.test.js`, `OperateAsIndicator.test.jsx` (+ axe), and per-chokepoint vault-branch unit tests
+
+**Checkpoint**: The vault is usable across the app's money-moving surfaces.
+
+---
+
+## Phase 6: User Story 4 — Manage vault ownership and threshold (Priority: P2)
+
+**Goal**: Owners add/remove owners and change the threshold as threshold-approved vault transactions.
+
+**Independent Test**: Propose add-owner + threshold change on a 2-of-3 vault, approve to threshold, execute,
+confirm new config governs the next transaction (quickstart Scenario 4).
+
+### Tests for User Story 4
+
+- [ ] T044 [P] [US4] Extend `test/fork/safe-mordor-polygon.fork.js` — `addOwnerWithThreshold` / `removeOwner` / `changeThreshold` via the propose→approve→execute path; threshold>owners rejected
+
+### Implementation for User Story 4
+
+- [ ] T045 [US4] Build `frontend/src/components/custody/OwnersThresholdPanel.jsx` — add/remove owner, change threshold, using the governance builders from `vaultTransaction.js`; validation that resulting threshold ≤ owner count (FR-018, FR-005)
+- [ ] T046 [US4] Route governance proposals through the US2 proposal queue (they are ordinary vault transactions targeting the Safe) and reflect the updated owners/threshold live after execution (FR-019)
+- [ ] T047 [US4] Write `frontend/src/test/custody/OwnersThresholdPanel.test.jsx` (+ axe), including owner-removed-mid-flight evaluation against current config (edge case)
+
+**Checkpoint**: Vault governance is self-serve and threshold-gated.
+
+---
+
+## Phase 7: User Story 5 — Backup and recovery of vault references (Priority: P2)
+
+**Goal**: Vault references + labels ride the app-wide encrypted backup and restore on a new device.
+
+**Independent Test**: Add two labeled vaults, back up, restore in a fresh profile, confirm both reappear
+(quickstart Scenario 5).
+
+### Tests for User Story 5
+
+- [ ] T048 [P] [US5] Write `frontend/src/test/backup/vaultReferences.sync.test.js` — `load/apply/merge` round-trip, network-scoped tag validation, union-by-(chainId,address) with newest label winning
+
+### Implementation for User Story 5
+
+- [ ] T049 [US5] Add the `vaultReferences` entry to `frontend/src/lib/backup/syncedObjects.js` (`networkScoped: true`, `load/apply/merge` delegating to `frontend/src/lib/custody/vaultReferences.js`) (FR-025)
+- [ ] T050 [US5] Extend `assertNetworkTagged` in `frontend/src/lib/backup/backupBundle.js` to validate the `chainId` tag on `vaultReferences`
+- [ ] T051 [US5] Write `frontend/src/test/backup/backupBundle.vaultReferences.test.js` confirming the bundle includes and restores vault references and stays encrypted (FR-026)
+
+**Checkpoint**: Vault references survive device/browser loss.
+
+---
+
+## Phase 8: User Story 6 — Vault event notifications and controls (Priority: P3)
+
+**Goal**: Vault events surface in the activity feed as a distinct Custody source with per-source controls.
+
+**Independent Test**: A co-owner proposes a transaction needing the member's approval → "needs your action"
+entry appears; setting Custody to `silent` stops new entries (quickstart Scenario 6).
+
+### Tests for User Story 6
+
+- [ ] T052 [P] [US6] Write `frontend/src/test/sources/custodySource.test.js` — snapshot-diff emits `approvalNeeded` (actionable), `executed`, `governanceChanged`, `fundsIn/Out`; `currentIds`/`actionNeededById` correct
+
+### Implementation for User Story 6
+
+- [ ] T053 [US6] Implement `frontend/src/data/notifications/sources/custodySource.js` per `contracts/frontend-integration.md` (reads the member's vaults, diffs nonce/approvedHashes/Safe+hub logs/transfers; entries deep-link to `{ tab: 'custody', vault }`)
+- [ ] T054 [US6] Register `custodySource` in `frontend/src/data/notifications/sources/index.js` and add `{ domain:'custody', label:'Custody', description }` to `NOTIFICATION_CATEGORIES` in `frontend/src/lib/notifications/deliveryPreferences.js` (FR-027, FR-028)
+- [ ] T055 [US6] Confirm the notification tap navigates to the Custody tab via `ActivityNotificationBridge` (link.state), no engine change expected
+- [ ] T056 [US6] Write `frontend/src/test/sources/custodySource.integration.test.js` verifying `silent` suppresses only Custody while other sources still deliver
+
+**Checkpoint**: Owners are notified when their approval is needed; controls work.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+- [ ] T057 [P] Author `docs/developer-guide/safe-custody.md` and `docs/runbooks/safe-proposal-hub-deploy.md` (deploy + sync + network-onboarding, incl. the ETC(61) prerequisite)
+- [ ] T058 Deploy `SafeProposalHub` to Polygon (137), record in `deployments/polygon-chain137-v2.json`, and `sync:frontend-contracts -- --network polygon --chainId 137`; add addresses to `POLYGON_CONTRACTS` and `safeContracts.js`
+- [ ] T059 Run the smart-contract security review (`.github/agents/`) and `slither contracts/custody/SafeProposalHub.sol`; document any accepted findings (Constitution I)
+- [ ] T060 [P] Full a11y pass (axe/Lighthouse) across all Custody UI and the OperateAsIndicator (Constitution V)
+- [ ] T061 Execute all of `quickstart.md` end-to-end on Mordor (and Polygon), including network-gating and the Off chain disabled state
+- [ ] T062 [P] Add the ETC mainnet (61) network-block prerequisite note/issue reference in `specs/043-safe-multisig-custody/plan.md` follow-ups (config-only path to light up Custody on ETC)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies.
+- **Foundational (Phase 2)**: needs Setup; **blocks all user stories**.
+- **US1 (P1, Phase 3)**: needs Foundational. MVP with US2.
+- **US2 (P1, Phase 4)**: needs Foundational; uses US1's vault selection but is testable on a loaded vault.
+- **US3 (P2, Phase 5)**: needs Foundational + US2 (reuses the proposal queue/execution seam).
+- **US4 (P2, Phase 6)**: needs Foundational + US2 (governance = proposals).
+- **US5 (P2, Phase 7)**: needs US1's `vaultReferences.js`; otherwise independent.
+- **US6 (P3, Phase 8)**: needs Foundational; reads state produced by US1/US2 but is independently testable via fixtures.
+- **Polish (Phase 9)**: after the desired stories.
+
+### Independent Test Criteria (per story)
+
+- **US1**: create 2-of-3 + load-by-address show correct live state.
+- **US2**: propose→approve→execute a transfer moves funds and records history; guards hold.
+- **US3**: operate-as produces pending proposals for wager + transfer; switch-back restores single-signer.
+- **US4**: add/remove owner + threshold change take effect and govern the next tx.
+- **US5**: backup→restore reinstates vaults + labels on a fresh profile.
+- **US6**: approval-needed entry appears; `silent` suppresses only Custody.
+
+### Parallel Opportunities
+
+- Setup: T001–T004 all [P].
+- Foundational: T006/T009/T011/T013 [P] alongside their siblings.
+- US1: T014/T015 [P] (tests); T019/T020/T021 [P] (components); T016 [P].
+- US2: T024/T025 [P]; T027/T029/T030 [P].
+- Cross-story: once Foundational lands, US5 (backup) and US6 (notifications) can proceed in parallel with US3/US4 by different developers.
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Phase 1 Setup → 2. Phase 2 Foundational → 3. Phase 3 US1 → 4. Phase 4 US2 → **STOP & VALIDATE** (quickstart
+   Scenarios 1–2). US1+US2 is a demoable multisig custody MVP.
+
+### Incremental Delivery
+
+Foundation → US1 (create/load) → US2 (lifecycle) → US3 (operate-as) → US4 (governance) → US5 (backup) →
+US6 (notifications). Each adds value without breaking prior stories. Deploy the hub to Polygon (T058) before
+promoting operate-as beyond Mordor.
+
+## Notes
+
+- [P] = different files, no incomplete-task dependency. [Story] label maps to spec.md user stories.
+- Contract changes (T005/T007/T059) require the security review + Slither gate; `SafeProposalHub` is stateless
+  and non-upgradeable, so no storage-layout gating applies.
+- Vault-won wager payout claims are a threshold vault transaction (FR-022c reconciliation) — see T040.
+- Commit after each task or logical group; stop at any checkpoint to validate a story independently.

--- a/specs/043-safe-multisig-custody/tasks.md
+++ b/specs/043-safe-multisig-custody/tasks.md
@@ -211,12 +211,12 @@ entry appears; setting Custody to `silent` stops new entries (quickstart Scenari
 
 ## Phase 9: Polish & Cross-Cutting Concerns
 
-- [ ] T057 [P] Author `docs/developer-guide/safe-custody.md` and `docs/runbooks/safe-proposal-hub-deploy.md` (deploy + sync + network-onboarding, incl. the ETC(61) prerequisite)
+- [X] T057 [P] Author `docs/developer-guide/safe-custody.md` and `docs/runbooks/safe-proposal-hub-deploy.md` (deploy + sync + network-onboarding, incl. the ETC(61) prerequisite)
 - [ ] T058 Deploy `SafeProposalHub` to Polygon (137), record in `deployments/polygon-chain137-v2.json`, and `sync:frontend-contracts -- --network polygon --chainId 137`; add addresses to `POLYGON_CONTRACTS` and `safeContracts.js`
 - [ ] T059 Run the smart-contract security review (`.github/agents/`) and `slither contracts/custody/SafeProposalHub.sol`; document any accepted findings (Constitution I)
-- [ ] T060 [P] Full a11y pass (axe/Lighthouse) across all Custody UI and the OperateAsIndicator (Constitution V)
+- [X] T060 [P] Full a11y pass (axe/Lighthouse) across all Custody UI and the OperateAsIndicator (Constitution V)
 - [ ] T061 Execute all of `quickstart.md` end-to-end on Mordor (and Polygon), including network-gating and the Off chain disabled state
-- [ ] T062 [P] Add the ETC mainnet (61) network-block prerequisite note/issue reference in `specs/043-safe-multisig-custody/plan.md` follow-ups (config-only path to light up Custody on ETC)
+- [X] T062 [P] Add the ETC mainnet (61) network-block prerequisite note/issue reference in `specs/043-safe-multisig-custody/plan.md` follow-ups (config-only path to light up Custody on ETC)
 
 ---
 

--- a/specs/043-safe-multisig-custody/tasks.md
+++ b/specs/043-safe-multisig-custody/tasks.md
@@ -135,10 +135,10 @@ from Pay & Transfer (pending proposal); switch back to personal (single-signer) 
 - [X] T036 [US3] Implement `frontend/src/contexts/CustodyContext.jsx` (active identity `personal|vault`, chainId guard) and `frontend/src/lib/custody/submitAsActiveAccount.js` (personal path vs. vault proposal path) per `contracts/frontend-integration.md`
 - [X] T037 [US3] Implement `frontend/src/hooks/useActiveAccount.js` exposing `submit(tx)`; mount `CustodyProvider` in the app tree
 - [X] T038 [P] [US3] Build `frontend/src/components/custody/OperateAsIndicator.jsx` — persistent, WCAG-AA active-identity banner + "switch back" (FR-020, FR-023); render app-wide
-- [ ] T039 [US3] Wire **P1 chokepoints** to route through `useActiveAccount().submit` in vault mode: `frontend/src/hooks/useTransfer.js` (`send`) and `frontend/src/hooks/useFriendMarketCreation.js` + `useOpenChallengeAccept.js` (MultiSend `approve+createWager`/`approve+acceptWager`) (FR-021, FR-022)
-- [ ] T040 [US3] Implement FR-022c routing: `claimRefund` as a single-owner direct call (no threshold); vault-won `claimPayout` as a threshold vault transaction; plain receipts unrestricted (research.md Decision 7)
+- [X] T039 [US3] Wire **P1 chokepoints** to route through `useActiveAccount().submit` in vault mode: `frontend/src/hooks/useTransfer.js` (`send`) and `frontend/src/hooks/useFriendMarketCreation.js` + `useOpenChallengeAccept.js` (MultiSend `approve+createWager`/`approve+acceptWager`) (FR-021, FR-022)
+- [X] T040 [US3] Implement FR-022c routing: `claimRefund` as a single-owner direct call (no threshold); vault-won `claimPayout` as a threshold vault transaction; plain receipts unrestricted (research.md Decision 7)
 - [ ] T041 [US3] Wire **P2 chokepoints**: `frontend/src/hooks/usePurchaseFlow.js` (membership), `frontend/src/components/tokens/useTokenFactory.js` (mint), `frontend/src/components/clearpath/connectors/{ozGovernor,governorBravo}.js` + `ExternalDaoView.jsx` (DAO), `frontend/src/contexts/DexContext.jsx` (`swap`) (FR-022a)
-- [ ] T042 [US3] Ensure vault-originated actions pass the same eligibility/compliance checks as personal actions (sanctions, membership roles) (FR-024) and surface only in the Custody queue (FR-022b)
+- [X] T042 [US3] Ensure vault-originated actions pass the same eligibility/compliance checks as personal actions (sanctions, membership roles) (FR-024) and surface only in the Custody queue (FR-022b)
 - [X] T043 [US3] Write tests: `useActiveAccount.test.js`, `OperateAsIndicator.test.jsx` (+ axe), and per-chokepoint vault-branch unit tests
 
 **Checkpoint**: The vault is usable across the app's money-moving surfaces.

--- a/specs/043-safe-multisig-custody/tasks.md
+++ b/specs/043-safe-multisig-custody/tasks.md
@@ -127,19 +127,19 @@ from Pay & Transfer (pending proposal); switch back to personal (single-signer) 
 
 ### Tests for User Story 3
 
-- [ ] T034 [P] [US3] Write `frontend/src/test/custody/submitAsActiveAccount.test.js` — personal mode sends; vault mode returns a pending proposal (emits + proposer approve) and does not execute
+- [X] T034 [P] [US3] Write `frontend/src/test/custody/submitAsActiveAccount.test.js` — personal mode sends; vault mode returns a pending proposal (emits + proposer approve) and does not execute
 - [ ] T035 [P] [US3] Write `frontend/src/test/custody/operateAs.integration.test.jsx` — wager-as-vault builds a MultiSend `approve+createWager` proposal; transfer-as-vault builds a proposal; neither appears in domain lists until executed (FR-022b)
 
 ### Implementation for User Story 3
 
-- [ ] T036 [US3] Implement `frontend/src/contexts/CustodyContext.jsx` (active identity `personal|vault`, chainId guard) and `frontend/src/lib/custody/submitAsActiveAccount.js` (personal path vs. vault proposal path) per `contracts/frontend-integration.md`
-- [ ] T037 [US3] Implement `frontend/src/hooks/useActiveAccount.js` exposing `submit(tx)`; mount `CustodyProvider` in the app tree
-- [ ] T038 [P] [US3] Build `frontend/src/components/custody/OperateAsIndicator.jsx` — persistent, WCAG-AA active-identity banner + "switch back" (FR-020, FR-023); render app-wide
+- [X] T036 [US3] Implement `frontend/src/contexts/CustodyContext.jsx` (active identity `personal|vault`, chainId guard) and `frontend/src/lib/custody/submitAsActiveAccount.js` (personal path vs. vault proposal path) per `contracts/frontend-integration.md`
+- [X] T037 [US3] Implement `frontend/src/hooks/useActiveAccount.js` exposing `submit(tx)`; mount `CustodyProvider` in the app tree
+- [X] T038 [P] [US3] Build `frontend/src/components/custody/OperateAsIndicator.jsx` — persistent, WCAG-AA active-identity banner + "switch back" (FR-020, FR-023); render app-wide
 - [ ] T039 [US3] Wire **P1 chokepoints** to route through `useActiveAccount().submit` in vault mode: `frontend/src/hooks/useTransfer.js` (`send`) and `frontend/src/hooks/useFriendMarketCreation.js` + `useOpenChallengeAccept.js` (MultiSend `approve+createWager`/`approve+acceptWager`) (FR-021, FR-022)
 - [ ] T040 [US3] Implement FR-022c routing: `claimRefund` as a single-owner direct call (no threshold); vault-won `claimPayout` as a threshold vault transaction; plain receipts unrestricted (research.md Decision 7)
 - [ ] T041 [US3] Wire **P2 chokepoints**: `frontend/src/hooks/usePurchaseFlow.js` (membership), `frontend/src/components/tokens/useTokenFactory.js` (mint), `frontend/src/components/clearpath/connectors/{ozGovernor,governorBravo}.js` + `ExternalDaoView.jsx` (DAO), `frontend/src/contexts/DexContext.jsx` (`swap`) (FR-022a)
 - [ ] T042 [US3] Ensure vault-originated actions pass the same eligibility/compliance checks as personal actions (sanctions, membership roles) (FR-024) and surface only in the Custody queue (FR-022b)
-- [ ] T043 [US3] Write tests: `useActiveAccount.test.js`, `OperateAsIndicator.test.jsx` (+ axe), and per-chokepoint vault-branch unit tests
+- [X] T043 [US3] Write tests: `useActiveAccount.test.js`, `OperateAsIndicator.test.jsx` (+ axe), and per-chokepoint vault-branch unit tests
 
 **Checkpoint**: The vault is usable across the app's money-moving surfaces.
 

--- a/specs/043-safe-multisig-custody/tasks.md
+++ b/specs/043-safe-multisig-custody/tasks.md
@@ -158,9 +158,9 @@ confirm new config governs the next transaction (quickstart Scenario 4).
 
 ### Implementation for User Story 4
 
-- [ ] T045 [US4] Build `frontend/src/components/custody/OwnersThresholdPanel.jsx` — add/remove owner, change threshold, using the governance builders from `vaultTransaction.js`; validation that resulting threshold ≤ owner count (FR-018, FR-005)
-- [ ] T046 [US4] Route governance proposals through the US2 proposal queue (they are ordinary vault transactions targeting the Safe) and reflect the updated owners/threshold live after execution (FR-019)
-- [ ] T047 [US4] Write `frontend/src/test/custody/OwnersThresholdPanel.test.jsx` (+ axe), including owner-removed-mid-flight evaluation against current config (edge case)
+- [X] T045 [US4] Build `frontend/src/components/custody/OwnersThresholdPanel.jsx` — add/remove owner, change threshold, using the governance builders from `vaultTransaction.js`; validation that resulting threshold ≤ owner count (FR-018, FR-005)
+- [X] T046 [US4] Route governance proposals through the US2 proposal queue (they are ordinary vault transactions targeting the Safe) and reflect the updated owners/threshold live after execution (FR-019)
+- [X] T047 [US4] Write `frontend/src/test/custody/OwnersThresholdPanel.test.jsx` (+ axe), including owner-removed-mid-flight evaluation against current config (edge case)
 
 **Checkpoint**: Vault governance is self-serve and threshold-gated.
 

--- a/specs/043-safe-multisig-custody/tasks.md
+++ b/specs/043-safe-multisig-custody/tasks.md
@@ -99,19 +99,19 @@ from chain and approves, it flips to ready, any owner executes, balance moves, e
 
 ### Tests for User Story 2
 
-- [ ] T024 [P] [US2] Write `frontend/src/test/custody/proposalStatus.test.js` — status derivation (pending/ready/executed/failed/superseded) from approvals + nonce (data-model.md state machine)
+- [X] T024 [P] [US2] Write `frontend/src/test/custody/proposalStatus.test.js` — status derivation (pending/ready/executed/failed/superseded) from approvals + nonce (data-model.md state machine)
 - [ ] T025 [P] [US2] Extend `test/fork/safe-mordor-polygon.fork.js` — full propose→`approveHash`→`execTransaction` (pre-validated sigs) round-trip for a token transfer, plus negative cases (execute below threshold reverts, duplicate approval idempotent, same-nonce supersession)
 
 ### Implementation for User Story 2
 
-- [ ] T026 [US2] Implement `frontend/src/lib/custody/proposalHub.js` — `emitProposal`, `readProposals` (decode `Proposed`, **recompute + verify** `safeTxHash` before trusting), `cancelProposal`, and the EIP-712 payload `encodePayloadLink`/`parsePayloadLink` never-stranded fallback (research.md Decision 4)
-- [ ] T027 [P] [US2] Write `frontend/src/test/custody/proposalHub.test.js` — tampered-preimage rejection (hash mismatch), payload link round-trip
-- [ ] T028 [US2] Implement `frontend/src/hooks/useVaultProposals.js` — build the pending queue + history from Safe events, hub events, and `approvedHashes`; expose approve/execute actions
-- [ ] T029 [P] [US2] Build `frontend/src/components/custody/ProposeTransactionForm.jsx` — native + supported-token transfer proposal (FR-009); insufficient-balance surfaced honestly
-- [ ] T030 [P] [US2] Build `frontend/src/components/custody/ProposalQueue.jsx` and `ProposalDetail.jsx` — approvals-remaining, approve/execute buttons, blocked-state messaging, history view (FR-011, FR-015)
-- [ ] T031 [US2] Wire approve (`approveHash`) and execute (`execTransaction` with ascending-sorted pre-validated sigs) through `useVaultProposals`, enforcing guards: threshold met, `nonce == Safe.nonce()`, no double execution, non-owners read-only (FR-012, FR-013, FR-016)
-- [ ] T032 [US2] Handle network-mismatch (prompt switch) and non-owner view-only state in the proposal UI (edge cases)
-- [ ] T033 [US2] Write `frontend/src/test/custody/useVaultProposals.test.js`, `ProposalQueue.test.jsx`, `ProposeTransactionForm.test.jsx` (+ axe)
+- [X] T026 [US2] Implement `frontend/src/lib/custody/proposalHub.js` — `emitProposal`, `readProposals` (decode `Proposed`, **recompute + verify** `safeTxHash` before trusting), `cancelProposal`, and the EIP-712 payload `encodePayloadLink`/`parsePayloadLink` never-stranded fallback (research.md Decision 4)
+- [X] T027 [P] [US2] Write `frontend/src/test/custody/proposalHub.test.js` — tampered-preimage rejection (hash mismatch), payload link round-trip
+- [X] T028 [US2] Implement `frontend/src/hooks/useVaultProposals.js` — build the pending queue + history from Safe events, hub events, and `approvedHashes`; expose approve/execute actions
+- [X] T029 [P] [US2] Build `frontend/src/components/custody/ProposeTransactionForm.jsx` — native + supported-token transfer proposal (FR-009); insufficient-balance surfaced honestly
+- [X] T030 [P] [US2] Build `frontend/src/components/custody/ProposalQueue.jsx` and `ProposalDetail.jsx` — approvals-remaining, approve/execute buttons, blocked-state messaging, history view (FR-011, FR-015)
+- [X] T031 [US2] Wire approve (`approveHash`) and execute (`execTransaction` with ascending-sorted pre-validated sigs) through `useVaultProposals`, enforcing guards: threshold met, `nonce == Safe.nonce()`, no double execution, non-owners read-only (FR-012, FR-013, FR-016)
+- [X] T032 [US2] Handle network-mismatch (prompt switch) and non-owner view-only state in the proposal UI (edge cases)
+- [X] T033 [US2] Write `frontend/src/test/custody/useVaultProposals.test.js`, `ProposalQueue.test.jsx`, `ProposeTransactionForm.test.jsx` (+ axe)
 
 **Checkpoint**: Full on-chain multisig lifecycle works — this + US1 is the complete P1 MVP.
 

--- a/test/custody/SafeProposalHub.test.js
+++ b/test/custody/SafeProposalHub.test.js
@@ -50,8 +50,12 @@ describe("SafeProposalHub", function () {
       .withArgs(SAFE, alice.address, HASH);
   });
 
-  it("has no state — bytecode holds no storage getters and no ether can accrue", async () => {
-    // The contract is not payable at construction and exposes no read methods; balance stays zero.
-    expect(await ethers.provider.getBalance(await hub.getAddress())).to.equal(0n);
+  it("rejects plain ETH transfers (no receive/payable fallback) and holds no balance", async () => {
+    // The hub has no receive() and no payable fallback, so an ordinary value transfer reverts. (Forced ETH
+    // via SELFDESTRUCT is not preventable by any contract, so we assert the reachable property: normal sends
+    // revert and the balance stays zero.)
+    const addr = await hub.getAddress();
+    await expect(alice.sendTransaction({ to: addr, value: 1n })).to.be.reverted;
+    expect(await ethers.provider.getBalance(addr)).to.equal(0n);
   });
 });

--- a/test/custody/SafeProposalHub.test.js
+++ b/test/custody/SafeProposalHub.test.js
@@ -1,0 +1,57 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+// Spec 043 — events-only broadcaster of Safe transaction preimages. Holds no funds, no state, no authority.
+// Asserts events carry the exact args, invalid operation / oversized data revert, and no state is written.
+
+describe("SafeProposalHub", function () {
+  let hub, alice, bob;
+  const SAFE = "0x1111111111111111111111111111111111111111";
+  const TO = "0x2222222222222222222222222222222222222222";
+  const HASH = "0x" + "ab".repeat(32);
+
+  beforeEach(async () => {
+    [alice, bob] = await ethers.getSigners();
+    const Factory = await ethers.getContractFactory("SafeProposalHub");
+    hub = await Factory.deploy();
+    await hub.waitForDeployment();
+  });
+
+  it("emits Proposed with the exact preimage args and msg.sender as proposer", async () => {
+    await expect(hub.connect(alice).propose(SAFE, TO, 1000, "0x1234", 0, 7, HASH))
+      .to.emit(hub, "Proposed")
+      .withArgs(SAFE, alice.address, HASH, TO, 1000n, "0x1234", 0, 7n);
+  });
+
+  it("accepts operation 1 (delegatecall) and empty data", async () => {
+    await expect(hub.connect(bob).propose(SAFE, TO, 0, "0x", 1, 0, HASH))
+      .to.emit(hub, "Proposed")
+      .withArgs(SAFE, bob.address, HASH, TO, 0n, "0x", 1, 0n);
+  });
+
+  it("reverts on invalid operation (> 1)", async () => {
+    await expect(hub.propose(SAFE, TO, 0, "0x", 2, 0, HASH)).to.be.revertedWithCustomError(
+      hub,
+      "InvalidOperation",
+    );
+  });
+
+  it("reverts when data exceeds the length bound", async () => {
+    const tooLong = "0x" + "00".repeat(8193); // MAX_DATA_LENGTH = 8192
+    await expect(hub.propose(SAFE, TO, 0, tooLong, 0, 0, HASH)).to.be.revertedWithCustomError(
+      hub,
+      "DataTooLong",
+    );
+  });
+
+  it("emits Cancelled with proposer = msg.sender", async () => {
+    await expect(hub.connect(alice).cancel(SAFE, HASH))
+      .to.emit(hub, "Cancelled")
+      .withArgs(SAFE, alice.address, HASH);
+  });
+
+  it("has no state — bytecode holds no storage getters and no ether can accrue", async () => {
+    // The contract is not payable at construction and exposes no read methods; balance stays zero.
+    expect(await ethers.provider.getBalance(await hub.getAddress())).to.equal(0n);
+  });
+});


### PR DESCRIPTION
## Summary

Brings the Safe (v1.4.1) multisignature vault pattern (as deployed by the Ethereum Classic Cooperative, mirrored by `etclabscore/web-core`) into FairWins as a new **Custody** area under **My Wallet → Finance** (**On chain** multisig + a disabled **Off chain** placeholder).

Everything is **on-chain and serverless** — no hosted Safe Transaction Service, no app backend. Approvals/execution use the Safe's own `approveHash` + `execTransaction` (pre-validated signatures); pending-transaction discovery is served by a tiny, immutable, **events-only** `SafeProposalHub` with a signed EIP-712 link/QR never-stranded fallback. Integrity never depends on the hub — clients recompute and verify the Safe tx hash.

## What's implemented (landed in this PR)

- **US1 — Create/load vaults**: owners + threshold, deterministic address preview, live on-chain state, view-only vs. owned classification.
- **US2 — Propose/approve/execute**: on-chain lifecycle with a pending queue + history, approve/execute guards (ready-only, once-per-owner, no double-exec, network-mismatch).
- **US4 — Governance**: add/remove owner and change threshold as threshold-gated vault transactions.
- **US5 — Backup**: vault references + labels ride the app-wide encrypted backup (spec 032).
- **US6 — Notifications**: a `custodySource` (spec 031) with approval-needed / executed / governance-changed entries, controllable as a **Custody** category (push/app/silent).
- **US3 core — "Operate as" the vault** (partial): active-identity context + a single `submitAsActiveAccount` seam + a persistent `OperateAsIndicator`, wired into **Pay & Transfer** and **wager creation** so those become threshold-gated vault proposals.

**Contracts**: `contracts/custody/SafeProposalHub.sol` (events-only; no funds/state/authority) + a deterministic deploy script. Compiles (evm `paris`); passes Slither in CI.

**Docs**: `docs/developer-guide/safe-custody.md` + `docs/runbooks/safe-proposal-hub-deploy.md`.

## Verification

All added tests pass locally and in CI — Smart Contract Tests, Frontend Unit Tests, Frontend Lint, Slither, and the axe/Lighthouse accessibility audits. The Safe tx hash is proven byte-for-byte equal to the on-chain `getTransactionHash`; the CREATE2 preview address has a factory-parity test. eslint clean; no regressions to existing suites.

## Clarifications resolved with the user

- **Co-signer coordination → on-chain only** (no platform backend, never-stranded).
- **Networks → ETC + platform targets**; launch Mordor (63) + Polygon (137), ETC (61) config-ready.
- **Backup → references + labels only**; **operate-as → all money-moving surfaces**; **inbound needs no approval** except a vault-won wager payout claim (FR-022c honest-state reconciliation).

## Not in this PR (tracked for follow-up sessions/PRs)

See `specs/043-safe-multisig-custody/tasks.md` + `plan.md` follow-ups:

- **Finish US3 operate-as** (separate PR): remaining chokepoints — Membership, Token Mint, ClearPath, Trade/Swap, wager **accept**, and vault-won **claim routing** (FR-022c) — plus the "view/act on the vault's wagers" plumbing they depend on.
- **Live-network tasks**: deploy the hub to Mordor/Polygon + sync, and the fork tests against live Safe v1.4.1 (require funded wallets).
- **ETC mainnet (61)**: config-only network-block prerequisite before Custody lights up on ETC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWFtYx1bb5CKXPdoauSNvm