### PR TITLE
Let members choose among passkeys on connect, not just index 0 (issue #849)

### DIFF
--- a/frontend/src/components/wallet/ConnectModal.jsx
+++ b/frontend/src/components/wallet/ConnectModal.jsx
@@ -5,9 +5,11 @@
  * choices. Passkey and WalletConnect are featured ahead of browser wallets
  * (all three stay fully supported).
  *
- * Passkey path: first-time explainer (US4) → in-app account picker when this
- * browser knows several passkeys (US3 — Brave/Chromium won't reliably offer
- * the choice, so the app does) → ceremony pinned to the chosen credential.
+ * Passkey path: first-time explainer (US4) → in-app account picker whenever
+ * this browser knows at least one passkey (US3 + issue #849 — Brave/Chromium
+ * won't reliably offer the choice, and even a lone recorded passkey must not
+ * silently pin the member to index 0) → ceremony pinned to the chosen
+ * credential, or a discoverable request for a passkey not yet in the book.
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react'
@@ -113,16 +115,18 @@ function ConnectModalDialog() {
 
   const startPasskey = useCallback(() => {
     const known = knownCredentials().filter(isTransactComplete)
-    if (known.length >= 2) {
+    // Issue #849: whenever this browser knows at least one passkey, present the
+    // chooser instead of silently pinning to the first (index 0). The picker
+    // lets the member select any known passkey, reach a different one on the
+    // device via "Use a different passkey…", or create another account — the
+    // three acceptance scenarios. Only a browser with an empty book skips
+    // straight to sign-up (there is nothing yet to choose between).
+    if (known.length >= 1) {
       setPickerAccounts(known)
       setStep('picker')
       return
     }
-    // 0 known → connector runs sign-up; 1 known → sign-in pinned to it.
-    doConnect(
-      PASSKEY_CONNECTOR_ID,
-      known.length === 1 ? { credentialId: known[0].credentialId, mode: 'sign-in' } : undefined
-    )
+    doConnect(PASSKEY_CONNECTOR_ID, undefined)
   }, [doConnect])
 
   const handleSelect = useCallback(
@@ -254,8 +258,9 @@ function ConnectModalDialog() {
         {step === 'picker' && (
           <div className="connect-modal__list" data-testid="passkey-picker">
             <p className="connect-modal__hint">
-              This browser knows several passkey accounts. Pick the one to sign into — the app never
-              guesses.
+              {pickerAccounts.length > 1
+                ? 'This browser knows several passkey accounts. Pick the one to sign into — the app never guesses.'
+                : 'Pick a passkey to sign into, use another passkey on this device, or create a new account.'}
             </p>
             {pickerAccounts.map((cred) => (
               <div key={cred.credentialId} className="connect-modal__account-row">
@@ -285,7 +290,7 @@ function ConnectModalDialog() {
               type="button"
               className="connect-modal__option connect-modal__option--secondary"
               disabled={pendingId !== null}
-              onClick={() => doConnect(PASSKEY_CONNECTOR_ID, { mode: 'sign-in' })}
+              onClick={() => doConnect(PASSKEY_CONNECTOR_ID, { mode: 'sign-in', discoverable: true })}
             >
               Use a different passkey…
             </button>

--- a/frontend/src/components/wallet/__tests__/ConnectModal.test.jsx
+++ b/frontend/src/components/wallet/__tests__/ConnectModal.test.jsx
@@ -161,11 +161,20 @@ describe('ConnectModal — multi-passkey account picker (US3)', () => {
     markExplainerSeen()
   })
 
-  it('pins a single known passkey without a picker (one-tap return, SC-004)', async () => {
-    rememberCredential({ credentialId: 'c-only', publicKey: PK(1), address: '0x' + 'a'.repeat(40) })
+  it('offers the chooser for a single known passkey — never silently pins index 0 (issue #849)', async () => {
+    rememberCredential({ credentialId: 'c-only', publicKey: PK(1), address: '0x' + 'a'.repeat(40), label: 'Phone' })
     const user = userEvent.setup()
     render(<ConnectModal />)
     await user.click(screen.getByText('Passkey').closest('button'))
+
+    // A member with one recorded passkey is still presented with a choice
+    // (acceptance #1) rather than being locked to the first credential.
+    expect(screen.getByTestId('passkey-picker')).toBeInTheDocument()
+    expect(mockWallet.connectWallet).not.toHaveBeenCalled()
+    expect(screen.getByText('Use a different passkey…')).toBeInTheDocument()
+    expect(screen.getByText('Create a new account')).toBeInTheDocument()
+
+    await user.click(screen.getByText('Phone').closest('button'))
     expect(mockWallet.connectWallet).toHaveBeenCalledWith('fairwinsPasskey', {
       credentialId: 'c-only',
       mode: 'sign-in',
@@ -195,7 +204,12 @@ describe('ConnectModal — multi-passkey account picker (US3)', () => {
     const user = userEvent.setup()
     render(<ConnectModal />)
     await user.click(screen.getByText('Passkey').closest('button'))
-    // Only one usable record -> pinned directly, no picker.
+    // The picker lists only the usable record; the broken one never appears.
+    expect(screen.getByTestId('passkey-picker')).toBeInTheDocument()
+    expect(screen.getByText('Phone')).toBeInTheDocument()
+    expect(screen.queryByText('Broken')).not.toBeInTheDocument()
+
+    await user.click(screen.getByText('Phone').closest('button'))
     expect(mockWallet.connectWallet).toHaveBeenCalledWith('fairwinsPasskey', {
       credentialId: 'c1',
       mode: 'sign-in',
@@ -210,7 +224,12 @@ describe('ConnectModal — multi-passkey account picker (US3)', () => {
     await user.click(screen.getByText('Passkey').closest('button'))
 
     await user.click(screen.getByText('Use a different passkey…'))
-    expect(mockWallet.connectWallet).toHaveBeenLastCalledWith('fairwinsPasskey', { mode: 'sign-in' })
+    // Discoverable request (no allowCredentials) so passkeys this browser has
+    // never recorded — but that live on the device — are reachable (issue #849).
+    expect(mockWallet.connectWallet).toHaveBeenLastCalledWith('fairwinsPasskey', {
+      mode: 'sign-in',
+      discoverable: true,
+    })
 
     await user.click(screen.getByText('Create a new account'))
     expect(mockWallet.connectWallet).toHaveBeenLastCalledWith('fairwinsPasskey', { mode: 'sign-up' })

--- a/frontend/src/connectors/__tests__/passkey.test.js
+++ b/frontend/src/connectors/__tests__/passkey.test.js
@@ -122,6 +122,13 @@ describe('connect', () => {
     expect(readSession().credentialId).toBe('cred-2') // session pins what was ASSERTED
   })
 
+  it('sign-in forwards discoverable to the assertion so any device passkey is reachable (issue #849)', async () => {
+    rememberCompleteRecord()
+    const { connector, deps } = makeConnector({ options: { mode: 'sign-in' } })
+    await connector.connect({ chainId: 80002, discoverable: true })
+    expect(deps.getAssertion).toHaveBeenCalledWith(expect.objectContaining({ discoverable: true }))
+  })
+
   it('sign-in REFUSES (no session) when the record still cannot transact after repair (FR-005)', async () => {
     // Partial record + ambiguous chain state (two passkey owners): the key
     // cannot be reconstructed, so minting a session would just crash later.

--- a/frontend/src/connectors/passkey.js
+++ b/frontend/src/connectors/passkey.js
@@ -62,7 +62,7 @@ export function passkeyConnector(options = {}) {
       this.capability = await (deps.detectCapability ?? detectCapability)()
     },
 
-    async connect({ chainId, isReconnecting, credentialId, mode: requestedMode } = {}) {
+    async connect({ chainId, isReconnecting, credentialId, discoverable, mode: requestedMode } = {}) {
       const targetChain = chainId ?? config.chains[0]?.id
       requirePasskeySupport(targetChain) // throws ChainNotSupportedError (FR-022)
 
@@ -97,9 +97,13 @@ export function passkeyConnector(options = {}) {
         // when `credentialId` is set; otherwise getAssertion offers the whole
         // local book via allowCredentials so the platform must show a chooser
         // (spec 045 US3 — the app never guesses, and neither may the browser).
+        // `discoverable` (issue #849) widens that to a bare discoverable request
+        // so passkeys this browser never recorded — but that live on the device
+        // — become reachable from "Use a different passkey…".
         const assertion = await (deps.getAssertion ?? getAssertion)({
           challenge: crypto.getRandomValues(new Uint8Array(32)),
           credentialId,
+          discoverable,
           deps,
         })
         credential = { credentialId: assertion.credentialId }

--- a/frontend/src/lib/passkey/__tests__/credentials.test.js
+++ b/frontend/src/lib/passkey/__tests__/credentials.test.js
@@ -117,6 +117,31 @@ describe('getAssertion', () => {
     expect(credentials.get.mock.calls[0][0].publicKey.allowCredentials).toBeUndefined()
   })
 
+  it('discoverable:true skips the local book so any device passkey is reachable (issue #849)', async () => {
+    // "Use a different passkey…" must reach passkeys this browser never recorded.
+    // A non-empty book would otherwise constrain allowCredentials to itself and
+    // hide every other FairWins passkey on the device.
+    const credentials = { get: vi.fn().mockResolvedValue(fakeAssertion) }
+    const book = () => [{ credentialId: 'Y3JlZC1hYmM' }, { credentialId: 'Y3JlZC1kZWY' }]
+    await getAssertion({
+      challenge: new Uint8Array(32),
+      discoverable: true,
+      deps: { credentials, knownCredentials: book },
+    })
+    expect(credentials.get.mock.calls[0][0].publicKey.allowCredentials).toBeUndefined()
+  })
+
+  it('an explicit credentialId still pins even when discoverable is set', async () => {
+    const credentials = { get: vi.fn().mockResolvedValue(fakeAssertion) }
+    await getAssertion({
+      challenge: new Uint8Array(32),
+      credentialId: 'Y3JlZC1hYmM',
+      discoverable: true,
+      deps: { credentials, knownCredentials: () => [] },
+    })
+    expect(credentials.get.mock.calls[0][0].publicKey.allowCredentials).toHaveLength(1)
+  })
+
   it('throws CeremonyCancelled when the browser resolves a null assertion (Brave cancel path)', async () => {
     const credentials = { get: vi.fn().mockResolvedValue(null) }
     await expect(

--- a/frontend/src/lib/passkey/credentials.js
+++ b/frontend/src/lib/passkey/credentials.js
@@ -190,17 +190,26 @@ export async function createCredential({ label, userName = 'FairWins account', d
  * but their first account (spec 045, US3). Only a browser with no local book
  * (fresh device) falls back to the bare discoverable-credential request.
  *
+ * `discoverable: true` deliberately skips the local-book `allowCredentials`
+ * even when the book is non-empty, issuing a bare discoverable request so the
+ * platform offers EVERY FairWins passkey on the device — including ones this
+ * browser has never recorded (issue #849: "several passkeys on one device").
+ * The in-app "Use a different passkey…" escape uses this; the app still never
+ * silently guesses because the platform's own chooser makes the pick.
+ *
  * `prfSalt` (optional Uint8Array(32)) also evaluates the PRF extension.
  * Returns the raw fields the signing layer needs:
  *   { credentialId, signature, authenticatorData, clientDataJSON, prfOutput? }
  */
-export async function getAssertion({ challenge, credentialId, prfSalt, deps = {} }) {
+export async function getAssertion({ challenge, credentialId, prfSalt, discoverable = false, deps = {} }) {
   const credentials = deps.credentials ?? globalThis.navigator?.credentials
   if (!credentials) throw new AuthenticatorUnavailable('no credential manager in this context')
 
   const pinnedIds = credentialId
     ? [credentialId]
-    : (deps.knownCredentials ?? knownCredentials)(deps.storage).map((c) => c.credentialId)
+    : discoverable
+      ? []
+      : (deps.knownCredentials ?? knownCredentials)(deps.storage).map((c) => c.credentialId)
   const allowCredentials = []
   for (const id of pinnedIds) {
     try {


### PR DESCRIPTION
## Summary

Closes #849.

Members signing in with a passkey were effectively locked to the first credential (index 0): the unified connect surface (spec 045) only showed the account chooser when the browser knew **two or more** passkeys. With exactly one recorded passkey it silently pinned to it, and the "Use a different passkey…" escape constrained the WebAuthn assertion to the local book — so a member with several passkeys on one device couldn't select another or create a new one.

This change satisfies all three acceptance scenarios in the issue:

1. **Presented with current passkeys to choose from** — the picker now appears whenever the browser knows ≥ 1 usable passkey, not just ≥ 2.
2. **Select any passkey and have it connect** — known passkeys pin as before; a new `discoverable` path reaches device passkeys the browser has never recorded.
3. **Create more passkeys as needed** — the picker's "Create a new account" escape is now reachable in the single-passkey case too.

## Changes

- **`ConnectModal.jsx`** — `startPasskey` shows the account picker whenever `known.length >= 1` (was `>= 2`); a lone recorded passkey no longer auto-pins. The hint text adapts to the single-passkey case, and "Use a different passkey…" now requests a discoverable assertion.
- **`credentials.js` (`getAssertion`)** — new `discoverable` option that skips the local-book `allowCredentials` and issues a bare discoverable request, so passkeys living on the device but not in this browser's book become reachable. An explicit `credentialId` still pins.
- **`connectors/passkey.js`** — threads `discoverable` from the connect options through to `getAssertion`.

## Testing

- `ConnectModal.test.jsx` — updated the single-passkey case to expect the chooser (no silent index-0 pin) and the discoverable option on "Use a different passkey…".
- `credentials.test.js` — added coverage for the `discoverable` path (skips the book) and that an explicit `credentialId` still pins even when `discoverable` is set.
- `passkey.test.js` — added coverage that the connector forwards `discoverable` to the assertion.
- Full passkey/wallet suite: **115 tests pass**; ESLint clean on the changed files.

## Notes

This intentionally revises spec 045's SC-004 "one-tap return" for a single known passkey — issue #849 (filed after spec 045 shipped) explicitly asks for a choice in that case rather than a silent pin. Every gasless/self-submit fallback and the on-chain owner-index resolution (`resolveOwnerIndex`) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZVTMFWSQSqJ2Ejhe4zqKh

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZVTMFWSQSqJ2Ejhe4zqKh)_