### PR TITLE
Redesign app navigation: global menu drawer, account button, mobile section nav

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 //core
-import { BrowserRouter as Router, Routes, Route, Navigate, Outlet, useLocation } from 'react-router-dom'
+import { BrowserRouter as Router, Routes, Route, Navigate, Outlet } from 'react-router-dom'
 import './theme.css'
 import './App.css'
 
@@ -24,8 +24,10 @@ import PoolPage from './pages/PoolPage'
 import { TermsPage, RiskPage, PrivacyPage } from './pages/legal/LegalDocPage'
 import EntryGate from './components/compliance/EntryGate'
 import { ActivityProvider } from './contexts/ActivityProvider.jsx'
+import { NavDrawerProvider } from './contexts/NavDrawerContext.jsx'
 import ActivityNotificationBridge from './components/notifications/ActivityNotificationBridge'
 import OperateAsIndicator from './components/custody/OperateAsIndicator'
+import AppNavDrawer from './components/nav/AppNavDrawer'
 
 //admin
 import AdminPanel from './components/AdminPanel'
@@ -39,26 +41,26 @@ import PwaInstallPrompt from './components/pwa/PwaInstallPrompt'
 import PwaUpdateNotification from './components/pwa/PwaUpdateNotification'
 
 function AppLayout() {
-  // On the wallet screen the legal/policy footer is contained at the bottom of the
-  // section drawer (see WalletPage), so the page-level footer is omitted there to
-  // avoid duplication; every other in-app route keeps it in its usual location.
-  const { pathname } = useLocation()
-  const footerInDrawer = pathname === '/wallet'
-
   return (
     /* Spec 031: platform-wide activity watcher scoped to the app-mode tree — the header bell and the views
        below consume it (wagers + DAO/token/membership sources); landing pages never poll. */
     <ActivityProvider>
-      <Header appMode />
-      {/* Spec 043 (US3): persistent banner while operating as a vault, with switch-back. */}
-      <OperateAsIndicator />
-      {/* Spec 041: route a tapped push notification into in-app navigation. */}
-      <ActivityNotificationBridge />
-      {/* Spec 007 (US4): client-side eligibility notice gate before any app content. */}
-      <EntryGate />
-      <Outlet />
-      {/* Spec 010 (US2): condensed legal/policy footer inside the app. */}
-      {!footerInDrawer && <Footer variant="condensed" />}
+      {/* App navigation redesign: the section menu ("us") is now a global left
+          drawer opened by the clover logo, shared across every in-app route. */}
+      <NavDrawerProvider>
+        <Header appMode />
+        <AppNavDrawer />
+        {/* Spec 043 (US3): persistent banner while operating as a vault, with switch-back. */}
+        <OperateAsIndicator />
+        {/* Spec 041: route a tapped push notification into in-app navigation. */}
+        <ActivityNotificationBridge />
+        {/* Spec 007 (US4): client-side eligibility notice gate before any app content. */}
+        <EntryGate />
+        <Outlet />
+        {/* Spec 010 (US2): condensed legal/policy footer inside the app. The menu
+            drawer carries its own copy for when it is open. */}
+        <Footer variant="condensed" />
+      </NavDrawerProvider>
     </ActivityProvider>
   )
 }

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -14,7 +14,22 @@ import { MEMBERSHIP_MANAGER_ABI } from '../abis/MembershipManager'
 import OracleAdaptersTab from './admin/OracleAdaptersTab'
 import DenyListAdmin from './admin/DenyListAdmin'
 import PortalNav from './ui/PortalNav'
+import SectionIconNav from './nav/SectionIconNav'
 import './AdminPanel.css'
+
+// Icons for the mobile bottom quick-nav (SectionIconNav). Desktop uses the
+// text rail; mobile pins these so admins can hop between sections one-handed.
+const ADMIN_TAB_ICONS = {
+  overview: '📋',
+  emergency: '🚨',
+  tiers: '🎚️',
+  members: '👥',
+  moderation: '🛑',
+  'admin-roles': '🔑',
+  treasury: '🏦',
+  'oracle-adapters': '🔮',
+  'deny-list': '⛔',
+}
 
 const TIER_NAMES = { 1: 'Bronze', 2: 'Silver', 3: 'Gold', 4: 'Platinum' }
 const USDC_DECIMALS = 6
@@ -696,6 +711,14 @@ function AdminPanel() {
           />
         )}
           </main>
+
+          {/* Mobile-only bottom quick-nav between admin sections. */}
+          <SectionIconNav
+            items={adminTabs.map((tab) => ({ ...tab, icon: ADMIN_TAB_ICONS[tab.id] || '•' }))}
+            activeId={activeTab}
+            onSelect={setActiveTab}
+            ariaLabel="Admin sections"
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/components/Header.css
+++ b/frontend/src/components/Header.css
@@ -31,16 +31,28 @@
   gap: 2rem;
 }
 
