### PR TITLE
fix(frontend): let oracle challenge market picker fill the bottom sheet

### DIFF
--- a/frontend/src/components/fairwins/OracleOpenChallengeModal.css
+++ b/frontend/src/components/fairwins/OracleOpenChallengeModal.css
@@ -30,10 +30,23 @@
   margin-top: 6px;
 }
 
-/* Keep the inline picker usable inside the modal on small screens: the feed scrolls
+/* Keep the inline picker usable inside the modal on wider screens: the feed scrolls
    within its own region instead of stretching the whole sheet (US3). */
 #ooc-market-picker {
   max-height: min(52vh, 460px);
   overflow-y: auto;
   border-radius: 12px;
+}
+
+/* Phones present this modal as a bottom sheet (max-width: 640px in
+   FriendMarketsModal.css). There the market picker IS the sheet's purpose while
+   creating a challenge, but the 460px cap above left it a short strip pinned to the
+   bottom of the screen with a large empty gap over it (issue #850). Let the picker
+   claim most of the viewport so the markets take up the majority of the sheet. The
+   modal is height:auto, so once a market is picked the sheet still collapses back to
+   the compact side/stake/timeline form — no wasted space in that state either. */
+@media (max-width: 640px) {
+  #ooc-market-picker {
+    max-height: 72vh;
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #850 — on phones the **Open Oracle Challenge** modal renders as a bottom sheet, and the market list was crammed into a short strip pinned to the bottom of the screen with a large empty gap above it, making markets hard to scan.

## Root cause

`.friend-markets-modal` is `height: auto` (it hugs its content), and on the bottom-sheet breakpoint (`max-width: 640px`) it anchors to the bottom of the viewport. The market picker's inner scroll region (`#ooc-market-picker`) was capped at `max-height: min(52vh, 460px)`. On tall phones that ~460px cap kept the whole sheet short, so the markets occupied only a small band at the very bottom while the backdrop above went unused.

## Change

Raise the picker's cap to `72vh` **only** on the bottom-sheet breakpoint (`@media (max-width: 640px)`), so the market feed claims the majority of the sheet and the sheet grows to fill most of the viewport. Because the modal remains `height: auto`, once a market is picked the sheet still collapses back to the compact side / stake / timeline form — no wasted space in that state either. Desktop/tablet layout is untouched.

- `frontend/src/components/fairwins/OracleOpenChallengeModal.css` — add a mobile media-query override for `#ooc-market-picker`.

## Testing

- `npx vitest run src/test/claimCode/OracleOpenChallengeModal.test.jsx` — 11/11 pass (behavioral tests, unaffected by the CSS-only change).

CSS-only, scoped to the one modal via its existing unique `#ooc-market-picker` hook; no JSX or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHTPzrm7L52W8Dg1rARAmT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHTPzrm7L52W8Dg1rARAmT)_