### PR TITLE
Route passkey membership purchase through one gasless ceremony

### DIFF
--- a/frontend/src/components/ui/PremiumPurchaseModal.jsx
+++ b/frontend/src/components/ui/PremiumPurchaseModal.jsx
@@ -7,7 +7,9 @@ import { useTierPrices } from '../../hooks/useTierPrices'
 import { useEncryption } from '../../hooks/useEncryption'
 import { recordRolePurchase } from '../../utils/roleStorage'
 import { getUserTierOnChain, buildMembershipPurchaseCalls } from '../../utils/blockchainService'
-import { EncryptionUnavailable } from '../../lib/passkey/prfKeys'
+import { ensurePasskeyEncryptionKeys } from '../../lib/passkey/encryption'
+import { buildRegisterKeyCalls, hasRegisteredKey } from '../../utils/keyRegistryService'
+import { readSession } from '../../connectors/passkey'
 import { getCurrentDocument } from '../../utils/legalDocs'
 import { getContractAddressForChain } from '../../config/contracts'
 import { ACCOUNT_MODERATION_PATH } from '../../constants/legalLinks'
@@ -93,7 +95,7 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
   const { grantRole, loadRoles } = useRoles()
   const {
     account, isConnected, isCorrectNetwork, switchNetwork, chainId,
-    loginMethod, sendCalls, provider, accountCapabilities,
+    loginMethod, sendCalls, provider,
   } = useWeb3()
   const { showNotification } = useNotification()
   const { getPrice, getLimits, usingFallbackPrices } = useTierPrices()
@@ -249,14 +251,21 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
           return { hash: res?.txHash, txHash: res?.txHash, route: res?.route }
         }
 
