### PR TITLE
Portfolio v1.2: on-chain prices, asset detail sheet, wrapped-asset aggregation (spec 044)

### DIFF
--- a/frontend/src/abis/AggregatorV3.js
+++ b/frontend/src/abis/AggregatorV3.js
@@ -1,0 +1,9 @@
+// Chainlink AggregatorV3Interface — minimal read surface for price feeds
+// (spec 044 v1.2 FR-022). Full interface:
+// https://docs.chain.link/data-feeds/api-reference
+export const AGGREGATOR_V3_ABI = [
+  'function latestRoundData() view returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)',
+  'function decimals() view returns (uint8)',
+]
+
+export default AGGREGATOR_V3_ABI

--- a/frontend/src/abis/UniswapV3PoolReader.js
+++ b/frontend/src/abis/UniswapV3PoolReader.js
@@ -1,0 +1,14 @@
+// Minimal Uniswap V3 factory + pool read surface for verifiable DEX spot
+// prices (spec 044 v1.2 FR-022). The app's swap flow uses QuoterV2; the
+// portfolio only needs the pool's current sqrtPriceX96 for a spot valuation.
+export const UNISWAP_V3_FACTORY_ABI = [
+  'function getPool(address tokenA, address tokenB, uint24 fee) view returns (address pool)',
+]
+
+export const UNISWAP_V3_POOL_ABI = [
+  'function slot0() view returns (uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint8 feeProtocol, bool unlocked)',
+  'function token0() view returns (address)',
+  'function liquidity() view returns (uint128)',
+]
+
+export default { UNISWAP_V3_FACTORY_ABI, UNISWAP_V3_POOL_ABI }

--- a/frontend/src/components/account/PortfolioPreferencesPanel.jsx
+++ b/frontend/src/components/account/PortfolioPreferencesPanel.jsx
@@ -3,40 +3,63 @@ import './PortfolioPreferencesPanel.css'
 
 /**
  * PortfolioPreferencesPanel — the "Portfolio" area of the Preferences tab
- * (spec 044 follow-up). One switch: whether the cross-chain portfolio also
- * scans and lists assets on test networks (Sepolia, Amoy, Mordor).
+ * (spec 044 v1.1 + v1.2). Two switches: whether the cross-chain portfolio
+ * also scans test networks, and whether zero-balance assets are listed
+ * (default hidden, FR-023).
  */
+function PrefSwitch({ id, label, sub, on, onToggle }) {
+  return (
+    <div className="portfolio-prefs-row">
+      <div className="portfolio-prefs-text">
+        <span className="portfolio-prefs-label" id={id}>
+          {label}
+        </span>
+        <span className="portfolio-prefs-sub">{sub}</span>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={on}
+        aria-labelledby={id}
+        className={`portfolio-prefs-switch ${on ? 'on' : ''}`}
+        onClick={onToggle}
+      >
+        <span className="sr-only">{on ? `${label} on` : `${label} off`}</span>
+      </button>
+    </div>
+  )
+}
+
 function PortfolioPreferencesPanel() {
-  const { preferences, setShowTestnetAssets } = useUserPreferences()
-  const on = Boolean(preferences?.showTestnetAssets)
+  const { preferences, setShowTestnetAssets, setShowZeroBalances } = useUserPreferences()
+  const testnetsOn = Boolean(preferences?.showTestnetAssets)
+  const zerosOn = Boolean(preferences?.showZeroBalances)
 
   return (
     <div className="portfolio-prefs">
       <h3 className="portfolio-prefs-title">Portfolio</h3>
-      <div className="portfolio-prefs-row">
-        <div className="portfolio-prefs-text">
-          <span className="portfolio-prefs-label" id="portfolio-prefs-testnet-label">
-            Show testnet tokens
-          </span>
-          <span className="portfolio-prefs-sub">
-            {on
-              ? 'On — the portfolio also lists assets on test networks (Sepolia, Amoy, Mordor).'
-              : 'Off — the portfolio lists mainnet assets only (Ethereum, Ethereum Classic, Polygon).'}
-          </span>
-        </div>
-        <button
-          type="button"
-          role="switch"
-          aria-checked={on}
-          aria-labelledby="portfolio-prefs-testnet-label"
-          className={`portfolio-prefs-switch ${on ? 'on' : ''}`}
-          onClick={() => setShowTestnetAssets(!on)}
-        >
-          <span className="sr-only">
-            {on ? 'Testnet tokens shown' : 'Testnet tokens hidden'}
-          </span>
-        </button>
-      </div>
+      <PrefSwitch
+        id="portfolio-prefs-testnet-label"
+        label="Show testnet tokens"
+        sub={
+          testnetsOn
+            ? 'On — the portfolio also lists assets on test networks (Sepolia, Amoy, Mordor).'
+            : 'Off — the portfolio lists mainnet assets only (Ethereum, Ethereum Classic, Polygon).'
+        }
+        on={testnetsOn}
+        onToggle={() => setShowTestnetAssets(!testnetsOn)}
+      />
+      <PrefSwitch
+        id="portfolio-prefs-zero-label"
+        label="Show zero-balance assets"
+        sub={
+          zerosOn
+            ? 'On — assets you hold none of are listed with a 0 balance.'
+            : 'Off — only assets with a balance are listed.'
+        }
+        on={zerosOn}
+        onToggle={() => setShowZeroBalances(!zerosOn)}
+      />
     </div>
   )
 }

