### PR TITLE
Spec 051: unified activity ledger — spec, plan, and implementation

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/050-sponsored-paymaster"
+  "feature_directory": "specs/051-unified-activity-ledger"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,5 +114,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/050-sponsored-paymaster/plan.md
+at specs/051-unified-activity-ledger/plan.md
 <!-- SPECKIT END -->

--- a/docs/developer-guide/activity-ledger.md
+++ b/docs/developer-guide/activity-ledger.md
@@ -1,0 +1,94 @@
+# Unified Activity Ledger (spec 051)
+
+The activity ledger is the single read path for a member's financial history:
+wager value events, wallet transfers (including failed gasless/sponsored
+operations), earn/lending actions, pool joins/claims/refunds, and
+membership/voucher purchases. The Account tab, the Pay & Transfer Activity
+tab, and the tax report all consume it — which is what makes their line items
+and totals structurally incapable of disagreeing.
+
+Design artifacts: `specs/051-unified-activity-ledger/` (spec, plan,
+data-model, contracts, quickstart).
+
+## Architecture
+
+```
+sources/*.js  ──► ledgerRepository ──► useActivityLedger ──► Account tab feed
+ (5 domains)        │  normalize            │                Transfer Activity tab
+                    │  merge/dedup          └───────────────► useAccountStats (tiles/P&L)
+                    │  enrich (token+USD)
+                    └────────────────────────────────────────► reportBuilder (CSV/PDF)
+```
+
+- **`frontend/src/data/ledger/ledgerRepository.js`** — assembles sources for
+  one `(account, chainId)`, normalizes (invariants below), dedups, enriches
+  token meta + USD, filters (class/status/kind/period), sorts newest-first.
+  A failing source degrades to `staleClasses` (disclosed in the UI) instead
+  of failing the ledger.
+- **Sources** (`frontend/src/data/ledger/sources/`) implement the adapter
+  contract in `specs/051-unified-activity-ledger/contracts/ledger-source.md`:
+  - `wagerLedgerSource` — subgraph `WagerTransfer` rows (primary; real
+    txHash + block time) or, on subgraph-less networks, rows derived from
+    wager state with block times hydrated by `timestamps.js`.
+  - `transferLedgerSource` — the append-only client ledger plus (pre-
+    migration) legacy `fairwins.transfers.v1` rows mapped to the same ids.
+  - `earnLedgerSource` — client records captured at action time
+    (`captureEarnAction`, called beside `queueEarnAction` in the earn flows).
+  - `poolLedgerSource` / `membershipLedgerSource` — subgraph
+    `PoolMember`/`PoolClaim`/`PoolRefund` and `Voucher` entities.
+
+## Identity & merge
+
+Every entry has a stable `entryId` (`data-model.md` "Identity"):
+
+- `oc:{chainId}:…` on-chain (requires `txHash`),
+- `dv:{chainId}:wager:{id}:{kind}:{party}` derived (deterministic →
+  re-derivation is idempotent),
+- `cl:{uuid}` client-only.
+
+Merge precedence: `oc:` beats `dv:` for the same underlying event (via
+`refs.dedupKey`); a `cl:` record whose txHash matches an `oc:` entry is
+folded in as context, never duplicated.
+
+## Invariants (enforced by `normalize.js`)
+
+- `timestamp` is real epoch **ms** or `null` + `timestampProvenance:
+  'unavailable'` — the value `0` never survives, so the "20645d ago" defect
+  class cannot render (`formatRelativeTime` also returns `null` for invalid
+  input; callers show "date unavailable").
+- `status: 'failed'` ⇒ `direction: 'none'`; failed entries are listed
+  everywhere but excluded from every total.
+- `valuationStatus: 'unvalued'` entries are flagged, never zeroed or dropped.
+- Entries are strictly scoped to the queried `chainId`.
+
+## Durability (backup + migration)
+
+- Client-only records live in the **append-only**
+  `ledgerClientStore` (status transitions append superseding records via
+  `refs.supersedes`; nothing is mutated). They travel in the spec-032
+  encrypted backup as the `activityLedger` synced object
+  (`frontend/src/lib/backup/syncedObjects.js`) — union-by-entryId in both
+  restore modes, because a destructive replace would violate the audit
+  guarantee.
+- On-chain/derived entries are **not** backed up: they re-derive from public
+  data on any device.
+- `migrate.js` imports the legacy transfer log once per account (marker-
+  guarded, id-stable so overlaps dedup), triggered by any ledger query.
+
+## Known, disclosed limits
+
+- Earn actions made outside this app are not in the ledger (no fixed vault
+  registry to scan); the notification feed's snapshot diff still surfaces
+  them as they happen.
+- Pool/membership history requires the chain's subgraph; RPC-only networks
+  return an honest empty list for those classes.
+- Timestamp hydration on RPC-only networks is budgeted per poll
+  (`timestamps.js`); unhydrated entries say "date unavailable" until a later
+  poll fills them.
+- Client-record pruning (`pruneClientRecords`) is off by default and can
+  never touch the current or previous tax year; any pruning is disclosed via
+  `prunedBefore` in the UI and report headers.
+
+See also: `docs/developer-guide/gasless-intents.md` (the flows whose failed
+operations the ledger captures) and spec 016/020/031/032 for the surfaces the
+ledger consolidated.

--- a/frontend/src/components/account/AccountDashboard.jsx
+++ b/frontend/src/components/account/AccountDashboard.jsx
@@ -21,7 +21,7 @@ function AccountDashboard() {
   const { disconnectWallet } = useWalletConnection()
   const stats = useAccountStats()
   const {
-    summary, series, setRange, breakdowns, activity,
+    summary, series, setRange, breakdowns, activity, staleClasses, prunedBefore,
     isSupportedNetwork, chainId, isLoading, isEmpty, freshness, refresh,
   } = stats
 
@@ -57,7 +57,12 @@ function AccountDashboard() {
           <SummaryTiles summary={summary} isEmpty={isLoading && !summary} />
           <PnlChart series={series} onRangeChange={setRange} onCreateWager={goCreate} />
           <ActivityBreakdowns breakdowns={breakdowns} />
-          <RecentActivityFeed activity={activity} chainId={chainId} />
+          <RecentActivityFeed
+            entries={activity}
+            chainId={chainId}
+            staleClasses={staleClasses}
+            prunedBefore={prunedBefore}
+          />
         </>
       )}
 

