### PR TITLE
Wallet: unify section drawer as left slide-over with contained footer

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 //core
-import { BrowserRouter as Router, Routes, Route, Navigate, Outlet } from 'react-router-dom'
+import { BrowserRouter as Router, Routes, Route, Navigate, Outlet, useLocation } from 'react-router-dom'
 import './theme.css'
 import './App.css'
 
@@ -38,6 +38,12 @@ import PwaInstallPrompt from './components/pwa/PwaInstallPrompt'
 import PwaUpdateNotification from './components/pwa/PwaUpdateNotification'
 
 function AppLayout() {
+  // On the wallet screen the legal/policy footer is contained at the bottom of the
+  // section drawer (see WalletPage), so the page-level footer is omitted there to
+  // avoid duplication; every other in-app route keeps it in its usual location.
+  const { pathname } = useLocation()
+  const footerInDrawer = pathname === '/wallet'
+
   return (
     /* Spec 031: platform-wide activity watcher scoped to the app-mode tree — the header bell and the views
        below consume it (wagers + DAO/token/membership sources); landing pages never poll. */
@@ -49,7 +55,7 @@ function AppLayout() {
       <EntryGate />
       <Outlet />
       {/* Spec 010 (US2): condensed legal/policy footer inside the app. */}
-      <Footer variant="condensed" />
+      {!footerInDrawer && <Footer variant="condensed" />}
     </ActivityProvider>
   )
 }

--- a/frontend/src/components/Footer.css
+++ b/frontend/src/components/Footer.css
@@ -49,3 +49,24 @@
     margin-top: 2rem;
   }
 }
+
+/*
+ * Drawer variant — the same condensed legal footer, restyled to be contained at
+ * the bottom of the wallet section drawer (WalletPage.css). It stacks vertically,
+ * drops the wide centered layout, and uses margin-top:auto so it is pinned to the
+ * bottom of the flex-column drawer regardless of how tall the section list is.
+ */
+.app-footer--drawer {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+  max-width: none;
+  margin: auto 0 0;
+  padding: 1rem 12px;
+  font-size: 0.8125rem;
+}
+
+.app-footer--drawer .app-footer-links {
+  flex-direction: column;
+  gap: 0.5rem;
+}

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -8,6 +8,8 @@ import './Footer.css'
  *
  *   variant="full"      → landing-page footer (brand + Oracles/Docs/Legal/Community) + copyright.
  *   variant="condensed" → in-app footer: legal/policy links + copyright only (no marketing columns).
+ *   variant="drawer"    → condensed footer restyled to sit contained at the bottom of the
+ *                         wallet section drawer (same links/copyright, stacked + compact).
  *
  * The copyright year is derived from the current date so it never goes stale (FR-008),
  * and the legal links come from the single LEGAL_LINKS source so the two footers can't