--- a/frontend/src/components/wallet/AssetDetailSheet.css
+++ b/frontend/src/components/wallet/AssetDetailSheet.css
@@ -1,0 +1,211 @@
+/* AssetDetailSheet (spec 044 v1.2) — bottom sheet at the modal overlay tier. */
+
+.asset-sheet-backdrop {
+  align-items: flex-end;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  position: fixed;
+  z-index: 2000; /* modal tier — above header (1000) and nav drawer (1401) */
+  animation: assetSheetFade 0.15s ease;
+}
+.asset-sheet-scrim {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  inset: 0;
+  position: absolute;
+}
+.asset-sheet {
+  animation: assetSheetRise 0.2s ease;
+  background: var(--surface-color, var(--bg-secondary, #fff));
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-bottom: none;
+  border-radius: 16px 16px 0 0;
+  color: var(--text-primary, #111827);
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  max-height: 85vh;
+  max-width: 40rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0.6rem 1rem 1.2rem;
+  position: relative;
+  width: 100%;
+}
+.asset-sheet:focus-visible {
+  outline: 2px solid var(--brand-primary, #36B37E);
+  outline-offset: -2px;
+}
+.asset-sheet-grabber {
+  background: var(--border-color, #e5e7eb);
+  border-radius: 999px;
+  height: 4px;
+  margin: 0 auto 0.2rem;
+  width: 42px;
+}
+
+/* Header */
+.asset-sheet-header {
+  align-items: flex-start;
+  display: flex;
+  gap: 0.75rem;
+}
+.asset-sheet-heading {
+  flex: 1;
+  min-width: 0;
+}
+.asset-sheet-heading h3 {
+  font-size: 1.05rem;
+  margin: 0;
+}
+.asset-sheet-position {
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 0.15rem 0 0;
+}
+.asset-sheet-usd {
+  color: var(--brand-primary, #36B37E);
+}
+.asset-sheet-price {
+  color: var(--text-secondary, #6b7280);
+  font-size: 0.8rem;
+  margin: 0.15rem 0 0;
+}
+.asset-sheet-price-source {
+  color: var(--text-muted, #9ca3af);
+}
+.asset-sheet-close {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 6px;
+  color: var(--text-primary, #111827);
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.3rem 0.7rem;
+}
+.asset-sheet-close:focus-visible,
+.asset-sheet-action:focus-visible,
+.asset-sheet-instance input:focus-visible {
+  outline: 2px solid var(--brand-primary, #36B37E);
+  outline-offset: 2px;
+}
+
+/* Instance selection */
+.asset-sheet-instances {
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  padding: 0.25rem 0.6rem 0.6rem;
+}
+.asset-sheet-instances legend {
+  color: var(--text-secondary, #6b7280);
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0 0.25rem;
+}
+.asset-sheet-instance {
+  align-items: center;
+  border-radius: 8px;
+  cursor: pointer;
+  display: flex;
+  gap: 0.6rem;
+  padding: 0.45rem 0.4rem;
+}
+.asset-sheet-instance.selected {
+  background: var(--bg-primary, rgba(54, 179, 126, 0.08));
+}
+.asset-sheet-instance-text {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+.asset-sheet-instance-form {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+.asset-sheet-instance-meta {
+  color: var(--text-secondary, #6b7280);
+  font-size: 0.75rem;
+}
+.asset-sheet-instance-values {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  font-variant-numeric: tabular-nums;
+  gap: 0.1rem;
+}
+.asset-sheet-instance-balance {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+.asset-sheet-instance-usd {
+  color: var(--text-secondary, #6b7280);
+  font-size: 0.8rem;
+}
+
+/* Actions */
+.asset-sheet-actions {
+  display: flex;
+  gap: 0.6rem;
+}
+.asset-sheet-action {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--border-color, #e5e7eb);
+  border-radius: 999px;
+  color: var(--text-primary, #111827);
+  cursor: pointer;
+  flex: 1;
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 0.55rem 0;
+}
+.asset-sheet-action.primary {
+  background: var(--primary-button, var(--brand-primary, #36B37E));
+  border-color: var(--primary-button, var(--brand-primary, #36B37E));
+  color: var(--primary-button-text, #fff);
+}
+.asset-sheet-action:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+.asset-sheet-actions-note {
+  color: var(--text-muted, #9ca3af);
+  font-size: 0.75rem;
+  margin: 0;
+}
+
+@keyframes assetSheetRise {
+  from {
+    transform: translateY(24px);
+    opacity: 0.6;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+@keyframes assetSheetFade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .asset-sheet-backdrop,
+  .asset-sheet {
+    animation: none;
+  }
+}

--- a/frontend/src/components/wallet/AssetDetailSheet.jsx
+++ b/frontend/src/components/wallet/AssetDetailSheet.jsx
@@ -1,0 +1,211 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import AssetLogo from './AssetLogo'
+import { NETWORKS } from '../../config/networks'
+import { priceSourceLabel } from '../../lib/portfolio/prices'
+import { isHomeInstance, instanceFormLabel, formatAssetAmount } from '../../lib/portfolio/aggregate'
+import './AssetDetailSheet.css'
+
+// Member-facing names for the classification provenance (FR-006).
+const SOURCE_LABELS = {
+  'sec-baseline': 'SEC baseline',
+  'curated-registry': 'Curated registry',
+  'app-config': 'App configuration',
+}
+
+function formatUsdFull(n) {
+  return `$${Number(n || 0).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`
+}
+
+function formatAmount(holding) {
+  return formatAssetAmount(holding.balance, holding.asset.symbol, holding.asset.kind)
+}
+
+// Action eligibility per instance — actions the app cannot perform render
+// disabled with a reason, never as dead buttons (constitution III).
+function actionsFor(instance) {
+  if (!instance) return []
+  const { asset } = instance
+  const net = NETWORKS[asset.chainId]
+  return [
+    {
+      id: 'trade',
+      label: 'Trade',
+      enabled: asset.kind !== 'nft' && Boolean(net?.dex),
+      reason: asset.kind === 'nft' ? 'Collectibles cannot be traded here' : 'No in-app trading on this network',
+      to: `/wallet?tab=trade&chain=${asset.chainId}&token=${encodeURIComponent(asset.symbol)}`,
+    },
+    {
+      id: 'transfer',
+      label: 'Transfer',
+      enabled: asset.kind === 'native' || asset.categoryId === 'payment-stablecoins',
+      reason: 'Pay & Transfer supports native and stablecoin sends',
+      to: `/wallet?tab=paytransfer&chain=${asset.chainId}&token=${encodeURIComponent(asset.symbol)}`,
+    },
+    {
+      id: 'stake',
+      label: 'Stake',
+      enabled: false,
+      reason: 'Staking is not available in the app yet',
+      to: null,
+    },
+  ]
+}
+
+/**
+ * AssetDetailSheet (spec 044 v1.2, FR-024/FR-027) — bottom sheet with the
+ * aggregate position, the per-instance balances (native + wrapped forms per
+ * network, shown separately), and instance-scoped actions. Self-contained
+ * isOpen/onClose modal per repo convention (Escape + backdrop close, focus
+ * managed, modal-tier overlay).
+ */
+export default function AssetDetailSheet({ aggregate, onClose }) {
+  const navigate = useNavigate()
+  const sheetRef = useRef(null)
+  const restoreFocusRef = useRef(null)
+  const [selectedId, setSelectedId] = useState(null)
+
+  const instances = useMemo(() => aggregate?.instances || [], [aggregate])
+  const selected = useMemo(() => {
+    const found = instances.find((h) => `${h.asset.chainId}:${h.asset.id}` === selectedId)
+    return found || instances.find((h) => h.balance > 0) || instances[0] || null
+  }, [instances, selectedId])
+
+  useEffect(() => {
+    if (!aggregate) return undefined
+    restoreFocusRef.current = document.activeElement
+    sheetRef.current?.focus()
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', onKeyDown, true)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown, true)
+      document.body.style.overflow = previousOverflow
+      restoreFocusRef.current?.focus?.()
+    }
+  }, [aggregate, onClose])
+
+  if (!aggregate) return null
+
+  const priceLabel = priceSourceLabel(aggregate.priceEntry)
+  const titleId = 'asset-sheet-title'
+
+  const runAction = (action) => {
+    if (!action.enabled || !action.to) return
+    onClose()
+    navigate(action.to)
+  }
+
+  return (
+    <div className="asset-sheet-backdrop">
+      <button type="button" className="asset-sheet-scrim" aria-label="Close asset details" onClick={onClose} />
+      <div
+        className="asset-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        ref={sheetRef}
+      >
+        <div className="asset-sheet-grabber" aria-hidden="true" />
+        <div className="asset-sheet-header">
+          <AssetLogo symbol={aggregate.underlying} size={40} />
+          <div className="asset-sheet-heading">
+            <h3 id={titleId}>{aggregate.name} details</h3>
+            <p className="asset-sheet-position">
+              {formatAssetAmount(aggregate.balance, aggregate.underlying, aggregate.kind)}
+              {aggregate.usd != null && <span className="asset-sheet-usd"> · {formatUsdFull(aggregate.usd)}</span>}
+            </p>
+            {aggregate.unitPriceUsd != null && (
+              <p className="asset-sheet-price">
+                {formatUsdFull(aggregate.unitPriceUsd)} per {aggregate.underlying}
+                {priceLabel && <span className="asset-sheet-price-source"> · {priceLabel}</span>}
+                {aggregate.categoryId === 'payment-stablecoins' && (
+                  <span className="asset-sheet-price-source"> · valued at par</span>
+                )}
+              </p>
+            )}
+          </div>
+          <button type="button" className="asset-sheet-close" onClick={onClose}>
+            Close
+          </button>
+        </div>
+
+        <fieldset className="asset-sheet-instances">
+          <legend>Select an instance</legend>
+          {instances.map((holding) => {
+            const id = `${holding.asset.chainId}:${holding.asset.id}`
+            const isSelected = selected && `${selected.asset.chainId}:${selected.asset.id}` === id
+            return (
+              <label key={id} className={`asset-sheet-instance ${isSelected ? 'selected' : ''}`}>
+                <input
+                  type="radio"
+                  name="asset-instance"
+                  value={id}
+                  checked={Boolean(isSelected)}
+                  onChange={() => setSelectedId(id)}
+                />
+                <AssetLogo
+                  symbol={aggregate.underlying}
+                  chainId={holding.asset.chainId}
+                  showBadge={!isHomeInstance(holding.asset)}
+                  size={28}
+                />
+                <span className="asset-sheet-instance-text">
+                  <span className="asset-sheet-instance-form">{instanceFormLabel(holding.asset)}</span>
+                  <span className="asset-sheet-instance-meta">
+                    {holding.network} · {SOURCE_LABELS[holding.asset.source] || holding.asset.source}
+                  </span>
+                </span>
+                <span className="asset-sheet-instance-values">
+                  <span className="asset-sheet-instance-balance">{formatAmount(holding)}</span>
+                  {holding.usd == null ? (
+                    <span className="asset-sheet-instance-usd">
+                      <span aria-hidden="true">—</span>
+                      <span className="portfolio-visually-hidden">price unavailable</span>
+                    </span>
+                  ) : (
+                    <span className="asset-sheet-instance-usd">{formatUsdFull(holding.usd)}</span>
+                  )}
+                </span>
+              </label>
+            )
+          })}
+        </fieldset>
+
+        <div className="asset-sheet-actions">
+          {actionsFor(selected).map((action) => (
+            <button
+              key={action.id}
+              type="button"
+              className={`asset-sheet-action ${action.id === 'trade' ? 'primary' : ''}`}
+              disabled={!action.enabled}
+              title={action.enabled ? undefined : action.reason}
+              onClick={() => runAction(action)}
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+        {selected && actionsFor(selected).some((a) => !a.enabled) && (
+          <p className="asset-sheet-actions-note">
+            {actionsFor(selected)
+              .filter((a) => !a.enabled)
+              .map((a) => `${a.label}: ${a.reason}`)
+              .join('. ')}
+            .
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/wallet/AssetLogo.css
+++ b/frontend/src/components/wallet/AssetLogo.css
@@ -1,0 +1,19 @@
+/* AssetLogo (spec 044 v1.2) — bundled SVG asset glyph + network sub-badge. */
+
+.asset-logo {
+  display: inline-flex;
+  flex: none;
+  position: relative;
+}
+.asset-logo-badge {
+  border: 2px solid var(--surface-color, var(--bg-secondary, #fff));
+  border-radius: 50%;
+  bottom: -2px;
+  height: 45%;
+  position: absolute;
+  right: -2px;
+  width: 45%;
+}
+.asset-logo-badge-testnet {
+  border-style: dashed;
+}

--- a/frontend/src/components/wallet/AssetLogo.jsx
+++ b/frontend/src/components/wallet/AssetLogo.jsx
@@ -1,0 +1,114 @@
+import './AssetLogo.css'
+
+/**
+ * AssetLogo (spec 044 v1.2, FR-026) — a primary asset logo with an optional
+ * network sub-badge. All artwork is bundled inline SVG (no external image
+ * CDNs). A native coin on its home mainnet renders the logo alone; wrapped,
+ * bridged, and testnet instances carry the hosting network's badge so it is
+ * always clear what an asset is and where it lives.
+ *
+ * Decorative: the surrounding row/sheet supplies the accessible text, so the
+ * whole element is aria-hidden.
+ */
+
+// Simple, recognizable glyphs per underlying symbol. Fallback: a neutral
+// disc with the symbol's first letters.
+const ASSET_GLYPHS = {
+  ETH: { bg: '#627EEA', glyph: 'diamond', fg: '#ffffff' },
+  BTC: { bg: '#F7931A', glyph: 'B', fg: '#ffffff' },
+  MATIC: { bg: '#8247E5', glyph: 'poly', fg: '#ffffff' },
+  POL: { bg: '#8247E5', glyph: 'poly', fg: '#ffffff' },
+  ETC: { bg: '#3AB83A', glyph: 'diamond', fg: '#ffffff' },
+  SOL: { bg: '#1B1F2A', glyph: 'S', fg: '#14F195' },
+  XRP: { bg: '#23292F', glyph: 'X', fg: '#ffffff' },
+  LINK: { bg: '#2A5ADA', glyph: 'hex', fg: '#ffffff' },
+  USDC: { bg: '#2775CA', glyph: '$', fg: '#ffffff' },
+  USDT: { bg: '#26A17B', glyph: 'T', fg: '#ffffff' },
+  USC: { bg: '#0F8A5F', glyph: '$', fg: '#ffffff' },
+  FWMV: { bg: '#36B37E', glyph: 'clover', fg: '#ffffff' },
+}
+
+// Per-network badge colors (chainId → fill). Testnets get a dashed ring so
+// they read as non-production at a glance.
+const NETWORK_BADGES = {
+  1: { bg: '#627EEA', label: 'E' },
+  61: { bg: '#3AB83A', label: 'C' },
+  137: { bg: '#8247E5', label: 'P' },
+  11155111: { bg: '#9AA6B2', label: 'S', testnet: true },
+  80002: { bg: '#B39DED', label: 'A', testnet: true },
+  63: { bg: '#7FBF8E', label: 'M', testnet: true },
+}
+
+function Glyph({ spec }) {
+  switch (spec.glyph) {
+    case 'diamond':
+      return (
+        <g fill={spec.fg}>
+          <path d="M16 5 L23.5 16.2 L16 20.6 L8.5 16.2 Z" opacity="0.9" />
+          <path d="M16 22.6 L23.2 18.2 L16 27 L8.8 18.2 Z" opacity="0.75" />
+        </g>
+      )
+    case 'poly':
+      return (
+        <path
+          d="M21.5 12.7l-3.4-2a1.6 1.6 0 0 0-1.6 0l-3.9 2.3-2.6 1.5-3.9 2.2a1.6 1.6 0 0 0-1.6 0l-3 1.8"
+          transform="translate(6.2 5.5) scale(0.82)"
+          fill="none"
+          stroke={spec.fg}
+          strokeWidth="2.4"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      )
+    case 'hex':
+      return (
+        <path
+          d="M16 6l8.5 5v10L16 26l-8.5-5V11z"
+          fill="none"
+          stroke={spec.fg}
+          strokeWidth="2.6"
+          strokeLinejoin="round"
+        />
+      )
+    case 'clover':
+      return (
+        <g fill={spec.fg}>
+          <circle cx="12.6" cy="12.6" r="4" />
+          <circle cx="19.4" cy="12.6" r="4" />
+          <circle cx="12.6" cy="19.4" r="4" />
+          <circle cx="19.4" cy="19.4" r="4" />
+        </g>
+      )
+    default:
+      return (
+        <text x="16" y="21" textAnchor="middle" fontSize="13" fontWeight="700" fill={spec.fg}>
+          {spec.glyph}
+        </text>
+      )
+  }
+}
+
+export default function AssetLogo({ symbol, chainId = null, showBadge = false, size = 32 }) {
+  const key = (symbol || '').toUpperCase()
+  const spec = ASSET_GLYPHS[key] || { bg: '#5A6772', glyph: key.slice(0, 2) || '?', fg: '#ffffff' }
+  const badge = showBadge && chainId != null ? NETWORK_BADGES[chainId] : null
+
+  return (
+    <span className="asset-logo" style={{ width: size, height: size }} aria-hidden="true">
+      <svg viewBox="0 0 32 32" width={size} height={size}>
+        <circle cx="16" cy="16" r="16" fill={spec.bg} />
+        <Glyph spec={spec} />
+      </svg>
+      {badge && (
+        <span className={`asset-logo-badge ${badge.testnet ? 'asset-logo-badge-testnet' : ''}`}>
+          <svg viewBox="0 0 16 16" width="100%" height="100%">
+            <circle cx="8" cy="8" r="7" fill={badge.bg} />
+            <text x="8" y="11" textAnchor="middle" fontSize="8" fontWeight="700" fill="#ffffff">
+              {badge.label}
+            </text>
+          </svg>
+        </span>
+      )}
+    </span>
+  )
+}

--- a/frontend/src/components/wallet/Portfolio.css
+++ b/frontend/src/components/wallet/Portfolio.css
@@ -124,17 +124,36 @@
   padding: 0.35rem 0 0.35rem;
 }
 .portfolio-row {
-  align-items: center;
   display: flex;
-  gap: 0.75rem;
-  justify-content: space-between;
-  padding: 0.55rem 0.9rem;
 }
 .portfolio-row + .portfolio-row {
   border-top: 1px solid var(--color-border, var(--border-color, #e5e7eb));
 }
+/* The whole row is a button that opens the asset detail sheet (FR-024). */
+.portfolio-row-button {
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  gap: 0.75rem;
+  padding: 0.55rem 0.9rem;
+  text-align: left;
+  width: 100%;
+}
+.portfolio-row-button:hover {
+  background: var(--bg-primary, rgba(54, 179, 126, 0.06));
+}
+.portfolio-row-button:focus-visible {
+  outline: 2px solid var(--brand-primary, #36B37E);
+  outline-offset: -2px;
+}
 .portfolio-row-asset {
   display: flex;
+  flex: 1;
   flex-direction: column;
   gap: 0.15rem;
   min-width: 0;

--- a/frontend/src/components/wallet/PortfolioPanel.jsx
+++ b/frontend/src/components/wallet/PortfolioPanel.jsx
@@ -1,7 +1,9 @@
 import { useState } from 'react'
-import { formatUnits } from 'ethers'
 import usePortfolio from '../../hooks/usePortfolio'
 import InfoTip from '../ui/InfoTip'
+import AssetLogo from './AssetLogo'
+import AssetDetailSheet from './AssetDetailSheet'
+import { formatAssetAmount } from '../../lib/portfolio/aggregate'
 import './Portfolio.css'
 
 // Full-precision USD for a compliance-flavored view — deliberately not the
@@ -13,66 +15,51 @@ function formatUsdFull(n) {
   })}`
 }
 
-// Max fraction digits shown for a fungible balance.
-const FRACTION_DIGITS = 6
-
-function formatBalance(holding) {
-  const { asset, balance, balanceRaw } = holding
-  if (asset.kind === 'nft') {
-    return `${balance} ${balance === 1 ? 'item' : 'items'}`
-  }
-  // Format from the raw units string so a nonzero dust holding can never
-  // round to a misleading "0" (honest state). Falls back to the numeric
-  // balance only when raw units aren't available.
-  if (typeof balanceRaw === 'bigint' && Number.isInteger(asset.decimals)) {
-    const [int, frac = ''] = formatUnits(balanceRaw, asset.decimals).split('.')
-    const intFmt = BigInt(int).toLocaleString('en-US')
-    const fracShown = frac.slice(0, FRACTION_DIGITS).replace(/0+$/, '')
-    if (int === '0' && fracShown === '' && balanceRaw > 0n) {
-      return `< 0.${'0'.repeat(FRACTION_DIGITS - 1)}1 ${asset.symbol}`
-    }
-    return `${intFmt}${fracShown ? `.${fracShown}` : ''} ${asset.symbol}`
-  }
-  const digits = balance !== 0 && Math.abs(balance) < 1 ? 6 : 4
-  return `${Number(balance).toLocaleString('en-US', { maximumFractionDigits: digits })} ${asset.symbol}`
+function formatAggregateBalance(aggregate) {
+  return formatAssetAmount(aggregate.balance, aggregate.underlying, aggregate.kind)
 }
 
-// Member-facing names for the classification provenance (FR-006).
-const SOURCE_LABELS = {
-  'sec-baseline': 'SEC baseline',
-  'curated-registry': 'Curated registry',
-  'app-config': 'App configuration',
-}
-
-function AssetRow({ holding }) {
-  const { asset, usd, network } = holding
+function AggregateRow({ aggregate, onOpen }) {
+  const networks = new Set(aggregate.instances.map((h) => h.asset.chainId))
+  const singleInstance = aggregate.instances.length === 1 ? aggregate.instances[0] : null
   return (
     <li className="portfolio-row">
-      <div className="portfolio-row-asset">
-        <span className="portfolio-row-name">{asset.name}</span>
-        <span className="portfolio-row-meta">
-          {asset.symbol}
-          <span className="portfolio-row-network">{network}</span>
-          <span className="portfolio-row-source">{SOURCE_LABELS[asset.source] || asset.source}</span>
-        </span>
-      </div>
-      <div className="portfolio-row-values">
-        <span className="portfolio-row-balance">{formatBalance(holding)}</span>
-        {usd == null ? (
-          <span className="portfolio-row-usd portfolio-row-usd-unavailable">
-            <span aria-hidden="true">—</span>
-            <span className="portfolio-visually-hidden">price unavailable</span>
+      <button
+        type="button"
+        className="portfolio-row-button"
+        onClick={() => onOpen(aggregate)}
+        aria-haspopup="dialog"
+      >
+        <AssetLogo symbol={aggregate.underlying} size={32} />
+        <span className="portfolio-row-asset">
+          <span className="portfolio-row-name">{aggregate.name}</span>
+          <span className="portfolio-row-meta">
+            {aggregate.underlying}
+            <span className="portfolio-row-network">
+              {singleInstance
+                ? singleInstance.network
+                : `${aggregate.instances.length} instances · ${networks.size} network${networks.size === 1 ? '' : 's'}`}
+            </span>
           </span>
-        ) : (
-          <span className="portfolio-row-usd">{formatUsdFull(usd)}</span>
-        )}
-      </div>
+        </span>
+        <span className="portfolio-row-values">
+          <span className="portfolio-row-balance">{formatAggregateBalance(aggregate)}</span>
+          {aggregate.usd == null ? (
+            <span className="portfolio-row-usd portfolio-row-usd-unavailable">
+              <span aria-hidden="true">—</span>
+              <span className="portfolio-visually-hidden">price unavailable</span>
+            </span>
+          ) : (
+            <span className="portfolio-row-usd">{formatUsdFull(aggregate.usd)}</span>
+          )}
+        </span>
+      </button>
     </li>
   )
 }
 
-function CategorySection({ group, collapsed, onToggle }) {
-  const { category, holdings, subtotalUsd } = group
+function CategorySection({ group, collapsed, onToggle, onOpen }) {
+  const { category, aggregates, subtotalUsd } = group
   const regionId = `portfolio-category-${category.id}`
   const expanded = !collapsed
   return (
@@ -98,12 +85,12 @@ function CategorySection({ group, collapsed, onToggle }) {
         </InfoTip>
       </div>
       <div id={regionId} role="region" aria-label={category.label} hidden={!expanded}>
-        {holdings.length === 0 ? (
+        {aggregates.length === 0 ? (
           <p className="portfolio-category-empty">No assets in this category.</p>
         ) : (
           <ul className="portfolio-rows">
-            {holdings.map((h) => (
-              <AssetRow key={`${h.asset.chainId}:${h.asset.id}`} holding={h} />
+            {aggregates.map((aggregate) => (
+              <AggregateRow key={aggregate.id} aggregate={aggregate} onOpen={onOpen} />
             ))}
           </ul>
         )}
@@ -113,14 +100,20 @@ function CategorySection({ group, collapsed, onToggle }) {
 }
 
 /**
- * Connected Account Portfolio (spec 044 + follow-up) — the member's holdings
- * across every supported network, grouped by the SEC/CFTC asset taxonomy.
- * Read-only; category explainers live in InfoTip bubbles; testnet networks
- * are included per the "show testnet tokens" preference.
+ * Connected Account Portfolio (spec 044 v1.2) — the member's holdings across
+ * every supported network, grouped by the SEC/CFTC asset taxonomy with
+ * wrapped forms combined into their underlying asset. Tapping a row opens
+ * the asset detail sheet (instances + actions). Category explainers live in
+ * InfoTip bubbles; testnet and zero-balance visibility follow the
+ * Preferences → Portfolio settings.
  */
 export default function PortfolioPanel() {
   const portfolio = usePortfolio()
   const [collapsedIds, setCollapsedIds] = useState(() => new Set())
+  const [openAggregateId, setOpenAggregateId] = useState(null)
+
+  // Resolve from the live snapshot so a refresh keeps the sheet current.
+  const openAggregate = portfolio.aggregates.find((a) => a.id === openAggregateId) || null
 
   const toggleCategory = (id) => {
     setCollapsedIds((prev) => {
@@ -187,6 +180,7 @@ export default function PortfolioPanel() {
           group={group}
           collapsed={collapsedIds.has(group.category.id)}
           onToggle={toggleCategory}
+          onOpen={(aggregate) => setOpenAggregateId(aggregate.id)}
         />
       ))}
 
@@ -194,12 +188,19 @@ export default function PortfolioPanel() {
         {!portfolio.showTestnetAssets && (
           <p>Testnet tokens are hidden — enable them under Preferences → Portfolio.</p>
         )}
+        {!portfolio.showZeroBalances && (
+          <p>Zero-balance assets are hidden — enable them under Preferences → Portfolio.</p>
+        )}
         <p>
           Classifications are informational, not legal or investment advice. Only assets in the
-          app&apos;s curated registry are scanned, and USD totals include only assets with an
-          available price.
+          app&apos;s curated registry are scanned; prices come from on-chain sources (oracle
+          feeds, DEX pools) and USD totals include only priced assets.
         </p>
       </footer>
+
+      {openAggregate && (
+        <AssetDetailSheet aggregate={openAggregate} onClose={() => setOpenAggregateId(null)} />
+      )}
     </div>
   )
 }

--- a/frontend/src/config/assetTaxonomy.js
+++ b/frontend/src/config/assetTaxonomy.js
@@ -98,6 +98,33 @@ export const SEC_COMMODITY_BASELINE = ['BTC', 'ETH', 'SOL', 'XRP', 'MATIC', 'POL
 
 const BASELINE_SET = new Set(SEC_COMMODITY_BASELINE)
 
+/**
+ * Display metadata per underlying asset symbol (spec 044 v1.2). `homeChainId`
+ * is the canonical mainnet whose NATIVE coin the symbol is — a native
+ * instance on that chain renders its logo without a network badge (FR-026);
+ * every other instance (wrapped, bridged, testnet) carries the hosting
+ * network's badge.
+ */
+export const UNDERLYING_META = {
+  ETH: { name: 'Ethereum', homeChainId: 1 },
+  BTC: { name: 'Bitcoin', homeChainId: null },
+  MATIC: { name: 'Polygon', homeChainId: 137 },
+  POL: { name: 'Polygon', homeChainId: 137 },
+  ETC: { name: 'Ethereum Classic', homeChainId: 61 },
+  SOL: { name: 'Solana', homeChainId: null },
+  XRP: { name: 'XRP', homeChainId: null },
+  LINK: { name: 'Chainlink', homeChainId: null },
+  USDC: { name: 'USD Coin', homeChainId: null },
+  USDT: { name: 'Tether USD', homeChainId: null },
+  USC: { name: 'Classic USD', homeChainId: null },
+  FWMV: { name: 'FairWins Membership Voucher', homeChainId: null },
+}
+
+export function getUnderlyingMeta(symbol) {
+  const key = (symbol || '').toUpperCase()
+  return UNDERLYING_META[key] || { name: key, homeChainId: null }
+}
+
 // Curated per-network token entries. Canonical, well-known deployments only —
 // the same convention as the canonical Uniswap addresses in networks.js.
 // `baselineSymbol` marks a token as the wrapped form of an SEC-baseline

--- a/frontend/src/config/priceFeeds.js
+++ b/frontend/src/config/priceFeeds.js
@@ -1,0 +1,34 @@
+/**
+ * Verifiable on-chain price sources for the portfolio (spec 044 v1.2, FR-022).
+ *
+ * Layered per underlying asset symbol:
+ *   1. Chainlink AggregatorV3 feeds — decentralized oracle network, the
+ *      highest-trust source. Canonical Polygon mainnet feed addresses from
+ *      https://docs.chain.link/data-feeds/price-feeds/addresses (network:
+ *      Polygon). Override per feed via env if a feed migrates.
+ *   2. DEX pool spot — Uniswap V3 (or ETCswap V3) pool of the asset vs the
+ *      network's configured stablecoin, read from slot0 (see
+ *      lib/portfolio/prices.js). Used where no Chainlink feed exists
+ *      (e.g. the ETC family).
+ *
+ * Stablecoins are valued at par $1 (app-wide convention) and are not listed
+ * here. Assets with neither source stay honestly unpriced.
+ */
+
+// chainId → underlying symbol → AggregatorV3 address (all */USD, 8 decimals).
+export const CHAINLINK_FEEDS = {
+  137: {
+    MATIC: import.meta.env?.VITE_FEED_POLYGON_MATIC_USD || '0xAB594600376Ec9fD91F8e885dADF0CE036862dE0',
+    ETH: import.meta.env?.VITE_FEED_POLYGON_ETH_USD || '0xF9680D99D6C9589e2a93a78A04A279e509205945',
+    BTC: import.meta.env?.VITE_FEED_POLYGON_BTC_USD || '0xc907E116054Ad103354f2D350FD2514433D57F6f',
+    LINK: import.meta.env?.VITE_FEED_POLYGON_LINK_USD || '0xd9FFdb71EbE7496cC440152d43986Aae0AB76665',
+  },
+}
+
+// A feed answer older than this is treated as unavailable rather than
+// presented as current (honest-state rule).
+export const FEED_MAX_AGE_SECONDS = 24 * 60 * 60
+
+// Uniswap V3 fee tiers probed (most-liquid-first) when resolving a DEX spot
+// pool for an asset vs the network stablecoin.
+export const DEX_SPOT_FEE_TIERS = [500, 3000, 10000]

--- a/frontend/src/contexts/UserPreferencesContext.jsx
+++ b/frontend/src/contexts/UserPreferencesContext.jsx
@@ -21,6 +21,7 @@ export function UserPreferencesProvider({ children }) {
     defaultSlippage: 0.5,
     polymarketCategories: [],
     showTestnetAssets: false,
+    showZeroBalances: false,
   })
   const [isLoading, setIsLoading] = useState(false)
 
@@ -36,6 +37,7 @@ export function UserPreferencesProvider({ children }) {
         defaultSlippage: 0.5,
         polymarketCategories: [],
         showTestnetAssets: false,
+        showZeroBalances: false,
       })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -49,6 +51,7 @@ export function UserPreferencesProvider({ children }) {
       const defaultSlippage = getUserPreference(walletAddress, 'default_slippage', 0.5, true)
       const polymarketCategories = getUserPreference(walletAddress, 'polymarket_categories', [], true)
       const showTestnetAssets = getUserPreference(walletAddress, 'show_testnet_assets', false, true)
+      const showZeroBalances = getUserPreference(walletAddress, 'show_zero_balances', false, true)
 
       setPreferences({
         recentSearches,
@@ -56,6 +59,7 @@ export function UserPreferencesProvider({ children }) {
         defaultSlippage,
         polymarketCategories,
         showTestnetAssets,
+        showZeroBalances,
       })
     } catch (error) {
       console.error('Error loading user preferences:', error)
@@ -135,6 +139,14 @@ export function UserPreferencesProvider({ children }) {
     setPreferences(prev => ({ ...prev, showTestnetAssets: next }))
   }, [account])
 
+  const setShowZeroBalances = useCallback((show) => {
+    if (!account) return
+
+    const next = Boolean(show)
+    saveUserPreference(account, 'show_zero_balances', next, true)
+    setPreferences(prev => ({ ...prev, showZeroBalances: next }))
+  }, [account])
+
   const clearAllPreferences = useCallback(() => {
     if (!account) return
 
@@ -145,6 +157,7 @@ export function UserPreferencesProvider({ children }) {
       defaultSlippage: 0.5,
       polymarketCategories: [],
       showTestnetAssets: false,
+      showZeroBalances: false,
     })
   }, [account])
 
@@ -157,6 +170,7 @@ export function UserPreferencesProvider({ children }) {
     setDefaultSlippage,
     setPolymarketCategories,
     setShowTestnetAssets,
+    setShowZeroBalances,
     savePreference,
     clearAllPreferences,
   }

--- a/frontend/src/hooks/usePortfolio.js
+++ b/frontend/src/hooks/usePortfolio.js
@@ -1,7 +1,7 @@
 /**
- * usePortfolio (spec 044 + follow-up) — the connected account's holdings
- * across every network the app supports, grouped by the SEC/CFTC asset
- * taxonomy.
+ * usePortfolio (spec 044 v1.2) — the connected account's holdings across
+ * every supported network, grouped by the SEC/CFTC asset taxonomy and
+ * aggregated per underlying asset (native + wrapped forms combined, FR-025).
  *
  * Cross-chain: balances are read over each network's own read provider
  * (makeReadProvider), independent of the wallet's active chain. Testnet
@@ -9,21 +9,20 @@
  * assets" preference. Discovery stays registry-driven (the panel discloses
  * this, FR-013).
  *
- * Honest-state rules (constitution III):
- *   - a failed read never renders as a zero balance — the asset is skipped
+ * Pricing (FR-022): USD values come from verifiable on-chain sources —
+ * Chainlink feeds first, then DEX pool spot vs the network stablecoin
+ * (lib/portfolio/prices.js); stablecoins at par $1. Honest-state rules
+ * (constitution III):
+ *   - a failed balance read never renders as zero — the asset is skipped
  *     and reported in `failedAssets`;
- *   - an asset with no trustworthy USD price gets `usd: null` and is simply
- *     excluded from USD sums (the feed's hardcoded fallback rate counts as
- *     unavailable, and the MATIC/USD feed never prices another chain's
- *     native coin);
- *   - Digital Commodities are always listed in full — a zero balance renders
- *     as a true 0 (worth $0.00), other categories list only nonzero holdings.
+ *   - an asset with no resolvable on-chain price gets `usd: null` and is
+ *     excluded from USD sums;
+ *   - zero of anything is worth exactly $0.00 (no price feed required).
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Contract, formatUnits } from 'ethers'
 import { useWallet } from './useWalletManagement'
 import { useUserPreferences } from './useUserPreferences'
-import { usePrice } from '../contexts/PriceContext'
 import { makeReadProvider } from '../utils/rpcProvider'
 import { NETWORKS } from '../config/networks'
 import {
@@ -32,16 +31,13 @@ import {
   getTaxonomyCategory,
   TAXONOMY_CATEGORIES,
 } from '../config/assetTaxonomy'
+import { fetchPortfolioPrices, underlyingSymbolOf } from '../lib/portfolio/prices'
+import { aggregateHoldings } from '../lib/portfolio/aggregate'
 
 const POLL_MS = 60_000
 
 // Works for ERC-20 balances and ERC-721 item counts alike.
 const BALANCE_OF_ABI = ['function balanceOf(address) view returns (uint256)']
-
-// The app's only price feed quotes MATIC/USD (usePriceConversion), so the
-// native/wrapped-native rate applies solely on MATIC-native chains. Applying
-// it elsewhere (e.g. pricing ETH or ETC with a MATIC rate) would fabricate value.
-const PRICE_FEED_NATIVE_SYMBOLS = new Set(['MATIC', 'POL'])
 
 async function readAssetBalance(asset, { provider, address }) {
   if (asset.kind === 'native') {
@@ -51,7 +47,7 @@ async function readAssetBalance(asset, { provider, address }) {
   return token.balanceOf(address)
 }
 
-function toHolding(asset, balanceRaw, { nativeUsdRate }) {
+function toHolding(asset, balanceRaw, priceMap) {
   const balance =
     asset.kind === 'nft' ? Number(balanceRaw) : Number(formatUnits(balanceRaw, asset.decimals))
 
@@ -62,13 +58,9 @@ function toHolding(asset, balanceRaw, { nativeUsdRate }) {
   } else if (asset.categoryId === 'payment-stablecoins') {
     // Par $1 — the app-wide stablecoin convention (see useAccountStats).
     usd = balance
-  } else if (
-    asset.kind !== 'nft' &&
-    nativeUsdRate != null &&
-    asset.baselineSymbol &&
-    PRICE_FEED_NATIVE_SYMBOLS.has(asset.baselineSymbol.toUpperCase())
-  ) {
-    usd = balance * nativeUsdRate
+  } else if (asset.kind !== 'nft') {
+    const price = priceMap.get(underlyingSymbolOf(asset))
+    if (price) usd = balance * price.usd
   }
   return { asset, balance, balanceRaw, usd, network: NETWORKS[asset.chainId]?.name || String(asset.chainId) }
 }
@@ -78,10 +70,7 @@ export function usePortfolio() {
   const { address, isConnected } = wallet
   const { preferences } = useUserPreferences() || {}
   const showTestnetAssets = Boolean(preferences?.showTestnetAssets)
-  const price = usePrice()
-  // A feed error means the exported rate is the hardcoded fallback — honest
-  // portfolios treat that as "no price" rather than presenting it as real.
-  const nativeUsdRate = price?.error ? null : price?.nativeUsdRate ?? null
+  const showZeroBalances = Boolean(preferences?.showZeroBalances)
 
   const chainIds = useMemo(
     () => getPortfolioChainIds({ includeTestnets: showTestnetAssets }),
@@ -96,6 +85,7 @@ export function usePortfolio() {
   )
 
   const [reads, setReads] = useState({ balances: null, failedAssets: [], error: null })
+  const [priceMap, setPriceMap] = useState(() => new Map())
   const [isLoading, setIsLoading] = useState(false)
   const [lastUpdated, setLastUpdated] = useState(null)
   const reqIdRef = useRef(0)
@@ -109,11 +99,16 @@ export function usePortfolio() {
     // inviting overlapping retries against a stale error.
     setReads((prev) => (prev.error ? { balances: null, failedAssets: [], error: null } : prev))
     try {
-      const settled = await Promise.allSettled(
-        registry.map((asset) =>
-          readAssetBalance(asset, { provider: providers.get(asset.chainId), address }),
+      // Prices resolve concurrently with balances; a total pricing failure
+      // leaves assets honestly unpriced without failing the portfolio.
+      const [settled, priced] = await Promise.all([
+        Promise.allSettled(
+          registry.map((asset) =>
+            readAssetBalance(asset, { provider: providers.get(asset.chainId), address }),
+          ),
         ),
-      )
+        fetchPortfolioPrices(providers, registry).catch(() => new Map()),
+      ])
       if (reqId !== reqIdRef.current) return
 
       const balances = new Map()
@@ -133,6 +128,7 @@ export function usePortfolio() {
         setReads({ balances: null, failedAssets, error: 'Unable to read balances from the supported networks.' })
       } else {
         setReads({ balances, failedAssets, error: null })
+        setPriceMap(priced)
         setLastUpdated(Date.now())
       }
     } catch (err) {
@@ -148,6 +144,7 @@ export function usePortfolio() {
   useEffect(() => {
     reqIdRef.current++
     setReads({ balances: null, failedAssets: [], error: null })
+    setPriceMap(new Map())
     setLastUpdated(null)
     load()
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -165,34 +162,39 @@ export function usePortfolio() {
     else if (reads.error) status = 'error'
     else if (!reads.balances) status = 'loading'
 
+    // Every readable registry instance becomes a holding — zero balances
+    // included, so aggregates can list all their instances in the sheet.
+    // Zero-balance AGGREGATES are hidden from the main view unless the
+    // member enables the zero-balance preference (FR-023).
     const holdings = []
     if (reads.balances) {
       for (const asset of registry) {
         const raw = reads.balances.get(`${asset.chainId}:${asset.id}`)
         if (raw == null) continue
-        // Digital Commodities always render in full (zero balances included);
-        // every other category lists only what the account actually holds.
-        if (raw <= 0n && asset.categoryId !== 'digital-commodities') continue
-        holdings.push(toHolding(asset, raw, { nativeUsdRate }))
+        holdings.push(toHolding(asset, raw, priceMap))
       }
     }
 
+    const aggregates = aggregateHoldings(holdings, priceMap).filter(
+      (agg) => showZeroBalances || agg.balance > 0,
+    )
+
     const byCategory = new Map()
-    for (const h of holdings) {
-      const list = byCategory.get(h.asset.categoryId) || []
-      list.push(h)
-      byCategory.set(h.asset.categoryId, list)
+    for (const agg of aggregates) {
+      const list = byCategory.get(agg.categoryId) || []
+      list.push(agg)
+      byCategory.set(agg.categoryId, list)
     }
     const categories = TAXONOMY_CATEGORIES
       // The regulatory categories always render; Unclassified only when it
       // actually holds something (FR-012).
       .filter((cat) => cat.id !== 'unclassified' || (byCategory.get(cat.id) || []).length > 0)
       .map((cat) => {
-        const catHoldings = byCategory.get(cat.id) || []
+        const catAggregates = byCategory.get(cat.id) || []
         return {
           category: getTaxonomyCategory(cat.id),
-          holdings: catHoldings,
-          subtotalUsd: catHoldings.reduce((sum, h) => sum + (h.usd ?? 0), 0),
+          aggregates: catAggregates,
+          subtotalUsd: catAggregates.reduce((sum, a) => sum + (a.usd ?? 0), 0),
         }
       })
 
@@ -201,14 +203,17 @@ export function usePortfolio() {
       isLoading,
       error: reads.error,
       holdings,
+      aggregates,
       categories,
-      totalUsd: holdings.reduce((sum, h) => sum + (h.usd ?? 0), 0),
+      totalUsd: aggregates.reduce((sum, a) => sum + (a.usd ?? 0), 0),
       failedAssets: reads.failedAssets,
+      priceMap,
       showTestnetAssets,
+      showZeroBalances,
       lastUpdated,
       refresh: load,
     }
-  }, [registry, isConnected, address, reads, nativeUsdRate, isLoading, lastUpdated, load, showTestnetAssets])
+  }, [registry, isConnected, address, reads, priceMap, isLoading, lastUpdated, load, showTestnetAssets, showZeroBalances])
 }
 
 export default usePortfolio

--- a/frontend/src/lib/portfolio/aggregate.js
+++ b/frontend/src/lib/portfolio/aggregate.js
@@ -1,0 +1,113 @@
+/**
+ * Wrapped-asset aggregation for the portfolio (spec 044 v1.2, FR-025).
+ *
+ * Instances (per-chain holdings, native + wrapped forms) are combined into
+ * one aggregate row per (category, underlying symbol): native ETH + WETH on
+ * every scanned chain roll up into a single "Ethereum" position valued
+ * together. The bottom sheet lists each instance's balance separately.
+ *
+ * Pure functions — no chain reads — so the grouping logic is unit-testable.
+ */
+import { getUnderlyingMeta } from '../../config/assetTaxonomy'
+import { underlyingSymbolOf } from './prices'
+
+// A native instance on its underlying's canonical mainnet is "at home" —
+// it renders without a network badge (FR-026).
+export function isHomeInstance(asset) {
+  const meta = getUnderlyingMeta(underlyingSymbolOf(asset))
+  return asset.kind === 'native' && meta.homeChainId === asset.chainId
+}
+
+// Member-facing form label for an instance ("Native" / "Wrapped (WETH)").
+export function instanceFormLabel(asset) {
+  if (asset.kind === 'native') return 'Native'
+  if (asset.kind === 'nft') return 'Collection'
+  const underlying = underlyingSymbolOf(asset)
+  if (underlying && underlying !== asset.symbol.toUpperCase()) {
+    return `Wrapped (${asset.symbol})`
+  }
+  return 'Token'
+}
+
+// Max fraction digits shown for a fungible amount.
+const FRACTION_DIGITS = 6
+
+/**
+ * Dust-safe display amount: a nonzero balance never rounds to a misleading
+ * "0" (honest state) — it floors at "< 0.000001".
+ */
+export function formatAssetAmount(balance, symbol, kind = 'erc20') {
+  if (kind === 'nft') return `${balance} ${balance === 1 ? 'item' : 'items'}`
+  const value = Number(balance) || 0
+  if (value > 0 && value < 10 ** -FRACTION_DIGITS) {
+    return `< 0.${'0'.repeat(FRACTION_DIGITS - 1)}1 ${symbol}`
+  }
+  const digits = value !== 0 && Math.abs(value) < 1 ? FRACTION_DIGITS : 4
+  return `${value.toLocaleString('en-US', { maximumFractionDigits: digits })} ${symbol}`
+}
+
+/**
+ * Group holdings into aggregates keyed by (categoryId, underlying symbol).
+ *
+ * @param {Array} holdings - Holding[] from usePortfolio (asset + balance + usd)
+ * @param {Map<string, {usd:number, source:string, chainId:number}>} priceMap
+ * @returns {Array} aggregates: {id, categoryId, underlying, name, kind,
+ *   balance, usd, unitPriceUsd, priceEntry, instances[]}
+ */
+export function aggregateHoldings(holdings, priceMap = new Map()) {
+  const byKey = new Map()
+  for (const holding of holdings) {
+    const underlying = underlyingSymbolOf(holding.asset) || holding.asset.symbol.toUpperCase()
+    const key = `${holding.asset.categoryId}|${underlying}`
+    let agg = byKey.get(key)
+    if (!agg) {
+      const priceEntry =
+        holding.asset.categoryId === 'payment-stablecoins' ? null : priceMap.get(underlying) || null
+      agg = {
+        id: key,
+        categoryId: holding.asset.categoryId,
+        underlying,
+        name: getUnderlyingMeta(underlying).name,
+        kind: holding.asset.kind === 'nft' ? 'nft' : 'fungible',
+        balance: 0,
+        usd: null,
+        unitPriceUsd:
+          holding.asset.categoryId === 'payment-stablecoins' ? 1 : priceEntry?.usd ?? null,
+        priceEntry,
+        instances: [],
+      }
+      byKey.set(key, agg)
+    }
+    agg.instances.push(holding)
+    agg.balance += holding.balance
+  }
+
+  // Aggregate USD: zero-balance instances are neutral; if any NONZERO
+  // instance is unpriced the aggregate is unpriced (usd null) — summing only
+  // the priced part would present an incomplete figure as the position's
+  // value. All-zero aggregates are honestly worth $0.00.
+  for (const agg of byKey.values()) {
+    const nonzero = agg.instances.filter((h) => h.balance > 0)
+    if (nonzero.length === 0) {
+      agg.usd = 0
+    } else if (nonzero.some((h) => h.usd == null)) {
+      agg.usd = null
+    } else {
+      agg.usd = nonzero.reduce((sum, h) => sum + h.usd, 0)
+    }
+  }
+
+  // Stable ordering: home/native instances first, then mainnets, then
+  // testnets, then by chain id — so the sheet reads naturally.
+  for (const agg of byKey.values()) {
+    agg.instances.sort((a, b) => {
+      const home = Number(isHomeInstance(b.asset)) - Number(isHomeInstance(a.asset))
+      if (home !== 0) return home
+      const native = Number(b.asset.kind === 'native') - Number(a.asset.kind === 'native')
+      if (native !== 0) return native
+      return a.asset.chainId - b.asset.chainId
+    })
+  }
+
+  return Array.from(byKey.values())
+}

--- a/frontend/src/lib/portfolio/prices.js
+++ b/frontend/src/lib/portfolio/prices.js
@@ -1,0 +1,160 @@
+/**
+ * Verifiable on-chain USD prices for portfolio assets (spec 044 v1.2, FR-022).
+ *
+ * Resolution ladder per underlying symbol (ETH, BTC, MATIC, ETC, LINK, …):
+ *   1. Chainlink AggregatorV3 feed (config/priceFeeds.js) — rejected when the
+ *      answer is non-positive or older than FEED_MAX_AGE_SECONDS.
+ *   2. DEX pool spot: the asset's representative ERC-20 vs the network's
+ *      stablecoin on that chain's configured Uniswap-V3-style DEX, from the
+ *      pool's slot0 sqrtPriceX96 (stablecoin at par $1).
+ *
+ * Stablecoins are valued at par elsewhere and never priced here. A symbol
+ * with no resolvable source is simply absent from the result — the caller
+ * renders it unpriced rather than inventing a value.
+ */
+import { Contract } from 'ethers'
+import { AGGREGATOR_V3_ABI } from '../../abis/AggregatorV3'
+import { UNISWAP_V3_FACTORY_ABI, UNISWAP_V3_POOL_ABI } from '../../abis/UniswapV3PoolReader'
+import { CHAINLINK_FEEDS, FEED_MAX_AGE_SECONDS, DEX_SPOT_FEE_TIERS } from '../../config/priceFeeds'
+import { NETWORKS } from '../../config/networks'
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+const Q96 = 2 ** 96
+
+export function underlyingSymbolOf(asset) {
+  return (asset.baselineSymbol || asset.symbol || '').toUpperCase()
+}
+
+async function readChainlinkUsd(provider, feedAddress, nowSeconds) {
+  const feed = new Contract(feedAddress, AGGREGATOR_V3_ABI, provider)
+  const [roundData, decimals] = await Promise.all([feed.latestRoundData(), feed.decimals()])
+  const answer = roundData[1]
+  const updatedAt = Number(roundData[3])
+  if (answer <= 0n) throw new Error('non-positive feed answer')
+  if (nowSeconds - updatedAt > FEED_MAX_AGE_SECONDS) throw new Error('stale feed answer')
+  return Number(answer) / 10 ** Number(decimals)
+}
+
+/**
+ * Spot price of `token` in the stablecoin (≈USD), from the most liquid
+ * existing pool across the probed fee tiers. Returns null when no pool
+ * exists or the pool is empty.
+ */
+async function readDexSpotUsd(provider, dex, token, stable) {
+  const factory = new Contract(dex.factory, UNISWAP_V3_FACTORY_ABI, provider)
+  for (const fee of DEX_SPOT_FEE_TIERS) {
+    let poolAddress
+    try {
+      poolAddress = await factory.getPool(token.address, stable.address, fee)
+    } catch {
+      continue
+    }
+    if (!poolAddress || poolAddress === ZERO_ADDRESS) continue
+    try {
+      const pool = new Contract(poolAddress, UNISWAP_V3_POOL_ABI, provider)
+      const [slot0, token0, liquidity] = await Promise.all([
+        pool.slot0(),
+        pool.token0(),
+        pool.liquidity(),
+      ])
+      if (liquidity === 0n) continue
+      const sqrtPriceX96 = Number(slot0[0])
+      if (!sqrtPriceX96) continue
+      // rawRatio = raw token1 per raw token0. Human price of our token in
+      // the stablecoin: token0 → rawRatio·10^(dTok−dStable);
+      // token1 → (1/rawRatio)·10^(dTok−dStable).
+      const rawRatio = (sqrtPriceX96 / Q96) ** 2
+      const tokenIsToken0 = token0.toLowerCase() === token.address.toLowerCase()
+      const price =
+        (tokenIsToken0 ? rawRatio : 1 / rawRatio) * 10 ** (token.decimals - stable.decimals)
+      if (Number.isFinite(price) && price > 0) return price
+    } catch {
+      continue
+    }
+  }
+  return null
+}
+
+// The ERC-20 stand-in used to price an underlying on a DEX chain: the
+// wrapped native for the chain's own gas asset, else a registry token whose
+// underlying matches (e.g. WETH pricing ETH).
+function dexCandidateFor(underlying, chainId, registryEntries) {
+  return registryEntries.find(
+    (e) =>
+      e.chainId === chainId &&
+      e.kind === 'erc20' &&
+      e.categoryId !== 'payment-stablecoins' &&
+      underlyingSymbolOf(e) === underlying,
+  )
+}
+
+/**
+ * Resolve USD prices for every non-stablecoin underlying in the registry.
+ *
+ * @param {Map<number, import('ethers').Provider>} providers - per-chain read providers
+ * @param {Array} registryEntries - combined per-chain registry entries in scope
+ * @param {number} [nowSeconds] - clock for feed staleness checks (testable)
+ * @returns {Promise<Map<string, {usd: number, source: string, chainId: number}>>}
+ */
+export async function fetchPortfolioPrices(providers, registryEntries, nowSeconds = Math.floor(Date.now() / 1000)) {
+  const prices = new Map()
+  const underlyings = new Set(
+    registryEntries
+      .filter((e) => e.categoryId !== 'payment-stablecoins' && e.kind !== 'nft')
+      .map((e) => underlyingSymbolOf(e))
+      .filter(Boolean),
+  )
+
+  // 1. Chainlink feeds (highest trust), all fetched concurrently.
+  const feedJobs = []
+  for (const [chainIdKey, feeds] of Object.entries(CHAINLINK_FEEDS)) {
+    const chainId = Number(chainIdKey)
+    const provider = providers.get(chainId)
+    if (!provider) continue
+    for (const [symbol, feedAddress] of Object.entries(feeds)) {
+      if (!underlyings.has(symbol) || prices.has(symbol)) continue
+      feedJobs.push(
+        readChainlinkUsd(provider, feedAddress, nowSeconds)
+          .then((usd) => ({ symbol, usd, chainId }))
+          .catch(() => null),
+      )
+    }
+  }
+  for (const result of await Promise.all(feedJobs)) {
+    if (result && !prices.has(result.symbol)) {
+      prices.set(result.symbol, { usd: result.usd, source: 'chainlink', chainId: result.chainId })
+    }
+  }
+
+  // 2. DEX pool spot for whatever is still unpriced, chain by chain.
+  for (const underlying of underlyings) {
+    if (prices.has(underlying)) continue
+    for (const [chainIdKey, provider] of providers) {
+      const chainId = Number(chainIdKey)
+      const net = NETWORKS[chainId]
+      if (!net?.dex || !net?.stablecoin?.address) continue
+      const candidate = dexCandidateFor(underlying, chainId, registryEntries)
+      if (!candidate) continue
+      try {
+        const usd = await readDexSpotUsd(provider, net.dex, candidate, net.stablecoin)
+        if (usd != null) {
+          prices.set(underlying, { usd, source: 'dex', chainId })
+          break
+        }
+      } catch {
+        /* try the next chain */
+      }
+    }
+  }
+
+  return prices
+}
+
+// Member-facing names for price provenance (shown in the asset sheet).
+export function priceSourceLabel(entry) {
+  if (!entry) return null
+  const network = NETWORKS[entry.chainId]?.name || `chain ${entry.chainId}`
+  if (entry.source === 'chainlink') return `Chainlink oracle (${network})`
+  if (entry.source === 'dex') return `DEX pool spot (${network})`
+  return null
+}

--- a/frontend/src/lib/portfolio/prices.js
+++ b/frontend/src/lib/portfolio/prices.js
@@ -19,7 +19,12 @@ import { CHAINLINK_FEEDS, FEED_MAX_AGE_SECONDS, DEX_SPOT_FEE_TIERS } from '../..
 import { NETWORKS } from '../../config/networks'
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
-const Q96 = 2 ** 96
+// sqrtPriceX96 is a uint160 — far beyond Number.MAX_SAFE_INTEGER — so the
+// squaring happens in BigInt and only the final scaled ratio is converted.
+// RATIO_SCALE keeps 27 significant decimal digits through the conversion;
+// raw ratios below 1e-27 (no real pool) round to 0 and are rejected.
+const Q192 = 1n << 192n
+const RATIO_SCALE = 10n ** 27n
 
 export function underlyingSymbolOf(asset) {
   return (asset.baselineSymbol || asset.symbol || '').toUpperCase()
@@ -58,12 +63,13 @@ async function readDexSpotUsd(provider, dex, token, stable) {
         pool.liquidity(),
       ])
       if (liquidity === 0n) continue
-      const sqrtPriceX96 = Number(slot0[0])
-      if (!sqrtPriceX96) continue
-      // rawRatio = raw token1 per raw token0. Human price of our token in
-      // the stablecoin: token0 → rawRatio·10^(dTok−dStable);
-      // token1 → (1/rawRatio)·10^(dTok−dStable).
-      const rawRatio = (sqrtPriceX96 / Q96) ** 2
+      const sqrtPriceX96 = BigInt(slot0[0])
+      if (sqrtPriceX96 === 0n) continue
+      // rawRatio = raw token1 per raw token0 = sqrtPriceX96² / 2¹⁹². Human
+      // price of our token in the stablecoin:
+      // token0 → rawRatio·10^(dTok−dStable); token1 → (1/rawRatio)·10^(dTok−dStable).
+      const rawRatio = Number((sqrtPriceX96 * sqrtPriceX96 * RATIO_SCALE) / Q192) / 1e27
+      if (rawRatio === 0) continue
       const tokenIsToken0 = token0.toLowerCase() === token.address.toLowerCase()
       const price =
         (tokenIsToken0 ? rawRatio : 1 / rawRatio) * 10 ** (token.decimals - stable.decimals)

--- a/frontend/src/test/portfolio/AssetDetailSheet.test.jsx
+++ b/frontend/src/test/portfolio/AssetDetailSheet.test.jsx
@@ -1,0 +1,153 @@
+/**
+ * AssetDetailSheet (spec 044 v1.2, FR-024/FR-026/FR-027) — bottom-sheet
+ * contract: instance list with separate balances and network badges,
+ * instance selection, action eligibility, and deep-linking.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, within, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import AssetDetailSheet from '../../components/wallet/AssetDetailSheet'
+
+// Semicolon required: vitest's hoisting transform concatenates this with
+// the vi.mock call below.
+const mockNavigate = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+function instance({ symbol, baselineSymbol = 'ETH', kind = 'erc20', chainId = 137, network = 'Polygon', balance = 1, usd = null, categoryId = 'digital-commodities', source = 'sec-baseline' }) {
+  return {
+    asset: { id: symbol.toLowerCase(), chainId, kind, address: kind === 'native' ? null : `0x${symbol}`, symbol, baselineSymbol, categoryId, source, decimals: 18 },
+    balance,
+    balanceRaw: 1n,
+    usd,
+    network,
+  }
+}
+
+const ETH_AGG = {
+  id: 'digital-commodities|ETH',
+  categoryId: 'digital-commodities',
+  underlying: 'ETH',
+  name: 'Ethereum',
+  kind: 'fungible',
+  balance: 1.75,
+  usd: 3500,
+  unitPriceUsd: 2000,
+  priceEntry: { source: 'chainlink', chainId: 137 },
+  instances: [
+    instance({ symbol: 'ETH', kind: 'native', chainId: 1, network: 'Ethereum', balance: 1, usd: 2000 }),
+    instance({ symbol: 'WETH', chainId: 1, network: 'Ethereum', balance: 0.5, usd: 1000 }),
+    instance({ symbol: 'WETH', chainId: 137, network: 'Polygon', balance: 0.25, usd: 500 }),
+  ],
+}
+
+const VOUCHER_AGG = {
+  id: 'digital-tools|FWMV',
+  categoryId: 'digital-tools',
+  underlying: 'FWMV',
+  name: 'FairWins Membership Voucher',
+  kind: 'nft',
+  balance: 2,
+  usd: null,
+  unitPriceUsd: null,
+  priceEntry: null,
+  instances: [instance({ symbol: 'FWMV', baselineSymbol: undefined, kind: 'nft', chainId: 137, balance: 2, categoryId: 'digital-tools', source: 'app-config' })],
+}
+
+function renderSheet(aggregate, onClose = vi.fn()) {
+  render(
+    <MemoryRouter>
+      <AssetDetailSheet aggregate={aggregate} onClose={onClose} />
+    </MemoryRouter>,
+  )
+  return onClose
+}
+
+beforeEach(() => {
+  mockNavigate.mockReset()
+})
+
+describe('AssetDetailSheet content', () => {
+  it('shows the aggregate position, unit price, and its on-chain source', () => {
+    renderSheet(ETH_AGG)
+    const sheet = screen.getByRole('dialog', { name: /ethereum details/i })
+    expect(within(sheet).getByText(/1\.75 ETH/)).toBeInTheDocument()
+    expect(within(sheet).getByText(/\$3,500\.00/)).toBeInTheDocument()
+    expect(within(sheet).getByText(/\$2,000\.00 per ETH/)).toBeInTheDocument()
+    expect(within(sheet).getByText(/Chainlink oracle \(Polygon\)/)).toBeInTheDocument()
+  })
+
+  it('lists each instance separately with form, network, provenance, and balance (FR-025)', () => {
+    renderSheet(ETH_AGG)
+    const radios = screen.getAllByRole('radio')
+    expect(radios).toHaveLength(3)
+    expect(screen.getByText('Native')).toBeInTheDocument()
+    expect(screen.getAllByText('Wrapped (WETH)')).toHaveLength(2)
+    expect(screen.getByText(/1 ETH$/)).toBeInTheDocument()
+    expect(screen.getByText('0.5 WETH')).toBeInTheDocument()
+    expect(screen.getByText('0.25 WETH')).toBeInTheDocument()
+    expect(screen.getAllByText(/SEC baseline/).length).toBeGreaterThan(0)
+  })
+
+  it('defaults the selection to the first nonzero instance and lets the member switch (FR-027)', () => {
+    renderSheet(ETH_AGG)
+    const radios = screen.getAllByRole('radio')
+    expect(radios[0]).toBeChecked()
+    fireEvent.click(radios[2])
+    expect(radios[2]).toBeChecked()
+    expect(radios[0]).not.toBeChecked()
+  })
+})
+
+describe('AssetDetailSheet actions', () => {
+  it('deep-links Trade to the selected instance network and token', () => {
+    const onClose = renderSheet(ETH_AGG)
+    // Select the Polygon WETH instance, then trade.
+    fireEvent.click(screen.getAllByRole('radio')[2])
+    fireEvent.click(screen.getByRole('button', { name: 'Trade' }))
+    expect(mockNavigate).toHaveBeenCalledWith('/wallet?tab=trade&chain=137&token=WETH')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('disables Trade on networks without an in-app DEX', () => {
+    renderSheet(ETH_AGG)
+    // Ethereum mainnet (chain 1) has dex: null — select the native instance.
+    fireEvent.click(screen.getAllByRole('radio')[0])
+    expect(screen.getByRole('button', { name: 'Trade' })).toBeDisabled()
+    expect(screen.getByText(/no in-app trading on this network/i)).toBeInTheDocument()
+  })
+
+  it('enables Transfer for native coins and disables it for plain wrapped tokens', () => {
+    renderSheet(ETH_AGG)
+    fireEvent.click(screen.getAllByRole('radio')[0]) // native ETH
+    expect(screen.getByRole('button', { name: 'Transfer' })).toBeEnabled()
+    fireEvent.click(screen.getAllByRole('radio')[2]) // WETH on Polygon
+    expect(screen.getByRole('button', { name: 'Transfer' })).toBeDisabled()
+  })
+
+  it('always shows Stake as honestly unavailable (no staking surface yet)', () => {
+    renderSheet(ETH_AGG)
+    const stake = screen.getByRole('button', { name: 'Stake' })
+    expect(stake).toBeDisabled()
+    expect(screen.getByText(/staking is not available in the app yet/i)).toBeInTheDocument()
+  })
+
+  it('offers no trading for collectibles', () => {
+    renderSheet(VOUCHER_AGG)
+    expect(screen.getByRole('button', { name: 'Trade' })).toBeDisabled()
+    expect(screen.getByText(/collectibles cannot be traded here/i)).toBeInTheDocument()
+  })
+})
+
+describe('AssetDetailSheet dismissal', () => {
+  it('closes on Escape and on the backdrop scrim', () => {
+    const onClose = renderSheet(ETH_AGG)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByRole('button', { name: /close asset details/i }))
+    expect(onClose).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/test/portfolio/PortfolioPanel.axe.test.jsx
+++ b/frontend/src/test/portfolio/PortfolioPanel.axe.test.jsx
@@ -1,9 +1,10 @@
 /**
- * PortfolioPanel (spec 044 + follow-up) — WCAG 2.1 AA audits via vitest-axe.
+ * PortfolioPanel + AssetDetailSheet (spec 044 v1.2) — WCAG 2.1 AA audits.
  */
 import { describe, it, expect, vi } from 'vitest'
 import { render, fireEvent, screen } from '@testing-library/react'
 import { axe } from 'vitest-axe'
+import { MemoryRouter } from 'react-router-dom'
 import PortfolioPanel from '../../components/wallet/PortfolioPanel'
 import { getTaxonomyCategory } from '../../config/assetTaxonomy'
 
@@ -13,79 +14,123 @@ vi.mock('../../hooks/usePortfolio', () => ({
   usePortfolio: (...args) => mockUsePortfolio(...args),
 }))
 
-const HOLDINGS = [
-  {
-    asset: { id: 'native', chainId: 137, kind: 'native', address: null, symbol: 'MATIC', name: 'MATIC', categoryId: 'digital-commodities', source: 'sec-baseline', decimals: 18 },
-    balance: 2,
-    balanceRaw: 2n * 10n ** 18n,
-    usd: 1,
-    network: 'Polygon',
-  },
-  {
-    asset: { id: '0xusdc', chainId: 137, kind: 'erc20', address: '0xusdc', symbol: 'USDC', name: 'USD Coin', categoryId: 'payment-stablecoins', source: 'app-config', decimals: 6 },
-    balance: 100,
-    balanceRaw: 100_000_000n,
-    usd: 100,
-    network: 'Polygon',
-  },
-  {
-    asset: { id: '0xlink', chainId: 137, kind: 'erc20', address: '0xlink', symbol: 'LINK', name: 'ChainLink Token', categoryId: 'digital-tools', source: 'curated-registry', decimals: 18 },
-    balance: 5,
-    balanceRaw: 5n * 10n ** 18n,
-    usd: null,
-    network: 'Polygon',
-  },
-]
+const ETH_AGG = {
+  id: 'digital-commodities|ETH',
+  categoryId: 'digital-commodities',
+  underlying: 'ETH',
+  name: 'Ethereum',
+  kind: 'fungible',
+  balance: 1.75,
+  usd: 3500,
+  unitPriceUsd: 2000,
+  priceEntry: { source: 'chainlink', chainId: 137 },
+  instances: [
+    {
+      asset: { id: 'native', chainId: 1, kind: 'native', address: null, symbol: 'ETH', baselineSymbol: 'ETH', categoryId: 'digital-commodities', source: 'sec-baseline', decimals: 18 },
+      balance: 1,
+      balanceRaw: 10n ** 18n,
+      usd: 2000,
+      network: 'Ethereum',
+    },
+    {
+      asset: { id: '0xweth', chainId: 137, kind: 'erc20', address: '0xweth', symbol: 'WETH', baselineSymbol: 'ETH', categoryId: 'digital-commodities', source: 'sec-baseline', decimals: 18 },
+      balance: 0.75,
+      balanceRaw: 75n * 10n ** 16n,
+      usd: 1500,
+      network: 'Polygon',
+    },
+  ],
+}
+
+const USDC_AGG = {
+  id: 'payment-stablecoins|USDC',
+  categoryId: 'payment-stablecoins',
+  underlying: 'USDC',
+  name: 'USD Coin',
+  kind: 'fungible',
+  balance: 100,
+  usd: 100,
+  unitPriceUsd: 1,
+  priceEntry: null,
+  instances: [
+    {
+      asset: { id: '0xusdc', chainId: 137, kind: 'erc20', address: '0xusdc', symbol: 'USDC', categoryId: 'payment-stablecoins', source: 'app-config', decimals: 6 },
+      balance: 100,
+      balanceRaw: 100_000_000n,
+      usd: 100,
+      network: 'Polygon',
+    },
+  ],
+}
 
 function makeSnapshot(overrides = {}) {
-  const holdings = overrides.holdings ?? HOLDINGS
+  const aggregates = overrides.aggregates ?? [ETH_AGG, USDC_AGG]
   const ids = ['digital-commodities', 'digital-securities', 'payment-stablecoins', 'digital-tools', 'digital-collectibles']
   return {
     status: 'ready',
     isLoading: false,
     error: null,
-    holdings,
+    holdings: aggregates.flatMap((a) => a.instances),
+    aggregates,
     categories: ids.map((id) => {
-      const catHoldings = holdings.filter((h) => h.asset.categoryId === id)
+      const catAggregates = aggregates.filter((a) => a.categoryId === id)
       return {
         category: getTaxonomyCategory(id),
-        holdings: catHoldings,
-        subtotalUsd: catHoldings.reduce((s, h) => s + (h.usd ?? 0), 0),
+        aggregates: catAggregates,
+        subtotalUsd: catAggregates.reduce((s, a) => s + (a.usd ?? 0), 0),
       }
     }),
-    totalUsd: 101,
+    totalUsd: 3600,
     failedAssets: [],
+    priceMap: new Map(),
     showTestnetAssets: false,
+    showZeroBalances: false,
     lastUpdated: 1,
     refresh: vi.fn(),
     ...overrides,
   }
 }
 
-describe('PortfolioPanel accessibility (WCAG 2.1 AA)', () => {
+function renderPanel() {
+  return render(
+    <MemoryRouter>
+      <PortfolioPanel />
+    </MemoryRouter>,
+  )
+}
+
+describe('Portfolio accessibility (WCAG 2.1 AA)', () => {
   it('populated portfolio view has no violations', async () => {
     mockUsePortfolio.mockReturnValue(makeSnapshot())
-    const { container } = render(<PortfolioPanel />)
+    const { container } = renderPanel()
     expect(await axe(container)).toHaveNoViolations()
   })
 
   it('collapsed category state has no violations', async () => {
     mockUsePortfolio.mockReturnValue(makeSnapshot())
-    const { container } = render(<PortfolioPanel />)
+    const { container } = renderPanel()
     fireEvent.click(screen.getByRole('button', { name: /payment stablecoins \$/i }))
     expect(await axe(container)).toHaveNoViolations()
   })
 
   it('open category info bubble has no violations', async () => {
     mockUsePortfolio.mockReturnValue(makeSnapshot())
-    const { container } = render(<PortfolioPanel />)
+    const { container } = renderPanel()
     fireEvent.click(screen.getByRole('button', { name: 'About Digital Commodities' }))
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('open asset detail sheet has no violations', async () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot())
+    const { container } = renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /ethereum eth 2 instances/i }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(await axe(container)).toHaveNoViolations()
   })
 
   it('error state has no violations', async () => {
     mockUsePortfolio.mockReturnValue(makeSnapshot({ status: 'error', error: 'Unable to read balances from the supported networks.' }))
-    const { container } = render(<PortfolioPanel />)
+    const { container } = renderPanel()
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/frontend/src/test/portfolio/PortfolioPanel.test.jsx
+++ b/frontend/src/test/portfolio/PortfolioPanel.test.jsx
@@ -1,10 +1,12 @@
 /**
- * PortfolioPanel (spec 044 + follow-up) — rendering-contract tests.
+ * PortfolioPanel (spec 044 v1.2) — rendering-contract tests.
  * The data seam (usePortfolio) is mocked; see usePortfolio.test.jsx for the
- * live-read behavior.
+ * live-read behavior and AssetDetailSheet.test.jsx for the sheet's own
+ * contract.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, within, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import PortfolioPanel from '../../components/wallet/PortfolioPanel'
 import { getTaxonomyCategory } from '../../config/assetTaxonomy'
 
@@ -14,39 +16,51 @@ vi.mock('../../hooks/usePortfolio', () => ({
   usePortfolio: (...args) => mockUsePortfolio(...args),
 }))
 
-function makeHolding({
-  symbol,
-  name,
-  categoryId,
-  source = 'app-config',
-  kind = 'erc20',
-  balance = 1,
-  balanceRaw = 1n,
-  usd = null,
-  chainId = 137,
-  network = 'Polygon',
-  decimals,
-}) {
+function instance({ symbol, baselineSymbol, kind = 'erc20', chainId = 137, network = 'Polygon', balance = 1, usd = null, categoryId = 'digital-commodities', source = 'sec-baseline', decimals = 18 }) {
   return {
-    asset: {
-      id: symbol.toLowerCase(),
-      chainId,
-      kind,
-      address: kind === 'native' ? null : `0x${symbol}`,
-      symbol,
-      name,
-      categoryId,
-      source,
-      decimals,
-    },
+    asset: { id: symbol.toLowerCase(), chainId, kind, address: kind === 'native' ? null : `0x${symbol}`, symbol, baselineSymbol, categoryId, source, decimals },
     balance,
-    balanceRaw,
+    balanceRaw: 1n,
     usd,
     network,
   }
 }
 
-function groupsFromHoldings(holdings, { includeUnclassified = false } = {}) {
+function aggregate({ underlying, name, categoryId = 'digital-commodities', kind = 'fungible', instances, usd, unitPriceUsd = null, priceEntry = null }) {
+  const balance = instances.reduce((s, h) => s + h.balance, 0)
+  return { id: `${categoryId}|${underlying}`, categoryId, underlying, name, kind, balance, usd, unitPriceUsd, priceEntry, instances }
+}
+
+const ETH_AGG = aggregate({
+  underlying: 'ETH',
+  name: 'Ethereum',
+  instances: [
+    instance({ symbol: 'ETH', baselineSymbol: 'ETH', kind: 'native', chainId: 1, network: 'Ethereum', balance: 1, usd: 2000 }),
+    instance({ symbol: 'WETH', baselineSymbol: 'ETH', chainId: 1, network: 'Ethereum', balance: 0.5, usd: 1000 }),
+    instance({ symbol: 'WETH', baselineSymbol: 'ETH', chainId: 137, network: 'Polygon', balance: 0.25, usd: 500 }),
+  ],
+  usd: 3500,
+  unitPriceUsd: 2000,
+  priceEntry: { source: 'chainlink', chainId: 137 },
+})
+
+const USDC_AGG = aggregate({
+  underlying: 'USDC',
+  name: 'USD Coin',
+  categoryId: 'payment-stablecoins',
+  instances: [instance({ symbol: 'USDC', categoryId: 'payment-stablecoins', source: 'app-config', balance: 100, usd: 100, decimals: 6 })],
+  usd: 100,
+  unitPriceUsd: 1,
+})
+
+const ETC_AGG = aggregate({
+  underlying: 'ETC',
+  name: 'Ethereum Classic',
+  instances: [instance({ symbol: 'ETC', baselineSymbol: 'ETC', kind: 'native', chainId: 61, network: 'Ethereum Classic', balance: 2, usd: null })],
+  usd: null,
+})
+
+function groupsFrom(aggregates, { includeUnclassified = false } = {}) {
   const ids = [
     'digital-commodities',
     'digital-securities',
@@ -56,38 +70,44 @@ function groupsFromHoldings(holdings, { includeUnclassified = false } = {}) {
     ...(includeUnclassified ? ['unclassified'] : []),
   ]
   return ids.map((id) => {
-    const catHoldings = holdings.filter((h) => h.asset.categoryId === id)
+    const catAggregates = aggregates.filter((a) => a.categoryId === id)
     return {
       category: getTaxonomyCategory(id),
-      holdings: catHoldings,
-      subtotalUsd: catHoldings.reduce((s, h) => s + (h.usd ?? 0), 0),
+      aggregates: catAggregates,
+      subtotalUsd: catAggregates.reduce((s, a) => s + (a.usd ?? 0), 0),
     }
   })
 }
 
 function makeSnapshot(overrides = {}) {
-  const holdings = overrides.holdings ?? []
+  const aggregates = overrides.aggregates ?? []
   return {
     status: 'ready',
     isLoading: false,
     error: null,
-    holdings,
-    categories: groupsFromHoldings(holdings, overrides.groupOptions),
-    totalUsd: holdings.reduce((s, h) => s + (h.usd ?? 0), 0),
+    holdings: aggregates.flatMap((a) => a.instances),
+    aggregates,
+    categories: groupsFrom(aggregates, overrides.groupOptions),
+    totalUsd: aggregates.reduce((s, a) => s + (a.usd ?? 0), 0),
     failedAssets: [],
+    priceMap: new Map(),
     showTestnetAssets: false,
+    showZeroBalances: false,
     lastUpdated: 1,
     refresh: vi.fn(),
     ...overrides,
   }
 }
 
-const POPULATED = [
-  makeHolding({ symbol: 'MATIC', name: 'MATIC', categoryId: 'digital-commodities', source: 'sec-baseline', kind: 'native', balance: 2, balanceRaw: 2n * 10n ** 18n, decimals: 18, usd: 1 }),
-  makeHolding({ symbol: 'ETH', name: 'Ether', categoryId: 'digital-commodities', source: 'sec-baseline', kind: 'native', balance: 0, balanceRaw: 0n, decimals: 18, usd: 0, chainId: 1, network: 'Ethereum' }),
-  makeHolding({ symbol: 'USDC', name: 'USD Coin', categoryId: 'payment-stablecoins', source: 'app-config', balance: 100, balanceRaw: 100_000_000n, decimals: 6, usd: 100 }),
-  makeHolding({ symbol: 'LINK', name: 'ChainLink Token', categoryId: 'digital-tools', source: 'curated-registry', balance: 5, balanceRaw: 5n * 10n ** 18n, decimals: 18, usd: null }),
-]
+const POPULATED = [ETH_AGG, USDC_AGG, ETC_AGG]
+
+function renderPanel() {
+  return render(
+    <MemoryRouter>
+      <PortfolioPanel />
+    </MemoryRouter>,
+  )
+}
 
 beforeEach(() => {
   mockUsePortfolio.mockReset()
@@ -96,189 +116,176 @@ beforeEach(() => {
 describe('PortfolioPanel states', () => {
   it('shows a connect prompt when disconnected', () => {
     mockUsePortfolio.mockReturnValue(makeSnapshot({ status: 'disconnected' }))
-    render(<PortfolioPanel />)
+    renderPanel()
     expect(screen.getByText(/connect a wallet/i)).toBeInTheDocument()
     expect(screen.queryByText(/total portfolio balance/i)).not.toBeInTheDocument()
   })
 
   it('shows a loading state', () => {
     mockUsePortfolio.mockReturnValue(makeSnapshot({ status: 'loading' }))
-    render(<PortfolioPanel />)
+    renderPanel()
     expect(screen.getByRole('status')).toHaveTextContent(/loading portfolio/i)
   })
 
   it('shows the error state with a working retry', () => {
     const snapshot = makeSnapshot({ status: 'error', error: 'Unable to read balances from the supported networks.' })
     mockUsePortfolio.mockReturnValue(snapshot)
-    render(<PortfolioPanel />)
+    renderPanel()
     expect(screen.getByRole('alert')).toHaveTextContent(/unable to read balances/i)
     fireEvent.click(screen.getByRole('button', { name: /retry/i }))
     expect(snapshot.refresh).toHaveBeenCalled()
   })
 })
 
-describe('PortfolioPanel portfolio view', () => {
-  it('renders the total, category subtotals, and asset rows', () => {
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
-    render(<PortfolioPanel />)
+describe('PortfolioPanel aggregate rows', () => {
+  it('renders one combined row per underlying with total, subtotal, and instance summary (FR-025)', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ aggregates: POPULATED }))
+    renderPanel()
 
     expect(screen.getByText('Total portfolio balance')).toBeInTheDocument()
-    expect(screen.getByText(/\$101\.00/)).toBeInTheDocument()
+    expect(screen.getByText('$3,600.00')).toBeInTheDocument()
 
-    const stables = screen.getByRole('region', { name: 'Payment Stablecoins' })
-    expect(within(stables).getByText('USD Coin')).toBeInTheDocument()
-    expect(within(stables).getByText(/100 USDC/)).toBeInTheDocument()
-    expect(within(stables).getByText('$100.00')).toBeInTheDocument()
-  })
-
-  it('labels each row with its network', () => {
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
-    render(<PortfolioPanel />)
     const commodities = screen.getByRole('region', { name: 'Digital Commodities' })
-    expect(within(commodities).getByText('Polygon')).toBeInTheDocument()
-    expect(within(commodities).getByText('Ethereum')).toBeInTheDocument()
+    const ethRow = within(commodities).getByRole('button', { name: /ethereum eth 3 instances/i })
+    expect(ethRow).toHaveTextContent('3 instances · 2 networks')
+    expect(ethRow).toHaveTextContent('$3,500.00')
+    // Single-instance aggregates name their network directly.
+    const etcRow = within(commodities).getByRole('button', { name: /ethereum classic/i })
+    expect(etcRow).toHaveTextContent('Ethereum Classic')
   })
 
-  it('renders zero-balance commodities as an honest 0 worth $0.00', () => {
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
-    render(<PortfolioPanel />)
-    const commodities = screen.getByRole('region', { name: 'Digital Commodities' })
-    expect(within(commodities).getByText('0 ETH')).toBeInTheDocument()
-    expect(within(commodities).getByText('$0.00')).toBeInTheDocument()
+  it('renders unpriced aggregates with an em dash, never $0.00', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ aggregates: POPULATED }))
+    renderPanel()
+    const etcRow = screen.getByRole('button', { name: /ethereum classic 2 etc/i })
+    expect(within(etcRow).getByText('price unavailable')).toBeInTheDocument()
+    expect(within(etcRow).queryByText('$0.00')).not.toBeInTheDocument()
   })
 
-  it('renders unpriced assets with an em dash and no partial labeling anywhere', () => {
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
-    render(<PortfolioPanel />)
+  it('opens the asset detail sheet when a row is tapped (FR-024)', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ aggregates: POPULATED }))
+    renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /ethereum eth 3 instances/i }))
 
-    const tools = screen.getByRole('region', { name: 'Digital Tools' })
-    expect(within(tools).getByText('price unavailable')).toBeInTheDocument()
-    expect(within(tools).queryByText('$0.00')).not.toBeInTheDocument()
-    expect(screen.queryByText(/\(partial\)/i)).not.toBeInTheDocument()
-    expect(screen.queryByText(/excluded from USD totals/i)).not.toBeInTheDocument()
+    const sheet = screen.getByRole('dialog', { name: /ethereum details/i })
+    expect(sheet).toBeInTheDocument()
+    // Instances are listed separately inside the sheet.
+    expect(within(sheet).getByText('Native')).toBeInTheDocument()
+    expect(within(sheet).getAllByText('Wrapped (WETH)')).toHaveLength(2)
+
+    fireEvent.click(within(sheet).getByRole('button', { name: 'Close' }))
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
   it('collapses a category on toggle, keeping header and subtotal visible', () => {
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
-    render(<PortfolioPanel />)
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ aggregates: POPULATED }))
+    renderPanel()
 
-    // The toggle's accessible name includes the subtotal, which separates it
-    // from the "About Payment Stablecoins" info-bubble button.
     const toggle = screen.getByRole('button', { name: /payment stablecoins \$/i })
     expect(toggle).toHaveAttribute('aria-expanded', 'true')
 
     fireEvent.click(toggle)
     expect(toggle).toHaveAttribute('aria-expanded', 'false')
-    // Rows hide (hidden region) while header and subtotal remain visible.
     expect(screen.getByText('USD Coin')).not.toBeVisible()
-    expect(within(toggle).getByText('Payment Stablecoins')).toBeVisible()
     expect(within(toggle).getByText(/\$100\.00/)).toBeVisible()
 
     fireEvent.click(toggle)
     expect(screen.getByText('USD Coin')).toBeVisible()
   })
 
-  it('shows an explicit empty state for categories with no holdings', () => {
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
-    render(<PortfolioPanel />)
+  it('shows an explicit empty state for categories with no aggregates', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ aggregates: POPULATED }))
+    renderPanel()
     const securities = screen.getByRole('region', { name: 'Digital Securities' })
     expect(within(securities).getByText(/no assets in this category/i)).toBeInTheDocument()
   })
 
   it('never renders a nonzero dust balance as zero (honest state)', () => {
-    const dust = makeHolding({
-      symbol: 'WETH',
-      name: 'Wrapped Ether',
-      categoryId: 'digital-commodities',
-      source: 'sec-baseline',
-      balance: 1e-18,
-      balanceRaw: 1n, // 1 wei of WETH
-      decimals: 18,
+    const dust = aggregate({
+      underlying: 'ETH',
+      name: 'Ethereum',
+      instances: [instance({ symbol: 'WETH', baselineSymbol: 'ETH', balance: 1e-18, usd: null })],
       usd: null,
     })
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: [dust] }))
-    render(<PortfolioPanel />)
-    expect(screen.getByText('< 0.000001 WETH')).toBeInTheDocument()
-    expect(screen.queryByText(/^0 WETH$/)).not.toBeInTheDocument()
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ aggregates: [dust] }))
+    renderPanel()
+    expect(screen.getByText(/< 0\.000001 ETH/)).toBeInTheDocument()
   })
 
   it('refresh button triggers a reload', () => {
-    const snapshot = makeSnapshot({ holdings: POPULATED })
+    const snapshot = makeSnapshot({ aggregates: POPULATED })
     mockUsePortfolio.mockReturnValue(snapshot)
-    render(<PortfolioPanel />)
-    fireEvent.click(screen.getByRole('button', { name: /refresh/i }))
+    renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /^refresh$/i }))
     expect(snapshot.refresh).toHaveBeenCalled()
   })
 })
 
-describe('PortfolioPanel taxonomy provenance (info bubbles)', () => {
+describe('PortfolioPanel taxonomy info bubbles', () => {
   it('keeps category descriptions out of the page until the info bubble opens', () => {
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
-    render(<PortfolioPanel />)
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ aggregates: POPULATED }))
+    renderPanel()
     const commodities = getTaxonomyCategory('digital-commodities')
-
-    // Dense inline explainer is gone…
     expect(screen.queryByText(commodities.description)).not.toBeInTheDocument()
-
-    // …and lives in the shared InfoTip bubble beside the category header.
     fireEvent.click(screen.getByRole('button', { name: 'About Digital Commodities' }))
     expect(screen.getByText(commodities.description)).toBeInTheDocument()
   })
 
   it('offers an info bubble for every rendered category', () => {
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
-    render(<PortfolioPanel />)
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ aggregates: POPULATED }))
+    renderPanel()
     for (const id of ['digital-commodities', 'digital-securities', 'payment-stablecoins', 'digital-tools', 'digital-collectibles']) {
       const cat = getTaxonomyCategory(id)
       expect(screen.getByRole('button', { name: `About ${cat.label}` })).toBeInTheDocument()
     }
   })
-
-  it('labels each row with its classification source', () => {
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
-    render(<PortfolioPanel />)
-    expect(screen.getAllByText('SEC baseline').length).toBeGreaterThan(0)
-    expect(screen.getByText('Curated registry')).toBeInTheDocument()
-    expect(screen.getByText('App configuration')).toBeInTheDocument()
-  })
-
-  it('always shows the compact disclosure line in the portfolio view', () => {
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: [] }))
-    render(<PortfolioPanel />)
-    expect(screen.getByText(/not legal or investment advice/i)).toBeInTheDocument()
-    expect(screen.getByText(/curated registry are scanned/i)).toBeInTheDocument()
-  })
 })
 
-describe('PortfolioPanel testnet visibility', () => {
-  it('notes that testnet tokens are hidden when the preference is off', () => {
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED, showTestnetAssets: false }))
-    render(<PortfolioPanel />)
+describe('PortfolioPanel visibility notes and disclosures', () => {
+  it('notes hidden testnet and zero-balance assets when the preferences are off', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ aggregates: POPULATED }))
+    renderPanel()
     expect(screen.getByText(/testnet tokens are hidden/i)).toBeInTheDocument()
+    expect(screen.getByText(/zero-balance assets are hidden/i)).toBeInTheDocument()
   })
 
-  it('drops the note when testnet tokens are shown', () => {
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED, showTestnetAssets: true }))
-    render(<PortfolioPanel />)
+  it('drops the notes when the preferences are on', () => {
+    mockUsePortfolio.mockReturnValue(
+      makeSnapshot({ aggregates: POPULATED, showTestnetAssets: true, showZeroBalances: true }),
+    )
+    renderPanel()
     expect(screen.queryByText(/testnet tokens are hidden/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/zero-balance assets are hidden/i)).not.toBeInTheDocument()
+  })
+
+  it('always shows the compact disclosure line naming on-chain price sources', () => {
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ aggregates: [] }))
+    renderPanel()
+    expect(screen.getByText(/not legal or investment advice/i)).toBeInTheDocument()
+    expect(screen.getByText(/on-chain sources \(oracle/i)).toBeInTheDocument()
   })
 })
 
 describe('PortfolioPanel unclassified handling', () => {
-  it('renders unclassified holdings in an explicit Unclassified group', () => {
-    const holdings = [
-      ...POPULATED,
-      makeHolding({ symbol: 'MYST', name: 'Mystery Token', categoryId: 'unclassified', balance: 3, balanceRaw: 3n * 10n ** 18n, decimals: 18, usd: null }),
-    ]
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings, groupOptions: { includeUnclassified: true } }))
-    render(<PortfolioPanel />)
+  it('renders unclassified aggregates in an explicit Unclassified group', () => {
+    const myst = aggregate({
+      underlying: 'MYST',
+      name: 'MYST',
+      categoryId: 'unclassified',
+      instances: [instance({ symbol: 'MYST', categoryId: 'unclassified', source: 'app-config', balance: 3 })],
+      usd: null,
+    })
+    mockUsePortfolio.mockReturnValue(
+      makeSnapshot({ aggregates: [...POPULATED, myst], groupOptions: { includeUnclassified: true } }),
+    )
+    renderPanel()
     const region = screen.getByRole('region', { name: 'Unclassified' })
-    expect(within(region).getByText('Mystery Token')).toBeInTheDocument()
+    expect(within(region).getByRole('button', { name: /myst/i })).toBeInTheDocument()
   })
 
   it('omits the Unclassified group when nothing is unclassified', () => {
-    mockUsePortfolio.mockReturnValue(makeSnapshot({ holdings: POPULATED }))
-    render(<PortfolioPanel />)
+    mockUsePortfolio.mockReturnValue(makeSnapshot({ aggregates: POPULATED }))
+    renderPanel()
     expect(screen.queryByRole('region', { name: 'Unclassified' })).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/test/portfolio/PortfolioPreferencesPanel.test.jsx
+++ b/frontend/src/test/portfolio/PortfolioPreferencesPanel.test.jsx
@@ -7,14 +7,19 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { axe } from 'vitest-axe'
 import PortfolioPreferencesPanel from '../../components/account/PortfolioPreferencesPanel'
 
-const mockPrefs = { preferences: { showTestnetAssets: false }, setShowTestnetAssets: vi.fn() }
+const mockPrefs = {
+  preferences: { showTestnetAssets: false, showZeroBalances: false },
+  setShowTestnetAssets: vi.fn(),
+  setShowZeroBalances: vi.fn(),
+}
 vi.mock('../../hooks/useUserPreferences', () => ({
   useUserPreferences: () => mockPrefs,
 }))
 
 beforeEach(() => {
-  mockPrefs.preferences = { showTestnetAssets: false }
+  mockPrefs.preferences = { showTestnetAssets: false, showZeroBalances: false }
   mockPrefs.setShowTestnetAssets = vi.fn()
+  mockPrefs.setShowZeroBalances = vi.fn()
 })
 
 describe('PortfolioPreferencesPanel', () => {
@@ -37,6 +42,23 @@ describe('PortfolioPreferencesPanel', () => {
     expect(screen.getByText(/sepolia, amoy, mordor/i)).toBeInTheDocument()
     fireEvent.click(screen.getByRole('switch', { name: /show testnet tokens/i }))
     expect(mockPrefs.setShowTestnetAssets).toHaveBeenCalledWith(false)
+  })
+
+  it('renders and flips the zero-balance switch (default hide, FR-023)', () => {
+    render(<PortfolioPreferencesPanel />)
+    const toggle = screen.getByRole('switch', { name: /show zero-balance assets/i })
+    expect(toggle).toHaveAttribute('aria-checked', 'false')
+    expect(screen.getByText(/only assets with a balance are listed/i)).toBeInTheDocument()
+    fireEvent.click(toggle)
+    expect(mockPrefs.setShowZeroBalances).toHaveBeenCalledWith(true)
+  })
+
+  it('describes the enabled zero-balance state and turns off again', () => {
+    mockPrefs.preferences = { showTestnetAssets: false, showZeroBalances: true }
+    render(<PortfolioPreferencesPanel />)
+    expect(screen.getByText(/listed with a 0 balance/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('switch', { name: /show zero-balance assets/i }))
+    expect(mockPrefs.setShowZeroBalances).toHaveBeenCalledWith(false)
   })
 
   it('has no accessibility violations', async () => {

--- a/frontend/src/test/portfolio/aggregate.test.js
+++ b/frontend/src/test/portfolio/aggregate.test.js
@@ -1,0 +1,103 @@
+/**
+ * lib/portfolio/aggregate (spec 044 v1.2, FR-025/FR-026) — wrapped-asset
+ * aggregation, instance labeling, and dust-safe amount formatting.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  aggregateHoldings,
+  isHomeInstance,
+  instanceFormLabel,
+  formatAssetAmount,
+} from '../../lib/portfolio/aggregate'
+
+function holding({ symbol, baselineSymbol, categoryId = 'digital-commodities', kind = 'erc20', chainId = 137, balance = 0, usd = null, network = 'Polygon' }) {
+  return {
+    asset: { id: `${symbol.toLowerCase()}`, chainId, kind, symbol, baselineSymbol, categoryId, source: 'sec-baseline' },
+    balance,
+    balanceRaw: BigInt(Math.round(balance * 1e6)),
+    usd,
+    network,
+  }
+}
+
+const ETH_NATIVE_1 = holding({ symbol: 'ETH', baselineSymbol: 'ETH', kind: 'native', chainId: 1, balance: 1, usd: 2358.22, network: 'Ethereum' })
+const WETH_1 = holding({ symbol: 'WETH', baselineSymbol: 'ETH', chainId: 1, balance: 0.5, usd: 1179.11, network: 'Ethereum' })
+const WETH_137 = holding({ symbol: 'WETH', baselineSymbol: 'ETH', chainId: 137, balance: 0.25, usd: 589.55 })
+const MATIC_NATIVE = holding({ symbol: 'MATIC', baselineSymbol: 'MATIC', kind: 'native', chainId: 137, balance: 7, usd: 3.64 })
+
+describe('aggregateHoldings', () => {
+  it('combines native and wrapped forms across chains into one underlying row (FR-025)', () => {
+    const priceMap = new Map([['ETH', { usd: 2358.22, source: 'chainlink', chainId: 137 }]])
+    const aggregates = aggregateHoldings([ETH_NATIVE_1, WETH_1, WETH_137, MATIC_NATIVE], priceMap)
+
+    expect(aggregates).toHaveLength(2)
+    const eth = aggregates.find((a) => a.underlying === 'ETH')
+    expect(eth.name).toBe('Ethereum')
+    expect(eth.instances).toHaveLength(3)
+    expect(eth.balance).toBeCloseTo(1.75)
+    expect(eth.usd).toBeCloseTo(2358.22 + 1179.11 + 589.55)
+    expect(eth.unitPriceUsd).toBeCloseTo(2358.22)
+    expect(eth.priceEntry.source).toBe('chainlink')
+  })
+
+  it('orders instances home-native first, then by chain', () => {
+    const [eth] = aggregateHoldings([WETH_137, WETH_1, ETH_NATIVE_1])
+    expect(eth.instances[0].asset.kind).toBe('native')
+    expect(eth.instances[0].asset.chainId).toBe(1)
+    expect(eth.instances.map((h) => h.asset.chainId)).toEqual([1, 1, 137])
+  })
+
+  it('keeps aggregates unpriced (usd null) when every instance is unpriced', () => {
+    const [agg] = aggregateHoldings([holding({ symbol: 'WETC', baselineSymbol: 'ETC', chainId: 63, balance: 2 })])
+    expect(agg.usd).toBeNull()
+    expect(agg.unitPriceUsd).toBeNull()
+  })
+
+  it('never presents a partial sum: any unpriced nonzero instance makes the aggregate unpriced', () => {
+    const [agg] = aggregateHoldings([
+      holding({ symbol: 'ETC', baselineSymbol: 'ETC', kind: 'native', chainId: 61, balance: 0, usd: 0 }),
+      holding({ symbol: 'ETC', baselineSymbol: 'ETC', kind: 'native', chainId: 63, balance: 1, usd: null }),
+    ])
+    expect(agg.balance).toBe(1)
+    expect(agg.usd).toBeNull() // not a fabricated $0.00
+  })
+
+  it('separates the same underlying across different categories', () => {
+    const aggregates = aggregateHoldings([
+      holding({ symbol: 'USDC', categoryId: 'payment-stablecoins', balance: 5, usd: 5 }),
+      holding({ symbol: 'USDC', categoryId: 'unclassified', chainId: 1, balance: 1, usd: null }),
+    ])
+    expect(aggregates).toHaveLength(2)
+    // Stablecoins are par-valued; no price entry needed.
+    const stable = aggregates.find((a) => a.categoryId === 'payment-stablecoins')
+    expect(stable.unitPriceUsd).toBe(1)
+  })
+})
+
+describe('isHomeInstance (FR-026)', () => {
+  it('is true only for a native coin on its canonical mainnet', () => {
+    expect(isHomeInstance(ETH_NATIVE_1.asset)).toBe(true)
+    expect(isHomeInstance(WETH_1.asset)).toBe(false) // wrapped, even on home chain
+    expect(isHomeInstance(MATIC_NATIVE.asset)).toBe(true)
+    expect(isHomeInstance({ kind: 'native', chainId: 11155111, symbol: 'ETH', baselineSymbol: 'ETH' })).toBe(false) // testnet
+  })
+})
+
+describe('instanceFormLabel', () => {
+  it('labels native, wrapped, token, and collection forms', () => {
+    expect(instanceFormLabel(ETH_NATIVE_1.asset)).toBe('Native')
+    expect(instanceFormLabel(WETH_137.asset)).toBe('Wrapped (WETH)')
+    expect(instanceFormLabel({ kind: 'erc20', symbol: 'LINK' })).toBe('Token')
+    expect(instanceFormLabel({ kind: 'nft', symbol: 'FWMV' })).toBe('Collection')
+  })
+})
+
+describe('formatAssetAmount', () => {
+  it('floors nonzero dust instead of rounding to a misleading 0', () => {
+    expect(formatAssetAmount(1e-18, 'WETH')).toBe('< 0.000001 WETH')
+    expect(formatAssetAmount(0, 'ETH')).toBe('0 ETH')
+    expect(formatAssetAmount(1234.5, 'USDC')).toBe('1,234.5 USDC')
+    expect(formatAssetAmount(2, 'FWMV', 'nft')).toBe('2 items')
+    expect(formatAssetAmount(1, 'FWMV', 'nft')).toBe('1 item')
+  })
+})

--- a/frontend/src/test/portfolio/prices.test.js
+++ b/frontend/src/test/portfolio/prices.test.js
@@ -140,6 +140,15 @@ describe('fetchPortfolioPrices', () => {
     expect(prices.get('ETC').usd).toBeCloseTo(15, 1)
   })
 
+  it('keeps precision for full-magnitude sqrtPriceX96 values (uint160 ≫ 2^53)', async () => {
+    // USC as token0 with a high WETC price ⇒ sqrtPriceX96 ≈ 1.8e33, far
+    // beyond Number.MAX_SAFE_INTEGER — the BigInt path must stay accurate.
+    setEtcPool(2000, { wetcIsToken0: false })
+    const prices = await fetchPortfolioPrices(providers, registry, NOW)
+    const usd = prices.get('ETC').usd
+    expect(Math.abs(usd - 2000) / 2000).toBeLessThan(1e-6)
+  })
+
   it('leaves assets unpriced when neither source resolves', async () => {
     const prices = await fetchPortfolioPrices(providers, registry, NOW)
     expect(prices.size).toBe(0)

--- a/frontend/src/test/portfolio/prices.test.js
+++ b/frontend/src/test/portfolio/prices.test.js
@@ -1,0 +1,155 @@
+/**
+ * lib/portfolio/prices (spec 044 v1.2, FR-022) — on-chain price ladder tests.
+ * ethers Contract is stubbed with an address-keyed fixture registry.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { fetchPortfolioPrices, priceSourceLabel, underlyingSymbolOf } from '../../lib/portfolio/prices'
+import { CHAINLINK_FEEDS } from '../../config/priceFeeds'
+import { getPortfolioRegistry } from '../../config/assetTaxonomy'
+import { NETWORKS } from '../../config/networks'
+
+// addressLower -> methods object. Semicolon required: vitest's hoisting
+// transform concatenates this with the vi.mock call below.
+const contracts = vi.hoisted(() => new Map());
+
+vi.mock('ethers', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    Contract: class {
+      constructor(address) {
+        const fixture = contracts.get(String(address).toLowerCase())
+        // Returning an object from a constructor substitutes the instance.
+        return (
+          fixture || {
+            latestRoundData: () => Promise.reject(new Error('no fixture')),
+            decimals: () => Promise.reject(new Error('no fixture')),
+            getPool: () => Promise.reject(new Error('no fixture')),
+            slot0: () => Promise.reject(new Error('no fixture')),
+            token0: () => Promise.reject(new Error('no fixture')),
+            liquidity: () => Promise.reject(new Error('no fixture')),
+          }
+        )
+      }
+    },
+  }
+})
+
+const NOW = 1_800_000_000
+const Q96 = 2 ** 96
+
+function feedFixture(priceUsd, { updatedAt = NOW - 60, decimals = 8 } = {}) {
+  const answer = BigInt(Math.round(priceUsd * 10 ** decimals))
+  return {
+    latestRoundData: () => Promise.resolve([1n, answer, 0n, BigInt(updatedAt), 1n]),
+    decimals: () => Promise.resolve(BigInt(decimals)),
+  }
+}
+
+function setFeed(chainId, symbol, fixture) {
+  contracts.set(CHAINLINK_FEEDS[chainId][symbol].toLowerCase(), fixture)
+}
+
+// ETC-family DEX fixture: WETC/USC pool on chain 61 (canonical dex config in
+// networks.js). token0 = WETC (18 dec), token1 = USC (6 dec).
+const ETC_DEX = NETWORKS[61].dex
+const WETC = ETC_DEX.wnative.toLowerCase()
+const USC = NETWORKS[61].stablecoin.address.toLowerCase()
+const POOL_ADDRESS = '0x00000000000000000000000000000000000000AA'
+
+function setEtcPool(priceUsdPerWetc, { wetcIsToken0 = true } = {}) {
+  const rawRatio = wetcIsToken0
+    ? priceUsdPerWetc * 10 ** (6 - 18) // token1(USC raw) per token0(WETC raw)
+    : (1 / priceUsdPerWetc) * 10 ** (18 - 6)
+  const sqrtPriceX96 = BigInt(Math.round(Math.sqrt(rawRatio) * Q96))
+  contracts.set(ETC_DEX.factory.toLowerCase(), {
+    getPool: (a, b, fee) =>
+      Promise.resolve(fee === 500 ? '0x0000000000000000000000000000000000000000' : POOL_ADDRESS),
+  })
+  contracts.set(POOL_ADDRESS.toLowerCase(), {
+    slot0: () => Promise.resolve([sqrtPriceX96, 0n]),
+    token0: () => Promise.resolve(wetcIsToken0 ? WETC : USC),
+    liquidity: () => Promise.resolve(10n ** 18n),
+  })
+}
+
+const registry = [...getPortfolioRegistry(137), ...getPortfolioRegistry(61), ...getPortfolioRegistry(1)]
+const providers = new Map([
+  [137, { chainId: 137 }],
+  [61, { chainId: 61 }],
+  [1, { chainId: 1 }],
+])
+
+beforeEach(() => {
+  contracts.clear()
+})
+
+describe('underlyingSymbolOf', () => {
+  it('maps wrapped forms to their underlying and plain tokens to themselves', () => {
+    expect(underlyingSymbolOf({ symbol: 'WETH', baselineSymbol: 'ETH' })).toBe('ETH')
+    expect(underlyingSymbolOf({ symbol: 'LINK' })).toBe('LINK')
+  })
+})
+
+describe('fetchPortfolioPrices', () => {
+  it('prices baseline assets from Chainlink feeds (highest trust)', async () => {
+    setFeed(137, 'MATIC', feedFixture(0.52))
+    setFeed(137, 'ETH', feedFixture(2358.22))
+    setFeed(137, 'BTC', feedFixture(64000))
+    setFeed(137, 'LINK', feedFixture(14.5))
+
+    const prices = await fetchPortfolioPrices(providers, registry, NOW)
+    expect(prices.get('MATIC')).toMatchObject({ usd: 0.52, source: 'chainlink', chainId: 137 })
+    expect(prices.get('ETH').usd).toBeCloseTo(2358.22)
+    expect(prices.get('BTC').usd).toBeCloseTo(64000)
+    expect(prices.get('LINK').usd).toBeCloseTo(14.5)
+  })
+
+  it('never prices stablecoins or collectibles', async () => {
+    setFeed(137, 'MATIC', feedFixture(0.52))
+    const prices = await fetchPortfolioPrices(providers, registry, NOW)
+    for (const symbol of ['USDC', 'USDT', 'USC', 'FWMV']) {
+      expect(prices.has(symbol)).toBe(false)
+    }
+  })
+
+  it('rejects stale feed answers instead of presenting them as current', async () => {
+    setFeed(137, 'ETH', feedFixture(2358.22, { updatedAt: NOW - 25 * 60 * 60 }))
+    const prices = await fetchPortfolioPrices(providers, registry, NOW)
+    expect(prices.has('ETH')).toBe(false)
+  })
+
+  it('rejects non-positive feed answers', async () => {
+    setFeed(137, 'BTC', feedFixture(-1))
+    const prices = await fetchPortfolioPrices(providers, registry, NOW)
+    expect(prices.has('BTC')).toBe(false)
+  })
+
+  it('falls back to DEX pool spot where no feed exists (ETC via WETC/USC)', async () => {
+    setEtcPool(15)
+    const prices = await fetchPortfolioPrices(providers, registry, NOW)
+    const etc = prices.get('ETC')
+    expect(etc.source).toBe('dex')
+    expect(etc.chainId).toBe(61)
+    expect(etc.usd).toBeCloseTo(15, 1)
+  })
+
+  it('handles the stablecoin being token0 in the pool (inverse ratio)', async () => {
+    setEtcPool(15, { wetcIsToken0: false })
+    const prices = await fetchPortfolioPrices(providers, registry, NOW)
+    expect(prices.get('ETC').usd).toBeCloseTo(15, 1)
+  })
+
+  it('leaves assets unpriced when neither source resolves', async () => {
+    const prices = await fetchPortfolioPrices(providers, registry, NOW)
+    expect(prices.size).toBe(0)
+  })
+})
+
+describe('priceSourceLabel', () => {
+  it('names the source and network for provenance display', () => {
+    expect(priceSourceLabel({ source: 'chainlink', chainId: 137 })).toBe('Chainlink oracle (Polygon)')
+    expect(priceSourceLabel({ source: 'dex', chainId: 61 })).toBe('DEX pool spot (Ethereum Classic)')
+    expect(priceSourceLabel(null)).toBeNull()
+  })
+})

--- a/frontend/src/test/portfolio/usePortfolio.test.jsx
+++ b/frontend/src/test/portfolio/usePortfolio.test.jsx
@@ -1,25 +1,27 @@
 /**
- * usePortfolio (spec 044 + follow-up) — cross-chain balance hook tests.
+ * usePortfolio (spec 044 v1.2) — cross-chain aggregated portfolio tests.
  *
- * Wallet + price state are mocked at the context level per repo convention —
- * never raw wagmi hooks. Per-chain read providers (utils/rpcProvider) and
- * ethers' Contract are stubbed with chain-scoped fixture maps.
+ * Wallet state is mocked at the context level per repo convention — never
+ * raw wagmi hooks. Per-chain read providers (utils/rpcProvider), ethers'
+ * Contract, and the on-chain price ladder (lib/portfolio/prices) are stubbed
+ * with fixture maps.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, waitFor, act } from '@testing-library/react'
 import { WalletContext } from '../../contexts'
-import PriceContext from '../../contexts/PriceContext'
 import usePortfolio from '../../hooks/usePortfolio'
 import { getPortfolioRegistry, getPortfolioChainIds } from '../../config/assetTaxonomy'
-import { NETWORKS } from '../../config/networks'
 
-// Chain-scoped fixtures. Values may be bigints or functions (to simulate
-// rejections). Unlisted assets read as 0n.
+// Chain-scoped fixtures. Balance values may be bigints or functions (to
+// simulate rejections); unlisted assets read as 0n. Semicolon required:
+// vitest's hoisting transform concatenates this with the vi.mock calls.
 const fixtures = vi.hoisted(() => ({
   nativeBalances: new Map(), // chainId -> bigint | fn
   tokenBalances: new Map(), // `${chainId}:${addressLower}` -> bigint | fn
-  prefs: { showTestnetAssets: false },
-}))
+  prefs: { showTestnetAssets: false, showZeroBalances: false },
+  prices: new Map(), // underlying -> {usd, source, chainId}
+  pricesFail: false,
+}));
 
 function resolveFixture(value) {
   if (typeof value === 'function') return value()
@@ -49,10 +51,22 @@ vi.mock('ethers', async (importOriginal) => {
   }
 })
 
+vi.mock('../../lib/portfolio/prices', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    fetchPortfolioPrices: () =>
+      fixtures.pricesFail
+        ? Promise.reject(new Error('pricing down'))
+        : Promise.resolve(new Map(fixtures.prices)),
+  }
+})
+
 vi.mock('../../hooks/useUserPreferences', () => ({
   useUserPreferences: () => ({
     preferences: { ...fixtures.prefs },
     setShowTestnetAssets: vi.fn(),
+    setShowZeroBalances: vi.fn(),
   }),
 }))
 
@@ -65,20 +79,16 @@ function makeWallet(overrides = {}) {
   return { address: ADDRESS, isConnected: true, chainId: 137, ...overrides }
 }
 
-const PRICE_OK = { nativeUsdRate: 0.5, error: null }
-
 let latest
 function Probe() {
   latest = usePortfolio()
   return null
 }
 
-function Harness({ wallet, price = PRICE_OK }) {
+function Harness({ wallet }) {
   return (
     <WalletContext.Provider value={wallet}>
-      <PriceContext.Provider value={price}>
-        <Probe />
-      </PriceContext.Provider>
+      <Probe />
     </WalletContext.Provider>
   )
 }
@@ -86,95 +96,115 @@ function Harness({ wallet, price = PRICE_OK }) {
 async function renderPortfolio(props = {}) {
   let view
   await act(async () => {
-    view = render(<Harness wallet={props.wallet || makeWallet()} price={props.price || PRICE_OK} />)
+    view = render(<Harness wallet={props.wallet || makeWallet()} />)
   })
   return view
 }
 
+const aggFor = (underlying, categoryId = null) =>
+  latest.aggregates.find(
+    (a) => a.underlying === underlying && (categoryId == null || a.categoryId === categoryId),
+  )
+
 beforeEach(() => {
   fixtures.nativeBalances.clear()
   fixtures.tokenBalances.clear()
+  fixtures.prices.clear()
+  fixtures.pricesFail = false
   fixtures.prefs.showTestnetAssets = false
+  fixtures.prefs.showZeroBalances = false
   latest = undefined
 })
 
-describe('usePortfolio (cross-chain)', () => {
+describe('usePortfolio (aggregated, on-chain priced)', () => {
   it('is disconnected without a connected account', async () => {
     await renderPortfolio({ wallet: makeWallet({ address: undefined, isConnected: false }) })
     expect(latest.status).toBe('disconnected')
-    expect(latest.holdings).toEqual([])
+    expect(latest.aggregates).toEqual([])
   })
 
-  it('scans mainnets only by default and never lists testnet assets', async () => {
+  it('values holdings from the on-chain price map and hides zero aggregates by default (FR-022/023)', async () => {
     fixtures.nativeBalances.set(137, 2n * 10n ** 18n)
     fixtures.tokenBalances.set(addr(137, 'USDC'), 100_000_000n)
-    fixtures.tokenBalances.set(addr(63, 'USC'), 40_000_000n) // Mordor — must stay hidden
+    fixtures.prices.set('MATIC', { usd: 0.5, source: 'chainlink', chainId: 137 })
     await renderPortfolio()
     await waitFor(() => expect(latest.status).toBe('ready'))
 
-    const mainnets = new Set(getPortfolioChainIds())
-    expect(mainnets.has(63)).toBe(false)
-    for (const h of latest.holdings) {
-      expect(mainnets.has(h.asset.chainId)).toBe(true)
-    }
-    expect(latest.holdings.some((h) => h.asset.symbol === 'USC')).toBe(false)
-    expect(latest.totalUsd).toBeCloseTo(101) // 2 MATIC × $0.50 + 100 USDC
+    const matic = aggFor('MATIC')
+    expect(matic.usd).toBeCloseTo(1)
+    expect(matic.unitPriceUsd).toBe(0.5)
+    expect(matic.priceEntry.source).toBe('chainlink')
+    expect(aggFor('USDC').usd).toBeCloseTo(100)
+    expect(latest.totalUsd).toBeCloseTo(101)
+    // Zero-balance aggregates (ETH, BTC, LINK, …) are hidden by default.
+    expect(aggFor('ETH')).toBeUndefined()
+    expect(latest.aggregates.every((a) => a.balance > 0)).toBe(true)
   })
 
-  it('lists every digital commodity across scanned chains, zero balances included', async () => {
+  it('lists zero-balance aggregates when the preference is on, worth an honest $0.00', async () => {
+    fixtures.prefs.showZeroBalances = true
     await renderPortfolio()
     await waitFor(() => expect(latest.status).toBe('ready'))
 
-    const commodities = latest.categories.find((g) => g.category.id === 'digital-commodities')
-    const expected = getPortfolioChainIds()
-      .flatMap((id) => getPortfolioRegistry(id))
-      .filter((e) => e.categoryId === 'digital-commodities')
-    expect(commodities.holdings).toHaveLength(expected.length)
-    // Zero of anything is honestly worth $0.00 — no dash, no fabricated price.
-    const zeroEth = commodities.holdings.find((h) => h.asset.chainId === 1 && h.asset.kind === 'native')
-    expect(zeroEth.balance).toBe(0)
-    expect(zeroEth.usd).toBe(0)
-    expect(zeroEth.network).toBe('Ethereum')
-    // Other categories stay holdings-only: no zero-balance stablecoin rows.
-    const stables = latest.categories.find((g) => g.category.id === 'payment-stablecoins')
-    expect(stables.holdings).toEqual([])
+    const eth = aggFor('ETH', 'digital-commodities')
+    expect(eth.balance).toBe(0)
+    expect(eth.usd).toBe(0)
+    expect(latest.totalUsd).toBe(0)
   })
 
-  it('includes testnet chains when the preference is on', async () => {
-    fixtures.prefs.showTestnetAssets = true
-    fixtures.nativeBalances.set(63, 10n ** 18n) // 1 ETC on Mordor
+  it('combines native and wrapped forms into one underlying aggregate (FR-025)', async () => {
+    fixtures.nativeBalances.set(1, 10n ** 18n) // 1 ETH on Ethereum
+    fixtures.tokenBalances.set(addr(1, 'WETH'), 5n * 10n ** 17n) // 0.5 WETH on Ethereum
+    fixtures.tokenBalances.set(addr(137, 'WETH'), 25n * 10n ** 16n) // 0.25 WETH on Polygon
+    fixtures.prices.set('ETH', { usd: 2000, source: 'chainlink', chainId: 137 })
+    await renderPortfolio()
+    await waitFor(() => expect(latest.status).toBe('ready'))
+
+    const eth = aggFor('ETH')
+    expect(eth.instances).toHaveLength(3)
+    expect(eth.balance).toBeCloseTo(1.75)
+    expect(eth.usd).toBeCloseTo(3500)
+    // Home native first, wrapped and cross-chain instances after.
+    expect(eth.instances[0].asset.kind).toBe('native')
+    expect(eth.instances.map((h) => h.asset.chainId)).toEqual([1, 1, 137])
+    // The main list shows ONE ETH row — instances live in the sheet.
+    expect(latest.aggregates.filter((a) => a.underlying === 'ETH')).toHaveLength(1)
+  })
+
+  it('scans testnets only when enabled and never prices them with foreign rates', async () => {
     fixtures.tokenBalances.set(addr(63, 'USC'), 40_000_000n)
     await renderPortfolio()
     await waitFor(() => expect(latest.status).toBe('ready'))
+    expect(aggFor('USC')).toBeUndefined()
 
-    const usc = latest.holdings.find((h) => h.asset.symbol === 'USC')
-    expect(usc.usd).toBeCloseTo(40)
-    expect(usc.network).toBe('Ethereum Classic Mordor')
-    // A nonzero ETC native must NOT be priced with the MATIC feed rate.
-    const mordorNative = latest.holdings.find(
-      (h) => h.asset.chainId === 63 && h.asset.kind === 'native',
-    )
-    expect(mordorNative.balance).toBe(1)
-    expect(mordorNative.usd).toBeNull()
-    // Sepolia joins the scan set alongside Amoy and Mordor.
+    fixtures.prefs.showTestnetAssets = true
+    fixtures.nativeBalances.set(63, 10n ** 18n) // 1 ETC on Mordor — no price entry
+    await renderPortfolio()
+    await waitFor(() => expect(aggFor('USC')).toBeTruthy())
+
+    expect(aggFor('USC').usd).toBeCloseTo(40)
     expect(getPortfolioChainIds({ includeTestnets: true })).toContain(11155111)
-    expect(latest.holdings.some((h) => h.asset.chainId === 11155111)).toBe(true)
+    const etc = aggFor('ETC')
+    expect(etc.balance).toBe(1)
+    expect(etc.usd).toBeNull() // unpriced, never borrowed from another asset
   })
 
-  it('treats an errored price feed as no price rather than using the fallback rate', async () => {
+  it('keeps the portfolio ready when pricing fails entirely — assets just go unpriced', async () => {
+    fixtures.pricesFail = true
     fixtures.nativeBalances.set(137, 10n ** 18n)
-    await renderPortfolio({ price: { nativeUsdRate: 0.5, error: 'feed down' } })
+    await renderPortfolio()
     await waitFor(() => expect(latest.status).toBe('ready'))
-    const matic = latest.holdings.find((h) => h.asset.chainId === 137 && h.asset.kind === 'native')
+    const matic = aggFor('MATIC')
     expect(matic.usd).toBeNull()
     expect(latest.totalUsd).toBe(0)
   })
 
-  it('renders NFT holdings as item counts', async () => {
+  it('renders NFT holdings as item-count aggregates', async () => {
     fixtures.tokenBalances.set(addr(137, 'FWMV'), 2n)
     await renderPortfolio()
     await waitFor(() => expect(latest.status).toBe('ready'))
-    const voucher = latest.holdings.find((h) => h.asset.symbol === 'FWMV')
+    const voucher = aggFor('FWMV')
+    expect(voucher.kind).toBe('nft')
     expect(voucher.balance).toBe(2)
     expect(voucher.usd).toBeNull()
   })
@@ -186,7 +216,7 @@ describe('usePortfolio (cross-chain)', () => {
     await waitFor(() => expect(latest.status).toBe('ready'))
 
     expect(latest.failedAssets).toContain('LINK')
-    expect(latest.holdings.some((h) => h.asset.symbol === 'LINK')).toBe(false)
+    expect(aggFor('LINK')).toBeUndefined()
     expect(latest.totalUsd).toBeCloseTo(25)
   })
 
@@ -200,7 +230,7 @@ describe('usePortfolio (cross-chain)', () => {
     }
     await renderPortfolio()
     await waitFor(() => expect(latest.status).toBe('error'))
-    expect(latest.holdings).toEqual([])
+    expect(latest.aggregates).toEqual([])
 
     // Retry leaves the error state immediately (loading, not retry spam)...
     let resolveNative

--- a/specs/044-connected-account-portfolio/spec.md
+++ b/specs/044-connected-account-portfolio/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-07-10
 
-**Status**: Implemented (v1.0 merged in PR #836); v1.1 follow-up in progress
+**Status**: Implemented (v1.0 merged in PR #836, v1.1 merged in PR #838); v1.2 follow-up in progress
 
 **Input**: User description: "Connected Account Portfolio in the Finance section. Add a new 'Portfolio' section under My Wallet → Finance that shows the connected account's assets grouped by SEC/CFTC regulatory taxonomy categories, matching the provided mobile mockup (total portfolio balance at top, collapsible category sections each with a category subtotal and per-asset rows showing balance and USD value). Categories: Digital Securities, Digital Commodities, Digital Collectibles, Digital Tools, Payment Stablecoins. Classification uses the official SEC commodity list as a hardcoded baseline plus curated open-source registry lists mapped to the regulatory definitions. Assets shown must be the real on-chain holdings of the connected account, scoped to the active network. Unclassified tokens must be handled honestly."
 
@@ -279,3 +279,36 @@ Owner-requested refinements after v1.0 shipped ("the page is too information den
 - **FR-021**: A "Portfolio" settings group in Preferences holds a "Show testnet
   tokens" switch (default off, persisted per wallet). When off, testnet networks are
   not scanned and a compact note in the portfolio says testnet tokens are hidden.
+
+## Follow-up Amendments (v1.2, 2026-07-10)
+
+Owner-requested next iteration (asset detail + verifiable pricing):
+
+- **FR-022 (verifiable prices)**: USD prices come from verifiable on-chain sources
+  where available — decentralized oracle price feeds (Chainlink aggregators) first,
+  then DEX pool spot prices (Uniswap V3 `slot0` vs the network stablecoin) — read
+  live over RPC. Stablecoins stay at par $1. Assets with no on-chain source remain
+  honestly unpriced. (Replaces the CoinGecko rate for the portfolio; subgraph-backed
+  pricing is a documented future performance option.)
+- **FR-023 (zero-balance visibility)**: a Preferences → Portfolio setting shows/hides
+  zero-balance assets, default **hide**. (Supersedes v1.1 FR-018 "always list all
+  commodities": commodity instances are still always scanned, but zero-balance
+  aggregate rows are hidden unless the setting is on.)
+- **FR-024 (asset detail sheet)**: tapping an asset row opens a bottom sheet with
+  the aggregate position (logo, combined balance, USD, unit price), the list of
+  underlying instances, and actions — Trade, Transfer, and (when the app gains a
+  staking surface) Stake; actions unavailable in the app render disabled/hidden,
+  never as dead buttons.
+- **FR-025 (wrapped-asset aggregation)**: for Digital Commodities, wrapped forms are
+  combined with their underlying asset into one row (e.g. ETH = native ETH + WETH on
+  every scanned chain, valued together); the bottom sheet lists each instance's
+  balance separately.
+- **FR-026 (logos + network badges)**: every asset renders a primary asset logo with
+  a small network sub-badge. A native coin on its home network shows the logo only;
+  a wrapped or bridged form shows the underlying asset's logo with the hosting
+  network's badge (e.g. WETH on Polygon = ETH logo + Polygon badge). Logos are
+  bundled with the app (no external image CDNs).
+- **FR-027 (instance selection)**: within the bottom sheet the member selects a
+  specific instance (chain + form) before invoking Trade/Transfer/other eligible
+  operations; the action deep-links to the target surface for that instance's
+  network and token.

--- a/specs/044-connected-account-portfolio/tasks.md
+++ b/specs/044-connected-account-portfolio/tasks.md
@@ -120,3 +120,15 @@ US3 → US4 → Polish, validating each checkpoint's tests before moving on.
 - [X] T022 Rework `frontend/src/components/wallet/PortfolioPanel.jsx`: category descriptions in shared `InfoTip` bubbles, per-row network badges, no partial labels, compact single-line disclosure, testnet-hidden note
 - [X] T023 Add `showTestnetAssets` preference (default false, persisted per wallet) to `frontend/src/contexts/UserPreferencesContext.jsx` and a Preferences → Portfolio group (`frontend/src/components/account/PortfolioPreferencesPanel.jsx`) wired into WalletPage
 - [X] T024 Update/extend tests: cross-chain hook suite, InfoTip/network/no-partial panel suite, `getPortfolioChainIds` + Sepolia registry tests, PortfolioPreferencesPanel suite, refreshed axe audits
+
+## Phase 9: Follow-up v1.2 (on-chain prices, asset detail sheet, aggregation)
+
+- [X] T025 Add Chainlink AggregatorV3 + Uniswap V3 factory/pool read ABIs (`frontend/src/abis/AggregatorV3.js`, `frontend/src/abis/UniswapV3PoolReader.js`) and the per-chain feed map `frontend/src/config/priceFeeds.js` (canonical Polygon */USD feeds, staleness bound, DEX fee tiers)
+- [X] T026 Implement the verifiable price ladder `frontend/src/lib/portfolio/prices.js` (Chainlink first — stale/non-positive answers rejected; then DEX pool spot vs the network stablecoin from slot0 with token0/token1 decimal handling; stablecoins par; else unpriced) + `priceSourceLabel` provenance
+- [X] T027 Implement wrapped-asset aggregation `frontend/src/lib/portfolio/aggregate.js` (per-(category, underlying) aggregates; zero-balance instances neutral; any unpriced nonzero instance → aggregate unpriced; home-instance + form-label helpers; dust-safe shared amount formatter) and `UNDERLYING_META` in assetTaxonomy.js
+- [X] T028 Rework `frontend/src/hooks/usePortfolio.js`: concurrent balance + price loading, holdings for every readable instance (zeros included), aggregate rows filtered by the new zero-balance preference (default hide)
+- [X] T029 Add `frontend/src/components/wallet/AssetLogo.jsx` (+css): bundled inline SVG asset glyphs with network sub-badges (home natives badge-free, testnets dash-ringed)
+- [X] T030 Add `frontend/src/components/wallet/AssetDetailSheet.jsx` (+css): bottom sheet (modal tier, Escape/backdrop/focus handling) with aggregate position, unit price + on-chain source provenance, per-instance radio selection, and Trade/Transfer/Stake actions gated by real eligibility (deep links carry chain+token)
+- [X] T031 Panel rework `PortfolioPanel.jsx`: tappable aggregate rows (logo, combined balance, instance/network summary), zero-hidden note, price-source disclosure line
+- [X] T032 Preferences: `showZeroBalances` (default false) in UserPreferencesContext + second switch in PortfolioPreferencesPanel
+- [X] T033 Tests: prices ladder suite (feed decode/staleness/negative, pool math both token orders), aggregation suite (combination, no-partial-sums rule, dust), rewritten hook suite, panel aggregate-row suite, AssetDetailSheet suite (selection, eligibility, deep links, dismissal), refreshed axe audits incl. open sheet


### PR DESCRIPTION
## Summary

Third iteration of the Connected Account Portfolio (spec 044 v1.2 amendments, FR-022–FR-027), following #836/#838:

- **Verifiable on-chain prices (FR-022)** — USD values now come from a per-underlying price ladder read live over RPC: **Chainlink AggregatorV3 feeds** first (canonical Polygon MATIC/ETH/BTC/LINK-USD aggregators; answers rejected when stale >24h or non-positive), then **DEX pool spot** (Uniswap-V3-style `slot0` vs the network stablecoin, handling both token orderings — gives ETC pricing via ETCswap WETC/USC), stablecoins at par. Assets with no on-chain source stay honestly unpriced. The portfolio no longer uses the CoinGecko rate; the app-wide `PriceContext` display toggle is untouched.
- **Wrapped-asset aggregation (FR-025)** — Digital Commodities (and every category) combine native + wrapped forms per underlying: one **Ethereum** row totals native ETH + WETH (Ethereum) + WETH (Polygon). Honest-sum rule: an aggregate with any unpriced nonzero instance shows "—", never a partial figure presented as the position's value.
- **Asset detail bottom sheet (FR-024/FR-027)** — tapping a row opens a modal-tier bottom sheet (Escape/backdrop/focus handling per repo modal conventions) showing the aggregate position, unit price **with source provenance** ("Chainlink oracle (Polygon)" / "DEX pool spot (Ethereum Classic)" / "valued at par"), each instance's balance separately, and a radio **instance selector**. **Trade / Transfer / Stake** actions are gated by real eligibility: Trade deep-links `/wallet?tab=trade&chain=…&token=…` where the chain has an in-app DEX; Transfer for native/stablecoin sends; Stake renders disabled with "not available yet" (no staking surface exists — no dead buttons).
- **Logos + network badges (FR-026)** — new `AssetLogo` renders bundled inline SVG glyphs (ETH/BTC/MATIC/ETC/SOL/XRP/LINK/USDC/USDT/USC/FWMV + letter fallback) with a network sub-badge; a native coin on its home mainnet is badge-free, testnet badges are dash-ringed. No external image CDNs.
- **Zero-balance visibility (FR-023)** — new Preferences → Portfolio switch **"Show zero-balance assets"** (default **hide**, persisted per wallet); the portfolio notes when zero-balance assets are hidden. Supersedes v1.1's always-list-commodities rule (instances are still scanned for the sheet).

## Changes

- `frontend/src/abis/AggregatorV3.js`, `frontend/src/abis/UniswapV3PoolReader.js` — minimal read ABIs
- `frontend/src/config/priceFeeds.js` — feed map + staleness bound + fee tiers
- `frontend/src/lib/portfolio/prices.js` — price ladder + provenance labels
- `frontend/src/lib/portfolio/aggregate.js` — aggregation, home-instance/form-label helpers, dust-safe formatter
- `frontend/src/hooks/usePortfolio.js` — concurrent balances + prices, aggregates, zero-balance filter
- `frontend/src/components/wallet/AssetLogo.jsx/.css`, `AssetDetailSheet.jsx/.css` — new components
- `frontend/src/components/wallet/PortfolioPanel.jsx` + `Portfolio.css` — tappable aggregate rows
- `frontend/src/contexts/UserPreferencesContext.jsx`, `components/account/PortfolioPreferencesPanel.jsx` — `showZeroBalances`
- `frontend/src/test/portfolio/` — 93 tests (new prices/aggregate/sheet suites, rewritten hook/panel suites, axe audits incl. the open sheet)
- `specs/044-connected-account-portfolio/` — v1.2 amendment record

## Testing

- `src/test/portfolio`: **93/93 pass** (16 prices+aggregate, 10 hook, 17 panel, 10 sheet, 29 registry, 6 prefs, 5 axe)
- Pool-spot math verified in both token orderings against hand-computed sqrtPriceX96 fixtures; a real sign bug in the inverse-ratio branch was caught and fixed by these tests
- `WalletPage` tests pass; ESLint clean; `vite build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9vh9Lj9RNgD7tvrLoAcKY

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9vh9Lj9RNgD7tvrLoAcKY)_