### PR TITLE
Add Connected Account Portfolio to My Wallet → Finance (spec 044)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/043-safe-multisig-custody"
+  "feature_directory": "specs/044-connected-account-portfolio"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,5 +104,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/043-safe-multisig-custody/plan.md
+at specs/044-connected-account-portfolio/plan.md
 <!-- SPECKIT END -->

--- a/frontend/src/components/wallet/Portfolio.css
+++ b/frontend/src/components/wallet/Portfolio.css
@@ -1,0 +1,208 @@
+/* Connected Account Portfolio (spec 044) — theme-aware, maps onto the shared app CSS variables. */
+
+.portfolio-root {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* Explicit states (connect / unsupported / loading / error) */
+.portfolio-state {
+  color: var(--color-text-secondary, var(--text-secondary, #6b7280));
+  font-size: 0.95rem;
+  margin: 0;
+}
+.portfolio-state-error {
+  color: var(--color-danger, #b91c1c);
+}
+
+/* Header */
+.portfolio-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  align-items: flex-start;
+}
+.portfolio-total-label {
+  color: var(--color-text-secondary, var(--text-secondary, #6b7280));
+  font-size: 0.85rem;
+  margin: 0;
+}
+.portfolio-total {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin: 0;
+  color: var(--color-text, var(--text-primary, #111827));
+}
+.portfolio-partial-flag {
+  color: var(--color-warning, #b45309);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+.portfolio-partial-total {
+  font-size: 0.95rem;
+}
+.portfolio-partial-note {
+  color: var(--color-text-tertiary, var(--text-muted, #9ca3af));
+  font-size: 0.8rem;
+  margin: 0;
+}
+.portfolio-refresh {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--color-border, var(--border-color, #e5e7eb));
+  border-radius: 6px;
+  color: var(--color-text, var(--text-primary, #111827));
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-top: 0.35rem;
+  padding: 0.35rem 0.85rem;
+}
+.portfolio-refresh:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+.portfolio-refresh:focus-visible {
+  outline: 2px solid var(--color-primary, #6d28d9);
+  outline-offset: 2px;
+}
+
+/* Category sections */
+.portfolio-category {
+  border: 1px solid var(--color-border, var(--border-color, #e5e7eb));
+  border-radius: 10px;
+  overflow: hidden;
+}
+.portfolio-category-heading {
+  margin: 0;
+}
+.portfolio-category-toggle {
+  align-items: center;
+  appearance: none;
+  background: var(--color-surface-2, var(--surface-secondary, #f9fafb));
+  border: none;
+  color: var(--color-text, var(--text-primary, #111827));
+  cursor: pointer;
+  display: flex;
+  font-size: 0.95rem;
+  font-weight: 600;
+  gap: 0.5rem;
+  padding: 0.7rem 0.9rem;
+  text-align: left;
+  width: 100%;
+}
+.portfolio-category-toggle:focus-visible {
+  outline: 2px solid var(--color-primary, #6d28d9);
+  outline-offset: -2px;
+}
+.portfolio-category-chevron {
+  color: var(--color-text-tertiary, var(--text-muted, #9ca3af));
+}
+.portfolio-category-label {
+  flex: 1;
+}
+.portfolio-category-subtotal {
+  color: var(--color-primary, var(--brand-primary, #6d28d9));
+  font-variant-numeric: tabular-nums;
+}
+.portfolio-category-description {
+  color: var(--color-text-tertiary, var(--text-muted, #9ca3af));
+  font-size: 0.8rem;
+  margin: 0;
+  padding: 0.6rem 0.9rem 0;
+}
+.portfolio-category-empty {
+  color: var(--color-text-secondary, var(--text-secondary, #6b7280));
+  font-size: 0.85rem;
+  margin: 0;
+  padding: 0.6rem 0.9rem 0.8rem;
+}
+
+/* Asset rows */
+.portfolio-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0.35rem 0 0.35rem;
+}
+.portfolio-row {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  padding: 0.55rem 0.9rem;
+}
+.portfolio-row + .portfolio-row {
+  border-top: 1px solid var(--color-border, var(--border-color, #e5e7eb));
+}
+.portfolio-row-asset {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+.portfolio-row-name {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.portfolio-row-meta {
+  align-items: center;
+  color: var(--color-text-secondary, var(--text-secondary, #6b7280));
+  display: flex;
+  font-size: 0.8rem;
+  gap: 0.5rem;
+}
+.portfolio-row-source {
+  background: var(--color-surface-2, var(--surface-secondary, #f3f4f6));
+  border: 1px solid var(--color-border, var(--border-color, #e5e7eb));
+  border-radius: 999px;
+  font-size: 0.7rem;
+  padding: 0.05rem 0.5rem;
+  white-space: nowrap;
+}
+.portfolio-row-values {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.15rem;
+  font-variant-numeric: tabular-nums;
+}
+.portfolio-row-balance {
+  font-weight: 600;
+}
+.portfolio-row-usd {
+  color: var(--color-text-secondary, var(--text-secondary, #6b7280));
+  font-size: 0.85rem;
+}
+.portfolio-row-usd-unavailable {
+  color: var(--color-text-tertiary, var(--text-muted, #9ca3af));
+}
+
+/* Disclosures */
+.portfolio-disclosures {
+  border-top: 1px solid var(--color-border, var(--border-color, #e5e7eb));
+  color: var(--color-text-tertiary, var(--text-muted, #9ca3af));
+  display: flex;
+  flex-direction: column;
+  font-size: 0.75rem;
+  gap: 0.35rem;
+  padding-top: 0.75rem;
+}
+.portfolio-disclosures p {
+  margin: 0;
+}
+
+/* Screen-reader-only text (e.g. "price unavailable" behind the — glyph) */
+.portfolio-visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/frontend/src/components/wallet/PortfolioPanel.jsx
+++ b/frontend/src/components/wallet/PortfolioPanel.jsx
@@ -1,0 +1,209 @@
+import { useState } from 'react'
+import usePortfolio from '../../hooks/usePortfolio'
+import './Portfolio.css'
+
+// Full-precision USD for a compliance-flavored view — deliberately not the
+// dashboard's compact "$1.2K" (a portfolio total wants exact figures).
+function formatUsdFull(n) {
+  return `$${Number(n || 0).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`
+}
+
+function formatBalance(holding) {
+  const { asset, balance } = holding
+  if (asset.kind === 'nft') {
+    return `${balance} ${balance === 1 ? 'item' : 'items'}`
+  }
+  const digits = balance !== 0 && Math.abs(balance) < 1 ? 6 : 4
+  return `${Number(balance).toLocaleString('en-US', { maximumFractionDigits: digits })} ${asset.symbol}`
+}
+
+// Member-facing names for the classification provenance (FR-006).
+const SOURCE_LABELS = {
+  'sec-baseline': 'SEC baseline',
+  'curated-registry': 'Curated registry',
+  'app-config': 'App configuration',
+}
+
+function AssetRow({ holding }) {
+  const { asset, usd } = holding
+  return (
+    <li className="portfolio-row">
+      <div className="portfolio-row-asset">
+        <span className="portfolio-row-name">{asset.name}</span>
+        <span className="portfolio-row-meta">
+          {asset.symbol}
+          <span className="portfolio-row-source">{SOURCE_LABELS[asset.source] || asset.source}</span>
+        </span>
+      </div>
+      <div className="portfolio-row-values">
+        <span className="portfolio-row-balance">{formatBalance(holding)}</span>
+        {usd == null ? (
+          <span className="portfolio-row-usd portfolio-row-usd-unavailable">
+            <span aria-hidden="true">—</span>
+            <span className="portfolio-visually-hidden">price unavailable</span>
+          </span>
+        ) : (
+          <span className="portfolio-row-usd">{formatUsdFull(usd)}</span>
+        )}
+      </div>
+    </li>
+  )
+}
+
+function CategorySection({ group, collapsed, onToggle }) {
+  const { category, holdings, subtotalUsd, isPartial } = group
+  const regionId = `portfolio-category-${category.id}`
+  const expanded = !collapsed
+  return (
+    <section className="portfolio-category">
+      <h3 className="portfolio-category-heading">
+        <button
+          type="button"
+          className="portfolio-category-toggle"
+          aria-expanded={expanded}
+          aria-controls={regionId}
+          onClick={() => onToggle(category.id)}
+        >
+          <span className="portfolio-category-chevron" aria-hidden="true">
+            {expanded ? '▾' : '▸'}
+          </span>
+          <span className="portfolio-category-label">{category.label}</span>
+          <span className="portfolio-category-subtotal">
+            {formatUsdFull(subtotalUsd)}
+            {isPartial && (
+              <span className="portfolio-partial-flag" title="Some assets in this category have no available price">
+                {' '}
+                (partial)
+              </span>
+            )}
+          </span>
+        </button>
+      </h3>
+      <div id={regionId} role="region" aria-label={category.label} hidden={!expanded}>
+        <p className="portfolio-category-description">{category.description}</p>
+        {holdings.length === 0 ? (
+          <p className="portfolio-category-empty">No assets in this category.</p>
+        ) : (
+          <ul className="portfolio-rows">
+            {holdings.map((h) => (
+              <AssetRow key={h.asset.id} holding={h} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  )
+}
+
+/**
+ * Connected Account Portfolio (spec 044) — the member's live holdings on the
+ * active network, grouped by the SEC/CFTC asset taxonomy. Read-only; honest
+ * states for disconnected / unsupported network / loading / error / partial
+ * pricing (FR-010/012/013/014).
+ */
+export default function PortfolioPanel() {
+  const portfolio = usePortfolio()
+  const [collapsedIds, setCollapsedIds] = useState(() => new Set())
+
+  const toggleCategory = (id) => {
+    setCollapsedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  if (portfolio.status === 'disconnected') {
+    return (
+      <div className="portfolio-root">
+        <p className="portfolio-state">Connect a wallet to see your portfolio.</p>
+      </div>
+    )
+  }
+
+  if (!portfolio.isSupportedNetwork) {
+    return (
+      <div className="portfolio-root">
+        <p className="portfolio-state">Portfolio isn&apos;t available on this network.</p>
+      </div>
+    )
+  }
+
+  if (portfolio.status === 'error') {
+    return (
+      <div className="portfolio-root">
+        <p className="portfolio-state portfolio-state-error" role="alert">
+          {portfolio.error}
+        </p>
+        <button type="button" className="portfolio-refresh" onClick={() => portfolio.refresh()}>
+          Retry
+        </button>
+      </div>
+    )
+  }
+
+  if (portfolio.status === 'loading') {
+    return (
+      <div className="portfolio-root">
+        <p className="portfolio-state" role="status">
+          Loading portfolio…
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="portfolio-root">
+      <header className="portfolio-header">
+        <p className="portfolio-total-label" id="portfolio-total-label">
+          Total portfolio balance
+        </p>
+        <p className="portfolio-total" aria-labelledby="portfolio-total-label">
+          {formatUsdFull(portfolio.totalUsd)}
+          {portfolio.isPartial && (
+            <span className="portfolio-partial-flag portfolio-partial-total"> (partial)</span>
+          )}
+        </p>
+        {portfolio.isPartial && (
+          <p className="portfolio-partial-note">
+            Some assets have no available price or could not be read
+            {portfolio.failedAssets.length > 0 && <> (unreadable: {portfolio.failedAssets.join(', ')})</>}
+            ; they are excluded from USD totals.
+          </p>
+        )}
+        <button
+          type="button"
+          className="portfolio-refresh"
+          onClick={() => portfolio.refresh()}
+          disabled={portfolio.isLoading}
+        >
+          {portfolio.isLoading ? 'Refreshing…' : 'Refresh'}
+        </button>
+      </header>
+
+      {portfolio.categories.map((group) => (
+        <CategorySection
+          key={group.category.id}
+          group={group}
+          collapsed={collapsedIds.has(group.category.id)}
+          onToggle={toggleCategory}
+        />
+      ))}
+
+      <footer className="portfolio-disclosures">
+        <p>
+          Classifications follow the app&apos;s SEC/CFTC-aligned taxonomy and are informational
+          only — not legal or investment advice.
+        </p>
+        <p>
+          Only assets in the app&apos;s curated registry are scanned, so other holdings may exist
+          on-chain that are not listed here.
+        </p>
+      </footer>
+    </div>
+  )
+}

--- a/frontend/src/components/wallet/PortfolioPanel.jsx
+++ b/frontend/src/components/wallet/PortfolioPanel.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { formatUnits } from 'ethers'
 import usePortfolio from '../../hooks/usePortfolio'
 import './Portfolio.css'
 
@@ -11,10 +12,25 @@ function formatUsdFull(n) {
   })}`
 }
 
+// Max fraction digits shown for a fungible balance.
+const FRACTION_DIGITS = 6
+
 function formatBalance(holding) {
-  const { asset, balance } = holding
+  const { asset, balance, balanceRaw } = holding
   if (asset.kind === 'nft') {
     return `${balance} ${balance === 1 ? 'item' : 'items'}`
+  }
+  // Format from the raw units string so a nonzero dust holding can never
+  // round to a misleading "0" (honest state). Falls back to the numeric
+  // balance only when raw units aren't available.
+  if (typeof balanceRaw === 'bigint' && Number.isInteger(asset.decimals)) {
+    const [int, frac = ''] = formatUnits(balanceRaw, asset.decimals).split('.')
+    const intFmt = BigInt(int).toLocaleString('en-US')
+    const fracShown = frac.slice(0, FRACTION_DIGITS).replace(/0+$/, '')
+    if (int === '0' && fracShown === '' && balanceRaw > 0n) {
+      return `< 0.${'0'.repeat(FRACTION_DIGITS - 1)}1 ${asset.symbol}`
+    }
+    return `${intFmt}${fracShown ? `.${fracShown}` : ''} ${asset.symbol}`
   }
   const digits = balance !== 0 && Math.abs(balance) < 1 ? 6 : 4
   return `${Number(balance).toLocaleString('en-US', { maximumFractionDigits: digits })} ${asset.symbol}`

--- a/frontend/src/config/assetTaxonomy.js
+++ b/frontend/src/config/assetTaxonomy.js
@@ -103,6 +103,19 @@ const BASELINE_SET = new Set(SEC_COMMODITY_BASELINE)
 // `baselineSymbol` marks a token as the wrapped form of an SEC-baseline
 // commodity (upgrades its source to sec-baseline).
 const CURATED_REGISTRY = {
+  1: [
+    {
+      // Canonical WETH9 on Ethereum mainnet. Chain 1 has no dex config or
+      // wmatic deployment record, so without this curated entry the wrapped
+      // form of the chain's own baseline commodity would never be scanned.
+      address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+      symbol: 'WETH',
+      name: 'Wrapped Ether',
+      decimals: 18,
+      categoryId: 'digital-commodities',
+      baselineSymbol: 'ETH',
+    },
+  ],
   137: [
     {
       // Canonical Wrapped Ether on Polygon PoS (Polygon canonical bridge).

--- a/frontend/src/config/assetTaxonomy.js
+++ b/frontend/src/config/assetTaxonomy.js
@@ -1,0 +1,256 @@
+/**
+ * Asset Taxonomy Registry (spec 044) — SEC/CFTC-aligned classification of the
+ * assets the Portfolio section scans for the connected account.
+ *
+ * Layered classification, industry-standard for wallet taxonomy filters:
+ *   1. `sec-baseline`     — hardcoded baseline derived from the SEC's public
+ *                           commodity classifications (major L1/L2 assets);
+ *                           applies to native coins and their canonical
+ *                           wrapped forms.
+ *   2. `curated-registry` — bundled, per-network curated token entries
+ *                           (Tokenlists-style data reduced to what the app
+ *                           supports), mapped to a category by known issuer
+ *                           status / contract behavior.
+ *   3. `app-config`       — assets the app already knows from its own config
+ *                           and sync artifacts (per-network stablecoin,
+ *                           wrapped native, MembershipVoucher credential).
+ *
+ * Precedence on conflicts: sec-baseline > curated-registry > app-config
+ * (FR-006). The registry is pure config — no chain reads — and strictly
+ * per-network: entries never leak across chains (FR-007, constitution III).
+ *
+ * Discovery is registry-driven: the portfolio only scans assets listed here,
+ * and the UI discloses that limitation (FR-013). Classifications are
+ * informational, not legal or investment advice.
+ */
+import { NETWORKS } from './networks'
+import { getContractAddressForChain } from './contracts'
+
+// The five app-aligned regulatory categories (FR-004) plus the honest
+// `unclassified` fallback (FR-012). Order is display order.
+export const TAXONOMY_CATEGORIES = [
+  {
+    id: 'digital-commodities',
+    label: 'Digital Commodities',
+    order: 1,
+    description:
+      'Crypto assets intrinsically linked to, and deriving value from, the programmatic ' +
+      'operation of an already functional decentralized system and general supply/demand ' +
+      'dynamics — not the active managerial efforts of a core team. The SEC categorized ' +
+      'major layer-1 and layer-2 assets here (e.g. Bitcoin, Ether, Solana, XRP).',
+  },
+  {
+    id: 'digital-securities',
+    label: 'Digital Securities',
+    order: 2,
+    description:
+      'Tokens that represent an on-chain format of traditional financial instruments ' +
+      '(equity, debt, or structured investments) or possess the economic characteristics ' +
+      'of an investment contract. Fully subject to standard securities registration and ' +
+      'compliance obligations.',
+  },
+  {
+    id: 'payment-stablecoins',
+    label: 'Payment Stablecoins',
+    order: 3,
+    description:
+      'Stablecoins issued by an approved issuer under the scope of federal banking ' +
+      'guidelines (such as the GENIUS Act framework), structurally isolated from being ' +
+      'treated as securities when utilized as transactional payment instruments.',
+  },
+  {
+    id: 'digital-tools',
+    label: 'Digital Tools',
+    order: 4,
+    description:
+      'Utility tokens that carry no intrinsic economic yield or capital-raising function ' +
+      'but perform a distinct, practical function on an application or protocol — identity ' +
+      'badges, name-service domains, or network credentials.',
+  },
+  {
+    id: 'digital-collectibles',
+    label: 'Digital Collectibles',
+    order: 5,
+    description:
+      'Assets intended for collection, consumer use, or artistic media rights — typically ' +
+      'non-fungible tokens representing artwork, music, and in-game items, provided they ' +
+      'carry no profit-sharing characteristics.',
+  },
+  {
+    id: 'unclassified',
+    label: 'Unclassified',
+    order: 6,
+    description:
+      'Assets the app knows about but cannot map to a regulatory category. Shown here ' +
+      'rather than hidden, so the portfolio never silently omits a holding.',
+  },
+]
+
+// Classification sources, highest precedence first (FR-006).
+export const CLASSIFICATION_SOURCES = ['sec-baseline', 'curated-registry', 'app-config']
+
+// Symbol-level baseline derived from the SEC's public commodity
+// classifications (major L1/L2 assets named by the SEC: BTC, ETH, SOL, XRP)
+// plus the gas assets of the networks this app runs on (MATIC/POL, ETC),
+// which sit in the same functional-network bucket. Wrapped forms inherit the
+// underlying symbol's classification via `baselineSymbol`.
+export const SEC_COMMODITY_BASELINE = ['BTC', 'ETH', 'SOL', 'XRP', 'MATIC', 'POL', 'ETC']
+
+const BASELINE_SET = new Set(SEC_COMMODITY_BASELINE)
+
+// Curated per-network token entries. Canonical, well-known deployments only —
+// the same convention as the canonical Uniswap addresses in networks.js.
+// `baselineSymbol` marks a token as the wrapped form of an SEC-baseline
+// commodity (upgrades its source to sec-baseline).
+const CURATED_REGISTRY = {
+  137: [
+    {
+      // Canonical Wrapped Ether on Polygon PoS (Polygon canonical bridge).
+      address: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
+      symbol: 'WETH',
+      name: 'Wrapped Ether',
+      decimals: 18,
+      categoryId: 'digital-commodities',
+      baselineSymbol: 'ETH',
+    },
+    {
+      // Canonical Wrapped BTC on Polygon PoS.
+      address: '0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6',
+      symbol: 'WBTC',
+      name: 'Wrapped BTC',
+      decimals: 8,
+      categoryId: 'digital-commodities',
+      baselineSymbol: 'BTC',
+    },
+    {
+      // Chainlink token on Polygon PoS — protocol utility (oracle payment),
+      // no yield/capital-raising function.
+      address: '0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39',
+      symbol: 'LINK',
+      name: 'ChainLink Token',
+      decimals: 18,
+      categoryId: 'digital-tools',
+    },
+    {
+      // Tether USD on Polygon PoS — transactional stablecoin by known issuer.
+      address: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
+      symbol: 'USDT',
+      name: 'Tether USD',
+      decimals: 6,
+      categoryId: 'payment-stablecoins',
+    },
+  ],
+}
+
+function normalizeAddress(address) {
+  return typeof address === 'string' ? address.toLowerCase() : address
+}
+
+/**
+ * The taxonomy category for `categoryId`, falling back to the `unclassified`
+ * category (never undefined) so display code can always render a group.
+ */
+export function getTaxonomyCategory(categoryId) {
+  return (
+    TAXONOMY_CATEGORIES.find((c) => c.id === categoryId) ||
+    TAXONOMY_CATEGORIES.find((c) => c.id === 'unclassified')
+  )
+}
+
+// Apply the SEC baseline on top of an entry's own classification: a native
+// coin or wrapped form whose underlying symbol sits on the baseline is a
+// Digital Commodity from the highest-precedence source, whatever the lower
+// layers said (FR-006).
+function withBaseline(entry) {
+  const underlying = (entry.baselineSymbol || entry.symbol || '').toUpperCase()
+  if ((entry.kind === 'native' || entry.baselineSymbol) && BASELINE_SET.has(underlying)) {
+    return { ...entry, categoryId: 'digital-commodities', source: 'sec-baseline' }
+  }
+  return entry
+}
+
+/**
+ * Build the scannable asset registry for one network (FR-005/006/007).
+ *
+ * Pure function of bundled config — no chain reads, no async. Returns [] for
+ * unknown chains, which drives the honest "unavailable on this network" state
+ * (FR-014). Every returned entry carries the queried chainId; entries whose
+ * address cannot be resolved from config are omitted, never emitted empty.
+ */
+export function getPortfolioRegistry(chainId) {
+  const net = NETWORKS[chainId]
+  if (!net) return []
+
+  // Assembled lowest-precedence first; later same-address inserts overwrite.
+  const byId = new Map()
+  const put = (entry) => {
+    if (entry.kind !== 'native' && !entry.address) return
+    const id = entry.kind === 'native' ? 'native' : normalizeAddress(entry.address)
+    byId.set(id, withBaseline({ ...entry, id, chainId, address: entry.address || null }))
+  }
+
+  // --- app-config layer ---------------------------------------------------
+  // Native coin. All currently supported natives (MATIC, ETC, ETH) sit on the
+  // SEC baseline; withBaseline handles any future non-baseline native by
+  // leaving it unclassified rather than guessing (FR-012).
+  put({
+    kind: 'native',
+    symbol: net.nativeCurrency.symbol,
+    name: net.nativeCurrency.name,
+    decimals: net.nativeCurrency.decimals,
+    categoryId: 'unclassified',
+    source: 'app-config',
+    baselineSymbol: net.nativeCurrency.symbol,
+  })
+
+  // Wrapped native — from the network's DEX config, falling back to the
+  // synced per-chain deployment record.
+  const wnative = net.dex?.wnative || getContractAddressForChain('wmatic', chainId)
+  if (wnative) {
+    put({
+      kind: 'erc20',
+      address: wnative,
+      symbol: `W${net.nativeCurrency.symbol}`,
+      name: `Wrapped ${net.nativeCurrency.name}`,
+      decimals: 18,
+      categoryId: 'unclassified',
+      source: 'app-config',
+      baselineSymbol: net.nativeCurrency.symbol,
+    })
+  }
+
+  // The network's configured stablecoin — known issuer status via app config.
+  if (net.stablecoin?.address) {
+    put({
+      kind: 'erc20',
+      address: net.stablecoin.address,
+      symbol: net.stablecoin.symbol,
+      name: net.stablecoin.name,
+      decimals: net.stablecoin.decimals,
+      categoryId: 'payment-stablecoins',
+      source: 'app-config',
+    })
+  }
+
+  // MembershipVoucher (ERC-721) — an app-issued network credential, the
+  // textbook Digital Tools case. Rendered as an item count (FR-011).
+  const voucher = getContractAddressForChain('membershipVoucher', chainId)
+  if (voucher) {
+    put({
+      kind: 'nft',
+      address: voucher,
+      symbol: 'FWMV',
+      name: 'FairWins Membership Voucher',
+      decimals: null,
+      categoryId: 'digital-tools',
+      source: 'app-config',
+    })
+  }
+
+  // --- curated-registry layer (overwrites app-config on the same address) --
+  for (const token of CURATED_REGISTRY[chainId] || []) {
+    put({ kind: 'erc20', categoryId: 'unclassified', ...token, source: 'curated-registry' })
+  }
+
+  return Array.from(byId.values())
+}

--- a/frontend/src/hooks/usePortfolio.js
+++ b/frontend/src/hooks/usePortfolio.js
@@ -1,0 +1,181 @@
+/**
+ * usePortfolio (spec 044) — live, per-network holdings of the connected
+ * account, grouped by the SEC/CFTC asset taxonomy.
+ *
+ * Discovery is registry-driven: only assets in getPortfolioRegistry(chainId)
+ * are scanned (the panel discloses this, FR-013). Balances are read live from
+ * the wallet context's read provider; nothing is persisted. Honest-state
+ * rules (constitution III):
+ *   - a zero balance is not a holding;
+ *   - a failed read is reported in `failedAssets` and marks the snapshot
+ *     partial — it is never rendered as a zero balance;
+ *   - an asset with no trustworthy USD price gets `usd: null`, is excluded
+ *     from totals, and flips `isPartial` (FR-010) — the price feed's
+ *     hardcoded fallback rate is treated as unavailable, and the MATIC/USD
+ *     feed is never applied to another chain's native coin.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Contract, formatUnits } from 'ethers'
+import { useWallet } from './useWalletManagement'
+import { usePrice } from '../contexts/PriceContext'
+import { getPortfolioRegistry, getTaxonomyCategory, TAXONOMY_CATEGORIES } from '../config/assetTaxonomy'
+
+const POLL_MS = 60_000
+
+// Works for ERC-20 balances and ERC-721 item counts alike.
+const BALANCE_OF_ABI = ['function balanceOf(address) view returns (uint256)']
+
+// The app's only price feed quotes MATIC/USD (usePriceConversion), so the
+// native/wrapped-native rate applies solely on MATIC-native chains. Applying
+// it elsewhere (e.g. pricing ETC with a MATIC rate) would fabricate value.
+const PRICE_FEED_NATIVE_SYMBOLS = new Set(['MATIC', 'POL'])
+
+async function readAssetBalance(asset, { provider, address }) {
+  if (asset.kind === 'native') {
+    return provider.getBalance(address)
+  }
+  const token = new Contract(asset.address, BALANCE_OF_ABI, provider)
+  return token.balanceOf(address)
+}
+
+function toHolding(asset, balanceRaw, { nativeUsdRate }) {
+  const balance =
+    asset.kind === 'nft' ? Number(balanceRaw) : Number(formatUnits(balanceRaw, asset.decimals))
+
+  let usd = null
+  if (asset.categoryId === 'payment-stablecoins') {
+    // Par $1 — the app-wide stablecoin convention (see useAccountStats).
+    usd = balance
+  } else if (
+    asset.kind !== 'nft' &&
+    nativeUsdRate != null &&
+    asset.baselineSymbol &&
+    PRICE_FEED_NATIVE_SYMBOLS.has(asset.baselineSymbol.toUpperCase())
+  ) {
+    usd = balance * nativeUsdRate
+  }
+  return { asset, balance, balanceRaw, usd }
+}
+
+export function usePortfolio() {
+  const wallet = useWallet() || {}
+  const { address, chainId, isConnected, provider } = wallet
+  const price = usePrice()
+  // A feed error means the exported rate is the hardcoded fallback — honest
+  // portfolios treat that as "no price" rather than presenting it as real.
+  const nativeUsdRate = price?.error ? null : price?.nativeUsdRate ?? null
+
+  const registry = useMemo(() => getPortfolioRegistry(chainId), [chainId])
+
+  const [reads, setReads] = useState({ balances: null, failedAssets: [], error: null })
+  const [isLoading, setIsLoading] = useState(false)
+  const [lastUpdated, setLastUpdated] = useState(null)
+  const reqIdRef = useRef(0)
+
+  const load = useCallback(async () => {
+    if (!isConnected || !address || !provider || registry.length === 0) return
+    const reqId = ++reqIdRef.current
+    setIsLoading(true)
+    try {
+      const settled = await Promise.allSettled(
+        registry.map((asset) => readAssetBalance(asset, { provider, address })),
+      )
+      if (reqId !== reqIdRef.current) return
+
+      const balances = new Map()
+      const failedAssets = []
+      settled.forEach((res, i) => {
+        if (res.status === 'fulfilled') {
+          balances.set(registry[i].id, res.value)
+        } else {
+          failedAssets.push(registry[i].symbol)
+        }
+      })
+
+      if (failedAssets.length === registry.length) {
+        // Nothing readable — an explicit error state, never a $0 portfolio.
+        setReads({ balances: null, failedAssets, error: 'Unable to read balances from the network.' })
+      } else {
+        setReads({ balances, failedAssets, error: null })
+        setLastUpdated(Date.now())
+      }
+    } catch (err) {
+      if (reqId !== reqIdRef.current) return
+      setReads({ balances: null, failedAssets: [], error: err?.message || 'Failed to load portfolio' })
+    } finally {
+      if (reqId === reqIdRef.current) setIsLoading(false)
+    }
+  }, [isConnected, address, provider, registry])
+
+  // Reset synchronously on account/network change so a stale snapshot from
+  // another chain can never render (SC-004), then reload.
+  useEffect(() => {
+    reqIdRef.current++
+    setReads({ balances: null, failedAssets: [], error: null })
+    setLastUpdated(null)
+    load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [address, chainId])
+
+  useEffect(() => {
+    if (!isConnected || !address) return undefined
+    const id = setInterval(() => load(), POLL_MS)
+    return () => clearInterval(id)
+  }, [isConnected, address, load])
+
+  return useMemo(() => {
+    const supported = registry.length > 0
+
+    let status = 'ready'
+    if (!isConnected || !address) status = 'disconnected'
+    else if (reads.error) status = 'error'
+    // An unsupported network never loads — the panel renders its explicit
+    // state off isSupportedNetwork instead (FR-014).
+    else if (!reads.balances && supported) status = 'loading'
+
+    const holdings = []
+    if (reads.balances) {
+      for (const asset of registry) {
+        const raw = reads.balances.get(asset.id)
+        if (raw == null || raw <= 0n) continue
+        holdings.push(toHolding(asset, raw, { nativeUsdRate }))
+      }
+    }
+
+    const byCategory = new Map()
+    for (const h of holdings) {
+      const list = byCategory.get(h.asset.categoryId) || []
+      list.push(h)
+      byCategory.set(h.asset.categoryId, list)
+    }
+    const categories = TAXONOMY_CATEGORIES
+      // The regulatory categories always render; Unclassified only when it
+      // actually holds something (FR-012).
+      .filter((cat) => cat.id !== 'unclassified' || (byCategory.get(cat.id) || []).length > 0)
+      .map((cat) => {
+        const catHoldings = byCategory.get(cat.id) || []
+        return {
+          category: getTaxonomyCategory(cat.id),
+          holdings: catHoldings,
+          subtotalUsd: catHoldings.reduce((sum, h) => sum + (h.usd ?? 0), 0),
+          isPartial: catHoldings.some((h) => h.usd == null),
+        }
+      })
+
+    return {
+      status,
+      isSupportedNetwork: supported,
+      isLoading,
+      error: reads.error,
+      holdings,
+      categories,
+      totalUsd: holdings.reduce((sum, h) => sum + (h.usd ?? 0), 0),
+      isPartial: holdings.some((h) => h.usd == null) || reads.failedAssets.length > 0,
+      failedAssets: reads.failedAssets,
+      lastUpdated,
+      refresh: load,
+    }
+  }, [registry, isConnected, address, reads, nativeUsdRate, isLoading, lastUpdated, load])
+}
+
+export default usePortfolio

--- a/frontend/src/hooks/usePortfolio.js
+++ b/frontend/src/hooks/usePortfolio.js
@@ -76,6 +76,10 @@ export function usePortfolio() {
     if (!isConnected || !address || !provider || registry.length === 0) return
     const reqId = ++reqIdRef.current
     setIsLoading(true)
+    // A retry after a failed load must leave the error state immediately so
+    // the panel shows loading (and its Retry button goes away) instead of
+    // inviting overlapping retries against a stale error.
+    setReads((prev) => (prev.error ? { balances: null, failedAssets: [], error: null } : prev))
     try {
       const settled = await Promise.allSettled(
         registry.map((asset) => readAssetBalance(asset, { provider, address })),

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -12,6 +12,7 @@ import { ROLES, ROLE_INFO } from '../contexts/RoleContext'
 import { hasRegisteredKey, ensureKeyRegistered } from '../utils/keyRegistryService'
 import TradePanel from '../components/fairwins/TradePanel'
 import PayTransferPanel from '../components/wallet/PayTransferPanel'
+import PortfolioPanel from '../components/wallet/PortfolioPanel'
 import CustodyPanel from '../components/custody/CustodyPanel'
 import TokensPanel from '../components/tokens/TokensPanel'
 import ClearPathPanel from '../components/clearpath/ClearPathPanel'
@@ -50,6 +51,7 @@ const WALLET_TAB_GROUPS = [
   {
     label: 'Finance',
     items: [
+      { id: 'portfolio', label: 'Portfolio' },
       { id: 'trade', label: 'Trade' },
       { id: 'paytransfer', label: 'Pay & Transfer' },
       { id: 'custody', label: 'Custody' },
@@ -404,6 +406,12 @@ function WalletPage() {
                         <button onClick={handleNavigateToAdmin} className="admin-panel-btn">Role Management</button>
                       </div>
                     )}
+                  </div>
+                )}
+
+                {activeTab === 'portfolio' && (
+                  <div className="portfolio-section" role="tabpanel">
+                    <PortfolioPanel />
                   </div>
                 )}
 

--- a/frontend/src/test/portfolio/PortfolioPanel.axe.test.jsx
+++ b/frontend/src/test/portfolio/PortfolioPanel.axe.test.jsx
@@ -1,0 +1,83 @@
+/**
+ * PortfolioPanel (spec 044) — WCAG 2.1 AA audits via vitest-axe (FR-016).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent, screen } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import PortfolioPanel from '../../components/wallet/PortfolioPanel'
+import { getTaxonomyCategory } from '../../config/assetTaxonomy'
+
+const mockUsePortfolio = vi.fn()
+vi.mock('../../hooks/usePortfolio', () => ({
+  default: (...args) => mockUsePortfolio(...args),
+  usePortfolio: (...args) => mockUsePortfolio(...args),
+}))
+
+const HOLDINGS = [
+  {
+    asset: { id: 'native', chainId: 137, kind: 'native', address: null, symbol: 'MATIC', name: 'MATIC', categoryId: 'digital-commodities', source: 'sec-baseline' },
+    balance: 2,
+    balanceRaw: 2n,
+    usd: 1,
+  },
+  {
+    asset: { id: '0xusdc', chainId: 137, kind: 'erc20', address: '0xusdc', symbol: 'USDC', name: 'USD Coin', categoryId: 'payment-stablecoins', source: 'app-config' },
+    balance: 100,
+    balanceRaw: 100n,
+    usd: 100,
+  },
+  {
+    asset: { id: '0xlink', chainId: 137, kind: 'erc20', address: '0xlink', symbol: 'LINK', name: 'ChainLink Token', categoryId: 'digital-tools', source: 'curated-registry' },
+    balance: 5,
+    balanceRaw: 5n,
+    usd: null,
+  },
+]
+
+function makeSnapshot(overrides = {}) {
+  const holdings = overrides.holdings ?? HOLDINGS
+  const ids = ['digital-commodities', 'digital-securities', 'payment-stablecoins', 'digital-tools', 'digital-collectibles']
+  return {
+    status: 'ready',
+    isSupportedNetwork: true,
+    isLoading: false,
+    error: null,
+    holdings,
+    categories: ids.map((id) => {
+      const catHoldings = holdings.filter((h) => h.asset.categoryId === id)
+      return {
+        category: getTaxonomyCategory(id),
+        holdings: catHoldings,
+        subtotalUsd: catHoldings.reduce((s, h) => s + (h.usd ?? 0), 0),
+        isPartial: catHoldings.some((h) => h.usd == null),
+      }
+    }),
+    totalUsd: 101,
+    isPartial: true,
+    failedAssets: [],
+    lastUpdated: 1,
+    refresh: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('PortfolioPanel accessibility (WCAG 2.1 AA)', () => {
+  it('populated portfolio view has no violations', async () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot())
+    const { container } = render(<PortfolioPanel />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('collapsed category state has no violations', async () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot())
+    const { container } = render(<PortfolioPanel />)
+    fireEvent.click(screen.getByRole('button', { name: /payment stablecoins/i }))
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('error state has no violations', async () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ status: 'error', error: 'Unable to read balances from the network.' }))
+    const { container } = render(<PortfolioPanel />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/portfolio/PortfolioPanel.test.jsx
+++ b/frontend/src/test/portfolio/PortfolioPanel.test.jsx
@@ -168,6 +168,27 @@ describe('PortfolioPanel portfolio view', () => {
     expect(screen.getAllByText('$0.00').length).toBeGreaterThanOrEqual(6) // total + 5 subtotals
   })
 
+  it('never renders a nonzero dust balance as zero (honest state)', () => {
+    const dust = {
+      asset: { id: '0xweth', chainId: 137, kind: 'erc20', address: '0xweth', symbol: 'WETH', name: 'Wrapped Ether', categoryId: 'digital-commodities', source: 'sec-baseline', decimals: 18 },
+      balance: 1e-18,
+      balanceRaw: 1n, // 1 wei of WETH
+      usd: null,
+    }
+    const usdc = {
+      asset: { id: '0xusdc2', chainId: 137, kind: 'erc20', address: '0xusdc2', symbol: 'USDC', name: 'USD Coin', categoryId: 'payment-stablecoins', source: 'app-config', decimals: 6 },
+      balance: 1234.5,
+      balanceRaw: 1_234_500_000n,
+      usd: 1234.5,
+    }
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: [dust, usdc] }))
+    render(<PortfolioPanel />)
+    // Raw-units formatting: dust floors at "< 0.000001", never "0 WETH".
+    expect(screen.getByText('< 0.000001 WETH')).toBeInTheDocument()
+    expect(screen.queryByText(/^0 WETH$/)).not.toBeInTheDocument()
+    expect(screen.getByText('1,234.5 USDC')).toBeInTheDocument()
+  })
+
   it('refresh button triggers a reload (FR-015)', () => {
     const snapshot = makeSnapshot({ holdings: POPULATED })
     mockUsePortfolio.mockReturnValue(snapshot)

--- a/frontend/src/test/portfolio/PortfolioPanel.test.jsx
+++ b/frontend/src/test/portfolio/PortfolioPanel.test.jsx
@@ -1,0 +1,225 @@
+/**
+ * PortfolioPanel (spec 044) — rendering-contract tests.
+ * The data seam (usePortfolio) is mocked; see usePortfolio.test.jsx for the
+ * live-read behavior.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, within, fireEvent } from '@testing-library/react'
+import PortfolioPanel from '../../components/wallet/PortfolioPanel'
+import { getTaxonomyCategory } from '../../config/assetTaxonomy'
+
+const mockUsePortfolio = vi.fn()
+vi.mock('../../hooks/usePortfolio', () => ({
+  default: (...args) => mockUsePortfolio(...args),
+  usePortfolio: (...args) => mockUsePortfolio(...args),
+}))
+
+function makeHolding({ symbol, name, categoryId, source = 'app-config', kind = 'erc20', balance = 1, usd = null }) {
+  return {
+    asset: { id: symbol.toLowerCase(), chainId: 137, kind, address: kind === 'native' ? null : `0x${symbol}`, symbol, name, categoryId, source },
+    balance,
+    balanceRaw: 1n,
+    usd,
+  }
+}
+
+function groupsFromHoldings(holdings, { includeUnclassified = false } = {}) {
+  const ids = [
+    'digital-commodities',
+    'digital-securities',
+    'payment-stablecoins',
+    'digital-tools',
+    'digital-collectibles',
+    ...(includeUnclassified ? ['unclassified'] : []),
+  ]
+  return ids.map((id) => {
+    const catHoldings = holdings.filter((h) => h.asset.categoryId === id)
+    return {
+      category: getTaxonomyCategory(id),
+      holdings: catHoldings,
+      subtotalUsd: catHoldings.reduce((s, h) => s + (h.usd ?? 0), 0),
+      isPartial: catHoldings.some((h) => h.usd == null),
+    }
+  })
+}
+
+function makeSnapshot(overrides = {}) {
+  const holdings = overrides.holdings ?? []
+  return {
+    status: 'ready',
+    isSupportedNetwork: true,
+    isLoading: false,
+    error: null,
+    holdings,
+    categories: groupsFromHoldings(holdings, overrides.groupOptions),
+    totalUsd: holdings.reduce((s, h) => s + (h.usd ?? 0), 0),
+    isPartial: holdings.some((h) => h.usd == null),
+    failedAssets: [],
+    lastUpdated: 1,
+    refresh: vi.fn(),
+    ...overrides,
+  }
+}
+
+const POPULATED = [
+  makeHolding({ symbol: 'MATIC', name: 'MATIC', categoryId: 'digital-commodities', source: 'sec-baseline', kind: 'native', balance: 2, usd: 1 }),
+  makeHolding({ symbol: 'USDC', name: 'USD Coin', categoryId: 'payment-stablecoins', source: 'app-config', balance: 100, usd: 100 }),
+  makeHolding({ symbol: 'LINK', name: 'ChainLink Token', categoryId: 'digital-tools', source: 'curated-registry', balance: 5, usd: null }),
+]
+
+beforeEach(() => {
+  mockUsePortfolio.mockReset()
+})
+
+describe('PortfolioPanel states (FR-014)', () => {
+  it('shows a connect prompt when disconnected', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ status: 'disconnected' }))
+    render(<PortfolioPanel />)
+    expect(screen.getByText(/connect a wallet/i)).toBeInTheDocument()
+    expect(screen.queryByText(/total portfolio balance/i)).not.toBeInTheDocument()
+  })
+
+  it('shows an explicit unavailable state on unsupported networks', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ status: 'ready', isSupportedNetwork: false, categories: [] }))
+    render(<PortfolioPanel />)
+    expect(screen.getByText(/isn't available on this network/i)).toBeInTheDocument()
+  })
+
+  it('shows a loading state', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ status: 'loading' }))
+    render(<PortfolioPanel />)
+    expect(screen.getByRole('status')).toHaveTextContent(/loading portfolio/i)
+  })
+
+  it('shows the error state with a working retry', () => {
+    const snapshot = makeSnapshot({ status: 'error', error: 'Unable to read balances from the network.' })
+    mockUsePortfolio.mockReturnValue(snapshot)
+    render(<PortfolioPanel />)
+    expect(screen.getByRole('alert')).toHaveTextContent(/unable to read balances/i)
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    expect(snapshot.refresh).toHaveBeenCalled()
+  })
+})
+
+describe('PortfolioPanel portfolio view', () => {
+  it('renders the total, category subtotals, and asset rows', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
+    render(<PortfolioPanel />)
+
+    expect(screen.getByText('Total portfolio balance')).toBeInTheDocument()
+    expect(screen.getByText(/\$101\.00/)).toBeInTheDocument()
+
+    const stables = screen.getByRole('region', { name: 'Payment Stablecoins' })
+    expect(within(stables).getByText('USD Coin')).toBeInTheDocument()
+    expect(within(stables).getByText(/100 USDC/)).toBeInTheDocument()
+    expect(within(stables).getByText('$100.00')).toBeInTheDocument()
+  })
+
+  it('renders unpriced assets with an em dash — never $0.00 — and labels totals partial (SC-005)', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
+    render(<PortfolioPanel />)
+
+    const tools = screen.getByRole('region', { name: 'Digital Tools' })
+    expect(within(tools).getByText('price unavailable')).toBeInTheDocument()
+    expect(within(tools).queryByText('$0.00')).not.toBeInTheDocument()
+
+    // Grand total and the affected category flag partial.
+    expect(screen.getAllByText(/\(partial\)/i).length).toBeGreaterThanOrEqual(2)
+    expect(screen.getByText(/excluded from USD totals/i)).toBeInTheDocument()
+  })
+
+  it('names unreadable assets in the partial note', () => {
+    mockUsePortfolio.mockReturnValue(
+      makeSnapshot({ holdings: POPULATED, isPartial: true, failedAssets: ['WBTC'] }),
+    )
+    render(<PortfolioPanel />)
+    expect(screen.getByText(/unreadable: WBTC/i)).toBeInTheDocument()
+  })
+
+  it('collapses a category on toggle, keeping header and subtotal visible', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
+    render(<PortfolioPanel />)
+
+    const toggle = screen.getByRole('button', { name: /payment stablecoins/i })
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    // Rows hide (hidden region) while header and subtotal remain visible.
+    expect(screen.getByText('USD Coin')).not.toBeVisible()
+    expect(within(toggle).getByText('Payment Stablecoins')).toBeVisible()
+    expect(within(toggle).getByText(/\$100\.00/)).toBeVisible()
+
+    fireEvent.click(toggle)
+    expect(screen.getByText('USD Coin')).toBeVisible()
+  })
+
+  it('shows an explicit empty state for categories with no holdings', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
+    render(<PortfolioPanel />)
+    const securities = screen.getByRole('region', { name: 'Digital Securities' })
+    expect(within(securities).getByText(/no assets in this category/i)).toBeInTheDocument()
+  })
+
+  it('renders all five regulatory categories with $0.00 subtotals when nothing is held', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: [] }))
+    render(<PortfolioPanel />)
+    expect(screen.getAllByText(/no assets in this category/i)).toHaveLength(5)
+    expect(screen.getAllByText('$0.00').length).toBeGreaterThanOrEqual(6) // total + 5 subtotals
+  })
+
+  it('refresh button triggers a reload (FR-015)', () => {
+    const snapshot = makeSnapshot({ holdings: POPULATED })
+    mockUsePortfolio.mockReturnValue(snapshot)
+    render(<PortfolioPanel />)
+    fireEvent.click(screen.getByRole('button', { name: /refresh/i }))
+    expect(snapshot.refresh).toHaveBeenCalled()
+  })
+})
+
+describe('PortfolioPanel taxonomy provenance (US2)', () => {
+  it('exposes each category description from its header region', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
+    render(<PortfolioPanel />)
+    for (const id of ['digital-commodities', 'digital-securities', 'payment-stablecoins', 'digital-tools', 'digital-collectibles']) {
+      const cat = getTaxonomyCategory(id)
+      const region = screen.getByRole('region', { name: cat.label })
+      expect(within(region).getByText(cat.description)).toBeInTheDocument()
+    }
+  })
+
+  it('labels each row with its classification source (FR-006)', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
+    render(<PortfolioPanel />)
+    expect(screen.getByText('SEC baseline')).toBeInTheDocument()
+    expect(screen.getByText('Curated registry')).toBeInTheDocument()
+    expect(screen.getByText('App configuration')).toBeInTheDocument()
+  })
+
+  it('always shows the informational and coverage disclosures in the portfolio view (FR-013)', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: [] }))
+    render(<PortfolioPanel />)
+    expect(screen.getByText(/not legal or investment advice/i)).toBeInTheDocument()
+    expect(screen.getByText(/only assets in the app's curated registry are scanned/i)).toBeInTheDocument()
+  })
+})
+
+describe('PortfolioPanel unclassified handling (US3, FR-012)', () => {
+  it('renders unclassified holdings in an explicit Unclassified group', () => {
+    const holdings = [
+      ...POPULATED,
+      makeHolding({ symbol: 'MYST', name: 'Mystery Token', categoryId: 'unclassified', balance: 3, usd: null }),
+    ]
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings, groupOptions: { includeUnclassified: true } }))
+    render(<PortfolioPanel />)
+    const region = screen.getByRole('region', { name: 'Unclassified' })
+    expect(within(region).getByText('Mystery Token')).toBeInTheDocument()
+  })
+
+  it('omits the Unclassified group when nothing is unclassified', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
+    render(<PortfolioPanel />)
+    expect(screen.queryByRole('region', { name: 'Unclassified' })).not.toBeInTheDocument()
+    expect(screen.queryByText('Unclassified')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/portfolio/assetTaxonomy.test.js
+++ b/frontend/src/test/portfolio/assetTaxonomy.test.js
@@ -1,0 +1,148 @@
+/**
+ * Asset taxonomy registry (spec 044) — classification config tests.
+ * Pure config: no chain reads, no context mocking needed.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  TAXONOMY_CATEGORIES,
+  CLASSIFICATION_SOURCES,
+  SEC_COMMODITY_BASELINE,
+  getPortfolioRegistry,
+  getTaxonomyCategory,
+} from '../../config/assetTaxonomy'
+import { listSupportedChainIds, NETWORKS } from '../../config/networks'
+
+const REGULATORY_IDS = [
+  'digital-commodities',
+  'digital-securities',
+  'payment-stablecoins',
+  'digital-tools',
+  'digital-collectibles',
+]
+
+describe('TAXONOMY_CATEGORIES', () => {
+  it('defines the five regulatory categories plus unclassified, in display order', () => {
+    expect(TAXONOMY_CATEGORIES.map((c) => c.id)).toEqual([...REGULATORY_IDS, 'unclassified'])
+    const orders = TAXONOMY_CATEGORIES.map((c) => c.order)
+    expect([...orders].sort((a, b) => a - b)).toEqual(orders)
+    expect(TAXONOMY_CATEGORIES.at(-1).id).toBe('unclassified')
+  })
+
+  it('gives every category a member-facing description and label', () => {
+    for (const cat of TAXONOMY_CATEGORIES) {
+      expect(cat.label).toBeTruthy()
+      expect(cat.description.length).toBeGreaterThan(40)
+    }
+  })
+
+  it('getTaxonomyCategory falls back to unclassified for unknown ids', () => {
+    expect(getTaxonomyCategory('digital-tools').id).toBe('digital-tools')
+    expect(getTaxonomyCategory('nonsense').id).toBe('unclassified')
+    expect(getTaxonomyCategory(undefined).id).toBe('unclassified')
+  })
+})
+
+describe('getPortfolioRegistry', () => {
+  it('returns [] for unknown chain ids (drives the unsupported-network state)', () => {
+    expect(getPortfolioRegistry(999999)).toEqual([])
+    expect(getPortfolioRegistry(undefined)).toEqual([])
+  })
+
+  it.each(listSupportedChainIds())('chain %s: entries are scoped, unique, and valid', (chainId) => {
+    const registry = getPortfolioRegistry(chainId)
+    expect(registry.length).toBeGreaterThan(0)
+
+    const ids = registry.map((e) => e.id)
+    expect(new Set(ids).size).toBe(ids.length)
+
+    for (const entry of registry) {
+      // FR-007: every entry carries the queried chain, never another one.
+      expect(entry.chainId).toBe(chainId)
+      expect(['native', 'erc20', 'nft']).toContain(entry.kind)
+      expect(CLASSIFICATION_SOURCES).toContain(entry.source)
+      // Every referenced category exists (unclassified included).
+      expect(getTaxonomyCategory(entry.categoryId).id).toBe(entry.categoryId)
+      if (entry.kind === 'native') {
+        expect(entry.address).toBeNull()
+      } else {
+        expect(entry.address).toMatch(/^0x[0-9a-fA-F]{40}$/)
+      }
+      if (entry.kind === 'erc20') expect(entry.decimals).toBeGreaterThan(0)
+    }
+  })
+
+  it.each(listSupportedChainIds())('chain %s: has a native entry', (chainId) => {
+    const native = getPortfolioRegistry(chainId).find((e) => e.kind === 'native')
+    expect(native).toBeTruthy()
+    expect(native.id).toBe('native')
+    expect(native.symbol).toBe(NETWORKS[chainId].nativeCurrency.symbol)
+  })
+
+  it('classifies baseline natives and wrapped natives as SEC-baseline commodities', () => {
+    for (const chainId of [137, 63]) {
+      const registry = getPortfolioRegistry(chainId)
+      const native = registry.find((e) => e.kind === 'native')
+      expect(SEC_COMMODITY_BASELINE).toContain(native.symbol)
+      expect(native.categoryId).toBe('digital-commodities')
+      expect(native.source).toBe('sec-baseline')
+    }
+    const wmatic = getPortfolioRegistry(137).find((e) => e.symbol === 'WMATIC')
+    expect(wmatic.categoryId).toBe('digital-commodities')
+    expect(wmatic.source).toBe('sec-baseline')
+  })
+
+  it('maps the configured stablecoin to payment-stablecoins via app-config', () => {
+    const usdc = getPortfolioRegistry(137).find(
+      (e) => e.address?.toLowerCase() === NETWORKS[137].stablecoin.address.toLowerCase(),
+    )
+    expect(usdc.categoryId).toBe('payment-stablecoins')
+    expect(usdc.source).toBe('app-config')
+
+    const usc = getPortfolioRegistry(63).find((e) => e.symbol === 'USC')
+    expect(usc.categoryId).toBe('payment-stablecoins')
+    expect(usc.source).toBe('app-config')
+  })
+
+  it('lists the MembershipVoucher credential as a digital-tools NFT where deployed', () => {
+    const voucher = getPortfolioRegistry(137).find((e) => e.kind === 'nft')
+    expect(voucher).toBeTruthy()
+    expect(voucher.symbol).toBe('FWMV')
+    expect(voucher.categoryId).toBe('digital-tools')
+    expect(voucher.source).toBe('app-config')
+    expect(voucher.decimals).toBeNull()
+  })
+
+  it('includes curated Polygon entries with their curated classifications', () => {
+    const registry = getPortfolioRegistry(137)
+    const bySymbol = Object.fromEntries(registry.map((e) => [e.symbol, e]))
+    expect(bySymbol.LINK.categoryId).toBe('digital-tools')
+    expect(bySymbol.LINK.source).toBe('curated-registry')
+    expect(bySymbol.USDT.categoryId).toBe('payment-stablecoins')
+    expect(bySymbol.USDT.source).toBe('curated-registry')
+  })
+
+  it('applies source precedence: SEC baseline outranks curated data (FR-006)', () => {
+    // WETH/WBTC ship in the curated layer but wrap baseline commodities —
+    // the baseline classification and source must win.
+    const registry = getPortfolioRegistry(137)
+    for (const symbol of ['WETH', 'WBTC']) {
+      const entry = registry.find((e) => e.symbol === symbol)
+      expect(entry.categoryId).toBe('digital-commodities')
+      expect(entry.source).toBe('sec-baseline')
+    }
+  })
+
+  it('never leaks Polygon addresses into the ETC-family registries (SC-004)', () => {
+    const polygonAddresses = new Set(
+      getPortfolioRegistry(137)
+        .filter((e) => e.address)
+        .map((e) => e.address.toLowerCase()),
+    )
+    for (const chainId of [63, 61]) {
+      for (const entry of getPortfolioRegistry(chainId)) {
+        if (!entry.address) continue
+        expect(polygonAddresses.has(entry.address.toLowerCase())).toBe(false)
+      }
+    }
+  })
+})

--- a/frontend/src/test/portfolio/assetTaxonomy.test.js
+++ b/frontend/src/test/portfolio/assetTaxonomy.test.js
@@ -121,6 +121,15 @@ describe('getPortfolioRegistry', () => {
     expect(bySymbol.USDT.source).toBe('curated-registry')
   })
 
+  it('scans canonical WETH on Ethereum mainnet despite no dex/wmatic config', () => {
+    // Chain 1 has dex: null and no wmatic deployment record — the curated
+    // layer must still surface the wrapped form of its baseline commodity.
+    const weth = getPortfolioRegistry(1).find((e) => e.symbol === 'WETH')
+    expect(weth).toBeTruthy()
+    expect(weth.categoryId).toBe('digital-commodities')
+    expect(weth.source).toBe('sec-baseline')
+  })
+
   it('applies source precedence: SEC baseline outranks curated data (FR-006)', () => {
     // WETH/WBTC ship in the curated layer but wrap baseline commodities —
     // the baseline classification and source must win.

--- a/frontend/src/test/portfolio/usePortfolio.test.jsx
+++ b/frontend/src/test/portfolio/usePortfolio.test.jsx
@@ -1,0 +1,234 @@
+/**
+ * usePortfolio (spec 044) — live-balance hook tests.
+ *
+ * Wallet + price state are mocked at the context level per repo convention —
+ * never raw wagmi hooks. Chain reads are stubbed by replacing ethers'
+ * Contract with an address-keyed fixture map.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, waitFor, act } from '@testing-library/react'
+import { WalletContext } from '../../contexts'
+import PriceContext from '../../contexts/PriceContext'
+import usePortfolio from '../../hooks/usePortfolio'
+import { getPortfolioRegistry } from '../../config/assetTaxonomy'
+import { NETWORKS } from '../../config/networks'
+
+// Address-keyed ERC-20/721 balance fixtures. A value may be a bigint or a
+// function (to simulate rejections). Unlisted addresses read as 0n.
+const tokenBalances = new Map()
+
+vi.mock('ethers', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    Contract: class {
+      constructor(address) {
+        this.address = String(address).toLowerCase()
+      }
+
+      balanceOf() {
+        const fixture = tokenBalances.get(this.address)
+        if (typeof fixture === 'function') return fixture()
+        return Promise.resolve(fixture ?? 0n)
+      }
+    },
+  }
+})
+
+const ADDRESS = '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'
+
+const registry137 = getPortfolioRegistry(137)
+const addr = (symbol) => registry137.find((e) => e.symbol === symbol).address.toLowerCase()
+
+function makeProvider(nativeBalance = 0n) {
+  return { getBalance: vi.fn().mockResolvedValue(nativeBalance) }
+}
+
+function makeWallet(overrides = {}) {
+  return {
+    address: ADDRESS,
+    isConnected: true,
+    chainId: 137,
+    provider: makeProvider(),
+    ...overrides,
+  }
+}
+
+const PRICE_OK = { nativeUsdRate: 0.5, error: null }
+
+let latest
+function Probe() {
+  latest = usePortfolio()
+  return null
+}
+
+function Harness({ wallet, price = PRICE_OK }) {
+  return (
+    <WalletContext.Provider value={wallet}>
+      <PriceContext.Provider value={price}>
+        <Probe />
+      </PriceContext.Provider>
+    </WalletContext.Provider>
+  )
+}
+
+async function renderPortfolio(props) {
+  let view
+  await act(async () => {
+    view = render(<Harness {...props} />)
+  })
+  return view
+}
+
+beforeEach(() => {
+  tokenBalances.clear()
+  latest = undefined
+})
+
+describe('usePortfolio', () => {
+  it('is disconnected without a connected account and issues no reads', async () => {
+    const provider = makeProvider()
+    await renderPortfolio({ wallet: makeWallet({ address: undefined, isConnected: false, provider }) })
+    expect(latest.status).toBe('disconnected')
+    expect(latest.holdings).toEqual([])
+    expect(provider.getBalance).not.toHaveBeenCalled()
+  })
+
+  it('maps nonzero balances to categorized holdings and drops zero balances', async () => {
+    tokenBalances.set(addr('USDC'), 100_000_000n) // 100 USDC (6 decimals)
+    await renderPortfolio({ wallet: makeWallet({ provider: makeProvider(2n * 10n ** 18n) }) })
+    await waitFor(() => expect(latest.status).toBe('ready'))
+
+    expect(latest.holdings).toHaveLength(2)
+    const bySymbol = Object.fromEntries(latest.holdings.map((h) => [h.asset.symbol, h]))
+    // Native MATIC priced by the feed (2 × $0.50), stablecoin at par $1.
+    expect(bySymbol.MATIC.balance).toBe(2)
+    expect(bySymbol.MATIC.usd).toBeCloseTo(1)
+    expect(bySymbol.USDC.usd).toBeCloseTo(100)
+    expect(latest.totalUsd).toBeCloseTo(101)
+    expect(latest.isPartial).toBe(false)
+
+    // Zero-balance registry assets are not holdings; regulatory categories
+    // still all render (with empty groups), unclassified stays hidden.
+    expect(latest.categories.map((g) => g.category.id)).toEqual([
+      'digital-commodities',
+      'digital-securities',
+      'payment-stablecoins',
+      'digital-tools',
+      'digital-collectibles',
+    ])
+    const commodities = latest.categories.find((g) => g.category.id === 'digital-commodities')
+    expect(commodities.subtotalUsd).toBeCloseTo(1)
+    expect(latest.categories.find((g) => g.category.id === 'digital-securities').holdings).toEqual([])
+  })
+
+  it('renders NFT holdings as item counts with no price', async () => {
+    tokenBalances.set(addr('FWMV'), 2n)
+    await renderPortfolio({ wallet: makeWallet() })
+    await waitFor(() => expect(latest.status).toBe('ready'))
+    const voucher = latest.holdings.find((h) => h.asset.symbol === 'FWMV')
+    expect(voucher.balance).toBe(2)
+    expect(voucher.usd).toBeNull()
+  })
+
+  it('marks unpriced assets usd:null, excludes them from totals, and flags partial (FR-010)', async () => {
+    tokenBalances.set(addr('WETH'), 10n ** 18n) // 1 WETH — no price feed
+    tokenBalances.set(addr('USDC'), 50_000_000n)
+    await renderPortfolio({ wallet: makeWallet() })
+    await waitFor(() => expect(latest.status).toBe('ready'))
+
+    const weth = latest.holdings.find((h) => h.asset.symbol === 'WETH')
+    expect(weth.usd).toBeNull()
+    expect(latest.totalUsd).toBeCloseTo(50)
+    expect(latest.isPartial).toBe(true)
+    const commodities = latest.categories.find((g) => g.category.id === 'digital-commodities')
+    expect(commodities.isPartial).toBe(true)
+  })
+
+  it('treats an errored price feed as no price rather than using the fallback rate', async () => {
+    await renderPortfolio({
+      wallet: makeWallet({ provider: makeProvider(10n ** 18n) }),
+      price: { nativeUsdRate: 0.5, error: 'feed down' },
+    })
+    await waitFor(() => expect(latest.status).toBe('ready'))
+    const native = latest.holdings.find((h) => h.asset.kind === 'native')
+    expect(native.usd).toBeNull()
+    expect(latest.isPartial).toBe(true)
+  })
+
+  it('surfaces single failed reads as partial with the asset named, never as zero', async () => {
+    tokenBalances.set(addr('LINK'), () => Promise.reject(new Error('revert')))
+    tokenBalances.set(addr('USDC'), 25_000_000n)
+    await renderPortfolio({ wallet: makeWallet() })
+    await waitFor(() => expect(latest.status).toBe('ready'))
+
+    expect(latest.failedAssets).toEqual(['LINK'])
+    expect(latest.isPartial).toBe(true)
+    expect(latest.holdings.some((h) => h.asset.symbol === 'LINK')).toBe(false)
+    expect(latest.totalUsd).toBeCloseTo(25)
+  })
+
+  it('enters the error state with retry when every read fails', async () => {
+    const provider = { getBalance: vi.fn().mockRejectedValue(new Error('rpc down')) }
+    for (const entry of registry137) {
+      if (entry.address) tokenBalances.set(entry.address.toLowerCase(), () => Promise.reject(new Error('rpc down')))
+    }
+    await renderPortfolio({ wallet: makeWallet({ provider }) })
+    await waitFor(() => expect(latest.status).toBe('error'))
+    expect(latest.error).toBeTruthy()
+    expect(latest.holdings).toEqual([])
+
+    // Recovery: the network comes back, refresh reloads to ready.
+    provider.getBalance.mockResolvedValue(10n ** 18n)
+    tokenBalances.clear()
+    await act(async () => {
+      await latest.refresh()
+    })
+    await waitFor(() => expect(latest.status).toBe('ready'))
+    expect(latest.holdings.some((h) => h.asset.kind === 'native')).toBe(true)
+  })
+
+  it('reports unsupported networks explicitly instead of loading forever', async () => {
+    await renderPortfolio({ wallet: makeWallet({ chainId: 999999 }) })
+    expect(latest.isSupportedNetwork).toBe(false)
+    expect(latest.status).not.toBe('loading')
+    expect(latest.holdings).toEqual([])
+  })
+
+  it('clears the snapshot on chain switch and never leaks assets across networks (SC-004)', async () => {
+    tokenBalances.set(addr('USDC'), 100_000_000n)
+    const view = await renderPortfolio({ wallet: makeWallet({ provider: makeProvider(10n ** 18n) }) })
+    await waitFor(() => expect(latest.status).toBe('ready'))
+    expect(latest.holdings.length).toBeGreaterThan(0)
+
+    // Switch to Mordor (63): the old snapshot must clear synchronously.
+    const uscAddress = NETWORKS[63].stablecoin.address.toLowerCase()
+    tokenBalances.set(uscAddress, 40_000_000n) // 40 USC
+    await act(async () => {
+      view.rerender(<Harness wallet={makeWallet({ chainId: 63, provider: makeProvider(10n ** 18n) })} price={PRICE_OK} />)
+    })
+    await waitFor(() => expect(latest.status).toBe('ready'))
+
+    for (const holding of latest.holdings) {
+      expect(holding.asset.chainId).toBe(63)
+    }
+    // ETC native must NOT be priced with the MATIC feed rate.
+    const native = latest.holdings.find((h) => h.asset.kind === 'native')
+    expect(native.asset.symbol).toBe('ETC')
+    expect(native.usd).toBeNull()
+    const usc = latest.holdings.find((h) => h.asset.symbol === 'USC')
+    expect(usc.usd).toBeCloseTo(40)
+  })
+
+  it('refresh() reloads balances on demand (FR-015)', async () => {
+    const provider = makeProvider(10n ** 18n)
+    await renderPortfolio({ wallet: makeWallet({ provider }) })
+    await waitFor(() => expect(latest.status).toBe('ready'))
+    const callsAfterLoad = provider.getBalance.mock.calls.length
+
+    await act(async () => {
+      await latest.refresh()
+    })
+    expect(provider.getBalance.mock.calls.length).toBeGreaterThan(callsAfterLoad)
+  })
+})

--- a/frontend/src/test/portfolio/usePortfolio.test.jsx
+++ b/frontend/src/test/portfolio/usePortfolio.test.jsx
@@ -178,11 +178,20 @@ describe('usePortfolio', () => {
     expect(latest.error).toBeTruthy()
     expect(latest.holdings).toEqual([])
 
-    // Recovery: the network comes back, refresh reloads to ready.
-    provider.getBalance.mockResolvedValue(10n ** 18n)
+    // Retry must leave the error state immediately (loading, not a stale
+    // error inviting retry spam) while the new request is in flight.
+    let resolveNative
+    provider.getBalance.mockImplementation(() => new Promise((res) => { resolveNative = res }))
     tokenBalances.clear()
+    act(() => {
+      latest.refresh()
+    })
+    await waitFor(() => expect(latest.status).toBe('loading'))
+    expect(latest.error).toBeNull()
+
+    // Recovery: the network comes back and the reload lands on ready.
     await act(async () => {
-      await latest.refresh()
+      resolveNative(10n ** 18n)
     })
     await waitFor(() => expect(latest.status).toBe('ready'))
     expect(latest.holdings.some((h) => h.asset.kind === 'native')).toBe(true)

--- a/specs/044-connected-account-portfolio/checklists/requirements.md
+++ b/specs/044-connected-account-portfolio/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Connected Account Portfolio
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on first iteration (2026-07-10). Reasonable defaults were chosen
+  for discovery strategy (curated registry, no indexer), read-only scope, bundled
+  registry updates, and price-availability handling — all recorded in Assumptions.
+- Ready for `/speckit-plan`.

--- a/specs/044-connected-account-portfolio/contracts/asset-registry.md
+++ b/specs/044-connected-account-portfolio/contracts/asset-registry.md
@@ -1,0 +1,62 @@
+# Interface Contract: Asset Taxonomy Registry & Portfolio Hook
+
+**Feature**: 044-connected-account-portfolio
+
+No on-chain or HTTP contracts — this feature exposes two internal module interfaces
+that other frontend code (and tests) rely on.
+
+## `frontend/src/config/assetTaxonomy.js`
+
+```js
+// Ordered array: the five regulatory categories + unclassified (always last).
+export const TAXONOMY_CATEGORIES // TaxonomyCategory[]
+
+// Classification source ids (FR-006 precedence order, highest first).
+export const CLASSIFICATION_SOURCES // ['sec-baseline', 'curated-registry', 'app-config']
+
+// Symbol-level SEC commodity baseline (uppercase symbols).
+export const SEC_COMMODITY_BASELINE // Set<string> semantics (exported as array)
+
+// Per-network registry. Pure function of config — no chain reads, no async.
+// Returns [] for unknown chainIds (drives the FR-014 "unsupported" state).
+export function getPortfolioRegistry(chainId) // RegistryAsset[]
+
+// Lookup helper for descriptions/labels; returns the unclassified category
+// for unknown ids rather than undefined.
+export function getTaxonomyCategory(categoryId) // TaxonomyCategory
+```
+
+Guarantees:
+- Every `RegistryAsset.chainId` equals the argument (no cross-network leakage, FR-007).
+- No duplicate `id` within a chain; source precedence already applied.
+- Native entry (`kind: 'native'`) present for every supported chain.
+- All five regulatory category ids referenced by entries exist in `TAXONOMY_CATEGORIES`.
+
+## `frontend/src/hooks/usePortfolio.js`
+
+```js
+// Reads live balances for the connected account on the active chain.
+export function usePortfolio() // PortfolioSnapshot (see data-model.md)
+```
+
+Guarantees:
+- `status: 'disconnected'` when no account; never issues reads while disconnected.
+- Snapshot is cleared synchronously on `chainId`/`address` change before reloading (SC-004).
+- `totalUsd`/`subtotalUsd` sum only priced holdings; `isPartial` set whenever an
+  unpriced holding or failed read exists (FR-010, SC-005).
+- Polls at 60s while connected; `refresh()` forces a reload (FR-015).
+
+## `frontend/src/components/wallet/PortfolioPanel.jsx`
+
+```jsx
+export default function PortfolioPanel() // no props; composes usePortfolio
+```
+
+UI contract (asserted by tests):
+- Renders exactly one of the FR-014 states: connect prompt, loading, error+retry,
+  or the portfolio view (which itself handles empty holdings and partial totals).
+- Category sections are buttons with `aria-expanded`/`aria-controls`; rows expose
+  name, symbol, balance, USD (or "—" + accessible "price unavailable" label), and
+  classification source; disclaimers (informational + registry coverage) always visible
+  in the portfolio view.
+```

--- a/specs/044-connected-account-portfolio/data-model.md
+++ b/specs/044-connected-account-portfolio/data-model.md
@@ -1,0 +1,88 @@
+# Data Model: Connected Account Portfolio
+
+**Feature**: 044-connected-account-portfolio | **Date**: 2026-07-10
+
+All entities are client-side view/config models — nothing is persisted.
+
+## TaxonomyCategory (config, `assetTaxonomy.js`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | string | `digital-commodities` \| `digital-securities` \| `payment-stablecoins` \| `digital-tools` \| `digital-collectibles` \| `unclassified` |
+| `label` | string | Display name (e.g. "Digital Commodities") |
+| `description` | string | Member-facing plain-language regulatory definition (from spec FR-004) |
+| `order` | number | Display order; `unclassified` always last |
+
+Validation: exactly five regulatory categories + the `unclassified` fallback; ids are
+stable (used in tests, CSS hooks, aria wiring).
+
+## RegistryAsset (config, produced by `getPortfolioRegistry(chainId)`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | string | Stable per-chain key: `native` or lowercased contract address |
+| `chainId` | number | Owning network — entries never cross chains (FR-007) |
+| `kind` | string | `native` \| `erc20` \| `nft` (nft = balanceOf item count, FR-011) |
+| `address` | string\|null | Contract address; `null` for native |
+| `symbol` | string | e.g. `MATIC`, `USDC`, `FWMV` |
+| `name` | string | e.g. `USD Coin` |
+| `decimals` | number\|null | Fungibles only; `null` for `nft` |
+| `categoryId` | string | TaxonomyCategory id (may be `unclassified`) |
+| `source` | string | `sec-baseline` \| `curated-registry` \| `app-config` (FR-006) |
+
+Rules:
+- Merge precedence when the same address appears in more than one source:
+  `sec-baseline` > `curated-registry` > `app-config` (FR-006); the winning source is
+  reported on the row.
+- Addresses resolve from `config/networks.js` (`stablecoin`, `dex.wnative`,
+  `nativeCurrency`) and `config/contracts.js#getContractAddressForChain('wmatic'|'membershipVoucher', chainId)`;
+  curated entries are bundled config data with provenance comments.
+- Unresolvable entries (e.g. no `membershipVoucher` deployed on the chain) are omitted —
+  never emitted with an empty address.
+
+## Holding (runtime, `usePortfolio`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `asset` | RegistryAsset | — |
+| `balance` | number | Human units (`formatUnits`); item count for `nft` |
+| `balanceRaw` | bigint | Raw chain value |
+| `usd` | number\|null | `null` = price unavailable → excluded from totals (FR-010) |
+
+Rules: only assets with `balanceRaw > 0n` become holdings (zero-balance registry assets
+are not "held"); a failed read produces **no** Holding — the failure is reported via
+`failedAssets`, never rendered as zero.
+
+## PortfolioSnapshot (runtime, `usePortfolio` return)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `holdings` | Holding[] | All discovered holdings for `address`@`chainId` |
+| `categories` | CategoryGroup[] | Ordered; every regulatory category always present, `unclassified` only when non-empty |
+| `totalUsd` | number | Sum of priced holdings only |
+| `isPartial` | boolean | true when any holding is unpriced OR any read failed |
+| `failedAssets` | string[] | Symbols of registry assets whose read failed |
+| `status` | string | `disconnected` \| `loading` \| `ready` \| `error` (FR-014) |
+| `error` | string\|null | Set when every read failed / provider unavailable |
+| `lastUpdated` | number\|null | Epoch ms of last successful load |
+| `refresh` | function | Manual reload (FR-015) |
+
+### CategoryGroup (derived)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `category` | TaxonomyCategory | — |
+| `holdings` | Holding[] | Possibly empty (explicit empty state) |
+| `subtotalUsd` | number | Priced holdings only |
+| `isPartial` | boolean | Any unpriced holding in the group |
+
+## State transitions
+
+```
+disconnected ──connect──▶ loading ──all reads settle──▶ ready (isPartial?)
+     ▲                        │
+     │                        └──every read fails──▶ error ──retry──▶ loading
+     └──disconnect (from any state; snapshot cleared)
+
+chainId/address change (any state) ──▶ snapshot cleared ──▶ loading   (SC-004)
+```

--- a/specs/044-connected-account-portfolio/plan.md
+++ b/specs/044-connected-account-portfolio/plan.md
@@ -1,0 +1,131 @@
+# Implementation Plan: Connected Account Portfolio
+
+**Branch**: `claude/connected-account-portfolio-h26qk3` | **Date**: 2026-07-10 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/044-connected-account-portfolio/spec.md`
+
+## Summary
+
+Add a **Portfolio** section to **My Wallet → Finance** that shows the connected account's
+real on-chain holdings on the active network, grouped under the app's five SEC/CFTC-aligned
+taxonomy categories (Digital Commodities, Digital Securities, Payment Stablecoins, Digital
+Tools, Digital Collectibles) plus an honest **Unclassified** fallback. Classification is
+driven by a layered, per-network **asset taxonomy registry** config module: a hardcoded SEC
+commodity baseline (native + wrapped-native coins), curated registry entries (canonical
+well-known tokens per chain), and app configuration (the network's stablecoin, the
+MembershipVoucher credential NFT). A `usePortfolio` hook reads live balances via the
+existing wallet read provider; USD values come from the existing price capability with
+strictly honest "price unavailable → partial totals" semantics. Frontend-only: no new
+dependencies, no backend, no contract changes.
+
+## Technical Context
+
+**Language/Version**: JavaScript/JSX, React 18 + Vite (existing `frontend/`)
+
+**Primary Dependencies**: Existing stack only — ethers v6 for reads (via
+`WalletContext` `provider`), wagmi v3/viem for connection state (never touched directly;
+mocked at context level in tests), react-router-dom v7 (existing `/wallet?tab=` deep
+links). **No new runtime dependencies.**
+
+**Storage**: None. All portfolio data is derived live from chain reads + bundled config.
+No localStorage, no backend.
+
+**Testing**: Vitest (jsdom) + @testing-library/react + vitest-axe, following the repo
+convention of mocking wallet state at the context level (see
+`frontend/src/test/WalletPage.test.jsx`). Tests run under `VITE_NETWORK_ID=63`,
+`VITE_SKIP_BLOCKCHAIN_CALLS=true`.
+
+**Target Platform**: PWA (desktop/mobile browsers). Networks: all `NETWORKS` entries —
+Polygon 137, Amoy 80002, Mordor 63, ETC 61, Ethereum 1, Hardhat 1337 — each with its own
+registry; a chain without registry entries beyond the native coin still renders honestly.
+
+**Project Type**: Web application (existing `frontend/` of the monorepo).
+
+**Performance Goals**: Categorized holdings visible < 5s on a healthy RPC (SC-001).
+Balance reads batched with `Promise.allSettled` (one `getBalance` + one `balanceOf` per
+registry asset; registries are ≤ ~8 assets/chain, so no multicall needed — YAGNI).
+
+**Constraints**:
+- **Honest state (constitution III)**: no fabricated USD values. The app's price feed is
+  MATIC-only (`usePriceConversion` via CoinGecko), so native/wrapped-native USD applies
+  only on MATIC-native chains (137/80002); stablecoins value at par $1 (existing
+  `useAccountStats` convention); every other asset shows "USD unavailable" and flips
+  totals to a visible **partial** state (FR-010). The CoinGecko fallback-rate path
+  (`error` set in `usePriceConversion`) is treated as price-unavailable for portfolio
+  totals rather than presenting a hardcoded rate as real.
+- **Network scoping (constitution III)**: registry resolution and every read is keyed on
+  the active `chainId`; a chain switch resets state before reloading.
+- **Config from sync artifacts (constitution V)**: app-known addresses resolve through
+  `config/networks.js` (`stablecoin`, `dex.wnative`) and
+  `config/contracts.js#getContractAddressForChain` (`wmatic`, `membershipVoucher`).
+  Curated registry entries (canonical WETH/WBTC/LINK/USDT on Polygon) are new config
+  *data* — the same pattern as the canonical Uniswap addresses already declared in
+  `networks.js` — documented with provenance and env-override-free (bundled, updated by
+  release, per spec Assumptions).
+
+**Scale/Scope**: 1 config module, 1 hook, 1 panel component tree + CSS, 1 nav entry in
+`WalletPage.jsx`, 4 test files. No contracts, no subgraph, no scripts.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment |
+|-----------|------------|
+| **I. Security-First Smart Contracts** | N/A — no contract changes. Read-only `balanceOf`/`getBalance` calls from the frontend; no approvals, no writes, no funds moved. ✅ |
+| **II. Test-First & Coverage** | Registry (classification, precedence, per-network scoping), hook (load/error/partial/refresh/chain-switch), and panel (all FR-014 states, collapse behavior, unclassified group, disclaimers) each get Vitest coverage; panel gets a vitest-axe audit. ✅ |
+| **III. Honest State, No Mocks** | Balances read live per active chain; zero-balance registry assets are not shown as holdings; unpriced assets never render $0.00 and totals are labeled partial; failed reads surface an error/partial state, never zeros; registry-coverage disclosure states that unlisted tokens won't appear; Unclassified group prevents silent hiding. No mock data in shipped paths — the registry is real config data, and the demo-like mockup values are NOT reproduced. ✅ |
+| **IV. Fail Loudly in CI** | New tests join the existing Vitest gate; no `continue-on-error`. ✅ |
+| **V. Accessible, Consistent Frontend** | Collapsible category sections are keyboard-operable buttons with `aria-expanded`/`aria-controls`; totals and rows carry accessible labels; vitest-axe test included; addresses come from config helpers, not hand-copied into components (curated registry entries live in config with provenance comments). ✅ |
+| **Additional: tech stack** | No new core technology; plain co-located CSS; custom hook pattern (`useTransfer`/`useAccountStats` precedent). ✅ |
+
+**Post-Phase-1 re-check**: design introduces no violations — no Complexity Tracking
+entries needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/044-connected-account-portfolio/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── asset-registry.md  # Registry + hook interface contract
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/
+├── config/
+│   └── assetTaxonomy.js            # NEW — categories, SEC baseline, curated registry,
+│                                   #        getPortfolioRegistry(chainId)
+├── hooks/
+│   └── usePortfolio.js             # NEW — live balances + USD join + states
+├── components/wallet/
+│   ├── PortfolioPanel.jsx          # NEW — header total, category sections, rows,
+│   │                               #        disclosures, states (FR-014)
+│   └── Portfolio.css               # NEW — co-located styles (theme.css tokens)
+├── pages/
+│   └── WalletPage.jsx              # EDIT — Finance group nav entry + tabpanel block
+└── test/portfolio/                 # NEW — central test dir (repo convention)
+    ├── assetTaxonomy.test.js
+    ├── usePortfolio.test.jsx
+    ├── PortfolioPanel.test.jsx
+    └── PortfolioPanel.axe.test.jsx
+```
+
+**Structure Decision**: Single-page-app extension inside the existing `frontend/`
+workspace; mirrors the Pay & Transfer / Custody panel layout (config module + hook +
+co-located panel) with tests under `frontend/src/test/portfolio/`.
+
+## Complexity Tracking
+
+No constitution violations — table intentionally empty.

--- a/specs/044-connected-account-portfolio/quickstart.md
+++ b/specs/044-connected-account-portfolio/quickstart.md
@@ -1,0 +1,51 @@
+# Quickstart: Connected Account Portfolio
+
+**Feature**: 044-connected-account-portfolio
+
+## Prerequisites
+
+- `npm ci` at repo root (workspaces install the frontend).
+- No contracts, deployments, or env vars required — the feature is frontend-only.
+
+## Run the tests
+
+```bash
+# Full frontend suite (includes the new portfolio tests)
+npm run test:frontend
+
+# Just this feature
+cd frontend && npx vitest run src/test/portfolio
+```
+
+Expected: registry, hook, panel, and axe suites pass; no other suites regress
+(`WalletPage` tests still pass with the new Finance tab).
+
+## Validate in the app
+
+```bash
+npm run frontend   # Vite dev server
+```
+
+1. Open `http://localhost:5173/wallet?tab=portfolio` (deep link resolves the new tab).
+2. **Disconnected**: the Portfolio section shows a connect prompt — no data (FR-014).
+3. Connect a wallet on Polygon (137) or Amoy (80002):
+   - Header shows "Total portfolio balance" in USD; if any listed asset has no price
+     (e.g. WETH/WBTC/LINK holdings), the total is labeled **partial** and those rows
+     show "—", never $0.00 (FR-010).
+   - Native MATIC (and WMATIC/WETH/WBTC if held) appear under **Digital Commodities**;
+     USDC under **Payment Stablecoins**; LINK and any held MembershipVoucher (item
+     count) under **Digital Tools**; empty categories show an explicit empty state.
+   - Each row discloses its classification source (SEC baseline / curated registry /
+     app configuration); the informational + coverage disclaimers are visible (FR-013).
+4. Collapse/expand a category with mouse and keyboard — header stays visible with the
+   subtotal; `aria-expanded` flips (FR-016).
+5. Switch networks (e.g. to Mordor 63): the view resets and shows only ETC-family
+   assets — ETC native, USC stablecoin, WETC if configured — with native USD shown as
+   unavailable (no MATIC-rate leakage) and totals partial (SC-004, R4).
+6. Click refresh: balances reload; disconnect: back to the connect prompt.
+
+## Reference
+
+- Interfaces: [contracts/asset-registry.md](./contracts/asset-registry.md)
+- Entities/states: [data-model.md](./data-model.md)
+- Decisions: [research.md](./research.md)

--- a/specs/044-connected-account-portfolio/research.md
+++ b/specs/044-connected-account-portfolio/research.md
@@ -1,0 +1,124 @@
+# Research: Connected Account Portfolio
+
+**Feature**: 044-connected-account-portfolio | **Date**: 2026-07-10
+
+## R1 — Asset discovery strategy (registry scan vs. indexer)
+
+**Decision**: Registry-driven discovery. The portfolio scans a bundled, per-network
+asset registry (`config/assetTaxonomy.js`) and reads the connected account's balance for
+each entry; it does not enumerate token transfers.
+
+**Rationale**: Matches the feature's stated industry-standard approach (SEC baseline +
+curated token lists), the app's no-backend architecture, and the constitution's honesty
+rules — the UI explicitly discloses that only registry-listed assets are scanned
+(FR-013). Full discovery needs an indexer (covalent-style API or subgraph per chain);
+Mordor/ETC have no hosted Graph indexer at all, so an indexer path could not even be
+uniform across supported networks.
+
+**Alternatives considered**: (a) The Graph token subgraphs — not available on the ETC
+family, adds per-chain infra; (b) explorer APIs (Polygonscan/Blockscout) — API keys,
+rate limits, and a second source of truth; (c) log-scanning `Transfer` events over RPC —
+unbounded reads on public endpoints. All rejected for v1.
+
+## R2 — Registry layering, sources, and precedence
+
+**Decision**: Three classification sources merged per chain, with precedence
+**SEC baseline > curated registry > app configuration** (FR-006):
+
+1. **SEC baseline** (`sec-baseline`): a hardcoded symbol-level list derived from the
+   SEC's public statements on commodity-classified assets (BTC, ETH, SOL, XRP, plus the
+   networks' own native coins MATIC/POL and ETC as majors functioning as L1 gas assets).
+   Applies to native coins and their canonical wrapped forms → **Digital Commodities**.
+2. **Curated registry** (`curated-registry`): per-chain canonical token entries bundled
+   with the app (Tokenlists-style data reduced to what the app supports), each mapped to
+   a category by known issuer status / contract behavior. Initial curation: Polygon
+   WETH + WBTC (wrapped baseline commodities), LINK (protocol utility → Digital Tools),
+   USDT (transactional stablecoin → Payment Stablecoins).
+3. **App configuration** (`app-config`): assets the app already knows from sync
+   artifacts/config — the per-network `stablecoin` (→ Payment Stablecoins),
+   `dex.wnative` / `wmatic` (→ Digital Commodities via baseline), and the
+   `membershipVoucher` ERC-721 (membership credential → **Digital Tools**, rendered as
+   an item count per FR-011).
+
+**Rationale**: Mirrors the requested implementation tip exactly; precedence gives the
+regulator-published baseline the last word and makes conflicts deterministic and
+testable. The voucher NFT gives the Collectibles/count rendering path a real, app-owned
+asset without inventing NFT data (constitution III).
+
+**Alternatives considered**: Runtime ingestion of remote token lists (Tokenlists.org
+URLs) — rejected for v1: network dependency, list-integrity questions, and the spec
+assumption that the registry ships with app releases.
+
+## R3 — Digital Securities and Digital Collectibles population in v1
+
+**Decision**: Both categories always render with their regulatory description; on
+networks where the curated registry has no entry for them they show the explicit empty
+state ("No assets in this category"). No tokenized-security or third-party NFT
+collection is listed at launch.
+
+**Rationale**: The app's supported chains have no security tokens the app can vouch for,
+and honest-empty beats fabricated coverage (constitution III). The mockup's BUIDL/BITO
+rows are visual reference only (spec Assumptions). Registry structure supports adding
+them later as pure config data.
+
+## R4 — USD pricing and "partial totals" semantics
+
+**Decision**: Prices resolve per asset kind:
+- **Stablecoins** (Payment Stablecoins category): par $1 — the existing
+  `useAccountStats` convention.
+- **Native / wrapped-native**: `usePriceConversion().nativeUsdRate` (PriceContext) —
+  applied **only** on chains whose native symbol the feed actually quotes (MATIC chains
+  137/80002). When the feed errored (CoinGecko down → hardcoded fallback rate) the rate
+  is treated as unavailable for portfolio purposes.
+- **Everything else** (WETH, WBTC, LINK, vouchers, unclassified): no price → balance
+  shown, `usd: null`.
+
+Any `usd: null` holding flips the grand total and its category subtotal to a labeled
+**partial** state; unpriced assets are excluded from sums and never shown as $0.00
+(FR-010, SC-005).
+
+**Rationale**: The app has exactly one price feed (MATIC/USD). Constitution III forbids
+presenting the fallback rate or a cross-asset guess as real value. Extending the price
+service (multi-asset CoinGecko queries) is deliberately out of scope — the partial-total
+mechanics make the limitation visible instead of hidden.
+
+**Alternatives considered**: multi-id CoinGecko batch quote — viable later, but adds
+rate-limit exposure and scope; DEX pool spot prices — manipulable, wrong tool for a
+compliance-flavored view.
+
+## R5 — Balance reading and refresh cadence
+
+**Decision**: One `provider.getBalance(address)` for the native entry and one
+`balanceOf(address)` (minimal ERC-20/721 ABI, `['function balanceOf(address) view returns (uint256)']`)
+per token entry, issued concurrently via `Promise.allSettled` against the wallet
+context's read provider. Per-asset failures mark the snapshot **partial** (with the
+failed assets skipped and named), an all-assets failure surfaces the FR-014 error state
+with retry. Poll every 60s (`useAccountStats` precedent) plus a manual refresh action;
+a request-id ref guards against out-of-order responses; state resets on
+`address`/`chainId` change (SC-004).
+
+**Rationale**: Registries are ≤ ~8 entries per chain — a multicall batch (Multicall3 ABI
+exists but is unused in `src/`) would introduce a new pattern for no measurable win
+(constitution: simplicity/YAGNI).
+
+## R6 — Navigation and rendering surface
+
+**Decision**: Add `{ id: 'portfolio', label: 'Portfolio' }` to the **Finance** group of
+`WALLET_TAB_GROUPS` in `WalletPage.jsx` and a matching
+`{activeTab === 'portfolio' && <div className="portfolio-section" role="tabpanel"><PortfolioPanel /></div>}`
+block. Deep-linking (`/wallet?tab=portfolio`) works through the existing
+`searchParams` resolution with no extra code.
+
+**Rationale**: Exact repeat of how Trade / Pay & Transfer / Custody are wired; zero new
+navigation machinery.
+
+## R7 — Collapsible category sections (accessibility)
+
+**Decision**: Each category header is a `<button aria-expanded aria-controls>` toggling
+a `role="region"`-labeled body; all five categories (plus Unclassified when non-empty)
+render expanded by default with subtotal visible when collapsed. Keyboard operability
+and name/role/value come from native button semantics; vitest-axe audits the populated
+and collapsed states.
+
+**Rationale**: WCAG 2.1 AA via native elements (constitution V); matches the disclosure
+pattern rather than importing an accordion dependency.

--- a/specs/044-connected-account-portfolio/spec.md
+++ b/specs/044-connected-account-portfolio/spec.md
@@ -1,0 +1,258 @@
+# Feature Specification: Connected Account Portfolio
+
+**Feature Branch**: `claude/connected-account-portfolio-h26qk3`
+
+**Created**: 2026-07-10
+
+**Status**: Draft
+
+**Input**: User description: "Connected Account Portfolio in the Finance section. Add a new 'Portfolio' section under My Wallet → Finance that shows the connected account's assets grouped by SEC/CFTC regulatory taxonomy categories, matching the provided mobile mockup (total portfolio balance at top, collapsible category sections each with a category subtotal and per-asset rows showing balance and USD value). Categories: Digital Securities, Digital Commodities, Digital Collectibles, Digital Tools, Payment Stablecoins. Classification uses the official SEC commodity list as a hardcoded baseline plus curated open-source registry lists mapped to the regulatory definitions. Assets shown must be the real on-chain holdings of the connected account, scoped to the active network. Unclassified tokens must be handled honestly."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - View my assets grouped by regulatory category (Priority: P1)
+
+A member connects their wallet, opens **My Wallet → Finance → Portfolio**, and sees a
+single portfolio view of their real holdings on the active network: a total portfolio
+balance (in USD) at the top, followed by one collapsible section per regulatory
+category — **Digital Commodities**, **Digital Securities**, **Payment Stablecoins**,
+**Digital Tools**, and **Digital Collectibles** — each showing a category subtotal and
+per-asset rows with the asset's name, symbol, on-chain balance, and USD value where a
+price is available.
+
+**Why this priority**: This is the feature. Everything else refines it. A member who
+sees their live holdings organized by the app's regulatory taxonomy gets the full core
+value even if nothing below ships.
+
+**Independent Test**: Connect an account holding at least the network's native coin and
+one registry-listed token; open the Portfolio tab; verify the total, category subtotals,
+and per-asset rows reflect the account's actual on-chain balances for the active network.
+
+**Acceptance Scenarios**:
+
+1. **Given** a connected account on a supported network with a nonzero native-coin
+   balance and a nonzero balance of a registry-listed stablecoin, **When** the member
+   opens the Portfolio section, **Then** the native coin appears under Digital
+   Commodities, the stablecoin under Payment Stablecoins, each category shows a
+   subtotal, and the header total equals the sum of all listed assets' USD values.
+2. **Given** the Portfolio section is displayed, **When** the member collapses a
+   category, **Then** its asset rows hide while its header and subtotal remain visible,
+   and expanding restores the rows.
+3. **Given** an asset with a known balance but no available USD price, **When** it is
+   displayed, **Then** its on-chain balance is shown and its USD value is shown as
+   unavailable (never as $0.00), and it is excluded from USD totals with the totals
+   labeled as partial.
+4. **Given** a member who is not connected, **When** they open the Portfolio section,
+   **Then** they see a connect prompt instead of portfolio data.
+
+---
+
+### User Story 2 - Understand what each category means and why an asset is there (Priority: P2)
+
+A member wants to understand the taxonomy: each category exposes a plain-language
+description aligned to the SEC/CFTC framing (e.g. Digital Commodities "derive value from
+the programmatic operation of a functional decentralized system, not the managerial
+efforts of a core team"), and each asset row can reveal its classification source —
+the SEC commodity baseline, a curated registry mapping, or the app's own network
+configuration (known issuer status).
+
+**Why this priority**: The taxonomy is only trustworthy if members can see the
+definitions and the provenance of each classification. It builds on P1's rendering.
+
+**Independent Test**: Open the Portfolio tab and inspect any category header and any
+asset row; verify the category description is visible/discoverable and the asset's
+classification source is displayed.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Portfolio section is displayed, **When** the member views a category,
+   **Then** a plain-language description of that regulatory category is discoverable
+   from the category header.
+2. **Given** an asset classified from the SEC commodity baseline, **When** the member
+   inspects the asset row, **Then** the classification source is identified as the SEC
+   baseline list; likewise for curated-registry and app-configuration sources.
+3. **Given** any portfolio view, **When** it renders, **Then** an informational
+   disclaimer is visible stating that classifications are informational and not legal
+   or investment advice.
+
+---
+
+### User Story 3 - Honest handling of unclassified and undiscoverable assets (Priority: P3)
+
+The registry cannot know every token. Any asset the app knows the account holds but
+cannot map to one of the five categories appears in an explicit **Unclassified** group
+(never silently hidden), and the view discloses that asset discovery is limited to the
+app's curated registry — tokens outside it are not shown.
+
+**Why this priority**: Honesty guardrail. Matters for trust but only observable once
+P1 renders holdings.
+
+**Independent Test**: Configure an account holding an app-known token that has no
+category mapping; verify it renders in an "Unclassified" group; verify the coverage
+disclosure is visible.
+
+**Acceptance Scenarios**:
+
+1. **Given** the account holds an app-known token with no category mapping, **When**
+   the portfolio renders, **Then** the token appears under "Unclassified" with its
+   balance, and is included in totals when priced.
+2. **Given** the portfolio view, **When** it renders, **Then** a disclosure states that
+   only assets in the app's curated registry are scanned, so other holdings may exist
+   on-chain that are not listed.
+
+---
+
+### User Story 4 - Portfolio stays scoped to the active network and stays fresh (Priority: P3)
+
+When the member switches networks, the portfolio reloads and shows only assets and
+balances for the new active network — holdings never leak across networks. The member
+can manually refresh, and balances refresh automatically at a reasonable cadence.
+
+**Why this priority**: Correctness-preserving behavior for multi-network members;
+builds directly on P1.
+
+**Independent Test**: Load the portfolio on one network, switch to another; verify all
+rows, subtotals, and totals now reflect only the new network and its registry.
+
+**Acceptance Scenarios**:
+
+1. **Given** a loaded portfolio on network A, **When** the member switches to network
+   B, **Then** the view reloads and shows only network B assets, with network B's
+   native coin and registry.
+2. **Given** a network the app does not support for portfolio scanning, **When** the
+   member opens the Portfolio section, **Then** an explicit "unavailable on this
+   network" state is shown rather than an empty or stale portfolio.
+3. **Given** balance reads fail (e.g. network provider unreachable), **When** the
+   portfolio renders, **Then** an explicit error state with a retry action is shown
+   rather than zeros or stale data presented as current.
+
+### Edge Cases
+
+- Account holds none of the registry assets: all categories render with an explicit
+  empty state and a $0.00 total — not a blank screen.
+- An asset appears in more than one source list with conflicting categories: the
+  highest-precedence source wins (SEC baseline > curated registry > app configuration),
+  and the winning source is what the row reports.
+- Collectibles (non-fungible assets) have no market price: rows show the item count
+  held; USD subtotal shows as unavailable rather than $0.00.
+- Prices become temporarily unavailable mid-session: previously shown USD values are
+  not silently frozen; the view marks totals as partial/unavailable.
+- Very small balances ("dust"): still listed with their true balance; no hiding
+  threshold in v1.
+- The registry lists a token whose on-chain contract does not respond as expected
+  (e.g. reverts on balance queries): the asset is skipped with the failure surfaced in
+  the error/partial state, not rendered as zero.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The app MUST add a "Portfolio" entry to the Finance group of the My
+  Wallet navigation, opening the Connected Account Portfolio view, deep-linkable like
+  existing Finance sections.
+- **FR-002**: The portfolio MUST display only real on-chain holdings of the currently
+  connected account, read live from the active network — no mock, cached-as-current, or
+  placeholder balances.
+- **FR-003**: The portfolio MUST be scoped to the active network; switching networks
+  MUST reload the portfolio and never display assets or balances from another network.
+- **FR-004**: The app MUST define exactly five regulatory taxonomy categories —
+  Digital Securities, Digital Commodities, Digital Collectibles, Digital Tools, and
+  Payment Stablecoins — each with a member-facing plain-language description aligned to
+  the SEC/CFTC definitions provided in the feature description.
+- **FR-005**: Asset classification MUST be driven by a layered registry: (a) a
+  hardcoded baseline derived from the official SEC commodity list for Digital
+  Commodities (covering at least the network's native coin and wrapped-native token),
+  (b) curated open-source token-registry mappings for the remaining tiers, and (c) the
+  app's own network configuration for tokens it already knows (e.g. the network's
+  configured stablecoin maps to Payment Stablecoins).
+- **FR-006**: Each classified asset MUST record and expose its classification source
+  (SEC baseline, curated registry, or app configuration); when sources conflict, SEC
+  baseline takes precedence over curated registry, which takes precedence over app
+  configuration.
+- **FR-007**: The registry MUST be maintained per network (asset identifiers are
+  network-specific), and only the active network's registry entries are scanned.
+- **FR-008**: The view MUST show a total portfolio balance in USD at the top,
+  aggregating all displayed assets with available prices.
+- **FR-009**: Each category MUST render as a collapsible section with a USD subtotal
+  and per-asset rows showing asset name, symbol, on-chain balance, and USD value.
+- **FR-010**: Assets with a balance but no available USD price MUST display their
+  balance with USD marked unavailable (never $0.00), be excluded from USD totals, and
+  cause affected totals to be labeled as partial.
+- **FR-011**: Non-fungible (collectible) holdings, where present in the registry, MUST
+  be represented by the count of items held per collection; they follow the same
+  no-price rule as FR-010.
+- **FR-012**: App-known assets that cannot be mapped to any of the five categories MUST
+  appear in an explicit "Unclassified" group; no discovered holding may be silently
+  hidden.
+- **FR-013**: The view MUST disclose that (a) classifications are informational, not
+  legal or investment advice, and (b) asset discovery is limited to the app's curated
+  registry, so unlisted on-chain holdings will not appear.
+- **FR-014**: The view MUST present explicit states for: wallet not connected, network
+  not supported for portfolio scanning, balances loading, balance-read failure (with
+  retry), and empty holdings.
+- **FR-015**: The member MUST be able to manually refresh the portfolio, and balances
+  MUST refresh automatically at a reasonable cadence consistent with the app's existing
+  balance displays.
+- **FR-016**: The portfolio view MUST meet the app's accessibility standard (WCAG 2.1
+  AA), including keyboard operability of the collapsible sections and accessible
+  labeling of totals and rows.
+
+### Key Entities
+
+- **Taxonomy Category**: One of the five regulatory groupings (plus the Unclassified
+  fallback). Attributes: identifier, display name, plain-language regulatory
+  description, display order.
+- **Registry Asset**: A per-network asset entry eligible for scanning. Attributes:
+  network identifier, asset identifier (contract address or native-coin marker), kind
+  (native coin, fungible token, collectible collection), symbol, name, decimals (for
+  fungibles), assigned category, classification source (SEC baseline / curated registry
+  / app configuration).
+- **Holding**: A registry asset joined with the connected account's live balance and,
+  when available, its USD value. Attributes: balance, USD value (optional), price
+  availability.
+- **Portfolio Snapshot**: The set of holdings for one account on one network at one
+  point in time, with per-category subtotals, the grand total, and partial/failed-read
+  flags.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A connected member can see their categorized holdings within 5 seconds of
+  opening the Portfolio section on a healthy network connection.
+- **SC-002**: 100% of assets displayed correspond to real, current on-chain balances of
+  the connected account on the active network (verifiable by independent balance
+  lookup).
+- **SC-003**: Every displayed asset shows a category (one of the five, or Unclassified)
+  and a discoverable classification source; zero discovered holdings are hidden.
+- **SC-004**: Switching networks never leaves a stale asset row from the previous
+  network visible (0 cross-network leaks in testing).
+- **SC-005**: With prices unavailable for some assets, totals are visibly marked
+  partial and no asset displays a fabricated $0.00 value.
+- **SC-006**: Accessibility audits of the new section report zero WCAG 2.1 AA
+  violations.
+
+## Assumptions
+
+- The portfolio is **read-only** in v1: no buy/sell/transfer actions from this view
+  (existing Trade and Pay & Transfer sections cover actions).
+- **Registry-driven discovery** is acceptable for v1: the app scans a curated
+  per-network asset registry rather than indexing all token transfers. This matches the
+  stated implementation tip (SEC baseline + curated token lists) and the app's
+  no-backend architecture; full-chain discovery via an indexer is out of scope.
+- The curated registry ships **bundled with the app** and is updated through normal app
+  releases; live ingestion of remote token lists at runtime is out of scope for v1.
+- USD prices come from the app's existing pricing capability; assets without an
+  available price are displayed per FR-010 rather than blocking the feature on a new
+  price service.
+- Stablecoins configured by the app's per-network settings are treated as Payment
+  Stablecoins (known issuer status); the app does not independently verify GENIUS Act
+  issuer approval.
+- The five categories and their descriptions follow the definitions supplied in the
+  feature description; regulatory reinterpretation is handled by registry updates, not
+  by this feature.
+- Networks currently supported by the app (e.g. Polygon and the app's testnets) are the
+  target; a network without a registry shows the FR-014 "not supported" state.
+- The mobile mockup is a visual reference for structure (header total, collapsible
+  category sections, asset rows); exact visual styling follows the app's existing
+  design system rather than the mockup's.

--- a/specs/044-connected-account-portfolio/tasks.md
+++ b/specs/044-connected-account-portfolio/tasks.md
@@ -1,0 +1,113 @@
+# Tasks: Connected Account Portfolio
+
+**Input**: Design documents from `specs/044-connected-account-portfolio/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/asset-registry.md, quickstart.md
+
+**Tests**: Included — constitution principle II (Test-First) is non-negotiable.
+
+**Organization**: Tasks are grouped by user story so each story is independently
+implementable and testable. Feature is frontend-only (no contracts, no subgraph).
+
+## Phase 1: Setup
+
+**Purpose**: No project scaffolding needed — the frontend workspace exists. Single
+verification task.
+
+- [X] T001 Verify frontend test harness runs clean before changes: `cd frontend && npx vitest run src/test/WalletPage.test.jsx` (baseline for the WalletPage edits in US1)
+
+## Phase 2: Foundational (blocking prerequisites for all stories)
+
+**Purpose**: The taxonomy registry config module — every story (rendering,
+classification sources, unclassified handling, network scoping) consumes it.
+
+- [X] T002 Create `frontend/src/config/assetTaxonomy.js` exporting `TAXONOMY_CATEGORIES` (five regulatory categories + `unclassified`, each with id/label/description/order per data-model.md and FR-004 definitions), `CLASSIFICATION_SOURCES`, and `SEC_COMMODITY_BASELINE` (BTC, ETH, SOL, XRP, MATIC, POL, ETC — provenance comment citing the SEC commodity baseline)
+- [X] T003 In `frontend/src/config/assetTaxonomy.js`, implement `getPortfolioRegistry(chainId)` merging the three sources with precedence sec-baseline > curated-registry > app-config (FR-006): native coin from `NETWORKS[chainId].nativeCurrency`, wrapped native from `NETWORKS[chainId].dex?.wnative` / `getContractAddressForChain('wmatic', chainId)`, stablecoin from `NETWORKS[chainId].stablecoin` (→ payment-stablecoins), `membershipVoucher` via `getContractAddressForChain` (→ digital-tools, kind `nft`), plus curated Polygon entries (WETH/WBTC → digital-commodities, LINK → digital-tools, USDT → payment-stablecoins, canonical addresses with provenance comments); omit unresolvable entries; also implement `getTaxonomyCategory(categoryId)`
+- [X] T004 Write registry tests in `frontend/src/test/portfolio/assetTaxonomy.test.js`: five categories + unclassified present and ordered; per-chain entries carry the queried chainId only (FR-007); no duplicate ids; source precedence (an address in two sources reports the higher source and its category); native entry exists for every `listSupportedChainIds()` chain; unknown chainId → `[]`; Mordor/ETC registries contain no Polygon addresses (SC-004 config side)
+
+**Checkpoint**: Registry is buildable and tested — user stories can start.
+
+## Phase 3: User Story 1 — View assets grouped by regulatory category (P1) 🎯 MVP
+
+**Goal**: Connected member opens My Wallet → Finance → Portfolio and sees live
+holdings grouped by category with total, subtotals, collapsible sections, and
+per-asset rows (balance + USD or honest "unavailable").
+
+**Independent Test**: quickstart.md steps 1–4 on Polygon/Amoy; Vitest suites for hook
+and panel pass in isolation.
+
+- [X] T005 [US1] Create `frontend/src/hooks/usePortfolio.js` per contracts/asset-registry.md and data-model.md: registry lookup for active chainId; native `provider.getBalance` + per-token minimal-ABI `balanceOf` via `Promise.allSettled` on `useWallet().provider`; holdings only for `balanceRaw > 0n`; USD join (stablecoin par $1; native/wrapped-native via PriceContext `nativeUsdRate` only on MATIC-native chains and only when the feed has no `error`; else `usd: null`); category grouping with subtotals; `totalUsd`/`isPartial`/`failedAssets`; states disconnected/loading/ready/error; request-id guard; synchronous snapshot reset on address/chainId change; 60s poll + `refresh()` (FR-002/003/008/010/014/015, R4/R5)
+- [X] T006 [P] [US1] Write hook tests in `frontend/src/test/portfolio/usePortfolio.test.jsx` (mock WalletContext + PriceContext at context level per repo convention; stub ethers Contract/provider): maps balances to holdings and drops zero balances; par-$1 stablecoin and MATIC-chain native pricing; unpriced asset → `usd: null`, excluded from totals, `isPartial` true; price-feed error → native unpriced; single failed read → partial + `failedAssets`; all reads fail → error state with retry; disconnect clears; chainId change resets before reload (SC-004)
+- [X] T007 [US1] Create `frontend/src/components/wallet/PortfolioPanel.jsx` + `frontend/src/components/wallet/Portfolio.css`: header "Total portfolio balance" USD figure with partial badge and refresh button; ordered collapsible category sections (`<button aria-expanded aria-controls>` + `role="region"`, subtotal visible when collapsed, explicit empty state per category); asset rows (name, symbol, balance, USD or "—" with accessible "price unavailable" label, item count for `nft` kind, classification-source tag); FR-014 states (connect prompt / loading / error+retry); styles from theme.css tokens matching Pay & Transfer conventions
+- [X] T008 [P] [US1] Write panel tests in `frontend/src/test/portfolio/PortfolioPanel.test.jsx` (mock `usePortfolio`): disconnected prompt; loading; error with working retry; populated view with correct total/subtotals; unpriced row renders "—" never "$0.00" and total shows partial label (SC-005); collapse toggle hides rows, keeps header+subtotal, flips `aria-expanded`; empty category shows explicit empty state
+- [X] T009 [US1] Wire navigation in `frontend/src/pages/WalletPage.jsx`: add `{ id: 'portfolio', label: 'Portfolio' }` to the Finance group of `WALLET_TAB_GROUPS` and a `{activeTab === 'portfolio' && (<div className="portfolio-section" role="tabpanel"><PortfolioPanel /></div>)}` block; update `frontend/src/test/WalletPage.test.jsx` if the tab list is asserted (deep link `?tab=portfolio` resolves via existing logic, FR-001)
+
+**Checkpoint**: MVP demonstrable end-to-end (quickstart steps 1–4).
+
+## Phase 4: User Story 2 — Category meaning & classification provenance (P2)
+
+**Goal**: Category descriptions are discoverable, every row shows its classification
+source, and the informational disclaimer is always visible.
+
+**Independent Test**: In the populated view, each category header reveals its
+regulatory description; rows show source labels; disclaimer visible (quickstart step 3).
+
+- [X] T010 [US2] In `frontend/src/components/wallet/PortfolioPanel.jsx`, surface `TAXONOMY_CATEGORIES` descriptions from each category header (accessible disclosure — e.g. an info toggle or always-visible description line), render per-row source labels ("SEC baseline" / "Curated registry" / "App configuration"), and add the always-visible informational disclaimer ("classifications are informational, not legal or investment advice") in the portfolio view footer (FR-004/006/013a)
+- [X] T011 [P] [US2] Extend `frontend/src/test/portfolio/PortfolioPanel.test.jsx`: each rendered category exposes its description text; rows for sec-baseline/curated-registry/app-config assets show the correct source label; disclaimer present in every non-prompt state
+
+## Phase 5: User Story 3 — Honest unclassified & coverage disclosure (P3)
+
+**Goal**: Unmappable app-known holdings render in an explicit Unclassified group;
+the registry-coverage disclosure is always visible.
+
+**Independent Test**: A registry entry with `categoryId: 'unclassified'` and nonzero
+balance renders in an "Unclassified" group included in totals; coverage disclosure
+visible.
+
+- [X] T012 [US3] Ensure the unclassified path is complete: `getPortfolioRegistry` emits `unclassified` for app-known tokens without a category mapping (in `frontend/src/config/assetTaxonomy.js`), `usePortfolio` groups them last and includes priced ones in totals (in `frontend/src/hooks/usePortfolio.js`), and `PortfolioPanel.jsx` renders the Unclassified group only when non-empty plus the coverage disclosure ("only registry-listed assets are scanned…") alongside the T010 disclaimer (FR-012/013b)
+- [X] T013 [P] [US3] Add tests: registry test in `frontend/src/test/portfolio/assetTaxonomy.test.js` for the unclassified fallback; panel test in `frontend/src/test/portfolio/PortfolioPanel.test.jsx` asserting an unclassified holding renders (never silently hidden), the group is absent when empty, and the coverage disclosure is visible
+
+## Phase 6: User Story 4 — Network scoping & freshness (P4/P3)
+
+**Goal**: Chain switches fully reset the view; unsupported networks and read failures
+are explicit; manual + polled refresh work.
+
+**Independent Test**: quickstart step 5–6; hook tests for chain-switch reset and
+unsupported chain.
+
+- [X] T014 [US4] Verify/complete in `frontend/src/hooks/usePortfolio.js` and `PortfolioPanel.jsx`: empty registry (unknown chainId) → explicit "Portfolio isn't available on this network" state; chain switch clears holdings before reload; manual refresh button wired to `refresh()`; ETC-family native shows USD unavailable (no MATIC-rate leakage) (FR-003/014, R4)
+- [X] T015 [P] [US4] Extend `frontend/src/test/portfolio/usePortfolio.test.jsx` + `PortfolioPanel.test.jsx`: unsupported-network state renders; after simulated chainId change no stale row from the previous chain is present (SC-004); refresh triggers a reload
+
+## Phase 7: Polish & Cross-Cutting
+
+- [X] T016 [P] Write `frontend/src/test/portfolio/PortfolioPanel.axe.test.jsx` with vitest-axe: populated (expanded + collapsed) and error states report zero violations (FR-016, SC-006)
+- [X] T017 Run full gates: `cd frontend && npx eslint src/config/assetTaxonomy.js src/hooks/usePortfolio.js src/components/wallet/PortfolioPanel.jsx src/pages/WalletPage.jsx src/test/portfolio` then `npm run test:frontend` and fix any regressions (constitution IV)
+- [X] T018 Validate quickstart.md manually where possible (dev server render of `?tab=portfolio` states) and correct any doc drift in `specs/044-connected-account-portfolio/quickstart.md`
+
+## Dependencies & Execution Order
+
+- **Phase 2 (T002–T004)** blocks all user stories (registry is the shared model).
+- **US1 (T005–T009)**: T005 → T006/T007; T007 → T008/T009. MVP checkpoint.
+- **US2 (T010–T011)** and **US3 (T012–T013)** depend on US1's panel; independent of each other.
+- **US4 (T014–T015)** depends on US1's hook; independent of US2/US3.
+- **Polish (T016–T018)** last; T016 needs the final panel markup.
+
+```
+T001 → T002 → T003 → T004 → T005 → T006
+                              └──→ T007 → T008
+                                     ├──→ T009   (US1 done)
+                                     ├──→ T010 → T011  (US2)
+                                     ├──→ T012 → T013  (US3)
+                                     └──→ T014 → T015  (US4)
+                                                  └→ T016 → T017 → T018
+```
+
+**Parallel opportunities**: T006 ∥ T007 (different files); T008 ∥ T009; after US1,
+{T010, T012, T014} touch overlapping files — run their test tasks (T011, T013, T015)
+in parallel but serialize the implementation edits to PortfolioPanel.jsx/usePortfolio.js.
+
+## Implementation Strategy
+
+Ship US1 as the MVP (registry + hook + panel + nav). US2/US3 are small panel/config
+increments on top; US4 hardens scoping/freshness; polish gates close with axe + ESLint +
+full suite. Since all stories land in one PR here, implement sequentially US1 → US2 →
+US3 → US4 → Polish, validating each checkpoint's tests before moving on.


### PR DESCRIPTION
## Summary

Adds a new **Portfolio** section under **My Wallet → Finance** that shows the connected account's real on-chain holdings on the active network, grouped by the app's five SEC/CFTC-aligned taxonomy categories — **Digital Commodities, Digital Securities, Payment Stablecoins, Digital Tools, Digital Collectibles** — plus an honest **Unclassified** fallback. Built through the full Spec Kit workflow (`specs/044-connected-account-portfolio/`: spec → plan → research → data model → tasks, all 18 tasks complete).

## Classification approach (per the feature request)

Layered registry with precedence **SEC baseline > curated registry > app configuration** (each row displays its source):

- **SEC baseline** — hardcoded commodity list (BTC, ETH, SOL, XRP + network gas assets); classifies native coins and canonical wrapped forms as Digital Commodities.
- **Curated registry** — bundled canonical token entries per chain (Polygon: WETH/WBTC → commodities, LINK → tools, USDT → payment stablecoins), Tokenlists-style data mapped to the regulatory definitions.
- **App configuration** — the per-network stablecoin (USDC/USC → Payment Stablecoins) and the MembershipVoucher ERC-721 credential (→ Digital Tools, rendered as an item count), resolved via `config/networks.js` / `getContractAddressForChain` per constitution V.

## Honest-state guarantees (constitution III)

- Balances read live per active chain; registries and reads are strictly network-scoped (no cross-chain leakage).
- No fabricated USD: stablecoins at par $1, native/wrapped-native priced only on MATIC-native chains where the app's feed actually applies; unpriced assets show "—" (never $0.00), are excluded from totals, and flip totals to a labeled **partial** state. The price feed's hardcoded fallback rate is treated as unavailable.
- Failed reads surface as partial (asset named) or an error state with retry — never as zeros. Explicit states for disconnected / unsupported network / loading / empty.
- Disclosures: classifications are informational (not legal/investment advice) and discovery is limited to the curated registry.

## Changes

- `frontend/src/config/assetTaxonomy.js` — categories + descriptions, SEC baseline, curated entries, `getPortfolioRegistry(chainId)`
- `frontend/src/hooks/usePortfolio.js` — live balance reads (ethers v6 via the wallet read provider), category grouping, partial/total math, 60s poll + refresh
- `frontend/src/components/wallet/PortfolioPanel.jsx` + `Portfolio.css` — header total, keyboard-operable collapsible category sections (`aria-expanded`/`aria-controls`), asset rows with classification-source tags and regulatory descriptions
- `frontend/src/pages/WalletPage.jsx` — new Finance tab `portfolio` (deep-linkable `?tab=portfolio`)
- `frontend/src/test/portfolio/` — 51 Vitest tests (registry, hook, panel, vitest-axe WCAG audits)
- `specs/044-connected-account-portfolio/` — full Spec Kit artifacts

## Testing

- `src/test/portfolio`: **51/51 pass** (22 registry, 10 hook, 16 panel, 3 axe)
- `src/test/WalletPage.test.jsx`: 10/10 pass with the new tab
- ESLint clean on all touched files; `vite build` succeeds
- Full frontend suite: 2405 passed; the 17 failures (quickAccessPreference, ClearPathPanel, ProposalBuilder) were verified pre-existing on the base branch via stash-and-rerun — unrelated to this change
- Headless Chromium smoke on the built app: `/wallet?tab=portfolio` renders with zero page errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9vh9Lj9RNgD7tvrLoAcKY

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9vh9Lj9RNgD7tvrLoAcKY)_