### PR TITLE
Fix portfolio category InfoTip bubbles clipped by overflow:hidden

### DIFF
--- a/frontend/src/components/wallet/Portfolio.css
+++ b/frontend/src/components/wallet/Portfolio.css
@@ -59,14 +59,27 @@
 .portfolio-category {
   border: 1px solid var(--color-border, var(--border-color, #e5e7eb));
   border-radius: 10px;
-  overflow: hidden;
+  /* No overflow:hidden here — the InfoTip bubble in the heading row must be
+     able to escape this box (spec 039 FR-008); it was getting clipped to
+     the collapsed section's short height (issue #858). Rounding is instead
+     applied to the heading row and the rows region individually below. */
 }
 .portfolio-category-heading-row {
   align-items: center;
   background: var(--surface-color, var(--bg-secondary, #f9fafb));
+  border-radius: 9px 9px 0 0;
   display: flex;
   gap: 0.25rem;
   padding-right: 0.6rem;
+}
+/* When the category is collapsed, the heading row is the section's only
+   visible child and needs its bottom corners rounded too. */
+.portfolio-category-heading-row:has(+ [hidden]) {
+  border-radius: 9px;
+}
+.portfolio-category > [role='region'] {
+  border-radius: 0 0 9px 9px;
+  overflow: hidden;
 }
 .portfolio-category-heading {
   flex: 1;


### PR DESCRIPTION
## Summary

- Fixes #858: on the portfolio page, opening a category's info bubble (ⓘ) rendered the explainer under the next section, unreadable.
- Root cause: `.portfolio-category` had `overflow: hidden` to clip the heading row's square background corners to the section's rounded border. That box's total height is just the heading row when the category is collapsed, so the `InfoTip` bubble — absolutely positioned below the ⓘ button and taller than that collapsed height — got clipped instead of floating over the page.
- Fix: drop `overflow: hidden` from the section itself, and instead round the heading row directly (rounding its bottom corners too when the following rows region is `hidden`, i.e. collapsed) and scope `overflow: hidden` to just the rows region, which is the only part that actually needs corner clipping.

## Test plan

- [x] `npm run test:frontend -- portfolio InfoTip` — all 119 tests across the portfolio and InfoTip suites (including axe a11y checks) pass.
- [x] Manually reasoned through collapsed/expanded states to confirm the heading row's rounded corners still match the section border in both cases.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SNin4bMKY2kj69df7gK9qq)_