@@ -17,9 +19,10 @@ export default function Footer({ variant = 'full' }) {
   const year = new Date().getFullYear()
   const copyright = `© ${year} ChipprRobotics LLC. Apache License 2.0`
 
-  if (variant === 'condensed') {
+  if (variant === 'condensed' || variant === 'drawer') {
+    const className = variant === 'drawer' ? 'app-footer app-footer--drawer' : 'app-footer'
     return (
-      <footer className="app-footer">
+      <footer className={className}>
         <nav className="app-footer-links" aria-label="Legal">
           {LEGAL_LINKS.map((l) => (
             <a key={l.href} href={l.href}>{l.label}</a>

--- a/frontend/src/pages/WalletPage.css
+++ b/frontend/src/pages/WalletPage.css
@@ -296,59 +296,71 @@
   color: var(--color-text);
 }
 
-@media (max-width: 768px) {
-  /* On phones the section nav becomes a slide-over drawer that overlays the
-     content instead of a docked column that pushes it down. The drawer is
-     anchored to the wallet card and animates in/out from the left edge. */
-  .wallet-portal.portal-shell {
-    min-height: 0;
-    position: relative;
-  }
+/* The section nav is a left slide-over drawer at EVERY breakpoint so it always
+   opens and collapses from the left, overlaying the content instead of docking as
+   a column. It is anchored to the wallet card and animates in/out from the left
+   edge, with the in-app footer pinned to its bottom. These overrides are scoped to
+   .wallet-portal* so the shared Admin portal keeps its docked column. */
+.wallet-portal.portal-shell {
+  min-height: 320px;
+  position: relative;
+}
 
+.wallet-portal-sidebar.portal-sidebar {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 30;
+  display: flex;
+  width: 80%;
+  max-width: 300px;
+  flex-basis: auto;
+  overflow-y: auto;
+  border-right: 1px solid var(--color-border);
+  box-shadow: 4px 0 24px rgba(0, 0, 0, 0.18);
+  transform: translateX(-100%);
+  visibility: hidden;
+  transition: transform 0.25s ease, visibility 0s linear 0.25s;
+}
+
+/* The section list keeps its natural height so the footer's margin-top:auto can
+   pin it to the bottom of the drawer regardless of how many sections there are. */
+.wallet-portal-sidebar .portal-nav {
+  flex: 0 0 auto;
+}
+
+/* Open state: slide in and become focusable. */
+.wallet-portal.portal-shell:not(.portal-collapsed) .wallet-portal-sidebar.portal-sidebar {
+  transform: translateX(0);
+  visibility: visible;
+  transition: transform 0.25s ease, visibility 0s;
+}
+
+/* Closed state: keep it rendered (override the shared display:none) so it can
+   animate back out rather than vanish. */
+.wallet-portal.portal-shell.portal-collapsed .wallet-portal-sidebar.portal-sidebar {
+  display: flex;
+}
+
+.wallet-portal-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  padding: 0;
+  border: none;
+  cursor: pointer;
+  background: rgba(0, 0, 0, 0.4);
+  animation: wallet-portal-backdrop-fade 0.2s ease;
+}
+
+@media (max-width: 768px) {
   .wallet-portal-current {
     font-size: 14px;
   }
 
   .wallet-portal-sidebar.portal-sidebar {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 30;
-    display: flex;
-    width: 80%;
-    max-width: 300px;
-    flex-basis: auto;
-    overflow-y: auto;
-    border-right: 1px solid var(--color-border);
-    box-shadow: 4px 0 24px rgba(0, 0, 0, 0.18);
-    transform: translateX(-100%);
-    visibility: hidden;
-    transition: transform 0.25s ease, visibility 0s linear 0.25s;
-  }
-
-  /* Open state: slide in and become focusable. */
-  .wallet-portal.portal-shell:not(.portal-collapsed) .wallet-portal-sidebar.portal-sidebar {
-    transform: translateX(0);
-    visibility: visible;
-    transition: transform 0.25s ease, visibility 0s;
-  }
-
-  /* Closed state: keep it rendered (override the shared display:none) so it can
-     animate back out rather than vanish. */
-  .wallet-portal.portal-shell.portal-collapsed .wallet-portal-sidebar.portal-sidebar {
-    display: flex;
-  }
-
-  .wallet-portal-backdrop {
-    position: absolute;
-    inset: 0;
-    z-index: 20;
-    padding: 0;
-    border: none;
-    cursor: pointer;
-    background: rgba(0, 0, 0, 0.4);
-    animation: wallet-portal-backdrop-fade 0.2s ease;
+    width: 85%;
   }
 }
 

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -21,6 +21,7 @@ import RecoveryCodesPanel from '../components/account/RecoveryCodesPanel'
 import NetworkSettings from '../components/wallet/NetworkSettings'
 import TaxReportsPanel from '../components/wallet/TaxReportsPanel'
 import PortalNav from '../components/ui/PortalNav'
+import Footer from '../components/Footer'
 import PremiumPurchaseModal from '../components/ui/PremiumPurchaseModal'
 import BlockiesAvatar from '../components/ui/BlockiesAvatar'
 import LoadingScreen from '../components/ui/LoadingScreen'
@@ -117,12 +118,11 @@ function WalletPage() {
     const resolved = TAB_ALIASES[requested] || requested
     return WALLET_TABS.some((t) => t.id === resolved) ? resolved : 'account'
   })
-  // On phones the section nav is a slide-over drawer that overlays the content,
-  // so it starts closed; on wider screens it stays docked open like a portal.
-  const [isMobile, setIsMobile] = useState(
-    () => typeof window !== 'undefined' && window.matchMedia('(max-width: 768px)').matches
-  )
-  const [sidebarOpen, setSidebarOpen] = useState(() => !isMobile)
+  // The section nav is a left slide-over drawer at every breakpoint so it always
+  // opens and collapses from the left (see WalletPage.css). It starts closed and
+  // is opened from the ☰ control in the topbar; the in-app footer is contained at
+  // the bottom of the drawer.
+  const [sidebarOpen, setSidebarOpen] = useState(false)
   const [connectingConnectorId, setConnectingConnectorId] = useState(null)
   const [connectionError, setConnectionError] = useState(null)
   const [keyRegistered, setKeyRegistered] = useState(null)
@@ -220,34 +220,21 @@ function WalletPage() {
     }
   }, [activeTab, isConnected, keyRegistered, handleCheckKeyStatus])
 
-  // Track viewport so the section nav can dock (desktop) or slide over (mobile).
-  // Crossing the breakpoint resets the drawer to its natural state for that size.
+  // Close the slide-over drawer on Escape.
   useEffect(() => {
-    if (typeof window === 'undefined') return
-    const mq = window.matchMedia('(max-width: 768px)')
-    const handleChange = (event) => {
-      setIsMobile(event.matches)
-      setSidebarOpen(!event.matches)
-    }
-    mq.addEventListener('change', handleChange)
-    return () => mq.removeEventListener('change', handleChange)
-  }, [])
-
-  // Close the slide-over drawer on Escape (mobile only).
-  useEffect(() => {
-    if (!isMobile || !sidebarOpen) return
+    if (!sidebarOpen) return
     const handleKeyDown = (event) => {
       if (event.key === 'Escape') setSidebarOpen(false)
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [isMobile, sidebarOpen])
+  }, [sidebarOpen])
 
-  // Jumping to a section closes the drawer on mobile so the content is visible.
+  // Jumping to a section closes the drawer so the content is visible.
   const handleSelectTab = useCallback((id) => {
     setActiveTab(id)
-    if (isMobile) setSidebarOpen(false)
-  }, [isMobile])
+    setSidebarOpen(false)
+  }, [])
 
   const handleCheckForUpdate = useCallback(async () => {
     setPwaChecking(true)
@@ -360,10 +347,14 @@ function WalletPage() {
                   onSelect={handleSelectTab}
                   ariaLabel="Account sections"
                 />
+                {/* The in-app legal/policy footer is contained at the bottom of the
+                    section drawer on the wallet screen; App.jsx omits the page-level
+                    footer here so it never renders twice. */}
+                <Footer variant="drawer" />
               </aside>
 
-              {/* Mobile only: dim + dismiss the slide-over drawer by tapping outside it. */}
-              {isMobile && sidebarOpen && (
+              {/* Dim + dismiss the slide-over drawer by tapping outside it. */}
+              {sidebarOpen && (
                 <button
                   type="button"
                   className="wallet-portal-backdrop"

--- a/frontend/src/test/WalletPage.test.jsx
+++ b/frontend/src/test/WalletPage.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import WalletPage from '../pages/WalletPage'
 import { WalletContext, UIContext } from '../contexts'
@@ -158,35 +158,10 @@ describe('WalletPage — address QR entry point', () => {
 })
 
 describe('WalletPage — section nav slide-over drawer', () => {
-  // matchMedia defaults to matches:false (desktop) in setup.js. Force a mobile
-  // match so the section nav behaves as an overlay drawer.
-  const setViewport = (isMobile) => {
-    window.matchMedia = vi.fn().mockImplementation((query) => ({
-      matches: isMobile,
-      media: query,
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }))
-  }
-
-  it('docks the nav open on desktop (no backdrop)', () => {
-    setViewport(false)
-    renderPage(connectedWalletContext)
-
-    expect(
-      screen.getByRole('button', { name: /hide menu/i })
-    ).toHaveAttribute('aria-expanded', 'true')
-    expect(
-      screen.queryByRole('button', { name: /close menu/i })
-    ).not.toBeInTheDocument()
-  })
-
-  it('starts closed on mobile and toggles open with a backdrop', () => {
-    setViewport(true)
+  // The section nav is a left slide-over drawer at every breakpoint: it starts
+  // closed, opens/collapses from the left, and dims the content with a backdrop
+  // while open (WalletPage.css). Behaviour is uniform across viewport widths.
+  it('starts closed and exposes the ☰ open control', () => {
     renderPage(connectedWalletContext)
 
     const toggle = screen.getByRole('button', { name: /show menu/i })
@@ -194,8 +169,12 @@ describe('WalletPage — section nav slide-over drawer', () => {
     expect(
       screen.queryByRole('button', { name: /close menu/i })
     ).not.toBeInTheDocument()
+  })
 
-    fireEvent.click(toggle)
+  it('opens from the ☰ control with a dismiss backdrop', () => {
+    renderPage(connectedWalletContext)
+
+    fireEvent.click(screen.getByRole('button', { name: /show menu/i }))
 
     expect(
       screen.getByRole('button', { name: /hide menu/i })
@@ -205,8 +184,7 @@ describe('WalletPage — section nav slide-over drawer', () => {
     ).toBeInTheDocument()
   })
 
-  it('closes the drawer after a section is selected on mobile', () => {
-    setViewport(true)
+  it('closes the drawer after a section is selected', () => {
     renderPage(connectedWalletContext)
 
     fireEvent.click(screen.getByRole('button', { name: /show menu/i }))
@@ -224,8 +202,7 @@ describe('WalletPage — section nav slide-over drawer', () => {
     ).toHaveAttribute('aria-expanded', 'false')
   })
 
-  it('dismisses the drawer when the backdrop is tapped on mobile', () => {
-    setViewport(true)
+  it('dismisses the drawer when the backdrop is tapped', () => {
     renderPage(connectedWalletContext)
 
     fireEvent.click(screen.getByRole('button', { name: /show menu/i }))
@@ -234,5 +211,19 @@ describe('WalletPage — section nav slide-over drawer', () => {
     expect(
       screen.getByRole('button', { name: /show menu/i })
     ).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('contains the in-app legal footer at the bottom of the drawer', () => {
+    const { container } = renderPage(connectedWalletContext)
+
+    // The condensed legal footer is rendered inside the section drawer (aside),
+    // not as a separate page-level footer, on the wallet screen.
+    const drawer = container.querySelector('.wallet-portal-sidebar')
+    expect(drawer).toBeTruthy()
+    const footer = drawer.querySelector('.app-footer--drawer')
+    expect(footer).toBeTruthy()
+    expect(
+      within(footer).getByRole('link', { name: /Terms & Conditions/i })
+    ).toHaveAttribute('href', '/terms')
   })
 })


### PR DESCRIPTION
## What & why

On the wallet screen the section nav ("accordion menu") and the in-app footer needed better management:

- The nav **docked as a column on desktop** but only became a **left slide-over drawer on mobile** — inconsistent between resolutions.
- The condensed legal footer floated **below the dimmed drawer**, detached from the menu.

This change makes the drawer behave the same at every breakpoint and tidies the footer placement.

## Changes

- **`WalletPage.jsx`** — the section nav is now a **left slide-over drawer at every breakpoint**. It starts closed and opens/collapses from the left via the ☰ topbar control, with a dismiss backdrop, Escape-to-close, and close-on-section-select. Removed the mobile/desktop `matchMedia` branching so the behaviour is uniform.
- **`WalletPage.css`** — promoted the slide-over rules out of the `@media (max-width: 768px)` query so they apply at all resolutions, **scoped to `.wallet-portal*`** so the shared Admin portal keeps its docked column. The section list holds its natural height so the footer can pin to the bottom.
- **`Footer.jsx` / `Footer.css`** — added a `variant="drawer"` (same `LEGAL_LINKS` + copyright, stacked and compact) rendered at the bottom of the drawer and pinned via `margin-top: auto`, so the footer is **contained in the menu side view**.
- **`App.jsx`** — the page-level condensed footer is omitted **only on `/wallet`** (it now lives in the drawer); it stays in its usual location on every other in-app route. The `<Footer variant="condensed" />` usage is preserved.
- **`WalletPage.test.jsx`** — updated to cover the uniform drawer (open/close/backdrop/select) and to assert the legal footer is contained inside the drawer.

## Behaviour

| State | Result |
| --- | --- |
| Closed (all resolutions) | Drawer hidden off the left, content full width, no footer on the wallet page |
| Open (desktop + mobile) | Drawer slides in from the left, backdrop dims content, legal footer + copyright pinned at the drawer bottom |
| Elsewhere in the app | Condensed footer stays in its usual page-bottom location |

## Testing

- `npx vitest run` for `WalletPage`, `Footer`, and `compliance.accessibility` — **18 passed**.
- `npx eslint` on the changed files — clean.
- `npx vite build` — succeeds.
- Visually verified the drawer open/closed states on desktop and mobile widths against the real stylesheets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgQTnqF83qGUjDA1NF33oU

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgQTnqF83qGUjDA1NF33oU)_