### PR TITLE
Fix passkey transfers (missing ERC-20 paymaster wiring) and theme the confirm/warning dialogs

### DIFF
--- a/frontend/src/components/wallet/DeviceLossWarning.css
+++ b/frontend/src/components/wallet/DeviceLossWarning.css
@@ -1,0 +1,54 @@
+/* Single-credential risk warning (spec 041 T051) — theme-aware, mirrors the
+   shared app CSS variables (theme.css) and the Pay & Transfer notice/button
+   conventions (PayTransfer.css). Scoped under .device-loss-warning so its
+   .btn primitives never leak into unrelated buttons elsewhere in the app. */
+
+.device-loss-warning {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 1rem 1.1rem;
+  border-radius: var(--radius-lg, 12px);
+  border: 1px solid color-mix(in srgb, #d97706 35%, transparent);
+  background: color-mix(in srgb, #d97706 12%, transparent);
+  color: var(--color-text, var(--text-primary, #111827));
+}
+
+.device-loss-warning strong {
+  color: #b45309;
+  font-size: 0.95rem;
+}
+
+.device-loss-warning p {
+  margin: 0;
+  color: var(--color-text-secondary, var(--text-secondary, #6b7280));
+  font-size: 0.9rem;
+}
+
+.device-loss-warning__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 0.2rem;
+}
+
+.device-loss-warning .btn {
+  appearance: none;
+  border-radius: var(--radius-md, 8px);
+  border: 1px solid var(--color-border, var(--border-color, #e5e7eb));
+  background: var(--color-surface, var(--surface-color, #fff));
+  color: var(--color-text, var(--text-primary, #111827));
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 0.6rem 1rem;
+  transition: border-color var(--transition-fast, 0.15s ease), background-color var(--transition-fast, 0.15s ease);
+}
+.device-loss-warning .btn-primary {
+  border-color: transparent;
+  background: var(--primary-button, var(--brand-primary, #36B37E));
+  color: var(--primary-button-text, #fff);
+}
+.device-loss-warning .btn-primary:hover {
+  background: var(--primary-button-hover, #2F9E6E);
+}

--- a/frontend/src/components/wallet/DeviceLossWarning.jsx
+++ b/frontend/src/components/wallet/DeviceLossWarning.jsx
@@ -12,6 +12,7 @@ import { useState, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { usePasskeyAccount } from '../../hooks/usePasskeyAccount'
 import { WARNING_MOMENTS, dismissedAt, recordDismissal } from '../../lib/passkey/accountProfile'
+import './DeviceLossWarning.css'
 
 function DeviceLossWarning({ moment, onAddController, deps = {} }) {
   const account = usePasskeyAccount(deps)

--- a/frontend/src/components/wallet/PasskeyConfirm.css
+++ b/frontend/src/components/wallet/PasskeyConfirm.css
@@ -1,0 +1,102 @@
+/* Passkey transaction confirmation dialog (spec 041 T031) — theme-aware, mirrors
+   the shared app CSS variables (theme.css) and the Pay & Transfer button/notice
+   conventions (PayTransfer.css). Scoped under .passkey-confirm so its .btn
+   primitives never leak into unrelated buttons elsewhere in the app. */
+
+.passkey-confirm {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1.25rem;
+  border-radius: var(--radius-lg, 12px);
+  border: 1px solid var(--color-border, var(--border-color, #e5e7eb));
+  background: var(--color-surface, var(--surface-color, #fff));
+  box-shadow: var(--shadow-md, 0 4px 6px rgba(0, 0, 0, 0.1));
+  color: var(--color-text, var(--text-primary, #111827));
+}
+
+.passkey-confirm__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-text, var(--text-primary, #111827));
+}
+
+.passkey-confirm__details {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.35rem 0.75rem;
+  margin: 0;
+}
+.passkey-confirm__details dt {
+  color: var(--color-text-secondary, var(--text-secondary, #6b7280));
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+.passkey-confirm__details dd {
+  margin: 0;
+  color: var(--color-text, var(--text-primary, #111827));
+  font-size: 0.95rem;
+  text-align: right;
+  word-break: break-all;
+}
+
+.passkey-confirm__insufficient,
+.passkey-confirm__fallback {
+  border-radius: 10px;
+  padding: 0.7rem 0.9rem;
+  font-size: 0.9rem;
+}
+.passkey-confirm__insufficient {
+  background: color-mix(in srgb, var(--color-error, var(--danger-color, #dc2626)) 12%, transparent);
+  color: var(--color-error, var(--danger-color, #dc2626));
+}
+.passkey-confirm__fallback {
+  background: color-mix(in srgb, #d97706 14%, transparent);
+  color: #b45309;
+}
+.passkey-confirm__fallback p {
+  margin: 0 0 0.5rem;
+}
+.passkey-confirm__fallback-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.passkey-confirm__actions {
+  display: flex;
+  gap: 0.6rem;
+  margin-top: 0.25rem;
+}
+
+/* Button primitives, scoped to this dialog — a clear primary/secondary pair
+   instead of the unstyled global `button` rule every action here fell back to. */
+.passkey-confirm .btn {
+  appearance: none;
+  border-radius: var(--radius-md, 8px);
+  border: 1px solid var(--color-border, var(--border-color, #e5e7eb));
+  background: transparent;
+  color: var(--color-text, var(--text-primary, #111827));
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.65rem 1.1rem;
+  flex: 1;
+  transition: border-color var(--transition-fast, 0.15s ease), background-color var(--transition-fast, 0.15s ease);
+}
+.passkey-confirm .btn-primary {
+  border-color: transparent;
+  background: var(--primary-button, var(--brand-primary, #36B37E));
+  color: var(--primary-button-text, #fff);
+}
+.passkey-confirm .btn-primary:hover:not(:disabled) {
+  background: var(--primary-button-hover, #2F9E6E);
+}
+.passkey-confirm .btn:hover:not(:disabled):not(.btn-primary) {
+  border-color: var(--color-primary, var(--brand-primary, #36B37E));
+}
+.passkey-confirm .btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/wallet/PasskeyConfirm.jsx
+++ b/frontend/src/components/wallet/PasskeyConfirm.jsx
@@ -11,6 +11,7 @@
  */
 
 import PropTypes from 'prop-types'
+import './PasskeyConfirm.css'
 
 function formatFeeLine({ feeQuote }) {
   if (!feeQuote) return 'Network fee: none (relayed intent)'

--- a/frontend/src/lib/passkey/__tests__/smartAccount.test.js
+++ b/frontend/src/lib/passkey/__tests__/smartAccount.test.js
@@ -3,7 +3,7 @@
  * MultiOwnable ABI exactly — parity vectors from test/account/factory.test.js),
  * batch composition, guard refusals, capability gating per network.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('../../../config/networks', () => ({
   getNetwork: vi.fn((chainId) => {
@@ -15,13 +15,24 @@ vi.mock('../../../config/networks', () => ({
         passkey: { bundlerUrls: ['https://bundler.example'], erc20PaymasterUrl: null },
       }
     }
+    if (chainId === 137) {
+      return {
+        chainId: 137,
+        rpcUrl: 'https://rpc.example',
+        capabilities: { passkeyAccounts: true },
+        passkey: {
+          bundlerUrls: ['https://bundler.example/polygon'],
+          erc20PaymasterUrl: 'https://paymaster.example/polygon',
+        },
+      }
+    }
     return { chainId, capabilities: { passkeyAccounts: false }, passkey: null }
   }),
 }))
 
 vi.mock('../../../config/contracts', () => ({
   getContractAddressForChain: vi.fn((key, chainId) => {
-    if (chainId !== 80002) return null
+    if (chainId !== 80002 && chainId !== 137) return null
     return {
       accountFactory: '0xFAC70000000000000000000000000000000000001'.slice(0, 42),
       entryPoint: '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789',
@@ -29,6 +40,18 @@ vi.mock('../../../config/contracts', () => ({
   }),
 }))
 
+vi.mock('viem/account-abstraction', async () => {
+  const actual = await vi.importActual('viem/account-abstraction')
+  return {
+    ...actual,
+    toWebAuthnAccount: vi.fn(() => ({ type: 'webAuthnAccount' })),
+    toCoinbaseSmartAccount: vi.fn(async () => ({ address: '0xACC0000000000000000000000000000000000001' })),
+    createBundlerClient: vi.fn((opts) => opts),
+    createPaymasterClient: vi.fn((opts) => ({ __isPaymasterClient: true, ...opts })),
+  }
+})
+
+import { createBundlerClient, createPaymasterClient } from 'viem/account-abstraction'
 import {
   publicKeyToOwnerBytes,
   addressToOwnerBytes,
@@ -129,6 +152,43 @@ describe('buildAccount credential validation (spec 045 FR-006)', () => {
       buildAccount({ chainId: 80002, credential: { credentialId: 'c1' }, deps: { publicClient } })
     ).rejects.toBeInstanceOf(CredentialRecordIncomplete)
     expect(publicClient.readContract).not.toHaveBeenCalled()
+  })
+})
+
+describe('buildAccount ERC-20 paymaster wiring (issue #854)', () => {
+  const credential = { credentialId: 'c1', publicKey: { x: X, y: Y } }
+  const publicClient = { readContract: vi.fn(), getCode: vi.fn() }
+
+  beforeEach(() => {
+    createBundlerClient.mockClear()
+    createPaymasterClient.mockClear()
+  })
+
+  it('builds a paymaster client from the network config and passes it to the bundler client', async () => {
+    await buildAccount({ chainId: 137, credential, ownerIndex: 0, deps: { publicClient } })
+
+    expect(createPaymasterClient).toHaveBeenCalledTimes(1)
+    const bundlerOpts = createBundlerClient.mock.calls[0][0]
+    expect(bundlerOpts.paymaster).toEqual(
+      expect.objectContaining({ __isPaymasterClient: true })
+    )
+  })
+
+  it('omits the paymaster (native-token fallback) when no ERC-20 paymaster is configured', async () => {
+    await buildAccount({ chainId: 80002, credential, ownerIndex: 0, deps: { publicClient } })
+
+    expect(createPaymasterClient).not.toHaveBeenCalled()
+    const bundlerOpts = createBundlerClient.mock.calls[0][0]
+    expect(bundlerOpts.paymaster).toBeUndefined()
+  })
+
+  it('a test-injected deps.paymaster still overrides the configured URL', async () => {
+    const injected = { __testPaymaster: true }
+    await buildAccount({ chainId: 137, credential, ownerIndex: 0, deps: { publicClient, paymaster: injected } })
+
+    expect(createPaymasterClient).not.toHaveBeenCalled()
+    const bundlerOpts = createBundlerClient.mock.calls[0][0]
+    expect(bundlerOpts.paymaster).toBe(injected)
   })
 })
 

--- a/frontend/src/lib/passkey/smartAccount.js
+++ b/frontend/src/lib/passkey/smartAccount.js
@@ -12,7 +12,12 @@
  */
 
 import { http, createPublicClient, encodeFunctionData, parseAbi } from 'viem'
-import { toWebAuthnAccount, toCoinbaseSmartAccount, createBundlerClient } from 'viem/account-abstraction'
+import {
+  toWebAuthnAccount,
+  toCoinbaseSmartAccount,
+  createBundlerClient,
+  createPaymasterClient,
+} from 'viem/account-abstraction'
 import { getNetwork } from '../../config/networks'
 import { getContractAddressForChain } from '../../config/contracts'
 import { CeremonyCancelled, isTransactComplete } from './credentials'
@@ -85,7 +90,13 @@ export function requirePasskeySupport(chainId) {
   if (!net?.capabilities?.passkeyAccounts || !factory || !entryPoint) {
     throw new ChainNotSupportedError(chainId)
   }
-  return { network: net, factory, entryPoint, bundlerUrls: net.passkey.bundlerUrls }
+  return {
+    network: net,
+    factory,
+    entryPoint,
+    bundlerUrls: net.passkey.bundlerUrls,
+    erc20PaymasterUrl: net.passkey.erc20PaymasterUrl ?? null,
+  }
 }
 
 function safeAddress(key, chainId) {
@@ -156,7 +167,7 @@ export async function resolveOwnerIndex({ chainId, accountAddress, credential, d
  * `signPayload` lets the connector own the ceremony UX (deps-injectable).
  */
 export async function buildAccount({ chainId, credential, ownersBytes, ownerIndex, nonce = 0n, deps = {} }) {
-  const { entryPoint, bundlerUrls } = requirePasskeySupport(chainId)
+  const { entryPoint, bundlerUrls, erc20PaymasterUrl } = requirePasskeySupport(chainId)
   const client = deps.publicClient ?? defaultPublicClient(chainId)
 
   // Refuse incomplete records BEFORE any ceremony — an undefined id/key here
@@ -197,11 +208,19 @@ export async function buildAccount({ chainId, credential, ownersBytes, ownerInde
     ...(ownersBytes ? {} : {}),
   })
 
+  // Fee-in-USDC path (spec 041 §4/FR-014): when a third-party ERC-20 paymaster is configured
+  // for this network, the bundler client fetches paymaster data automatically so the account
+  // never needs a native-token balance to pay gas — the config was previously parsed but never
+  // reached the bundler client, so every UserOp silently required native token (issue #854).
+  // Falls back to native-token fee payment when unconfigured (clarification Q3).
+  const paymaster =
+    deps.paymaster ?? (erc20PaymasterUrl ? createPaymasterClient({ transport: http(erc20PaymasterUrl) }) : undefined)
+
   const bundlerClient = createBundlerClient({
     account,
     client,
     transport: http(bundlerUrls[0]),
-    ...(deps.paymaster ? { paymaster: deps.paymaster } : {}),
+    ...(paymaster ? { paymaster } : {}),
   })
 
   return { account, bundlerClient, entryPoint, bundlerUrls, publicClient: client }


### PR DESCRIPTION
## Summary

Fixes #854 — passkey wallets were unable to complete transfers on Polygon mainnet.

- **Root cause**: passkey stablecoin/native transfers route through the smart-account UserOperation path (`sendPasskeyBatch` → `buildAccount` → `createBundlerClient`). `frontend/src/config/networks.js` already parsed a per-network `erc20PaymasterUrl` (the "pay gas in USDC" rail from spec 041 §4), but `buildAccount` never read it — `requirePasskeySupport` didn't return it and `createBundlerClient` only ever received a `paymaster` when a test injected `deps.paymaster` directly. In production every passkey UserOp silently fell back to requiring a **native MATIC balance** in the smart account. A freshly created passkey account that only holds the USDC it's trying to send has no MATIC to pay that fee, so the transfer failed.
- **Fix**: `buildAccount` now builds a real `viem` paymaster client (`createPaymasterClient`) from the network's configured `erc20PaymasterUrl` and passes it to `createBundlerClient`, so the fee is paid in USDC as designed. When no paymaster is configured for a network, behavior is unchanged (native-token fallback, per spec 041 clarification Q3) — this doesn't change routing/behavior on networks without the env var set, only unblocks it where it is.
- Also fills in the missing theme-aware styling for `PasskeyConfirm` and `DeviceLossWarning` — the pre-ceremony confirmation dialog (amount/counterparty/fee, shown before a passkey transfer signs) and the single-credential risk warning had **no stylesheet at all** and fell through to the unstyled global `button` rule (no primary/secondary visual hierarchy, no dialog surface, no alert tinting). New CSS follows the existing `PayTransfer.css` convention (`var(--color-x, var(--legacy-x, fallback))`, `color-mix()` alert tints) and is scoped under each component's root class so it can't leak into unrelated buttons.

## Changes

- `frontend/src/lib/passkey/smartAccount.js` — wire `erc20PaymasterUrl` through `requirePasskeySupport` → `buildAccount` → `createBundlerClient`.
- `frontend/src/lib/passkey/__tests__/smartAccount.test.js` — new coverage: paymaster client built when configured, omitted (native fallback) when not, test-injected `deps.paymaster` still overrides.
- `frontend/src/components/wallet/PasskeyConfirm.css` (new) + import in `PasskeyConfirm.jsx`.
- `frontend/src/components/wallet/DeviceLossWarning.css` (new) + import in `DeviceLossWarning.jsx`.

## Test plan

- [x] `npx vitest run src/lib/passkey/__tests__/smartAccount.test.js` — 16/16 pass (including 3 new paymaster-wiring tests)
- [x] `npx vitest run src/lib/passkey src/hooks/__tests__/usePasskeyAccount.test.jsx src/connectors/__tests__/passkey.test.js src/test/TransferForm.test.jsx src/test/useTransfer.balances.test.jsx src/contexts/WalletContext.passkey.test.jsx` — 101/101 pass
- [x] `npx vitest run src/components/wallet/__tests__/PasskeyConfirm.test.jsx` — 6/6 pass
- [x] Full frontend suite (`npx vitest run`) — same 3 pre-existing failures on `main` (unrelated `clearpath/ProposalBuilder` tests), no new failures
- [x] `npx eslint` on all changed files — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_0131fZukbS2ApJbaG7LQkg1Q)_