-/* Logo Section */
+/* Logo Section — rendered as a <button> (the site menu trigger in app mode). */
 .header-logo {
   display: flex;
   align-items: center;
   cursor: pointer;
   transition: opacity 0.2s;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: inherit;
+  font: inherit;
 }
 
 .header-logo:hover {
   opacity: 0.8;
+}
+
+.header-logo:focus-visible {
+  outline: 2px solid var(--color-primary, #36B37E);
+  outline-offset: 4px;
+  border-radius: 6px;
 }
 
 .header-logo-image {

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -10,7 +10,7 @@ import './Header.css'
 function Header({ hideWalletButton = false, appMode = false }) {
   const navigate = useNavigate()
   const location = useLocation()
-  const { open: openNavDrawer, available: navDrawerAvailable } = useNavDrawer()
+  const { open: openNavDrawer, isOpen: navDrawerOpen, available: navDrawerAvailable } = useNavDrawer()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [logoError, setLogoError] = useState(false)
 
@@ -59,8 +59,8 @@ function Header({ hideWalletButton = false, appMode = false }) {
           className="header-logo"
           onClick={handleLogoClick}
           aria-label={appMode && navDrawerAvailable ? 'Open menu' : 'FairWins home'}
-          aria-haspopup={appMode && navDrawerAvailable ? 'menu' : undefined}
           aria-controls={appMode && navDrawerAvailable ? 'app-nav-drawer' : undefined}
+          aria-expanded={appMode && navDrawerAvailable ? navDrawerOpen : undefined}
         >
           {!logoError ? (
             <img

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -4,13 +4,26 @@ import WalletButton from './wallet/WalletButton'
 import ThemeToggle from './ui/ThemeToggle'
 import NotificationBell from './notifications/NotificationBell'
 import NetworkCrawler from './fairwins/NetworkCrawler'
+import { useNavDrawer } from '../contexts/NavDrawerContext.js'
 import './Header.css'
 
 function Header({ hideWalletButton = false, appMode = false }) {
   const navigate = useNavigate()
   const location = useLocation()
+  const { open: openNavDrawer, available: navDrawerAvailable } = useNavDrawer()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [logoError, setLogoError] = useState(false)
+
+  // In app mode the clover logo is the site menu button — it opens the global
+  // navigation drawer ("us"). On the landing pages (no drawer provider) it keeps
+  // its classic "return home" behaviour.
+  const handleLogoClick = () => {
+    if (appMode && navDrawerAvailable) {
+      openNavDrawer()
+    } else {
+      navigate(appMode ? '/app' : '/')
+    }
+  }
 
   const toggleMenu = () => {
     setIsMenuOpen(!isMenuOpen)
@@ -40,8 +53,15 @@ function Header({ hideWalletButton = false, appMode = false }) {
   return (
     <header className="site-header" role="banner">
       <div className="header-container">
-        {/* Logo Section */}
-        <div className="header-logo" onClick={() => navigate(appMode ? '/app' : '/')}>
+        {/* Logo Section — in app mode this is the site menu button. */}
+        <button
+          type="button"
+          className="header-logo"
+          onClick={handleLogoClick}
+          aria-label={appMode && navDrawerAvailable ? 'Open menu' : 'FairWins home'}
+          aria-haspopup={appMode && navDrawerAvailable ? 'menu' : undefined}
+          aria-controls={appMode && navDrawerAvailable ? 'app-nav-drawer' : undefined}
+        >
           {!logoError ? (
             <img
               src="/assets/fairwins_no-text_logo.svg"
@@ -54,7 +74,7 @@ function Header({ hideWalletButton = false, appMode = false }) {
           ) : (
             <span className="header-logo-text">FairWins</span>
           )}
-        </div>
+        </button>
 
         {/* Desktop Navigation */}
         <nav className="header-nav desktop-nav" aria-label="Main navigation">

--- a/frontend/src/components/nav/AppNavDrawer.css
+++ b/frontend/src/components/nav/AppNavDrawer.css
@@ -30,13 +30,18 @@
   border-right: 1px solid var(--border-color, var(--color-border, #e5e7eb));
   box-shadow: 2px 0 16px rgba(0, 0, 0, 0.18);
   transform: translateX(-100%);
-  transition: transform 0.22s ease;
+  /* Hidden (and so not tabbable) while off-screen; visibility flips after the
+     slide-out finishes. */
+  visibility: hidden;
+  transition: transform 0.22s ease, visibility 0s linear 0.22s;
   overflow-y: auto;
   overscroll-behavior: contain;
 }
 
 .app-nav-drawer.open {
   transform: translateX(0);
+  visibility: visible;
+  transition: transform 0.22s ease, visibility 0s;
 }
 
 .app-nav-drawer-header {
@@ -97,8 +102,9 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .app-nav-drawer {
-    transition: none;
+  .app-nav-drawer,
+  .app-nav-drawer.open {
+    transition: visibility 0s;
   }
   .app-nav-backdrop {
     animation: none;

--- a/frontend/src/components/nav/AppNavDrawer.css
+++ b/frontend/src/components/nav/AppNavDrawer.css
@@ -1,0 +1,106 @@
+/* Global navigation drawer ("us") — a left slide-over opened by the clover logo
+   on every in-app route. Sits above the sticky header. */
+
+.app-nav-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1400;
+  border: none;
+  padding: 0;
+  background: rgba(0, 0, 0, 0.45);
+  cursor: pointer;
+  animation: app-nav-backdrop-fade 0.2s ease;
+}
+
+@keyframes app-nav-backdrop-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.app-nav-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  z-index: 1401;
+  width: min(84vw, 320px);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-secondary, var(--color-surface, #fff));
+  border-right: 1px solid var(--border-color, var(--color-border, #e5e7eb));
+  box-shadow: 2px 0 16px rgba(0, 0, 0, 0.18);
+  transform: translateX(-100%);
+  transition: transform 0.22s ease;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.app-nav-drawer.open {
+  transform: translateX(0);
+}
+
+.app-nav-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  border-bottom: 1px solid var(--border-color, var(--color-border, #e5e7eb));
+}
+
+.app-nav-drawer-title {
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--text-primary, var(--color-text, #1F2933));
+}
+
+.app-nav-drawer-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary, var(--color-text-secondary, #5A6772));
+  font-size: 16px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.app-nav-drawer-close:hover {
+  background: var(--bg-primary, var(--color-surface-hover, rgba(0, 0, 0, 0.05)));
+  color: var(--text-primary, var(--color-text, #1F2933));
+}
+
+.app-nav-drawer-close:focus-visible {
+  outline: 2px solid var(--brand-primary, var(--color-primary, #36B37E));
+  outline-offset: 2px;
+}
+
+/* The section list grows to fill so the footer sits at the bottom. */
+.app-nav-drawer .portal-nav {
+  flex: 1 1 auto;
+}
+
+.app-nav-drawer .app-footer--drawer {
+  margin-top: auto;
+}
+
+/* Icon + label alignment inside the drawer entries. */
+.portal-nav-item-icon {
+  display: inline-flex;
+  width: 1.25rem;
+  justify-content: center;
+  font-size: 15px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-nav-drawer {
+    transition: none;
+  }
+  .app-nav-backdrop {
+    animation: none;
+  }
+}

--- a/frontend/src/components/nav/AppNavDrawer.jsx
+++ b/frontend/src/components/nav/AppNavDrawer.jsx
@@ -1,0 +1,97 @@
+import { useEffect } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { useNavDrawer } from '../../contexts/NavDrawerContext.js'
+import PortalNav from '../ui/PortalNav'
+import Footer from '../Footer'
+import { HOME_ITEM, NAV_GROUPS, pathForNavItem } from '../../config/appNav'
+import './AppNavDrawer.css'
+
+// Deep-link alias parity with WalletPage (the Swap tab is now "Trade").
+const TAB_ALIASES = { swap: 'trade' }
+
+// The drawer list = a top "Quick Access" group (Home) + the section groups.
+const DRAWER_GROUPS = [
+  { label: 'Quick Access', items: [HOME_ITEM] },
+  ...NAV_GROUPS,
+]
+
+// Which drawer entry reflects the current route, so the open menu highlights it.
+function resolveActiveId(location) {
+  const { pathname, search } = location
+  if (pathname === '/wallet') {
+    const requested = new URLSearchParams(search).get('tab')
+    return TAB_ALIASES[requested] || requested
+  }
+  if (pathname === '/app' || pathname === '/main' || pathname === '/fairwins') {
+    return HOME_ITEM.id
+  }
+  return null
+}
+
+/**
+ * AppNavDrawer — the global left navigation drawer ("us"), opened by the clover
+ * logo on every in-app route. Replaces the per-page section rail that used to
+ * live only on My Account. Selecting an entry routes to the section and closes
+ * the drawer; the in-app legal footer is pinned to the bottom.
+ */
+export default function AppNavDrawer() {
+  const { isOpen, close } = useNavDrawer()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const activeId = resolveActiveId(location)
+
+  // Close on Escape while open.
+  useEffect(() => {
+    if (!isOpen) return
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') close()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [isOpen, close])
+
+  const handleSelect = (id) => {
+    navigate(pathForNavItem(id))
+    close()
+  }
+
+  return (
+    <>
+      {isOpen && (
+        <button
+          type="button"
+          className="app-nav-backdrop"
+          aria-label="Close menu"
+          onClick={close}
+        />
+      )}
+      <aside
+        id="app-nav-drawer"
+        className={`app-nav-drawer ${isOpen ? 'open' : ''}`}
+        aria-hidden={!isOpen}
+        aria-label="Site navigation"
+      >
+        <div className="app-nav-drawer-header">
+          <span className="app-nav-drawer-title">Menu</span>
+          <button
+            type="button"
+            className="app-nav-drawer-close"
+            aria-label="Close menu"
+            onClick={close}
+          >
+            <span aria-hidden="true">✕</span>
+          </button>
+        </div>
+
+        <PortalNav
+          groups={DRAWER_GROUPS}
+          activeId={activeId}
+          onSelect={handleSelect}
+          ariaLabel="Site sections"
+        />
+
+        <Footer variant="drawer" />
+      </aside>
+    </>
+  )
+}

--- a/frontend/src/components/nav/AppNavDrawer.jsx
+++ b/frontend/src/components/nav/AppNavDrawer.jsx
@@ -84,6 +84,7 @@ export default function AppNavDrawer() {
         </div>
 
         <PortalNav
+          variant="nav"
           groups={DRAWER_GROUPS}
           activeId={activeId}
           onSelect={handleSelect}

--- a/frontend/src/components/nav/SectionIconNav.css
+++ b/frontend/src/components/nav/SectionIconNav.css
@@ -1,0 +1,62 @@
+/* Mobile bottom icon bar for quick switching between the sub-items of the
+   current section (Finance / Tools / Admin …). Rendered only on mobile. */
+
+.section-icon-nav {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1200;
+  display: flex;
+  justify-content: space-around;
+  align-items: stretch;
+  gap: 2px;
+  padding: 4px 4px calc(4px + env(safe-area-inset-bottom, 0px));
+  background: var(--bg-secondary, var(--color-surface, #fff));
+  border-top: 1px solid var(--border-color, var(--color-border, #e5e7eb));
+  box-shadow: 0 -1px 8px rgba(0, 0, 0, 0.08);
+  overflow-x: auto;
+}
+
+.section-icon-nav-item {
+  flex: 1 1 0;
+  min-width: 56px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 6px 4px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary, var(--color-text-secondary, #5A6772));
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.section-icon-nav-item:hover {
+  background: var(--bg-primary, var(--color-surface-hover, rgba(0, 0, 0, 0.04)));
+}
+
+.section-icon-nav-item.active {
+  color: var(--brand-primary, var(--color-primary, #36B37E));
+}
+
+.section-icon-nav-item:focus-visible {
+  outline: 2px solid var(--brand-primary, var(--color-primary, #36B37E));
+  outline-offset: -2px;
+}
+
+.section-icon-nav-icon {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.section-icon-nav-label {
+  font-size: 10px;
+  font-weight: 600;
+  white-space: nowrap;
+  max-width: 72px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/frontend/src/components/nav/SectionIconNav.jsx
+++ b/frontend/src/components/nav/SectionIconNav.jsx
@@ -1,0 +1,35 @@
+import { useIsMobile } from '../../hooks/useMediaQuery'
+import './SectionIconNav.css'
+
+/**
+ * SectionIconNav — a mobile-only bottom bar that pins the current section's
+ * sibling sub-items as tap targets, so a user deep in one area (Finance, Tools,
+ * an Admin section…) can jump between its related views without reopening the
+ * menu.
+ *
+ * Presentational: the host passes the sibling `items` (each `{ id, label, icon }`),
+ * the `activeId`, and an `onSelect`. Renders nothing on desktop or when there are
+ * fewer than two siblings (a single view has nothing to switch between).
+ */
+export default function SectionIconNav({ items = [], activeId, onSelect, ariaLabel = 'Section navigation' }) {
+  const isMobile = useIsMobile()
+
+  if (!isMobile || items.length < 2) return null
+
+  return (
+    <nav className="section-icon-nav" aria-label={ariaLabel}>
+      {items.map((item) => (
+        <button
+          key={item.id}
+          type="button"
+          className={`section-icon-nav-item ${item.id === activeId ? 'active' : ''}`}
+          aria-current={item.id === activeId ? 'page' : undefined}
+          onClick={() => onSelect(item.id)}
+        >
+          <span className="section-icon-nav-icon" aria-hidden="true">{item.icon}</span>
+          <span className="section-icon-nav-label">{item.label}</span>
+        </button>
+      ))}
+    </nav>
+  )
+}

--- a/frontend/src/components/ui/PortalNav.jsx
+++ b/frontend/src/components/ui/PortalNav.jsx
@@ -1,26 +1,33 @@
 /**
- * PortalNav — a vertical, admin-portal-style tab rail. Renders the sections
- * down the left side as an accessible vertical tablist. Shared by My Account
- * (WalletPage) and the Admin Panel so both read like a portal.
+ * PortalNav — a vertical, admin-portal-style section rail. Shared by the Admin
+ * Panel, the global nav drawer, and other portal-style surfaces.
  *
- * Flat form: pass `items` = [{ id, label }].
- * Grouped form: pass `groups` = [{ label, items: [{ id, label }] }] to break the
- * rail into labelled sections (e.g. Admin / Finance / Tools / Apps). The group
- * labels are presentational headers; every entry stays a tab in the one tablist
- * so keyboard/tablist semantics are unchanged. The active item is reflected with
- * aria-selected and an accent border. Pair with role="tabpanel" content keyed
- * off the same id.
+ * Flat form: pass `items` = [{ id, label, icon? }].
+ * Grouped form: pass `groups` = [{ label, items: [...] }] to break the rail into
+ * labelled sections (e.g. Finance / Tools / Apps). The group labels are
+ * presentational headers.
+ *
+ * `variant` picks the semantics of the entries:
+ *   - 'tabs' (default): a `role="tablist"` of `role="tab"` buttons that switch
+ *     panels within the SAME page (active reflected via aria-selected). Pair with
+ *     role="tabpanel" content keyed off the same id.
+ *   - 'nav': a navigation landmark of plain buttons that route ELSEWHERE (active
+ *     reflected via aria-current="page"). Use this when selecting an entry
+ *     navigates between routes rather than swapping an in-page panel.
  */
 import { Fragment } from 'react'
 import './PortalNav.css'
 
-export default function PortalNav({ items, groups, activeId, onSelect, ariaLabel }) {
+export default function PortalNav({ items, groups, activeId, onSelect, ariaLabel, variant = 'tabs' }) {
+  const isTabs = variant === 'tabs'
+
   const renderItem = (item) => (
     <button
       key={item.id}
       type="button"
-      role="tab"
-      aria-selected={item.id === activeId}
+      role={isTabs ? 'tab' : undefined}
+      aria-selected={isTabs ? item.id === activeId : undefined}
+      aria-current={!isTabs && item.id === activeId ? 'page' : undefined}
       className={`portal-nav-item ${item.id === activeId ? 'active' : ''}`}
       onClick={() => onSelect(item.id)}
     >
@@ -34,8 +41,8 @@ export default function PortalNav({ items, groups, activeId, onSelect, ariaLabel
   return (
     <nav
       className="portal-nav"
-      role="tablist"
-      aria-orientation="vertical"
+      role={isTabs ? 'tablist' : undefined}
+      aria-orientation={isTabs ? 'vertical' : undefined}
       aria-label={ariaLabel}
     >
       {groups

--- a/frontend/src/components/ui/PortalNav.jsx
+++ b/frontend/src/components/ui/PortalNav.jsx
@@ -24,7 +24,10 @@ export default function PortalNav({ items, groups, activeId, onSelect, ariaLabel
       className={`portal-nav-item ${item.id === activeId ? 'active' : ''}`}
       onClick={() => onSelect(item.id)}
     >
-      {item.label}
+      {item.icon && (
+        <span className="portal-nav-item-icon" aria-hidden="true">{item.icon}</span>
+      )}
+      <span className="portal-nav-item-label">{item.label}</span>
     </button>
   )
 

--- a/frontend/src/components/wallet/WalletButton.jsx
+++ b/frontend/src/components/wallet/WalletButton.jsx
@@ -41,7 +41,7 @@ function WalletButton({ className = '' }) {
   const navigate = useNavigate()
   const { showModal } = useModal()
   const { balances, loading: balanceLoading } = useDex()
-  const { isTestnet, network } = useNetworkMode()
+  const { network } = useNetworkMode()
   const { hasRole, rolesLoading, refreshRoles } = useWalletRoles()
   const {
     roleDetails,
@@ -390,23 +390,41 @@ function WalletButton({ className = '' }) {
                 </div>
               )}
 
-              {/* Navigation Actions */}
+              {/* Account Actions \u2014 personal account entries live here (moved off
+                  the section menu): Account, Membership, Preferences, plus the
+                  membership purchase flow and Disconnect. */}
               <div className="dropdown-actions">
                 <button
-                  onClick={() => { setIsOpen(false); navigate('/wallet') }}
+                  onClick={() => { setIsOpen(false); navigate('/wallet?tab=account') }}
                   className="action-button"
                   role="menuitem"
                 >
                   <span aria-hidden="true">{'\u2699\uFE0F'}</span>
-                  <span>My Account</span>
+                  <span>Account</span>
                 </button>
                 <button
-                  onClick={() => { setIsOpen(false); navigate('/vouchers') }}
+                  onClick={() => { setIsOpen(false); navigate('/wallet?tab=membership') }}
                   className="action-button"
                   role="menuitem"
                 >
-                  <span aria-hidden="true">{'\uD83C\uDF9F\uFE0F'}</span>
-                  <span>Membership Vouchers</span>
+                  <span aria-hidden="true">{'\uD83C\uDFAB'}</span>
+                  <span>Membership</span>
+                </button>
+                <button
+                  onClick={() => { setIsOpen(false); navigate('/wallet?tab=preferences') }}
+                  className="action-button"
+                  role="menuitem"
+                >
+                  <span aria-hidden="true">{'\uD83C\uDF9B\uFE0F'}</span>
+                  <span>Preferences</span>
+                </button>
+                <button
+                  onClick={() => handleOpenPurchaseModal()}
+                  className="action-button"
+                  role="menuitem"
+                >
+                  <span aria-hidden="true">{'\u2B50'}</span>
+                  <span>Purchase Membership</span>
                 </button>
                 {hasRole(ROLES.ADMIN) && (
                   <button
@@ -418,16 +436,6 @@ function WalletButton({ className = '' }) {
                     <span>Role Management</span>
                   </button>
                 )}
-                <a
-                  href={isTestnet ? "https://faucet.circle.com/" : "https://app.uniswap.org/swap?chain=polygon"}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="action-button get-usdc-btn"
-                  role="menuitem"
-                >
-                  <span aria-hidden="true">💰</span>
-                  <span>Get USDC</span>
-                </a>
                 <button
                   onClick={handleDisconnect}
                   className="action-button disconnect-button"

--- a/frontend/src/config/appNav.js
+++ b/frontend/src/config/appNav.js
@@ -1,0 +1,60 @@
+/**
+ * Shared app-navigation model for the redesigned nav shell.
+ *
+ * One source of truth consumed by three surfaces:
+ *   - AppNavDrawer      — the global left drawer opened by the clover logo ("us")
+ *   - SectionIconNav    — the mobile bottom icon bar for quick sub-section switching
+ *   - WalletPage        — hosts the section panels, keyed by the same tab ids
+ *
+ * Every section item routes to `/wallet?tab=<id>` (the panels render there); the
+ * Home entry is the dashboard. Account / Membership / Preferences intentionally
+ * live on the account button (top right), NOT in this menu, so they are absent
+ * from the groups below.
+ */
+
+// Quick-access entry pinned to the top of the drawer list.
+export const HOME_ITEM = { id: 'home', label: 'Home', icon: '🏠', to: '/app' }
+
+// Grouped section rail. `id` matches the WalletPage tab id; `icon` drives both
+// the drawer and the mobile bottom nav.
+export const NAV_GROUPS = [
+  {
+    label: 'Finance',
+    items: [
+      { id: 'trade', label: 'Trade', icon: '🔄' },
+      { id: 'paytransfer', label: 'Pay & Transfer', icon: '💸' },
+      // 'custody' tab id preserved; surfaced to users as "Protect".
+      { id: 'custody', label: 'Protect', icon: '🛡️' },
+    ],
+  },
+  {
+    label: 'Tools',
+    items: [
+      { id: 'addressbook', label: 'Address Book', icon: '📇' },
+      { id: 'backup', label: 'Backup', icon: '💾' },
+      { id: 'reports', label: 'Reporting', icon: '📊' },
+      // Security relocated here from the former Admin group.
+      { id: 'security', label: 'Security', icon: '🔐' },
+      { id: 'network', label: 'Network', icon: '🌐' },
+    ],
+  },
+  {
+    label: 'Apps',
+    items: [
+      { id: 'clearpath', label: 'ClearPath', icon: '🧭' },
+      { id: 'tokens', label: 'Token Mint', icon: '🪙' },
+    ],
+  },
+]
+
+// Path a section item navigates to. Home has its own absolute route.
+export function pathForNavItem(id) {
+  if (id === HOME_ITEM.id) return HOME_ITEM.to
+  return `/wallet?tab=${id}`
+}
+
+// The group a given tab id belongs to (used by SectionIconNav to show siblings).
+// Returns null for tabs that are not part of the menu (account/membership/etc.).
+export function groupForTab(tabId) {
+  return NAV_GROUPS.find((group) => group.items.some((item) => item.id === tabId)) || null
+}

--- a/frontend/src/contexts/NavDrawerContext.js
+++ b/frontend/src/contexts/NavDrawerContext.js
@@ -1,0 +1,25 @@
+import { createContext, useContext } from 'react'
+
+/**
+ * Global navigation drawer state (spec: app navigation redesign).
+ *
+ * The redesigned nav shell moves the section menu out of the My Account page and
+ * into a global left slide-over ("us") that the clover logo opens on every
+ * in-app route. This context is the single open/close handle shared by the
+ * Header logo (opener) and AppNavDrawer (the drawer itself).
+ *
+ * The provider lives in NavDrawerContext.jsx (mirrors DexContext.js/.jsx).
+ */
+export const NavDrawerContext = createContext(null)
+
+/**
+ * Access the global nav drawer. Returns a no-op handle when used outside a
+ * provider (e.g. the landing-page Header) so callers never have to guard.
+ */
+export function useNavDrawer() {
+  const ctx = useContext(NavDrawerContext)
+  if (!ctx) {
+    return { isOpen: false, open: () => {}, close: () => {}, toggle: () => {}, available: false }
+  }
+  return { ...ctx, available: true }
+}

--- a/frontend/src/contexts/NavDrawerContext.jsx
+++ b/frontend/src/contexts/NavDrawerContext.jsx
@@ -1,0 +1,18 @@
+import { useCallback, useMemo, useState } from 'react'
+import { NavDrawerContext } from './NavDrawerContext.js'
+
+/**
+ * Provider for the global navigation drawer ("us"). See NavDrawerContext.js for
+ * the context + useNavDrawer hook.
+ */
+export function NavDrawerProvider({ children }) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const open = useCallback(() => setIsOpen(true), [])
+  const close = useCallback(() => setIsOpen(false), [])
+  const toggle = useCallback(() => setIsOpen((o) => !o), [])
+
+  const value = useMemo(() => ({ isOpen, open, close, toggle }), [isOpen, open, close, toggle])
+
+  return <NavDrawerContext.Provider value={value}>{children}</NavDrawerContext.Provider>
+}

--- a/frontend/src/pages/WalletPage.css
+++ b/frontend/src/pages/WalletPage.css
@@ -312,62 +312,18 @@
   color: var(--color-text);
 }
 
-/* The section nav is a left slide-over drawer at EVERY breakpoint so it always
-   opens and collapses from the left, overlaying the content instead of docking as
-   a column. It is anchored to the wallet card and animates in/out from the left
-   edge, with the in-app footer pinned to its bottom. These overrides are scoped to
-   .wallet-portal* so the shared Admin portal keeps its docked column. */
-.wallet-portal.portal-shell {
+/* Flat My Account layout. The section MENU now lives in the global nav drawer
+   ("us") + the account button, so this page simply stacks an identity row over
+   the active panel — no in-page sidebar or slide-over here anymore. */
+.wallet-portal--flat {
+  display: flex;
+  flex-direction: column;
   min-height: 320px;
-  position: relative;
 }
 
-.wallet-portal-sidebar.portal-sidebar {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 30;
-  display: flex;
-  width: 80%;
-  max-width: 300px;
-  flex-basis: auto;
-  overflow-y: auto;
-  border-right: 1px solid var(--color-border);
-  box-shadow: 4px 0 24px rgba(0, 0, 0, 0.18);
-  transform: translateX(-100%);
-  visibility: hidden;
-  transition: transform 0.25s ease, visibility 0s linear 0.25s;
-}
-
-/* The section list keeps its natural height so the footer's margin-top:auto can
-   pin it to the bottom of the drawer regardless of how many sections there are. */
-.wallet-portal-sidebar .portal-nav {
-  flex: 0 0 auto;
-}
-
-/* Open state: slide in and become focusable. */
-.wallet-portal.portal-shell:not(.portal-collapsed) .wallet-portal-sidebar.portal-sidebar {
-  transform: translateX(0);
-  visibility: visible;
-  transition: transform 0.25s ease, visibility 0s;
-}
-
-/* Closed state: keep it rendered (override the shared display:none) so it can
-   animate back out rather than vanish. */
-.wallet-portal.portal-shell.portal-collapsed .wallet-portal-sidebar.portal-sidebar {
-  display: flex;
-}
-
-.wallet-portal-backdrop {
-  position: absolute;
-  inset: 0;
-  z-index: 20;
-  padding: 0;
-  border: none;
-  cursor: pointer;
-  background: rgba(0, 0, 0, 0.4);
-  animation: wallet-portal-backdrop-fade 0.2s ease;
+.wallet-portal--flat .wallet-portal-main {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 @media (max-width: 768px) {
@@ -375,41 +331,10 @@
     font-size: 14px;
   }
 
-  /* On mobile the drawer must cover the full viewport so it renders above the
-     page footer. Using fixed positioning takes it out of the overflow:hidden
-     clipping context of .wallet-page and anchors it to the viewport instead
-     of the card, ensuring all navigation items are visible and no footer can
-     appear on top of or behind the panel. */
-  .wallet-portal-sidebar.portal-sidebar {
-    position: fixed;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    width: 85%;
-    z-index: 200;
-  }
-
-  /* Dim overlay must also cover the full viewport on mobile. */
-  .wallet-portal-backdrop {
-    position: fixed;
-    inset: 0;
-    z-index: 190;
-  }
-}
-
-@keyframes wallet-portal-backdrop-fade {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .wallet-portal-sidebar.portal-sidebar,
-  .wallet-portal.portal-shell:not(.portal-collapsed) .wallet-portal-sidebar.portal-sidebar {
-    transition: visibility 0s;
-  }
-
-  .wallet-portal-backdrop {
-    animation: none;
+  /* Leave room for the fixed mobile SectionIconNav so it never covers the last
+     row of the active panel. */
+  .wallet-portal--flat .tab-content {
+    padding-bottom: 84px;
   }
 }
 

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -24,54 +24,35 @@ import BackupPanel from '../components/account/BackupPanel'
 import RecoveryCodesPanel from '../components/account/RecoveryCodesPanel'
 import NetworkSettings from '../components/wallet/NetworkSettings'
 import TaxReportsPanel from '../components/wallet/TaxReportsPanel'
-import PortalNav from '../components/ui/PortalNav'
-import Footer from '../components/Footer'
+import SectionIconNav from '../components/nav/SectionIconNav'
+import { groupForTab } from '../config/appNav'
 import PremiumPurchaseModal from '../components/ui/PremiumPurchaseModal'
 import BlockiesAvatar from '../components/ui/BlockiesAvatar'
 import LoadingScreen from '../components/ui/LoadingScreen'
 import { getWalletLabel, getWalletIcon } from '../utils/walletLabel'
 import './WalletPage.css'
 
-// My Account sections, grouped by function so the section rail stays legible as
-// the number of tabs grows. Each group renders a heading in PortalNav; the tabs
-// themselves stay a single tablist. WALLET_TABS is the flat projection used for
-// deep-link/alias resolution and for looking up the active tab's label.
-const WALLET_TAB_GROUPS = [
-  {
-    label: 'Admin',
-    items: [
-      { id: 'account', label: 'Account' },
-      { id: 'membership', label: 'Membership' },
-      { id: 'network', label: 'Network' },
-      { id: 'preferences', label: 'Preferences' },
-      { id: 'security', label: 'Security' },
-    ],
-  },
-  {
-    label: 'Finance',
-    items: [
-      { id: 'trade', label: 'Trade' },
-      { id: 'paytransfer', label: 'Pay & Transfer' },
-      { id: 'custody', label: 'Custody' },
-    ],
-  },
-  {
-    label: 'Tools',
-    items: [
-      { id: 'addressbook', label: 'Address Book' },
-      { id: 'backup', label: 'Backup' },
-      { id: 'reports', label: 'Reporting' },
-    ],
-  },
-  {
-    label: 'Apps',
-    items: [
-      { id: 'clearpath', label: 'ClearPath' },
-      { id: 'tokens', label: 'Token Mint' },
-    ],
-  },
+// My Account section panels, keyed by tab id. The section MENU now lives in the
+// global nav drawer + account button (see config/appNav.js) — this page just
+// hosts the panels and reads `?tab=` to pick one. WALLET_TABS is the flat list
+// used for deep-link/alias resolution and for the active tab's heading label.
+// (Account / Membership / Preferences are reached from the account button;
+// 'custody' is surfaced to users as "Protect".)
+const WALLET_TABS = [
+  { id: 'account', label: 'Account' },
+  { id: 'membership', label: 'Membership' },
+  { id: 'network', label: 'Network' },
+  { id: 'preferences', label: 'Preferences' },
+  { id: 'security', label: 'Security' },
+  { id: 'trade', label: 'Trade' },
+  { id: 'paytransfer', label: 'Pay & Transfer' },
+  { id: 'custody', label: 'Protect' },
+  { id: 'addressbook', label: 'Address Book' },
+  { id: 'backup', label: 'Backup' },
+  { id: 'reports', label: 'Reporting' },
+  { id: 'clearpath', label: 'ClearPath' },
+  { id: 'tokens', label: 'Token Mint' },
 ]
-const WALLET_TABS = WALLET_TAB_GROUPS.flatMap((group) => group.items)
 
 // Legacy deep-link aliases → canonical tab ids (the Swap tab is now "Trade").
 const TAB_ALIASES = { swap: 'trade' }
@@ -118,17 +99,13 @@ function WalletPage() {
   const [pwaChecking, setPwaChecking] = useState(false)
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
-  // Allow deep-linking straight to a section (e.g. the update toast → ?tab=preferences).
+  // The section is driven by `?tab=` so the global nav drawer and the account
+  // button can route straight to a panel (e.g. the update toast → ?tab=preferences).
   const [activeTab, setActiveTab] = useState(() => {
     const requested = searchParams.get('tab')
     const resolved = TAB_ALIASES[requested] || requested
     return WALLET_TABS.some((t) => t.id === resolved) ? resolved : 'account'
   })
-  // The section nav is a left slide-over drawer at every breakpoint so it always
-  // opens and collapses from the left (see WalletPage.css). It starts closed and
-  // is opened from the ☰ control in the topbar; the in-app footer is contained at
-  // the bottom of the drawer.
-  const [sidebarOpen, setSidebarOpen] = useState(false)
   const [connectingConnectorId, setConnectingConnectorId] = useState(null)
   const [connectionError, setConnectionError] = useState(null)
   const [keyRegistered, setKeyRegistered] = useState(null)
@@ -226,21 +203,15 @@ function WalletPage() {
     }
   }, [activeTab, isConnected, keyRegistered, handleCheckKeyStatus])
 
-  // Close the slide-over drawer on Escape.
+  // Keep the active panel in sync with `?tab=` so navigating from the global
+  // nav drawer / account button (which change the URL) switches sections here.
   useEffect(() => {
-    if (!sidebarOpen) return
-    const handleKeyDown = (event) => {
-      if (event.key === 'Escape') setSidebarOpen(false)
+    const requested = searchParams.get('tab')
+    const resolved = TAB_ALIASES[requested] || requested
+    if (resolved && WALLET_TABS.some((t) => t.id === resolved)) {
+      setActiveTab(resolved)
     }
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [sidebarOpen])
-
-  // Jumping to a section closes the drawer so the content is visible.
-  const handleSelectTab = useCallback((id) => {
-    setActiveTab(id)
-    setSidebarOpen(false)
-  }, [])
+  }, [searchParams])
 
   const handleCheckForUpdate = useCallback(async () => {
     setPwaChecking(true)
@@ -280,6 +251,11 @@ function WalletPage() {
   }
 
   const activeTabLabel = (WALLET_TABS.find((t) => t.id === activeTab) || WALLET_TABS[0]).label
+
+  // Sibling sub-items for the mobile bottom icon nav — the group the active tab
+  // belongs to (Finance / Tools / Apps). Absent for account/membership/etc.
+  const currentSectionGroup = groupForTab(activeTab)
+  const sectionNavItems = currentSectionGroup?.items || []
 
   return (
     <div className="wallet-page-wrapper">
@@ -337,58 +313,23 @@ function WalletPage() {
               </div>
             </div>
           ) : (
-            <div className={`wallet-portal portal-shell ${sidebarOpen ? '' : 'portal-collapsed'}`}>
-              <aside
-                id="wallet-portal-nav"
-                className="portal-sidebar wallet-portal-sidebar"
-              >
-                <div className="wallet-portal-identity">
-                  <BlockiesAvatar address={address} size={36} className="wallet-avatar" />
-                  <button
-                    type="button"
-                    className="wallet-address-display"
-                    onClick={() => copyAddress(address)}
-                    title={address}
-                    aria-label={addressCopied ? 'Copied!' : 'Copy wallet address'}
-                  >
-                    {addressCopied ? 'Copied!' : shortenAddress(address)}
-                  </button>
-                  <span className="status-dot connected" aria-hidden="true"></span>
-                </div>
-                <PortalNav
-                  groups={WALLET_TAB_GROUPS}
-                  activeId={activeTab}
-                  onSelect={handleSelectTab}
-                  ariaLabel="Account sections"
-                />
-                {/* The in-app legal/policy footer is contained at the bottom of the
-                    section drawer on the wallet screen; App.jsx omits the page-level
-                    footer here so it never renders twice. */}
-                <Footer variant="drawer" />
-              </aside>
-
-              {/* Dim + dismiss the slide-over drawer by tapping outside it. */}
-              {sidebarOpen && (
+            <div className="wallet-portal wallet-portal--flat">
+              <div className="wallet-portal-identity">
+                <BlockiesAvatar address={address} size={36} className="wallet-avatar" />
                 <button
                   type="button"
-                  className="wallet-portal-backdrop"
-                  aria-label="Close menu"
-                  onClick={() => setSidebarOpen(false)}
-                />
-              )}
+                  className="wallet-address-display"
+                  onClick={() => copyAddress(address)}
+                  title={address}
+                  aria-label={addressCopied ? 'Copied!' : 'Copy wallet address'}
+                >
+                  {addressCopied ? 'Copied!' : shortenAddress(address)}
+                </button>
+                <span className="status-dot connected" aria-hidden="true"></span>
+              </div>
 
-              <div className="portal-main wallet-portal-main">
+              <div className="wallet-portal-main">
                 <div className="wallet-portal-topbar">
-                  <button
-                    type="button"
-                    className="portal-sidebar-toggle"
-                    aria-expanded={sidebarOpen}
-                    aria-controls="wallet-portal-nav"
-                    aria-label={sidebarOpen ? 'Hide menu' : 'Show menu'}
-                    onClick={() => setSidebarOpen((o) => !o)}
-                  >
-                    <span aria-hidden="true">{'☰'}</span>
-                  </button>
                   <span className="wallet-portal-current">{activeTabLabel}</span>
                 </div>
 
@@ -697,6 +638,15 @@ function WalletPage() {
                   </div>
                 )}
                 </div>
+
+                {/* Mobile-only quick switching between the current section's
+                    sibling views (Finance / Tools / Apps), pinned to the bottom. */}
+                <SectionIconNav
+                  items={sectionNavItems}
+                  activeId={activeTab}
+                  onSelect={(id) => navigate(`/wallet?tab=${id}`)}
+                  ariaLabel={currentSectionGroup ? `${currentSectionGroup.label} sections` : 'Section navigation'}
+                />
               </div>
             </div>
           )}

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -205,12 +205,12 @@ function WalletPage() {
 
   // Keep the active panel in sync with `?tab=` so navigating from the global
   // nav drawer / account button (which change the URL) switches sections here.
+  // Always derive from the URL — a missing or unknown tab falls back to Account
+  // so the panel never drifts out of sync with the address bar.
   useEffect(() => {
     const requested = searchParams.get('tab')
     const resolved = TAB_ALIASES[requested] || requested
-    if (resolved && WALLET_TABS.some((t) => t.id === resolved)) {
-      setActiveTab(resolved)
-    }
+    setActiveTab(WALLET_TABS.some((t) => t.id === resolved) ? resolved : 'account')
   }, [searchParams])
 
   const handleCheckForUpdate = useCallback(async () => {

--- a/frontend/src/test/AppNavDrawer.test.jsx
+++ b/frontend/src/test/AppNavDrawer.test.jsx
@@ -41,37 +41,41 @@ describe('AppNavDrawer (global nav drawer)', () => {
   it('lists Home plus the Finance / Tools / Apps sections', () => {
     renderDrawer()
 
-    expect(screen.getByRole('tab', { name: /home/i })).toBeInTheDocument()
-    expect(screen.getByRole('tab', { name: 'Trade' })).toBeInTheDocument()
+    // Drawer entries navigate between routes, so they use navigation (button)
+    // semantics with aria-current — not tablist/tab.
+    expect(screen.getByRole('button', { name: /home/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Trade' })).toBeInTheDocument()
     // Custody is surfaced as "Protect"; Security relocated into Tools.
-    expect(screen.getByRole('tab', { name: 'Protect' })).toBeInTheDocument()
-    expect(screen.getByRole('tab', { name: 'Security' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Protect' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Security' })).toBeInTheDocument()
+    // Not a tablist.
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument()
 
     expect(screen.getByText('Finance')).toBeInTheDocument()
     expect(screen.getByText('Tools')).toBeInTheDocument()
     expect(screen.getByText('Apps')).toBeInTheDocument()
 
     // Removed Admin group / personal-account entries are absent from the menu.
-    expect(screen.queryByRole('tab', { name: 'Preferences' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('tab', { name: 'Account' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Preferences' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Account' })).not.toBeInTheDocument()
   })
 
   it('routes Home to the dashboard', () => {
     renderDrawer('/wallet?tab=trade')
-    fireEvent.click(screen.getByRole('tab', { name: /home/i }))
+    fireEvent.click(screen.getByRole('button', { name: /home/i }))
     expect(screen.getByTestId('loc')).toHaveTextContent('/app')
   })
 
   it('routes a section item to its wallet tab (Protect → custody)', () => {
     renderDrawer()
-    fireEvent.click(screen.getByRole('tab', { name: 'Protect' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Protect' }))
     expect(screen.getByTestId('loc')).toHaveTextContent('/wallet?tab=custody')
   })
 
-  it('highlights the active section from the URL', () => {
+  it('highlights the active section from the URL with aria-current', () => {
     renderDrawer('/wallet?tab=security')
-    expect(screen.getByRole('tab', { name: 'Security' })).toHaveAttribute('aria-selected', 'true')
-    expect(screen.getByRole('tab', { name: 'Trade' })).toHaveAttribute('aria-selected', 'false')
+    expect(screen.getByRole('button', { name: 'Security' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('button', { name: 'Trade' })).not.toHaveAttribute('aria-current')
   })
 
   it('contains the in-app legal footer', () => {

--- a/frontend/src/test/AppNavDrawer.test.jsx
+++ b/frontend/src/test/AppNavDrawer.test.jsx
@@ -1,0 +1,85 @@
+import { useEffect } from 'react'
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import AppNavDrawer from '../components/nav/AppNavDrawer'
+import { NavDrawerProvider } from '../contexts/NavDrawerContext.jsx'
+import { useNavDrawer } from '../contexts/NavDrawerContext.js'
+
+// The drawer is aria-hidden while closed (off-screen), so open it on mount to
+// exercise its contents — mirrors the clover-logo trigger.
+function OpenOnMount() {
+  const { open } = useNavDrawer()
+  useEffect(() => { open() }, [open])
+  return null
+}
+
+// App navigation redesign — the global left drawer ("us"). It lists Home plus
+// the Finance/Tools/Apps sections, routes each entry, highlights the active one
+// from the URL, and carries the in-app legal footer. Personal-account entries
+// (Account/Membership/Preferences) intentionally live on the account button, not
+// here.
+
+function LocationProbe() {
+  const location = useLocation()
+  return <div data-testid="loc">{location.pathname}{location.search}</div>
+}
+
+function renderDrawer(route = '/app') {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <NavDrawerProvider>
+        <OpenOnMount />
+        <AppNavDrawer />
+        <LocationProbe />
+      </NavDrawerProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('AppNavDrawer (global nav drawer)', () => {
+  it('lists Home plus the Finance / Tools / Apps sections', () => {
+    renderDrawer()
+
+    expect(screen.getByRole('tab', { name: /home/i })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Trade' })).toBeInTheDocument()
+    // Custody is surfaced as "Protect"; Security relocated into Tools.
+    expect(screen.getByRole('tab', { name: 'Protect' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Security' })).toBeInTheDocument()
+
+    expect(screen.getByText('Finance')).toBeInTheDocument()
+    expect(screen.getByText('Tools')).toBeInTheDocument()
+    expect(screen.getByText('Apps')).toBeInTheDocument()
+
+    // Removed Admin group / personal-account entries are absent from the menu.
+    expect(screen.queryByRole('tab', { name: 'Preferences' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('tab', { name: 'Account' })).not.toBeInTheDocument()
+  })
+
+  it('routes Home to the dashboard', () => {
+    renderDrawer('/wallet?tab=trade')
+    fireEvent.click(screen.getByRole('tab', { name: /home/i }))
+    expect(screen.getByTestId('loc')).toHaveTextContent('/app')
+  })
+
+  it('routes a section item to its wallet tab (Protect → custody)', () => {
+    renderDrawer()
+    fireEvent.click(screen.getByRole('tab', { name: 'Protect' }))
+    expect(screen.getByTestId('loc')).toHaveTextContent('/wallet?tab=custody')
+  })
+
+  it('highlights the active section from the URL', () => {
+    renderDrawer('/wallet?tab=security')
+    expect(screen.getByRole('tab', { name: 'Security' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('tab', { name: 'Trade' })).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('contains the in-app legal footer', () => {
+    const { container } = renderDrawer()
+    const footer = container.querySelector('.app-footer--drawer')
+    expect(footer).toBeTruthy()
+    expect(
+      within(footer).getByRole('link', { name: /Terms & Conditions/i })
+    ).toHaveAttribute('href', '/terms')
+  })
+})

--- a/frontend/src/test/SectionIconNav.test.jsx
+++ b/frontend/src/test/SectionIconNav.test.jsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+// Force the mobile branch — SectionIconNav renders only on mobile.
+vi.mock('../hooks/useMediaQuery', () => ({
+  useIsMobile: () => true,
+}))
+
+import SectionIconNav from '../components/nav/SectionIconNav'
+
+const ITEMS = [
+  { id: 'trade', label: 'Trade', icon: '🔄' },
+  { id: 'paytransfer', label: 'Pay & Transfer', icon: '💸' },
+  { id: 'custody', label: 'Protect', icon: '🛡️' },
+]
+
+describe('SectionIconNav (mobile bottom quick-nav)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders one button per sibling item with its label', () => {
+    render(<SectionIconNav items={ITEMS} activeId="trade" onSelect={vi.fn()} ariaLabel="Finance sections" />)
+    const nav = screen.getByRole('navigation', { name: /finance sections/i })
+    expect(nav).toBeInTheDocument()
+    for (const item of ITEMS) {
+      expect(screen.getByRole('button', { name: new RegExp(item.label, 'i') })).toBeInTheDocument()
+    }
+  })
+
+  it('marks the active item with aria-current', () => {
+    render(<SectionIconNav items={ITEMS} activeId="custody" onSelect={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /protect/i })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getByRole('button', { name: /trade/i })).not.toHaveAttribute('aria-current')
+  })
+
+  it('calls onSelect with the item id when tapped', () => {
+    const onSelect = vi.fn()
+    render(<SectionIconNav items={ITEMS} activeId="trade" onSelect={onSelect} />)
+    fireEvent.click(screen.getByRole('button', { name: /pay & transfer/i }))
+    expect(onSelect).toHaveBeenCalledWith('paytransfer')
+  })
+
+  it('renders nothing when there is only one sibling (nothing to switch to)', () => {
+    const { container } = render(
+      <SectionIconNav items={[ITEMS[0]]} activeId="trade" onSelect={vi.fn()} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/frontend/src/test/WalletButton.test.jsx
+++ b/frontend/src/test/WalletButton.test.jsx
@@ -237,7 +237,7 @@ describe('WalletButton Component - Wagers', () => {
       expect(screen.queryByText('My Wagers')).not.toBeInTheDocument()
     })
 
-    it('exposes the Membership Vouchers entry so the voucher view is reachable', async () => {
+    it('exposes a Purchase Membership entry that opens the purchase modal', async () => {
       const user = userEvent.setup()
       useWalletRoles.mockReturnValue({
         roles: [],
@@ -249,11 +249,33 @@ describe('WalletButton Component - Wagers', () => {
       const button = screen.getByRole('button', { name: /wallet account/i })
       await user.click(button)
 
+      // The former "Membership Vouchers" action is now "Purchase Membership".
       await waitFor(() => {
-        expect(screen.getByText('Membership Vouchers')).toBeInTheDocument()
+        expect(screen.getByText('Purchase Membership')).toBeInTheDocument()
       })
-      // Non-members also get a direct redeem entry point.
+      expect(screen.queryByText('Membership Vouchers')).not.toBeInTheDocument()
+
+      // Non-members also get a direct redeem entry point in the upsell (assert
+      // before clicking Purchase, which closes the dropdown).
       expect(screen.getByText(/Have a voucher\? Redeem it/)).toBeInTheDocument()
+
+      // Clicking Purchase Membership opens the purchase modal (mocked here).
+      await user.click(screen.getByText('Purchase Membership'))
+      expect(mockShowModal).toHaveBeenCalled()
+    })
+
+    it('no longer shows the Get USDC action in the dropdown', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<WalletButton />)
+
+      const button = screen.getByRole('button', { name: /wallet account/i })
+      await user.click(button)
+
+      await screen.findByRole('menu')
+      expect(screen.queryByText('Get USDC')).not.toBeInTheDocument()
+      // Personal-account entries moved onto the account button.
+      expect(screen.getByText('Account')).toBeInTheDocument()
+      expect(screen.getByText('Preferences')).toBeInTheDocument()
     })
 
     it('hides Create Prediction Market button (removed feature)', async () => {

--- a/frontend/src/test/WalletPage.test.jsx
+++ b/frontend/src/test/WalletPage.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, fireEvent, within } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import WalletPage from '../pages/WalletPage'
 import { WalletContext, UIContext } from '../contexts'
@@ -101,9 +101,9 @@ const uiContext = {
   clearError: vi.fn(),
 }
 
-function renderPage(walletContext) {
+function renderPage(walletContext, route = '/wallet') {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={[route]}>
       <UIContext.Provider value={uiContext}>
         <WalletContext.Provider value={walletContext}>
           <WalletPage />
@@ -118,23 +118,20 @@ beforeEach(() => {
 })
 
 describe('WalletPage — address QR entry point', () => {
-  // Show QR Code (and pool phrase language) moved from the Account tab to the
-  // Preferences tab's "Wallet" section, alongside other settings.
-  function goToPreferences() {
-    fireEvent.click(screen.getByRole('tab', { name: 'Preferences' }))
-  }
+  // Show QR Code (and pool phrase language) live in the Preferences panel's
+  // "Wallet" section. Preferences is now reached from the account button, so the
+  // panel is deep-linked here via ?tab=preferences rather than an in-page tab.
+  const PREFERENCES_ROUTE = '/wallet?tab=preferences'
 
-  it('shows a "Show QR Code" button on the Preferences tab when connected (W1)', () => {
-    renderPage(connectedWalletContext)
-    goToPreferences()
+  it('shows a "Show QR Code" button on the Preferences panel when connected (W1)', () => {
+    renderPage(connectedWalletContext, PREFERENCES_ROUTE)
     expect(
       screen.getByRole('button', { name: /show qr/i })
     ).toBeInTheDocument()
   })
 
   it('opens the address QR modal with the connected address — one interaction (W1 / SC-001)', () => {
-    const { container } = renderPage(connectedWalletContext)
-    goToPreferences()
+    const { container } = renderPage(connectedWalletContext, PREFERENCES_ROUTE)
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('button', { name: /show qr/i }))
@@ -146,8 +143,7 @@ describe('WalletPage — address QR entry point', () => {
   })
 
   it('closes the modal again via its close button (M3 wiring)', () => {
-    renderPage(connectedWalletContext)
-    goToPreferences()
+    renderPage(connectedWalletContext, PREFERENCES_ROUTE)
     fireEvent.click(screen.getByRole('button', { name: /show qr/i }))
     expect(screen.getByRole('dialog')).toBeInTheDocument()
 
@@ -155,11 +151,11 @@ describe('WalletPage — address QR entry point', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
-  it('renders the connect prompt with no Preferences tab when disconnected (W2 / FR-008)', () => {
-    renderPage(disconnectedWalletContext)
+  it('renders the connect prompt with no section content when disconnected (W2 / FR-008)', () => {
+    renderPage(disconnectedWalletContext, PREFERENCES_ROUTE)
     expect(screen.getByText(/connect your wallet/i)).toBeInTheDocument()
     expect(
-      screen.queryByRole('tab', { name: 'Preferences' })
+      screen.queryByRole('button', { name: /show qr/i })
     ).not.toBeInTheDocument()
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
@@ -179,73 +175,28 @@ describe('WalletPage — sidebar identity', () => {
   })
 })
 
-describe('WalletPage — section nav slide-over drawer', () => {
-  // The section nav is a left slide-over drawer at every breakpoint: it starts
-  // closed, opens/collapses from the left, and dims the content with a backdrop
-  // while open (WalletPage.css). Behaviour is uniform across viewport widths.
-  it('starts closed and exposes the ☰ open control', () => {
-    renderPage(connectedWalletContext)
-
-    const toggle = screen.getByRole('button', { name: /show menu/i })
-    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+describe('WalletPage — section routing', () => {
+  // The in-page section rail/drawer was lifted into the global nav drawer. The
+  // page is now a flat host: it reads `?tab=` to pick a panel and shows the
+  // active section's heading. No in-page ☰ toggle, backdrop, or footer here.
+  it('defaults to the Account section with no ?tab', () => {
+    renderPage(connectedWalletContext, '/wallet')
+    expect(screen.getByText('Account')).toBeInTheDocument()
     expect(
-      screen.queryByRole('button', { name: /close menu/i })
+      screen.queryByRole('button', { name: /show menu/i })
     ).not.toBeInTheDocument()
   })
 
-  it('opens from the ☰ control with a dismiss backdrop', () => {
-    renderPage(connectedWalletContext)
-
-    fireEvent.click(screen.getByRole('button', { name: /show menu/i }))
-
-    expect(
-      screen.getByRole('button', { name: /hide menu/i })
-    ).toHaveAttribute('aria-expanded', 'true')
-    expect(
-      screen.getByRole('button', { name: /close menu/i })
-    ).toBeInTheDocument()
+  it('deep-links to the Membership section via ?tab=membership', () => {
+    renderPage(connectedWalletContext, '/wallet?tab=membership')
+    // The Membership panel renders its "Your Roles" / "Membership" headings.
+    expect(screen.getByRole('heading', { name: /membership/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /your roles/i })).toBeInTheDocument()
   })
 
-  it('closes the drawer after a section is selected', () => {
-    renderPage(connectedWalletContext)
-
-    fireEvent.click(screen.getByRole('button', { name: /show menu/i }))
-    expect(
-      screen.getByRole('button', { name: /close menu/i })
-    ).toBeInTheDocument()
-
-    fireEvent.click(screen.getByRole('tab', { name: 'Membership' }))
-
-    expect(
-      screen.queryByRole('button', { name: /close menu/i })
-    ).not.toBeInTheDocument()
-    expect(
-      screen.getByRole('button', { name: /show menu/i })
-    ).toHaveAttribute('aria-expanded', 'false')
-  })
-
-  it('dismisses the drawer when the backdrop is tapped', () => {
-    renderPage(connectedWalletContext)
-
-    fireEvent.click(screen.getByRole('button', { name: /show menu/i }))
-    fireEvent.click(screen.getByRole('button', { name: /close menu/i }))
-
-    expect(
-      screen.getByRole('button', { name: /show menu/i })
-    ).toHaveAttribute('aria-expanded', 'false')
-  })
-
-  it('contains the in-app legal footer at the bottom of the drawer', () => {
-    const { container } = renderPage(connectedWalletContext)
-
-    // The condensed legal footer is rendered inside the section drawer (aside),
-    // not as a separate page-level footer, on the wallet screen.
-    const drawer = container.querySelector('.wallet-portal-sidebar')
-    expect(drawer).toBeTruthy()
-    const footer = drawer.querySelector('.app-footer--drawer')
-    expect(footer).toBeTruthy()
-    expect(
-      within(footer).getByRole('link', { name: /Terms & Conditions/i })
-    ).toHaveAttribute('href', '/terms')
+  it('shows the active section label in the topbar', () => {
+    const { container } = renderPage(connectedWalletContext, '/wallet?tab=membership')
+    const current = container.querySelector('.wallet-portal-current')
+    expect(current).toHaveTextContent('Membership')
   })
 })


### PR DESCRIPTION
## Summary

Phase 1 of the app navigation redesign. Restructures the in-app nav shell around three surfaces so the app reads as **"us" (the site menu)** on the left and **"them" (your account)** on the right.

### 🧭 Side panel → global nav drawer ("us")
- The section menu moves **out of the My Account page** and into a **global left slide-over** opened by the **clover logo** on every in-app route (`NavDrawerContext` + `AppNavDrawer`).
- **Home / Quick Access** entry added at the top of the list.
- **Admin group removed** from the menu (and its personal-account sub-items redistributed — see below).
- **Security moved into Tools**; **Custody surfaced as "Protect"**.
- Network setting relocated into Tools (it lived in the removed Admin group).

### 👤 Account button ("them")
- The wallet dropdown now carries the personal entries: **Account, Membership, Preferences, Disconnect**.
- **"Membership Vouchers" → "Purchase Membership"**, which opens the purchase modal directly.
- **"Get USDC" removed.**

### 📱 New component: mobile bottom icon nav
- `SectionIconNav` pins the **current section's sibling sub-items** to the bottom on mobile for one-handed switching between similar views.
- Wired into **WalletPage** (Finance / Tools / Apps) and the **Admin panel** (its sections).

### Supporting changes
- `WalletPage` is now a flat panel host driven by `?tab=`, so the drawer and account button can deep-link straight to a section.
- The clover logo is now a real `<button>` (menu trigger in app mode, home on landing).
- Shared nav model lives in `config/appNav.js`; `PortalNav` gains optional per-item icons.

## Testing
- New tests: `AppNavDrawer.test.jsx`, `SectionIconNav.test.jsx`.
- Updated tests: `WalletButton.test.jsx`, `WalletPage.test.jsx` (URL-driven sections, dropdown relabels).
- `npm run lint` — clean on all changed files.
- `npm run build` — succeeds.
- Frontend test suite green except a **pre-existing** unrelated failure in `quickAccessPreference.test.js` (fails identically on `main`).

## Notes / decisions
- Confirmed with the requester: menu is a **global** left drawer (not scoped to My Account), the bottom nav shows **contextual sub-items**, and "Purchase Membership" **opens the purchase modal**.
- The orphaned **Network** tab (previously in the removed Admin group) was placed under **Tools** — happy to move it if you'd prefer it elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnWZoKJGAjVi1GwvWwR4MA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnWZoKJGAjVi1GwvWwR4MA)_