### PR TITLE
Portfolio v1.1: cross-chain scan, info bubbles, testnet preference (spec 044 follow-up)

### DIFF
--- a/frontend/src/components/account/PortfolioPreferencesPanel.css
+++ b/frontend/src/components/account/PortfolioPreferencesPanel.css
@@ -1,0 +1,64 @@
+/* Portfolio preferences (spec 044 follow-up) — mirrors the Notifications switch idiom. */
+
+.portfolio-prefs {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+.portfolio-prefs-title {
+  margin: 0;
+}
+.portfolio-prefs-row {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+.portfolio-prefs-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+.portfolio-prefs-label {
+  font-weight: 600;
+}
+.portfolio-prefs-sub {
+  color: var(--color-text-secondary, var(--text-secondary, #6b7280));
+  font-size: 0.85rem;
+}
+.portfolio-prefs-switch {
+  appearance: none;
+  background: var(--color-surface-2, var(--surface-secondary, #e5e7eb));
+  border: 1px solid var(--color-border, var(--border-color, #d1d5db));
+  border-radius: 999px;
+  cursor: pointer;
+  flex: none;
+  height: 24px;
+  padding: 0;
+  position: relative;
+  transition: background 0.15s ease;
+  width: 44px;
+}
+.portfolio-prefs-switch::after {
+  background: #fff;
+  border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  content: '';
+  height: 18px;
+  left: 2px;
+  position: absolute;
+  top: 2px;
+  transition: transform 0.15s ease;
+  width: 18px;
+}
+.portfolio-prefs-switch.on {
+  background: var(--color-primary, var(--brand-primary, #6d28d9));
+  border-color: var(--color-primary, var(--brand-primary, #6d28d9));
+}
+.portfolio-prefs-switch.on::after {
+  transform: translateX(20px);
+}
+.portfolio-prefs-switch:focus-visible {
+  outline: 2px solid var(--color-primary, #6d28d9);
+  outline-offset: 2px;
+}

--- a/frontend/src/components/account/PortfolioPreferencesPanel.css
+++ b/frontend/src/components/account/PortfolioPreferencesPanel.css
@@ -23,13 +23,13 @@
   font-weight: 600;
 }
 .portfolio-prefs-sub {
-  color: var(--color-text-secondary, var(--text-secondary, #6b7280));
+  color: var(--text-secondary, #6b7280);
   font-size: 0.85rem;
 }
 .portfolio-prefs-switch {
   appearance: none;
-  background: var(--color-surface-2, var(--surface-secondary, #e5e7eb));
-  border: 1px solid var(--color-border, var(--border-color, #d1d5db));
+  background: var(--surface-color, var(--bg-secondary, #e5e7eb));
+  border: 1px solid var(--border-color, #d1d5db);
   border-radius: 999px;
   cursor: pointer;
   flex: none;
@@ -52,13 +52,13 @@
   width: 18px;
 }
 .portfolio-prefs-switch.on {
-  background: var(--color-primary, var(--brand-primary, #6d28d9));
-  border-color: var(--color-primary, var(--brand-primary, #6d28d9));
+  background: var(--brand-primary, #36B37E);
+  border-color: var(--brand-primary, #36B37E);
 }
 .portfolio-prefs-switch.on::after {
   transform: translateX(20px);
 }
 .portfolio-prefs-switch:focus-visible {
-  outline: 2px solid var(--color-primary, #6d28d9);
+  outline: 2px solid var(--brand-primary, #36B37E);
   outline-offset: 2px;
 }

--- a/frontend/src/components/account/PortfolioPreferencesPanel.jsx
+++ b/frontend/src/components/account/PortfolioPreferencesPanel.jsx
@@ -1,0 +1,44 @@
+import { useUserPreferences } from '../../hooks/useUserPreferences'
+import './PortfolioPreferencesPanel.css'
+
+/**
+ * PortfolioPreferencesPanel — the "Portfolio" area of the Preferences tab
+ * (spec 044 follow-up). One switch: whether the cross-chain portfolio also
+ * scans and lists assets on test networks (Sepolia, Amoy, Mordor).
+ */
+function PortfolioPreferencesPanel() {
+  const { preferences, setShowTestnetAssets } = useUserPreferences()
+  const on = Boolean(preferences?.showTestnetAssets)
+
+  return (
+    <div className="portfolio-prefs">
+      <h3 className="portfolio-prefs-title">Portfolio</h3>
+      <div className="portfolio-prefs-row">
+        <div className="portfolio-prefs-text">
+          <span className="portfolio-prefs-label" id="portfolio-prefs-testnet-label">
+            Show testnet tokens
+          </span>
+          <span className="portfolio-prefs-sub">
+            {on
+              ? 'On — the portfolio also lists assets on test networks (Sepolia, Amoy, Mordor).'
+              : 'Off — the portfolio lists mainnet assets only (Ethereum, Ethereum Classic, Polygon).'}
+          </span>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={on}
+          aria-labelledby="portfolio-prefs-testnet-label"
+          className={`portfolio-prefs-switch ${on ? 'on' : ''}`}
+          onClick={() => setShowTestnetAssets(!on)}
+        >
+          <span className="sr-only">
+            {on ? 'Testnet tokens shown' : 'Testnet tokens hidden'}
+          </span>
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default PortfolioPreferencesPanel

--- a/frontend/src/components/ui/InfoTip.css
+++ b/frontend/src/components/ui/InfoTip.css
@@ -28,17 +28,17 @@
 
 .infotip-btn:hover,
 .infotip-btn:focus-visible {
-  color: var(--accent, #2563eb);
+  color: var(--accent-color, #2563eb);
   opacity: 1;
 }
 
 .infotip-btn[aria-expanded='true'] {
-  color: var(--accent, #2563eb);
+  color: var(--accent-color, #2563eb);
   opacity: 1;
 }
 
 .infotip-btn:focus-visible {
-  outline: 2px solid var(--accent, #2563eb);
+  outline: 2px solid var(--accent-color, #2563eb);
   outline-offset: 2px;
 }
 
@@ -61,7 +61,7 @@
   left: -6px;
   border: 6px solid transparent;
   border-top-width: 0;
-  border-bottom-color: var(--card-bg, #fff);
+  border-bottom-color: var(--surface-color, var(--bg-secondary, #fff));
   filter: drop-shadow(0 -1px 0 var(--border-color, #cbd5e1));
 }
 
@@ -72,7 +72,7 @@
   left: -6px;
   border: 6px solid transparent;
   border-bottom-width: 0;
-  border-top-color: var(--card-bg, #fff);
+  border-top-color: var(--surface-color, var(--bg-secondary, #fff));
   filter: drop-shadow(0 1px 0 var(--border-color, #cbd5e1));
 }
 
@@ -88,7 +88,7 @@
   padding: 0.6rem 0.75rem;
   border: 1px solid var(--border-color, #cbd5e1);
   border-radius: 0.5rem;
-  background: var(--card-bg, #fff);
+  background: var(--surface-color, var(--bg-secondary, #fff));
   color: var(--text-primary, #1e293b);
   box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
   font-size: 0.8rem;

--- a/frontend/src/components/wallet/Portfolio.css
+++ b/frontend/src/components/wallet/Portfolio.css
@@ -34,19 +34,6 @@
   margin: 0;
   color: var(--color-text, var(--text-primary, #111827));
 }
-.portfolio-partial-flag {
-  color: var(--color-warning, #b45309);
-  font-size: 0.8rem;
-  font-weight: 600;
-}
-.portfolio-partial-total {
-  font-size: 0.95rem;
-}
-.portfolio-partial-note {
-  color: var(--color-text-tertiary, var(--text-muted, #9ca3af));
-  font-size: 0.8rem;
-  margin: 0;
-}
 .portfolio-refresh {
   appearance: none;
   background: transparent;
@@ -74,8 +61,17 @@
   border-radius: 10px;
   overflow: hidden;
 }
+.portfolio-category-heading-row {
+  align-items: center;
+  background: var(--color-surface-2, var(--surface-secondary, #f9fafb));
+  display: flex;
+  gap: 0.25rem;
+  padding-right: 0.6rem;
+}
 .portfolio-category-heading {
+  flex: 1;
   margin: 0;
+  min-width: 0;
 }
 .portfolio-category-toggle {
   align-items: center;
@@ -106,11 +102,13 @@
   color: var(--color-primary, var(--brand-primary, #6d28d9));
   font-variant-numeric: tabular-nums;
 }
-.portfolio-category-description {
-  color: var(--color-text-tertiary, var(--text-muted, #9ca3af));
-  font-size: 0.8rem;
-  margin: 0;
-  padding: 0.6rem 0.9rem 0;
+.portfolio-row-network {
+  background: var(--color-surface-2, var(--surface-secondary, #f3f4f6));
+  border: 1px solid var(--color-border, var(--border-color, #e5e7eb));
+  border-radius: 999px;
+  font-size: 0.7rem;
+  padding: 0.05rem 0.5rem;
+  white-space: nowrap;
 }
 .portfolio-category-empty {
   color: var(--color-text-secondary, var(--text-secondary, #6b7280));

--- a/frontend/src/components/wallet/Portfolio.css
+++ b/frontend/src/components/wallet/Portfolio.css
@@ -13,7 +13,7 @@
   margin: 0;
 }
 .portfolio-state-error {
-  color: var(--color-danger, #b91c1c);
+  color: var(--danger-color, #b91c1c);
 }
 
 /* Header */
@@ -51,7 +51,7 @@
   opacity: 0.6;
 }
 .portfolio-refresh:focus-visible {
-  outline: 2px solid var(--color-primary, #6d28d9);
+  outline: 2px solid var(--brand-primary, #36B37E);
   outline-offset: 2px;
 }
 
@@ -63,7 +63,7 @@
 }
 .portfolio-category-heading-row {
   align-items: center;
-  background: var(--color-surface-2, var(--surface-secondary, #f9fafb));
+  background: var(--surface-color, var(--bg-secondary, #f9fafb));
   display: flex;
   gap: 0.25rem;
   padding-right: 0.6rem;
@@ -76,7 +76,7 @@
 .portfolio-category-toggle {
   align-items: center;
   appearance: none;
-  background: var(--color-surface-2, var(--surface-secondary, #f9fafb));
+  background: var(--surface-color, var(--bg-secondary, #f9fafb));
   border: none;
   color: var(--color-text, var(--text-primary, #111827));
   cursor: pointer;
@@ -89,7 +89,7 @@
   width: 100%;
 }
 .portfolio-category-toggle:focus-visible {
-  outline: 2px solid var(--color-primary, #6d28d9);
+  outline: 2px solid var(--brand-primary, #36B37E);
   outline-offset: -2px;
 }
 .portfolio-category-chevron {
@@ -99,11 +99,11 @@
   flex: 1;
 }
 .portfolio-category-subtotal {
-  color: var(--color-primary, var(--brand-primary, #6d28d9));
+  color: var(--brand-primary, #36B37E);
   font-variant-numeric: tabular-nums;
 }
 .portfolio-row-network {
-  background: var(--color-surface-2, var(--surface-secondary, #f3f4f6));
+  background: var(--surface-color, var(--bg-secondary, #f3f4f6));
   border: 1px solid var(--color-border, var(--border-color, #e5e7eb));
   border-radius: 999px;
   font-size: 0.7rem;
@@ -153,7 +153,7 @@
   gap: 0.5rem;
 }
 .portfolio-row-source {
-  background: var(--color-surface-2, var(--surface-secondary, #f3f4f6));
+  background: var(--surface-color, var(--bg-secondary, #f3f4f6));
   border: 1px solid var(--color-border, var(--border-color, #e5e7eb));
   border-radius: 999px;
   font-size: 0.7rem;

--- a/frontend/src/components/wallet/PortfolioPanel.jsx
+++ b/frontend/src/components/wallet/PortfolioPanel.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { formatUnits } from 'ethers'
 import usePortfolio from '../../hooks/usePortfolio'
+import InfoTip from '../ui/InfoTip'
 import './Portfolio.css'
 
 // Full-precision USD for a compliance-flavored view — deliberately not the
@@ -44,13 +45,14 @@ const SOURCE_LABELS = {
 }
 
 function AssetRow({ holding }) {
-  const { asset, usd } = holding
+  const { asset, usd, network } = holding
   return (
     <li className="portfolio-row">
       <div className="portfolio-row-asset">
         <span className="portfolio-row-name">{asset.name}</span>
         <span className="portfolio-row-meta">
           {asset.symbol}
+          <span className="portfolio-row-network">{network}</span>
           <span className="portfolio-row-source">{SOURCE_LABELS[asset.source] || asset.source}</span>
         </span>
       </div>
@@ -70,42 +72,38 @@ function AssetRow({ holding }) {
 }
 
 function CategorySection({ group, collapsed, onToggle }) {
-  const { category, holdings, subtotalUsd, isPartial } = group
+  const { category, holdings, subtotalUsd } = group
   const regionId = `portfolio-category-${category.id}`
   const expanded = !collapsed
   return (
     <section className="portfolio-category">
-      <h3 className="portfolio-category-heading">
-        <button
-          type="button"
-          className="portfolio-category-toggle"
-          aria-expanded={expanded}
-          aria-controls={regionId}
-          onClick={() => onToggle(category.id)}
-        >
-          <span className="portfolio-category-chevron" aria-hidden="true">
-            {expanded ? '▾' : '▸'}
-          </span>
-          <span className="portfolio-category-label">{category.label}</span>
-          <span className="portfolio-category-subtotal">
-            {formatUsdFull(subtotalUsd)}
-            {isPartial && (
-              <span className="portfolio-partial-flag" title="Some assets in this category have no available price">
-                {' '}
-                (partial)
-              </span>
-            )}
-          </span>
-        </button>
-      </h3>
+      <div className="portfolio-category-heading-row">
+        <h3 className="portfolio-category-heading">
+          <button
+            type="button"
+            className="portfolio-category-toggle"
+            aria-expanded={expanded}
+            aria-controls={regionId}
+            onClick={() => onToggle(category.id)}
+          >
+            <span className="portfolio-category-chevron" aria-hidden="true">
+              {expanded ? '▾' : '▸'}
+            </span>
+            <span className="portfolio-category-label">{category.label}</span>
+            <span className="portfolio-category-subtotal">{formatUsdFull(subtotalUsd)}</span>
+          </button>
+        </h3>
+        <InfoTip label={`About ${category.label}`} className="portfolio-category-info">
+          {category.description}
+        </InfoTip>
+      </div>
       <div id={regionId} role="region" aria-label={category.label} hidden={!expanded}>
-        <p className="portfolio-category-description">{category.description}</p>
         {holdings.length === 0 ? (
           <p className="portfolio-category-empty">No assets in this category.</p>
         ) : (
           <ul className="portfolio-rows">
             {holdings.map((h) => (
-              <AssetRow key={h.asset.id} holding={h} />
+              <AssetRow key={`${h.asset.chainId}:${h.asset.id}`} holding={h} />
             ))}
           </ul>
         )}
@@ -115,10 +113,10 @@ function CategorySection({ group, collapsed, onToggle }) {
 }
 
 /**
- * Connected Account Portfolio (spec 044) — the member's live holdings on the
- * active network, grouped by the SEC/CFTC asset taxonomy. Read-only; honest
- * states for disconnected / unsupported network / loading / error / partial
- * pricing (FR-010/012/013/014).
+ * Connected Account Portfolio (spec 044 + follow-up) — the member's holdings
+ * across every supported network, grouped by the SEC/CFTC asset taxonomy.
+ * Read-only; category explainers live in InfoTip bubbles; testnet networks
+ * are included per the "show testnet tokens" preference.
  */
 export default function PortfolioPanel() {
   const portfolio = usePortfolio()
@@ -137,14 +135,6 @@ export default function PortfolioPanel() {
     return (
       <div className="portfolio-root">
         <p className="portfolio-state">Connect a wallet to see your portfolio.</p>
-      </div>
-    )
-  }
-
-  if (!portfolio.isSupportedNetwork) {
-    return (
-      <div className="portfolio-root">
-        <p className="portfolio-state">Portfolio isn&apos;t available on this network.</p>
       </div>
     )
   }
@@ -180,17 +170,7 @@ export default function PortfolioPanel() {
         </p>
         <p className="portfolio-total" aria-labelledby="portfolio-total-label">
           {formatUsdFull(portfolio.totalUsd)}
-          {portfolio.isPartial && (
-            <span className="portfolio-partial-flag portfolio-partial-total"> (partial)</span>
-          )}
         </p>
-        {portfolio.isPartial && (
-          <p className="portfolio-partial-note">
-            Some assets have no available price or could not be read
-            {portfolio.failedAssets.length > 0 && <> (unreadable: {portfolio.failedAssets.join(', ')})</>}
-            ; they are excluded from USD totals.
-          </p>
-        )}
         <button
           type="button"
           className="portfolio-refresh"
@@ -211,13 +191,13 @@ export default function PortfolioPanel() {
       ))}
 
       <footer className="portfolio-disclosures">
+        {!portfolio.showTestnetAssets && (
+          <p>Testnet tokens are hidden — enable them under Preferences → Portfolio.</p>
+        )}
         <p>
-          Classifications follow the app&apos;s SEC/CFTC-aligned taxonomy and are informational
-          only — not legal or investment advice.
-        </p>
-        <p>
-          Only assets in the app&apos;s curated registry are scanned, so other holdings may exist
-          on-chain that are not listed here.
+          Classifications are informational, not legal or investment advice. Only assets in the
+          app&apos;s curated registry are scanned, and USD totals include only assets with an
+          available price.
         </p>
       </footer>
     </div>

--- a/frontend/src/config/assetTaxonomy.js
+++ b/frontend/src/config/assetTaxonomy.js
@@ -159,6 +159,23 @@ function normalizeAddress(address) {
   return typeof address === 'string' ? address.toLowerCase() : address
 }
 
+// Local-only sandboxes are never part of the portfolio scan.
+const LOCAL_CHAIN_IDS = new Set([1337])
+
+/**
+ * The chains the cross-chain portfolio scans (spec 044 follow-up): every
+ * configured network except local sandboxes, mainnets first. Testnets are
+ * included only when the member has opted in via the "show testnet assets"
+ * preference.
+ */
+export function getPortfolioChainIds({ includeTestnets = false } = {}) {
+  return Object.values(NETWORKS)
+    .filter((net) => !LOCAL_CHAIN_IDS.has(net.chainId))
+    .filter((net) => includeTestnets || !net.isTestnet)
+    .sort((a, b) => Number(a.isTestnet) - Number(b.isTestnet))
+    .map((net) => net.chainId)
+}
+
 /**
  * The taxonomy category for `categoryId`, falling back to the `unclassified`
  * category (never undefined) so display code can always render a group.

--- a/frontend/src/config/networks.js
+++ b/frontend/src/config/networks.js
@@ -373,6 +373,41 @@ const NETWORKS = {
       }
     },
   },
+  11155111: {
+    chainId: 11155111,
+    name: 'Sepolia',
+    isTestnet: true,
+    isPrimary: false,
+    // Portfolio-scan only (spec 044 follow-up): balances are read over RPC for
+    // the cross-chain portfolio. Not offered in the network switcher and no
+    // app feature is deployed here, so every capability self-discloses off.
+    selectable: false,
+    nativeCurrency: { decimals: 18, name: 'Sepolia Ether', symbol: 'ETH' },
+    rpcUrl: import.meta.env?.VITE_RPC_URL_SEPOLIA || 'https://ethereum-sepolia-rpc.publicnode.com',
+    explorer: { name: 'Etherscan', baseUrl: 'https://sepolia.etherscan.io' },
+    subgraphUrl: null,
+    // Circle's canonical faucet USDC on Sepolia. Override via VITE_SEPOLIA_USDC.
+    stablecoin: {
+      address: import.meta.env?.VITE_SEPOLIA_USDC || '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238',
+      symbol: 'USDC',
+      name: 'USD Coin',
+      decimals: 6,
+      domainVersion: '2',
+    },
+    dex: null,
+    contracts: {},
+    polymarket: null,
+    passkey: null,
+    get capabilities() {
+      return {
+        polymarketSidebets: false,
+        dex: false,
+        friendMarkets: false,
+        passkeyAccounts: false,
+        clearpath: false,
+      }
+    },
+  },
   1337: {
     chainId: 1337,
     name: 'Hardhat',

--- a/frontend/src/contexts/UserPreferencesContext.jsx
+++ b/frontend/src/contexts/UserPreferencesContext.jsx
@@ -20,6 +20,7 @@ export function UserPreferencesProvider({ children }) {
     favoriteMarkets: [],
     defaultSlippage: 0.5,
     polymarketCategories: [],
+    showTestnetAssets: false,
   })
   const [isLoading, setIsLoading] = useState(false)
 
@@ -34,6 +35,7 @@ export function UserPreferencesProvider({ children }) {
         favoriteMarkets: [],
         defaultSlippage: 0.5,
         polymarketCategories: [],
+        showTestnetAssets: false,
       })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -46,12 +48,14 @@ export function UserPreferencesProvider({ children }) {
       const favoriteMarkets = getUserPreference(walletAddress, 'favorite_markets', [], true)
       const defaultSlippage = getUserPreference(walletAddress, 'default_slippage', 0.5, true)
       const polymarketCategories = getUserPreference(walletAddress, 'polymarket_categories', [], true)
+      const showTestnetAssets = getUserPreference(walletAddress, 'show_testnet_assets', false, true)
 
       setPreferences({
         recentSearches,
         favoriteMarkets,
         defaultSlippage,
         polymarketCategories,
+        showTestnetAssets,
       })
     } catch (error) {
       console.error('Error loading user preferences:', error)
@@ -123,6 +127,14 @@ export function UserPreferencesProvider({ children }) {
     setPreferences(prev => ({ ...prev, polymarketCategories: next }))
   }, [account])
 
+  const setShowTestnetAssets = useCallback((show) => {
+    if (!account) return
+
+    const next = Boolean(show)
+    saveUserPreference(account, 'show_testnet_assets', next, true)
+    setPreferences(prev => ({ ...prev, showTestnetAssets: next }))
+  }, [account])
+
   const clearAllPreferences = useCallback(() => {
     if (!account) return
 
@@ -132,6 +144,7 @@ export function UserPreferencesProvider({ children }) {
       favoriteMarkets: [],
       defaultSlippage: 0.5,
       polymarketCategories: [],
+      showTestnetAssets: false,
     })
   }, [account])
 
@@ -143,6 +156,7 @@ export function UserPreferencesProvider({ children }) {
     toggleFavoriteMarket,
     setDefaultSlippage,
     setPolymarketCategories,
+    setShowTestnetAssets,
     savePreference,
     clearAllPreferences,
   }

--- a/frontend/src/hooks/usePortfolio.js
+++ b/frontend/src/hooks/usePortfolio.js
@@ -1,24 +1,37 @@
 /**
- * usePortfolio (spec 044) — live, per-network holdings of the connected
- * account, grouped by the SEC/CFTC asset taxonomy.
+ * usePortfolio (spec 044 + follow-up) — the connected account's holdings
+ * across every network the app supports, grouped by the SEC/CFTC asset
+ * taxonomy.
  *
- * Discovery is registry-driven: only assets in getPortfolioRegistry(chainId)
- * are scanned (the panel discloses this, FR-013). Balances are read live from
- * the wallet context's read provider; nothing is persisted. Honest-state
- * rules (constitution III):
- *   - a zero balance is not a holding;
- *   - a failed read is reported in `failedAssets` and marks the snapshot
- *     partial — it is never rendered as a zero balance;
- *   - an asset with no trustworthy USD price gets `usd: null`, is excluded
- *     from totals, and flips `isPartial` (FR-010) — the price feed's
- *     hardcoded fallback rate is treated as unavailable, and the MATIC/USD
- *     feed is never applied to another chain's native coin.
+ * Cross-chain: balances are read over each network's own read provider
+ * (makeReadProvider), independent of the wallet's active chain. Testnet
+ * networks are scanned only when the member enables the "show testnet
+ * assets" preference. Discovery stays registry-driven (the panel discloses
+ * this, FR-013).
+ *
+ * Honest-state rules (constitution III):
+ *   - a failed read never renders as a zero balance — the asset is skipped
+ *     and reported in `failedAssets`;
+ *   - an asset with no trustworthy USD price gets `usd: null` and is simply
+ *     excluded from USD sums (the feed's hardcoded fallback rate counts as
+ *     unavailable, and the MATIC/USD feed never prices another chain's
+ *     native coin);
+ *   - Digital Commodities are always listed in full — a zero balance renders
+ *     as a true 0 (worth $0.00), other categories list only nonzero holdings.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Contract, formatUnits } from 'ethers'
 import { useWallet } from './useWalletManagement'
+import { useUserPreferences } from './useUserPreferences'
 import { usePrice } from '../contexts/PriceContext'
-import { getPortfolioRegistry, getTaxonomyCategory, TAXONOMY_CATEGORIES } from '../config/assetTaxonomy'
+import { makeReadProvider } from '../utils/rpcProvider'
+import { NETWORKS } from '../config/networks'
+import {
+  getPortfolioRegistry,
+  getPortfolioChainIds,
+  getTaxonomyCategory,
+  TAXONOMY_CATEGORIES,
+} from '../config/assetTaxonomy'
 
 const POLL_MS = 60_000
 
@@ -27,7 +40,7 @@ const BALANCE_OF_ABI = ['function balanceOf(address) view returns (uint256)']
 
 // The app's only price feed quotes MATIC/USD (usePriceConversion), so the
 // native/wrapped-native rate applies solely on MATIC-native chains. Applying
-// it elsewhere (e.g. pricing ETC with a MATIC rate) would fabricate value.
+// it elsewhere (e.g. pricing ETH or ETC with a MATIC rate) would fabricate value.
 const PRICE_FEED_NATIVE_SYMBOLS = new Set(['MATIC', 'POL'])
 
 async function readAssetBalance(asset, { provider, address }) {
@@ -43,7 +56,10 @@ function toHolding(asset, balanceRaw, { nativeUsdRate }) {
     asset.kind === 'nft' ? Number(balanceRaw) : Number(formatUnits(balanceRaw, asset.decimals))
 
   let usd = null
-  if (asset.categoryId === 'payment-stablecoins') {
+  if (balanceRaw === 0n) {
+    // Zero of anything is worth exactly $0 — no price feed required.
+    usd = 0
+  } else if (asset.categoryId === 'payment-stablecoins') {
     // Par $1 — the app-wide stablecoin convention (see useAccountStats).
     usd = balance
   } else if (
@@ -54,18 +70,30 @@ function toHolding(asset, balanceRaw, { nativeUsdRate }) {
   ) {
     usd = balance * nativeUsdRate
   }
-  return { asset, balance, balanceRaw, usd }
+  return { asset, balance, balanceRaw, usd, network: NETWORKS[asset.chainId]?.name || String(asset.chainId) }
 }
 
 export function usePortfolio() {
   const wallet = useWallet() || {}
-  const { address, chainId, isConnected, provider } = wallet
+  const { address, isConnected } = wallet
+  const { preferences } = useUserPreferences() || {}
+  const showTestnetAssets = Boolean(preferences?.showTestnetAssets)
   const price = usePrice()
   // A feed error means the exported rate is the hardcoded fallback — honest
   // portfolios treat that as "no price" rather than presenting it as real.
   const nativeUsdRate = price?.error ? null : price?.nativeUsdRate ?? null
 
-  const registry = useMemo(() => getPortfolioRegistry(chainId), [chainId])
+  const chainIds = useMemo(
+    () => getPortfolioChainIds({ includeTestnets: showTestnetAssets }),
+    [showTestnetAssets],
+  )
+  // One registry entry list across all in-scope chains; entries carry their
+  // chainId so nothing ever mixes across networks.
+  const registry = useMemo(() => chainIds.flatMap((id) => getPortfolioRegistry(id)), [chainIds])
+  const providers = useMemo(
+    () => new Map(chainIds.map((id) => [id, makeReadProvider(NETWORKS[id].rpcUrl, id)])),
+    [chainIds],
+  )
 
   const [reads, setReads] = useState({ balances: null, failedAssets: [], error: null })
   const [isLoading, setIsLoading] = useState(false)
@@ -73,7 +101,7 @@ export function usePortfolio() {
   const reqIdRef = useRef(0)
 
   const load = useCallback(async () => {
-    if (!isConnected || !address || !provider || registry.length === 0) return
+    if (!isConnected || !address || registry.length === 0) return
     const reqId = ++reqIdRef.current
     setIsLoading(true)
     // A retry after a failed load must leave the error state immediately so
@@ -82,23 +110,27 @@ export function usePortfolio() {
     setReads((prev) => (prev.error ? { balances: null, failedAssets: [], error: null } : prev))
     try {
       const settled = await Promise.allSettled(
-        registry.map((asset) => readAssetBalance(asset, { provider, address })),
+        registry.map((asset) =>
+          readAssetBalance(asset, { provider: providers.get(asset.chainId), address }),
+        ),
       )
       if (reqId !== reqIdRef.current) return
 
       const balances = new Map()
       const failedAssets = []
       settled.forEach((res, i) => {
+        const asset = registry[i]
         if (res.status === 'fulfilled') {
-          balances.set(registry[i].id, res.value)
+          balances.set(`${asset.chainId}:${asset.id}`, res.value)
         } else {
-          failedAssets.push(registry[i].symbol)
+          failedAssets.push(asset.symbol)
         }
       })
 
       if (failedAssets.length === registry.length) {
-        // Nothing readable — an explicit error state, never a $0 portfolio.
-        setReads({ balances: null, failedAssets, error: 'Unable to read balances from the network.' })
+        // Nothing readable on any network — an explicit error state, never a
+        // $0 portfolio.
+        setReads({ balances: null, failedAssets, error: 'Unable to read balances from the supported networks.' })
       } else {
         setReads({ balances, failedAssets, error: null })
         setLastUpdated(Date.now())
@@ -109,17 +141,17 @@ export function usePortfolio() {
     } finally {
       if (reqId === reqIdRef.current) setIsLoading(false)
     }
-  }, [isConnected, address, provider, registry])
+  }, [isConnected, address, providers, registry])
 
-  // Reset synchronously on account/network change so a stale snapshot from
-  // another chain can never render (SC-004), then reload.
+  // Reset synchronously on account or scan-scope change so a stale snapshot
+  // (e.g. testnet rows after the preference flips off) can never render.
   useEffect(() => {
     reqIdRef.current++
     setReads({ balances: null, failedAssets: [], error: null })
     setLastUpdated(null)
     load()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [address, chainId])
+  }, [address, chainIds])
 
   useEffect(() => {
     if (!isConnected || !address) return undefined
@@ -128,20 +160,19 @@ export function usePortfolio() {
   }, [isConnected, address, load])
 
   return useMemo(() => {
-    const supported = registry.length > 0
-
     let status = 'ready'
     if (!isConnected || !address) status = 'disconnected'
     else if (reads.error) status = 'error'
-    // An unsupported network never loads — the panel renders its explicit
-    // state off isSupportedNetwork instead (FR-014).
-    else if (!reads.balances && supported) status = 'loading'
+    else if (!reads.balances) status = 'loading'
 
     const holdings = []
     if (reads.balances) {
       for (const asset of registry) {
-        const raw = reads.balances.get(asset.id)
-        if (raw == null || raw <= 0n) continue
+        const raw = reads.balances.get(`${asset.chainId}:${asset.id}`)
+        if (raw == null) continue
+        // Digital Commodities always render in full (zero balances included);
+        // every other category lists only what the account actually holds.
+        if (raw <= 0n && asset.categoryId !== 'digital-commodities') continue
         holdings.push(toHolding(asset, raw, { nativeUsdRate }))
       }
     }
@@ -162,24 +193,22 @@ export function usePortfolio() {
           category: getTaxonomyCategory(cat.id),
           holdings: catHoldings,
           subtotalUsd: catHoldings.reduce((sum, h) => sum + (h.usd ?? 0), 0),
-          isPartial: catHoldings.some((h) => h.usd == null),
         }
       })
 
     return {
       status,
-      isSupportedNetwork: supported,
       isLoading,
       error: reads.error,
       holdings,
       categories,
       totalUsd: holdings.reduce((sum, h) => sum + (h.usd ?? 0), 0),
-      isPartial: holdings.some((h) => h.usd == null) || reads.failedAssets.length > 0,
       failedAssets: reads.failedAssets,
+      showTestnetAssets,
       lastUpdated,
       refresh: load,
     }
-  }, [registry, isConnected, address, reads, nativeUsdRate, isLoading, lastUpdated, load])
+  }, [registry, isConnected, address, reads, nativeUsdRate, isLoading, lastUpdated, load, showTestnetAssets])
 }
 
 export default usePortfolio

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -20,6 +20,7 @@ import AccountDashboard from '../components/account/AccountDashboard'
 import NotificationPreferencesPanel from '../components/account/NotificationPreferencesPanel'
 import QuickAccessCardsPanel from '../components/account/QuickAccessCardsPanel'
 import WalletDisplayPreferencesPanel from '../components/account/WalletDisplayPreferencesPanel'
+import PortfolioPreferencesPanel from '../components/account/PortfolioPreferencesPanel'
 import AddressBookPanel from '../components/account/AddressBookPanel'
 import BackupPanel from '../components/account/BackupPanel'
 import RecoveryCodesPanel from '../components/account/RecoveryCodesPanel'
@@ -494,6 +495,11 @@ function WalletPage() {
                     <h2 className="preferences-group-heading">Wallet</h2>
                     <div className="section">
                       <WalletDisplayPreferencesPanel address={address} />
+                    </div>
+
+                    <h2 className="preferences-group-heading">Portfolio</h2>
+                    <div className="section">
+                      <PortfolioPreferencesPanel />
                     </div>
 
                     <h2 className="preferences-group-heading">Notifications</h2>

--- a/frontend/src/test/portfolio/PortfolioPanel.axe.test.jsx
+++ b/frontend/src/test/portfolio/PortfolioPanel.axe.test.jsx
@@ -1,5 +1,5 @@
 /**
- * PortfolioPanel (spec 044) — WCAG 2.1 AA audits via vitest-axe (FR-016).
+ * PortfolioPanel (spec 044 + follow-up) — WCAG 2.1 AA audits via vitest-axe.
  */
 import { describe, it, expect, vi } from 'vitest'
 import { render, fireEvent, screen } from '@testing-library/react'
@@ -15,22 +15,25 @@ vi.mock('../../hooks/usePortfolio', () => ({
 
 const HOLDINGS = [
   {
-    asset: { id: 'native', chainId: 137, kind: 'native', address: null, symbol: 'MATIC', name: 'MATIC', categoryId: 'digital-commodities', source: 'sec-baseline' },
+    asset: { id: 'native', chainId: 137, kind: 'native', address: null, symbol: 'MATIC', name: 'MATIC', categoryId: 'digital-commodities', source: 'sec-baseline', decimals: 18 },
     balance: 2,
-    balanceRaw: 2n,
+    balanceRaw: 2n * 10n ** 18n,
     usd: 1,
+    network: 'Polygon',
   },
   {
-    asset: { id: '0xusdc', chainId: 137, kind: 'erc20', address: '0xusdc', symbol: 'USDC', name: 'USD Coin', categoryId: 'payment-stablecoins', source: 'app-config' },
+    asset: { id: '0xusdc', chainId: 137, kind: 'erc20', address: '0xusdc', symbol: 'USDC', name: 'USD Coin', categoryId: 'payment-stablecoins', source: 'app-config', decimals: 6 },
     balance: 100,
-    balanceRaw: 100n,
+    balanceRaw: 100_000_000n,
     usd: 100,
+    network: 'Polygon',
   },
   {
-    asset: { id: '0xlink', chainId: 137, kind: 'erc20', address: '0xlink', symbol: 'LINK', name: 'ChainLink Token', categoryId: 'digital-tools', source: 'curated-registry' },
+    asset: { id: '0xlink', chainId: 137, kind: 'erc20', address: '0xlink', symbol: 'LINK', name: 'ChainLink Token', categoryId: 'digital-tools', source: 'curated-registry', decimals: 18 },
     balance: 5,
-    balanceRaw: 5n,
+    balanceRaw: 5n * 10n ** 18n,
     usd: null,
+    network: 'Polygon',
   },
 ]
 
@@ -39,7 +42,6 @@ function makeSnapshot(overrides = {}) {
   const ids = ['digital-commodities', 'digital-securities', 'payment-stablecoins', 'digital-tools', 'digital-collectibles']
   return {
     status: 'ready',
-    isSupportedNetwork: true,
     isLoading: false,
     error: null,
     holdings,
@@ -49,12 +51,11 @@ function makeSnapshot(overrides = {}) {
         category: getTaxonomyCategory(id),
         holdings: catHoldings,
         subtotalUsd: catHoldings.reduce((s, h) => s + (h.usd ?? 0), 0),
-        isPartial: catHoldings.some((h) => h.usd == null),
       }
     }),
     totalUsd: 101,
-    isPartial: true,
     failedAssets: [],
+    showTestnetAssets: false,
     lastUpdated: 1,
     refresh: vi.fn(),
     ...overrides,
@@ -71,12 +72,19 @@ describe('PortfolioPanel accessibility (WCAG 2.1 AA)', () => {
   it('collapsed category state has no violations', async () => {
     mockUsePortfolio.mockReturnValue(makeSnapshot())
     const { container } = render(<PortfolioPanel />)
-    fireEvent.click(screen.getByRole('button', { name: /payment stablecoins/i }))
+    fireEvent.click(screen.getByRole('button', { name: /payment stablecoins \$/i }))
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('open category info bubble has no violations', async () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot())
+    const { container } = render(<PortfolioPanel />)
+    fireEvent.click(screen.getByRole('button', { name: 'About Digital Commodities' }))
     expect(await axe(container)).toHaveNoViolations()
   })
 
   it('error state has no violations', async () => {
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ status: 'error', error: 'Unable to read balances from the network.' }))
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ status: 'error', error: 'Unable to read balances from the supported networks.' }))
     const { container } = render(<PortfolioPanel />)
     expect(await axe(container)).toHaveNoViolations()
   })

--- a/frontend/src/test/portfolio/PortfolioPanel.test.jsx
+++ b/frontend/src/test/portfolio/PortfolioPanel.test.jsx
@@ -1,5 +1,5 @@
 /**
- * PortfolioPanel (spec 044) — rendering-contract tests.
+ * PortfolioPanel (spec 044 + follow-up) — rendering-contract tests.
  * The data seam (usePortfolio) is mocked; see usePortfolio.test.jsx for the
  * live-read behavior.
  */
@@ -14,12 +14,35 @@ vi.mock('../../hooks/usePortfolio', () => ({
   usePortfolio: (...args) => mockUsePortfolio(...args),
 }))
 
-function makeHolding({ symbol, name, categoryId, source = 'app-config', kind = 'erc20', balance = 1, usd = null }) {
+function makeHolding({
+  symbol,
+  name,
+  categoryId,
+  source = 'app-config',
+  kind = 'erc20',
+  balance = 1,
+  balanceRaw = 1n,
+  usd = null,
+  chainId = 137,
+  network = 'Polygon',
+  decimals,
+}) {
   return {
-    asset: { id: symbol.toLowerCase(), chainId: 137, kind, address: kind === 'native' ? null : `0x${symbol}`, symbol, name, categoryId, source },
+    asset: {
+      id: symbol.toLowerCase(),
+      chainId,
+      kind,
+      address: kind === 'native' ? null : `0x${symbol}`,
+      symbol,
+      name,
+      categoryId,
+      source,
+      decimals,
+    },
     balance,
-    balanceRaw: 1n,
+    balanceRaw,
     usd,
+    network,
   }
 }
 
@@ -38,7 +61,6 @@ function groupsFromHoldings(holdings, { includeUnclassified = false } = {}) {
       category: getTaxonomyCategory(id),
       holdings: catHoldings,
       subtotalUsd: catHoldings.reduce((s, h) => s + (h.usd ?? 0), 0),
-      isPartial: catHoldings.some((h) => h.usd == null),
     }
   })
 }
@@ -47,14 +69,13 @@ function makeSnapshot(overrides = {}) {
   const holdings = overrides.holdings ?? []
   return {
     status: 'ready',
-    isSupportedNetwork: true,
     isLoading: false,
     error: null,
     holdings,
     categories: groupsFromHoldings(holdings, overrides.groupOptions),
     totalUsd: holdings.reduce((s, h) => s + (h.usd ?? 0), 0),
-    isPartial: holdings.some((h) => h.usd == null),
     failedAssets: [],
+    showTestnetAssets: false,
     lastUpdated: 1,
     refresh: vi.fn(),
     ...overrides,
@@ -62,27 +83,22 @@ function makeSnapshot(overrides = {}) {
 }
 
 const POPULATED = [
-  makeHolding({ symbol: 'MATIC', name: 'MATIC', categoryId: 'digital-commodities', source: 'sec-baseline', kind: 'native', balance: 2, usd: 1 }),
-  makeHolding({ symbol: 'USDC', name: 'USD Coin', categoryId: 'payment-stablecoins', source: 'app-config', balance: 100, usd: 100 }),
-  makeHolding({ symbol: 'LINK', name: 'ChainLink Token', categoryId: 'digital-tools', source: 'curated-registry', balance: 5, usd: null }),
+  makeHolding({ symbol: 'MATIC', name: 'MATIC', categoryId: 'digital-commodities', source: 'sec-baseline', kind: 'native', balance: 2, balanceRaw: 2n * 10n ** 18n, decimals: 18, usd: 1 }),
+  makeHolding({ symbol: 'ETH', name: 'Ether', categoryId: 'digital-commodities', source: 'sec-baseline', kind: 'native', balance: 0, balanceRaw: 0n, decimals: 18, usd: 0, chainId: 1, network: 'Ethereum' }),
+  makeHolding({ symbol: 'USDC', name: 'USD Coin', categoryId: 'payment-stablecoins', source: 'app-config', balance: 100, balanceRaw: 100_000_000n, decimals: 6, usd: 100 }),
+  makeHolding({ symbol: 'LINK', name: 'ChainLink Token', categoryId: 'digital-tools', source: 'curated-registry', balance: 5, balanceRaw: 5n * 10n ** 18n, decimals: 18, usd: null }),
 ]
 
 beforeEach(() => {
   mockUsePortfolio.mockReset()
 })
 
-describe('PortfolioPanel states (FR-014)', () => {
+describe('PortfolioPanel states', () => {
   it('shows a connect prompt when disconnected', () => {
     mockUsePortfolio.mockReturnValue(makeSnapshot({ status: 'disconnected' }))
     render(<PortfolioPanel />)
     expect(screen.getByText(/connect a wallet/i)).toBeInTheDocument()
     expect(screen.queryByText(/total portfolio balance/i)).not.toBeInTheDocument()
-  })
-
-  it('shows an explicit unavailable state on unsupported networks', () => {
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ status: 'ready', isSupportedNetwork: false, categories: [] }))
-    render(<PortfolioPanel />)
-    expect(screen.getByText(/isn't available on this network/i)).toBeInTheDocument()
   })
 
   it('shows a loading state', () => {
@@ -92,7 +108,7 @@ describe('PortfolioPanel states (FR-014)', () => {
   })
 
   it('shows the error state with a working retry', () => {
-    const snapshot = makeSnapshot({ status: 'error', error: 'Unable to read balances from the network.' })
+    const snapshot = makeSnapshot({ status: 'error', error: 'Unable to read balances from the supported networks.' })
     mockUsePortfolio.mockReturnValue(snapshot)
     render(<PortfolioPanel />)
     expect(screen.getByRole('alert')).toHaveTextContent(/unable to read balances/i)
@@ -115,32 +131,40 @@ describe('PortfolioPanel portfolio view', () => {
     expect(within(stables).getByText('$100.00')).toBeInTheDocument()
   })
 
-  it('renders unpriced assets with an em dash — never $0.00 — and labels totals partial (SC-005)', () => {
+  it('labels each row with its network', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
+    render(<PortfolioPanel />)
+    const commodities = screen.getByRole('region', { name: 'Digital Commodities' })
+    expect(within(commodities).getByText('Polygon')).toBeInTheDocument()
+    expect(within(commodities).getByText('Ethereum')).toBeInTheDocument()
+  })
+
+  it('renders zero-balance commodities as an honest 0 worth $0.00', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
+    render(<PortfolioPanel />)
+    const commodities = screen.getByRole('region', { name: 'Digital Commodities' })
+    expect(within(commodities).getByText('0 ETH')).toBeInTheDocument()
+    expect(within(commodities).getByText('$0.00')).toBeInTheDocument()
+  })
+
+  it('renders unpriced assets with an em dash and no partial labeling anywhere', () => {
     mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
     render(<PortfolioPanel />)
 
     const tools = screen.getByRole('region', { name: 'Digital Tools' })
     expect(within(tools).getByText('price unavailable')).toBeInTheDocument()
     expect(within(tools).queryByText('$0.00')).not.toBeInTheDocument()
-
-    // Grand total and the affected category flag partial.
-    expect(screen.getAllByText(/\(partial\)/i).length).toBeGreaterThanOrEqual(2)
-    expect(screen.getByText(/excluded from USD totals/i)).toBeInTheDocument()
-  })
-
-  it('names unreadable assets in the partial note', () => {
-    mockUsePortfolio.mockReturnValue(
-      makeSnapshot({ holdings: POPULATED, isPartial: true, failedAssets: ['WBTC'] }),
-    )
-    render(<PortfolioPanel />)
-    expect(screen.getByText(/unreadable: WBTC/i)).toBeInTheDocument()
+    expect(screen.queryByText(/\(partial\)/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/excluded from USD totals/i)).not.toBeInTheDocument()
   })
 
   it('collapses a category on toggle, keeping header and subtotal visible', () => {
     mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
     render(<PortfolioPanel />)
 
-    const toggle = screen.getByRole('button', { name: /payment stablecoins/i })
+    // The toggle's accessible name includes the subtotal, which separates it
+    // from the "About Payment Stablecoins" info-bubble button.
+    const toggle = screen.getByRole('button', { name: /payment stablecoins \$/i })
     expect(toggle).toHaveAttribute('aria-expanded', 'true')
 
     fireEvent.click(toggle)
@@ -161,35 +185,24 @@ describe('PortfolioPanel portfolio view', () => {
     expect(within(securities).getByText(/no assets in this category/i)).toBeInTheDocument()
   })
 
-  it('renders all five regulatory categories with $0.00 subtotals when nothing is held', () => {
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: [] }))
-    render(<PortfolioPanel />)
-    expect(screen.getAllByText(/no assets in this category/i)).toHaveLength(5)
-    expect(screen.getAllByText('$0.00').length).toBeGreaterThanOrEqual(6) // total + 5 subtotals
-  })
-
   it('never renders a nonzero dust balance as zero (honest state)', () => {
-    const dust = {
-      asset: { id: '0xweth', chainId: 137, kind: 'erc20', address: '0xweth', symbol: 'WETH', name: 'Wrapped Ether', categoryId: 'digital-commodities', source: 'sec-baseline', decimals: 18 },
+    const dust = makeHolding({
+      symbol: 'WETH',
+      name: 'Wrapped Ether',
+      categoryId: 'digital-commodities',
+      source: 'sec-baseline',
       balance: 1e-18,
       balanceRaw: 1n, // 1 wei of WETH
+      decimals: 18,
       usd: null,
-    }
-    const usdc = {
-      asset: { id: '0xusdc2', chainId: 137, kind: 'erc20', address: '0xusdc2', symbol: 'USDC', name: 'USD Coin', categoryId: 'payment-stablecoins', source: 'app-config', decimals: 6 },
-      balance: 1234.5,
-      balanceRaw: 1_234_500_000n,
-      usd: 1234.5,
-    }
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: [dust, usdc] }))
+    })
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: [dust] }))
     render(<PortfolioPanel />)
-    // Raw-units formatting: dust floors at "< 0.000001", never "0 WETH".
     expect(screen.getByText('< 0.000001 WETH')).toBeInTheDocument()
     expect(screen.queryByText(/^0 WETH$/)).not.toBeInTheDocument()
-    expect(screen.getByText('1,234.5 USDC')).toBeInTheDocument()
   })
 
-  it('refresh button triggers a reload (FR-015)', () => {
+  it('refresh button triggers a reload', () => {
     const snapshot = makeSnapshot({ holdings: POPULATED })
     mockUsePortfolio.mockReturnValue(snapshot)
     render(<PortfolioPanel />)
@@ -198,38 +211,64 @@ describe('PortfolioPanel portfolio view', () => {
   })
 })
 
-describe('PortfolioPanel taxonomy provenance (US2)', () => {
-  it('exposes each category description from its header region', () => {
+describe('PortfolioPanel taxonomy provenance (info bubbles)', () => {
+  it('keeps category descriptions out of the page until the info bubble opens', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
+    render(<PortfolioPanel />)
+    const commodities = getTaxonomyCategory('digital-commodities')
+
+    // Dense inline explainer is gone…
+    expect(screen.queryByText(commodities.description)).not.toBeInTheDocument()
+
+    // …and lives in the shared InfoTip bubble beside the category header.
+    fireEvent.click(screen.getByRole('button', { name: 'About Digital Commodities' }))
+    expect(screen.getByText(commodities.description)).toBeInTheDocument()
+  })
+
+  it('offers an info bubble for every rendered category', () => {
     mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
     render(<PortfolioPanel />)
     for (const id of ['digital-commodities', 'digital-securities', 'payment-stablecoins', 'digital-tools', 'digital-collectibles']) {
       const cat = getTaxonomyCategory(id)
-      const region = screen.getByRole('region', { name: cat.label })
-      expect(within(region).getByText(cat.description)).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: `About ${cat.label}` })).toBeInTheDocument()
     }
   })
 
-  it('labels each row with its classification source (FR-006)', () => {
+  it('labels each row with its classification source', () => {
     mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
     render(<PortfolioPanel />)
-    expect(screen.getByText('SEC baseline')).toBeInTheDocument()
+    expect(screen.getAllByText('SEC baseline').length).toBeGreaterThan(0)
     expect(screen.getByText('Curated registry')).toBeInTheDocument()
     expect(screen.getByText('App configuration')).toBeInTheDocument()
   })
 
-  it('always shows the informational and coverage disclosures in the portfolio view (FR-013)', () => {
+  it('always shows the compact disclosure line in the portfolio view', () => {
     mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: [] }))
     render(<PortfolioPanel />)
     expect(screen.getByText(/not legal or investment advice/i)).toBeInTheDocument()
-    expect(screen.getByText(/only assets in the app's curated registry are scanned/i)).toBeInTheDocument()
+    expect(screen.getByText(/curated registry are scanned/i)).toBeInTheDocument()
   })
 })
 
-describe('PortfolioPanel unclassified handling (US3, FR-012)', () => {
+describe('PortfolioPanel testnet visibility', () => {
+  it('notes that testnet tokens are hidden when the preference is off', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED, showTestnetAssets: false }))
+    render(<PortfolioPanel />)
+    expect(screen.getByText(/testnet tokens are hidden/i)).toBeInTheDocument()
+  })
+
+  it('drops the note when testnet tokens are shown', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED, showTestnetAssets: true }))
+    render(<PortfolioPanel />)
+    expect(screen.queryByText(/testnet tokens are hidden/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('PortfolioPanel unclassified handling', () => {
   it('renders unclassified holdings in an explicit Unclassified group', () => {
     const holdings = [
       ...POPULATED,
-      makeHolding({ symbol: 'MYST', name: 'Mystery Token', categoryId: 'unclassified', balance: 3, usd: null }),
+      makeHolding({ symbol: 'MYST', name: 'Mystery Token', categoryId: 'unclassified', balance: 3, balanceRaw: 3n * 10n ** 18n, decimals: 18, usd: null }),
     ]
     mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings, groupOptions: { includeUnclassified: true } }))
     render(<PortfolioPanel />)
@@ -241,6 +280,5 @@ describe('PortfolioPanel unclassified handling (US3, FR-012)', () => {
     mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
     render(<PortfolioPanel />)
     expect(screen.queryByRole('region', { name: 'Unclassified' })).not.toBeInTheDocument()
-    expect(screen.queryByText('Unclassified')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/test/portfolio/PortfolioPreferencesPanel.test.jsx
+++ b/frontend/src/test/portfolio/PortfolioPreferencesPanel.test.jsx
@@ -1,0 +1,46 @@
+/**
+ * PortfolioPreferencesPanel (spec 044 follow-up) — the Preferences → Portfolio
+ * settings group with the "show testnet tokens" switch.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import PortfolioPreferencesPanel from '../../components/account/PortfolioPreferencesPanel'
+
+const mockPrefs = { preferences: { showTestnetAssets: false }, setShowTestnetAssets: vi.fn() }
+vi.mock('../../hooks/useUserPreferences', () => ({
+  useUserPreferences: () => mockPrefs,
+}))
+
+beforeEach(() => {
+  mockPrefs.preferences = { showTestnetAssets: false }
+  mockPrefs.setShowTestnetAssets = vi.fn()
+})
+
+describe('PortfolioPreferencesPanel', () => {
+  it('renders an accessible switch reflecting the stored preference', () => {
+    render(<PortfolioPreferencesPanel />)
+    const toggle = screen.getByRole('switch', { name: /show testnet tokens/i })
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+    expect(screen.getByText(/mainnet assets only/i)).toBeInTheDocument()
+  })
+
+  it('flips the preference on click', () => {
+    render(<PortfolioPreferencesPanel />)
+    fireEvent.click(screen.getByRole('switch', { name: /show testnet tokens/i }))
+    expect(mockPrefs.setShowTestnetAssets).toHaveBeenCalledWith(true)
+  })
+
+  it('describes the enabled state and turns off again', () => {
+    mockPrefs.preferences = { showTestnetAssets: true }
+    render(<PortfolioPreferencesPanel />)
+    expect(screen.getByText(/sepolia, amoy, mordor/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('switch', { name: /show testnet tokens/i }))
+    expect(mockPrefs.setShowTestnetAssets).toHaveBeenCalledWith(false)
+  })
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<PortfolioPreferencesPanel />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/portfolio/assetTaxonomy.test.js
+++ b/frontend/src/test/portfolio/assetTaxonomy.test.js
@@ -8,6 +8,7 @@ import {
   CLASSIFICATION_SOURCES,
   SEC_COMMODITY_BASELINE,
   getPortfolioRegistry,
+  getPortfolioChainIds,
   getTaxonomyCategory,
 } from '../../config/assetTaxonomy'
 import { listSupportedChainIds, NETWORKS } from '../../config/networks'
@@ -39,6 +40,25 @@ describe('TAXONOMY_CATEGORIES', () => {
     expect(getTaxonomyCategory('digital-tools').id).toBe('digital-tools')
     expect(getTaxonomyCategory('nonsense').id).toBe('unclassified')
     expect(getTaxonomyCategory(undefined).id).toBe('unclassified')
+  })
+})
+
+describe('getPortfolioChainIds', () => {
+  it('scans mainnets only by default (Ethereum, Ethereum Classic, Polygon)', () => {
+    expect(new Set(getPortfolioChainIds())).toEqual(new Set([1, 61, 137]))
+  })
+
+  it('adds Sepolia, Amoy, and Mordor when testnets are enabled', () => {
+    expect(new Set(getPortfolioChainIds({ includeTestnets: true }))).toEqual(
+      new Set([1, 61, 137, 11155111, 80002, 63]),
+    )
+  })
+
+  it('orders mainnets before testnets and never includes local sandboxes', () => {
+    const ids = getPortfolioChainIds({ includeTestnets: true })
+    expect(ids).not.toContain(1337)
+    const testnetFlags = ids.map((id) => Boolean(NETWORKS[id].isTestnet))
+    expect(testnetFlags.indexOf(true)).toBeGreaterThanOrEqual(testnetFlags.lastIndexOf(false))
   })
 })
 
@@ -119,6 +139,17 @@ describe('getPortfolioRegistry', () => {
     expect(bySymbol.LINK.source).toBe('curated-registry')
     expect(bySymbol.USDT.categoryId).toBe('payment-stablecoins')
     expect(bySymbol.USDT.source).toBe('curated-registry')
+  })
+
+  it('covers Sepolia: baseline-commodity native ETH plus Circle USDC', () => {
+    const registry = getPortfolioRegistry(11155111)
+    const native = registry.find((e) => e.kind === 'native')
+    expect(native.symbol).toBe('ETH')
+    expect(native.categoryId).toBe('digital-commodities')
+    expect(native.source).toBe('sec-baseline')
+    const usdc = registry.find((e) => e.symbol === 'USDC')
+    expect(usdc.categoryId).toBe('payment-stablecoins')
+    expect(usdc.source).toBe('app-config')
   })
 
   it('scans canonical WETH on Ethereum mainnet despite no dex/wmatic config', () => {

--- a/frontend/src/test/portfolio/usePortfolio.test.jsx
+++ b/frontend/src/test/portfolio/usePortfolio.test.jsx
@@ -1,57 +1,68 @@
 /**
- * usePortfolio (spec 044) — live-balance hook tests.
+ * usePortfolio (spec 044 + follow-up) — cross-chain balance hook tests.
  *
  * Wallet + price state are mocked at the context level per repo convention —
- * never raw wagmi hooks. Chain reads are stubbed by replacing ethers'
- * Contract with an address-keyed fixture map.
+ * never raw wagmi hooks. Per-chain read providers (utils/rpcProvider) and
+ * ethers' Contract are stubbed with chain-scoped fixture maps.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, waitFor, act } from '@testing-library/react'
 import { WalletContext } from '../../contexts'
 import PriceContext from '../../contexts/PriceContext'
 import usePortfolio from '../../hooks/usePortfolio'
-import { getPortfolioRegistry } from '../../config/assetTaxonomy'
+import { getPortfolioRegistry, getPortfolioChainIds } from '../../config/assetTaxonomy'
 import { NETWORKS } from '../../config/networks'
 
-// Address-keyed ERC-20/721 balance fixtures. A value may be a bigint or a
-// function (to simulate rejections). Unlisted addresses read as 0n.
-const tokenBalances = new Map()
+// Chain-scoped fixtures. Values may be bigints or functions (to simulate
+// rejections). Unlisted assets read as 0n.
+const fixtures = vi.hoisted(() => ({
+  nativeBalances: new Map(), // chainId -> bigint | fn
+  tokenBalances: new Map(), // `${chainId}:${addressLower}` -> bigint | fn
+  prefs: { showTestnetAssets: false },
+}))
+
+function resolveFixture(value) {
+  if (typeof value === 'function') return value()
+  return Promise.resolve(value ?? 0n)
+}
+
+vi.mock('../../utils/rpcProvider', () => ({
+  makeReadProvider: (url, chainId) => ({
+    chainId,
+    getBalance: () => resolveFixture(fixtures.nativeBalances.get(chainId)),
+  }),
+}))
 
 vi.mock('ethers', async (importOriginal) => {
   const actual = await importOriginal()
   return {
     ...actual,
     Contract: class {
-      constructor(address) {
-        this.address = String(address).toLowerCase()
+      constructor(address, abi, provider) {
+        this.key = `${provider.chainId}:${String(address).toLowerCase()}`
       }
 
       balanceOf() {
-        const fixture = tokenBalances.get(this.address)
-        if (typeof fixture === 'function') return fixture()
-        return Promise.resolve(fixture ?? 0n)
+        return resolveFixture(fixtures.tokenBalances.get(this.key))
       }
     },
   }
 })
 
+vi.mock('../../hooks/useUserPreferences', () => ({
+  useUserPreferences: () => ({
+    preferences: { ...fixtures.prefs },
+    setShowTestnetAssets: vi.fn(),
+  }),
+}))
+
 const ADDRESS = '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'
 
-const registry137 = getPortfolioRegistry(137)
-const addr = (symbol) => registry137.find((e) => e.symbol === symbol).address.toLowerCase()
-
-function makeProvider(nativeBalance = 0n) {
-  return { getBalance: vi.fn().mockResolvedValue(nativeBalance) }
-}
+const addr = (chainId, symbol) =>
+  `${chainId}:${getPortfolioRegistry(chainId).find((e) => e.symbol === symbol).address.toLowerCase()}`
 
 function makeWallet(overrides = {}) {
-  return {
-    address: ADDRESS,
-    isConnected: true,
-    chainId: 137,
-    provider: makeProvider(),
-    ...overrides,
-  }
+  return { address: ADDRESS, isConnected: true, chainId: 137, ...overrides }
 }
 
 const PRICE_OK = { nativeUsdRate: 0.5, error: null }
@@ -72,172 +83,153 @@ function Harness({ wallet, price = PRICE_OK }) {
   )
 }
 
-async function renderPortfolio(props) {
+async function renderPortfolio(props = {}) {
   let view
   await act(async () => {
-    view = render(<Harness {...props} />)
+    view = render(<Harness wallet={props.wallet || makeWallet()} price={props.price || PRICE_OK} />)
   })
   return view
 }
 
 beforeEach(() => {
-  tokenBalances.clear()
+  fixtures.nativeBalances.clear()
+  fixtures.tokenBalances.clear()
+  fixtures.prefs.showTestnetAssets = false
   latest = undefined
 })
 
-describe('usePortfolio', () => {
-  it('is disconnected without a connected account and issues no reads', async () => {
-    const provider = makeProvider()
-    await renderPortfolio({ wallet: makeWallet({ address: undefined, isConnected: false, provider }) })
+describe('usePortfolio (cross-chain)', () => {
+  it('is disconnected without a connected account', async () => {
+    await renderPortfolio({ wallet: makeWallet({ address: undefined, isConnected: false }) })
     expect(latest.status).toBe('disconnected')
     expect(latest.holdings).toEqual([])
-    expect(provider.getBalance).not.toHaveBeenCalled()
   })
 
-  it('maps nonzero balances to categorized holdings and drops zero balances', async () => {
-    tokenBalances.set(addr('USDC'), 100_000_000n) // 100 USDC (6 decimals)
-    await renderPortfolio({ wallet: makeWallet({ provider: makeProvider(2n * 10n ** 18n) }) })
+  it('scans mainnets only by default and never lists testnet assets', async () => {
+    fixtures.nativeBalances.set(137, 2n * 10n ** 18n)
+    fixtures.tokenBalances.set(addr(137, 'USDC'), 100_000_000n)
+    fixtures.tokenBalances.set(addr(63, 'USC'), 40_000_000n) // Mordor — must stay hidden
+    await renderPortfolio()
     await waitFor(() => expect(latest.status).toBe('ready'))
 
-    expect(latest.holdings).toHaveLength(2)
-    const bySymbol = Object.fromEntries(latest.holdings.map((h) => [h.asset.symbol, h]))
-    // Native MATIC priced by the feed (2 × $0.50), stablecoin at par $1.
-    expect(bySymbol.MATIC.balance).toBe(2)
-    expect(bySymbol.MATIC.usd).toBeCloseTo(1)
-    expect(bySymbol.USDC.usd).toBeCloseTo(100)
-    expect(latest.totalUsd).toBeCloseTo(101)
-    expect(latest.isPartial).toBe(false)
-
-    // Zero-balance registry assets are not holdings; regulatory categories
-    // still all render (with empty groups), unclassified stays hidden.
-    expect(latest.categories.map((g) => g.category.id)).toEqual([
-      'digital-commodities',
-      'digital-securities',
-      'payment-stablecoins',
-      'digital-tools',
-      'digital-collectibles',
-    ])
-    const commodities = latest.categories.find((g) => g.category.id === 'digital-commodities')
-    expect(commodities.subtotalUsd).toBeCloseTo(1)
-    expect(latest.categories.find((g) => g.category.id === 'digital-securities').holdings).toEqual([])
+    const mainnets = new Set(getPortfolioChainIds())
+    expect(mainnets.has(63)).toBe(false)
+    for (const h of latest.holdings) {
+      expect(mainnets.has(h.asset.chainId)).toBe(true)
+    }
+    expect(latest.holdings.some((h) => h.asset.symbol === 'USC')).toBe(false)
+    expect(latest.totalUsd).toBeCloseTo(101) // 2 MATIC × $0.50 + 100 USDC
   })
 
-  it('renders NFT holdings as item counts with no price', async () => {
-    tokenBalances.set(addr('FWMV'), 2n)
-    await renderPortfolio({ wallet: makeWallet() })
+  it('lists every digital commodity across scanned chains, zero balances included', async () => {
+    await renderPortfolio()
+    await waitFor(() => expect(latest.status).toBe('ready'))
+
+    const commodities = latest.categories.find((g) => g.category.id === 'digital-commodities')
+    const expected = getPortfolioChainIds()
+      .flatMap((id) => getPortfolioRegistry(id))
+      .filter((e) => e.categoryId === 'digital-commodities')
+    expect(commodities.holdings).toHaveLength(expected.length)
+    // Zero of anything is honestly worth $0.00 — no dash, no fabricated price.
+    const zeroEth = commodities.holdings.find((h) => h.asset.chainId === 1 && h.asset.kind === 'native')
+    expect(zeroEth.balance).toBe(0)
+    expect(zeroEth.usd).toBe(0)
+    expect(zeroEth.network).toBe('Ethereum')
+    // Other categories stay holdings-only: no zero-balance stablecoin rows.
+    const stables = latest.categories.find((g) => g.category.id === 'payment-stablecoins')
+    expect(stables.holdings).toEqual([])
+  })
+
+  it('includes testnet chains when the preference is on', async () => {
+    fixtures.prefs.showTestnetAssets = true
+    fixtures.nativeBalances.set(63, 10n ** 18n) // 1 ETC on Mordor
+    fixtures.tokenBalances.set(addr(63, 'USC'), 40_000_000n)
+    await renderPortfolio()
+    await waitFor(() => expect(latest.status).toBe('ready'))
+
+    const usc = latest.holdings.find((h) => h.asset.symbol === 'USC')
+    expect(usc.usd).toBeCloseTo(40)
+    expect(usc.network).toBe('Ethereum Classic Mordor')
+    // A nonzero ETC native must NOT be priced with the MATIC feed rate.
+    const mordorNative = latest.holdings.find(
+      (h) => h.asset.chainId === 63 && h.asset.kind === 'native',
+    )
+    expect(mordorNative.balance).toBe(1)
+    expect(mordorNative.usd).toBeNull()
+    // Sepolia joins the scan set alongside Amoy and Mordor.
+    expect(getPortfolioChainIds({ includeTestnets: true })).toContain(11155111)
+    expect(latest.holdings.some((h) => h.asset.chainId === 11155111)).toBe(true)
+  })
+
+  it('treats an errored price feed as no price rather than using the fallback rate', async () => {
+    fixtures.nativeBalances.set(137, 10n ** 18n)
+    await renderPortfolio({ price: { nativeUsdRate: 0.5, error: 'feed down' } })
+    await waitFor(() => expect(latest.status).toBe('ready'))
+    const matic = latest.holdings.find((h) => h.asset.chainId === 137 && h.asset.kind === 'native')
+    expect(matic.usd).toBeNull()
+    expect(latest.totalUsd).toBe(0)
+  })
+
+  it('renders NFT holdings as item counts', async () => {
+    fixtures.tokenBalances.set(addr(137, 'FWMV'), 2n)
+    await renderPortfolio()
     await waitFor(() => expect(latest.status).toBe('ready'))
     const voucher = latest.holdings.find((h) => h.asset.symbol === 'FWMV')
     expect(voucher.balance).toBe(2)
     expect(voucher.usd).toBeNull()
   })
 
-  it('marks unpriced assets usd:null, excludes them from totals, and flags partial (FR-010)', async () => {
-    tokenBalances.set(addr('WETH'), 10n ** 18n) // 1 WETH — no price feed
-    tokenBalances.set(addr('USDC'), 50_000_000n)
-    await renderPortfolio({ wallet: makeWallet() })
+  it('skips failed reads (named in failedAssets) instead of rendering zeros', async () => {
+    fixtures.tokenBalances.set(addr(137, 'LINK'), () => Promise.reject(new Error('revert')))
+    fixtures.tokenBalances.set(addr(137, 'USDC'), 25_000_000n)
+    await renderPortfolio()
     await waitFor(() => expect(latest.status).toBe('ready'))
 
-    const weth = latest.holdings.find((h) => h.asset.symbol === 'WETH')
-    expect(weth.usd).toBeNull()
-    expect(latest.totalUsd).toBeCloseTo(50)
-    expect(latest.isPartial).toBe(true)
-    const commodities = latest.categories.find((g) => g.category.id === 'digital-commodities')
-    expect(commodities.isPartial).toBe(true)
-  })
-
-  it('treats an errored price feed as no price rather than using the fallback rate', async () => {
-    await renderPortfolio({
-      wallet: makeWallet({ provider: makeProvider(10n ** 18n) }),
-      price: { nativeUsdRate: 0.5, error: 'feed down' },
-    })
-    await waitFor(() => expect(latest.status).toBe('ready'))
-    const native = latest.holdings.find((h) => h.asset.kind === 'native')
-    expect(native.usd).toBeNull()
-    expect(latest.isPartial).toBe(true)
-  })
-
-  it('surfaces single failed reads as partial with the asset named, never as zero', async () => {
-    tokenBalances.set(addr('LINK'), () => Promise.reject(new Error('revert')))
-    tokenBalances.set(addr('USDC'), 25_000_000n)
-    await renderPortfolio({ wallet: makeWallet() })
-    await waitFor(() => expect(latest.status).toBe('ready'))
-
-    expect(latest.failedAssets).toEqual(['LINK'])
-    expect(latest.isPartial).toBe(true)
+    expect(latest.failedAssets).toContain('LINK')
     expect(latest.holdings.some((h) => h.asset.symbol === 'LINK')).toBe(false)
     expect(latest.totalUsd).toBeCloseTo(25)
   })
 
-  it('enters the error state with retry when every read fails', async () => {
-    const provider = { getBalance: vi.fn().mockRejectedValue(new Error('rpc down')) }
-    for (const entry of registry137) {
-      if (entry.address) tokenBalances.set(entry.address.toLowerCase(), () => Promise.reject(new Error('rpc down')))
+  it('enters the error state when every read fails, and retry recovers via loading', async () => {
+    const reject = () => Promise.reject(new Error('rpc down'))
+    for (const id of getPortfolioChainIds()) {
+      fixtures.nativeBalances.set(id, reject)
+      for (const entry of getPortfolioRegistry(id)) {
+        if (entry.address) fixtures.tokenBalances.set(`${id}:${entry.address.toLowerCase()}`, reject)
+      }
     }
-    await renderPortfolio({ wallet: makeWallet({ provider }) })
+    await renderPortfolio()
     await waitFor(() => expect(latest.status).toBe('error'))
-    expect(latest.error).toBeTruthy()
     expect(latest.holdings).toEqual([])
 
-    // Retry must leave the error state immediately (loading, not a stale
-    // error inviting retry spam) while the new request is in flight.
+    // Retry leaves the error state immediately (loading, not retry spam)...
     let resolveNative
-    provider.getBalance.mockImplementation(() => new Promise((res) => { resolveNative = res }))
-    tokenBalances.clear()
+    fixtures.nativeBalances.set(137, () => new Promise((res) => { resolveNative = res }))
     act(() => {
       latest.refresh()
     })
     await waitFor(() => expect(latest.status).toBe('loading'))
     expect(latest.error).toBeNull()
 
-    // Recovery: the network comes back and the reload lands on ready.
+    // ...and lands on ready once the network answers.
     await act(async () => {
       resolveNative(10n ** 18n)
     })
     await waitFor(() => expect(latest.status).toBe('ready'))
-    expect(latest.holdings.some((h) => h.asset.kind === 'native')).toBe(true)
   })
 
-  it('reports unsupported networks explicitly instead of loading forever', async () => {
-    await renderPortfolio({ wallet: makeWallet({ chainId: 999999 }) })
-    expect(latest.isSupportedNetwork).toBe(false)
-    expect(latest.status).not.toBe('loading')
-    expect(latest.holdings).toEqual([])
-  })
-
-  it('clears the snapshot on chain switch and never leaks assets across networks (SC-004)', async () => {
-    tokenBalances.set(addr('USDC'), 100_000_000n)
-    const view = await renderPortfolio({ wallet: makeWallet({ provider: makeProvider(10n ** 18n) }) })
-    await waitFor(() => expect(latest.status).toBe('ready'))
-    expect(latest.holdings.length).toBeGreaterThan(0)
-
-    // Switch to Mordor (63): the old snapshot must clear synchronously.
-    const uscAddress = NETWORKS[63].stablecoin.address.toLowerCase()
-    tokenBalances.set(uscAddress, 40_000_000n) // 40 USC
-    await act(async () => {
-      view.rerender(<Harness wallet={makeWallet({ chainId: 63, provider: makeProvider(10n ** 18n) })} price={PRICE_OK} />)
+  it('refresh() reloads balances on demand', async () => {
+    let calls = 0
+    fixtures.nativeBalances.set(137, () => {
+      calls++
+      return Promise.resolve(10n ** 18n)
     })
+    await renderPortfolio()
     await waitFor(() => expect(latest.status).toBe('ready'))
-
-    for (const holding of latest.holdings) {
-      expect(holding.asset.chainId).toBe(63)
-    }
-    // ETC native must NOT be priced with the MATIC feed rate.
-    const native = latest.holdings.find((h) => h.asset.kind === 'native')
-    expect(native.asset.symbol).toBe('ETC')
-    expect(native.usd).toBeNull()
-    const usc = latest.holdings.find((h) => h.asset.symbol === 'USC')
-    expect(usc.usd).toBeCloseTo(40)
-  })
-
-  it('refresh() reloads balances on demand (FR-015)', async () => {
-    const provider = makeProvider(10n ** 18n)
-    await renderPortfolio({ wallet: makeWallet({ provider }) })
-    await waitFor(() => expect(latest.status).toBe('ready'))
-    const callsAfterLoad = provider.getBalance.mock.calls.length
-
+    const callsAfterLoad = calls
     await act(async () => {
       await latest.refresh()
     })
-    expect(provider.getBalance.mock.calls.length).toBeGreaterThan(callsAfterLoad)
+    expect(calls).toBeGreaterThan(callsAfterLoad)
   })
 })

--- a/specs/044-connected-account-portfolio/spec.md
+++ b/specs/044-connected-account-portfolio/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-10
 
-**Status**: Draft
+**Status**: Implemented (v1.0 merged in PR #836); v1.1 follow-up in progress
 
 **Input**: User description: "Connected Account Portfolio in the Finance section. Add a new 'Portfolio' section under My Wallet → Finance that shows the connected account's assets grouped by SEC/CFTC regulatory taxonomy categories, matching the provided mobile mockup (total portfolio balance at top, collapsible category sections each with a category subtotal and per-asset rows showing balance and USD value). Categories: Digital Securities, Digital Commodities, Digital Collectibles, Digital Tools, Payment Stablecoins. Classification uses the official SEC commodity list as a hardcoded baseline plus curated open-source registry lists mapped to the regulatory definitions. Assets shown must be the real on-chain holdings of the connected account, scoped to the active network. Unclassified tokens must be handled honestly."
 
@@ -256,3 +256,26 @@ rows, subtotals, and totals now reflect only the new network and its registry.
 - The mobile mockup is a visual reference for structure (header total, collapsible
   category sections, asset rows); exact visual styling follows the app's existing
   design system rather than the mockup's.
+
+## Follow-up Amendments (v1.1, 2026-07-10)
+
+Owner-requested refinements after v1.0 shipped ("the page is too information dense"):
+
+- **FR-017**: Category regulatory descriptions move out of the inline layout into the
+  app's shared info bubbles (spec 039 `InfoTip`) on each category header.
+- **FR-018**: The Digital Commodities category lists ALL registry commodity assets in
+  scope, including zero balances (a zero balance renders as a true 0 worth $0.00);
+  other categories remain holdings-only.
+- **FR-019**: Partial-balance labeling is removed. Unpriced assets still show their
+  balance with USD as "—" and are excluded from USD sums; a single compact disclosure
+  line states that totals include only priced assets. (Supersedes the FR-010 labeling
+  requirement; the no-fabricated-USD rule stands.)
+- **FR-020**: The portfolio is cross-chain: it scans every supported network
+  (Ethereum, Ethereum Classic, Polygon, and — when enabled — Sepolia, Amoy, Mordor)
+  over per-network read providers, independent of the wallet's active chain. Each row
+  is labeled with its network. (Supersedes FR-003's single-active-network scoping;
+  the never-mix-networks rule now applies per row.) Sepolia is added to the network
+  config as a portfolio-scan-only testnet.
+- **FR-021**: A "Portfolio" settings group in Preferences holds a "Show testnet
+  tokens" switch (default off, persisted per wallet). When off, testnet networks are
+  not scanned and a compact note in the portfolio says testnet tokens are hidden.

--- a/specs/044-connected-account-portfolio/tasks.md
+++ b/specs/044-connected-account-portfolio/tasks.md
@@ -111,3 +111,12 @@ Ship US1 as the MVP (registry + hook + panel + nav). US2/US3 are small panel/con
 increments on top; US4 hardens scoping/freshness; polish gates close with axe + ESLint +
 full suite. Since all stories land in one PR here, implement sequentially US1 → US2 →
 US3 → US4 → Polish, validating each checkpoint's tests before moving on.
+
+## Phase 8: Follow-up v1.1 (density, cross-chain, testnet preference)
+
+- [X] T019 Add Sepolia (11155111) to `frontend/src/config/networks.js` as a portfolio-scan-only testnet (publicnode RPC, Circle Sepolia USDC, all capabilities off, not selectable)
+- [X] T020 Add `getPortfolioChainIds({ includeTestnets })` to `frontend/src/config/assetTaxonomy.js` (all networks except local sandboxes, mainnets first, testnets opt-in)
+- [X] T021 Rewrite `frontend/src/hooks/usePortfolio.js` for cross-chain reads via `makeReadProvider` per network; always-list digital commodities (zero balances render as 0 / $0.00); drop partial-total labeling; scope reset on preference change
+- [X] T022 Rework `frontend/src/components/wallet/PortfolioPanel.jsx`: category descriptions in shared `InfoTip` bubbles, per-row network badges, no partial labels, compact single-line disclosure, testnet-hidden note
+- [X] T023 Add `showTestnetAssets` preference (default false, persisted per wallet) to `frontend/src/contexts/UserPreferencesContext.jsx` and a Preferences → Portfolio group (`frontend/src/components/account/PortfolioPreferencesPanel.jsx`) wired into WalletPage
+- [X] T024 Update/extend tests: cross-chain hook suite, InfoTip/network/no-partial panel suite, `getPortfolioChainIds` + Sepolia registry tests, PortfolioPreferencesPanel suite, refreshed axe audits


### PR DESCRIPTION
## Summary

Follow-up to #836 addressing information density and coverage of the Connected Account Portfolio (spec 044 v1.1 amendments, FR-017–FR-021):

- **Info bubbles** — category regulatory descriptions move out of the inline layout into the app's shared `InfoTip` toggletips (spec 039) beside each category header.
- **All commodities listed** — the Digital Commodities section always lists every registry commodity in scope; a zero balance renders as an honest `0` worth `$0.00`. Other categories remain holdings-only.
- **No partial-balance labeling** — the `(partial)` badges and the partial note are gone. Unpriced assets still show "—" (never a fabricated USD value) and a single compact disclosure line covers registry scope + priced-only totals.
- **Cross-chain portfolio** — balances are now read on every supported network via per-network read providers (`makeReadProvider`), independent of the wallet's active chain: Ethereum, Ethereum Classic, Polygon, and — when enabled — Sepolia, Amoy, Mordor. Each row carries a network badge. **Sepolia (11155111) is added to `networks.js`** as a portfolio-scan-only testnet (publicnode RPC, Circle faucet USDC, not user-switchable, all other capabilities off).
- **Testnet preference** — new **Preferences → Portfolio** settings group with a "Show testnet tokens" switch (`showTestnetAssets`, persisted per wallet, default off). When off, testnet networks aren't scanned and the portfolio shows a compact "testnet tokens are hidden" note.

## Changes

- `frontend/src/config/networks.js` — Sepolia network entry
- `frontend/src/config/assetTaxonomy.js` — `getPortfolioChainIds({ includeTestnets })`
- `frontend/src/hooks/usePortfolio.js` — cross-chain rewrite; zero-balance commodity rows; scope reset on preference flip
- `frontend/src/components/wallet/PortfolioPanel.jsx` + `Portfolio.css` — InfoTip headers, network badges, de-densified footer/states
- `frontend/src/contexts/UserPreferencesContext.jsx` — `showTestnetAssets` + `setShowTestnetAssets`
- `frontend/src/components/account/PortfolioPreferencesPanel.jsx/.css` — the new settings group, wired into `WalletPage`
- `frontend/src/test/portfolio/` — suites rewritten/extended (65 tests incl. vitest-axe audits of populated/collapsed/info-bubble/error states)
- `specs/044-connected-account-portfolio/` — v1.1 amendment record (spec.md, tasks.md)

## Testing

- `src/test/portfolio`: **65/65 pass** (29 registry, 9 hook, 19 panel, 4 prefs, 4 axe)
- `src/test/WalletPage.test.jsx` passes with the new Preferences group; ESLint clean; `vite build` succeeds
- Full frontend suite: 2427 passed; the same 17 pre-existing failures (quickAccessPreference, ClearPathPanel, ProposalBuilder) as on `main` — unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9vh9Lj9RNgD7tvrLoAcKY

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9vh9Lj9RNgD7tvrLoAcKY)_