### PR TITLE
Fix passkey UserOp "HTTP request failed": CORS on the alto bundler ingress

### DIFF
--- a/services/alto-bundler/README.md
+++ b/services/alto-bundler/README.md
@@ -16,7 +16,7 @@ browser ─▶ bundler.fairwins.app ─▶ Cloudflare (Transform Rule: +X-Origin
 
 | File | Purpose |
 |---|---|
-| `nginx/bundler.conf.template` | origin-lock map (`$origin_denied`, `map_hash_bucket_size 128`) + `/healthz` exempt + proxy to `127.0.0.1:3000` |
+| `nginx/bundler.conf.template` | origin-lock map (`$origin_denied`, `map_hash_bucket_size 128`) + **CORS allow-list** (`$cors_allow_origin`) + `/healthz` exempt + proxy to `127.0.0.1:3000` |
 | `nginx/docker-entrypoint.sh` | derives `ORIGIN_LOCK_ENABLED` from whether `ORIGIN_LOCK_SECRET` is set (fail-open, never a 403-brick); trims the secret |
 | `nginx/Dockerfile` | `nginx:1.27-alpine` + `envsubst` |
 | `cloudbuild.yaml` | manual/isolated rollout — build the nginx image + `gcloud run services replace` the full 2-container spec |
@@ -30,6 +30,24 @@ change here rolls the bundler out automatically. (It redeploys on *every* main m
 The origin lock is **fail-open by design**: no `ORIGIN_LOCK_SECRET` → `ORIGIN_LOCK_ENABLED=0` → all
 traffic allowed. Mounting the Secret-Manager `origin-lock-secret` is the single switch that arms it, so
 you cannot half-configure it into a deny-everything state.
+
+## CORS (why the bundler needs it)
+
+The SPA (`fairwins.app`) and the bundler (`bundler.fairwins.app`) are **different origins**, so viem's
+browser bundler client makes a **cross-origin** request: its `application/json` UserOp POST
+(`eth_estimateUserOperationGas` / `eth_sendUserOperation`) triggers a CORS preflight. The origin lock is
+*orthogonal* to CORS — it lets the request through, but the browser still blocks it unless the response
+carries `Access-Control-Allow-Origin`. alto emits no CORS headers and 404s `OPTIONS`, so before this the
+first passkey transfer failed with viem's `UserOperationExecutionError: … HTTP request failed` **even
+though the bundler was healthy server-side** (`eth_chainId` → `0x89`). The nginx ingress now:
+
+- answers the preflight `OPTIONS` itself, **before** the origin lock (browsers can't attach
+  `X-Origin-Auth` to a preflight, and `OPTIONS` is side-effect-free), and
+- echoes an allow-listed `Origin` on the actual response.
+
+The allow-list lives in the `$cors_allow_origin` map in `nginx/bundler.conf.template` — **keep it in sync
+with the relay-gateway's `ALLOWED_ORIGINS`** (`services/relay-gateway/src/server.js`), which this mirrors.
+Add one line per SPA origin. A non-allow-listed `Origin` gets no header, so it stays denied by the browser.
 
 ## Rollout status
 

--- a/services/alto-bundler/nginx/bundler.conf.template
+++ b/services/alto-bundler/nginx/bundler.conf.template
@@ -20,6 +20,19 @@ map "${ORIGIN_LOCK_ENABLED}:$http_x_origin_auth" $origin_denied {
     "1:${ORIGIN_LOCK_SECRET}"    0;   # enforcement on + exact secret match => allow
 }
 
+# CORS allow-list. The SPA (fairwins.app) is a DIFFERENT origin than the bundler
+# (bundler.fairwins.app), so viem's browser bundler client makes a cross-origin request: the
+# application/json POST triggers a preflight, and the browser blocks the UserOp unless both the
+# preflight and the actual response carry Access-Control-Allow-Origin. Without this the passkey
+# transfer failed with viem's "HTTP request failed" even though the bundler itself was healthy.
+# $cors_allow_origin echoes the request Origin only when allow-listed (else "" — nginx then omits
+# the header, so unknown origins stay blocked). Keep in sync with the relay-gateway's
+# ALLOWED_ORIGINS (services/relay-gateway/src/server.js); add one line per additional SPA origin.
+map $http_origin $cors_allow_origin {
+    default                 "";
+    "https://fairwins.app"  "https://fairwins.app";
+}
+
 log_format bundler_edge '$remote_addr cf_ip=$http_cf_connecting_ip '
                         'cf_country=$http_cf_ipcountry "$request" $status '
                         '$body_bytes_sent rt=$request_time';
@@ -45,7 +58,25 @@ server {
     # JSON-RPC surface (eth_sendUserOperation, eth_estimateUserOperationGas, pimlico_*). Only
     # Cloudflare-proxied requests carrying the origin-lock secret may reach the bundler.
     location / {
+        # CORS preflight — answer HERE, before the origin lock. Browsers can't attach the
+        # X-Origin-Auth header to a preflight, and OPTIONS is side-effect-free, so we never proxy it
+        # to alto (which 404s OPTIONS and emits no CORS headers). Mirrors relay-gateway server.js.
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin  $cors_allow_origin    always;
+            add_header Vary                         Origin                always;
+            add_header Access-Control-Allow-Methods "GET, POST, OPTIONS"  always;
+            add_header Access-Control-Allow-Headers "Content-Type"        always;
+            add_header Access-Control-Max-Age       600                   always;
+            return 204;
+        }
+
         if ($origin_denied) { return 403; }
+
+        # CORS on the actual response too — the browser checks Access-Control-Allow-Origin on the
+        # real POST, not only the preflight. Empty $cors_allow_origin (non-allow-listed Origin) makes
+        # nginx omit the header, so unknown origins stay denied.
+        add_header Access-Control-Allow-Origin $cors_allow_origin always;
+        add_header Vary                        Origin             always;
 
         proxy_pass http://alto;
         proxy_http_version 1.1;


### PR DESCRIPTION
## Summary

Continuation of the passkey-transfer troubleshooting (#854 / #855 / #856). With signing fixed by #856, the transfer finally reached **bundler submission** and immediately hit viem's

```
UserOperationExecutionError: An error occurred while executing user operation
  └─ HttpRequestError: HTTP request failed
```

## Root cause — missing CORS, not a dead bundler

The SPA is served from `https://fairwins.app`; the bundler is `https://bundler.fairwins.app` — a **different origin**. viem's browser bundler client POSTs `application/json` (`eth_estimateUserOperationGas` / `eth_sendUserOperation`), which triggers a **CORS preflight**. The alto-bundler nginx ingress emitted **no CORS headers** and alto **404s `OPTIONS`**, so the browser blocked every UserOp — even though the bundler is healthy server-side.

Proven live against production:

| Endpoint | Preflight `OPTIONS` (Origin: fairwins.app) | `Access-Control-Allow-Origin` |
|---|---|---|
| `bundler.fairwins.app` (alto) | 404 (no OPTIONS route) | **absent** ❌ |
| `relay.fairwins.app` (gateway) | 204 | `https://fairwins.app` ✅ |

Server-side `eth_chainId` on the bundler returns `200 {"result":"0x89"}` — the bundler works; only the **browser** call is blocked. The origin lock is orthogonal to CORS: it let the request through, but the browser still requires `Access-Control-Allow-Origin`.

## Fix

The relay-gateway already solved the identical `fairwins.app → relay.fairwins.app` case in [`services/relay-gateway/src/server.js`](services/relay-gateway/src/server.js). This mirrors it in the bundler's nginx ingress:

- **Answer the `OPTIONS` preflight at nginx, before the origin lock** — browsers can't attach `X-Origin-Auth` to a preflight, and `OPTIONS` is side-effect-free (never proxied to alto).
- **Echo an allow-listed `Origin`** (new `$cors_allow_origin` map, seeded with `https://fairwins.app`) on the real response. A non-allow-listed origin gets no header, so unknown origins stay denied.

## Test plan

- [x] `nginx -t` passes with the origin lock **armed** and **disarmed**
- [x] End-to-end against live nginx + a mock alto (404s OPTIONS, no CORS — like real alto):
  - preflight → **204 + full CORS**, with *and without* the lock header
  - real POST from `fairwins.app` → **200 + ACAO + proxied `0x89`**
  - disallowed origin (`evil.com`) → 200 but **no ACAO** (browser denies)
  - armed lock, no header → **403 (origin lock preserved)**
  - `/healthz` → 200
- [x] No change to alto, secrets, or the origin-lock semantics — ingress-only

## Deploy note

Merging to `main` auto-rebuilds `alto-bundler-nginx` and `gcloud run services replace`s the bundler (root `cloudbuild.yaml`), so this rolls out on merge. Verify after deploy:

```sh
curl -si -X OPTIONS https://bundler.fairwins.app/ -H 'Origin: https://fairwins.app' \
  -H 'Access-Control-Request-Method: POST' | grep -i access-control-allow-origin
# expect: access-control-allow-origin: https://fairwins.app
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)