--- a/frontend/src/components/account/BackupPanel.jsx
+++ b/frontend/src/components/account/BackupPanel.jsx
@@ -27,9 +27,9 @@ function BackupPanel() {
     <section className="backup-panel" aria-labelledby="backup-heading">
       <h3 id="backup-heading" className="backup-title">Data backup</h3>
       <p className="backup-intro">
-        Back up your address book and preferences as a single <strong>encrypted</strong> file on IPFS, located
-        by a trustless on-chain pointer. Only your wallet can read it — restore on any device with the same
-        wallet. This is an explicit step; nothing leaves your device until you back up.
+        Back up your address book, preferences, and activity history as a single <strong>encrypted</strong> file
+        on IPFS, located by a trustless on-chain pointer. Only your wallet can read it — restore on any device
+        with the same wallet. This is an explicit step; nothing leaves your device until you back up.
       </p>
 
       {!available ? (
@@ -49,6 +49,14 @@ function BackupPanel() {
               <dd>{hasRemote ? 'Yes — a backup exists for this wallet' : 'None found'}</dd>
             </div>
           </dl>
+
+          {!hasRemote && (
+            <p className="backup-notice" role="status">
+              Without a backup, device-local activity history — sent transfers, failed operations, and earn
+              actions — cannot be recovered if this device’s data is cleared. On-chain activity (wagers, pools,
+              memberships) always rebuilds automatically.
+            </p>
+          )}
 
           {!onCanonical && (
             <p className="backup-notice" role="status">

--- a/frontend/src/components/account/RecentActivityFeed.css
+++ b/frontend/src/components/account/RecentActivityFeed.css
@@ -92,3 +92,64 @@
 .account-feed-link:hover {
   text-decoration: underline;
 }
+
+/* --- spec 051: unified ledger feed --- */
+
+.account-feed-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0 0 10px;
+}
+
+.account-feed-filter {
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-secondary);
+  border-radius: var(--radius-full, 9999px);
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.account-feed-filter.active {
+  background: var(--brand-secondary, #4C9AFF);
+  border-color: var(--brand-secondary, #4C9AFF);
+  color: #fff;
+}
+
+.account-feed-icon.tone-failed {
+  background: rgba(229, 83, 61, 0.18);
+  color: var(--semantic-loss, #E5533D);
+}
+
+.account-feed-badge-failed {
+  color: var(--semantic-loss, #E5533D);
+  font-weight: 700;
+}
+
+.account-feed-badge-unvalued {
+  color: var(--text-muted, var(--text-secondary));
+  font-weight: 400;
+}
+
+.account-feed-reason {
+  font-size: 0.75rem;
+  color: var(--text-muted, var(--text-secondary));
+  overflow-wrap: anywhere;
+}
+
+.account-feed-nodate {
+  font-style: italic;
+}
+
+.account-feed-stale,
+.account-feed-pruned {
+  font-size: 0.75rem;
+  color: var(--text-muted, var(--text-secondary));
+  margin: 0 0 8px;
+}
+
+.account-feed-pruned {
+  margin: 8px 0 0;
+}

--- a/frontend/src/components/account/RecentActivityFeed.jsx
+++ b/frontend/src/components/account/RecentActivityFeed.jsx
@@ -1,63 +1,149 @@
+import { useMemo, useState } from 'react'
 import { getNetwork } from '../../config/networks'
 import { formatUsd, formatRelativeTime } from '../../lib/account/format'
 import SensitiveValue from '../common/SensitiveValue'
 import EmptyState from './EmptyState'
 import './RecentActivityFeed.css'
 
-const DIRECTION_META = {
+/** kind → icon/label/tone for every ledger activity class (spec 051 US1). */
+const KIND_META = {
   deposit: { icon: '↑', label: 'Deposit', tone: 'out' },
   payout: { icon: '↓', label: 'Payout', tone: 'in' },
   refund: { icon: '↩', label: 'Refund', tone: 'in' },
+  send: { icon: '➡', label: 'Transfer', tone: 'out' },
+  vault_deposit: { icon: '🌱', label: 'Earn deposit', tone: 'out' },
+  vault_withdraw: { icon: '🌾', label: 'Earn withdrawal', tone: 'in' },
+  reward_claim: { icon: '✦', label: 'Rewards claimed', tone: 'in' },
+  pool_join: { icon: '⛳', label: 'Pool join', tone: 'out' },
+  pool_claim: { icon: '🏆', label: 'Pool claim', tone: 'in' },
+  pool_refund: { icon: '↩', label: 'Pool refund', tone: 'in' },
+  voucher_purchase: { icon: '🎟', label: 'Voucher purchase', tone: 'out' },
+  voucher_redeem: { icon: '🎟', label: 'Voucher redeemed', tone: 'in' },
 }
 
+const CLASS_FILTERS = [
+  { key: null, label: 'All activity' },
+  { key: 'wager', label: 'Wagers' },
+  { key: 'transfer', label: 'Transfers' },
+  { key: 'earn', label: 'Earn' },
+  { key: 'pool', label: 'Pools' },
+  { key: 'membership', label: 'Membership' },
+]
+
 function explorerTxUrl(chainId, txHash) {
+  // Only real 66-char tx hashes are explorer-linkable (not userOp/intent ids).
+  if (!txHash || String(txHash).length !== 66) return null
   const net = getNetwork(Number(chainId))
   const base = net?.explorer?.baseUrl
-  if (!base || !txHash) return null
+  if (!base) return null
   return `${base.replace(/\/$/, '')}/tx/${txHash}`
 }
 
+function amountLine(e) {
+  if (e.valueUsd != null) return formatUsd(e.valueUsd)
+  if (e.amount != null) return String(e.amount)
+  return null
+}
+
 /**
- * RecentActivityFeed — newest-first deposits/payouts/refunds (spec 020 US4).
- * Shows direction (icon + text), amount + token, USD value, relative time, and
- * a link to the transaction on the active network's explorer.
+ * RecentActivityFeed — the Account tab's canonical activity record
+ * (spec 051 US1): every ledger class, newest first, with class filters,
+ * honest failed states, and an explicit "date unavailable" state instead of
+ * a fabricated relative time (FR-006).
  */
-function RecentActivityFeed({ activity = [], chainId }) {
-  if (!activity.length) {
-    return (
-      <section className="account-feed" aria-label="Recent activity">
-        <h3 className="account-feed-title">Recent activity</h3>
-        <EmptyState compact title="No recent activity" message="Your deposits, payouts, and refunds will appear here." />
-      </section>
-    )
-  }
+function RecentActivityFeed({ entries = [], chainId, staleClasses = [], prunedBefore = null }) {
+  const [classFilter, setClassFilter] = useState(null)
+
+  const rows = useMemo(
+    () => (classFilter ? entries.filter((e) => e.class === classFilter) : entries),
+    [entries, classFilter],
+  )
+
+  const filterChips = (
+    <div className="account-feed-filters" role="group" aria-label="Filter activity by type">
+      {CLASS_FILTERS.map((f) => (
+        <button
+          key={f.label}
+          type="button"
+          className={`account-feed-filter${classFilter === f.key ? ' active' : ''}`}
+          aria-pressed={classFilter === f.key}
+          onClick={() => setClassFilter(f.key)}
+        >
+          {f.label}
+        </button>
+      ))}
+    </div>
+  )
 
   return (
     <section className="account-feed" aria-label="Recent activity">
       <h3 className="account-feed-title">Recent activity</h3>
-      <ul className="account-feed-list">
-        {activity.map((e) => {
-          const meta = DIRECTION_META[e.direction] || { icon: '•', label: e.direction, tone: 'out' }
-          const url = explorerTxUrl(chainId, e.txHash)
-          return (
-            <li className="account-feed-row" key={e.id}>
-              <span className={`account-feed-icon tone-${meta.tone}`} aria-hidden="true">{meta.icon}</span>
-              <span className="account-feed-main">
-                <span className="account-feed-label">{meta.label}</span>
-                <span className="account-feed-amount"><SensitiveValue>{formatUsd(e.usdValue)}</SensitiveValue> <span className="account-feed-token">{e.symbol}</span></span>
-              </span>
-              <span className="account-feed-meta">
-                <time>{formatRelativeTime(e.timestamp)}</time>
-                {url && (
-                  <a href={url} target="_blank" rel="noopener noreferrer" className="account-feed-link">
-                    View tx
-                  </a>
-                )}
-              </span>
-            </li>
-          )
-        })}
-      </ul>
+      {filterChips}
+      {staleClasses.length > 0 && (
+        <p className="account-feed-stale" role="status">
+          Some activity may be out of date: {staleClasses.join(', ')} could not be refreshed.
+        </p>
+      )}
+      {rows.length === 0 ? (
+        <EmptyState
+          compact
+          title="No recent activity"
+          message="Your wagers, transfers, earn, pool, and membership activity will appear here."
+        />
+      ) : (
+        <ul className="account-feed-list">
+          {rows.map((e) => {
+            const meta = KIND_META[e.kind] || { icon: '•', label: e.kind, tone: 'out' }
+            const url = explorerTxUrl(e.chainId ?? chainId, e.txHash)
+            const relative = e.timestamp != null ? formatRelativeTime(e.timestamp) : null
+            const amount = amountLine(e)
+            const failed = e.status === 'failed'
+            return (
+              <li className={`account-feed-row${failed ? ' failed' : ''}`} key={e.entryId}>
+                <span className={`account-feed-icon tone-${failed ? 'failed' : meta.tone}`} aria-hidden="true">
+                  {failed ? '✕' : meta.icon}
+                </span>
+                <span className="account-feed-main">
+                  <span className="account-feed-label">
+                    {meta.label}
+                    {failed && <span className="account-feed-badge-failed"> Failed</span>}
+                    {e.valuationStatus === 'unvalued' && (
+                      <span className="account-feed-badge-unvalued" title="No USD value could be determined for this entry"> · unvalued</span>
+                    )}
+                  </span>
+                  {amount != null && (
+                    <span className="account-feed-amount">
+                      <SensitiveValue>{amount}</SensitiveValue>{' '}
+                      <span className="account-feed-token">{e.tokenSymbol || ''}</span>
+                    </span>
+                  )}
+                  {failed && e.failureReason && (
+                    <span className="account-feed-reason">{e.failureReason}</span>
+                  )}
+                </span>
+                <span className="account-feed-meta">
+                  {relative != null ? (
+                    <time>{relative}</time>
+                  ) : (
+                    <span className="account-feed-nodate">date unavailable</span>
+                  )}
+                  {url && (
+                    <a href={url} target="_blank" rel="noopener noreferrer" className="account-feed-link">
+                      View tx
+                    </a>
+                  )}
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+      {prunedBefore != null && (
+        <p className="account-feed-pruned">
+          Entries before {new Date(prunedBefore).toLocaleDateString()} were pruned from device history; on-chain
+          activity remains recoverable.
+        </p>
+      )}
     </section>
   )
 }

--- a/frontend/src/components/earn/VaultSheet.jsx
+++ b/frontend/src/components/earn/VaultSheet.jsx
@@ -26,6 +26,7 @@ import {
   withdrawFromVault,
 } from '../../lib/earn/vaultActions'
 import { queueEarnAction } from '../../lib/earn/earnActivityBuffer'
+import { captureEarnAction } from '../../data/ledger'
 import { formatApy } from '../../lib/earn/format'
 
 function fmt(amountBig, decimals, symbol) {
@@ -145,6 +146,18 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
         txHash: receipt.hash,
         txUrl,
         at: Date.now(),
+      })
+      // Durable audit entry in the unified activity ledger (spec 051).
+      captureEarnAction(address, chainId, {
+        type: mode === 'deposit' ? 'earn-deposit' : 'earn-withdraw',
+        txHash: receipt.hash,
+        at: Date.now(),
+        vaultAddress: vault.address,
+        amountRaw: amount?.toString?.() ?? String(amount),
+        tokenAddress: vault.asset?.address ?? null,
+        tokenSymbol: symbol,
+        tokenDecimals: decimals,
+        description: message,
       })
       activity?.refresh?.()
       setTxState({ step: 'done', txUrl, error: null })

--- a/frontend/src/components/earn/VaultSheet.jsx
+++ b/frontend/src/components/earn/VaultSheet.jsx
@@ -175,7 +175,7 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
       // Durable audit entry in the unified activity ledger (spec 051).
       captureEarnAction(address, chainId, {
         type: mode === 'deposit' ? 'earn-deposit' : 'earn-withdraw',
-        txHash: receipt.hash,
+        txHash,
         at: Date.now(),
         vaultAddress: vault.address,
         amountRaw: amount?.toString?.() ?? String(amount),

--- a/frontend/src/components/wallet/TaxReportsPanel.jsx
+++ b/frontend/src/components/wallet/TaxReportsPanel.jsx
@@ -68,12 +68,28 @@ export default function TaxReportsPanel({ hookOptions } = {}) {
       {status === REPORT_STATUS.READY && report && (
         <div className="report-result">
           {isEmpty ? (
-            <p className="report-empty">No wager activity in this period.</p>
+            <p className="report-empty">
+              {report.source === 'ledger'
+                ? 'No activity in this period.'
+                : 'No wager activity in this period.'}
+            </p>
           ) : (
             <>
               <p>
-                {`${report.lineItems.length} transfer(s) for ${report.period.label} on ${report.networkName}.`}
+                {report.source === 'ledger'
+                  ? `${report.lineItems.length} activity entr${report.lineItems.length === 1 ? 'y' : 'ies'} for ${report.period.label} on ${report.networkName}.`
+                  : `${report.lineItems.length} transfer(s) for ${report.period.label} on ${report.networkName}.`}
               </p>
+              {report.totals?.overall?.failedCount > 0 && (
+                <p className="report-note">
+                  {`${report.totals.overall.failedCount} failed operation(s) are listed but excluded from all totals.`}
+                </p>
+              )}
+              {report.staleClasses?.length > 0 && (
+                <p className="report-note" role="status">
+                  {`Could not refresh: ${report.staleClasses.join(', ')} — entries for these classes may be missing.`}
+                </p>
+              )}
               <Totals totals={report.totals} />
             </>
           )}

--- a/frontend/src/components/wallet/TransferActivityList.jsx
+++ b/frontend/src/components/wallet/TransferActivityList.jsx
@@ -1,21 +1,29 @@
-import { useMemo } from 'react'
-import { useTransferActivity } from '../../hooks/useTransferActivity'
+import { useActivityLedger } from '../../hooks/useActivityLedger'
 import { getNetwork } from '../../config/networks'
-import { TRANSFER_STATUS } from '../../lib/transfer/transferStore'
 
 const short = (a) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '')
 
 const STATUS_LABEL = {
-  [TRANSFER_STATUS.IN_PROCESS]: 'In process',
-  [TRANSFER_STATUS.COMPLETE]: 'Complete',
-  [TRANSFER_STATUS.FAILED]: 'Failed',
+  pending: 'In process',
+  settled: 'Complete',
+  failed: 'Failed',
+  cancelled: 'Cancelled',
+}
+
+// Legacy CSS hooks keyed by the old transferStore statuses.
+const STATUS_CLASS = {
+  pending: 'in_process',
+  settled: 'complete',
+  failed: 'failed',
+  cancelled: 'failed',
 }
 
 function formatDate(ts) {
+  if (ts == null) return null
   try {
     return new Date(ts).toLocaleDateString(undefined, { year: 'numeric', month: '2-digit', day: '2-digit' })
   } catch {
-    return ''
+    return null
   }
 }
 
@@ -26,16 +34,15 @@ function explorerTxUrl(chainId, txHash) {
 }
 
 /**
- * Activity tab — the transfers this browser has sent, newest first, with truthful status. Mirrors the
- * reference design: status label, amount, from → to, date, and a deep link to the on-chain transaction
- * once it is known.
+ * Activity tab — transfer entries from the unified activity ledger
+ * (spec 051), newest first, with truthful status. Reading the ledger (instead
+ * of the raw device log) keeps this tab and the Account tab structurally
+ * consistent (FR-002): both render the same entries.
  */
 export default function TransferActivityList() {
-  const { transfers } = useTransferActivity()
+  const { entries } = useActivityLedger({ filter: { classes: ['transfer'] } })
 
-  const rows = useMemo(() => transfers, [transfers])
-
-  if (rows.length === 0) {
+  if (entries.length === 0) {
     return (
       <div className="pt-activity">
         <p className="pt-activity-empty">No transfers yet. Payments you send from this device will appear here.</p>
@@ -45,23 +52,25 @@ export default function TransferActivityList() {
 
   return (
     <ul className="pt-activity" aria-label="Transfer activity">
-      {rows.map((r) => {
-        const url = explorerTxUrl(r.chainId, r.txHash)
+      {entries.map((e) => {
+        const url = explorerTxUrl(e.chainId, e.txHash)
+        const date = formatDate(e.timestamp)
+        const statusClass = STATUS_CLASS[e.status] || e.status
         return (
-          <li key={r.id} className="pt-item">
-            <span className={`pt-status-dot ${r.status}`} aria-hidden="true" />
+          <li key={e.entryId} className="pt-item">
+            <span className={`pt-status-dot ${statusClass}`} aria-hidden="true" />
             <div className="pt-item-body">
-              <div className="pt-item-status">{STATUS_LABEL[r.status] || r.status}</div>
-              <div className="pt-item-amount">{r.amount} {r.symbol}</div>
+              <div className="pt-item-status">{STATUS_LABEL[e.status] || e.status}</div>
+              <div className="pt-item-amount">{e.amount} {e.tokenSymbol}</div>
               <div className="pt-item-route">
-                <span>{short(r.from)}</span>
+                <span>{short(e.account)}</span>
                 <span className="pt-item-arrow" aria-hidden="true">➡</span>
-                <span>{short(r.to)}</span>
+                <span>{short(e.counterparty)}</span>
               </div>
               <div className="pt-item-date">
-                {formatDate(r.createdAt)}
-                {r.route === 'gasless' ? ' · gasless' : ''}
-                {r.status === TRANSFER_STATUS.FAILED && r.error ? ` · ${r.error}` : ''}
+                {date ?? 'date unavailable'}
+                {e.refs?.route === 'gasless' ? ' · gasless' : ''}
+                {e.status === 'failed' && e.failureReason ? ` · ${e.failureReason}` : ''}
               </div>
             </div>
             {url && (

--- a/frontend/src/data/ledger/constants.js
+++ b/frontend/src/data/ledger/constants.js
@@ -1,0 +1,60 @@
+/**
+ * Shared vocabulary for the unified activity ledger (spec 051).
+ * Mirrors specs/051-unified-activity-ledger/data-model.md — the enums here are
+ * the single source of truth the sources, repository, UI, and report share.
+ */
+
+/** Activity classes the ledger covers (FR-001). */
+export const LEDGER_CLASS = Object.freeze({
+  WAGER: 'wager',
+  TRANSFER: 'transfer',
+  EARN: 'earn',
+  POOL: 'pool',
+  MEMBERSHIP: 'membership',
+})
+
+export const LEDGER_CLASSES = Object.freeze(Object.values(LEDGER_CLASS))
+
+/** Final status of an entry. Failed entries are listed, never totaled (FR-003). */
+export const LEDGER_STATUS = Object.freeze({
+  SETTLED: 'settled',
+  PENDING: 'pending',
+  FAILED: 'failed',
+  CANCELLED: 'cancelled',
+})
+
+export const LEDGER_STATUSES = Object.freeze(Object.values(LEDGER_STATUS))
+
+/** Value direction relative to the account. Failed ops carry 'none'. */
+export const LEDGER_DIRECTION = Object.freeze({
+  IN: 'in',
+  OUT: 'out',
+  NONE: 'none',
+})
+
+/** Where an entry's data comes from — surfaced to auditing (constitution III). */
+export const PROVENANCE = Object.freeze({
+  ONCHAIN: 'onchain', // re-derivable from chain/subgraph; carries a txHash
+  DERIVED: 'derived', // synthesized from on-chain state (no single tx)
+  CLIENT: 'client', // exists only on this device; travels in the encrypted backup
+})
+
+/** entryId namespace per provenance (data-model.md Identity). */
+export const ID_NS = Object.freeze({
+  [PROVENANCE.ONCHAIN]: 'oc',
+  [PROVENANCE.DERIVED]: 'dv',
+  [PROVENANCE.CLIENT]: 'cl',
+})
+
+/** Where an entry's timestamp comes from (FR-005). */
+export const TS_PROVENANCE = Object.freeze({
+  CHAIN: 'chain', // block time — the only provenance for on-chain events
+  DEVICE: 'device', // device clock — only for client-only events
+  UNAVAILABLE: 'unavailable', // no real time exists; UI shows "date unavailable" (FR-006)
+})
+
+/** Valuation flags — unvalued entries are kept and flagged, never zeroed (FR-016). */
+export const VALUATION_STATUS = Object.freeze({
+  VALUED: 'valued',
+  UNVALUED: 'unvalued',
+})

--- a/frontend/src/data/ledger/identity.js
+++ b/frontend/src/data/ledger/identity.js
@@ -1,0 +1,102 @@
+/**
+ * Ledger entry identity + merge precedence (spec 051, data-model.md "Identity").
+ *
+ * Every entry carries a stable `entryId` in a provenance namespace:
+ *   oc:  on-chain    — re-derivable, carries a txHash
+ *   dv:  derived     — synthesized from on-chain state, deterministic so
+ *                      re-derivation is idempotent (FR-009/011)
+ *   cl:  client-only — exists only on this device; travels in the backup
+ *
+ * Merge precedence: `oc:` beats `dv:` for the same underlying event
+ * (via refs.dedupKey), and a `cl:` record whose txHash matches an `oc:` entry
+ * is linked into it (context annotation) rather than shown twice. Pure module.
+ */
+
+const NS = new Set(['oc', 'dv', 'cl'])
+
+export function onchainEntryId({ chainId, txHash, logIndex }) {
+  return `oc:${Number(chainId)}:${txHash}:${logIndex ?? 'x'}`
+}
+
+/** On-chain id from a subgraph entity that already encodes tx+log uniqueness. */
+export function subgraphEntryId({ chainId, entityId }) {
+  return `oc:${Number(chainId)}:wt:${entityId}`
+}
+
+export function derivedWagerEntryId({ chainId, wagerId, kind, party }) {
+  return `dv:${Number(chainId)}:wager:${String(wagerId)}:${kind}:${String(party || '').toLowerCase()}`
+}
+
+export function clientEntryId(uuid) {
+  return `cl:${uuid}`
+}
+
+/** 'oc' | 'dv' | 'cl' | null */
+export function namespaceOf(entryId) {
+  const ns = String(entryId || '').split(':', 1)[0]
+  return NS.has(ns) ? ns : null
+}
+
+/**
+ * Dedup key for a wager value event — the underlying-event identity shared by
+ * the subgraph row and the derived fallback row (account + chain are implied:
+ * merge always runs within one (account, chainId) query).
+ */
+export function wagerDedupKey({ wagerId, kind }) {
+  return `wager:${String(wagerId)}:${kind}`
+}
+
+/**
+ * Merge normalized entries from all sources into the deduplicated ledger view.
+ * Precedence per data-model.md: union by entryId → drop `dv:` covered by an
+ * `oc:` with the same refs.dedupKey → fold `cl:` records into the `oc:` entry
+ * that shares their txHash. Never mutates inputs; returns new objects only
+ * where annotation is needed.
+ *
+ * @param {Array} entries - normalized LedgerEntry objects
+ * @returns {Array} merged entries
+ */
+export function mergeEntries(entries = []) {
+  // 1. Union by entryId — first occurrence wins (append-only records with the
+  //    same id are identical by design).
+  const byId = new Map()
+  for (const e of entries) {
+    if (!e || byId.has(e.entryId)) continue
+    byId.set(e.entryId, e)
+  }
+  let merged = [...byId.values()]
+
+  // 2. oc: beats dv: for the same underlying event.
+  const onchainDedupKeys = new Set()
+  for (const e of merged) {
+    if (namespaceOf(e.entryId) === 'oc' && e.refs?.dedupKey) onchainDedupKeys.add(e.refs.dedupKey)
+  }
+  merged = merged.filter(
+    (e) => !(namespaceOf(e.entryId) === 'dv' && e.refs?.dedupKey && onchainDedupKeys.has(e.refs.dedupKey)),
+  )
+
+  // 3. Link cl: records into the oc: entry sharing their txHash (context, not
+  //    duplication): the on-chain entry wins financial fields and gains the
+  //    client record's route/id as annotations.
+  const ocByTx = new Map()
+  for (const e of merged) {
+    if (namespaceOf(e.entryId) === 'oc' && e.txHash) ocByTx.set(e.txHash.toLowerCase(), e)
+  }
+  const out = []
+  const annotations = new Map() // oc entryId → { linkedClientEntryId, route }
+  for (const e of merged) {
+    if (namespaceOf(e.entryId) === 'cl' && e.txHash && ocByTx.has(e.txHash.toLowerCase())) {
+      const oc = ocByTx.get(e.txHash.toLowerCase())
+      annotations.set(oc.entryId, {
+        linkedClientEntryId: e.entryId,
+        ...(e.refs?.route ? { route: e.refs.route } : {}),
+      })
+      continue // folded into the on-chain entry
+    }
+    out.push(e)
+  }
+  if (annotations.size === 0) return out
+  return out.map((e) =>
+    annotations.has(e.entryId) ? { ...e, refs: { ...(e.refs || {}), ...annotations.get(e.entryId) } } : e,
+  )
+}

--- a/frontend/src/data/ledger/index.js
+++ b/frontend/src/data/ledger/index.js
@@ -1,0 +1,44 @@
+/**
+ * Unified activity ledger (spec 051) — public module surface.
+ * `getDefaultLedgerRepository(chainId)` wires the five domain sources; tests
+ * and the report builder can compose their own via createLedgerRepository.
+ */
+import { createLedgerRepository } from './ledgerRepository'
+import { createWagerLedgerSource } from './sources/wagerLedgerSource'
+import { createTransferLedgerSource } from './sources/transferLedgerSource'
+import { createEarnLedgerSource } from './sources/earnLedgerSource'
+import { createPoolLedgerSource } from './sources/poolLedgerSource'
+import { createMembershipLedgerSource } from './sources/membershipLedgerSource'
+import { getPrunedBefore } from './ledgerClientStore'
+
+export { createLedgerRepository, defaultEnrich } from './ledgerRepository'
+export { createWagerLedgerSource } from './sources/wagerLedgerSource'
+export { createTransferLedgerSource, transferRecordToEntry } from './sources/transferLedgerSource'
+export { createEarnLedgerSource, captureEarnAction } from './sources/earnLedgerSource'
+export { createPoolLedgerSource } from './sources/poolLedgerSource'
+export { createMembershipLedgerSource } from './sources/membershipLedgerSource'
+export * from './constants'
+export * from './identity'
+export { normalizeEntry } from './normalize'
+export {
+  appendClientRecord,
+  listClientRecords,
+  listAllClientRecords,
+  mergeClientRecords,
+  getPrunedBefore,
+  pruneClientRecords,
+} from './ledgerClientStore'
+
+/** The app's standard ledger for a chain — all five sources wired. */
+export function getDefaultLedgerRepository() {
+  return createLedgerRepository({
+    sources: [
+      createWagerLedgerSource(),
+      createTransferLedgerSource(),
+      createEarnLedgerSource(),
+      createPoolLedgerSource(),
+      createMembershipLedgerSource(),
+    ],
+    getPrunedBefore: ({ account, chainId }) => getPrunedBefore(account, chainId),
+  })
+}

--- a/frontend/src/data/ledger/index.js
+++ b/frontend/src/data/ledger/index.js
@@ -10,6 +10,7 @@ import { createEarnLedgerSource } from './sources/earnLedgerSource'
 import { createPoolLedgerSource } from './sources/poolLedgerSource'
 import { createMembershipLedgerSource } from './sources/membershipLedgerSource'
 import { getPrunedBefore } from './ledgerClientStore'
+import { migrateLegacyActivity } from './migrate'
 
 export { createLedgerRepository, defaultEnrich } from './ledgerRepository'
 export { createWagerLedgerSource } from './sources/wagerLedgerSource'
@@ -28,10 +29,11 @@ export {
   getPrunedBefore,
   pruneClientRecords,
 } from './ledgerClientStore'
+export { migrateLegacyActivity } from './migrate'
 
 /** The app's standard ledger for a chain — all five sources wired. */
 export function getDefaultLedgerRepository() {
-  return createLedgerRepository({
+  const repository = createLedgerRepository({
     sources: [
       createWagerLedgerSource(),
       createTransferLedgerSource(),
@@ -41,4 +43,12 @@ export function getDefaultLedgerRepository() {
     ],
     getPrunedBefore: ({ account, chainId }) => getPrunedBefore(account, chainId),
   })
+  return {
+    // Every consumer triggers the one-time legacy import (FR-017) — the
+    // per-account marker makes repeat calls a cheap no-op.
+    listEntries: (q) => {
+      migrateLegacyActivity(q?.account)
+      return repository.listEntries(q)
+    },
+  }
 }

--- a/frontend/src/data/ledger/ledgerClientStore.js
+++ b/frontend/src/data/ledger/ledgerClientStore.js
@@ -143,6 +143,45 @@ export function mergeClientRecords(account, chainId, incoming = []) {
   return { added: fresh.length }
 }
 
+/**
+ * All client records for the account across every chain (flat array; each
+ * record carries its chainId) — the spec-032 backup payload. Chain ids are
+ * discovered from the account's storage keys so no network registry is needed.
+ */
+export function listClientRecordsAllChains(account) {
+  if (!account || typeof localStorage === 'undefined') return []
+  const prefix = `fw_user_${String(account).toLowerCase()}_activity_ledger_v1_`
+  const out = []
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (!key || !key.startsWith(prefix)) continue
+    const chainId = Number(key.slice(prefix.length))
+    if (Number.isFinite(chainId)) out.push(...listAllClientRecords(account, chainId))
+  }
+  return out
+}
+
+/**
+ * Merge a flat cross-chain record array (from a backup) into the store.
+ * Append-only union by entryId per chain (FR-011). Both restore modes use
+ * this — "replace" would delete history and violate FR-008.
+ * @returns {{added: number}}
+ */
+export function mergeClientRecordsAllChains(account, incoming = []) {
+  const byChain = new Map()
+  for (const r of incoming || []) {
+    if (!r?.entryId || r.chainId == null) continue
+    const cid = Number(r.chainId)
+    if (!byChain.has(cid)) byChain.set(cid, [])
+    byChain.get(cid).push(r)
+  }
+  let added = 0
+  for (const [chainId, records] of byChain) {
+    added += mergeClientRecords(account, chainId, records).added
+  }
+  return { added }
+}
+
 /** Test/util seam: wipe every account's client ledger (localStorage scan). */
 export function __clearClientLedger() {
   if (typeof localStorage === 'undefined') return

--- a/frontend/src/data/ledger/ledgerClientStore.js
+++ b/frontend/src/data/ledger/ledgerClientStore.js
@@ -1,0 +1,155 @@
+/**
+ * ledgerClientStore — the durable home of client-only ledger records
+ * (spec 051, data-model.md "ClientLedgerRecord").
+ *
+ * Holds the `cl:` provenance subset of the ledger: activity that exists only
+ * on this device (failed gasless ops, client-captured earn actions, transfer
+ * history) and therefore travels in the spec-032 encrypted backup. Records
+ * are APPEND-ONLY (FR-008): a status transition appends a superseding record
+ * (`refs.supersedes`) — nothing is ever mutated or deleted in place; readers
+ * resolve chains to the latest record while the full chain stays readable
+ * for audit.
+ *
+ * Persistence: localStorage via userStorage (per-account), one feature key
+ * per chainId (the activityStore convention). Writes never throw into the
+ * caller — activity capture must never break the action that produced it.
+ *
+ * Retention: no cap by default. `pruneClientRecords` exists as a disclosed
+ * size guard that records a `prunedBefore` marker and REFUSES any cutoff
+ * inside the current or previous tax year (FR-013).
+ */
+import { getUserPreference, saveUserPreference } from '../../utils/userStorage'
+
+const STORE_VERSION = 1
+
+function featureKey(chainId) {
+  return `activity_ledger_v1_${chainId}`
+}
+
+function defaultStore() {
+  return { version: STORE_VERSION, records: [], prunedBefore: null }
+}
+
+function loadStore(account, chainId) {
+  if (!account) return defaultStore()
+  const stored = getUserPreference(account, featureKey(chainId), null, true)
+  if (
+    stored &&
+    typeof stored === 'object' &&
+    stored.version === STORE_VERSION &&
+    Array.isArray(stored.records)
+  ) {
+    return stored
+  }
+  if (stored !== null) {
+    console.warn('[ledgerClientStore] Unsupported store shape — resetting to defaults')
+  }
+  return defaultStore()
+}
+
+function saveStore(account, chainId, store) {
+  if (!account) return
+  try {
+    saveUserPreference(account, featureKey(chainId), store, true)
+  } catch {
+    // Storage full/disabled — capture is best-effort and must never break the
+    // action that produced the record (transferStore rule).
+  }
+}
+
+/**
+ * Append one client record. No-op if the entryId already exists (append-only:
+ * identical ids are identical records; the original always wins). Never throws.
+ * @param {string} account
+ * @param {object} record - full ClientLedgerRecord including entryId + chainId
+ */
+export function appendClientRecord(account, record) {
+  if (!account || !record?.entryId || record.chainId == null) return
+  try {
+    const chainId = Number(record.chainId)
+    const store = loadStore(account, chainId)
+    if (store.records.some((r) => r.entryId === record.entryId)) return
+    const next = {
+      ...store,
+      records: [...store.records, { ...record, recordedAt: record.recordedAt ?? Date.now() }],
+    }
+    saveStore(account, chainId, next)
+  } catch {
+    // never throw into the caller
+  }
+}
+
+/** Raw append-only history (audit view) for (account, chainId). */
+export function listAllClientRecords(account, chainId) {
+  return loadStore(account, chainId).records
+}
+
+/**
+ * Latest record per supersede chain: a record is shadowed when another record
+ * names it in `refs.supersedes`. Chains stay short (pending → complete/failed),
+ * so a single shadowed-set pass resolves them.
+ */
+export function listClientRecords(account, chainId) {
+  const records = listAllClientRecords(account, chainId)
+  const shadowed = new Set()
+  for (const r of records) {
+    if (r?.refs?.supersedes) shadowed.add(r.refs.supersedes)
+  }
+  return records.filter((r) => !shadowed.has(r.entryId))
+}
+
+/** FR-013 disclosure marker — epoch ms records were pruned before, or null. */
+export function getPrunedBefore(account, chainId) {
+  return loadStore(account, chainId).prunedBefore ?? null
+}
+
+/**
+ * Disclosed size guard (FR-013). Refuses any cutoff that would touch the
+ * current or previous tax year; otherwise drops records older than cutoff
+ * (by timestamp, falling back to recordedAt) and records `prunedBefore`.
+ * @returns {{pruned: number}}
+ */
+export function pruneClientRecords(account, chainId, { cutoffMs, nowMs = Date.now() } = {}) {
+  if (!account || !Number.isFinite(Number(cutoffMs))) return { pruned: 0 }
+  const previousTaxYearStart = Date.UTC(new Date(nowMs).getUTCFullYear() - 1, 0, 1)
+  if (cutoffMs > previousTaxYearStart) return { pruned: 0 }
+
+  const store = loadStore(account, chainId)
+  const keep = store.records.filter((r) => {
+    const ts = r.timestamp ?? r.recordedAt ?? Infinity
+    return ts >= cutoffMs
+  })
+  const pruned = store.records.length - keep.length
+  if (pruned > 0 || store.prunedBefore !== cutoffMs) {
+    saveStore(account, chainId, { ...store, records: keep, prunedBefore: cutoffMs })
+  }
+  return { pruned }
+}
+
+/**
+ * Replace-or-merge the full client record set from a backup restore.
+ * Append-only union by entryId — existing records always survive, incoming
+ * new ids are added (FR-011: identical ids are identical records).
+ * @returns {{added: number}}
+ */
+export function mergeClientRecords(account, chainId, incoming = []) {
+  if (!account) return { added: 0 }
+  const store = loadStore(account, chainId)
+  const have = new Set(store.records.map((r) => r.entryId))
+  const fresh = (incoming || []).filter((r) => r?.entryId && !have.has(r.entryId))
+  if (fresh.length > 0) {
+    saveStore(account, chainId, { ...store, records: [...store.records, ...fresh] })
+  }
+  return { added: fresh.length }
+}
+
+/** Test/util seam: wipe every account's client ledger (localStorage scan). */
+export function __clearClientLedger() {
+  if (typeof localStorage === 'undefined') return
+  const doomed = []
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key && key.includes('_activity_ledger_')) doomed.push(key)
+  }
+  doomed.forEach((k) => localStorage.removeItem(k))
+}

--- a/frontend/src/data/ledger/ledgerRepository.js
+++ b/frontend/src/data/ledger/ledgerRepository.js
@@ -1,0 +1,143 @@
+/**
+ * ledgerRepository — assembly of the unified activity ledger (spec 051).
+ *
+ * Aggregates LedgerSource adapters (contracts/ledger-source.md) into one
+ * normalized, deduplicated, enriched, sorted entry stream per (account,
+ * chainId). Per-source degradation: a failing source marks its class stale
+ * (`staleClasses`) instead of failing the ledger — the UI discloses staleness
+ * honestly (constitution III) rather than blanking or fabricating.
+ *
+ * Failed entries are INCLUDED here; excluding them from financial totals is
+ * the summary helpers' job (FR-003), not the repository's.
+ */
+import { formatUnits } from 'ethers'
+import { getNetwork } from '../../config/networks'
+import { resolveTokenMeta } from '../reports/tokenMeta'
+import { valueTransfer } from '../reports/valuation'
+import { normalizeEntry } from './normalize'
+import { mergeEntries } from './identity'
+import { VALUATION_STATUS } from './constants'
+
+/**
+ * Default enrichment: token meta (symbol/decimals), human amount, and USD
+ * valuation. Stablecoins value at the par baseline (spec 016 policy); entries
+ * that arrive pre-valued (captured at activity time) keep their value; every
+ * other asset is honestly flagged `unvalued` — never zeroed (FR-016).
+ */
+export async function defaultEnrich(entries, { chainId, fetchOnChain } = {}) {
+  const net = getNetwork(Number(chainId))
+  const stableAddress = String(net?.stablecoin?.address || '').toLowerCase()
+  const out = []
+  for (const e of entries) {
+    let tokenSymbol = e.tokenSymbol
+    let tokenDecimals = e.tokenDecimals
+    let amount = e.amount
+
+    if (e.tokenAddress) {
+      const meta = await resolveTokenMeta(e.tokenAddress, chainId, { fetchOnChain })
+      tokenSymbol = tokenSymbol || meta.ticker
+      tokenDecimals = tokenDecimals ?? meta.decimals
+    } else {
+      tokenSymbol = tokenSymbol || net?.nativeCurrency?.symbol || 'NATIVE'
+      tokenDecimals = tokenDecimals ?? 18
+    }
+
+    if (amount == null && e.amountRaw != null) {
+      try {
+        amount = Number(formatUnits(BigInt(e.amountRaw), tokenDecimals))
+      } catch {
+        amount = null
+      }
+    }
+
+    let valueUsd = e.valueUsd
+    let valuationStatus = e.valuationStatus
+    if (valuationStatus == null) {
+      if (valueUsd != null && Number.isFinite(Number(valueUsd))) {
+        valuationStatus = VALUATION_STATUS.VALUED
+      } else if (e.tokenAddress && e.tokenAddress === stableAddress && amount != null) {
+        valueUsd = valueTransfer(amount).usdValue
+        valuationStatus = VALUATION_STATUS.VALUED
+      } else {
+        valueUsd = null
+        valuationStatus = VALUATION_STATUS.UNVALUED
+      }
+    }
+
+    out.push({ ...e, tokenSymbol, tokenDecimals, amount, valueUsd, valuationStatus })
+  }
+  return out
+}
+
+function matchesFilter(entry, filter) {
+  if (!filter) return true
+  if (filter.classes?.length && !filter.classes.includes(entry.class)) return false
+  if (filter.statuses?.length && !filter.statuses.includes(entry.status)) return false
+  if (filter.kinds?.length && !filter.kinds.includes(entry.kind)) return false
+  return true
+}
+
+function inPeriod(entry, period) {
+  if (!period) return true
+  // Entries without a real timestamp cannot be placed in a period; keeping
+  // them out of period-scoped views is the honest choice — the full ledger
+  // (no period) always lists them.
+  if (entry.timestamp == null) return false
+  if (period.fromMs != null && entry.timestamp < period.fromMs) return false
+  if (period.toMs != null && entry.timestamp > period.toMs) return false
+  return true
+}
+
+/** Newest first; entries with no real timestamp sort after all dated ones. */
+function compareEntries(a, b) {
+  const at = a.timestamp
+  const bt = b.timestamp
+  if (at != null && bt != null) return bt - at
+  if (at != null) return -1
+  if (bt != null) return 1
+  return (b.recordedAt || 0) - (a.recordedAt || 0)
+}
+
+/**
+ * @param {object} deps
+ * @param {Array}  deps.sources - LedgerSource adapters
+ * @param {Function} [deps.enrich] - (entries, {chainId}) => enriched entries
+ * @param {Function} [deps.getPrunedBefore] - ({account, chainId}) => epoch ms | null (FR-013 disclosure)
+ */
+export function createLedgerRepository({ sources = [], enrich = defaultEnrich, getPrunedBefore } = {}) {
+  /**
+   * @param {object} q - { account, chainId, filter?, period?, provider?, signal? }
+   * @returns {Promise<{entries: Array, staleClasses: string[], prunedBefore: number|null}>}
+   */
+  async function listEntries(q) {
+    const ctx = { account: String(q.account || '').toLowerCase(), chainId: Number(q.chainId) }
+    const staleClasses = []
+    const settled = await Promise.allSettled(
+      sources.map(async (src) => {
+        const items = await src.list({ ...ctx, provider: q.provider, signal: q.signal })
+        // Normalize inside the per-source boundary so one bad source degrades
+        // to stale instead of poisoning the whole ledger.
+        return items.map((item) => normalizeEntry(item, ctx))
+      }),
+    )
+
+    const collected = []
+    settled.forEach((res, i) => {
+      if (res.status === 'fulfilled') collected.push(...res.value)
+      else staleClasses.push(sources[i].class)
+    })
+
+    const merged = mergeEntries(collected)
+    const enriched = await enrich(merged, { chainId: ctx.chainId, provider: q.provider })
+    const filtered = enriched.filter((e) => matchesFilter(e, q.filter) && inPeriod(e, q.period))
+    filtered.sort(compareEntries)
+
+    return {
+      entries: filtered,
+      staleClasses,
+      prunedBefore: typeof getPrunedBefore === 'function' ? getPrunedBefore(ctx) ?? null : null,
+    }
+  }
+
+  return { listEntries }
+}

--- a/frontend/src/data/ledger/migrate.js
+++ b/frontend/src/data/ledger/migrate.js
@@ -1,0 +1,53 @@
+/**
+ * One-time migration of legacy device-local activity into the client ledger
+ * (spec 051, FR-017/SC-007).
+ *
+ * Imports every `fairwins.transfers.v1` row for the account as a `cl:` ledger
+ * record (via the same pure mapper the live mirror uses, so ids are identical
+ * and the union is duplicate-free). Guarded by a per-account marker so it
+ * runs once; a re-run against overlapping data is harmless because
+ * appendClientRecord is a no-op on existing entryIds.
+ *
+ * The legacy store itself is left in place (it remains the transfer flow's
+ * write path); only the READ paths moved to the ledger.
+ */
+import { listTransfers } from '../../lib/transfer/transferStore'
+import { getUserPreference, saveUserPreference } from '../../utils/userStorage'
+import { transferRecordToEntry } from './sources/transferLedgerSource'
+import { appendClientRecord, listAllClientRecords } from './ledgerClientStore'
+
+const MIGRATION_MARKER = 'activity_ledger_migrated_v1'
+
+/**
+ * @param {string|null} account
+ * @returns {{migrated: number, skipped?: boolean}}
+ */
+export function migrateLegacyActivity(account) {
+  if (!account) return { migrated: 0, skipped: true }
+  try {
+    if (getUserPreference(account, MIGRATION_MARKER, false, true)) {
+      return { migrated: 0, skipped: true }
+    }
+
+    // All chains at once: legacy rows carry their chainId.
+    const legacy = listTransfers(account) || []
+    let migrated = 0
+    for (const record of legacy) {
+      if (record?.chainId == null || !record.id) continue
+      const entry = transferRecordToEntry(record, { account })
+      const existing = listAllClientRecords(account, record.chainId)
+      if (existing.some((r) => r.entryId === entry.entryId)) continue
+      appendClientRecord(account, entry)
+      migrated += 1
+    }
+
+    saveUserPreference(account, MIGRATION_MARKER, true, true)
+    return { migrated }
+  } catch {
+    // Migration is best-effort — never break app bootstrap. The marker is NOT
+    // set on failure so the next load retries.
+    return { migrated: 0, skipped: true }
+  }
+}
+
+export default migrateLegacyActivity

--- a/frontend/src/data/ledger/normalize.js
+++ b/frontend/src/data/ledger/normalize.js
@@ -1,0 +1,89 @@
+/**
+ * Normalization + invariant enforcement for ledger entries (spec 051).
+ *
+ * Sources return pre-items; this module turns each into a validated
+ * LedgerEntry (data-model.md) or throws. The invariants here are the
+ * fidelity guarantees of contracts/ledger-entry.md:
+ *   G2 — timestamp is real epoch ms or null+unavailable; 0 never survives
+ *   G3 — failed entries carry direction 'none' (and are excluded from totals
+ *        downstream by status, not by omission)
+ *   G4 — on-chain provenance requires a txHash
+ *   G5 — strict chainId scoping against the query context
+ */
+import {
+  LEDGER_CLASSES,
+  LEDGER_STATUSES,
+  LEDGER_STATUS,
+  LEDGER_DIRECTION,
+  PROVENANCE,
+  ID_NS,
+  TS_PROVENANCE,
+} from './constants'
+import { namespaceOf } from './identity'
+
+/**
+ * @param {object} pre - source pre-item
+ * @param {{account:string, chainId:number}} ctx - query scope
+ * @returns {object} validated LedgerEntry
+ */
+export function normalizeEntry(pre, ctx) {
+  if (!pre || typeof pre !== 'object') throw new Error('ledger: entry must be an object')
+  if (!pre.entryId) throw new Error('ledger: entry missing entryId')
+  if (!LEDGER_CLASSES.includes(pre.class)) throw new Error(`ledger: unknown class "${pre.class}"`)
+
+  const status = pre.status || LEDGER_STATUS.SETTLED
+  if (!LEDGER_STATUSES.includes(status)) throw new Error(`ledger: unknown status "${status}"`)
+
+  const provenance = pre.provenance
+  if (!Object.values(PROVENANCE).includes(provenance)) {
+    throw new Error(`ledger: unknown provenance "${provenance}"`)
+  }
+  if (namespaceOf(pre.entryId) !== ID_NS[provenance]) {
+    throw new Error(`ledger: entryId namespace does not match provenance for "${pre.entryId}"`)
+  }
+  if (provenance === PROVENANCE.ONCHAIN && !pre.txHash) {
+    throw new Error(`ledger: on-chain entry "${pre.entryId}" missing txHash`)
+  }
+
+  const chainId = Number(pre.chainId)
+  if (ctx?.chainId != null && chainId !== Number(ctx.chainId)) {
+    throw new Error(`ledger: entry chainId ${chainId} leaked into query for chainId ${ctx.chainId}`)
+  }
+
+  // G2 — a missing/zero/invalid time is honestly unavailable, never epoch-0.
+  const tsNum = Number(pre.timestamp)
+  const hasRealTs = Number.isFinite(tsNum) && tsNum > 0 && pre.timestamp !== null && pre.timestamp !== undefined
+  const timestamp = hasRealTs ? tsNum : null
+  const timestampProvenance = hasRealTs
+    ? pre.timestampProvenance || TS_PROVENANCE.CHAIN
+    : TS_PROVENANCE.UNAVAILABLE
+
+  // G3 — failed operations moved no value.
+  const direction = status === LEDGER_STATUS.FAILED ? LEDGER_DIRECTION.NONE : pre.direction || LEDGER_DIRECTION.NONE
+
+  return {
+    entryId: pre.entryId,
+    account: String(ctx?.account ?? pre.account ?? '').toLowerCase(),
+    chainId,
+    class: pre.class,
+    kind: pre.kind || pre.class,
+    direction,
+    status,
+    failureReason: pre.failureReason ?? null,
+    tokenAddress: pre.tokenAddress ? String(pre.tokenAddress).toLowerCase() : null,
+    tokenSymbol: pre.tokenSymbol ?? null,
+    tokenDecimals: pre.tokenDecimals ?? null,
+    amountRaw: pre.amountRaw != null ? String(pre.amountRaw) : null,
+    amount: pre.amount ?? null,
+    valueUsd: pre.valueUsd ?? null,
+    valuationStatus: pre.valuationStatus ?? null,
+    counterparty: pre.counterparty ? String(pre.counterparty).toLowerCase() : null,
+    txHash: pre.txHash || null,
+    logIndex: pre.logIndex ?? null,
+    timestamp,
+    timestampProvenance,
+    provenance,
+    recordedAt: pre.recordedAt ?? null,
+    refs: pre.refs && typeof pre.refs === 'object' ? pre.refs : {},
+  }
+}

--- a/frontend/src/data/ledger/sources/earnLedgerSource.js
+++ b/frontend/src/data/ledger/sources/earnLedgerSource.js
@@ -1,0 +1,67 @@
+/**
+ * Earn/lending ledger source (spec 051, research.md D2 — adjusted).
+ *
+ * Earn vaults are discovered dynamically from the Morpho API (spec 050);
+ * there is no fixed on-chain vault registry to scan events from, so an
+ * exhaustive ERC-4626 event sweep is not viable on public RPCs. Instead,
+ * earn activity is captured at ACTION TIME — the deposit/withdraw/claim
+ * flows call `captureEarnAction` with the receipt tx hash — into the
+ * append-only client ledger store, exactly like wallet transfers. The
+ * records carry the real txHash (chain-verifiable) and travel in the
+ * encrypted backup. Positions changed outside this app are a DISCLOSED gap
+ * (the notification feed's snapshot-diff backstop still surfaces them as
+ * they happen; FR-013 disclosure covers the ledger).
+ */
+import { listClientRecords, appendClientRecord } from '../ledgerClientStore'
+import { clientEntryId } from '../identity'
+import { LEDGER_CLASS, LEDGER_STATUS, PROVENANCE, TS_PROVENANCE } from '../constants'
+
+const KIND_BY_ACTION = {
+  'earn-deposit': { kind: 'vault_deposit', direction: 'out' },
+  'earn-withdraw': { kind: 'vault_withdraw', direction: 'in' },
+  'earn-rewards-claimed': { kind: 'reward_claim', direction: 'in' },
+}
+
+/**
+ * Record an earn action into the ledger. Called by the earn flows right where
+ * they queue the notification entry (VaultSheet deposit/withdraw,
+ * useEarnRewards claim). Never throws — capture must not break the action.
+ *
+ * @param {string} account
+ * @param {number} chainId
+ * @param {object} a - { type, txHash, at, vaultAddress?, amountRaw?, tokenAddress?, tokenSymbol?, tokenDecimals?, description? }
+ */
+export function captureEarnAction(account, chainId, a) {
+  if (!account || !a?.type || !a?.txHash) return
+  const mapping = KIND_BY_ACTION[a.type]
+  if (!mapping) return
+  appendClientRecord(account, {
+    entryId: clientEntryId(`earn:${chainId}:${a.type}:${a.txHash}`),
+    chainId: Number(chainId),
+    account: String(account).toLowerCase(),
+    class: LEDGER_CLASS.EARN,
+    kind: mapping.kind,
+    direction: mapping.direction,
+    status: LEDGER_STATUS.SETTLED,
+    provenance: PROVENANCE.CLIENT,
+    tokenAddress: a.tokenAddress ? String(a.tokenAddress).toLowerCase() : null,
+    tokenSymbol: a.tokenSymbol || null,
+    tokenDecimals: a.tokenDecimals ?? null,
+    amountRaw: a.amountRaw != null ? String(a.amountRaw) : null,
+    counterparty: a.vaultAddress ? String(a.vaultAddress).toLowerCase() : null,
+    txHash: a.txHash,
+    timestamp: Number(a.at) > 0 ? Number(a.at) : Date.now(),
+    timestampProvenance: TS_PROVENANCE.DEVICE,
+    refs: { vaultAddress: a.vaultAddress || null, description: a.description || null },
+  })
+}
+
+export function createEarnLedgerSource(deps = {}) {
+  const readClientRecords = deps.listClientRecords || listClientRecords
+  return {
+    class: LEDGER_CLASS.EARN,
+    async list({ account, chainId }) {
+      return readClientRecords(account, chainId).filter((r) => r.class === LEDGER_CLASS.EARN)
+    },
+  }
+}

--- a/frontend/src/data/ledger/sources/membershipLedgerSource.js
+++ b/frontend/src/data/ledger/sources/membershipLedgerSource.js
@@ -1,0 +1,97 @@
+/**
+ * Membership/voucher ledger source (spec 051, research.md D2) — voucher
+ * lifecycle events for the account from the spec-026 subgraph `Voucher`
+ * entity:
+ *   minted by the account   → voucher_purchase (out; mint price is not
+ *                             indexed, so the entry is honestly unvalued)
+ *   redeemed by the account → voucher_redeem (no value movement)
+ * Chains without a subgraph return [] — a disclosed gap.
+ */
+import { querySubgraph } from './subgraphClient'
+import { onchainEntryId } from '../identity'
+import { LEDGER_CLASS, LEDGER_DIRECTION, LEDGER_STATUS, PROVENANCE, TS_PROVENANCE, VALUATION_STATUS } from '../constants'
+
+const VOUCHER_QUERY = `
+  query LedgerVouchers($account: Bytes!) {
+    minted: vouchers(where: { minter: $account }, first: 1000) {
+      id
+      tokenId
+      tier
+      mintedAt
+      mintTxHash
+    }
+    redeemed: vouchers(where: { redeemedBy: $account }, first: 1000) {
+      id
+      tokenId
+      tier
+      redeemedAt
+      redeemTxHash
+    }
+  }
+`
+
+function entry({ chainId, account, kind, direction, txHash, timestampSec, tokenId, tier }) {
+  const sec = Number(timestampSec)
+  return {
+    entryId: onchainEntryId({ chainId, txHash, logIndex: `${kind}:${tokenId}` }),
+    chainId,
+    account,
+    class: LEDGER_CLASS.MEMBERSHIP,
+    kind,
+    direction,
+    status: LEDGER_STATUS.SETTLED,
+    provenance: PROVENANCE.ONCHAIN,
+    tokenAddress: null,
+    amountRaw: null,
+    // The voucher price is not indexed on the entity — flagged, never zeroed.
+    valuationStatus: VALUATION_STATUS.UNVALUED,
+    counterparty: null,
+    txHash,
+    timestamp: sec > 0 ? sec * 1000 : null,
+    timestampProvenance: sec > 0 ? TS_PROVENANCE.CHAIN : TS_PROVENANCE.UNAVAILABLE,
+    refs: { voucherId: String(tokenId), tier: tier != null ? Number(tier) : null },
+  }
+}
+
+export function createMembershipLedgerSource(deps = {}) {
+  const query = deps.querySubgraph || querySubgraph
+  return {
+    class: LEDGER_CLASS.MEMBERSHIP,
+    async list({ account, chainId }) {
+      const data = await query(chainId, VOUCHER_QUERY, { account })
+      if (!data) return []
+      const entries = []
+      for (const v of data.minted || []) {
+        if (!v.mintTxHash) continue
+        entries.push(
+          entry({
+            chainId,
+            account,
+            kind: 'voucher_purchase',
+            direction: LEDGER_DIRECTION.OUT,
+            txHash: v.mintTxHash,
+            timestampSec: v.mintedAt,
+            tokenId: v.tokenId,
+            tier: v.tier,
+          }),
+        )
+      }
+      for (const v of data.redeemed || []) {
+        if (!v.redeemTxHash) continue
+        entries.push(
+          entry({
+            chainId,
+            account,
+            kind: 'voucher_redeem',
+            direction: LEDGER_DIRECTION.NONE,
+            txHash: v.redeemTxHash,
+            timestampSec: v.redeemedAt,
+            tokenId: v.tokenId,
+            tier: v.tier,
+          }),
+        )
+      }
+      return entries
+    },
+  }
+}

--- a/frontend/src/data/ledger/sources/poolLedgerSource.js
+++ b/frontend/src/data/ledger/sources/poolLedgerSource.js
@@ -1,0 +1,112 @@
+/**
+ * Pool ledger source (spec 051, research.md D2) — the member's group-pool
+ * value events from the spec-034 subgraph entities:
+ *   PoolMember  → pool_join   (buy-in escrowed; out)
+ *   PoolClaim   → pool_claim  (winning share paid; in)
+ *   PoolRefund  → pool_refund (buy-in returned; in)
+ * All three carry real txHash + block timestamp. On chains without a
+ * subgraph the source returns [] — pool history there is a disclosed gap
+ * until pools ship an RPC enumeration path (FR-013 disclosure).
+ */
+import { querySubgraph } from './subgraphClient'
+import { onchainEntryId } from '../identity'
+import { LEDGER_CLASS, LEDGER_STATUS, PROVENANCE, TS_PROVENANCE } from '../constants'
+
+const POOL_ACTIVITY_QUERY = `
+  query LedgerPoolActivity($member: Bytes!) {
+    poolMembers(where: { member: $member }, first: 1000) {
+      id
+      buyIn
+      joinedAt
+      joinTxHash
+      pool { id poolId token }
+    }
+    poolClaims(where: { winner: $member }, first: 1000) {
+      id
+      amount
+      timestamp
+      txHash
+      pool { id poolId token }
+    }
+    poolRefunds(where: { member: $member }, first: 1000) {
+      id
+      amount
+      timestamp
+      txHash
+      pool { id poolId token }
+    }
+  }
+`
+
+function base(row, { chainId, account, kind, direction, txHash, timestamp, amount }) {
+  const sec = Number(timestamp)
+  return {
+    entryId: onchainEntryId({ chainId, txHash, logIndex: `${kind}:${row.pool?.id}` }),
+    chainId,
+    account,
+    class: LEDGER_CLASS.POOL,
+    kind,
+    direction,
+    status: LEDGER_STATUS.SETTLED,
+    provenance: PROVENANCE.ONCHAIN,
+    tokenAddress: row.pool?.token || null,
+    amountRaw: String(amount ?? 0),
+    counterparty: row.pool?.id || null,
+    txHash,
+    timestamp: sec > 0 ? sec * 1000 : null,
+    timestampProvenance: sec > 0 ? TS_PROVENANCE.CHAIN : TS_PROVENANCE.UNAVAILABLE,
+    refs: { poolId: row.pool?.poolId != null ? String(row.pool.poolId) : null, poolAddress: row.pool?.id || null },
+  }
+}
+
+export function createPoolLedgerSource(deps = {}) {
+  const query = deps.querySubgraph || querySubgraph
+  return {
+    class: LEDGER_CLASS.POOL,
+    async list({ account, chainId }) {
+      const data = await query(chainId, POOL_ACTIVITY_QUERY, { member: account })
+      if (!data) return [] // no subgraph on this chain — disclosed gap
+      const entries = []
+      for (const m of data.poolMembers || []) {
+        entries.push(
+          base(m, {
+            chainId,
+            account,
+            kind: 'pool_join',
+            direction: 'out',
+            txHash: m.joinTxHash,
+            timestamp: m.joinedAt,
+            amount: m.buyIn,
+          }),
+        )
+      }
+      for (const c of data.poolClaims || []) {
+        entries.push(
+          base(c, {
+            chainId,
+            account,
+            kind: 'pool_claim',
+            direction: 'in',
+            txHash: c.txHash,
+            timestamp: c.timestamp,
+            amount: c.amount,
+          }),
+        )
+      }
+      for (const r of data.poolRefunds || []) {
+        entries.push(
+          base(r, {
+            chainId,
+            account,
+            kind: 'pool_refund',
+            direction: 'in',
+            txHash: r.txHash,
+            timestamp: r.timestamp,
+            amount: r.amount,
+          }),
+        )
+      }
+      return entries
+    },
+  }
+}

--- a/frontend/src/data/ledger/sources/subgraphClient.js
+++ b/frontend/src/data/ledger/sources/subgraphClient.js
@@ -1,0 +1,20 @@
+/**
+ * Minimal subgraph POST helper for ledger sources (spec 051).
+ * Returns null (not an error) when the chain has no subgraph configured so
+ * sources can degrade to their fallback or to an honest empty result.
+ */
+import { getSubgraphUrl } from '../../../config/networks'
+
+export async function querySubgraph(chainId, query, variables) {
+  const url = getSubgraphUrl(chainId)
+  if (!url) return null
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query, variables }),
+  })
+  if (!res.ok) throw new Error(`Subgraph HTTP ${res.status}`)
+  const json = await res.json()
+  if (json.errors) throw new Error(`Subgraph: ${json.errors[0]?.message || 'unknown error'}`)
+  return json.data
+}

--- a/frontend/src/data/ledger/sources/transferLedgerSource.js
+++ b/frontend/src/data/ledger/sources/transferLedgerSource.js
@@ -1,0 +1,82 @@
+/**
+ * Wallet-transfer ledger source (spec 051, research.md D2/D4).
+ *
+ * Reads the append-only client ledger store (the durable, backed-up home of
+ * client-captured activity) plus, until migration has run, the legacy
+ * `transferStore` (`fairwins.transfers.v1`) rows mapped to the same `cl:` ids
+ * — so pre-migration history is visible and post-migration the union is a
+ * no-op. When both stores describe the same transfer, the client-ledger
+ * chain (which carries append-only status history) wins.
+ *
+ * Failed gasless/sponsored operations are first-class entries here: status
+ * `failed` + the verbatim bundler/paymaster reason (FR-003).
+ */
+import { getNetwork } from '../../../config/networks'
+import { listTransfers } from '../../../lib/transfer/transferStore'
+import { listClientRecords } from '../ledgerClientStore'
+import { clientEntryId } from '../identity'
+import { LEDGER_CLASS, LEDGER_STATUS, PROVENANCE, TS_PROVENANCE } from '../constants'
+
+const STATUS_MAP = {
+  in_process: LEDGER_STATUS.PENDING,
+  complete: LEDGER_STATUS.SETTLED,
+  failed: LEDGER_STATUS.FAILED,
+}
+
+/**
+ * Map a transferStore record to a client ledger entry. Pure; reused by the
+ * useTransfer mirror and the one-time migration so all three paths produce
+ * byte-identical entries (identical entryIds ⇒ union dedup).
+ */
+export function transferRecordToEntry(record, { account } = {}) {
+  const chainId = Number(record.chainId)
+  const net = getNetwork(chainId)
+  const isStable = record.kind === 'stable'
+  const stable = net?.stablecoin
+  const amount = Number(record.amount)
+  return {
+    entryId: clientEntryId(record.id),
+    chainId,
+    account: String(account || record.from || '').toLowerCase(),
+    class: LEDGER_CLASS.TRANSFER,
+    kind: 'send',
+    direction: 'out',
+    status: STATUS_MAP[record.status] || LEDGER_STATUS.PENDING,
+    failureReason: record.error || null,
+    tokenAddress: isStable ? stable?.address || null : null,
+    tokenSymbol: record.symbol || null,
+    tokenDecimals: record.decimals ?? null,
+    amount: Number.isFinite(amount) ? amount : null,
+    // Stablecoin sends value at par (the spec-016 policy); everything else is
+    // honestly unvalued until a price source exists (FR-016).
+    valueUsd: isStable && Number.isFinite(amount) ? amount : null,
+    counterparty: record.to || null,
+    txHash: record.txHash || null,
+    timestamp: Number(record.createdAt) > 0 ? Number(record.createdAt) : null,
+    timestampProvenance: Number(record.createdAt) > 0 ? TS_PROVENANCE.DEVICE : TS_PROVENANCE.UNAVAILABLE,
+    provenance: PROVENANCE.CLIENT,
+    recordedAt: Number(record.updatedAt) || Number(record.createdAt) || null,
+    refs: { route: record.route || null, transferId: record.id },
+  }
+}
+
+export function createTransferLedgerSource(deps = {}) {
+  const readClientRecords = deps.listClientRecords || listClientRecords
+  const readLegacyTransfers = deps.listTransfers || listTransfers
+
+  return {
+    class: LEDGER_CLASS.TRANSFER,
+    async list({ account, chainId }) {
+      const clientRecords = readClientRecords(account, chainId).filter(
+        (r) => r.class === LEDGER_CLASS.TRANSFER,
+      )
+      const mirroredTransferIds = new Set(
+        clientRecords.map((r) => r.refs?.transferId).filter(Boolean),
+      )
+      const legacy = readLegacyTransfers(account, chainId)
+        .filter((r) => !mirroredTransferIds.has(r.id))
+        .map((r) => transferRecordToEntry(r, { account }))
+      return [...clientRecords, ...legacy]
+    },
+  }
+}

--- a/frontend/src/data/ledger/sources/wagerLedgerSource.js
+++ b/frontend/src/data/ledger/sources/wagerLedgerSource.js
@@ -15,6 +15,7 @@
 import { createReportDataSource } from '../../reports/reportDataSource'
 import { getDefaultWagerRepository } from '../../wagers/WagerRepository'
 import { deriveTransfersFromWagers } from '../../../lib/account/deriveTransfers'
+import { hydrateWagerTimestamps } from '../timestamps'
 import { subgraphEntryId, derivedWagerEntryId, wagerDedupKey } from '../identity'
 import { LEDGER_CLASS, LEDGER_STATUS, PROVENANCE, TS_PROVENANCE } from '../constants'
 
@@ -109,9 +110,10 @@ export function createWagerLedgerSource(deps = {}) {
         deps.listWagers ||
         (async (q) => loadAllWagers(getDefaultWagerRepository(q.chainId), q.account))
       let wagers = await listWagers({ account, chainId })
-      if (typeof deps.hydrateWagerTimestamps === 'function') {
-        wagers = await deps.hydrateWagerTimestamps(wagers, chainId)
-      }
+      // Real block times for the derived rows (US4/FR-005): bounded chain
+      // scan + cache; anything unhydrated stays null → "date unavailable".
+      const hydrate = deps.hydrateWagerTimestamps || ((ws, cid) => hydrateWagerTimestamps(ws, cid, { provider }))
+      wagers = await hydrate(wagers, chainId)
       const derived = deriveTransfersFromWagers({ wagers, address: account })
       return derived.map((row) => derivedTransferToEntry(row, { chainId, account }))
     },

--- a/frontend/src/data/ledger/sources/wagerLedgerSource.js
+++ b/frontend/src/data/ledger/sources/wagerLedgerSource.js
@@ -1,0 +1,119 @@
+/**
+ * Wager ledger source (spec 051, research.md D2).
+ *
+ * Primary path: the subgraph `WagerTransfer` entity via the report data
+ * source — real txHash, block timestamp, from/to (the fidelity FR-004 needs).
+ * Fallback path (subgraph-less networks): derive value events from the same
+ * wager records that power "My Wagers" (`deriveTransfersFromWagers`) —
+ * provenance `dv:`, deterministic ids so re-derivation is idempotent, and
+ * timestamps hydrated from chain block times where the budget allows
+ * (timestamps.js); a time that cannot be established is `null`, never 0.
+ *
+ * Both paths stamp the same refs.dedupKey so the repository merge drops the
+ * derived row whenever the indexed row for the same underlying event exists.
+ */
+import { createReportDataSource } from '../../reports/reportDataSource'
+import { getDefaultWagerRepository } from '../../wagers/WagerRepository'
+import { deriveTransfersFromWagers } from '../../../lib/account/deriveTransfers'
+import { subgraphEntryId, derivedWagerEntryId, wagerDedupKey } from '../identity'
+import { LEDGER_CLASS, LEDGER_STATUS, PROVENANCE, TS_PROVENANCE } from '../constants'
+
+/** deposit leaves the account; payout/refund return to it. */
+const DIRECTION_BY_KIND = { deposit: 'out', payout: 'in', refund: 'in' }
+
+/** Map one subgraph WagerTransfer pre-item to a ledger pre-item. */
+export function wagerTransferToEntry(row, { chainId, account }) {
+  const kind = row.direction
+  return {
+    entryId: subgraphEntryId({ chainId, entityId: `${row.txHash}-${row.wagerId}-${kind}` }),
+    chainId,
+    account,
+    class: LEDGER_CLASS.WAGER,
+    kind,
+    direction: DIRECTION_BY_KIND[kind] || 'none',
+    status: LEDGER_STATUS.SETTLED,
+    provenance: PROVENANCE.ONCHAIN,
+    tokenAddress: row.tokenAddress,
+    amountRaw: row.amountRaw,
+    counterparty: kind === 'deposit' ? row.toAddress || null : row.fromAddress || null,
+    txHash: row.txHash,
+    timestamp: row.timestamp, // already epoch ms from the report source
+    timestampProvenance: TS_PROVENANCE.CHAIN,
+    refs: { wagerId: String(row.wagerId), dedupKey: wagerDedupKey({ wagerId: row.wagerId, kind }) },
+  }
+}
+
+/** Map one derived pre-item (deriveTransfersFromWagers) to a ledger pre-item. */
+export function derivedTransferToEntry(row, { chainId, account }) {
+  const kind = row.direction
+  const ts = Number(row.timestamp)
+  return {
+    entryId: derivedWagerEntryId({ chainId, wagerId: row.wagerId, kind, party: account }),
+    chainId,
+    account,
+    class: LEDGER_CLASS.WAGER,
+    kind,
+    direction: DIRECTION_BY_KIND[kind] || 'none',
+    status: LEDGER_STATUS.SETTLED,
+    provenance: PROVENANCE.DERIVED,
+    tokenAddress: row.tokenAddress,
+    amountRaw: row.amountRaw,
+    counterparty: null,
+    txHash: null,
+    // Derived rows have no single log; a real block time is hydrated upstream
+    // when available, otherwise the honest answer is "unavailable" (FR-006).
+    timestamp: Number.isFinite(ts) && ts > 0 ? ts : null,
+    timestampProvenance: Number.isFinite(ts) && ts > 0 ? TS_PROVENANCE.CHAIN : TS_PROVENANCE.UNAVAILABLE,
+    refs: { wagerId: String(row.wagerId), dedupKey: wagerDedupKey({ wagerId: row.wagerId, kind }) },
+  }
+}
+
+async function loadAllWagers(repository, account) {
+  const all = []
+  let cursor = null
+  for (let page = 0; page < 200; page++) {
+    const res = await repository.listMyWagers({
+      userAddress: account,
+      cursor,
+      pageSize: 100,
+      filter: { includeExpired: true },
+    })
+    all.push(...(res.items || []))
+    if (!res.hasMore || !res.nextCursor) break
+    cursor = res.nextCursor
+  }
+  return all
+}
+
+/**
+ * @param {object} [deps] - injectable for tests
+ * @param {(q:{account:string})=>Promise<Array|null>} [deps.listTransfers] - subgraph rows or null when unindexed
+ * @param {(q:{account:string,chainId:number})=>Promise<Array>} [deps.listWagers] - rich wager records
+ * @param {(wagers:Array, chainId:number)=>Promise<Array>} [deps.hydrateWagerTimestamps] - fills createdAt/resolvedAt (ms) from chain
+ */
+export function createWagerLedgerSource(deps = {}) {
+  return {
+    class: LEDGER_CLASS.WAGER,
+    async list({ account, chainId, provider }) {
+      const listTransfers =
+        deps.listTransfers ||
+        ((q) => createReportDataSource({ chainId, provider }).listTransfers(q))
+
+      const indexed = await listTransfers({ account })
+      if (indexed !== null && indexed !== undefined) {
+        return indexed.map((row) => wagerTransferToEntry(row, { chainId, account }))
+      }
+
+      // Subgraph-less network — derive from wager state (the My Wagers truth).
+      const listWagers =
+        deps.listWagers ||
+        (async (q) => loadAllWagers(getDefaultWagerRepository(q.chainId), q.account))
+      let wagers = await listWagers({ account, chainId })
+      if (typeof deps.hydrateWagerTimestamps === 'function') {
+        wagers = await deps.hydrateWagerTimestamps(wagers, chainId)
+      }
+      const derived = deriveTransfersFromWagers({ wagers, address: account })
+      return derived.map((row) => derivedTransferToEntry(row, { chainId, account }))
+    },
+  }
+}

--- a/frontend/src/data/ledger/timestamps.js
+++ b/frontend/src/data/ledger/timestamps.js
@@ -1,0 +1,151 @@
+/**
+ * Chain-time hydration for subgraph-less networks (spec 051 US4, FR-005).
+ *
+ * RegistrySource returns `createdAt: 0` because WagerRegistry stores no
+ * creation time on-chain. This module recovers REAL block times by reusing
+ * the report data source's bounded per-wager event scan (adaptive chunking +
+ * request budget — never a genesis scan), then reading the matched events'
+ * block timestamps. Results are cached in localStorage keyed by
+ * (chainId, wagerId): the cache is pure performance — wager event times are
+ * immutable chain facts, and losing the cache only costs a re-scan (FR-009).
+ *
+ * Honesty rule: when the budget is exhausted or the scan fails, timestamps
+ * are left untouched (falsy) so downstream mapping renders the explicit
+ * "date unavailable" state — a real time or none, never a fabricated one
+ * (FR-006).
+ */
+import { createReportDataSource } from '../reports/reportDataSource'
+
+const CACHE_KEY_PREFIX = 'fw_ledger_ts_cache_v1_'
+// Per-call cap on newly-scanned wagers: each scan costs several RPC reads, so
+// a large backlog hydrates progressively across polls instead of bursting.
+const DEFAULT_MAX_WAGERS_PER_CALL = 8
+
+const CREATION_EVENTS = new Set(['WagerCreated', 'MarketCreatedPending'])
+const SETTLEMENT_EVENTS = new Set([
+  'PayoutClaimed',
+  'WagerRefunded',
+  'WagerCancelled',
+  'WagerDrawn',
+  'WinningsClaimed',
+  'StakeRefunded',
+])
+
+function readCache(chainId) {
+  if (typeof localStorage === 'undefined') return {}
+  try {
+    const raw = localStorage.getItem(`${CACHE_KEY_PREFIX}${chainId}`)
+    const parsed = raw ? JSON.parse(raw) : {}
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+function writeCache(chainId, cache) {
+  if (typeof localStorage === 'undefined') return
+  try {
+    localStorage.setItem(`${CACHE_KEY_PREFIX}${chainId}`, JSON.stringify(cache))
+  } catch {
+    // cache is best-effort
+  }
+}
+
+/** Test seam: drop every chain's timestamp cache. */
+export function __clearTimestampCache() {
+  if (typeof localStorage === 'undefined') return
+  const doomed = []
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key && key.startsWith(CACHE_KEY_PREFIX)) doomed.push(key)
+  }
+  doomed.forEach((k) => localStorage.removeItem(k))
+}
+
+/**
+ * Fill missing createdAt/resolvedAt (epoch ms) on wager records from chain
+ * truth, bounded per call. Returns new records; inputs are not mutated.
+ *
+ * @param {Array} wagers - RegistrySource-shaped records (createdAt may be 0)
+ * @param {number} chainId
+ * @param {object} [deps] - injectable for tests
+ * @param {(wagerId:string)=>Promise<Array>} [deps.getWagerEvents]
+ * @param {(blockNumber:number)=>Promise<{timestamp:number}>} [deps.getBlock]
+ * @param {number} [deps.maxWagersPerCall]
+ */
+export async function hydrateWagerTimestamps(wagers = [], chainId, deps = {}) {
+  const needsHydration = wagers.filter((w) => !(Number(w.createdAt) > 0))
+  if (needsHydration.length === 0) return wagers
+
+  let dataSource = null
+  const getWagerEvents =
+    deps.getWagerEvents ||
+    ((id) => {
+      if (!dataSource) dataSource = createReportDataSource({ chainId, provider: deps.provider })
+      return dataSource.getWagerEvents(id)
+    })
+  const getBlock =
+    deps.getBlock ||
+    ((n) => {
+      if (!dataSource) dataSource = createReportDataSource({ chainId, provider: deps.provider })
+      return dataSource.getBlock(n)
+    })
+  const maxWagersPerCall = deps.maxWagersPerCall ?? DEFAULT_MAX_WAGERS_PER_CALL
+
+  const cache = readCache(chainId)
+  let cacheDirty = false
+  let scanned = 0
+
+  const timesById = new Map()
+  for (const w of needsHydration) {
+    const id = String(w.id)
+    if (cache[id]) {
+      timesById.set(id, cache[id])
+      continue
+    }
+    if (scanned >= maxWagersPerCall) continue // hydrate the rest on later polls
+    scanned += 1
+    try {
+      const events = await getWagerEvents(id)
+      const blockTimeMs = new Map()
+      const timeOf = async (blockNumber) => {
+        if (!blockTimeMs.has(blockNumber)) {
+          const block = await getBlock(blockNumber)
+          const sec = Number(block?.timestamp)
+          blockTimeMs.set(blockNumber, sec > 0 ? sec * 1000 : null)
+        }
+        return blockTimeMs.get(blockNumber)
+      }
+      let createdAtMs = null
+      let resolvedAtMs = null
+      for (const ev of events || []) {
+        const name = ev.name || ev.fragment?.name || ev.eventName
+        if (CREATION_EVENTS.has(name)) createdAtMs = await timeOf(ev.blockNumber)
+        else if (SETTLEMENT_EVENTS.has(name)) resolvedAtMs = await timeOf(ev.blockNumber)
+      }
+      if (createdAtMs != null || resolvedAtMs != null) {
+        const entry = { createdAtMs, resolvedAtMs }
+        timesById.set(id, entry)
+        cache[id] = entry
+        cacheDirty = true
+      }
+    } catch {
+      // Budget exhausted or scan failed — leave this wager's times untouched
+      // (renders "date unavailable"), retry on a later poll.
+    }
+  }
+
+  if (cacheDirty) writeCache(chainId, cache)
+
+  return wagers.map((w) => {
+    const t = timesById.get(String(w.id))
+    if (!t) return w
+    return {
+      ...w,
+      createdAt: t.createdAtMs ?? w.createdAt,
+      resolvedAt: t.resolvedAtMs ?? w.resolvedAt,
+    }
+  })
+}
+
+export default hydrateWagerTimestamps

--- a/frontend/src/data/reports/csvReport.js
+++ b/frontend/src/data/reports/csvReport.js
@@ -1,15 +1,21 @@
 /**
  * CSV renderer for the wager tax/activity report
- * (spec 016-wager-tax-report, FR-006/FR-007/FR-008; contracts/report-line-item.md).
+ * (spec 016-wager-tax-report, FR-006/FR-007/FR-008; contracts/report-line-item.md;
+ * extended by spec 051 to the full activity-ledger column contract —
+ * specs/051-unified-activity-ledger/contracts/ledger-entry.md).
  *
  * Emits a metadata preamble (account, network, period, generated-at, valuation
- * note, disclaimer) followed by the canonical 11-column line-item table and a
- * totals block. Full, untruncated transaction hashes and addresses (FR-006).
+ * note, disclosures, disclaimer) followed by the line-item table and a totals
+ * block. Full, untruncated transaction hashes and addresses (FR-006).
+ *
+ * Two column sets share one renderer: ledger-built reports (`report.source ===
+ * 'ledger'`) carry every activity class with status/valuation fidelity;
+ * legacy wager-only reports keep the original 11 columns byte-for-byte.
  */
 
 import Papa from 'papaparse'
 
-/** Canonical column order shared with the PDF renderer. */
+/** Legacy canonical column order (spec 016), shared with the PDF renderer. */
 export const REPORT_COLUMNS = [
   'Timestamp (UTC)',
   'Direction',
@@ -24,6 +30,27 @@ export const REPORT_COLUMNS = [
   'Wager ID',
 ]
 
+/** Spec 051 extended column order (contracts/ledger-entry.md). */
+export const LEDGER_REPORT_COLUMNS = [
+  'Timestamp (UTC)',
+  'Class',
+  'Kind',
+  'Direction',
+  'Status',
+  'Failure Reason',
+  'Token',
+  'Amount',
+  'USD Value',
+  'Valuation',
+  'Cost Basis',
+  'Network Fee',
+  'Transaction Hash',
+  'From',
+  'To',
+  'Wager ID',
+  'Entry ID',
+]
+
 export function feeCell(item) {
   if (typeof item.feeNative === 'number') {
     return `${item.feeNative} ${item.feeNativeSymbol || ''}`.trim()
@@ -31,14 +58,14 @@ export function feeCell(item) {
   return item.feeUnavailableReason || 'N/A'
 }
 
-/** Map a line item to the canonical column row (shared with the PDF renderer). */
-export function lineItemToRow(item) {
-  return lineRow(item)
+/** Real activity time or an explicit flag — never a fabricated date (FR-006). */
+function timestampCell(item) {
+  return item.timestamp != null ? new Date(item.timestamp).toISOString() : 'unavailable'
 }
 
-function lineRow(item) {
+function legacyRow(item) {
   return [
-    new Date(item.timestamp).toISOString(),
+    timestampCell(item),
     item.direction,
     item.tokenTicker,
     item.amount,
@@ -52,25 +79,67 @@ function lineRow(item) {
   ]
 }
 
+function ledgerRow(item) {
+  const unvalued = item.valuationStatus === 'unvalued'
+  return [
+    timestampCell(item),
+    item.class ?? 'wager',
+    item.kind ?? item.direction,
+    item.direction,
+    item.status ?? 'settled',
+    item.failureReason ?? '',
+    item.tokenTicker,
+    item.amount,
+    // Flagged, never silently zeroed (FR-016).
+    unvalued ? 'unvalued' : item.usdValue.toFixed(2),
+    item.valuationStatus ?? 'valued',
+    unvalued ? 'unvalued' : item.costBasis.toFixed(2),
+    feeCell(item),
+    item.txHash,
+    item.fromAddress,
+    item.toAddress,
+    item.wagerId,
+    item.entryId ?? '',
+  ]
+}
+
+export function reportColumns(report) {
+  return report?.source === 'ledger' ? LEDGER_REPORT_COLUMNS : REPORT_COLUMNS
+}
+
+/** Map a line item to its column row (shared with the PDF renderer). */
+export function lineItemToRow(item, report) {
+  return report?.source === 'ledger' ? ledgerRow(item) : legacyRow(item)
+}
+
 /**
  * @param {object} report - ActivityReport from buildReport
  * @returns {string} CSV text (RFC 4180)
  */
 export function render(report) {
   const preamble = [
-    ['Wager Activity / Tax Report'],
+    ['Activity / Tax Report'],
     ['Account', report.account],
     ['Network', `${report.networkName}${report.isTestnet ? ' (testnet)' : ''}`],
     ['Period', report.period.label],
     ['Generated', new Date(report.generatedAt).toISOString()],
     ['Valuation', report.valuationNote],
-    ['Disclaimer', report.disclaimer],
-    [],
   ]
+  // Spec 051 disclosures: stale sources and any device-history pruning marker.
+  if (report.staleClasses?.length) {
+    preamble.push(['Coverage note', `Could not refresh: ${report.staleClasses.join(', ')} — entries for these classes may be missing.`])
+  }
+  if (report.prunedBefore != null) {
+    preamble.push(['Retention note', `Device-local entries before ${new Date(report.prunedBefore).toISOString()} were pruned; on-chain activity remains recoverable.`])
+  }
+  if (report.totals?.overall?.failedCount > 0) {
+    preamble.push(['Failed operations', `${report.totals.overall.failedCount} failed operation(s) are listed but excluded from all totals.`])
+  }
+  preamble.push(['Disclaimer', report.disclaimer], [])
 
-  const table = [REPORT_COLUMNS, ...report.lineItems.map(lineRow)]
+  const table = [reportColumns(report), ...report.lineItems.map((it) => lineItemToRow(it, report))]
 
-  const totals = [[], ['Totals by stablecoin']]
+  const totals = [[], ['Totals by token (settled activity only)']]
   for (const t of Object.values(report.totals.byTicker)) {
     totals.push([
       t.ticker,

--- a/frontend/src/data/reports/pdfReport.js
+++ b/frontend/src/data/reports/pdfReport.js
@@ -10,7 +10,7 @@
 
 import { jsPDF } from 'jspdf'
 import autoTable from 'jspdf-autotable'
-import { REPORT_COLUMNS, lineItemToRow } from './csvReport'
+import { reportColumns, lineItemToRow } from './csvReport'
 
 /**
  * @param {object} report - ActivityReport from buildReport
@@ -32,14 +32,24 @@ export function render(report) {
     `Period: ${report.period.label}`,
     `Generated: ${new Date(report.generatedAt).toISOString()}`,
   ]
+  // Spec 051 disclosures mirror the CSV preamble.
+  if (report.staleClasses?.length) {
+    headerLines.push(`Coverage note: could not refresh ${report.staleClasses.join(', ')} — entries may be missing.`)
+  }
+  if (report.prunedBefore != null) {
+    headerLines.push(`Retention note: device-local entries before ${new Date(report.prunedBefore).toISOString()} were pruned.`)
+  }
+  if (report.totals?.overall?.failedCount > 0) {
+    headerLines.push(`${report.totals.overall.failedCount} failed operation(s) listed but excluded from all totals.`)
+  }
   for (const line of headerLines) {
     doc.text(line, marginX, y)
     y += 13
   }
 
   autoTable(doc, {
-    head: [REPORT_COLUMNS],
-    body: report.lineItems.map(lineItemToRow),
+    head: [reportColumns(report)],
+    body: report.lineItems.map((it) => lineItemToRow(it, report)),
     startY: y + 6,
     styles: { fontSize: 6, font: 'courier', cellPadding: 2, overflow: 'linebreak' },
     headStyles: { fontSize: 6, fillColor: [40, 40, 40] },

--- a/frontend/src/data/reports/reportBuilder.js
+++ b/frontend/src/data/reports/reportBuilder.js
@@ -1,15 +1,21 @@
 /**
  * Report builder — orchestrates production of an ActivityReport for a user +
  * period on the active network (spec 016-wager-tax-report;
- * contracts/report-builder.md).
+ * contracts/report-builder.md; extended by spec 051 to read the unified
+ * activity ledger).
  *
- * Pipeline: enumerate the user's wagers → derive transfers from lifecycle
- * events → enrich with txHash/timestamp/fee from receipts → filter to the
- * period → value at the $1.00 par baseline → compute reconciling totals.
+ * Primary pipeline (spec 051): query the SAME activity ledger the Account tab
+ * renders — all activity classes, one read path — filter to the period, and
+ * enrich entries that reached the chain with the gas fee from their receipt.
+ * Because dashboard and report consume identical entries, their line items
+ * and totals can never disagree (FR-014/FR-015).
  *
- * All chain/index I/O is behind the injected `dataSource` so the orchestration
- * is deterministic and unit-testable. Deterministic for a fixed
- * (account, chainId, period) against immutable chain data (FR-010).
+ * Legacy pipeline (no `ledger` injected): enumerate the user's wagers →
+ * derive transfers from lifecycle events → enrich from receipts → value at
+ * the $1.00 par baseline. Kept for callers/tests that predate the ledger.
+ *
+ * All chain/index I/O is behind the injected `dataSource`/`ledger` so the
+ * orchestration is deterministic and unit-testable (FR-010).
  */
 
 import { formatUnits } from 'ethers'
@@ -31,12 +37,18 @@ function isParty(wager, account) {
   return (wager.participants || []).some((p) => eq(p, account))
 }
 
-/** Sum line items into per-ticker + overall totals (must reconcile, SC-004). */
+/** Sum line items into per-ticker + overall totals (must reconcile, SC-004).
+ *  Failed entries are listed but NEVER totaled (spec 051 FR-003). */
 function computeTotals(lineItems, nativeSymbol) {
   const byTicker = {}
   let overallUsd = 0
   let overallFees = 0
+  let failedCount = 0
   for (const it of lineItems) {
+    if (it.status === 'failed') {
+      failedCount += 1
+      continue
+    }
     const t = (byTicker[it.tokenTicker] ||= {
       ticker: it.tokenTicker, deposits: 0, payouts: 0, refunds: 0, usdValue: 0, count: 0,
     })
@@ -58,7 +70,50 @@ function computeTotals(lineItems, nativeSymbol) {
       feesNative: overallFees,
       feesNativeSymbol: nativeSymbol,
       count: lineItems.length,
+      failedCount,
     },
+  }
+}
+
+/** Real 66-char tx hash — the only kind a receipt can be fetched for. */
+function isRealTxHash(h) {
+  return typeof h === 'string' && h.length === 66
+}
+
+/** Ledger kinds that map onto the legacy wager direction vocabulary. */
+const WAGER_DIRECTIONS = new Set(['deposit', 'payout', 'refund'])
+
+/**
+ * Map one ledger entry to a report line item (contracts/ledger-entry.md CSV
+ * mapping). Keeps the legacy wager fields so per-ticker totals reconcile.
+ */
+function ledgerEntryToLineItem(entry, { feeNative, feeNativeSymbol, feeUnavailableReason }) {
+  const amountNumber = Number(entry.amount) || 0
+  return {
+    entryId: entry.entryId,
+    class: entry.class,
+    kind: entry.kind,
+    // Legacy direction for wager math; other classes carry their kind.
+    direction: WAGER_DIRECTIONS.has(entry.kind) ? entry.kind : entry.kind,
+    status: entry.status,
+    failureReason: entry.failureReason ?? null,
+    timestamp: entry.timestamp, // may be null — flagged, sorted last (FR-006)
+    tokenTicker: entry.tokenSymbol || '',
+    tokenDecimals: entry.tokenDecimals ?? null,
+    tokenAddress: entry.tokenAddress,
+    amount: entry.amount != null ? String(entry.amount) : '',
+    amountNumber,
+    usdValue: entry.valueUsd ?? 0,
+    costBasis: entry.valueUsd ?? 0,
+    valuationStatus: entry.valuationStatus,
+    valuationSource: entry.valuationStatus === 'valued' ? 'ledger' : null,
+    feeNative,
+    feeNativeSymbol,
+    feeUnavailableReason,
+    txHash: entry.txHash || '',
+    fromAddress: entry.direction === 'in' ? entry.counterparty || '' : entry.account,
+    toAddress: entry.direction === 'in' ? entry.account : entry.counterparty || '',
+    wagerId: entry.refs?.wagerId ?? '',
   }
 }
 
@@ -69,6 +124,8 @@ function computeTotals(lineItems, nativeSymbol) {
  * @param {{kind,from,to,label}} params.period - resolved + validated
  * @param {object} params.dataSource - { enumerateWagers, getWagerEvents, getBlock, getTransactionReceipt }
  * @param {object} params.networkMeta - getNetwork(chainId) result
+ * @param {object} [params.ledger] - spec-051 ledger repository ({ listEntries }); when present the
+ *                                   report enumerates the SAME entries the Account tab renders
  * @param {function} [params.tokenResolver] - (address, chainId) => Promise<{ticker,decimals}>
  * @param {function} [params.onProgress] - (fraction, label) => void
  * @param {number} [params.generatedAt] - epoch ms (defaults to now)
@@ -80,6 +137,7 @@ export async function buildReport({
   period,
   dataSource,
   networkMeta,
+  ledger,
   tokenResolver,
   onProgress = () => {},
   generatedAt = Date.now(),
@@ -87,6 +145,73 @@ export async function buildReport({
   const nativeSymbol = networkMeta?.nativeCurrency?.symbol || 'NATIVE'
   const registryAddress = networkMeta?.contracts?.wagerRegistry || networkMeta?.wagerRegistry
   const resolveToken = tokenResolver || ((addr) => resolveTokenMeta(addr, chainId))
+
+  // ---- Spec 051 primary path: the unified activity ledger ----
+  if (ledger && typeof ledger.listEntries === 'function') {
+    onProgress(0.05, 'Loading your activity ledger…')
+    const { entries, staleClasses, prunedBefore } = await ledger.listEntries({
+      account,
+      chainId,
+      period: { fromMs: period.from, toMs: period.to },
+    })
+
+    onProgress(0.5, 'Fetching transaction fees…')
+    const receiptCache = new Map()
+    const getReceipt = async (h) => {
+      if (!receiptCache.has(h)) receiptCache.set(h, await dataSource.getTransactionReceipt(h))
+      return receiptCache.get(h)
+    }
+
+    const lineItems = []
+    for (const entry of entries) {
+      let feeNative = null
+      let feeUnavailableReason = null
+      if (isRealTxHash(entry.txHash) && typeof dataSource?.getTransactionReceipt === 'function') {
+        try {
+          const receipt = await getReceipt(entry.txHash)
+          if (receipt && String(receipt.from).toLowerCase() === String(account).toLowerCase()) {
+            const gasUsed = receipt.gasUsed
+            const price = receipt.effectiveGasPrice ?? receipt.gasPrice
+            feeNative = gasUsed != null && price != null ? Number(BigInt(gasUsed) * BigInt(price)) / 1e18 : null
+            if (feeNative == null) feeUnavailableReason = 'Fee data unavailable for this transaction.'
+          } else {
+            feeUnavailableReason = 'Not sent by you — no gas fee paid.'
+          }
+        } catch {
+          feeUnavailableReason = 'Fee data unavailable for this transaction.'
+        }
+      } else {
+        feeUnavailableReason =
+          entry.status === 'failed' ? 'Never reached the chain — no fee.' : 'No transaction reference.'
+      }
+      lineItems.push(ledgerEntryToLineItem(entry, { feeNative, feeNativeSymbol: nativeSymbol, feeUnavailableReason }))
+    }
+
+    // Chronological, entries with no real timestamp last (contract G2/FR-006).
+    lineItems.sort((a, b) => {
+      if (a.timestamp != null && b.timestamp != null) return a.timestamp - b.timestamp
+      if (a.timestamp != null) return -1
+      if (b.timestamp != null) return 1
+      return 0
+    })
+    onProgress(1, 'Done')
+
+    return {
+      account,
+      chainId: Number(chainId),
+      networkName: networkMeta?.name || `Chain ${chainId}`,
+      isTestnet: Boolean(networkMeta?.isTestnet),
+      period,
+      generatedAt,
+      source: 'ledger',
+      lineItems,
+      totals: computeTotals(lineItems, nativeSymbol),
+      staleClasses,
+      prunedBefore,
+      valuationNote: PAR_VALUATION_NOTE,
+      disclaimer: REPORT_DISCLAIMER,
+    }
+  }
 
   onProgress(0.05, 'Loading your wager activity…')
 

--- a/frontend/src/hooks/useAccountStats.js
+++ b/frontend/src/hooks/useAccountStats.js
@@ -1,9 +1,13 @@
 /**
- * useAccountStats — the Account dashboard's single data seam (spec 020).
+ * useAccountStats — the Account dashboard's single data seam (spec 020,
+ * re-pointed at the unified activity ledger by spec 051).
  *
  * Composes existing feeds into the derived view models in data-model.md:
  *  - member wagers (WagerRepository.listMyWagers, all pages)
- *  - valued WagerTransfers (report data source `listTransfers` + enrichment)
+ *  - the unified activity ledger (spec 051) — ALL activity classes; the
+ *    wager-class entries feed the P&L/summary/breakdown math via
+ *    lib/account/ledgerAdapters so dashboard figures and the tax report read
+ *    the same ledger and can never disagree (FR-014/015)
  *  - wallet balances + native→USD (wallet context + usePriceConversion)
  *
  * Pure aggregation lives in lib/account/*; this hook only wires feeds, manages
@@ -18,16 +22,16 @@ import { useWallet } from './useWalletManagement'
 import usePriceConversion from './usePriceConversion'
 import { useChainTokens } from './useChainTokens'
 import { getDefaultWagerRepository } from '../data/wagers/WagerRepository'
+import { getDefaultLedgerRepository } from '../data/ledger'
 import { getContractAddressForChain } from '../config/contracts'
 import {
   computeSummary,
   computePnlSeries,
   computeBreakdowns,
-  enrichTransfers,
-  deriveTransfersFromWagers,
   isSettledStatus,
   DEFAULT_RANGE,
 } from '../lib/account'
+import { wagerTransfersFromLedger, tokenMetaFromLedger } from '../lib/account/ledgerAdapters'
 
 const POLL_MS = 60_000
 
@@ -80,8 +84,9 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
   const [range, setRange] = useState(initialRange)
   const [wagers, setWagers] = useState([])
   const [stableBalance, setStableBalance] = useState(null)
-  const [valuedTransfers, setValuedTransfers] = useState([])
-  const [tokenMetaByAddress, setTokenMetaByAddress] = useState({})
+  const [ledgerEntries, setLedgerEntries] = useState([])
+  const [staleClasses, setStaleClasses] = useState([])
+  const [prunedBefore, setPrunedBefore] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState(null)
   const [isSupportedNetwork, setIsSupportedNetwork] = useState(true)
@@ -94,10 +99,13 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
 
   const reqIdRef = useRef(0)
 
+  const ledgerRepository = useMemo(() => getDefaultLedgerRepository(), [])
+
   const load = useCallback(async () => {
     if (!isConnected || !address) {
       setWagers([])
-      setValuedTransfers([])
+      setLedgerEntries([])
+      setStaleClasses([])
       setStableBalance(null)
       setIsLoading(false)
       return
@@ -113,8 +121,8 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
     if (!escrowConfigured) {
       setIsSupportedNetwork(false)
       setWagers([])
-      setValuedTransfers([])
-      setTokenMetaByAddress({})
+      setLedgerEntries([])
+      setStaleClasses([])
       setIsLoading(false)
       const settled = { lastUpdated: Date.now(), status: 'fresh' }
       setFreshness({ summary: settled, series: settled, balances: settled, activity: settled })
@@ -132,7 +140,7 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
     }))
     try {
       const repository = getDefaultWagerRepository(chainId)
-      const [loadedWagers, stable] = await Promise.all([
+      const [loadedWagers, stable, ledger] = await Promise.all([
         loadAllWagers(repository, address),
         fetchStableBalance({
           provider,
@@ -140,20 +148,17 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
           stableAddress: tokens.stableAddress,
           stableDecimals: tokens.stableDecimals,
         }),
+        // The unified activity ledger (spec 051): all classes, one read path
+        // shared with the tax report so the two can never disagree.
+        ledgerRepository.listEntries({ account: address, chainId, provider }),
       ])
-      if (reqId !== reqIdRef.current) return
-
-      // Derive the member's value movements from the SAME authoritative wagers
-      // that power My Wagers — not the separate WagerTransfer entity — so totals,
-      // P&L, breakdowns, and activity are always consistent with the wager list.
-      const rawTransfers = deriveTransfersFromWagers({ wagers: loadedWagers, address })
-      const { transfers, tokenMetaByAddress: meta } = await enrichTransfers(rawTransfers, { chainId })
       if (reqId !== reqIdRef.current) return
 
       setWagers(loadedWagers)
       if (stable != null) setStableBalance(stable)
-      setValuedTransfers(transfers)
-      setTokenMetaByAddress(meta)
+      setLedgerEntries(ledger.entries)
+      setStaleClasses(ledger.staleClasses)
+      setPrunedBefore(ledger.prunedBefore)
       setIsSupportedNetwork(true)
       const now = Date.now()
       const fresh = { lastUpdated: now, status: 'fresh' }
@@ -175,7 +180,7 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
     } finally {
       if (reqId === reqIdRef.current) setIsLoading(false)
     }
-  }, [isConnected, address, chainId, provider, tokens.stableAddress, tokens.stableDecimals])
+  }, [isConnected, address, chainId, provider, tokens.stableAddress, tokens.stableDecimals, ledgerRepository])
 
   // Reload on connect / account / network change.
   useEffect(() => {
@@ -225,6 +230,11 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
     return m
   }, [wagers])
 
+  // Wager money flows come from the ledger (single read path, FR-015); failed
+  // entries are excluded by the adapter so they never touch a total (FR-003).
+  const valuedTransfers = useMemo(() => wagerTransfersFromLedger(ledgerEntries), [ledgerEntries])
+  const tokenMetaByAddress = useMemo(() => tokenMetaFromLedger(ledgerEntries), [ledgerEntries])
+
   const summary = useMemo(
     () => computeSummary({ wagers, transfers: valuedTransfers, address, walletBalanceUsd, walletBalances }),
     [wagers, valuedTransfers, address, walletBalanceUsd, walletBalances],
@@ -245,23 +255,11 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
     [wagers, valuedTransfers, tokenMetaByAddress],
   )
 
-  const activity = useMemo(() => {
-    return [...valuedTransfers]
-      .sort((a, b) => b.timestamp - a.timestamp)
-      .slice(0, 25)
-      .map((t) => ({
-        id: `${t.txHash}-${t.wagerId}-${t.direction}`,
-        direction: t.direction,
-        amount: t.amount,
-        symbol: t.ticker,
-        usdValue: t.usdValue,
-        timestamp: t.timestamp,
-        txHash: t.txHash,
-        wagerId: t.wagerId,
-      }))
-  }, [valuedTransfers])
+  // The Account tab's canonical activity record: ALL classes, newest first,
+  // failed entries included and labeled (they are excluded from totals above).
+  const activity = useMemo(() => ledgerEntries.slice(0, 50), [ledgerEntries])
 
-  const isEmpty = isConnected && !isLoading && wagers.length === 0 && valuedTransfers.length === 0
+  const isEmpty = isConnected && !isLoading && wagers.length === 0 && ledgerEntries.length === 0
 
   return {
     summary,
@@ -269,6 +267,8 @@ export function useAccountStats({ range: initialRange = DEFAULT_RANGE } = {}) {
     setRange,
     breakdowns,
     activity,
+    staleClasses,
+    prunedBefore,
     isConnected: Boolean(isConnected),
     isSupportedNetwork,
     chainId,

--- a/frontend/src/hooks/useActivityLedger.js
+++ b/frontend/src/hooks/useActivityLedger.js
@@ -1,0 +1,81 @@
+/**
+ * useActivityLedger — reactive view of the unified activity ledger (spec 051)
+ * for the active (account, chainId). One query hook for every consumer
+ * (Account tab, Transfer activity tab, reports) so surfaces cannot diverge
+ * (FR-002/FR-014). Polling follows the dashboard's 60s model; client-record
+ * writes (transfers) also trigger an immediate refresh via the transferStore
+ * change event.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useWallet } from './useWalletManagement'
+import { getDefaultLedgerRepository } from '../data/ledger'
+import { subscribeTransfers } from '../lib/transfer/transferStore'
+
+const POLL_MS = 60_000
+
+export function useActivityLedger({ filter, period, pollMs = POLL_MS } = {}) {
+  const { address, chainId, isConnected, provider } = useWallet() || {}
+  const [state, setState] = useState({ entries: [], staleClasses: [], prunedBefore: null })
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const reqIdRef = useRef(0)
+
+  const repository = useMemo(() => getDefaultLedgerRepository(), [])
+
+  // Stable serialized deps so object literals don't re-trigger the effect.
+  const filterKey = JSON.stringify(filter ?? null)
+  const periodKey = JSON.stringify(period ?? null)
+
+  const load = useCallback(async () => {
+    if (!isConnected || !address || chainId == null) {
+      setState({ entries: [], staleClasses: [], prunedBefore: null })
+      setIsLoading(false)
+      return
+    }
+    const reqId = ++reqIdRef.current
+    setIsLoading(true)
+    setError(null)
+    try {
+      const result = await repository.listEntries({
+        account: address,
+        chainId,
+        provider,
+        filter: filterKey === 'null' ? undefined : JSON.parse(filterKey),
+        period: periodKey === 'null' ? undefined : JSON.parse(periodKey),
+      })
+      if (reqId !== reqIdRef.current) return
+      setState(result)
+    } catch (err) {
+      if (reqId !== reqIdRef.current) return
+      setError(err?.message || 'Failed to load activity')
+      // keep last-known entries — stale beats blank (constitution III)
+    } finally {
+      if (reqId === reqIdRef.current) setIsLoading(false)
+    }
+  }, [isConnected, address, chainId, provider, repository, filterKey, periodKey])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  useEffect(() => {
+    if (!isConnected || !address) return undefined
+    const id = setInterval(() => load(), pollMs)
+    const unsubscribe = subscribeTransfers(() => load())
+    return () => {
+      clearInterval(id)
+      unsubscribe()
+    }
+  }, [isConnected, address, load, pollMs])
+
+  return {
+    entries: state.entries,
+    staleClasses: state.staleClasses,
+    prunedBefore: state.prunedBefore,
+    isLoading,
+    error,
+    refresh: load,
+  }
+}
+
+export default useActivityLedger

--- a/frontend/src/hooks/useEarnRewards.js
+++ b/frontend/src/hooks/useEarnRewards.js
@@ -17,6 +17,7 @@ import { getBlockscoutUrl } from '../config/blockExplorer'
 import { fetchRewards, buildClaimArgs } from '../lib/earn/merkl'
 import { MERKL_DISTRIBUTOR_ABI } from '../abis/MerklDistributor'
 import { queueEarnAction } from '../lib/earn/earnActivityBuffer'
+import { captureEarnAction } from '../data/ledger'
 import { useActivityOptional } from './useActivity'
 
 export function useEarnRewards() {
@@ -84,6 +85,14 @@ export function useEarnRewards() {
         txHash: receipt.hash,
         txUrl,
         at: Date.now(),
+      })
+      // Durable audit entry in the unified activity ledger (spec 051).
+      captureEarnAction(address, chainId, {
+        type: 'earn-rewards-claimed',
+        txHash: receipt.hash,
+        at: Date.now(),
+        tokenAddress: args.tokens[0] ?? null,
+        description: `Claimed earn rewards: ${summary}`,
       })
       activity?.refresh?.()
       setClaimState({ status: 'confirmed', txUrl, error: null })

--- a/frontend/src/hooks/useEarnRewards.js
+++ b/frontend/src/hooks/useEarnRewards.js
@@ -115,7 +115,7 @@ export function useEarnRewards() {
       // Durable audit entry in the unified activity ledger (spec 051).
       captureEarnAction(address, chainId, {
         type: 'earn-rewards-claimed',
-        txHash: receipt.hash,
+        txHash,
         at: Date.now(),
         tokenAddress: args.tokens[0] ?? null,
         description: `Claimed earn rewards: ${summary}`,

--- a/frontend/src/hooks/useTaxReport.js
+++ b/frontend/src/hooks/useTaxReport.js
@@ -41,9 +41,11 @@ export function useTaxReport(options = {}) {
   // Spec 051: the report reads the SAME activity ledger the Account tab
   // renders, so line items and totals can never disagree (FR-014/FR-015).
   // Injectable for tests; `ledger: null` forces the legacy wager-only path.
+  const hasLedgerOption = 'ledger' in options
+  const ledgerOption = options.ledger
   const ledger = useMemo(
-    () => ('ledger' in options ? options.ledger : getDefaultLedgerRepository()),
-    [options.ledger],
+    () => (hasLedgerOption ? ledgerOption : getDefaultLedgerRepository()),
+    [hasLedgerOption, ledgerOption],
   )
   const networkOf = useMemo(() => options.getNetwork || getNetwork, [options.getNetwork])
   const escrowOf = useMemo(

--- a/frontend/src/hooks/useTaxReport.js
+++ b/frontend/src/hooks/useTaxReport.js
@@ -14,6 +14,7 @@ import { getContractAddressForChain } from '../config/contracts'
 import { resolvePeriod, resolveCustomPeriod, validateRange } from '../utils/reportPeriods'
 import { buildReport as defaultBuildReport } from '../data/reports/reportBuilder'
 import { createReportDataSource } from '../data/reports/reportDataSource'
+import { getDefaultLedgerRepository } from '../data/ledger'
 import * as pdfReport from '../data/reports/pdfReport'
 import * as csvReport from '../data/reports/csvReport'
 import * as historyStore from '../data/reports/reportHistoryStore'
@@ -37,6 +38,13 @@ export function useTaxReport(options = {}) {
   // useCallback hooks below keep stable identities across renders.
   const buildReportFn = useMemo(() => options.buildReport || defaultBuildReport, [options.buildReport])
   const makeDataSource = useMemo(() => options.createDataSource || createReportDataSource, [options.createDataSource])
+  // Spec 051: the report reads the SAME activity ledger the Account tab
+  // renders, so line items and totals can never disagree (FR-014/FR-015).
+  // Injectable for tests; `ledger: null` forces the legacy wager-only path.
+  const ledger = useMemo(
+    () => ('ledger' in options ? options.ledger : getDefaultLedgerRepository()),
+    [options.ledger],
+  )
   const networkOf = useMemo(() => options.getNetwork || getNetwork, [options.getNetwork])
   const escrowOf = useMemo(
     () =>
@@ -102,6 +110,7 @@ export function useTaxReport(options = {}) {
           period,
           dataSource: makeDataSource({ chainId }),
           networkMeta,
+          ledger,
           generatedAt: nowMs,
           onProgress: (fraction, label) => setProgress({ fraction, label }),
         })
@@ -122,7 +131,7 @@ export function useTaxReport(options = {}) {
         return null
       }
     },
-    [account, chainId, buildReportFn, makeDataSource, networkOf, escrowOf, history, refreshHistory, now],
+    [account, chainId, buildReportFn, makeDataSource, ledger, networkOf, escrowOf, history, refreshHistory, now],
   )
 
   const downloadPdf = useCallback(
@@ -166,6 +175,7 @@ export function useTaxReport(options = {}) {
         period,
         dataSource: makeDataSource({ chainId }),
         networkMeta,
+        ledger,
         generatedAt: now(),
       })
       if (format === 'csv') {
@@ -175,7 +185,7 @@ export function useTaxReport(options = {}) {
       }
       return built
     },
-    [account, chainId, buildReportFn, makeDataSource, networkOf, escrowOf, saveAs, now],
+    [account, chainId, buildReportFn, makeDataSource, ledger, networkOf, escrowOf, saveAs, now],
   )
 
   return {

--- a/frontend/src/hooks/useTransfer.js
+++ b/frontend/src/hooks/useTransfer.js
@@ -12,6 +12,33 @@ import {
   relayGaslessTransfer,
 } from '../lib/transfer/eip3009Transfer'
 import { recordTransfer, updateTransfer, TRANSFER_STATUS } from '../lib/transfer/transferStore'
+import { appendClientRecord } from '../data/ledger'
+import { transferRecordToEntry } from '../data/ledger/sources/transferLedgerSource'
+
+/**
+ * Mirror a transfer record (or a status transition) into the append-only
+ * client ledger (spec 051 FR-008/FR-010): the initial record keeps its
+ * `cl:<id>` identity; each transition appends a superseding record instead
+ * of mutating. Deterministic suffixes make re-mirroring a no-op. Best-effort:
+ * the ledger must never break a transfer.
+ */
+function mirrorToLedger(account, record, patch = null, suffix = null) {
+  try {
+    const entry = transferRecordToEntry({ ...record, ...(patch || {}) }, { account })
+    if (!suffix) {
+      appendClientRecord(account, entry)
+      return
+    }
+    appendClientRecord(account, {
+      ...entry,
+      entryId: `${entry.entryId}:${suffix}`,
+      recordedAt: Date.now(),
+      refs: { ...entry.refs, supersedes: entry.entryId },
+    })
+  } catch {
+    /* capture is best-effort */
+  }
+}
 
 /**
  * useTransfer — the send engine behind the Pay & Transfer wallet section.
@@ -171,6 +198,7 @@ export function useTransfer() {
         to,
         route: gasless ? 'gasless' : kind === TRANSFER_KIND.STABLE ? 'self' : 'direct',
       })
+      mirrorToLedger(address, entry)
 
       setError(null)
       setStatus('signing')
@@ -234,6 +262,7 @@ export function useTransfer() {
         }
 
         updateTransfer(address, entry.id, { status: TRANSFER_STATUS.COMPLETE, txHash, route })
+        mirrorToLedger(address, entry, { status: TRANSFER_STATUS.COMPLETE, txHash, route }, 'done')
         setStatus('success')
         const result = { txHash, route, id: entry.id }
         setLastResult(result)
@@ -242,6 +271,7 @@ export function useTransfer() {
       } catch (err) {
         const message = err?.shortMessage || err?.message || 'Transfer failed.'
         updateTransfer(address, entry.id, { status: TRANSFER_STATUS.FAILED, error: message })
+        mirrorToLedger(address, entry, { status: TRANSFER_STATUS.FAILED, error: message }, 'fail')
         setError(message)
         setStatus('error')
         throw err

--- a/frontend/src/lib/account/deriveTransfers.js
+++ b/frontend/src/lib/account/deriveTransfers.js
@@ -71,8 +71,10 @@ export function deriveTransfersFromWagers({ wagers = [], address } = {}) {
     // time for the opponent, so we attribute their deposit to createdAt too.
     // Settlement uses resolvedAt when present, else createdAt (refund/cancel/
     // decline events don't set resolvedAt in the index).
-    const createdAt = Number(w.createdAt) || 0
-    const settledAt = Number(w.resolvedAt) || createdAt
+    // A missing time is NULL, never 0 — epoch-0 rendered as "20645d ago"
+    // (spec 051 FR-006); consumers show an explicit "date unavailable" state.
+    const createdAt = Number(w.createdAt) > 0 ? Number(w.createdAt) : null
+    const settledAt = Number(w.resolvedAt) > 0 ? Number(w.resolvedAt) : createdAt
 
     const push = (direction, amount, timestamp) => {
       if (amount <= 0n) return

--- a/frontend/src/lib/account/format.js
+++ b/frontend/src/lib/account/format.js
@@ -39,9 +39,16 @@ export function formatPercent(rate) {
   return `${Math.round(Number(rate) * 100)}%`
 }
 
-/** Relative "Ns/Nm/Nh/Nd ago" from an epoch-ms timestamp. */
+/**
+ * Relative "Ns/Nm/Nh/Nd ago" from an epoch-ms timestamp — or `null` when no
+ * real timestamp exists. A missing/zero/negative input MUST NOT render as
+ * time-since-epoch (the "20645d ago" defect, spec 051 FR-006): callers render
+ * an explicit "date unavailable" state on `null`.
+ */
 export function formatRelativeTime(ts, now = Date.now()) {
-  const diff = Math.max(0, now - Number(ts || 0))
+  const t = Number(ts)
+  if (!Number.isFinite(t) || t <= 0) return null
+  const diff = Math.max(0, now - t)
   const s = Math.floor(diff / 1000)
   if (s < 60) return `${s}s ago`
   const m = Math.floor(s / 60)

--- a/frontend/src/lib/account/ledgerAdapters.js
+++ b/frontend/src/lib/account/ledgerAdapters.js
@@ -1,0 +1,43 @@
+/**
+ * Adapters between the unified activity ledger (spec 051) and the Account
+ * dashboard's pure helpers (spec 020).
+ *
+ * The dashboard's P&L/summary/breakdown math consumes the "valued transfer"
+ * shape ({ wagerId, direction: deposit|payout|refund, usdValue, … }). The
+ * ledger is now the single source of those rows (FR-015): this adapter maps
+ * wager-class ledger entries into that shape, EXCLUDING failed entries so
+ * they can never contribute to a total (FR-003) — they remain visible in the
+ * activity record itself.
+ */
+
+/** Ledger entries (class 'wager', not failed) → dashboard transfer rows. */
+export function wagerTransfersFromLedger(entries = []) {
+  const out = []
+  for (const e of entries) {
+    if (e.class !== 'wager') continue
+    if (e.status === 'failed') continue
+    out.push({
+      wagerId: String(e.refs?.wagerId ?? ''),
+      direction: e.kind, // deposit | payout | refund
+      tokenAddress: e.tokenAddress || '',
+      ticker: e.tokenSymbol || '',
+      decimals: e.tokenDecimals ?? null,
+      amount: e.amount ?? 0,
+      usdValue: e.valueUsd ?? 0, // unvalued entries contribute 0, flagged in UI
+      timestamp: e.timestamp, // may be null — series filters non-finite times
+      txHash: e.txHash || '',
+    })
+  }
+  return out
+}
+
+/** tokenMetaByAddress map (breakdowns) from ledger entries. */
+export function tokenMetaFromLedger(entries = []) {
+  const meta = {}
+  for (const e of entries) {
+    if (!e.tokenAddress) continue
+    const key = String(e.tokenAddress).toLowerCase()
+    if (!meta[key]) meta[key] = { ticker: e.tokenSymbol || '', decimals: e.tokenDecimals ?? 18, address: key }
+  }
+  return meta
+}

--- a/frontend/src/lib/backup/syncedObjects.js
+++ b/frontend/src/lib/backup/syncedObjects.js
@@ -9,6 +9,10 @@ import {
   saveVaultReferences,
   mergeVaultReferences,
 } from '../custody/vaultReferences'
+import {
+  listClientRecordsAllChains,
+  mergeClientRecordsAllChains,
+} from '../../data/ledger/ledgerClientStore'
 
 const PREF_KEYS = {
   recentSearches: 'recent_searches',
@@ -73,6 +77,28 @@ export const syncedObjects = [
       return { conflicts }
     },
     merge: (current, incoming) => mergeVaultReferences(current, incoming),
+  },
+  {
+    // Spec 051 — client-only activity ledger records (failed gasless ops,
+    // transfer history, earn action captures): the part of the audit trail
+    // that cannot be re-derived from public chain data (FR-010). On-chain
+    // entries are deliberately NOT in the bundle — they re-derive (FR-009).
+    key: 'activityLedger',
+    label: 'Activity history',
+    networkScoped: true, // every record carries chainId
+    load: (account) => listClientRecordsAllChains(account),
+    // Records are append-only value objects, so BOTH modes union by entryId:
+    // a "replace" that deleted history would violate the append-only audit
+    // guarantee (FR-008). Identical ids are identical records — conflict-free.
+    apply: (account, value, _mode) => {
+      mergeClientRecordsAllChains(account, value)
+      return { conflicts: [] }
+    },
+    merge: (current, incoming) => {
+      const have = new Set((current || []).map((r) => r.entryId))
+      const fresh = (incoming || []).filter((r) => r?.entryId && !have.has(r.entryId))
+      return { value: [...(current || []), ...fresh], conflicts: [] }
+    },
   },
 ]
 

--- a/frontend/src/test/account/AccountDashboard.axe.test.jsx
+++ b/frontend/src/test/account/AccountDashboard.axe.test.jsx
@@ -28,8 +28,15 @@ const stats = {
     byOracle: [{ resolutionType: 1, label: 'Polymarket', count: 10 }],
   },
   activity: [
-    { id: 'a', direction: 'payout', amount: 190, symbol: 'USDC', usdValue: 190, timestamp: 2_000_000, txHash: '0xabc', wagerId: '1' },
+    {
+      entryId: 'oc:80002:wt:0xabc-1-payout', chainId: 80002, class: 'wager', kind: 'payout',
+      direction: 'in', status: 'settled', tokenSymbol: 'USDC', amount: 190, valueUsd: 190,
+      valuationStatus: 'valued', timestamp: Date.now() - 60_000, timestampProvenance: 'chain',
+      txHash: '0x' + 'ab'.repeat(32), refs: { wagerId: '1' },
+    },
   ],
+  staleClasses: [],
+  prunedBefore: null,
   isConnected: true, isSupportedNetwork: true, chainId: 80002,
   isLoading: false, isEmpty: false, error: null,
   freshness: { summary: { lastUpdated: Date.now(), status: 'fresh' } },

--- a/frontend/src/test/account/RecentActivityFeed.test.jsx
+++ b/frontend/src/test/account/RecentActivityFeed.test.jsx
@@ -1,35 +1,129 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import RecentActivityFeed from '../../components/account/RecentActivityFeed'
 
-const activity = [
-  { id: 'a', direction: 'payout', amount: 190, symbol: 'USDC', usdValue: 190, timestamp: 2_000_000, txHash: '0xabc', wagerId: '1' },
-  { id: 'b', direction: 'deposit', amount: 100, symbol: 'USDC', usdValue: 100, timestamp: 1_000_000, txHash: '0xdef', wagerId: '1' },
+const TX_A = '0x' + 'aa'.repeat(32)
+const TX_B = '0x' + 'bb'.repeat(32)
+const NOW = Date.now()
+
+const entries = [
+  {
+    entryId: `oc:80002:wt:${TX_A}-1-payout`,
+    chainId: 80002,
+    class: 'wager',
+    kind: 'payout',
+    direction: 'in',
+    status: 'settled',
+    tokenSymbol: 'USDC',
+    amount: 190,
+    valueUsd: 190,
+    valuationStatus: 'valued',
+    timestamp: NOW - 60_000,
+    timestampProvenance: 'chain',
+    txHash: TX_A,
+    refs: { wagerId: '1' },
+  },
+  {
+    entryId: `oc:80002:wt:${TX_B}-1-deposit`,
+    chainId: 80002,
+    class: 'wager',
+    kind: 'deposit',
+    direction: 'out',
+    status: 'settled',
+    tokenSymbol: 'USDC',
+    amount: 100,
+    valueUsd: 100,
+    valuationStatus: 'valued',
+    timestamp: NOW - 120_000,
+    timestampProvenance: 'chain',
+    txHash: TX_B,
+    refs: { wagerId: '1' },
+  },
+  {
+    entryId: 'cl:t-9',
+    chainId: 80002,
+    class: 'transfer',
+    kind: 'send',
+    direction: 'none',
+    status: 'failed',
+    failureReason: 'Smart Account does not have sufficient funds to execute the User Operation.',
+    tokenSymbol: 'USDC',
+    amount: 1,
+    valueUsd: null,
+    valuationStatus: 'unvalued',
+    timestamp: null,
+    timestampProvenance: 'unavailable',
+    txHash: null,
+    refs: { route: 'gasless' },
+  },
 ]
 
-describe('RecentActivityFeed (spec 020 US4)', () => {
-  it('lists entries with direction, amount and token', () => {
-    render(<RecentActivityFeed activity={activity} chainId={80002} />)
+describe('RecentActivityFeed (spec 051 US1)', () => {
+  it('lists entries of every class with kind label, amount and token', () => {
+    render(<RecentActivityFeed entries={entries} chainId={80002} />)
     expect(screen.getByText('Payout')).toBeInTheDocument()
     expect(screen.getByText('Deposit')).toBeInTheDocument()
-    expect(screen.getAllByText('USDC').length).toBe(2)
+    expect(screen.getByText('Transfer')).toBeInTheDocument()
+    expect(screen.getAllByText('USDC').length).toBeGreaterThanOrEqual(2)
   })
 
-  it('builds an explorer transaction link for the active network', () => {
-    render(<RecentActivityFeed activity={activity} chainId={80002} />)
+  it('builds an explorer link only for entries with a real transaction hash', () => {
+    render(<RecentActivityFeed entries={entries} chainId={80002} />)
     const links = screen.getAllByRole('link', { name: /view tx/i })
-    expect(links[0]).toHaveAttribute('href', expect.stringContaining('/tx/0xabc'))
+    expect(links).toHaveLength(2) // the failed client entry has no tx to link
+    expect(links[0]).toHaveAttribute('href', expect.stringContaining(`/tx/${TX_A}`))
     expect(links[0]).toHaveAttribute('href', expect.stringContaining('amoy.polygonscan.com'))
   })
 
+  it('marks failed entries with a Failed badge and the verbatim reason (FR-003)', () => {
+    render(<RecentActivityFeed entries={entries} chainId={80002} />)
+    expect(screen.getByText('Failed')).toBeInTheDocument()
+    expect(screen.getByText(/sufficient funds/)).toBeInTheDocument()
+  })
+
+  it('renders an explicit "date unavailable" state instead of a fabricated relative time (FR-006)', () => {
+    render(<RecentActivityFeed entries={entries} chainId={80002} />)
+    expect(screen.getByText(/date unavailable/i)).toBeInTheDocument()
+    expect(screen.queryByText(/20645d/)).not.toBeInTheDocument()
+  })
+
+  it('flags unvalued entries instead of showing $0 (FR-016)', () => {
+    render(<RecentActivityFeed entries={entries} chainId={80002} />)
+    expect(screen.getByText(/unvalued/i)).toBeInTheDocument()
+  })
+
+  it('filters by activity class', async () => {
+    const user = userEvent.setup()
+    render(<RecentActivityFeed entries={entries} chainId={80002} />)
+    await user.click(screen.getByRole('button', { name: 'Transfers' }))
+    expect(screen.queryByText('Payout')).not.toBeInTheDocument()
+    expect(screen.getByText('Transfer')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'All activity' }))
+    expect(screen.getByText('Payout')).toBeInTheDocument()
+  })
+
   it('shows an empty state when there is no activity', () => {
-    render(<RecentActivityFeed activity={[]} chainId={80002} />)
+    render(<RecentActivityFeed entries={[]} chainId={80002} />)
     expect(screen.getByText(/no recent activity/i)).toBeInTheDocument()
   })
 
-  it('renders newest entry first', () => {
-    render(<RecentActivityFeed activity={activity} chainId={80002} />)
+  it('renders entries in the order given (repository sorts newest first)', () => {
+    render(<RecentActivityFeed entries={entries} chainId={80002} />)
     const rows = screen.getAllByRole('listitem')
     expect(within(rows[0]).getByText('Payout')).toBeInTheDocument()
+  })
+
+  it('discloses stale classes and the pruning marker', () => {
+    render(
+      <RecentActivityFeed
+        entries={entries}
+        chainId={80002}
+        staleClasses={['earn']}
+        prunedBefore={Date.UTC(2024, 0, 1)}
+      />,
+    )
+    expect(screen.getByText(/could not be refreshed/i)).toBeInTheDocument()
+    expect(screen.getByText(/pruned from device history/i)).toBeInTheDocument()
   })
 })

--- a/frontend/src/test/account/format.test.js
+++ b/frontend/src/test/account/format.test.js
@@ -1,0 +1,32 @@
+/**
+ * Spec 051 T034 — formatRelativeTime null-guard (US4, FR-006): a missing,
+ * zero, or invalid timestamp must never render as time-since-epoch
+ * ("20645d ago"); callers show an explicit "date unavailable" state on null.
+ */
+import { describe, it, expect } from 'vitest'
+import { formatRelativeTime } from '../../lib/account/format'
+
+const NOW = Date.UTC(2026, 6, 11)
+
+describe('formatRelativeTime (FR-006)', () => {
+  it('returns null for zero / negative / null / undefined / NaN input', () => {
+    for (const bad of [0, -1, null, undefined, NaN, '0', 'not-a-time']) {
+      expect(formatRelativeTime(bad, NOW)).toBe(null)
+    }
+  })
+
+  it('never emits an epoch-era relative time (the "20645d ago" defect class)', () => {
+    expect(String(formatRelativeTime(0, NOW) ?? '')).not.toMatch(/\d{4,}d ago/)
+  })
+
+  it('formats real timestamps across all units', () => {
+    expect(formatRelativeTime(NOW - 5_000, NOW)).toBe('5s ago')
+    expect(formatRelativeTime(NOW - 5 * 60_000, NOW)).toBe('5m ago')
+    expect(formatRelativeTime(NOW - 5 * 3_600_000, NOW)).toBe('5h ago')
+    expect(formatRelativeTime(NOW - 5 * 86_400_000, NOW)).toBe('5d ago')
+  })
+
+  it('clamps future timestamps to "0s ago" rather than negative time', () => {
+    expect(formatRelativeTime(NOW + 60_000, NOW)).toBe('0s ago')
+  })
+})

--- a/frontend/src/test/ledger/activityLedgerBackup.test.js
+++ b/frontend/src/test/ledger/activityLedgerBackup.test.js
@@ -1,0 +1,93 @@
+/**
+ * Spec 051 T031 — the `activityLedger` spec-032 synced object: backup
+ * round-trip, union-by-entryId merge in every mode, restore dedup (FR-010/011).
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import syncedObjects from '../../lib/backup/syncedObjects'
+import {
+  appendClientRecord,
+  listClientRecords,
+  __clearClientLedger,
+} from '../../data/ledger/ledgerClientStore'
+
+const ACCOUNT = '0xAbc0000000000000000000000000000000000031'
+
+const failedGasless = {
+  entryId: 'cl:t-fail',
+  chainId: 137,
+  class: 'transfer',
+  kind: 'send',
+  direction: 'none',
+  status: 'failed',
+  failureReason: 'Smart Account does not have sufficient funds to execute the User Operation.',
+  provenance: 'client',
+  txHash: null,
+  timestamp: 1_760_000_000_000,
+  timestampProvenance: 'device',
+  recordedAt: 1_760_000_000_000,
+  refs: { route: 'gasless', transferId: 't-fail' },
+}
+
+const mordorRecord = {
+  ...failedGasless,
+  entryId: 'cl:t-mordor',
+  chainId: 63,
+  refs: { route: 'direct', transferId: 't-mordor' },
+}
+
+const ledgerObject = syncedObjects.find((o) => o.key === 'activityLedger')
+
+beforeEach(() => {
+  __clearClientLedger()
+  localStorage.clear()
+})
+
+describe('activityLedger synced object (spec 032 registry)', () => {
+  it('is registered and network-scoped', () => {
+    expect(ledgerObject).toBeTruthy()
+    expect(ledgerObject.networkScoped).toBe(true)
+  })
+
+  it('load returns all client records across chains (the backup payload)', () => {
+    appendClientRecord(ACCOUNT, failedGasless)
+    appendClientRecord(ACCOUNT, mordorRecord)
+    const payload = ledgerObject.load(ACCOUNT)
+    expect(payload).toHaveLength(2)
+    expect(new Set(payload.map((r) => r.chainId))).toEqual(new Set([137, 63]))
+  })
+
+  it('survives a full wipe + restore round-trip, including the failed gasless entry (SC-003)', () => {
+    appendClientRecord(ACCOUNT, failedGasless)
+    const backup = ledgerObject.load(ACCOUNT)
+
+    __clearClientLedger() // the "new device"
+    expect(listClientRecords(ACCOUNT, 137)).toHaveLength(0)
+
+    ledgerObject.apply(ACCOUNT, backup, 'merge')
+    const restored = listClientRecords(ACCOUNT, 137)
+    expect(restored).toHaveLength(1)
+    expect(restored[0].failureReason).toMatch(/sufficient funds/)
+  })
+
+  it('restore is a union — repeating it or overlapping live data never duplicates (FR-011)', () => {
+    appendClientRecord(ACCOUNT, failedGasless)
+    const backup = ledgerObject.load(ACCOUNT)
+    ledgerObject.apply(ACCOUNT, backup, 'merge')
+    ledgerObject.apply(ACCOUNT, backup, 'merge')
+    expect(listClientRecords(ACCOUNT, 137)).toHaveLength(1)
+  })
+
+  it('replace mode also unions — restoring must never delete audit history (FR-008)', () => {
+    appendClientRecord(ACCOUNT, failedGasless)
+    appendClientRecord(ACCOUNT, { ...failedGasless, entryId: 'cl:t-local-only' })
+    // A backup made before the second record existed:
+    ledgerObject.apply(ACCOUNT, [failedGasless], 'replace')
+    expect(listClientRecords(ACCOUNT, 137)).toHaveLength(2)
+  })
+
+  it('merge helper unions by entryId with no conflicts', () => {
+    const { value, conflicts } = ledgerObject.merge([failedGasless], [failedGasless, mordorRecord])
+    expect(value).toHaveLength(2)
+    expect(conflicts).toEqual([])
+  })
+})

--- a/frontend/src/test/ledger/identity.test.js
+++ b/frontend/src/test/ledger/identity.test.js
@@ -1,0 +1,129 @@
+/**
+ * Spec 051 T003 — entryId builders + merge precedence
+ * (specs/051-unified-activity-ledger/data-model.md "Identity").
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  onchainEntryId,
+  subgraphEntryId,
+  derivedWagerEntryId,
+  clientEntryId,
+  namespaceOf,
+  wagerDedupKey,
+  mergeEntries,
+} from '../../data/ledger/identity'
+
+const TX = '0x' + 'ab'.repeat(32)
+
+function entry(overrides = {}) {
+  return {
+    entryId: 'oc:137:' + TX + ':0',
+    chainId: 137,
+    account: '0xuser',
+    class: 'wager',
+    kind: 'deposit',
+    provenance: 'onchain',
+    txHash: TX,
+    refs: {},
+    ...overrides,
+  }
+}
+
+describe('entryId builders', () => {
+  it('builds namespaced ids deterministically', () => {
+    expect(onchainEntryId({ chainId: 137, txHash: TX, logIndex: 3 })).toBe(`oc:137:${TX}:3`)
+    expect(subgraphEntryId({ chainId: 137, entityId: `${TX}-1` })).toBe(`oc:137:wt:${TX}-1`)
+    expect(
+      derivedWagerEntryId({ chainId: 63, wagerId: '7', kind: 'refund', party: '0xABC' }),
+    ).toBe('dv:63:wager:7:refund:0xabc')
+    expect(clientEntryId('u-u-i-d')).toBe('cl:u-u-i-d')
+  })
+
+  it('is idempotent across re-derivation (same inputs → same id)', () => {
+    const a = derivedWagerEntryId({ chainId: 63, wagerId: 7, kind: 'deposit', party: '0xAbC' })
+    const b = derivedWagerEntryId({ chainId: 63, wagerId: '7', kind: 'deposit', party: '0xabc' })
+    expect(a).toBe(b)
+  })
+
+  it('exposes the namespace of an id', () => {
+    expect(namespaceOf('oc:1:x:0')).toBe('oc')
+    expect(namespaceOf('dv:1:wager:1:deposit:0xa')).toBe('dv')
+    expect(namespaceOf('cl:uuid')).toBe('cl')
+    expect(namespaceOf('garbage')).toBe(null)
+  })
+})
+
+describe('mergeEntries', () => {
+  it('unions by entryId — identical ids collapse to one record', () => {
+    const a = entry()
+    const merged = mergeEntries([a, { ...a }])
+    expect(merged).toHaveLength(1)
+  })
+
+  it('drops a derived entry when an on-chain entry covers the same underlying event', () => {
+    const key = wagerDedupKey({ wagerId: '7', kind: 'deposit' })
+    const oc = entry({ refs: { wagerId: '7', dedupKey: key } })
+    const dv = entry({
+      entryId: 'dv:137:wager:7:deposit:0xuser',
+      provenance: 'derived',
+      txHash: null,
+      refs: { wagerId: '7', dedupKey: key },
+    })
+    const merged = mergeEntries([dv, oc])
+    expect(merged).toHaveLength(1)
+    expect(merged[0].provenance).toBe('onchain')
+  })
+
+  it('keeps derived entries whose underlying event has no on-chain record', () => {
+    const dv = entry({
+      entryId: 'dv:137:wager:9:refund:0xuser',
+      provenance: 'derived',
+      txHash: null,
+      refs: { wagerId: '9', dedupKey: wagerDedupKey({ wagerId: '9', kind: 'refund' }) },
+    })
+    expect(mergeEntries([dv])).toHaveLength(1)
+  })
+
+  it('links a client record to its on-chain entry by txHash instead of duplicating', () => {
+    const oc = entry({ class: 'transfer', kind: 'send' })
+    const cl = entry({
+      entryId: 'cl:uuid-1',
+      class: 'transfer',
+      kind: 'send',
+      provenance: 'client',
+      txHash: TX,
+      refs: { route: 'gasless' },
+    })
+    const merged = mergeEntries([cl, oc])
+    expect(merged).toHaveLength(1)
+    expect(merged[0].entryId).toBe(oc.entryId)
+    expect(merged[0].refs.linkedClientEntryId).toBe('cl:uuid-1')
+    expect(merged[0].refs.route).toBe('gasless')
+  })
+
+  it('keeps client records with no matching on-chain entry (e.g. failed gasless ops)', () => {
+    const cl = entry({
+      entryId: 'cl:uuid-2',
+      class: 'transfer',
+      provenance: 'client',
+      status: 'failed',
+      txHash: null,
+    })
+    expect(mergeEntries([cl])).toHaveLength(1)
+  })
+
+  it('never mutates its inputs', () => {
+    const oc = entry({ class: 'transfer' })
+    const frozenRefs = Object.freeze({ route: 'gasless' })
+    const cl = entry({
+      entryId: 'cl:uuid-3',
+      class: 'transfer',
+      provenance: 'client',
+      txHash: TX,
+      refs: frozenRefs,
+    })
+    const snapshot = JSON.stringify([oc, cl])
+    mergeEntries([oc, cl])
+    expect(JSON.stringify([oc, cl])).toBe(snapshot)
+  })
+})

--- a/frontend/src/test/ledger/ledgerClientStore.test.js
+++ b/frontend/src/test/ledger/ledgerClientStore.test.js
@@ -1,0 +1,121 @@
+/**
+ * Spec 051 T026 — append-only client-record store (data-model.md
+ * "ClientLedgerRecord"): supersede resolution, chainId scoping, FR-013
+ * pruning guard, storage failure isolation.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  appendClientRecord,
+  listClientRecords,
+  listAllClientRecords,
+  getPrunedBefore,
+  pruneClientRecords,
+  __clearClientLedger,
+} from '../../data/ledger/ledgerClientStore'
+
+const ACCOUNT = '0xAbCd000000000000000000000000000000000001'
+
+function record(overrides = {}) {
+  return {
+    entryId: 'cl:r1',
+    chainId: 137,
+    class: 'transfer',
+    kind: 'send',
+    direction: 'out',
+    status: 'pending',
+    provenance: 'client',
+    amountRaw: '1000000',
+    tokenAddress: '0xtoken',
+    timestamp: 1_700_000_000_000,
+    timestampProvenance: 'device',
+    recordedAt: 1_700_000_000_000,
+    refs: {},
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  __clearClientLedger()
+})
+
+describe('ledgerClientStore', () => {
+  it('appends and lists records scoped by account and chainId', () => {
+    appendClientRecord(ACCOUNT, record())
+    appendClientRecord(ACCOUNT, record({ entryId: 'cl:r2', chainId: 63 }))
+    expect(listClientRecords(ACCOUNT, 137)).toHaveLength(1)
+    expect(listClientRecords(ACCOUNT, 63)).toHaveLength(1)
+    expect(listClientRecords('0xother', 137)).toHaveLength(0)
+  })
+
+  it('is append-only: re-appending an existing entryId is a no-op (original preserved)', () => {
+    appendClientRecord(ACCOUNT, record({ status: 'pending' }))
+    appendClientRecord(ACCOUNT, record({ status: 'failed' })) // same entryId — ignored
+    const rows = listClientRecords(ACCOUNT, 137)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].status).toBe('pending')
+  })
+
+  it('resolves supersede chains to the latest record while keeping the full chain readable', () => {
+    appendClientRecord(ACCOUNT, record({ status: 'pending' }))
+    appendClientRecord(
+      ACCOUNT,
+      record({
+        entryId: 'cl:r1:u1',
+        status: 'failed',
+        failureReason: 'insufficient funds',
+        recordedAt: 1_700_000_001_000,
+        refs: { supersedes: 'cl:r1' },
+      }),
+    )
+    const resolved = listClientRecords(ACCOUNT, 137)
+    expect(resolved).toHaveLength(1)
+    expect(resolved[0].status).toBe('failed')
+    expect(resolved[0].refs.supersedes).toBe('cl:r1')
+    // Audit trail: raw history keeps both records.
+    expect(listAllClientRecords(ACCOUNT, 137)).toHaveLength(2)
+  })
+
+  it('never throws into the caller when storage is unavailable', () => {
+    const original = Storage.prototype.setItem
+    Storage.prototype.setItem = () => {
+      throw new Error('quota exceeded')
+    }
+    try {
+      expect(() => appendClientRecord(ACCOUNT, record())).not.toThrow()
+    } finally {
+      Storage.prototype.setItem = original
+    }
+  })
+
+  describe('pruning (FR-013)', () => {
+    it('has no cap and no pruning by default', () => {
+      for (let i = 0; i < 150; i++) {
+        appendClientRecord(ACCOUNT, record({ entryId: `cl:bulk-${i}` }))
+      }
+      expect(listClientRecords(ACCOUNT, 137)).toHaveLength(150)
+      expect(getPrunedBefore(ACCOUNT, 137)).toBe(null)
+    })
+
+    it('refuses to prune into the current or previous tax year', () => {
+      const now = Date.UTC(2026, 6, 11) // 2026-07-11
+      const janPrevYear = Date.UTC(2025, 0, 1)
+      appendClientRecord(ACCOUNT, record())
+      const result = pruneClientRecords(ACCOUNT, 137, { cutoffMs: janPrevYear + 1, nowMs: now })
+      expect(result.pruned).toBe(0)
+      expect(getPrunedBefore(ACCOUNT, 137)).toBe(null)
+    })
+
+    it('prunes older-than-cutoff records and records the disclosed marker', () => {
+      const now = Date.UTC(2026, 6, 11)
+      const old = Date.UTC(2023, 3, 1)
+      const recent = Date.UTC(2026, 5, 1)
+      appendClientRecord(ACCOUNT, record({ entryId: 'cl:old', timestamp: old, recordedAt: old }))
+      appendClientRecord(ACCOUNT, record({ entryId: 'cl:new', timestamp: recent, recordedAt: recent }))
+      const cutoff = Date.UTC(2024, 0, 1) // before Jan 1 of previous tax year (2025)
+      const result = pruneClientRecords(ACCOUNT, 137, { cutoffMs: cutoff, nowMs: now })
+      expect(result.pruned).toBe(1)
+      expect(listClientRecords(ACCOUNT, 137).map((r) => r.entryId)).toEqual(['cl:new'])
+      expect(getPrunedBefore(ACCOUNT, 137)).toBe(cutoff)
+    })
+  })
+})

--- a/frontend/src/test/ledger/ledgerConsistency.test.js
+++ b/frontend/src/test/ledger/ledgerConsistency.test.js
@@ -1,0 +1,76 @@
+/**
+ * Spec 051 T039 — FR-002 cross-surface consistency: no activity surface may
+ * show a financial event that is absent from the ledger.
+ *
+ * Automated slice: every transfer the device log (Pay & Transfer Activity's
+ * old backing store) knows about resolves to a ledger entry with the same
+ * identity, status, and failure reason; every earn action captured beside the
+ * notification buffer resolves to a ledger entry carrying the same txHash.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { recordTransfer, updateTransfer, listTransfers, __clearTransfers, TRANSFER_STATUS } from '../../lib/transfer/transferStore'
+import { queueEarnAction, peekEarnActions } from '../../lib/earn/earnActivityBuffer'
+import { captureEarnAction } from '../../data/ledger/sources/earnLedgerSource'
+import { createTransferLedgerSource } from '../../data/ledger/sources/transferLedgerSource'
+import { createEarnLedgerSource } from '../../data/ledger/sources/earnLedgerSource'
+import { __clearClientLedger } from '../../data/ledger/ledgerClientStore'
+
+const ACCOUNT = '0xAbc0000000000000000000000000000000000039'
+const TX = '0x' + '39'.repeat(32)
+
+beforeEach(() => {
+  __clearTransfers()
+  __clearClientLedger()
+  localStorage.clear()
+})
+
+describe('cross-surface consistency (FR-002)', () => {
+  it('every device-log transfer resolves to a ledger entry (incl. failures, verbatim reason)', async () => {
+    const ok = recordTransfer(ACCOUNT, { chainId: 137, kind: 'stable', symbol: 'USC', decimals: 6, amount: '5', from: ACCOUNT, to: '0xd', route: 'gasless' })
+    updateTransfer(ACCOUNT, ok.id, { status: TRANSFER_STATUS.COMPLETE, txHash: TX })
+    const bad = recordTransfer(ACCOUNT, { chainId: 137, kind: 'native', symbol: 'MATIC', decimals: 18, amount: '0.01', from: ACCOUNT, to: '0xd', route: 'gasless' })
+    updateTransfer(ACCOUNT, bad.id, { status: TRANSFER_STATUS.FAILED, error: 'Smart Account does not have sufficient funds to execute the User Operation.' })
+
+    const source = createTransferLedgerSource()
+    const entries = await source.list({ account: ACCOUNT, chainId: 137 })
+    const byTransferId = new Map(entries.map((e) => [e.refs?.transferId, e]))
+
+    for (const record of listTransfers(ACCOUNT, 137)) {
+      const entry = byTransferId.get(record.id)
+      expect(entry, `transfer ${record.id} missing from ledger`).toBeTruthy()
+      if (record.status === TRANSFER_STATUS.FAILED) {
+        expect(entry.status).toBe('failed')
+        expect(entry.failureReason).toBe(record.error)
+      }
+    }
+  })
+
+  it('every earn action queued for the notification feed has a ledger entry with the same txHash', async () => {
+    const action = {
+      type: 'earn-deposit',
+      refId: '0xvault',
+      message: 'Deposited 5 USDC into Vault',
+      txHash: TX,
+      txUrl: null,
+      at: Date.now(),
+    }
+    queueEarnAction(ACCOUNT, 137, action)
+    captureEarnAction(ACCOUNT, 137, {
+      type: action.type,
+      txHash: action.txHash,
+      at: action.at,
+      vaultAddress: action.refId,
+      amountRaw: '5000000',
+      tokenSymbol: 'USDC',
+      tokenDecimals: 6,
+    })
+
+    const ledgerEntries = await createEarnLedgerSource().list({ account: ACCOUNT, chainId: 137 })
+    for (const queued of peekEarnActions(ACCOUNT, 137)) {
+      expect(
+        ledgerEntries.some((e) => e.txHash === queued.txHash),
+        `earn action ${queued.txHash} missing from ledger`,
+      ).toBe(true)
+    }
+  })
+})

--- a/frontend/src/test/ledger/ledgerRepository.test.js
+++ b/frontend/src/test/ledger/ledgerRepository.test.js
@@ -1,0 +1,161 @@
+/**
+ * Spec 051 T007 — repository assembly: aggregation, dedup, per-source
+ * degradation, filters, sorting (contracts/ledger-source.md).
+ */
+import { describe, it, expect } from 'vitest'
+import { createLedgerRepository } from '../../data/ledger/ledgerRepository'
+
+const TX = (n) => '0x' + String(n).padStart(2, '0').repeat(32)
+const CTX = { account: '0xUser', chainId: 137 }
+
+function preItem(overrides = {}) {
+  const tx = overrides.txHash ?? TX(1)
+  return {
+    entryId: `oc:137:${tx}:0`,
+    chainId: 137,
+    class: 'wager',
+    kind: 'deposit',
+    direction: 'out',
+    status: 'settled',
+    provenance: 'onchain',
+    txHash: tx,
+    amountRaw: '1000000',
+    tokenAddress: '0xtoken',
+    timestamp: 1_700_000_000_000,
+    timestampProvenance: 'chain',
+    ...overrides,
+  }
+}
+
+function source(cls, items) {
+  return { class: cls, list: async () => items }
+}
+
+// Identity enrichment: mark everything valued so tests are deterministic.
+const passThroughEnrich = async (entries) =>
+  entries.map((e) => ({ ...e, amount: 1, tokenSymbol: 'USC', tokenDecimals: 6, valueUsd: 1, valuationStatus: 'valued' }))
+
+describe('ledgerRepository.listEntries', () => {
+  it('aggregates entries from all sources, sorted newest first', async () => {
+    const repo = createLedgerRepository({
+      sources: [
+        source('wager', [preItem({ timestamp: 3000 })]),
+        source('transfer', [
+          preItem({ entryId: `oc:137:${TX(2)}:0`, txHash: TX(2), class: 'transfer', kind: 'send', timestamp: 5000 }),
+        ]),
+      ],
+      enrich: passThroughEnrich,
+    })
+    const { entries, staleClasses } = await repo.listEntries(CTX)
+    expect(entries.map((e) => e.class)).toEqual(['transfer', 'wager'])
+    expect(staleClasses).toEqual([])
+  })
+
+  it('degrades per source: a failing source is reported stale, others still return', async () => {
+    const repo = createLedgerRepository({
+      sources: [
+        { class: 'earn', list: async () => { throw new Error('subgraph down') } },
+        source('wager', [preItem()]),
+      ],
+      enrich: passThroughEnrich,
+    })
+    const { entries, staleClasses } = await repo.listEntries(CTX)
+    expect(entries).toHaveLength(1)
+    expect(staleClasses).toEqual(['earn'])
+  })
+
+  it('dedups the same underlying event across sources (oc beats dv)', async () => {
+    const dedupKey = 'wager:7:deposit'
+    const repo = createLedgerRepository({
+      sources: [
+        source('wager', [preItem({ refs: { wagerId: '7', dedupKey } })]),
+        source('wager', [
+          preItem({
+            entryId: 'dv:137:wager:7:deposit:0xuser',
+            provenance: 'derived',
+            txHash: null,
+            timestamp: null,
+            refs: { wagerId: '7', dedupKey },
+          }),
+        ]),
+      ],
+      enrich: passThroughEnrich,
+    })
+    const { entries } = await repo.listEntries(CTX)
+    expect(entries).toHaveLength(1)
+    expect(entries[0].provenance).toBe('onchain')
+  })
+
+  it('sorts null-timestamp entries after dated ones', async () => {
+    const repo = createLedgerRepository({
+      sources: [
+        source('wager', [
+          preItem({ entryId: 'dv:137:wager:1:deposit:0xuser', provenance: 'derived', txHash: null, timestamp: null }),
+          preItem({ entryId: `oc:137:${TX(3)}:0`, txHash: TX(3), timestamp: 1000 }),
+        ]),
+      ],
+      enrich: passThroughEnrich,
+    })
+    const { entries } = await repo.listEntries(CTX)
+    expect(entries[0].timestamp).toBe(1000)
+    expect(entries[1].timestamp).toBe(null)
+  })
+
+  it('filters by class, status, and period; failed entries are included by default', async () => {
+    const repo = createLedgerRepository({
+      sources: [
+        source('transfer', [
+          preItem({ entryId: `oc:137:${TX(4)}:0`, txHash: TX(4), class: 'transfer', kind: 'send', timestamp: 2000 }),
+          preItem({
+            entryId: 'cl:fail-1',
+            provenance: 'client',
+            class: 'transfer',
+            kind: 'send',
+            status: 'failed',
+            failureReason: 'insufficient funds',
+            txHash: null,
+            timestamp: 4000,
+            timestampProvenance: 'device',
+          }),
+        ]),
+        source('wager', [preItem({ timestamp: 3000 })]),
+      ],
+      enrich: passThroughEnrich,
+    })
+
+    const all = await repo.listEntries(CTX)
+    expect(all.entries).toHaveLength(3)
+
+    const transfersOnly = await repo.listEntries({ ...CTX, filter: { classes: ['transfer'] } })
+    expect(transfersOnly.entries.every((e) => e.class === 'transfer')).toBe(true)
+    expect(transfersOnly.entries).toHaveLength(2)
+
+    const failedOnly = await repo.listEntries({ ...CTX, filter: { statuses: ['failed'] } })
+    expect(failedOnly.entries).toHaveLength(1)
+    expect(failedOnly.entries[0].failureReason).toBe('insufficient funds')
+
+    const period = await repo.listEntries({ ...CTX, period: { fromMs: 2500, toMs: 3500 } })
+    expect(period.entries).toHaveLength(1)
+    expect(period.entries[0].timestamp).toBe(3000)
+  })
+
+  it('marks a source stale when it returns entries violating invariants (e.g. leaked chainId)', async () => {
+    const repo = createLedgerRepository({
+      sources: [source('pool', [preItem({ chainId: 1 })]), source('wager', [preItem()])],
+      enrich: passThroughEnrich,
+    })
+    const { entries, staleClasses } = await repo.listEntries(CTX)
+    expect(entries).toHaveLength(1)
+    expect(staleClasses).toEqual(['pool'])
+  })
+
+  it('exposes prunedBefore from the injected disclosure provider', async () => {
+    const repo = createLedgerRepository({
+      sources: [source('wager', [preItem()])],
+      enrich: passThroughEnrich,
+      getPrunedBefore: () => 12345,
+    })
+    const { prunedBefore } = await repo.listEntries(CTX)
+    expect(prunedBefore).toBe(12345)
+  })
+})

--- a/frontend/src/test/ledger/migrate.test.js
+++ b/frontend/src/test/ledger/migrate.test.js
@@ -1,0 +1,99 @@
+/**
+ * Spec 051 T029 — one-time idempotent migration of the legacy
+ * `fairwins.transfers.v1` device log into the client ledger (FR-017, SC-007).
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { recordTransfer, updateTransfer, __clearTransfers, TRANSFER_STATUS } from '../../lib/transfer/transferStore'
+import { migrateLegacyActivity } from '../../data/ledger/migrate'
+import { listClientRecords, __clearClientLedger } from '../../data/ledger/ledgerClientStore'
+
+const ACCOUNT = '0xAbc0000000000000000000000000000000000009'
+
+beforeEach(() => {
+  __clearTransfers()
+  __clearClientLedger()
+  localStorage.clear()
+})
+
+function seedLegacy() {
+  const ok = recordTransfer(ACCOUNT, {
+    chainId: 137,
+    kind: 'stable',
+    symbol: 'USC',
+    decimals: 6,
+    amount: '7.5',
+    from: ACCOUNT,
+    to: '0xdest',
+    route: 'gasless',
+  })
+  updateTransfer(ACCOUNT, ok.id, { status: TRANSFER_STATUS.COMPLETE, txHash: '0x' + 'aa'.repeat(32) })
+  const failed = recordTransfer(ACCOUNT, {
+    chainId: 137,
+    kind: 'native',
+    symbol: 'MATIC',
+    decimals: 18,
+    amount: '0.01',
+    from: ACCOUNT,
+    to: '0xdest',
+    route: 'gasless',
+  })
+  updateTransfer(ACCOUNT, failed.id, {
+    status: TRANSFER_STATUS.FAILED,
+    error: 'Smart Account does not have sufficient funds to execute the User Operation.',
+  })
+  const otherChain = recordTransfer(ACCOUNT, {
+    chainId: 63,
+    kind: 'native',
+    symbol: 'METC',
+    decimals: 18,
+    amount: '1',
+    from: ACCOUNT,
+    to: '0xdest',
+    route: 'direct',
+  })
+  return { ok, failed, otherChain }
+}
+
+describe('migrateLegacyActivity', () => {
+  it('imports legacy transfers into the client ledger preserving status/error/txHash/createdAt, per chain', () => {
+    const { ok, failed } = seedLegacy()
+    const result = migrateLegacyActivity(ACCOUNT)
+    expect(result.migrated).toBe(3)
+
+    const polygon = listClientRecords(ACCOUNT, 137)
+    expect(polygon).toHaveLength(2)
+    const okEntry = polygon.find((r) => r.entryId === `cl:${ok.id}`)
+    expect(okEntry.status).toBe('settled')
+    expect(okEntry.txHash).toBe('0x' + 'aa'.repeat(32))
+    expect(okEntry.timestamp).toBe(ok.createdAt)
+    const failEntry = polygon.find((r) => r.entryId === `cl:${failed.id}`)
+    expect(failEntry.status).toBe('failed')
+    expect(failEntry.failureReason).toMatch(/sufficient funds/)
+
+    expect(listClientRecords(ACCOUNT, 63)).toHaveLength(1)
+  })
+
+  it('is idempotent: a second run (marker set) imports nothing and duplicates nothing', () => {
+    seedLegacy()
+    migrateLegacyActivity(ACCOUNT)
+    const second = migrateLegacyActivity(ACCOUNT)
+    expect(second.migrated).toBe(0)
+    expect(second.skipped).toBe(true)
+    expect(listClientRecords(ACCOUNT, 137)).toHaveLength(2)
+  })
+
+  it('does not duplicate records already mirrored live (same cl: ids)', () => {
+    const { ok } = seedLegacy()
+    // Simulate the live mirror having already captured the settled transfer.
+    migrateLegacyActivity(ACCOUNT)
+    // Force marker off to simulate a re-run against overlapping data.
+    localStorage.removeItem(`fw_user_${ACCOUNT.toLowerCase()}_activity_ledger_migrated_v1`)
+    const rerun = migrateLegacyActivity(ACCOUNT)
+    expect(rerun.migrated).toBe(0) // union by entryId — nothing new
+    expect(listClientRecords(ACCOUNT, 137).filter((r) => r.entryId === `cl:${ok.id}`)).toHaveLength(1)
+  })
+
+  it('no-ops without an account', () => {
+    expect(migrateLegacyActivity(null)).toEqual({ migrated: 0, skipped: true })
+  })
+})

--- a/frontend/src/test/ledger/normalize.test.js
+++ b/frontend/src/test/ledger/normalize.test.js
@@ -1,0 +1,81 @@
+/**
+ * Spec 051 T005 — normalization invariants (data-model.md "Invariants").
+ */
+import { describe, it, expect } from 'vitest'
+import { normalizeEntry } from '../../data/ledger/normalize'
+
+const TX = '0x' + 'cd'.repeat(32)
+const CTX = { account: '0xUSER', chainId: 137 }
+
+function pre(overrides = {}) {
+  return {
+    entryId: `oc:137:${TX}:0`,
+    chainId: 137,
+    class: 'wager',
+    kind: 'deposit',
+    direction: 'out',
+    status: 'settled',
+    provenance: 'onchain',
+    txHash: TX,
+    amountRaw: '1000000',
+    tokenAddress: '0xToken',
+    timestamp: 1_700_000_000_000,
+    timestampProvenance: 'chain',
+    ...overrides,
+  }
+}
+
+describe('normalizeEntry', () => {
+  it('passes a valid entry through with lowercased account + token', () => {
+    const e = normalizeEntry(pre(), CTX)
+    expect(e.account).toBe('0xuser')
+    expect(e.tokenAddress).toBe('0xtoken')
+    expect(e.timestamp).toBe(1_700_000_000_000)
+  })
+
+  it('rejects timestamp 0 / negative / NaN — coerces to null + unavailable (never renders as epoch)', () => {
+    for (const bad of [0, -5, NaN, '0', undefined]) {
+      const e = normalizeEntry(pre({ timestamp: bad, timestampProvenance: 'chain' }), CTX)
+      expect(e.timestamp).toBe(null)
+      expect(e.timestampProvenance).toBe('unavailable')
+    }
+  })
+
+  it('forces direction to none on failed entries', () => {
+    const e = normalizeEntry(pre({ status: 'failed', direction: 'out', txHash: null, provenance: 'client', entryId: 'cl:u1' }), CTX)
+    expect(e.direction).toBe('none')
+  })
+
+  it('throws when an on-chain entry has no txHash', () => {
+    expect(() => normalizeEntry(pre({ txHash: null }), CTX)).toThrow(/txHash/)
+  })
+
+  it('throws on cross-network leakage (entry chainId ≠ query chainId)', () => {
+    expect(() => normalizeEntry(pre({ chainId: 1 }), CTX)).toThrow(/chainId/)
+  })
+
+  it('throws on unknown class or status', () => {
+    expect(() => normalizeEntry(pre({ class: 'lottery' }), CTX)).toThrow(/class/)
+    expect(() => normalizeEntry(pre({ status: 'maybe' }), CTX)).toThrow(/status/)
+  })
+
+  it('throws when entryId namespace disagrees with provenance', () => {
+    expect(() => normalizeEntry(pre({ provenance: 'derived' }), CTX)).toThrow(/namespace/)
+  })
+
+  it('defaults refs to an object and preserves failureReason verbatim', () => {
+    const e = normalizeEntry(
+      pre({
+        entryId: 'cl:u2',
+        provenance: 'client',
+        txHash: null,
+        status: 'failed',
+        failureReason: 'Smart Account does not have sufficient funds to execute the User Operation.',
+        timestampProvenance: 'device',
+      }),
+      CTX,
+    )
+    expect(e.refs).toEqual({})
+    expect(e.failureReason).toMatch(/sufficient funds/)
+  })
+})

--- a/frontend/src/test/ledger/sources.test.js
+++ b/frontend/src/test/ledger/sources.test.js
@@ -1,0 +1,229 @@
+/**
+ * Spec 051 T009–T015 — the five ledger source adapters.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createWagerLedgerSource } from '../../data/ledger/sources/wagerLedgerSource'
+import { createTransferLedgerSource, transferRecordToEntry } from '../../data/ledger/sources/transferLedgerSource'
+import { createEarnLedgerSource, captureEarnAction } from '../../data/ledger/sources/earnLedgerSource'
+import { createPoolLedgerSource } from '../../data/ledger/sources/poolLedgerSource'
+import { createMembershipLedgerSource } from '../../data/ledger/sources/membershipLedgerSource'
+import { __clearClientLedger } from '../../data/ledger/ledgerClientStore'
+
+const ACCOUNT = '0xabc0000000000000000000000000000000000001'
+const TX = '0x' + 'ef'.repeat(32)
+const CTX = { account: ACCOUNT, chainId: 137 }
+
+beforeEach(() => __clearClientLedger())
+
+describe('wagerLedgerSource', () => {
+  it('maps subgraph WagerTransfer rows to on-chain entries with dedup keys', async () => {
+    const src = createWagerLedgerSource({
+      listTransfers: async () => [
+        {
+          wagerId: '7',
+          direction: 'payout',
+          tokenAddress: '0xToken',
+          amountRaw: '2000000',
+          fromAddress: '0xEscrow',
+          toAddress: ACCOUNT,
+          txHash: TX,
+          timestamp: 1_700_000_000_000,
+        },
+      ],
+    })
+    const [e] = await src.list(CTX)
+    expect(e.entryId).toBe(`oc:137:wt:${TX}-7-payout`)
+    expect(e.provenance).toBe('onchain')
+    expect(e.direction).toBe('in')
+    expect(e.timestamp).toBe(1_700_000_000_000)
+    expect(e.timestampProvenance).toBe('chain')
+    expect(e.refs.dedupKey).toBe('wager:7:payout')
+  })
+
+  it('falls back to derived entries on subgraph-less networks — null timestamps, never 0', async () => {
+    const src = createWagerLedgerSource({
+      listTransfers: async () => null, // no subgraph
+      listWagers: async () => [
+        {
+          id: '9',
+          creator: ACCOUNT,
+          opponent: '0xother',
+          status: 'active',
+          creatorStake: '1000000',
+          opponentStake: '1000000',
+          stakeTokenAddress: '0xtoken',
+          createdAt: 0, // RegistrySource has no on-chain creation time
+          resolvedAt: null,
+        },
+      ],
+    })
+    const entries = await src.list(CTX)
+    const mine = entries.find((e) => e.kind === 'deposit')
+    expect(mine.entryId).toBe(`dv:137:wager:9:deposit:${ACCOUNT}`)
+    expect(mine.provenance).toBe('derived')
+    expect(mine.timestamp).toBe(null)
+    expect(mine.timestampProvenance).toBe('unavailable')
+    expect(mine.txHash).toBe(null)
+  })
+
+  it('uses hydrated timestamps on the fallback path when the hydrator supplies them', async () => {
+    const src = createWagerLedgerSource({
+      listTransfers: async () => null,
+      listWagers: async () => [
+        {
+          id: '9',
+          creator: ACCOUNT,
+          opponent: null,
+          status: 'open',
+          creatorStake: '1000000',
+          stakeTokenAddress: '0xtoken',
+          createdAt: 0,
+          resolvedAt: null,
+        },
+      ],
+      hydrateWagerTimestamps: async (wagers) =>
+        wagers.map((w) => ({ ...w, createdAt: 1_700_000_123_000 })),
+    })
+    const [e] = await src.list(CTX)
+    expect(e.timestamp).toBe(1_700_000_123_000)
+    expect(e.timestampProvenance).toBe('chain')
+  })
+})
+
+describe('transferLedgerSource', () => {
+  const legacyRecord = {
+    id: 't-1',
+    chainId: 137,
+    kind: 'stable',
+    symbol: 'USC',
+    decimals: 6,
+    amount: '7.5',
+    from: ACCOUNT,
+    to: '0xdest',
+    status: 'failed',
+    route: 'gasless',
+    txHash: null,
+    error: 'Smart Account does not have sufficient funds to execute the User Operation.',
+    createdAt: 1_760_000_000_000,
+    updatedAt: 1_760_000_001_000,
+  }
+
+  it('maps legacy transferStore records to failed client entries with the verbatim reason', () => {
+    const e = transferRecordToEntry(legacyRecord, { account: ACCOUNT })
+    expect(e.entryId).toBe('cl:t-1')
+    expect(e.class).toBe('transfer')
+    expect(e.status).toBe('failed')
+    expect(e.failureReason).toMatch(/sufficient funds/)
+    expect(e.refs.route).toBe('gasless')
+    expect(e.valueUsd).toBe(7.5) // stable at par
+    expect(e.timestampProvenance).toBe('device')
+  })
+
+  it('prefers the client-ledger chain over the legacy record for the same transfer', async () => {
+    const src = createTransferLedgerSource({
+      listClientRecords: () => [
+        {
+          entryId: 'cl:t-1:u1',
+          chainId: 137,
+          class: 'transfer',
+          kind: 'send',
+          status: 'settled',
+          provenance: 'client',
+          refs: { transferId: 't-1', supersedes: 'cl:t-1' },
+        },
+      ],
+      listTransfers: () => [legacyRecord],
+    })
+    const entries = await src.list(CTX)
+    expect(entries).toHaveLength(1)
+    expect(entries[0].entryId).toBe('cl:t-1:u1')
+  })
+
+  it('returns legacy records when nothing is mirrored yet (pre-migration)', async () => {
+    const src = createTransferLedgerSource({
+      listClientRecords: () => [],
+      listTransfers: () => [legacyRecord],
+    })
+    const entries = await src.list(CTX)
+    expect(entries).toHaveLength(1)
+    expect(entries[0].entryId).toBe('cl:t-1')
+  })
+})
+
+describe('earnLedgerSource + captureEarnAction', () => {
+  it('captures deposit/withdraw/claim actions as settled client entries with txHash', async () => {
+    captureEarnAction(ACCOUNT, 137, {
+      type: 'earn-deposit',
+      txHash: TX,
+      at: 1_760_000_000_000,
+      vaultAddress: '0xVault',
+      amountRaw: '5000000',
+      tokenAddress: '0xUsdc',
+      tokenSymbol: 'USDC',
+      tokenDecimals: 6,
+    })
+    const src = createEarnLedgerSource()
+    const [e] = await src.list(CTX)
+    expect(e.class).toBe('earn')
+    expect(e.kind).toBe('vault_deposit')
+    expect(e.direction).toBe('out')
+    expect(e.txHash).toBe(TX)
+    expect(e.counterparty).toBe('0xvault')
+    expect(e.timestampProvenance).toBe('device')
+  })
+
+  it('is idempotent per (type, txHash) — re-capture does not duplicate', async () => {
+    const a = { type: 'earn-withdraw', txHash: TX, at: 1, vaultAddress: '0xv', amountRaw: '1' }
+    captureEarnAction(ACCOUNT, 137, a)
+    captureEarnAction(ACCOUNT, 137, a)
+    const src = createEarnLedgerSource()
+    expect(await src.list(CTX)).toHaveLength(1)
+  })
+})
+
+describe('poolLedgerSource', () => {
+  it('maps joins, claims, and refunds with block times in ms', async () => {
+    const src = createPoolLedgerSource({
+      querySubgraph: async () => ({
+        poolMembers: [
+          { id: 'p-m', buyIn: '1000000', joinedAt: '1700000000', joinTxHash: TX, pool: { id: '0xpool', poolId: '3', token: '0xusdc' } },
+        ],
+        poolClaims: [
+          { id: `${TX}-1`, amount: '3000000', timestamp: '1700000100', txHash: TX, pool: { id: '0xpool', poolId: '3', token: '0xusdc' } },
+        ],
+        poolRefunds: [],
+      }),
+    })
+    const entries = await src.list(CTX)
+    expect(entries).toHaveLength(2)
+    const join = entries.find((e) => e.kind === 'pool_join')
+    expect(join.direction).toBe('out')
+    expect(join.timestamp).toBe(1_700_000_000_000)
+    const claim = entries.find((e) => e.kind === 'pool_claim')
+    expect(claim.direction).toBe('in')
+    expect(claim.refs.poolId).toBe('3')
+  })
+
+  it('returns an honest empty list when the chain has no subgraph', async () => {
+    const src = createPoolLedgerSource({ querySubgraph: async () => null })
+    expect(await src.list(CTX)).toEqual([])
+  })
+})
+
+describe('membershipLedgerSource', () => {
+  it('maps voucher purchases (unvalued — price not indexed) and redemptions', async () => {
+    const src = createMembershipLedgerSource({
+      querySubgraph: async () => ({
+        minted: [{ id: '1', tokenId: '1', tier: 2, mintedAt: '1700000000', mintTxHash: TX }],
+        redeemed: [{ id: '1', tokenId: '1', tier: 2, redeemedAt: '1700000500', redeemTxHash: TX }],
+      }),
+    })
+    const entries = await src.list(CTX)
+    expect(entries).toHaveLength(2)
+    const purchase = entries.find((e) => e.kind === 'voucher_purchase')
+    expect(purchase.valuationStatus).toBe('unvalued')
+    expect(purchase.direction).toBe('out')
+    const redeem = entries.find((e) => e.kind === 'voucher_redeem')
+    expect(redeem.direction).toBe('none')
+  })
+})

--- a/frontend/src/test/ledger/sources.test.js
+++ b/frontend/src/test/ledger/sources.test.js
@@ -43,6 +43,7 @@ describe('wagerLedgerSource', () => {
   it('falls back to derived entries on subgraph-less networks — null timestamps, never 0', async () => {
     const src = createWagerLedgerSource({
       listTransfers: async () => null, // no subgraph
+      hydrateWagerTimestamps: async (ws) => ws, // hydration exhausted — nothing recovered
       listWagers: async () => [
         {
           id: '9',

--- a/frontend/src/test/ledger/timestamps.test.js
+++ b/frontend/src/test/ledger/timestamps.test.js
@@ -1,0 +1,84 @@
+/**
+ * Spec 051 T036 — chain-time hydration for subgraph-less networks (US4,
+ * FR-005): bounded event scan → block timestamps in ms; budget exhaustion or
+ * scan failure yields null (never 0); cache short-circuits RPC; cache loss is
+ * harmless (re-derivable).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { hydrateWagerTimestamps, __clearTimestampCache } from '../../data/ledger/timestamps'
+
+const CHAIN_ID = 63 // Mordor — no subgraph
+
+function wager(id, overrides = {}) {
+  return {
+    id: String(id),
+    creator: '0xme',
+    status: 'resolved',
+    createdAt: 0, // RegistrySource: no creation time on-chain
+    resolvedAt: null,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  __clearTimestampCache()
+  localStorage.clear()
+})
+
+describe('hydrateWagerTimestamps', () => {
+  it('fills createdAt/resolvedAt (ms) from the wager events + block times', async () => {
+    const getWagerEvents = vi.fn(async (id) => [
+      { name: 'WagerCreated', blockNumber: 100, args: { wagerId: id } },
+      { name: 'PayoutClaimed', blockNumber: 200, args: { wagerId: id } },
+    ])
+    const getBlock = vi.fn(async (n) => ({ timestamp: n === 100 ? 1_700_000_000 : 1_700_000_600 }))
+    const out = await hydrateWagerTimestamps([wager(7)], CHAIN_ID, { getWagerEvents, getBlock })
+    expect(out[0].createdAt).toBe(1_700_000_000_000)
+    expect(out[0].resolvedAt).toBe(1_700_000_600_000)
+  })
+
+  it('leaves timestamps falsy (never fabricated) when the scan fails or is over budget', async () => {
+    const getWagerEvents = vi.fn(async () => {
+      throw new Error('This report period is too large to read from the network')
+    })
+    const out = await hydrateWagerTimestamps([wager(8)], CHAIN_ID, { getWagerEvents, getBlock: vi.fn() })
+    expect(out[0].createdAt).toBe(0) // untouched — deriveTransfers maps 0 → null timestamp
+    expect(out[0].resolvedAt).toBe(null)
+  })
+
+  it('caches resolved times so the second call makes no RPC reads', async () => {
+    const getWagerEvents = vi.fn(async (id) => [
+      { name: 'WagerCreated', blockNumber: 100, args: { wagerId: id } },
+    ])
+    const getBlock = vi.fn(async () => ({ timestamp: 1_700_000_000 }))
+    await hydrateWagerTimestamps([wager(9)], CHAIN_ID, { getWagerEvents, getBlock })
+    expect(getWagerEvents).toHaveBeenCalledTimes(1)
+
+    const out = await hydrateWagerTimestamps([wager(9)], CHAIN_ID, { getWagerEvents, getBlock })
+    expect(getWagerEvents).toHaveBeenCalledTimes(1) // cache hit — no new scan
+    expect(out[0].createdAt).toBe(1_700_000_000_000)
+  })
+
+  it('skips wagers that already carry a real createdAt', async () => {
+    const getWagerEvents = vi.fn()
+    const out = await hydrateWagerTimestamps(
+      [wager(10, { createdAt: 1_700_000_111_000 })],
+      CHAIN_ID,
+      { getWagerEvents, getBlock: vi.fn() },
+    )
+    expect(getWagerEvents).not.toHaveBeenCalled()
+    expect(out[0].createdAt).toBe(1_700_000_111_000)
+  })
+
+  it('bounds work per call: stops scanning new wagers once the budget is spent', async () => {
+    let calls = 0
+    const getWagerEvents = vi.fn(async (id) => {
+      calls += 1
+      return [{ name: 'WagerCreated', blockNumber: 100, args: { wagerId: id } }]
+    })
+    const getBlock = vi.fn(async () => ({ timestamp: 1_700_000_000 }))
+    const many = Array.from({ length: 10 }, (_, i) => wager(100 + i))
+    await hydrateWagerTimestamps(many, CHAIN_ID, { getWagerEvents, getBlock, maxWagersPerCall: 3 })
+    expect(calls).toBe(3) // remaining wagers hydrate on later polls
+  })
+})

--- a/frontend/src/test/ledger/useActivityLedger.test.jsx
+++ b/frontend/src/test/ledger/useActivityLedger.test.jsx
@@ -1,0 +1,57 @@
+/**
+ * Spec 051 T016 — useActivityLedger hook: scoping, filters, refresh, and
+ * honest error handling (keeps last-known entries).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+
+const listEntries = vi.fn()
+const wallet = {
+  address: '0xUser',
+  chainId: 137,
+  isConnected: true,
+  provider: null,
+}
+
+vi.mock('../../hooks/useWalletManagement', () => ({ useWallet: () => wallet }))
+vi.mock('../../data/ledger', () => ({ getDefaultLedgerRepository: () => ({ listEntries }) }))
+
+const { useActivityLedger } = await import('../../hooks/useActivityLedger')
+
+beforeEach(() => {
+  listEntries.mockReset()
+})
+
+describe('useActivityLedger', () => {
+  it('queries the ledger scoped to the active account + chain and returns entries', async () => {
+    listEntries.mockResolvedValue({ entries: [{ entryId: 'cl:a' }], staleClasses: ['earn'], prunedBefore: null })
+    const { result } = renderHook(() => useActivityLedger())
+    await waitFor(() => expect(result.current.entries).toHaveLength(1))
+    expect(listEntries).toHaveBeenCalledWith(
+      expect.objectContaining({ account: '0xUser', chainId: 137 }),
+    )
+    expect(result.current.staleClasses).toEqual(['earn'])
+  })
+
+  it('passes filter and period through to the repository', async () => {
+    listEntries.mockResolvedValue({ entries: [], staleClasses: [], prunedBefore: null })
+    const filter = { classes: ['transfer'] }
+    const period = { fromMs: 1, toMs: 2 }
+    renderHook(() => useActivityLedger({ filter, period }))
+    await waitFor(() => expect(listEntries).toHaveBeenCalled())
+    expect(listEntries).toHaveBeenCalledWith(expect.objectContaining({ filter, period }))
+  })
+
+  it('keeps last-known entries on a failed refresh and surfaces the error', async () => {
+    listEntries.mockResolvedValueOnce({ entries: [{ entryId: 'cl:a' }], staleClasses: [], prunedBefore: null })
+    const { result } = renderHook(() => useActivityLedger())
+    await waitFor(() => expect(result.current.entries).toHaveLength(1))
+
+    listEntries.mockRejectedValueOnce(new Error('rpc down'))
+    await act(async () => {
+      await result.current.refresh()
+    })
+    expect(result.current.entries).toHaveLength(1) // stale beats blank
+    expect(result.current.error).toMatch(/rpc down/)
+  })
+})

--- a/frontend/src/test/reports/TaxReportsPanel.test.jsx
+++ b/frontend/src/test/reports/TaxReportsPanel.test.jsx
@@ -10,6 +10,9 @@ function hookOptions(saveAs) {
     account: USER,
     chainId: CHAIN_ID,
     createDataSource: () => makeFixtureDataSource(),
+    // Exercise the legacy wager-only pipeline against the wager fixtures;
+    // ledger-path behavior is covered in reportParity.test.js.
+    ledger: null,
     getNetwork: () => ({ name: 'Polygon', isTestnet: false, nativeCurrency: { symbol: 'MATIC' } }),
     getEscrow: () => REGISTRY,
     saveAs,

--- a/frontend/src/test/reports/reportParity.test.js
+++ b/frontend/src/test/reports/reportParity.test.js
@@ -1,0 +1,178 @@
+/**
+ * Spec 051 T022 — reporting parity (US2, FR-014/FR-015, SC-002):
+ * for the same (account, chainId, period), the report and the Account tab
+ * consume the IDENTICAL ledger entry set, and totals agree. Also covers the
+ * ledger-path line-item contract (all classes, failed flagged and excluded
+ * from totals, unvalued flagged never zeroed).
+ */
+import { describe, it, expect } from 'vitest'
+import { createLedgerRepository } from '../../data/ledger/ledgerRepository'
+import { buildReport } from '../../data/reports/reportBuilder'
+import { render as renderCsv } from '../../data/reports/csvReport'
+import { resolveCustomPeriod } from '../../utils/reportPeriods'
+import { wagerTransfersFromLedger } from '../../lib/account/ledgerAdapters'
+import { computeSummary } from '../../lib/account/computeSummary'
+
+const ACCOUNT = '0xabc0000000000000000000000000000000000001'
+const CHAIN_ID = 137
+const TX = (n) => '0x' + String(n).padStart(2, '0').repeat(32)
+const T0 = Date.UTC(2026, 2, 1)
+
+// One entry per class, plus a failed gasless transfer and an unvalued entry.
+const FIXTURE_ENTRIES = [
+  {
+    entryId: `oc:137:wt:${TX(1)}-1-deposit`, chainId: CHAIN_ID, class: 'wager', kind: 'deposit',
+    direction: 'out', status: 'settled', provenance: 'onchain', txHash: TX(1),
+    tokenAddress: '0xusdc', amountRaw: '100000000', timestamp: T0, timestampProvenance: 'chain',
+    refs: { wagerId: '1', dedupKey: 'wager:1:deposit' },
+  },
+  {
+    entryId: `oc:137:wt:${TX(2)}-1-payout`, chainId: CHAIN_ID, class: 'wager', kind: 'payout',
+    direction: 'in', status: 'settled', provenance: 'onchain', txHash: TX(2),
+    tokenAddress: '0xusdc', amountRaw: '190000000', timestamp: T0 + 3600_000, timestampProvenance: 'chain',
+    refs: { wagerId: '1', dedupKey: 'wager:1:payout' },
+  },
+  {
+    entryId: 'cl:t-ok', chainId: CHAIN_ID, class: 'transfer', kind: 'send',
+    direction: 'out', status: 'settled', provenance: 'client', txHash: TX(3),
+    tokenAddress: '0xusdc', amount: 7.5, valueUsd: 7.5, valuationStatus: 'valued',
+    timestamp: T0 + 2 * 3600_000, timestampProvenance: 'device', refs: { route: 'gasless' },
+  },
+  {
+    entryId: 'cl:t-fail', chainId: CHAIN_ID, class: 'transfer', kind: 'send',
+    direction: 'out', status: 'failed',
+    failureReason: 'Smart Account does not have sufficient funds to execute the User Operation.',
+    provenance: 'client', txHash: null, tokenAddress: '0xusdc', amount: 1,
+    timestamp: T0 + 3 * 3600_000, timestampProvenance: 'device', refs: { route: 'gasless' },
+  },
+  {
+    entryId: 'cl:earn-1', chainId: CHAIN_ID, class: 'earn', kind: 'vault_deposit',
+    direction: 'out', status: 'settled', provenance: 'client', txHash: TX(4),
+    tokenAddress: '0xusdc', amountRaw: '5000000', timestamp: T0 + 4 * 3600_000,
+    timestampProvenance: 'device', refs: { vaultAddress: '0xvault' },
+  },
+  {
+    entryId: `oc:137:${TX(5)}:voucher_purchase:9`, chainId: CHAIN_ID, class: 'membership',
+    kind: 'voucher_purchase', direction: 'out', status: 'settled', provenance: 'onchain',
+    txHash: TX(5), tokenAddress: null, amountRaw: null, valuationStatus: 'unvalued',
+    timestamp: T0 + 5 * 3600_000, timestampProvenance: 'chain', refs: { voucherId: '9' },
+  },
+]
+
+// Stablecoin fixture enrichment: USDC 6dp at par.
+const enrich = async (entries) =>
+  entries.map((e) => {
+    const amount = e.amount ?? (e.amountRaw != null ? Number(e.amountRaw) / 1e6 : null)
+    const valued = e.valuationStatus === 'unvalued' ? null : amount
+    return {
+      ...e,
+      tokenSymbol: e.tokenAddress ? 'USDC' : 'MATIC',
+      tokenDecimals: 6,
+      amount,
+      valueUsd: e.valueUsd ?? valued,
+      valuationStatus: e.valuationStatus ?? (valued != null ? 'valued' : 'unvalued'),
+    }
+  })
+
+function makeLedger() {
+  return createLedgerRepository({
+    sources: [{ class: 'wager', list: async () => FIXTURE_ENTRIES }],
+    enrich,
+  })
+}
+
+const PERIOD = resolveCustomPeriod(T0 - 1, T0 + 6 * 3600_000)
+const NETWORK_META = { name: 'Polygon', isTestnet: false, nativeCurrency: { symbol: 'MATIC' } }
+
+async function build() {
+  return buildReport({
+    account: ACCOUNT,
+    chainId: CHAIN_ID,
+    period: PERIOD,
+    dataSource: { getTransactionReceipt: async () => null },
+    networkMeta: NETWORK_META,
+    ledger: makeLedger(),
+    generatedAt: T0 + 7 * 3600_000,
+  })
+}
+
+describe('report ↔ Account tab parity (spec 051 US2)', () => {
+  it('the report line-item set is exactly the ledger entry set the Account tab renders', async () => {
+    const ledger = makeLedger()
+    const { entries } = await ledger.listEntries({
+      account: ACCOUNT,
+      chainId: CHAIN_ID,
+      period: { fromMs: PERIOD.from, toMs: PERIOD.to },
+    })
+    const report = await build()
+    expect(report.source).toBe('ledger')
+    expect(new Set(report.lineItems.map((i) => i.entryId))).toEqual(
+      new Set(entries.map((e) => e.entryId)),
+    )
+    expect(report.lineItems).toHaveLength(FIXTURE_ENTRIES.length)
+  })
+
+  it('report wager totals equal the dashboard summary computed from the same entries (SC-002)', async () => {
+    const ledger = makeLedger()
+    const { entries } = await ledger.listEntries({
+      account: ACCOUNT,
+      chainId: CHAIN_ID,
+      period: { fromMs: PERIOD.from, toMs: PERIOD.to },
+    })
+    const report = await build()
+
+    // Dashboard math over the same ledger (wager class, settled wager).
+    const transfers = wagerTransfersFromLedger(entries)
+    const summary = computeSummary({
+      wagers: [{ id: '1', status: 'resolved', creator: ACCOUNT, winner: ACCOUNT }],
+      transfers,
+      address: ACCOUNT,
+    })
+    const usdc = report.totals.byTicker.USDC
+    // deposits/payouts/refunds are the wager-kind columns; the report's wager
+    // math must equal the dashboard's realized P&L over the same entries.
+    expect(usdc.payouts).toBe(190)
+    expect(usdc.deposits).toBe(100)
+    expect(usdc.payouts - usdc.deposits).toBe(summary.netPnlUsd)
+    // Every settled valued entry (wager + send + earn) contributes to USD volume.
+    expect(usdc.usdValue).toBeCloseTo(100 + 190 + 7.5 + 5)
+  })
+
+  it('failed operations are listed but excluded from every total (FR-003/SC-006)', async () => {
+    const report = await build()
+    const failedRow = report.lineItems.find((i) => i.status === 'failed')
+    expect(failedRow).toBeTruthy()
+    expect(failedRow.failureReason).toMatch(/sufficient funds/)
+    expect(report.totals.overall.failedCount).toBe(1)
+    // Totals unchanged by the failed $1 send: settled USD volume only.
+    expect(report.totals.byTicker.USDC.usdValue).toBeCloseTo(302.5)
+    expect(report.totals.overall.usdValue).toBeCloseTo(302.5)
+  })
+
+  it('unvalued entries are flagged in the CSV, never zeroed or dropped (FR-016)', async () => {
+    const report = await build()
+    const csv = renderCsv(report)
+    expect(csv).toContain('voucher_purchase')
+    expect(csv).toContain('unvalued')
+    expect(csv).toContain('Failed operations')
+    // Every class made it into the export.
+    for (const cls of ['wager', 'transfer', 'earn', 'membership']) expect(csv).toContain(cls)
+  })
+
+  it('entries outside the period are excluded from both surfaces identically', async () => {
+    const ledger = makeLedger()
+    const narrow = { fromMs: T0 + 90 * 60_000, toMs: T0 + 150 * 60_000 } // only the settled send
+    const { entries } = await ledger.listEntries({ account: ACCOUNT, chainId: CHAIN_ID, period: narrow })
+    const report = await buildReport({
+      account: ACCOUNT,
+      chainId: CHAIN_ID,
+      period: { ...resolveCustomPeriod(narrow.fromMs, narrow.toMs) },
+      dataSource: { getTransactionReceipt: async () => null },
+      networkMeta: NETWORK_META,
+      ledger,
+      generatedAt: T0 + 7 * 3600_000,
+    })
+    expect(entries.map((e) => e.entryId)).toEqual(['cl:t-ok'])
+    expect(report.lineItems.map((i) => i.entryId)).toEqual(['cl:t-ok'])
+  })
+})

--- a/frontend/src/test/reports/reportsAccessibility.test.jsx
+++ b/frontend/src/test/reports/reportsAccessibility.test.jsx
@@ -12,6 +12,8 @@ const hookOptions = (saveAs = vi.fn()) => ({
   account: USER,
   chainId: CHAIN_ID,
   createDataSource: () => makeFixtureDataSource(),
+  // Legacy wager-only pipeline against the wager fixtures (see reportParity.test.js).
+  ledger: null,
   getNetwork: () => ({ name: 'Polygon', isTestnet: false, nativeCurrency: { symbol: 'MATIC' } }),
   getEscrow: () => REGISTRY,
   saveAs,

--- a/frontend/src/test/reports/useTaxReport.test.js
+++ b/frontend/src/test/reports/useTaxReport.test.js
@@ -12,6 +12,9 @@ function setup(overrides = {}) {
     account: USER,
     chainId: CHAIN_ID,
     createDataSource: () => makeFixtureDataSource(),
+    // These cases exercise the legacy wager-only pipeline against the wager
+    // fixtures; ledger-path behavior is covered in reportParity.test.js.
+    ledger: null,
     getNetwork: () => ({ name: 'Polygon', isTestnet: false, nativeCurrency: { symbol: 'MATIC' } }),
     getEscrow: () => REGISTRY,
     saveAs,

--- a/specs/051-unified-activity-ledger/checklists/requirements.md
+++ b/specs/051-unified-activity-ledger/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Unified Activity Ledger with Durable Audit Logging
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The Problem Statement and Dependencies sections reference existing spec
+  numbers and current storage behavior (e.g. device-local logs) to ground the
+  problem; requirements themselves stay technology-agnostic.
+- Ambiguities resolved via documented Assumptions instead of clarification
+  markers: no new server-side per-user storage (privacy stance preserved),
+  spec-032 backup is the durability vehicle for client-only records, USD as
+  reporting currency, "loans" = earn/lending (spec 050), incoming-transfer
+  detection is best-effort and disclosed.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`

--- a/specs/051-unified-activity-ledger/contracts/backup-object.md
+++ b/specs/051-unified-activity-ledger/contracts/backup-object.md
@@ -1,0 +1,38 @@
+# Contract: `activityLedger` Synced Object (spec 032 extension)
+
+One new entry in `frontend/src/lib/backup/syncedObjects.js`, honoring the
+registry's design ("adding a future object = one entry here").
+
+```js
+{
+  key: 'activityLedger',
+  label: 'Activity history',
+  networkScoped: true,               // every record carries chainId
+  load:  (account) => listClientRecords(account),        // ledgerClientStore
+  apply: (account, value, mode) => { /* replace | merge */ },
+  merge: (current, incoming) => unionByEntryId(current, incoming),
+}
+```
+
+## Rules
+
+1. **Payload = client-provenance records only** (`cl:` namespace). On-chain
+   and derived entries are excluded — they re-derive from public data
+   (FR-009); this keeps bundles small and avoids duplicating chain truth.
+2. **Merge is conflict-free**: records are append-only value objects; union
+   by `entryId`. Identical ids ⇒ identical records; `mergeConflicts` is
+   always empty (unlike addressBook nickname conflicts).
+3. **`mode: 'replace'`** still unions — replace semantics would delete
+   history and violate FR-008 append-only. This is the one synced object
+   where replace and merge are intentionally the same operation; the
+   behavior is documented in the backup UI copy.
+4. **Restore outcomes** (FR-010/012):
+   - backup present + decrypts → client records restored, then deduped
+     against re-derived entries (identity precedence);
+   - no backup / undecryptable → on-chain ledger still rebuilds; the restore
+     flow surfaces "device-local activity history was not recovered".
+5. **Automatic inclusion**: new client records are picked up by the next
+   backup with no user selection (FR-010) — `load` always returns the full
+   current set.
+6. **Privacy**: records travel only inside the existing encrypted bundle
+   (user-held keys); nothing is uploaded in plaintext, no new endpoints.

--- a/specs/051-unified-activity-ledger/contracts/ledger-entry.md
+++ b/specs/051-unified-activity-ledger/contracts/ledger-entry.md
@@ -1,0 +1,37 @@
+# Contract: LedgerEntry Schema & Identity
+
+Normative schema lives in [`../data-model.md`](../data-model.md). This
+contract fixes the guarantees consumers may rely on and producers must uphold.
+
+## Consumers
+
+- `useActivityLedger` / Account tab (`RecentActivityFeed`, summary tiles,
+  P&L chart, breakdowns)
+- `TransferActivityList` (ledger filtered to `class: 'transfer'`)
+- Tax/activity report (`reportDataSource` → `reportBuilder` → CSV/PDF)
+- Backup (`activityLedger` synced object — client-provenance records only)
+
+## Guarantees
+
+| # | Guarantee | Backing requirement |
+|---|---|---|
+| G1 | `entryId` is stable across sessions, re-derivations, and restores | FR-009, FR-011 |
+| G2 | `timestamp` is real activity time in epoch ms, or `null` with `timestampProvenance: 'unavailable'`; the value `0` never appears | FR-005, FR-006 |
+| G3 | Entries with `status: 'failed'` never contribute to any total (dashboard, breakdowns, report) but always appear in listings/exports | FR-003, SC-006 |
+| G4 | Every entry with `provenance: 'onchain'` carries a `txHash` resolvable on the entry's `chainId` block explorer | FR-004 |
+| G5 | An entry's `chainId` equals the query's `chainId` — no cross-network leakage | FR-007 |
+| G6 | `valuationStatus: 'unvalued'` entries are present in every consumer's output, flagged, never zero-filled | FR-016 |
+| G7 | For a given (account, chainId, period, filter), the report builder and the Account tab receive the identical entry set | FR-014, FR-015, SC-002 |
+| G8 | Persisted client records are append-only; supersession is expressed via `supersedes`, and prior records remain readable | FR-008 |
+
+## CSV export column mapping (report)
+
+Extends the spec-016 layout; one row per LedgerEntry:
+
+`date (ISO, from timestamp or "unavailable"), network, class, kind, direction,
+status, failureReason, token, amount, valueUsd, valuationStatus,
+counterparty, txHash, entryId`
+
+Rows are ordered by timestamp ascending; entries with `timestamp: null` sort
+last within their class and are flagged. The report header states the network
+scope and any `prunedBefore` disclosure (FR-013).

--- a/specs/051-unified-activity-ledger/contracts/ledger-source.md
+++ b/specs/051-unified-activity-ledger/contracts/ledger-source.md
@@ -1,0 +1,55 @@
+# Contract: Ledger Source Adapter
+
+Every activity domain plugs into the ledger through this interface
+(`frontend/src/data/ledger/sources/*.js`). Mirrors the spec-031 domain-source
+pattern but returns canonical LedgerEntry pre-items instead of notifications.
+
+```js
+/**
+ * @typedef {object} LedgerSource
+ * @property {string} class                    // 'wager' | 'transfer' | 'earn' | 'pool' | 'membership'
+ * @property {(ctx: SourceContext) => Promise<LedgerEntryPreItem[]>} list
+ * @property {(listener: () => void) => (() => void)} [subscribe]  // optional change signal (e.g. transferStore events)
+ */
+
+/**
+ * @typedef {object} SourceContext
+ * @property {string} account     // lowercased address
+ * @property {number} chainId     // strict scoping — a source MUST NOT return entries for other chains
+ * @property {object} [provider]  // injected read provider (tests / RPC reuse)
+ * @property {AbortSignal} [signal]
+ */
+```
+
+## Rules
+
+1. **Pure fetch**: `list` performs reads only; it never writes stores and
+   never throws for empty history (returns `[]`). Network errors reject; the
+   repository degrades per-source and reports which classes are stale rather
+   than failing the whole ledger (honest-state principle).
+2. **Pre-item shape**: everything in `data-model.md` LedgerEntry except
+   enrichment fields (`tokenSymbol/tokenDecimals/valueUsd/valuationStatus`),
+   which the repository adds via the shared enrichment pipeline. `entryId`
+   MUST be set by the source using `identity.js` builders.
+3. **Timestamps**: sources return epoch **ms** or `null` — never `0`, never
+   seconds. Chain-time hydration (wager fallback path) happens inside the
+   wager source via `timestamps.js`, bounded by the existing scan budget.
+4. **Determinism**: for `oc:` and `dv:` entries, calling `list` twice yields
+   identical `entryId`s (idempotent re-derivation, FR-009/011).
+5. **No cross-domain reach**: a source only reads its own domain's data
+   paths; consistency across surfaces is the repository's job.
+
+## Repository assembly contract (`ledgerRepository.js`)
+
+```
+listEntries({ account, chainId, filter?, period?, signal? })
+  → { entries: LedgerEntry[],          // deduped, enriched, sorted desc by (timestamp ?? recordedAt)
+      staleClasses: string[],          // sources that errored; UI must disclose
+      prunedBefore: number | null }    // FR-013 disclosure marker
+```
+
+- Dedup/merge per `data-model.md` Identity precedence.
+- Filters: by class, kind, status, date range — used by the Account tab UI
+  and by the report builder (same code path, FR-014).
+- Failed entries are included in `entries` and excluded by the summary
+  helpers, not by the repository.

--- a/specs/051-unified-activity-ledger/data-model.md
+++ b/specs/051-unified-activity-ledger/data-model.md
@@ -1,0 +1,100 @@
+# Data Model: Unified Activity Ledger (spec 051)
+
+## LedgerEntry (canonical, in-memory shape served by `ledgerRepository`)
+
+| Field | Type | Rules |
+|---|---|---|
+| `entryId` | string | Stable identity — see Identity below. Unique within (account, chainId). |
+| `account` | string (address, lowercased) | The user the entry belongs to. |
+| `chainId` | number | Strict scoping (FR-007); never mixed across networks unlabeled. |
+| `class` | enum `wager \| transfer \| earn \| pool \| membership` | Activity class (FR-001). |
+| `kind` | string | Class-specific event, e.g. `deposit`, `payout`, `refund`, `draw`, `cancel`, `send`, `receive`, `vault_deposit`, `vault_withdraw`, `loan_repay`, `reward_claim`, `pool_join`, `pool_claim`, `pool_refund`, `voucher_purchase`. |
+| `direction` | enum `in \| out \| none` | Value direction relative to the account; `none` for failed ops. |
+| `status` | enum `settled \| pending \| failed \| cancelled` | Failed entries are listed but excluded from all totals (FR-003). |
+| `failureReason` | string \| null | Verbatim reason for `failed` entries (e.g. bundler/paymaster message). |
+| `tokenAddress` | string \| null | Asset; null for native currency. |
+| `tokenSymbol`, `tokenDecimals` | string, number | From existing token-meta enrichment. |
+| `amountRaw` | string (integer units) | Exact chain units; formatting at render. |
+| `valueUsd` | number \| null | USD value at activity time (D7). |
+| `valuationStatus` | enum `valued \| unvalued` | `unvalued` entries are kept and flagged, never zeroed (FR-016). |
+| `counterparty` | string \| null | Other address where one exists (FR-004). |
+| `txHash` | string \| null | Verifiable reference for anything that reached the chain (FR-004). |
+| `logIndex` | number \| null | Disambiguates multiple events per tx. |
+| `timestamp` | number (epoch **ms**) \| null | Real activity time. **Never 0.** Null when genuinely unavailable (FR-006). |
+| `timestampProvenance` | enum `chain \| device \| unavailable` | `chain` = block time (FR-005); `device` only for client-only events; `unavailable` renders the explicit "date unavailable" state. |
+| `provenance` | enum `onchain \| derived \| client` | Matches the `oc:`/`dv:`/`cl:` id namespace; surfaced to auditing (constitution III). |
+| `refs` | object | Class-specific links: `{ wagerId?, poolId?, vaultAddress?, voucherId?, route?, supersedes?, linkedTxEntryId?, retryOf? }`. |
+
+**Invariants**
+- `status === 'failed'` ⇒ excluded from `computeSummary` / `computePnlSeries`
+  / report totals; still present in listings and exports.
+- `timestamp === null` ⇔ `timestampProvenance === 'unavailable'`; the value
+  `0` is invalid and rejected by normalization.
+- `provenance === 'onchain'` ⇒ `txHash` present.
+- Entries are value objects: the repository never mutates a returned entry.
+
+## Identity (`identity.js`)
+
+- On-chain: `oc:{chainId}:{txHash}:{logIndex}`; where the subgraph row does
+  not expose logIndex, reuse its unique entity id: `oc:{chainId}:wt:{WagerTransfer.id}`.
+- Derived fallback: `dv:{chainId}:wager:{wagerId}:{kind}:{party}` —
+  deterministic so re-derivation is idempotent (FR-009/011).
+- Client-only: `cl:{uuid}` (reuses the `transferStore` record id).
+
+**Merge precedence** (dedup on assembly and on restore):
+1. `oc:` beats `dv:` for the same `(wagerId, kind, party)` — derived entry dropped.
+2. A `cl:` record whose `txHash` matches an `oc:` entry is not shown twice:
+   the on-chain entry wins financial fields and gains
+   `refs.linkedTxEntryId`/`refs.route` context from the client record.
+3. Identical `entryId`s are identical records (append-only) — last write is
+   byte-equal; merge is a set union (FR-011).
+
+## ClientLedgerRecord (persisted, `ledgerClientStore.js`)
+
+The subset of LedgerEntry with `provenance: 'client'`, stored append-only via
+`userStorage` per account, elements tagged `chainId` (pattern of
+`activityStore`). Additional persistence-only fields:
+
+| Field | Rules |
+|---|---|
+| `recordedAt` | Device epoch ms when appended. |
+| `supersedes` | entryId of the record this one supersedes (status transitions append, never mutate — FR-008). Readers resolve chains to the latest; full chain retained for audit. |
+
+**Retention**: no default cap. A size guard may prune only entries older than
+the previous tax year and must record a disclosed `prunedBefore` marker the
+UI and reports surface (FR-013).
+
+## TimestampCache (persisted, `timestamps.js`)
+
+`{ [chainId]: { [wagerId]: { createdAtMs, resolvedAtMs? } } }` — pure
+performance cache of RPC hydration results (D6); losing it is harmless
+(re-derivable).
+
+## Backup object (spec 032)
+
+`syncedObjects` gains `{ key: 'activityLedger', networkScoped: true }`;
+payload = all ClientLedgerRecords for the account. Merge = union by
+`entryId` (conflict-free by append-only design). On-chain/derived entries are
+never included (FR-009 keeps bundles small). Restore-without-backup path
+rebuilds `oc:`/`dv:` entries only and surfaces the "device-local history not
+recovered" notice (FR-012).
+
+## State transitions
+
+```
+Client transfer record:  in_process ──append──▶ settled
+                                   └──append──▶ failed (failureReason)
+Failed then retried:     failed  ◀─refs.retryOf─ new record (in_process → …)
+Derived wager entry:     re-derived each assembly; replaced by oc: when the
+                         subgraph/scan later yields the real event (same
+                         underlying event, higher-precedence id)
+```
+
+## Migration (FR-017, `migrate.js`)
+
+One-time, idempotent (guarded by a `userStorage` marker):
+1. `fairwins.transfers.v1` rows → ClientLedgerRecords (`cl:{existing id}`),
+   preserving status/error/txHash/createdAt (device provenance).
+2. Report-history and notification stores are left in place (different
+   concerns); a consistency test asserts every financial event they reference
+   resolves to a ledger entry (FR-002).

--- a/specs/051-unified-activity-ledger/plan.md
+++ b/specs/051-unified-activity-ledger/plan.md
@@ -1,0 +1,143 @@
+# Implementation Plan: Unified Activity Ledger with Durable Audit Logging
+
+**Branch**: `claude/activity-audit-logging-axj086` | **Date**: 2026-07-11 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/051-unified-activity-ledger/spec.md`
+
+## Summary
+
+Consolidate all user financial activity (wager value events, wallet/gasless
+transfers including failures, earn/lending, pools, membership purchases) behind
+one client-side **activity ledger** read path surfaced in the Account tab.
+On-chain-derivable entries re-derive from the subgraph/chain (record of
+record); client-only records (e.g. failed UserOps) persist in a new
+append-only store registered as a spec-032 encrypted-backup synced object.
+The Account tab dashboard and the spec-016 tax report both read the ledger, so
+they can never disagree. Real block timestamps are hydrated on subgraph-less
+networks and the UI never renders relative time from missing timestamps
+(retiring the "20645d ago" defect). No new server-side per-user storage, no
+contract changes, no subgraph schema changes. Full decision record:
+[research.md](./research.md) D1–D9.
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES modules), React 18 + Vite (existing frontend stack)
+
+**Primary Dependencies**: ethers v6 (chain reads), existing subgraph GraphQL
+endpoints (The Graph), existing modules reused: `WagerRepository`
+(`SubgraphSource`/`RegistrySource`), `reportDataSource` (bounded event
+scanner + `WagerTransfer` query), `transferStore`, `activityStore` pattern,
+`enrichTransfers` (token meta + USD), spec-032 backup (`syncedObjects`,
+encrypted IPFS bundle)
+
+**Storage**: localStorage via `userStorage` (per-account, chainId-scoped) for
+client-only ledger records + a re-derivable timestamp cache; durable copy of
+client-only records travels in the spec-032 encrypted backup bundle (IPFS +
+pointer tx). No server-side per-user storage. Chain/subgraph is the record of
+record for everything else.
+
+**Testing**: Vitest (frontend unit + integration; existing `npm run test:frontend`)
+
+**Target Platform**: Web (desktop + mobile browsers), all configured networks
+including subgraph-less chains (Mordor/ETC)
+
+**Project Type**: Web frontend feature (data layer + UI) — no backend, no contracts
+
+**Performance Goals**: Account tab ledger render within the existing 60s
+polling model; ledger assembly for a typical account (≤ few hundred entries)
+well under 1s; RPC timestamp hydration bounded by the existing per-wager
+request budget (`SCAN_BUDGET`), cached after first resolution
+
+**Constraints**: Append-only client records (FR-008); no silent truncation —
+retention limits disclosed and never pruning current + previous tax year
+(FR-013); strict chainId scoping (FR-007, constitution III); backup payload
+limited to client-only records to keep bundles small (FR-009/010); never
+block a transfer on ledger/storage failure (existing `transferStore` rule)
+
+**Scale/Scope**: Per-user history up to low thousands of entries across
+networks; 6 activity classes; ~1 new data module (`frontend/src/data/ledger/`),
+~2 new UI states, 4 integration points (account stats, transfer activity,
+backup, reports), 1 one-time migration
+
+## Constitution Check
+
+*GATE: evaluated against `.specify/memory/constitution.md` v1.0.0.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Security-first contracts | ✅ N/A by scope | Zero `contracts/` changes; no new on-chain surface. Slither/Medusa gates unaffected. |
+| II. Test-first & coverage | ✅ Planned | All ledger logic (normalize, identity/dedup, merge, supersede resolution, migration, timestamp hydration fallback, valuation flagging) is pure and Vitest-tested; integration tests for account-stats parity with the report and for backup round-trip. Tasks will order tests with implementation. |
+| III. Honest state, no mocks | ✅ Core of the design | Ledger entries carry provenance (`oc:`/`dv:`/`cl:`) and `timestampProvenance`; derived/fallback data is flagged, unpriceable entries flagged `unvalued`, failed ops excluded from totals but always listed; strict chainId scoping preserved end-to-end (FR-007). No mock data in shipped paths. |
+| IV. Fail loudly in CI | ✅ | Standard Vitest/ESLint gates; no `continue-on-error` introduced. |
+| V. Accessible, consistent frontend | ✅ Planned | New/changed UI ("date unavailable" state, class filters, disclosure notes) uses existing components/patterns; WCAG AA + axe/Lighthouse gates apply; config via synced artifacts only. |
+| Simplicity (workflow §4) | ✅ | Reuses six existing read/write paths; adds one aggregation module + one synced object instead of new backend/indexer (research D1, D9). |
+
+**Post-design re-check (after Phase 1)**: PASS — the data model introduces no
+new core technology, no server storage, and no contract surface; Complexity
+Tracking is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/051-unified-activity-ledger/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions D1–D9
+├── data-model.md        # Phase 1 — LedgerEntry, stores, state transitions
+├── quickstart.md        # Phase 1 — validation guide
+├── contracts/
+│   ├── ledger-entry.md  # Canonical entry schema + identity/merge contract
+│   ├── ledger-source.md # Source adapter interface contract
+│   └── backup-object.md # spec-032 synced-object contract for activityLedger
+├── checklists/requirements.md
+└── tasks.md             # Phase 2 output (/speckit-tasks — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/
+├── src/
+│   ├── data/
+│   │   ├── ledger/                      # NEW — the unified activity ledger
+│   │   │   ├── ledgerRepository.js      # aggregate sources → normalized, deduped, sorted entries
+│   │   │   ├── ledgerClientStore.js     # append-only client-only records (userStorage, chainId-scoped)
+│   │   │   ├── identity.js              # entryId builders + merge precedence (oc: > dv:; cl: linking)
+│   │   │   ├── timestamps.js            # RPC block-time hydration (bounded scan) + cache
+│   │   │   ├── migrate.js               # one-time import of fairwins.transfers.v1 & legacy stores (FR-017)
+│   │   │   └── sources/
+│   │   │       ├── wagerLedgerSource.js      # WagerTransfer (subgraph) | derived fallback + hydration
+│   │   │       ├── transferLedgerSource.js   # transferStore mirror (client-only + txHash-linked)
+│   │   │       ├── earnLedgerSource.js       # vault Deposit/Withdraw events + reward claims
+│   │   │       ├── poolLedgerSource.js       # PoolMember/PoolClaim/PoolRefund (subgraph)
+│   │   │       └── membershipLedgerSource.js # voucher/membership purchases
+│   │   ├── reports/reportDataSource.js  # CHANGED — enumerate via ledgerRepository
+│   │   └── reports/reportBuilder.js     # CHANGED — all classes + valuationStatus columns
+│   ├── hooks/
+│   │   ├── useActivityLedger.js         # NEW — query hook (account, chainId, filters, period)
+│   │   ├── useAccountStats.js           # CHANGED — reads ledger instead of deriveTransfers
+│   │   └── useTransfer.js               # CHANGED — mirrors records into ledgerClientStore
+│   ├── lib/
+│   │   ├── account/format.js            # CHANGED — formatRelativeTime returns null on invalid ts
+│   │   ├── account/{computeSummary,computePnlSeries,breakdowns}.js # CHANGED — pure fns of ledger entries
+│   │   └── backup/syncedObjects.js      # CHANGED — + activityLedger synced object
+│   └── components/
+│       ├── account/RecentActivityFeed.jsx   # CHANGED — all classes, filters, "date unavailable"
+│       └── wallet/TransferActivityList.jsx  # CHANGED — reads ledger (transfers filter)
+└── ... Vitest specs colocated per repo convention
+
+subgraph/    — unchanged
+contracts/   — unchanged
+services/    — unchanged
+```
+
+**Structure Decision**: Single-project web frontend change. The one new
+directory is `frontend/src/data/ledger/` following the established
+`data/<domain>/` + `sources/` convention from spec 031; everything else is
+targeted edits to the six integration points listed above.
+
+## Complexity Tracking
+
+No constitution violations to justify — table intentionally empty.

--- a/specs/051-unified-activity-ledger/quickstart.md
+++ b/specs/051-unified-activity-ledger/quickstart.md
@@ -1,0 +1,70 @@
+# Quickstart: Validating the Unified Activity Ledger (spec 051)
+
+Prerequisites: repo installed (`npm install`), frontend deps
+(`cd frontend && npm install`), a test network configured (one subgraph
+network, e.g. Polygon/Amoy-class, and one subgraph-less network, e.g. Mordor,
+to exercise both wager paths).
+
+## 1. Unit / integration tests (fast signal)
+
+```bash
+npm run test:frontend
+```
+
+Expected green suites (added by this feature):
+
+- `data/ledger/identity` — entryId builders, `oc:`>`dv:` precedence, `cl:` txHash linking
+- `data/ledger/ledgerRepository` — assembly, dedup, per-source degradation (`staleClasses`), filters
+- `data/ledger/ledgerClientStore` — append-only, supersede resolution, chainId scoping, FR-013 pruning disclosure
+- `data/ledger/migrate` — idempotent import of `fairwins.transfers.v1`
+- `data/ledger/timestamps` — hydration fallback → `null` + `unavailable` (never `0`)
+- `lib/account/format` — `formatRelativeTime(0|null|-1) === null`
+- Parity test — same (account, chainId, period): report line set ≡ Account tab entry set; totals equal (SC-002)
+- Backup round-trip — client records → synced object → restore → union dedup (SC-003)
+
+## 2. Manual validation — Account tab (US1)
+
+```bash
+npm run frontend
+```
+
+1. Seed activity: create/accept/resolve a wager; send a wallet transfer;
+   trigger a failing gasless transfer (underfunded smart account); make an
+   earn vault deposit; join a pool.
+2. Open `/wallet?tab=account` → every action above appears once in the
+   activity record with class, amount, token, status, timestamp, and (where
+   on-chain) a working block-explorer link.
+3. The failed gasless entry shows status Failed + the verbatim reason, and
+   dashboard totals are identical before/after the failure (SC-006).
+4. Switch networks → only the active network's entries render (FR-007).
+5. Apply a class filter → list and displayed totals follow the filter.
+
+## 3. Manual validation — timestamps on a subgraph-less network (US4)
+
+On the RPC-only network: create + refund a wager, open the Account tab.
+Expected: real dates matching the block explorer; if hydration is exhausted,
+an explicit "date unavailable" label — grep the rendered page for `20645d`
+must find nothing (SC-004).
+
+## 4. Manual validation — report parity (US2)
+
+Open `/wallet?tab=reports`, generate CSV for a period covering step 2.
+Expected: every ledger entry in the period is a CSV row (all classes, failed
+rows flagged, `valuationStatus` column present); totals equal the Account tab
+figures for the same period/network (SC-002); unvalued entries flagged, not
+zeroed.
+
+## 5. Manual validation — backup & recovery (US3)
+
+1. Run an encrypted backup (spec-032 flow) after step 2.
+2. Clear site data (or use a fresh browser profile), restore from backup.
+3. Expected: full activity record returns, including the failed gasless
+   entry (SC-003); repeating the restore creates no duplicates (FR-011).
+4. Negative path: fresh profile, no restore → on-chain entries rebuild and
+   the UI states device-local history was not recovered (FR-012).
+
+## 6. Migration check (FR-017)
+
+On a profile that has pre-feature `fairwins.transfers.v1` history: load the
+app once → old transfer entries (statuses, errors, txHashes) appear in the
+ledger; reloading does not duplicate them (SC-007).

--- a/specs/051-unified-activity-ledger/research.md
+++ b/specs/051-unified-activity-ledger/research.md
@@ -1,0 +1,176 @@
+# Research: Unified Activity Ledger (spec 051)
+
+All decisions below resolve the Technical Context unknowns for `plan.md`.
+Grounding: the current-state audit of activity surfaces (spec 051 Problem
+Statement) and direct reading of the existing data paths:
+`frontend/src/lib/account/deriveTransfers.js`, `frontend/src/lib/transfer/transferStore.js`,
+`frontend/src/lib/backup/syncedObjects.js`, `frontend/src/data/reports/reportDataSource.js`,
+`frontend/src/data/wagers/{SubgraphSource,RegistrySource}.js`,
+`frontend/src/data/notifications/*`.
+
+---
+
+## D1 — Ledger architecture: client-side aggregating read model, no new backend
+
+**Decision**: Build the ledger as a frontend data module (`frontend/src/data/ledger/`)
+that aggregates **ledger sources** (one per activity domain) into a canonical,
+deduplicated, per-account + per-network entry stream. On-chain-derivable
+entries are re-derived on demand (chain/subgraph is the record of record);
+client-only entries live in a new append-only local store that is registered
+as a spec-032 synced object.
+
+**Rationale**: The spec's assumptions forbid new server-side per-user storage
+(privacy stance). Every source the ledger needs already has a client read
+path; what is missing is one normalization + merge layer and durable backup
+for the client-only remainder. This mirrors the proven spec-031 pattern
+(domain sources → engine → store) but for a financial record instead of
+notifications.
+
+**Alternatives considered**:
+- *Server-side ledger in relay-gateway*: rejected — violates the no-dossier
+  privacy assumption, adds an availability dependency, and only sees relayed
+  traffic anyway.
+- *Subgraph-only ledger*: rejected — subgraph does not exist on all networks
+  (Mordor), cannot see failed UserOps or wallet-to-wallet sends, and cannot
+  carry client-only context.
+- *Extend the spec-031 notification store into the ledger*: rejected — that
+  store is capped (100), lossy by design (diff snapshots), and read-state
+  oriented; an audit log needs different retention and immutability rules.
+
+## D2 — Source strategy per activity class
+
+**Decision** (per class, in priority order of data path):
+
+| Class | Primary source | Fallback / notes |
+|---|---|---|
+| Wager value events | Subgraph `WagerTransfer` (real `txHash`, `timestamp`, `from/to`) via the existing `reportDataSource` enumeration | On subgraph-less networks: derive from wager state (`deriveTransfersFromWagers`) **plus timestamp hydration** (D6) using the bounded per-wager event scan already implemented in `reportDataSource` (`SCAN_BUDGET`, adaptive chunking) |
+| Wallet transfers (outgoing, incl. gasless) | `transferStore` records (the write path already captures route, status transitions, failure reasons) | Confirmed sends are linked to chain truth by `txHash`; failed/gasless-failed records remain client-only entries |
+| Gasless/sponsored UserOps | Same `transferStore` write path (spec 041/050 flows already record `route: 'gasless'` + errors) | No subgraph entity exists for UserOps; out of scope to add one (see D9) |
+| Earn/lending (loans) | New thin source reading the user's vault events (ERC-4626 `Deposit`/`Withdraw` for the account) with the same bounded-window scan pattern; rewards from the existing `useEarnRewards` claim path recording at claim time | Position snapshots (spec 050) remain the balance view; the ledger records *events* |
+| Pools | Subgraph `PoolMember` / `PoolClaim` / `PoolRefund` entities (already indexed, spec 034) | RPC-only networks: pool factory event scan, bounded |
+| Membership/voucher | Subgraph `Voucher` entity + purchase events (spec 026) | Membership purchase already surfaces in `membershipSource`; reuse its query |
+
+**Rationale**: Reuse over rebuild — every row above is an existing, tested
+read path; the ledger adds normalization, identity, and merge, not new
+indexing. The two divergent wager money paths (Account tab derived vs report
+`WagerTransfer`) are unified by making the **subgraph transfers the primary**
+(they carry the fidelity FR-004 requires) and the derived path a clearly
+flagged fallback — the exact inverse of today's Account tab, which is what
+lets dashboard and report agree (FR-014/015).
+
+**Alternatives**: keeping `deriveTransfersFromWagers` primary everywhere was
+rejected because it has empty `txHash` and synthetic timestamps — it can never
+meet FR-004 on its own.
+
+## D3 — Entry identity & deduplication
+
+**Decision**: Every ledger entry gets a stable `entryId`:
+- On-chain entries: `oc:{chainId}:{txHash}:{logIndex}` (or `oc:{chainId}:{txHash}:{eventKey}`
+  where logIndex is unavailable from the subgraph row — `WagerTransfer.id`
+  already encodes this uniqueness and is reused verbatim).
+- Derived (fallback) wager entries: `dv:{chainId}:wager:{wagerId}:{direction}:{party}` —
+  deterministic, so re-derivation is idempotent.
+- Client-only entries: `cl:{uuid}` (the existing `transferStore` record `id`).
+
+Merge precedence: `oc:` > `dv:` for the same underlying event (a derived
+entry is dropped when an on-chain entry for the same
+`(wagerId, direction, party)` exists). A client-only record that carries a
+`txHash` which also appears as an on-chain entry is **linked** (annotation),
+not duplicated: the on-chain entry wins for financial fields, the client
+record contributes context (route, failure→retry association per edge case).
+
+**Rationale**: Satisfies FR-011 (no duplicates on restore/re-sync) with pure,
+testable functions; deterministic derived ids make re-derivation append-safe.
+
+## D4 — Immutability model for client-only records
+
+**Decision**: New append-only store `frontend/src/data/ledger/ledgerClientStore.js`
+keyed per account (via `userStorage`) with entries scoped by `chainId`
+(pattern proven by `activityStore`). Records are never mutated: status
+transitions (in_process → complete/failed) append a superseding record with
+`supersedes: <entryId>`; readers resolve to the latest while auditing can see
+the chain. `transferStore` remains the *write path* the transfer flow calls
+(no churn in `useTransfer.js` semantics); a mirror hook appends each
+create/update into the ledger client store. One-time migration (FR-017)
+imports existing `fairwins.transfers.v1` rows.
+
+**Rationale**: FR-008 append-only requirement; avoids rewriting the working
+transfer flow; the mirror + migration keeps the old Activity tab data intact
+while the ledger becomes the read path.
+
+**Alternatives**: making `transferStore` itself append-only (v2 schema) was
+rejected — it churns a shipped write path and its capped, mutable design is
+fine for what it is; the ledger store owns durability instead. The 100-entry
+cap moves to the ledger store as a *disclosed* pruning rule that never prunes
+entries within the current + previous tax year (FR-013); practically this
+means no cap by default and a size-based guard with user-visible disclosure.
+
+## D5 — Backup integration (spec 032)
+
+**Decision**: Register one new synced object in
+`frontend/src/lib/backup/syncedObjects.js`:
+`{ key: 'activityLedger', networkScoped: true }` whose payload is the
+client-only record set (D4). Merge is additive by `entryId` (append-only
+makes merge conflict-free; identical ids are identical records). Restore
+applies through the existing flow; on-chain entries are *not* backed up —
+they re-derive (FR-009), keeping bundles small.
+
+**Rationale**: The synced-object registry was explicitly designed for this
+("Adding a future object = one entry here", `syncedObjects.js:1-3`); FR-010's
+"included automatically" falls out of the existing backup flow.
+
+## D6 — Real timestamps on subgraph-less networks (kills "20645d ago")
+
+**Decision**: Two-part fix:
+1. **Data**: on RPC-only networks, hydrate wager event timestamps from chain
+   truth using the bounded event-window scanner that `reportDataSource`
+   already implements (per-wager window, adaptive chunk, request budget), then
+   `getBlock` timestamps for matched events; results cached in a small
+   localStorage timestamp cache (pure perf — safe to lose, re-derivable).
+   Derived entries whose timestamp cannot be established within budget carry
+   `timestamp: null` + `timestampProvenance: 'unavailable'` — never `0`.
+2. **Render**: `formatRelativeTime` (`frontend/src/lib/account/format.js`)
+   returns `null` for missing/zero/negative input; all call sites
+   (`RecentActivityFeed`, ledger UI, `TransferActivityList`) render an
+   explicit "date unavailable" state on `null`. `deriveTransfersFromWagers`
+   stops coercing missing times to `0`/`createdAt`.
+
+**Rationale**: FR-005/006 and SC-004. The render guard alone would hide the
+symptom but fail FR-005 (real block time on every network); the scan gives
+truth within a disclosed budget, and the guard covers the remainder honestly.
+
+## D7 — Valuation (USD value-at-time)
+
+**Decision**: Reuse the existing enrichment pipeline
+(`frontend/src/lib/account/enrichTransfers.js` + the tax report's pricing in
+`reportBuilder`): each entry gets `valueUsd` + `valuationStatus:
+'valued' | 'unvalued'`. No new price provider; unpriceable entries are
+flagged, never zeroed or dropped (FR-016, edge case).
+
+## D8 — Reporting & dashboard parity
+
+**Decision**: `useAccountStats` and the tax report both consume the ledger:
+- `useAccountStats` replaces its `deriveTransfersFromWagers` internals with a
+  ledger query scoped to (account, chainId); `computeSummary`,
+  `computePnlSeries`, `computeBreakdowns` become pure functions **of ledger
+  entries** (settled only — failed entries excluded from totals, FR-003).
+- `reportBuilder`/`reportDataSource` enumerate the same ledger query for the
+  selected period, extending the CSV/PDF columns to all activity classes and
+  the `valuationStatus` flag.
+
+**Rationale**: FR-014/015 "can never disagree" is achieved structurally —
+one read path — rather than by reconciliation.
+
+## D9 — Scope boundaries (what stays out)
+
+- **No subgraph schema changes** in this feature: every FR is satisfiable
+  from existing entities + client capture. Indexing UserOps/transfers is a
+  possible future spec; noted, not planned here (YAGNI).
+- **No contract changes**: zero `contracts/` surface; constitution Principle I
+  gates are trivially met.
+- **Incoming arbitrary transfers** (third-party airdrops): best-effort only,
+  disclosed in report output (spec assumption). Detection limited to what
+  existing sources see.
+- **Notification feed (spec 031)** stays a notification system; it gains no
+  new duties. Consistency (FR-002) is validated by test: any financial event
+  the feed shows must resolve to a ledger entry.

--- a/specs/051-unified-activity-ledger/spec.md
+++ b/specs/051-unified-activity-ledger/spec.md
@@ -1,0 +1,400 @@
+# Feature Specification: Unified Activity Ledger with Durable Audit Logging
+
+**Feature Branch**: `claude/activity-audit-logging-axj086`
+
+**Created**: 2026-07-11
+
+**Status**: Draft
+
+**Input**: User description: "We are currently tracking activity in several locations. The appropriate place for it is in the user's Account tab. In order to provide robust reporting and auditing abilities for a user we need to make sure activities across all surfaces are properly tracked, recorded, backed up, and made available to the reporting function. This will ensure an immutable log is recoverable of all trades, loans, transfers, wagers, deposits, etc. with appropriate data fidelity to facilitate tax reporting functionality in the app."
+
+## Problem Statement
+
+User activity is currently tracked in several disconnected places, each with its
+own data path, retention, and fidelity:
+
+- The **Account tab** (spec 020) derives deposit/payout/refund rows at runtime
+  from wager state; on networks without an indexer these rows have no real
+  timestamps, producing displays like "20645d ago".
+- The **Pay & Transfer Activity tab** keeps wallet-transfer history — including
+  failed gasless/sponsored operations — only in a device-local log capped at
+  100 entries.
+- The **platform notification feed** (spec 031) keeps a separate device-local
+  activity store.
+- The **tax report** (spec 016) reads a different data path entirely (indexed
+  wager value-transfer records), so its totals can disagree with the Account
+  tab.
+- **Earn/lending (loans), pool activity, and gasless operations have no durable
+  per-user history at all.**
+- **None of the device-local activity stores are included in the encrypted
+  backup** (spec 032), so activity history is lost on cache clear or device
+  change.
+
+A user who needs to audit their financial activity — especially for tax
+reporting — cannot today obtain a single, complete, trustworthy record.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - One Complete Activity Record in the Account Tab (Priority: P1)
+
+As a FairWins user, I open my Account tab and see a single, complete,
+chronological record of every financial activity on my account for the active
+network — wager deposits, payouts, refunds, draws, and cancellations; wallet
+transfers of native currency and tokens (including failed attempts and
+gasless/sponsored operations); earn/lending deposits, withdrawals, loans, and
+rewards; pool joins, claims, and refunds; and membership/voucher purchases —
+each with accurate details: what happened, when, how much, in what token, its
+value at the time, who the counterparty was, whether it succeeded or failed,
+and a verifiable transaction reference where one exists.
+
+**Why this priority**: This is the core of the request — the Account tab is
+the appropriate single home for activity, and every other capability (backup,
+reporting, auditing) depends on one canonical ledger existing. Without it,
+users must visit several screens and still see an incomplete picture.
+
+**Independent Test**: Perform one activity of each class (wager lifecycle
+events, a wallet transfer, a failed gasless transfer, an earn deposit, a pool
+join/claim, a membership purchase) on a test network, then open the Account
+tab and verify each appears exactly once in the activity record with correct
+type, amount, token, timestamp, status, and transaction reference.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has performed activity across wagers, wallet transfers,
+   earn, pools, and membership, **When** they open the Account tab, **Then**
+   all of that activity appears in one chronological record without visiting
+   any other screen.
+2. **Given** a gasless transfer failed before reaching the chain (e.g.
+   "Smart Account does not have sufficient funds"), **When** the user views
+   the activity record, **Then** the failed attempt appears with a failed
+   status, the failure reason, and the date it was attempted.
+3. **Given** a user switches the active network, **When** they view the
+   activity record, **Then** only activity for that network is shown and no
+   activity from other networks leaks in.
+4. **Given** an activity record entry has a confirmed on-chain transaction,
+   **When** the user selects it, **Then** they can reach the corresponding
+   block-explorer entry to independently verify it.
+5. **Given** the user filters the record by activity class (e.g. only
+   transfers, only wagers), **When** the filter is applied, **Then** only
+   matching entries are shown and displayed totals reflect the filter.
+
+---
+
+### User Story 2 - Reporting Reads the Same Ledger (Priority: P2)
+
+As a user preparing my taxes, I generate an activity/tax report for a chosen
+period and the report contains exactly the same activities, amounts, and
+timestamps that the Account tab shows for that period — every trade, loan,
+transfer, wager, and deposit — because both read from the same ledger. The
+export has enough fidelity (real timestamps, transaction references, token,
+amount, value at time of activity, counterparty, status) for me to hand it to
+a tax professional.
+
+**Why this priority**: Tax reporting is the stated end goal, and today the
+report and the dashboard can disagree because they use different data paths.
+Agreement between the audit view and the export is what makes the record
+trustworthy.
+
+**Independent Test**: Generate a report for a period containing known
+activity of every class and compare it line-by-line and total-by-total against
+the Account tab's record filtered to the same period; they must match.
+
+**Acceptance Scenarios**:
+
+1. **Given** a period with activity of every class, **When** the user
+   generates a report for that period, **Then** every ledger entry in the
+   period appears in the report and no entry appears in only one of the two
+   surfaces.
+2. **Given** the Account tab shows summary figures (net P&L, total wagered),
+   **When** a report is generated for the same period and network, **Then**
+   the report's totals equal the Account tab's figures.
+3. **Given** activity classes that previously never reached the report
+   (wallet transfers, earn/lending, pools, failed gasless operations),
+   **When** a report is generated, **Then** those activities are included and
+   clearly categorized, with failed operations distinguishable from settled
+   value movements.
+4. **Given** an entry whose value-at-time could not be determined, **When**
+   the report is generated, **Then** the entry is still present and is
+   explicitly flagged as missing valuation rather than silently showing zero.
+
+---
+
+### User Story 3 - The Ledger Is Immutable and Recoverable (Priority: P3)
+
+As a user who cleared my browser data or moved to a new device, I restore my
+account (via my existing encrypted backup flow) and my complete activity
+history comes back: everything that happened on-chain is re-derived from the
+public record, and activity that only ever existed on my device — such as
+failed operations that never reached the chain — is restored from my encrypted
+backup. Past entries are never silently edited or deleted; corrections appear
+as new entries.
+
+**Why this priority**: "Immutable and recoverable" is the durability guarantee
+that makes the ledger an audit log rather than a cache. It depends on the
+ledger existing (P1) but not on reporting (P2).
+
+**Independent Test**: Record activity including at least one client-only
+event, run a backup, clear all local data (or use a fresh device), restore,
+and verify the activity record is byte-for-byte equivalent in content to the
+pre-wipe record.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user with on-chain activity and a current encrypted backup,
+   **When** they restore on a new device, **Then** the Account tab shows the
+   same complete activity record they had before, including client-only
+   entries such as failed gasless attempts.
+2. **Given** a user restores without any backup, **When** the ledger is
+   rebuilt, **Then** all on-chain-derivable activity is present and the user
+   is informed that device-local-only history (e.g. failed attempts) could
+   not be recovered.
+3. **Given** an existing ledger entry, **When** any subsequent processing
+   occurs (re-sync, restore, correction), **Then** the original entry is
+   never mutated in place; superseding information appears as a new entry or
+   annotation and the original remains visible to auditing.
+4. **Given** a restore overlaps with re-derived on-chain history, **When**
+   the two are merged, **Then** no duplicate entries are shown for the same
+   underlying event.
+5. **Given** new client-only activity occurs after the last backup, **When**
+   the user next backs up, **Then** the new activity is included without the
+   user having to select it manually.
+
+---
+
+### User Story 4 - Every Timestamp Is Real and Rendered Honestly (Priority: P4)
+
+As a user, every activity entry I see carries the real date and time the
+activity occurred, on every supported network — including networks without an
+indexing service — and the interface never invents a time. Displays like
+"20645d ago" never appear; if a true timestamp is genuinely unavailable, the
+entry says so instead of rendering a misleading relative time.
+
+**Why this priority**: Timestamps are the backbone of audit and tax fidelity;
+a wrong date can change a tax year. This is last only because it is a fidelity
+refinement of entries that P1 already surfaces.
+
+**Independent Test**: On a network without an indexer, perform wager activity
+and verify the Account tab shows the true activity dates (matching the block
+explorer) and that no entry anywhere renders a relative time derived from a
+missing or zero timestamp.
+
+**Acceptance Scenarios**:
+
+1. **Given** activity on a network without an indexing service, **When** the
+   user views the activity record, **Then** each entry shows the true date
+   and time of the underlying transaction.
+2. **Given** an entry whose true timestamp cannot be established, **When** it
+   is displayed, **Then** the interface shows an explicit "date unavailable"
+   state and never a computed relative time such as "20645d ago".
+3. **Given** any entry with a known timestamp, **When** it is displayed as
+   relative time, **Then** the value is consistent with the absolute
+   timestamp shown on the entry's detail view and with the block explorer.
+
+---
+
+### Edge Cases
+
+- A restore is performed from a backup made on a device that also had
+  activity the current device never saw, while the current device has newer
+  activity the backup lacks — the merged ledger must contain both without
+  duplicates.
+- The same underlying event is observable from two sources (e.g. an indexed
+  record and a live chain read) — the ledger must deduplicate to one entry
+  keyed on the underlying transaction/event identity.
+- A failed gasless attempt is later retried and succeeds — both the failed
+  attempt and the successful operation appear, distinguishable and ideally
+  associated.
+- Value-at-time cannot be priced (obscure token, missing price history) — the
+  entry is kept and flagged, never dropped or silently zeroed.
+- Activity volume exceeds any local cap (e.g. an active user's 101st
+  transfer) — history visible in the ledger and included in backups must not
+  be silently truncated; if practical limits exist they must be disclosed.
+- The user has activity on multiple networks with the same address — entries
+  must remain strictly network-scoped in display and in reports, and a report
+  states which network(s) it covers.
+- An activity occurs while the app is closed (e.g. an incoming transfer or a
+  wager resolved by a third party) — it must still appear in the ledger the
+  next time the ledger syncs.
+- Clock skew between the user's device and the chain — recorded times for
+  on-chain events come from the chain, not the device clock.
+- A backup exists but cannot be decrypted (wrong key) — the on-chain-derived
+  ledger still loads; the user is told client-only history was not restored.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Coverage**
+
+- **FR-001**: The system MUST maintain, per user account and per network, a
+  single activity ledger that records every financial activity class the
+  product supports: wager lifecycle value events (deposit, payout, refund,
+  draw, cancellation), wallet transfers of native currency and tokens
+  (incoming where detectable, and all outgoing), gasless/sponsored operations
+  (including those that failed before reaching the chain), earn/lending
+  events (deposits, withdrawals, loan originations/repayments, rewards), pool
+  events (join, claim, refund), and membership/voucher purchases.
+- **FR-002**: The Account tab MUST present this ledger as the user's canonical
+  activity record, and every activity surface elsewhere in the product
+  (transfer activity list, notification feed) MUST be consistent with it —
+  no surface may show a financial activity that is absent from the ledger.
+- **FR-003**: Failed operations MUST be first-class ledger entries carrying a
+  failed status and the failure reason, clearly distinguished from settled
+  value movements so they are never counted in financial totals.
+
+**Data fidelity**
+
+- **FR-004**: Each ledger entry MUST record: activity class and direction; the
+  date and time the activity actually occurred; asset and amount; the value of
+  the amount at the time of the activity in the user's reporting currency
+  (or an explicit "unvalued" flag when unavailable); counterparty where one
+  exists; final status (settled, pending, failed, cancelled); the network it
+  occurred on; and a verifiable on-chain transaction reference for every
+  entry that reached the chain.
+- **FR-005**: Timestamps for on-chain events MUST come from the chain's own
+  record (block time), on every supported network including those without an
+  indexing service; the device clock is used only for client-only events that
+  never reached the chain.
+- **FR-006**: The interface MUST never render a relative or absolute time
+  derived from a missing, zero, or invalid timestamp; such entries MUST show
+  an explicit "date unavailable" state. (This retires the "20645d ago" class
+  of defect.)
+- **FR-007**: Ledger entries MUST be strictly scoped to the network they
+  occurred on; display, totals, backup, and reports MUST never mix networks
+  without explicitly labeling them.
+
+**Immutability & recoverability**
+
+- **FR-008**: The ledger MUST be append-only from the user's perspective:
+  recorded entries are never edited in place or deleted; corrections and
+  status transitions appear as new information that supersedes without
+  erasing.
+- **FR-009**: All activity that reached the chain MUST be re-derivable from
+  public on-chain/indexed data at any time, so the on-chain portion of the
+  ledger is recoverable with no backup at all.
+- **FR-010**: Activity that exists only on the user's device (e.g. failed
+  operations that never reached the chain, and any locally-enriched detail
+  that cannot be re-derived) MUST be included automatically in the user's
+  existing encrypted backup, and restored by the existing restore flow.
+- **FR-011**: On restore or re-sync, the system MUST merge re-derived
+  on-chain history with backed-up client-only history without creating
+  duplicate entries for the same underlying event.
+- **FR-012**: When client-only history cannot be recovered (no backup, or
+  backup cannot be decrypted), the system MUST still rebuild the
+  on-chain-derived ledger and MUST tell the user that device-local history
+  was not recovered.
+- **FR-013**: Ledger history MUST NOT be silently truncated. Any practical
+  retention limit MUST be disclosed to the user, and no limit may cause
+  activity within at least the current and previous tax year to become
+  unavailable to reporting.
+
+**Reporting**
+
+- **FR-014**: The reporting function (activity/tax report) MUST read from the
+  same ledger the Account tab presents, cover all ledger activity classes,
+  and produce exports whose line items and totals match what the Account tab
+  shows for the same period and network.
+- **FR-015**: Account tab summary figures (net P&L, totals, breakdowns) MUST
+  be computed from the ledger so that dashboard, activity record, and report
+  can never disagree.
+- **FR-016**: Exports MUST carry the full fidelity of FR-004 per line item so
+  the output is usable for tax preparation, and MUST explicitly flag entries
+  with missing valuations rather than omitting or zeroing them.
+
+**Migration & continuity**
+
+- **FR-017**: Existing device-local activity history (transfer history,
+  notification-feed history, report history) MUST be migrated into the ledger
+  on first use so no previously visible history is lost by this feature.
+
+### Key Entities
+
+- **Activity Ledger**: The per-account, per-network, append-only collection of
+  activity entries; the single source read by the Account tab, all activity
+  surfaces, and the reporting function.
+- **Ledger Entry**: One recorded activity: class, direction, asset, amount,
+  value-at-time (or unvalued flag), timestamp and its provenance (chain vs
+  device), status, counterparty, network, transaction reference, and a stable
+  identity for deduplication across sources and restores.
+- **Client-Only Record**: The subset of ledger entries not re-derivable from
+  public data (e.g. failed gasless attempts); the portion that must travel in
+  the encrypted backup.
+- **Activity Report**: A user-requested export over the ledger for a period
+  and network, with line items and totals that match the Account tab.
+- **Backup Bundle (existing, spec 032)**: The encrypted user-data container;
+  extended to carry Client-Only Records.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of supported financial activity classes (wagers, wallet
+  transfers, gasless operations including failures, earn/lending, pools,
+  membership purchases) appear in the Account tab activity record — verified
+  by performing one of each and finding each exactly once.
+- **SC-002**: For any chosen period and network, the generated report and the
+  Account tab agree exactly: zero line items present in one but not the
+  other, and identical totals.
+- **SC-003**: After a full local-data wipe and restore from backup, the user
+  recovers 100% of their prior activity record, including client-only
+  entries; with no backup, 100% of on-chain-derivable entries are recovered.
+- **SC-004**: Zero occurrences of relative times computed from missing or
+  zero timestamps (the "20645d ago" defect class) across all supported
+  networks; every displayed activity date for an on-chain event matches the
+  block explorer.
+- **SC-005**: A user can locate any specific past activity (by class, date
+  range, or status) from the Account tab in under 30 seconds without visiting
+  another screen.
+- **SC-006**: Failed operations are never counted in financial totals on any
+  surface — dashboard figures, breakdowns, and report totals exclude them
+  while still listing them — verified by comparing totals before and after a
+  failed attempt.
+- **SC-007**: No user-visible activity history that existed before this
+  feature is lost after it ships (migration completeness), verified against
+  pre-migration snapshots of each legacy store.
+
+## Assumptions
+
+- The public chain (and, where available, indexed data) is the record of
+  record for on-chain activity; the ledger is a faithful, re-derivable view of
+  it, not a competing store. Deep history re-derivation on indexer-less
+  networks may be best-effort within disclosed limits (FR-013).
+- The existing encrypted backup/restore flow (spec 032) is the vehicle for
+  durable client-only data; this feature extends what that bundle carries
+  rather than introducing a new backup mechanism, preserving its privacy
+  model (user-held keys, no plaintext leaves the device).
+- No new server-side per-user activity storage is introduced; durability comes
+  from the chain plus the user's encrypted backup. This preserves the
+  product's existing privacy stance (the platform does not hold user activity
+  dossiers).
+- Value-at-time uses the product's existing pricing sources; where historical
+  prices are unavailable the entry is flagged unvalued rather than estimated
+  silently.
+- "Loans" refers to the earn/lending capability (spec 050 earn-lending) —
+  positions, originations/repayments where applicable, and rewards; there is
+  no separate loan product.
+- Incoming wallet transfers are included where they are practically
+  detectable for the user's account; the spec does not require exhaustive
+  detection of arbitrary third-party airdrops, and any such limitation is
+  disclosed in the reporting output.
+- The reporting currency for value-at-time is USD, consistent with the
+  existing tax report (spec 016).
+- Nicknames/labels applied to counterparties remain client-side (consistent
+  with existing address-book behavior) and travel via the existing backup,
+  not on-chain.
+
+## Dependencies
+
+- **Spec 016 (wager tax report)**: reporting function to be re-pointed at the
+  ledger and extended to all activity classes.
+- **Spec 020 (account stats dashboard)**: Account tab surfaces to read the
+  ledger instead of runtime-derived transfers.
+- **Spec 031 (platform notifications)**: notification feed must stay
+  consistent with the ledger.
+- **Spec 032 (encrypted data sync)**: backup bundle extended to carry
+  client-only ledger records.
+- **Specs 035/036/041/050 (intents, relayer, passkey wallet, sponsored
+  paymaster)**: sources of gasless/UserOp activity, including failures, that
+  the ledger must capture.
+- **Spec 034 (wager pools)** and **spec 050 (earn-lending)**: sources of pool
+  and earn/loan activity.

--- a/specs/051-unified-activity-ledger/tasks.md
+++ b/specs/051-unified-activity-ledger/tasks.md
@@ -1,0 +1,155 @@
+# Tasks: Unified Activity Ledger with Durable Audit Logging
+
+**Input**: Design documents from `/specs/051-unified-activity-ledger/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: INCLUDED — constitution Principle II (test-first) is non-negotiable; every
+behavior task is preceded by its Vitest coverage. Test files colocate with the module
+per repo convention (`*.test.js[x]` next to source or under the module's `__tests__/`).
+
+**Organization**: Grouped by user story (US1–US4 from spec.md) so each story is an
+independently testable increment.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: parallelizable (different files, no dependency on an incomplete task)
+- **[Story]**: US1 (unified record), US2 (reporting parity), US3 (immutable/recoverable), US4 (timestamps)
+
+## Phase 1: Setup
+
+**Purpose**: Skeleton for the new ledger module — no behavior yet
+
+- [ ] T001 Create `frontend/src/data/ledger/` module skeleton (`ledgerRepository.js`, `ledgerClientStore.js`, `identity.js`, `timestamps.js`, `migrate.js`, `sources/` with five empty source files exporting the LedgerSource shape from `contracts/ledger-source.md`)
+- [ ] T002 [P] Add shared ledger constants/enums (`class`, `kind`, `status`, provenance namespaces `oc:`/`dv:`/`cl:`) in `frontend/src/data/ledger/constants.js` mirroring `data-model.md`
+
+---
+
+## Phase 2: Foundational (blocking all stories)
+
+**Purpose**: Identity, normalization, and assembly core every story depends on
+
+- [ ] T003 [P] Write Vitest specs for entryId builders and merge precedence (`oc:` > `dv:` same-event drop; `cl:`→`oc:` txHash linking; idempotent re-derivation) in `frontend/src/data/ledger/identity.test.js`
+- [ ] T004 Implement `frontend/src/data/ledger/identity.js` (builders + `mergeEntries(entries)` precedence per data-model.md) to pass T003
+- [ ] T005 [P] Write Vitest specs for entry normalization invariants (reject `timestamp: 0`, `failed ⇒ direction none excluded from totals flag`, `onchain ⇒ txHash`, chainId scoping) in `frontend/src/data/ledger/normalize.test.js`
+- [ ] T006 Implement `frontend/src/data/ledger/normalize.js` (pre-item → LedgerEntry validation/enrichment seam) to pass T005
+- [ ] T007 [P] Write Vitest specs for repository assembly (multi-source aggregation, dedup, sort by `timestamp ?? recordedAt` desc, per-source failure → `staleClasses`, class/status/period filters) in `frontend/src/data/ledger/ledgerRepository.test.js`
+- [ ] T008 Implement `frontend/src/data/ledger/ledgerRepository.js` (`listEntries({account, chainId, filter, period, signal})` per `contracts/ledger-source.md`, wiring `identity.js` + `normalize.js` + the shared `enrichTransfers` token/USD pipeline with `valuationStatus` flagging) to pass T007
+
+**Checkpoint**: Core assembly proven against fixture sources — story phases can start (US phases are independent of each other after this point)
+
+---
+
+## Phase 3: User Story 1 — One Complete Activity Record in the Account Tab (P1) 🎯 MVP
+
+**Goal**: Account tab shows one chronological, filterable record of all activity classes with fidelity fields; failed ops listed but excluded from totals
+
+**Independent Test**: quickstart.md §2 — seed one activity per class, verify each appears once with class/amount/token/status/timestamp/explorer link; totals unchanged by a failed gasless transfer; strict per-network scoping
+
+- [ ] T009 [P] [US1] Write Vitest specs for the wager source (subgraph `WagerTransfer` primary mapping; derived fallback flagged `dv:`; both yield stable ids) in `frontend/src/data/ledger/sources/wagerLedgerSource.test.js`
+- [ ] T010 [P] [US1] Implement `frontend/src/data/ledger/sources/wagerLedgerSource.js` reusing `reportDataSource` transfer enumeration (subgraph path) and `deriveTransfersFromWagers` (fallback path, timestamps deferred to US4 hydration — emit `null`, never 0)
+- [ ] T011 [P] [US1] Write Vitest specs for the transfer source (maps `transferStore`/client records incl. `route: 'gasless'`, failed status + verbatim `failureReason`) in `frontend/src/data/ledger/sources/transferLedgerSource.test.js`
+- [ ] T012 [P] [US1] Implement `frontend/src/data/ledger/sources/transferLedgerSource.js` reading `ledgerClientStore` (fed by T024 mirror; pre-mirror fallback reads `transferStore` directly)
+- [ ] T013 [P] [US1] Write Vitest specs + implement `frontend/src/data/ledger/sources/poolLedgerSource.js` (subgraph `PoolMember`/`PoolClaim`/`PoolRefund` → join/claim/refund entries) with `poolLedgerSource.test.js`
+- [ ] T014 [P] [US1] Write Vitest specs + implement `frontend/src/data/ledger/sources/membershipLedgerSource.js` (voucher/membership purchases via the existing membership queries) with `membershipLedgerSource.test.js`
+- [ ] T015 [P] [US1] Write Vitest specs + implement `frontend/src/data/ledger/sources/earnLedgerSource.js` (user-scoped ERC-4626 `Deposit`/`Withdraw` events via bounded window scan; reward claims recorded at claim time) with `earnLedgerSource.test.js`
+- [ ] T016 [US1] Write Vitest specs + implement `frontend/src/hooks/useActivityLedger.js` (account/chainId scoping, 60s polling model, filters, `staleClasses` surfaced) in `useActivityLedger.test.js`
+- [ ] T017 [US1] Rework `frontend/src/components/account/RecentActivityFeed.jsx` (+ its test) to render ledger entries: all classes, class/status filters, failed badge + reason, explorer link only for real ≥66-char txHash, "date unavailable" state on null timestamp
+- [ ] T018 [US1] Update `frontend/src/hooks/useAccountStats.js` (+ test) to source activity from `useActivityLedger`/`ledgerRepository` instead of `deriveTransfersFromWagers`, keeping the wager-list consistency guarantees
+- [ ] T019 [US1] Update `frontend/src/lib/account/{computeSummary,computePnlSeries,breakdowns}.js` (+ tests) to be pure functions of LedgerEntry arrays that exclude `failed` from all totals (SC-006)
+- [ ] T020 [US1] Update `frontend/src/components/wallet/TransferActivityList.jsx` (+ test) to read the ledger filtered to `class: 'transfer'` so the Pay & Transfer tab and Account tab can never diverge (FR-002)
+- [ ] T021 [US1] Accessibility pass on changed Account-tab UI (labels for filters/status badges, axe clean) in the affected component tests
+
+**Checkpoint**: US1 fully functional — MVP deliverable
+
+---
+
+## Phase 4: User Story 2 — Reporting Reads the Same Ledger (P2)
+
+**Goal**: Tax/activity report enumerates the identical ledger query; line items and totals match the Account tab; all classes exported with `valuationStatus`
+
+**Independent Test**: quickstart.md §4 — CSV for a seeded period matches the Account tab line-for-line and total-for-total (SC-002)
+
+- [ ] T022 [P] [US2] Write parity Vitest spec: same (account, chainId, period) ⇒ report entry set ≡ Account tab entry set and totals equal, in `frontend/src/data/reports/reportParity.test.js`
+- [ ] T023 [US2] Update `frontend/src/data/reports/reportDataSource.js` to enumerate via `ledgerRepository.listEntries` (period filter) instead of its own `WagerTransfer` query path, keeping the bounded gas-fee receipt lookups
+- [ ] T024 [US2] Update `frontend/src/data/reports/reportBuilder.js` + `csvReport.js`/`pdfReport.js` (+ tests) to the column contract in `contracts/ledger-entry.md` (all classes, `status`/`failureReason`, `valuationStatus` flagged never zeroed, network-scope + `prunedBefore` disclosure header, null-timestamp rows flagged and sorted last)
+- [ ] T025 [US2] Update `frontend/src/hooks/useTaxReport.js` + `TaxReportsPanel.jsx` (+ tests) for the extended classes/columns and disclosure copy
+
+**Checkpoint**: Dashboard and report structurally cannot disagree
+
+---
+
+## Phase 5: User Story 3 — Immutable and Recoverable (P3)
+
+**Goal**: Append-only client store mirrored from the transfer flow, carried in the spec-032 encrypted backup, deduplicated on restore, honest failure messaging, legacy migration
+
+**Independent Test**: quickstart.md §5–6 — backup → wipe → restore returns the full record incl. failed gasless entries with no duplicates; no-backup restore rebuilds on-chain history and says client-only history wasn't recovered; `fairwins.transfers.v1` migrates once
+
+- [ ] T026 [P] [US3] Write Vitest specs for `ledgerClientStore` (append-only, `supersedes` chain resolution, per-account + chainId scoping via `userStorage`, FR-013 pruning guard + `prunedBefore` disclosure, storage failure never throws into caller) in `frontend/src/data/ledger/ledgerClientStore.test.js`
+- [ ] T027 [US3] Implement `frontend/src/data/ledger/ledgerClientStore.js` to pass T026
+- [ ] T028 [US3] Write Vitest specs + update `frontend/src/hooks/useTransfer.js` to mirror record/updateTransfer calls into `ledgerClientStore` as append+supersede records (transfer flow must never fail on ledger write) in `useTransfer.test.js`
+- [ ] T029 [P] [US3] Write Vitest specs for one-time idempotent migration of `fairwins.transfers.v1` (statuses/errors/txHash/createdAt preserved, marker prevents re-import) in `frontend/src/data/ledger/migrate.test.js`
+- [ ] T030 [US3] Implement `frontend/src/data/ledger/migrate.js` + invoke on app bootstrap to pass T029 (FR-017, SC-007)
+- [ ] T031 [P] [US3] Write backup round-trip Vitest spec (load → union merge by entryId, replace mode also unions, restore dedups against re-derived entries) in `frontend/src/lib/backup/activityLedgerObject.test.js`
+- [ ] T032 [US3] Register the `activityLedger` synced object in `frontend/src/lib/backup/syncedObjects.js` per `contracts/backup-object.md` to pass T031
+- [ ] T033 [US3] Update the restore flow UI (+ test) to surface "device-local activity history was not recovered" when no/undecryptable backup (FR-012) in the spec-032 restore components
+
+**Checkpoint**: Full wipe-and-recover path proven
+
+---
+
+## Phase 6: User Story 4 — Real, Honestly Rendered Timestamps (P4)
+
+**Goal**: Block-time hydration on subgraph-less networks; UI never renders relative time from missing/zero timestamps
+
+**Independent Test**: quickstart.md §3 — RPC-only network shows explorer-matching dates; "20645d" is unfindable (SC-004)
+
+- [ ] T034 [P] [US4] Write Vitest specs for `formatRelativeTime` null-guard (`0`, negative, null, undefined ⇒ `null`) and callers rendering the explicit "date unavailable" state in `frontend/src/lib/account/format.test.js`
+- [ ] T035 [US4] Update `frontend/src/lib/account/format.js` + all call sites (`RecentActivityFeed`, `TransferActivityList`, `FreshnessIndicator` unaffected-but-verified) to pass T034
+- [ ] T036 [P] [US4] Write Vitest specs for timestamp hydration (bounded scan + `getBlock` → ms; budget exhaustion ⇒ `null` + `unavailable`; cache hit skips RPC; cache loss harmless) in `frontend/src/data/ledger/timestamps.test.js`
+- [ ] T037 [US4] Implement `frontend/src/data/ledger/timestamps.js` reusing the `reportDataSource` bounded event-window scanner, and wire it into `wagerLedgerSource`'s derived fallback path (replacing the `createdAt: 0` coercion in `deriveTransfersFromWagers` usage) to pass T036
+- [ ] T038 [US4] Update `frontend/src/lib/account/deriveTransfers.js` (+ its test) to emit `timestamp: null` instead of `0`/createdAt-fallback when no real time exists
+
+**Checkpoint**: FR-005/006 satisfied on every network
+
+---
+
+## Phase 7: Polish & Cross-Cutting
+
+- [ ] T039 [P] Consistency test: every financial event surfaced by the spec-031 notification sources resolves to a ledger entry (FR-002) in `frontend/src/data/notifications/ledgerConsistency.test.js`
+- [ ] T040 [P] Update docs: `docs/developer-guide/` page for the activity ledger (architecture, identity/merge, backup object) and cross-link from gasless-intents + upgradeable docs where activity is mentioned
+- [ ] T041 Run full gates locally: `npm run test:frontend`, frontend lint/build, axe/Lighthouse on the Account tab; fix regressions
+- [ ] T042 Execute quickstart.md §2–§6 manual validation on one subgraph network and one RPC-only network; record results in the PR
+
+---
+
+## Dependencies
+
+```
+Setup (T001–T002)
+  └─▶ Foundational (T003–T008)
+        ├─▶ US1 (T009–T021)  ── MVP
+        ├─▶ US2 (T022–T025)  — depends on US1's sources for full-class parity
+        ├─▶ US3 (T026–T033)  — independent of US1 UI; T012 consumes T027 when present
+        └─▶ US4 (T034–T038)  — independent; T037 touches wagerLedgerSource (after T010)
+Polish (T039–T042) — after the stories it validates
+```
+
+Story order for sequential delivery: US1 → US2 → US3 → US4 (spec priority).
+US3 and US4 can proceed in parallel with US2 once US1's sources exist.
+
+## Parallel Opportunities
+
+- Foundational: T003, T005, T007 (specs) in parallel; implementations serialize per pair.
+- US1: T009–T015 (five sources + specs) are fully parallel — different files.
+- US3: T026/T029/T031 (specs) in parallel.
+- US4: T034/T036 in parallel.
+- Polish: T039/T040 in parallel.
+
+## Implementation Strategy
+
+MVP = Phase 1 + 2 + US1 (T001–T021): the Account tab becomes the single
+complete activity record. Ship, then US2 (reporting parity) as the second
+increment, US3 (durability/backup) third, US4 (timestamp truth) last —
+though US4's render guard (T034–T035) is cheap and may be pulled forward
+with US1 if the "20645d ago" symptom needs killing immediately.

--- a/specs/051-unified-activity-ledger/tasks.md
+++ b/specs/051-unified-activity-ledger/tasks.md
@@ -131,7 +131,7 @@ independently testable increment.
 
 - [X] T039 [P] Consistency test: every financial event surfaced by the spec-031 notification sources resolves to a ledger entry (FR-002) in `frontend/src/data/notifications/ledgerConsistency.test.js`
 - [X] T040 [P] Update docs: `docs/developer-guide/` page for the activity ledger (architecture, identity/merge, backup object) and cross-link from gasless-intents + upgradeable docs where activity is mentioned
-- [ ] T041 Run full gates locally: `npm run test:frontend`, frontend lint/build, axe/Lighthouse on the Account tab; fix regressions
+- [X] T041 Run full gates locally: `npm run test:frontend`, frontend lint/build, axe/Lighthouse on the Account tab; fix regressions
 - [ ] T042 Execute quickstart.md §2–§6 manual validation on one subgraph network and one RPC-only network; record results in the PR
 
 > **Phase 7 notes:** the T039 consistency test lives at

--- a/specs/051-unified-activity-ledger/tasks.md
+++ b/specs/051-unified-activity-ledger/tasks.md
@@ -101,11 +101,11 @@ independently testable increment.
 - [X] T026 [P] [US3] Write Vitest specs for `ledgerClientStore` (append-only, `supersedes` chain resolution, per-account + chainId scoping via `userStorage`, FR-013 pruning guard + `prunedBefore` disclosure, storage failure never throws into caller) in `frontend/src/data/ledger/ledgerClientStore.test.js`
 - [X] T027 [US3] Implement `frontend/src/data/ledger/ledgerClientStore.js` to pass T026
 - [X] T028 [US3] Write Vitest specs + update `frontend/src/hooks/useTransfer.js` to mirror record/updateTransfer calls into `ledgerClientStore` as append+supersede records (transfer flow must never fail on ledger write) in `useTransfer.test.js`
-- [ ] T029 [P] [US3] Write Vitest specs for one-time idempotent migration of `fairwins.transfers.v1` (statuses/errors/txHash/createdAt preserved, marker prevents re-import) in `frontend/src/data/ledger/migrate.test.js`
-- [ ] T030 [US3] Implement `frontend/src/data/ledger/migrate.js` + invoke on app bootstrap to pass T029 (FR-017, SC-007)
-- [ ] T031 [P] [US3] Write backup round-trip Vitest spec (load → union merge by entryId, replace mode also unions, restore dedups against re-derived entries) in `frontend/src/lib/backup/activityLedgerObject.test.js`
-- [ ] T032 [US3] Register the `activityLedger` synced object in `frontend/src/lib/backup/syncedObjects.js` per `contracts/backup-object.md` to pass T031
-- [ ] T033 [US3] Update the restore flow UI (+ test) to surface "device-local activity history was not recovered" when no/undecryptable backup (FR-012) in the spec-032 restore components
+- [X] T029 [P] [US3] Write Vitest specs for one-time idempotent migration of `fairwins.transfers.v1` (statuses/errors/txHash/createdAt preserved, marker prevents re-import) in `frontend/src/data/ledger/migrate.test.js`
+- [X] T030 [US3] Implement `frontend/src/data/ledger/migrate.js` + invoke on app bootstrap to pass T029 (FR-017, SC-007)
+- [X] T031 [P] [US3] Write backup round-trip Vitest spec (load → union merge by entryId, replace mode also unions, restore dedups against re-derived entries) in `frontend/src/lib/backup/activityLedgerObject.test.js`
+- [X] T032 [US3] Register the `activityLedger` synced object in `frontend/src/lib/backup/syncedObjects.js` per `contracts/backup-object.md` to pass T031
+- [X] T033 [US3] Update the restore flow UI (+ test) to surface "device-local activity history was not recovered" when no/undecryptable backup (FR-012) in the spec-032 restore components
 
 **Checkpoint**: Full wipe-and-recover path proven
 

--- a/specs/051-unified-activity-ledger/tasks.md
+++ b/specs/051-unified-activity-ledger/tasks.md
@@ -129,10 +129,17 @@ independently testable increment.
 
 ## Phase 7: Polish & Cross-Cutting
 
-- [ ] T039 [P] Consistency test: every financial event surfaced by the spec-031 notification sources resolves to a ledger entry (FR-002) in `frontend/src/data/notifications/ledgerConsistency.test.js`
-- [ ] T040 [P] Update docs: `docs/developer-guide/` page for the activity ledger (architecture, identity/merge, backup object) and cross-link from gasless-intents + upgradeable docs where activity is mentioned
+- [X] T039 [P] Consistency test: every financial event surfaced by the spec-031 notification sources resolves to a ledger entry (FR-002) in `frontend/src/data/notifications/ledgerConsistency.test.js`
+- [X] T040 [P] Update docs: `docs/developer-guide/` page for the activity ledger (architecture, identity/merge, backup object) and cross-link from gasless-intents + upgradeable docs where activity is mentioned
 - [ ] T041 Run full gates locally: `npm run test:frontend`, frontend lint/build, axe/Lighthouse on the Account tab; fix regressions
 - [ ] T042 Execute quickstart.md §2–§6 manual validation on one subgraph network and one RPC-only network; record results in the PR
+
+> **Phase 7 notes:** the T039 consistency test lives at
+> `frontend/src/test/ledger/ledgerConsistency.test.js` (repo test-dir
+> convention). T042 requires live wallets/networks and remains OPEN for a
+> maintainer; its automated equivalents (report↔dashboard parity, backup
+> round-trip, migration idempotence, timestamp guard) are covered by the
+> Vitest suites.
 
 ---
 

--- a/specs/051-unified-activity-ledger/tasks.md
+++ b/specs/051-unified-activity-ledger/tasks.md
@@ -20,8 +20,8 @@ independently testable increment.
 
 **Purpose**: Skeleton for the new ledger module — no behavior yet
 
-- [ ] T001 Create `frontend/src/data/ledger/` module skeleton (`ledgerRepository.js`, `ledgerClientStore.js`, `identity.js`, `timestamps.js`, `migrate.js`, `sources/` with five empty source files exporting the LedgerSource shape from `contracts/ledger-source.md`)
-- [ ] T002 [P] Add shared ledger constants/enums (`class`, `kind`, `status`, provenance namespaces `oc:`/`dv:`/`cl:`) in `frontend/src/data/ledger/constants.js` mirroring `data-model.md`
+- [X] T001 Create `frontend/src/data/ledger/` module skeleton (`ledgerRepository.js`, `ledgerClientStore.js`, `identity.js`, `timestamps.js`, `migrate.js`, `sources/` with five empty source files exporting the LedgerSource shape from `contracts/ledger-source.md`)
+- [X] T002 [P] Add shared ledger constants/enums (`class`, `kind`, `status`, provenance namespaces `oc:`/`dv:`/`cl:`) in `frontend/src/data/ledger/constants.js` mirroring `data-model.md`
 
 ---
 
@@ -29,12 +29,12 @@ independently testable increment.
 
 **Purpose**: Identity, normalization, and assembly core every story depends on
 
-- [ ] T003 [P] Write Vitest specs for entryId builders and merge precedence (`oc:` > `dv:` same-event drop; `cl:`→`oc:` txHash linking; idempotent re-derivation) in `frontend/src/data/ledger/identity.test.js`
-- [ ] T004 Implement `frontend/src/data/ledger/identity.js` (builders + `mergeEntries(entries)` precedence per data-model.md) to pass T003
-- [ ] T005 [P] Write Vitest specs for entry normalization invariants (reject `timestamp: 0`, `failed ⇒ direction none excluded from totals flag`, `onchain ⇒ txHash`, chainId scoping) in `frontend/src/data/ledger/normalize.test.js`
-- [ ] T006 Implement `frontend/src/data/ledger/normalize.js` (pre-item → LedgerEntry validation/enrichment seam) to pass T005
-- [ ] T007 [P] Write Vitest specs for repository assembly (multi-source aggregation, dedup, sort by `timestamp ?? recordedAt` desc, per-source failure → `staleClasses`, class/status/period filters) in `frontend/src/data/ledger/ledgerRepository.test.js`
-- [ ] T008 Implement `frontend/src/data/ledger/ledgerRepository.js` (`listEntries({account, chainId, filter, period, signal})` per `contracts/ledger-source.md`, wiring `identity.js` + `normalize.js` + the shared `enrichTransfers` token/USD pipeline with `valuationStatus` flagging) to pass T007
+- [X] T003 [P] Write Vitest specs for entryId builders and merge precedence (`oc:` > `dv:` same-event drop; `cl:`→`oc:` txHash linking; idempotent re-derivation) in `frontend/src/data/ledger/identity.test.js`
+- [X] T004 Implement `frontend/src/data/ledger/identity.js` (builders + `mergeEntries(entries)` precedence per data-model.md) to pass T003
+- [X] T005 [P] Write Vitest specs for entry normalization invariants (reject `timestamp: 0`, `failed ⇒ direction none excluded from totals flag`, `onchain ⇒ txHash`, chainId scoping) in `frontend/src/data/ledger/normalize.test.js`
+- [X] T006 Implement `frontend/src/data/ledger/normalize.js` (pre-item → LedgerEntry validation/enrichment seam) to pass T005
+- [X] T007 [P] Write Vitest specs for repository assembly (multi-source aggregation, dedup, sort by `timestamp ?? recordedAt` desc, per-source failure → `staleClasses`, class/status/period filters) in `frontend/src/data/ledger/ledgerRepository.test.js`
+- [X] T008 Implement `frontend/src/data/ledger/ledgerRepository.js` (`listEntries({account, chainId, filter, period, signal})` per `contracts/ledger-source.md`, wiring `identity.js` + `normalize.js` + the shared `enrichTransfers` token/USD pipeline with `valuationStatus` flagging) to pass T007
 
 **Checkpoint**: Core assembly proven against fixture sources — story phases can start (US phases are independent of each other after this point)
 
@@ -46,21 +46,34 @@ independently testable increment.
 
 **Independent Test**: quickstart.md §2 — seed one activity per class, verify each appears once with class/amount/token/status/timestamp/explorer link; totals unchanged by a failed gasless transfer; strict per-network scoping
 
-- [ ] T009 [P] [US1] Write Vitest specs for the wager source (subgraph `WagerTransfer` primary mapping; derived fallback flagged `dv:`; both yield stable ids) in `frontend/src/data/ledger/sources/wagerLedgerSource.test.js`
-- [ ] T010 [P] [US1] Implement `frontend/src/data/ledger/sources/wagerLedgerSource.js` reusing `reportDataSource` transfer enumeration (subgraph path) and `deriveTransfersFromWagers` (fallback path, timestamps deferred to US4 hydration — emit `null`, never 0)
-- [ ] T011 [P] [US1] Write Vitest specs for the transfer source (maps `transferStore`/client records incl. `route: 'gasless'`, failed status + verbatim `failureReason`) in `frontend/src/data/ledger/sources/transferLedgerSource.test.js`
-- [ ] T012 [P] [US1] Implement `frontend/src/data/ledger/sources/transferLedgerSource.js` reading `ledgerClientStore` (fed by T024 mirror; pre-mirror fallback reads `transferStore` directly)
-- [ ] T013 [P] [US1] Write Vitest specs + implement `frontend/src/data/ledger/sources/poolLedgerSource.js` (subgraph `PoolMember`/`PoolClaim`/`PoolRefund` → join/claim/refund entries) with `poolLedgerSource.test.js`
-- [ ] T014 [P] [US1] Write Vitest specs + implement `frontend/src/data/ledger/sources/membershipLedgerSource.js` (voucher/membership purchases via the existing membership queries) with `membershipLedgerSource.test.js`
-- [ ] T015 [P] [US1] Write Vitest specs + implement `frontend/src/data/ledger/sources/earnLedgerSource.js` (user-scoped ERC-4626 `Deposit`/`Withdraw` events via bounded window scan; reward claims recorded at claim time) with `earnLedgerSource.test.js`
-- [ ] T016 [US1] Write Vitest specs + implement `frontend/src/hooks/useActivityLedger.js` (account/chainId scoping, 60s polling model, filters, `staleClasses` surfaced) in `useActivityLedger.test.js`
-- [ ] T017 [US1] Rework `frontend/src/components/account/RecentActivityFeed.jsx` (+ its test) to render ledger entries: all classes, class/status filters, failed badge + reason, explorer link only for real ≥66-char txHash, "date unavailable" state on null timestamp
-- [ ] T018 [US1] Update `frontend/src/hooks/useAccountStats.js` (+ test) to source activity from `useActivityLedger`/`ledgerRepository` instead of `deriveTransfersFromWagers`, keeping the wager-list consistency guarantees
-- [ ] T019 [US1] Update `frontend/src/lib/account/{computeSummary,computePnlSeries,breakdowns}.js` (+ tests) to be pure functions of LedgerEntry arrays that exclude `failed` from all totals (SC-006)
-- [ ] T020 [US1] Update `frontend/src/components/wallet/TransferActivityList.jsx` (+ test) to read the ledger filtered to `class: 'transfer'` so the Pay & Transfer tab and Account tab can never diverge (FR-002)
-- [ ] T021 [US1] Accessibility pass on changed Account-tab UI (labels for filters/status badges, axe clean) in the affected component tests
+- [X] T009 [P] [US1] Write Vitest specs for the wager source (subgraph `WagerTransfer` primary mapping; derived fallback flagged `dv:`; both yield stable ids) in `frontend/src/data/ledger/sources/wagerLedgerSource.test.js`
+- [X] T010 [P] [US1] Implement `frontend/src/data/ledger/sources/wagerLedgerSource.js` reusing `reportDataSource` transfer enumeration (subgraph path) and `deriveTransfersFromWagers` (fallback path, timestamps deferred to US4 hydration — emit `null`, never 0)
+- [X] T011 [P] [US1] Write Vitest specs for the transfer source (maps `transferStore`/client records incl. `route: 'gasless'`, failed status + verbatim `failureReason`) in `frontend/src/data/ledger/sources/transferLedgerSource.test.js`
+- [X] T012 [P] [US1] Implement `frontend/src/data/ledger/sources/transferLedgerSource.js` reading `ledgerClientStore` (fed by T024 mirror; pre-mirror fallback reads `transferStore` directly)
+- [X] T013 [P] [US1] Write Vitest specs + implement `frontend/src/data/ledger/sources/poolLedgerSource.js` (subgraph `PoolMember`/`PoolClaim`/`PoolRefund` → join/claim/refund entries) with `poolLedgerSource.test.js`
+- [X] T014 [P] [US1] Write Vitest specs + implement `frontend/src/data/ledger/sources/membershipLedgerSource.js` (voucher/membership purchases via the existing membership queries) with `membershipLedgerSource.test.js`
+- [X] T015 [P] [US1] Write Vitest specs + implement `frontend/src/data/ledger/sources/earnLedgerSource.js` (user-scoped ERC-4626 `Deposit`/`Withdraw` events via bounded window scan; reward claims recorded at claim time) with `earnLedgerSource.test.js`
+- [X] T016 [US1] Write Vitest specs + implement `frontend/src/hooks/useActivityLedger.js` (account/chainId scoping, 60s polling model, filters, `staleClasses` surfaced) in `useActivityLedger.test.js`
+- [X] T017 [US1] Rework `frontend/src/components/account/RecentActivityFeed.jsx` (+ its test) to render ledger entries: all classes, class/status filters, failed badge + reason, explorer link only for real ≥66-char txHash, "date unavailable" state on null timestamp
+- [X] T018 [US1] Update `frontend/src/hooks/useAccountStats.js` (+ test) to source activity from `useActivityLedger`/`ledgerRepository` instead of `deriveTransfersFromWagers`, keeping the wager-list consistency guarantees
+- [X] T019 [US1] Update `frontend/src/lib/account/{computeSummary,computePnlSeries,breakdowns}.js` (+ tests) to be pure functions of LedgerEntry arrays that exclude `failed` from all totals (SC-006)
+- [X] T020 [US1] Update `frontend/src/components/wallet/TransferActivityList.jsx` (+ test) to read the ledger filtered to `class: 'transfer'` so the Pay & Transfer tab and Account tab can never diverge (FR-002)
+- [X] T021 [US1] Accessibility pass on changed Account-tab UI (labels for filters/status badges, axe clean) in the affected component tests
 
 **Checkpoint**: US1 fully functional — MVP deliverable
+
+> **Implementation notes (deviations, recorded per plan §Complexity):**
+> - T015: earn activity is captured at action time into the client ledger
+>   (`captureEarnAction` beside the existing `queueEarnAction` call sites)
+>   instead of an ERC-4626 event scan — earn vaults are Morpho-discovered with
+>   no fixed registry, so an event sweep is not viable on public RPCs. The gap
+>   (externally-made earn actions) is disclosed in the source header.
+> - T019: the summary/P&L/breakdown helpers keep their proven spec-020 math;
+>   they now consume the ledger through `lib/account/ledgerAdapters.js`, which
+>   maps wager-class entries and excludes `failed` (FR-003/FR-015 hold via the
+>   single read path).
+> - Ledger tests live under `frontend/src/test/ledger/` (repo convention)
+>   rather than colocated next to sources.
 
 ---
 
@@ -85,9 +98,9 @@ independently testable increment.
 
 **Independent Test**: quickstart.md §5–6 — backup → wipe → restore returns the full record incl. failed gasless entries with no duplicates; no-backup restore rebuilds on-chain history and says client-only history wasn't recovered; `fairwins.transfers.v1` migrates once
 
-- [ ] T026 [P] [US3] Write Vitest specs for `ledgerClientStore` (append-only, `supersedes` chain resolution, per-account + chainId scoping via `userStorage`, FR-013 pruning guard + `prunedBefore` disclosure, storage failure never throws into caller) in `frontend/src/data/ledger/ledgerClientStore.test.js`
-- [ ] T027 [US3] Implement `frontend/src/data/ledger/ledgerClientStore.js` to pass T026
-- [ ] T028 [US3] Write Vitest specs + update `frontend/src/hooks/useTransfer.js` to mirror record/updateTransfer calls into `ledgerClientStore` as append+supersede records (transfer flow must never fail on ledger write) in `useTransfer.test.js`
+- [X] T026 [P] [US3] Write Vitest specs for `ledgerClientStore` (append-only, `supersedes` chain resolution, per-account + chainId scoping via `userStorage`, FR-013 pruning guard + `prunedBefore` disclosure, storage failure never throws into caller) in `frontend/src/data/ledger/ledgerClientStore.test.js`
+- [X] T027 [US3] Implement `frontend/src/data/ledger/ledgerClientStore.js` to pass T026
+- [X] T028 [US3] Write Vitest specs + update `frontend/src/hooks/useTransfer.js` to mirror record/updateTransfer calls into `ledgerClientStore` as append+supersede records (transfer flow must never fail on ledger write) in `useTransfer.test.js`
 - [ ] T029 [P] [US3] Write Vitest specs for one-time idempotent migration of `fairwins.transfers.v1` (statuses/errors/txHash/createdAt preserved, marker prevents re-import) in `frontend/src/data/ledger/migrate.test.js`
 - [ ] T030 [US3] Implement `frontend/src/data/ledger/migrate.js` + invoke on app bootstrap to pass T029 (FR-017, SC-007)
 - [ ] T031 [P] [US3] Write backup round-trip Vitest spec (load → union merge by entryId, replace mode also unions, restore dedups against re-derived entries) in `frontend/src/lib/backup/activityLedgerObject.test.js`

--- a/specs/051-unified-activity-ledger/tasks.md
+++ b/specs/051-unified-activity-ledger/tasks.md
@@ -83,10 +83,10 @@ independently testable increment.
 
 **Independent Test**: quickstart.md §4 — CSV for a seeded period matches the Account tab line-for-line and total-for-total (SC-002)
 
-- [ ] T022 [P] [US2] Write parity Vitest spec: same (account, chainId, period) ⇒ report entry set ≡ Account tab entry set and totals equal, in `frontend/src/data/reports/reportParity.test.js`
-- [ ] T023 [US2] Update `frontend/src/data/reports/reportDataSource.js` to enumerate via `ledgerRepository.listEntries` (period filter) instead of its own `WagerTransfer` query path, keeping the bounded gas-fee receipt lookups
-- [ ] T024 [US2] Update `frontend/src/data/reports/reportBuilder.js` + `csvReport.js`/`pdfReport.js` (+ tests) to the column contract in `contracts/ledger-entry.md` (all classes, `status`/`failureReason`, `valuationStatus` flagged never zeroed, network-scope + `prunedBefore` disclosure header, null-timestamp rows flagged and sorted last)
-- [ ] T025 [US2] Update `frontend/src/hooks/useTaxReport.js` + `TaxReportsPanel.jsx` (+ tests) for the extended classes/columns and disclosure copy
+- [X] T022 [P] [US2] Write parity Vitest spec: same (account, chainId, period) ⇒ report entry set ≡ Account tab entry set and totals equal, in `frontend/src/data/reports/reportParity.test.js`
+- [X] T023 [US2] Update `frontend/src/data/reports/reportDataSource.js` to enumerate via `ledgerRepository.listEntries` (period filter) instead of its own `WagerTransfer` query path, keeping the bounded gas-fee receipt lookups
+- [X] T024 [US2] Update `frontend/src/data/reports/reportBuilder.js` + `csvReport.js`/`pdfReport.js` (+ tests) to the column contract in `contracts/ledger-entry.md` (all classes, `status`/`failureReason`, `valuationStatus` flagged never zeroed, network-scope + `prunedBefore` disclosure header, null-timestamp rows flagged and sorted last)
+- [X] T025 [US2] Update `frontend/src/hooks/useTaxReport.js` + `TaxReportsPanel.jsx` (+ tests) for the extended classes/columns and disclosure copy
 
 **Checkpoint**: Dashboard and report structurally cannot disagree
 

--- a/specs/051-unified-activity-ledger/tasks.md
+++ b/specs/051-unified-activity-ledger/tasks.md
@@ -117,11 +117,11 @@ independently testable increment.
 
 **Independent Test**: quickstart.md §3 — RPC-only network shows explorer-matching dates; "20645d" is unfindable (SC-004)
 
-- [ ] T034 [P] [US4] Write Vitest specs for `formatRelativeTime` null-guard (`0`, negative, null, undefined ⇒ `null`) and callers rendering the explicit "date unavailable" state in `frontend/src/lib/account/format.test.js`
-- [ ] T035 [US4] Update `frontend/src/lib/account/format.js` + all call sites (`RecentActivityFeed`, `TransferActivityList`, `FreshnessIndicator` unaffected-but-verified) to pass T034
-- [ ] T036 [P] [US4] Write Vitest specs for timestamp hydration (bounded scan + `getBlock` → ms; budget exhaustion ⇒ `null` + `unavailable`; cache hit skips RPC; cache loss harmless) in `frontend/src/data/ledger/timestamps.test.js`
-- [ ] T037 [US4] Implement `frontend/src/data/ledger/timestamps.js` reusing the `reportDataSource` bounded event-window scanner, and wire it into `wagerLedgerSource`'s derived fallback path (replacing the `createdAt: 0` coercion in `deriveTransfersFromWagers` usage) to pass T036
-- [ ] T038 [US4] Update `frontend/src/lib/account/deriveTransfers.js` (+ its test) to emit `timestamp: null` instead of `0`/createdAt-fallback when no real time exists
+- [X] T034 [P] [US4] Write Vitest specs for `formatRelativeTime` null-guard (`0`, negative, null, undefined ⇒ `null`) and callers rendering the explicit "date unavailable" state in `frontend/src/lib/account/format.test.js`
+- [X] T035 [US4] Update `frontend/src/lib/account/format.js` + all call sites (`RecentActivityFeed`, `TransferActivityList`, `FreshnessIndicator` unaffected-but-verified) to pass T034
+- [X] T036 [P] [US4] Write Vitest specs for timestamp hydration (bounded scan + `getBlock` → ms; budget exhaustion ⇒ `null` + `unavailable`; cache hit skips RPC; cache loss harmless) in `frontend/src/data/ledger/timestamps.test.js`
+- [X] T037 [US4] Implement `frontend/src/data/ledger/timestamps.js` reusing the `reportDataSource` bounded event-window scanner, and wire it into `wagerLedgerSource`'s derived fallback path (replacing the `createdAt: 0` coercion in `deriveTransfersFromWagers` usage) to pass T036
+- [X] T038 [US4] Update `frontend/src/lib/account/deriveTransfers.js` (+ its test) to emit `timestamp: null` instead of `0`/createdAt-fallback when no real time exists
 
 **Checkpoint**: FR-005/006 satisfied on every network
 


### PR DESCRIPTION
## Summary

Implements **spec 051**: one canonical, append-only **activity ledger** per (account, network) that consolidates every financial activity surface — wager value events, wallet transfers (including **failed gasless/sponsored operations**), earn/lending actions, pool joins/claims/refunds, and membership/voucher purchases — surfaced in the wallet **Account tab**, carried in the **spec-032 encrypted backup**, and feeding the **tax report from the same read path** so dashboard and export can never disagree. Includes the full Spec Kit artifact set (`specs/051-unified-activity-ledger/`: spec, plan, research, data-model, contracts, quickstart, tasks).

## Problem (before)

- Account tab derived money flows at runtime from wager state; on subgraph-less networks it rendered **"20645d ago"** (`RegistrySource` returns `createdAt: 0`).
- Pay & Transfer history (incl. failed sponsored UserOps) lived only in a 100-entry `localStorage` log; earn/pools/gasless ops had no durable per-user history.
- The tax report read a different data path (`WagerTransfer` subgraph entity), so its totals could disagree with the dashboard.
- None of the device-local activity stores were included in the encrypted backup — history was lost on cache clear or device change.

## What changed

**Ledger core** (`frontend/src/data/ledger/`)
- Canonical `LedgerEntry` with provenance namespaces (`oc:` on-chain / `dv:` derived / `cl:` client-only), deterministic ids, and merge precedence (`oc:` beats `dv:`; client records fold into their on-chain entry by txHash).
- Normalization invariants: timestamp is real epoch ms or `null`+`unavailable` (0 never survives), failed ⇒ direction `none`, on-chain ⇒ txHash required, strict chainId scoping.
- Assembling repository with per-source degradation (`staleClasses` disclosed in UI/report), filters, token/USD enrichment with `valued`/`unvalued` flagging (unvalued entries flagged, never zeroed).

**Five sources**: wager (subgraph `WagerTransfer` primary; derived fallback with **block-time hydration** via bounded cached scan), transfer (append-only client store + legacy log), earn (action-time capture beside the notification buffer), pool + membership (subgraph entities).

**Surfaces**: Account tab feed reworked (all classes, class filters, Failed badge + verbatim reason, "date unavailable" state, explorer links only for real tx hashes); `useAccountStats` tiles/P&L/breakdowns now computed from ledger entries (failed excluded from all totals); Pay & Transfer Activity tab reads the same ledger (FR-002).

**Reporting parity (US2)**: `buildReport` gains a ledger-first path; extended CSV/PDF columns (class/kind/status/failureReason/valuation/entryId), failure + stale + pruning disclosures in export headers; parity suite proves report line-item set ≡ Account tab entry set with equal totals (SC-002).

**Durability (US3)**: append-only `ledgerClientStore` (supersede records, no in-place mutation — FR-008); new `activityLedger` synced object in the spec-032 backup (union-by-entryId in both restore modes); one-time idempotent migration of `fairwins.transfers.v1` (FR-017); BackupPanel copy discloses what is and isn't recoverable (FR-012).

**Timestamps (US4)**: `hydrateWagerTimestamps` recovers real block times on subgraph-less networks (bounded per-poll budget + cache); `formatRelativeTime` returns `null` on invalid input — the "20645d ago" defect class can no longer render (SC-004).

## Tests

~70 new Vitest cases across `src/test/ledger/` (identity, normalize, repository, sources, client store, migration, backup round-trip, timestamps, hook, FR-002 consistency), `reportParity.test.js`, reworked feed/axe/format tests. Full frontend suite, lint (0 errors), and production build green locally (4 clearpath test files fail identically on pristine `main` in this environment — pre-existing, unrelated).

## Remaining for a maintainer

- **T042 (open)**: quickstart.md §2–§6 manual validation on a live subgraph network + an RPC-only network (needs real wallets); automated equivalents are in the suites above.
- Docs: `docs/developer-guide/activity-ledger.md` covers architecture, invariants, and the disclosed limits (earn actions made outside the app; pool/membership history on subgraph-less chains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UeiJ64XuXGNY6U7Zrnm4zJ