-        // Private-wager encryption is signature-derived and not yet wired to the passkey
-        // PRF pipeline, so gate it off honestly (clarification Q1): the membership stays
-        // fully active, only encrypted features are unavailable on this account for now.
-        const ensureInitializedPasskey = async () => {
-          throw new EncryptionUnavailable(
-            accountCapabilities?.encryptionReason ||
-            'Private-wager encryption is not yet available for passkey accounts. Your membership is fully active.',
-          )
+        // Encryption keys are derived from the WebAuthn PRF master seed (one ceremony),
+        // not an EOA signature — same X25519 key the KeyRegistry publishes so envelope
+        // interop is identical to the EOA path. A non-PRF authenticator raises
+        // EncryptionUnavailable inside, so the flow degrades honestly (clarification Q1):
+        // the membership stays fully active, only encrypted features gate off.
+        const credentialId = readSession()?.credentialId
+        const ensureInitialized = () => ensurePasskeyEncryptionKeys({ account, credentialId })
+
+        // Publish the X25519 key on-chain through sendCalls (one ceremony) — a passkey
+        // session has no ethers signer for the KeyRegistry write.
+        const registerKey = async (publicKey) => {
+          if (await hasRegisteredKey(account, provider)) return false
+          const calls = buildRegisterKeyCalls(publicKey, chainId, acceptedTermsHash)
+          await sendCalls(calls)
+          return true
         }
 
         await flow.start({
@@ -268,7 +277,8 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
           action,
           termsHash: acceptedTermsHash,
           batchPurchase,
-          ensureInitialized: ensureInitializedPasskey,
+          ensureInitialized,
+          registerKey,
           onPaid,
         })
         return

--- a/frontend/src/components/ui/PremiumPurchaseModal.jsx
+++ b/frontend/src/components/ui/PremiumPurchaseModal.jsx
@@ -6,7 +6,8 @@ import { useNotification } from '../../hooks/useUI'
 import { useTierPrices } from '../../hooks/useTierPrices'
 import { useEncryption } from '../../hooks/useEncryption'
 import { recordRolePurchase } from '../../utils/roleStorage'
-import { getUserTierOnChain } from '../../utils/blockchainService'
+import { getUserTierOnChain, buildMembershipPurchaseCalls } from '../../utils/blockchainService'
+import { EncryptionUnavailable } from '../../lib/passkey/prfKeys'
 import { getCurrentDocument } from '../../utils/legalDocs'
 import { getContractAddressForChain } from '../../config/contracts'
 import { ACCOUNT_MODERATION_PATH } from '../../constants/legalLinks'
@@ -90,7 +91,10 @@ function TierLimits({ tierName, chainLimits }) {
  */
 function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
   const { grantRole, loadRoles } = useRoles()
-  const { account, isConnected, isCorrectNetwork, switchNetwork, chainId } = useWeb3()
+  const {
+    account, isConnected, isCorrectNetwork, switchNetwork, chainId,
+    loginMethod, sendCalls, provider, accountCapabilities,
+  } = useWeb3()
   const { showNotification } = useNotification()
   const { getPrice, getLimits, usingFallbackPrices } = useTierPrices()
   const { ensureInitialized } = useEncryption()
@@ -200,21 +204,83 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
 
     const tierValue = selectedTierInfo.id
     const tierName = selectedTierInfo.name
-    showNotification(`Confirm the wallet prompts to complete your ${tierName} membership (${selectedPrice} USDC)`, 'info', 10000)
+    const isPasskey = loginMethod === 'passkey'
+    showNotification(
+      isPasskey
+        ? `Confirm with your passkey to complete your ${tierName} membership (${selectedPrice} USDC)`
+        : `Confirm the wallet prompts to complete your ${tierName} membership (${selectedPrice} USDC)`,
+      'info',
+      10000,
+    )
 
     // Switch to the dedicated Processing view (spec 022) — the step indicator
     // surfaces each wallet interaction in turn.
     setShowProcessing(true)
     try {
-      // Get a fresh signer
+      // Spec 007 (FR-039): record the accepted in-force Terms version hash on-chain.
+      const acceptedTermsHash = getCurrentDocument('terms')?.hash || null
+
+      // Membership is active the moment payment confirms — run side effects then,
+      // before the (non-blocking) key steps.
+      const onPaid = async (receipt) => {
+        grantRole(ROLE_KEY)
+        recordRolePurchase(account, ROLE_KEY, {
+          price: selectedPrice,
+          currency: 'USDC',
+          tier: selectedTier,
+          tierValue,
+          txHash: receipt?.hash,
+          purchasedBy: account,
+        }, chainId)
+        try { await loadRoles() } catch (e) { console.warn('refresh roles failed:', e) }
+        showNotification(`${tierName} membership activated.`, 'success', 7000)
+      }
+
+      if (isPasskey) {
+        // Passkey smart account (spec 041, FR-016): approve + purchase are batched into
+        // ONE WebAuthn ceremony via the ERC-4337 bundler/relayer (WalletContext.sendCalls) —
+        // no browser-wallet prompt and no separate on-chain approval. Reads use the session's
+        // RPC provider; the batch carries the exact price the contract pulls.
+        const batchPurchase = async () => {
+          const { calls } = await buildMembershipPurchaseCalls(
+            provider, account, ROLE_KEY, tierValue, action, acceptedTermsHash,
+          )
+          const res = await sendCalls(calls)
+          return { hash: res?.txHash, txHash: res?.txHash, route: res?.route }
+        }
+
+        // Private-wager encryption is signature-derived and not yet wired to the passkey
+        // PRF pipeline, so gate it off honestly (clarification Q1): the membership stays
+        // fully active, only encrypted features are unavailable on this account for now.
+        const ensureInitializedPasskey = async () => {
+          throw new EncryptionUnavailable(
+            accountCapabilities?.encryptionReason ||
+            'Private-wager encryption is not yet available for passkey accounts. Your membership is fully active.',
+          )
+        }
+
+        await flow.start({
+          signer: null,
+          account,
+          roleName: ROLE_KEY,
+          priceUSD: selectedPrice,
+          tier: tierValue,
+          action,
+          termsHash: acceptedTermsHash,
+          batchPurchase,
+          ensureInitialized: ensureInitializedPasskey,
+          onPaid,
+        })
+        return
+      }
+
+      // Classic wallet path (EOA connectors): acquire the injected signer and route the
+      // purchase through the gasless-or-self-submit seam inside usePurchaseFlow.
       const { ethers } = await import('ethers')
       const accounts = await window.ethereum.request({ method: 'eth_requestAccounts' })
       if (!accounts || accounts.length === 0) throw new Error('No wallet account authorised')
-      const provider = new ethers.BrowserProvider(window.ethereum)
-      const signer = await provider.getSigner()
-
-      // Spec 007 (FR-039): record the accepted in-force Terms version hash on-chain.
-      const acceptedTermsHash = getCurrentDocument('terms')?.hash || null
+      const browserProvider = new ethers.BrowserProvider(window.ethereum)
+      const signer = await browserProvider.getSigner()
 
       await flow.start({
         signer,
@@ -225,21 +291,7 @@ function PremiumPurchaseModal({ isOpen = true, onClose, action = 'purchase' }) {
         action,
         termsHash: acceptedTermsHash,
         ensureInitialized,
-        // Membership is active the moment payment confirms — run side effects then,
-        // before the (non-blocking) key steps.
-        onPaid: async (receipt) => {
-          grantRole(ROLE_KEY)
-          recordRolePurchase(account, ROLE_KEY, {
-            price: selectedPrice,
-            currency: 'USDC',
-            tier: selectedTier,
-            tierValue,
-            txHash: receipt.hash,
-            purchasedBy: account,
-          }, chainId)
-          try { await loadRoles() } catch (e) { console.warn('refresh roles failed:', e) }
-          showNotification(`${tierName} membership activated.`, 'success', 7000)
-        },
+        onPaid,
       })
     } catch (err) {
       // Failure to even acquire a signer (before the flow starts). In-flow failures

--- a/frontend/src/hooks/useEncryption.js
+++ b/frontend/src/hooks/useEncryption.js
@@ -8,13 +8,14 @@
  * - Participants decrypt with their wallet-derived keys
  */
 
-import { useState, useCallback, useEffect, useMemo } from 'react'
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useWallet } from './useWalletManagement'
 import {
   // X25519 (v1.0) functions
   deriveKeyPair,
   deriveKeyPairFromSignature,
   publicKeyFromSignature,
+  encryptEnvelope,
   encryptMarketMetadata,
   decryptMarketMetadata,
   addParticipantToMarket,
@@ -22,7 +23,7 @@ import {
   // X-Wing (v2.0) functions
   deriveXWingKeyPairFromSignature,
   xwingPublicKeyFromSignature,
-  encryptMarketMetadataXWing,
+  encryptEnvelopeXWing,
   // Unified functions
   decryptEnvelopeUnified,
   addParticipantUnified,
@@ -38,8 +39,12 @@ import {
   lookupPublicKey,
   hasRegisteredKey,
   ensureKeyRegistered,
+  buildRegisterKeyCalls,
   clearKeyCache
 } from '../utils/keyRegistryService.js'
+import { ensurePasskeyEncryptionKeys } from '../lib/passkey/encryption.js'
+import { readSession } from '../connectors/passkey.js'
+import { getCurrentDocument } from '../utils/legalDocs.js'
 import { CURRENT_ENCRYPTION_VERSION } from '../utils/crypto/constants.js'
 
 // Cache signatures in session storage (now stores JSON with version info)
@@ -101,12 +106,23 @@ function clearSignatureCache(account) {
  * Supports both X25519 (v1.0) and X-Wing (v2.0 post-quantum) envelopes
  */
 export function useEncryption() {
-  const { account, signer, isConnected } = useWallet()
+  const { account, signer, isConnected, loginMethod, sendCalls, chainId, provider } = useWallet()
+  const isPasskey = loginMethod === 'passkey'
   // Dual keypair state: X25519 for backward compatibility, X-Wing for new markets
   const [keyPairs, setKeyPairs] = useState({
     x25519: null,  // { publicKey, privateKey }
     xwing: null    // { publicKey, secretKey }
   })
+  // Synchronous mirror of keyPairs: React state updates don't flush into the same
+  // event-handler tick, so createEncrypted() → addRecipientByPublicKey() in one
+  // handler would read stale (null) keys. The ref lets those synchronous readers
+  // see keys the moment they're derived (the passkey path has no signature cache
+  // to fall back on, so this is load-bearing there).
+  const keyPairsRef = useRef({ x25519: null, xwing: null })
+  const applyKeyPairs = useCallback((kp) => {
+    keyPairsRef.current = kp
+    setKeyPairs(kp)
+  }, [])
   const [signature, setSignature] = useState(null)
   const [cachedVersion, setCachedVersion] = useState(null) // Track signing version of cached signature
   const [isInitializing, setIsInitializing] = useState(false)
@@ -126,7 +142,7 @@ export function useEncryption() {
           const x25519Keys = deriveKeyPairFromSignature(cachedData.signature)
           const xwingKeys = deriveXWingKeyPairFromSignature(cachedData.signature)
           if (!ignore) {
-            setKeyPairs({
+            applyKeyPairs({
               x25519: {
                 publicKey: x25519Keys.publicKey,
                 privateKey: x25519Keys.privateKey
@@ -147,7 +163,7 @@ export function useEncryption() {
     }
 
     return () => { ignore = true }
-  }, [account])
+  }, [account, applyKeyPairs])
 
   /**
    * Initialize encryption keys by signing the derivation message
@@ -156,7 +172,8 @@ export function useEncryption() {
    * Uses global promise to prevent concurrent signature requests
    */
   const initializeKeys = useCallback(async () => {
-    if (!signer || !account) {
+    // Passkey sessions have no ethers signer — keys come from the PRF master seed.
+    if (!account || (!signer && !isPasskey)) {
       throw new Error('Wallet not connected')
     }
 
@@ -172,6 +189,42 @@ export function useEncryption() {
     // Create and store the promise to prevent concurrent requests
     initializationPromise = (async () => {
       try {
+        // ---- Passkey path (spec 041): derive keys from the WebAuthn PRF master
+        // seed (one ceremony), publish the X25519 key through sendCalls. Same key
+        // shapes as the EOA path, so all downstream encrypt/decrypt is identical. ----
+        if (isPasskey) {
+          const credentialId = readSession()?.credentialId
+          const keys = await ensurePasskeyEncryptionKeys({ account, credentialId })
+          const kp = {
+            x25519: { publicKey: keys.publicKey, privateKey: keys.privateKey },
+            xwing: { publicKey: keys.xwingPublicKey, secretKey: keys.xwingSecretKey },
+          }
+          applyKeyPairs(kp)
+          setSignature(null)
+          setCachedVersion(CURRENT_ENCRYPTION_VERSION)
+
+          // Auto-register the X25519 key on-chain (non-blocking) via sendCalls — one
+          // WebAuthn ceremony; a passkey session has no signer for the write.
+          ;(async () => {
+            try {
+              if (await hasRegisteredKey(account, provider)) return
+              const termsHash = getCurrentDocument('terms')?.hash || null
+              await sendCalls(buildRegisterKeyCalls(keys.publicKey, chainId, termsHash))
+              console.log('[useEncryption] Passkey encryption key registered on-chain')
+            } catch (e) {
+              console.warn('[useEncryption] Passkey key auto-register failed:', e?.message)
+            }
+          })()
+
+          return {
+            signature: null,
+            version: CURRENT_ENCRYPTION_VERSION,
+            publicKey: keys.publicKey,
+            xwingPublicKey: keys.xwingPublicKey,
+            keyPairs: kp,
+          }
+        }
+
         // Reuse a cached session signature if one exists, deriving keypairs WITHOUT a
         // wallet popup. This makes initialization idempotent across hook instances and
         // rapid sequential calls, so the encryption-terms message is only ever signed
@@ -180,24 +233,20 @@ export function useEncryption() {
         if (cached?.signature) {
           const x25519Keys = deriveKeyPairFromSignature(cached.signature)
           const xwingKeys = deriveXWingKeyPairFromSignature(cached.signature)
+          const kp = {
+            x25519: { publicKey: x25519Keys.publicKey, privateKey: x25519Keys.privateKey },
+            xwing: { publicKey: xwingKeys.publicKey, secretKey: xwingKeys.secretKey },
+          }
           setSignature(cached.signature)
           setCachedVersion(cached.version)
-          setKeyPairs({
-            x25519: {
-              publicKey: x25519Keys.publicKey,
-              privateKey: x25519Keys.privateKey
-            },
-            xwing: {
-              publicKey: xwingKeys.publicKey,
-              secretKey: xwingKeys.secretKey
-            }
-          })
+          applyKeyPairs(kp)
           console.log('[useEncryption] Reused cached session signature (no wallet popup)')
           return {
             signature: cached.signature,
             version: cached.version,
             publicKey: x25519Keys.publicKey,
-            xwingPublicKey: xwingKeys.publicKey
+            xwingPublicKey: xwingKeys.publicKey,
+            keyPairs: kp,
           }
         }
 
@@ -207,18 +256,13 @@ export function useEncryption() {
         // Derive X-Wing keypair from the same signature (no additional wallet popup)
         const xwingKeys = deriveXWingKeyPairFromSignature(x25519Result.signature)
 
+        const kp = {
+          x25519: { publicKey: x25519Result.publicKey, privateKey: x25519Result.privateKey },
+          xwing: { publicKey: xwingKeys.publicKey, secretKey: xwingKeys.secretKey },
+        }
         setSignature(x25519Result.signature)
         setCachedVersion(signingVersion)
-        setKeyPairs({
-          x25519: {
-            publicKey: x25519Result.publicKey,
-            privateKey: x25519Result.privateKey
-          },
-          xwing: {
-            publicKey: xwingKeys.publicKey,
-            secretKey: xwingKeys.secretKey
-          }
-        })
+        applyKeyPairs(kp)
 
         // Cache signature with version info
         saveSignatureToCache(account, x25519Result.signature, signingVersion)
@@ -241,7 +285,8 @@ export function useEncryption() {
           signature: x25519Result.signature,
           version: signingVersion,
           publicKey: x25519Result.publicKey,
-          xwingPublicKey: xwingKeys.publicKey
+          xwingPublicKey: xwingKeys.publicKey,
+          keyPairs: kp,
         }
       } catch (err) {
         setError(err.message)
@@ -253,49 +298,47 @@ export function useEncryption() {
     })()
 
     return initializationPromise
-  }, [signer, account])
+  }, [signer, account, isPasskey, applyKeyPairs, sendCalls, chainId, provider])
 
   /**
    * Ensure keys are initialized, prompting if needed
-   * Uses cached signature if available (no wallet popup)
+   * Uses cached signature (EOA) or in-state keys (both) without a fresh ceremony.
    */
   const ensureInitialized = useCallback(async () => {
-    // Already have both keypairs
-    if (keyPairs.x25519?.privateKey && keyPairs.xwing?.secretKey) {
+    // Already have both keypairs (covers passkey too — no signature to re-derive from).
+    const held = keyPairs.x25519?.privateKey ? keyPairs : keyPairsRef.current
+    if (held.x25519?.privateKey && held.xwing?.secretKey) {
       return {
         signature,
         version: cachedVersion ?? CURRENT_ENCRYPTION_VERSION,
-        publicKey: keyPairs.x25519.publicKey,
-        xwingPublicKey: keyPairs.xwing.publicKey
+        publicKey: held.x25519.publicKey,
+        xwingPublicKey: held.xwing.publicKey,
+        keyPairs: held,
       }
     }
 
-    // Try to derive from cached signature WITHOUT wallet interaction
-    if (signature) {
+    // Try to derive from cached signature WITHOUT wallet interaction (EOA only).
+    if (!isPasskey && signature) {
       const x25519Keys = deriveKeyPairFromSignature(signature)
       const xwingKeys = deriveXWingKeyPairFromSignature(signature)
-      setKeyPairs({
-        x25519: {
-          publicKey: x25519Keys.publicKey,
-          privateKey: x25519Keys.privateKey
-        },
-        xwing: {
-          publicKey: xwingKeys.publicKey,
-          secretKey: xwingKeys.secretKey
-        }
-      })
+      const kp = {
+        x25519: { publicKey: x25519Keys.publicKey, privateKey: x25519Keys.privateKey },
+        xwing: { publicKey: xwingKeys.publicKey, secretKey: xwingKeys.secretKey },
+      }
+      applyKeyPairs(kp)
       console.log('[useEncryption] Derived dual keypairs from cached signature (no wallet popup)')
       return {
         signature,
         version: cachedVersion ?? CURRENT_ENCRYPTION_VERSION,
         publicKey: x25519Keys.publicKey,
-        xwingPublicKey: xwingKeys.publicKey
+        xwingPublicKey: xwingKeys.publicKey,
+        keyPairs: kp,
       }
     }
 
-    // No cached signature - need to prompt user to sign
+    // No keys yet — derive them (EOA: sign message; passkey: one PRF ceremony).
     return initializeKeys()
-  }, [signature, cachedVersion, keyPairs, initializeKeys])
+  }, [signature, cachedVersion, keyPairs, isPasskey, applyKeyPairs, initializeKeys])
 
   /**
    * Create encrypted market metadata
@@ -310,29 +353,30 @@ export function useEncryption() {
   const createEncrypted = useCallback(async (metadata, options = {}) => {
     const { algorithm = 'xwing', termsVersion = null } = options
 
-    if (!signer || !account) {
+    if (!account || (!signer && !isPasskey)) {
       throw new Error('Wallet not connected')
     }
 
-    // Obtain the creator's key-derivation signature ONCE (prompts at most a single
-    // wallet popup, or none if a session signature is cached). The envelope is then
-    // built synchronously from that signature via the encryptMarketMetadata* helpers.
-    //
-    // Previously this called createEncryptedMarket{,XWing}(metadata, signer, ...),
-    // which re-derived the keypair by signing the message a SECOND time — the source
-    // of the duplicate "sign the rules" prompt on every wager creation.
-    const { signature: creatorSignature, version } = await ensureInitialized()
+    // Derive the creator's keys ONCE (EOA: at most one signature popup, or none if
+    // cached; passkey: one PRF ceremony, or none if already held). The envelope is
+    // built directly from the creator's PUBLIC keys — login-method agnostic, and it
+    // avoids re-deriving from a signature the passkey path doesn't have. (Previously
+    // this signed the derivation message here, the source of the duplicate prompt.)
+    const { keyPairs: kp, version } = await ensureInitialized()
     const signingVersion = version || CURRENT_ENCRYPTION_VERSION
 
-    const recipients = [{ address: account, signature: creatorSignature }]
+    const recipients = [{
+      address: account,
+      publicKey: algorithm === 'xwing' ? kp.xwing.publicKey : kp.x25519.publicKey,
+    }]
 
     // Use X-Wing (post-quantum) by default for new markets
     const envelope = algorithm === 'xwing'
-      ? encryptMarketMetadataXWing(metadata, recipients, signingVersion, termsVersion)
-      : encryptMarketMetadata(metadata, recipients, signingVersion, termsVersion)
+      ? encryptEnvelopeXWing(metadata, recipients, signingVersion, termsVersion)
+      : encryptEnvelope(metadata, recipients, signingVersion, termsVersion)
 
-    return { envelope, creatorSignature, signingVersion }
-  }, [signer, account, ensureInitialized])
+    return { envelope, signingVersion }
+  }, [signer, account, isPasskey, ensureInitialized])
 
   /**
    * Encrypt metadata for specific participants
@@ -373,43 +417,36 @@ export function useEncryption() {
     // signer-based path and prompt the user to sign a SECOND time — the decrypt
     // double-signature bug. With the signature in hand we derive the keys
     // synchronously, so a single signature unlocks the wager (click → sign → see).
+    // Passkey keys are seed-derived (version-independent), so the EOA "envelope
+    // version ≠ cached signing version ⇒ re-sign" dance doesn't apply to them.
     let init
-    if (cachedVersion !== null && cachedVersion !== envelopeVersion) {
+    if (!isPasskey && cachedVersion !== null && cachedVersion !== envelopeVersion) {
       console.log(`[useEncryption] Version mismatch: cached v${cachedVersion}, envelope v${envelopeVersion}. Re-signing...`)
       // Clear the stale cache and directly call initializeKeys to force fresh signature
       clearSignatureCache(account)
       init = await initializeKeys()
     } else {
-      // Ensure we have keys (may prompt user once if no cached signature)
+      // Ensure we have keys (may prompt once if none are held yet)
       init = await ensureInitialized()
     }
 
-    // Derive both private keys from the freshly-obtained signature and decrypt
-    // in the same pass — no dependence on the not-yet-flushed keyPairs state.
-    if (init?.signature) {
-      const x25519Keys = deriveKeyPairFromSignature(init.signature)
-      const xwingKeys = deriveXWingKeyPairFromSignature(init.signature)
+    // Decrypt with the keys returned in-hand (EOA and passkey alike) — no dependence
+    // on the not-yet-flushed keyPairs state, so a single ceremony unlocks the wager.
+    const kp = init?.keyPairs || (keyPairs.x25519?.privateKey ? keyPairs : keyPairsRef.current)
+    if (kp?.x25519?.privateKey && kp?.xwing?.secretKey) {
       return decryptEnvelopeUnified(envelope, account, {
-        x25519PrivateKey: x25519Keys.privateKey,
-        xwingSecretKey: xwingKeys.secretKey
-      })
-    }
-
-    // Fallback: use in-state keys if they already happen to be populated.
-    if (keyPairs.x25519?.privateKey && keyPairs.xwing?.secretKey) {
-      return decryptEnvelopeUnified(envelope, account, {
-        x25519PrivateKey: keyPairs.x25519.privateKey,
-        xwingSecretKey: keyPairs.xwing.secretKey
+        x25519PrivateKey: kp.x25519.privateKey,
+        xwingSecretKey: kp.xwing.secretKey
       })
     }
 
     // Last-resort signer-based decryption for v1.0 only (shouldn't happen after
-    // ensureInitialized returns a signature).
+    // ensureInitialized returns keys). Passkey never reaches here — it has no signer.
     if (!signer) {
       throw new Error('No signer available')
     }
     return decryptMarketMetadata(envelope, account, signer)
-  }, [signer, account, keyPairs, cachedVersion, ensureInitialized, initializeKeys])
+  }, [signer, account, keyPairs, cachedVersion, isPasskey, ensureInitialized, initializeKeys])
 
   /**
    * Add a participant to an encrypted market
@@ -421,13 +458,14 @@ export function useEncryption() {
       throw new Error('Wallet not connected')
     }
 
-    await ensureInitialized()
+    const init = await ensureInitialized()
 
-    // Use unified add participant with both key types
-    if (keyPairs.x25519?.privateKey && keyPairs.xwing?.secretKey) {
+    // Use unified add participant with both key types (in-hand keys, EOA + passkey).
+    const kp = init?.keyPairs || (keyPairs.x25519?.privateKey ? keyPairs : keyPairsRef.current)
+    if (kp?.x25519?.privateKey && kp?.xwing?.secretKey) {
       return addParticipantUnified(envelope, account, {
-        x25519PrivateKey: keyPairs.x25519.privateKey,
-        xwingSecretKey: keyPairs.xwing.secretKey
+        x25519PrivateKey: kp.x25519.privateKey,
+        xwingSecretKey: kp.xwing.secretKey
       }, newAddress, newSignature)
     }
 
@@ -488,12 +526,13 @@ export function useEncryption() {
    */
   const lookupOpponentKey = useCallback(async (opponentAddress) => {
     if (!opponentAddress) return null
-    const provider = signer?.provider
-    if (!provider) {
+    // Passkey sessions have no ethers signer — fall back to the context read provider.
+    const readProvider = signer?.provider || provider
+    if (!readProvider) {
       throw new Error('No provider available')
     }
-    return lookupPublicKey(opponentAddress, provider)
-  }, [signer])
+    return lookupPublicKey(opponentAddress, readProvider)
+  }, [signer, provider])
 
   /**
    * Check if an opponent has a registered encryption key
@@ -502,10 +541,10 @@ export function useEncryption() {
    */
   const opponentHasKey = useCallback(async (opponentAddress) => {
     if (!opponentAddress) return false
-    const provider = signer?.provider
-    if (!provider) return false
-    return hasRegisteredKey(opponentAddress, provider)
-  }, [signer])
+    const readProvider = signer?.provider || provider
+    if (!readProvider) return false
+    return hasRegisteredKey(opponentAddress, readProvider)
+  }, [signer, provider])
 
   /**
    * Add a recipient to an existing envelope using their on-chain public key
@@ -519,13 +558,14 @@ export function useEncryption() {
     if (!account) {
       throw new Error('Wallet not connected')
     }
-    // Prefer the in-state private key, but fall back to deriving it from the cached
-    // session signature. setKeyPairs() from a just-completed initializeKeys() hasn't
-    // flushed into this render's closure yet, so reading keyPairs alone can spuriously
-    // report "Encryption keys not initialized" when this is called right after
-    // createEncrypted() within the same handler tick (the user-visible bug).
-    let x25519PrivateKey = keyPairs.x25519?.privateKey
-    if (!x25519PrivateKey) {
+    // Prefer the in-state private key, then the synchronous ref (set the moment keys
+    // are derived), then — EOA only — the cached session signature. setKeyPairs() from
+    // a just-completed initializeKeys() hasn't flushed into this render's closure yet,
+    // so reading keyPairs alone can spuriously report "Encryption keys not initialized"
+    // when this is called right after createEncrypted() in the same handler tick. The
+    // ref is what makes this work for passkey (no signature cache to fall back on).
+    let x25519PrivateKey = keyPairs.x25519?.privateKey || keyPairsRef.current.x25519?.privateKey
+    if (!x25519PrivateKey && !isPasskey) {
       const cached = getCachedSignatureData(account)
       if (cached?.signature) {
         x25519PrivateKey = deriveKeyPairFromSignature(cached.signature).privateKey
@@ -547,7 +587,7 @@ export function useEncryption() {
       address: recipientAddress,
       publicKey: recipientPublicKey
     })
-  }, [account, keyPairs])
+  }, [account, keyPairs, isPasskey])
 
   /**
    * Clear cached keys
@@ -557,23 +597,23 @@ export function useEncryption() {
       sessionStorage.removeItem(`${SIGNATURE_CACHE_KEY}_${account.toLowerCase()}`)
       clearKeyCache(account)
     }
-    setKeyPairs({ x25519: null, xwing: null })
+    applyKeyPairs({ x25519: null, xwing: null })
     setSignature(null)
     setCachedVersion(null)
-  }, [account])
+  }, [account, applyKeyPairs])
 
   // Clear on disconnect
   useEffect(() => {
     let ignore = false
 
     if (!isConnected && !ignore) {
-      setKeyPairs({ x25519: null, xwing: null })
+      applyKeyPairs({ x25519: null, xwing: null })
       setSignature(null)
       setCachedVersion(null)
     }
 
     return () => { ignore = true }
-  }, [isConnected])
+  }, [isConnected, applyKeyPairs])
 
   return {
     // State
@@ -617,7 +657,7 @@ export function useEncryption() {
  */
 export function useDecryptedMarkets(markets) {
   const { decryptMetadata, canUserDecrypt, isEncrypted } = useEncryption()
-  const { account, isConnected, signer } = useWallet()
+  const { account, isConnected } = useWallet()
   const [decryptedMarkets, setDecryptedMarkets] = useState([])
   const [isDecrypting, setIsDecrypting] = useState(false)
 
@@ -634,7 +674,7 @@ export function useDecryptedMarkets(markets) {
       return () => { ignore = true }
     }
 
-    if (!isConnected || !signer) {
+    if (!isConnected || !account) {
       // Not connected - mark encrypted as not viewable
       const processNotConnected = async () => {
         const processed = markets.map(market => {
@@ -719,7 +759,7 @@ export function useDecryptedMarkets(markets) {
     decryptAll()
 
     return () => { ignore = true }
-  }, [markets, account, isConnected, signer, decryptMetadata, canUserDecrypt, isEncrypted])
+  }, [markets, account, isConnected, decryptMetadata, canUserDecrypt, isEncrypted])
 
   // Filter helpers
   const viewableMarkets = useMemo(() =>

--- a/frontend/src/hooks/usePurchaseFlow.js
+++ b/frontend/src/hooks/usePurchaseFlow.js
@@ -157,9 +157,13 @@ export function usePurchaseFlow(deps = {}) {
         }
       }
 
-      // register
+      // register — passkey sessions have no ethers signer, so they supply a
+      // `registerKey(publicKey)` closure that publishes the key through sendCalls
+      // (one WebAuthn ceremony); EOA wallets keep the signer-based service call.
       updateStep('register', { state: 'active', failureReason: null })
-      const wasNew = await registerKeyFn(p.signer, p.account, publicKeyRef.current)
+      const wasNew = typeof p.registerKey === 'function'
+        ? await p.registerKey(publicKeyRef.current)
+        : await registerKeyFn(p.signer, p.account, publicKeyRef.current)
       updateStep('register', { state: 'completed' })
       setKeyRegOutcome(wasNew ? 'success' : 'skipped')
       setStatus('succeeded')

--- a/frontend/src/lib/passkey/__tests__/encryption.test.js
+++ b/frontend/src/lib/passkey/__tests__/encryption.test.js
@@ -1,0 +1,100 @@
+/**
+ * Spec 041 — passkey PRF → X25519/X-Wing derivation and the resolve/init seam.
+ *
+ * ensurePasskeyEncryptionKeys turns the per-account master seed (recovered from
+ * the WebAuthn PRF extension) into the SAME kind of keypairs the EOA signature
+ * path produces, so the published X25519 key and envelope interop are identical.
+ * Verified here without a real authenticator by injecting getAssertion/store.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ensurePasskeyEncryptionKeys, resolveMasterSeed } from '../encryption'
+import { blobStore } from '../prfKeys'
+import { x25519 } from '@noble/curves/ed25519'
+
+const ACCOUNT = '0x00000000000000000000000000000000000000aa'
+const CRED_A = 'cred-A'
+const CRED_B = 'cred-B'
+
+// Deterministic PRF output per credential so wrap/unwrap round-trips like a real
+// PRF-capable authenticator; a null prfOutput models a non-PRF device.
+function makeAssertion(prfByte) {
+  return async ({ credentialId }) => ({
+    prfOutput: prfByte == null ? undefined : new Uint8Array(32).fill(prfByte + credentialId.length),
+    signature: new Uint8Array(64),
+    authenticatorData: new Uint8Array(37),
+    clientDataJSON: new TextEncoder().encode('{}'),
+  })
+}
+
+// Fresh in-memory localStorage-ish store per test.
+function memStorage() {
+  const m = new Map()
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+  }
+}
+
+let storage
+beforeEach(() => {
+  storage = memStorage()
+})
+
+describe('ensurePasskeyEncryptionKeys', () => {
+  it('initializes a fresh account and derives a valid X25519 + X-Wing keypair', async () => {
+    const store = blobStore(storage)
+    const keys = await ensurePasskeyEncryptionKeys({
+      account: ACCOUNT,
+      credentialId: CRED_A,
+      deps: { store, getAssertion: makeAssertion(7) },
+    })
+    expect(keys.publicKey).toHaveLength(32)
+    expect(keys.privateKey).toHaveLength(32)
+    // Public key must be the curve point of the private key (registrable + usable).
+    expect(Array.from(x25519.getPublicKey(keys.privateKey))).toEqual(Array.from(keys.publicKey))
+    expect(keys.xwingPublicKey).toHaveLength(1216)
+    // The init wrote a wrapped seed for this credential.
+    expect(store.get(ACCOUNT, CRED_A)).toBeTruthy()
+  })
+
+  it('is deterministic: unwrap on a later ceremony yields the same keys as init', async () => {
+    const store = blobStore(storage)
+    const first = await ensurePasskeyEncryptionKeys({
+      account: ACCOUNT, credentialId: CRED_A, deps: { store, getAssertion: makeAssertion(3) },
+    })
+    const second = await ensurePasskeyEncryptionKeys({
+      account: ACCOUNT, credentialId: CRED_A, deps: { store, getAssertion: makeAssertion(3) },
+    })
+    expect(Array.from(second.publicKey)).toEqual(Array.from(first.publicKey))
+    expect(Array.from(second.xwingPublicKey)).toEqual(Array.from(first.xwingPublicKey))
+  })
+
+  it('degrades honestly (EncryptionUnavailable) on a non-PRF authenticator', async () => {
+    const store = blobStore(storage)
+    await expect(
+      ensurePasskeyEncryptionKeys({
+        account: ACCOUNT, credentialId: CRED_A, deps: { store, getAssertion: makeAssertion(null) },
+      })
+    ).rejects.toMatchObject({ name: 'EncryptionUnavailable' })
+  })
+
+  it('refuses a credential with no key material on an already-initialized account', async () => {
+    const store = blobStore(storage)
+    // CRED_A initializes the account…
+    await ensurePasskeyEncryptionKeys({
+      account: ACCOUNT, credentialId: CRED_A, deps: { store, getAssertion: makeAssertion(1) },
+    })
+    // …CRED_B has no blob → never derive wrong keys, surface EncryptionUnavailable.
+    await expect(
+      resolveMasterSeed({ account: ACCOUNT, credentialId: CRED_B, deps: { store, getAssertion: makeAssertion(9) } })
+    ).rejects.toMatchObject({ name: 'EncryptionUnavailable' })
+  })
+
+  it('requires a bound credential id', async () => {
+    const store = blobStore(storage)
+    await expect(
+      resolveMasterSeed({ account: ACCOUNT, credentialId: null, deps: { store } })
+    ).rejects.toMatchObject({ name: 'EncryptionUnavailable' })
+  })
+})

--- a/frontend/src/lib/passkey/encryption.js
+++ b/frontend/src/lib/passkey/encryption.js
@@ -1,0 +1,78 @@
+/**
+ * Passkey encryption keys (spec 041) — the PRF → master-seed → X25519/X-Wing
+ * bridge that lets a passkey account participate in FairWins envelope encryption
+ * exactly like an EOA, WITHOUT an EOA signature.
+ *
+ * Flow:
+ *   1. Recover (or, for a fresh account, create) the per-account master seed from
+ *      the WebAuthn PRF extension — ONE assertion ceremony (prfKeys.js).
+ *   2. Deterministically derive the X25519 + X-Wing keypairs from that seed
+ *      (crypto/envelopeEncryption.js seed helpers). Same seed ⇒ same keys on every
+ *      device/controller.
+ *
+ * The returned `publicKey` (X25519, 32 bytes) is exactly what gets published to
+ * the on-chain KeyRegistry (keyRegistryService.buildRegisterKeyCalls) so senders
+ * can look it up and encrypt to this account — identical interop to the EOA path.
+ *
+ * Honest degradation (clarification Q1 / FR-012): a non-PRF authenticator, or a
+ * credential with no key material on an already-initialized account, surfaces
+ * `EncryptionUnavailable` (thrown by prfKeys) — the caller keeps the membership
+ * fully valid and only gates encrypted features off.
+ */
+
+import { blobStore, initMasterSeed, unwrapMasterSeed, EncryptionUnavailable } from './prfKeys'
+import { deriveKeyPairFromSeed, deriveXWingKeyPairFromSeed } from '../../utils/crypto/envelopeEncryption'
+
+/**
+ * Recover or initialize the master seed for a passkey credential (one PRF ceremony).
+ *
+ *  - blob for this credential exists ⇒ unwrap it (returning device / synced credential);
+ *  - account has NO blobs at all ⇒ first-time init (this credential becomes the first controller);
+ *  - account initialized but not for THIS credential ⇒ EncryptionUnavailable (add it from a
+ *    signed-in device via Account → Controllers), never derive wrong keys.
+ *
+ * @param {object} opts
+ * @param {string} opts.account - passkey smart-account address
+ * @param {string} opts.credentialId - the session credential (pins the ceremony)
+ * @param {object} [opts.deps] - injectable getAssertion / store / subtle for tests
+ * @returns {Promise<Uint8Array>} 32-byte master seed (memory-only)
+ */
+export async function resolveMasterSeed({ account, credentialId, deps = {} }) {
+  if (!account) throw new Error('resolveMasterSeed: account is required')
+  if (!credentialId) {
+    throw new EncryptionUnavailable('no passkey credential is bound to this session — sign in again')
+  }
+  const store = deps.store ?? blobStore()
+  if (store.get(account, credentialId)) {
+    return unwrapMasterSeed({ account, credentialId, deps })
+  }
+  if (store.listCredentials(account).length === 0) {
+    return initMasterSeed({ account, credentialId, deps })
+  }
+  throw new EncryptionUnavailable(
+    'this passkey has no key material on this account yet — add it from a signed-in device (Account → Controllers)'
+  )
+}
+
+/**
+ * Ensure the passkey account's encryption keypairs, deriving them from the PRF
+ * master seed. Shape matches the EOA `ensureInitialized` contract so it can drop
+ * into usePurchaseFlow's `sign` step (`{ publicKey }` is required; the rest lets
+ * callers encrypt/decrypt locally).
+ *
+ * @param {object} opts - { account, credentialId, deps }
+ * @returns {Promise<{publicKey: Uint8Array, privateKey: Uint8Array,
+ *   xwingPublicKey: Uint8Array, xwingSecretKey: Uint8Array}>}
+ * @throws {EncryptionUnavailable} on a non-PRF authenticator or missing key material
+ */
+export async function ensurePasskeyEncryptionKeys({ account, credentialId, deps = {} }) {
+  const seed = await resolveMasterSeed({ account, credentialId, deps })
+  const x25519 = deriveKeyPairFromSeed(seed)
+  const xwing = deriveXWingKeyPairFromSeed(seed)
+  return {
+    publicKey: x25519.publicKey,
+    privateKey: x25519.privateKey,
+    xwingPublicKey: xwing.publicKey,
+    xwingSecretKey: xwing.secretKey,
+  }
+}

--- a/frontend/src/test/blockchainService.purchaseCalls.test.js
+++ b/frontend/src/test/blockchainService.purchaseCalls.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Unit test for buildMembershipPurchaseCalls (spec 041, FR-016): the read-only helper that shapes the
+// [approve, purchase] batch a passkey session submits through WalletContext.sendCalls — ONE ceremony,
+// no separate on-chain approval. We stub the contract resolver and the MembershipManager / ERC20 reads
+// so no real chain call happens, but keep the real ethers Interface so the encoded calldata is genuine
+// (and must match the exact price the contract pulls).
+const { resolverMock, stubs } = vi.hoisted(() => ({
+  resolverMock: vi.fn(),
+  stubs: {},
+}))
+
+vi.mock('../config/contracts', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, getContractAddressForChain: resolverMock }
+})
+
+vi.mock('ethers', async () => {
+  const real = await vi.importActual('ethers')
+  // Real Interface (genuine calldata), but reads dispatch to a per-address stub.
+  function FakeContract(address, abi) {
+    const iface = new real.ethers.Interface(abi)
+    const reads = stubs[String(address).toLowerCase()] || {}
+    return { interface: iface, ...reads }
+  }
+  return { ...real, ethers: { ...real.ethers, Contract: FakeContract } }
+})
+
+import { buildMembershipPurchaseCalls, getRoleHash } from '../utils/blockchainService'
+import { ethers } from 'ethers'
+
+const MM_ADDR = '0x00c3ef4e02Ef00Ad6eE955dF5022A22F6ea73dae'
+const TOKEN_ADDR = '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174'
+const ACCOUNT = '0x0000000000000000000000000000000000000001'
+const ROLE = 'WAGER_PARTICIPANT'
+
+const makeProvider = (chainId = 137) => ({
+  getNetwork: async () => ({ chainId: BigInt(chainId) }),
+  getCode: async () => '0x60fe', // non-empty → contract deployed
+})
+
+const realIface = new ethers.Interface([
+  'function approve(address,uint256)',
+  'function purchaseTier(bytes32,uint8)',
+  'function purchaseTierWithTerms(bytes32,uint8,bytes32)',
+  'function upgradeTier(bytes32,uint8)',
+  'function extendMembership(bytes32)',
+])
+
+beforeEach(() => {
+  resolverMock.mockReset()
+  resolverMock.mockReturnValue(MM_ADDR)
+  stubs[MM_ADDR.toLowerCase()] = {
+    paymentToken: vi.fn(async () => TOKEN_ADDR),
+    getTierConfig: vi.fn(async (_role, tier) => ({ priceUSDC: BigInt(Number(tier)) * 10_000_000n })),
+    getMembership: vi.fn(async () => ({ tier: 1 })),
+  }
+  stubs[TOKEN_ADDR.toLowerCase()] = {
+    balanceOf: vi.fn(async () => 1_000_000_000n), // plenty
+  }
+})
+
+describe('buildMembershipPurchaseCalls (passkey batch)', () => {
+  it('builds [approve(price), purchaseTier] for a fresh purchase with the exact tier price', async () => {
+    const { calls, price, membershipManager, paymentToken } = await buildMembershipPurchaseCalls(
+      makeProvider(), ACCOUNT, ROLE, 2, 'purchase', null,
+    )
+    expect(price).toBe(20_000_000n)
+    expect(membershipManager).toBe(MM_ADDR)
+    expect(paymentToken).toBe(TOKEN_ADDR)
+    expect(calls).toHaveLength(2)
+
+    // Leg 1: approve the membership manager for EXACTLY the price.
+    expect(calls[0].target).toBe(TOKEN_ADDR)
+    const approve = realIface.decodeFunctionData('approve', calls[0].data)
+    expect(approve[0]).toBe(MM_ADDR)
+    expect(approve[1]).toBe(20_000_000n)
+
+    // Leg 2: purchaseTier(role, tier) on the membership manager (no terms → plain overload).
+    expect(calls[1].target).toBe(MM_ADDR)
+    const purchase = realIface.decodeFunctionData('purchaseTier', calls[1].data)
+    expect(purchase[0]).toBe(getRoleHash(ROLE))
+    expect(Number(purchase[1])).toBe(2)
+  })
+
+  it('uses the *WithTerms overload when an accepted terms hash is supplied', async () => {
+    const bare = 'ab'.repeat(32)
+    const { calls } = await buildMembershipPurchaseCalls(makeProvider(), ACCOUNT, ROLE, 1, 'purchase', bare)
+    const decoded = realIface.decodeFunctionData('purchaseTierWithTerms', calls[1].data)
+    expect(decoded[2]).toBe('0x' + bare)
+  })
+
+  it('encodes extendMembership(role) for the extend action', async () => {
+    const { calls } = await buildMembershipPurchaseCalls(makeProvider(), ACCOUNT, ROLE, 2, 'extend', null)
+    const decoded = realIface.decodeFunctionData('extendMembership', calls[1].data)
+    expect(decoded[0]).toBe(getRoleHash(ROLE))
+  })
+
+  it('approves the upgrade delta (new tier price − current tier price)', async () => {
+    const { calls, price } = await buildMembershipPurchaseCalls(makeProvider(), ACCOUNT, ROLE, 4, 'upgrade', null)
+    // getTierConfig(role, 4) − getTierConfig(role, 1) = 40 − 10 USDC
+    expect(price).toBe(30_000_000n)
+    const approve = realIface.decodeFunctionData('approve', calls[0].data)
+    expect(approve[1]).toBe(30_000_000n)
+    const decoded = realIface.decodeFunctionData('upgradeTier', calls[1].data)
+    expect(Number(decoded[1])).toBe(4)
+  })
+
+  it('throws with an actionable message when the balance is short of the price', async () => {
+    stubs[TOKEN_ADDR.toLowerCase()].balanceOf = vi.fn(async () => 1n)
+    await expect(
+      buildMembershipPurchaseCalls(makeProvider(), ACCOUNT, ROLE, 2, 'purchase', null),
+    ).rejects.toThrow(/insufficient usdc balance/i)
+  })
+
+  it('throws when no MembershipManager is configured on the chain', async () => {
+    resolverMock.mockReturnValue(undefined)
+    await expect(
+      buildMembershipPurchaseCalls(makeProvider(), ACCOUNT, ROLE, 1, 'purchase', null),
+    ).rejects.toThrow(/no membership contract/i)
+  })
+
+  it('throws on a missing provider or account', async () => {
+    await expect(buildMembershipPurchaseCalls(null, ACCOUNT, ROLE, 1)).rejects.toThrow(/read provider/i)
+    await expect(buildMembershipPurchaseCalls(makeProvider(), null, ROLE, 1)).rejects.toThrow(/account/i)
+  })
+})

--- a/frontend/src/test/crypto/seedDerivation.test.js
+++ b/frontend/src/test/crypto/seedDerivation.test.js
@@ -1,0 +1,76 @@
+/**
+ * Spec 041 — seed-based key derivation for passkey accounts.
+ *
+ * deriveKeyPairFromSeed / deriveXWingKeyPairFromSeed turn the PRF master seed into
+ * the same kind of X25519 / X-Wing keypairs the signature path produces. These
+ * assert determinism, correct key shapes, domain separation between the two
+ * keypairs, and a full X-Wing encrypt→decrypt round-trip against a seed-derived key.
+ */
+import { describe, it, expect } from 'vitest'
+import { x25519 } from '@noble/curves/ed25519'
+import {
+  deriveKeyPairFromSeed,
+  deriveXWingKeyPairFromSeed,
+  encryptEnvelopeXWing,
+  decryptEnvelopeUnified,
+} from '../../utils/crypto/envelopeEncryption'
+
+const seed = (fill) => new Uint8Array(32).fill(fill)
+
+describe('deriveKeyPairFromSeed (X25519)', () => {
+  it('is deterministic and returns a valid 32-byte keypair', () => {
+    const a = deriveKeyPairFromSeed(seed(1))
+    const b = deriveKeyPairFromSeed(seed(1))
+    expect(a.publicKey).toHaveLength(32)
+    expect(a.privateKey).toHaveLength(32)
+    expect(Array.from(a.publicKey)).toEqual(Array.from(b.publicKey))
+    // publicKey is the curve point of privateKey
+    expect(Array.from(x25519.getPublicKey(a.privateKey))).toEqual(Array.from(a.publicKey))
+  })
+
+  it('different seeds ⇒ different keys', () => {
+    const a = deriveKeyPairFromSeed(seed(1))
+    const b = deriveKeyPairFromSeed(seed(2))
+    expect(Array.from(a.publicKey)).not.toEqual(Array.from(b.publicKey))
+  })
+
+  it('rejects a non-32-byte seed', () => {
+    expect(() => deriveKeyPairFromSeed(new Uint8Array(16))).toThrow(/32 bytes/i)
+  })
+})
+
+describe('deriveXWingKeyPairFromSeed (post-quantum)', () => {
+  it('is deterministic and returns a 1216-byte public key', () => {
+    const a = deriveXWingKeyPairFromSeed(seed(5))
+    const b = deriveXWingKeyPairFromSeed(seed(5))
+    expect(a.publicKey).toHaveLength(1216)
+    expect(a.secretKey).toHaveLength(32)
+    expect(Array.from(a.publicKey)).toEqual(Array.from(b.publicKey))
+  })
+})
+
+describe('domain separation', () => {
+  it('X25519 and X-Wing material from the same seed are independent', () => {
+    const s = seed(9)
+    const x = deriveKeyPairFromSeed(s)
+    const xw = deriveXWingKeyPairFromSeed(s)
+    // The X-Wing secret seed must not equal the raw master seed or the X25519 key.
+    expect(Array.from(xw.secretKey)).not.toEqual(Array.from(s))
+    expect(Array.from(xw.secretKey)).not.toEqual(Array.from(x.privateKey))
+  })
+})
+
+describe('interop: a sender can encrypt to a seed-derived X-Wing key', () => {
+  it('round-trips an X-Wing envelope for a passkey recipient', () => {
+    const recipientAddr = '0x00000000000000000000000000000000000000bb'
+    const { publicKey, secretKey } = deriveXWingKeyPairFromSeed(seed(42))
+
+    const envelope = encryptEnvelopeXWing(
+      { title: 'private wager', stake: '10' },
+      [{ address: recipientAddr, publicKey }],
+    )
+    const decrypted = decryptEnvelopeUnified(envelope, recipientAddr, { xwingSecretKey: secretKey })
+    expect(decrypted.title).toBe('private wager')
+    expect(decrypted.stake).toBe('10')
+  })
+})

--- a/frontend/src/test/keyRegistryService.registerCalls.test.js
+++ b/frontend/src/test/keyRegistryService.registerCalls.test.js
@@ -1,0 +1,63 @@
+/**
+ * Spec 041 — buildRegisterKeyCalls: the sendCalls batch a passkey session uses to
+ * publish its X25519 key on-chain (no ethers signer). Mirrors registerEncryptionKey's
+ * method selection (registerKeyWithEligibility when a terms hash is present, else
+ * registerKey). We stub the contract resolver so no chain is touched, and decode the
+ * emitted calldata with the real KeyRegistry ABI.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { resolverMock } = vi.hoisted(() => ({ resolverMock: vi.fn() }))
+vi.mock('../config/contracts', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, getContractAddressForChain: resolverMock }
+})
+
+import { buildRegisterKeyCalls } from '../utils/keyRegistryService'
+import { KEY_REGISTRY_ABI } from '../abis/KeyRegistry'
+import { ethers } from 'ethers'
+
+const KR_ADDR = '0x00000000000000000000000000000000000000Ec'
+const iface = new ethers.Interface(KEY_REGISTRY_ABI)
+const pubkey = new Uint8Array(32).fill(0x11)
+const pubkeyHex = '0x' + '11'.repeat(32)
+
+beforeEach(() => {
+  resolverMock.mockReset()
+  resolverMock.mockReturnValue(KR_ADDR)
+})
+
+describe('buildRegisterKeyCalls', () => {
+  it('encodes registerKeyWithEligibility(pubkey, termsRef) when a terms hash is supplied', () => {
+    const terms = 'ab'.repeat(32)
+    const calls = buildRegisterKeyCalls(pubkey, 137, terms)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].target).toBe(KR_ADDR)
+    expect(calls[0].value).toBe(0n)
+    const decoded = iface.decodeFunctionData('registerKeyWithEligibility', calls[0].data)
+    expect(decoded[0]).toBe(pubkeyHex)
+    expect(decoded[1]).toBe('0x' + terms)
+  })
+
+  it('encodes plain registerKey(pubkey) when no terms hash is supplied', () => {
+    const calls = buildRegisterKeyCalls(pubkey, 137, null)
+    const decoded = iface.decodeFunctionData('registerKey', calls[0].data)
+    expect(decoded[0]).toBe(pubkeyHex)
+  })
+
+  it('normalizes a 0x-prefixed terms hash without double-prefixing', () => {
+    const terms = '0x' + 'cd'.repeat(32)
+    const calls = buildRegisterKeyCalls(pubkey, 137, terms)
+    const decoded = iface.decodeFunctionData('registerKeyWithEligibility', calls[0].data)
+    expect(decoded[1]).toBe(terms)
+  })
+
+  it('throws on a non-32-byte public key', () => {
+    expect(() => buildRegisterKeyCalls(new Uint8Array(16), 137, null)).toThrow(/32 bytes/i)
+  })
+
+  it('throws when no KeyRegistry is configured on the chain', () => {
+    resolverMock.mockReturnValue(undefined)
+    expect(() => buildRegisterKeyCalls(pubkey, 137, null)).toThrow(/not configured/i)
+  })
+})

--- a/frontend/src/test/useEncryption.passkey.test.jsx
+++ b/frontend/src/test/useEncryption.passkey.test.jsx
@@ -1,0 +1,131 @@
+/**
+ * Spec 041 — app-wide passkey encrypt/decrypt surface.
+ *
+ * A passkey session has no ethers signer: encryption keys come from the WebAuthn
+ * PRF master seed, and the on-chain KeyRegistry write goes through sendCalls. These
+ * tests verify useEncryption drives that path — derive from PRF (no signMessage),
+ * auto-register via sendCalls, and a full createEncrypted → decryptMetadata
+ * round-trip — so encrypted wagers work identically to the EOA path.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+import { deriveKeyPairFromSeed, deriveXWingKeyPairFromSeed } from '../utils/crypto/envelopeEncryption.js'
+
+const ACCOUNT = '0x00000000000000000000000000000000000000aa'
+const OPPONENT = '0x00000000000000000000000000000000000000bb'
+const SEED = new Uint8Array(32).fill(7)
+
+// The passkey account's deterministic keys (as ensurePasskeyEncryptionKeys would return).
+const x = deriveKeyPairFromSeed(SEED)
+const xw = deriveXWingKeyPairFromSeed(SEED)
+const PASSKEY_KEYS = {
+  publicKey: x.publicKey,
+  privateKey: x.privateKey,
+  xwingPublicKey: xw.publicKey,
+  xwingSecretKey: xw.secretKey,
+}
+
+const sendCalls = vi.fn(async () => ({ route: 'userop', txHash: '0xregister' }))
+const readProvider = { getNetwork: async () => ({ chainId: 137n }) }
+
+vi.mock('../hooks/useWalletManagement', () => ({
+  useWallet: () => ({
+    account: ACCOUNT,
+    isConnected: true,
+    loginMethod: 'passkey',
+    signer: null, // the whole point: no EOA signer
+    sendCalls,
+    chainId: 137,
+    provider: readProvider,
+  }),
+}))
+
+// PRF derivation is exercised in its own suite; here we assert the wiring, so we
+// stub it to return the deterministic keys above.
+const ensurePasskeyEncryptionKeys = vi.fn(async () => PASSKEY_KEYS)
+vi.mock('../lib/passkey/encryption.js', () => ({
+  ensurePasskeyEncryptionKeys: (...a) => ensurePasskeyEncryptionKeys(...a),
+}))
+vi.mock('../connectors/passkey.js', () => ({
+  readSession: () => ({ credentialId: 'cred-1' }),
+}))
+vi.mock('../utils/legalDocs.js', () => ({
+  getCurrentDocument: () => ({ hash: null }),
+}))
+
+const buildRegisterKeyCalls = vi.fn(() => [{ target: '0xkeyRegistry', data: '0xdead', value: 0n }])
+const hasRegisteredKey = vi.fn(async () => false)
+vi.mock('../utils/keyRegistryService.js', () => ({
+  lookupPublicKey: vi.fn(async () => null),
+  hasRegisteredKey: (...a) => hasRegisteredKey(...a),
+  ensureKeyRegistered: vi.fn(async () => false),
+  buildRegisterKeyCalls: (...a) => buildRegisterKeyCalls(...a),
+  clearKeyCache: vi.fn(),
+}))
+
+import { useEncryption } from '../hooks/useEncryption'
+import { getRecipients } from '../utils/crypto/envelopeEncryption.js'
+
+const metadata = { name: 'Private passkey wager', description: 'Heads or tails for 10 USDC' }
+
+describe('useEncryption — passkey encrypt/decrypt surface', () => {
+  beforeEach(() => {
+    sendCalls.mockClear()
+    ensurePasskeyEncryptionKeys.mockClear()
+    buildRegisterKeyCalls.mockClear()
+    hasRegisteredKey.mockClear()
+  })
+
+  it('derives encryption keys from the PRF seed — no signer, no signMessage', async () => {
+    const { result } = renderHook(() => useEncryption())
+    let init
+    await act(async () => {
+      init = await result.current.ensureInitialized()
+    })
+    expect(ensurePasskeyEncryptionKeys).toHaveBeenCalledTimes(1)
+    expect(Array.from(init.publicKey)).toEqual(Array.from(PASSKEY_KEYS.publicKey))
+    expect(result.current.isInitialized).toBe(true)
+  })
+
+  it('auto-registers the X25519 key on-chain through sendCalls (not a signer write)', async () => {
+    const { result } = renderHook(() => useEncryption())
+    await act(async () => {
+      await result.current.initializeKeys()
+    })
+    await vi.waitFor(() => expect(sendCalls).toHaveBeenCalledTimes(1))
+    expect(buildRegisterKeyCalls).toHaveBeenCalledWith(PASSKEY_KEYS.publicKey, 137, null)
+    // The batch handed to sendCalls is the register call.
+    expect(sendCalls.mock.calls[0][0]).toEqual([{ target: '0xkeyRegistry', data: '0xdead', value: 0n }])
+  })
+
+  it('createEncrypted → decryptMetadata round-trips for a passkey account (X-Wing)', async () => {
+    const { result } = renderHook(() => useEncryption())
+    let created
+    await act(async () => {
+      created = await result.current.createEncrypted(metadata) // default xwing
+    })
+    expect(getRecipients(created.envelope)).toEqual([ACCOUNT.toLowerCase()])
+
+    let decrypted
+    await act(async () => {
+      decrypted = await result.current.decryptMetadata(created.envelope)
+    })
+    expect(decrypted).toMatchObject(metadata)
+  })
+
+  it('createEncrypted (x25519) + addRecipientByPublicKey adds an opponent in the same tick', async () => {
+    const { result } = renderHook(() => useEncryption())
+    let finalEnvelope
+    await act(async () => {
+      const { envelope } = await result.current.createEncrypted(metadata, { algorithm: 'x25519' })
+      // Same handler tick as createEncrypted — the ref (not React state) must supply
+      // the private key, since a passkey session has no signature cache to fall back on.
+      const opponentKey = deriveKeyPairFromSeed(new Uint8Array(32).fill(9)).publicKey
+      finalEnvelope = result.current.addRecipientByPublicKey(envelope, OPPONENT, opponentKey)
+    })
+    expect(getRecipients(finalEnvelope)).toEqual(
+      expect.arrayContaining([ACCOUNT.toLowerCase(), OPPONENT.toLowerCase()])
+    )
+  })
+})

--- a/frontend/src/test/usePurchaseFlow.passkey.test.js
+++ b/frontend/src/test/usePurchaseFlow.passkey.test.js
@@ -125,4 +125,37 @@ describe('usePurchaseFlow — passkey batch path (spec 041)', () => {
     expect(result.current.status).toBe('failed')
     expect(result.current.steps.find((s) => s.id === 'sign').state).toBe('failed')
   })
+
+  it('registers the derived key through the passkey registerKey closure (not the signer service)', async () => {
+    const registerKey = vi.fn(async () => true)
+    const params = passkeyParams({ registerKey })
+    const { result } = renderHook(() => usePurchaseFlow())
+    await act(async () => {
+      await result.current.start(params)
+    })
+
+    expect(result.current.status).toBe('succeeded')
+    expect(result.current.steps.find((s) => s.id === 'register').state).toBe('completed')
+    // The publicKey derived in the sign step is what gets published on-chain.
+    expect(registerKey).toHaveBeenCalledTimes(1)
+    expect(registerKey.mock.calls[0][0]).toBeInstanceOf(Uint8Array)
+    expect(ensureKeyRegistered).not.toHaveBeenCalled() // signer path is bypassed for passkey
+    expect(result.current.keyRegOutcome).toBe('success')
+  })
+
+  it('a failed passkey registerKey surfaces as a non-blocking register failure (membership stays active)', async () => {
+    const registerKey = vi.fn(async () => { throw new Error('user cancelled the key ceremony') })
+    const params = passkeyParams({ registerKey })
+    const { result } = renderHook(() => usePurchaseFlow())
+    await act(async () => {
+      await result.current.start(params)
+    })
+
+    expect(result.current.status).toBe('failed')
+    const register = result.current.steps.find((s) => s.id === 'register')
+    expect(register.state).toBe('failed')
+    expect(register.blocking).toBe(false) // Continue anyway is offered — the membership is real
+    expect(result.current.canContinueAnyway).toBe(true)
+    expect(params.onPaid).toHaveBeenCalledTimes(1) // payment already succeeded
+  })
 })

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -1456,6 +1456,109 @@ export async function resolveMembershipIntentParams(signer, roleName, tier = Mem
 }
 
 /**
+ * Passkey smart accounts (spec 041, FR-016): build the [approve, purchase] call
+ * batch a passkey session submits through {@link WalletContext.sendCalls} — ONE
+ * WebAuthn ceremony authorizes the whole batch via the ERC-4337 bundler (gasless
+ * where a paymaster serves the chain), so there is no separate on-chain approval
+ * and no browser-wallet prompt.
+ *
+ * Read-only: `provider` is a plain RPC provider (no signer). Price + terms + method
+ * selection mirror {@link purchaseRoleWithStablecoin} exactly, so the batched
+ * `approve(price)` matches the amount the contract pulls and the purchase method
+ * matches the self-submit path byte-for-byte.
+ *
+ * @param {ethers.Provider} provider - RPC read provider for the connected chain
+ * @param {string} account - the passkey smart-account address (the member)
+ * @param {string} roleName - role being purchased/upgraded/extended
+ * @param {number} tier - target tier (1=Bronze..4=Platinum), clamped to [1,4]
+ * @param {string} [action='purchase'] - 'purchase' (default), 'upgrade', or 'extend'
+ * @param {string|null} [termsHash=null] - accepted T&C version hash (bare 64-hex or 0x-prefixed)
+ * @returns {Promise<{calls: Array<{target: string, data: string, value: bigint}>, price: bigint,
+ *   membershipManager: string, paymentToken: string, roleHash: string, validTier: number}>}
+ */
+export async function buildMembershipPurchaseCalls(provider, account, roleName, tier = MembershipTier.BRONZE, action = 'purchase', termsHash = null) {
+  if (!provider) throw new Error('No read provider available')
+  if (!account) throw new Error('No account address available')
+  const roleHash = getRoleHash(roleName)
+  if (!roleHash) throw new Error(`Unknown role: ${roleName}`)
+  const validTier = [1, 2, 3, 4].includes(tier) ? tier : MembershipTier.BRONZE
+
+  let walletChainId = null
+  try {
+    walletChainId = Number((await provider.getNetwork()).chainId)
+  } catch { /* provider without a network; fall back to build-time chain */ }
+  const mmAddress = getContractAddressForChain('membershipManager', walletChainId)
+  if (!mmAddress) {
+    throw new Error(`No membership contract is configured on the connected network (chain ${walletChainId ?? 'unknown'}).`)
+  }
+  const code = await provider.getCode(mmAddress)
+  if (!code || code === '0x') {
+    throw new Error(
+      `No membership contract is deployed at ${mmAddress} on the connected network (chain ${walletChainId ?? 'unknown'}). ` +
+        `Please switch to Polygon and try again.`
+    )
+  }
+
+  const mm = new ethers.Contract(mmAddress, MEMBERSHIP_MANAGER_ABI, provider)
+  const paymentTokenAddr = await mm.paymentToken()
+  if (!paymentTokenAddr || paymentTokenAddr === ethers.ZeroAddress) {
+    throw new Error('MembershipManager has no payment token configured. Contact the DAO administrator.')
+  }
+  const paymentToken = new ethers.Contract(paymentTokenAddr, ERC20_ABI, provider)
+
+  // Exact price the contract will charge (this becomes the batched approve amount).
+  let price
+  if (action === 'upgrade') {
+    const membership = await mm.getMembership(account, roleHash)
+    const currentCfg = await mm.getTierConfig(roleHash, membership.tier)
+    const newCfg = await mm.getTierConfig(roleHash, validTier)
+    price = newCfg.priceUSDC - currentCfg.priceUSDC
+  } else {
+    const tierCfg = await mm.getTierConfig(roleHash, validTier)
+    price = tierCfg.priceUSDC
+  }
+
+  const balance = await paymentToken.balanceOf(account)
+  if (balance < price) {
+    throw new Error(
+      `Insufficient USDC balance. Have ${ethers.formatUnits(balance, 6)}, need ${ethers.formatUnits(price, 6)}.`
+    )
+  }
+
+  // Spec 007 (FR-039): record the accepted T&C version on-chain via the *WithTerms overloads.
+  const normTerms = typeof termsHash === 'string'
+    ? (termsHash.startsWith('0x') ? termsHash : '0x' + termsHash)
+    : null
+  const hasTerms = normTerms !== null && /^0x[0-9a-fA-F]{64}$/.test(normTerms)
+
+  let purchaseData
+  if (action === 'upgrade') {
+    purchaseData = hasTerms
+      ? mm.interface.encodeFunctionData('upgradeTierWithTerms', [roleHash, validTier, normTerms])
+      : mm.interface.encodeFunctionData('upgradeTier', [roleHash, validTier])
+  } else if (action === 'extend') {
+    purchaseData = mm.interface.encodeFunctionData('extendMembership', [roleHash])
+  } else {
+    purchaseData = hasTerms
+      ? mm.interface.encodeFunctionData('purchaseTierWithTerms', [roleHash, validTier, normTerms])
+      : mm.interface.encodeFunctionData('purchaseTier', [roleHash, validTier])
+  }
+  const approveData = paymentToken.interface.encodeFunctionData('approve', [mmAddress, price])
+
+  return {
+    calls: [
+      { target: paymentTokenAddr, data: approveData, value: 0n },
+      { target: mmAddress, data: purchaseData, value: 0n },
+    ],
+    price,
+    membershipManager: mmAddress,
+    paymentToken: paymentTokenAddr,
+    roleHash,
+    validTier,
+  }
+}
+
+/**
  * Spec 022: read-only pre-flight to decide whether the membership purchase will
  * require a separate ERC-20 approval prompt. Lets the progress indicator build the
  * exact step list up front and OMIT the approval step entirely when the member

--- a/frontend/src/utils/crypto/envelopeEncryption.js
+++ b/frontend/src/utils/crypto/envelopeEncryption.js
@@ -225,6 +225,46 @@ export function deriveKeyPairFromSignature(signature) {
   }
 }
 
+// ==================== Passkey seed-based derivation ====================
+// Passkey accounts have no EOA signature to derive from; instead a per-account
+// 32-byte master seed is recovered from the WebAuthn PRF extension (lib/passkey/
+// prfKeys.js). These helpers turn that seed into the SAME kind of X25519 / X-Wing
+// keypairs the signature path produces, so the on-chain KeyRegistry entry and the
+// envelope interop are identical regardless of login method. The seed is expanded
+// through HKDF with distinct info labels so the two keypairs are domain-separated
+// from each other and can never collide with signature-derived material.
+const PASSKEY_X25519_INFO = utf8ToBytes('fairwins-passkey-x25519-v1')
+const PASSKEY_XWING_INFO = utf8ToBytes('fairwins-passkey-xwing-v1')
+const PASSKEY_DERIVE_SALT = new Uint8Array(32)
+
+/**
+ * Derive the X25519 keypair for a passkey account from its master seed.
+ * Deterministic: same seed ⇒ same keypair on every device/controller.
+ *
+ * @param {Uint8Array} seed - 32-byte PRF-derived master seed
+ * @returns {{publicKey: Uint8Array, privateKey: Uint8Array}}
+ */
+export function deriveKeyPairFromSeed(seed) {
+  if (!seed || seed.length !== 32) throw new Error('deriveKeyPairFromSeed: seed must be 32 bytes')
+  const privateKey = hkdf(sha256, seed, PASSKEY_DERIVE_SALT, PASSKEY_X25519_INFO, 32)
+  const publicKey = x25519.getPublicKey(privateKey)
+  return { publicKey, privateKey }
+}
+
+/**
+ * Derive the X-Wing (post-quantum) keypair for a passkey account from its master
+ * seed. Deterministic: same seed ⇒ same keypair.
+ *
+ * @param {Uint8Array} seed - 32-byte PRF-derived master seed
+ * @returns {{publicKey: Uint8Array, secretKey: Uint8Array}}
+ */
+export function deriveXWingKeyPairFromSeed(seed) {
+  if (!seed || seed.length !== 32) throw new Error('deriveXWingKeyPairFromSeed: seed must be 32 bytes')
+  const xwingSeed = hkdf(sha256, seed, PASSKEY_DERIVE_SALT, PASSKEY_XWING_INFO, 32)
+  const { publicKey, secretKey } = xwingKeygen(xwingSeed)
+  return { publicKey, secretKey }
+}
+
 // ==================== X-Wing Post-Quantum Functions ====================
 
 /**

--- a/frontend/src/utils/keyRegistryService.js
+++ b/frontend/src/utils/keyRegistryService.js
@@ -183,6 +183,43 @@ export async function registerEncryptionKey(signer, publicKeyBytes) {
 }
 
 /**
+ * Build the KeyRegistry `registerKey` call batch for a passkey smart account
+ * (spec 041) — submitted through WalletContext.sendCalls as a single WebAuthn
+ * ceremony, since a passkey session has no ethers signer.
+ *
+ * Mirrors {@link registerEncryptionKey}: prefers `registerKeyWithEligibility`
+ * (Spec 007 FR-043 — records the in-force Terms version hash on-chain) when a
+ * terms hash is supplied and the ABI exposes it, else plain `registerKey`.
+ *
+ * @param {Uint8Array} publicKeyBytes - X25519 public key (32 bytes)
+ * @param {number} chainId - chain the passkey account is on
+ * @param {string|null} [termsHash] - in-force Terms version hash (bare 64-hex or 0x-prefixed)
+ * @returns {Array<{target: string, data: string, value: bigint}>} single-call batch
+ */
+export function buildRegisterKeyCalls(publicKeyBytes, chainId, termsHash = null) {
+  if (!publicKeyBytes || publicKeyBytes.length !== 32) {
+    throw new Error('Invalid public key: must be 32 bytes')
+  }
+  const address = getContractAddressForChain('keyRegistry', chainId) || getContractAddressForChain('zkKeyManager', chainId)
+  if (!address) throw new Error('KeyRegistry contract not configured')
+
+  const iface = new ethers.Interface(KEY_REGISTRY_ABI)
+  const publicKeyHex = '0x' + bytesToHex(publicKeyBytes)
+  const normTerms = typeof termsHash === 'string'
+    ? (termsHash.startsWith('0x') ? termsHash : '0x' + termsHash)
+    : null
+  const hasEligibility = iface.fragments.some(
+    (f) => f.type === 'function' && f.name === 'registerKeyWithEligibility'
+  )
+
+  const data = (normTerms && hasEligibility)
+    ? iface.encodeFunctionData('registerKeyWithEligibility', [publicKeyHex, normTerms])
+    : iface.encodeFunctionData('registerKey', [publicKeyHex])
+
+  return [{ target: address, data, value: 0n }]
+}
+
+/**
  * Ensure a user's key is registered on-chain. If already registered, no-op.
  *
  * @param {ethers.Signer} signer - Connected wallet signer


### PR DESCRIPTION
## Problem

When a passkey-only user clicked **Confirm Purchase** in the membership modal, `PremiumPurchaseModal.handlePurchase` always forced a browser wallet (`window.ethereum`) and did **two** on-chain actions (approve, then purchase). A passkey account has no injected wallet, so the flow either dead-ended or demanded a second wallet. Separately, encrypted-wager create/decrypt only worked for EOA accounts because `useEncryption` derived keys from an EOA signature.

## Change

Passkey membership + encryption now work **end to end, app-wide** — same outcome an EOA gets.

### 1. Purchase — one gasless ceremony

Branch the purchase on `loginMethod`:

- **Passkey** batches `[approve, purchaseTier]` into a **single WebAuthn ceremony** via `WalletContext.sendCalls` (ERC-4337 bundler / relayer — gasless where a paymaster serves the chain). No browser prompt, no separate approval. Reuses the existing `batchPurchase` seam in `usePurchaseFlow` (spec 041, FR-016).
- **Classic EOA wallets** keep the existing signer + gasless-or-self-submit path, unchanged.

`buildMembershipPurchaseCalls()` (new, `blockchainService.js`) resolves the exact tier price and shapes the approve + purchase/upgrade/extend batch (`*WithTerms` overloads), mirroring `purchaseRoleWithStablecoin`.

### 2. Encryption keys — PRF → X25519 → KeyRegistry

- **`deriveKeyPairFromSeed` / `deriveXWingKeyPairFromSeed`** (`crypto/envelopeEncryption.js`): turn the PRF master seed into the same X25519 / X-Wing keypairs the signature path yields, HKDF-domain-separated.
- **`ensurePasskeyEncryptionKeys()`** (`lib/passkey/encryption.js`): recovers or first-time-inits the per-account master seed via **one PRF ceremony** and derives the keypairs. Non-PRF authenticators surface `EncryptionUnavailable` (clarification Q1) — membership stays valid, encryption gates off.
- **`buildRegisterKeyCalls()`** (`keyRegistryService.js`): the KeyRegistry write as a `sendCalls` batch (passkey has no signer), preferring `registerKeyWithEligibility` when a Terms hash is present.
- **`usePurchaseFlow`**: optional `registerKey(publicKey)` seam for the register step; EOA unchanged.

### 3. App-wide encrypt/decrypt — `useEncryption` is now login-method agnostic

The hook is re-centered on `keyPairs` instead of an EOA signature, so encrypted-wager create/decrypt works for passkey everywhere (FriendMarkets, MyMarkets, MarketAcceptance):

- `initializeKeys` derives from the PRF seed for passkey (signMessage for EOA), and auto-registers via `sendCalls`.
- `createEncrypted` builds the creator recipient from the **public key** (behavior-identical for EOA — pubkey == signature-derived key — and lets passkey participate).
- `decryptMetadata` / `addParticipant` consume the in-hand `keyPairs`; a synchronous `keyPairsRef` makes `createEncrypted → addRecipientByPublicKey` in one tick work (passkey has no signature cache to fall back on).
- `lookupOpponentKey` / `opponentHasKey` fall back to the context read provider; `useDecryptedMarkets` gates on `account`, not `signer`.

The published X25519 key is identical in kind to the EOA registration, so envelope interop is the same regardless of login method.

## Ceremony count

Purchase (1) → derive/PRF (1) → register (1). Sign + register are non-blocking, so a user can stop after purchase (membership is active on payment) and add encryption later.

## Tests

- `blockchainService.purchaseCalls.test.js` — batch builder (price, terms, upgrade delta, extend, balance guard, errors).
- `crypto/seedDerivation.test.js` — determinism, shapes, domain separation, **full X-Wing encrypt→decrypt round-trip against a seed-derived key**.
- `lib/passkey/__tests__/encryption.test.js` — init/unwrap determinism, non-PRF degradation, wrong-credential refusal.
- `keyRegistryService.registerCalls.test.js` — method selection + errors.
- `usePurchaseFlow.passkey.test.js` — the `registerKey` seam (success + non-blocking failure).
- `useEncryption.passkey.test.jsx` — derive-from-PRF (no signMessage), auto-register via `sendCalls`, **createEncrypted→decryptMetadata round-trip**, same-tick addRecipient.
- Existing EOA `useEncryption` suite + FriendMarkets / MyMarkets / MarketAcceptance component suites (**163 tests**) stay green. Full touched-area sweep passing; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Knearh2PpM8cDJhFhVXdqL