### PR TITLE
Multisig policy engine — Protect policy management portal (spec 049, closes #852)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/048-ethereum-mainnet-support"
+  "feature_directory": "specs/049-multisig-policy-engine"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,5 +104,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/048-ethereum-mainnet-support/plan.md
+at specs/049-multisig-policy-engine/plan.md
 <!-- SPECKIT END -->

--- a/contracts/custody/ISafeGuard.sol
+++ b/contracts/custody/ISafeGuard.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title ISafeGuard
+/// @notice Local replica of the Safe v1.4.1 transaction guard interface (`Guard` in the canonical
+///         safe-contracts GuardManager.sol), kept dependency-free so the custody contract family
+///         compiles without external imports (spec 049; SafeProposalHub precedent).
+/// @dev `operation` is declared `uint8` where Safe uses `Enum.Operation` — enums are `uint8` in the
+///      ABI, so every selector (and therefore `type(ISafeGuard).interfaceId`, which Safe's
+///      `setGuard` checks via ERC-165 "GS300") is byte-identical to the canonical interface.
+interface ISafeGuard {
+    function checkTransaction(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        uint8 operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver,
+        bytes calldata signatures,
+        address msgSender
+    ) external;
+
+    function checkAfterExecution(bytes32 txHash, bool success) external;
+}
+
+/// @notice Minimal ERC-165 surface (dependency-free).
+interface IERC165Like {
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}

--- a/contracts/custody/PolicyGuardSetup.sol
+++ b/contracts/custody/PolicyGuardSetup.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ISafeGuard, IERC165Like} from "./ISafeGuard.sol";
+
+/// @title PolicyGuardSetup
+/// @notice Stateless helper delegatecalled from `Safe.setup(to, data, ...)` so a new vault is
+///         policy-governed from its very first transaction (spec 049, US1). Running in the new
+///         proxy's context it (1) writes the guard address into the Safe's guard storage slot,
+///         (2) emits Safe's `ChangedGuard` event signature for indexer/log parity with a
+///         post-create `setGuard`, and (3) `call`s the guard's configuration calldata — at that
+///         point `msg.sender` seen by the guard IS the new Safe, so the guard's
+///         `msg.sender == safe` authority model covers creation with no special path.
+/// @dev Deliberately stateless (a delegatecall target must not rely on its own storage), holds no
+///      funds, has no payable/fallback surface, and contains no selfdestruct. Calling
+///      `enablePolicy` directly (not via delegatecall from a Safe) merely writes the caller's own
+///      storage slot — harmless to third parties, same posture as Safe-ecosystem module setup
+///      helpers. Reverts bubble up and abort the entire vault creation, so a half-configured
+///      vault can never deploy. The full initializer (including this call) is hashed into the
+///      CREATE2 salt, so the predicted vault address commits to the initial policy.
+contract PolicyGuardSetup {
+    /// @dev keccak256("guard_manager.guard.address") — the Safe v1.4.1 guard storage slot.
+    bytes32 private constant _GUARD_STORAGE_SLOT = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
+
+    /// @dev Byte-identical to Safe v1.4.1 GuardManager's event so explorers see the same trail.
+    event ChangedGuard(address indexed guard);
+
+    error ZeroGuard();
+    error NotAGuard();
+
+    /// @notice Attach `guard` to the calling Safe and apply its initial policy configuration.
+    /// @param guard             The SafePolicyGuard singleton for this chain.
+    /// @param configureCalldata ABI-encoded `configureRules(...)` call; empty to attach with no
+    ///                          initial rules.
+    function enablePolicy(address guard, bytes calldata configureCalldata) external {
+        if (guard == address(0)) revert ZeroGuard();
+        // Mirror the ERC-165 acceptance check Safe.setGuard performs ("GS300"), since writing
+        // the slot directly bypasses it.
+        if (!IERC165Like(guard).supportsInterface(type(ISafeGuard).interfaceId)) revert NotAGuard();
+
+        assembly ("memory-safe") {
+            sstore(_GUARD_STORAGE_SLOT, guard)
+        }
+        emit ChangedGuard(guard);
+
+        if (configureCalldata.length > 0) {
+            (bool ok, bytes memory ret) = guard.call(configureCalldata);
+            if (!ok) {
+                // Bubble the guard's typed error up through Safe.setup.
+                assembly ("memory-safe") {
+                    revert(add(ret, 32), mload(ret))
+                }
+            }
+        }
+    }
+}

--- a/contracts/custody/SafePolicyGuard.sol
+++ b/contracts/custody/SafePolicyGuard.sol
@@ -1,0 +1,443 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ISafeGuard, IERC165Like} from "./ISafeGuard.sol";
+
+/// @title SafePolicyGuard
+/// @notice Singleton Safe v1.4.1 transaction guard enforcing per-vault fund policies (spec 049,
+///         issue #852): per-transaction spending limits, 24-hour-window spending limits, a
+///         recipient allowlist, and a cooldown between outgoing transactions. Rules run AFTER a
+///         Safe transaction has collected its owner-approval threshold and BEFORE it executes, so
+///         an approved-but-violating transaction reverts and never moves funds.
+/// @dev Trust model (see specs/049-multisig-policy-engine/contracts/SafePolicyGuard.md):
+///      - Restriction-only: the guard can block a Safe transaction but can never initiate,
+///        approve, or execute one, and holds no funds (non-payable everywhere).
+///      - Authority is the vault itself: every mutator requires `msg.sender` to be the Safe whose
+///        policy is touched, so a policy change is only reachable as a threshold-approved Safe
+///        self-transaction. No owner, no admin role, and deliberately NOT upgradeable — an
+///        upgrade key would be a backdoor over every vault's enforcement (plan.md Complexity
+///        Tracking).
+///      - Lockout-proof: transactions targeting the Safe itself (owner/threshold/guard
+///        management) or this guard (policy configuration) bypass all fund rules, so a threshold
+///        of owners can always loosen a too-strict policy (FR-008/SC-003).
+///      - CEI: evaluation is read-only (`_checkPolicy`), then state commits (`_commitAccounting`)
+///        — the guard makes no external calls at all, so no reentrancy surface exists.
+///      - Accounting is conservative: window/cooldown state committed in `checkTransaction`
+///        persists even if the Safe's inner call later fails without reverting the outer
+///        transaction; overcounting can only restrict, never permit (research.md R3).
+///      Accepted, documented limits: the 24 h window is fixed-reset (≤ 2× limit across a
+///      straddling span, disclosed in the UI); calldata the guard cannot value (anything other
+///      than native value and ERC-20 transfer/transferFrom/approve) passes spending limits
+///      unvalued but still faces the allowlist (call target) and cooldown-exempt rules.
+contract SafePolicyGuard is ISafeGuard {
+    // ---------------------------------------------------------------- constants
+
+    /// @notice Duration of one spending-accounting window.
+    uint256 public constant WINDOW = 24 hours;
+    /// @notice Upper bound on the configurable cooldown (extreme-value guard, FR-015).
+    uint32 public constant MAX_COOLDOWN = 365 days;
+    /// @notice Max assets with configured limits per vault (bounds enumeration gas).
+    uint256 public constant MAX_ASSETS = 16;
+    /// @notice Max allowlist additions+removals per configuration call.
+    uint256 public constant MAX_ALLOWLIST_BATCH = 64;
+
+    /// @dev ERC-165 id of the Safe guard interface, checked by Safe.setGuard ("GS300").
+    bytes4 private constant _GUARD_INTERFACE_ID = type(ISafeGuard).interfaceId;
+    bytes4 private constant _ERC165_INTERFACE_ID = 0x01ffc9a7;
+
+    /// @dev ERC-20 selectors the guard values: transfer(address,uint256),
+    ///      transferFrom(address,address,uint256), approve(address,uint256). Approvals are
+    ///      spending grants — counting them closes the approve-then-pull bypass.
+    bytes4 private constant _SEL_TRANSFER = 0xa9059cbb;
+    bytes4 private constant _SEL_TRANSFER_FROM = 0x23b872dd;
+    bytes4 private constant _SEL_APPROVE = 0x095ea7b3;
+
+    // ---------------------------------------------------------------- storage
+
+    struct AssetRule {
+        uint128 perTxLimit; // 0 = rule off
+        uint128 windowLimit; // 0 = rule off
+        uint128 spentInWindow; // live state
+        uint64 windowStart; // live state; window resets when now >= windowStart + WINDOW
+    }
+
+    struct RuleConfig {
+        address asset; // address(0) = native coin
+        uint128 perTxLimit;
+        uint128 windowLimit;
+    }
+
+    struct PolicyMeta {
+        bool allowlistEnabled;
+        uint32 cooldown; // seconds; 0 = rule off
+        uint64 lastCountedTxAt; // live state
+        uint32 allowlistCount;
+    }
+
+    mapping(address safe => PolicyMeta) private _policies;
+    mapping(address safe => mapping(address asset => AssetRule)) private _assetRules;
+    mapping(address safe => address[]) private _configuredAssets;
+    mapping(address safe => mapping(address entry => bool)) private _allowlisted;
+    mapping(address safe => address[]) private _allowlistEntries;
+    /// @dev 1-based index into `_allowlistEntries` for O(1) swap-and-pop removal.
+    mapping(address safe => mapping(address entry => uint256)) private _allowlistIndex;
+
+    // ---------------------------------------------------------------- events
+
+    event RulesConfigured(address indexed safe, address indexed asset, uint128 perTxLimit, uint128 windowLimit);
+    event CooldownSet(address indexed safe, uint32 cooldown);
+    event AllowlistEnabled(address indexed safe, bool enabled);
+    event AllowlistChanged(address indexed safe, address indexed entry, bool allowed);
+
+    // ---------------------------------------------------------------- errors
+
+    error DelegatecallBlocked();
+    error GasRefundBlocked();
+    error RecipientNotAllowed(address recipient);
+    error CooldownActive(uint64 nextAllowedAt);
+    error PerTxLimitExceeded(address asset, uint256 amount, uint256 limit);
+    error WindowLimitExceeded(address asset, uint256 attempted, uint256 remaining);
+    error ValueToGuardBlocked();
+    error EmptyAllowlist();
+    error CooldownTooLong();
+    error TooManyAssets();
+    error AllowlistBatchTooLarge();
+
+    // ================================================================ guard hooks
+
+    /// @notice Called by the Safe (as `msg.sender`) before executing an approved transaction.
+    ///         Reverts with a typed error when any active rule is violated; on success commits
+    ///         window/cooldown accounting.
+    function checkTransaction(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        uint8 operation,
+        uint256, /* safeTxGas */
+        uint256, /* baseGas */
+        uint256 gasPrice,
+        address, /* gasToken */
+        address payable, /* refundReceiver */
+        bytes calldata, /* signatures */
+        address /* msgSender */
+    ) external override {
+        address safe = msg.sender;
+        (bytes memory err, bool counted) = _checkPolicy(safe, to, value, data, operation, gasPrice);
+        if (err.length > 0) {
+            assembly ("memory-safe") {
+                revert(add(err, 32), mload(err))
+            }
+        }
+        if (counted) _commitAccounting(safe, to, value, data);
+    }
+
+    /// @notice Post-execution hook — intentionally a no-op (accounting commits pre-execution;
+    ///         conservative on inner-call failure, research.md R3).
+    function checkAfterExecution(bytes32, bool) external override {}
+
+    /// @notice ERC-165: Safe v1.4.1 `setGuard` requires the guard interface id ("GS300").
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == _GUARD_INTERFACE_ID || interfaceId == _ERC165_INTERFACE_ID;
+    }
+
+    // ================================================================ configuration
+    // Only callable by the Safe itself: reached either as a threshold-approved Safe
+    // self-transaction (spec 043 proposal queue) or from PolicyGuardSetup during Safe.setup
+    // (delegatecall context makes msg.sender the new Safe). There is no other authority.
+
+    /// @notice Set a vault's full policy: per-asset limits, cooldown, and allowlist changes.
+    ///         `msg.sender` is the vault being configured.
+    /// @param limits          Per-asset limit updates; both fields 0 clears the asset's limits.
+    /// @param cooldown        Minimum seconds between counted transactions (0 = off, ≤ 365 days).
+    /// @param allowlistEnabled Whether the recipient allowlist rule is active after this call.
+    /// @param allowlistAdd    Entries to add (idempotent).
+    /// @param allowlistRemove Entries to remove (idempotent; processed before additions).
+    function configureRules(
+        RuleConfig[] calldata limits,
+        uint32 cooldown,
+        bool allowlistEnabled,
+        address[] calldata allowlistAdd,
+        address[] calldata allowlistRemove
+    ) external {
+        address safe = msg.sender;
+        if (cooldown > MAX_COOLDOWN) revert CooldownTooLong();
+        if (allowlistAdd.length + allowlistRemove.length > MAX_ALLOWLIST_BATCH) revert AllowlistBatchTooLarge();
+
+        for (uint256 i = 0; i < limits.length; i++) {
+            _setAssetRule(safe, limits[i]);
+        }
+
+        for (uint256 i = 0; i < allowlistRemove.length; i++) {
+            _removeAllowlisted(safe, allowlistRemove[i]);
+        }
+        for (uint256 i = 0; i < allowlistAdd.length; i++) {
+            _addAllowlisted(safe, allowlistAdd[i]);
+        }
+
+        PolicyMeta storage meta = _policies[safe];
+        if (allowlistEnabled && meta.allowlistCount == 0) revert EmptyAllowlist();
+        if (meta.allowlistEnabled != allowlistEnabled) {
+            meta.allowlistEnabled = allowlistEnabled;
+            emit AllowlistEnabled(safe, allowlistEnabled);
+        }
+        if (meta.cooldown != cooldown) {
+            meta.cooldown = cooldown;
+            emit CooldownSet(safe, cooldown);
+        }
+    }
+
+    // ================================================================ views
+
+    /// @notice Aggregate policy summary for one vault.
+    function getPolicy(address safe)
+        external
+        view
+        returns (
+            bool hasRules,
+            bool allowlistEnabled,
+            uint32 allowlistCount,
+            uint32 cooldown,
+            uint64 lastCountedTxAt,
+            address[] memory configuredAssets
+        )
+    {
+        PolicyMeta storage meta = _policies[safe];
+        configuredAssets = _configuredAssets[safe];
+        allowlistEnabled = meta.allowlistEnabled;
+        allowlistCount = meta.allowlistCount;
+        cooldown = meta.cooldown;
+        lastCountedTxAt = meta.lastCountedTxAt;
+        hasRules = allowlistEnabled || cooldown > 0 || configuredAssets.length > 0;
+    }
+
+    /// @notice Raw limit config + live window state for one vault × asset. `spentInWindow` /
+    ///         `windowStart` are raw storage; use `remainingInWindow` for elapsed-window-aware
+    ///         remaining capacity.
+    function getAssetRule(address safe, address asset)
+        external
+        view
+        returns (uint128 perTxLimit, uint128 windowLimit, uint128 spentInWindow, uint64 windowStart)
+    {
+        AssetRule storage r = _assetRules[safe][asset];
+        return (r.perTxLimit, r.windowLimit, r.spentInWindow, r.windowStart);
+    }
+
+    /// @notice Current allowlist entries (bounded by MAX_ALLOWLIST_BATCH per change call).
+    function getAllowlist(address safe) external view returns (address[] memory) {
+        return _allowlistEntries[safe];
+    }
+
+    function isAllowlisted(address safe, address who) external view returns (bool) {
+        return _allowlisted[safe][who];
+    }
+
+    /// @notice Remaining window capacity for an asset; `type(uint256).max` when no window limit.
+    function remainingInWindow(address safe, address asset) external view returns (uint256) {
+        AssetRule storage r = _assetRules[safe][asset];
+        if (r.windowLimit == 0) return type(uint256).max;
+        if (block.timestamp >= uint256(r.windowStart) + WINDOW) return r.windowLimit;
+        return uint256(r.windowLimit) - uint256(r.spentInWindow);
+    }
+
+    /// @notice Earliest timestamp the next counted transaction may execute (0 = no cooldown).
+    function nextAllowedAt(address safe) external view returns (uint64) {
+        PolicyMeta storage meta = _policies[safe];
+        if (meta.cooldown == 0) return 0;
+        return meta.lastCountedTxAt + meta.cooldown;
+    }
+
+    /// @notice Read-only twin of `checkTransaction` for pre-flight checks (FR-012): evaluates the
+    ///         exact enforcement logic without state writes and returns the would-be revert data
+    ///         (typed custom error, FR-011) so clients decode one canonical format.
+    /// @dev `gasPrice` is evaluated as 0 — the app never builds gas-refund transactions, and the
+    ///      guard rejects them at execution regardless.
+    function previewTransaction(address safe, address to, uint256 value, bytes calldata data, uint8 operation)
+        external
+        view
+        returns (bool ok, bytes memory revertData)
+    {
+        (revertData,) = _checkPolicy(safe, to, value, data, operation, 0);
+        ok = revertData.length == 0;
+    }
+
+    // ================================================================ internal — evaluation
+
+    /// @dev Full rule evaluation, read-only. Returns (encoded custom error or empty, whether the
+    ///      transaction is "counted" and needs accounting committed). Shared verbatim by
+    ///      enforcement and preview so the two can never drift.
+    function _checkPolicy(address safe, address to, uint256 value, bytes calldata data, uint8 operation, uint256 gasPrice)
+        internal
+        view
+        returns (bytes memory err, bool counted)
+    {
+        // Lockout-proof exemptions (FR-008): vault self-management and policy configuration
+        // bypass all fund rules; both still require the vault's own approval threshold.
+        if (to == safe) return ("", false);
+        if (to == address(this)) {
+            if (value != 0) return (abi.encodeWithSelector(ValueToGuardBlocked.selector), false);
+            return ("", false);
+        }
+
+        PolicyMeta storage meta = _policies[safe];
+        bool hasLimits = _configuredAssets[safe].length > 0;
+        if (!meta.allowlistEnabled && meta.cooldown == 0 && !hasLimits) return ("", false); // no policy
+
+        // Hard denials while any rule is active: delegatecall executes foreign code in the
+        // Safe's context (bypasses all accounting; can rewrite the guard slot), and gas refunds
+        // pay refundReceiver from the vault as an uncounted outflow.
+        if (operation != 0) return (abi.encodeWithSelector(DelegatecallBlocked.selector), false);
+        if (gasPrice != 0) return (abi.encodeWithSelector(GasRefundBlocked.selector), false);
+
+        (address tokenAsset, uint256 tokenAmount, address tokenRecipient, bool isTokenAction) = _classify(to, data);
+        counted = value > 0 || isTokenAction;
+
+        // Recipient allowlist (FR-002): token actions gate the decoded beneficiary; everything
+        // else gates the call target — so unrecognized calldata cannot reach un-allowlisted
+        // contracts. Native value riding a call additionally gates the target.
+        if (meta.allowlistEnabled) {
+            if (isTokenAction && !_allowlisted[safe][tokenRecipient]) {
+                return (abi.encodeWithSelector(RecipientNotAllowed.selector, tokenRecipient), counted);
+            }
+            if ((!isTokenAction || value > 0) && !_allowlisted[safe][to]) {
+                return (abi.encodeWithSelector(RecipientNotAllowed.selector, to), counted);
+            }
+        }
+
+        // Cooldown between counted (fund-moving) transactions.
+        if (counted && meta.cooldown > 0) {
+            uint64 nextAt = meta.lastCountedTxAt + meta.cooldown;
+            if (block.timestamp < nextAt) return (abi.encodeWithSelector(CooldownActive.selector, nextAt), counted);
+        }
+
+        // Spending limits, per counted asset. Unconfigured assets pass unvalued (disclosed).
+        if (value > 0) {
+            err = _checkLimits(safe, address(0), value);
+            if (err.length > 0) return (err, counted);
+        }
+        if (isTokenAction) {
+            err = _checkLimits(safe, tokenAsset, tokenAmount);
+            if (err.length > 0) return (err, counted);
+        }
+        return ("", counted);
+    }
+
+    /// @dev Limit evaluation for one asset, elapsed-window aware, read-only.
+    function _checkLimits(address safe, address asset, uint256 amount) internal view returns (bytes memory) {
+        AssetRule storage r = _assetRules[safe][asset];
+        uint128 perTx = r.perTxLimit;
+        uint128 windowLimit = r.windowLimit;
+        if (perTx == 0 && windowLimit == 0) return "";
+        if (perTx > 0 && amount > perTx) {
+            return abi.encodeWithSelector(PerTxLimitExceeded.selector, asset, amount, uint256(perTx));
+        }
+        if (windowLimit > 0) {
+            uint256 spent = block.timestamp >= uint256(r.windowStart) + WINDOW ? 0 : r.spentInWindow;
+            uint256 remaining = uint256(windowLimit) - spent;
+            if (amount > remaining) {
+                return abi.encodeWithSelector(WindowLimitExceeded.selector, asset, amount, remaining);
+            }
+        }
+        return "";
+    }
+
+    /// @dev Post-check state commit (CEI: all checks passed first; no external calls).
+    function _commitAccounting(address safe, address to, uint256 value, bytes calldata data) internal {
+        PolicyMeta storage meta = _policies[safe];
+        if (meta.cooldown > 0) meta.lastCountedTxAt = uint64(block.timestamp);
+        if (value > 0) _commitSpend(safe, address(0), value);
+        (address tokenAsset, uint256 tokenAmount,, bool isTokenAction) = _classify(to, data);
+        if (isTokenAction) _commitSpend(safe, tokenAsset, tokenAmount);
+    }
+
+    /// @dev Accumulate a spend into the asset's window. The uint128 cast is safe: `_checkLimits`
+    ///      proved `amount ≤ remaining ≤ windowLimit ≤ type(uint128).max` when a window limit is
+    ///      set, and no accumulation happens otherwise.
+    function _commitSpend(address safe, address asset, uint256 amount) internal {
+        AssetRule storage r = _assetRules[safe][asset];
+        if (r.windowLimit == 0) return;
+        if (block.timestamp >= uint256(r.windowStart) + WINDOW) {
+            r.windowStart = uint64(block.timestamp);
+            r.spentInWindow = uint128(amount);
+        } else {
+            r.spentInWindow += uint128(amount);
+        }
+    }
+
+    /// @dev Decode the ERC-20 actions the guard values. Anything else is a generic call.
+    function _classify(address to, bytes calldata data)
+        internal
+        pure
+        returns (address tokenAsset, uint256 tokenAmount, address tokenRecipient, bool isTokenAction)
+    {
+        if (data.length < 4) return (address(0), 0, address(0), false);
+        bytes4 selector = bytes4(data[0:4]);
+        if (selector == _SEL_TRANSFER && data.length >= 68) {
+            (address recipient, uint256 amount) = abi.decode(data[4:], (address, uint256));
+            return (to, amount, recipient, true);
+        }
+        if (selector == _SEL_APPROVE && data.length >= 68) {
+            (address spender, uint256 amount) = abi.decode(data[4:], (address, uint256));
+            return (to, amount, spender, true);
+        }
+        if (selector == _SEL_TRANSFER_FROM && data.length >= 100) {
+            (, address recipient, uint256 amount) = abi.decode(data[4:], (address, address, uint256));
+            return (to, amount, recipient, true);
+        }
+        return (address(0), 0, address(0), false);
+    }
+
+    // ================================================================ internal — config writes
+
+    function _setAssetRule(address safe, RuleConfig calldata cfg) internal {
+        AssetRule storage r = _assetRules[safe][cfg.asset];
+        bool wasConfigured = r.perTxLimit > 0 || r.windowLimit > 0;
+        bool nowConfigured = cfg.perTxLimit > 0 || cfg.windowLimit > 0;
+        r.perTxLimit = cfg.perTxLimit;
+        r.windowLimit = cfg.windowLimit;
+        if (nowConfigured && !wasConfigured) {
+            if (_configuredAssets[safe].length >= MAX_ASSETS) revert TooManyAssets();
+            _configuredAssets[safe].push(cfg.asset);
+        } else if (!nowConfigured && wasConfigured) {
+            _removeConfiguredAsset(safe, cfg.asset);
+            // Reset live state so a re-enabled rule starts a fresh window.
+            r.spentInWindow = 0;
+            r.windowStart = 0;
+        }
+        emit RulesConfigured(safe, cfg.asset, cfg.perTxLimit, cfg.windowLimit);
+    }
+
+    function _removeConfiguredAsset(address safe, address asset) internal {
+        address[] storage assets = _configuredAssets[safe];
+        uint256 len = assets.length;
+        for (uint256 i = 0; i < len; i++) {
+            if (assets[i] == asset) {
+                assets[i] = assets[len - 1];
+                assets.pop();
+                return;
+            }
+        }
+    }
+
+    function _addAllowlisted(address safe, address entry) internal {
+        if (_allowlisted[safe][entry]) return;
+        _allowlisted[safe][entry] = true;
+        _allowlistEntries[safe].push(entry);
+        _allowlistIndex[safe][entry] = _allowlistEntries[safe].length; // 1-based
+        _policies[safe].allowlistCount += 1;
+        emit AllowlistChanged(safe, entry, true);
+    }
+
+    function _removeAllowlisted(address safe, address entry) internal {
+        if (!_allowlisted[safe][entry]) return;
+        _allowlisted[safe][entry] = false;
+        address[] storage entries = _allowlistEntries[safe];
+        uint256 idx = _allowlistIndex[safe][entry]; // 1-based, guaranteed > 0
+        address last = entries[entries.length - 1];
+        entries[idx - 1] = last;
+        _allowlistIndex[safe][last] = idx;
+        entries.pop();
+        delete _allowlistIndex[safe][entry];
+        _policies[safe].allowlistCount -= 1;
+        emit AllowlistChanged(safe, entry, false);
+    }
+}

--- a/contracts/custody/SafePolicyGuard.sol
+++ b/contracts/custody/SafePolicyGuard.sol
@@ -364,6 +364,10 @@ contract SafePolicyGuard is ISafeGuard {
     }
 
     /// @dev Decode the ERC-20 actions the guard values. Anything else is a generic call.
+    ///      Slices the exact canonical argument length: Solidity functions ignore extra trailing
+    ///      calldata for static args, so decoding only the canonical words classifies the call
+    ///      exactly as the token itself would execute it — padded calldata can neither bypass
+    ///      classification nor spuriously revert it.
     function _classify(address to, bytes calldata data)
         internal
         pure
@@ -372,15 +376,15 @@ contract SafePolicyGuard is ISafeGuard {
         if (data.length < 4) return (address(0), 0, address(0), false);
         bytes4 selector = bytes4(data[0:4]);
         if (selector == _SEL_TRANSFER && data.length >= 68) {
-            (address recipient, uint256 amount) = abi.decode(data[4:], (address, uint256));
+            (address recipient, uint256 amount) = abi.decode(data[4:68], (address, uint256));
             return (to, amount, recipient, true);
         }
         if (selector == _SEL_APPROVE && data.length >= 68) {
-            (address spender, uint256 amount) = abi.decode(data[4:], (address, uint256));
+            (address spender, uint256 amount) = abi.decode(data[4:68], (address, uint256));
             return (to, amount, spender, true);
         }
         if (selector == _SEL_TRANSFER_FROM && data.length >= 100) {
-            (, address recipient, uint256 amount) = abi.decode(data[4:], (address, address, uint256));
+            (, address recipient, uint256 amount) = abi.decode(data[4:100], (address, address, uint256));
             return (to, amount, recipient, true);
         }
         return (address(0), 0, address(0), false);

--- a/contracts/mocks/MockSafe.sol
+++ b/contracts/mocks/MockSafe.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ISafeGuard} from "../custody/ISafeGuard.sol";
+
+/// @title MockSafe
+/// @notice Test-only harness mimicking the Safe v1.4.1 guard calling convention (spec 049):
+///         guard storage slot, `checkTransaction` → inner call → `checkAfterExecution` flow, and
+///         a `setupDelegate` entry that reproduces `Safe.setup`'s delegatecall so
+///         `PolicyGuardSetup` can be exercised under a real delegatecall context.
+/// @dev NOT a Safe: no owners, no signatures, no threshold — unit tests drive the guard's rule
+///      logic through it directly. Integration tests use the real Safe v1.4.1 (devDependency).
+contract MockSafe {
+    /// @dev keccak256("guard_manager.guard.address") — same slot as Safe v1.4.1.
+    bytes32 private constant _GUARD_STORAGE_SLOT = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
+
+    error DelegateSetupFailed();
+
+    receive() external payable {}
+
+    function setGuard(address guard) external {
+        assembly ("memory-safe") {
+            sstore(_GUARD_STORAGE_SLOT, guard)
+        }
+    }
+
+    function getGuard() public view returns (address guard) {
+        assembly ("memory-safe") {
+            guard := sload(_GUARD_STORAGE_SLOT)
+        }
+    }
+
+    /// @notice Reproduce `Safe.setup`'s optional delegatecall (used to test PolicyGuardSetup).
+    function setupDelegate(address to, bytes calldata data) external {
+        (bool ok, bytes memory ret) = to.delegatecall(data);
+        if (!ok) {
+            if (ret.length > 0) {
+                assembly ("memory-safe") {
+                    revert(add(ret, 32), mload(ret))
+                }
+            }
+            revert DelegateSetupFailed();
+        }
+    }
+
+    /// @notice Safe-shaped execution: consult the guard (if set), run the inner call, then the
+    ///         post-hook — mirroring execTransaction's ordering. Reverts bubble from the guard.
+    function execTransactionMock(address to, uint256 value, bytes calldata data, uint8 operation, uint256 gasPrice)
+        external
+        returns (bool success)
+    {
+        address guard = getGuard();
+        if (guard != address(0)) {
+            ISafeGuard(guard).checkTransaction(
+                to, value, data, operation, 0, 0, gasPrice, address(0), payable(address(0)), "", msg.sender
+            );
+        }
+        // Mock executes CALL only; the guard rejects delegatecall for policy vaults before this.
+        (success,) = to.call{value: value}(data);
+        if (guard != address(0)) {
+            ISafeGuard(guard).checkAfterExecution(bytes32(0), success);
+        }
+    }
+}

--- a/contracts/mocks/vendor/SafeVendorImports.sol
+++ b/contracts/mocks/vendor/SafeVendorImports.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.24;
+
+// Test-only compilation shim (spec 049): pulls the real Safe v1.4.1 sources (devDependency
+// @safe-global/safe-contracts) into the Hardhat artifact set so the policy-guard integration
+// suite (test/integration/policy-guard-safe.test.js) can deploy an actual Safe + proxy factory
+// and exercise execTransaction/setGuard/setup semantics. Never deployed by any script; live
+// networks use the canonical pre-deployed Safe contracts (frontend/src/config/safeContracts.js).
+
+import {SafeL2} from "@safe-global/safe-contracts/contracts/SafeL2.sol";
+import {SafeProxyFactory} from "@safe-global/safe-contracts/contracts/proxies/SafeProxyFactory.sol";
+import {CompatibilityFallbackHandler} from "@safe-global/safe-contracts/contracts/handler/CompatibilityFallbackHandler.sol";
+import {MultiSendCallOnly} from "@safe-global/safe-contracts/contracts/libraries/MultiSendCallOnly.sol";

--- a/deployments/hardhat-chain1337-v2.json
+++ b/deployments/hardhat-chain1337-v2.json
@@ -10,7 +10,9 @@
     "polymarketAdapter": "0x423d2Ca885d67E46062CFF732Eff952f4F736136",
     "membershipManager": "0x9D29Dfe091111099dCd317159Fa41f8E80F50489",
     "wagerRegistry": "0x31F2B0a0d14a8814af2430154ee39E551b66BA8A",
-    "keyRegistry": "0xb314c4Ee52D9D89bf7FEE66a43aBeAc7D047a5Cb"
+    "keyRegistry": "0xb314c4Ee52D9D89bf7FEE66a43aBeAc7D047a5Cb",
+    "safePolicyGuard": "0xBE509C8E6c4F132e2Af49761A318FfA362e9CE38",
+    "policyGuardSetup": "0xD0CB9D0ca2E56e9552cb833eC6D16F86ce818C2b"
   },
   "mocks": {
     "mockUSDC": "0x065606eeE0D7BB3d2e7959D56c3ca177625385a7",
@@ -20,6 +22,12 @@
   "saltPrefix": "FairWins-P2P-v2.0-",
   "timestamp": "2026-05-22T01:20:23.586Z",
   "deployBlocks": {
-    "wagerRegistry": null
+    "wagerRegistry": null,
+    "safePolicyGuard": 3,
+    "policyGuardSetup": 4
+  },
+  "constructorArgs": {
+    "safePolicyGuard": [],
+    "policyGuardSetup": []
   }
 }

--- a/docs/developer-guide/multisig-policy-engine.md
+++ b/docs/developer-guide/multisig-policy-engine.md
@@ -1,0 +1,101 @@
+# Multisig Policy Engine (spec 049)
+
+On-chain, opt-in fund policies for the Protect (custody) Safe vaults from spec 043. A policy
+constrains what an **approved** vault transaction may do — after the owners' threshold is met,
+before execution. Feature artifacts: `specs/049-multisig-policy-engine/`.
+
+## Architecture
+
+Two immutable contracts per chain (no proxies, no admin, no upgrade keys):
+
+| Contract | Deployment key | Role |
+|----------|----------------|------|
+| `contracts/custody/SafePolicyGuard.sol` | `safePolicyGuard` | Singleton Safe v1.4.1 transaction guard holding every vault's rule config + live accounting. |
+| `contracts/custody/PolicyGuardSetup.sol` | `policyGuardSetup` | Stateless `Safe.setup` delegatecall helper that attaches the guard + initial rules at vault creation. |
+
+A vault opts in either at creation (setup helper) or later via a threshold-approved
+`setGuard` self-transaction. The vault itself is the only authority over its policy: every
+`SafePolicyGuard.configureRules` call requires `msg.sender == safe`, which is only reachable as a
+Safe self-transaction (or from the setup helper's call, which runs in the new proxy's context).
+FR-007 (threshold-gated changes) therefore needs no extra approval plumbing — it rides the spec
+043 propose/approve queue.
+
+### Rules (v1)
+
+Per vault, each independently optional:
+
+- **Per-transaction limit** — per asset (`address(0)` = native, or an ERC-20 address).
+- **24-hour-window limit** — per asset; the window opens at the first counted spend and resets
+  24 h later (fixed-reset, **not** rolling — see accepted risks).
+- **Recipient allowlist** — token actions gate the decoded beneficiary (`transfer`/
+  `transferFrom` recipient, `approve` spender); all other calls gate the target address.
+- **Cooldown** — minimum delay between counted (fund-moving) transactions.
+
+Counted actions: native `value > 0` and the ERC-20 selectors `transfer`, `transferFrom`,
+`approve` (approvals are spending grants; counting them closes the approve-then-pull bypass).
+
+### Hard denials while any rule is active
+
+- `operation == DELEGATECALL` — foreign code in the Safe's context can bypass any guard (and
+  rewrite the guard slot). Consequence: **MultiSend batching is unavailable on policy vaults**
+  (spec 043 flows are single-call, so nothing regresses).
+- `gasPrice != 0` — Safe gas refunds pay `refundReceiver` from the vault, an uncounted outflow.
+
+### Lockout-proofing (FR-008 / SC-003)
+
+Transactions targeting the **Safe itself** (owner/threshold/guard management) or the **guard**
+(policy config, `value == 0` enforced) bypass all fund rules — both still require the vault's
+threshold. A policy can therefore always be loosened; no vault can be bricked by its own rules.
+Proven on the real Safe in `test/integration/policy-guard-safe.test.js`.
+
+### Accepted risks (documented, disclosed in UI)
+
+1. **Window straddle** — fixed-reset windows admit up to 2× the limit across a span straddling a
+   reset. A true rolling window needs unbounded per-tx history; rejected (research.md R3).
+2. **Unvalued calldata** — calls the guard cannot value (DEX swaps, arbitrary contract calls)
+   pass spending limits unvalued; they remain subject to the allowlist (call target) and can be
+   fully locked down by enabling it.
+3. **Conservative accounting** — window/cooldown state commits in `checkTransaction`; if the
+   Safe's inner call fails without reverting the outer transaction, the spend still counts.
+   Overcounting only restricts.
+4. **Slither** — remaining findings are informational and deliberate: timestamp comparisons
+   (inherent to time-window rules; miner drift of seconds is immaterial against 24 h windows),
+   annotated memory-safe inline assembly (guard-slot sstore, typed-error revert bubbling), and
+   one low-level call in the setup helper (bubbles reverts by design).
+
+## Frontend
+
+- Library: `frontend/src/lib/custody/policy.js` (status/read/encode/preview/decode/describe).
+  Pre-flight uses the guard's own `previewTransaction` view, so client display can never drift
+  from enforcement.
+- ABI: `frontend/src/abis/SafePolicyGuard.js`.
+- Surfaces: Policy step in `CreateVaultWizard`, `PolicyPanel` in `VaultDetail`, `PolicyBadge` in
+  `VaultList`, pre-flight warnings in `ProposeTransactionForm`, policy-change decoding in
+  `ProposalQueue`. Guard events feed the existing `custody` notification domain.
+- Network gating: `getContractAddressForChain('safePolicyGuard'|'policyGuardSetup', chainId)`;
+  `undefined` ⇒ policy UI renders its unsupported states and custody behaves exactly as spec 043.
+- Attach-to-existing ordering: queue `configureRules` **first** (inert without the guard), then
+  `setGuard` (activates) — no half-set gap.
+
+## Deployment / rollout
+
+```bash
+npx hardhat run scripts/deploy/custody/deploy-policy-guard.js --network <localhost|mordor|polygon>
+npm run sync:frontend-contracts -- --network <net> --chainId <id>
+```
+
+Deterministic CREATE2 via the Safe singleton factory (same salt prefix as the v2 suite), recorded
+in `deployments/<net>-chain<id>-v2.json` under `safePolicyGuard` / `policyGuardSetup`. Rollout
+follows custody support: **Mordor (63) → Polygon (137)**; both contracts are admin-free so the
+deploy key holds no ongoing power. Upgrades ship as a NEW guard deployment that vaults adopt via
+threshold-approved `setGuard` — never an in-place upgrade (`check:storage-layout` is not
+applicable; there is no proxy).
+
+## Tests
+
+- `test/custody/SafePolicyGuard.test.js`, `test/custody/PolicyGuardSetup.test.js` — unit, against
+  `contracts/mocks/MockSafe.sol`.
+- `test/integration/policy-guard-safe.test.js` — real Safe v1.4.1 (devDependency
+  `@safe-global/safe-contracts`, compiled test-only via `contracts/mocks/vendor/SafeVendorImports.sol`
+  WITHOUT viaIR — Safe's assembly is not memory-safe-annotated; see hardhat.config.js overrides).
+- `frontend/src/test/custody/policy.test.js` + component suites.

--- a/docs/developer-guide/multisig-policy-engine.md
+++ b/docs/developer-guide/multisig-policy-engine.md
@@ -87,7 +87,13 @@ npm run sync:frontend-contracts -- --network <net> --chainId <id>
 Deterministic CREATE2 via the Safe singleton factory (same salt prefix as the v2 suite), recorded
 in `deployments/<net>-chain<id>-v2.json` under `safePolicyGuard` / `policyGuardSetup`. Rollout
 follows custody support: **Mordor (63) → Polygon (137)**; both contracts are admin-free so the
-deploy key holds no ongoing power. Upgrades ship as a NEW guard deployment that vaults adopt via
+deploy key holds no ongoing power.
+
+> **Deploy-owner checklist per network**: after running the script + sync, also add a
+> `safePolicyGuard` entry to `DEPLOYMENT_BLOCKS_BY_CHAIN` in `frontend/src/config/contracts.js`
+> (the deploy block is printed by the script and recorded in `deployments/`). The policy-event
+> notification source (FR-016) deliberately no-ops until that bounded scan-start block exists —
+> the never-scan-from-genesis rule (issue #703/#704) gates it, same as the proposal hub. Upgrades ship as a NEW guard deployment that vaults adopt via
 threshold-approved `setGuard` — never an in-place upgrade (`check:storage-layout` is not
 applicable; there is no proxy).
 

--- a/frontend/src/abis/SafePolicyGuard.js
+++ b/frontend/src/abis/SafePolicyGuard.js
@@ -1,0 +1,53 @@
+// Spec 049 — SafePolicyGuard (multisig policy engine) + PolicyGuardSetup ABIs.
+// Human-readable fragments curated from contracts/custody/SafePolicyGuard.sol and
+// PolicyGuardSetup.sol; includes every custom error so violation revert data decodes to a
+// typed rule (FR-011) in frontend/src/lib/custody/policy.js.
+
+export const SAFE_POLICY_GUARD_ABI = [
+  // guard hooks (present for completeness; the app never calls these directly)
+  'function checkTransaction(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures, address msgSender)',
+  'function checkAfterExecution(bytes32 txHash, bool success)',
+  'function supportsInterface(bytes4 interfaceId) view returns (bool)',
+
+  // configuration (called by the vault itself as a threshold-approved self-transaction)
+  'function configureRules((address asset, uint128 perTxLimit, uint128 windowLimit)[] limits, uint32 cooldown, bool allowlistEnabled, address[] allowlistAdd, address[] allowlistRemove)',
+
+  // views
+  'function WINDOW() view returns (uint256)',
+  'function MAX_COOLDOWN() view returns (uint32)',
+  'function MAX_ASSETS() view returns (uint256)',
+  'function MAX_ALLOWLIST_BATCH() view returns (uint256)',
+  'function getPolicy(address safe) view returns (bool hasRules, bool allowlistEnabled, uint32 allowlistCount, uint32 cooldown, uint64 lastCountedTxAt, address[] configuredAssets)',
+  'function getAssetRule(address safe, address asset) view returns (uint128 perTxLimit, uint128 windowLimit, uint128 spentInWindow, uint64 windowStart)',
+  'function getAllowlist(address safe) view returns (address[])',
+  'function isAllowlisted(address safe, address who) view returns (bool)',
+  'function remainingInWindow(address safe, address asset) view returns (uint256)',
+  'function nextAllowedAt(address safe) view returns (uint64)',
+  'function previewTransaction(address safe, address to, uint256 value, bytes data, uint8 operation) view returns (bool ok, bytes revertData)',
+
+  // events (notification feed, FR-016)
+  'event RulesConfigured(address indexed safe, address indexed asset, uint128 perTxLimit, uint128 windowLimit)',
+  'event CooldownSet(address indexed safe, uint32 cooldown)',
+  'event AllowlistEnabled(address indexed safe, bool enabled)',
+  'event AllowlistChanged(address indexed safe, address indexed entry, bool allowed)',
+
+  // typed rule errors (FR-011 — decoded by decodePolicyError)
+  'error DelegatecallBlocked()',
+  'error GasRefundBlocked()',
+  'error RecipientNotAllowed(address recipient)',
+  'error CooldownActive(uint64 nextAllowedAt)',
+  'error PerTxLimitExceeded(address asset, uint256 amount, uint256 limit)',
+  'error WindowLimitExceeded(address asset, uint256 attempted, uint256 remaining)',
+  'error ValueToGuardBlocked()',
+  'error EmptyAllowlist()',
+  'error CooldownTooLong()',
+  'error TooManyAssets()',
+  'error AllowlistBatchTooLarge()',
+]
+
+export const POLICY_GUARD_SETUP_ABI = [
+  'function enablePolicy(address guard, bytes configureCalldata)',
+  'event ChangedGuard(address indexed guard)',
+  'error ZeroGuard()',
+  'error NotAGuard()',
+]

--- a/frontend/src/components/custody/CreateVaultWizard.jsx
+++ b/frontend/src/components/custody/CreateVaultWizard.jsx
@@ -1,14 +1,20 @@
 // Spec 043 (US1) — create a new Safe vault: choose owners + threshold, preview the deterministic address, and
 // deploy. Validation mirrors validateVaultConfig (FR-005). Presentational; all chain work is delegated to the
 // injected callbacks so the component is unit-testable.
+// Spec 049 (US1) — an optional Policy step sits between configuration and review: when rules are configured
+// they become a `policySetup` ({setupTo, setupData}) threaded into vault creation; when skipped the payload
+// carries no policySetup, keeping the initializer byte-identical to spec 043 (FR-010).
 
 import { useState, useMemo, useEffect } from 'react'
 import { validateVaultConfig } from '../../lib/custody/safeVault'
+import { buildEnablePolicySetup } from '../../lib/custody/policy'
+import PolicyStep from './PolicyStep'
 
-export default function CreateVaultWizard({ connectedAddress, onCreate, onPreview, onDone }) {
+export default function CreateVaultWizard({ connectedAddress, chainId, onCreate, onPreview, onDone }) {
   const [owners, setOwners] = useState([connectedAddress || ''])
   const [threshold, setThreshold] = useState(1)
   const [label, setLabel] = useState('')
+  const [policy, setPolicy] = useState(null)
   const [predicted, setPredicted] = useState(null)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState(null)
@@ -23,14 +29,19 @@ export default function CreateVaultWizard({ connectedAddress, onCreate, onPrevie
     }
   }, [owners, threshold])
 
-  // A previewed address is only valid for the exact owners+threshold it was computed from; clear it whenever
-  // the config changes so the user never sees a stale address that won't match what "Create vault" deploys.
+  // A previewed address is only valid for the exact owners+threshold+policy it was computed from (the policy
+  // setup is part of the initializer, which is hashed into the CREATE2 salt); clear it whenever the config
+  // changes so the user never sees a stale address that won't match what "Create vault" deploys.
   useEffect(() => {
     setPredicted(null)
-  }, [owners, threshold])
+  }, [owners, threshold, policy])
 
   const cleanedOwners = () => owners.map((o) => o.trim()).filter(Boolean)
   const nextSaltNonce = () => Date.now()
+
+  // Spec 049: a policy still being edited (invalid) blocks create; a skipped policy is null.
+  const policyBlocked = Boolean(policy?.invalid)
+  const buildPolicySetup = () => (policy && !policy.invalid ? buildEnablePolicySetup(chainId, policy) : undefined)
 
   const updateOwner = (i, val) => setOwners((prev) => prev.map((o, idx) => (idx === i ? val : o)))
   const addOwner = () => setOwners((prev) => [...prev, ''])
@@ -40,7 +51,12 @@ export default function CreateVaultWizard({ connectedAddress, onCreate, onPrevie
     setError(null)
     setBusy(true)
     try {
-      const addr = await onPreview({ owners: cleanedOwners(), threshold, saltNonce: previewNonce })
+      const addr = await onPreview({
+        owners: cleanedOwners(),
+        threshold,
+        saltNonce: previewNonce,
+        policySetup: buildPolicySetup(),
+      })
       setPredicted(addr)
     } catch (e) {
       setError(e?.message || 'Could not preview the vault address')
@@ -56,7 +72,13 @@ export default function CreateVaultWizard({ connectedAddress, onCreate, onPrevie
     setError(null)
     setBusy(true)
     try {
-      await onCreate({ owners: cleanedOwners(), threshold, saltNonce: previewNonce, label })
+      await onCreate({
+        owners: cleanedOwners(),
+        threshold,
+        saltNonce: previewNonce,
+        label,
+        policySetup: buildPolicySetup(),
+      })
       onDone?.()
     } catch (e) {
       setError(e?.message || 'Vault creation failed')
@@ -109,6 +131,8 @@ export default function CreateVaultWizard({ connectedAddress, onCreate, onPrevie
         <input id="vault-label" type="text" value={label} onChange={(e) => setLabel(e.target.value)} />
       </div>
 
+      <PolicyStep chainId={chainId} value={policy} onChange={setPolicy} />
+
       {validationError && (
         <p className="custody-error" role="alert">
           {validationError}
@@ -125,11 +149,17 @@ export default function CreateVaultWizard({ connectedAddress, onCreate, onPrevie
         </p>
       )}
 
+      <p className="custody-policy-review">
+        {policy && !policy.invalid
+          ? `Policy: ${(policy.summary || []).join('; ')}`
+          : 'No policy — the vault will have no spending rules.'}
+      </p>
+
       <div className="custody-actions">
-        <button type="button" onClick={handlePreview} disabled={!!validationError || busy}>
+        <button type="button" onClick={handlePreview} disabled={!!validationError || policyBlocked || busy}>
           Preview address
         </button>
-        <button type="button" onClick={handleCreate} disabled={!!validationError || busy}>
+        <button type="button" onClick={handleCreate} disabled={!!validationError || policyBlocked || busy}>
           {busy ? 'Working…' : 'Create vault'}
         </button>
       </div>

--- a/frontend/src/components/custody/Custody.css
+++ b/frontend/src/components/custody/Custody.css
@@ -237,6 +237,60 @@
   margin-left: auto;
 }
 
+/* Spec 049 — policy step in the create-vault wizard. */
+
+.custody-policy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+
+.custody-policy-title {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.custody-policy fieldset {
+  margin: 0.25rem 0;
+}
+
+.custody-policy fieldset label {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.custody-warning {
+  color: var(--warning-color, #b45309);
+  font-size: 0.875rem;
+}
+
+.custody-policy-summary {
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.25));
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.custody-policy-summary-title {
+  margin: 0 0 0.375rem;
+  font-size: 0.875rem;
+}
+
+.custody-policy-summary ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+}
+
+.custody-policy-review {
+  font-size: 0.875rem;
+  color: var(--text-muted, #6b7280);
+}
+
 .sr-only {
   position: absolute;
   width: 1px;

--- a/frontend/src/components/custody/CustodyPanel.jsx
+++ b/frontend/src/components/custody/CustodyPanel.jsx
@@ -6,6 +6,7 @@ import { useState } from 'react'
 import { useWallet } from '../../hooks'
 import { useCustody } from '../../hooks/useCustody'
 import { useCustodyVaults } from '../../hooks/useCustodyVaults'
+import { useVaultProposals } from '../../hooks/useVaultProposals'
 import { isCustodySupported, CUSTODY_SUPPORTED_CHAIN_IDS } from '../../config/safeContracts'
 import VaultList from './VaultList'
 import VaultDetail from './VaultDetail'
@@ -15,7 +16,7 @@ import LoadVaultForm from './LoadVaultForm'
 import './Custody.css'
 
 function OnChainSection() {
-  const { address } = useWallet()
+  const { address, chainId } = useWallet()
   const { active, operateAsVault } = useCustody()
   const {
     vaults,
@@ -30,6 +31,10 @@ function OnChainSection() {
     forget,
   } = useCustodyVaults()
   const [mode, setMode] = useState(null) // null | 'create' | 'load'
+  // Spec 049 — one shared proposal-queue instance for the active vault, so policy-change proposals
+  // (VaultDetail → PolicyPanel) land in the same queue the VaultProposalsPanel renders.
+  const proposals = useVaultProposals(activeVault)
+  const onVaultChain = activeVault && Number(chainId) === Number(activeVault.chainId)
 
   return (
     <div className="custody-onchain" role="region" aria-label="On-chain vaults">
@@ -45,6 +50,7 @@ function OnChainSection() {
       {mode === 'create' && (
         <CreateVaultWizard
           connectedAddress={address}
+          chainId={chainId}
           onCreate={createVault}
           onPreview={previewVaultAddress}
           onDone={() => setMode(null)}
@@ -68,8 +74,9 @@ function OnChainSection() {
               onForget={forget}
               onOperateAs={operateAsVault}
               isActiveIdentity={active.mode === 'vault' && active.vaultAddress === activeVault.address}
+              onProposePolicy={activeVault.owner && onVaultChain ? proposals.propose : undefined}
             />
-            <VaultProposalsPanel vault={activeVault} />
+            <VaultProposalsPanel vault={activeVault} proposals={proposals} />
           </div>
         )}
       </div>

--- a/frontend/src/components/custody/Policy.css
+++ b/frontend/src/components/custody/Policy.css
@@ -1,0 +1,138 @@
+/* Spec 049 — multisig policy engine surfaces (badge, panel, queue decoration). Follows the
+   Custody.css conventions: `custody-` prefix, app spacing/typography tokens, WCAG AA contrast. */
+
+.custody-policy-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3125rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.0625rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  max-width: 100%;
+}
+
+.custody-policy-badge svg {
+  flex: none;
+}
+
+.custody-policy-badge--managed {
+  color: #047857;
+}
+
+.custody-policy-badge--foreign {
+  color: #b45309;
+}
+
+.custody-policy-badge-summary {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.custody-policy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.custody-policy-rules,
+.custody-policy-live,
+.custody-policy-allowlist {
+  list-style: disc;
+  margin: 0.25rem 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.custody-policy-allowlist {
+  list-style: none;
+  padding-left: 0;
+  word-break: break-all;
+}
+
+.custody-policy-subtitle {
+  margin: 0.5rem 0 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.custody-policy-compare {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr);
+  margin: 0.5rem 0;
+}
+
+@media (min-width: 720px) {
+  .custody-policy-compare {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+}
+
+.custody-policy-compare-col {
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.25));
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.custody-policy-compare-col h6 {
+  margin: 0 0 0.375rem;
+  font-size: 0.8125rem;
+}
+
+.custody-policy-token-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: flex-end;
+  margin-bottom: 0.375rem;
+}
+
+.custody-policy-token-row .custody-field {
+  margin: 0;
+}
+
+.custody-policy-cooldown {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-end;
+}
+
+.custody-policy-cooldown .custody-field {
+  margin: 0;
+}
+
+.custody-warning {
+  color: #b45309;
+  font-size: 0.875rem;
+  border: 1px solid currentColor;
+  border-radius: 0.375rem;
+  padding: 0.375rem 0.625rem;
+  margin: 0.5rem 0;
+}
+
+.custody-policy-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3125rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #047857;
+  padding: 0.0625rem 0.5rem;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+}
+
+.custody-policy-diff {
+  list-style: disc;
+  margin: 0.25rem 0;
+  padding-left: 1.25rem;
+  font-size: 0.8125rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}

--- a/frontend/src/components/custody/PolicyBadge.jsx
+++ b/frontend/src/components/custody/PolicyBadge.jsx
@@ -1,0 +1,42 @@
+// Spec 049 (US2, FR-006) — vault-list badge: distinguishes policy-governed vaults with a shield
+// mark + one-line rule summary, and flags foreign guards ("unrecognized policy"). Vaults with no
+// policy (or on unsupported networks) render nothing so the list stays uncluttered. No emoji —
+// line-glyph SVG per the NavIcon convention.
+
+import './Policy.css'
+
+function ShieldGlyph() {
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+    </svg>
+  )
+}
+
+export default function PolicyBadge({ status, summary }) {
+  if (status === 'managed') {
+    return (
+      <span className="custody-policy-badge custody-policy-badge--managed">
+        <ShieldGlyph />
+        <span className="sr-only">Policy-governed vault.</span>
+        <span className="custody-policy-badge-summary">{summary || 'Policy active'}</span>
+      </span>
+    )
+  }
+  if (status === 'foreign') {
+    return <span className="custody-policy-badge custody-policy-badge--foreign">Unrecognized policy</span>
+  }
+  // 'none', 'unsupported', or unknown/unfetched: no badge (FR-010/FR-013).
+  return null
+}

--- a/frontend/src/components/custody/PolicyPanel.jsx
+++ b/frontend/src/components/custody/PolicyPanel.jsx
@@ -1,0 +1,596 @@
+// Spec 049 (US2/US3) — the vault detail's Policy section. Reads the vault's policy status +
+// rules straight from chain (FR-005/FR-014) and renders them in plain language with live state
+// (window consumption, next-allowed time — FR-006). Owners get the threshold-approved management
+// flows (FR-007): "propose change" with a current-vs-proposed comparison, and "attach a policy"
+// for policy-less vaults, queued as configureRules FIRST then setGuard (rules are inert without
+// the guard, so there is never a half-set active gap). Non-owners see rules, no actions.
+// Proposals go through the existing spec 043 queue via the `onPropose` prop
+// (useVaultProposals.propose), inheriting FR-009 approval binding.
+
+import { useState, useEffect, useCallback } from 'react'
+import { formatUnits, parseUnits, getAddress } from 'ethers'
+import {
+  getPolicyStatus,
+  readPolicy,
+  describeRules,
+  validatePolicyConfig,
+  buildPolicyChangeTx,
+  buildSetGuardTx,
+  NATIVE_ASSET,
+  shortAddress,
+} from '../../lib/custody/policy'
+import './Policy.css'
+
+const COOLDOWN_UNITS = [
+  { key: 'minutes', label: 'minutes', seconds: 60 },
+  { key: 'hours', label: 'hours', seconds: 3600 },
+  { key: 'days', label: 'days', seconds: 24 * 3600 },
+]
+
+function formatAmount(asset, amount) {
+  if (asset === NATIVE_ASSET) return `${formatUnits(amount, 18)} (native coin)`
+  return `${amount} units of ${shortAddress(asset)}`
+}
+
+/** Split a cooldown in seconds into the largest clean unit for the edit form. */
+function splitCooldown(seconds) {
+  const s = Number(seconds) || 0
+  if (s === 0) return { value: '', unit: 'hours' }
+  for (const u of [...COOLDOWN_UNITS].reverse()) {
+    if (s % u.seconds === 0) return { value: String(s / u.seconds), unit: u.key }
+  }
+  return { value: String(Math.ceil(s / 60)), unit: 'minutes' }
+}
+
+/**
+ * The policy a config would produce, in `readPolicy` shape, so `describeRules` can render the
+ * "Proposed" column. `configureRules` only touches the assets it names, so unnamed current rules
+ * carry over.
+ */
+function projectPolicy(config, current) {
+  const byAsset = new Map((current?.assetRules || []).map((r) => [r.asset.toLowerCase(), { ...r }]))
+  for (const l of config.limits || []) {
+    byAsset.set(String(l.asset).toLowerCase(), {
+      asset: l.asset,
+      perTxLimit: BigInt(l.perTxLimit ?? 0),
+      windowLimit: BigInt(l.windowLimit ?? 0),
+      spentInWindow: 0n,
+      windowStart: 0,
+      remainingInWindow: BigInt(l.windowLimit ?? 0),
+    })
+  }
+  const assetRules = [...byAsset.values()]
+  const removes = new Set((config.allowlistRemove || []).map((a) => a.toLowerCase()))
+  const kept = (current?.allowlist || []).filter((a) => !removes.has(a.toLowerCase()))
+  const adds = (config.allowlistAdd || []).filter((a) => !kept.some((k) => k.toLowerCase() === a.toLowerCase()))
+  const allowlist = [...kept, ...adds]
+  const cooldown = Number(config.cooldown || 0)
+  const hasRules =
+    assetRules.some((r) => r.perTxLimit > 0n || r.windowLimit > 0n) || !!config.allowlistEnabled || cooldown > 0
+  return {
+    hasRules,
+    allowlistEnabled: !!config.allowlistEnabled,
+    allowlistCount: allowlist.length,
+    cooldown,
+    nextAllowedAt: 0,
+    allowlist,
+    assetRules,
+  }
+}
+
+/**
+ * Rule configuration editor + review step. Edit → "Review change" (client-validated, FR-015) →
+ * current-vs-proposed side by side (US3-AS1) → submit. Native limits are entered in whole coins;
+ * token limits in the token's smallest (base) unit so no decimals guessing can corrupt a rule.
+ */
+function PolicyConfigEditor({ currentPolicy, attach, threshold, busy, onSubmit, onCancel }) {
+  const nativeRule = (currentPolicy?.assetRules || []).find((r) => r.asset === NATIVE_ASSET)
+  const tokenRules = (currentPolicy?.assetRules || []).filter((r) => r.asset !== NATIVE_ASSET)
+  const initialCooldown = splitCooldown(currentPolicy?.cooldown)
+
+  const [nativePerTx, setNativePerTx] = useState(nativeRule && nativeRule.perTxLimit > 0n ? formatUnits(nativeRule.perTxLimit, 18) : '')
+  const [nativeWindow, setNativeWindow] = useState(nativeRule && nativeRule.windowLimit > 0n ? formatUnits(nativeRule.windowLimit, 18) : '')
+  const [tokenRows, setTokenRows] = useState(
+    tokenRules.map((r) => ({ address: r.asset, perTx: r.perTxLimit.toString(), window: r.windowLimit.toString() })),
+  )
+  const [cooldownValue, setCooldownValue] = useState(initialCooldown.value)
+  const [cooldownUnit, setCooldownUnit] = useState(initialCooldown.unit)
+  const [allowlistEnabled, setAllowlistEnabled] = useState(!!currentPolicy?.allowlistEnabled)
+  const [removals, setRemovals] = useState([]) // existing entries ticked for removal
+  const [additions, setAdditions] = useState([])
+  const [newRecipient, setNewRecipient] = useState('')
+  const [formError, setFormError] = useState(null)
+  const [reviewConfig, setReviewConfig] = useState(null)
+
+  const currentAllowlist = currentPolicy?.allowlist || []
+
+  const toggleRemoval = (addr) =>
+    setRemovals((r) => (r.includes(addr) ? r.filter((a) => a !== addr) : [...r, addr]))
+
+  const addRecipient = () => {
+    setFormError(null)
+    try {
+      const a = getAddress(newRecipient.trim())
+      if (
+        additions.some((x) => x.toLowerCase() === a.toLowerCase()) ||
+        currentAllowlist.some((x) => x.toLowerCase() === a.toLowerCase())
+      ) {
+        setFormError('That recipient is already on the allowlist')
+        return
+      }
+      setAdditions((list) => [...list, a])
+      setNewRecipient('')
+    } catch {
+      setFormError('Enter a valid recipient address')
+    }
+  }
+
+  const buildConfig = () => {
+    const limits = []
+    if (nativePerTx.trim() || nativeWindow.trim() || nativeRule) {
+      limits.push({
+        asset: NATIVE_ASSET,
+        perTxLimit: nativePerTx.trim() ? parseUnits(nativePerTx.trim(), 18) : 0n,
+        windowLimit: nativeWindow.trim() ? parseUnits(nativeWindow.trim(), 18) : 0n,
+      })
+    }
+    for (const row of tokenRows) {
+      if (!row.address.trim()) continue
+      limits.push({
+        asset: getAddress(row.address.trim()),
+        perTxLimit: BigInt(row.perTx.trim() || '0'),
+        windowLimit: BigInt(row.window.trim() || '0'),
+      })
+    }
+    const cooldown = cooldownValue.trim()
+      ? Number(cooldownValue.trim()) * (COOLDOWN_UNITS.find((u) => u.key === cooldownUnit)?.seconds || 1)
+      : 0
+    const config = {
+      limits,
+      cooldown,
+      allowlistEnabled,
+      allowlistAdd: additions,
+      allowlistRemove: removals,
+      allowlistAlreadyPopulated: currentAllowlist.length - removals.length > 0,
+    }
+    if (allowlistEnabled && currentAllowlist.length - removals.length + additions.length === 0) {
+      throw new Error('Enable the allowlist with at least one recipient — an empty allowlist would block everything')
+    }
+    validatePolicyConfig(config)
+    return config
+  }
+
+  const review = () => {
+    setFormError(null)
+    try {
+      setReviewConfig(buildConfig())
+    } catch (e) {
+      setFormError(e?.message || 'Invalid policy configuration')
+    }
+  }
+
+  if (reviewConfig) {
+    const proposed = projectPolicy(reviewConfig, currentPolicy)
+    const proposedLines = describeRules(proposed)
+    const currentLines = currentPolicy?.hasRules ? describeRules(currentPolicy) : []
+    return (
+      <div className="custody-policy-review" role="region" aria-label="Review policy change">
+        <div className="custody-policy-compare">
+          <div className="custody-policy-compare-col">
+            <h6>Current policy</h6>
+            {currentLines.length > 0 ? (
+              <ul className="custody-policy-rules">
+                {currentLines.map((line) => (
+                  <li key={line}>{line}</li>
+                ))}
+              </ul>
+            ) : (
+              <p className="custody-hint">No rules — approvals only.</p>
+            )}
+          </div>
+          <div className="custody-policy-compare-col">
+            <h6>Proposed policy</h6>
+            {proposedLines.length > 0 ? (
+              <ul className="custody-policy-rules">
+                {proposedLines.map((line) => (
+                  <li key={line}>{line}</li>
+                ))}
+              </ul>
+            ) : (
+              <p className="custody-hint">No rules — approvals only.</p>
+            )}
+          </div>
+        </div>
+        {attach ? (
+          <p className="custody-hint">
+            This queues two vault transactions, in order: first configure the rules (inert until the
+            policy engine is attached), then activate the policy engine. Each needs
+            {threshold ? ` ${threshold}` : ' the vault’s threshold of'} owner approval{threshold === 1 ? '' : 's'};
+            the rules only take effect once the second transaction executes.
+          </p>
+        ) : (
+          <p className="custody-hint">
+            The change takes effect only after the vault’s approval threshold is met — co-owners will
+            see this exact current-vs-proposed comparison on the queued transaction.
+          </p>
+        )}
+        <div className="custody-actions">
+          <button type="button" onClick={() => onSubmit(reviewConfig)} disabled={busy}>
+            {busy ? 'Proposing…' : attach ? 'Queue both transactions' : 'Propose this change'}
+          </button>
+          <button type="button" className="custody-link" onClick={() => setReviewConfig(null)} disabled={busy}>
+            Back to editing
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <form className="custody-policy-editor" onSubmit={(e) => e.preventDefault()} aria-label={attach ? 'Attach a policy' : 'Edit policy rules'}>
+      <fieldset>
+        <legend>Spending limits — native coin</legend>
+        <div className="custody-field">
+          <label htmlFor="policy-native-pertx">Per-transaction limit (blank for none)</label>
+          <input
+            id="policy-native-pertx"
+            type="text"
+            inputMode="decimal"
+            value={nativePerTx}
+            onChange={(e) => setNativePerTx(e.target.value)}
+          />
+        </div>
+        <div className="custody-field">
+          <label htmlFor="policy-native-window">24-hour window limit (blank for none)</label>
+          <input
+            id="policy-native-window"
+            type="text"
+            inputMode="decimal"
+            value={nativeWindow}
+            onChange={(e) => setNativeWindow(e.target.value)}
+          />
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend>Spending limits — tokens (amounts in the token’s smallest unit)</legend>
+        {tokenRows.map((row, i) => (
+          <div className="custody-policy-token-row" key={`token-row-${i}`}>
+            <div className="custody-field">
+              <label htmlFor={`policy-token-addr-${i}`}>Token address</label>
+              <input
+                id={`policy-token-addr-${i}`}
+                type="text"
+                placeholder="0x…"
+                value={row.address}
+                onChange={(e) => setTokenRows((rows) => rows.map((r, j) => (j === i ? { ...r, address: e.target.value } : r)))}
+              />
+            </div>
+            <div className="custody-field">
+              <label htmlFor={`policy-token-pertx-${i}`}>Per-transaction limit</label>
+              <input
+                id={`policy-token-pertx-${i}`}
+                type="text"
+                inputMode="numeric"
+                value={row.perTx}
+                onChange={(e) => setTokenRows((rows) => rows.map((r, j) => (j === i ? { ...r, perTx: e.target.value } : r)))}
+              />
+            </div>
+            <div className="custody-field">
+              <label htmlFor={`policy-token-window-${i}`}>24-hour window limit</label>
+              <input
+                id={`policy-token-window-${i}`}
+                type="text"
+                inputMode="numeric"
+                value={row.window}
+                onChange={(e) => setTokenRows((rows) => rows.map((r, j) => (j === i ? { ...r, window: e.target.value } : r)))}
+              />
+            </div>
+            <button
+              type="button"
+              className="custody-link"
+              onClick={() => setTokenRows((rows) => rows.filter((_, j) => j !== i))}
+            >
+              Remove token row
+            </button>
+          </div>
+        ))}
+        <div className="custody-actions">
+          <button type="button" onClick={() => setTokenRows((rows) => [...rows, { address: '', perTx: '', window: '' }])}>
+            Add token limit
+          </button>
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend>Recipient allowlist</legend>
+        <label>
+          <input type="checkbox" checked={allowlistEnabled} onChange={(e) => setAllowlistEnabled(e.target.checked)} />
+          Only allow transfers to approved recipients
+        </label>
+        {currentAllowlist.length > 0 && (
+          <ul className="custody-policy-allowlist" aria-label="Current allowlist entries">
+            {currentAllowlist.map((a) => (
+              <li key={a}>
+                <label>
+                  <input type="checkbox" checked={removals.includes(a)} onChange={() => toggleRemoval(a)} />
+                  Remove <code>{a}</code>
+                </label>
+              </li>
+            ))}
+          </ul>
+        )}
+        {additions.length > 0 && (
+          <ul className="custody-policy-allowlist" aria-label="Recipients to add">
+            {additions.map((a) => (
+              <li key={a}>
+                <code>{a}</code>{' '}
+                <button type="button" className="custody-link" onClick={() => setAdditions((list) => list.filter((x) => x !== a))}>
+                  Undo add
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="custody-field">
+          <label htmlFor="policy-allowlist-new">Add recipient</label>
+          <input
+            id="policy-allowlist-new"
+            type="text"
+            placeholder="0x…"
+            value={newRecipient}
+            onChange={(e) => setNewRecipient(e.target.value)}
+          />
+        </div>
+        <div className="custody-actions">
+          <button type="button" onClick={addRecipient}>
+            Add recipient
+          </button>
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend>Transaction delay</legend>
+        <div className="custody-policy-cooldown">
+          <div className="custody-field">
+            <label htmlFor="policy-cooldown-value">Minimum time between transactions (blank for none)</label>
+            <input
+              id="policy-cooldown-value"
+              type="number"
+              min={0}
+              value={cooldownValue}
+              onChange={(e) => setCooldownValue(e.target.value)}
+            />
+          </div>
+          <div className="custody-field">
+            <label htmlFor="policy-cooldown-unit">Unit</label>
+            <select id="policy-cooldown-unit" value={cooldownUnit} onChange={(e) => setCooldownUnit(e.target.value)}>
+              {COOLDOWN_UNITS.map((u) => (
+                <option key={u.key} value={u.key}>
+                  {u.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </fieldset>
+
+      {formError && (
+        <p className="custody-error" role="alert">
+          {formError}
+        </p>
+      )}
+
+      <div className="custody-actions">
+        <button type="button" onClick={review} disabled={busy}>
+          Review {attach ? 'policy' : 'change'}
+        </button>
+        <button type="button" className="custody-link" onClick={onCancel} disabled={busy}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  )
+}
+
+export default function PolicyPanel({ vault, onPropose }) {
+  const [status, setStatus] = useState(null) // null = loading
+  const [policy, setPolicy] = useState(null)
+  const [readError, setReadError] = useState(null)
+  const [editing, setEditing] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [actionError, setActionError] = useState(null)
+  const [notice, setNotice] = useState(null)
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  const address = vault?.address
+  const chainId = vault?.chainId
+
+  useEffect(() => {
+    if (!address || chainId == null) return undefined
+    let cancelled = false
+    ;(async () => {
+      try {
+        const s = await getPolicyStatus(address, chainId)
+        const p = s === 'managed' ? await readPolicy(address, chainId) : null
+        if (!cancelled) {
+          setStatus(s)
+          setPolicy(p)
+          setReadError(null)
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setStatus(null)
+          setReadError(e?.message || 'Could not read the vault policy')
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [address, chainId, refreshKey])
+
+  const submit = useCallback(
+    async (config) => {
+      setActionError(null)
+      setNotice(null)
+      setBusy(true)
+      try {
+        if (status === 'none') {
+          // Attach flow (US3-AS4): configureRules FIRST (inert without the guard), setGuard SECOND
+          // (activates). The second is pinned to the next Safe nonce so it can only ever execute
+          // after the rules transaction — the order is enforced on-chain, not just visually.
+          const rulesTx = buildPolicyChangeTx(chainId, config)
+          const guardTx = buildSetGuardTx(address, chainId)
+          const first = await onPropose(rulesTx)
+          const nextNonce = first?.nonce != null ? Number(first.nonce) + 1 : undefined
+          await onPropose(nextNonce != null ? { ...guardTx, nonce: nextNonce } : guardTx)
+          setNotice(
+            'Two transactions are queued: (1) configure the rules, (2) activate the policy engine. Both need co-owner approval; the rules only take effect once the second executes.',
+          )
+        } else {
+          await onPropose(buildPolicyChangeTx(chainId, config))
+          setNotice('Policy change proposed — it takes effect once the vault’s approval threshold approves it.')
+        }
+        setEditing(false)
+        setRefreshKey((k) => k + 1)
+      } catch (e) {
+        setActionError(e?.message || 'Could not propose the policy change')
+      } finally {
+        setBusy(false)
+      }
+    },
+    [status, chainId, address, onPropose],
+  )
+
+  if (!vault || vault.isSafe === false) return null
+
+  const canManage = !!vault.owner && typeof onPropose === 'function'
+
+  return (
+    <div className="custody-policy" role="region" aria-label="Vault policy">
+      <h5>Policy</h5>
+
+      {readError && (
+        <p className="custody-error" role="alert">
+          {readError}
+        </p>
+      )}
+
+      {!readError && status === null && <p className="custody-hint">Checking policy…</p>}
+
+      {status === 'unsupported' && (
+        <p className="custody-hint">
+          Policy rules aren’t supported on this network. Custody works as usual — transactions need
+          owner approvals only.
+        </p>
+      )}
+
+      {status === 'foreign' && (
+        <p className="custody-hint">
+          This vault has rules set by another interface — manage them with the interface that
+          created them.
+        </p>
+      )}
+
+      {status === 'none' && (
+        <>
+          <p className="custody-hint">No policy — transactions need owner approvals only.</p>
+          {canManage && !editing && (
+            <div className="custody-actions">
+              <button type="button" onClick={() => setEditing(true)}>
+                Attach a policy
+              </button>
+            </div>
+          )}
+        </>
+      )}
+
+      {status === 'managed' && policy && !editing && (
+        <>
+          {policy.hasRules ? (
+            <ul className="custody-policy-rules" aria-label="Active policy rules">
+              {describeRules(policy).map((line) => (
+                <li key={line}>{line}</li>
+              ))}
+            </ul>
+          ) : (
+            <p className="custody-hint">The policy engine is attached but no rules are configured.</p>
+          )}
+
+          {policy.assetRules.some((r) => r.windowLimit > 0n) && (
+            <>
+              <h6 className="custody-policy-subtitle">Current 24-hour window</h6>
+              <ul className="custody-policy-live" aria-label="Window consumption">
+                {policy.assetRules
+                  .filter((r) => r.windowLimit > 0n)
+                  .map((r) => (
+                    <li key={r.asset}>
+                      {formatAmount(r.asset, r.spentInWindow)} of {formatAmount(r.asset, r.windowLimit)} used ·{' '}
+                      {formatAmount(r.asset, r.remainingInWindow)} remaining
+                    </li>
+                  ))}
+              </ul>
+            </>
+          )}
+
+          {policy.nextAllowedAt > 0 && policy.nextAllowedAt * 1000 > Date.now() && (
+            <p className="custody-hint">
+              Transaction delay active — next transaction allowed at{' '}
+              {new Date(policy.nextAllowedAt * 1000).toLocaleString()}.
+            </p>
+          )}
+
+          {policy.allowlistEnabled && policy.allowlist.length > 0 && (
+            <>
+              <h6 className="custody-policy-subtitle">Approved recipients</h6>
+              <ul className="custody-policy-allowlist" aria-label="Approved recipients">
+                {policy.allowlist.map((a) => (
+                  <li key={a}>
+                    <code>{a}</code>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+
+          <p className="custody-hint">
+            Spending windows cover 24 hours: a window opens with the first counted spend and resets
+            24 hours later. Limits cover the native coin and any tokens listed above; other assets
+            pass through limit rules unvalued but stay subject to the allowlist and delay.
+          </p>
+
+          {canManage && !editing && (
+            <div className="custody-actions">
+              <button type="button" onClick={() => setEditing(true)}>
+                Propose change
+              </button>
+            </div>
+          )}
+        </>
+      )}
+
+      {canManage && editing && (status === 'managed' || status === 'none') && (
+        <PolicyConfigEditor
+          currentPolicy={status === 'managed' ? policy : null}
+          attach={status === 'none'}
+          threshold={vault.threshold}
+          busy={busy}
+          onSubmit={submit}
+          onCancel={() => setEditing(false)}
+        />
+      )}
+
+      {actionError && (
+        <p className="custody-error" role="alert">
+          {actionError}
+        </p>
+      )}
+      {notice && (
+        <p className="custody-hint" role="status">
+          {notice}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/custody/PolicyStep.jsx
+++ b/frontend/src/components/custody/PolicyStep.jsx
@@ -1,0 +1,341 @@
+// Spec 049 (US1) — optional policy step for the vault creation wizard. Skippable by default
+// (FR-010: "No policy" keeps the creation flow byte-identical to spec 043); when enabled it
+// collects the four v1 rule types (per-transaction limit, 24-hour-window limit, recipient
+// allowlist, transaction delay), validates at entry (FR-015), and shows a plain-language live
+// summary — including the window-semantics disclosure — before anything is deployed (US1-AS1).
+//
+// Controlled contract: `onChange(configOrNull)`:
+//   - null                      → step skipped or unsupported network (no policy)
+//   - { invalid:true, error }   → rules enabled but not yet valid (parent must block create)
+//   - config                    → validated `configureRules` config (extra `summary` strings are
+//                                 ignored by encodeConfigureRules and reused by the review step)
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { parseUnits } from 'ethers'
+import {
+  NATIVE_ASSET,
+  formatDuration,
+  isPolicySupported,
+  validatePolicyConfig,
+} from '../../lib/custody/policy'
+import { summarizePolicyConfig } from '../../lib/custody/policySummary'
+import { getContractAddressForChain } from '../../config/contracts'
+import { getNetwork } from '../../config/networks'
+
+const COOLDOWN_CHOICES = [
+  { value: 'none', label: 'None' },
+  { value: '3600', label: '1 hour' },
+  { value: '21600', label: '6 hours' },
+  { value: '86400', label: '24 hours' },
+  { value: '259200', label: '72 hours' },
+  { value: 'custom', label: 'Custom…' },
+]
+
+const NATIVE_DECIMALS = 18
+const THIRTY_DAYS = 30 * 24 * 3600
+
+function parseAmount(fieldLabel, raw, decimals) {
+  const value = (raw || '').trim()
+  if (!value) return 0n
+  let parsed
+  try {
+    parsed = parseUnits(value, decimals)
+  } catch {
+    throw new Error(`Enter a valid amount for "${fieldLabel}" (got "${raw}")`)
+  }
+  if (parsed < 0n) throw new Error(`"${fieldLabel}" must be positive`)
+  return parsed
+}
+
+export default function PolicyStep({ chainId, value, onChange }) {
+  const supported = isPolicySupported(chainId)
+  const network = getNetwork(chainId)
+  const nativeSymbol = network?.nativeCurrency?.symbol || 'native coin'
+  const stableAddress = getContractAddressForChain('paymentToken', chainId) || null
+  const stableSymbol = network?.stablecoin?.symbol || 'stable token'
+  const stableDecimals = network?.stablecoin?.decimals ?? 6
+
+  const [enabled, setEnabled] = useState(Boolean(value))
+  const [nativePerTx, setNativePerTx] = useState('')
+  const [nativeWindow, setNativeWindow] = useState('')
+  const [stablePerTx, setStablePerTx] = useState('')
+  const [stableWindow, setStableWindow] = useState('')
+  const [allowlistOn, setAllowlistOn] = useState(false)
+  const [recipients, setRecipients] = useState([''])
+  const [cooldownChoice, setCooldownChoice] = useState('none')
+  const [customCooldown, setCustomCooldown] = useState('')
+
+  const assetMeta = useMemo(() => {
+    const meta = { [NATIVE_ASSET]: { symbol: nativeSymbol, decimals: NATIVE_DECIMALS } }
+    if (stableAddress) meta[stableAddress] = { symbol: stableSymbol, decimals: stableDecimals }
+    return meta
+  }, [nativeSymbol, stableAddress, stableSymbol, stableDecimals])
+
+  const cooldownSeconds = useMemo(() => {
+    if (cooldownChoice === 'none') return 0
+    if (cooldownChoice === 'custom') return Number(customCooldown || 0)
+    return Number(cooldownChoice)
+  }, [cooldownChoice, customCooldown])
+
+  // Derive + validate the config from the current inputs (FR-015: validate at entry).
+  const derived = useMemo(() => {
+    if (!supported || !enabled) return { config: null, error: null }
+    try {
+      const limits = []
+      const nativeLimits = {
+        perTxLimit: parseAmount(`Per-transaction limit (${nativeSymbol})`, nativePerTx, NATIVE_DECIMALS),
+        windowLimit: parseAmount(`24-hour limit (${nativeSymbol})`, nativeWindow, NATIVE_DECIMALS),
+      }
+      if (nativeLimits.perTxLimit > 0n || nativeLimits.windowLimit > 0n) {
+        limits.push({ asset: NATIVE_ASSET, ...nativeLimits })
+      }
+      if (stableAddress) {
+        const stableLimits = {
+          perTxLimit: parseAmount(`Per-transaction limit (${stableSymbol})`, stablePerTx, stableDecimals),
+          windowLimit: parseAmount(`24-hour limit (${stableSymbol})`, stableWindow, stableDecimals),
+        }
+        if (stableLimits.perTxLimit > 0n || stableLimits.windowLimit > 0n) {
+          limits.push({ asset: stableAddress, ...stableLimits })
+        }
+      }
+      if (cooldownChoice === 'custom') {
+        const n = Number(customCooldown)
+        if (!customCooldown.trim() || !Number.isInteger(n) || n < 0) {
+          throw new Error('Enter the custom delay as a whole number of seconds')
+        }
+      }
+      const allowlistAdd = recipients.map((r) => r.trim()).filter(Boolean)
+      const config = {
+        limits,
+        cooldown: cooldownSeconds,
+        allowlistEnabled: allowlistOn,
+        allowlistAdd: allowlistOn ? allowlistAdd : [],
+        allowlistRemove: [],
+      }
+      validatePolicyConfig(config)
+      if (limits.length === 0 && cooldownSeconds === 0 && !allowlistOn) {
+        throw new Error('Configure at least one rule, or choose "No policy (skip)"')
+      }
+      return { config, error: null }
+    } catch (e) {
+      return { config: null, error: e.message }
+    }
+  }, [
+    supported,
+    enabled,
+    nativePerTx,
+    nativeWindow,
+    stablePerTx,
+    stableWindow,
+    allowlistOn,
+    recipients,
+    cooldownChoice,
+    customCooldown,
+    cooldownSeconds,
+    nativeSymbol,
+    stableAddress,
+    stableSymbol,
+    stableDecimals,
+  ])
+
+  const summary = useMemo(() => summarizePolicyConfig(derived.config, assetMeta), [derived.config, assetMeta])
+
+  // Non-blocking strictness warning (FR-015): warn, but do not stop, an unusually long delay.
+  const strictWarning =
+    enabled && supported && cooldownSeconds > THIRTY_DAYS
+      ? `A ${formatDuration(cooldownSeconds)} delay between transactions is unusually strict — the vault will allow at most one outgoing transaction per ${formatDuration(cooldownSeconds)}.`
+      : null
+
+  // Push the derived value to the parent whenever it changes (skip identical re-emissions).
+  const lastEmitted = useRef('unset')
+  useEffect(() => {
+    let next = null
+    if (supported && enabled) {
+      next = derived.error ? { invalid: true, error: derived.error } : { ...derived.config, summary }
+    }
+    const key = JSON.stringify(next, (_, v) => (typeof v === 'bigint' ? `${v}n` : v))
+    if (key === lastEmitted.current) return
+    lastEmitted.current = key
+    onChange?.(next)
+  }, [supported, enabled, derived, summary, onChange])
+
+  const updateRecipient = (i, val) => setRecipients((prev) => prev.map((r, idx) => (idx === i ? val : r)))
+  const addRecipient = () => setRecipients((prev) => [...prev, ''])
+  const removeRecipient = (i) => setRecipients((prev) => prev.filter((_, idx) => idx !== i))
+
+  if (!supported) {
+    return (
+      <section className="custody-policy" aria-label="Vault policy">
+        <h4 className="custody-policy-title">Policy</h4>
+        <p role="status">Policy rules aren&apos;t available on this network yet.</p>
+        <p className="custody-hint">The vault will be created without spending rules; you can use it exactly as before.</p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="custody-policy" aria-label="Vault policy">
+      <fieldset>
+        <legend>Policy (optional)</legend>
+        <p className="custody-hint">
+          Rules are enforced on-chain from the vault&apos;s first transaction. You can skip this step for an
+          unrestricted vault.
+        </p>
+        <label>
+          <input
+            type="radio"
+            name="policy-mode"
+            checked={!enabled}
+            onChange={() => setEnabled(false)}
+          />
+          No policy (skip)
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="policy-mode"
+            checked={enabled}
+            onChange={() => setEnabled(true)}
+          />
+          Set spending rules
+        </label>
+      </fieldset>
+
+      {enabled && (
+        <>
+          <fieldset>
+            <legend>Spending limits ({nativeSymbol})</legend>
+            <div className="custody-field">
+              <label htmlFor="policy-native-pertx">Per-transaction limit ({nativeSymbol})</label>
+              <input
+                id="policy-native-pertx"
+                type="text"
+                inputMode="decimal"
+                placeholder="No limit"
+                value={nativePerTx}
+                onChange={(e) => setNativePerTx(e.target.value)}
+              />
+            </div>
+            <div className="custody-field">
+              <label htmlFor="policy-native-window">24-hour limit ({nativeSymbol})</label>
+              <input
+                id="policy-native-window"
+                type="text"
+                inputMode="decimal"
+                placeholder="No limit"
+                value={nativeWindow}
+                onChange={(e) => setNativeWindow(e.target.value)}
+              />
+            </div>
+          </fieldset>
+
+          {stableAddress && (
+            <fieldset>
+              <legend>Spending limits ({stableSymbol})</legend>
+              <div className="custody-field">
+                <label htmlFor="policy-stable-pertx">Per-transaction limit ({stableSymbol})</label>
+                <input
+                  id="policy-stable-pertx"
+                  type="text"
+                  inputMode="decimal"
+                  placeholder="No limit"
+                  value={stablePerTx}
+                  onChange={(e) => setStablePerTx(e.target.value)}
+                />
+              </div>
+              <div className="custody-field">
+                <label htmlFor="policy-stable-window">24-hour limit ({stableSymbol})</label>
+                <input
+                  id="policy-stable-window"
+                  type="text"
+                  inputMode="decimal"
+                  placeholder="No limit"
+                  value={stableWindow}
+                  onChange={(e) => setStableWindow(e.target.value)}
+                />
+              </div>
+            </fieldset>
+          )}
+
+          <fieldset>
+            <legend>Recipient allowlist</legend>
+            <label>
+              <input
+                type="checkbox"
+                checked={allowlistOn}
+                onChange={(e) => setAllowlistOn(e.target.checked)}
+              />
+              Only allow transfers to approved recipients
+            </label>
+            {allowlistOn && (
+              <>
+                {recipients.map((recipient, i) => (
+                  <div className="custody-owner-row" key={i}>
+                    <label className="sr-only" htmlFor={`policy-recipient-${i}`}>{`Allowed recipient ${i + 1}`}</label>
+                    <input
+                      id={`policy-recipient-${i}`}
+                      type="text"
+                      inputMode="text"
+                      placeholder="0x…"
+                      value={recipient}
+                      onChange={(e) => updateRecipient(i, e.target.value)}
+                    />
+                    {recipients.length > 1 && (
+                      <button type="button" onClick={() => removeRecipient(i)} aria-label={`Remove recipient ${i + 1}`}>
+                        Remove
+                      </button>
+                    )}
+                  </div>
+                ))}
+                <button type="button" onClick={addRecipient}>
+                  Add recipient
+                </button>
+              </>
+            )}
+          </fieldset>
+
+          <div className="custody-field">
+            <label htmlFor="policy-cooldown">Delay between outgoing transactions</label>
+            <select id="policy-cooldown" value={cooldownChoice} onChange={(e) => setCooldownChoice(e.target.value)}>
+              {COOLDOWN_CHOICES.map((c) => (
+                <option key={c.value} value={c.value}>
+                  {c.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          {cooldownChoice === 'custom' && (
+            <div className="custody-field">
+              <label htmlFor="policy-cooldown-custom">Custom delay (seconds)</label>
+              <input
+                id="policy-cooldown-custom"
+                type="number"
+                min={0}
+                value={customCooldown}
+                onChange={(e) => setCustomCooldown(e.target.value)}
+              />
+            </div>
+          )}
+
+          {derived.error && (
+            <p className="custody-error" role="alert">
+              {derived.error}
+            </p>
+          )}
+          {strictWarning && <p className="custody-warning">{strictWarning}</p>}
+
+          {summary.length > 0 && (
+            <div className="custody-policy-summary" role="status">
+              <h5 className="custody-policy-summary-title">These rules will be active from the first transaction</h5>
+              <ul>
+                {summary.map((line) => (
+                  <li key={line}>{line}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/components/custody/ProposalQueue.jsx
+++ b/frontend/src/components/custody/ProposalQueue.jsx
@@ -1,15 +1,107 @@
 // Spec 043 (US2) — the vault's pending queue + history with approve/execute actions. Non-owners see state
 // but no action buttons (FR-016). Blocked states are surfaced honestly (approvals remaining; not-ready).
+// Spec 049 (US3) — proposals targeting the chain's SafePolicyGuard that decode as configureRules render as a
+// distinct "Policy change" entry with the decoded rule diff; a self-tx setting that guard renders as
+// "Activate policy engine". Anything that fails to decode renders exactly as before.
 
+import { Interface, formatUnits } from 'ethers'
 import { STATUS } from '../../lib/custody/proposalStatus'
 import { approvalsRemaining } from '../../lib/custody/proposalStatus'
+import { getContractAddressForChain } from '../../config/contracts'
+import { guardIface, NATIVE_ASSET, shortAddress, formatDuration } from '../../lib/custody/policy'
+import './Policy.css'
+
+const SAFE_GUARD_IFACE = new Interface(['function setGuard(address guard)'])
 
 function shortHash(h) {
   return h ? `${h.slice(0, 10)}…${h.slice(-6)}` : ''
 }
 
-function ProposalRow({ p, isOwner, hasApproved, onApprove, onExecute, onCancel, busy }) {
+function assetName(asset) {
+  return asset === NATIVE_ASSET ? 'native coin' : `token ${shortAddress(asset)}`
+}
+
+function assetAmount(asset, amount) {
+  return asset === NATIVE_ASSET ? formatUnits(amount, 18) : `${amount} base units`
+}
+
+/**
+ * Classify a queued proposal against the chain's policy engine (spec 049). Returns
+ * `{ kind: 'configure', changes: string[] }`, `{ kind: 'set-guard' }`, `{ kind: 'remove-guard' }`,
+ * or null for an ordinary proposal. Never throws — unknown data renders as today.
+ */
+function classifyPolicyProposal(p, chainId, vaultAddress) {
+  try {
+    const guard = getContractAddressForChain('safePolicyGuard', chainId)
+    if (!guard || !p?.to || !p?.data || p.data === '0x') return null
+    const to = String(p.to).toLowerCase()
+    const guardLc = guard.toLowerCase()
+
+    if (to === guardLc) {
+      const parsed = guardIface.parseTransaction({ data: p.data })
+      if (!parsed || parsed.name !== 'configureRules') return null
+      const [limits, cooldown, allowlistEnabled, adds, removes] = parsed.args
+      const changes = []
+      for (const l of limits) {
+        const per = BigInt(l.perTxLimit)
+        const win = BigInt(l.windowLimit)
+        changes.push(
+          `${assetName(l.asset)}: per-transaction limit ${per > 0n ? assetAmount(l.asset, per) : 'off'}, ` +
+            `24-hour window limit ${win > 0n ? assetAmount(l.asset, win) : 'off'}`,
+        )
+      }
+      const cd = Number(cooldown)
+      changes.push(cd > 0 ? `Transaction delay: ${formatDuration(cd)}` : 'Transaction delay: off')
+      changes.push(`Recipient allowlist: ${allowlistEnabled ? 'enabled' : 'disabled'}`)
+      for (const a of adds) changes.push(`Add recipient ${shortAddress(a)}`)
+      for (const a of removes) changes.push(`Remove recipient ${shortAddress(a)}`)
+      return { kind: 'configure', changes }
+    }
+
+    if (vaultAddress && to === String(vaultAddress).toLowerCase()) {
+      const parsed = SAFE_GUARD_IFACE.parseTransaction({ data: p.data })
+      if (!parsed || parsed.name !== 'setGuard') return null
+      const target = String(parsed.args[0]).toLowerCase()
+      if (target === guardLc) return { kind: 'set-guard' }
+      if (/^0x0{40}$/.test(target)) return { kind: 'remove-guard' }
+      return null
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+function PolicyProposalFacts({ policyInfo }) {
+  if (policyInfo.kind === 'configure') {
+    return (
+      <div className="custody-proposal-facts custody-proposal-facts--policy">
+        <span className="custody-policy-tag">Policy change</span>
+        <ul className="custody-policy-diff" aria-label="Proposed rule changes">
+          {policyInfo.changes.map((c) => (
+            <li key={c}>{c}</li>
+          ))}
+        </ul>
+      </div>
+    )
+  }
+  return (
+    <div className="custody-proposal-facts custody-proposal-facts--policy">
+      <span className="custody-policy-tag">
+        {policyInfo.kind === 'set-guard' ? 'Activate policy engine' : 'Detach policy engine'}
+      </span>
+      <span>
+        {policyInfo.kind === 'set-guard'
+          ? 'Attaches the policy engine to this vault — the configured rules take effect when this executes.'
+          : 'Removes the policy engine from this vault — rules stop applying when this executes.'}
+      </span>
+    </div>
+  )
+}
+
+function ProposalRow({ p, isOwner, hasApproved, onApprove, onExecute, onCancel, busy, chainId, vaultAddress }) {
   const remaining = approvalsRemaining(p.approvals, p.threshold)
+  const policyInfo = classifyPolicyProposal(p, chainId, vaultAddress)
   return (
     <li className="custody-proposal-row">
       <div className="custody-proposal-main">
@@ -20,6 +112,7 @@ function ProposalRow({ p, isOwner, hasApproved, onApprove, onExecute, onCancel, 
         </span>
         <code className="custody-proposal-hash">{shortHash(p.safeTxHash)}</code>
       </div>
+      {policyInfo && <PolicyProposalFacts policyInfo={policyInfo} />}
       <div className="custody-proposal-facts">
         <span>to <code>{p.to}</code></span>
         <span>nonce {String(p.nonce)}</span>
@@ -47,7 +140,7 @@ function ProposalRow({ p, isOwner, hasApproved, onApprove, onExecute, onCancel, 
   )
 }
 
-export default function ProposalQueue({ queue, history, isOwner, connectedAddress, onApprove, onExecute, onCancel, busy }) {
+export default function ProposalQueue({ queue, history, isOwner, connectedAddress, onApprove, onExecute, onCancel, busy, chainId, vaultAddress }) {
   const approvedByMe = (p) =>
     !!connectedAddress && (p.approvers || []).some((a) => a.toLowerCase() === connectedAddress.toLowerCase())
 
@@ -70,6 +163,8 @@ export default function ProposalQueue({ queue, history, isOwner, connectedAddres
               onExecute={onExecute}
               onCancel={onCancel}
               busy={busy}
+              chainId={chainId}
+              vaultAddress={vaultAddress}
             />
           ))}
         </ul>

--- a/frontend/src/components/custody/ProposeTransactionForm.jsx
+++ b/frontend/src/components/custody/ProposeTransactionForm.jsx
@@ -1,10 +1,22 @@
 // Spec 043 (US2) — propose a transfer from the vault: native asset or an ERC-20. Builds {to,value,data} and
 // hands it to onPropose (which creates the vault proposal). Presentational; encoding is local + pure.
+// Spec 049 (US4, FR-012) — when the vault is policy-managed, the draft is pre-flighted against the guard's
+// own previewTransaction and any violation is surfaced (rule + values) WITHOUT blocking submission: the
+// chain remains the enforcer, the warning just saves co-owners from approving a doomed transaction.
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { buildTransferPayload } from '../../lib/custody/transfers'
+import { getPolicyStatus, previewPolicy } from '../../lib/custody/policy'
+import './Policy.css'
 
-export default function ProposeTransactionForm({ onPropose, onDone }) {
+const RULE_LABELS = {
+  perTxLimit: 'per-transaction limit',
+  windowLimit: '24-hour window limit',
+  allowlist: 'recipient allowlist',
+  cooldown: 'transaction delay',
+}
+
+export default function ProposeTransactionForm({ onPropose, onDone, vault }) {
   const [assetType, setAssetType] = useState('native') // 'native' | 'token'
   const [recipient, setRecipient] = useState('')
   const [amount, setAmount] = useState('')
@@ -27,6 +39,49 @@ export default function ProposeTransactionForm({ onPropose, onDone }) {
       return e.message
     }
   }, [recipient, amount, tokenAddress, decimals, assetType])
+
+  // Spec 049 — the vault's policy status, fetched once per vault; only 'managed' vaults preview.
+  const [policyStatus, setPolicyStatus] = useState(null)
+  useEffect(() => {
+    if (!vault?.address || vault?.chainId == null) return undefined
+    let on = true
+    getPolicyStatus(vault.address, vault.chainId)
+      .then((s) => {
+        if (on) setPolicyStatus(s)
+      })
+      .catch(() => {})
+    return () => {
+      on = false
+    }
+  }, [vault?.address, vault?.chainId])
+
+  // Pre-flight the draft whenever it changes (debounced). Failures stay silent — the preview is
+  // advisory; the chain enforces (FR-012).
+  const [violation, setViolation] = useState(null)
+  useEffect(() => {
+    if (policyStatus !== 'managed' || validationError) return undefined
+    let on = true
+    const timer = setTimeout(async () => {
+      try {
+        const payload = buildTransferPayload({
+          recipient: recipient.trim(),
+          amount,
+          tokenAddress: assetType === 'token' ? tokenAddress.trim() : null,
+          decimals,
+        })
+        const res = await previewPolicy(vault.address, vault.chainId, payload)
+        if (on) setViolation(res.ok ? null : res.violation)
+      } catch {
+        if (on) setViolation(null)
+      }
+    }, 250)
+    return () => {
+      on = false
+      clearTimeout(timer)
+    }
+  }, [policyStatus, validationError, recipient, amount, tokenAddress, decimals, assetType, vault?.address, vault?.chainId])
+  // Only surface the warning while the draft is valid and the vault is actually policy-managed.
+  const activeViolation = policyStatus === 'managed' && !validationError ? violation : null
 
   const submit = async () => {
     setError(null)
@@ -92,6 +147,13 @@ export default function ProposeTransactionForm({ onPropose, onDone }) {
         <label htmlFor="propose-amount">Amount</label>
         <input id="propose-amount" type="text" inputMode="decimal" value={amount} onChange={(e) => setAmount(e.target.value)} />
       </div>
+
+      {activeViolation && (
+        <p className="custody-warning" role="alert">
+          Policy warning — {RULE_LABELS[activeViolation.rule] || 'vault policy'}: {activeViolation.message}. You can
+          still propose this transaction, but the vault will block it at execution.
+        </p>
+      )}
 
       {validationError && (
         <p className="custody-error" role="alert">

--- a/frontend/src/components/custody/VaultDetail.jsx
+++ b/frontend/src/components/custody/VaultDetail.jsx
@@ -1,7 +1,12 @@
 // Spec 043 (US1) — a single vault's live on-chain state: address, network, owners, threshold, balance.
 // Honest state: everything shown here is read from chain (owners/threshold/nonce) or is a local label.
+// Spec 049 (US2/US3) — carries the Policy section (PolicyPanel). `onProposePolicy` is the spec 043
+// proposal-queue submit (useVaultProposals.propose); when absent (view-only member, wrong network)
+// the section is read-only.
 
-export default function VaultDetail({ vault, onForget, onOperateAs, isActiveIdentity }) {
+import PolicyPanel from './PolicyPanel'
+
+export default function VaultDetail({ vault, onForget, onOperateAs, isActiveIdentity, onProposePolicy }) {
   if (!vault) return null
   if (vault.isSafe === false) {
     return (
@@ -57,6 +62,7 @@ export default function VaultDetail({ vault, onForget, onOperateAs, isActiveIden
           </li>
         ))}
       </ul>
+      <PolicyPanel vault={vault} onPropose={onProposePolicy} />
       <div className="custody-actions">
         {vault.owner && onOperateAs && (
           <button type="button" onClick={() => onOperateAs(vault)} disabled={isActiveIdentity}>

--- a/frontend/src/components/custody/VaultList.jsx
+++ b/frontend/src/components/custody/VaultList.jsx
@@ -1,4 +1,8 @@
 // Spec 043 (US1) — the member's vaults on the active network, with selection (FR-007).
+// Spec 049 (US2) — each row carries a PolicyBadge when the vault is policy-governed (or has a
+// foreign guard); the status/summary are enriched by useCustodyVaults and absent on failure.
+
+import PolicyBadge from './PolicyBadge'
 
 export default function VaultList({ vaults, activeAddress, onSelect }) {
   if (!vaults?.length) {
@@ -30,6 +34,7 @@ export default function VaultList({ vaults, activeAddress, onSelect }) {
                 </span>
               )}
               {v.isSafe === false && <span className="custody-vault-meta custody-error">unreadable</span>}
+              <PolicyBadge status={v.policyStatus} summary={v.policySummary} />
             </button>
           </li>
         )

--- a/frontend/src/components/custody/VaultProposalsPanel.jsx
+++ b/frontend/src/components/custody/VaultProposalsPanel.jsx
@@ -8,9 +8,12 @@ import ProposeTransactionForm from './ProposeTransactionForm'
 import ProposalQueue from './ProposalQueue'
 import OwnersThresholdPanel from './OwnersThresholdPanel'
 
-export default function VaultProposalsPanel({ vault }) {
+export default function VaultProposalsPanel({ vault, proposals }) {
   const { address, chainId, switchNetwork } = useWallet()
-  const { queue, history, loading, error, propose, approve, execute, cancel } = useVaultProposals(vault)
+  // Spec 049 — the queue instance may be lifted (shared with the Policy section); the internal
+  // hook is only live when no instance is passed, so nothing is fetched twice.
+  const internal = useVaultProposals(proposals ? null : vault)
+  const { queue, history, loading, error, propose, approve, execute, cancel } = proposals || internal
   const [showPropose, setShowPropose] = useState(false)
   const [busy, setBusy] = useState(false)
   const [actionError, setActionError] = useState(null)
@@ -55,7 +58,7 @@ export default function VaultProposalsPanel({ vault }) {
         </div>
       )}
       {vault.owner && showPropose && (
-        <ProposeTransactionForm onPropose={run(propose)} onDone={() => setShowPropose(false)} />
+        <ProposeTransactionForm vault={vault} onPropose={run(propose)} onDone={() => setShowPropose(false)} />
       )}
 
       <OwnersThresholdPanel vault={vault} onPropose={run(propose)} busy={busy} />
@@ -71,6 +74,8 @@ export default function VaultProposalsPanel({ vault }) {
         queue={queue}
         history={history}
         isOwner={!!vault.owner}
+        chainId={vault.chainId}
+        vaultAddress={vault.address}
         connectedAddress={address}
         onApprove={run(approve)}
         onExecute={run(execute)}

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -54,6 +54,9 @@ const HARDHAT_CONTRACTS = {
   polymarketAdapter: '0x19D004863fB8F5A1707091C120e08aA1FEE8d65F',
   paymentToken: '0x065606eeE0D7BB3d2e7959D56c3ca177625385a7',
   wmatic: '0xE80bf16CAF66CAe0Ae5aBC4a5ab4acc27361553F',
+  // spec 049 — multisig policy engine (synced from deployments/hardhat-chain1337-v2.json)
+  safePolicyGuard: '0xBE509C8E6c4F132e2Af49761A318FfA362e9CE38',
+  policyGuardSetup: '0xD0CB9D0ca2E56e9552cb833eC6D16F86ce818C2b',
 }
 
 // Polygon Amoy testnet deployment (v2 — P2P betting architecture)

--- a/frontend/src/data/notifications/sources/custodySource.js
+++ b/frontend/src/data/notifications/sources/custodySource.js
@@ -3,6 +3,10 @@
  * active network: a pending proposal that needs the member's approval (action: approve), a proposal newly
  * executed, and an owners/threshold governance change. Pure snapshot-diff (first-sight = baseline). No hooks;
  * read-only provider. No-ops until the SafeProposalHub is deployed + its block recorded (never scans genesis).
+ *
+ * Spec 049 (FR-016): the SafePolicyGuard's rule events (RulesConfigured, CooldownSet, AllowlistEnabled,
+ * AllowlistChanged) join the same snapshot-diff — a per-vault event count is snapped, and any increase emits a
+ * "policy-changed" entry in the custody domain. No-ops until the guard is deployed + its block recorded.
  */
 import { ethers } from 'ethers'
 import { getProvider } from '../../../utils/blockchainService'
@@ -10,6 +14,7 @@ import { getContractAddressForChain, getDeploymentBlockForChain } from '../../..
 import { getSafeContracts } from '../../../config/safeContracts'
 import { loadVaultReferences } from '../../../lib/custody/vaultReferences'
 import { readVaultProposalState } from '../../../lib/custody/vaultProposalReads'
+import { readPolicyEventCount } from '../../../lib/custody/policyEvents'
 import { STATUS } from '../../../lib/custody/proposalStatus'
 
 const EMPTY = { ok: true, entries: [], nextSnapshots: {}, currentIds: [], actionNeededById: {} }
@@ -26,6 +31,11 @@ export const custodySource = {
 
     const refs = loadVaultReferences(account).filter((r) => r.chainId === Number(chainId))
     if (refs.length === 0) return EMPTY
+
+    // Spec 049 — policy engine coordinates (optional; policy diffing no-ops when absent).
+    const guardAddress = getContractAddressForChain('safePolicyGuard', chainId)
+    const guardFromBlock = getDeploymentBlockForChain('safePolicyGuard', chainId)
+    const policyEnabled = !!guardAddress && ethers.isAddress(guardAddress) && !!guardFromBlock
 
     let provider
     try {
@@ -79,7 +89,24 @@ export const custodySource = {
       const govKey = `${state.owners.length}:${state.threshold}`
 
       const prev = prior.snapshots?.[sid]
-      nextSnapshots[sid] = { needMe, executedCount, govKey, snappedAt: nowMs }
+
+      // Spec 049 (FR-016) — count the guard's rule events for this vault; on failure keep the
+      // prior count so the baseline survives a flaky read (no false "changed" later).
+      let policyEventCount = prev?.policyEventCount
+      if (policyEnabled) {
+        try {
+          policyEventCount = await readPolicyEventCount({
+            guardAddress,
+            safeAddress: vaultAddr,
+            provider,
+            fromBlock: guardFromBlock,
+          })
+        } catch {
+          // keep prior count
+        }
+      }
+
+      nextSnapshots[sid] = { needMe, executedCount, govKey, policyEventCount, snappedAt: nowMs }
 
       if (needMe.length > 0) actionNeededById[sid] = 'approve'
 
@@ -93,6 +120,13 @@ export const custodySource = {
         }
         if (prev.govKey && prev.govKey !== govKey) {
           entries.push(mk(vaultAddr, 'governance-changed', `The owners or threshold on “${label}” changed`, 'info', false))
+        }
+        if (
+          policyEventCount != null &&
+          prev.policyEventCount != null &&
+          policyEventCount > prev.policyEventCount
+        ) {
+          entries.push(mk(vaultAddr, 'policy-changed', `The policy rules on “${label}” changed`, 'info', false))
         }
       }
     }

--- a/frontend/src/hooks/useCustodyVaults.js
+++ b/frontend/src/hooks/useCustodyVaults.js
@@ -16,6 +16,23 @@ import {
   upsertVaultReference,
   removeVaultReference,
 } from '../lib/custody/vaultReferences'
+import { getPolicyStatus, readPolicy, summarizeRules, isPolicySupported } from '../lib/custody/policy'
+
+/**
+ * Spec 049 (US2/FR-006) — per-vault policy badge data for the list. Resilient by design: any
+ * failure yields `{}` so the row simply renders without a badge; custody itself is unaffected.
+ */
+async function readPolicyBadge(vaultAddress, chainId, provider) {
+  try {
+    if (!isPolicySupported(chainId)) return { policyStatus: 'unsupported' }
+    const policyStatus = await getPolicyStatus(vaultAddress, chainId, provider)
+    if (policyStatus !== 'managed') return { policyStatus }
+    const policy = await readPolicy(vaultAddress, chainId, provider)
+    return { policyStatus, policySummary: summarizeRules(policy) }
+  } catch {
+    return {}
+  }
+}
 
 export function useCustodyVaults() {
   const { address, chainId, signer, provider } = useWallet()
@@ -43,7 +60,8 @@ export function useCustodyVaults() {
         refs.map(async (ref) => {
           try {
             const state = await loadVault(ref.address, chainId, provider)
-            return { ...ref, ...state, owner: isVaultOwner(state, address) }
+            const badge = state.isSafe ? await readPolicyBadge(ref.address, chainId, provider) : {}
+            return { ...ref, ...state, owner: isVaultOwner(state, address), ...badge }
           } catch (e) {
             return { ...ref, isSafe: undefined, loadError: e?.message || 'load failed' }
           }
@@ -85,9 +103,10 @@ export function useCustodyVaults() {
     [address, chainId, provider, refresh],
   )
 
-  /** Create a new vault and persist its reference (owner role). */
+  /** Create a new vault and persist its reference (owner role). `policySetup` (spec 049, optional)
+   * attaches a policy guard atomically at creation. */
   const createVault = useCallback(
-    async ({ owners, threshold, saltNonce, label = '' }, nowMs = 0) => {
+    async ({ owners, threshold, saltNonce, label = '', policySetup }, nowMs = 0) => {
       if (!signer) throw new Error('Connect a wallet to create a vault')
       setError(null)
       const { address: vaultAddress, txHash } = await createVaultTx({
@@ -96,6 +115,7 @@ export function useCustodyVaults() {
         owners,
         threshold,
         saltNonce,
+        policySetup,
       })
       upsertVaultReference(
         address,
@@ -111,12 +131,13 @@ export function useCustodyVaults() {
 
   /** Preview the deterministic address a new vault would deploy to (before signing, FR US1). */
   const previewVaultAddress = useCallback(
-    async ({ owners, threshold, saltNonce }) => {
+    async ({ owners, threshold, saltNonce, policySetup }) => {
       const { predictedAddress } = await buildCreateVaultTx({
         chainId,
         owners,
         threshold,
         saltNonce,
+        policySetup,
         provider,
       })
       return predictedAddress

--- a/frontend/src/hooks/useVaultProposals.js
+++ b/frontend/src/hooks/useVaultProposals.js
@@ -105,20 +105,21 @@ export function useVaultProposals(vault) {
   }, [refresh])
 
   /** Propose a transaction: build the SafeTx at the current nonce, broadcast it, and record the proposer's
-   *  first approval on-chain. */
+   *  first approval on-chain. An explicit `nonce` may be passed to queue ordered follow-ups (spec 049
+   *  attach flow: configureRules at N, setGuard at N+1 — the chain then enforces the order). */
   const propose = useCallback(
-    async ({ to, value = 0n, data = '0x', operation = 0 }) => {
+    async ({ to, value = 0n, data = '0x', operation = 0, nonce: nonceOverride }) => {
       if (!signer) throw new Error('Connect a wallet to propose')
       if (!hubAddress) throw new Error('Custody proposals are not configured on this network')
       const safe = new Contract(vaultAddress, SAFE_ABI, signer)
-      const nonce = await safe.nonce()
+      const nonce = nonceOverride ?? (await safe.nonce())
       const safeTx = buildSafeTx({ to, value, data, operation, nonce })
       const safeTxHash = computeSafeTxHash(vaultAddress, chainId, safeTx)
       await emitProposal({ hubAddress, safe: vaultAddress, safeTx, safeTxHash, signer })
       const approveTx = await safe.approveHash(safeTxHash)
       await approveTx.wait()
       await refresh()
-      return { safeTxHash }
+      return { safeTxHash, nonce: Number(nonce) }
     },
     [signer, vaultAddress, hubAddress, chainId, refresh],
   )

--- a/frontend/src/lib/custody/policy.js
+++ b/frontend/src/lib/custody/policy.js
@@ -46,8 +46,9 @@ export async function readVaultGuard(vaultAddress, chainId, provider) {
  */
 export async function getPolicyStatus(vaultAddress, chainId, provider) {
   const engine = getPolicyEngineAddresses(chainId)
+  // FR-013: networks without the engine surface "policy unsupported" — no guard-slot read needed.
+  if (!engine) return 'unsupported'
   const guardSet = await readVaultGuard(vaultAddress, chainId, provider).catch(() => ZeroAddress)
-  if (!engine) return guardSet !== ZeroAddress ? 'foreign' : 'unsupported'
   if (guardSet === ZeroAddress) return 'none'
   return guardSet === engine.guard ? 'managed' : 'foreign'
 }

--- a/frontend/src/lib/custody/policy.js
+++ b/frontend/src/lib/custody/policy.js
@@ -1,0 +1,345 @@
+// Spec 049 — multisig policy engine client library. Reads/encodes SafePolicyGuard state, builds
+// the vault-creation setup payload and threshold-approved change transactions, runs pre-flight
+// checks via the guard's own previewTransaction (so client display can never drift from on-chain
+// enforcement), and decodes the guard's typed errors into plain language (FR-011/FR-012).
+// See specs/049-multisig-policy-engine/contracts/frontend-integration.md.
+
+import { Contract, Interface, ZeroAddress, formatUnits, getAddress } from 'ethers'
+import { POLICY_GUARD_SETUP_ABI, SAFE_POLICY_GUARD_ABI } from '../../abis/SafePolicyGuard'
+import { getContractAddressForChain } from '../../config/contracts'
+import { getProvider } from '../../utils/blockchainService'
+
+/** keccak256("guard_manager.guard.address") — the Safe v1.4.1 guard storage slot. */
+export const GUARD_STORAGE_SLOT = '0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8'
+
+/** Native-coin asset key inside the guard (address(0)). */
+export const NATIVE_ASSET = ZeroAddress
+
+export const guardIface = new Interface(SAFE_POLICY_GUARD_ABI)
+export const setupIface = new Interface(POLICY_GUARD_SETUP_ABI)
+
+/** Policy engine addresses for a chain; null when the engine is not deployed there (FR-013). */
+export function getPolicyEngineAddresses(chainId) {
+  const guard = getContractAddressForChain('safePolicyGuard', chainId)
+  const setup = getContractAddressForChain('policyGuardSetup', chainId)
+  if (!guard || !setup) return null
+  return { guard: getAddress(guard), setup: getAddress(setup) }
+}
+
+/** Whether the policy engine is available on a chain. */
+export function isPolicySupported(chainId) {
+  return getPolicyEngineAddresses(chainId) !== null
+}
+
+/** Read the guard address set on a vault (ZeroAddress when none). */
+export async function readVaultGuard(vaultAddress, chainId, provider) {
+  const reader = provider || getProvider(chainId)
+  const raw = await reader.getStorage(getAddress(vaultAddress), GUARD_STORAGE_SLOT)
+  const guard = getAddress('0x' + raw.slice(-40))
+  return guard
+}
+
+/**
+ * Derive a vault's policy status (US2): 'unsupported' (engine not on this network),
+ * 'none' (no guard set), 'managed' (our guard), or 'foreign' (another guard —
+ * "unrecognized rule — manage with the interface that created it").
+ */
+export async function getPolicyStatus(vaultAddress, chainId, provider) {
+  const engine = getPolicyEngineAddresses(chainId)
+  const guardSet = await readVaultGuard(vaultAddress, chainId, provider).catch(() => ZeroAddress)
+  if (!engine) return guardSet !== ZeroAddress ? 'foreign' : 'unsupported'
+  if (guardSet === ZeroAddress) return 'none'
+  return guardSet === engine.guard ? 'managed' : 'foreign'
+}
+
+/**
+ * Aggregate one vault's full policy for rendering (FR-005/FR-006, batched for SC-004):
+ * summary + per-asset rules with live window state + allowlist + next-allowed time.
+ */
+export async function readPolicy(vaultAddress, chainId, provider) {
+  const engine = getPolicyEngineAddresses(chainId)
+  if (!engine) return null
+  const reader = provider || getProvider(chainId)
+  const guard = new Contract(engine.guard, SAFE_POLICY_GUARD_ABI, reader)
+  const safe = getAddress(vaultAddress)
+  const [summary, allowlist, nextAllowed] = await Promise.all([
+    guard.getPolicy(safe),
+    guard.getAllowlist(safe),
+    guard.nextAllowedAt(safe),
+  ])
+  const configuredAssets = [...summary.configuredAssets]
+  const assetRules = await Promise.all(
+    configuredAssets.map(async (asset) => {
+      const [rule, remaining] = await Promise.all([
+        guard.getAssetRule(safe, asset),
+        guard.remainingInWindow(safe, asset),
+      ])
+      return {
+        asset: getAddress(asset),
+        perTxLimit: rule.perTxLimit,
+        windowLimit: rule.windowLimit,
+        spentInWindow: rule.spentInWindow,
+        windowStart: rule.windowStart,
+        remainingInWindow: remaining,
+      }
+    }),
+  )
+  return {
+    hasRules: summary.hasRules,
+    allowlistEnabled: summary.allowlistEnabled,
+    allowlistCount: Number(summary.allowlistCount),
+    cooldown: Number(summary.cooldown),
+    lastCountedTxAt: Number(summary.lastCountedTxAt),
+    nextAllowedAt: Number(nextAllowed),
+    allowlist: allowlist.map((a) => getAddress(a)),
+    assetRules,
+  }
+}
+
+/**
+ * Validate a policy config before encoding (FR-015). Throws with a user-facing message.
+ * @param {{limits?:Array<{asset:string,perTxLimit:bigint,windowLimit:bigint}>, cooldown?:number,
+ *   allowlistEnabled?:boolean, allowlistAdd?:string[], allowlistRemove?:string[]}} config
+ */
+export function validatePolicyConfig(config) {
+  const { limits = [], cooldown = 0, allowlistEnabled = false, allowlistAdd = [], allowlistRemove = [] } = config
+  const MAX_UINT128 = (1n << 128n) - 1n
+  const seen = new Set()
+  for (const l of limits) {
+    let asset
+    try {
+      asset = getAddress(l.asset)
+    } catch {
+      throw new Error(`Invalid asset address: ${l.asset}`)
+    }
+    if (seen.has(asset)) throw new Error(`Duplicate asset in limits: ${asset}`)
+    seen.add(asset)
+    const perTx = BigInt(l.perTxLimit ?? 0)
+    const window = BigInt(l.windowLimit ?? 0)
+    if (perTx < 0n || window < 0n) throw new Error('Limits must be positive')
+    if (perTx > MAX_UINT128 || window > MAX_UINT128) throw new Error('Limit exceeds the maximum representable amount')
+    if (perTx > 0n && window > 0n && perTx > window) {
+      throw new Error('A per-transaction limit above the 24-hour window limit can never be reached')
+    }
+  }
+  if (limits.length > 16) throw new Error('At most 16 assets can carry limits')
+  const cd = Number(cooldown)
+  if (!Number.isInteger(cd) || cd < 0) throw new Error('Cooldown must be a whole number of seconds')
+  if (cd > 365 * 24 * 3600) throw new Error('Cooldown cannot exceed 365 days')
+  for (const a of [...allowlistAdd, ...allowlistRemove]) {
+    try {
+      getAddress(a)
+    } catch {
+      throw new Error(`Invalid allowlist address: ${a}`)
+    }
+  }
+  if (allowlistAdd.length + allowlistRemove.length > 64) throw new Error('At most 64 allowlist changes per update')
+  if (allowlistEnabled && allowlistAdd.length === 0 && allowlistRemove.length === 0 && !config.allowlistAlreadyPopulated) {
+    // Guard enforces non-empty on-chain; catch the obvious client case early.
+    throw new Error('Enable the allowlist with at least one recipient — an empty allowlist would block everything')
+  }
+}
+
+/** Encode a full `configureRules` call for the guard (used at creation and for changes). */
+export function encodeConfigureRules(config) {
+  validatePolicyConfig(config)
+  const { limits = [], cooldown = 0, allowlistEnabled = false, allowlistAdd = [], allowlistRemove = [] } = config
+  return guardIface.encodeFunctionData('configureRules', [
+    limits.map((l) => ({
+      asset: getAddress(l.asset),
+      perTxLimit: BigInt(l.perTxLimit ?? 0),
+      windowLimit: BigInt(l.windowLimit ?? 0),
+    })),
+    Number(config.cooldown ?? cooldown),
+    allowlistEnabled,
+    allowlistAdd.map((a) => getAddress(a)),
+    allowlistRemove.map((a) => getAddress(a)),
+  ])
+}
+
+/**
+ * Build the `Safe.setup` delegatecall payload attaching the guard + initial rules at vault
+ * creation (US1). Feed the result to `buildSetupInitializer`'s `setupTo`/`setupData`.
+ * @returns {{setupTo:string, setupData:string}}
+ */
+export function buildEnablePolicySetup(chainId, config) {
+  const engine = getPolicyEngineAddresses(chainId)
+  if (!engine) throw new Error(`The policy engine is not available on chain ${chainId}`)
+  const configureCalldata = config ? encodeConfigureRules(config) : '0x'
+  return {
+    setupTo: engine.setup,
+    setupData: setupIface.encodeFunctionData('enablePolicy', [engine.guard, configureCalldata]),
+  }
+}
+
+/**
+ * Build the Safe self-transaction that changes a deployed vault's policy (US3). The returned
+ * `{to, value, data}` goes through the existing spec 043 propose/approve queue, so FR-007
+ * (threshold) and FR-009 (approvals bind to exact content via safeTxHash) are inherited.
+ */
+export function buildPolicyChangeTx(chainId, config) {
+  const engine = getPolicyEngineAddresses(chainId)
+  if (!engine) throw new Error(`The policy engine is not available on chain ${chainId}`)
+  return { to: engine.guard, value: 0n, data: encodeConfigureRules(config) }
+}
+
+/**
+ * Build the Safe self-transaction that attaches the guard to an EXISTING vault via
+ * `Safe.setGuard` (queued AFTER the configureRules tx so rules exist before the guard activates
+ * — no half-set gap; frontend-integration.md).
+ */
+export function buildSetGuardTx(vaultAddress, chainId) {
+  const engine = getPolicyEngineAddresses(chainId)
+  if (!engine) throw new Error(`The policy engine is not available on chain ${chainId}`)
+  const safeIface = new Interface(['function setGuard(address guard)'])
+  return { to: getAddress(vaultAddress), value: 0n, data: safeIface.encodeFunctionData('setGuard', [engine.guard]) }
+}
+
+/**
+ * Pre-flight a drafted vault transaction against the vault's live policy (US4/FR-012) using the
+ * guard's own read-only evaluation. Returns `{ok:true}` or `{ok:false, violation}`.
+ */
+export async function previewPolicy(vaultAddress, chainId, { to, value = 0n, data = '0x', operation = 0 }, provider) {
+  const engine = getPolicyEngineAddresses(chainId)
+  if (!engine) return { ok: true, unsupported: true }
+  const reader = provider || getProvider(chainId)
+  const guard = new Contract(engine.guard, SAFE_POLICY_GUARD_ABI, reader)
+  const [ok, revertData] = await guard.previewTransaction(getAddress(vaultAddress), getAddress(to), BigInt(value), data, operation)
+  if (ok) return { ok: true }
+  return { ok: false, violation: decodePolicyError(revertData) }
+}
+
+/**
+ * Decode guard revert data into `{rule, message, args}` (FR-011). Shared by pre-flight and
+ * failed-execution surfaces so members always see the same explanation.
+ * @param {string} revertData raw error bytes from previewTransaction or a failed execution
+ * @param {{formatAmount?:(asset:string, amount:bigint)=>string}} [opts]
+ */
+export function decodePolicyError(revertData, opts = {}) {
+  const fmt = opts.formatAmount || ((asset, amount) => `${amount} ${asset === NATIVE_ASSET ? '(native)' : shortAddress(asset)}`)
+  let parsed = null
+  try {
+    parsed = guardIface.parseError(revertData)
+  } catch {
+    parsed = null
+  }
+  if (!parsed) return { rule: 'unknown', message: 'Blocked by the vault policy', args: {} }
+  switch (parsed.name) {
+    case 'PerTxLimitExceeded': {
+      const [asset, amount, limit] = parsed.args
+      return {
+        rule: 'perTxLimit',
+        message: `Exceeds the per-transaction limit: ${fmt(asset, amount)} is over the ${fmt(asset, limit)} cap`,
+        args: { asset: getAddress(asset), amount, limit },
+      }
+    }
+    case 'WindowLimitExceeded': {
+      const [asset, attempted, remaining] = parsed.args
+      return {
+        rule: 'windowLimit',
+        message: `Exceeds the 24-hour spending window: ${fmt(asset, attempted)} attempted, only ${fmt(asset, remaining)} remaining`,
+        args: { asset: getAddress(asset), attempted, remaining },
+      }
+    }
+    case 'RecipientNotAllowed': {
+      const [recipient] = parsed.args
+      return {
+        rule: 'allowlist',
+        message: `Recipient ${shortAddress(recipient)} is not on the vault's allowlist`,
+        args: { recipient: getAddress(recipient) },
+      }
+    }
+    case 'CooldownActive': {
+      const [nextAllowedAtTs] = parsed.args
+      return {
+        rule: 'cooldown',
+        message: `The vault's transaction delay is active — next transaction allowed ${formatTimestamp(Number(nextAllowedAtTs))}`,
+        args: { nextAllowedAt: Number(nextAllowedAtTs) },
+      }
+    }
+    case 'DelegatecallBlocked':
+      return { rule: 'delegatecall', message: 'Delegate-call transactions are not allowed on a policy-managed vault', args: {} }
+    case 'GasRefundBlocked':
+      return { rule: 'gasRefund', message: 'Gas-refund transactions are not allowed on a policy-managed vault', args: {} }
+    case 'ValueToGuardBlocked':
+      return { rule: 'valueToGuard', message: 'The policy engine cannot receive funds', args: {} }
+    default:
+      return { rule: parsed.name, message: 'Blocked by the vault policy', args: {} }
+  }
+}
+
+/**
+ * Plain-language rule descriptions for the policy views (US2), including the window-semantics
+ * disclosure the spec mandates (FR-002).
+ * @param {ReturnType<typeof readPolicy>} policy
+ * @param {{assetMeta?:Record<string,{symbol:string,decimals:number}>, nativeSymbol?:string}} [opts]
+ */
+export function describeRules(policy, opts = {}) {
+  if (!policy || !policy.hasRules) return []
+  const { assetMeta = {}, nativeSymbol = 'ETC' } = opts
+  const fmt = (asset, amount) => {
+    if (asset === NATIVE_ASSET) return `${formatUnits(amount, 18)} ${nativeSymbol}`
+    const meta = assetMeta[asset] || assetMeta[asset?.toLowerCase?.()] || null
+    return meta ? `${formatUnits(amount, meta.decimals)} ${meta.symbol}` : `${amount} units of ${shortAddress(asset)}`
+  }
+  const out = []
+  for (const r of policy.assetRules) {
+    if (r.perTxLimit > 0n) out.push(`Max ${fmt(r.asset, r.perTxLimit)} per transaction`)
+    if (r.windowLimit > 0n) {
+      out.push(
+        `Max ${fmt(r.asset, r.windowLimit)} per 24-hour window (the window opens with the first spend and resets 24 hours later)`,
+      )
+    }
+  }
+  if (policy.allowlistEnabled) {
+    out.push(`Recipients limited to ${policy.allowlistCount} approved address${policy.allowlistCount === 1 ? '' : 'es'}`)
+  }
+  if (policy.cooldown > 0) out.push(`At least ${formatDuration(policy.cooldown)} between outgoing transactions`)
+  return out
+}
+
+/** One-line summary for vault-list badges (US2 acceptance scenario 1). */
+export function summarizeRules(policy) {
+  if (!policy || !policy.hasRules) return ''
+  const parts = []
+  const limited = policy.assetRules.filter((r) => r.perTxLimit > 0n || r.windowLimit > 0n).length
+  if (limited > 0) parts.push(`limits on ${limited} asset${limited === 1 ? '' : 's'}`)
+  if (policy.allowlistEnabled) parts.push(`${policy.allowlistCount}-address allowlist`)
+  if (policy.cooldown > 0) parts.push(`${formatDuration(policy.cooldown)} delay`)
+  return parts.join(' · ')
+}
+
+export function shortAddress(addr) {
+  try {
+    const a = getAddress(addr)
+    return `${a.slice(0, 6)}…${a.slice(-4)}`
+  } catch {
+    return String(addr)
+  }
+}
+
+export function formatDuration(seconds) {
+  const s = Number(seconds)
+  if (s % (24 * 3600) === 0) {
+    const d = s / (24 * 3600)
+    return `${d} day${d === 1 ? '' : 's'}`
+  }
+  if (s % 3600 === 0) {
+    const h = s / 3600
+    return `${h} hour${h === 1 ? '' : 's'}`
+  }
+  if (s % 60 === 0) {
+    const m = s / 60
+    return `${m} minute${m === 1 ? '' : 's'}`
+  }
+  return `${s} seconds`
+}
+
+function formatTimestamp(ts) {
+  if (!ts) return 'now'
+  try {
+    return `at ${new Date(ts * 1000).toLocaleString()}`
+  } catch {
+    return `at unix time ${ts}`
+  }
+}

--- a/frontend/src/lib/custody/policyEvents.js
+++ b/frontend/src/lib/custody/policyEvents.js
@@ -1,0 +1,26 @@
+// Spec 049 (FR-016) — guard event reads for the custody notification source. The four
+// SafePolicyGuard events (RulesConfigured, CooldownSet, AllowlistEnabled, AllowlistChanged) are
+// all indexed by safe, so one bounded scan per vault yields a monotonic activity count the
+// snapshot-diff engine (spec 031) can diff: any increase means "the policy on this vault
+// changed". Read-only; never scans from genesis (caller supplies the recorded deploy block).
+
+import { Contract } from 'ethers'
+import { SAFE_POLICY_GUARD_ABI } from '../../abis/SafePolicyGuard'
+
+/**
+ * Count all policy events the guard has emitted for one vault since `fromBlock`.
+ * @param {{guardAddress:string, safeAddress:string, provider:import('ethers').Provider, fromBlock:number}} args
+ * @returns {Promise<number>}
+ */
+export async function readPolicyEventCount({ guardAddress, safeAddress, provider, fromBlock }) {
+  const guard = new Contract(guardAddress, SAFE_POLICY_GUARD_ABI, provider)
+  const logs = await Promise.all([
+    guard.queryFilter(guard.filters.RulesConfigured(safeAddress), fromBlock),
+    guard.queryFilter(guard.filters.CooldownSet(safeAddress), fromBlock),
+    guard.queryFilter(guard.filters.AllowlistEnabled(safeAddress), fromBlock),
+    guard.queryFilter(guard.filters.AllowlistChanged(safeAddress), fromBlock),
+  ])
+  return logs.reduce((n, l) => n + l.length, 0)
+}
+
+export default readPolicyEventCount

--- a/frontend/src/lib/custody/policySummary.js
+++ b/frontend/src/lib/custody/policySummary.js
@@ -1,0 +1,35 @@
+// Spec 049 (US1) — plain-language summary of a DRAFT policy config (the shape fed to
+// encodeConfigureRules), used by the vault-creation wizard before anything is on-chain.
+// Deployed policies are summarized from live state by policy.js#describeRules instead.
+
+import { formatUnits } from 'ethers'
+import { formatDuration } from './policy'
+
+/**
+ * Plain-language lines for a policy config being drafted (US1-AS1), including the FR-002
+ * 24-hour-window disclosure. Returns [] for skipped (null) or still-invalid configs.
+ * @param {object|null} config `{limits, cooldown, allowlistEnabled, allowlistAdd}` (or `{invalid:true}`)
+ * @param {Record<string,{symbol:string,decimals:number}>} assetMeta per-asset display metadata
+ */
+export function summarizePolicyConfig(config, assetMeta = {}) {
+  if (!config || config.invalid) return []
+  const fmt = (asset, amount) => {
+    const meta = assetMeta[asset]
+    return meta ? `${formatUnits(amount, meta.decimals)} ${meta.symbol}` : `${amount} units`
+  }
+  const lines = []
+  for (const l of config.limits || []) {
+    if (l.perTxLimit > 0n) lines.push(`Max ${fmt(l.asset, l.perTxLimit)} per transaction`)
+    if (l.windowLimit > 0n) {
+      lines.push(
+        `Max ${fmt(l.asset, l.windowLimit)} per 24-hour window (the window opens with the first spend and resets 24 hours later)`,
+      )
+    }
+  }
+  if (config.allowlistEnabled) {
+    const n = (config.allowlistAdd || []).length
+    lines.push(`Recipients limited to ${n} approved address${n === 1 ? '' : 'es'}`)
+  }
+  if (config.cooldown > 0) lines.push(`At least ${formatDuration(config.cooldown)} between outgoing transactions`)
+  return lines
+}

--- a/frontend/src/lib/custody/safeVault.js
+++ b/frontend/src/lib/custody/safeVault.js
@@ -20,14 +20,20 @@ import { getProvider } from '../../utils/blockchainService'
 const setupIface = new Interface(SAFE_SETUP_ABI)
 const factoryIface = new Interface(SAFE_PROXY_FACTORY_ABI)
 
-/** Encode the Safe.setup initializer for a plain multisig (no setup delegatecall, no gas refunds). */
-export function buildSetupInitializer(owners, threshold, fallbackHandler) {
+/**
+ * Encode the Safe.setup initializer (no gas refunds). By default there is no setup delegatecall —
+ * the encoding is byte-identical to the original policy-less initializer (spec 049 FR-010/SC-007).
+ * Pass `policySetup` (`{setupTo, setupData}` from spec 049's `buildEnablePolicySetup`) to attach a
+ * policy guard atomically at creation.
+ */
+export function buildSetupInitializer(owners, threshold, fallbackHandler, policySetup = {}) {
+  const { setupTo = ZeroAddress, setupData = '0x' } = policySetup || {}
   const cleanOwners = owners.map((o) => getAddress(o))
   return setupIface.encodeFunctionData('setup', [
     cleanOwners,
     BigInt(threshold),
-    ZeroAddress, // to
-    '0x', // data
+    getAddress(setupTo), // to (setup delegatecall target; ZeroAddress = none)
+    setupData, // data (setup delegatecall payload; '0x' = none)
     getAddress(fallbackHandler),
     ZeroAddress, // paymentToken
     0n, // payment
@@ -91,13 +97,14 @@ export async function predictVaultAddress({ chainId, initializer, saltNonce, pro
 
 /**
  * Pure: build the createProxyWithNonce calldata for a new vault (no provider, no predicted address).
+ * `policySetup` ({setupTo, setupData}, optional) attaches a policy guard at creation (spec 049 US1).
  * @returns {{ to:string, data:string, value:bigint, initializer:string }}
  */
-export function buildCreateVaultCalldata({ chainId, owners, threshold, saltNonce }) {
+export function buildCreateVaultCalldata({ chainId, owners, threshold, saltNonce, policySetup }) {
   validateVaultConfig(owners, threshold)
   const safe = getSafeContracts(chainId)
   if (!safe) throw new Error(`Custody is not available on chain ${chainId}`)
-  const initializer = buildSetupInitializer(owners, threshold, safe.fallbackHandler)
+  const initializer = buildSetupInitializer(owners, threshold, safe.fallbackHandler, policySetup)
   const data = factoryIface.encodeFunctionData('createProxyWithNonce', [
     getAddress(safe.singletonL2),
     initializer,
@@ -111,8 +118,8 @@ export function buildCreateVaultCalldata({ chainId, owners, threshold, saltNonce
  * proxyCreationCode on-chain via `provider`).
  * @returns {{ to:string, data:string, value:bigint, predictedAddress:string }}
  */
-export async function buildCreateVaultTx({ chainId, owners, threshold, saltNonce, provider }) {
-  const { to, data, value, initializer } = buildCreateVaultCalldata({ chainId, owners, threshold, saltNonce })
+export async function buildCreateVaultTx({ chainId, owners, threshold, saltNonce, policySetup, provider }) {
+  const { to, data, value, initializer } = buildCreateVaultCalldata({ chainId, owners, threshold, saltNonce, policySetup })
   const predictedAddress = await predictVaultAddress({ chainId, initializer, saltNonce, provider })
   return { to, data, value, predictedAddress }
 }
@@ -121,8 +128,8 @@ export async function buildCreateVaultTx({ chainId, owners, threshold, saltNonce
  * Deploy a new vault. Sends createProxyWithNonce with `signer` and returns the deployed proxy address parsed
  * from the ProxyCreation event (falling back to the predicted address).
  */
-export async function createVault({ signer, chainId, owners, threshold, saltNonce }) {
-  const tx = await buildCreateVaultTx({ chainId, owners, threshold, saltNonce, provider: signer.provider })
+export async function createVault({ signer, chainId, owners, threshold, saltNonce, policySetup }) {
+  const tx = await buildCreateVaultTx({ chainId, owners, threshold, saltNonce, policySetup, provider: signer.provider })
   const sent = await signer.sendTransaction({ to: tx.to, data: tx.data, value: tx.value })
   const receipt = await sent.wait()
   let deployed = tx.predictedAddress

--- a/frontend/src/lib/notifications/deliveryPreferences.js
+++ b/frontend/src/lib/notifications/deliveryPreferences.js
@@ -40,7 +40,7 @@ export const NOTIFICATION_CATEGORIES = [
   { domain: 'membership', label: 'Membership', description: 'Renewals, upgrades, and redeemable vouchers' },
   { domain: 'dao', label: 'Governance', description: 'Proposals to vote on, queue, or execute' },
   { domain: 'token', label: 'Token admin', description: 'Role changes and pause/unpause events' },
-  { domain: 'custody', label: 'Custody', description: 'Vault approvals needed, executions, and owner/threshold changes' },
+  { domain: 'custody', label: 'Custody', description: 'Vault approvals needed, executions, owner/threshold changes, and policy rule changes' },
 ]
 
 const KNOWN_DOMAINS = NOTIFICATION_CATEGORIES.map((c) => c.domain)

--- a/frontend/src/test/custody/CreateVaultWizard.test.jsx
+++ b/frontend/src/test/custody/CreateVaultWizard.test.jsx
@@ -1,12 +1,24 @@
 // Spec 043 (US1) — create wizard: validation (FR-005), address preview, and create delegation.
+// Spec 049 (US1) — the optional policy step: skipped ⇒ payload/initializer unchanged (FR-010);
+// configured ⇒ policySetup threads through and the initializer's setup() decodes with
+// setupTo = the chain's PolicyGuardSetup.
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { axe } from 'vitest-axe'
+import { Interface, getAddress } from 'ethers'
 import CreateVaultWizard from '../../components/custody/CreateVaultWizard'
+import { buildCreateVaultCalldata } from '../../lib/custody/safeVault'
+import { getContractAddressForChain } from '../../config/contracts'
+import { SAFE_SETUP_ABI } from '../../abis/SafeProxyFactory'
+import { setupIface } from '../../lib/custody/policy'
 
 const OWNER = '0x1111111111111111111111111111111111111111'
 const OWNER2 = '0x2222222222222222222222222222222222222222'
+
+// Chain 1337 carries the synced spec 049 policy engine addresses (Safe custody itself is mocked
+// out of these component tests — encoding checks reuse chain 63's Safe deployment).
+const POLICY_CHAIN = 1337
 
 describe('CreateVaultWizard', () => {
   it('blocks create when threshold exceeds owner count (FR-005)', () => {
@@ -51,6 +63,69 @@ describe('CreateVaultWizard', () => {
     const { container } = render(
       <CreateVaultWizard connectedAddress={OWNER} onCreate={vi.fn()} onPreview={vi.fn()} />,
     )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('passes no policySetup when the policy step is skipped, keeping the initializer unchanged (FR-010)', async () => {
+    const onCreate = vi.fn().mockResolvedValue({ address: '0xabc' })
+    render(<CreateVaultWizard connectedAddress={OWNER} chainId={POLICY_CHAIN} onCreate={onCreate} onPreview={vi.fn()} />)
+    expect(screen.getByLabelText(/no policy \(skip\)/i)).toBeChecked()
+    expect(screen.getByText(/no policy — the vault will have no spending rules/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /create vault/i }))
+    await waitFor(() => expect(onCreate).toHaveBeenCalled())
+    const payload = onCreate.mock.calls[0][0]
+    expect(payload.policySetup).toBeUndefined()
+    // The skipped path builds the exact same initializer as before spec 049.
+    const withPayload = buildCreateVaultCalldata({ chainId: 63, owners: [OWNER], threshold: 1, saltNonce: 1, policySetup: payload.policySetup })
+    const legacy = buildCreateVaultCalldata({ chainId: 63, owners: [OWNER], threshold: 1, saltNonce: 1 })
+    expect(withPayload.initializer).toBe(legacy.initializer)
+  })
+
+  it('threads a configured policy through creation: setup() decodes with setupTo = PolicyGuardSetup (US1)', async () => {
+    const onCreate = vi.fn().mockResolvedValue({ address: '0xabc' })
+    render(<CreateVaultWizard connectedAddress={OWNER} chainId={POLICY_CHAIN} onCreate={onCreate} onPreview={vi.fn()} />)
+    fireEvent.click(screen.getByLabelText(/set spending rules/i))
+    fireEvent.change(screen.getByLabelText(/per-transaction limit \(ETH\)/i), { target: { value: '1' } })
+    expect(screen.getByText(/^Policy: Max 1\.0 ETH per transaction/)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /create vault/i }))
+    await waitFor(() => expect(onCreate).toHaveBeenCalled())
+
+    const { policySetup } = onCreate.mock.calls[0][0]
+    const guardSetupAddr = getAddress(getContractAddressForChain('policyGuardSetup', POLICY_CHAIN))
+    expect(policySetup.setupTo).toBe(guardSetupAddr)
+    expect(() => setupIface.decodeFunctionData('enablePolicy', policySetup.setupData)).not.toThrow()
+
+    // The initializer built from this payload commits the policy: setup()'s `to`/`data` carry it.
+    const tx = buildCreateVaultCalldata({ chainId: 63, owners: [OWNER], threshold: 1, saltNonce: 1, policySetup })
+    const decoded = new Interface(SAFE_SETUP_ABI).decodeFunctionData('setup', tx.initializer)
+    expect(getAddress(decoded[2])).toBe(guardSetupAddr)
+    expect(decoded[3]).toBe(policySetup.setupData)
+  })
+
+  it('blocks preview/create while the policy is invalid (FR-015)', () => {
+    render(<CreateVaultWizard connectedAddress={OWNER} chainId={POLICY_CHAIN} onCreate={vi.fn()} onPreview={vi.fn()} />)
+    fireEvent.click(screen.getByLabelText(/set spending rules/i))
+    fireEvent.click(screen.getByLabelText(/only allow transfers to approved recipients/i))
+    expect(screen.getByRole('alert')).toHaveTextContent(/at least one recipient/i)
+    expect(screen.getByRole('button', { name: /create vault/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /preview address/i })).toBeDisabled()
+  })
+
+  it('clears a previewed address when the policy changes (the initializer/address commitment moved)', async () => {
+    const onPreview = vi.fn().mockResolvedValue('0xABCdef0000000000000000000000000000000123')
+    render(<CreateVaultWizard connectedAddress={OWNER} chainId={POLICY_CHAIN} onCreate={vi.fn()} onPreview={onPreview} />)
+    fireEvent.click(screen.getByRole('button', { name: /preview address/i }))
+    await waitFor(() => expect(screen.getByText(/0xABCdef/i)).toBeInTheDocument())
+    fireEvent.click(screen.getByLabelText(/set spending rules/i))
+    fireEvent.change(screen.getByLabelText(/per-transaction limit \(ETH\)/i), { target: { value: '1' } })
+    expect(screen.queryByText(/0xABCdef/i)).not.toBeInTheDocument()
+  })
+
+  it('has no axe violations with the policy step enabled', async () => {
+    const { container } = render(
+      <CreateVaultWizard connectedAddress={OWNER} chainId={POLICY_CHAIN} onCreate={vi.fn()} onPreview={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByLabelText(/set spending rules/i))
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/frontend/src/test/custody/PolicyBadge.test.jsx
+++ b/frontend/src/test/custody/PolicyBadge.test.jsx
@@ -1,0 +1,68 @@
+// Spec 049 (US2, FR-006) — vault-list badge: 'managed' renders the shield badge + summary,
+// 'foreign' renders the unrecognized-policy marker, 'none'/'unsupported' render nothing.
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import PolicyBadge from '../../components/custody/PolicyBadge'
+import VaultList from '../../components/custody/VaultList'
+
+const A = '0x1111111111111111111111111111111111111111'
+
+describe('PolicyBadge', () => {
+  it('renders the policy summary for a managed vault', () => {
+    render(<PolicyBadge status="managed" summary="limits on 1 asset · 2-address allowlist" />)
+    expect(screen.getByText(/limits on 1 asset · 2-address allowlist/i)).toBeInTheDocument()
+    expect(screen.getByText(/policy-governed vault/i)).toBeInTheDocument()
+  })
+
+  it('falls back to a generic label when a managed vault has no summary', () => {
+    render(<PolicyBadge status="managed" summary="" />)
+    expect(screen.getByText(/policy active/i)).toBeInTheDocument()
+  })
+
+  it('marks a foreign guard as an unrecognized policy', () => {
+    render(<PolicyBadge status="foreign" />)
+    expect(screen.getByText(/unrecognized policy/i)).toBeInTheDocument()
+  })
+
+  it('renders nothing for none, unsupported, and unknown statuses', () => {
+    for (const status of ['none', 'unsupported', undefined]) {
+      const { container, unmount } = render(<PolicyBadge status={status} summary="ignored" />)
+      expect(container).toBeEmptyDOMElement()
+      unmount()
+    }
+  })
+
+  it('appears inside a VaultList row when the vault carries policy data', () => {
+    const vaults = [
+      {
+        chainId: 1337,
+        address: A,
+        label: 'Treasury',
+        isSafe: true,
+        owners: [A],
+        threshold: 1,
+        owner: true,
+        policyStatus: 'managed',
+        policySummary: '1-hour delay',
+      },
+    ]
+    render(<VaultList vaults={vaults} activeAddress={null} onSelect={vi.fn()} />)
+    expect(screen.getByText(/1-hour delay/i)).toBeInTheDocument()
+  })
+
+  it('has no axe violations in all rendering states', async () => {
+    const { container } = render(
+      <ul>
+        <li>
+          <PolicyBadge status="managed" summary="limits on 2 assets" />
+        </li>
+        <li>
+          <PolicyBadge status="foreign" />
+        </li>
+      </ul>,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/custody/PolicyPanel.change.test.jsx
+++ b/frontend/src/test/custody/PolicyPanel.change.test.jsx
@@ -1,0 +1,142 @@
+// Spec 049 (US3, FR-007/FR-009) — owner management flows. Uses the REAL policy lib for
+// encoding/validation (chain 1337 carries the synced guard addresses) with only the network reads
+// mocked, so the asserted payloads are byte-real: the change flow targets the guard with encoded
+// configureRules, and the attach flow queues configureRules BEFORE setGuard (ordered nonces).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { getAddress } from 'ethers'
+
+vi.mock('../../lib/custody/policy', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    getPolicyStatus: vi.fn(),
+    readPolicy: vi.fn(),
+  }
+})
+
+import PolicyPanel from '../../components/custody/PolicyPanel'
+import { getPolicyStatus, readPolicy, guardIface, NATIVE_ASSET } from '../../lib/custody/policy'
+import { getContractAddressForChain } from '../../config/contracts'
+
+const CHAIN = 1337
+const GUARD = getAddress(getContractAddressForChain('safePolicyGuard', CHAIN))
+const VAULT = getAddress('0x2222222222222222222222222222222222222222')
+const ONE = 10n ** 18n
+
+const ownerVault = {
+  isSafe: true,
+  address: VAULT,
+  chainId: CHAIN,
+  owners: [VAULT],
+  threshold: 2,
+  owner: true,
+}
+
+const currentPolicy = {
+  hasRules: true,
+  allowlistEnabled: false,
+  allowlistCount: 0,
+  cooldown: 0,
+  nextAllowedAt: 0,
+  allowlist: [],
+  assetRules: [
+    { asset: NATIVE_ASSET, perTxLimit: ONE, windowLimit: 0n, spentInWindow: 0n, windowStart: 0, remainingInWindow: 0n },
+  ],
+}
+
+beforeEach(() => {
+  getPolicyStatus.mockReset()
+  readPolicy.mockReset()
+})
+
+describe('PolicyPanel — owner change flow (managed vault)', () => {
+  it('shows current vs proposed side by side, then submits an encoded configureRules tx to the guard', async () => {
+    getPolicyStatus.mockResolvedValue('managed')
+    readPolicy.mockResolvedValue(currentPolicy)
+    const onPropose = vi.fn().mockResolvedValue({ safeTxHash: '0x1', nonce: 4 })
+    render(<PolicyPanel vault={ownerVault} onPropose={onPropose} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /propose change/i }))
+
+    // Prefilled from the current on-chain rule, then raised 1 → 2.
+    const perTx = screen.getByLabelText(/^per-transaction limit \(blank for none\)/i)
+    expect(perTx.value).toBe('1.0')
+    fireEvent.change(perTx, { target: { value: '2' } })
+    fireEvent.click(screen.getByRole('button', { name: /review change/i }))
+
+    // Current vs proposed side by side (US3-AS1), rendered by the real describeRules.
+    expect(screen.getByText(/current policy/i)).toBeInTheDocument()
+    expect(screen.getByText(/proposed policy/i)).toBeInTheDocument()
+    expect(screen.getByText(/max 1\.0 etc per transaction/i)).toBeInTheDocument()
+    expect(screen.getByText(/max 2\.0 etc per transaction/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /propose this change/i }))
+    await waitFor(() => expect(onPropose).toHaveBeenCalledTimes(1))
+
+    const tx = onPropose.mock.calls[0][0]
+    expect(getAddress(tx.to)).toBe(GUARD)
+    expect(tx.value).toBe(0n)
+    const parsed = guardIface.parseTransaction({ data: tx.data })
+    expect(parsed.name).toBe('configureRules')
+    const [limits] = parsed.args
+    expect(getAddress(limits[0].asset)).toBe(getAddress(NATIVE_ASSET))
+    expect(BigInt(limits[0].perTxLimit)).toBe(2n * ONE)
+  })
+
+  it('rejects an invalid configuration at review time (FR-015) without proposing', async () => {
+    getPolicyStatus.mockResolvedValue('managed')
+    readPolicy.mockResolvedValue(currentPolicy)
+    const onPropose = vi.fn()
+    render(<PolicyPanel vault={ownerVault} onPropose={onPropose} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /propose change/i }))
+    // per-tx 2 above a window of 1 can never be reached — must be caught client-side.
+    fireEvent.change(screen.getByLabelText(/^per-transaction limit \(blank for none\)/i), { target: { value: '2' } })
+    fireEvent.change(screen.getByLabelText(/^24-hour window limit \(blank for none\)/i), { target: { value: '1' } })
+    fireEvent.click(screen.getByRole('button', { name: /review change/i }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/never be reached/i)
+    expect(onPropose).not.toHaveBeenCalled()
+  })
+})
+
+describe('PolicyPanel — owner attach flow (vault without a policy)', () => {
+  it('queues configureRules FIRST and setGuard SECOND, pinned to consecutive nonces', async () => {
+    getPolicyStatus.mockResolvedValue('none')
+    const onPropose = vi
+      .fn()
+      .mockResolvedValueOnce({ safeTxHash: '0xaaa', nonce: 7 })
+      .mockResolvedValueOnce({ safeTxHash: '0xbbb', nonce: 8 })
+    render(<PolicyPanel vault={ownerVault} onPropose={onPropose} />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /attach a policy/i }))
+    fireEvent.change(screen.getByLabelText(/minimum time between transactions/i), { target: { value: '2' } })
+    fireEvent.change(screen.getByLabelText(/^unit$/i), { target: { value: 'hours' } })
+    fireEvent.click(screen.getByRole('button', { name: /review policy/i }))
+
+    // The two-transaction explanation (rules only activate with the second).
+    expect(screen.getByText(/rules only take effect once the second transaction executes/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /queue both transactions/i }))
+    await waitFor(() => expect(onPropose).toHaveBeenCalledTimes(2))
+
+    // (1) configureRules to the guard.
+    const first = onPropose.mock.calls[0][0]
+    expect(getAddress(first.to)).toBe(GUARD)
+    const parsedFirst = guardIface.parseTransaction({ data: first.data })
+    expect(parsedFirst.name).toBe('configureRules')
+    expect(Number(parsedFirst.args[1])).toBe(2 * 3600)
+
+    // (2) setGuard on the vault itself, pinned to the following nonce so the chain enforces order.
+    const second = onPropose.mock.calls[1][0]
+    expect(getAddress(second.to)).toBe(VAULT)
+    expect(second.data.startsWith('0xe19a9dd9')).toBe(true) // setGuard(address)
+    expect(second.data.toLowerCase()).toContain(GUARD.slice(2).toLowerCase())
+    expect(second.nonce).toBe(8)
+
+    // Confirmation explains the co-owner approval requirement.
+    expect(await screen.findByRole('status')).toHaveTextContent(/both need co-owner approval/i)
+  })
+})

--- a/frontend/src/test/custody/PolicyPanel.test.jsx
+++ b/frontend/src/test/custody/PolicyPanel.test.jsx
@@ -1,0 +1,164 @@
+// Spec 049 (US2, FR-005/FR-006/FR-013) — PolicyPanel read states: managed rules + live window
+// state + allowlist + window disclosure, foreign-guard notice, unsupported-network notice, and the
+// non-owner (view-only) rule that no management actions render. The policy lib is mocked — the
+// panel's rendering logic is the unit under test (chain reads are covered by policy.test.js).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+
+const getPolicyStatus = vi.fn()
+const readPolicy = vi.fn()
+const describeRules = vi.fn()
+
+vi.mock('../../lib/custody/policy', () => ({
+  getPolicyStatus: (...a) => getPolicyStatus(...a),
+  readPolicy: (...a) => readPolicy(...a),
+  describeRules: (...a) => describeRules(...a),
+  validatePolicyConfig: vi.fn(),
+  buildPolicyChangeTx: vi.fn(),
+  buildSetGuardTx: vi.fn(),
+  NATIVE_ASSET: '0x0000000000000000000000000000000000000000',
+  shortAddress: (a) => String(a),
+}))
+
+import PolicyPanel from '../../components/custody/PolicyPanel'
+
+const NATIVE = '0x0000000000000000000000000000000000000000'
+const VAULT = '0x2222222222222222222222222222222222222222'
+const R1 = '0x1111111111111111111111111111111111111111'
+const R2 = '0x3333333333333333333333333333333333333333'
+
+const ONE = 10n ** 18n
+
+const managedPolicy = {
+  hasRules: true,
+  allowlistEnabled: true,
+  allowlistCount: 2,
+  cooldown: 3600,
+  nextAllowedAt: Math.floor(Date.now() / 1000) + 1800, // 30 min in the future
+  allowlist: [R1, R2],
+  assetRules: [
+    {
+      asset: NATIVE,
+      perTxLimit: ONE,
+      windowLimit: 5n * ONE,
+      spentInWindow: 2n * ONE,
+      windowStart: 0,
+      remainingInWindow: 3n * ONE,
+    },
+  ],
+}
+
+const vault = (overrides = {}) => ({
+  isSafe: true,
+  address: VAULT,
+  chainId: 1337,
+  owners: [R1],
+  threshold: 2,
+  owner: false,
+  ...overrides,
+})
+
+beforeEach(() => {
+  getPolicyStatus.mockReset()
+  readPolicy.mockReset()
+  describeRules.mockReset()
+  describeRules.mockReturnValue([
+    'Max 1.0 ETC per transaction',
+    'Max 5.0 ETC per 24-hour window (the window opens with the first spend and resets 24 hours later)',
+    'Recipients limited to 2 approved addresses',
+    'At least 1 hour between outgoing transactions',
+  ])
+})
+
+describe('PolicyPanel — managed vault (read-only)', () => {
+  it('renders every rule in plain language plus live window state, next-allowed time, and allowlist', async () => {
+    getPolicyStatus.mockResolvedValue('managed')
+    readPolicy.mockResolvedValue(managedPolicy)
+    render(<PolicyPanel vault={vault()} />)
+
+    expect(await screen.findByText(/max 1\.0 etc per transaction/i)).toBeInTheDocument()
+    expect(screen.getByText(/max 5\.0 etc per 24-hour window/i)).toBeInTheDocument()
+
+    // Live window consumption (FR-006 / US2-AS3)
+    expect(screen.getByText(/2\.0 \(native coin\) of 5\.0 \(native coin\) used/i)).toBeInTheDocument()
+    expect(screen.getByText(/3\.0 \(native coin\) remaining/i)).toBeInTheDocument()
+
+    // Cooldown live state (next-allowed in the future)
+    expect(screen.getByText(/next transaction allowed at/i)).toBeInTheDocument()
+
+    // Allowlist entries
+    expect(screen.getByText(R1)).toBeInTheDocument()
+    expect(screen.getByText(R2)).toBeInTheDocument()
+
+    // 24h-window semantics disclosure (FR-002)
+    expect(screen.getByText(/window opens with the first counted spend/i)).toBeInTheDocument()
+  })
+
+  it('offers no management actions to a non-owner (view-only) member', async () => {
+    getPolicyStatus.mockResolvedValue('managed')
+    readPolicy.mockResolvedValue(managedPolicy)
+    render(<PolicyPanel vault={vault({ owner: false })} onPropose={vi.fn()} />)
+    await screen.findByText(/max 1\.0 etc per transaction/i)
+    expect(screen.queryByRole('button', { name: /propose change/i })).not.toBeInTheDocument()
+  })
+
+  it('offers the change flow to an owner with a proposal path', async () => {
+    getPolicyStatus.mockResolvedValue('managed')
+    readPolicy.mockResolvedValue(managedPolicy)
+    render(<PolicyPanel vault={vault({ owner: true })} onPropose={vi.fn()} />)
+    expect(await screen.findByRole('button', { name: /propose change/i })).toBeInTheDocument()
+  })
+
+  it('has no axe violations', async () => {
+    getPolicyStatus.mockResolvedValue('managed')
+    readPolicy.mockResolvedValue(managedPolicy)
+    const { container } = render(<PolicyPanel vault={vault({ owner: true })} onPropose={vi.fn()} />)
+    await screen.findByText(/max 1\.0 etc per transaction/i)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('PolicyPanel — other statuses', () => {
+  it('shows the foreign-guard notice, read-only, with no actions even for owners', async () => {
+    getPolicyStatus.mockResolvedValue('foreign')
+    render(<PolicyPanel vault={vault({ owner: true })} onPropose={vi.fn()} />)
+    expect(await screen.findByText(/rules set by another interface/i)).toBeInTheDocument()
+    expect(screen.getByText(/manage them with the interface that created them/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(readPolicy).not.toHaveBeenCalled()
+  })
+
+  it('shows the unsupported-network notice (custody keeps working)', async () => {
+    getPolicyStatus.mockResolvedValue('unsupported')
+    render(<PolicyPanel vault={vault({ owner: true })} onPropose={vi.fn()} />)
+    expect(await screen.findByText(/aren.t supported on this network/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('shows "no policy" for a bare vault; the attach action is owner-only', async () => {
+    getPolicyStatus.mockResolvedValue('none')
+    const { unmount } = render(<PolicyPanel vault={vault({ owner: false })} onPropose={vi.fn()} />)
+    expect(await screen.findByText(/no policy/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /attach a policy/i })).not.toBeInTheDocument()
+    unmount()
+
+    getPolicyStatus.mockResolvedValue('none')
+    render(<PolicyPanel vault={vault({ owner: true })} onPropose={vi.fn()} />)
+    expect(await screen.findByRole('button', { name: /attach a policy/i })).toBeInTheDocument()
+  })
+
+  it('surfaces a read failure without crashing', async () => {
+    getPolicyStatus.mockRejectedValue(new Error('rpc down'))
+    render(<PolicyPanel vault={vault()} />)
+    expect(await screen.findByRole('alert')).toHaveTextContent(/rpc down/i)
+  })
+
+  it('has no axe violations across notice states', async () => {
+    getPolicyStatus.mockResolvedValue('foreign')
+    const { container } = render(<PolicyPanel vault={vault()} />)
+    await waitFor(() => expect(screen.getByText(/another interface/i)).toBeInTheDocument())
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/custody/PolicyStep.test.jsx
+++ b/frontend/src/test/custody/PolicyStep.test.jsx
@@ -1,0 +1,142 @@
+// Spec 049 (US1) — policy step: skip-by-default (FR-010), rule entry emitting a valid
+// configureRules config, entry-time validation (FR-015), strictness warnings, network gating
+// (FR-013), and axe cleanliness. Chain 1337 carries the synced policy engine addresses;
+// 80002 does not (the unsupported case).
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import { parseEther, parseUnits } from 'ethers'
+import PolicyStep from '../../components/custody/PolicyStep'
+import { summarizePolicyConfig } from '../../lib/custody/policySummary'
+import { NATIVE_ASSET, validatePolicyConfig } from '../../lib/custody/policy'
+import { getContractAddressForChain } from '../../config/contracts'
+
+const CHAIN = 1337 // policy engine synced
+const UNSUPPORTED_CHAIN = 80002
+const RECIPIENT = '0x1111111111111111111111111111111111111111'
+
+const lastChange = (onChange) => onChange.mock.calls[onChange.mock.calls.length - 1][0]
+
+function enableRules() {
+  fireEvent.click(screen.getByLabelText(/set spending rules/i))
+}
+
+describe('PolicyStep', () => {
+  it('defaults to "No policy (skip)" and emits null (FR-010)', () => {
+    const onChange = vi.fn()
+    render(<PolicyStep chainId={CHAIN} value={null} onChange={onChange} />)
+    expect(screen.getByLabelText(/no policy \(skip\)/i)).toBeChecked()
+    expect(screen.queryByLabelText(/per-transaction limit/i)).not.toBeInTheDocument()
+    expect(onChange).toHaveBeenCalledWith(null)
+    expect(lastChange(onChange)).toBeNull()
+  })
+
+  it('emits a valid config once rules are entered (US1)', () => {
+    const onChange = vi.fn()
+    render(<PolicyStep chainId={CHAIN} value={null} onChange={onChange} />)
+    enableRules()
+    fireEvent.change(screen.getByLabelText(/per-transaction limit \(ETH\)/i), { target: { value: '1' } })
+    fireEvent.change(screen.getByLabelText(/24-hour limit \(ETH\)/i), { target: { value: '5' } })
+    fireEvent.change(screen.getByLabelText(/delay between outgoing transactions/i), { target: { value: '86400' } })
+    fireEvent.click(screen.getByLabelText(/only allow transfers to approved recipients/i))
+    fireEvent.change(screen.getByLabelText(/allowed recipient 1/i), { target: { value: RECIPIENT } })
+
+    const config = lastChange(onChange)
+    expect(config.invalid).toBeUndefined()
+    expect(() => validatePolicyConfig(config)).not.toThrow()
+    expect(config.limits).toEqual([
+      { asset: NATIVE_ASSET, perTxLimit: parseEther('1'), windowLimit: parseEther('5') },
+    ])
+    expect(config.cooldown).toBe(86400)
+    expect(config.allowlistEnabled).toBe(true)
+    expect(config.allowlistAdd).toEqual([RECIPIENT])
+  })
+
+  it('includes stable-token limits when the chain has a payment token', () => {
+    const onChange = vi.fn()
+    render(<PolicyStep chainId={CHAIN} value={null} onChange={onChange} />)
+    enableRules()
+    fireEvent.change(screen.getByLabelText(/per-transaction limit \(stable token\)/i), { target: { value: '250' } })
+    const config = lastChange(onChange)
+    expect(config.invalid).toBeUndefined()
+    expect(config.limits).toEqual([
+      {
+        asset: getContractAddressForChain('paymentToken', CHAIN),
+        perTxLimit: parseUnits('250', 6),
+        windowLimit: 0n,
+      },
+    ])
+  })
+
+  it('shows the live plain-language summary with the 24-hour-window disclosure (US1-AS1)', () => {
+    render(<PolicyStep chainId={CHAIN} value={null} onChange={vi.fn()} />)
+    enableRules()
+    fireEvent.change(screen.getByLabelText(/per-transaction limit \(ETH\)/i), { target: { value: '1' } })
+    fireEvent.change(screen.getByLabelText(/24-hour limit \(ETH\)/i), { target: { value: '5' } })
+    expect(screen.getByRole('status')).toHaveTextContent('Max 1.0 ETH per transaction')
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'the window opens with the first spend and resets 24 hours later',
+    )
+  })
+
+  it('renders inline validation errors and emits an invalid marker (FR-015)', () => {
+    const onChange = vi.fn()
+    render(<PolicyStep chainId={CHAIN} value={null} onChange={onChange} />)
+    enableRules()
+    fireEvent.change(screen.getByLabelText(/per-transaction limit \(ETH\)/i), { target: { value: '10' } })
+    fireEvent.change(screen.getByLabelText(/24-hour limit \(ETH\)/i), { target: { value: '5' } })
+    expect(screen.getByRole('alert')).toHaveTextContent(/never be reached/i)
+    expect(lastChange(onChange)).toMatchObject({ invalid: true })
+  })
+
+  it('rejects an allowlist with no recipients (accidental deny-all)', () => {
+    const onChange = vi.fn()
+    render(<PolicyStep chainId={CHAIN} value={null} onChange={onChange} />)
+    enableRules()
+    fireEvent.click(screen.getByLabelText(/only allow transfers to approved recipients/i))
+    expect(screen.getByRole('alert')).toHaveTextContent(/at least one recipient/i)
+    expect(lastChange(onChange)).toMatchObject({ invalid: true })
+  })
+
+  it('warns (without blocking) on an unusually strict cooldown (FR-015)', () => {
+    const onChange = vi.fn()
+    render(<PolicyStep chainId={CHAIN} value={null} onChange={onChange} />)
+    enableRules()
+    fireEvent.change(screen.getByLabelText(/delay between outgoing transactions/i), { target: { value: 'custom' } })
+    fireEvent.change(screen.getByLabelText(/custom delay \(seconds\)/i), { target: { value: String(31 * 24 * 3600) } })
+    expect(screen.getByText(/unusually strict/i)).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    const config = lastChange(onChange)
+    expect(config.invalid).toBeUndefined()
+    expect(config.cooldown).toBe(31 * 24 * 3600)
+  })
+
+  it('renders the unsupported state and forces the skip path on networks without the engine (FR-013)', () => {
+    const onChange = vi.fn()
+    render(<PolicyStep chainId={UNSUPPORTED_CHAIN} value={null} onChange={onChange} />)
+    expect(screen.getByRole('status')).toHaveTextContent(/aren't available on this network yet/i)
+    expect(screen.queryByLabelText(/set spending rules/i)).not.toBeInTheDocument()
+    expect(screen.queryByLabelText(/per-transaction limit/i)).not.toBeInTheDocument()
+    expect(lastChange(onChange)).toBeNull()
+  })
+
+  it('summarizePolicyConfig returns nothing for skipped or invalid configs', () => {
+    expect(summarizePolicyConfig(null)).toEqual([])
+    expect(summarizePolicyConfig({ invalid: true, error: 'x' })).toEqual([])
+  })
+
+  it('has no axe violations (skip, configured, and unsupported states)', async () => {
+    const { container, unmount } = render(<PolicyStep chainId={CHAIN} value={null} onChange={vi.fn()} />)
+    expect(await axe(container)).toHaveNoViolations()
+    enableRules()
+    fireEvent.click(screen.getByLabelText(/only allow transfers to approved recipients/i))
+    fireEvent.change(screen.getByLabelText(/delay between outgoing transactions/i), { target: { value: 'custom' } })
+    expect(await axe(container)).toHaveNoViolations()
+    unmount()
+    const { container: unsupported } = render(
+      <PolicyStep chainId={UNSUPPORTED_CHAIN} value={null} onChange={vi.fn()} />,
+    )
+    expect(await axe(unsupported)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/custody/ProposalQueue.test.jsx
+++ b/frontend/src/test/custody/ProposalQueue.test.jsx
@@ -1,11 +1,15 @@
 // Spec 043 (US2) — queue: owner can approve pending / execute ready; view-only sees no actions (FR-016);
 // approvals-remaining and history render.
+// Spec 049 (US3) — proposals targeting the chain's policy guard render as decoded "Policy change" /
+// "Activate policy engine" entries; ordinary proposals render exactly as before.
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { axe } from 'vitest-axe'
 import ProposalQueue from '../../components/custody/ProposalQueue'
 import { STATUS } from '../../lib/custody/proposalStatus'
+import { encodeConfigureRules, buildSetGuardTx, NATIVE_ASSET } from '../../lib/custody/policy'
+import { getContractAddressForChain } from '../../config/contracts'
 
 const A = '0xAAaAAa0000000000000000000000000000000001'
 const HASH1 = '0x' + '11'.repeat(32)
@@ -61,5 +65,78 @@ describe('ProposalQueue', () => {
     expect(screen.getByRole('status')).toHaveTextContent(/no pending transactions/i)
     expect(screen.getByText(/history/i)).toBeInTheDocument()
     expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('ProposalQueue — policy proposals (spec 049)', () => {
+  // Chain 1337 carries the synced spec 049 guard addresses.
+  const CHAIN = 1337
+  const GUARD = getContractAddressForChain('safePolicyGuard', CHAIN)
+  const VAULT = '0x4444444444444444444444444444444444444444'
+
+  it('renders a configureRules proposal as a decoded "Policy change" entry', async () => {
+    const data = encodeConfigureRules({
+      limits: [{ asset: NATIVE_ASSET, perTxLimit: 10n ** 18n, windowLimit: 0n }],
+      cooldown: 7200,
+      allowlistEnabled: true,
+      allowlistAdd: ['0x1111111111111111111111111111111111111111'],
+    })
+    const p = { ...pending, to: GUARD, data }
+    const { container } = render(
+      <ProposalQueue
+        queue={[p]}
+        history={[]}
+        isOwner
+        connectedAddress={A}
+        chainId={CHAIN}
+        vaultAddress={VAULT}
+        onApprove={vi.fn()}
+        onExecute={vi.fn()}
+      />,
+    )
+    expect(screen.getByText(/^policy change$/i)).toBeInTheDocument()
+    expect(screen.getByText(/per-transaction limit 1\.0/i)).toBeInTheDocument()
+    expect(screen.getByText(/transaction delay: 2 hours/i)).toBeInTheDocument()
+    expect(screen.getByText(/recipient allowlist: enabled/i)).toBeInTheDocument()
+    expect(screen.getByText(/add recipient 0x1111…1111/i)).toBeInTheDocument()
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('renders a setGuard self-tx as "Activate policy engine"', () => {
+    const tx = buildSetGuardTx(VAULT, CHAIN)
+    const p = { ...pending, to: tx.to, data: tx.data }
+    render(
+      <ProposalQueue
+        queue={[p]}
+        history={[]}
+        isOwner={false}
+        connectedAddress={A}
+        chainId={CHAIN}
+        vaultAddress={VAULT}
+        onApprove={vi.fn()}
+        onExecute={vi.fn()}
+      />,
+    )
+    expect(screen.getByText(/^activate policy engine$/i)).toBeInTheDocument()
+    expect(screen.getByText(/rules take effect when this executes/i)).toBeInTheDocument()
+  })
+
+  it('leaves ordinary and undecodable proposals rendering as before', () => {
+    const ordinary = { ...pending, data: '0x' }
+    const strange = { ...pending, safeTxHash: HASH2, to: GUARD, data: '0xdeadbeef' }
+    render(
+      <ProposalQueue
+        queue={[ordinary, strange]}
+        history={[]}
+        isOwner
+        connectedAddress={A}
+        chainId={CHAIN}
+        vaultAddress={VAULT}
+        onApprove={vi.fn()}
+        onExecute={vi.fn()}
+      />,
+    )
+    expect(screen.queryByText(/policy change/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/activate policy engine/i)).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/test/custody/ProposeTransactionForm.test.jsx
+++ b/frontend/src/test/custody/ProposeTransactionForm.test.jsx
@@ -1,14 +1,32 @@
 // Spec 043 (US2) — propose form: payload encoding (native + ERC-20) and submit delegation.
+// Spec 049 (US4, FR-012) — pre-flight policy preview: a violation warning renders (naming the
+// rule) without blocking submission, clears when the draft becomes compliant, and never appears
+// for vaults without a managed policy. The policy lib is mocked (tests run on a network without
+// the engine).
 
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { axe } from 'vitest-axe'
 import { parseEther, parseUnits } from 'ethers'
+
+const getPolicyStatus = vi.fn()
+const previewPolicy = vi.fn()
+vi.mock('../../lib/custody/policy', () => ({
+  getPolicyStatus: (...a) => getPolicyStatus(...a),
+  previewPolicy: (...a) => previewPolicy(...a),
+}))
+
 import ProposeTransactionForm from '../../components/custody/ProposeTransactionForm'
 import { buildTransferPayload } from '../../lib/custody/transfers'
 
 const R = '0x1111111111111111111111111111111111111111'
 const TOKEN = '0x2222222222222222222222222222222222222222'
+const VAULT = { isSafe: true, address: '0x3333333333333333333333333333333333333333', chainId: 1337, owner: true }
+
+beforeEach(() => {
+  getPolicyStatus.mockReset()
+  previewPolicy.mockReset()
+})
 
 describe('buildTransferPayload', () => {
   it('encodes a native transfer', () => {
@@ -43,5 +61,72 @@ describe('ProposeTransactionForm', () => {
     const { container } = render(<ProposeTransactionForm onPropose={vi.fn()} />)
     expect(screen.getByRole('button', { name: /propose transfer/i })).toBeDisabled()
     expect(await axe(container)).toHaveNoViolations()
+  })
+})
+
+describe('ProposeTransactionForm — policy pre-flight (spec 049)', () => {
+  it('shows the violated rule as a warning WITHOUT blocking submission', async () => {
+    getPolicyStatus.mockResolvedValue('managed')
+    previewPolicy.mockResolvedValue({
+      ok: false,
+      violation: { rule: 'allowlist', message: `Recipient 0x1111…1111 is not on the vault's allowlist`, args: {} },
+    })
+    const onPropose = vi.fn().mockResolvedValue({})
+    render(<ProposeTransactionForm vault={VAULT} onPropose={onPropose} />)
+
+    fireEvent.change(screen.getByLabelText(/recipient/i), { target: { value: R } })
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '1' } })
+
+    const warning = await screen.findByRole('alert')
+    expect(warning).toHaveTextContent(/recipient allowlist/i) // names the rule
+    expect(warning).toHaveTextContent(/is not on the vault's allowlist/i)
+    expect(warning).toHaveTextContent(/will block it at execution/i)
+
+    // Submission is NOT blocked — the chain enforces (US4).
+    const submitButton = screen.getByRole('button', { name: /propose transfer/i })
+    expect(submitButton).toBeEnabled()
+    fireEvent.click(submitButton)
+    await waitFor(() => expect(onPropose).toHaveBeenCalled())
+  })
+
+  it('clears the warning when the draft becomes compliant', async () => {
+    getPolicyStatus.mockResolvedValue('managed')
+    previewPolicy
+      .mockResolvedValueOnce({
+        ok: false,
+        violation: { rule: 'perTxLimit', message: 'Exceeds the per-transaction limit', args: {} },
+      })
+      .mockResolvedValue({ ok: true })
+    render(<ProposeTransactionForm vault={VAULT} onPropose={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText(/recipient/i), { target: { value: R } })
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '100' } })
+    expect(await screen.findByRole('alert')).toHaveTextContent(/per-transaction limit/i)
+
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '1' } })
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument())
+  })
+
+  it('never previews or warns for a vault without a managed policy', async () => {
+    getPolicyStatus.mockResolvedValue('none')
+    render(<ProposeTransactionForm vault={VAULT} onPropose={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText(/recipient/i), { target: { value: R } })
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '1' } })
+
+    await waitFor(() => expect(getPolicyStatus).toHaveBeenCalled())
+    // Give the debounce window time to elapse; no preview may fire for a policy-less vault.
+    await new Promise((r) => setTimeout(r, 350))
+    expect(previewPolicy).not.toHaveBeenCalled()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('stays silent when no vault context is provided (personal / legacy usage)', async () => {
+    render(<ProposeTransactionForm onPropose={vi.fn()} />)
+    fireEvent.change(screen.getByLabelText(/recipient/i), { target: { value: R } })
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '1' } })
+    await new Promise((r) => setTimeout(r, 300))
+    expect(getPolicyStatus).not.toHaveBeenCalled()
+    expect(previewPolicy).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/test/custody/VaultDetail.test.jsx
+++ b/frontend/src/test/custody/VaultDetail.test.jsx
@@ -1,8 +1,22 @@
 // Spec 043 (US1) — vault detail renders live on-chain facts and the unreadable-vault state.
+// Spec 049 — VaultDetail hosts the Policy section (PolicyPanel); the policy lib is mocked here
+// (tests run on a network without the engine) — PolicyPanel behavior has its own suites.
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { axe } from 'vitest-axe'
+
+vi.mock('../../lib/custody/policy', () => ({
+  getPolicyStatus: vi.fn(async () => 'unsupported'),
+  readPolicy: vi.fn(async () => null),
+  describeRules: () => [],
+  validatePolicyConfig: () => {},
+  buildPolicyChangeTx: vi.fn(),
+  buildSetGuardTx: vi.fn(),
+  NATIVE_ASSET: '0x0000000000000000000000000000000000000000',
+  shortAddress: (a) => String(a),
+}))
+
 import VaultDetail from '../../components/custody/VaultDetail'
 import VaultList from '../../components/custody/VaultList'
 
@@ -15,6 +29,9 @@ describe('VaultDetail', () => {
     const { container } = render(<VaultDetail vault={vault} />)
     expect(screen.getByText(/2 of 2 owners/i)).toBeInTheDocument()
     expect(screen.getByText(/can propose & approve/i)).toBeInTheDocument()
+    // Spec 049 — the Policy section is mounted (here in its unsupported-network state).
+    expect(screen.getByRole('heading', { name: /^policy$/i })).toBeInTheDocument()
+    expect(await screen.findByText(/aren.t supported on this network/i)).toBeInTheDocument()
     expect(await axe(container)).toHaveNoViolations()
   })
 

--- a/frontend/src/test/custody/policy.test.js
+++ b/frontend/src/test/custody/policy.test.js
@@ -229,7 +229,9 @@ describe('getPolicyStatus (US2 / edge cases)', () => {
   it("'foreign' when another guard is set (unrecognized rules)", async () => {
     expect(await getPolicyStatus(VAULT, CHAIN, providerWith(RECIPIENT))).toBe('foreign')
   })
-  it("'unsupported' on networks without the engine", async () => {
-    expect(await getPolicyStatus(VAULT, 80002, providerWith(ZeroAddress))).toBe('unsupported')
+  it("'unsupported' on networks without the engine — regardless of guard slot, with no RPC (FR-013)", async () => {
+    const provider = providerWith(RECIPIENT) // even a set guard reports unsupported here
+    expect(await getPolicyStatus(VAULT, 80002, provider)).toBe('unsupported')
+    expect(provider.getStorage).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/test/custody/policy.test.js
+++ b/frontend/src/test/custody/policy.test.js
@@ -1,0 +1,235 @@
+// Spec 049 — policy library unit tests (offline). Pure encode/validate/decode/describe logic;
+// getPolicyStatus network derivation with a mocked provider; live reads are covered by the
+// contract integration suite (test/integration/policy-guard-safe.test.js).
+
+import { describe, it, expect, vi } from 'vitest'
+import { Interface, ZeroAddress, getAddress, parseEther, toBeHex, zeroPadValue } from 'ethers'
+import {
+  GUARD_STORAGE_SLOT,
+  NATIVE_ASSET,
+  buildEnablePolicySetup,
+  buildPolicyChangeTx,
+  buildSetGuardTx,
+  decodePolicyError,
+  describeRules,
+  encodeConfigureRules,
+  getPolicyEngineAddresses,
+  getPolicyStatus,
+  guardIface,
+  isPolicySupported,
+  setupIface,
+  summarizeRules,
+  validatePolicyConfig,
+} from '../../lib/custody/policy'
+import { getContractAddressForChain } from '../../config/contracts'
+
+const RECIPIENT = '0x1111111111111111111111111111111111111111'
+const TOKEN = getAddress('0x00000000000000000000000000000000000c0ffe')
+const VAULT = '0x2222222222222222222222222222222222222222'
+
+// The hardhat sandbox block (1337) carries the synced spec 049 addresses.
+const CHAIN = 1337
+const guardAddr = getContractAddressForChain('safePolicyGuard', CHAIN)
+const setupAddr = getContractAddressForChain('policyGuardSetup', CHAIN)
+
+describe('network gating (FR-013)', () => {
+  it('resolves the engine on chains where both contracts are synced', () => {
+    expect(guardAddr).toBeTruthy()
+    expect(getPolicyEngineAddresses(CHAIN)).toEqual({ guard: getAddress(guardAddr), setup: getAddress(setupAddr) })
+    expect(isPolicySupported(CHAIN)).toBe(true)
+  })
+  it('returns null / unsupported on chains without the engine', () => {
+    expect(getPolicyEngineAddresses(80002)).toBeNull()
+    expect(isPolicySupported(80002)).toBe(false)
+  })
+})
+
+describe('validatePolicyConfig (FR-015)', () => {
+  it('accepts a full valid config', () => {
+    expect(() =>
+      validatePolicyConfig({
+        limits: [{ asset: NATIVE_ASSET, perTxLimit: parseEther('1'), windowLimit: parseEther('5') }],
+        cooldown: 3600,
+        allowlistEnabled: true,
+        allowlistAdd: [RECIPIENT],
+      }),
+    ).not.toThrow()
+  })
+  it('rejects an allowlist enabled with no entries (accidental deny-all)', () => {
+    expect(() => validatePolicyConfig({ allowlistEnabled: true })).toThrow(/at least one recipient/i)
+  })
+  it('rejects a per-tx limit above the window limit (never reachable)', () => {
+    expect(() =>
+      validatePolicyConfig({ limits: [{ asset: NATIVE_ASSET, perTxLimit: 10n, windowLimit: 5n }] }),
+    ).toThrow(/never be reached/i)
+  })
+  it('rejects cooldowns beyond 365 days, bad addresses, oversized batches, duplicate assets', () => {
+    expect(() => validatePolicyConfig({ cooldown: 366 * 24 * 3600 })).toThrow(/365 days/)
+    expect(() => validatePolicyConfig({ allowlistAdd: ['nope'] })).toThrow(/Invalid allowlist address/)
+    expect(() =>
+      validatePolicyConfig({ allowlistAdd: Array.from({ length: 65 }, (_, i) => toBeHex(i + 1, 20)) }),
+    ).toThrow(/64/)
+    expect(() =>
+      validatePolicyConfig({
+        limits: [
+          { asset: NATIVE_ASSET, perTxLimit: 1n, windowLimit: 0n },
+          { asset: ZeroAddress, perTxLimit: 2n, windowLimit: 0n },
+        ],
+      }),
+    ).toThrow(/Duplicate asset/)
+  })
+})
+
+describe('encodeConfigureRules / buildPolicyChangeTx (US3)', () => {
+  const config = {
+    limits: [{ asset: TOKEN, perTxLimit: 100n, windowLimit: 500n }],
+    cooldown: 60,
+    allowlistEnabled: true,
+    allowlistAdd: [RECIPIENT],
+    allowlistRemove: [],
+  }
+
+  it('round-trips through the guard ABI', () => {
+    const data = encodeConfigureRules(config)
+    const decoded = guardIface.decodeFunctionData('configureRules', data)
+    expect(decoded[0]).toHaveLength(1)
+    expect(getAddress(decoded[0][0].asset)).toBe(TOKEN)
+    expect(decoded[0][0].perTxLimit).toBe(100n)
+    expect(decoded[0][0].windowLimit).toBe(500n)
+    expect(decoded[1]).toBe(60n)
+    expect(decoded[2]).toBe(true)
+    expect(decoded[3].map(getAddress)).toEqual([getAddress(RECIPIENT)])
+  })
+
+  it('buildPolicyChangeTx targets the guard with zero value (threshold-approved self-tx)', () => {
+    const tx = buildPolicyChangeTx(CHAIN, config)
+    expect(tx.to).toBe(getAddress(guardAddr))
+    expect(tx.value).toBe(0n)
+    expect(() => guardIface.decodeFunctionData('configureRules', tx.data)).not.toThrow()
+  })
+
+  it('buildSetGuardTx targets the vault itself with the engine guard', () => {
+    const tx = buildSetGuardTx(VAULT, CHAIN)
+    expect(tx.to).toBe(getAddress(VAULT))
+    const decoded = new Interface(['function setGuard(address)']).decodeFunctionData('setGuard', tx.data)
+    expect(getAddress(decoded[0])).toBe(getAddress(guardAddr))
+  })
+
+  it('throws on unsupported networks instead of building a broken transaction', () => {
+    expect(() => buildPolicyChangeTx(80002, config)).toThrow(/not available/)
+    expect(() => buildEnablePolicySetup(80002, config)).toThrow(/not available/)
+  })
+})
+
+describe('buildEnablePolicySetup (US1)', () => {
+  it('wraps the configure calldata in an enablePolicy delegatecall payload', () => {
+    const { setupTo, setupData } = buildEnablePolicySetup(CHAIN, {
+      limits: [{ asset: NATIVE_ASSET, perTxLimit: 1n, windowLimit: 0n }],
+    })
+    expect(setupTo).toBe(getAddress(setupAddr))
+    const decoded = setupIface.decodeFunctionData('enablePolicy', setupData)
+    expect(getAddress(decoded[0])).toBe(getAddress(guardAddr))
+    const inner = guardIface.decodeFunctionData('configureRules', decoded[1])
+    expect(inner[0][0].perTxLimit).toBe(1n)
+  })
+  it('supports attach-with-no-rules (empty configure calldata)', () => {
+    const { setupData } = buildEnablePolicySetup(CHAIN, null)
+    const decoded = setupIface.decodeFunctionData('enablePolicy', setupData)
+    expect(decoded[1]).toBe('0x')
+  })
+})
+
+describe('decodePolicyError (FR-011)', () => {
+  const enc = (name, args) => guardIface.encodeErrorResult(name, args)
+
+  it('decodes every rule error into a named rule with plain language', () => {
+    expect(decodePolicyError(enc('PerTxLimitExceeded', [NATIVE_ASSET, 101n, 100n]))).toMatchObject({
+      rule: 'perTxLimit',
+      args: { amount: 101n, limit: 100n },
+    })
+    expect(decodePolicyError(enc('WindowLimitExceeded', [TOKEN, 50n, 10n]))).toMatchObject({
+      rule: 'windowLimit',
+      args: { attempted: 50n, remaining: 10n },
+    })
+    expect(decodePolicyError(enc('RecipientNotAllowed', [RECIPIENT]))).toMatchObject({
+      rule: 'allowlist',
+      args: { recipient: getAddress(RECIPIENT) },
+    })
+    expect(decodePolicyError(enc('CooldownActive', [1750000000n]))).toMatchObject({
+      rule: 'cooldown',
+      args: { nextAllowedAt: 1750000000 },
+    })
+    expect(decodePolicyError(enc('DelegatecallBlocked', [])).rule).toBe('delegatecall')
+    expect(decodePolicyError(enc('GasRefundBlocked', [])).rule).toBe('gasRefund')
+  })
+
+  it('falls back gracefully on unknown revert data', () => {
+    expect(decodePolicyError('0xdeadbeef')).toMatchObject({ rule: 'unknown' })
+  })
+
+  it('messages name the violated value (US4 acceptance)', () => {
+    const v = decodePolicyError(enc('RecipientNotAllowed', [RECIPIENT]))
+    expect(v.message).toMatch(/0x1111…1111/)
+    expect(v.message).toMatch(/allowlist/i)
+  })
+})
+
+describe('describeRules / summarizeRules (US2)', () => {
+  const policy = {
+    hasRules: true,
+    allowlistEnabled: true,
+    allowlistCount: 3,
+    cooldown: 24 * 3600,
+    assetRules: [
+      { asset: NATIVE_ASSET, perTxLimit: parseEther('1'), windowLimit: parseEther('5') },
+      { asset: TOKEN, perTxLimit: 0n, windowLimit: 0n },
+    ],
+  }
+
+  it('renders plain-language rules including the window-semantics disclosure (FR-002)', () => {
+    const lines = describeRules(policy, { nativeSymbol: 'ETC' })
+    expect(lines).toContain('Max 1.0 ETC per transaction')
+    expect(lines.find((l) => l.includes('per 24-hour window'))).toMatch(/resets 24 hours later/)
+    expect(lines).toContain('Recipients limited to 3 approved addresses')
+    expect(lines).toContain('At least 1 day between outgoing transactions')
+  })
+
+  it('formats known token metadata and returns empty for no policy', () => {
+    const withToken = {
+      ...policy,
+      assetRules: [{ asset: TOKEN, perTxLimit: 500000000n, windowLimit: 0n }],
+    }
+    const lines = describeRules(withToken, { assetMeta: { [TOKEN]: { symbol: 'USDC', decimals: 6 } } })
+    expect(lines[0]).toBe('Max 500.0 USDC per transaction')
+    expect(describeRules(null)).toEqual([])
+    expect(describeRules({ hasRules: false })).toEqual([])
+  })
+
+  it('summarizes for the vault-list badge', () => {
+    expect(summarizeRules(policy)).toBe('limits on 1 asset · 3-address allowlist · 1 day delay')
+    expect(summarizeRules(null)).toBe('')
+  })
+})
+
+describe('getPolicyStatus (US2 / edge cases)', () => {
+  const slotValue = (addr) => zeroPadValue(addr, 32)
+  const providerWith = (guardAtSlot) => ({
+    getStorage: vi.fn(async (vault, slot) => {
+      expect(slot).toBe(GUARD_STORAGE_SLOT)
+      return slotValue(guardAtSlot)
+    }),
+  })
+
+  it("'none' when no guard is set", async () => {
+    expect(await getPolicyStatus(VAULT, CHAIN, providerWith(ZeroAddress))).toBe('none')
+  })
+  it("'managed' when our guard is set", async () => {
+    expect(await getPolicyStatus(VAULT, CHAIN, providerWith(guardAddr))).toBe('managed')
+  })
+  it("'foreign' when another guard is set (unrecognized rules)", async () => {
+    expect(await getPolicyStatus(VAULT, CHAIN, providerWith(RECIPIENT))).toBe('foreign')
+  })
+  it("'unsupported' on networks without the engine", async () => {
+    expect(await getPolicyStatus(VAULT, 80002, providerWith(ZeroAddress))).toBe('unsupported')
+  })
+})

--- a/frontend/src/test/custody/safeVault.test.js
+++ b/frontend/src/test/custody/safeVault.test.js
@@ -21,6 +21,9 @@ const O2 = '0x2222222222222222222222222222222222222222'
 const O3 = '0x3333333333333333333333333333333333333333'
 const FALLBACK = '0xfd0732Dc9E303f09fCEf3a7388Ad10A83459Ec99'
 
+const SETUP_TO = '0x00000000000000000000000000000000000decaf'
+const SETUP_DATA = '0x12345678abcd'
+
 describe('buildSetupInitializer', () => {
   it('encodes Safe.setup with owners, threshold, and fallback handler', () => {
     const data = buildSetupInitializer([O1, O2, O3], 2, FALLBACK)
@@ -28,6 +31,27 @@ describe('buildSetupInitializer', () => {
     expect(decoded[0].map((a) => getAddress(a))).toEqual([O1, O2, O3].map(getAddress))
     expect(decoded[1]).toBe(2n)
     expect(getAddress(decoded[4])).toBe(getAddress(FALLBACK))
+  })
+
+  it('stays byte-identical without a policy setup (spec 049 FR-010: omitted, {}, and null defaults)', () => {
+    const base = buildSetupInitializer([O1, O2, O3], 2, FALLBACK)
+    expect(buildSetupInitializer([O1, O2, O3], 2, FALLBACK, {})).toBe(base)
+    expect(buildSetupInitializer([O1, O2, O3], 2, FALLBACK, null)).toBe(base)
+    const decoded = new Interface(SAFE_SETUP_ABI).decodeFunctionData('setup', base)
+    expect(decoded[2]).toBe(getAddress('0x0000000000000000000000000000000000000000')) // to
+    expect(decoded[3]).toBe('0x') // data
+  })
+
+  it('threads setupTo/setupData into the encoded setup() args (spec 049 US1)', () => {
+    const data = buildSetupInitializer([O1, O2, O3], 2, FALLBACK, { setupTo: SETUP_TO, setupData: SETUP_DATA })
+    const decoded = new Interface(SAFE_SETUP_ABI).decodeFunctionData('setup', data)
+    expect(getAddress(decoded[2])).toBe(getAddress(SETUP_TO))
+    expect(decoded[3]).toBe(SETUP_DATA)
+    // Everything else is unchanged relative to the plain initializer.
+    expect(decoded[0].map((a) => getAddress(a))).toEqual([O1, O2, O3].map(getAddress))
+    expect(decoded[1]).toBe(2n)
+    expect(getAddress(decoded[4])).toBe(getAddress(FALLBACK))
+    expect(decoded[6]).toBe(0n) // payment
   })
 })
 
@@ -93,6 +117,29 @@ describe('buildCreateVaultCalldata', () => {
 
   it('rejects an invalid config before building', () => {
     expect(() => buildCreateVaultCalldata({ chainId: 63, owners: [O1, O2], threshold: 3, saltNonce: 0 })).toThrow(/exceed/)
+  })
+
+  it('is unchanged when policySetup is omitted vs undefined (spec 049 FR-010)', () => {
+    const base = buildCreateVaultCalldata({ chainId: 63, owners: [O1, O2, O3], threshold: 2, saltNonce: 5 })
+    const explicit = buildCreateVaultCalldata({ chainId: 63, owners: [O1, O2, O3], threshold: 2, saltNonce: 5, policySetup: undefined })
+    expect(explicit.data).toBe(base.data)
+    expect(explicit.initializer).toBe(base.initializer)
+  })
+
+  it('threads policySetup into the initializer (spec 049 US1)', () => {
+    const tx = buildCreateVaultCalldata({
+      chainId: 63,
+      owners: [O1, O2, O3],
+      threshold: 2,
+      saltNonce: 5,
+      policySetup: { setupTo: SETUP_TO, setupData: SETUP_DATA },
+    })
+    const decoded = new Interface(SAFE_SETUP_ABI).decodeFunctionData('setup', tx.initializer)
+    expect(getAddress(decoded[2])).toBe(getAddress(SETUP_TO))
+    expect(decoded[3]).toBe(SETUP_DATA)
+    // A different initializer means a different CREATE2 address commitment than the plain vault.
+    const plain = buildCreateVaultCalldata({ chainId: 63, owners: [O1, O2, O3], threshold: 2, saltNonce: 5 })
+    expect(tx.initializer).not.toBe(plain.initializer)
   })
 })
 

--- a/frontend/src/test/sources/custodySource.test.js
+++ b/frontend/src/test/sources/custodySource.test.js
@@ -11,6 +11,7 @@ const VAULT = '0x1111111111111111111111111111111111111111'
 
 const readState = vi.fn()
 const refs = vi.fn()
+const policyCount = vi.fn()
 
 vi.mock('../../utils/blockchainService', () => ({ getProvider: () => ({}) }))
 vi.mock('../../config/safeContracts', () => ({ getSafeContracts: () => ({ multiSendCallOnly: VAULT }) }))
@@ -20,6 +21,7 @@ vi.mock('../../config/contracts', () => ({
 }))
 vi.mock('../../lib/custody/vaultReferences', () => ({ loadVaultReferences: (...a) => refs(...a) }))
 vi.mock('../../lib/custody/vaultProposalReads', () => ({ readVaultProposalState: (...a) => readState(...a) }))
+vi.mock('../../lib/custody/policyEvents', () => ({ readPolicyEventCount: (...a) => policyCount(...a) }))
 
 import { custodySource } from '../../data/notifications/sources/custodySource'
 
@@ -33,6 +35,8 @@ const pendingNeedingMe = {
 beforeEach(() => {
   refs.mockReturnValue([{ chainId: 63, address: VAULT, label: 'Coop', role: 'owner' }])
   readState.mockReset()
+  policyCount.mockReset()
+  policyCount.mockResolvedValue(0)
 })
 
 const sid = `custody:${VAULT}`
@@ -79,5 +83,35 @@ describe('custodySource', () => {
     readState.mockRejectedValue(new Error('rpc down'))
     const out = await custodySource.detect({ account: OWNER, chainId: 63, nowMs: NOW, prior: {} })
     expect(out.ok).toBe(false)
+  })
+
+  // Spec 049 (FR-016) — guard rule events join the same snapshot-diff.
+  it('baselines the policy event count on first sight without emitting', async () => {
+    readState.mockResolvedValue(base)
+    policyCount.mockResolvedValue(3)
+    const out = await custodySource.detect({ account: OWNER, chainId: 63, nowMs: NOW, prior: {} })
+    expect(out.entries).toEqual([])
+    expect(out.nextSnapshots[sid].policyEventCount).toBe(3)
+  })
+
+  it('emits policy-changed when new guard events appear for a member vault', async () => {
+    readState.mockResolvedValue(base)
+    policyCount.mockResolvedValue(4)
+    const prior = { snapshots: { [sid]: { needMe: [], executedCount: 0, govKey: '1:1', policyEventCount: 2 } } }
+    const out = await custodySource.detect({ account: OWNER, chainId: 63, nowMs: NOW, prior })
+    const e = out.entries.find((x) => x.type === 'policy-changed')
+    expect(e).toBeTruthy()
+    expect(e.domain).toBe('custody')
+    expect(e.message).toMatch(/policy rules on “Coop” changed/i)
+    expect(out.nextSnapshots[sid].policyEventCount).toBe(4)
+  })
+
+  it('keeps the prior policy baseline when the guard read fails (no false diff later)', async () => {
+    readState.mockResolvedValue(base)
+    policyCount.mockRejectedValue(new Error('rpc down'))
+    const prior = { snapshots: { [sid]: { needMe: [], executedCount: 0, govKey: '1:1', policyEventCount: 2 } } }
+    const out = await custodySource.detect({ account: OWNER, chainId: 63, nowMs: NOW, prior })
+    expect(out.entries.find((x) => x.type === 'policy-changed')).toBeFalsy()
+    expect(out.nextSnapshots[sid].policyEventCount).toBe(2)
   })
 })

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -287,9 +287,45 @@ module.exports = {
     // and OOM-thrashes a 16 GB box (and would do the same to CI). These are deployed standalone and
     // linked/held by address, so different codegen here cannot affect the viaIR app contracts.
     // Nothing in contracts/ imports this closure except SemaphoreDeploy.sol.
+    //
+    // The vendored Safe v1.4.1 closure (spec 049 test shim contracts/mocks/vendor/) likewise
+    // compiles WITHOUT viaIR: Safe's inline assembly is not annotated memory-safe, so the Yul IR
+    // pipeline cannot place a memoryguard and dies with a stack-too-deep YulException. The shim
+    // is test-only (never deployed by scripts) and nothing in contracts/ imports it, so legacy
+    // codegen here cannot affect the viaIR app contracts.
     overrides: Object.fromEntries(
       [
         "contracts/pools/SemaphoreDeploy.sol",
+        "contracts/mocks/vendor/SafeVendorImports.sol",
+        "@safe-global/safe-contracts/contracts/Safe.sol",
+        "@safe-global/safe-contracts/contracts/SafeL2.sol",
+        "@safe-global/safe-contracts/contracts/base/Executor.sol",
+        "@safe-global/safe-contracts/contracts/base/FallbackManager.sol",
+        "@safe-global/safe-contracts/contracts/base/GuardManager.sol",
+        "@safe-global/safe-contracts/contracts/base/ModuleManager.sol",
+        "@safe-global/safe-contracts/contracts/base/OwnerManager.sol",
+        "@safe-global/safe-contracts/contracts/common/Enum.sol",
+        "@safe-global/safe-contracts/contracts/common/NativeCurrencyPaymentFallback.sol",
+        "@safe-global/safe-contracts/contracts/common/SecuredTokenTransfer.sol",
+        "@safe-global/safe-contracts/contracts/common/SelfAuthorized.sol",
+        "@safe-global/safe-contracts/contracts/common/SignatureDecoder.sol",
+        "@safe-global/safe-contracts/contracts/common/Singleton.sol",
+        "@safe-global/safe-contracts/contracts/common/StorageAccessible.sol",
+        "@safe-global/safe-contracts/contracts/external/SafeMath.sol",
+        "@safe-global/safe-contracts/contracts/handler/CompatibilityFallbackHandler.sol",
+        "@safe-global/safe-contracts/contracts/handler/HandlerContext.sol",
+        "@safe-global/safe-contracts/contracts/handler/TokenCallbackHandler.sol",
+        "@safe-global/safe-contracts/contracts/interfaces/ERC1155TokenReceiver.sol",
+        "@safe-global/safe-contracts/contracts/interfaces/ERC721TokenReceiver.sol",
+        "@safe-global/safe-contracts/contracts/interfaces/ERC777TokensRecipient.sol",
+        "@safe-global/safe-contracts/contracts/interfaces/IERC165.sol",
+        "@safe-global/safe-contracts/contracts/interfaces/ISignatureValidator.sol",
+        "@safe-global/safe-contracts/contracts/interfaces/ViewStorageAccessible.sol",
+        "@safe-global/safe-contracts/contracts/libraries/MultiSendCallOnly.sol",
+        "@safe-global/safe-contracts/contracts/libraries/SafeStorage.sol",
+        "@safe-global/safe-contracts/contracts/proxies/IProxyCreationCallback.sol",
+        "@safe-global/safe-contracts/contracts/proxies/SafeProxy.sol",
+        "@safe-global/safe-contracts/contracts/proxies/SafeProxyFactory.sol",
         "@semaphore-protocol/contracts/Semaphore.sol",
         "@semaphore-protocol/contracts/base/SemaphoreGroups.sol",
         "@semaphore-protocol/contracts/base/SemaphoreVerifier.sol",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@openzeppelin/contracts-upgradeable": "5.4.0",
         "@openzeppelin/hardhat-upgrades": "^3.9.0",
         "@pinata/sdk": "^2.1.0",
+        "@safe-global/safe-contracts": "1.4.1",
         "@safe-global/safe-singleton-factory": "^2.0.0",
         "@semaphore-protocol/group": "^4.14.2",
         "@semaphore-protocol/identity": "^4.14.2",
@@ -4731,6 +4732,16 @@
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@safe-global/safe-contracts": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-contracts/-/safe-contracts-1.4.1.tgz",
+      "integrity": "sha512-fP1jewywSwsIniM04NsqPyVRFKPMAuirC3ftA/TA4X3Zc5EnwQp/UCJUU2PL/37/z/jMo8UUaJ+pnFNWmMU7dQ==",
+      "dev": true,
+      "license": "LGPL-3.0",
+      "peerDependencies": {
+        "ethers": "5.4.0"
+      }
     },
     "node_modules/@safe-global/safe-singleton-factory": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@openzeppelin/contracts-upgradeable": "5.4.0",
     "@openzeppelin/hardhat-upgrades": "^3.9.0",
     "@pinata/sdk": "^2.1.0",
+    "@safe-global/safe-contracts": "1.4.1",
     "@safe-global/safe-singleton-factory": "^2.0.0",
     "@semaphore-protocol/group": "^4.14.2",
     "@semaphore-protocol/identity": "^4.14.2",
@@ -100,5 +101,10 @@
   },
   "dependencies": {
     "@semaphore-protocol/contracts": "^4.14.2"
+  },
+  "overrides": {
+    "@safe-global/safe-contracts": {
+      "ethers": "$ethers"
+    }
   }
 }

--- a/scripts/deploy/custody/deploy-policy-guard.js
+++ b/scripts/deploy/custody/deploy-policy-guard.js
@@ -1,0 +1,87 @@
+/**
+ * Targeted deploy: SafePolicyGuard + PolicyGuardSetup (spec 049 — multisig policy engine).
+ *
+ * The guard is an immutable, admin-free, non-upgradeable Safe v1.4.1 transaction guard enforcing
+ * per-vault fund policies (per-tx limit, 24h-window limit, recipient allowlist, cooldown); the
+ * setup helper is the stateless Safe.setup delegatecall target that attaches the guard + initial
+ * rules at vault creation. Like the SafeProposalHub deploy, this script deploys ONLY these two
+ * contracts with deterministic CREATE2 salts and records them into the existing
+ * `deployments/<net>-chain<id>-v2.json` under `safePolicyGuard` / `policyGuardSetup` without
+ * disturbing any other field. It never touches the UUPS proxies.
+ *
+ * Rollout follows custody support: Mordor (63) then Polygon (137); hardhat/localhost (1337) is
+ * wired for the local quickstart. Neither contract has admin or funds, so only the deploy signs.
+ *
+ * Usage: npx hardhat run scripts/deploy/custody/deploy-policy-guard.js --network <localhost|mordor|polygon>
+ * Next:  npm run sync:frontend-contracts -- --network <net> --chainId <id>
+ */
+const fs = require("fs");
+const path = require("path");
+const hre = require("hardhat");
+const { ethers } = hre;
+const { deployDeterministic, ensureSingletonFactory, generateSalt } = require("../lib/helpers");
+const { SALT_PREFIXES } = require("../lib/constants");
+
+const TARGETS = [
+  { contract: "SafePolicyGuard", key: "safePolicyGuard" },
+  { contract: "PolicyGuardSetup", key: "policyGuardSetup" },
+];
+
+async function main() {
+  const net = await ethers.provider.getNetwork();
+  const chainId = Number(net.chainId);
+
+  const deploymentsDir = path.join(__dirname, "..", "..", "..", "deployments");
+  const fileByChain = {
+    63: "mordor-chain63-v2.json",
+    137: "polygon-chain137-v2.json",
+    1337: "hardhat-chain1337-v2.json",
+  };
+  const fileName = fileByChain[chainId];
+  if (!fileName) throw new Error(`Policy engine deploys to custody-supported chains (63, 137) or local 1337; got ${chainId}`);
+  const recordPath = path.join(deploymentsDir, fileName);
+  const record = JSON.parse(fs.readFileSync(recordPath, "utf8"));
+
+  const [deployer] = await ethers.getSigners();
+  const bal = await ethers.provider.getBalance(deployer.address);
+  console.log(`Network:   ${record.network} (chainId ${chainId})`);
+  console.log(`Deployer:  ${deployer.address}  (balance ${ethers.formatEther(bal)})`);
+
+  await ensureSingletonFactory(); // bootstraps the CREATE2 factory on local sessions
+
+  record.contracts = record.contracts || {};
+  record.constructorArgs = record.constructorArgs || {};
+  record.deployBlocks = record.deployBlocks || {};
+
+  let changed = false;
+  for (const { contract, key } of TARGETS) {
+    const existing = record.contracts[key];
+    if (existing) {
+      const code = await ethers.provider.getCode(existing);
+      if (code !== "0x") {
+        console.log(`\n✓ ${contract} already recorded + on-chain at ${existing} — skipping.`);
+        continue;
+      }
+    }
+    const salt = generateSalt(SALT_PREFIXES.V2 + contract);
+    const result = await deployDeterministic(contract, [], salt, deployer);
+    record.contracts[key] = result.address;
+    record.constructorArgs[key] = [];
+    try {
+      record.deployBlocks[key] = await ethers.provider.getBlockNumber();
+    } catch { /* non-fatal */ }
+    changed = true;
+    console.log(`\n✓ ${contract} deployed: ${result.address}`);
+  }
+
+  if (changed) {
+    fs.writeFileSync(recordPath, JSON.stringify(record, null, 2) + "\n");
+    console.log(`\nRecorded in deployments/${fileName}`);
+    console.log(`Next: npm run sync:frontend-contracts -- --network ${record.network} --chainId ${chainId}`);
+    for (const { key } of TARGETS) {
+      console.log(`      npx hardhat verify --network ${record.network} ${record.contracts[key]}`);
+    }
+  }
+}
+
+main().catch((e) => { console.error(e); process.exitCode = 1; });

--- a/scripts/utils/sync-frontend-contracts.js
+++ b/scripts/utils/sync-frontend-contracts.js
@@ -191,6 +191,9 @@ function main() {
         externalDAORegistry: deployed.externalDAORegistry, // spec 030 — ClearPath external-DAO registry
         backupPointerRegistry: deployed.backupPointerRegistry, // spec 032 — encrypted-backup pointer registry
         wagerPoolFactory: deployed.wagerPoolFactory, // spec 034 — WagerPools factory, address-based (only where deployed)
+        safeProposalHub: deployed.safeProposalHub, // spec 043 — Safe custody proposal broadcaster (only where deployed)
+        safePolicyGuard: deployed.safePolicyGuard, // spec 049 — multisig policy engine guard (only where deployed)
+        policyGuardSetup: deployed.policyGuardSetup, // spec 049 — Safe.setup policy attach helper (only where deployed)
         entryPoint: deployed.entryPoint, // spec 041 — ERC-4337 EntryPoint v0.6 (canonical or self-deployed)
         accountFactory: deployed.accountFactory, // spec 041 — deterministic CoinbaseSmartWalletFactory (same address on every network)
         p256Verifier: deployed.p256Verifier, // spec 041 — only on networks needing an external P-256 verifier

--- a/specs/049-multisig-policy-engine/checklists/requirements.md
+++ b/specs/049-multisig-policy-engine/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Multisig Policy Engine
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Scope decisions that would otherwise be [NEEDS CLARIFICATION] were resolved with documented
+  rationale in the Clarifications and Assumptions sections (personal-account policies deferred,
+  four v1 rule types, threshold-gated policy changes, lockout-proof management).
+- Spec deliberately avoids naming the enforcement mechanism (e.g. no contract or framework names);
+  those choices belong to `/speckit-plan`.

--- a/specs/049-multisig-policy-engine/contracts/PolicyGuardSetup.md
+++ b/specs/049-multisig-policy-engine/contracts/PolicyGuardSetup.md
@@ -1,0 +1,43 @@
+# Contract: PolicyGuardSetup
+
+Tiny, stateless helper delegatecalled from `Safe.setup(...)` so a new vault is policy-governed
+from its first transaction (spec 049, US1 / research R4). Resolved via
+`getContractAddressForChain('policyGuardSetup', chainId)`.
+
+## Interface
+
+```solidity
+function enablePolicy(address guard, bytes calldata configureCalldata) external;
+```
+
+Called with `operation = delegatecall` from the Safe proxy's `setup`, i.e. executes in the new
+Safe's own storage/context:
+
+1. Validates `guard != address(0)` and that `guard` self-reports the Safe guard interface via
+   ERC-165 (`supportsInterface`) — mirrors the check `setGuard` itself performs (v1.4.1).
+2. `sstore`s `guard` into the Safe guard storage slot
+   `0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8`
+   (`keccak256("guard_manager.guard.address")`).
+3. Emits Safe's `ChangedGuard(address)` event signature (log parity with a post-create `setGuard`,
+   so explorers/indexers see the same trail).
+4. Performs a **call** (not delegatecall) of `configureCalldata` on the guard. Because step 4 runs
+   in the proxy's context, `msg.sender` seen by the guard **is the new Safe**, so
+   `SafePolicyGuard.configureRules` authorization holds with no special creation path.
+   Reverts bubble up and abort the entire vault creation (no half-configured vault).
+
+## Security notes
+
+- Stateless; no storage of its own (delegatecall target must not rely on its own state).
+- No selfdestruct, no payable, no fallback.
+- Only reachable meaningfully via delegatecall from a Safe's `setup`; calling it directly writes
+  the caller's own storage slot — harmless to third parties (documented, mirrors how Safe module
+  setup helpers behave).
+- The full `initializer` (including this call) is hashed into the CREATE2 salt, so the predicted
+  vault address commits to the initial policy — co-owners approving the creation approve the
+  policy (spec 043 address-preview flow unchanged in shape).
+
+## Frontend wiring
+
+`buildSetupInitializer(owners, threshold, fallbackHandler, { setupTo, setupData })` — new optional
+final argument; defaults (`ZeroAddress`, `0x`) keep the existing initializer byte-identical for
+policy-less vaults (FR-010 / SC-007).

--- a/specs/049-multisig-policy-engine/contracts/SafePolicyGuard.md
+++ b/specs/049-multisig-policy-engine/contracts/SafePolicyGuard.md
@@ -1,0 +1,111 @@
+# Contract: SafePolicyGuard
+
+Singleton, **non-upgradeable**, admin-free Safe v1.4.1 transaction guard enforcing per-vault
+policies (spec 049). One deployment per chain, resolved via
+`getContractAddressForChain('safePolicyGuard', chainId)`. No OpenZeppelin imports.
+
+## Trust model
+
+- **Restriction-only**: can block a Safe transaction; can never initiate, approve, or execute one,
+  and holds no funds.
+- **Authority = the vault itself**: every mutating function requires `msg.sender` to be the Safe
+  whose policy is touched (`NotVault()` otherwise). Threshold approval is therefore inherited from
+  the Safe; the guard has no owner, admin, or upgrade key.
+- **EthTrust-SL target**: L2 (comprehensive tests, documented risks). Accepted risks: 24 h window
+  is fixed-reset (≤ 2× limit across a straddling span, disclosed in UI); unrecognized calldata is
+  constrained by target-allowlist/cooldown but not valued by limits (disclosed).
+
+## Guard interface (called by the Safe)
+
+```solidity
+function checkTransaction(
+    address to, uint256 value, bytes calldata data, uint8 operation,
+    uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken,
+    address payable refundReceiver, bytes calldata signatures, address msgSender
+) external;                                   // reverts on violation; writes accounting state
+function checkAfterExecution(bytes32 txHash, bool success) external; // no-op
+function supportsInterface(bytes4 id) external view returns (bool);  // ERC-165: Guard interface
+```
+
+`msg.sender` is treated as the Safe (`safe = msg.sender`). Evaluation order:
+
+1. **Exempt**: `to == safe` (self-management) or `to == address(this)` (policy config, requires
+   `value == 0`) → return immediately (FR-008 lockout-proofing). Also return if the safe has no
+   enabled rules (guard set but policy cleared).
+2. **Hard denials** (any rule enabled): `operation == 1` (delegatecall) → `DelegatecallBlocked()`;
+   `gasPrice != 0` → `GasRefundBlocked()`.
+3. **Classify**: `(asset, amount, recipient)` =
+   - native: `value > 0` → `(address(0), value, to)` — evaluated in addition to a token action;
+   - token: selector `transfer` → `(to, amount, recipient)`; `transferFrom` → `(to, amount, to_)`;
+     `approve` → `(to, amount, spender)`;
+   - otherwise `(none, 0, to)` (generic call).
+4. **Allowlist** (if enabled): each classified recipient (and the call target for generic calls)
+   must be allowlisted → `RecipientNotAllowed(recipient)`.
+5. **Cooldown** (if set, and the tx is counted — value > 0 or recognized token action):
+   `now - lastCountedTxAt >= cooldown` else `CooldownActive(nextAllowedAt)`; on pass, update
+   `lastCountedTxAt = now`.
+6. **Limits** per counted `(asset, amount)`: reset window if elapsed; then
+   `amount <= perTxLimit` else `PerTxLimitExceeded(asset, amount, limit)`;
+   `spentInWindow + amount <= windowLimit` else
+   `WindowLimitExceeded(asset, attempted, remaining)`; on pass, accumulate `spentInWindow`.
+   Zero-valued rule fields skip their check. Unconfigured assets skip limits entirely.
+
+State written in `checkTransaction` persists even if the Safe's inner call later fails without
+reverting the outer transaction — conservative overcounting, documented (research R3).
+
+## Configuration interface (called BY the Safe as a self-originated tx, or via `PolicyGuardSetup` at creation)
+
+```solidity
+struct RuleConfig { address asset; uint128 perTxLimit; uint128 windowLimit; }
+
+function configureRules(RuleConfig[] calldata limits, uint32 cooldown,
+                        bool allowlistEnabled, address[] calldata allowlistAdd,
+                        address[] calldata allowlistRemove) external;  // full policy write
+```
+
+Validation: allowlist may not end up enabled with zero entries (`EmptyAllowlist()`);
+`cooldown <= 365 days` (`CooldownTooLong()`); asset list bounded (`TooManyAssets()`, ≤ 16);
+allowlist batch bounded (≤ 64 per call). Setting every rule to zero/disabled clears the policy
+(vault may additionally `setGuard(0)` via self-tx to fully detach).
+
+Events (as implemented): `RulesConfigured(safe, asset, perTxLimit, windowLimit)` (one per asset
+entry), `CooldownSet(safe, cooldown)` (on change), `AllowlistEnabled(safe, enabled)` (on toggle),
+`AllowlistChanged(safe, entry, allowed)` (one per entry). Together they drive notifications
+(FR-016) and subgraph-free reads.
+
+## Read interface (client)
+
+```solidity
+function getPolicy(address safe) external view returns (
+    bool hasRules, bool allowlistEnabled, uint32 allowlistCount,
+    uint32 cooldown, uint64 lastCountedTxAt, address[] memory configuredAssets);
+function getAssetRule(address safe, address asset) external view returns (
+    uint128 perTxLimit, uint128 windowLimit, uint128 spentInWindow, uint64 windowStart);
+function getAllowlist(address safe) external view returns (address[] memory);
+function isAllowlisted(address safe, address who) external view returns (bool);
+function remainingInWindow(address safe, address asset) external view returns (uint256); // ∞ → type(uint256).max
+function nextAllowedAt(address safe) external view returns (uint64);
+function previewTransaction(address safe, address to, uint256 value, bytes calldata data,
+    uint8 operation) external view returns (bool ok, bytes memory revertData);
+```
+
+`previewTransaction` runs the same internal evaluation WITHOUT state writes and returns the
+would-be custom-error data (selector + args) so the client decodes one canonical format for both
+pre-flight (FR-012) and post-hoc failure explanation (FR-011).
+
+## Custom errors
+
+`NotVault()`, `DelegatecallBlocked()`, `GasRefundBlocked()`, `RecipientNotAllowed(address)`,
+`CooldownActive(uint64 nextAllowedAt)`, `PerTxLimitExceeded(address asset, uint256 amount,
+uint256 limit)`, `WindowLimitExceeded(address asset, uint256 attempted, uint256 remaining)`,
+`EmptyAllowlist()`, `CooldownTooLong()`, `TooManyAssets()`, `ValueToGuardBlocked()`.
+
+## Security checklist (Constitution I)
+
+- CEI: all checks precede state writes; no external calls anywhere in the guard.
+- Reentrancy: none possible (no external calls; Safe serializes execTransaction).
+- Access control: single rule, `msg.sender == safe`, applied to every mutator.
+- Overflow: solc ^0.8 checked math; `uint128` accumulation guarded by the same checked math.
+- Griefing: a third party cannot mutate another Safe's policy or state; `previewTransaction` is
+  view-only.
+- Slither + security-agent review before merge; unit + integration suites per plan R7.

--- a/specs/049-multisig-policy-engine/contracts/SafePolicyGuard.md
+++ b/specs/049-multisig-policy-engine/contracts/SafePolicyGuard.md
@@ -9,7 +9,8 @@ policies (spec 049). One deployment per chain, resolved via
 - **Restriction-only**: can block a Safe transaction; can never initiate, approve, or execute one,
   and holds no funds.
 - **Authority = the vault itself**: every mutating function requires `msg.sender` to be the Safe
-  whose policy is touched (`NotVault()` otherwise). Threshold approval is therefore inherited from
+  whose policy is touched (config is keyed by `msg.sender`, so an address can only ever write
+  its own policy). Threshold approval is therefore inherited from
   the Safe; the guard has no owner, admin, or upgrade key.
 - **EthTrust-SL target**: L2 (comprehensive tests, documented risks). Accepted risks: 24 h window
   is fixed-reset (≤ 2× limit across a straddling span, disclosed in UI); unrecognized calldata is
@@ -95,7 +96,7 @@ pre-flight (FR-012) and post-hoc failure explanation (FR-011).
 
 ## Custom errors
 
-`NotVault()`, `DelegatecallBlocked()`, `GasRefundBlocked()`, `RecipientNotAllowed(address)`,
+`DelegatecallBlocked()`, `GasRefundBlocked()`, `RecipientNotAllowed(address)`,
 `CooldownActive(uint64 nextAllowedAt)`, `PerTxLimitExceeded(address asset, uint256 amount,
 uint256 limit)`, `WindowLimitExceeded(address asset, uint256 attempted, uint256 remaining)`,
 `EmptyAllowlist()`, `CooldownTooLong()`, `TooManyAssets()`, `ValueToGuardBlocked()`.

--- a/specs/049-multisig-policy-engine/contracts/frontend-integration.md
+++ b/specs/049-multisig-policy-engine/contracts/frontend-integration.md
@@ -1,0 +1,57 @@
+# Frontend Integration Contract (spec 049)
+
+How the Protect (custody) UI consumes the policy engine. All addresses via
+`getContractAddressForChain('safePolicyGuard' | 'policyGuardSetup', chainId)`; `undefined` for
+either ⇒ policy features render their "unsupported on this network" states (FR-013) and custody
+behaves exactly as spec 043.
+
+## `frontend/src/lib/custody/policy.js` (new module)
+
+| Export | Contract |
+|--------|----------|
+| `GUARD_STORAGE_SLOT` | Safe guard slot constant. |
+| `readVaultGuard(address, chainId, provider?)` | `getStorageAt` → guard address or `ZeroAddress`. |
+| `getPolicyStatus(vault, chainId)` | `'none' \| 'managed' \| 'foreign' \| 'unsupported'` — `foreign` when a guard is set but ≠ our `safePolicyGuard` (renders "unrecognized rule — manage with the interface that created it"). |
+| `readPolicy(safeAddress, chainId, provider?)` | Aggregates `getPolicy` + per-asset `getAssetRule` + `getAllowlist` + `nextAllowedAt` into one plain object for rendering (SC-004: one round-trip batch). |
+| `encodeConfigureRules(config)` | Calldata for `configureRules` (used for both the setup helper and change proposals). Validates client-side per FR-015 before encoding. |
+| `buildEnablePolicySetup(chainId, config)` | `{ setupTo, setupData }` for `buildSetupInitializer` (US1). |
+| `buildPolicyChangeTx(safeAddress, chainId, config)` | Safe self-transaction `{ to: guard, value: 0, data }` fed to the existing spec 043 propose/approve queue (US3; FR-007/FR-009 inherited). |
+| `previewPolicy(safeAddress, chainId, { to, value, data, operation })` | Calls `previewTransaction`; returns `{ ok, violation? }`. |
+| `decodePolicyError(revertData)` | Custom-error → `{ rule, message, values }` plain-language mapping (FR-011), shared by preview and failed-execution surfaces. |
+| `describeRules(policy)` | Plain-language strings ("Max 500 USDC per transaction", window semantics disclosure) used by badge/panel. |
+
+## Component contracts
+
+- **`PolicyStep.jsx`** (in `CreateVaultWizard`): optional step; skip ⇒ initializer unchanged
+  (FR-010). Configures native + stable-token limits, allowlist entries, cooldown; shows
+  plain-language summary before deploy (US1-AS1). Gated by network support. Extreme-value warnings
+  per FR-015.
+- **`PolicyBadge.jsx`** (in `VaultList` rows): shield badge + one-line summary for `managed`
+  vaults; "unrecognized guard" marker for `foreign` (US2-AS1).
+- **`PolicyPanel.jsx`** (in `VaultDetail`): full rule list with live state (window consumption,
+  next-allowed time — US2-AS2/AS3); owner-only "propose change" flow rendering **current vs
+  proposed** side-by-side (US3-AS1) and submitting via `buildPolicyChangeTx` + existing proposal
+  queue; attach-first-policy path for `none` vaults on supported networks (US3-AS4:
+  batchless two-step — `setGuard` self-tx then `configureRules` self-tx, queued sequentially,
+  because policy vaults cannot delegatecall MultiSend; order enforced so rules exist before the
+  guard activates? **No** — reverse order: `configureRules` first (inert without guard), then
+  `setGuard` (activates) — no unguarded gap with rules half-set).
+- **`ProposeTransactionForm.jsx`**: before submit, `previewPolicy`; violations render the specific
+  rule + values and do not hard-block submission (US4-AS1; chain remains the enforcer).
+- **Notifications**: guard `RulesConfigured`/`AllowlistChanged`/`AllowlistEnabled` events join the
+  existing `custody` delivery domain watcher (FR-016); blocked executions surface via
+  `decodePolicyError` on the failed proposal-execution path.
+
+## Accessibility & style
+
+Custody CSS patterns (`Custody.css`), WCAG 2.1 AA, vitest-axe coverage for the three new
+components; no emoji icons (NavIcon line-glyph convention).
+
+## Test contract (Vitest)
+
+- `policy.test.js`: encode/decode round-trips, status derivation (all four states), error
+  decoding for every custom error, FR-015 validation.
+- Component suites: PolicyStep (skip path byte-identical initializer; configured path wires
+  setup), PolicyPanel (live state render, foreign guard, change flow ordering), PolicyBadge,
+  ProposeTransactionForm preview integration.
+- Regression: existing custody suites unchanged and green (SC-007).

--- a/specs/049-multisig-policy-engine/data-model.md
+++ b/specs/049-multisig-policy-engine/data-model.md
@@ -1,0 +1,89 @@
+# Data Model: Multisig Policy Engine (spec 049)
+
+All persistent state lives on-chain inside the `SafePolicyGuard` singleton, keyed by Safe (vault)
+address. No backend, no subgraph changes; the client reads views directly.
+
+## Entities
+
+### Policy (per vault)
+
+One record per Safe that has ever configured rules. A vault has zero or one policy; "no policy" is
+the absence of any enabled rule AND the guard not being set on the Safe.
+
+| Field | Type | Meaning / validation |
+|-------|------|----------------------|
+| `allowlistEnabled` | `bool` | Recipient allowlist rule active. May only be enabled with ≥ 1 entry (FR-015). |
+| `allowlistCount` | `uint32` | Number of allowlisted addresses (enumeration support). |
+| `cooldown` | `uint32` seconds | Minimum delay between counted transactions. `0` = rule off. Max bound `365 days` (extreme-value guard, FR-015). |
+| `lastCountedTxAt` | `uint64` | Timestamp of last counted transaction (cooldown state). |
+| `configuredAssets` | `address[]` | Assets with limit rules, for enumeration in the policy view. |
+
+Derived: `hasPolicy(safe)` = any rule enabled. `isPolicyManaged(vault)` (client-side) = Safe's
+guard storage slot == `safePolicyGuard` address for the chain.
+
+### AssetRule (per vault × asset)
+
+Spending limits are per asset; asset `address(0)` = native coin, otherwise ERC-20 address.
+
+| Field | Type | Meaning / validation |
+|-------|------|----------------------|
+| `perTxLimit` | `uint128` | Max counted amount per transaction. `0` = off. Must be > 0 when set (FR-015). |
+| `windowLimit` | `uint128` | Max cumulative counted amount per 24 h window. `0` = off. |
+| `spentInWindow` | `uint128` | Amount consumed in the current window (live state, FR-006). |
+| `windowStart` | `uint64` | Timestamp the current window opened. Window resets when `now ≥ windowStart + 24h`. |
+
+Invariant: `spentInWindow ≤ windowLimit` whenever `windowLimit > 0` (enforced at check time).
+
+### AllowlistEntry (per vault × address)
+
+`mapping(safe => mapping(address => bool))` plus `address[]` per safe for enumeration.
+Effective-recipient resolution (research R3): token `transfer`→recipient, `transferFrom`→recipient,
+`approve`→spender; all other calls → the transaction target `to`.
+
+### Policy-change proposal *(no new on-chain entity)*
+
+A rule change is a standard spec 043 Safe transaction whose `to` is the guard and whose calldata
+is the configuration call. Approval binding to exact content (FR-009) is inherited from Safe's
+`safeTxHash` mechanics; discovery reuses `SafeProposalHub`. The client renders "current vs
+proposed" by decoding the proposal calldata against current views.
+
+### Vault *(existing, spec 043 — unchanged)*
+
+Gains only a client-side derived attribute: `policyStatus` ∈
+`none | managed (our guard) | foreign-guard | unsupported-network`.
+
+## State transitions
+
+```
+(no guard)                 --setup w/ PolicyGuardSetup-->        managed, rules live
+(no guard, existing vault) --self-tx: setGuard + configure-->    managed, rules live
+managed                    --self-tx: configureRules-->          managed, rules changed
+managed                    --self-tx: setGuard(0)-->             no guard (policy removed)
+window: closed             --first counted spend-->              open(windowStart=now)
+window: open, now≥start+24h --any counted spend-->               reset(windowStart=now, spent=amount)
+```
+
+All transitions on the left arrow require the vault's threshold (Safe self-transactions);
+guard-targeted and self-targeted transactions are exempt from fund rules (FR-008), so every
+transition above is reachable regardless of how strict the policy is (SC-003).
+
+## Events (notification feed, FR-016 — `custody` domain)
+
+| Event | Emitted when |
+|-------|--------------|
+| `RulesConfigured(safe, asset, perTxLimit, windowLimit)` | Asset limits set or changed (one per asset, incl. at creation). |
+| `CooldownSet(safe, cooldown)` | Cooldown rule set or changed. |
+| `AllowlistChanged(safe, entry, allowed)` | Allowlist entry added/removed (one per entry). |
+| `AllowlistEnabled(safe, enabled)` | Allowlist rule toggled. |
+| `ChangedGuard(guard)` *(Safe's own event, emitted by `PolicyGuardSetup` in proxy context)* | Guard attached at creation. |
+
+Blocked executions revert (no event); the client reports them from decoded custom errors
+(FR-011) and pre-flight (`previewTransaction`, FR-012).
+
+## Validation rules (config-time, FR-015)
+
+- Allowlist cannot be enabled with zero entries; removing the last entry auto-disables (explicit).
+- `cooldown ≤ 365 days`; limits are `uint128`-bounded and must be non-zero to enable.
+- Config functions revert for `msg.sender` ≠ the Safe being configured (`NotVault()`).
+- UI warns when a configuration is unusually strict (per-tx limit of 0-after-decimals, cooldown
+  > 30 days) before letting the member proceed.

--- a/specs/049-multisig-policy-engine/data-model.md
+++ b/specs/049-multisig-policy-engine/data-model.md
@@ -84,6 +84,7 @@ Blocked executions revert (no event); the client reports them from decoded custo
 
 - Allowlist cannot be enabled with zero entries; removing the last entry auto-disables (explicit).
 - `cooldown ≤ 365 days`; limits are `uint128`-bounded and must be non-zero to enable.
-- Config functions revert for `msg.sender` ≠ the Safe being configured (`NotVault()`).
+- Config functions are scoped to `msg.sender` — an address can only ever write its own
+  policy, so no cross-vault writes exist (no separate error needed).
 - UI warns when a configuration is unusually strict (per-tx limit of 0-after-decimals, cooldown
   > 30 days) before letting the member proceed.

--- a/specs/049-multisig-policy-engine/plan.md
+++ b/specs/049-multisig-policy-engine/plan.md
@@ -1,0 +1,159 @@
+# Implementation Plan: Multisig Policy Engine
+
+**Branch**: `claude/issue-852-speckit-flow-jpxwxa` | **Date**: 2026-07-10 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/049-multisig-policy-engine/spec.md` (GitHub issue #852)
+
+## Summary
+
+Layer an on-chain policy engine over the spec 043 Safe multisig vaults. A single non-upgradeable
+`SafePolicyGuard` contract per chain implements the Safe v1.4.1 transaction-guard interface and
+enforces four opt-in rule types per vault (per-transaction limit, 24-hour-window limit, recipient
+allowlist, cooldown) on every fund movement out of the vault — after owner approvals, before
+execution. Rule configuration is only callable by the vault itself (`msg.sender == safe`), so every
+policy change rides the vault's existing threshold-approval flow. A `PolicyGuardSetup` delegatecall
+helper wires the guard + initial rules into `Safe.setup` so policies are live from a new vault's
+first transaction. The Protect view grows a Policy step in vault creation, a policy panel with live
+rule state on vault detail, policy badges in the vault list, pre-flight violation feedback when
+proposing transactions, and threshold-approved rule-change management — all network-gated via
+`getContractAddressForChain`. Full design rationale in [research.md](./research.md).
+
+## Technical Context
+
+**Language/Version**: Solidity ^0.8.24 (default repo compiler entry, viaIR, optimizer runs=1);
+JavaScript ES modules (React 19, ethers v6, wagmi v3/viem v2)
+
+**Primary Dependencies**: Safe v1.4.1 guard interface (interface replicated locally, no runtime
+dep); `@safe-global/safe-contracts@1.4.1` added as **devDependency** for integration tests only;
+no OpenZeppelin in the new contracts (custody-family precedent: `SafeProposalHub`)
+
+**Storage**: On-chain singleton state in `SafePolicyGuard` keyed by Safe address (rule configs +
+window/cooldown accounting); no backend; vault labels/references stay in the spec 043 encrypted
+backup
+
+**Testing**: Hardhat (`test/custody/*.test.js` unit with `MockSafe`, `test/integration/` with real
+Safe v1.4.1); frontend Vitest + Testing Library (+ vitest-axe for the new UI); Slither on new
+contracts
+
+**Target Platform**: EVM chains where custody is supported — Hardhat/localhost in this feature;
+Mordor (63) → Polygon (137) as ops rollout, matching `CUSTODY_SUPPORTED_CHAIN_IDS`
+
+**Project Type**: Web application (Solidity contracts + React frontend; no subgraph change — reads
+are direct RPC, consistent with spec 043's on-chain-only discovery)
+
+**Performance Goals**: Policy view renders complete rule state within 5 s (SC-004) — one
+`getPolicy` multicall-style read per vault; guard adds bounded gas to `execTransaction`
+(no unbounded loops; allowlist is O(1) mapping lookups)
+
+**Constraints**: Lockout-proof by construction (FR-008/SC-003); zero regression for policy-less
+vaults (FR-010/SC-007 — guard not set ⇒ Safe behavior byte-identical); no delegatecall and no gas
+refunds on policy-enabled vaults (documented v1 limitation); addresses resolved only via generated
+sync artifacts
+
+**Scale/Scope**: 2 new contracts (~350 lines total) + 1 test mock; ~6 frontend components
+touched/added; 2 deployment keys; no schema/subgraph changes
+
+## Constitution Check
+
+*GATE: evaluated against `.specify/memory/constitution.md` v1.0.0 — PASS (pre-Phase-0 and
+re-checked post-Phase-1).*
+
+- **I. Security-First (fund custody path — highest risk)**: PASS. Guard is restriction-only (can
+  block, never move funds); CEI respected (`checkTransaction` writes accounting state then
+  reverts-or-returns; no external calls out of the guard; `PolicyGuardSetup` external call is the
+  final action of setup delegatecall); no reentrancy surface (guard is called by the Safe, makes
+  no untrusted calls); explicit reasoning for access control: `msg.sender == safe` is the entire
+  authority model — no admin, no upgrade key, nothing to compromise. Delegatecall + gas-refund
+  denial closes the two known guard-bypass channels; `approve` counting closes allowance-drain.
+  Slither + security-agent review before merge; EthTrust-SL L2 target documented in the contract
+  doc. Accepted-risk register (documented in contract doc + UI): fixed window ≤2× straddle,
+  unrecognized-calldata value moves constrained only by allowlist/target rules.
+- **II. Test-First & Coverage**: PASS. Unit (MockSafe) + integration (real Safe 1.4.1) suites
+  specified per acceptance scenario, incl. failure/edge paths (window boundary, lockout attempt,
+  stale approvals, foreign guard). Frontend Vitest for policy lib + each new component. Spec 043
+  suites must stay green (SC-007).
+- **III. Honest State**: PASS. All policy reads from chain; window semantics disclosed in UI;
+  pre-flight uses the guard's own `previewTransaction` so client display cannot drift from
+  enforcement; foreign guards surfaced as "unrecognized", never hidden; network-scoped via
+  per-chain addresses.
+- **IV. Fail Loudly in CI**: PASS. No CI policy changes; new tests join existing gates;
+  `check:storage-layout` untouched (no proxy).
+- **V. Accessible, Consistent Frontend**: PASS. New UI follows custody component/CSS patterns,
+  WCAG 2.1 AA (axe tests), addresses/ABIs only via sync artifacts + `getContractAddressForChain`.
+- **Additional constraints**: Solidity+Hardhat / React+Vite+Vitest only — the one new
+  devDependency (`@safe-global/safe-contracts`, tests only) is justified in research R7. Deploy
+  script + `deployments/` recording per convention. No archived-code imports.
+- **Deviation from CLAUDE.md upgradeable-contract guidance**: `SafePolicyGuard` is deliberately
+  **non-upgradeable** — see Complexity Tracking.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/049-multisig-policy-engine/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions R1–R8
+├── data-model.md        # Phase 1 — entities & state
+├── quickstart.md        # Phase 1 — validation guide
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (passed)
+├── contracts/           # Phase 1 — interface contracts
+│   ├── SafePolicyGuard.md
+│   ├── PolicyGuardSetup.md
+│   └── frontend-integration.md
+└── tasks.md             # Phase 2 (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+contracts/
+├── custody/
+│   ├── SafeProposalHub.sol          # existing (spec 043)
+│   ├── SafePolicyGuard.sol          # NEW — singleton guard + policy state
+│   └── PolicyGuardSetup.sol         # NEW — Safe.setup delegatecall helper
+└── mocks/
+    └── MockSafe.sol                 # NEW — test-only Safe guard-flow harness
+
+test/
+├── custody/
+│   ├── SafePolicyGuard.test.js      # NEW — unit (rules, exemptions, errors, views)
+│   └── PolicyGuardSetup.test.js     # NEW — unit (delegatecall wiring)
+└── integration/
+    └── policy-guard-safe.test.js    # NEW — real Safe v1.4.1 end-to-end
+
+scripts/deploy/custody/
+└── deploy-policy-guard.js           # NEW — deploy + record both addresses
+
+frontend/src/
+├── abis/
+│   └── SafePolicyGuard.js           # NEW — synced/curated ABI (+ setup helper ABI)
+├── config/
+│   └── contracts.js                 # + safePolicyGuard / policyGuardSetup keys (via sync)
+├── lib/custody/
+│   ├── policy.js                    # NEW — reads, encoding, preview, error decoding
+│   └── safeVault.js                 # + optional setupTo/setupData in initializer
+├── components/custody/
+│   ├── PolicyStep.jsx               # NEW — wizard step
+│   ├── PolicyPanel.jsx              # NEW — detail view rules + live state + change flow
+│   ├── PolicyBadge.jsx              # NEW — vault list summary
+│   ├── CreateVaultWizard.jsx        # + Policy step
+│   ├── VaultDetail.jsx              # + PolicyPanel
+│   ├── VaultList.jsx                # + PolicyBadge
+│   ├── ProposeTransactionForm.jsx   # + pre-flight preview
+│   └── Custody.css                  # + policy styles
+└── test/custody/                    # NEW Vitest suites for all of the above
+```
+
+**Structure Decision**: Web application layout already in place — contracts under
+`contracts/custody/` beside their spec 043 sibling, frontend inside the existing custody feature
+folder, tests mirroring source per repo convention. No new top-level directories.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| New contract does NOT inherit `UUPSManaged` (deviates from CLAUDE.md upgradeable-contracts guidance) | A fund-restriction guard must be immutable to be trustworthy: any upgrade key is a backdoor that can rewrite every vault's enforcement | UUPS proxy would satisfy the guidance but inverts the trust model; future rule types ship as a new guard version that vaults adopt via threshold-approved `setGuard` |
+| New devDependency `@safe-global/safe-contracts@1.4.1` | Integration tests must exercise the real `execTransaction` guard calling convention, ERC-165 `setGuard` check, and `setup` delegatecall | MockSafe alone cannot prove compatibility with the actual Safe bytecode the vaults run; vendoring sources copies ~15 files into the repo for the same result |

--- a/specs/049-multisig-policy-engine/quickstart.md
+++ b/specs/049-multisig-policy-engine/quickstart.md
@@ -1,0 +1,68 @@
+# Quickstart: Multisig Policy Engine (spec 049)
+
+Runnable validation that the feature works end-to-end. See [data-model.md](./data-model.md) and
+[contracts/](./contracts/) for details; this is a validation guide, not implementation doc.
+
+## Prerequisites
+
+```bash
+npm ci                      # root deps (includes @safe-global/safe-contracts devDep)
+npm run compile             # contracts build clean
+```
+
+## 1. Contract suites
+
+```bash
+npx hardhat test test/custody/SafePolicyGuard.test.js test/custody/PolicyGuardSetup.test.js
+npx hardhat test test/integration/policy-guard-safe.test.js
+npm test                    # full suite — spec 043 custody tests must stay green (SC-007)
+```
+
+Expected: every FR-002 rule combination enforced (SC-002); exemption paths prove a max-strict
+policy still accepts self/guard-targeted transactions (SC-003); real-Safe integration creates a
+vault with `PolicyGuardSetup`, blocks an over-limit `execTransaction` with the typed error, and
+executes a threshold-approved `configureRules` change.
+
+## 2. Static analysis
+
+```bash
+npm run slither 2>/dev/null || slither contracts/custody/SafePolicyGuard.sol contracts/custody/PolicyGuardSetup.sol
+```
+
+Expected: no new high/critical findings.
+
+## 3. Local deployment + sync
+
+```bash
+npx hardhat node &
+npx hardhat run scripts/deploy/custody/deploy-policy-guard.js --network localhost
+npm run sync:frontend-contracts:local
+```
+
+Expected: `deployments/` gains `safePolicyGuard` + `policyGuardSetup`; frontend config resolves
+both via `getContractAddressForChain(..., 1337)`.
+
+## 4. Frontend suites
+
+```bash
+npm run test:frontend
+```
+
+Expected: `policy.test.js` + PolicyStep/PolicyPanel/PolicyBadge/ProposeTransactionForm suites pass
+including axe checks; existing custody suites untouched.
+
+## 5. Manual walkthrough (dev server)
+
+```bash
+npm run frontend
+```
+
+1. Protect → Create vault → Policy step: set per-tx limit + allowlist → deploy → detail view shows
+   the exact rules (US1).
+2. Vault list shows the policy badge; a policy-less vault shows none (US2).
+3. Propose a transfer exceeding the limit → pre-flight names the rule and amount (US4); submit
+   anyway + approve to threshold → execution blocked with the same message (US1-AS4).
+4. Propose a rule change; second owner sees current-vs-proposed; approve to threshold → panel
+   reflects the new rules (US3).
+5. Switch to an unsupported network → Policy step and panel show "unsupported", custody still
+   works (FR-013).

--- a/specs/049-multisig-policy-engine/research.md
+++ b/specs/049-multisig-policy-engine/research.md
@@ -1,0 +1,199 @@
+# Research: Multisig Policy Engine (spec 049)
+
+All Technical Context unknowns resolved. Each decision: what was chosen, why, and what else was
+evaluated.
+
+## R1. Enforcement mechanism — Safe transaction guard
+
+**Decision**: Enforce rules with the Safe v1.4.1 **transaction guard** mechanism. A single
+`SafePolicyGuard` contract (one deployment per chain) implements the Safe `Guard` interface
+(`checkTransaction` / `checkAfterExecution` + ERC-165 `supportsInterface`). A vault opts in by
+setting the guard (`Safe.setGuard`, a threshold-approved self-transaction, or at creation — see
+R4). The Safe calls `checkTransaction` before executing **every** transaction, so an approved
+transaction that violates a rule reverts and never executes (FR-003).
+
+**Rationale**: Guards are the only Safe-native hook that runs *after* approvals and *before*
+execution — exactly the spec's "constrain funds even after the owners have approved". They cannot
+initiate transactions (unlike modules), so the guard adds restriction without adding a new
+spending authority. Spec 043 vaults are stock Safe v1.4.1, which ships guard support.
+
+**Alternatives considered**:
+- *Safe module* — rejected: modules grant extra execution paths (they can move funds bypassing
+  signatures); the security direction is backwards for a restriction feature.
+- *Per-vault guard deployments* — rejected: per-vault code costs gas, sprawls addresses,
+  complicates `getContractAddressForChain` resolution, and makes rule reads N-contract instead of
+  one indexed singleton.
+- *Zodiac (Gnosis Guild) guard framework* — rejected: heavyweight dependency for four rules; repo
+  precedent (SafeProposalHub) favors small dependency-free custody contracts.
+- *Client-side-only checks* — rejected: violates FR-003 (on-chain enforcement) and Constitution
+  III (honest state); a colluding threshold could ignore the client.
+
+## R2. Configuration authority — `msg.sender == safe`, no admin, non-upgradeable
+
+**Decision**: All rule mutations on `SafePolicyGuard` require `msg.sender` to be the Safe whose
+policy is being changed. There is no owner, no admin role, and **no upgradeability** (plain
+non-proxy contract).
+
+**Rationale**: A policy config call therefore only ever happens as a Safe **self-originated
+transaction**, which already requires the vault's approval threshold — FR-007 falls out of the
+mechanism with zero new approval plumbing, reusing spec 043's proposal queue for proposing and
+approving the change (US3). No admin means no third party can weaken any vault's rules; the trust
+model of a fund-restriction contract demands immutability of the enforcement logic itself.
+
+**Constitution/CLAUDE.md note**: the "new upgradeable contracts MUST inherit `UUPSManaged`" rule
+applies to contracts that need in-place logic evolution at a stable address. The guard is
+deliberately **not** upgradeable — an upgradable guard would let an upgrade key rewrite every
+vault's enforcement. Future rule types ship as a new guard version; vaults migrate via a
+threshold-approved `setGuard` change. `check:storage-layout` is not applicable (no proxy).
+
+**Alternatives considered**: UUPS guard (rejected — upgrade key becomes a policy backdoor);
+per-vault `Ownable` config (rejected — a single owner could weaken rules, violating FR-007).
+
+## R3. Rule semantics
+
+**Decision** (all state keyed by `safe` address inside the singleton):
+
+- **Counted assets**: spending limits are **per-asset**. Asset key `address(0)` = native coin;
+  any ERC-20 address may carry its own limits (UI offers native + the platform stable token).
+  A Safe transaction is "counted" against an asset when it (a) carries native `value` (asset 0),
+  or (b) calls a token with selector `transfer(address,uint256)`,
+  `transferFrom(address,address,uint256)`, or `approve(address,uint256)` (approvals are spending
+  grants — counting them closes the approve-then-pull bypass). Tokens with no configured limit
+  pass through limit rules unvalued (spec assumption) but still face allowlist/delay.
+- **Per-transaction limit**: counted amount ≤ `perTxLimit[safe][asset]` when set (0 = unset).
+- **24-hour window limit**: window opens at first counted spend (`windowStart`), accumulates
+  `spentInWindow`, and resets when `block.timestamp >= windowStart + 24h`. Not a true rolling
+  window — bounded at ≤ 2× limit across any straddling 24 h span; disclosed in the policy view
+  (spec FR-002 wording updated accordingly).
+- **Recipient allowlist**: when enabled, the **effective recipient** must be allowlisted. The
+  effective recipient is the decoded token recipient (`transfer` → `to`, `transferFrom` → `to`,
+  `approve` → `spender`) for token calls, otherwise the Safe transaction's target `to` (covers
+  native transfers *and* arbitrary contract calls, so unknown calldata cannot escape to
+  un-allowlisted contracts). Enabling requires ≥ 1 entry (lockout edge case).
+- **Cooldown**: `block.timestamp - lastCountedTxAt >= cooldown` for counted transactions;
+  non-fund calls (no value, unrecognized selector) are not rate-limited.
+- **Hard denials while a policy is active** (any rule enabled):
+  - `operation == DELEGATECALL` is rejected. Delegatecall executes foreign code in the Safe's
+    own context and can bypass any guard accounting (and rewrite the guard slot). Consequence:
+    **MultiSend batching is unavailable on policy-enabled vaults in v1** (spec 043 flows are
+    single-call, so nothing regresses).
+  - Gas-refund escrows are rejected (`gasPrice != 0` in `execTransaction`) — refunds pay
+    `refundReceiver` from the vault, an uncounted outflow. Spec 043 builds transactions with
+    refunds zeroed, so nothing regresses.
+- **Exemptions (lockout-proofing, FR-008)**: transactions whose target is the **Safe itself**
+  (owner/threshold/guard management) or the **guard** (policy configuration) bypass all fund
+  rules. Both remain threshold-gated by the Safe itself. Guard-targeted calls must carry zero
+  native value (guard is non-payable anyway). This makes SC-003 structural: a loosening change is
+  always executable.
+- **Accounting timing**: window/cooldown state is written in `checkTransaction` (guards may write
+  state; the Safe reverts the whole `execTransaction` if the guard reverts). If the *inner* call
+  fails without reverting the outer transaction, the spend still counts — conservative
+  overcounting only ever restricts, never permits; documented in the contract and UI.
+  `checkAfterExecution` is a no-op. This avoids fragile commit/rollback machinery.
+
+**Alternatives considered**: true rolling window (per-tx timestamp queue — unbounded gas,
+rejected); valuing arbitrary calldata via oracles (out of scope, dishonest precision); decoding
+MultiSend batches in-guard (scope creep, v2 candidate); blanket denial of unrecognized calldata
+(would break wagering/DEX integrations that operate-as-vault relies on — allowlist rule gives
+groups that lockdown opt-in instead).
+
+## R4. Policy at creation — `PolicyGuardSetup` delegatecall helper
+
+**Decision**: A tiny `PolicyGuardSetup` contract is the `to`/`data` delegatecall target of
+`Safe.setup(...)`. Executing in the new proxy's context it (1) stores the guard address in the
+Safe's guard storage slot (`keccak256("guard_manager.guard.address")`), (2) emits Safe's
+`ChangedGuard` event signature for indexer parity, and (3) `call`s
+`SafePolicyGuard.configureRules(...)` — during that call `msg.sender` **is the new Safe**, so the
+same authority rule as R2 covers creation with zero special cases. Rules are live before the
+vault's first transaction (US1). `buildSetupInitializer` in `frontend/src/lib/custody/safeVault.js`
+gains optional `setupTo`/`setupData` parameters (defaults preserve the current initializer
+byte-for-byte, so existing vault address prediction and tests are untouched).
+
+**Rationale**: `setGuard` after creation would leave a rule-free gap and require a second
+threshold approval round; Safe's own `setup` delegatecall hook exists precisely for this pattern
+(Zodiac and Safe module setups use it). The CREATE2 address prediction already hashes the full
+initializer, so policy-at-creation composes with the existing deterministic-address preview.
+
+**Alternatives considered**: post-create `setGuard` proposal auto-queued by the wizard (rejected
+as primary path — violates US1 acceptance scenario 2 "active immediately"; retained as the US3
+flow for *existing* vaults); custom factory wrapping SafeProxyFactory (rejected — changes the
+vault deployment path spec 043 shipped and its address derivation).
+
+## R5. Violation reporting & pre-flight
+
+**Decision**: `checkTransaction` reverts with typed custom errors carrying the rule and values
+(e.g. `PerTxLimitExceeded(asset, amount, limit)`, `RecipientNotAllowed(recipient)`,
+`CooldownActive(nextAllowedAt)`, `WindowLimitExceeded(asset, attempted, remaining)`) so the UI
+can decode *which rule blocked and by how much* (FR-011). For pre-flight (US4/FR-012) the guard
+exposes a **read-only twin** `previewTransaction(safe, to, value, data, operation) view returns
+(bool ok, bytes4 ruleErrorSelector, ...detail)` sharing the internal rule evaluation, so the
+client never re-implements rule logic and cannot drift from enforcement. Live rule state for the
+policy view (FR-006) comes from views: `getPolicy(safe)`, `getAssetRule(safe, asset)`,
+`getAllowlist(safe)`, `remainingInWindow(safe, asset)`, `nextAllowedAt(safe)`.
+
+**Alternatives considered**: client-side simulation via `eth_call` of `checkTransaction`
+(rejected: it writes state and its revert data would need brittle decoding); duplicating rule
+logic in JS (rejected: drift risk — JS keeps only thin formatting).
+
+## R6. Frontend integration
+
+**Decision**: Extend spec 043 surfaces in place:
+- `frontend/src/lib/custody/policy.js` — encode `configureRules`/allowlist calls, read policy
+  views, decode guard errors, `previewTransaction` wrapper, guard-slot read
+  (`getStorageAt(GUARD_SLOT)`) to detect foreign guards.
+- `CreateVaultWizard` gains an optional **Policy step** (network-gated); it switches the
+  initializer to the `PolicyGuardSetup` path when rules are configured.
+- `VaultDetail` gains a **PolicyPanel**: plain-language rules, live window/cooldown state,
+  "unrecognized guard" notice for foreign guards (edge case), and — for owners — a rule-change
+  flow that builds a Safe **self-transaction** targeting the guard and hands it to the existing
+  spec 043 proposal queue (current vs proposed side-by-side; approvals bind to exact calldata via
+  the existing safeTxHash mechanics, satisfying FR-009).
+- `VaultList` rows show a policy badge with a one-line rule summary (FR-006).
+- `ProposeTransactionForm` runs `previewTransaction` pre-flight and renders violations (US4).
+- Network gating via `getContractAddressForChain('safePolicyGuard', chainId)` /
+  `('policyGuardSetup', chainId)` — `undefined` renders the "policy unsupported on this network"
+  states (FR-013).
+- Notifications: policy events (`RulesConfigured`, `AllowlistChanged`) join the existing
+  **`custody`** notification domain (`frontend/src/lib/notifications/deliveryPreferences.js`
+  already defines it) via the same event-watching path spec 043 uses; blocked-execution feedback
+  surfaces from decoded revert errors (FR-016).
+
+**Alternatives considered**: a separate top-level "Policies" page (rejected: issue asks the
+existing Protect view to become the portal; vault-centric placement matches how members think).
+
+## R7. Contract testing strategy
+
+**Decision**: Two layers under `test/custody/`:
+1. **Unit** — `SafePolicyGuard.test.js` + `PolicyGuardSetup.test.js` against a minimal
+   `contracts/mocks/MockSafe.sol` that mimics the Safe's guard flow (`checkTransaction` →
+   inner call → `checkAfterExecution`), its guard storage slot, and a `setupDelegate` entry to
+   exercise the setup helper under real delegatecall. Exhaustive rule/edge coverage (every FR-002
+   combination, exemptions, delegatecall/gas-refund denial, window reset boundaries, error data).
+2. **Integration** — `test/integration/policy-guard-safe.test.js` deploying the **real Safe
+   v1.4.1** (add `@safe-global/safe-contracts@1.4.1` as a devDependency; pragma `>=0.7.0 <0.9.0`
+   compiles under the repo's solc 0.8.24 entry): create a vault through `SafeProxyFactory` with
+   the `PolicyGuardSetup` initializer, run `execTransaction` happy/blocked paths, change policy
+   via self-transaction, verify ERC-165 `setGuard` acceptance for attach-to-existing-vault.
+
+Slither runs on the new contracts (Constitution I); fuzz-worthy state (window accounting) gets
+property-style unit tests. Fallback documented: if the devDependency fights the compiler matrix,
+vendor the handful of Safe 1.4.1 sources under `contracts/mocks/vendor/` (test-only).
+
+**Rationale**: MockSafe keeps the fast suite dependency-free (SafeProposalHub precedent); the
+real-Safe integration layer is required because the guard's whole contract surface is the Safe's
+calling convention — Constitution II calls for integration tests where external protocols are
+involved.
+
+## R8. Deployment & address plumbing
+
+**Decision**: `scripts/deploy/custody/deploy-policy-guard.js` (mirrors
+`deploy-safe-proposal-hub.js`) deploys `SafePolicyGuard` + `PolicyGuardSetup`, records
+`safePolicyGuard` / `policyGuardSetup` in `deployments/<network>-chain<id>-v2.json`, and
+`npm run sync:frontend-contracts` propagates them to `frontend/src/config/contracts.js`
+(`NETWORK_CONTRACTS`). Rollout follows the platform sequence: hardhat/localhost in this feature;
+Mordor then Polygon as ops steps (runbook note). Solidity `^0.8.24` under the default compiler
+entry (ETC Spiral supports shanghai opcodes; SafeProposalHub precedent). No OpenZeppelin imports
+(guard needs none; keeps the custody family dependency-free).
+
+**Alternatives considered**: hand-adding addresses to `contracts.js` (forbidden — Constitution V:
+sync artifacts only).

--- a/specs/049-multisig-policy-engine/spec.md
+++ b/specs/049-multisig-policy-engine/spec.md
@@ -1,0 +1,316 @@
+# Feature Specification: Multisig Policy Engine
+
+**Feature Branch**: `049-multisig-policy-engine`
+
+**Created**: 2026-07-10
+
+**Status**: Draft
+
+**Input**: User description: "Multisig policy engine (GitHub issue #852). Members need a way to set
+policy on their account and on multisig accounts. As a member I want the capability to set policies
+for multisig accounts created using the Protect on-chain multisigs. The 'Protect' view needs to be a
+professional policy management portal where an account can deploy multisig accounts with configurable
+rules that control the funds based on a policy engine. I want to be able to see account policies for
+multisigs I am associated with and manage rules for deployed contracts in a clean modern UX."
+
+## Overview
+
+FairWins members can already create and operate shared multisig vaults from the **Protect** view
+(spec 043): several owners jointly control funds, and any movement of money out of the vault needs a
+threshold of owner approvals. Approvals are the only control, though — once enough owners sign,
+*any* transaction goes through, for any amount, to any destination, at any time.
+
+This feature adds a **policy engine**: a set of configurable, on-chain-enforced rules attached to a
+vault that constrain what the vault's funds can do *even after the owners have approved a
+transaction*. A policy is chosen when the vault is created (or attached later with the owners'
+consent), is visible to every member associated with the vault, and can only be changed with the
+same collective consent that moving money requires. The Protect view grows into a professional
+policy management portal: members deploy vaults with rules, see at a glance which rules govern each
+vault they belong to, and manage those rules over the vault's life in a clean, modern UX.
+
+The rules in scope for v1 are the classic treasury controls:
+
+- **Per-transaction spending limit** — no single outgoing transaction may exceed a set amount.
+- **Daily spending limit** — total outgoing value within a 24-hour accounting window may not
+  exceed a set amount (the window opens with the first counted spend and resets 24 hours later).
+- **Recipient allowlist** — outgoing transfers may only go to a defined set of addresses.
+- **Transaction delay (cooldown)** — a minimum time must pass between consecutive outgoing
+  transactions.
+
+Each rule is individually optional; a vault may have none, one, or several. Rules constrain only
+movements of funds **out of** the vault — receiving funds is never restricted (consistent with the
+custody feature's "only outbound movements need approval" principle).
+
+## Clarifications
+
+### Session 2026-07-10
+
+- Q: The issue says members set policy "on their account and on multisig accounts" — does v1 cover
+  personal (single-signer) accounts? → A: **Multisig vaults only.** Both acceptance scenarios in the
+  issue concern multisigs, and rules on a personal account cannot be enforced on-chain the way vault
+  rules can (a single signer can always bypass a self-imposed client-side rule). Personal-account
+  policies are recorded as a future extension (see Out of Scope).
+- Q: Can a policy be edited after the vault is deployed, and by whom? → A: **Yes, with collective
+  consent.** A rule change is proposed by any owner and takes effect only after the vault's own
+  approval threshold is met — the same bar as moving money. No single owner (including the creator)
+  can weaken or remove rules unilaterally.
+- Q: What happens if a policy would block the owners from ever moving funds (lockout)? → A:
+  **Policy management itself is never blocked by fund rules.** Rules constrain fund movements only;
+  proposing and approving a rule change is always possible, so owners can always loosen a policy
+  that turned out to be too strict. A vault can therefore never be permanently locked by its own
+  policy.
+- Q: Do policies apply to vaults created before this feature ships? → A: **Yes, opt-in.** An
+  existing vault has no policy by default; its owners may attach one through the same
+  threshold-approved change flow.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Attach a policy while creating a vault (Priority: P1)
+
+A member opens **Protect** and creates a new shared vault. As part of the creation flow, they reach
+a **Policy** step where they can enable and configure rules — a per-transaction limit, a daily
+limit, a recipient allowlist, and/or a transaction delay — or skip the step for an unrestricted
+vault. When the vault is created, the chosen rules are live on-chain from the vault's first
+transaction onward.
+
+**Why this priority**: This is acceptance scenario 1 of the issue and the core of the feature —
+policy at creation is the moment of highest leverage, because the rules are in force before any
+funds arrive.
+
+**Independent Test**: Create a vault with a per-transaction limit of 100 units and a two-address
+allowlist; confirm the vault deploys, the policy is shown on the vault's detail view, and an
+approved transaction that violates either rule does not execute while a compliant one does.
+
+**Acceptance Scenarios**:
+
+1. **Given** a connected member creating a vault in Protect, **When** they reach the Policy step,
+   **Then** they can enable any combination of the four rule types, configure each enabled rule's
+   parameters, and see a plain-language summary of the policy before deploying.
+2. **Given** a member who configures a policy and deploys the vault, **When** the vault is created
+   on-chain, **Then** the policy is active immediately and appears on the vault's detail view with
+   the exact configured parameters.
+3. **Given** a member who skips the Policy step, **When** the vault is created, **Then** the vault
+   behaves exactly as today (threshold approvals only, no rules) and its detail view shows "no
+   policy".
+4. **Given** a policy-enabled vault with a fully approved outgoing transaction that violates a rule
+   (e.g. exceeds the per-transaction limit), **When** execution is attempted, **Then** the
+   transaction does not execute and the member is told which rule blocked it.
+
+---
+
+### User Story 2 - See the rules that govern my vaults (Priority: P1)
+
+A member opens Protect and sees, for every vault they are associated with, whether it has a policy
+and what that policy is. Opening a vault shows a clear, plain-language view of each active rule and
+its parameters (e.g. "Max 500 USDC per transaction", "Recipients limited to 3 approved addresses"),
+plus live rule state where relevant (e.g. how much of today's daily limit is already spent, when
+the next transaction is allowed).
+
+**Why this priority**: This is acceptance scenario 2 of the issue. Rules that members cannot see
+are not a policy — visibility is what makes the constraint trustworthy for co-owners.
+
+**Independent Test**: Load a policy-enabled vault as a co-owner; confirm the policy summary appears
+in the vault list and every rule with its parameters and current state renders on the detail view,
+matching on-chain values.
+
+**Acceptance Scenarios**:
+
+1. **Given** a member with two vaults (one with a policy, one without), **When** they open Protect,
+   **Then** the vault list distinguishes the policy-governed vault and summarizes its rules.
+2. **Given** a co-owner viewing a policy-enabled vault, **When** they open its policy view, **Then**
+   every active rule is shown with its parameters, in plain language, matching the on-chain state.
+3. **Given** a vault with a daily limit partially consumed, **When** a member views the policy,
+   **Then** they see how much of the limit is used and remaining for the current window.
+4. **Given** a member who loads by address an existing vault that another interface gave a policy,
+   **When** the vault is loaded, **Then** its rules are read from the chain and displayed the same
+   as rules created in-app.
+
+---
+
+### User Story 3 - Manage rules on a deployed vault (Priority: P2)
+
+An owner of a deployed vault proposes a policy change — adding a rule, adjusting a parameter,
+removing a rule, or attaching a first policy to a vault that has none. Co-owners see the proposed
+change side-by-side with the current policy and approve or ignore it. Once the vault's approval
+threshold is met, the change executes and the new rules are in force.
+
+**Why this priority**: Policies must evolve with the group (new payees, changed budgets), but this
+builds on US1/US2 — a vault whose policy can be seen and set at creation is already valuable.
+
+**Independent Test**: On a 2-of-3 vault with a 100-unit per-transaction limit, propose raising the
+limit to 200; confirm the change is inert after one approval, live after two, and that the policy
+view reflects the new limit.
+
+**Acceptance Scenarios**:
+
+1. **Given** an owner of a policy-enabled vault, **When** they propose a rule change, **Then**
+   co-owners can see the current and proposed policy side by side before approving.
+2. **Given** a proposed policy change with fewer approvals than the vault's threshold, **When** a
+   member checks the vault, **Then** the current policy remains in force unchanged.
+3. **Given** a proposed policy change that reaches the vault's threshold, **When** it executes,
+   **Then** the new rules govern the very next outgoing transaction and the policy view updates.
+4. **Given** a vault with no policy, **When** its owners complete the same change flow to attach
+   one, **Then** the vault becomes policy-governed without redeployment or moving funds.
+5. **Given** a vault whose policy is so strict no funds can move, **When** owners propose and
+   approve a loosening change, **Then** the change executes despite the rules (policy management is
+   never blocked by fund rules).
+
+---
+
+### User Story 4 - Pre-flight policy feedback when proposing transactions (Priority: P3)
+
+When a member proposes an outgoing transaction from a policy-enabled vault, the app checks the
+transaction against the vault's rules *before* it is proposed and warns which rule it would violate
+(e.g. "exceeds today's remaining daily limit by 40 USDC"). The member can adjust the transaction or
+proceed knowing it will be blocked at execution.
+
+**Why this priority**: Quality-of-life on top of enforcement. The chain blocks violations with or
+without this story; pre-flight feedback saves co-owners from approving doomed transactions.
+
+**Independent Test**: On a vault with a recipient allowlist, draft a transfer to a non-allowlisted
+address; confirm the violation warning appears before proposal, names the rule, and disappears when
+the recipient is changed to an allowlisted address.
+
+**Acceptance Scenarios**:
+
+1. **Given** a policy-enabled vault, **When** a member drafts a transaction that violates a rule,
+   **Then** the specific violated rule and the violating value are shown before the proposal is
+   submitted.
+2. **Given** a drafted transaction that complies with all rules, **When** the member reviews it,
+   **Then** no policy warning is shown.
+
+---
+
+### Edge Cases
+
+- A policy blocks an approved transaction at execution time even though it passed pre-flight when
+  proposed (e.g. the daily window filled up in between): the member is told which rule blocks it
+  now and that the proposal remains valid to retry later (e.g. next window).
+- An empty recipient allowlist is not silently deny-all: enabling the allowlist rule requires at
+  least one recipient, so owners cannot accidentally freeze the vault.
+- Rule parameters at extremes (zero per-transaction limit, delay of years) are rejected or clearly
+  warned about at configuration time; policy management remains available regardless (lockout-proof
+  by design).
+- A vault created outside the app, or a policy attached by another interface, renders correctly
+  from on-chain state; unknown or unrecognized rule types are surfaced as "unrecognized rule —
+  manage with the interface that created it" rather than hidden.
+- Two policy-change proposals in flight at once: approvals are bound to the exact proposed content,
+  so a stale approval cannot execute a different change than the one the owner saw.
+- Networks where the policy engine is not deployed: vault creation still works with the Policy step
+  shown as unavailable for that network, and existing vaults there show "policy unsupported on this
+  network" instead of erroring.
+- Native-coin and token amounts are limited by the same daily/per-transaction accounting rules the
+  policy defines; the policy view states clearly which assets a limit covers.
+- A member who is not an owner of a vault (mere observer via address) can see its policy but is
+  offered no management actions.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Members MUST be able to attach a policy to a new multisig vault during the creation
+  flow in Protect, before the vault is deployed.
+- **FR-002**: The policy engine MUST support four rule types in v1: per-transaction spending limit,
+  24-hour-window spending limit, recipient allowlist, and minimum delay between outgoing
+  transactions. Each rule is independently optional and configurable. The exact window semantics
+  (when it opens and resets) MUST be disclosed in the policy view.
+- **FR-003**: Rules MUST be enforced on-chain: an outgoing vault transaction that violates any
+  active rule MUST NOT execute, even when it has collected the vault's full approval threshold.
+- **FR-004**: Enforcement MUST apply only to movements of funds out of the vault; receiving funds
+  into the vault MUST never be restricted by policy.
+- **FR-005**: Every member associated with a vault MUST be able to see whether it has a policy, and
+  view each active rule with its parameters in plain language, sourced from on-chain state.
+- **FR-006**: The vault list in Protect MUST distinguish policy-governed vaults and summarize their
+  rules; the vault detail view MUST show full rule details and live rule state (e.g. daily-limit
+  consumption, next-allowed transaction time).
+- **FR-007**: Changing a vault's policy (adding, modifying, or removing rules, or attaching a first
+  policy to an existing vault) MUST require the vault's own approval threshold — the same consent
+  bar as moving funds. No single owner may change policy unilaterally.
+- **FR-008**: Policy management actions MUST NOT be subject to fund-movement rules, so that owners
+  can always loosen or remove a policy that is too strict (a vault can never be permanently locked
+  by its own policy).
+- **FR-009**: Policy-change proposals MUST bind approvals to the exact proposed rule content, so an
+  approval cannot be replayed for a different change.
+- **FR-010**: Vaults with no policy MUST behave exactly as they do today; the policy engine is
+  opt-in per vault and existing vaults are unaffected until their owners attach a policy.
+- **FR-011**: When a transaction is blocked by policy, the member MUST be told which rule blocked it
+  and, where meaningful, by how much (e.g. amount over limit, time remaining).
+- **FR-012**: The app SHOULD check drafted vault transactions against the policy before proposal and
+  surface any violation with the specific rule and value (pre-flight feedback).
+- **FR-013**: Policy availability MUST be network-aware: on networks without the policy engine, the
+  Policy step is shown as unavailable and existing vaults show that policy is unsupported there,
+  without breaking any custody functionality.
+- **FR-014**: Policies and rule states MUST be readable from on-chain state alone, so vaults and
+  policies created or modified by other interfaces render correctly, and no platform-operated
+  backend is required (consistent with the custody feature's on-chain-only discovery principle).
+- **FR-015**: Rule configuration MUST validate parameters at entry (e.g. allowlist requires at
+  least one address, limits must be positive) and warn about configurations that would block all
+  transactions.
+- **FR-016**: All policy events relevant to a member's vaults (policy attached, rule change
+  proposed, rule change executed, transaction blocked by policy) MUST flow into the existing
+  notification/activity system with per-source controls.
+
+### Key Entities
+
+- **Policy**: The set of rules attached to one vault. Exists on-chain; readable by anyone; mutable
+  only through the vault's own approval threshold. A vault has zero or one policy.
+- **Rule**: One constraint within a policy. Has a type (per-transaction limit, daily limit,
+  recipient allowlist, transaction delay), parameters (amount, addresses, duration), and live state
+  (consumed daily amount, last-transaction time).
+- **Policy-change proposal**: A pending request to alter a vault's policy — the exact new rule
+  content plus collected owner approvals. Executes when the vault's threshold is reached; inert
+  before that.
+- **Vault** *(existing, spec 043)*: The multisig account the policy governs. Gains an optional
+  reference to its policy; otherwise unchanged.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A member can configure and deploy a vault with a policy in a single creation flow,
+  adding no more than 2 minutes over policy-less vault creation.
+- **SC-002**: 100% of outgoing transactions that violate an active rule are prevented from
+  executing, in every combination of the four rule types.
+- **SC-003**: 0 vault-lockout states are reachable: for every expressible policy, a threshold of
+  owners can still execute a policy change.
+- **SC-004**: A co-owner opening a policy-enabled vault sees the complete, accurate rule set
+  (matching on-chain state) within 5 seconds on a typical connection.
+- **SC-005**: 100% of policy changes require the vault's approval threshold; none can be performed
+  by a single owner on a multi-owner vault.
+- **SC-006**: Members drafting a rule-violating transaction see the specific violated rule before
+  proposing in at least 95% of cases (pre-flight check coverage).
+- **SC-007**: Existing vaults and all custody flows continue to work unchanged when no policy is
+  attached (zero regressions in the spec 043 acceptance suite).
+
+## Assumptions
+
+- **Scope**: v1 covers policies on multisig vaults only. "Policy on my personal account" from the
+  issue is out of scope because single-signer accounts cannot have rules enforced against their own
+  signer on-chain; it is listed under Out of Scope as a future extension.
+- The four v1 rule types (per-transaction limit, daily limit, recipient allowlist, transaction
+  delay) are the accepted interpretation of "configurable rules that control the funds"; further
+  rule types (e.g. per-asset budgets, role-based limits) can be added later without changing the
+  model members see.
+- Spending-limit rules account value in the vault's primary treasury denominations (native coin and
+  the platform's supported stable token); exotic tokens a limit cannot value pass through limit
+  rules unvalued but remain subject to allowlist and delay rules. The policy view discloses this.
+- The existing vault creation, loading, proposal, and approval flows from spec 043 are reused; this
+  feature layers policy on top rather than replacing custody flows.
+- Policy support follows custody support per network: it is offered only on networks where both the
+  custody contracts and the policy engine are deployed (Mordor first, then Polygon, consistent with
+  the platform's launch sequencing).
+- Vault references and labels remain covered by the app-wide encrypted backup (spec 043); policy
+  state itself lives on-chain and needs no backup.
+- Two policy views exist for non-owners only in read form; policy management surfaces require the
+  connected account to be a vault owner.
+
+## Out of Scope
+
+- Policies on personal (single-signer) accounts — future extension; requires a different
+  enforcement model (e.g. smart-account-based).
+- Off-chain custody policies (the "Off chain" Protect section remains disabled).
+- New rule types beyond the four listed (per-asset budgets, weekly/monthly windows, role-tiered
+  limits, oracle-conditioned rules).
+- Changing anything about vault ownership/threshold mechanics themselves — owners and thresholds
+  are managed exactly as in spec 043.
+- Platform-operated policy services or backends; everything is on-chain plus client.

--- a/specs/049-multisig-policy-engine/tasks.md
+++ b/specs/049-multisig-policy-engine/tasks.md
@@ -1,0 +1,190 @@
+# Tasks: Multisig Policy Engine
+
+**Input**: Design documents from `/specs/049-multisig-policy-engine/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: INCLUDED — Constitution II (test-first) is non-negotiable for fund-custody contracts;
+frontend logic ships with Vitest suites in the same PR.
+
+**Organization**: Grouped by user story; the foundational phase carries the guard contract itself
+because every story enforces or reads it.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1 (policy at creation), US2 (see rules), US3 (manage rules), US4 (pre-flight)
+
+## Phase 1: Setup
+
+- [X] T001 Add `@safe-global/safe-contracts@1.4.1` devDependency to root `package.json` and
+      confirm `npm run compile` still passes (research R7; fallback documented there if the
+      compiler matrix objects).
+
+---
+
+## Phase 2: Foundational (blocking prerequisites)
+
+**⚠️ CRITICAL**: the guard + setup helper + their proofs block every user story.
+
+- [X] T002 Implement `contracts/custody/SafePolicyGuard.sol` per
+      `specs/049-multisig-policy-engine/contracts/SafePolicyGuard.md`: Guard interface +
+      ERC-165, evaluation order (exemptions → delegatecall/gas-refund denial → classify →
+      allowlist → cooldown → limits), `configureRules`, all views incl. `previewTransaction`,
+      typed custom errors, events. No OZ imports; solc ^0.8.24.
+- [X] T003 [P] Implement `contracts/custody/PolicyGuardSetup.sol` per
+      `specs/049-multisig-policy-engine/contracts/PolicyGuardSetup.md` (guard-slot sstore,
+      `ChangedGuard` log parity, configure call in proxy context).
+- [X] T004 [P] Implement `contracts/mocks/MockSafe.sol`: guard-slot storage, `execTransaction`-
+      shaped flow (checkTransaction → inner call → checkAfterExecution), `setupDelegate(to,data)`
+      to exercise the setup helper under delegatecall (test-only).
+- [X] T005 Unit tests `test/custody/SafePolicyGuard.test.js`: every rule alone + combined
+      (SC-002), per-asset limits incl. unconfigured-asset passthrough, window open/accumulate/
+      reset boundaries, cooldown, allowlist recipient resolution (native / transfer /
+      transferFrom / approve / generic call target), exemptions under max-strict policy (SC-003),
+      delegatecall + gas-refund + value-to-guard denials, `NotVault` on config, FR-015 config
+      validation, error argument payloads, `previewTransaction` parity with enforcement,
+      view outputs. Written against MockSafe; must fail before T002 lands, pass after.
+- [X] T006 [P] Unit tests `test/custody/PolicyGuardSetup.test.js`: slot write via delegatecall,
+      ERC-165 rejection of a non-guard, revert bubbles abort setup, direct-call harmlessness.
+- [X] T007 Integration test `test/integration/policy-guard-safe.test.js` with real Safe v1.4.1:
+      factory-create vault with PolicyGuardSetup initializer (rules live pre-first-tx),
+      execTransaction blocked/allowed paths with typed errors, threshold-approved
+      `configureRules` self-tx, `setGuard` ERC-165 attach to an existing vault, policy-less vault
+      byte-identical behavior (SC-007 guard).
+- [X] T008 Deploy script `scripts/deploy/custody/deploy-policy-guard.js` (mirror
+      `deploy-safe-proposal-hub.js`): deploy both contracts, record `safePolicyGuard` +
+      `policyGuardSetup` in `deployments/`, verify `npm run sync:frontend-contracts:local`
+      propagates to `frontend/src/config/contracts.js` `NETWORK_CONTRACTS`.
+- [X] T009 [P] Frontend ABI module `frontend/src/abis/SafePolicyGuard.js` (guard ABI incl.
+      errors + events + views, and `PolicyGuardSetup` `enablePolicy` fragment).
+- [X] T010 Frontend policy lib `frontend/src/lib/custody/policy.js` per
+      `contracts/frontend-integration.md` (status/read/encode/preview/decode/describe exports;
+      network gating via `getContractAddressForChain`).
+- [X] T011 Vitest `frontend/src/test/custody/policy.test.js`: encode/decode round-trips, all four
+      `getPolicyStatus` states, every custom-error decoding, FR-015 client validation,
+      `describeRules` window-semantics disclosure.
+
+**Checkpoint**: enforcement engine proven; UI stories can proceed (largely in parallel).
+
+---
+
+## Phase 3: User Story 1 — Attach a policy while creating a vault (P1) 🎯 MVP
+
+**Goal**: Policy step in vault creation; rules live from the vault's first transaction.
+
+**Independent Test**: quickstart §5.1 — create vault with per-tx limit + allowlist, rules render
+on detail, violating approved tx blocked, compliant tx executes.
+
+- [ ] T012 [US1] Extend `buildSetupInitializer` in `frontend/src/lib/custody/safeVault.js` with
+      optional `{ setupTo, setupData }` (defaults byte-identical; update its unit tests in
+      `frontend/src/test/custody/` to pin both paths).
+- [ ] T013 [US1] Implement `frontend/src/components/custody/PolicyStep.jsx` (+ styles in
+      `Custody.css`): enable/configure the four rules, plain-language summary, skip path,
+      network gating, FR-015 warnings.
+- [ ] T014 [US1] Wire PolicyStep into `frontend/src/components/custody/CreateVaultWizard.jsx`
+      (initializer switches to `buildEnablePolicySetup` output when configured; address preview
+      still matches deployment).
+- [ ] T015 [P] [US1] Vitest `frontend/src/test/custody/PolicyStep.test.jsx`: skip ⇒ unchanged
+      initializer, configured ⇒ setup wiring, summary text, unsupported-network state, axe pass.
+- [ ] T016 [US1] Vitest update `frontend/src/test/custody/CreateVaultWizard.test.jsx`: wizard
+      end-to-end with and without policy (US1 acceptance scenarios 1–3).
+
+**Checkpoint**: MVP — policy-governed vaults can be created and are enforced on-chain.
+
+---
+
+## Phase 4: User Story 2 — See the rules that govern my vaults (P1)
+
+**Goal**: Policy visibility in vault list + full live-state policy view on vault detail.
+
+**Independent Test**: quickstart §5.2 — badge on policy vault only; detail shows rules + live
+window/cooldown state matching chain; foreign-guard vault shows "unrecognized" notice.
+
+- [ ] T017 [US2] Implement `frontend/src/components/custody/PolicyBadge.jsx` and render it in
+      `frontend/src/components/custody/VaultList.jsx` (managed summary line; foreign marker).
+- [ ] T018 [US2] Implement `frontend/src/components/custody/PolicyPanel.jsx` (read-only half):
+      plain-language rules, live `remainingInWindow`/`nextAllowedAt`, window-semantics
+      disclosure, foreign-guard and unsupported-network states; mount in
+      `frontend/src/components/custody/VaultDetail.jsx`.
+- [ ] T019 [P] [US2] Vitest `frontend/src/test/custody/PolicyBadge.test.jsx` +
+      `PolicyPanel.test.jsx` (read-only): all four status states, live-state rendering from
+      mocked reads, axe pass (US2 acceptance scenarios 1–4).
+
+**Checkpoint**: co-owners see exactly what the chain enforces.
+
+---
+
+## Phase 5: User Story 3 — Manage rules on a deployed vault (P2)
+
+**Goal**: Threshold-approved rule changes; attach-first-policy to existing vaults; lockout-proof.
+
+**Independent Test**: quickstart §5.4 — propose limit raise on 2-of-3 vault: inert at 1 approval,
+live at 2; attach flow on a policy-less vault; loosening executes under max-strict policy.
+
+- [ ] T020 [US3] Extend `PolicyPanel.jsx` with the owner-only change flow: edit form reusing
+      PolicyStep's rule inputs, current-vs-proposed diff, submit via `buildPolicyChangeTx`
+      through the existing spec 043 proposal queue (`vaultTransaction.js`/`proposalHub.js`).
+- [ ] T021 [US3] Attach-first-policy flow in `PolicyPanel.jsx` for `none` vaults: queue
+      `configureRules` self-tx then `setGuard` self-tx in that order (no unguarded half-set gap
+      — `contracts/frontend-integration.md`).
+- [ ] T022 [US3] Render pending policy-change proposals distinctly in
+      `frontend/src/components/custody/ProposalQueue.jsx` (decode guard-targeted calldata to a
+      human diff; approvals bind to exact calldata — FR-009 inherited, show it).
+- [ ] T023 [P] [US3] Vitest `frontend/src/test/custody/PolicyPanel.change.test.jsx`: diff
+      rendering, queue submission payloads, attach ordering, non-owner sees no management
+      actions, axe pass (US3 acceptance scenarios 1–5).
+
+**Checkpoint**: full policy lifecycle manageable from the portal.
+
+---
+
+## Phase 6: User Story 4 — Pre-flight policy feedback (P3)
+
+**Goal**: Violations named before proposing; chain remains the enforcer.
+
+**Independent Test**: quickstart §5.3 — draft transfer to non-allowlisted address ⇒ named rule
+warning pre-submit; fix recipient ⇒ warning clears.
+
+- [ ] T024 [US4] Integrate `previewPolicy` into
+      `frontend/src/components/custody/ProposeTransactionForm.jsx`: debounce-evaluated warning
+      naming rule + values (via `decodePolicyError`), non-blocking submit, none for compliant or
+      policy-less vaults; surface the same decoder on failed execution paths (FR-011).
+- [ ] T025 [P] [US4] Vitest update `frontend/src/test/custody/ProposeTransactionForm.test.jsx`:
+      violation warning content per rule, clear-on-fix, no-policy silence, axe pass.
+
+---
+
+## Phase 7: Polish & Cross-Cutting
+
+- [ ] T026 [P] Wire guard events (`RulesConfigured`, `AllowlistChanged`, `AllowlistEnabled`) into
+      the existing `custody` notification domain watcher path (FR-016) and cover with a Vitest
+      case alongside the existing custody notification tests.
+- [X] T027 [P] Run Slither over `contracts/custody/SafePolicyGuard.sol` +
+      `PolicyGuardSetup.sol`; resolve or document findings per Constitution I.
+- [X] T028 [P] Developer doc `docs/developer-guide/multisig-policy-engine.md`: architecture,
+      trust model, accepted risks (window straddle, unvalued calldata, no-delegatecall
+      limitation), deployment/rollout runbook note (Mordor → Polygon).
+- [ ] T029 Full verification: `npm run compile`, `npm test`, `npm run test:frontend`, frontend
+      lint — quickstart.md §1–§4 outcomes; confirm spec 043 custody suites untouched (SC-007).
+
+---
+
+## Dependencies & Execution Order
+
+- **Phase 1 → Phase 2**: T001 blocks T007 (real-Safe tests) only; T002 blocks T005/T007/T008;
+  T003 blocks T006/T007; T009/T010 block T011 and all UI stories' logic.
+- **User stories**: US1 (Phase 3) and US2 (Phase 4) are independent of each other after Phase 2;
+  US3 (Phase 5) builds on US2's PolicyPanel; US4 (Phase 6) is independent after Phase 2.
+- **Polish** last; T029 is the gate for the PR.
+
+### Parallel opportunities
+
+- T003, T004 alongside T002 groundwork; T006, T009 while T005 runs; after Phase 2: Phases 3, 4,
+  and 6 can proceed in parallel; T026–T028 in parallel before T029.
+
+## Implementation Strategy
+
+MVP = Phases 1–3 (enforced policy at creation). Incremental: +Phase 4 (visibility), +Phase 5
+(management), +Phase 6 (pre-flight), then polish. Each checkpoint leaves the repo shippable with
+spec 043 behavior intact for policy-less vaults.

--- a/specs/049-multisig-policy-engine/tasks.md
+++ b/specs/049-multisig-policy-engine/tasks.md
@@ -42,7 +42,8 @@ because every story enforces or reads it.
       (SC-002), per-asset limits incl. unconfigured-asset passthrough, window open/accumulate/
       reset boundaries, cooldown, allowlist recipient resolution (native / transfer /
       transferFrom / approve / generic call target), exemptions under max-strict policy (SC-003),
-      delegatecall + gas-refund + value-to-guard denials, `NotVault` on config, FR-015 config
+      delegatecall + gas-refund + value-to-guard denials, msg.sender-scoped config (each
+      address can only configure its own policy), FR-015 config
       validation, error argument payloads, `previewTransaction` parity with enforcement,
       view outputs. Written against MockSafe; must fail before T002 lands, pass after.
 - [X] T006 [P] Unit tests `test/custody/PolicyGuardSetup.test.js`: slot write via delegatecall,

--- a/specs/049-multisig-policy-engine/tasks.md
+++ b/specs/049-multisig-policy-engine/tasks.md
@@ -77,18 +77,18 @@ because every story enforces or reads it.
 **Independent Test**: quickstart §5.1 — create vault with per-tx limit + allowlist, rules render
 on detail, violating approved tx blocked, compliant tx executes.
 
-- [ ] T012 [US1] Extend `buildSetupInitializer` in `frontend/src/lib/custody/safeVault.js` with
+- [X] T012 [US1] Extend `buildSetupInitializer` in `frontend/src/lib/custody/safeVault.js` with
       optional `{ setupTo, setupData }` (defaults byte-identical; update its unit tests in
       `frontend/src/test/custody/` to pin both paths).
-- [ ] T013 [US1] Implement `frontend/src/components/custody/PolicyStep.jsx` (+ styles in
+- [X] T013 [US1] Implement `frontend/src/components/custody/PolicyStep.jsx` (+ styles in
       `Custody.css`): enable/configure the four rules, plain-language summary, skip path,
       network gating, FR-015 warnings.
-- [ ] T014 [US1] Wire PolicyStep into `frontend/src/components/custody/CreateVaultWizard.jsx`
+- [X] T014 [US1] Wire PolicyStep into `frontend/src/components/custody/CreateVaultWizard.jsx`
       (initializer switches to `buildEnablePolicySetup` output when configured; address preview
       still matches deployment).
-- [ ] T015 [P] [US1] Vitest `frontend/src/test/custody/PolicyStep.test.jsx`: skip ⇒ unchanged
+- [X] T015 [P] [US1] Vitest `frontend/src/test/custody/PolicyStep.test.jsx`: skip ⇒ unchanged
       initializer, configured ⇒ setup wiring, summary text, unsupported-network state, axe pass.
-- [ ] T016 [US1] Vitest update `frontend/src/test/custody/CreateVaultWizard.test.jsx`: wizard
+- [X] T016 [US1] Vitest update `frontend/src/test/custody/CreateVaultWizard.test.jsx`: wizard
       end-to-end with and without policy (US1 acceptance scenarios 1–3).
 
 **Checkpoint**: MVP — policy-governed vaults can be created and are enforced on-chain.
@@ -102,13 +102,13 @@ on detail, violating approved tx blocked, compliant tx executes.
 **Independent Test**: quickstart §5.2 — badge on policy vault only; detail shows rules + live
 window/cooldown state matching chain; foreign-guard vault shows "unrecognized" notice.
 
-- [ ] T017 [US2] Implement `frontend/src/components/custody/PolicyBadge.jsx` and render it in
+- [X] T017 [US2] Implement `frontend/src/components/custody/PolicyBadge.jsx` and render it in
       `frontend/src/components/custody/VaultList.jsx` (managed summary line; foreign marker).
-- [ ] T018 [US2] Implement `frontend/src/components/custody/PolicyPanel.jsx` (read-only half):
+- [X] T018 [US2] Implement `frontend/src/components/custody/PolicyPanel.jsx` (read-only half):
       plain-language rules, live `remainingInWindow`/`nextAllowedAt`, window-semantics
       disclosure, foreign-guard and unsupported-network states; mount in
       `frontend/src/components/custody/VaultDetail.jsx`.
-- [ ] T019 [P] [US2] Vitest `frontend/src/test/custody/PolicyBadge.test.jsx` +
+- [X] T019 [P] [US2] Vitest `frontend/src/test/custody/PolicyBadge.test.jsx` +
       `PolicyPanel.test.jsx` (read-only): all four status states, live-state rendering from
       mocked reads, axe pass (US2 acceptance scenarios 1–4).
 
@@ -123,16 +123,16 @@ window/cooldown state matching chain; foreign-guard vault shows "unrecognized" n
 **Independent Test**: quickstart §5.4 — propose limit raise on 2-of-3 vault: inert at 1 approval,
 live at 2; attach flow on a policy-less vault; loosening executes under max-strict policy.
 
-- [ ] T020 [US3] Extend `PolicyPanel.jsx` with the owner-only change flow: edit form reusing
+- [X] T020 [US3] Extend `PolicyPanel.jsx` with the owner-only change flow: edit form reusing
       PolicyStep's rule inputs, current-vs-proposed diff, submit via `buildPolicyChangeTx`
       through the existing spec 043 proposal queue (`vaultTransaction.js`/`proposalHub.js`).
-- [ ] T021 [US3] Attach-first-policy flow in `PolicyPanel.jsx` for `none` vaults: queue
+- [X] T021 [US3] Attach-first-policy flow in `PolicyPanel.jsx` for `none` vaults: queue
       `configureRules` self-tx then `setGuard` self-tx in that order (no unguarded half-set gap
       — `contracts/frontend-integration.md`).
-- [ ] T022 [US3] Render pending policy-change proposals distinctly in
+- [X] T022 [US3] Render pending policy-change proposals distinctly in
       `frontend/src/components/custody/ProposalQueue.jsx` (decode guard-targeted calldata to a
       human diff; approvals bind to exact calldata — FR-009 inherited, show it).
-- [ ] T023 [P] [US3] Vitest `frontend/src/test/custody/PolicyPanel.change.test.jsx`: diff
+- [X] T023 [P] [US3] Vitest `frontend/src/test/custody/PolicyPanel.change.test.jsx`: diff
       rendering, queue submission payloads, attach ordering, non-owner sees no management
       actions, axe pass (US3 acceptance scenarios 1–5).
 
@@ -147,18 +147,18 @@ live at 2; attach flow on a policy-less vault; loosening executes under max-stri
 **Independent Test**: quickstart §5.3 — draft transfer to non-allowlisted address ⇒ named rule
 warning pre-submit; fix recipient ⇒ warning clears.
 
-- [ ] T024 [US4] Integrate `previewPolicy` into
+- [X] T024 [US4] Integrate `previewPolicy` into
       `frontend/src/components/custody/ProposeTransactionForm.jsx`: debounce-evaluated warning
       naming rule + values (via `decodePolicyError`), non-blocking submit, none for compliant or
       policy-less vaults; surface the same decoder on failed execution paths (FR-011).
-- [ ] T025 [P] [US4] Vitest update `frontend/src/test/custody/ProposeTransactionForm.test.jsx`:
+- [X] T025 [P] [US4] Vitest update `frontend/src/test/custody/ProposeTransactionForm.test.jsx`:
       violation warning content per rule, clear-on-fix, no-policy silence, axe pass.
 
 ---
 
 ## Phase 7: Polish & Cross-Cutting
 
-- [ ] T026 [P] Wire guard events (`RulesConfigured`, `AllowlistChanged`, `AllowlistEnabled`) into
+- [X] T026 [P] Wire guard events (`RulesConfigured`, `AllowlistChanged`, `AllowlistEnabled`) into
       the existing `custody` notification domain watcher path (FR-016) and cover with a Vitest
       case alongside the existing custody notification tests.
 - [X] T027 [P] Run Slither over `contracts/custody/SafePolicyGuard.sol` +
@@ -166,7 +166,7 @@ warning pre-submit; fix recipient ⇒ warning clears.
 - [X] T028 [P] Developer doc `docs/developer-guide/multisig-policy-engine.md`: architecture,
       trust model, accepted risks (window straddle, unvalued calldata, no-delegatecall
       limitation), deployment/rollout runbook note (Mordor → Polygon).
-- [ ] T029 Full verification: `npm run compile`, `npm test`, `npm run test:frontend`, frontend
+- [X] T029 Full verification: `npm run compile`, `npm test`, `npm run test:frontend`, frontend
       lint — quickstart.md §1–§4 outcomes; confirm spec 043 custody suites untouched (SC-007).
 
 ---

--- a/test/custody/PolicyGuardSetup.test.js
+++ b/test/custody/PolicyGuardSetup.test.js
@@ -1,0 +1,99 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+// Spec 049 — PolicyGuardSetup unit suite. Exercised under a REAL delegatecall via
+// MockSafe.setupDelegate (mirroring Safe.setup's optional delegatecall): verifies the guard
+// storage slot write, the ChangedGuard log, that the configure call reaches the guard with the
+// vault as msg.sender, that reverts bubble (no half-configured vault), and that the ERC-165
+// acceptance check rejects non-guards.
+
+const GUARD_SLOT = "0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8";
+const NATIVE = ethers.ZeroAddress;
+
+describe("PolicyGuardSetup", function () {
+  let guard, setup, mockSafe, deployer, recipient;
+  let guardAddr, setupAddr, mockSafeAddr;
+
+  beforeEach(async () => {
+    [deployer, recipient] = await ethers.getSigners();
+    guard = await (await ethers.getContractFactory("SafePolicyGuard")).deploy();
+    setup = await (await ethers.getContractFactory("PolicyGuardSetup")).deploy();
+    mockSafe = await (await ethers.getContractFactory("MockSafe")).deploy();
+    await Promise.all([guard.waitForDeployment(), setup.waitForDeployment(), mockSafe.waitForDeployment()]);
+    [guardAddr, setupAddr, mockSafeAddr] = await Promise.all([
+      guard.getAddress(), setup.getAddress(), mockSafe.getAddress(),
+    ]);
+  });
+
+  function enablePolicyData(configureCalldata = "0x") {
+    return setup.interface.encodeFunctionData("enablePolicy", [guardAddr, configureCalldata]);
+  }
+
+  function configureData() {
+    return guard.interface.encodeFunctionData("configureRules", [
+      [{ asset: NATIVE, perTxLimit: 100n, windowLimit: 500n }], 3600, true, [recipient.address], [],
+    ]);
+  }
+
+  it("writes the Safe guard storage slot in the caller's (vault's) context", async () => {
+    await mockSafe.setupDelegate(setupAddr, enablePolicyData());
+    const slot = await ethers.provider.getStorage(mockSafeAddr, GUARD_SLOT);
+    expect(ethers.getAddress(ethers.dataSlice(slot, 12))).to.equal(guardAddr);
+    // The helper's own storage/slot is untouched.
+    expect(await ethers.provider.getStorage(setupAddr, GUARD_SLOT)).to.equal(ethers.ZeroHash);
+  });
+
+  it("emits the Safe ChangedGuard event signature from the vault's address", async () => {
+    const tx = await mockSafe.setupDelegate(setupAddr, enablePolicyData());
+    const receipt = await tx.wait();
+    const topic = ethers.id("ChangedGuard(address)");
+    const log = receipt.logs.find((l) => l.address === mockSafeAddr && l.topics[0] === topic);
+    expect(log, "ChangedGuard log emitted by the vault").to.not.equal(undefined);
+    expect(ethers.getAddress(ethers.dataSlice(log.topics[1], 12))).to.equal(guardAddr);
+  });
+
+  it("applies the initial policy with the new vault as msg.sender (authority model holds)", async () => {
+    await mockSafe.setupDelegate(setupAddr, enablePolicyData(configureData()));
+    const p = await guard.getPolicy(mockSafeAddr);
+    expect(p.hasRules).to.equal(true);
+    expect(p.allowlistEnabled).to.equal(true);
+    expect(p.cooldown).to.equal(3600n);
+    const r = await guard.getAssetRule(mockSafeAddr, NATIVE);
+    expect(r.perTxLimit).to.equal(100n);
+    expect(r.windowLimit).to.equal(500n);
+  });
+
+  it("attaches with no initial rules when configure calldata is empty", async () => {
+    await mockSafe.setupDelegate(setupAddr, enablePolicyData("0x"));
+    expect((await guard.getPolicy(mockSafeAddr)).hasRules).to.equal(false);
+    const slot = await ethers.provider.getStorage(mockSafeAddr, GUARD_SLOT);
+    expect(ethers.getAddress(ethers.dataSlice(slot, 12))).to.equal(guardAddr);
+  });
+
+  it("bubbles guard config reverts, aborting the whole setup (no half-configured vault)", async () => {
+    // Allowlist enabled with zero entries → guard reverts EmptyAllowlist → creation aborts.
+    const bad = guard.interface.encodeFunctionData("configureRules", [[], 0, true, [], []]);
+    await expect(mockSafe.setupDelegate(setupAddr, enablePolicyData(bad)))
+      .to.be.revertedWithCustomError(guard, "EmptyAllowlist");
+    expect(await ethers.provider.getStorage(mockSafeAddr, GUARD_SLOT)).to.equal(ethers.ZeroHash);
+  });
+
+  it("rejects the zero guard address", async () => {
+    const data = setup.interface.encodeFunctionData("enablePolicy", [ethers.ZeroAddress, "0x"]);
+    await expect(mockSafe.setupDelegate(setupAddr, data)).to.be.revertedWithCustomError(setup, "ZeroGuard");
+  });
+
+  it("rejects a target that does not self-report the Safe guard interface (GS300 parity)", async () => {
+    // The proposal hub is a contract but not a guard.
+    const notGuard = await (await ethers.getContractFactory("SafeProposalHub")).deploy();
+    await notGuard.waitForDeployment();
+    const data = setup.interface.encodeFunctionData("enablePolicy", [await notGuard.getAddress(), "0x"]);
+    await expect(mockSafe.setupDelegate(setupAddr, data)).to.be.reverted; // ERC-165 probe reverts or NotAGuard
+    expect(await ethers.provider.getStorage(mockSafeAddr, GUARD_SLOT)).to.equal(ethers.ZeroHash);
+  });
+
+  it("direct (non-delegatecall) invocation cannot touch any vault's slot", async () => {
+    await expect(setup.connect(deployer).enablePolicy(guardAddr, "0x")).to.not.be.reverted;
+    expect(await ethers.provider.getStorage(mockSafeAddr, GUARD_SLOT)).to.equal(ethers.ZeroHash);
+  });
+});

--- a/test/custody/SafePolicyGuard.test.js
+++ b/test/custody/SafePolicyGuard.test.js
@@ -183,6 +183,18 @@ describe("SafePolicyGuard", function () {
       ).to.not.be.reverted;
     });
 
+    it("classifies token calldata with extra trailing bytes exactly as the token would execute it", async () => {
+      // Solidity functions ignore extra trailing calldata for static args; the guard slices the
+      // canonical words so padded calldata neither bypasses classification nor spuriously blocks.
+      const padded = erc20.encodeFunctionData("transfer", [recipient.address, 101n]) + "ab".repeat(13);
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: token, data: padded })))
+        .to.not.be.reverted; // token unconfigured for limits here — but classification must not revert
+      await guard.connect(safe).configureRules(...cfg({ limits: [{ asset: token, perTxLimit: 50n, windowLimit: 0n }] }));
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: token, data: padded })))
+        .to.be.revertedWithCustomError(guard, "PerTxLimitExceeded")
+        .withArgs(token, 101n, 50n);
+    });
+
     it("leaves unconfigured assets unvalued (disclosed passthrough)", async () => {
       const otherToken = ethers.getAddress("0x00000000000000000000000000000000000dead1");
       const data = erc20.encodeFunctionData("transfer", [recipient.address, ethers.MaxUint256]);

--- a/test/custody/SafePolicyGuard.test.js
+++ b/test/custody/SafePolicyGuard.test.js
@@ -1,0 +1,468 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { time } = require("@nomicfoundation/hardhat-network-helpers");
+
+// Spec 049 — SafePolicyGuard unit suite. The guard treats msg.sender as the Safe, so a plain
+// signer stands in as the "vault" for rule-logic tests; MockSafe covers the Safe-shaped
+// execTransaction flow. Covers every FR-002 rule alone and combined (SC-002), the lockout-proof
+// exemptions under a maximally strict policy (SC-003), the delegatecall / gas-refund / value-to-
+// guard hard denials, msg.sender authority, FR-015 config validation, typed error payloads, and
+// previewTransaction parity with enforcement.
+
+const NATIVE = ethers.ZeroAddress;
+const DAY = 24 * 60 * 60;
+
+const erc20 = new ethers.Interface([
+  "function transfer(address to, uint256 amount)",
+  "function transferFrom(address from, address to, uint256 amount)",
+  "function approve(address spender, uint256 amount)",
+]);
+
+/** configureRules with keyword-ish defaults so tests read as intent. */
+function cfg({ limits = [], cooldown = 0, allowlistEnabled = false, add = [], remove = [] } = {}) {
+  return [limits, cooldown, allowlistEnabled, add, remove];
+}
+
+/** checkTransaction with only the fields the guard evaluates. */
+function checkArgs({ to, value = 0n, data = "0x", operation = 0, gasPrice = 0n, sender = ethers.ZeroAddress }) {
+  return [to, value, data, operation, 0, 0, gasPrice, ethers.ZeroAddress, ethers.ZeroAddress, "0x", sender];
+}
+
+describe("SafePolicyGuard", function () {
+  let guard, safe, other, recipient, stranger, token;
+
+  beforeEach(async () => {
+    [safe, other, recipient, stranger] = await ethers.getSigners();
+    guard = await (await ethers.getContractFactory("SafePolicyGuard")).deploy();
+    await guard.waitForDeployment();
+    token = ethers.getAddress("0x00000000000000000000000000000000000c0ffe"); // classification never calls the token
+  });
+
+  // ------------------------------------------------------------------ ERC-165 / interface
+
+  it("supports the Safe guard interface id and ERC-165 (GS300 acceptance)", async () => {
+    // XOR of checkTransaction + checkAfterExecution selectors = Safe v1.4.1 Guard interface id.
+    const ct = ethers.dataSlice(ethers.id("checkTransaction(address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,bytes,address)"), 0, 4);
+    const cae = ethers.dataSlice(ethers.id("checkAfterExecution(bytes32,bool)"), 0, 4);
+    const guardId = ethers.toBeHex(BigInt(ct) ^ BigInt(cae), 4);
+    expect(await guard.supportsInterface(guardId)).to.equal(true);
+    expect(await guard.supportsInterface("0x01ffc9a7")).to.equal(true);
+    expect(await guard.supportsInterface("0xdeadbeef")).to.equal(false);
+  });
+
+  // ------------------------------------------------------------------ configuration authority
+
+  it("scopes all configuration to msg.sender — one vault cannot touch another's policy", async () => {
+    await guard.connect(safe).configureRules(...cfg({ limits: [{ asset: NATIVE, perTxLimit: 100n, windowLimit: 0n }] }));
+    const mine = await guard.getPolicy(safe.address);
+    const theirs = await guard.getPolicy(other.address);
+    expect(mine.hasRules).to.equal(true);
+    expect(theirs.hasRules).to.equal(false);
+  });
+
+  it("emits config events and reflects state in views", async () => {
+    await expect(
+      guard.connect(safe).configureRules(
+        ...cfg({
+          limits: [{ asset: NATIVE, perTxLimit: 100n, windowLimit: 500n }],
+          cooldown: 3600,
+          allowlistEnabled: true,
+          add: [recipient.address],
+        }),
+      ),
+    )
+      .to.emit(guard, "RulesConfigured").withArgs(safe.address, NATIVE, 100n, 500n)
+      .and.to.emit(guard, "CooldownSet").withArgs(safe.address, 3600)
+      .and.to.emit(guard, "AllowlistEnabled").withArgs(safe.address, true)
+      .and.to.emit(guard, "AllowlistChanged").withArgs(safe.address, recipient.address, true);
+
+    const p = await guard.getPolicy(safe.address);
+    expect(p.hasRules).to.equal(true);
+    expect(p.allowlistEnabled).to.equal(true);
+    expect(p.allowlistCount).to.equal(3n - 2n); // 1
+    expect(p.cooldown).to.equal(3600n);
+    expect(p.configuredAssets).to.deep.equal([NATIVE]);
+    const r = await guard.getAssetRule(safe.address, NATIVE);
+    expect(r.perTxLimit).to.equal(100n);
+    expect(r.windowLimit).to.equal(500n);
+    expect(await guard.getAllowlist(safe.address)).to.deep.equal([recipient.address]);
+    expect(await guard.isAllowlisted(safe.address, recipient.address)).to.equal(true);
+  });
+
+  it("FR-015: rejects enabling the allowlist with zero entries (no accidental deny-all)", async () => {
+    await expect(guard.connect(safe).configureRules(...cfg({ allowlistEnabled: true })))
+      .to.be.revertedWithCustomError(guard, "EmptyAllowlist");
+    // ...including when the same call removes the last entry.
+    await guard.connect(safe).configureRules(...cfg({ allowlistEnabled: true, add: [recipient.address] }));
+    await expect(
+      guard.connect(safe).configureRules(...cfg({ allowlistEnabled: true, remove: [recipient.address] })),
+    ).to.be.revertedWithCustomError(guard, "EmptyAllowlist");
+  });
+
+  it("FR-015: rejects a cooldown beyond 365 days and oversized batches", async () => {
+    await expect(guard.connect(safe).configureRules(...cfg({ cooldown: 366 * DAY })))
+      .to.be.revertedWithCustomError(guard, "CooldownTooLong");
+    const many = Array.from({ length: 65 }, (_, i) => ethers.getAddress(ethers.toBeHex(i + 1, 20)));
+    await expect(guard.connect(safe).configureRules(...cfg({ add: many })))
+      .to.be.revertedWithCustomError(guard, "AllowlistBatchTooLarge");
+  });
+
+  it("bounds configured assets at MAX_ASSETS and clears cleanly", async () => {
+    const limits = Array.from({ length: 16 }, (_, i) => ({
+      asset: ethers.getAddress(ethers.toBeHex(i + 1, 20)),
+      perTxLimit: 1n,
+      windowLimit: 0n,
+    }));
+    await guard.connect(safe).configureRules(...cfg({ limits }));
+    await expect(
+      guard.connect(safe).configureRules(...cfg({ limits: [{ asset: token, perTxLimit: 1n, windowLimit: 0n }] })),
+    ).to.be.revertedWithCustomError(guard, "TooManyAssets");
+    // Clearing an asset (both limits zero) frees a slot and resets live window state.
+    await guard.connect(safe).configureRules(...cfg({ limits: [{ asset: limits[0].asset, perTxLimit: 0n, windowLimit: 0n }] }));
+    await guard.connect(safe).configureRules(...cfg({ limits: [{ asset: token, perTxLimit: 1n, windowLimit: 0n }] }));
+    expect((await guard.getPolicy(safe.address)).configuredAssets).to.have.length(16);
+  });
+
+  it("allowlist removal keeps enumeration consistent (swap-and-pop)", async () => {
+    const [a, b, c] = [other.address, recipient.address, stranger.address];
+    await guard.connect(safe).configureRules(...cfg({ add: [a, b, c] }));
+    await guard.connect(safe).configureRules(...cfg({ remove: [a] }));
+    const list = await guard.getAllowlist(safe.address);
+    expect([...list].sort()).to.deep.equal([b, c].sort());
+    expect(await guard.isAllowlisted(safe.address, a)).to.equal(false);
+    expect((await guard.getPolicy(safe.address)).allowlistCount).to.equal(2n);
+    // Re-add after removal round-trips.
+    await guard.connect(safe).configureRules(...cfg({ add: [a] }));
+    expect(await guard.isAllowlisted(safe.address, a)).to.equal(true);
+  });
+
+  // ------------------------------------------------------------------ no-policy passthrough
+
+  it("FR-010: passes everything through for a vault with no rules", async () => {
+    await expect(
+      guard.connect(safe).checkTransaction(...checkArgs({ to: stranger.address, value: ethers.parseEther("1000") })),
+    ).to.not.be.reverted;
+    // Even delegatecall and gas refunds — the hard denials only arm once a policy exists.
+    await expect(
+      guard.connect(safe).checkTransaction(...checkArgs({ to: stranger.address, operation: 1, gasPrice: 1n })),
+    ).to.not.be.reverted;
+  });
+
+  // ------------------------------------------------------------------ per-transaction limit
+
+  describe("per-transaction limit", () => {
+    beforeEach(async () => {
+      await guard.connect(safe).configureRules(...cfg({ limits: [{ asset: NATIVE, perTxLimit: 100n, windowLimit: 0n }] }));
+    });
+
+    it("blocks an over-limit native transfer with the typed error payload", async () => {
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, value: 101n })))
+        .to.be.revertedWithCustomError(guard, "PerTxLimitExceeded")
+        .withArgs(NATIVE, 101n, 100n);
+    });
+
+    it("allows exactly at the limit", async () => {
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, value: 100n })))
+        .to.not.be.reverted;
+    });
+
+    it("values token transfer, transferFrom, and approve against the token's own limit", async () => {
+      await guard.connect(safe).configureRules(...cfg({ limits: [{ asset: token, perTxLimit: 50n, windowLimit: 0n }] }));
+      const over = [
+        erc20.encodeFunctionData("transfer", [recipient.address, 51n]),
+        erc20.encodeFunctionData("transferFrom", [safe.address, recipient.address, 51n]),
+        erc20.encodeFunctionData("approve", [recipient.address, 51n]),
+      ];
+      for (const data of over) {
+        await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: token, data })))
+          .to.be.revertedWithCustomError(guard, "PerTxLimitExceeded")
+          .withArgs(token, 51n, 50n);
+      }
+      await expect(
+        guard.connect(safe).checkTransaction(...checkArgs({ to: token, data: erc20.encodeFunctionData("transfer", [recipient.address, 50n]) })),
+      ).to.not.be.reverted;
+    });
+
+    it("leaves unconfigured assets unvalued (disclosed passthrough)", async () => {
+      const otherToken = ethers.getAddress("0x00000000000000000000000000000000000dead1");
+      const data = erc20.encodeFunctionData("transfer", [recipient.address, ethers.MaxUint256]);
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: otherToken, data }))).to.not.be.reverted;
+    });
+
+    it("checks native and token legs independently in one transaction", async () => {
+      await guard.connect(safe).configureRules(...cfg({ limits: [{ asset: token, perTxLimit: 50n, windowLimit: 0n }] }));
+      const data = erc20.encodeFunctionData("transfer", [recipient.address, 10n]);
+      // token leg fine (10 ≤ 50) but native leg over (101 > 100)
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: token, value: 101n, data })))
+        .to.be.revertedWithCustomError(guard, "PerTxLimitExceeded")
+        .withArgs(NATIVE, 101n, 100n);
+    });
+  });
+
+  // ------------------------------------------------------------------ 24h window limit
+
+  describe("window limit", () => {
+    beforeEach(async () => {
+      await guard.connect(safe).configureRules(...cfg({ limits: [{ asset: NATIVE, perTxLimit: 0n, windowLimit: 100n }] }));
+    });
+
+    it("accumulates spends and blocks when the window is exhausted, reporting remaining", async () => {
+      await guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, value: 60n }));
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, value: 41n })))
+        .to.be.revertedWithCustomError(guard, "WindowLimitExceeded")
+        .withArgs(NATIVE, 41n, 40n);
+      expect(await guard.remainingInWindow(safe.address, NATIVE)).to.equal(40n);
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, value: 40n })))
+        .to.not.be.reverted;
+      expect(await guard.remainingInWindow(safe.address, NATIVE)).to.equal(0n);
+    });
+
+    it("resets 24h after the window opened (boundary-exact)", async () => {
+      await guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, value: 100n }));
+      const { windowStart } = await guard.getAssetRule(safe.address, NATIVE);
+      // One second before the boundary: still closed.
+      await time.setNextBlockTimestamp(Number(windowStart) + DAY - 1);
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, value: 1n })))
+        .to.be.revertedWithCustomError(guard, "WindowLimitExceeded");
+      // At the boundary: fresh window.
+      await time.setNextBlockTimestamp(Number(windowStart) + DAY);
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, value: 100n })))
+        .to.not.be.reverted;
+      const after = await guard.getAssetRule(safe.address, NATIVE);
+      expect(after.spentInWindow).to.equal(100n);
+      expect(after.windowStart).to.be.greaterThan(windowStart);
+    });
+
+    it("remainingInWindow reports the full limit for an elapsed window without a write", async () => {
+      await guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, value: 100n }));
+      await time.increase(DAY + 1);
+      expect(await guard.remainingInWindow(safe.address, NATIVE)).to.equal(100n);
+    });
+
+    it("returns max-uint for assets with no window limit", async () => {
+      expect(await guard.remainingInWindow(safe.address, token)).to.equal(ethers.MaxUint256);
+    });
+
+    it("an amount that can never fit (> uint128 window limit) is rejected, not wrapped", async () => {
+      await expect(
+        guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, value: ethers.MaxUint256 })),
+      ).to.be.revertedWithCustomError(guard, "WindowLimitExceeded");
+    });
+  });
+
+  // ------------------------------------------------------------------ allowlist
+
+  describe("recipient allowlist", () => {
+    beforeEach(async () => {
+      await guard.connect(safe).configureRules(...cfg({ allowlistEnabled: true, add: [recipient.address, token] }));
+    });
+
+    it("blocks native transfers to non-allowlisted targets, allows allowlisted", async () => {
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: stranger.address, value: 1n })))
+        .to.be.revertedWithCustomError(guard, "RecipientNotAllowed")
+        .withArgs(stranger.address);
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, value: 1n })))
+        .to.not.be.reverted;
+    });
+
+    it("gates the DECODED beneficiary for token actions (transfer/transferFrom/approve)", async () => {
+      const bad = [
+        erc20.encodeFunctionData("transfer", [stranger.address, 1n]),
+        erc20.encodeFunctionData("transferFrom", [safe.address, stranger.address, 1n]),
+        erc20.encodeFunctionData("approve", [stranger.address, 1n]),
+      ];
+      for (const data of bad) {
+        await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: token, data })))
+          .to.be.revertedWithCustomError(guard, "RecipientNotAllowed")
+          .withArgs(stranger.address);
+      }
+      await expect(
+        guard.connect(safe).checkTransaction(...checkArgs({ to: token, data: erc20.encodeFunctionData("transfer", [recipient.address, 1n]) })),
+      ).to.not.be.reverted;
+    });
+
+    it("gates the call target for generic (unrecognized) calldata — no escape hatch", async () => {
+      const data = "0x12345678aabbcc";
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: stranger.address, data })))
+        .to.be.revertedWithCustomError(guard, "RecipientNotAllowed")
+        .withArgs(stranger.address);
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, data })))
+        .to.not.be.reverted;
+    });
+
+    it("native value riding a token call additionally gates the token target", async () => {
+      const nonListedToken = ethers.getAddress("0x00000000000000000000000000000000000dead1");
+      const data = erc20.encodeFunctionData("transfer", [recipient.address, 1n]);
+      // Recipient allowlisted, but the native leg pays the (unlisted) token contract.
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: nonListedToken, value: 1n, data })))
+        .to.be.revertedWithCustomError(guard, "RecipientNotAllowed")
+        .withArgs(nonListedToken);
+    });
+  });
+
+  // ------------------------------------------------------------------ cooldown
+
+  describe("cooldown", () => {
+    beforeEach(async () => {
+      await guard.connect(safe).configureRules(...cfg({ cooldown: 3600 }));
+    });
+
+    it("blocks a second counted transaction inside the cooldown, reporting nextAllowedAt", async () => {
+      await guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, value: 1n }));
+      const next = await guard.nextAllowedAt(safe.address);
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, value: 1n })))
+        .to.be.revertedWithCustomError(guard, "CooldownActive")
+        .withArgs(next);
+      await time.setNextBlockTimestamp(Number(next));
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, value: 1n })))
+        .to.not.be.reverted;
+    });
+
+    it("does not rate-limit non-fund calls (value 0, unrecognized calldata)", async () => {
+      await guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, value: 1n }));
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: stranger.address, data: "0x12345678" })))
+        .to.not.be.reverted;
+    });
+
+    it("counts token actions", async () => {
+      const data = erc20.encodeFunctionData("transfer", [recipient.address, 1n]);
+      await guard.connect(safe).checkTransaction(...checkArgs({ to: token, data }));
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: token, data })))
+        .to.be.revertedWithCustomError(guard, "CooldownActive");
+    });
+  });
+
+  // ------------------------------------------------------------------ hard denials
+
+  describe("hard denials while a policy is active", () => {
+    beforeEach(async () => {
+      await guard.connect(safe).configureRules(...cfg({ cooldown: 1 }));
+    });
+
+    it("rejects delegatecall (guard-bypass channel)", async () => {
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, operation: 1 })))
+        .to.be.revertedWithCustomError(guard, "DelegatecallBlocked");
+    });
+
+    it("rejects gas-refund transactions (uncounted outflow)", async () => {
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, gasPrice: 1n })))
+        .to.be.revertedWithCustomError(guard, "GasRefundBlocked");
+    });
+  });
+
+  // ------------------------------------------------------------------ lockout-proof exemptions
+
+  describe("lockout-proofing (FR-008 / SC-003) under a maximally strict policy", () => {
+    beforeEach(async () => {
+      // Strictest expressible policy: 1-wei limits, tiny window, huge cooldown, 1-entry allowlist.
+      await guard.connect(safe).configureRules(
+        ...cfg({
+          limits: [{ asset: NATIVE, perTxLimit: 1n, windowLimit: 1n }],
+          cooldown: 365 * DAY,
+          allowlistEnabled: true,
+          add: [other.address],
+        }),
+      );
+      // Exhaust everything.
+      await guard.connect(safe).checkTransaction(...checkArgs({ to: other.address, value: 1n }));
+    });
+
+    it("still allows Safe self-management transactions (owners, threshold, setGuard)", async () => {
+      await expect(
+        guard.connect(safe).checkTransaction(...checkArgs({ to: safe.address, value: 5n, data: "0x deadbeef".replace(" ", "") })),
+      ).to.not.be.reverted;
+    });
+
+    it("still allows policy-configuration calls to the guard, and a loosening change works", async () => {
+      const target = await guard.getAddress();
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: target, data: "0x12345678" })))
+        .to.not.be.reverted;
+      // The loosening itself (direct config call as the vault) executes despite the strict rules.
+      await guard.connect(safe).configureRules(...cfg({ limits: [{ asset: NATIVE, perTxLimit: 0n, windowLimit: 0n }], cooldown: 0, allowlistEnabled: false }));
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: stranger.address, value: ethers.parseEther("1") })))
+        .to.not.be.reverted;
+    });
+
+    it("rejects native value sent TO the guard (guard holds no funds)", async () => {
+      const target = await guard.getAddress();
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: target, value: 1n })))
+        .to.be.revertedWithCustomError(guard, "ValueToGuardBlocked");
+    });
+  });
+
+  // ------------------------------------------------------------------ preview parity
+
+  describe("previewTransaction (FR-011/FR-012)", () => {
+    beforeEach(async () => {
+      await guard.connect(safe).configureRules(
+        ...cfg({ limits: [{ asset: NATIVE, perTxLimit: 100n, windowLimit: 0n }], allowlistEnabled: true, add: [recipient.address] }),
+      );
+    });
+
+    it("returns ok for a compliant transaction and writes no state", async () => {
+      const [ok, data] = await guard.previewTransaction(safe.address, recipient.address, 100n, "0x", 0);
+      expect(ok).to.equal(true);
+      expect(data).to.equal("0x");
+    });
+
+    it("returns the exact revert data enforcement would produce", async () => {
+      const [ok, data] = await guard.previewTransaction(safe.address, recipient.address, 101n, "0x", 0);
+      expect(ok).to.equal(false);
+      const expected = guard.interface.encodeErrorResult("PerTxLimitExceeded", [NATIVE, 101n, 100n]);
+      expect(data).to.equal(expected);
+      // Enforcement parity: same call through checkTransaction reverts with the same error.
+      await expect(guard.connect(safe).checkTransaction(...checkArgs({ to: recipient.address, value: 101n })))
+        .to.be.revertedWithCustomError(guard, "PerTxLimitExceeded")
+        .withArgs(NATIVE, 101n, 100n);
+    });
+
+    it("previews allowlist violations for third parties (read-only, any caller)", async () => {
+      const [ok, data] = await guard.connect(stranger).previewTransaction(safe.address, stranger.address, 1n, "0x", 0);
+      expect(ok).to.equal(false);
+      expect(data).to.equal(guard.interface.encodeErrorResult("RecipientNotAllowed", [stranger.address]));
+    });
+
+    it("reports exemptions as ok", async () => {
+      const [ok] = await guard.previewTransaction(safe.address, safe.address, 0n, "0x", 0);
+      expect(ok).to.equal(true);
+    });
+  });
+
+  // ------------------------------------------------------------------ Safe-shaped flow via MockSafe
+
+  describe("MockSafe execTransaction flow", () => {
+    let mockSafe, mockSafeAddr, guardAddr;
+
+    beforeEach(async () => {
+      mockSafe = await (await ethers.getContractFactory("MockSafe")).deploy();
+      await mockSafe.waitForDeployment();
+      mockSafeAddr = await mockSafe.getAddress();
+      guardAddr = await guard.getAddress();
+      await mockSafe.setGuard(guardAddr);
+      await safe.sendTransaction({ to: mockSafeAddr, value: ethers.parseEther("1") });
+      // Configure via the Safe-shaped path: the vault calls the guard about itself (exempt target).
+      const configure = guard.interface.encodeFunctionData("configureRules", [
+        [{ asset: NATIVE, perTxLimit: 100n, windowLimit: 0n }], 0, false, [], [],
+      ]);
+      await mockSafe.execTransactionMock(guardAddr, 0, configure, 0, 0);
+    });
+
+    it("configured through its own execution path, the vault's policy is live", async () => {
+      const p = await guard.getPolicy(mockSafeAddr);
+      expect(p.hasRules).to.equal(true);
+    });
+
+    it("blocks an approved over-limit execution end-to-end and allows a compliant one", async () => {
+      await expect(mockSafe.execTransactionMock(recipient.address, 101n, "0x", 0, 0))
+        .to.be.revertedWithCustomError(guard, "PerTxLimitExceeded");
+      const before = await ethers.provider.getBalance(recipient.address);
+      await mockSafe.execTransactionMock(recipient.address, 100n, "0x", 0, 0);
+      expect(await ethers.provider.getBalance(recipient.address)).to.equal(before + 100n);
+    });
+
+    it("blocks delegatecall executions for the policy-managed vault", async () => {
+      await expect(mockSafe.execTransactionMock(recipient.address, 0, "0x", 1, 0))
+        .to.be.revertedWithCustomError(guard, "DelegatecallBlocked");
+    });
+  });
+});

--- a/test/integration/policy-guard-safe.test.js
+++ b/test/integration/policy-guard-safe.test.js
@@ -1,0 +1,169 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+// Spec 049 — integration suite against the REAL Safe v1.4.1 (devDependency, compiled via
+// contracts/mocks/vendor/SafeVendorImports.sol). Proves the guard's whole contract surface —
+// the Safe's execTransaction calling convention, setGuard's ERC-165 "GS300" acceptance, and
+// Safe.setup's delegatecall hook — against the actual bytecode the custody vaults run:
+//   • factory-create a vault with the PolicyGuardSetup initializer → rules live pre-first-tx (US1)
+//   • approved-but-violating execTransaction reverts with the guard's typed error (FR-003)
+//   • compliant execTransaction moves funds
+//   • threshold-approved configureRules self-transaction changes the policy (US3 / FR-007)
+//   • setGuard attaches the guard to a pre-existing vault (ERC-165 accepted)
+//   • a policy-less vault (plain initializer) behaves exactly as stock Safe (FR-010 / SC-007)
+
+const SAFE_QN = "@safe-global/safe-contracts/contracts/SafeL2.sol:SafeL2";
+const FACTORY_QN = "@safe-global/safe-contracts/contracts/proxies/SafeProxyFactory.sol:SafeProxyFactory";
+const HANDLER_QN = "@safe-global/safe-contracts/contracts/handler/CompatibilityFallbackHandler.sol:CompatibilityFallbackHandler";
+
+const GUARD_SLOT = "0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8";
+const NATIVE = ethers.ZeroAddress;
+const AddressZero = ethers.ZeroAddress;
+
+describe("SafePolicyGuard × real Safe v1.4.1 (integration)", function () {
+  let owner1, owner2, owner3, outsider;
+  let singleton, factory, handler, guard, setup;
+  let saltNonce = 1000n;
+
+  before(async () => {
+    [owner1, owner2, owner3, outsider] = await ethers.getSigners();
+    singleton = await (await ethers.getContractFactory(SAFE_QN)).deploy();
+    factory = await (await ethers.getContractFactory(FACTORY_QN)).deploy();
+    handler = await (await ethers.getContractFactory(HANDLER_QN)).deploy();
+    guard = await (await ethers.getContractFactory("SafePolicyGuard")).deploy();
+    setup = await (await ethers.getContractFactory("PolicyGuardSetup")).deploy();
+    await Promise.all([singleton, factory, handler, guard, setup].map((c) => c.waitForDeployment()));
+  });
+
+  /** Deploy a 2-of-3 Safe; optional setupTo/setupData wires PolicyGuardSetup at creation. */
+  async function createVault({ setupTo = AddressZero, setupData = "0x" } = {}) {
+    const owners = [owner1.address, owner2.address, owner3.address];
+    const initializer = singleton.interface.encodeFunctionData("setup", [
+      owners, 2n, setupTo, setupData, await handler.getAddress(), AddressZero, 0n, AddressZero,
+    ]);
+    const tx = await factory.createProxyWithNonce(await singleton.getAddress(), initializer, saltNonce++);
+    const receipt = await tx.wait();
+    const log = receipt.logs.map((l) => { try { return factory.interface.parseLog(l); } catch { return null; } })
+      .find((p) => p?.name === "ProxyCreation");
+    const vault = await ethers.getContractAt(SAFE_QN, log.args.proxy);
+    await owner1.sendTransaction({ to: log.args.proxy, value: ethers.parseEther("10") });
+    return vault;
+  }
+
+  function enablePolicyCalldata(configure) {
+    return setup.interface.encodeFunctionData("enablePolicy", [guard.target, configure]);
+  }
+
+  function configureCalldata({ limits = [], cooldown = 0, allowlistEnabled = false, add = [], remove = [] } = {}) {
+    return guard.interface.encodeFunctionData("configureRules", [limits, cooldown, allowlistEnabled, add, remove]);
+  }
+
+  /** Threshold-approve (approveHash by each owner) then execute a Safe transaction. */
+  async function execAsOwners(vault, { to, value = 0n, data = "0x", operation = 0 }, signers = [owner1, owner2]) {
+    const nonce = await vault.nonce();
+    const txHash = await vault.getTransactionHash(to, value, data, operation, 0, 0, 0, AddressZero, AddressZero, nonce);
+    for (const s of signers) await vault.connect(s).approveHash(txHash);
+    const sorted = [...signers].sort((a, b) => (BigInt(a.address) < BigInt(b.address) ? -1 : 1));
+    // Pre-validated signature encoding: r = owner, s = 0, v = 1.
+    const signatures = ethers.concat(
+      sorted.map((s) => ethers.concat([ethers.zeroPadValue(s.address, 32), ethers.ZeroHash, "0x01"])),
+    );
+    return vault.connect(signers[0]).execTransaction(to, value, data, operation, 0, 0, 0, AddressZero, AddressZero, signatures);
+  }
+
+  it("US1: a vault created with PolicyGuardSetup has its rules live before its first transaction", async () => {
+    const vault = await createVault({
+      setupTo: setup.target,
+      setupData: enablePolicyCalldata(
+        configureCalldata({ limits: [{ asset: NATIVE, perTxLimit: ethers.parseEther("1"), windowLimit: 0n }] }),
+      ),
+    });
+    const slot = await ethers.provider.getStorage(vault.target, GUARD_SLOT);
+    expect(ethers.getAddress(ethers.dataSlice(slot, 12))).to.equal(guard.target);
+    const p = await guard.getPolicy(vault.target);
+    expect(p.hasRules).to.equal(true);
+
+    // Approved-but-violating execution reverts with the guard's typed error (FR-003)...
+    await expect(execAsOwners(vault, { to: outsider.address, value: ethers.parseEther("2") }))
+      .to.be.revertedWithCustomError(guard, "PerTxLimitExceeded")
+      .withArgs(NATIVE, ethers.parseEther("2"), ethers.parseEther("1"));
+
+    // ...and a compliant one moves funds.
+    const before = await ethers.provider.getBalance(outsider.address);
+    await execAsOwners(vault, { to: outsider.address, value: ethers.parseEther("1") });
+    expect(await ethers.provider.getBalance(outsider.address)).to.equal(before + ethers.parseEther("1"));
+  });
+
+  it("US3/FR-007: a threshold-approved self-transaction to the guard changes the policy", async () => {
+    const vault = await createVault({
+      setupTo: setup.target,
+      setupData: enablePolicyCalldata(
+        configureCalldata({ limits: [{ asset: NATIVE, perTxLimit: ethers.parseEther("1"), windowLimit: 0n }] }),
+      ),
+    });
+    // Raise the limit to 3 ETH via the vault's own approval flow (guard target = exempt path).
+    await execAsOwners(vault, {
+      to: guard.target,
+      data: configureCalldata({ limits: [{ asset: NATIVE, perTxLimit: ethers.parseEther("3"), windowLimit: 0n }] }),
+    });
+    const rule = await guard.getAssetRule(vault.target, NATIVE);
+    expect(rule.perTxLimit).to.equal(ethers.parseEther("3"));
+    // The very next transaction is governed by the new rules.
+    await expect(execAsOwners(vault, { to: outsider.address, value: ethers.parseEther("2") })).to.not.be.reverted;
+  });
+
+  it("lockout-proofing on the real Safe: a max-strict policy still admits the loosening change", async () => {
+    const vault = await createVault({
+      setupTo: setup.target,
+      setupData: enablePolicyCalldata(
+        configureCalldata({
+          limits: [{ asset: NATIVE, perTxLimit: 1n, windowLimit: 1n }],
+          cooldown: 365 * 24 * 3600,
+          allowlistEnabled: true,
+          add: [owner3.address],
+        }),
+      ),
+    });
+    // Nothing moves...
+    await expect(execAsOwners(vault, { to: outsider.address, value: ethers.parseEther("1") }))
+      .to.be.revertedWithCustomError(guard, "RecipientNotAllowed");
+    // ...but the loosening executes despite every rule (FR-008/SC-003).
+    await execAsOwners(vault, {
+      to: guard.target,
+      data: configureCalldata({ limits: [{ asset: NATIVE, perTxLimit: 0n, windowLimit: 0n }], cooldown: 0, allowlistEnabled: false }),
+    });
+    await expect(execAsOwners(vault, { to: outsider.address, value: ethers.parseEther("1") })).to.not.be.reverted;
+  });
+
+  it("attach-to-existing: Safe.setGuard accepts the guard via ERC-165 (GS300) on a plain vault", async () => {
+    const vault = await createVault(); // no policy at creation
+    // Order matters (frontend contract): configure rules first (inert), then setGuard (activates).
+    await execAsOwners(vault, {
+      to: guard.target,
+      data: configureCalldata({ limits: [{ asset: NATIVE, perTxLimit: ethers.parseEther("1"), windowLimit: 0n }] }),
+    });
+    await execAsOwners(vault, { to: vault.target, data: vault.interface.encodeFunctionData("setGuard", [guard.target]) });
+    const slot = await ethers.provider.getStorage(vault.target, GUARD_SLOT);
+    expect(ethers.getAddress(ethers.dataSlice(slot, 12))).to.equal(guard.target);
+    await expect(execAsOwners(vault, { to: outsider.address, value: ethers.parseEther("2") }))
+      .to.be.revertedWithCustomError(guard, "PerTxLimitExceeded");
+  });
+
+  it("FR-010/SC-007: a vault created WITHOUT the policy initializer behaves as stock Safe", async () => {
+    const vault = await createVault();
+    expect(await ethers.provider.getStorage(vault.target, GUARD_SLOT)).to.equal(ethers.ZeroHash);
+    expect((await guard.getPolicy(vault.target)).hasRules).to.equal(false);
+    // Arbitrary large transfer executes with plain threshold approval — no policy interference.
+    await expect(execAsOwners(vault, { to: outsider.address, value: ethers.parseEther("5") })).to.not.be.reverted;
+  });
+
+  it("a half-configured vault cannot deploy: invalid initial policy aborts creation", async () => {
+    // Allowlist enabled with zero entries → guard reverts → setup delegatecall reverts → GS000.
+    await expect(
+      createVault({
+        setupTo: setup.target,
+        setupData: enablePolicyCalldata(configureCalldata({ allowlistEnabled: true })),
+      }),
+    ).to.be.reverted;
+  });
+});


### PR DESCRIPTION
Implements issue #852 through the full Spec Kit flow (specify → plan → tasks → analyze → implement). Feature artifacts live in `specs/049-multisig-policy-engine/`.

## What this adds

On-chain, **opt-in fund policies** for the Protect (custody) Safe vaults from spec 043. A policy constrains what an *approved* vault transaction may do — after the owners' threshold is met, before execution — via the Safe v1.4.1 transaction-guard mechanism.

### Contracts (immutable, admin-free — no proxy, no upgrade key)

- **`SafePolicyGuard`** — singleton guard per chain holding every vault's rules + live accounting:
  - Four rule types, each optional per vault: per-transaction limit and 24h-window limit (per asset: native + ERC-20), recipient allowlist (gates decoded `transfer`/`transferFrom`/`approve` beneficiaries and generic call targets), and cooldown between fund-moving transactions.
  - Authority model: `msg.sender == safe` — every policy change is only reachable as a threshold-approved Safe self-transaction (FR-007 with zero new approval plumbing).
  - Lockout-proof by construction: self/guard-targeted transactions bypass fund rules, so a too-strict policy can always be loosened (FR-008/SC-003).
  - Hard denials while a policy is active: delegatecall (guard-bypass channel) and gas-refund transactions.
  - Typed custom errors + `previewTransaction` read-only twin so UI pre-flight can never drift from enforcement.
- **`PolicyGuardSetup`** — stateless `Safe.setup` delegatecall helper attaching guard + initial rules at vault creation (rules live before the vault's first transaction).

### Frontend (Protect portal)

- **Policy step** in vault creation (skippable; skip path byte-identical to today).
- **PolicyPanel** on vault detail: plain-language rules, live window/cooldown state, owner-only change flow with current-vs-proposed diff through the existing spec 043 proposal queue, attach-first-policy flow for existing vaults (configureRules queued before setGuard — no half-set gap), foreign-guard and unsupported-network states.
- **PolicyBadge** in the vault list; **pre-flight violation warnings** in the propose-transaction form; policy-change proposals decoded human-readably in the queue; guard events wired into the existing `custody` notification domain.
- Network-gated via `getContractAddressForChain('safePolicyGuard'|'policyGuardSetup', chainId)` — custody is unchanged where the engine isn't deployed.

### Tests & tooling

- 45 unit tests (dependency-free `MockSafe` harness) + 6 integration tests against the **real Safe v1.4.1** (`@safe-global/safe-contracts` devDependency; compiled test-only without viaIR via `contracts/mocks/vendor/` override — Safe's assembly lacks memory-safe annotations).
- Frontend Vitest suites for the policy library and each new component (incl. axe accessibility checks).
- Deterministic CREATE2 deploy script + `deployments/` recording + frontend contract sync keys (also closes the pre-existing `safeProposalHub` sync gap).
- Slither over the new contracts: no high/critical findings; remaining informational findings documented in `docs/developer-guide/multisig-policy-engine.md`.
- Full contract suite: 733 passing.

### Constitution notes (documented deviations)

- The guard is deliberately **non-upgradeable** (deviation from the UUPS guidance, justified in `plan.md` Complexity Tracking): an upgrade key would be a backdoor over every vault's enforcement. Future rule types ship as a new guard that vaults adopt via threshold-approved `setGuard`.
- Accepted, disclosed limits: fixed-reset 24h window (≤2× straddle), unvalued exotic calldata (still allowlist/target-gated), no MultiSend batching on policy vaults in v1.

## Rollout

Hardhat/localhost wired in this PR; Mordor (63) → Polygon (137) as ops steps per the platform launch sequence (`scripts/deploy/custody/deploy-policy-guard.js` + sync).

Closes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Scg94wus7Zd17ETZE15Zh

---
_Generated by [Claude Code](https://claude.ai/code/session_019Scg94wus7Zd17ETZE15Zh)_