### PR TITLE
Earn section: Morpho lending & Merkl rewards (spec 050, closes #861)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/049-multisig-policy-engine"
+  "feature_directory": "specs/050-earn-lending-rewards"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,5 +104,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/049-multisig-policy-engine/plan.md
+at specs/050-earn-lending-rewards/plan.md
 <!-- SPECKIT END -->

--- a/docs/developer-guide/earn-integration.md
+++ b/docs/developer-guide/earn-integration.md
@@ -1,0 +1,107 @@
+# Earn Integration (Morpho Lending & Merkl Rewards)
+
+Spec 050 (`specs/050-earn-lending-rewards/`) adds the Finance → Earn section: lending into
+curated Morpho ERC-4626 vaults with Merkl reward claiming. This page documents the architecture,
+configuration contract, and the platform-fee decision. It is frontend-only — no FairWins
+contracts, no backend.
+
+## Architecture
+
+```text
+config/earn.js                 global endpoints + limits + earnPath() deep links
+config/networks.js             per-network `earn` block + capability + helpers
+lib/earn/morphoApi.js          Morpho GraphQL: vault discovery + position enrichment
+lib/earn/merkl.js              Merkl REST: reward balances + claim-arg builder
+lib/earn/vaultActions.js       ethers v6 ERC-4626 reads/validators/deposit/withdraw
+lib/earn/earnActivityBuffer.js queues user actions for the activity source
+hooks/useEarnVaults|Positions|Rewards.js
+components/earn/*              EarnPanel (hub) / EarnLendView / VaultSheet /
+                               EarnRewardsView / EarnPositionsList
+data/notifications/sources/earnSource.js   spec-031 activity source
+```
+
+Data flow is honest-state throughout (constitution III): vault lists and APY come live from
+Morpho's API (explicit `unavailable` on failure — deposits disabled, never stale numbers);
+positions are authoritative on-chain reads (`balanceOf` + `convertToAssets` + `maxWithdraw`)
+with API USD/pnl enrichment that degrades to "—"; reward figures carry Merkl's ~8-hour cadence
+in the UI copy and a fetch failure is an explicit state, never a zero.
+
+## External coordinates
+
+| What | Where |
+|---|---|
+| Morpho GraphQL API | `https://api.morpho.org/graphql` (public, 750 req/min) |
+| Merkl rewards API | `https://api.merkl.xyz/v4/users/{lowercased}/rewards?chainId=` |
+| Merkl Distributor | `0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae` (same on all chains) |
+| Legacy rewards (pre-MIP-111) | `https://rewards-legacy.morpho.org/` (link-out only) |
+
+The deprecated `rewards.morpho.org` / Universal Rewards Distributor flow is intentionally not
+implemented — Morpho migrated all reward distribution to Merkl (MIP-111). Claims pass the
+**cumulative** earned amount + proofs; the distributor pays the unclaimed difference, so repeat
+claims are safe no-ops.
+
+## Vault curation
+
+No hand-maintained vault lists. The client queries `vaults(where: { chainId_in, whitelisted:
+true })`, requires `listed: true` (vaults shown on the Morpho app itself), keeps API TVL
+ordering, and caps at `VAULT_LIST_LIMIT`. Only Morpho **Vault V1 (MetaMorpho)** is surfaced in
+this cut: V1 implements the full ERC-4626 surface including honest `maxDeposit`/`maxWithdraw`
+(Vault V2 returns 0 from `max*` by design, which breaks honest limit display).
+
+## Enabling a new network
+
+Everything is config-driven (`FR-008`). To enable earn on a chain (e.g. Base once it becomes a
+FairWins network):
+
+1. Confirm Morpho vaults **and** the Morpho API serve the chain, and Merkl covers it.
+2. Add `earn: earnConfig()` to the chain's `NETWORKS` entry in
+   `frontend/src/config/networks.js` (the capability getter picks it up automatically).
+3. Done — nav, panel gating, portfolio action, and the activity source all key off
+   `capabilities.earn` / `isEarnAvailable(chainId)`.
+
+Networks without the block render an honest unavailable state naming `getEarnNetworks()`.
+Testnets stay disabled: the Morpho API has no testnet data, and a mock vault list would violate
+constitution III.
+
+## Deposit/withdraw safety rails
+
+- Pure validators (`validateDepositAmount`/`validateWithdrawAmount`) reject zero/junk/over-limit
+  amounts with member-facing reasons **before** any wallet prompt.
+- Deposits: exact-amount `approve` (no unlimited allowances) → `previewDeposit` quote →
+  `deposit.staticCall` dry-run → transaction.
+- Withdrawals: bounded by `maxWithdraw` (vault liquidity, surfaced in the UI); full exits use
+  `redeem(shares)` so share dust never strands.
+
+## Activity feed (FR-010)
+
+`earnSource` follows the spec-031 ActivitySource contract. User actions queue
+`{type, refId, message, txHash, txUrl}` records via `earnActivityBuffer`; the source drains them
+into precise entries (entries carry `txUrl`, which the feed renders as a "View transaction"
+explorer link) and snapshot-diffs tracked vault share balances as a backstop for changes made
+outside the app. First sight is baseline; a hard read failure returns `ok:false` so the engine
+keeps the prior slice.
+
+## Platform attribution & treasury fee (the issue #861 conditional)
+
+Morpho has **no transaction-source referral or fee parameter** — nothing like Aave's referral
+code exists in the ERC-4626 path, Bundler3, or the API. Resolution (research.md R4):
+
+- The protocol-**mandated** UI attribution ("Powered by Morpho" + risk disclosure) is
+  implemented in `EarnPanel`.
+- **No platform fee is charged in this release** (FR-013), and the UI says so.
+- The documented path to treasury revenue is a **fee-wrapper vault** (a Vault V2 owned by the
+  FairWins treasury wrapping a curated vault with a performance/management fee — see Morpho's
+  ["How can distributors generate revenue"](https://docs.morpho.org/build/earn/concepts/generate-revenue/)),
+  or an offchain curator revenue-share agreement. The wrapper is a new value-bearing contract
+  and therefore a future spec with the full security lifecycle (constitution I), not a rider on
+  this frontend feature.
+
+## Testing
+
+`frontend/src/test/earn/` covers config gating, API normalizers, cumulative claim math,
+validators, the activity source contract, panel/sheet/rewards component states (including
+honest unavailable states and deep links), and axe WCAG audits. Run with:
+
+```bash
+npm run test:frontend -- earn
+```

--- a/docs/user-guide/earn.md
+++ b/docs/user-guide/earn.md
@@ -1,0 +1,92 @@
+# Earn — Lending & Rewards
+
+The **Earn** section (Finance → Earn) lets you put money you are not using to work. You lend it
+out through **Morpho**, an established on-chain lending protocol, and it earns a return over
+time. You stay in control the whole time: deposits go straight from your own wallet, FairWins
+never holds your money, and you can withdraw whenever you like.
+
+!!! note "Where Earn works"
+    Lending is available on **Ethereum** and **Polygon**. On other networks the Earn section
+    stays visible and tells you where earning is available — switch networks from
+    My Account → Network to use it.
+
+## What lending is (in plain terms)
+
+When you deposit into a **vault**, your money is pooled with other people's and lent to
+borrowers who put up collateral worth more than they borrow. Borrowers pay interest, and your
+share of the pool grows. A professional team — the vault's **curator** — decides where the vault
+lends and how it manages risk. FairWins does not manage vaults and charges **no fee** on Earn.
+
+Every unfamiliar term in the app has a small ⓘ info bubble next to it — tap it for a
+plain-language explanation.
+
+## Lending step by step
+
+1. Open the menu and choose **Earn** in the Finance group, then open **Lend**.
+2. Browse the vault list. For each vault you can see:
+    - the asset it accepts (for example USDC),
+    - the estimated **yearly rate (APY)** — an estimate, not a promise; rates change constantly,
+    - how much everyone has deposited in total,
+    - who manages the vault.
+3. Pick a vault and enter an amount (or tap **Max**). The app checks your amount before your
+   wallet is ever involved and explains any problem in plain language.
+4. Confirm in your wallet. **Your first deposit takes two quick confirmations**: the first gives
+   the vault permission to take exactly the amount you typed, the second makes the deposit. This
+   is standard for on-chain tokens — you never approve more than you typed.
+5. Your position appears under **Your positions** with its current value, which includes the
+   return earned so far.
+
+## Withdrawing
+
+Open your position and choose **Withdraw**. Vaults lend money out, so occasionally not all of it
+can be taken out at the same instant — the sheet always shows what is **available to withdraw
+right now**. If that is temporarily less than your full balance, withdraw what is available and
+come back shortly for the rest. Withdrawing returns your money **plus the return it has earned**
+to your wallet.
+
+## Rewards
+
+Some vaults pay **bonus tokens** on top of the lending return, funded by reward programs run
+through Merkl (the rewards system Morpho uses). Open **Earn → Rewards** to see them:
+
+- **Ready to claim** — tokens you can move to your wallet now with one **Claim** action.
+- **Building up** — rewards that have been earned but are not claimable yet.
+
+Reward figures are recalculated every few hours, so they update on that schedule rather than
+every second. Claiming is safe to repeat — you can never claim the same reward twice. If you
+lent through Morpho before mid-2025, older rewards live on
+[Morpho's legacy rewards page](https://rewards-legacy.morpho.org/).
+
+## Your activity record
+
+Every deposit, withdrawal, and reward claim is recorded in your activity feed (the bell icon)
+with a link to the transaction on the block explorer, so you always have an audit trail.
+
+## Getting there from your portfolio
+
+Viewing an asset in **Portfolio**? Tap **Earn** in the asset's action row and you land directly
+on the vaults that accept that asset. If the asset can't be lent (for example on a network
+without lending), the button says why instead of doing nothing.
+
+## Risks and fees — the honest version
+
+- **Returns are variable.** APY is an estimate based on current conditions and is not guaranteed
+  by FairWins, Morpho, or the vault curator.
+- **Smart contracts carry risk.** Vaults are third-party audited contracts, but no on-chain
+  system is risk-free. Only deposit what you can afford to have at risk.
+- **FairWins charges no fee on Earn** and never takes custody of your deposit. Network gas fees
+  and the vault's own performance fee (already reflected in the displayed APY) still apply.
+- The vault list shows only vaults curated and listed by the Morpho protocol itself.
+
+## FAQ
+
+**Can I lose money?** Vault curators manage risk conservatively and loans are over-collateralized,
+but smart-contract failures or extreme market events can cause losses. The APY shown is net of
+vault fees but is never a guarantee.
+
+**Why is my withdrawal limited right now?** The vault's funds are lent out and the currently idle
+portion is what can leave instantly. Liquidity replenishes continuously.
+
+**Why don't I see rewards immediately after depositing?** Rewards accrue over time and the
+figures refresh every few hours. Not every vault runs a reward program — the vault list shows a
+reward badge in the rate breakdown where one applies.

--- a/frontend/src/abis/ERC4626Vault.js
+++ b/frontend/src/abis/ERC4626Vault.js
@@ -1,0 +1,30 @@
+/**
+ * Minimal ERC-4626 vault ABI for the Earn section (spec 050). Covers the reads
+ * and actions the lending flow needs against Morpho Vault V1 (MetaMorpho)
+ * vaults — which implement the standard faithfully, including working
+ * maxDeposit/maxWithdraw. Human-readable fragments, ethers v6.
+ */
+export const ERC4626_VAULT_ABI = [
+  // Identity / underlying
+  'function asset() view returns (address)',
+  'function name() view returns (string)',
+  'function symbol() view returns (string)',
+  'function decimals() view returns (uint8)',
+  // Share accounting
+  'function balanceOf(address account) view returns (uint256)',
+  'function totalAssets() view returns (uint256)',
+  'function convertToAssets(uint256 shares) view returns (uint256)',
+  'function convertToShares(uint256 assets) view returns (uint256)',
+  // Quotes + honest limits
+  'function previewDeposit(uint256 assets) view returns (uint256)',
+  'function previewWithdraw(uint256 assets) view returns (uint256)',
+  'function previewRedeem(uint256 shares) view returns (uint256)',
+  'function maxDeposit(address receiver) view returns (uint256)',
+  'function maxWithdraw(address owner) view returns (uint256)',
+  // Actions
+  'function deposit(uint256 assets, address receiver) returns (uint256 shares)',
+  'function withdraw(uint256 assets, address receiver, address owner) returns (uint256 shares)',
+  'function redeem(uint256 shares, address receiver, address owner) returns (uint256 assets)',
+]
+
+export default ERC4626_VAULT_ABI

--- a/frontend/src/abis/MerklDistributor.js
+++ b/frontend/src/abis/MerklDistributor.js
@@ -1,0 +1,13 @@
+/**
+ * Merkl Distributor claim ABI (spec 050). Morpho distributes all current
+ * rewards through Merkl (MIP-111); users claim by presenting the CUMULATIVE
+ * earned amount + Merkle proof from the Merkl API. Parallel arrays, one slot
+ * per reward token. The distributor transfers only the unclaimed difference,
+ * so re-claiming with the same cumulative amount is a safe no-op.
+ * Address comes from networks.js earn config — never from user/API input.
+ */
+export const MERKL_DISTRIBUTOR_ABI = [
+  'function claim(address[] users, address[] tokens, uint256[] amounts, bytes32[][] proofs)',
+]
+
+export default MERKL_DISTRIBUTOR_ABI

--- a/frontend/src/components/earn/Earn.css
+++ b/frontend/src/components/earn/Earn.css
@@ -1,0 +1,435 @@
+/* Earn section styles (spec 050). Reuses the asset-sheet modal shell from
+   AssetDetailSheet.css for VaultSheet; everything earn-specific lives here. */
+
+.earn-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.earn-title {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
+}
+
+.earn-subtitle {
+  margin: 0.25rem 0 0;
+  color: var(--text-secondary);
+}
+
+.earn-switch-note,
+.earn-unavailable {
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.35));
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  color: var(--text-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.earn-switch-note p,
+.earn-unavailable p {
+  margin: 0;
+}
+
+/* Area cards (hub) */
+.earn-areas {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 0.75rem;
+}
+
+.earn-area-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  text-align: left;
+  padding: 1rem;
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.35));
+  border-radius: 12px;
+  background: var(--bg-secondary, transparent);
+  color: var(--text-primary, inherit);
+  cursor: pointer;
+}
+
+.earn-area-card:hover:not(:disabled),
+.earn-area-card:focus-visible:not(:disabled) {
+  border-color: var(--brand-primary);
+}
+
+.earn-area-card:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.earn-area-name {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.earn-area-desc {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.earn-area-flag {
+  font-size: 0.75rem;
+  color: var(--text-muted, var(--text-secondary));
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.35));
+  border-radius: 999px;
+  padding: 0.1rem 0.55rem;
+}
+
+.earn-back {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  color: var(--brand-primary);
+  cursor: pointer;
+  padding: 0.25rem 0;
+  font-size: 0.9rem;
+}
+
+/* Lend view */
+.earn-lend,
+.earn-rewards {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.earn-lend-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.earn-lend-header h3,
+.earn-positions h3 {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
+}
+
+.earn-filter-chip {
+  border: 1px solid var(--brand-primary);
+  color: var(--brand-primary);
+  background: none;
+  border-radius: 999px;
+  padding: 0.2rem 0.7rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.earn-state {
+  color: var(--text-secondary);
+  margin: 0.25rem 0;
+}
+
+.earn-vault-list,
+.earn-positions-list,
+.earn-rewards-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.earn-vault-row,
+.earn-position-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.35));
+  border-radius: 10px;
+  background: var(--bg-secondary, transparent);
+  color: var(--text-primary, inherit);
+  cursor: pointer;
+  text-align: left;
+}
+
+.earn-vault-row:hover,
+.earn-vault-row:focus-visible,
+.earn-position-row:hover,
+.earn-position-row:focus-visible {
+  border-color: var(--brand-primary);
+}
+
+.earn-vault-main,
+.earn-position-name {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.earn-vault-name {
+  font-weight: 600;
+}
+
+.earn-vault-asset,
+.earn-vault-curator {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+.earn-vault-numbers,
+.earn-position-values,
+.earn-reward-values {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.15rem;
+  white-space: nowrap;
+}
+
+.earn-vault-apy {
+  font-weight: 600;
+  color: var(--brand-primary);
+}
+
+.earn-vault-tvl,
+.earn-position-usd,
+.earn-reward-pending {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+.earn-position-pnl.up {
+  color: var(--brand-primary);
+  font-size: 0.8rem;
+}
+
+.earn-position-pnl.down {
+  color: var(--danger-color, #c0392b);
+  font-size: 0.8rem;
+}
+
+.earn-legend {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  margin: 0;
+}
+
+/* Rewards */
+.earn-freshness {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+.earn-reward-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.35));
+  border-radius: 10px;
+}
+
+.earn-reward-token {
+  font-weight: 600;
+}
+
+.earn-legacy-note {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  margin: 0;
+}
+
+/* Buttons */
+.earn-btn {
+  border-radius: 8px;
+  padding: 0.55rem 1.1rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.35));
+  background: var(--bg-secondary, transparent);
+  color: var(--text-primary, inherit);
+}
+
+.earn-btn.primary {
+  background: var(--brand-primary);
+  border-color: var(--brand-primary);
+  color: #fff;
+}
+
+.earn-btn.secondary {
+  color: var(--brand-primary);
+  border-color: var(--brand-primary);
+  background: none;
+  align-self: flex-start;
+}
+
+.earn-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* Vault sheet (modal internals) */
+.earn-vault-sheet-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  margin: 0.15rem 0 0;
+}
+
+.earn-mode-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.75rem 0;
+}
+
+.earn-mode-tab {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.35));
+  border-radius: 8px;
+  background: none;
+  color: var(--text-primary, inherit);
+  cursor: pointer;
+}
+
+.earn-mode-tab.active {
+  border-color: var(--brand-primary);
+  color: var(--brand-primary);
+  font-weight: 600;
+}
+
+.earn-mode-tab:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.earn-vault-sheet-facts {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin: 0 0 0.75rem;
+}
+
+.earn-vault-sheet-facts div {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.earn-vault-sheet-facts dt {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.earn-vault-sheet-facts dd {
+  margin: 0;
+  font-weight: 500;
+}
+
+.earn-amount-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 0.75rem;
+}
+
+.earn-amount-input {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.earn-amount-input input {
+  flex: 1;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.35));
+  border-radius: 8px;
+  background: var(--bg-secondary, transparent);
+  color: var(--text-primary, inherit);
+  font-size: 1rem;
+}
+
+.earn-input-error {
+  color: var(--danger-color, #c0392b);
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.earn-summary {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  margin: 0 0 0.75rem;
+}
+
+.earn-submit {
+  width: 100%;
+}
+
+.earn-tx-done {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 0.75rem 0;
+}
+
+.earn-tx-done p {
+  margin: 0;
+}
+
+.earn-tx-done a,
+.earn-docs-link,
+.earn-attribution {
+  color: var(--brand-primary);
+  text-decoration: none;
+}
+
+.earn-tx-done a:hover,
+.earn-docs-link:hover,
+.earn-attribution:hover {
+  text-decoration: underline;
+}
+
+/* Footer: attribution + risk disclosure */
+.earn-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  border-top: 1px solid var(--border-color, rgba(128, 128, 128, 0.35));
+  padding-top: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.earn-attribution {
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.earn-risk {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  margin: 0;
+}
+
+.earn-docs-link {
+  font-size: 0.85rem;
+}

--- a/frontend/src/components/earn/EarnLendView.jsx
+++ b/frontend/src/components/earn/EarnLendView.jsx
@@ -1,0 +1,133 @@
+/**
+ * EarnLendView (spec 050, US1) — the curated lending vault list for the
+ * active network plus the member's open positions. Selecting a vault opens
+ * VaultSheet for deposit/withdraw. Honest states: loading, explicit
+ * "temporarily unavailable" (deposits disabled — never stale numbers), and a
+ * plain empty state. `tokenFilter` (from portfolio deep links) narrows the
+ * list to vaults accepting that asset, with a one-tap clear.
+ */
+import { useMemo, useState } from 'react'
+import { useEarnVaults } from '../../hooks/useEarnVaults'
+import { useEarnPositions } from '../../hooks/useEarnPositions'
+import InfoTip from '../ui/InfoTip'
+import VaultSheet from './VaultSheet'
+import EarnPositionsList from './EarnPositionsList'
+import { EARN_TIPS } from '../../lib/earn/earnCopy'
+import { formatApy, formatTvl } from '../../lib/earn/format'
+
+export default function EarnLendView({ tokenFilter: initialTokenFilter = null }) {
+  const { vaults, status, refresh } = useEarnVaults()
+  const positionsApi = useEarnPositions(vaults)
+  const [tokenFilter, setTokenFilter] = useState(initialTokenFilter)
+  const [selectedVault, setSelectedVault] = useState(null)
+
+  const shownVaults = useMemo(() => {
+    if (!tokenFilter) return vaults
+    const wanted = tokenFilter.toUpperCase()
+    return vaults.filter((v) => v.asset.symbol.toUpperCase() === wanted)
+  }, [vaults, tokenFilter])
+
+  const selectedState = selectedVault
+    ? positionsApi.userStates?.get(selectedVault.address.toLowerCase()) || null
+    : null
+
+  return (
+    <div className="earn-lend">
+      <EarnPositionsList
+        positions={positionsApi.positions}
+        status={positionsApi.status}
+        onSelect={(position) => setSelectedVault(position.vault)}
+      />
+
+      <div className="earn-lend-header">
+        <h3>
+          Lending vaults
+          <InfoTip label="About vaults" className="earn-info">
+            {EARN_TIPS.vault}
+          </InfoTip>
+        </h3>
+        {tokenFilter && (
+          <button type="button" className="earn-filter-chip" onClick={() => setTokenFilter(null)}>
+            {tokenFilter} only · clear ✕
+          </button>
+        )}
+      </div>
+
+      {status === 'loading' && <p className="earn-state">Loading vaults…</p>}
+
+      {status === 'unavailable' && (
+        <div className="earn-unavailable" role="alert">
+          <p>
+            Vault information is temporarily unavailable, so deposits are paused. Your money and
+            existing positions are not affected.
+          </p>
+          <button type="button" className="earn-btn secondary" onClick={refresh}>
+            Try again
+          </button>
+        </div>
+      )}
+
+      {status === 'ready' && shownVaults.length === 0 && (
+        <p className="earn-state">
+          {tokenFilter
+            ? `No vaults accept ${tokenFilter} on this network right now.`
+            : 'No vaults are available on this network right now.'}
+        </p>
+      )}
+
+      {status === 'ready' && shownVaults.length > 0 && (
+        <ul className="earn-vault-list">
+          {shownVaults.map((vault) => (
+            <li key={vault.address}>
+              <button
+                type="button"
+                className="earn-vault-row"
+                onClick={() => setSelectedVault(vault)}
+              >
+                <span className="earn-vault-main">
+                  <span className="earn-vault-name">{vault.name}</span>
+                  <span className="earn-vault-asset">Deposits {vault.asset.symbol}</span>
+                  {vault.curator && (
+                    <span className="earn-vault-curator">Managed by {vault.curator}</span>
+                  )}
+                </span>
+                <span className="earn-vault-numbers">
+                  <span className="earn-vault-apy">{formatApy(vault.netApy)}</span>
+                  <span className="earn-vault-tvl">{formatTvl(vault.totalAssetsUsd)} deposited</span>
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {status === 'ready' && shownVaults.length > 0 && (
+        <p className="earn-legend">
+          <InfoTip label="What is APY?" className="earn-info">
+            {EARN_TIPS.apy}
+          </InfoTip>{' '}
+          Yearly rate (APY) ·{' '}
+          <InfoTip label="What does total deposited mean?" className="earn-info">
+            {EARN_TIPS.totalDeposits}
+          </InfoTip>{' '}
+          Total deposited ·{' '}
+          <InfoTip label="Who manages a vault?" className="earn-info">
+            {EARN_TIPS.curator}
+          </InfoTip>{' '}
+          Vault managers
+        </p>
+      )}
+
+      {selectedVault && (
+        <VaultSheet
+          vault={selectedVault}
+          userState={selectedState}
+          onClose={() => setSelectedVault(null)}
+          onActionComplete={() => {
+            positionsApi.refresh()
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/earn/EarnPanel.jsx
+++ b/frontend/src/components/earn/EarnPanel.jsx
@@ -1,0 +1,180 @@
+/**
+ * EarnPanel (spec 050, issue #861) — the Finance → Earn section hub.
+ *
+ * A member-friendly gateway to passive earning: live area (Lend via Morpho
+ * vaults) plus honest "not yet available" areas (Staking, Bridges), the
+ * member's rewards, protocol attribution + risk disclosure, and a link to the
+ * user guide. Every DeFi term carries an InfoTip (FR-011). On networks
+ * without earn support the panel explains where earning IS available instead
+ * of dead-ending (FR-008).
+ *
+ * Deep links: /wallet?tab=earn[&view=lend|rewards][&chain=<id>][&token=<sym>]
+ * — `chain` is a hint (prompts a switch when it differs from the active
+ * network), `token` prefilters the vault list (used by the portfolio's Earn
+ * action).
+ */
+import { useMemo } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { useWallet } from '../../hooks/useWalletManagement'
+import { getNetwork, isEarnAvailable, getEarnConfig, getEarnNetworks, NETWORKS } from '../../config/networks'
+import InfoTip from '../ui/InfoTip'
+import EarnLendView from './EarnLendView'
+import EarnRewardsView from './EarnRewardsView'
+import { EARN_TIPS, EARN_DISCLOSURE, EARN_AREAS_FUTURE, earnUnavailableCopy } from '../../lib/earn/earnCopy'
+import './Earn.css'
+
+const EARN_DOCS_URL = 'https://docs.FairWins.app/user-guide/earn/'
+const VIEWS = ['home', 'lend', 'rewards']
+
+export default function EarnPanel() {
+  const { chainId, switchNetwork } = useWallet() || {}
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const supported = isEarnAvailable(chainId)
+  const network = getNetwork(chainId)
+  const earnConfig = getEarnConfig(chainId)
+  const earnNetworkNames = useMemo(() => getEarnNetworks().map((n) => n.name), [])
+
+  // View selection is derived from ?view= so nav/portfolio deep links land
+  // directly and back/forward keep working — no duplicated state.
+  const requestedView = searchParams.get('view')
+  const view = VIEWS.includes(requestedView) ? requestedView : 'home'
+
+  const openView = (next) => {
+    const params = new URLSearchParams(searchParams)
+    if (next === 'home') params.delete('view')
+    else params.set('view', next)
+    setSearchParams(params, { replace: true })
+  }
+
+  // ?chain= hint from deep links: when it names a different earn-enabled
+  // network, offer the switch honestly instead of silently ignoring it.
+  const chainHint = Number(searchParams.get('chain')) || null
+  const hintNetwork = chainHint && chainHint !== chainId ? NETWORKS[chainHint] : null
+  const tokenFilter = searchParams.get('token') || null
+
+  return (
+    <div className="earn-panel section">
+      <div className="earn-header">
+        <h2 className="earn-title">
+          Earn
+          <InfoTip label="About Earn" className="earn-info">
+            {EARN_TIPS.earn}
+          </InfoTip>
+        </h2>
+        <p className="earn-subtitle">
+          Put money you are not using to work and earn a return — you stay in control the whole
+          time.
+        </p>
+      </div>
+
+      {hintNetwork && (
+        <div className="earn-switch-note" role="note">
+          <p>
+            You followed a link for {hintNetwork.name}, but your wallet is on{' '}
+            {network?.name || 'another network'}.
+          </p>
+          {typeof switchNetwork === 'function' && (
+            <button
+              type="button"
+              className="earn-btn secondary"
+              onClick={() => switchNetwork(chainHint)}
+            >
+              Switch to {hintNetwork.name}
+            </button>
+          )}
+        </div>
+      )}
+
+      {!supported && (
+        <div className="earn-unavailable" role="note">
+          <p>{earnUnavailableCopy(network?.name, earnNetworkNames)}</p>
+        </div>
+      )}
+
+      {view === 'home' && (
+        <div className="earn-areas" aria-label="Earning opportunities">
+          <button
+            type="button"
+            className="earn-area-card"
+            disabled={!supported}
+            title={supported ? undefined : earnUnavailableCopy(network?.name, earnNetworkNames)}
+            onClick={() => openView('lend')}
+          >
+            <span className="earn-area-name">Lend</span>
+            <span className="earn-area-desc">
+              Deposit into a managed lending vault and earn interest. Withdraw any time.
+            </span>
+            {!supported && <span className="earn-area-flag">Not on this network</span>}
+          </button>
+
+          <button
+            type="button"
+            className="earn-area-card"
+            disabled={!supported}
+            title={supported ? undefined : earnUnavailableCopy(network?.name, earnNetworkNames)}
+            onClick={() => openView('rewards')}
+          >
+            <span className="earn-area-name">Rewards</span>
+            <span className="earn-area-desc">
+              See bonus tokens your deposits have earned and claim them to your wallet.
+            </span>
+            {!supported && <span className="earn-area-flag">Not on this network</span>}
+          </button>
+
+          {/* Future areas render honestly disabled — same pattern as the
+              portfolio's Stake action (constitution III: no dead buttons
+              without a reason, no pretend features). */}
+          <button
+            type="button"
+            className="earn-area-card"
+            disabled
+            title={EARN_AREAS_FUTURE.staking}
+          >
+            <span className="earn-area-name">Stake</span>
+            <span className="earn-area-desc">{EARN_AREAS_FUTURE.staking}</span>
+            <span className="earn-area-flag">Coming later</span>
+          </button>
+          <button
+            type="button"
+            className="earn-area-card"
+            disabled
+            title={EARN_AREAS_FUTURE.bridges}
+          >
+            <span className="earn-area-name">Bridges</span>
+            <span className="earn-area-desc">{EARN_AREAS_FUTURE.bridges}</span>
+            <span className="earn-area-flag">Coming later</span>
+          </button>
+        </div>
+      )}
+
+      {view !== 'home' && (
+        <button type="button" className="earn-back" onClick={() => openView('home')}>
+          ← All earning options
+        </button>
+      )}
+
+      {/* The not-supported explanation renders once above (FR-008), so the
+          sub-views simply stay absent on non-earn networks. */}
+      {view === 'lend' && supported && <EarnLendView tokenFilter={tokenFilter} />}
+      {view === 'rewards' && supported && <EarnRewardsView />}
+
+      <footer className="earn-footer">
+        {earnConfig?.provider && (
+          <a
+            className="earn-attribution"
+            href={earnConfig.provider.url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {EARN_DISCLOSURE.attribution}
+          </a>
+        )}
+        <p className="earn-risk">{EARN_DISCLOSURE.risk}</p>
+        <a className="earn-docs-link" href={EARN_DOCS_URL} target="_blank" rel="noopener noreferrer">
+          Learn more in the Earn guide ↗
+        </a>
+      </footer>
+    </div>
+  )
+}

--- a/frontend/src/components/earn/EarnPositionsList.jsx
+++ b/frontend/src/components/earn/EarnPositionsList.jsx
@@ -1,0 +1,66 @@
+/**
+ * EarnPositionsList (spec 050, FR-005) — the member's active lending
+ * positions on the active network: current value (on-chain truth) with USD
+ * value and earned-so-far shown only when the data service can price them
+ * ("—" otherwise — honest degradation, never a fabricated number).
+ */
+import { formatUnits } from 'ethers'
+import InfoTip from '../ui/InfoTip'
+import SensitiveValue from '../common/SensitiveValue'
+import { EARN_TIPS } from '../../lib/earn/earnCopy'
+
+function formatUsd(n) {
+  if (n == null) return null
+  return `$${Number(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+}
+
+function formatAssets(position) {
+  const value = Number(formatUnits(position.assets, position.vault.asset.decimals))
+  return `${value.toLocaleString('en-US', { maximumFractionDigits: 6 })} ${position.vault.asset.symbol}`
+}
+
+export default function EarnPositionsList({ positions, status, onSelect }) {
+  if (status !== 'ready' || !positions?.length) return null
+  return (
+    <div className="earn-positions">
+      <h3>
+        Your positions
+        <InfoTip label="About your positions" className="earn-info">
+          {EARN_TIPS.positions}
+        </InfoTip>
+      </h3>
+      <ul className="earn-positions-list">
+        {positions.map((position) => (
+          <li key={position.vault.address}>
+            <button
+              type="button"
+              className="earn-position-row"
+              onClick={() => onSelect?.(position)}
+            >
+              <span className="earn-position-name">{position.vault.name}</span>
+              <span className="earn-position-values">
+                <SensitiveValue className="earn-position-assets">
+                  {formatAssets(position)}
+                </SensitiveValue>
+                {formatUsd(position.assetsUsd) ? (
+                  <SensitiveValue className="earn-position-usd">
+                    {formatUsd(position.assetsUsd)}
+                  </SensitiveValue>
+                ) : (
+                  <span className="earn-position-usd" aria-label="USD value unavailable">
+                    —
+                  </span>
+                )}
+                {position.pnlUsd != null && (
+                  <SensitiveValue className={`earn-position-pnl ${position.pnlUsd >= 0 ? 'up' : 'down'}`}>
+                    {`${position.pnlUsd >= 0 ? '+' : ''}${formatUsd(position.pnlUsd)} so far`}
+                  </SensitiveValue>
+                )}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/frontend/src/components/earn/EarnRewardsView.jsx
+++ b/frontend/src/components/earn/EarnRewardsView.jsx
@@ -1,0 +1,125 @@
+/**
+ * EarnRewardsView (spec 050, US2) — bonus reward tokens the member's lending
+ * has earned (Merkl program), with a single claim action.
+ *
+ * Honest states: an unreachable rewards service is an explicit "temporarily
+ * unavailable" (never a fabricated zero); figures carry their refresh cadence
+ * ("updates every few hours"); the claim button never prompts the wallet when
+ * nothing is claimable. Claim success is reported from the tx receipt.
+ */
+import { formatUnits } from 'ethers'
+import { useEarnRewards } from '../../hooks/useEarnRewards'
+import InfoTip from '../ui/InfoTip'
+import SensitiveValue from '../common/SensitiveValue'
+import { EARN_TIPS } from '../../lib/earn/earnCopy'
+
+function fmtToken(amountBig, token) {
+  const value = Number(formatUnits(amountBig, token.decimals))
+  return `${value.toLocaleString('en-US', { maximumFractionDigits: 6 })} ${token.symbol}`
+}
+
+export default function EarnRewardsView() {
+  const { rewards, status, fetchedAt, totalClaimable, claim, claimState, legacyRewardsUrl, refresh } =
+    useEarnRewards()
+
+  return (
+    <div className="earn-rewards">
+      <div className="earn-lend-header">
+        <h3>
+          Rewards
+          <InfoTip label="About rewards" className="earn-info">
+            {EARN_TIPS.rewards}
+          </InfoTip>
+        </h3>
+        {fetchedAt && (
+          <span className="earn-freshness">
+            Updates every few hours
+            <InfoTip label="Why not real-time?" className="earn-info">
+              {EARN_TIPS.rewardsFreshness}
+            </InfoTip>
+          </span>
+        )}
+      </div>
+
+      {status === 'loading' && <p className="earn-state">Checking your rewards…</p>}
+
+      {status === 'unavailable' && (
+        <div className="earn-unavailable" role="alert">
+          <p>
+            Reward information is temporarily unavailable. Any rewards you have earned are safe —
+            check back shortly.
+          </p>
+          <button type="button" className="earn-btn secondary" onClick={refresh}>
+            Try again
+          </button>
+        </div>
+      )}
+
+      {status === 'ready' && rewards.length === 0 && (
+        <p className="earn-state">
+          Nothing to claim yet. Rewards build up over time while you have money lent out in a vault
+          that runs a reward program — they will appear here.
+        </p>
+      )}
+
+      {status === 'ready' && rewards.length > 0 && (
+        <>
+          <ul className="earn-rewards-list">
+            {rewards.map((reward) => (
+              <li key={reward.token.address} className="earn-reward-row">
+                <span className="earn-reward-token">{reward.token.symbol}</span>
+                <span className="earn-reward-values">
+                  <SensitiveValue className="earn-reward-claimable">
+                    {reward.claimable > 0n
+                      ? `${fmtToken(reward.claimable, reward.token)} ready to claim`
+                      : 'Nothing ready yet'}
+                  </SensitiveValue>
+                  {reward.pending > 0n && (
+                    <SensitiveValue className="earn-reward-pending">
+                      {`${fmtToken(reward.pending, reward.token)} building up`}
+                    </SensitiveValue>
+                  )}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          {claimState.status === 'confirmed' ? (
+            <div className="earn-tx-done" role="status">
+              <p>Rewards claimed — they are in your wallet.</p>
+              {claimState.txUrl && (
+                <a href={claimState.txUrl} target="_blank" rel="noopener noreferrer">
+                  View transaction ↗
+                </a>
+              )}
+            </div>
+          ) : (
+            <button
+              type="button"
+              className="earn-btn primary"
+              onClick={claim}
+              disabled={totalClaimable === 0 || claimState.status === 'pending'}
+              title={totalClaimable === 0 ? 'Nothing is ready to claim yet' : undefined}
+            >
+              {claimState.status === 'pending' ? 'Waiting for confirmation…' : 'Claim rewards'}
+            </button>
+          )}
+          {claimState.status === 'error' && (
+            <p className="earn-input-error" role="alert">
+              {claimState.error}
+            </p>
+          )}
+        </>
+      )}
+
+      {legacyRewardsUrl && (
+        <p className="earn-legacy-note">
+          Lent through Morpho before mid-2025?{' '}
+          <a href={legacyRewardsUrl} target="_blank" rel="noopener noreferrer">
+            Check Morpho&rsquo;s legacy rewards page ↗
+          </a>
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/earn/VaultSheet.jsx
+++ b/frontend/src/components/earn/VaultSheet.jsx
@@ -1,0 +1,342 @@
+/**
+ * VaultSheet (spec 050, US1) — deposit into / withdraw from one lending
+ * vault. Bottom-sheet modal per repo convention (Escape + backdrop close,
+ * focus managed).
+ *
+ * Non-intimidating by design: amounts are validated with member-facing
+ * reasons BEFORE any wallet prompt; a first deposit explains the two wallet
+ * confirmations (approval + deposit) up front; a plain-English summary states
+ * exactly what will happen; withdrawal honors the vault's honest liquidity
+ * bound (maxWithdraw). Every completed action is queued for the activity
+ * feed with its transaction link (FR-010).
+ */
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { formatUnits, parseUnits } from 'ethers'
+import { useWallet } from '../../hooks/useWalletManagement'
+import { useActivityOptional } from '../../hooks/useActivity'
+import { getBlockscoutUrl } from '../../config/blockExplorer'
+import InfoTip from '../ui/InfoTip'
+import { EARN_TIPS } from '../../lib/earn/earnCopy'
+import {
+  validateDepositAmount,
+  validateWithdrawAmount,
+  needsApproval,
+  approveDeposit,
+  depositToVault,
+  withdrawFromVault,
+} from '../../lib/earn/vaultActions'
+import { queueEarnAction } from '../../lib/earn/earnActivityBuffer'
+import { formatApy } from '../../lib/earn/format'
+
+function fmt(amountBig, decimals, symbol) {
+  if (amountBig == null) return '—'
+  const value = Number(formatUnits(amountBig, decimals))
+  return `${value.toLocaleString('en-US', { maximumFractionDigits: 6 })} ${symbol}`
+}
+
+export default function VaultSheet({ vault, userState, onClose, onActionComplete }) {
+  const { address, chainId, signer } = useWallet() || {}
+  const activity = useActivityOptional()
+  const sheetRef = useRef(null)
+  const restoreFocusRef = useRef(null)
+
+  const [mode, setMode] = useState('deposit')
+  const [amountText, setAmountText] = useState('')
+  const [inputError, setInputError] = useState(null)
+  // idle | approving | confirming | done | error
+  const [txState, setTxState] = useState({ step: 'idle', txUrl: null, error: null })
+
+  useEffect(() => {
+    restoreFocusRef.current = document.activeElement
+    sheetRef.current?.focus()
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', onKeyDown, true)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown, true)
+      document.body.style.overflow = previousOverflow
+      restoreFocusRef.current?.focus?.()
+    }
+  }, [onClose])
+
+  const decimals = vault.asset.decimals
+  const symbol = vault.asset.symbol
+  const hasPosition = (userState?.shares ?? 0n) > 0n
+
+  const amount = useMemo(() => {
+    const trimmed = amountText.trim()
+    if (!trimmed) return null
+    try {
+      return parseUnits(trimmed, decimals)
+    } catch {
+      return undefined // unparseable — distinct from empty
+    }
+  }, [amountText, decimals])
+
+  const maxAmount =
+    mode === 'deposit' ? userState?.walletBalance ?? null : userState?.maxWithdrawAssets ?? null
+
+  const setMax = () => {
+    if (maxAmount == null) return
+    setAmountText(formatUnits(maxAmount, decimals))
+    setInputError(null)
+  }
+
+  const validate = () => {
+    if (amount === undefined) return { ok: false, reason: 'Enter a valid number.' }
+    return mode === 'deposit'
+      ? validateDepositAmount({
+          amount,
+          walletBalance: userState?.walletBalance ?? null,
+          maxDepositAssets: userState?.maxDepositAssets ?? null,
+        })
+      : validateWithdrawAmount({ amount, maxWithdrawAssets: userState?.maxWithdrawAssets ?? null })
+  }
+
+  const submit = async () => {
+    const check = validate()
+    if (!check.ok) {
+      setInputError(check.reason)
+      return
+    }
+    setInputError(null)
+    if (!signer || !address) return
+
+    try {
+      let receipt
+      let message
+      if (mode === 'deposit') {
+        const provider = signer.provider
+        const requiresApproval = await needsApproval({ vault, account: address, amount, provider })
+        if (requiresApproval) {
+          setTxState({ step: 'approving', txUrl: null, error: null })
+          await approveDeposit({ vault, amount, signer })
+        }
+        setTxState({ step: 'confirming', txUrl: null, error: null })
+        ;({ receipt } = await depositToVault({ vault, account: address, amount, signer }))
+        message = `Deposited ${fmt(amount, decimals, symbol)} into ${vault.name}`
+      } else {
+        setTxState({ step: 'confirming', txUrl: null, error: null })
+        // A full withdrawal redeems all shares so no dust strands.
+        const isFullExit =
+          userState?.maxWithdrawAssets != null && amount === userState.maxWithdrawAssets &&
+          userState?.shares != null
+        ;({ receipt } = await withdrawFromVault({
+          vault,
+          account: address,
+          amount,
+          redeemAllShares: isFullExit ? userState.shares : null,
+          signer,
+        }))
+        message = `Withdrew ${fmt(amount, decimals, symbol)} from ${vault.name}`
+      }
+
+      const txUrl = getBlockscoutUrl(chainId, receipt.hash, 'tx')
+      queueEarnAction(address, chainId, {
+        type: mode === 'deposit' ? 'earn-deposit' : 'earn-withdraw',
+        refId: vault.address,
+        message,
+        txHash: receipt.hash,
+        txUrl,
+        at: Date.now(),
+      })
+      activity?.refresh?.()
+      setTxState({ step: 'done', txUrl, error: null })
+      onActionComplete?.()
+    } catch (err) {
+      const rejected = /rejected|denied/i.test(err?.message || '')
+      setTxState({
+        step: 'error',
+        txUrl: null,
+        error: rejected
+          ? 'Transaction was cancelled in your wallet. Nothing was moved.'
+          : 'The transaction could not be completed. Nothing was moved — you can try again.',
+      })
+    }
+  }
+
+  const busy = txState.step === 'approving' || txState.step === 'confirming'
+  const titleId = 'earn-vault-sheet-title'
+
+  return (
+    <div className="asset-sheet-backdrop">
+      <button type="button" className="asset-sheet-scrim" aria-label="Close vault details" onClick={onClose} />
+      <div
+        className="asset-sheet earn-vault-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        ref={sheetRef}
+      >
+        <div className="asset-sheet-grabber" aria-hidden="true" />
+        <div className="asset-sheet-header">
+          <div className="asset-sheet-heading">
+            <h3 id={titleId}>{vault.name}</h3>
+            <p className="earn-vault-sheet-meta">
+              Deposits {symbol} · {formatApy(vault.netApy)} yearly rate
+              <InfoTip label="What is APY?" className="earn-info">
+                {EARN_TIPS.apy}
+              </InfoTip>
+            </p>
+            {vault.curator && <p className="earn-vault-sheet-meta">Managed by {vault.curator}</p>}
+          </div>
+          <button type="button" className="asset-sheet-close" onClick={onClose}>
+            Close
+          </button>
+        </div>
+
+        {userState == null ? (
+          <p className="earn-state">Loading your balances…</p>
+        ) : txState.step === 'done' ? (
+          <div className="earn-tx-done" role="status">
+            <p>
+              {mode === 'deposit' ? 'Deposit complete.' : 'Withdrawal complete.'} Your balances
+              update in a moment.
+            </p>
+            {txState.txUrl && (
+              <a href={txState.txUrl} target="_blank" rel="noopener noreferrer">
+                View transaction ↗
+              </a>
+            )}
+            <button type="button" className="earn-btn primary" onClick={onClose}>
+              Done
+            </button>
+          </div>
+        ) : (
+          <>
+            <div className="earn-mode-tabs" role="tablist" aria-label="Deposit or withdraw">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={mode === 'deposit'}
+                className={`earn-mode-tab ${mode === 'deposit' ? 'active' : ''}`}
+                onClick={() => {
+                  setMode('deposit')
+                  setAmountText('')
+                  setInputError(null)
+                }}
+              >
+                Deposit
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={mode === 'withdraw'}
+                className={`earn-mode-tab ${mode === 'withdraw' ? 'active' : ''}`}
+                disabled={!hasPosition}
+                title={hasPosition ? undefined : 'You have nothing in this vault yet'}
+                onClick={() => {
+                  setMode('withdraw')
+                  setAmountText('')
+                  setInputError(null)
+                }}
+              >
+                Withdraw
+              </button>
+            </div>
+
+            <dl className="earn-vault-sheet-facts">
+              {mode === 'deposit' ? (
+                <>
+                  <div>
+                    <dt>In your wallet</dt>
+                    <dd>{fmt(userState.walletBalance, decimals, symbol)}</dd>
+                  </div>
+                  {hasPosition && (
+                    <div>
+                      <dt>Already in this vault</dt>
+                      <dd>{fmt(userState.assets, decimals, symbol)}</dd>
+                    </div>
+                  )}
+                </>
+              ) : (
+                <>
+                  <div>
+                    <dt>In this vault</dt>
+                    <dd>{fmt(userState.assets, decimals, symbol)}</dd>
+                  </div>
+                  <div>
+                    <dt>
+                      Available to withdraw now
+                      <InfoTip label="Why can availability differ?" className="earn-info">
+                        {EARN_TIPS.withdrawalLiquidity}
+                      </InfoTip>
+                    </dt>
+                    <dd>{fmt(userState.maxWithdrawAssets, decimals, symbol)}</dd>
+                  </div>
+                </>
+              )}
+            </dl>
+
+            <div className="earn-amount-row">
+              <label htmlFor="earn-amount">Amount ({symbol})</label>
+              <div className="earn-amount-input">
+                <input
+                  id="earn-amount"
+                  type="text"
+                  inputMode="decimal"
+                  autoComplete="off"
+                  placeholder="0.00"
+                  value={amountText}
+                  disabled={busy}
+                  onChange={(e) => {
+                    setAmountText(e.target.value)
+                    setInputError(null)
+                  }}
+                />
+                <button type="button" className="earn-btn secondary" onClick={setMax} disabled={busy || maxAmount == null}>
+                  Max
+                </button>
+              </div>
+              {inputError && (
+                <p className="earn-input-error" role="alert">
+                  {inputError}
+                </p>
+              )}
+            </div>
+
+            {mode === 'deposit' && (
+              <p className="earn-summary">
+                Your {symbol} moves from your wallet into this vault and starts earning. You can
+                withdraw it whenever you like. A first deposit asks for two quick wallet
+                confirmations.
+                <InfoTip label="Why two confirmations?" className="earn-info">
+                  {EARN_TIPS.approval}
+                </InfoTip>
+              </p>
+            )}
+            {mode === 'withdraw' && (
+              <p className="earn-summary">
+                Your {symbol}, including what it has earned, moves from the vault back to your
+                wallet.
+              </p>
+            )}
+
+            {txState.step === 'error' && (
+              <p className="earn-input-error" role="alert">
+                {txState.error}
+              </p>
+            )}
+
+            <button type="button" className="earn-btn primary earn-submit" onClick={submit} disabled={busy}>
+              {txState.step === 'approving'
+                ? 'Waiting for approval…'
+                : txState.step === 'confirming'
+                  ? 'Waiting for confirmation…'
+                  : mode === 'deposit'
+                    ? `Deposit ${symbol}`
+                    : `Withdraw ${symbol}`}
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/nav/NavIcon.jsx
+++ b/frontend/src/components/nav/NavIcon.jsx
@@ -41,6 +41,8 @@ const ICON_PATHS = {
   check: <><path d="m5 12.5 4.5 4.5L19 6.5" /></>,
   user: <><circle cx="12" cy="8" r="3.5" /><path d="M5.5 20c.8-4.2 12.2-4.2 13 0" /></>,
   trending: <><path d="M4 15.5 9.5 10l3.5 3.5L20 6" /><path d="M15.5 6H20v4.5" /></>,
+  // Earn (spec 050) — a sprouting seedling: assets at rest, growing.
+  sprout: <><path d="M12 20v-7" /><path d="M12 13c0-3.3-2.7-6-6-6H4.5v.5c0 3.3 2.7 6 6 6H12" /><path d="M12 11c0-2.8 2.2-5 5-5h2.5v.5c0 2.8-2.2 5-5 5H12" /><path d="M7.5 20h9" /></>,
 }
 
 export default function NavIcon({ name, size = 18, className = '' }) {

--- a/frontend/src/components/notifications/ActivityFeed.css
+++ b/frontend/src/components/notifications/ActivityFeed.css
@@ -180,6 +180,20 @@
   white-space: nowrap;
 }
 
+/* External explorer link for entries stamped with a txUrl (spec 050 earn). */
+.entry-tx-link {
+  display: block;
+  padding: 0 0.75rem 0.5rem 2.4rem;
+  font-size: 0.75rem;
+  color: var(--brand-primary);
+  text-decoration: none;
+}
+
+.entry-tx-link:hover,
+.entry-tx-link:focus-visible {
+  text-decoration: underline;
+}
+
 @media (max-width: 480px) {
   .activity-feed {
     position: fixed;

--- a/frontend/src/components/notifications/ActivityFeed.jsx
+++ b/frontend/src/components/notifications/ActivityFeed.jsx
@@ -138,6 +138,13 @@ function ActivityFeed({ onClose }) {
                 </span>
                 <span className="entry-time">{relativeTime(entry.createdAt, now)}</span>
               </button>
+              {/* Entries stamped with a txUrl (e.g. earn actions, spec 050) get a
+                  direct explorer link alongside the in-app deep link. */}
+              {entry.txUrl && (
+                <a className="entry-tx-link" href={entry.txUrl} target="_blank" rel="noopener noreferrer">
+                  View transaction ↗
+                </a>
+              )}
             </li>
           ))}
         </ul>

--- a/frontend/src/components/wallet/AssetDetailSheet.jsx
+++ b/frontend/src/components/wallet/AssetDetailSheet.jsx
@@ -47,6 +47,19 @@ function actionsFor(instance) {
       to: `/wallet?tab=paytransfer&chain=${asset.chainId}&token=${encodeURIComponent(asset.symbol)}`,
     },
     {
+      // Earn (spec 050): lend this asset through the Earn section. Enabled
+      // when the instance's network supports earn and the asset is fungible;
+      // the lend view prefilters to vaults accepting this asset.
+      id: 'earn',
+      label: 'Earn',
+      enabled: asset.kind !== 'nft' && Boolean(net?.earn),
+      reason:
+        asset.kind === 'nft'
+          ? 'Collectibles cannot be lent'
+          : 'Earning is not available on this network',
+      to: `/wallet?tab=earn&view=lend&chain=${asset.chainId}&token=${encodeURIComponent(asset.symbol)}`,
+    },
+    {
       id: 'stake',
       label: 'Stake',
       enabled: false,

--- a/frontend/src/config/appNav.js
+++ b/frontend/src/config/appNav.js
@@ -23,6 +23,9 @@ export const NAV_GROUPS = [
     label: 'Finance',
     items: [
       { id: 'portfolio', label: 'Portfolio', icon: 'trending' },
+      // Earn — lending & rewards (spec 050). Always present; the panel
+      // self-discloses per-network availability.
+      { id: 'earn', label: 'Earn', icon: 'sprout' },
       { id: 'trade', label: 'Trade', icon: 'trade' },
       { id: 'paytransfer', label: 'Pay & Transfer', icon: 'transfer' },
       // 'custody' tab id preserved; surfaced to users as "Protect".

--- a/frontend/src/config/earn.js
+++ b/frontend/src/config/earn.js
@@ -1,0 +1,40 @@
+/**
+ * Earn section constants (spec 050 — lending & rewards, issue #861).
+ *
+ * Global, chain-independent coordinates for the Morpho lending integration and
+ * the Merkl rewards program. Per-network coordinates (provider identity, the
+ * Merkl distributor address, legacy rewards link) live on each NETWORKS entry's
+ * `earn` block — see config/networks.js and
+ * specs/050-earn-lending-rewards/contracts/earn-config.md.
+ *
+ * All values are public canonical endpoints/limits, not secrets.
+ */
+
+// Morpho's public GraphQL API — vault discovery, APY/TVL, position enrichment.
+// Public, no auth; rate limit 750 req/min (we issue a handful per session).
+export const MORPHO_API_URL = 'https://api.morpho.org/graphql'
+
+// Merkl rewards API (Morpho migrated all reward distribution to Merkl under
+// MIP-111 — the legacy rewards.morpho.org/URD flow is deprecated).
+export const MERKL_API_URL = 'https://api.merkl.xyz/v4'
+
+// Cap on curated vaults surfaced per chain (TVL-ordered, whitelisted+listed
+// only). Keeps the list scannable for non-technical members.
+export const VAULT_LIST_LIMIT = 20
+
+// Position refresh cadence — aligned with usePortfolio's 60s poll.
+export const POSITIONS_POLL_MS = 60_000
+
+/**
+ * Build a deep link into the Earn section.
+ * `/wallet?tab=earn[&view=lend|rewards][&chain=<id>][&token=<sym>]`
+ * `chain` is a hint (the section operates on the active wallet network and
+ * prompts a switch when they differ); `token` prefilters the vault list.
+ */
+export function earnPath({ view, chainId, tokenSymbol } = {}) {
+  const params = new URLSearchParams({ tab: 'earn' })
+  if (view) params.set('view', view)
+  if (chainId != null) params.set('chain', String(chainId))
+  if (tokenSymbol) params.set('token', tokenSymbol)
+  return `/wallet?${params.toString()}`
+}

--- a/frontend/src/config/networks.js
+++ b/frontend/src/config/networks.js
@@ -38,6 +38,20 @@ const PRIMARY_CHAIN_ID = 137
 const MAINNET_CHAIN_ID = 137
 const TESTNET_CHAIN_ID = 80002
 
+// Earn / lending integration (spec 050). Declared per network — only chains
+// where Morpho vaults AND the Morpho data API are live get a block; everywhere
+// else the earn capability self-discloses off (honest-state, no mock vaults).
+// The Merkl Distributor is Merkl's canonical claim contract, deployed at the
+// same address on every chain it supports; it is config-fixed here and never
+// derived from user input or API responses.
+// See specs/050-earn-lending-rewards/contracts/earn-config.md.
+const MERKL_DISTRIBUTOR = '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae'
+const earnConfig = () => ({
+  provider: { name: 'Morpho', url: 'https://app.morpho.org' },
+  merklDistributor: MERKL_DISTRIBUTOR,
+  legacyRewardsUrl: 'https://rewards-legacy.morpho.org/',
+})
+
 // Passkey smart-account submission config (spec 041, data-model
 // "SubmissionRoute"). Parses a comma-separated ERC-4337 bundler URL list
 // (ordered: self-hosted alto first, public fallbacks). Empty/unset → null so
@@ -125,6 +139,7 @@ const NETWORKS = {
       return {
         polymarketSidebets: true,
         dex: Boolean(this.dex),
+        earn: Boolean(this.earn),
         friendMarkets: true,
         passkeyAccounts: Boolean(this.passkey),
         // ClearPath DAO governance (spec 042) — network-agnostic; runs wherever a read RPC exists,
@@ -202,6 +217,7 @@ const NETWORKS = {
       return {
         polymarketSidebets: false,
         dex: Boolean(this.dex),
+        earn: Boolean(this.earn),
         friendMarkets: true,
         passkeyAccounts: false,
         // ClearPath DAO governance (spec 042) — Olympia lives on the ETC family; registry-optional.
@@ -268,6 +284,7 @@ const NETWORKS = {
       return {
         polymarketSidebets: false,
         dex: Boolean(this.dex),
+        earn: Boolean(this.earn),
         friendMarkets: true,
         passkeyAccounts: false,
         // ClearPath DAO governance (spec 042) — Olympia lives on the ETC family; registry-optional.
@@ -320,6 +337,8 @@ const NETWORKS = {
       name: 'Uniswap',
       url: 'https://app.uniswap.org/swap?chain=polygon',
     },
+    // Earn / lending (spec 050): Morpho vaults + data API are live on Polygon PoS.
+    earn: earnConfig(),
     // Passkey smart accounts (spec 041) — production network: RIP-7212
     // precompile live since the Napoli upgrade, canonical EntryPoint v0.6.
     passkey: passkeyConfig(
@@ -330,6 +349,7 @@ const NETWORKS = {
       return {
         polymarketSidebets: true,
         dex: Boolean(this.dex),
+        earn: Boolean(this.earn),
         friendMarkets: true,
         passkeyAccounts: Boolean(this.passkey),
         // ClearPath DAO governance (spec 042) — network-agnostic; runs wherever a read RPC exists,
@@ -370,6 +390,8 @@ const NETWORKS = {
     },
     // No in-app DEX/swap on this network in this cut (ClearPath-only).
     dex: null,
+    // Earn / lending (spec 050): Morpho's home chain — vaults + data API live.
+    earn: earnConfig(),
     contracts: {}, // no wager/membership deployment — ClearPath needs none (registry-optional)
     polymarket: null,
     // Passkey smart accounts are not enabled on this ClearPath-only network in this cut.
@@ -378,6 +400,7 @@ const NETWORKS = {
       return {
         polymarketSidebets: false,
         dex: false,
+        earn: Boolean(this.earn),
         friendMarkets: false,
         passkeyAccounts: false,
         // The single enabled capability: ClearPath DAO governance (ENS, Uniswap, …).
@@ -415,6 +438,7 @@ const NETWORKS = {
       return {
         polymarketSidebets: false,
         dex: false,
+        earn: Boolean(this.earn),
         friendMarkets: false,
         passkeyAccounts: false,
         clearpath: false,
@@ -451,6 +475,7 @@ const NETWORKS = {
       return {
         polymarketSidebets: false,
         dex: false,
+        earn: Boolean(this.earn),
         friendMarkets: false,
         passkeyAccounts: false,
         clearpath: false,
@@ -480,6 +505,7 @@ const NETWORKS = {
       return {
         polymarketSidebets: false,
         dex: false,
+        earn: Boolean(this.earn),
         friendMarkets: true,
         passkeyAccounts: Boolean(this.passkey),
         // Local Hardhat sandbox is not a ClearPath governance network.
@@ -514,6 +540,37 @@ export function isDexAvailable(chainId) {
  */
 export function getDexProvider(chainId) {
   return getNetwork(chainId)?.dexProvider ?? null
+}
+
+/**
+ * Whether the Earn (lending) section is live on `chainId` (spec 050). True only
+ * where a real Morpho deployment + data API exist; everywhere else the Earn UI
+ * shows an honest unavailable state naming the enabled networks.
+ * Resolved strictly per-chain (no getNetwork fallback) so a chain without an
+ * entry never inherits another network's earn support.
+ */
+export function isEarnAvailable(chainId) {
+  const net = chainId != null ? NETWORKS[chainId] : null
+  return Boolean(net?.earn)
+}
+
+/**
+ * The earn config block (`{ provider, merklDistributor, legacyRewardsUrl }`)
+ * for `chainId`, or null when earn is not available there.
+ */
+export function getEarnConfig(chainId) {
+  const net = chainId != null ? NETWORKS[chainId] : null
+  return net?.earn ?? null
+}
+
+/**
+ * The networks where Earn is live — used by the honest unavailable-state copy
+ * ("Lending is available on Ethereum and Polygon") and by tests.
+ */
+export function getEarnNetworks() {
+  return listSupportedChainIds()
+    .map((id) => NETWORKS[id])
+    .filter((net) => net?.earn)
 }
 
 /**

--- a/frontend/src/data/notifications/domains.js
+++ b/frontend/src/data/notifications/domains.js
@@ -13,6 +13,8 @@ export const DOMAIN_META = {
   custody: { label: 'Custody' },
   // Spec 035 intent lifecycle entries (emitted via useIntentAction's onActivity callback).
   intents: { label: 'Gasless' },
+  // Spec 050 earn (lending & rewards) events.
+  earn: { label: 'Earn' },
 }
 
 /** Display label for a domain key (falls back to the key itself for an unknown/future domain). */

--- a/frontend/src/data/notifications/sources/earnSource.js
+++ b/frontend/src/data/notifications/sources/earnSource.js
@@ -1,0 +1,128 @@
+/**
+ * Earn activity source (spec 050 / spec 031, FR-010). Two inputs, one feed:
+ *
+ * 1. **Action buffer** — deposit/withdraw/claim flows queue what the member
+ *    just did (with the tx hash + explorer URL) via lib/earn/earnActivityBuffer;
+ *    detect drains the buffer into precise entries. Routing user actions
+ *    through the source keeps all store writes inside the engine's poll.
+ * 2. **Snapshot-diff backstop** — vault share balances for every vault the
+ *    member has touched through the app are snapped each cycle over the
+ *    chain's read provider; a change with no matching drained action (e.g. a
+ *    deposit made on the Morpho app directly) emits a generic
+ *    position-changed entry. First-sight = baseline; ids are stable;
+ *    hard read failure returns ok:false so the engine keeps the prior slice.
+ *
+ * No Morpho/Merkl API calls here — the 30s activity cadence would hammer
+ * them; on-chain share reads are the cheap, honest signal.
+ */
+import { ethers, Contract } from 'ethers'
+import { NETWORKS, isEarnAvailable } from '../../../config/networks'
+import { makeReadProvider } from '../../../utils/rpcProvider'
+import { drainEarnActions } from '../../../lib/earn/earnActivityBuffer'
+import { earnPath } from '../../../config/earn'
+
+const EMPTY = { ok: true, entries: [], nextSnapshots: {}, currentIds: [], actionNeededById: {} }
+const BALANCE_OF_ABI = ['function balanceOf(address) view returns (uint256)']
+
+export const earnSource = {
+  key: 'earn',
+  label: 'Earn',
+  async detect({ account, chainId, nowMs, prior }) {
+    if (!account || !isEarnAvailable(chainId)) return EMPTY
+
+    const entries = []
+    const nextSnapshots = {}
+    const currentIds = []
+    // Vaults whose change is already explained by a drained action this cycle
+    // (skip the generic position-changed entry for them).
+    const actedVaults = new Set()
+
+    // 1) Precise entries for actions the member just performed in the app.
+    for (const record of drainEarnActions(account, chainId)) {
+      const refId = String(record.refId || '').toLowerCase()
+      entries.push({
+        id: `earn:${chainId}:${record.type}:${record.txHash}`,
+        domain: 'earn',
+        refId,
+        type: record.type,
+        message: record.message,
+        severity: 'success',
+        actionable: false,
+        link: { to: earnPath() },
+        txUrl: record.txUrl || null,
+        createdAt: record.at || nowMs,
+        read: false,
+      })
+      if (record.type === 'earn-deposit' || record.type === 'earn-withdraw') {
+        actedVaults.add(refId)
+        // Ensure the vault joins the tracked set from now on.
+        nextSnapshots[`earn:${refId}`] = nextSnapshots[`earn:${refId}`] || null
+      }
+    }
+
+    // 2) Snapshot-diff the tracked vaults' share balances.
+    const priorSnapshots = prior?.snapshots || {}
+    const trackedVaults = new Set([
+      ...Object.keys(priorSnapshots).map((sid) => sid.replace(/^earn:/, '')),
+      ...actedVaults,
+    ])
+    if (trackedVaults.size === 0) return { ...EMPTY, entries, currentIds: entries.map((e) => e.refId) }
+
+    let provider
+    try {
+      provider = makeReadProvider(NETWORKS[chainId].rpcUrl, chainId)
+    } catch {
+      return { ok: false }
+    }
+
+    let anyOk = false
+    for (const vaultAddress of trackedVaults) {
+      if (!ethers.isAddress(vaultAddress)) continue
+      const sid = `earn:${vaultAddress}`
+      currentIds.push(sid)
+      let shares
+      try {
+        const vault = new Contract(vaultAddress, BALANCE_OF_ABI, provider)
+        shares = (await vault.balanceOf(account)).toString()
+        anyOk = true
+      } catch {
+        // Keep the prior snapshot so the baseline survives a flaky read.
+        if (priorSnapshots[sid]) nextSnapshots[sid] = priorSnapshots[sid]
+        continue
+      }
+
+      const prev = priorSnapshots[sid]
+      nextSnapshots[sid] = { shares, snappedAt: nowMs }
+
+      // First sight = baseline (no retroactive entries); action-explained
+      // changes already have their precise entry above.
+      if (prev?.shares != null && prev.shares !== shares && !actedVaults.has(vaultAddress)) {
+        const grew = BigInt(shares) > BigInt(prev.shares)
+        entries.push({
+          id: `earn:${chainId}:position-changed:${vaultAddress}:${nowMs}`,
+          domain: 'earn',
+          refId: vaultAddress,
+          type: 'earn-position-changed',
+          message: grew
+            ? 'Your lending position increased'
+            : 'Your lending position decreased',
+          severity: 'info',
+          actionable: false,
+          link: { to: earnPath() },
+          createdAt: nowMs,
+          read: false,
+        })
+      }
+    }
+
+    if (!anyOk && trackedVaults.size > 0) return { ok: false }
+    // Drop the placeholder nulls for vaults whose first read failed — they
+    // re-enter tracking on the next action or successful read.
+    for (const [sid, snap] of Object.entries(nextSnapshots)) {
+      if (snap === null) delete nextSnapshots[sid]
+    }
+    return { ok: true, entries, nextSnapshots, currentIds, actionNeededById: {} }
+  },
+}
+
+export default earnSource

--- a/frontend/src/data/notifications/sources/index.js
+++ b/frontend/src/data/notifications/sources/index.js
@@ -11,7 +11,8 @@ import { tokenSource } from './tokenSource'
 import { membershipSource } from './membershipSource'
 import { poolsSource } from './poolsSource'
 import { custodySource } from './custodySource'
+import { earnSource } from './earnSource'
 
-export const activitySources = [wagerSource, daoSource, tokenSource, membershipSource, poolsSource, custodySource]
+export const activitySources = [wagerSource, daoSource, tokenSource, membershipSource, poolsSource, custodySource, earnSource]
 
 export default activitySources

--- a/frontend/src/hooks/useEarnPositions.js
+++ b/frontend/src/hooks/useEarnPositions.js
@@ -1,0 +1,113 @@
+/**
+ * useEarnPositions (spec 050) — the member's lending positions on the active
+ * network. Authoritative state is on-chain (share balance + convertToAssets +
+ * maxWithdraw over the chain's read provider); USD value and earned-so-far are
+ * best-effort enrichment from the Morpho API that degrades honestly to "—"
+ * when the API is down (position still shown — constitution III).
+ *
+ * Polls every POSITIONS_POLL_MS (60s, aligned with usePortfolio), scoped to
+ * (account, chain) — a scope change resets synchronously so nothing leaks.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useWallet } from './useWalletManagement'
+import { NETWORKS, isEarnAvailable } from '../config/networks'
+import { makeReadProvider } from '../utils/rpcProvider'
+import { POSITIONS_POLL_MS } from '../config/earn'
+import { readVaultUserState } from '../lib/earn/vaultActions'
+import { fetchPositionsEnrichment } from '../lib/earn/morphoApi'
+
+export function useEarnPositions(vaults) {
+  const { address, isConnected, chainId } = useWallet() || {}
+  const supported = isEarnAvailable(chainId)
+
+  const [userStates, setUserStates] = useState(null) // Map vaultAddrLc -> chain reads
+  const [enrichment, setEnrichment] = useState({})
+  const [status, setStatus] = useState('loading')
+  const reqIdRef = useRef(0)
+
+  const provider = useMemo(
+    () => (supported ? makeReadProvider(NETWORKS[chainId].rpcUrl, chainId) : null),
+    [supported, chainId],
+  )
+
+  const load = useCallback(async () => {
+    if (!supported || !isConnected || !address || !provider || !vaults?.length) return
+    const reqId = ++reqIdRef.current
+    try {
+      const [settled, enriched] = await Promise.all([
+        Promise.allSettled(
+          vaults.map((vault) => readVaultUserState({ vault, account: address, provider })),
+        ),
+        // Enrichment failure degrades to on-chain values only — never blocks.
+        fetchPositionsEnrichment(address, chainId).catch(() => ({})),
+      ])
+      if (reqId !== reqIdRef.current) return
+      const next = new Map()
+      let anyOk = false
+      settled.forEach((res, i) => {
+        if (res.status === 'fulfilled') {
+          anyOk = true
+          next.set(vaults[i].address.toLowerCase(), res.value)
+        }
+      })
+      if (!anyOk) {
+        setUserStates(null)
+        setStatus('unavailable')
+        return
+      }
+      setUserStates(next)
+      setEnrichment(enriched)
+      setStatus('ready')
+    } catch {
+      if (reqId !== reqIdRef.current) return
+      setUserStates(null)
+      setStatus('unavailable')
+    }
+  }, [supported, isConnected, address, provider, chainId, vaults])
+
+  // Scope change: hard reset so another account/chain's positions never render.
+  useEffect(() => {
+    reqIdRef.current++
+    setUserStates(null)
+    setEnrichment({})
+    setStatus(supported && isConnected ? 'loading' : 'idle')
+    load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [address, chainId, vaults])
+
+  useEffect(() => {
+    if (!supported || !isConnected || !address) return undefined
+    const id = setInterval(() => load(), POSITIONS_POLL_MS)
+    return () => clearInterval(id)
+  }, [supported, isConnected, address, load])
+
+  return useMemo(() => {
+    const positions = []
+    if (userStates && vaults?.length) {
+      for (const vault of vaults) {
+        const state = userStates.get(vault.address.toLowerCase())
+        if (!state || state.shares === 0n) continue
+        const extra = enrichment[vault.address.toLowerCase()] || {}
+        positions.push({
+          vault,
+          shares: state.shares,
+          assets: state.assets,
+          maxWithdrawAssets: state.maxWithdrawAssets,
+          walletBalance: state.walletBalance,
+          maxDepositAssets: state.maxDepositAssets,
+          assetsUsd: extra.assetsUsd ?? null,
+          pnlUsd: extra.pnlUsd ?? null,
+        })
+      }
+    }
+    return {
+      positions,
+      // Per-vault wallet/limit reads for the deposit form, position or not.
+      userStates,
+      status,
+      refresh: load,
+    }
+  }, [userStates, enrichment, vaults, status, load])
+}
+
+export default useEarnPositions

--- a/frontend/src/hooks/useEarnRewards.js
+++ b/frontend/src/hooks/useEarnRewards.js
@@ -1,0 +1,116 @@
+/**
+ * useEarnRewards (spec 050, US2) — the member's Merkl reward balances on the
+ * active network plus the claim action.
+ *
+ * Honest-state: a failed fetch is an explicit 'unavailable' status (never a
+ * fabricated zero); reward figures update on Merkl's ~8-hour cadence, so the
+ * view carries `fetchedAt` freshness rather than implying real-time accrual.
+ * Claim success is reported from the tx receipt, not from the API (which may
+ * lag the chain); after a claim we re-fetch and the queued activity entry
+ * carries the explorer link (FR-010).
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Contract, formatUnits } from 'ethers'
+import { useWallet } from './useWalletManagement'
+import { isEarnAvailable, getEarnConfig } from '../config/networks'
+import { getBlockscoutUrl } from '../config/blockExplorer'
+import { fetchRewards, buildClaimArgs } from '../lib/earn/merkl'
+import { MERKL_DISTRIBUTOR_ABI } from '../abis/MerklDistributor'
+import { queueEarnAction } from '../lib/earn/earnActivityBuffer'
+import { useActivityOptional } from './useActivity'
+
+export function useEarnRewards() {
+  const { address, isConnected, chainId, signer } = useWallet() || {}
+  const activity = useActivityOptional()
+  const supported = isEarnAvailable(chainId)
+  const earnConfig = getEarnConfig(chainId)
+
+  const [rewards, setRewards] = useState([])
+  const [status, setStatus] = useState('loading')
+  const [fetchedAt, setFetchedAt] = useState(null)
+  const [claimState, setClaimState] = useState({ status: 'idle', txUrl: null, error: null })
+  const reqIdRef = useRef(0)
+
+  const load = useCallback(async () => {
+    if (!supported || !isConnected || !address) return
+    const reqId = ++reqIdRef.current
+    setStatus('loading')
+    try {
+      const list = await fetchRewards(address, chainId)
+      if (reqId !== reqIdRef.current) return
+      setRewards(list)
+      setFetchedAt(Date.now())
+      setStatus('ready')
+    } catch {
+      if (reqId !== reqIdRef.current) return
+      setRewards([])
+      setStatus('unavailable')
+    }
+  }, [supported, isConnected, address, chainId])
+
+  useEffect(() => {
+    reqIdRef.current++
+    setRewards([])
+    setFetchedAt(null)
+    setClaimState({ status: 'idle', txUrl: null, error: null })
+    setStatus(supported && isConnected ? 'loading' : 'idle')
+    load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [address, chainId])
+
+  const totalClaimable = useMemo(
+    () => rewards.reduce((n, r) => n + (r.claimable > 0n ? 1 : 0), 0),
+    [rewards],
+  )
+
+  /** Claim every claimable reward in one distributor transaction. */
+  const claim = useCallback(async () => {
+    if (!signer || !address || !earnConfig?.merklDistributor) return
+    const args = buildClaimArgs(address, rewards)
+    if (!args) return // nothing claimable — never prompt the wallet for a no-op
+    setClaimState({ status: 'pending', txUrl: null, error: null })
+    try {
+      const distributor = new Contract(earnConfig.merklDistributor, MERKL_DISTRIBUTOR_ABI, signer)
+      const tx = await distributor.claim(args.users, args.tokens, args.amounts, args.proofs)
+      const receipt = await tx.wait()
+      const txUrl = getBlockscoutUrl(chainId, receipt.hash, 'tx')
+      const summary = args.rewards
+        .map((r) => `${formatUnits(r.claimable, r.token.decimals)} ${r.token.symbol}`.trim())
+        .join(', ')
+      queueEarnAction(address, chainId, {
+        type: 'earn-rewards-claimed',
+        refId: args.tokens[0],
+        message: `Claimed earn rewards: ${summary}`,
+        txHash: receipt.hash,
+        txUrl,
+        at: Date.now(),
+      })
+      activity?.refresh?.()
+      setClaimState({ status: 'confirmed', txUrl, error: null })
+      load()
+    } catch (err) {
+      const rejected = /rejected|denied/i.test(err?.message || '')
+      setClaimState({
+        status: 'error',
+        txUrl: null,
+        error: rejected ? 'Transaction was cancelled in your wallet.' : 'Claim failed. Please try again.',
+      })
+    }
+  }, [signer, address, chainId, rewards, earnConfig, activity, load])
+
+  return useMemo(
+    () => ({
+      rewards,
+      status,
+      fetchedAt,
+      totalClaimable,
+      claim,
+      claimState,
+      legacyRewardsUrl: earnConfig?.legacyRewardsUrl || null,
+      refresh: load,
+    }),
+    [rewards, status, fetchedAt, totalClaimable, claim, claimState, earnConfig, load],
+  )
+}
+
+export default useEarnRewards

--- a/frontend/src/hooks/useEarnVaults.js
+++ b/frontend/src/hooks/useEarnVaults.js
@@ -1,0 +1,58 @@
+/**
+ * useEarnVaults (spec 050) — the curated Morpho vault list for the active
+ * network. Capability-gated: on chains without earn support it stays inert
+ * with status 'unsupported' so the panel renders the honest unavailable state.
+ *
+ * Status model (honest-state): 'unsupported' | 'loading' | 'ready' |
+ * 'unavailable'. A fetch failure is an explicit 'unavailable' — the UI
+ * disables deposit entry points instead of showing stale numbers.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useWallet } from './useWalletManagement'
+import { isEarnAvailable } from '../config/networks'
+import { fetchVaults } from '../lib/earn/morphoApi'
+
+export function useEarnVaults() {
+  const { chainId } = useWallet() || {}
+  const supported = isEarnAvailable(chainId)
+
+  const [vaults, setVaults] = useState([])
+  const [status, setStatus] = useState('loading')
+  const reqIdRef = useRef(0)
+
+  const load = useCallback(async () => {
+    if (!supported) return
+    const reqId = ++reqIdRef.current
+    setStatus('loading')
+    try {
+      const list = await fetchVaults(chainId)
+      if (reqId !== reqIdRef.current) return
+      setVaults(list)
+      setStatus('ready')
+    } catch {
+      if (reqId !== reqIdRef.current) return
+      setVaults([])
+      setStatus('unavailable')
+    }
+  }, [supported, chainId])
+
+  // Reset synchronously on chain change so another network's vaults never
+  // linger (per-chain data isolation).
+  useEffect(() => {
+    reqIdRef.current++
+    setVaults([])
+    if (!supported) {
+      setStatus('unsupported')
+      return
+    }
+    load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chainId, supported])
+
+  return useMemo(
+    () => ({ vaults, status, isSupported: supported, refresh: load }),
+    [vaults, status, supported, load],
+  )
+}
+
+export default useEarnVaults

--- a/frontend/src/lib/earn/earnActivityBuffer.js
+++ b/frontend/src/lib/earn/earnActivityBuffer.js
@@ -1,0 +1,49 @@
+/**
+ * Earn action buffer (spec 050, FR-010).
+ *
+ * Deposit / withdraw / claim flows record what the member just did (with the
+ * tx hash) here; the earn ActivitySource drains the buffer on its next detect
+ * cycle and turns each record into a feed entry with an explorer link. Routing
+ * the records through the source keeps ALL activity-store writes inside the
+ * poll (no racing the engine) while still giving user actions their exact tx
+ * link instead of a generic snapshot-diff message. Flows call the activity
+ * context's refresh() right after queueing so the entry lands immediately.
+ *
+ * Persistence is account+chain scoped localStorage (same convention as the
+ * activity store) so a pending record survives a reload between action and
+ * poll.
+ */
+import { getUserPreference, saveUserPreference } from '../../utils/userStorage'
+
+const FEATURE_KEY_PREFIX = 'earn_pending_actions_v1_'
+const MAX_BUFFERED = 20
+
+function featureKey(chainId) {
+  return `${FEATURE_KEY_PREFIX}${chainId}`
+}
+
+/**
+ * Queue one action record:
+ * { type: 'earn-deposit'|'earn-withdraw'|'earn-rewards-claimed',
+ *   refId, message, txHash, txUrl, at }
+ */
+export function queueEarnAction(account, chainId, record) {
+  if (!account || !chainId || !record?.type || !record?.txHash) return
+  const existing = getUserPreference(account, featureKey(chainId), [], true) || []
+  const next = [...existing.filter((r) => r.txHash !== record.txHash), record].slice(-MAX_BUFFERED)
+  saveUserPreference(account, featureKey(chainId), next, true)
+}
+
+/** Read-and-clear the pending records for (account, chain). */
+export function drainEarnActions(account, chainId) {
+  if (!account || !chainId) return []
+  const records = getUserPreference(account, featureKey(chainId), [], true) || []
+  if (records.length > 0) saveUserPreference(account, featureKey(chainId), [], true)
+  return records
+}
+
+/** Peek without clearing (tests / diagnostics). */
+export function peekEarnActions(account, chainId) {
+  if (!account || !chainId) return []
+  return getUserPreference(account, featureKey(chainId), [], true) || []
+}

--- a/frontend/src/lib/earn/earnCopy.js
+++ b/frontend/src/lib/earn/earnCopy.js
@@ -1,0 +1,49 @@
+/**
+ * Member-facing copy for the Earn section (spec 050, FR-011/FR-012).
+ *
+ * Every DeFi term the section shows gets a plain-language explainer here,
+ * rendered through InfoTip next to where the term appears. Keeping the copy in
+ * one module keeps wording consistent, testable, and easy to review for tone:
+ * written for members with no DeFi background (SC-002).
+ */
+
+export const EARN_TIPS = {
+  earn: 'Earn puts money you are not using to work. You lend it out through an established lending service and it earns a return over time. You stay in control and can take your money back out.',
+  lending:
+    'Lending means your money is pooled with other people’s and lent to borrowers who put up collateral. In exchange, the pool pays you a share of the interest borrowers pay.',
+  vault:
+    'A vault is a shared pot that does the lending for you. You put an asset in, the vault lends it out, and your share of the pot grows as interest comes in.',
+  apy: 'APY (annual percentage yield) estimates how much your deposit would grow in a year at the current rate. Rates change all the time, so this is an estimate — not a promise.',
+  curator:
+    'The curator is the professional team that manages the vault: choosing where it lends and how it manages risk. FairWins does not manage vaults.',
+  totalDeposits:
+    'The total value everyone has deposited into this vault. Bigger, long-running vaults tend to have more history to judge them by.',
+  approval:
+    'Your first deposit takes two quick confirmations in your wallet: the first gives the vault permission to take exactly the amount you typed, and the second makes the deposit. This is standard and you approve only that amount.',
+  withdrawalLiquidity:
+    'Vaults lend money out, so occasionally not all of it can be taken out at the same moment. If that happens you can withdraw what is available now and come back for the rest shortly.',
+  rewards:
+    'Some vaults pay bonus tokens on top of the lending return, funded by reward programs. They collect here and you can claim them to your wallet whenever you like.',
+  rewardsFreshness:
+    'Reward figures are recalculated by the rewards program every few hours, so what you see updates on that schedule — not every second.',
+  positions:
+    'Your active positions: what your deposit is worth right now in each vault. The value includes the return earned so far.',
+}
+
+/** Powered-by attribution + risk disclosure (FR-012; Morpho integration terms). */
+export const EARN_DISCLOSURE = {
+  attribution: 'Powered by Morpho',
+  risk: 'Lending happens through Morpho, a third-party on-chain lending protocol, from your own wallet. Returns are variable and not guaranteed, and smart contracts carry risk. FairWins never holds your deposit and charges no fee on Earn.',
+}
+
+/** Honest unavailable-state copy for networks without earn support (FR-008). */
+export function earnUnavailableCopy(networkName, earnNetworkNames) {
+  const names = (earnNetworkNames || []).join(' and ')
+  return `Earning is not available on ${networkName || 'this network'} yet. Lending is available on ${names || 'supported networks'} — switch networks to use it.`
+}
+
+/** Honest "not yet" copy for future earning areas (FR-002). */
+export const EARN_AREAS_FUTURE = {
+  staking: 'Staking is not available in the app yet.',
+  bridges: 'Bridge earning is not available in the app yet.',
+}

--- a/frontend/src/lib/earn/format.js
+++ b/frontend/src/lib/earn/format.js
@@ -1,0 +1,19 @@
+/**
+ * Shared display formatters for the Earn section (spec 050). Null-safe:
+ * missing protocol data renders as "—", never a fabricated zero
+ * (constitution III).
+ */
+
+/** Net APY fraction (0.043) → "4.30%"; null → "—". */
+export function formatApy(netApy) {
+  if (netApy == null) return '—'
+  return `${(netApy * 100).toFixed(2)}%`
+}
+
+/** Total deposits in USD → compact "$1.2M" / "$450K"; null → "—". */
+export function formatTvl(totalAssetsUsd) {
+  if (totalAssetsUsd == null) return '—'
+  if (totalAssetsUsd >= 1_000_000) return `$${(totalAssetsUsd / 1_000_000).toFixed(1)}M`
+  if (totalAssetsUsd >= 1_000) return `$${(totalAssetsUsd / 1_000).toFixed(0)}K`
+  return `$${totalAssetsUsd.toFixed(0)}`
+}

--- a/frontend/src/lib/earn/merkl.js
+++ b/frontend/src/lib/earn/merkl.js
@@ -1,0 +1,108 @@
+/**
+ * Merkl rewards module (spec 050).
+ *
+ * Morpho distributes all current rewards through Merkl (MIP-111). Members'
+ * reward balances come from the Merkl REST API; claiming calls the Merkl
+ * Distributor with the CUMULATIVE earned amount + Merkle proofs (the contract
+ * transfers only the unclaimed difference, so repeat claims are safe no-ops).
+ * The legacy rewards.morpho.org/URD flow is deprecated and intentionally not
+ * implemented — the UI links to Morpho's legacy claim page instead.
+ * Contract details: specs/050-earn-lending-rewards/contracts/merkl-rewards.md.
+ */
+import { MERKL_API_URL } from '../../config/earn'
+
+export class MerklApiError extends Error {
+  constructor(message, { cause } = {}) {
+    super(message)
+    this.name = 'MerklApiError'
+    if (cause) this.cause = cause
+  }
+}
+
+function toBigIntOrZero(v) {
+  try {
+    return BigInt(v ?? 0)
+  } catch {
+    return 0n
+  }
+}
+
+/**
+ * Normalize one Merkl reward record into the RewardBalance model
+ * (data-model.md). Returns null for records missing token coordinates.
+ */
+export function normalizeReward(record, { nowMs }) {
+  const token = record?.token
+  if (!token?.address) return null
+  const amount = toBigIntOrZero(record.amount)
+  const claimed = toBigIntOrZero(record.claimed)
+  const claimable = amount > claimed ? amount - claimed : 0n
+  return {
+    token: {
+      address: token.address,
+      symbol: token.symbol || '',
+      decimals: Number.isInteger(Number(token.decimals)) ? Number(token.decimals) : 18,
+    },
+    amount,
+    claimed,
+    claimable,
+    pending: toBigIntOrZero(record.pending),
+    proofs: Array.isArray(record.proofs) ? record.proofs : [],
+    fetchedAt: nowMs,
+  }
+}
+
+/**
+ * The member's reward balances on one chain. Rewards with nothing claimable
+ * AND nothing pending are dropped (there is nothing to show). Throws
+ * MerklApiError on failure — the UI maps it to an explicit unavailable state,
+ * never a fabricated zero.
+ */
+export async function fetchRewards(address, chainId, { fetchImpl = fetch, nowMs = Date.now() } = {}) {
+  if (!address) return []
+  // Merkl requires the lowercased address form.
+  const url = `${MERKL_API_URL}/users/${String(address).toLowerCase()}/rewards?chainId=${Number(chainId)}`
+  let res
+  try {
+    res = await fetchImpl(url)
+  } catch (err) {
+    throw new MerklApiError('Could not reach the rewards service', { cause: err })
+  }
+  if (!res.ok) throw new MerklApiError(`Rewards service error (HTTP ${res.status})`)
+  let body
+  try {
+    body = await res.json()
+  } catch (err) {
+    throw new MerklApiError('Rewards service returned an unreadable response', { cause: err })
+  }
+  const chains = Array.isArray(body) ? body : []
+  const rewards = []
+  for (const chainBlock of chains) {
+    if (Number(chainBlock?.chain?.id) !== Number(chainId)) continue
+    for (const record of chainBlock.rewards || []) {
+      const normalized = normalizeReward(record, { nowMs })
+      if (normalized && (normalized.claimable > 0n || normalized.pending > 0n)) {
+        rewards.push(normalized)
+      }
+    }
+  }
+  return rewards
+}
+
+/**
+ * Build the Merkl Distributor claim(users, tokens, amounts, proofs) arguments
+ * for every claimable reward. Amounts are the CUMULATIVE `amount`, per the
+ * distributor's accounting — never the difference. Returns null when nothing
+ * is claimable (callers must not prompt the wallet for a no-op).
+ */
+export function buildClaimArgs(account, rewards) {
+  const claimables = (rewards || []).filter((r) => r.claimable > 0n && r.proofs.length > 0)
+  if (!account || claimables.length === 0) return null
+  return {
+    users: claimables.map(() => account),
+    tokens: claimables.map((r) => r.token.address),
+    amounts: claimables.map((r) => r.amount),
+    proofs: claimables.map((r) => r.proofs),
+    rewards: claimables,
+  }
+}

--- a/frontend/src/lib/earn/morphoApi.js
+++ b/frontend/src/lib/earn/morphoApi.js
@@ -1,0 +1,168 @@
+/**
+ * Morpho GraphQL client + normalizers (spec 050).
+ *
+ * Vault discovery, APY/TVL, and position USD/earnings enrichment come from
+ * Morpho's public GraphQL API. This module is the only place that speaks the
+ * API's shapes; everything downstream consumes the normalized Vault /
+ * PositionEnrichment models (specs/050-earn-lending-rewards/data-model.md).
+ *
+ * Honest-state rules (constitution III):
+ *   - curation is the API's own flags: `whitelisted: true` filter + `listed`
+ *     requirement (vaults shown on the Morpho app) — never a hand-kept list;
+ *   - null APY/TVL stays null (rendered "—"), never coerced to 0;
+ *   - any transport/GraphQL failure throws MorphoApiError so hooks can map it
+ *     to an explicit `unavailable` state — stale numbers are never truth.
+ */
+import { MORPHO_API_URL, VAULT_LIST_LIMIT } from '../../config/earn'
+
+export class MorphoApiError extends Error {
+  constructor(message, { cause } = {}) {
+    super(message)
+    this.name = 'MorphoApiError'
+    if (cause) this.cause = cause
+  }
+}
+
+const VAULTS_QUERY = `
+query EarnVaults($chainIds: [Int!]!, $first: Int!) {
+  vaults(
+    first: $first
+    orderBy: TotalAssetsUsd
+    orderDirection: Desc
+    where: { chainId_in: $chainIds, whitelisted: true }
+  ) {
+    items {
+      address symbol name listed whitelisted
+      state {
+        totalAssetsUsd apy netApy curator
+        allRewards { asset { address symbol } supplyApr }
+      }
+      asset { name address decimals symbol }
+      chain { id }
+    }
+  }
+}`
+
+const POSITIONS_QUERY = `
+query EarnPositions($address: String!, $chainId: Int!) {
+  userByAddress(address: $address, chainId: $chainId) {
+    vaultPositions {
+      vault { address }
+      state { shares assets assetsUsd pnlUsd }
+    }
+  }
+}`
+
+async function graphql(query, variables, { fetchImpl = fetch } = {}) {
+  let res
+  try {
+    res = await fetchImpl(MORPHO_API_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ query, variables }),
+    })
+  } catch (err) {
+    throw new MorphoApiError('Could not reach the lending data service', { cause: err })
+  }
+  if (!res.ok) throw new MorphoApiError(`Lending data service error (HTTP ${res.status})`)
+  let body
+  try {
+    body = await res.json()
+  } catch (err) {
+    throw new MorphoApiError('Lending data service returned an unreadable response', { cause: err })
+  }
+  if (Array.isArray(body?.errors) && body.errors.length > 0) {
+    throw new MorphoApiError(body.errors[0]?.message || 'Lending data service query failed')
+  }
+  return body?.data ?? null
+}
+
+/** null-safe finite number (API may return null for young/unpriced vaults). */
+function numOrNull(v) {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null
+}
+
+/**
+ * Normalize one API vault item; returns null for items that fail curation or
+ * consistency guards (non-listed, foreign chain, missing coordinates).
+ */
+export function normalizeVault(item, chainId) {
+  if (!item?.address || !item?.asset?.address) return null
+  if (item.listed !== true || item.whitelisted !== true) return null
+  if (Number(item.chain?.id) !== Number(chainId)) return null
+  const decimals = Number(item.asset.decimals)
+  if (!Number.isInteger(decimals) || decimals < 0) return null
+  return {
+    address: item.address,
+    chainId: Number(chainId),
+    name: item.name || item.symbol || 'Vault',
+    symbol: item.symbol || '',
+    asset: {
+      address: item.asset.address,
+      symbol: item.asset.symbol || '',
+      name: item.asset.name || item.asset.symbol || '',
+      decimals,
+    },
+    netApy: numOrNull(item.state?.netApy),
+    apy: numOrNull(item.state?.apy),
+    rewards: (item.state?.allRewards || [])
+      .filter((r) => r?.asset?.symbol != null)
+      .map((r) => ({ assetSymbol: r.asset.symbol, supplyApr: numOrNull(r.supplyApr) })),
+    totalAssetsUsd: numOrNull(item.state?.totalAssetsUsd),
+    curator: item.state?.curator || null,
+  }
+}
+
+/**
+ * Curated vault list for one chain — TVL-ordered (API order preserved),
+ * capped at VAULT_LIST_LIMIT. Throws MorphoApiError on failure.
+ */
+export async function fetchVaults(chainId, { fetchImpl } = {}) {
+  const data = await graphql(
+    VAULTS_QUERY,
+    // first is generous: curation drops non-listed items after the fetch.
+    { chainIds: [Number(chainId)], first: 100 },
+    { fetchImpl },
+  )
+  const items = data?.vaults?.items || []
+  return items
+    .map((item) => normalizeVault(item, chainId))
+    .filter(Boolean)
+    .slice(0, VAULT_LIST_LIMIT)
+}
+
+/**
+ * USD/earnings enrichment for the member's vault positions on one chain,
+ * keyed by lowercased vault address:
+ *   { [vaultAddress]: { assetsUsd, pnlUsd } }
+ * A user the API has never seen yields {} (not an error). Throws
+ * MorphoApiError on transport failure — callers degrade to on-chain values.
+ */
+export async function fetchPositionsEnrichment(address, chainId, { fetchImpl } = {}) {
+  if (!address) return {}
+  let data
+  try {
+    data = await graphql(
+      POSITIONS_QUERY,
+      { address: String(address), chainId: Number(chainId) },
+      { fetchImpl },
+    )
+  } catch (err) {
+    // The API answers unknown users with a GraphQL error rather than an empty
+    // user — treat that specific shape as "no enrichment", keep transport
+    // failures loud.
+    if (err instanceof MorphoApiError && /no.*user|not.*found/i.test(err.message)) return {}
+    throw err
+  }
+  const positions = data?.userByAddress?.vaultPositions || []
+  const byVault = {}
+  for (const pos of positions) {
+    const vaultAddress = pos?.vault?.address
+    if (!vaultAddress) continue
+    byVault[vaultAddress.toLowerCase()] = {
+      assetsUsd: numOrNull(pos.state?.assetsUsd),
+      pnlUsd: numOrNull(pos.state?.pnlUsd),
+    }
+  }
+  return byVault
+}

--- a/frontend/src/lib/earn/vaultActions.js
+++ b/frontend/src/lib/earn/vaultActions.js
@@ -1,0 +1,128 @@
+/**
+ * ERC-4626 vault reads + actions for the Earn section (spec 050).
+ *
+ * Deposits and withdrawals run directly from the member's own wallet against
+ * curated Morpho vaults — FairWins never takes custody. Safety rails
+ * (research.md R1/R9):
+ *   - pure validators reject bad amounts BEFORE any wallet prompt;
+ *   - deposits are quoted with previewDeposit and dry-run with staticCall
+ *     before the real transaction;
+ *   - withdrawals are bounded by maxWithdraw (the vault's honest liquidity
+ *     limit), full exits use redeem(shares) so dust never strands.
+ */
+import { Contract } from 'ethers'
+import { ERC4626_VAULT_ABI } from '../../abis/ERC4626Vault'
+
+const ERC20_MIN_ABI = [
+  'function balanceOf(address) view returns (uint256)',
+  'function allowance(address owner, address spender) view returns (uint256)',
+  'function approve(address spender, uint256 value) returns (bool)',
+]
+
+/**
+ * Read the member's state against one vault over a read provider:
+ * shares, current value in underlying assets, honest withdraw bound, wallet
+ * balance of the underlying, and the vault's deposit cap for the member.
+ */
+export async function readVaultUserState({ vault, account, provider }) {
+  const vaultContract = new Contract(vault.address, ERC4626_VAULT_ABI, provider)
+  const token = new Contract(vault.asset.address, ERC20_MIN_ABI, provider)
+  const [shares, walletBalance, maxDepositAssets] = await Promise.all([
+    vaultContract.balanceOf(account),
+    token.balanceOf(account),
+    vaultContract.maxDeposit(account),
+  ])
+  let assets = 0n
+  let maxWithdrawAssets = 0n
+  if (shares > 0n) {
+    ;[assets, maxWithdrawAssets] = await Promise.all([
+      vaultContract.convertToAssets(shares),
+      vaultContract.maxWithdraw(account),
+    ])
+  }
+  return { shares, assets, maxWithdrawAssets, walletBalance, maxDepositAssets }
+}
+
+/**
+ * Validate a deposit amount before any wallet prompt.
+ * Returns { ok: true } or { ok: false, reason } with member-facing wording.
+ */
+export function validateDepositAmount({ amount, walletBalance, maxDepositAssets }) {
+  if (amount == null || amount <= 0n) {
+    return { ok: false, reason: 'Enter an amount greater than zero.' }
+  }
+  if (walletBalance != null && amount > walletBalance) {
+    return { ok: false, reason: 'That is more than you have in your wallet.' }
+  }
+  if (maxDepositAssets != null && maxDepositAssets > 0n && amount > maxDepositAssets) {
+    return { ok: false, reason: 'That is more than this vault currently accepts.' }
+  }
+  return { ok: true }
+}
+
+/**
+ * Validate a withdrawal amount before any wallet prompt.
+ */
+export function validateWithdrawAmount({ amount, maxWithdrawAssets }) {
+  if (amount == null || amount <= 0n) {
+    return { ok: false, reason: 'Enter an amount greater than zero.' }
+  }
+  if (maxWithdrawAssets != null && amount > maxWithdrawAssets) {
+    return {
+      ok: false,
+      reason: 'That is more than can be withdrawn right now — see the available amount above.',
+    }
+  }
+  return { ok: true }
+}
+
+/**
+ * Whether a deposit of `amount` needs an approval transaction first.
+ */
+export async function needsApproval({ vault, account, amount, provider }) {
+  const token = new Contract(vault.asset.address, ERC20_MIN_ABI, provider)
+  const allowance = await token.allowance(account, vault.address)
+  return allowance < amount
+}
+
+/**
+ * Send the approval for exactly `amount` (no unlimited allowances — the
+ * member approves what they are depositing). Returns the tx receipt.
+ */
+export async function approveDeposit({ vault, amount, signer }) {
+  const token = new Contract(vault.asset.address, ERC20_MIN_ABI, signer)
+  const tx = await token.approve(vault.address, amount)
+  return tx.wait()
+}
+
+/**
+ * Quote then execute a deposit. The staticCall dry-run surfaces vault-side
+ * rejections (cap reached, paused) before the member pays gas.
+ * Returns { receipt, expectedShares }.
+ */
+export async function depositToVault({ vault, account, amount, signer }) {
+  const vaultContract = new Contract(vault.address, ERC4626_VAULT_ABI, signer)
+  const expectedShares = await vaultContract.previewDeposit(amount)
+  await vaultContract.deposit.staticCall(amount, account)
+  const tx = await vaultContract.deposit(amount, account)
+  const receipt = await tx.wait()
+  return { receipt, expectedShares }
+}
+
+/**
+ * Withdraw `amount` of the underlying, or the full position via redeem when
+ * `redeemAllShares` is set (so share dust never strands). Returns { receipt }.
+ */
+export async function withdrawFromVault({ vault, account, amount, redeemAllShares, signer }) {
+  const vaultContract = new Contract(vault.address, ERC4626_VAULT_ABI, signer)
+  let tx
+  if (redeemAllShares != null && redeemAllShares > 0n) {
+    await vaultContract.redeem.staticCall(redeemAllShares, account, account)
+    tx = await vaultContract.redeem(redeemAllShares, account, account)
+  } else {
+    await vaultContract.withdraw.staticCall(amount, account, account)
+    tx = await vaultContract.withdraw(amount, account, account)
+  }
+  const receipt = await tx.wait()
+  return { receipt }
+}

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -10,6 +10,7 @@ import { useModal } from '../hooks/useUI'
 import { ROLES, ROLE_INFO } from '../contexts/RoleContext'
 import { hasRegisteredKey, ensureKeyRegistered } from '../utils/keyRegistryService'
 import TradePanel from '../components/fairwins/TradePanel'
+import EarnPanel from '../components/earn/EarnPanel'
 import PayTransferPanel from '../components/wallet/PayTransferPanel'
 import PortfolioPanel from '../components/wallet/PortfolioPanel'
 import CustodyPanel from '../components/custody/CustodyPanel'
@@ -46,6 +47,7 @@ const WALLET_TABS = [
   { id: 'preferences', label: 'Preferences' },
   { id: 'security', label: 'Security' },
   { id: 'portfolio', label: 'Portfolio' },
+  { id: 'earn', label: 'Earn' },
   { id: 'trade', label: 'Trade' },
   { id: 'paytransfer', label: 'Pay & Transfer' },
   { id: 'custody', label: 'Protect' },
@@ -571,6 +573,11 @@ function WalletPage() {
                 {activeTab === 'trade' && (
                   <div className="trade-section" role="tabpanel">
                     <TradePanel />
+                  </div>
+                )}
+                {activeTab === 'earn' && (
+                  <div className="earn-section" role="tabpanel">
+                    <EarnPanel />
                   </div>
                 )}
                 </div>

--- a/frontend/src/test/earn/EarnPanel.axe.test.jsx
+++ b/frontend/src/test/earn/EarnPanel.axe.test.jsx
@@ -1,0 +1,126 @@
+/**
+ * Earn section WCAG 2.1 AA audits (spec 050, FR-015 / SC-007) — hub, lend
+ * view with vaults + positions, vault sheet, and rewards view.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent, screen } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import { MemoryRouter } from 'react-router-dom'
+
+const mockWallet = vi.hoisted(() => ({ current: {} }))
+vi.mock('../../hooks/useWalletManagement', () => ({
+  useWallet: () => mockWallet.current,
+}))
+
+const mockVaults = vi.hoisted(() => ({ current: {} }))
+vi.mock('../../hooks/useEarnVaults', () => ({
+  useEarnVaults: () => mockVaults.current,
+  default: () => mockVaults.current,
+}))
+
+const mockPositions = vi.hoisted(() => ({ current: {} }))
+vi.mock('../../hooks/useEarnPositions', () => ({
+  useEarnPositions: () => mockPositions.current,
+  default: () => mockPositions.current,
+}))
+
+const mockRewards = vi.hoisted(() => ({ current: {} }))
+vi.mock('../../hooks/useEarnRewards', () => ({
+  useEarnRewards: () => mockRewards.current,
+  default: () => mockRewards.current,
+}))
+
+import EarnPanel from '../../components/earn/EarnPanel'
+import VaultSheet from '../../components/earn/VaultSheet'
+
+const VAULT = {
+  address: '0x00000000000000000000000000000000000000a1',
+  chainId: 137,
+  name: 'Prime USDC Vault',
+  symbol: 'mUSDC',
+  asset: { address: '0xusdc', symbol: 'USDC', name: 'USD Coin', decimals: 6 },
+  netApy: 0.043,
+  apy: 0.031,
+  rewards: [],
+  totalAssetsUsd: 12_000_000,
+  curator: 'Prime Curation',
+}
+
+const USER_STATE = {
+  shares: 10_000_000n,
+  assets: 10_000_000n,
+  maxWithdrawAssets: 8_000_000n,
+  walletBalance: 25_000_000n,
+  maxDepositAssets: 0n,
+}
+
+beforeEach(() => {
+  mockWallet.current = { chainId: 137, address: '0xac', isConnected: true, signer: null, switchNetwork: vi.fn() }
+  mockVaults.current = { vaults: [VAULT], status: 'ready', isSupported: true, refresh: vi.fn() }
+  mockPositions.current = {
+    positions: [{ vault: VAULT, shares: 10_000_000n, assets: 10_000_000n, maxWithdrawAssets: 8_000_000n, assetsUsd: 10.0, pnlUsd: 0.12 }],
+    userStates: new Map([[VAULT.address.toLowerCase(), USER_STATE]]),
+    status: 'ready',
+    refresh: vi.fn(),
+  }
+  mockRewards.current = {
+    rewards: [
+      {
+        token: { address: '0xmorpho', symbol: 'MORPHO', decimals: 18 },
+        amount: 2n,
+        claimed: 1n,
+        claimable: 1n,
+        pending: 0n,
+        proofs: ['0xaa'],
+        fetchedAt: 1,
+      },
+    ],
+    status: 'ready',
+    fetchedAt: 1,
+    totalClaimable: 1,
+    claim: vi.fn(),
+    claimState: { status: 'idle', txUrl: null, error: null },
+    legacyRewardsUrl: 'https://rewards-legacy.morpho.org/',
+    refresh: vi.fn(),
+  }
+})
+
+const renderAt = (path) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <EarnPanel />
+    </MemoryRouter>,
+  )
+
+describe('Earn section accessibility (FR-015)', () => {
+  it('hub has no axe violations', async () => {
+    const { container } = renderAt('/wallet?tab=earn')
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('lend view (vaults + positions) has no axe violations', async () => {
+    const { container } = renderAt('/wallet?tab=earn&view=lend')
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('rewards view has no axe violations', async () => {
+    const { container } = renderAt('/wallet?tab=earn&view=rewards')
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('vault sheet (deposit + withdraw modes) has no axe violations', async () => {
+    const { container } = render(
+      <VaultSheet vault={VAULT} userState={USER_STATE} onClose={vi.fn()} onActionComplete={vi.fn()} />,
+    )
+    expect(await axe(container)).toHaveNoViolations()
+    fireEvent.click(screen.getByRole('tab', { name: /withdraw/i }))
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  it('unavailable-network state has no axe violations', async () => {
+    mockWallet.current = { ...mockWallet.current, chainId: 63 }
+    mockVaults.current = { vaults: [], status: 'unsupported', isSupported: false, refresh: vi.fn() }
+    const { container } = renderAt('/wallet?tab=earn')
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/earn/EarnPanel.test.jsx
+++ b/frontend/src/test/earn/EarnPanel.test.jsx
@@ -1,0 +1,140 @@
+/**
+ * EarnPanel tests (spec 050 US1/US3) — hub areas, attribution + risk
+ * disclosure + docs link, honest unavailable state on non-earn networks,
+ * and deep-link consumption (?view=, ?chain=, ?token=).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+const mockWallet = vi.hoisted(() => ({ current: {} }))
+vi.mock('../../hooks/useWalletManagement', () => ({
+  useWallet: () => mockWallet.current,
+}))
+
+const mockVaults = vi.hoisted(() => ({ current: {} }))
+vi.mock('../../hooks/useEarnVaults', () => ({
+  useEarnVaults: () => mockVaults.current,
+  default: () => mockVaults.current,
+}))
+
+const mockPositions = vi.hoisted(() => ({ current: {} }))
+vi.mock('../../hooks/useEarnPositions', () => ({
+  useEarnPositions: () => mockPositions.current,
+  default: () => mockPositions.current,
+}))
+
+const mockRewards = vi.hoisted(() => ({ current: {} }))
+vi.mock('../../hooks/useEarnRewards', () => ({
+  useEarnRewards: () => mockRewards.current,
+  default: () => mockRewards.current,
+}))
+
+import EarnPanel from '../../components/earn/EarnPanel'
+
+const USDC_VAULT = {
+  address: '0x00000000000000000000000000000000000000a1',
+  chainId: 137,
+  name: 'Prime USDC Vault',
+  symbol: 'mUSDC',
+  asset: { address: '0xusdc', symbol: 'USDC', name: 'USD Coin', decimals: 6 },
+  netApy: 0.043,
+  apy: 0.031,
+  rewards: [],
+  totalAssetsUsd: 12_000_000,
+  curator: 'Prime Curation',
+}
+const ETH_VAULT = {
+  ...USDC_VAULT,
+  address: '0x00000000000000000000000000000000000000a2',
+  name: 'Blue ETH Vault',
+  asset: { address: '0xweth', symbol: 'WETH', name: 'Wrapped Ether', decimals: 18 },
+}
+
+function renderPanel(path = '/wallet?tab=earn') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <EarnPanel />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockWallet.current = { chainId: 137, address: '0xac', isConnected: true, signer: null, switchNetwork: vi.fn() }
+  mockVaults.current = { vaults: [USDC_VAULT, ETH_VAULT], status: 'ready', isSupported: true, refresh: vi.fn() }
+  mockPositions.current = { positions: [], userStates: new Map(), status: 'ready', refresh: vi.fn() }
+  mockRewards.current = {
+    rewards: [],
+    status: 'ready',
+    fetchedAt: Date.now(),
+    totalClaimable: 0,
+    claim: vi.fn(),
+    claimState: { status: 'idle', txUrl: null, error: null },
+    legacyRewardsUrl: 'https://rewards-legacy.morpho.org/',
+    refresh: vi.fn(),
+  }
+})
+
+describe('EarnPanel hub (US1)', () => {
+  it('shows all earning areas with future ones honestly disabled', () => {
+    renderPanel()
+    expect(screen.getByRole('button', { name: /^Lend/ })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /^Rewards/ })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /^Stake/ })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /^Bridges/ })).toBeDisabled()
+    expect(screen.getAllByText(/not available in the app yet/i).length).toBeGreaterThan(0)
+  })
+
+  it('displays protocol attribution, risk disclosure, and the docs link (FR-012/FR-014)', () => {
+    renderPanel()
+    const attribution = screen.getByRole('link', { name: /powered by morpho/i })
+    expect(attribution).toHaveAttribute('href', 'https://app.morpho.org')
+    expect(screen.getByText(/not guaranteed/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /earn guide/i })).toHaveAttribute(
+      'href',
+      expect.stringContaining('docs.FairWins.app'),
+    )
+  })
+
+  it('opens the lend view from the Lend area card', () => {
+    renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: /^Lend/ }))
+    expect(screen.getByText('Prime USDC Vault')).toBeInTheDocument()
+    expect(screen.getByText('Blue ETH Vault')).toBeInTheDocument()
+  })
+})
+
+describe('EarnPanel honest unavailable state (US1/AS5, FR-008)', () => {
+  it('explains unavailability and names earn-enabled networks on Mordor', () => {
+    mockWallet.current = { ...mockWallet.current, chainId: 63 }
+    mockVaults.current = { vaults: [], status: 'unsupported', isSupported: false, refresh: vi.fn() }
+    renderPanel()
+    expect(screen.getByText(/not available on Ethereum Classic Mordor/i)).toBeInTheDocument()
+    expect(screen.getByText(/Ethereum and Polygon/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Lend/ })).toBeDisabled()
+  })
+})
+
+describe('EarnPanel deep links (US3)', () => {
+  it('lands on the lend view prefiltered by ?token= with a clear affordance', () => {
+    renderPanel('/wallet?tab=earn&view=lend&chain=137&token=USDC')
+    expect(screen.getByText('Prime USDC Vault')).toBeInTheDocument()
+    expect(screen.queryByText('Blue ETH Vault')).not.toBeInTheDocument()
+    // Clearing the filter restores the full list.
+    fireEvent.click(screen.getByRole('button', { name: /USDC only/i }))
+    expect(screen.getByText('Blue ETH Vault')).toBeInTheDocument()
+  })
+
+  it('offers a network switch when ?chain= names a different network', () => {
+    renderPanel('/wallet?tab=earn&view=lend&chain=1&token=USDC')
+    expect(screen.getByText(/wallet is on Polygon/i)).toBeInTheDocument()
+    const switchBtn = screen.getByRole('button', { name: /switch to Ethereum/i })
+    fireEvent.click(switchBtn)
+    expect(mockWallet.current.switchNetwork).toHaveBeenCalledWith(1)
+  })
+
+  it('lands on the rewards view via ?view=rewards', () => {
+    renderPanel('/wallet?tab=earn&view=rewards')
+    expect(screen.getByText(/nothing to claim yet/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/earn/EarnRewardsView.test.jsx
+++ b/frontend/src/test/earn/EarnRewardsView.test.jsx
@@ -1,0 +1,101 @@
+/**
+ * EarnRewardsView tests (spec 050 US2) — claimable/pending display,
+ * freshness copy, claim disabled at zero, explicit unavailable state
+ * (never a fabricated zero), empty-state education, legacy link.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+const mockRewards = vi.hoisted(() => ({ current: {} }))
+vi.mock('../../hooks/useEarnRewards', () => ({
+  useEarnRewards: () => mockRewards.current,
+  default: () => mockRewards.current,
+}))
+
+import EarnRewardsView from '../../components/earn/EarnRewardsView'
+
+const MORPHO_REWARD = {
+  token: { address: '0xmorpho', symbol: 'MORPHO', decimals: 18 },
+  amount: 2_000_000_000_000_000_000n,
+  claimed: 500_000_000_000_000_000n,
+  claimable: 1_500_000_000_000_000_000n,
+  pending: 100_000_000_000_000_000n,
+  proofs: ['0xaa'],
+  fetchedAt: 1_752_000_000_000,
+}
+
+const baseApi = () => ({
+  rewards: [MORPHO_REWARD],
+  status: 'ready',
+  fetchedAt: 1_752_000_000_000,
+  totalClaimable: 1,
+  claim: vi.fn(),
+  claimState: { status: 'idle', txUrl: null, error: null },
+  legacyRewardsUrl: 'https://rewards-legacy.morpho.org/',
+  refresh: vi.fn(),
+})
+
+beforeEach(() => {
+  mockRewards.current = baseApi()
+})
+
+describe('EarnRewardsView (US2)', () => {
+  it('lists claimable and pending amounts with freshness copy', () => {
+    render(<EarnRewardsView />)
+    expect(screen.getByText('MORPHO')).toBeInTheDocument()
+    expect(screen.getByText(/1\.5 MORPHO ready to claim/i)).toBeInTheDocument()
+    expect(screen.getByText(/0\.1 MORPHO building up/i)).toBeInTheDocument()
+    expect(screen.getByText(/updates every few hours/i)).toBeInTheDocument()
+  })
+
+  it('claims via the hook and reflects confirmation from the tx receipt', () => {
+    render(<EarnRewardsView />)
+    fireEvent.click(screen.getByRole('button', { name: /claim rewards/i }))
+    expect(mockRewards.current.claim).toHaveBeenCalledTimes(1)
+
+    mockRewards.current = {
+      ...baseApi(),
+      claimState: { status: 'confirmed', txUrl: 'https://polygonscan.com/tx/0xh', error: null },
+    }
+    render(<EarnRewardsView />)
+    expect(screen.getByText(/rewards claimed/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /view transaction/i })).toHaveAttribute(
+      'href',
+      'https://polygonscan.com/tx/0xh',
+    )
+  })
+
+  it('disables Claim when nothing is claimable (no wallet no-ops)', () => {
+    mockRewards.current = {
+      ...baseApi(),
+      rewards: [{ ...MORPHO_REWARD, claimable: 0n }],
+      totalClaimable: 0,
+    }
+    render(<EarnRewardsView />)
+    expect(screen.getByRole('button', { name: /claim rewards/i })).toBeDisabled()
+  })
+
+  it('explains accrual in the empty state', () => {
+    mockRewards.current = { ...baseApi(), rewards: [], totalClaimable: 0 }
+    render(<EarnRewardsView />)
+    expect(screen.getByText(/nothing to claim yet/i)).toBeInTheDocument()
+    expect(screen.getByText(/build up over time/i)).toBeInTheDocument()
+  })
+
+  it('shows an explicit unavailable state on fetch failure — never a zero (US2/AS4)', () => {
+    mockRewards.current = { ...baseApi(), rewards: [], status: 'unavailable', totalClaimable: 0 }
+    render(<EarnRewardsView />)
+    expect(screen.getByRole('alert')).toHaveTextContent(/temporarily unavailable/i)
+    expect(screen.queryByText(/nothing to claim yet/i)).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+    expect(mockRewards.current.refresh).toHaveBeenCalled()
+  })
+
+  it('links to the legacy rewards page', () => {
+    render(<EarnRewardsView />)
+    expect(screen.getByRole('link', { name: /legacy rewards page/i })).toHaveAttribute(
+      'href',
+      'https://rewards-legacy.morpho.org/',
+    )
+  })
+})

--- a/frontend/src/test/earn/VaultSheet.test.jsx
+++ b/frontend/src/test/earn/VaultSheet.test.jsx
@@ -1,0 +1,100 @@
+/**
+ * VaultSheet tests (spec 050 US1) — pre-wallet amount validation with
+ * member-facing reasons, Max shortcut, two-prompt approval explanation,
+ * honest withdraw liquidity bound, and withdraw disabled without a position.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+const mockWallet = vi.hoisted(() => ({ current: {} }))
+vi.mock('../../hooks/useWalletManagement', () => ({
+  useWallet: () => mockWallet.current,
+}))
+
+import VaultSheet from '../../components/earn/VaultSheet'
+
+const VAULT = {
+  address: '0x00000000000000000000000000000000000000a1',
+  chainId: 137,
+  name: 'Prime USDC Vault',
+  asset: { address: '0xusdc', symbol: 'USDC', name: 'USD Coin', decimals: 6 },
+  netApy: 0.043,
+  curator: 'Prime Curation',
+}
+
+// 25 USDC wallet, 10 USDC position, 8 USDC withdrawable right now.
+const USER_STATE = {
+  shares: 10_000_000n,
+  assets: 10_000_000n,
+  maxWithdrawAssets: 8_000_000n,
+  walletBalance: 25_000_000n,
+  maxDepositAssets: 0n,
+}
+
+beforeEach(() => {
+  mockWallet.current = { address: '0xac', chainId: 137, signer: null }
+})
+
+function renderSheet(userState = USER_STATE) {
+  return render(<VaultSheet vault={VAULT} userState={userState} onClose={vi.fn()} onActionComplete={vi.fn()} />)
+}
+
+describe('VaultSheet deposit validation (pre-wallet)', () => {
+  it('rejects zero, junk, and over-balance amounts with plain reasons', () => {
+    renderSheet()
+    const input = screen.getByLabelText(/amount/i)
+    const submit = screen.getByRole('button', { name: /deposit usdc/i })
+
+    fireEvent.change(input, { target: { value: '0' } })
+    fireEvent.click(submit)
+    expect(screen.getByRole('alert')).toHaveTextContent(/greater than zero/i)
+
+    fireEvent.change(input, { target: { value: 'abc' } })
+    fireEvent.click(submit)
+    expect(screen.getByRole('alert')).toHaveTextContent(/valid number/i)
+
+    fireEvent.change(input, { target: { value: '26' } })
+    fireEvent.click(submit)
+    expect(screen.getByRole('alert')).toHaveTextContent(/more than you have/i)
+  })
+
+  it('Max fills the wallet balance and the two-prompt approval is explained up front', () => {
+    renderSheet()
+    fireEvent.click(screen.getByRole('button', { name: /^max$/i }))
+    expect(screen.getByLabelText(/amount/i)).toHaveValue('25.0')
+    expect(screen.getByText(/two quick wallet confirmations/i)).toBeInTheDocument()
+  })
+
+  it('shows wallet and existing-position balances', () => {
+    renderSheet()
+    expect(screen.getByText(/in your wallet/i)).toBeInTheDocument()
+    expect(screen.getByText(/already in this vault/i)).toBeInTheDocument()
+  })
+})
+
+describe('VaultSheet withdraw (honest liquidity bound)', () => {
+  it('surfaces the available-now amount and rejects amounts above it', () => {
+    renderSheet()
+    fireEvent.click(screen.getByRole('tab', { name: /withdraw/i }))
+    expect(screen.getByText(/available to withdraw now/i)).toBeInTheDocument()
+
+    const input = screen.getByLabelText(/amount/i)
+    fireEvent.change(input, { target: { value: '9' } }) // > 8 available
+    fireEvent.click(screen.getByRole('button', { name: /withdraw usdc/i }))
+    expect(screen.getByRole('alert')).toHaveTextContent(/withdrawn right now/i)
+  })
+
+  it('Max fills the available liquidity, not the full position', () => {
+    renderSheet()
+    fireEvent.click(screen.getByRole('tab', { name: /withdraw/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^max$/i }))
+    expect(screen.getByLabelText(/amount/i)).toHaveValue('8.0')
+  })
+
+  it('is disabled with a reason when the member has no position', () => {
+    renderSheet({ ...USER_STATE, shares: 0n, assets: 0n, maxWithdrawAssets: 0n })
+    const withdrawTab = screen.getByRole('tab', { name: /withdraw/i })
+    expect(withdrawTab).toBeDisabled()
+    expect(withdrawTab).toHaveAttribute('title', expect.stringMatching(/nothing in this vault/i))
+  })
+})

--- a/frontend/src/test/earn/earnConfig.test.js
+++ b/frontend/src/test/earn/earnConfig.test.js
@@ -1,0 +1,74 @@
+/**
+ * Earn config gating tests (spec 050, FR-001/FR-008) — the earn capability is
+ * on exactly for chains with a real Morpho deployment + data API (1, 137),
+ * helpers resolve strictly per-chain, deep links build correctly, and the nav
+ * item lives in the Finance group with its own icon.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  NETWORKS,
+  isEarnAvailable,
+  getEarnConfig,
+  getEarnNetworks,
+  listSupportedChainIds,
+} from '../../config/networks'
+import { earnPath } from '../../config/earn'
+import { NAV_GROUPS } from '../../config/appNav'
+
+const EARN_CHAINS = [1, 137]
+
+describe('earn network capability (spec 050)', () => {
+  it('is available exactly on Ethereum mainnet and Polygon', () => {
+    for (const chainId of listSupportedChainIds()) {
+      expect(isEarnAvailable(chainId), `chain ${chainId}`).toBe(EARN_CHAINS.includes(chainId))
+      expect(NETWORKS[chainId].capabilities.earn, `capabilities ${chainId}`).toBe(
+        EARN_CHAINS.includes(chainId),
+      )
+    }
+  })
+
+  it('never falls back across chains for unknown ids', () => {
+    expect(isEarnAvailable(999999)).toBe(false)
+    expect(isEarnAvailable(null)).toBe(false)
+    expect(getEarnConfig(999999)).toBeNull()
+  })
+
+  it('provides provider identity, distributor, and legacy link where enabled', () => {
+    for (const chainId of EARN_CHAINS) {
+      const config = getEarnConfig(chainId)
+      expect(config.provider.name).toBe('Morpho')
+      expect(config.merklDistributor).toMatch(/^0x[0-9a-fA-F]{40}$/)
+      expect(config.legacyRewardsUrl).toContain('rewards-legacy.morpho.org')
+    }
+  })
+
+  it('lists the earn-enabled networks for honest unavailable copy', () => {
+    const names = getEarnNetworks().map((n) => n.name)
+    expect(names).toContain('Ethereum')
+    expect(names).toContain('Polygon')
+    expect(names).toHaveLength(EARN_CHAINS.length)
+  })
+})
+
+describe('earnPath deep links', () => {
+  it('builds the bare earn tab path', () => {
+    expect(earnPath()).toBe('/wallet?tab=earn')
+  })
+
+  it('builds view/chain/token deep links (portfolio Earn action shape)', () => {
+    expect(earnPath({ view: 'lend', chainId: 137, tokenSymbol: 'USDC' })).toBe(
+      '/wallet?tab=earn&view=lend&chain=137&token=USDC',
+    )
+  })
+})
+
+describe('earn navigation entry (FR-001)', () => {
+  it('appears in the Finance group with a unique icon', () => {
+    const finance = NAV_GROUPS.find((g) => g.label === 'Finance')
+    const earnItem = finance.items.find((i) => i.id === 'earn')
+    expect(earnItem).toMatchObject({ label: 'Earn', icon: 'sprout' })
+    // Unique icon: no other nav item shares it.
+    const allItems = NAV_GROUPS.flatMap((g) => g.items)
+    expect(allItems.filter((i) => i.icon === 'sprout')).toHaveLength(1)
+  })
+})

--- a/frontend/src/test/earn/earnSource.test.js
+++ b/frontend/src/test/earn/earnSource.test.js
@@ -1,0 +1,115 @@
+/**
+ * earnSource tests (spec 050 / spec 031 contract) — buffered user actions
+ * become precise entries with tx links; share-balance snapshot-diff is a
+ * baseline-first, idempotent backstop; hard read failure returns ok:false.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const m = vi.hoisted(() => ({ fns: {} }))
+
+vi.mock('../../utils/rpcProvider', () => ({ makeReadProvider: () => ({}) }))
+vi.mock('ethers', async (orig) => {
+  const actual = await orig()
+  function FakeContract() {
+    return new Proxy(
+      {},
+      {
+        get(_t, prop) {
+          if (prop === 'then') return undefined
+          return (...args) => {
+            const fn = m.fns[prop]
+            if (!fn) throw new Error('unmocked contract method: ' + String(prop))
+            return fn(...args)
+          }
+        },
+      },
+    )
+  }
+  return {
+    ...actual,
+    Contract: vi.fn(FakeContract),
+    ethers: { ...actual.ethers, Contract: vi.fn(FakeContract) },
+  }
+})
+
+import { earnSource } from '../../data/notifications/sources/earnSource'
+import { queueEarnAction, peekEarnActions } from '../../lib/earn/earnActivityBuffer'
+
+const ACCT = '0x00000000000000000000000000000000000000ac'
+const VAULT = '0x00000000000000000000000000000000000000a1'
+const NOW = 3_000_000
+const CHAIN = 137
+
+const detect = (prior = { snapshots: {}, aux: {} }) =>
+  earnSource.detect({ account: ACCT, chainId: CHAIN, nowMs: NOW, prior })
+
+beforeEach(() => {
+  localStorage.clear()
+  m.fns = { balanceOf: async () => 1000n }
+})
+
+describe('earnSource (spec 050 FR-010)', () => {
+  it('no-ops on networks without earn support', async () => {
+    const res = await earnSource.detect({ account: ACCT, chainId: 63, nowMs: NOW, prior: { snapshots: {} } })
+    expect(res).toMatchObject({ ok: true, entries: [] })
+  })
+
+  it('drains buffered actions into entries with tx links and starts tracking the vault', async () => {
+    queueEarnAction(ACCT, CHAIN, {
+      type: 'earn-deposit',
+      refId: VAULT,
+      message: 'Deposited 10 USDC into Prime Vault',
+      txHash: '0xhash1',
+      txUrl: 'https://polygonscan.com/tx/0xhash1',
+      at: NOW - 5,
+    })
+    const res = await detect()
+    expect(res.ok).toBe(true)
+    expect(res.entries).toHaveLength(1)
+    expect(res.entries[0]).toMatchObject({
+      id: `earn:${CHAIN}:earn-deposit:0xhash1`,
+      domain: 'earn',
+      type: 'earn-deposit',
+      txUrl: 'https://polygonscan.com/tx/0xhash1',
+      severity: 'success',
+    })
+    // Buffer drained; vault share balance snapped (baseline for future diffs).
+    expect(peekEarnActions(ACCT, CHAIN)).toEqual([])
+    expect(res.nextSnapshots[`earn:${VAULT.toLowerCase()}`]).toMatchObject({ shares: '1000' })
+    // The action already explains this cycle's change — no duplicate diff entry.
+    expect(res.entries.filter((e) => e.type === 'earn-position-changed')).toHaveLength(0)
+  })
+
+  it('first sight of a tracked vault is baseline — no retroactive entries', async () => {
+    queueEarnAction(ACCT, CHAIN, {
+      type: 'earn-deposit',
+      refId: VAULT,
+      message: 'dep',
+      txHash: '0xh',
+      txUrl: '',
+      at: NOW,
+    })
+    const first = await detect()
+    // Re-run with the produced snapshots and no new actions: idempotent.
+    const second = await detect({ snapshots: first.nextSnapshots, aux: {} })
+    expect(second.entries).toEqual([])
+    expect(second.nextSnapshots).toMatchObject(first.nextSnapshots)
+  })
+
+  it('emits a position-changed entry when shares change outside the app', async () => {
+    const prior = { snapshots: { [`earn:${VAULT.toLowerCase()}`]: { shares: '500', snappedAt: NOW - 60 } }, aux: {} }
+    const res = await detect(prior)
+    expect(res.entries).toHaveLength(1)
+    expect(res.entries[0]).toMatchObject({ type: 'earn-position-changed', severity: 'info' })
+    expect(res.entries[0].message).toMatch(/increased/i)
+  })
+
+  it('returns ok:false when every tracked vault read fails (engine keeps prior slice)', async () => {
+    m.fns.balanceOf = async () => {
+      throw new Error('rpc down')
+    }
+    const prior = { snapshots: { [`earn:${VAULT.toLowerCase()}`]: { shares: '500', snappedAt: NOW - 60 } }, aux: {} }
+    const res = await detect(prior)
+    expect(res.ok).toBe(false)
+  })
+})

--- a/frontend/src/test/earn/merkl.test.js
+++ b/frontend/src/test/earn/merkl.test.js
@@ -1,0 +1,99 @@
+/**
+ * Merkl rewards module tests (spec 050, contracts/merkl-rewards.md) —
+ * cumulative claimable math, lowercased address, per-chain scoping, claim-arg
+ * construction (CUMULATIVE amounts), and honest failure.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { fetchRewards, buildClaimArgs, normalizeReward, MerklApiError } from '../../lib/earn/merkl'
+
+const NOW = 1_752_000_000_000
+const ACCOUNT = '0x00000000000000000000000000000000000000AC'
+
+const REWARD_RECORD = {
+  token: { address: '0xMORPHO', symbol: 'MORPHO', decimals: 18 },
+  amount: '2000000000000000000',
+  claimed: '500000000000000000',
+  pending: '100000000000000000',
+  proofs: ['0xaa', '0xbb'],
+}
+
+const responseFor = (records, chainId = 137) => [{ chain: { id: chainId }, rewards: records }]
+
+describe('normalizeReward', () => {
+  it('computes claimable = amount − claimed as bigints', () => {
+    const reward = normalizeReward(REWARD_RECORD, { nowMs: NOW })
+    expect(reward.amount).toBe(2000000000000000000n)
+    expect(reward.claimed).toBe(500000000000000000n)
+    expect(reward.claimable).toBe(1500000000000000000n)
+    expect(reward.pending).toBe(100000000000000000n)
+    expect(reward.fetchedAt).toBe(NOW)
+  })
+
+  it('never goes negative when claimed exceeds amount', () => {
+    const reward = normalizeReward({ ...REWARD_RECORD, amount: '1', claimed: '5' }, { nowMs: NOW })
+    expect(reward.claimable).toBe(0n)
+  })
+})
+
+describe('fetchRewards', () => {
+  it('lowercases the address in the request URL and scopes to the chain', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => [
+        ...responseFor([REWARD_RECORD], 137),
+        ...responseFor([{ ...REWARD_RECORD, token: { ...REWARD_RECORD.token, address: '0xOther' } }], 1),
+      ],
+    }))
+    const rewards = await fetchRewards(ACCOUNT, 137, { fetchImpl, nowMs: NOW })
+    expect(fetchImpl.mock.calls[0][0]).toContain(`/users/${ACCOUNT.toLowerCase()}/rewards?chainId=137`)
+    expect(rewards).toHaveLength(1)
+    expect(rewards[0].token.address).toBe('0xMORPHO')
+  })
+
+  it('drops rewards with nothing claimable and nothing pending', async () => {
+    const spent = { ...REWARD_RECORD, amount: '5', claimed: '5', pending: '0' }
+    const fetchImpl = async () => ({ ok: true, json: async () => responseFor([spent]) })
+    await expect(fetchRewards(ACCOUNT, 137, { fetchImpl, nowMs: NOW })).resolves.toEqual([])
+  })
+
+  it('throws MerklApiError on HTTP/network failure (never a fabricated zero)', async () => {
+    await expect(
+      fetchRewards(ACCOUNT, 137, { fetchImpl: async () => ({ ok: false, status: 500 }), nowMs: NOW }),
+    ).rejects.toBeInstanceOf(MerklApiError)
+    await expect(
+      fetchRewards(ACCOUNT, 137, {
+        fetchImpl: async () => {
+          throw new Error('offline')
+        },
+        nowMs: NOW,
+      }),
+    ).rejects.toBeInstanceOf(MerklApiError)
+  })
+})
+
+describe('buildClaimArgs', () => {
+  const claimable = normalizeReward(REWARD_RECORD, { nowMs: NOW })
+  const pendingOnly = normalizeReward(
+    { ...REWARD_RECORD, token: { ...REWARD_RECORD.token, address: '0xP' }, amount: '5', claimed: '5' },
+    { nowMs: NOW },
+  )
+  const noProofs = normalizeReward(
+    { ...REWARD_RECORD, token: { ...REWARD_RECORD.token, address: '0xN' }, proofs: [] },
+    { nowMs: NOW },
+  )
+
+  it('builds index-aligned parallel arrays with CUMULATIVE amounts', () => {
+    const args = buildClaimArgs(ACCOUNT, [claimable, pendingOnly, noProofs])
+    expect(args.users).toEqual([ACCOUNT])
+    expect(args.tokens).toEqual(['0xMORPHO'])
+    // Cumulative amount, NOT the claimable difference.
+    expect(args.amounts).toEqual([2000000000000000000n])
+    expect(args.proofs).toEqual([['0xaa', '0xbb']])
+  })
+
+  it('returns null when nothing is claimable — the wallet is never prompted for a no-op', () => {
+    expect(buildClaimArgs(ACCOUNT, [pendingOnly, noProofs])).toBeNull()
+    expect(buildClaimArgs(ACCOUNT, [])).toBeNull()
+    expect(buildClaimArgs(null, [claimable])).toBeNull()
+  })
+})

--- a/frontend/src/test/earn/morphoApi.test.js
+++ b/frontend/src/test/earn/morphoApi.test.js
@@ -1,0 +1,108 @@
+/**
+ * Morpho API client tests (spec 050, contracts/morpho-api.md) — curation
+ * filters, chain guards, null-safe APY/TVL, typed failure, and position
+ * enrichment shape.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  fetchVaults,
+  fetchPositionsEnrichment,
+  normalizeVault,
+  MorphoApiError,
+} from '../../lib/earn/morphoApi'
+
+const VAULT_ITEM = {
+  address: '0xVault1',
+  symbol: 'mUSDC',
+  name: 'Prime USDC Vault',
+  listed: true,
+  whitelisted: true,
+  state: {
+    totalAssetsUsd: 12_345_678,
+    apy: 0.031,
+    netApy: 0.043,
+    curator: 'Prime Curation',
+    allRewards: [{ asset: { address: '0xMorpho', symbol: 'MORPHO' }, supplyApr: 0.012 }],
+  },
+  asset: { name: 'USD Coin', address: '0xUSDC', decimals: 6, symbol: 'USDC' },
+  chain: { id: 137 },
+}
+
+const okFetch = (data) => async () => ({ ok: true, json: async () => ({ data }) })
+
+describe('normalizeVault', () => {
+  it('normalizes a curated vault', () => {
+    const vault = normalizeVault(VAULT_ITEM, 137)
+    expect(vault).toMatchObject({
+      address: '0xVault1',
+      chainId: 137,
+      name: 'Prime USDC Vault',
+      asset: { symbol: 'USDC', decimals: 6 },
+      netApy: 0.043,
+      apy: 0.031,
+      totalAssetsUsd: 12_345_678,
+      curator: 'Prime Curation',
+    })
+    expect(vault.rewards).toEqual([{ assetSymbol: 'MORPHO', supplyApr: 0.012 }])
+  })
+
+  it('drops non-listed, non-whitelisted, and foreign-chain items', () => {
+    expect(normalizeVault({ ...VAULT_ITEM, listed: false }, 137)).toBeNull()
+    expect(normalizeVault({ ...VAULT_ITEM, whitelisted: false }, 137)).toBeNull()
+    expect(normalizeVault({ ...VAULT_ITEM, chain: { id: 1 } }, 137)).toBeNull()
+  })
+
+  it('keeps missing APY/TVL as null — never zero (honest-state)', () => {
+    const vault = normalizeVault(
+      { ...VAULT_ITEM, state: { ...VAULT_ITEM.state, netApy: null, totalAssetsUsd: null } },
+      137,
+    )
+    expect(vault.netApy).toBeNull()
+    expect(vault.totalAssetsUsd).toBeNull()
+  })
+})
+
+describe('fetchVaults', () => {
+  it('returns normalized, curated vaults', async () => {
+    const fetchImpl = okFetch({ vaults: { items: [VAULT_ITEM, { ...VAULT_ITEM, address: '0xV2', listed: false }] } })
+    const vaults = await fetchVaults(137, { fetchImpl })
+    expect(vaults).toHaveLength(1)
+    expect(vaults[0].address).toBe('0xVault1')
+  })
+
+  it('throws MorphoApiError on HTTP failure', async () => {
+    const fetchImpl = async () => ({ ok: false, status: 503 })
+    await expect(fetchVaults(137, { fetchImpl })).rejects.toBeInstanceOf(MorphoApiError)
+  })
+
+  it('throws MorphoApiError on network failure', async () => {
+    const fetchImpl = async () => {
+      throw new Error('offline')
+    }
+    await expect(fetchVaults(137, { fetchImpl })).rejects.toBeInstanceOf(MorphoApiError)
+  })
+
+  it('throws MorphoApiError on GraphQL-level errors', async () => {
+    const fetchImpl = async () => ({ ok: true, json: async () => ({ errors: [{ message: 'boom' }] }) })
+    await expect(fetchVaults(137, { fetchImpl })).rejects.toBeInstanceOf(MorphoApiError)
+  })
+})
+
+describe('fetchPositionsEnrichment', () => {
+  it('keys enrichment by lowercased vault address', async () => {
+    const fetchImpl = okFetch({
+      userByAddress: {
+        vaultPositions: [
+          { vault: { address: '0xVAULT1' }, state: { shares: '1', assets: '2', assetsUsd: 100.5, pnlUsd: 2.25 } },
+        ],
+      },
+    })
+    const enrichment = await fetchPositionsEnrichment('0xabc', 137, { fetchImpl })
+    expect(enrichment['0xvault1']).toEqual({ assetsUsd: 100.5, pnlUsd: 2.25 })
+  })
+
+  it('treats an unknown user as empty enrichment, not an error', async () => {
+    const fetchImpl = async () => ({ ok: true, json: async () => ({ errors: [{ message: 'No user found' }] }) })
+    await expect(fetchPositionsEnrichment('0xabc', 137, { fetchImpl })).resolves.toEqual({})
+  })
+})

--- a/frontend/src/test/earn/vaultActions.test.js
+++ b/frontend/src/test/earn/vaultActions.test.js
@@ -1,0 +1,68 @@
+/**
+ * Vault action validator tests (spec 050, US1 edge cases) — every bad amount
+ * is rejected with a member-facing reason BEFORE any wallet prompt, and the
+ * display formatters stay honest about missing data.
+ */
+import { describe, it, expect } from 'vitest'
+import { validateDepositAmount, validateWithdrawAmount } from '../../lib/earn/vaultActions'
+import { formatApy, formatTvl } from '../../lib/earn/format'
+
+const BALANCE = 1_000_000n // 1 USDC at 6 decimals
+
+describe('validateDepositAmount', () => {
+  it('rejects empty/zero/negative amounts', () => {
+    expect(validateDepositAmount({ amount: null, walletBalance: BALANCE }).ok).toBe(false)
+    expect(validateDepositAmount({ amount: 0n, walletBalance: BALANCE }).ok).toBe(false)
+    expect(validateDepositAmount({ amount: -1n, walletBalance: BALANCE }).ok).toBe(false)
+  })
+
+  it('rejects more than the wallet balance with a plain reason', () => {
+    const res = validateDepositAmount({ amount: BALANCE + 1n, walletBalance: BALANCE })
+    expect(res.ok).toBe(false)
+    expect(res.reason).toMatch(/more than you have/i)
+  })
+
+  it('rejects more than the vault currently accepts', () => {
+    const res = validateDepositAmount({
+      amount: 600n,
+      walletBalance: BALANCE,
+      maxDepositAssets: 500n,
+    })
+    expect(res.ok).toBe(false)
+    expect(res.reason).toMatch(/vault currently accepts/i)
+  })
+
+  it('accepts a valid amount (dust included — no artificial minimum)', () => {
+    expect(validateDepositAmount({ amount: 1n, walletBalance: BALANCE }).ok).toBe(true)
+    expect(
+      validateDepositAmount({ amount: BALANCE, walletBalance: BALANCE, maxDepositAssets: 0n }).ok,
+    ).toBe(true) // maxDeposit 0 is treated as "no cap signal", not a hard stop
+  })
+})
+
+describe('validateWithdrawAmount', () => {
+  it('rejects zero and over-liquidity amounts honestly', () => {
+    expect(validateWithdrawAmount({ amount: 0n, maxWithdrawAssets: BALANCE }).ok).toBe(false)
+    const res = validateWithdrawAmount({ amount: BALANCE + 1n, maxWithdrawAssets: BALANCE })
+    expect(res.ok).toBe(false)
+    expect(res.reason).toMatch(/withdrawn right now/i)
+  })
+
+  it('accepts up to the available liquidity bound', () => {
+    expect(validateWithdrawAmount({ amount: BALANCE, maxWithdrawAssets: BALANCE }).ok).toBe(true)
+  })
+})
+
+describe('display formatters (honest "—" for missing data)', () => {
+  it('formats APY fractions and preserves null', () => {
+    expect(formatApy(0.0432)).toBe('4.32%')
+    expect(formatApy(null)).toBe('—')
+  })
+
+  it('formats TVL compactly and preserves null', () => {
+    expect(formatTvl(12_345_678)).toBe('$12.3M')
+    expect(formatTvl(45_000)).toBe('$45K')
+    expect(formatTvl(999)).toBe('$999')
+    expect(formatTvl(null)).toBe('—')
+  })
+})

--- a/frontend/src/test/portfolio/AssetDetailSheet.test.jsx
+++ b/frontend/src/test/portfolio/AssetDetailSheet.test.jsx
@@ -128,6 +128,25 @@ describe('AssetDetailSheet actions', () => {
     expect(screen.getByRole('button', { name: 'Transfer' })).toBeDisabled()
   })
 
+  it('deep-links Earn to the lend view scoped to the instance (spec 050, US3)', () => {
+    const onClose = renderSheet(ETH_AGG)
+    // WETH on Polygon — an earn-enabled network (chain 137).
+    fireEvent.click(screen.getAllByRole('radio')[2])
+    const earn = screen.getByRole('button', { name: 'Earn' })
+    expect(earn).toBeEnabled()
+    fireEvent.click(earn)
+    expect(mockNavigate).toHaveBeenCalledWith('/wallet?tab=earn&view=lend&chain=137&token=WETH')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('disables Earn with a reason on non-earn networks and for collectibles (spec 050)', () => {
+    // Mordor voucher NFT: wrong kind AND (were it fungible) non-earn network.
+    renderSheet(VOUCHER_AGG)
+    const earn = screen.getByRole('button', { name: 'Earn' })
+    expect(earn).toBeDisabled()
+    expect(screen.getByText(/collectibles cannot be lent/i)).toBeInTheDocument()
+  })
+
   it('always shows Stake as honestly unavailable (no staking surface yet)', () => {
     renderSheet(ETH_AGG)
     const stake = screen.getByRole('button', { name: 'Stake' })

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
     - Accepting a Wager: user-guide/accept-wager.md
     - Open Challenges: user-guide/open-challenges.md
     - Membership Vouchers: user-guide/membership-vouchers.md
+    - Earn (Lending & Rewards): user-guide/earn.md
     - Resolving a Wager: user-guide/resolve-wager.md
     - Private Wager Encryption: user-guide/private-market-encryption.md
     - Address Book & Screening: user-guide/address-book.md
@@ -101,6 +102,7 @@ nav:
     - Smart Contracts: developer-guide/smart-contracts.md
     - Frontend Development: developer-guide/frontend.md
     - ClearPath Multi-Network DAOs: developer-guide/clearpath-multi-network.md
+    - Earn Integration: developer-guide/earn-integration.md
     - Encryption Architecture: developer-guide/encryption-architecture.md
     - Envelope Encryption Spec: developer-guide/envelope-encryption-spec.md
     - Ethereum Security Agent: developer-guide/ethereum-security-agent.md

--- a/specs/050-earn-lending-rewards/checklists/requirements.md
+++ b/specs/050-earn-lending-rewards/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Earn Section — Lending & Rewards
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Protocol identity (Morpho, Merkl) is named in requirements/assumptions deliberately: the issue
+  and prior art (spec 033 naming ETCswap/Uniswap) treat external protocol identity as a
+  user-facing product fact, not an implementation detail.
+- The issue's conditional "platform fee / tx identification" request is resolved explicitly in
+  FR-013 + Assumptions (no referral mechanism exists; UI attribution now; fee-wrapper vault
+  deferred as a documented decision) rather than left ambiguous.
+- Items validated 2026-07-11; ready for `/speckit-plan`.

--- a/specs/050-earn-lending-rewards/contracts/earn-config.md
+++ b/specs/050-earn-lending-rewards/contracts/earn-config.md
@@ -1,0 +1,52 @@
+# Contract: per-network earn configuration (`frontend/src/config/networks.js`)
+
+The earn capability follows the `dex` precedent: a per-network config block whose presence flips
+the capability, resolved strictly per-chain (no cross-network leakage).
+
+## Shape
+
+```js
+// On NETWORKS[1] and NETWORKS[137] only (Morpho + Morpho API coverage — research.md R2):
+earn: {
+  // Attribution identity (mandated by Morpho's integration terms) + outbound link.
+  provider: { name: 'Morpho', url: 'https://app.morpho.org' },
+  // Canonical Merkl Distributor (same address on all supported chains). Config-fixed;
+  // never derived from user input or API responses.
+  merklDistributor: '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae',
+  // Where members claim pre-MIP-111 legacy rewards (we link out, never re-implement).
+  legacyRewardsUrl: 'https://rewards-legacy.morpho.org/',
+},
+get capabilities() {
+  return {
+    ...,
+    earn: Boolean(this.earn),
+  }
+},
+```
+
+## Helpers (exported from networks.js)
+
+```js
+isEarnAvailable(chainId)  // Boolean(getNetwork(chainId)?.earn)
+getEarnConfig(chainId)    // the block above, or null
+getEarnNetworks()         // NETWORKS entries with earn — names used by honest unavailable copy
+```
+
+## Global constants (`frontend/src/config/earn.js`)
+
+```js
+MORPHO_API_URL = 'https://api.morpho.org/graphql'
+MERKL_API_URL = 'https://api.merkl.xyz/v4'
+VAULT_LIST_LIMIT      // cap on curated vaults surfaced per chain (TVL-ordered)
+POSITIONS_POLL_MS     // 60_000, aligned with usePortfolio
+earnPath({ view, chainId, tokenSymbol })  // builds /wallet?tab=earn&… deep links
+```
+
+## Rules
+
+- Networks WITHOUT an `earn` block MUST render the honest unavailable state naming
+  `getEarnNetworks()` — never a mock list, never a hidden tab (nav item is always present).
+- Adding a network later (e.g. Base 8453) = one `earn` block + Morpho API chain support check;
+  no component changes (spec FR-008).
+- Env overrides are not needed for v1 (all values are public canonical constants); introducing
+  per-env overrides later must keep the "missing value ⇒ capability off" gating rule.

--- a/specs/050-earn-lending-rewards/contracts/merkl-rewards.md
+++ b/specs/050-earn-lending-rewards/contracts/merkl-rewards.md
@@ -1,0 +1,45 @@
+# Contract: Merkl rewards read + claim (`frontend/src/lib/earn/merkl.js`)
+
+Morpho distributes all current rewards via Merkl (MIP-111). The deprecated
+`rewards.morpho.org` / Universal Rewards Distributor flow is intentionally NOT implemented;
+legacy balances link out to `https://rewards-legacy.morpho.org/`.
+
+## Read
+
+```
+GET https://api.merkl.xyz/v4/users/{addressLowercase}/rewards?chainId={chainId}
+```
+
+- Address MUST be lowercased (API requirement).
+- Response: array of `{ chain: { id }, rewards: [{ token, amount, claimed, pending, proofs }] }`.
+- Amounts are cumulative lifetime strings → `bigint`. `claimable = amount − claimed`.
+- Entries with empty `proofs` or `claimable === 0n && pending === 0n` are filtered out of the
+  claim surface (pending-only entries render informatively, without a claim button).
+- Data updates ~every 8 hours ⇒ UI carries freshness copy ("Reward figures update every few
+  hours"); a fetch failure maps to status `unavailable` (explicit state, never zero).
+
+## Claim (on-chain)
+
+Contract: Merkl Distributor `0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae` (identical on Ethereum
+mainnet + Polygon; sourced from `networks.js` earn config, never from the API response).
+
+```solidity
+function claim(
+  address[] calldata users,    // all = connected account
+  address[] calldata tokens,   // reward token per entry
+  uint256[] calldata amounts,  // CUMULATIVE amount per entry (NOT the difference)
+  bytes32[][] calldata proofs  // per-entry Merkle proofs from the API
+) external;
+```
+
+Builder rule (`buildClaimArgs(account, rewards)`): include every reward with `claimable > 0n` and
+non-empty proofs; four parallel arrays index-aligned. The distributor transfers only the
+unclaimed difference; repeating a claim with the same cumulative amount is a safe no-op — the UI
+still prevents pointless prompts by disabling Claim when `claimable === 0n`.
+
+## Post-claim
+
+- Refresh on-chain reward-token balances immediately; re-fetch Merkl data and reconcile
+  (API `claimed` may lag the chain — display "claim submitted/confirmed" from the tx receipt, not
+  from the API).
+- Emit `earn-rewards-claimed` activity entry with the tx explorer link (spec 031 shape).

--- a/specs/050-earn-lending-rewards/contracts/morpho-api.md
+++ b/specs/050-earn-lending-rewards/contracts/morpho-api.md
@@ -1,0 +1,58 @@
+# Contract: Morpho GraphQL consumption (`frontend/src/lib/earn/morphoApi.js`)
+
+Endpoint: `POST https://api.morpho.org/graphql` (public, no auth; 750 req/min — we issue a handful
+per session). All queries filter by the active `chainId`; responses are normalized into the
+`Vault` / position-enrichment shapes in [data-model.md](../data-model.md).
+
+## Vault list (curated)
+
+```graphql
+query EarnVaults($chainIds: [Int!]!, $first: Int!) {
+  vaults(
+    first: $first
+    orderBy: TotalAssetsUsd
+    orderDirection: Desc
+    where: { chainId_in: $chainIds, whitelisted: true }
+  ) {
+    items {
+      address symbol name listed whitelisted
+      state {
+        totalAssetsUsd apy netApy curator
+        allRewards { asset { address symbol } supplyApr }
+      }
+      asset { name address decimals symbol }
+      chain { id }
+    }
+  }
+}
+```
+
+Normalizer rules:
+- Drop items with `listed !== true` or `chain.id !== chainId` (defense against API drift).
+- `netApy`/`apy`/`totalAssetsUsd` may be null → keep null (render "—"), never 0.
+- Order preserved (TVL desc), capped at `VAULT_LIST_LIMIT`.
+
+## Position enrichment (USD value + earnings)
+
+```graphql
+query EarnPositions($address: String!, $chainId: Int!) {
+  userByAddress(address: $address, chainId: $chainId) {
+    vaultPositions {
+      vault { address }
+      state { shares assets assetsUsd pnlUsd }
+    }
+  }
+}
+```
+
+- Enrichment only: the authoritative "member has a position" signal is the on-chain
+  `balanceOf`/`convertToAssets` read. A missing/failed enrichment degrades to on-chain values with
+  USD/pnl rendered "—" (honest), position still shown.
+- Unknown user (never deposited) returns null user — treated as empty enrichment, not an error.
+
+## Failure contract
+
+- Network/HTTP/GraphQL-errors ⇒ throw a typed `MorphoApiError`; hooks map it to status
+  `unavailable`. Components MUST show the explicit unavailable state and disable deposit entry
+  points; they MUST NOT render cached numbers as current or substitute zeros.
+- No retries beyond one immediate retry; manual refresh affordance instead (rate-limit courtesy).

--- a/specs/050-earn-lending-rewards/data-model.md
+++ b/specs/050-earn-lending-rewards/data-model.md
@@ -1,0 +1,91 @@
+# Data Model: Earn Section — Lending & Rewards (spec 050)
+
+All models are client-side normalized shapes (plain objects) produced by `lib/earn/*` and consumed
+by hooks/components. Amounts are kept as `bigint` (raw units) alongside `decimals`; formatting
+happens at the edge. Every model is scoped to one `chainId` — nothing crosses networks.
+
+## EarnNetworkConfig (`networks.js` → `earn` block)
+
+| Field | Type | Notes |
+|---|---|---|
+| `provider` | `{ name, url }` | `{ name: 'Morpho', url: 'https://app.morpho.org' }` — attribution + outbound link |
+| `merklDistributor` | `address` | `0x3Ef3D8bA38EBe18DB133cEc00Dd9Ae…` canonical claim contract (config-fixed, never user input) |
+| `legacyRewardsUrl` | `string` | `https://rewards-legacy.morpho.org/` |
+
+Derived: `capabilities.earn === Boolean(this.earn)`. Helpers: `isEarnAvailable(chainId)`,
+`getEarnConfig(chainId)`, `getEarnNetworks()` (earn-enabled network names for honest copy).
+Validation: block present only on chains the Morpho API serves (1, 137 initially).
+
+## Vault (normalized from Morpho GraphQL `vaults.items[]`)
+
+| Field | Type | Source | Notes |
+|---|---|---|---|
+| `address` | address | `address` | vault contract (ERC-4626) |
+| `chainId` | number | `chain.id` | must equal requested chain (guard) |
+| `name` / `symbol` | string | `name`/`symbol` | display |
+| `asset` | `{ address, symbol, decimals, name }` | `asset` | underlying token |
+| `netApy` | number \| null | `state.netApy` | fraction (0.043 = 4.3%); null → "—" |
+| `apy` | number \| null | `state.apy` | native APY (pre-rewards) for the breakdown InfoTip |
+| `rewards` | `{ assetSymbol, supplyApr }[]` | `state.allRewards` | reward campaign breakdown |
+| `totalAssetsUsd` | number \| null | `state.totalAssetsUsd` | "total deposits" display |
+| `curator` | string \| null | `state.curator` | curator identity (FR-003) |
+| `whitelisted`/`listed` | boolean | top-level | both must be true to surface (curation) |
+
+State: fetched per chain; list status ∈ `loading | ready | unavailable` (fetch failure ⇒
+`unavailable`, deposits disabled — never stale numbers as truth).
+
+## Position (per member × vault)
+
+| Field | Type | Source | Notes |
+|---|---|---|---|
+| `vault` | Vault ref | — | |
+| `shares` | bigint | on-chain `balanceOf(account)` | source of truth for "has position" |
+| `assets` | bigint | on-chain `convertToAssets(shares)` | current value in underlying units |
+| `assetsUsd` | number \| null | API `state.assetsUsd` | enrichment; null → "—" (honest) |
+| `pnlUsd` | number \| null | API `state.pnlUsd` | "earned so far"; omitted when unavailable |
+| `maxWithdrawAssets` | bigint | on-chain `maxWithdraw(account)` | honest withdraw bound (liquidity) |
+
+Transitions: deposit ⇒ shares↑; withdraw/redeem ⇒ shares↓ (0 ⇒ position closed). Poll 60s
+(aligned with usePortfolio), scoped to active chain + connected account.
+
+## RewardBalance (normalized from Merkl `/v4/users/{addr}/rewards?chainId=`)
+
+| Field | Type | Source | Notes |
+|---|---|---|---|
+| `token` | `{ address, symbol, decimals }` | `rewards[].token` | |
+| `amount` | bigint | `rewards[].amount` | cumulative earned (lifetime) |
+| `claimed` | bigint | `rewards[].claimed` | cumulative claimed |
+| `claimable` | bigint | derived | `amount − claimed`; claim passes cumulative `amount` |
+| `pending` | bigint | `rewards[].pending` | accruing, not yet claimable (shown informatively) |
+| `proofs` | `bytes32[]` | `rewards[].proofs` | Merkle proof for the distributor call |
+| `fetchedAt` | number | client clock | drives the freshness copy |
+
+Invariants: claim tx uses parallel arrays `(users[], tokens[], amounts[], proofs[][])` with
+`users[i] = account`, `amounts[i] = amount` (cumulative — re-claiming is safe/no-op by design).
+Rewards with `claimable === 0n && pending === 0n` are hidden. Status ∈
+`loading | ready | unavailable` — `unavailable` is an explicit state, never rendered as zero.
+
+## EarnActivityEntry (spec 031 entry shape, `domain: 'earn'`)
+
+| Field | Value |
+|---|---|
+| `id` | stable: `earn:<chainId>:<type>:<vaultOrToken>:<txHash \| snapshotEpoch>` |
+| `domain` | `'earn'` (new `DOMAIN_META` entry: label "Earn", feed tag) |
+| `refId` | vault address (positions) or reward token address (claims) |
+| `type` | `earn-deposit` \| `earn-withdraw` \| `earn-position-changed` \| `earn-rewards-claimed` |
+| `message` | plain language incl. amount + asset + vault/reward name |
+| `severity` | `info` |
+| `actionable` | `false` |
+| `link` | tx explorer URL (action rider) or earn tab path (poll-detected) |
+| `createdAt` / `read` | per contract |
+
+Source snapshots per (account, chain): `{ [vaultAddress]: sharesString }` and
+`{ [rewardTokenAddress]: claimedString }`. Contract obligations (first-sight = baseline,
+idempotent, `ok:false` on hard failure) per `sources/README.md`.
+
+## Deep-link contract
+
+`/wallet?tab=earn[&view=lend|rewards][&chain=<chainId>][&token=<symbol>]` — `chain` is a hint (UI
+still operates on the active wallet network and shows a switch prompt when they differ); `token`
+prefilters the vault list to vaults whose `asset.symbol` matches. Produced by the portfolio
+AssetDetailSheet earn action.

--- a/specs/050-earn-lending-rewards/plan.md
+++ b/specs/050-earn-lending-rewards/plan.md
@@ -1,0 +1,161 @@
+# Implementation Plan: Earn Section — Lending & Rewards
+
+**Branch**: `claude/earn-lending-rewards-3j5y70` | **Date**: 2026-07-11 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/050-earn-lending-rewards/spec.md` (issue #861)
+
+## Summary
+
+Add an **Earn** sub-section to the Finance navigation group where members lend idle assets into
+curated Morpho (ERC-4626) vaults on Ethereum mainnet and Polygon, watch their positions, and see &
+claim protocol rewards via Merkl — with plain-language InfoTip explainers on every DeFi concept,
+activity-feed audit entries for every action, per-network capability gating, a portfolio "Earn"
+deep-link action, and a user guide on the docs site. Frontend-only: ethers v6 against public
+vault/distributor contracts, Morpho GraphQL API for discovery/APY, Merkl REST API for rewards. No
+platform fee in this release — Morpho has no tx-source referral mechanism; the treasury
+fee-wrapper vault path is documented and deferred (research.md R4).
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES2022), React 18 + Vite (existing frontend stack)
+
+**Primary Dependencies**: ethers v6 (contract reads/writes), react-router-dom, existing InfoTip /
+nav / activity-feed infrastructure. **No new npm dependencies** — Morpho GraphQL and Merkl REST
+are consumed with `fetch`; ERC-4626 + Merkl Distributor calls use minimal inline ABIs
+(research.md R1/R3).
+
+**Storage**: none new — activity entries persist through the existing spec 031 activity store
+(`localStorage`, per account+chain); no backend.
+
+**Testing**: Vitest + Testing Library + vitest-axe (existing frontend suite; new tests under
+`frontend/src/test/earn/`).
+
+**Target Platform**: web (desktop + mobile PWA), same as existing app.
+
+**Project Type**: web frontend (frontend/ only) + docs site (docs/ + mkdocs.yml).
+
+**Performance Goals**: vault list interactive < 2s on normal network; polling aligned with
+existing cadences (positions 60s like usePortfolio; rewards on open + manual refresh — Merkl data
+only changes ~8-hourly).
+
+**Constraints**: honest-state everywhere (no mock vaults, no fake zeros, freshness labels on
+reward data); WCAG 2.1 AA; per-chain data isolation; Morpho API rate limit 750 req/min (a handful
+of queries per session — no risk); all copy non-technical with InfoTip explainers.
+
+**Scale/Scope**: 2 earn-enabled networks (1, 137), ~10–30 curated vaults per network, 1 nav item,
+~8 new components/modules, 2 docs pages.
+
+## Constitution Check
+
+*GATE evaluated against constitution v1.0.0 — PASS (pre-Phase-0 and re-checked post-Phase-1).*
+
+- **I. Security-First Smart Contracts**: PASS — no `contracts/` changes. The feature only calls
+  audited third-party contracts (Morpho vaults, Merkl Distributor) from the user's own wallet.
+  Client-side safeguards: `previewDeposit` + `staticCall` before sending, amount validation before
+  any wallet prompt, curated (whitelisted+listed) vaults only, canonical distributor address from
+  config not user input. The treasury fee-wrapper vault (which WOULD be a value-bearing contract)
+  is explicitly deferred to its own spec for exactly this reason (research.md R4).
+- **II. Test-First / Coverage**: PASS — Vitest units for API normalizers, claimable math,
+  validation, hooks; component tests incl. failure/edge states (API down, unsupported network,
+  over-balance amounts); axe tests for new views.
+- **III. Honest State**: PASS — live Morpho/Merkl data only; explicit unavailable states; no
+  earn surface on networks without real support (testnets excluded because the Morpho API has no
+  testnet data — R2); reward freshness disclosed; no fee implied while none is charged.
+- **IV. Fail Loudly in CI**: PASS — no CI changes; new tests join the gating suite.
+- **V. Accessible, Consistent Frontend**: PASS — InfoTip/nav/panel patterns reused; WCAG AA via
+  axe tests; ESLint clean. Note: Morpho vault/distributor addresses are *external protocol*
+  deployments resolved via `networks.js` config (the same pattern as Uniswap/ETCswap dex config —
+  they are not FairWins deployments, so `deployments/`-derived sync artifacts don't apply).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/050-earn-lending-rewards/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   ├── earn-config.md   # networks.js earn block + capability contract
+│   ├── morpho-api.md    # GraphQL queries + normalized shapes consumed
+│   └── merkl-rewards.md # Merkl API + Distributor claim contract
+├── checklists/requirements.md
+└── tasks.md             # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/
+├── config/
+│   ├── appNav.js                    # + { id: 'earn', label: 'Earn', icon: 'sprout' } in Finance
+│   ├── networks.js                  # + earn block on chains 1 & 137, + earn capability,
+│   │                                #   + isEarnAvailable/getEarnConfig/getEarnNetworks helpers
+│   └── earn.js                      # NEW — Morpho/Merkl endpoints, distributor address,
+│                                    #   curation filters, poll cadences, deep-link helper
+├── abis/
+│   ├── ERC4626Vault.js              # NEW — minimal vault ABI (deposit/withdraw/redeem/previews/
+│   │                                #   maxWithdraw/convertToAssets/balanceOf/asset)
+│   └── MerklDistributor.js          # NEW — claim(users,tokens,amounts,proofs)
+├── lib/earn/
+│   ├── morphoApi.js                 # NEW — GraphQL fetch + normalize vaults/positions
+│   ├── merkl.js                     # NEW — rewards fetch, claimable math, claim args builder
+│   ├── vaultActions.js              # NEW — ethers v6 approve/deposit/withdraw helpers + validation
+│   └── earnCopy.js                  # NEW — all member-facing explainer copy (InfoTip text)
+├── hooks/
+│   ├── useEarnVaults.js             # NEW — vault list for active chain (fetch + refresh + status)
+│   ├── useEarnPositions.js          # NEW — on-chain share balances + API enrichment (60s poll)
+│   └── useEarnRewards.js            # NEW — Merkl rewards + claim action + freshness
+├── components/earn/
+│   ├── EarnPanel.jsx                # NEW — hub: areas, attribution, disclosure, docs link,
+│   │                                #   honest unavailable state per network
+│   ├── EarnLendView.jsx             # NEW — vault list (+ ?token= prefilter from deep link)
+│   ├── VaultSheet.jsx               # NEW — single vault: deposit/withdraw with summary + InfoTips
+│   ├── EarnRewardsView.jsx          # NEW — rewards list + claim + freshness + legacy link
+│   ├── EarnPositionsList.jsx        # NEW — member's active positions
+│   └── Earn.css                     # NEW
+├── components/nav/NavIcon.jsx       # + 'sprout' glyph
+├── components/wallet/AssetDetailSheet.jsx  # + earn action in actionsFor()
+├── pages/WalletPage.jsx             # + WALLET_TABS entry + earn panel
+└── data/notifications/
+    ├── domains.js                   # + earn DOMAIN_META
+    └── sources/
+        ├── earnSource.js            # NEW — spec 031 ActivitySource (snapshot-diff + action rider)
+        └── index.js                 # + register earnSource
+
+frontend/src/test/earn/              # NEW — unit/component/axe tests (see tasks.md)
+docs/user-guide/earn.md              # NEW — member guide
+docs/developer-guide/earn-integration.md  # NEW — architecture + config + deferred fee decision
+mkdocs.yml                           # + nav entries
+```
+
+**Structure Decision**: frontend-only feature following the established section pattern
+(config-gated capability → lib + hooks → panel hosted as `/wallet?tab=earn`), plus docs. No
+backend, no contracts/, no subgraph changes.
+
+## Design decisions (Phase 1 digest)
+
+1. **Capability gating** mirrors `dex`: `NETWORKS[id].earn` block (provider identity, Merkl
+   distributor, morpho chain support) → `capabilities.earn` → UI self-gates; unavailable networks
+   name the earn-enabled networks (from `getEarnNetworks()`), never dead-end.
+2. **Vault curation**: Morpho API `whitelisted: true` filter + `listed: true` requirement, ordered
+   by TVL desc, capped (config) — no hand-maintained vault lists.
+3. **Deposit flow**: validate → (allowance check → approve prompt, explained up front) →
+   `previewDeposit` quote → `deposit.staticCall` dry-run → send → success + activity entry.
+   Withdraw: `maxWithdraw` bound honestly (vault liquidity), `withdraw(assets)` partial /
+   `redeem(shares)` full-exit.
+4. **Rewards**: Merkl cumulative accounting (`claimable = amount − claimed`); claim passes
+   cumulative `amount` + proofs to the distributor; freshness copy; API-down → explicit
+   unavailable, never zero.
+5. **Activity**: earnSource snapshot-diff (share balances, cumulative claimed) + immediate action
+   entries with tx links appended at action time (stable ids keep the poll idempotent).
+6. **Deep link**: `/wallet?tab=earn&chain=<id>&token=<sym>` consumed by EarnPanel (chain hint +
+   asset prefilter) and produced by the portfolio earn action.
+
+## Complexity Tracking
+
+No constitution violations to justify. New-technology check: none added (fetch + ethers v6 +
+existing patterns). The single scope-shaped decision — deferring the treasury fee-wrapper vault —
+is recorded in research.md R4 and spec FR-013.

--- a/specs/050-earn-lending-rewards/quickstart.md
+++ b/specs/050-earn-lending-rewards/quickstart.md
@@ -1,0 +1,52 @@
+# Quickstart: validating the Earn section (spec 050)
+
+## Prerequisites
+
+- `npm ci` at repo root (workspaces install the frontend).
+- For live-flow checks: a browser wallet with a small USDC balance on Polygon (137) — the
+  cheapest real-money validation path — or Ethereum mainnet (1).
+
+## Automated validation
+
+```bash
+npm run test:frontend            # full Vitest suite, includes frontend/src/test/earn/*
+npm run test:frontend -- earn    # just the earn feature tests
+npm run lint --workspace frontend
+npm run build --workspace frontend
+```
+
+Expected: all green; earn tests cover API normalization, claimable math, amount validation,
+capability gating, honest unavailable states, activity source contract, and axe (WCAG) passes.
+
+## Manual validation script
+
+1. `npm run frontend` → open the app, connect a wallet.
+2. **Nav (US1/AS1)**: open the nav drawer → Finance shows **Earn** with its own icon; mobile
+   bottom bar shows it among Finance siblings. Route: `/wallet?tab=earn`.
+3. **Unsupported network honesty (US1/AS5)**: switch to Mordor → Earn explains lending isn't
+   available here and names Ethereum & Polygon; no vault data, no dead buttons.
+4. **Vault list (US1/AS2)**: switch to Polygon → Lend area lists curated Morpho vaults with
+   asset, APY, total deposits, curator; every term has an InfoTip; "Powered by Morpho" + risk
+   disclosure visible; docs link opens the user guide.
+5. **Deposit (US1/AS3)**: pick a USDC vault → enter amount (try 0, dust, > balance — all
+   rejected pre-wallet with reasons; Max works) → summary explains approval + deposit prompts →
+   confirm both → success state; position appears with current value.
+6. **Withdraw (US1/AS4)**: open the position → withdraw part (bounded by available liquidity,
+   shown honestly) → balance returns to wallet.
+7. **Rewards (US2)**: open Earn → Rewards with an address holding Merkl rewards → claimable
+   amounts + freshness copy shown; Claim → wallet prompt → tokens arrive; empty state explains
+   accrual when there's nothing to claim; kill network → explicit "temporarily unavailable".
+8. **Portfolio entry (US3/AS1-2)**: Portfolio → USDC detail → **Earn** action routes to
+   `/wallet?tab=earn&chain=137&token=USDC` with the list prefiltered; on a non-earn network the
+   action is disabled with a reason.
+9. **Activity audit (US3/AS3)**: after steps 5–7, the activity feed shows earn entries
+   (deposit/withdraw/claim) with amounts and working tx links.
+10. **Docs (FR-014)**: `pip install -r requirements.txt && mkdocs serve` → User Guide → "Earn"
+    page renders; developer guide "Earn integration" documents config + the deferred
+    treasury-fee decision.
+
+## Reference
+
+- Data shapes: [data-model.md](./data-model.md)
+- Config/API/claim contracts: [contracts/](./contracts/)
+- External decisions & sources: [research.md](./research.md)

--- a/specs/050-earn-lending-rewards/research.md
+++ b/specs/050-earn-lending-rewards/research.md
@@ -1,0 +1,177 @@
+# Research: Earn Section — Lending & Rewards (spec 050)
+
+**Date**: 2026-07-11 · All external findings verified against docs.morpho.org, api.morpho.org,
+api.merkl.xyz, npm, and block explorers on this date.
+
+## R1 — Lending protocol integration surface (Morpho)
+
+**Decision**: Integrate **Morpho Vault V1 (MetaMorpho)** vaults as plain **ERC-4626** contracts
+via ethers v6 (`deposit(assets, receiver)` / `withdraw(assets, receiver, owner)` /
+`redeem(shares, receiver, owner)` / `previewDeposit` / `maxWithdraw` / `convertToAssets`),
+with vault discovery and APY/TVL/position data from Morpho's public GraphQL API
+(`https://api.morpho.org/graphql`, no auth, 750 req/min). Filter
+`where: { chainId_in: [...], whitelisted: true }` and require `listed: true` so we only surface
+vaults curated on the Morpho app itself.
+
+**Rationale**:
+- Vault V1 is the mature surface: full ERC-4626 semantics including working
+  `maxDeposit`/`maxWithdraw` (Vault V2 returns 0 from the max* functions by design, which breaks
+  honest limit display). V2 support can be layered on later behind the same normalized model.
+- Plain ethers + GraphQL is the docs' own documented lightweight path ("Path 2.2" in the
+  assets-flow tutorial). The `@morpho-org/morpho-sdk` umbrella package (v5.x) is viem-native and
+  pulls in Bundler3 routing — the app's tx layer is ethers v6, so the SDK would add a second
+  web3 stack for marginal benefit (slippage-guard bundling) — rejected under constitution
+  "Simplicity".
+- Deposit safety without Bundler3: quote with `previewDeposit`, then `deposit.staticCall` before
+  sending; curated (whitelisted+listed) vaults carry the Morpho-required inflation-attack "dead
+  deposit", and share price manipulation on them is not a practical risk for retail-size deposits.
+
+**Alternatives considered**:
+- `@morpho-org/morpho-sdk` / `bundler-sdk-viem`: rejected for v1 (new core dependency + second
+  web3 stack; justification bar in constitution not met).
+- Operating a FairWins-curated vault list by hand: rejected — hardcoded lists rot and violate the
+  live-data requirement (FR-003); the API's `whitelisted`/`listed` flags are the curation filter.
+- Aave/Compound instead of Morpho: the issue names Morpho explicitly.
+
+## R2 — Supported networks
+
+**Decision**: Enable earn on **Ethereum mainnet (1)** and **Polygon PoS (137)** via a new
+per-network `earn` config block in `frontend/src/config/networks.js` plus an `earn` capability
+flag. All other configured networks (ETC family, Amoy, Sepolia, Hoodi, Hardhat) show the honest
+unavailable state naming where earn is available.
+
+**Rationale**: {1, 137} is the intersection of FairWins-configured networks and Morpho + Morpho
+API deployments (API supports 1, 10, 137, 8453, 42161, …; ETC family is not supported and never
+will be). Polygon is the app's primary network; Ethereum mainnet became a first-class value
+network in spec 048 (send/receive + portfolio — a contract deposit from a connected EOA wallet is
+within that envelope; passkey smart-account sessions transact via their linked wallet, as
+established by spec 048).
+
+**Alternatives considered**: adding Base (8453) — Morpho's biggest earn chain — rejected for now
+because Base is not a configured FairWins network; the config-driven design makes it a
+one-entry addition later. Testnet enablement (Sepolia has Morpho contracts) — rejected: the
+GraphQL API serves mainnet chains only, so a testnet lend surface would need mock data
+(constitution III violation); testnets keep the honest unavailable state.
+
+## R3 — Rewards: current mechanism is Merkl, not the legacy URD flow
+
+**Decision**: Implement rewards via **Merkl**: read
+`GET https://api.merkl.xyz/v4/users/{lowercased address}/rewards?chainId={id}`; claimable =
+`amount − claimed` (cumulative accounting); claim by calling
+`claim(address[] users, address[] tokens, uint256[] amounts, bytes32[][] proofs)` on the Merkl
+Distributor `0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae` (same address on all supported chains),
+passing the **cumulative** `amount` and API-provided proofs. Link out to
+`https://rewards-legacy.morpho.org/` for any pre-migration balances.
+
+**Rationale**: Morpho migrated all new reward distribution to Merkl under MIP-111; the
+`rewards.morpho.org` API + Universal Rewards Distributor flow referenced by the issue's linked
+tutorial is **deprecated** (docs.morpho.org/build/rewards/get-started). Building against the URD
+would ship a dead integration. Merkl data updates ~every 8 hours — the UI must show freshness
+("as of") rather than implying real-time accrual (spec edge case).
+
+**Alternatives considered**: URD `claim(account, reward, claimable, proof)` — kept out of scope
+(legacy claims remain possible on Morpho's own legacy page; no value in re-implementing a
+deprecated path).
+
+## R4 — Platform attribution & treasury fee
+
+**Decision (resolves the issue's conditional)**: Morpho has **no transaction-source referral or
+fee parameter** anywhere in the deposit path (ERC-4626, Bundler3, or API) — nothing like Aave's
+referral code exists. Therefore:
+1. Ship the protocol-**mandated** UI attribution ("Powered by Morpho" + risk disclaimer,
+   per docs.morpho.org/build/earn/get-started) — this satisfies "identification that the
+   FairWins platform is used" at the product level.
+2. Charge **no platform fee in this release** (FR-013) and disclose that plainly.
+3. Record the documented revenue path for a future feature: Morpho's official "distributor
+   revenue" models (docs.morpho.org/build/earn/concepts/generate-revenue/) — (a) **fee-wrapper
+   Vault V2** owned by the FairWins treasury wrapping a curated vault with a
+   performance/management fee (recommended, trustless, but introduces a new value-bearing
+   contract → full security lifecycle per constitution I), (b) offchain curator revenue-share
+   agreement, (c) onchain fee splitter on a dedicated vault. Deferred to its own spec.
+
+**Rationale**: deploying a treasury fee-wrapper vault is a smart-contract feature with fund
+custody implications — it cannot ride along inside a frontend feature under this repo's
+constitution (security-first, spec-before-funds-code). Deferring with a documented decision
+answers the issue honestly instead of silently dropping the request.
+
+## R5 — Placement in the app shell
+
+**Decision**: `Earn` becomes a Finance-group nav item (`id: 'earn'`, new `NavIcon` glyph
+`sprout`) in `frontend/src/config/appNav.js`, hosted as a `?tab=earn` panel in
+`frontend/src/pages/WalletPage.jsx` (`WALLET_TABS` + panel switch), mirroring exactly how
+Trade/Portfolio/Protect work. Deep-link contract: `/wallet?tab=earn[&chain=<id>][&token=<sym>]`
+— the same param shape TradePanel already accepts, used by the portfolio Earn action.
+
+**Rationale**: issue acceptance scenario 1–2 (Finance sub-section, unique icon); one nav model is
+the repo's established single source of truth.
+
+## R6 — Portfolio "Earn" action
+
+**Decision**: extend `actionsFor(instance)` in
+`frontend/src/components/wallet/AssetDetailSheet.jsx` with an `earn` action: enabled when the
+instance's network has the `earn` capability and the asset is a fungible token/native asset
+(`asset.kind !== 'nft'`); routes to `/wallet?tab=earn&chain=<chainId>&token=<symbol>`; disabled
+otherwise with a plain-language reason (mirrors the existing disabled `stake` precedent —
+constitution III: no dead buttons).
+
+## R7 — Activity feed integration
+
+**Decision**: add an `earn` ActivitySource (`frontend/src/data/notifications/sources/earnSource.js`
++ registration in `sources/index.js` + `DOMAIN_META` entry in `domains.js`) following the spec 031
+contract (snapshot-diff, first-sight-is-baseline, idempotent, honest `ok:false`). Snapshots per
+(account, chain): vault share balances and cumulative-claimed reward amounts. Share balance
+changes → "lending position increased/decreased" entries; cumulative-claimed increases → "rewards
+claimed" entries. Additionally, user-initiated deposit/withdraw/claim handlers append an
+immediate action entry (with tx hash link) through the same store partition so FR-010's audit
+trail carries the transaction link without waiting for the next poll; the source's dedup-stable
+ids make the subsequent snapshot-diff a no-op for the same event.
+
+**Rationale**: matches how every other domain records activity; the direct-append rider is the
+established `useIntentAction`/`onActivity` precedent for user-initiated actions.
+
+## R8 — Non-intimidating UX & info bubbles
+
+**Decision**: every DeFi term gets an adjacent `InfoTip` (`frontend/src/components/ui/InfoTip.jsx`,
+spec 039 single-open toggletip): APY, vault, curator, TVL/total deposits, approval (two-prompt
+deposits), withdrawal liquidity, rewards origin/freshness. Copy lives with the earn components in
+one `earnCopy.js` module so wording is testable and consistent. Flow design: hub → area cards
+(Lend live; Staking/Bridges honest "not yet available" cards, same honesty pattern as the
+disabled Stake action) → vault list → single-vault sheet with Deposit/Withdraw tabs and a
+plain-English "what will happen" summary before each wallet prompt. WCAG 2.1 AA enforced via
+vitest-axe tests like the portfolio panels.
+
+## R9 — Data honesty & failure modes
+
+**Decision**:
+- Vault list/APY: Morpho API fetch with explicit loading/unavailable states; a failed fetch shows
+  "temporarily unavailable" and disables deposit entry points (never stale numbers as truth).
+- Positions: share balances read on-chain per user (`balanceOf` + `convertToAssets` — real state),
+  enriched with API USD valuation/earnings (`assetsUsd`, `pnlUsd`) when available; enrichment
+  degrades honestly (value shown, USD "—") if the API is down.
+- Rewards: Merkl API with `updatedAt`-style freshness copy ("Rewards update every few hours");
+  fetch failure → explicit unavailable state (never "0").
+- Amount validation before any wallet prompt: 0 < amount ≤ wallet balance (deposit) /
+  ≤ `maxWithdraw` (withdraw); vault paused/cap states surfaced from `maxDeposit` where nonzero.
+- All external fetches are scoped per active chainId; nothing crosses the testnet/mainnet
+  boundary (reuses the per-chain read-provider pattern from `usePortfolio`).
+
+## R10 — Documentation site
+
+**Decision**: add `docs/user-guide/earn.md` (what Earn is, how lending works, step-by-step
+deposit/withdraw, rewards + claiming, risks, fees — written for non-technical members) and
+`docs/developer-guide/earn-integration.md` (architecture, Morpho/Merkl endpoints, config shape,
+how to enable a new network, the deferred treasury-fee decision), both registered in `mkdocs.yml`
+nav. The Earn hub links to the user guide (FR-014).
+
+## Canonical external references
+
+| Item | Value |
+|---|---|
+| Morpho GraphQL API | `https://api.morpho.org/graphql` (vault discovery, APY, positions) |
+| Merkl rewards API | `https://api.merkl.xyz/v4/users/{address}/rewards?chainId={id}` |
+| Merkl Distributor (1, 137, …) | `0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00Dd9Ae` |
+| Morpho legacy rewards page | `https://rewards-legacy.morpho.org/` |
+| Morpho attribution requirement | docs.morpho.org/build/earn/get-started ("Powered by Morpho") |
+| Distributor revenue models | docs.morpho.org/build/earn/concepts/generate-revenue/ |
+| ERC-4626 flow tutorial | docs.morpho.org/build/earn/tutorials/assets-flow/ |
+| Rewards migration (MIP-111) | docs.morpho.org/build/rewards/get-started |

--- a/specs/050-earn-lending-rewards/spec.md
+++ b/specs/050-earn-lending-rewards/spec.md
@@ -1,0 +1,268 @@
+# Feature Specification: Earn Section — Lending & Rewards
+
+**Feature Branch**: `050-earn-lending-rewards`
+
+**Created**: 2026-07-11
+
+**Status**: Draft
+
+**Input**: User description: "Earn section (GitHub issue #861): members need a way to participate
+in DeFi protocols and earn returns on their assets at rest. Add an Earn sub-section in the Finance
+section where members can lend funds on chain (Morpho vaults) to earn a return, with full
+integration so the user can see and claim rewards. If Morpho allows a platform fee or
+identification that FairWins originated the transaction (treasury reward), configure that. The UI
+must be non-intimidating for non-technical users, using info bubbles to explain areas, and the
+feature must be documented on the FairWins documentation site."
+
+## User Scenarios & Testing *(mandatory)*
+
+FairWins members hold stablecoins and other assets in their connected accounts between wagers.
+Today those assets sit idle. This feature adds an **Earn** sub-section to the Finance area where a
+member can put supported assets to work in audited, third-party lending vaults (Morpho), watch the
+position grow, withdraw at any time, and see & claim any bonus reward tokens the lending protocol
+distributes — all in plain, non-intimidating language. Earning opportunities beyond lending
+(staking, bridges) are presented honestly as not yet available.
+
+### User Story 1 - Discover Earn and lend idle assets (Priority: P1)
+
+A member opens the app's navigation and sees a new **Earn** entry (with its own icon) in the
+Finance group. Opening it shows a friendly hub that explains, in plain language, what earning is
+and what's available. Under **Lend**, the member sees a curated list of lending vaults for the
+active network family — each with the asset it accepts, the current estimated yearly return (APY),
+the amount already deposited by all lenders, who manages the vault, and an info bubble explaining
+every unfamiliar term. The member picks a vault, enters an amount (with a Max shortcut bounded by
+their balance), reviews a clear summary of what will happen, confirms in their wallet, and sees
+their new position reflected. Every step has an info bubble; nothing assumes prior DeFi knowledge.
+
+**Why this priority**: This is the core of the request — a member cannot earn anything until they
+can discover the section and deposit. It is independently valuable even before rewards or
+portfolio links exist.
+
+**Independent Test**: With a connected account holding a supported stablecoin on a supported
+network, navigate to Earn, deposit into a vault, and confirm the position (deposited amount +
+current value) appears in the Earn section. Delivers the full lend-to-earn loop.
+
+**Acceptance Scenarios**:
+
+1. **Given** a connected member on any network, **When** they open the app navigation, **Then**
+   an "Earn" item with a unique icon appears in the Finance group and routes to the Earn section.
+2. **Given** a member on a network where lending is supported, **When** they open Earn → Lend,
+   **Then** they see a list of curated vaults showing asset, estimated APY, total deposits,
+   curator, and the protocol's name — each concept explained by an info bubble.
+3. **Given** a member viewing a vault with a balance of the vault's asset, **When** they enter an
+   amount within their balance and confirm the deposit (including any token-spending approval),
+   **Then** the deposit executes, a success state is shown, and their position appears with its
+   current value.
+4. **Given** a member with an active position, **When** they choose Withdraw and confirm, **Then**
+   the withdrawal returns the asset (including earned yield) to their account and the position
+   shrinks or closes accordingly.
+5. **Given** a member on a network family with no lending support (e.g. an Ethereum Classic
+   network), **When** they open Earn, **Then** the section explains honestly that lending is not
+   available on this network and names the networks where it is — no mock data, no dead buttons
+   without explanation.
+
+---
+
+### User Story 2 - See and claim rewards (Priority: P2)
+
+A member who has lent through Earn may accrue bonus reward tokens distributed by the lending
+protocol's rewards program (separate from the lending yield itself). In Earn → Rewards, the member
+sees any reward balances attributable to their account — what token, how much is claimable now,
+and an info bubble explaining where rewards come from and why they update periodically. One action
+claims the claimable rewards to their account. If they have no rewards, the section says so
+plainly and explains how rewards accrue.
+
+**Why this priority**: Rewards are real value users would otherwise strand; the issue explicitly
+asks for full rewards integration. It depends on User Story 1 existing but is separately testable
+against any address with accrued rewards.
+
+**Independent Test**: With an account that has accrued protocol rewards, open Earn → Rewards,
+verify the claimable balance is listed, claim, and verify the tokens arrive and the claimable
+balance reflects the claim.
+
+**Acceptance Scenarios**:
+
+1. **Given** a member with claimable rewards on the active network, **When** they open Earn →
+   Rewards, **Then** each reward token is listed with its claimable amount and an explanation of
+   its origin.
+2. **Given** a member views a listed reward, **When** they confirm Claim in their wallet, **Then**
+   the reward tokens are transferred to their account and the UI reflects the updated claimable
+   amount.
+3. **Given** a member with no rewards, **When** they open Earn → Rewards, **Then** the section
+   states there is nothing to claim yet and explains how lending positions can accrue rewards.
+4. **Given** reward data cannot be fetched (service unreachable), **When** the member opens
+   Rewards, **Then** the UI says reward information is temporarily unavailable — it never shows a
+   zero balance as if it were confirmed truth.
+
+---
+
+### User Story 3 - Reach Earn from the portfolio and audit every action (Priority: P3)
+
+A member viewing an asset in their Portfolio sees an **Earn** action alongside Trade and Transfer.
+When earning is possible for that asset on its network, the action takes them straight to the
+matching lending view with the asset preselected; when it isn't, the action is visibly disabled
+with a reason. Every earn activity the member performs — deposit, withdrawal, reward claim — is
+recorded in the platform activity log for record keeping.
+
+**Why this priority**: This wires Earn into the member's existing journeys (portfolio-first
+discovery, audit trail). It builds on Stories 1–2 and completes the issue's acceptance scenarios.
+
+**Independent Test**: From the portfolio detail of a supported stablecoin, tap Earn and land on
+the vault list filtered/preselected for that asset; perform a deposit and confirm an activity log
+entry is recorded.
+
+**Acceptance Scenarios**:
+
+1. **Given** a member views a portfolio asset that can be lent on its network, **When** they tap
+   the Earn action, **Then** they land in Earn → Lend scoped to that asset and network.
+2. **Given** a member views a portfolio asset that cannot be lent, **When** they look at the Earn
+   action, **Then** it is disabled with a plain-language reason (never a dead or missing control).
+3. **Given** a member completes a deposit, withdrawal, or reward claim, **When** they open the
+   platform activity feed, **Then** an entry describes the action (asset, amount, vault/reward,
+   time) with a link to the transaction.
+
+---
+
+### Edge Cases
+
+- **Unsupported network active**: Earn stays visible in navigation; the section explains lending
+  availability honestly per network and offers the network switcher — no cross-network data leak.
+- **Vault/APY data source unreachable**: vault list shows an honest "temporarily unavailable"
+  state; deposits are disabled while data is stale rather than shown with wrong numbers.
+- **Amount edge cases**: zero, dust, more than balance, or more than the vault accepts — all
+  rejected before any wallet prompt, with a reason.
+- **Two-step deposits**: when a token-spending approval is required first, the flow explains the
+  two prompts up front so the second wallet prompt is expected, not alarming.
+- **Withdrawal limits**: when a vault temporarily cannot honor a full withdrawal (liquidity is
+  deployed), the UI surfaces the currently withdrawable amount honestly.
+- **Rewards cadence**: reward figures update on the protocol's schedule (hours, not seconds); the
+  UI communicates "as of" freshness instead of implying real-time accrual.
+- **Reward claim replay**: after a claim, the claimable amount reflects the cumulative-claim model
+  used by the protocol (claiming twice never double-pays and never errors confusingly).
+- **Testnet/mainnet boundary**: positions, vault lists, and rewards are scoped to the active
+  network and never mix across the boundary.
+- **Fee/attribution honesty**: if and when a platform fee applies to earn flows, it is disclosed
+  in the flow before confirmation; while no fee applies, no fee is implied.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST add an "Earn" sub-section to the Finance navigation group with a
+  unique icon, reachable on all networks.
+- **FR-002**: The Earn section MUST present earning opportunity areas (lending now; staking and
+  bridges as honestly-labeled future areas) and let the member navigate between the areas, each
+  with a view relevant to that opportunity.
+- **FR-003**: On supported networks, the Lend area MUST list curated lending vaults with, at
+  minimum: accepted asset, estimated net yearly return (APY), total deposits, curator identity,
+  and the underlying protocol's identity; the data MUST come from live protocol data, never
+  hardcoded samples.
+- **FR-004**: Members MUST be able to deposit a chosen amount of a vault's asset (bounded by
+  balance and any vault limits) and withdraw from their position at any time the vault permits,
+  with pre-transaction validation of amounts and a clear summary before each wallet prompt.
+- **FR-005**: The system MUST show the member's active lending positions (amount deposited,
+  current value, and the difference earned) scoped to the active network.
+- **FR-006**: The Rewards area MUST show reward tokens attributable to the member's account with
+  claimable amounts, and let the member claim them in a single action; claimed amounts MUST
+  follow the protocol's cumulative accounting so repeat claims are safe.
+- **FR-007**: When reward or vault data is unavailable, the system MUST present an explicit
+  unavailable state and MUST NOT present zeros or stale numbers as current truth.
+- **FR-008**: Lending availability MUST be a per-network capability: enabled networks are
+  configured (not hardcoded in components), and unsupported networks present an honest
+  explanation naming where lending is available.
+- **FR-009**: The portfolio asset detail view MUST offer an "Earn" action that deep-links to the
+  Lend area scoped to that asset and network when supported, and is disabled with a
+  plain-language reason when not.
+- **FR-010**: Every earn action (deposit, withdrawal, reward claim) MUST be recorded in the
+  platform activity feed with asset, amount, counterpart (vault or reward token), timestamp, and
+  transaction link.
+- **FR-011**: Every screen in the Earn section MUST explain unfamiliar concepts (APY, vault,
+  curator, rewards, approvals, withdrawal liquidity) via the app's info-bubble pattern, in
+  plain language suitable for non-technical members; no jargon may appear without an explanation
+  adjacent to it.
+- **FR-012**: The Earn section MUST display the lending protocol's identity ("Powered by Morpho")
+  and a risk disclosure that lending involves third-party smart-contract risk and yields are
+  variable and not guaranteed by FairWins.
+- **FR-013**: The system MUST NOT charge a platform fee on earn flows in this release. Because the
+  protocol offers no transaction-source referral mechanism, platform attribution is satisfied by
+  the protocol-mandated UI attribution; the documented path to treasury revenue (a fee-wrapper
+  vault owned by the FairWins treasury) is recorded as a decision for a future release and MUST
+  be documented in this feature's design records.
+- **FR-014**: User documentation for the Earn section (what it is, how to lend, how to withdraw,
+  how rewards work, risks, fees) MUST be published on the FairWins documentation site and
+  linked from the Earn section.
+- **FR-015**: All Earn views MUST meet the app's accessibility standard (WCAG 2.1 AA), including
+  the info bubbles, forms, and claim/deposit/withdraw controls.
+
+### Key Entities *(include if feature involves data)*
+
+- **Earning Opportunity Area**: a category of passive earning (Lend now; Staking, Bridges
+  future). Attributes: name, availability state per network, explanatory copy.
+- **Lending Vault**: a third-party managed on-chain vault that accepts one asset and lends it
+  out. Attributes: network, address, name, accepted asset, estimated net APY, total deposits,
+  curator, protocol identity, listing/curation status.
+- **Lending Position**: a member's stake in one vault. Attributes: member account, vault,
+  deposited value, current value, earnings to date.
+- **Reward Balance**: protocol-distributed bonus tokens attributable to a member. Attributes:
+  network, reward token, cumulative earned, cumulative claimed, claimable now, data freshness.
+- **Earn Activity Entry**: audit record of a deposit, withdrawal, or claim. Attributes: type,
+  asset/token, amount, vault or reward source, timestamp, transaction reference.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A member holding a supported stablecoin can go from opening the Earn section to a
+  confirmed lending deposit in under 3 minutes without external help.
+- **SC-002**: 100% of DeFi-specific terms visible in the Earn section (APY, vault, curator,
+  rewards, approval, withdrawal liquidity) have an adjacent plain-language info bubble.
+- **SC-003**: Members can see and claim 100% of the rewards the protocol attributes to their
+  address on supported networks, and a completed claim is reflected in the UI within one refresh.
+- **SC-004**: 100% of earn deposits, withdrawals, and claims performed in the app produce an
+  activity-feed entry with a working transaction link.
+- **SC-005**: On unsupported networks, 0 earn actions are offered as if available; every
+  unavailable state names at least one network where earning is available.
+- **SC-006**: The portfolio Earn action routes to the correct pre-scoped lend view for 100% of
+  lendable assets, and is never rendered as an unexplained dead control for non-lendable ones.
+- **SC-007**: Accessibility audits of the new Earn views pass with zero critical violations.
+- **SC-008**: The documentation site gains an Earn user guide covering lending, withdrawing,
+  rewards, risks, and fees, reachable from the site navigation and from the Earn section itself.
+
+## Assumptions
+
+- **Lending protocol**: Morpho is the lending integration for this feature (per the issue),
+  reusing its curated/whitelisted vault listings rather than FairWins operating vaults. The
+  protocol's own vault-listing curation is trusted as the quality filter, with FairWins able to
+  narrow the list via configuration.
+- **Supported networks (initial)**: Ethereum mainnet and Polygon PoS — the intersection of
+  FairWins-configured networks and the protocol's deployments. Ethereum Classic family and other
+  configured networks present the honest unavailable state. Networks are added by configuration
+  later (e.g. Base) without code restructuring.
+- **Rewards program**: protocol rewards are distributed through the protocol's current rewards
+  system (Merkl, per protocol governance MIP-111); the deprecated legacy rewards flow described
+  in older tutorials is out of scope beyond linking members to the protocol's legacy claim page.
+  Reward data freshness follows that system's update cadence (~hours).
+- **Platform fee / attribution**: the protocol offers **no** transaction-source referral or fee
+  parameter. Mandated UI attribution ("Powered by Morpho") is implemented now; treasury revenue
+  via a FairWins fee-wrapper vault (or a curator revenue-share agreement) is deliberately
+  deferred to a future feature because it introduces a new value-bearing contract surface. This
+  resolves the issue's conditional request with a documented decision rather than silence.
+- **Scope of earning areas**: lending ships now; staking and bridge earning are represented as
+  honest "not yet available" areas (matching the existing disabled "Stake" action precedent) and
+  specified separately later.
+- **Custody model**: deposits are made directly from the member's connected account to the
+  protocol; FairWins never takes custody of deposited assets or rewards.
+- **Testnets**: the protocol's data services do not cover testnets, so testnet behavior is the
+  honest unavailable state; automated tests exercise flows with simulated data at the test layer
+  only (never shipped).
+- **No new backend**: the feature is frontend-only, consuming the protocol's public data services
+  and on-chain contracts, consistent with the app's no-backend footprint.
+
+## Dependencies
+
+- Existing per-network configuration and capability gating (single source of truth for networks).
+- Existing navigation model (Finance group), portfolio asset detail actions, info-bubble
+  component, and platform activity feed.
+- Morpho protocol: vault contracts (ERC-4626), public data API for vault/position/APY data, and
+  the Merkl rewards API + on-chain distributor for reward claims.
+- FairWins documentation site (MkDocs) for the user guide.

--- a/specs/050-earn-lending-rewards/tasks.md
+++ b/specs/050-earn-lending-rewards/tasks.md
@@ -1,0 +1,184 @@
+# Tasks: Earn Section — Lending & Rewards
+
+**Input**: Design documents from `/specs/050-earn-lending-rewards/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: included — constitution II makes frontend tests mandatory for non-trivial logic.
+
+**Organization**: grouped by user story (US1 lend, US2 rewards, US3 portfolio+activity) so each
+story is an independently testable increment.
+
+## Format: `[ID] [P?] [Story] Description`
+
+## Phase 1: Setup (Shared Infrastructure)
+
+- [ ] T001 Add earn constants module `frontend/src/config/earn.js` (MORPHO_API_URL,
+      MERKL_API_URL, VAULT_LIST_LIMIT, POSITIONS_POLL_MS, `earnPath()` deep-link builder) per
+      contracts/earn-config.md
+- [ ] T002 Add `earn` config blocks (provider, merklDistributor, legacyRewardsUrl) to chains 1
+      and 137 in `frontend/src/config/networks.js`, add `earn` to every network's
+      `capabilities` getter (`Boolean(this.earn)`), and export
+      `isEarnAvailable`/`getEarnConfig`/`getEarnNetworks` helpers
+- [ ] T003 [P] Add minimal ERC-4626 vault ABI in `frontend/src/abis/ERC4626Vault.js`
+      (asset/decimals/balanceOf/convertToAssets/previewDeposit/previewRedeem/maxDeposit/
+      maxWithdraw/deposit/withdraw/redeem) and Merkl Distributor ABI in
+      `frontend/src/abis/MerklDistributor.js` (claim)
+- [ ] T004 [P] Add `sprout` glyph to `frontend/src/components/nav/NavIcon.jsx` and the
+      `{ id: 'earn', label: 'Earn', icon: 'sprout' }` item to the Finance group in
+      `frontend/src/config/appNav.js`
+- [ ] T005 Unit tests for config gating in `frontend/src/test/earn/earnConfig.test.js`
+      (capability on 1/137 only, helpers, earnPath builder, nav item present in Finance group)
+
+**Checkpoint**: config + nav shell exists; `?tab=earn` not yet routed.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+- [ ] T006 Implement Morpho GraphQL client + normalizers in
+      `frontend/src/lib/earn/morphoApi.js` (fetchVaults(chainId), fetchPositionsEnrichment
+      (address, chainId), typed MorphoApiError, drop non-listed/foreign-chain items, null-safe
+      APY/TVL) per contracts/morpho-api.md
+- [ ] T007 [P] Implement Merkl module `frontend/src/lib/earn/merkl.js` (fetchRewards with
+      lowercased address, bigint cumulative math `claimable = amount − claimed`,
+      buildClaimArgs parallel arrays, filter empty-proof/zero entries) per
+      contracts/merkl-rewards.md
+- [ ] T008 [P] Implement vault action helpers in `frontend/src/lib/earn/vaultActions.js`
+      (readVaultUserState, validateDepositAmount/validateWithdrawAmount pure validators,
+      ensureAllowance→approve, deposit with previewDeposit + staticCall dry-run, withdraw/redeem)
+      using ethers v6
+- [ ] T009 [P] Create member-facing copy module `frontend/src/lib/earn/earnCopy.js` (InfoTip
+      texts: APY, vault, curator, total deposits, approval two-prompt, withdrawal liquidity,
+      rewards origin/freshness; risk disclosure; unavailable-state copy referencing
+      `getEarnNetworks()`)
+- [ ] T010 Unit tests `frontend/src/test/earn/morphoApi.test.js` (normalization, curation
+      filters, error→MorphoApiError, null APY preserved) and
+      `frontend/src/test/earn/merkl.test.js` (claimable math, claim args alignment, filtering,
+      lowercase address) with mocked fetch
+- [ ] T011 [P] Unit tests `frontend/src/test/earn/vaultActions.test.js` (validators: zero, dust,
+      > balance, > maxWithdraw; approve-then-deposit ordering with mocked contracts)
+
+**Checkpoint**: data + action layers proven; no UI yet.
+
+---
+
+## Phase 3: User Story 1 — Discover Earn and lend idle assets (P1) 🎯 MVP
+
+**Goal**: Earn tab in Finance nav; hub with areas; curated vault list; deposit/withdraw with
+honest gating and InfoTips everywhere.
+
+**Independent test**: quickstart.md steps 2–6.
+
+- [ ] T012 [US1] Implement `frontend/src/hooks/useEarnVaults.js` (per-active-chain vault list,
+      status loading/ready/unavailable, manual refresh, capability-gated no-op on non-earn
+      chains)
+- [ ] T013 [US1] Implement `frontend/src/hooks/useEarnPositions.js` (on-chain shares/assets/
+      maxWithdraw via read provider + API USD/pnl enrichment, 60s poll, per account+chain scope,
+      honest degradation when enrichment fails)
+- [ ] T014 [US1] Build `frontend/src/components/earn/EarnPanel.jsx` + `Earn.css`: hub with
+      area cards (Lend live; Staking + Bridges honest "not yet available"), Powered-by-Morpho
+      attribution + risk disclosure + docs link, honest unavailable state on non-earn networks
+      naming earn-enabled networks, `?view=`/`?chain=`/`?token=` deep-link consumption
+- [ ] T015 [US1] Build `frontend/src/components/earn/EarnLendView.jsx` (vault list rows: asset,
+      net APY, total deposits, curator, InfoTips from earnCopy; token prefilter; unavailable/
+      loading/empty states) and `frontend/src/components/earn/EarnPositionsList.jsx` (deposited
+      value, current value, earned-so-far when available)
+- [ ] T016 [US1] Build `frontend/src/components/earn/VaultSheet.jsx`: single-vault bottom sheet
+      (repo modal convention) with Deposit and Withdraw modes — amount input + Max, pre-wallet
+      validation errors, two-prompt approval explanation, plain-English pre-confirmation summary,
+      pending/success/failure states, maxWithdraw liquidity bound surfaced honestly
+- [ ] T017 [US1] Register the earn tab: `WALLET_TABS` entry + `{activeTab === 'earn'}` panel in
+      `frontend/src/pages/WalletPage.jsx` rendering EarnPanel
+- [ ] T018 [P] [US1] Component tests `frontend/src/test/earn/EarnPanel.test.jsx` (nav-reachable
+      hub, honest unavailable network state, area cards, attribution/disclosure present, docs
+      link) with mocked hooks
+- [ ] T019 [P] [US1] Component tests `frontend/src/test/earn/EarnLendView.test.jsx` and
+      `frontend/src/test/earn/VaultSheet.test.jsx` (list rendering incl. null-APY "—",
+      unavailable state disables deposit, validation messages pre-wallet, approval-two-prompt
+      copy, withdraw bound)
+- [ ] T020 [P] [US1] Accessibility tests `frontend/src/test/earn/EarnPanel.axe.test.jsx`
+      (hub + lend view + vault sheet render with no axe violations)
+
+**Checkpoint**: MVP — a member can discover Earn, lend, see the position, withdraw.
+
+---
+
+## Phase 4: User Story 2 — See and claim rewards (P2)
+
+**Goal**: Rewards area listing Merkl reward balances with freshness + one-action claim.
+
+**Independent test**: quickstart.md step 7.
+
+- [ ] T021 [US2] Implement `frontend/src/hooks/useEarnRewards.js` (Merkl fetch per
+      account+chain, claimable/pending split, freshness timestamp, claim(signer) sending
+      distributor tx from `getEarnConfig(chainId).merklDistributor`, post-claim refetch +
+      receipt-driven success)
+- [ ] T022 [US2] Build `frontend/src/components/earn/EarnRewardsView.jsx` (reward rows with
+      token, claimable, pending; freshness copy; Claim button disabled at zero claimable;
+      empty-state explains accrual; unavailable state on API failure — never zero; legacy
+      rewards link; InfoTips) and wire it as the `rewards` view in EarnPanel
+- [ ] T023 [P] [US2] Tests `frontend/src/test/earn/useEarnRewards.test.jsx` (claim arg
+      construction from hook state, unavailable on fetch failure, post-claim refresh) and
+      `frontend/src/test/earn/EarnRewardsView.test.jsx` (states: loading/empty/unavailable/
+      claimable, freshness copy, claim disabled at zero) + axe pass in
+      `frontend/src/test/earn/EarnRewardsView.axe.test.jsx`
+
+**Checkpoint**: rewards visible + claimable; US1 unaffected.
+
+---
+
+## Phase 5: User Story 3 — Portfolio entry point + activity audit (P3)
+
+**Goal**: Earn action on portfolio asset detail; every earn action recorded in the activity feed.
+
+**Independent test**: quickstart.md steps 8–9.
+
+- [ ] T024 [US3] Add `earn` action to `actionsFor()` in
+      `frontend/src/components/wallet/AssetDetailSheet.jsx` (enabled when
+      `NETWORKS[chainId]?.earn` && `asset.kind !== 'nft'`; deep link
+      `/wallet?tab=earn&chain=<id>&token=<sym>`; disabled reason otherwise) and update
+      `frontend/src/test/portfolio/AssetDetailSheet.test.jsx` for the new action
+- [ ] T025 [US3] Add `earn` domain to `frontend/src/data/notifications/domains.js` and
+      implement `frontend/src/data/notifications/sources/earnSource.js` (spec 031 contract:
+      snapshot-diff over vault share balances + cumulative claimed rewards; first-sight
+      baseline; stable ids; ok:false on hard failure) and register it in
+      `frontend/src/data/notifications/sources/index.js`
+- [ ] T026 [US3] Emit immediate action entries with tx links from the deposit/withdraw/claim
+      flows (VaultSheet + useEarnRewards) into the earn store partition using the earnSource
+      stable-id scheme so the next poll dedups (per data-model.md EarnActivityEntry)
+- [ ] T027 [P] [US3] Tests `frontend/src/test/earn/earnSource.test.js` (baseline-no-entries,
+      diff→entry, idempotent re-run, ok:false on fetch error, claim-detection) and deep-link
+      test additions in `frontend/src/test/earn/EarnPanel.test.jsx` (`?token=` prefilter,
+      `?chain=` hint)
+
+**Checkpoint**: issue #861 acceptance scenarios 1–4 all pass.
+
+---
+
+## Phase 6: Polish & Cross-Cutting
+
+- [ ] T028 [P] Write member docs `docs/user-guide/earn.md` (what Earn is, step-by-step lend/
+      withdraw, rewards + claiming, risks, fees — plain language, mirrors in-app copy) and
+      register under User Guide in `mkdocs.yml`
+- [ ] T029 [P] Write `docs/developer-guide/earn-integration.md` (architecture, config contract,
+      Morpho/Merkl endpoints + addresses, how to enable a new network, deferred treasury
+      fee-wrapper decision per research.md R4) and register under Developer Guide in
+      `mkdocs.yml`; link the user guide from EarnPanel (FR-014)
+- [ ] T030 Run `npm run test:frontend`, `npm run lint --workspace frontend`, and
+      `npm run build --workspace frontend`; fix regressions (incl. existing appNav/WalletPage
+      tests affected by the new tab)
+- [ ] T031 Validate quickstart.md manual script items that are automatable (nav presence,
+      unavailable states, deep links) and update spec 050 checklists
+
+## Dependencies
+
+- Phase 1 → Phase 2 → US1 (Phase 3) → US2 (Phase 4, needs hub) → US3 (Phase 5, needs flows) →
+  Polish. T024 only needs T002+T017; T025–T027 need T016/T021.
+- Parallel opportunities: T003/T004 ∥; T007/T008/T009 ∥ after T006 starts; T018–T020 ∥;
+  T023 ∥ T024; T028/T029 ∥ everything after copy stabilizes.
+
+## Implementation Strategy
+
+MVP = Phases 1–3 (US1). Ship increments in story order; each checkpoint leaves the app
+releasable. US2/US3 layer onto the same hub without touching US1 internals.


### PR DESCRIPTION
Closes #861.

Adds an **Earn** sub-section to the Finance group where members lend idle assets into curated Morpho vaults, watch their positions grow, and see & claim protocol rewards — designed to be non-intimidating for non-technical members, with ⓘ info bubbles on every DeFi term.

## What's included

**Earn hub (`/wallet?tab=earn`, unique sprout nav icon)**
- Areas: **Lend** and **Rewards** live; Staking/Bridges shown honestly as "not yet available" (issue AS 1–3).
- Per-network capability gating in `networks.js` (Ethereum 1 + Polygon 137 — the intersection of FairWins networks and Morpho/Morpho-API deployments). Other networks get an honest unavailable state naming where earning works; adding a chain later (e.g. Base) is one config block.

**Lend (Morpho, ERC-4626)**
- Vault discovery/APY/TVL/curator via Morpho's public GraphQL API, filtered to `whitelisted` + `listed` vaults only (no hand-kept lists, no mock data; API failure = explicit unavailable state with deposits paused).
- Deposit flow: pre-wallet amount validation with plain-language reasons, exact-amount approvals with the two-prompt flow explained up front, `previewDeposit` + `staticCall` dry-run before sending. Withdrawals honor `maxWithdraw` (vault liquidity) honestly; full exits `redeem` shares so no dust strands.
- Positions: on-chain truth (`balanceOf`/`convertToAssets`) with API USD/earned-so-far enrichment that degrades to "—" when unavailable.

**Rewards (Merkl)**
- The issue's linked rewards tutorial (URD / rewards.morpho.org) is **deprecated** — Morpho moved all reward distribution to Merkl (MIP-111). This PR implements the current flow: Merkl API for balances (cumulative accounting, ~8-hour freshness disclosed in-UI) and one-tap claim on the canonical Merkl Distributor. Legacy balances link out to Morpho's legacy claim page.

**Platform attribution / treasury fee (the issue's conditional)**
- Morpho has **no tx-source referral or fee parameter**. This PR ships the protocol-mandated "Powered by Morpho" attribution + risk disclosure, charges **no platform fee** (and says so), and documents the real treasury-revenue path — a FairWins fee-wrapper vault or curator revenue share — as a deferred decision (`specs/050-earn-lending-rewards/research.md` R4), since a wrapper vault is a new value-bearing contract requiring its own spec + security lifecycle per the constitution.

**Integration (issue AS 4)**
- Portfolio → asset detail gains an **Earn** action deep-linking to the lend view scoped to that asset/network (disabled with a reason where not applicable, like the existing Stake precedent).
- Every deposit/withdraw/claim lands in the activity feed (new `earn` domain + spec-031 source) with a working explorer transaction link; a snapshot-diff backstop catches position changes made outside the app.

**Docs (FairWins docs site)**
- `docs/user-guide/earn.md` (member guide: lending, withdrawing, rewards, risks, fees) and `docs/developer-guide/earn-integration.md` (architecture, config contract, new-network enablement, fee decision), both in the mkdocs nav; the Earn hub links to the user guide.

**Spec Kit artifacts**
- Full spec 050 under `specs/050-earn-lending-rewards/` (spec, plan with constitution check, research, data model, contracts, quickstart, tasks).

## Testing

- 71 new/updated Vitest tests (`frontend/src/test/earn/*` + portfolio sheet): config gating, API normalizers, cumulative claim math, amount validators, activity-source contract (baseline/idempotency/ok:false), panel/sheet/rewards component states incl. honest unavailable states and deep links, and **axe WCAG 2.1 AA audits** on all new views.
- `npm run test:frontend`: 2740 passed; the only failures (quickAccessPreference, 2 ClearPath files — 17 tests) fail identically on `main` in the same environment and are unrelated to this change.
- `npm run lint` (0 errors; all warnings pre-existing) and `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LizwRCtWZEqdsCobwCwApJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LizwRCtWZEqdsCobwCwApJ)_