### PR TITLE
Let My Account section panels fill the screen; remove duplicate section title

### DIFF
--- a/frontend/src/pages/WalletPage.css
+++ b/frontend/src/pages/WalletPage.css
@@ -282,47 +282,33 @@
   outline-offset: -2px;
 }
 
-/* Tab Content */
+/* Tab Content — grows with the panel so each section fills the available space;
+   the page scrolls rather than boxing the content into a short inner scroller. */
 .tab-content {
   padding: 24px;
-  max-height: 500px;
-  overflow-y: auto;
 }
 
-/* My Account portal layout */
-.wallet-portal-topbar {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--color-border);
-}
-
-.wallet-portal-current {
-  font-size: 15px;
-  font-weight: 600;
-  color: var(--color-text);
-}
-
-/* Flat My Account layout. The section MENU now lives in the global nav drawer
-   ("us") + the account button, so this page simply stacks an identity row over
-   the active panel — no in-page sidebar or slide-over here anymore. */
+/* Flat My Account layout. The section MENU lives in the global nav drawer ("us")
+   + the account button, so this page is just a full-height host for the active
+   panel — no in-page sidebar, slide-over, or duplicate section title. */
 .wallet-portal--flat {
   display: flex;
   flex-direction: column;
-  min-height: 320px;
+  min-height: 60vh;
 }
 
 .wallet-portal--flat .wallet-portal-main {
   flex: 1 1 auto;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.wallet-portal--flat .tab-content {
+  flex: 1 1 auto;
 }
 
 @media (max-width: 768px) {
-  .wallet-portal-current {
-    font-size: 14px;
-  }
-
   /* Leave room for the fixed mobile SectionIconNav so it never covers the last
      row of the active panel. */
   .wallet-portal--flat .tab-content {
@@ -879,7 +865,6 @@
 
   .tab-content {
     padding: 16px;
-    max-height: 400px;
   }
 
   .key-actions {

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -244,8 +244,6 @@ function WalletPage() {
     setPolymarketCategories(next)
   }, [isConnected, selectedPolymarketCategories, setPolymarketCategories])
 
-  const activeTabLabel = (WALLET_TABS.find((t) => t.id === activeTab) || WALLET_TABS[0]).label
-
   // Sibling sub-items for the mobile bottom icon nav — the group the active tab
   // belongs to (Finance / Tools / Apps). Absent for account/membership/etc.
   const currentSectionGroup = groupForTab(activeTab)
@@ -312,10 +310,8 @@ function WalletPage() {
                   account button (top right); the section panels below no longer
                   duplicate it. */}
               <div className="wallet-portal-main">
-                <div className="wallet-portal-topbar">
-                  <span className="wallet-portal-current">{activeTabLabel}</span>
-                </div>
-
+                {/* No in-page section title — every panel renders its own
+                    heading, and the section name is shown in the nav. */}
                 <div className="tab-content">
                 {activeTab === 'account' && (
                   <div className="profile-section" role="tabpanel">

--- a/frontend/src/test/WalletPage.test.jsx
+++ b/frontend/src/test/WalletPage.test.jsx
@@ -175,26 +175,25 @@ describe('WalletPage — identity moved to the wallet button', () => {
 
 describe('WalletPage — section routing', () => {
   // The in-page section rail/drawer was lifted into the global nav drawer. The
-  // page is now a flat host: it reads `?tab=` to pick a panel and shows the
-  // active section's heading. No in-page ☰ toggle, backdrop, or footer here.
+  // page is now a flat host: it reads `?tab=` to pick a panel. Each panel renders
+  // its own heading, so there is no duplicate in-page section title, ☰ toggle,
+  // backdrop, or footer here.
   it('defaults to the Account section with no ?tab', () => {
-    renderPage(connectedWalletContext, '/wallet')
-    expect(screen.getByText('Account')).toBeInTheDocument()
-    expect(
-      screen.queryByRole('button', { name: /show menu/i })
-    ).not.toBeInTheDocument()
+    const { container } = renderPage(connectedWalletContext, '/wallet')
+    expect(container.querySelector('.profile-section')).toBeTruthy()
+    expect(container.querySelector('.membership-section')).toBeFalsy()
   })
 
   it('deep-links to the Membership section via ?tab=membership', () => {
-    renderPage(connectedWalletContext, '/wallet?tab=membership')
-    // The Membership panel renders its "Your Roles" / "Membership" headings.
-    expect(screen.getByRole('heading', { name: /membership/i })).toBeInTheDocument()
+    const { container } = renderPage(connectedWalletContext, '/wallet?tab=membership')
+    expect(container.querySelector('.membership-section')).toBeTruthy()
+    // The Membership panel renders its own "Your Roles" / "Membership" headings.
     expect(screen.getByRole('heading', { name: /your roles/i })).toBeInTheDocument()
   })
 
-  it('shows the active section label in the topbar', () => {
+  it('does not render a duplicate in-page section title', () => {
     const { container } = renderPage(connectedWalletContext, '/wallet?tab=membership')
-    const current = container.querySelector('.wallet-portal-current')
-    expect(current).toHaveTextContent('Membership')
+    expect(container.querySelector('.wallet-portal-current')).toBeFalsy()
+    expect(container.querySelector('.wallet-portal-topbar')).toBeFalsy()
   })
 })


### PR DESCRIPTION
## Summary

Follow-up to the navigation redesign, fixing two issues visible on the live My Account screens (Trade, Address Book, etc.).

### Remove the duplicate section title
Each section panel already renders its own heading (e.g. the Trade card's "Trade", the Address Book panel's "Address Book"), yet the page also showed a small section-name topbar above it — two headings for the same view. Removed the in-page `wallet-portal-topbar` title; the section name still appears in the nav (drawer + mobile bar).

### Let panels fill the available space
The tab content was capped at `max-height: 500px` (400px on mobile) with its own `overflow-y: auto`, so each section sat in a short internal scroll box while the rest of the screen went unused. Removed the height cap and inner scroller — panels now grow to fit and the page scrolls normally. The flat host also stretches (`min-height: 60vh`, flex column) so content fills the area.

## Testing
- Updated `WalletPage` section-routing tests to assert panels by their own markup (no longer the removed topbar); all `WalletPage` tests pass (8), affected suites green (25).
- `npm run lint` clean; `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SnWZoKJGAjVi1GwvWwR4MA

---
_Generated by [Claude Code](https://claude.ai/code/session_01SnWZoKJGAjVi1GwvWwR4MA)_