### PR TITLE
Add GitHub issue templates for bugs, features, and asset listing requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,113 @@
+name: "🐛 Bug Report"
+description: Report a defect in a FairWins contract, the frontend, the subgraph, or tooling.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Security vulnerabilities**: do not file a public issue for anything that could put user
+        funds or PII at risk (reentrancy, access-control bypass, oracle manipulation, key leakage,
+        etc.). Instead follow the process in `docs/developer-guide/contributing.md` (email
+        security@example.com). This template is for functional bugs only.
+
+        Fields below are intentionally structured — the team feeds well-formed bug reports
+        straight into the Spec Kit workflow (`/speckit-specify`) when a fix needs a spec.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      description: Which part of the repo does this bug live in?
+      options:
+        - Contracts (contracts/)
+        - Frontend (frontend/)
+        - Subgraph (subgraph/)
+        - Scripts / deployment (scripts/, deployments/)
+        - Documentation
+        - CI / infrastructure
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: network
+    attributes:
+      label: Network / environment
+      description: Where did you observe the bug?
+      options:
+        - Local Hardhat node
+        - Ethereum Classic Mordor (testnet)
+        - Polygon Amoy (testnet)
+        - Ethereum Classic (mainnet)
+        - Polygon (mainnet)
+        - Ethereum (mainnet)
+        - Sepolia (testnet)
+        - Not applicable / N/A
+    validations:
+      required: true
+
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: One sentence describing the bug.
+      placeholder: "Claiming a payout on an open-challenge wager reverts for the second acceptor"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Exact steps, inputs, wallet/role, and (for contract bugs) tx hashes or contract addresses.
+      placeholder: |
+        1. Deploy/connect to ...
+        2. Call/click ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include error messages, revert reasons, stack traces, or screenshots.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Critical — funds/keys at risk or contract stuck
+        - High — core functionality broken
+        - Medium — degraded UX, workaround exists
+        - Low — cosmetic / minor
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, related issues/PRs, browser/OS, Node version, etc.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and this isn't a duplicate
+          required: true
+        - label: This is a regression (it used to work)
+          required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,7 +10,7 @@ body:
         **Security vulnerabilities**: do not file a public issue for anything that could put user
         funds or PII at risk (reentrancy, access-control bypass, oracle manipulation, key leakage,
         etc.). Instead follow the process in `docs/developer-guide/contributing.md` (email
-        security@example.com). This template is for functional bugs only.
+        security@chipprbots.com). This template is for functional bugs only.
 
         Fields below are intentionally structured — the team feeds well-formed bug reports
         straight into the Spec Kit workflow (`/speckit-specify`) when a fix needs a spec.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability disclosure
+    url: https://github.com/chippr-robotics/prediction-dao-research/blob/main/docs/developer-guide/contributing.md#reporting-vulnerabilities
+    about: Do not file a public issue for security vulnerabilities — email security@example.com instead.
+  - name: Contributing guide
+    url: https://github.com/chippr-robotics/prediction-dao-research/blob/main/docs/developer-guide/contributing.md
+    about: How to contribute, coding standards, and PR process.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability disclosure
     url: https://github.com/chippr-robotics/prediction-dao-research/blob/main/docs/developer-guide/contributing.md#reporting-vulnerabilities
-    about: Do not file a public issue for security vulnerabilities — email security@example.com instead.
+    about: Do not file a public issue for security vulnerabilities — email security@chipprbots.com instead.
   - name: Contributing guide
     url: https://github.com/chippr-robotics/prediction-dao-research/blob/main/docs/developer-guide/contributing.md
     about: How to contribute, coding standards, and PR process.

--- a/.github/ISSUE_TEMPLATE/digital_asset_listing_request.yml
+++ b/.github/ISSUE_TEMPLATE/digital_asset_listing_request.yml
@@ -1,0 +1,205 @@
+name: "💰 Digital Asset Listing Request"
+description: Request that a token or digital asset be added to the FairWins platform (as wager collateral, an oracle-tracked market category, or a recognized portfolio asset).
+title: "[Asset Listing]: "
+labels:
+  - asset-listing
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to request that your project's token/asset be recognized by FairWins. The
+        fields below map directly to what the FairWins UI needs to render an asset correctly
+        (logo, name/symbol, network badge, and its entry in the asset taxonomy — see
+        `frontend/src/config/assetTaxonomy.js` and `frontend/src/schemas/token-metadata-v1.json`).
+
+        **This is a request, not a guarantee.** The FairWins team independently reviews every
+        submission for accuracy, contract safety, and regulatory classification before anything
+        is added — your self-reported classification below is a starting point, not the final
+        word (see constitution principle I, Security-First; and `specs/007-compliance-gating`).
+        Submitting this form does not constitute investment or legal advice, and is not an
+        endorsement of the asset.
+
+  - type: input
+    id: project_name
+    attributes:
+      label: Project name
+    validations:
+      required: true
+
+  - type: input
+    id: contact_name
+    attributes:
+      label: Point of contact (name and role)
+      placeholder: "Jane Doe, Head of Partnerships"
+    validations:
+      required: true
+
+  - type: input
+    id: contact_email
+    attributes:
+      label: Contact email
+    validations:
+      required: true
+
+  - type: input
+    id: project_website
+    attributes:
+      label: Official project website
+      placeholder: "https://example.org"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: authority
+    attributes:
+      label: Authorization
+      options:
+        - label: I am an authorized representative of this project and am submitting this request on its behalf
+          required: true
+
+  - type: input
+    id: asset_name
+    attributes:
+      label: Asset / token name
+      description: Full display name, as it should appear in the UI (matches `name` in the token metadata schema).
+      placeholder: "Example Token"
+    validations:
+      required: true
+
+  - type: input
+    id: asset_symbol
+    attributes:
+      label: Token symbol / ticker
+      placeholder: "EXT"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: token_standard
+    attributes:
+      label: Token standard
+      options:
+        - ERC-20
+        - ERC-721
+        - ERC-1155
+        - Native coin
+        - Other (describe in additional context)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: networks
+    attributes:
+      label: Network(s) this asset is deployed on
+      multiple: true
+      options:
+        - Ethereum (mainnet)
+        - Polygon (mainnet)
+        - Ethereum Classic (mainnet)
+        - Sepolia (testnet)
+        - Polygon Amoy (testnet)
+        - Ethereum Classic Mordor (testnet)
+        - Other network (not yet supported by FairWins — describe below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: contract_addresses
+    attributes:
+      label: Contract address(es) by network
+      description: 'One per line, in the form `network: 0x...`. For a native coin, write "native" instead of an address.'
+      placeholder: |
+        Polygon (mainnet): 0x1234...
+        Ethereum Classic (mainnet): 0xabcd...
+    validations:
+      required: true
+
+  - type: input
+    id: decimals
+    attributes:
+      label: Decimals
+      placeholder: "18"
+    validations:
+      required: true
+
+  - type: input
+    id: logo_url
+    attributes:
+      label: Logo / image URL
+      description: Square, transparent background preferred. `ipfs://` preferred, `https://` accepted (matches the `image` field pattern in the token metadata schema).
+      placeholder: "ipfs://Qm... or https://example.org/logo.png"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Short description
+      description: 1-3 sentences, plain language, suitable for display as-is in the UI (10-200 characters).
+    validations:
+      required: true
+
+  - type: dropdown
+    id: classification
+    attributes:
+      label: Requested asset classification
+      description: |
+        FairWins' asset taxonomy (see `assetTaxonomy.js`) is SEC/CFTC-aligned. Pick the closest
+        fit — the FairWins compliance review determines the final category, and may override
+        this selection, regardless of what you select here.
+      options:
+        - Digital Commodity (e.g. functional L1/L2 network asset)
+        - Digital Security (represents equity, debt, or an investment contract)
+        - Payment Stablecoin (approved-issuer, transactional)
+        - Digital Tool / Utility (no yield or capital-raising function)
+        - Digital Collectible (NFT-style, no profit-sharing)
+        - Unsure — let the FairWins team classify
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: token_facts
+    attributes:
+      label: Token facts
+      options:
+        - label: Contract source is verified on a public block explorer
+        - label: Token is listed on at least one DEX
+        - label: Token has a public third-party security audit
+
+  - type: input
+    id: explorer_link
+    attributes:
+      label: Block explorer link (verified contract)
+      placeholder: "https://polygonscan.com/address/0x..."
+
+  - type: input
+    id: dex_link
+    attributes:
+      label: DEX / liquidity pool link (if applicable)
+
+  - type: input
+    id: audit_link
+    attributes:
+      label: Audit report link (if applicable)
+
+  - type: textarea
+    id: additional_links
+    attributes:
+      label: Additional links
+      description: Docs, GitHub, whitepaper, and official social accounts (one per line).
+
+  - type: checkboxes
+    id: compliance
+    attributes:
+      label: Compliance acknowledgment
+      options:
+        - label: To my knowledge, this asset and project are not associated with a sanctioned entity, individual, or jurisdiction
+          required: true
+        - label: I understand FairWins may decline, delay, or reclassify this listing for security, legal, or compliance reasons, and that no fee or submission guarantees inclusion
+          required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else the review team should know (tokenomics, upcoming network deployments, prior listing history elsewhere, etc.).

--- a/.github/ISSUE_TEMPLATE/digital_asset_listing_request.yml
+++ b/.github/ISSUE_TEMPLATE/digital_asset_listing_request.yml
@@ -12,12 +12,13 @@ body:
         (logo, name/symbol, network badge, and its entry in the asset taxonomy — see
         `frontend/src/config/assetTaxonomy.js` and `frontend/src/schemas/token-metadata-v1.json`).
 
-        **This is a request, not a guarantee.** The FairWins team independently reviews every
-        submission for accuracy, contract safety, and regulatory classification before anything
-        is added — your self-reported classification below is a starting point, not the final
-        word (see constitution principle I, Security-First; and `specs/007-compliance-gating`).
-        Submitting this form does not constitute investment or legal advice, and is not an
-        endorsement of the asset.
+        **This is a request, not a guarantee.** FairWins is the platform; listings are reviewed
+        and managed by **Chippr Robotics LLC**, the company that operates FairWins. Chippr
+        Robotics independently reviews every submission for accuracy, contract safety, and
+        regulatory classification before anything is added — your self-reported classification
+        below is a starting point, not the final word (see constitution principle I,
+        Security-First; and `specs/007-compliance-gating`). Submitting this form does not
+        constitute investment or legal advice, and is not an endorsement of the asset.
 
   - type: input
     id: project_name
@@ -145,15 +146,15 @@ body:
       label: Requested asset classification
       description: |
         FairWins' asset taxonomy (see `assetTaxonomy.js`) is SEC/CFTC-aligned. Pick the closest
-        fit — the FairWins compliance review determines the final category, and may override
-        this selection, regardless of what you select here.
+        fit — the Chippr Robotics compliance review determines the final category, and may
+        override this selection, regardless of what you select here.
       options:
         - Digital Commodity (e.g. functional L1/L2 network asset)
         - Digital Security (represents equity, debt, or an investment contract)
         - Payment Stablecoin (approved-issuer, transactional)
         - Digital Tool / Utility (no yield or capital-raising function)
         - Digital Collectible (NFT-style, no profit-sharing)
-        - Unsure — let the FairWins team classify
+        - Unsure — let the Chippr Robotics team classify
     validations:
       required: true
 
@@ -195,11 +196,11 @@ body:
       options:
         - label: To my knowledge, this asset and project are not associated with a sanctioned entity, individual, or jurisdiction
           required: true
-        - label: I understand FairWins may decline, delay, or reclassify this listing for security, legal, or compliance reasons, and that no fee or submission guarantees inclusion
+        - label: I understand Chippr Robotics may decline, delay, or reclassify this listing for security, legal, or compliance reasons, and that no fee or submission guarantees inclusion
           required: true
 
   - type: textarea
     id: context
     attributes:
       label: Additional context
-      description: Anything else the review team should know (tokenomics, upcoming network deployments, prior listing history elsewhere, etc.).
+      description: Anything else the Chippr Robotics review team should know (tokenomics, upcoming network deployments, prior listing history elsewhere, etc.).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,93 @@
+name: "✨ Feature Request"
+description: Propose a new capability or enhancement for FairWins.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This repo builds features through [Spec Kit](https://github.com/github/spec-kit)
+        (`/speckit-specify` → `/speckit-plan` → `/speckit-tasks` → `/speckit-implement`). For
+        anything beyond a trivial change, the fields below are written to map directly onto
+        `spec-template.md` so the team can turn this issue into `specs/<feature>/spec.md` with
+        minimal back-and-forth.
+
+  - type: input
+    id: problem
+    attributes:
+      label: Problem / user need
+      description: What pain point or gap does this address? Plain language, no tech choices yet.
+      placeholder: "Members can't tell which of their open wagers are about to expire"
+    validations:
+      required: true
+
+  - type: textarea
+    id: user_story
+    attributes:
+      label: User story
+      description: "As a [role], I want [capability], so that [benefit]."
+      placeholder: "As a wager participant, I want an expiry warning badge, so that I don't miss the accept/resolve deadline."
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance scenarios
+      description: Given/When/Then bullets describing observable, testable outcomes.
+      placeholder: |
+        1. Given a wager with acceptDeadline < 24h away, When I open My Wagers, Then it shows an "expiring soon" badge.
+        2. Given a wager past its deadline, When the page loads, Then the badge is not shown.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - P1 — critical path / blocking
+        - P2 — important, not blocking
+        - P3 — nice to have
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Primary affected area
+      options:
+        - Contracts (contracts/)
+        - Frontend (frontend/)
+        - Subgraph (subgraph/)
+        - Scripts / deployment
+        - Documentation
+        - Other / cross-cutting
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution / approach (optional)
+      description: Sketch an approach if you have one. Tech-stack decisions belong in plan.md, not here — keep this conceptual.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, links to related issues/specs, constraints, out-of-scope notes.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues/specs and this isn't a duplicate
+          required: true


### PR DESCRIPTION
## Summary

The repo had no GitHub issue templates. This adds three structured issue forms under `.github/ISSUE_TEMPLATE/`, plus a `config.yml`:

- **`bug_report.yml`** — affected area, network/environment, repro steps, expected/actual behavior, severity. Points to the existing security-disclosure process (per `docs/developer-guide/contributing.md`) for anything sensitive instead of filing it publicly.
- **`feature_request.yml`** — problem statement, user story, acceptance scenarios (Given/When/Then), priority, affected area. Fields are shaped to map directly onto `.specify/templates/spec-template.md` so a well-filled issue can be turned into a Spec Kit spec (`/speckit-specify`) with minimal rework.
- **`digital_asset_listing_request.yml`** — lets external projects request their token/asset be added to the platform. Captures every field the UI actually needs to display an asset correctly: name, symbol, token standard, per-network contract address(es), decimals, logo URL, description, and a requested taxonomy classification — aligned with `frontend/src/schemas/token-metadata-v1.json` and `frontend/src/config/assetTaxonomy.js` (the SEC/CFTC-aligned category set: digital commodity / security / stablecoin / tool / collectible). Also collects verification/audit/DEX links and compliance acknowledgments (sanctions, no listing guarantee), consistent with `specs/007-compliance-gating`.
- **`config.yml`** — disables blank issues and links to the security-disclosure process and contributing guide.

Labels used (`bug`, `enhancement`) already exist in `release-drafter.yml`'s categorization; `asset-listing` is new and a maintainer may want to create it (or it will be created automatically by GitHub on first use).

## Test plan

- [x] Validated all four YAML files parse (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] Render each form in the GitHub "New issue" picker to confirm layout/labels look right


---
_Generated by [Claude Code](https://claude.ai/code/session_01KyPoyMAmWUg28SLfch9zKW)_