### PR TITLE
Fix Earn vault list 400: Morpho API removed `whitelisted` — curate on `listed`

### DIFF
--- a/frontend/src/config/earn.js
+++ b/frontend/src/config/earn.js
@@ -18,8 +18,8 @@ export const MORPHO_API_URL = 'https://api.morpho.org/graphql'
 // MIP-111 — the legacy rewards.morpho.org/URD flow is deprecated).
 export const MERKL_API_URL = 'https://api.merkl.xyz/v4'
 
-// Cap on curated vaults surfaced per chain (TVL-ordered, whitelisted+listed
-// only). Keeps the list scannable for non-technical members.
+// Cap on curated vaults surfaced per chain (TVL-ordered, Morpho-listed only).
+// Keeps the list scannable for non-technical members.
 export const VAULT_LIST_LIMIT = 20
 
 // Position refresh cadence — aligned with usePortfolio's 60s poll.

--- a/frontend/src/lib/earn/morphoApi.js
+++ b/frontend/src/lib/earn/morphoApi.js
@@ -7,8 +7,9 @@
  * PositionEnrichment models (specs/050-earn-lending-rewards/data-model.md).
  *
  * Honest-state rules (constitution III):
- *   - curation is the API's own flags: `whitelisted: true` filter + `listed`
- *     requirement (vaults shown on the Morpho app) — never a hand-kept list;
+ *   - curation is the API's own `listed` flag (vaults shown on the Morpho app)
+ *     — never a hand-kept list. The docs' `whitelisted` field was removed from
+ *     the live schema (queries using it 400); `listed` is its successor;
  *   - null APY/TVL stays null (rendered "—"), never coerced to 0;
  *   - any transport/GraphQL failure throws MorphoApiError so hooks can map it
  *     to an explicit `unavailable` state — stale numbers are never truth.
@@ -29,12 +30,13 @@ query EarnVaults($chainIds: [Int!]!, $first: Int!) {
     first: $first
     orderBy: TotalAssetsUsd
     orderDirection: Desc
-    where: { chainId_in: $chainIds, whitelisted: true }
+    where: { chainId_in: $chainIds, listed: true }
   ) {
     items {
-      address symbol name listed whitelisted
+      address symbol name listed
       state {
-        totalAssetsUsd apy netApy curator
+        totalAssetsUsd apy netApy
+        curators { name }
         allRewards { asset { address symbol } supplyApr }
       }
       asset { name address decimals symbol }
@@ -88,10 +90,15 @@ function numOrNull(v) {
  */
 export function normalizeVault(item, chainId) {
   if (!item?.address || !item?.asset?.address) return null
-  if (item.listed !== true || item.whitelisted !== true) return null
+  if (item.listed !== true) return null
   if (Number(item.chain?.id) !== Number(chainId)) return null
   const decimals = Number(item.asset.decimals)
   if (!Number.isInteger(decimals) || decimals < 0) return null
+  // Human curator names ("Gauntlet", "Steakhouse Financial"); the schema's
+  // scalar `state.curator` is a raw address — never shown to members.
+  const curatorNames = (item.state?.curators || [])
+    .map((c) => c?.name)
+    .filter(Boolean)
   return {
     address: item.address,
     chainId: Number(chainId),
@@ -109,7 +116,7 @@ export function normalizeVault(item, chainId) {
       .filter((r) => r?.asset?.symbol != null)
       .map((r) => ({ assetSymbol: r.asset.symbol, supplyApr: numOrNull(r.supplyApr) })),
     totalAssetsUsd: numOrNull(item.state?.totalAssetsUsd),
-    curator: item.state?.curator || null,
+    curator: curatorNames.length > 0 ? curatorNames.join(' & ') : null,
   }
 }
 

--- a/frontend/src/test/earn/morphoApi.test.js
+++ b/frontend/src/test/earn/morphoApi.test.js
@@ -11,17 +11,19 @@ import {
   MorphoApiError,
 } from '../../lib/earn/morphoApi'
 
+// Mirrors the LIVE api.morpho.org schema (verified 2026-07-11): curation is the
+// `listed` flag (`whitelisted` was removed from the schema — querying it 400s),
+// and curators come as named entities under state.curators.
 const VAULT_ITEM = {
   address: '0xVault1',
   symbol: 'mUSDC',
   name: 'Prime USDC Vault',
   listed: true,
-  whitelisted: true,
   state: {
     totalAssetsUsd: 12_345_678,
     apy: 0.031,
     netApy: 0.043,
-    curator: 'Prime Curation',
+    curators: [{ name: 'Prime Curation' }],
     allRewards: [{ asset: { address: '0xMorpho', symbol: 'MORPHO' }, supplyApr: 0.012 }],
   },
   asset: { name: 'USD Coin', address: '0xUSDC', decimals: 6, symbol: 'USDC' },
@@ -46,10 +48,30 @@ describe('normalizeVault', () => {
     expect(vault.rewards).toEqual([{ assetSymbol: 'MORPHO', supplyApr: 0.012 }])
   })
 
-  it('drops non-listed, non-whitelisted, and foreign-chain items', () => {
+  it('drops non-listed and foreign-chain items', () => {
     expect(normalizeVault({ ...VAULT_ITEM, listed: false }, 137)).toBeNull()
-    expect(normalizeVault({ ...VAULT_ITEM, whitelisted: false }, 137)).toBeNull()
     expect(normalizeVault({ ...VAULT_ITEM, chain: { id: 1 } }, 137)).toBeNull()
+  })
+
+  it('joins multiple curator names and yields null when none are named', () => {
+    const multi = normalizeVault(
+      { ...VAULT_ITEM, state: { ...VAULT_ITEM.state, curators: [{ name: 'Gauntlet' }, { name: 'Steakhouse' }] } },
+      137,
+    )
+    expect(multi.curator).toBe('Gauntlet & Steakhouse')
+    const anon = normalizeVault({ ...VAULT_ITEM, state: { ...VAULT_ITEM.state, curators: [] } }, 137)
+    expect(anon.curator).toBeNull()
+  })
+
+  it('never sends the removed `whitelisted` field (live schema 400s on it)', async () => {
+    let sentBody
+    const fetchImpl = async (_url, init) => {
+      sentBody = init.body
+      return { ok: true, json: async () => ({ data: { vaults: { items: [] } } }) }
+    }
+    await fetchVaults(137, { fetchImpl })
+    expect(sentBody).not.toContain('whitelisted')
+    expect(sentBody).toContain('listed: true')
   })
 
   it('keeps missing APY/TVL as null — never zero (honest-state)', () => {

--- a/specs/050-earn-lending-rewards/contracts/morpho-api.md
+++ b/specs/050-earn-lending-rewards/contracts/morpho-api.md
@@ -6,18 +6,24 @@ per session). All queries filter by the active `chainId`; responses are normaliz
 
 ## Vault list (curated)
 
+> **Schema drift note (verified against the live API 2026-07-11):** the docs' example
+> `whitelisted` field was REMOVED from the production schema — any query naming it fails
+> GraphQL validation with HTTP 400. Curation is the `listed` flag. Likewise the scalar
+> `state.curator` is a raw address; human curator names come from `state.curators { name }`.
+
 ```graphql
 query EarnVaults($chainIds: [Int!]!, $first: Int!) {
   vaults(
     first: $first
     orderBy: TotalAssetsUsd
     orderDirection: Desc
-    where: { chainId_in: $chainIds, whitelisted: true }
+    where: { chainId_in: $chainIds, listed: true }
   ) {
     items {
-      address symbol name listed whitelisted
+      address symbol name listed
       state {
-        totalAssetsUsd apy netApy curator
+        totalAssetsUsd apy netApy
+        curators { name }
         allRewards { asset { address symbol } supplyApr }
       }
       asset { name address decimals symbol }
@@ -30,6 +36,8 @@ query EarnVaults($chainIds: [Int!]!, $first: Int!) {
 Normalizer rules:
 - Drop items with `listed !== true` or `chain.id !== chainId` (defense against API drift).
 - `netApy`/`apy`/`totalAssetsUsd` may be null → keep null (render "—"), never 0.
+- `curator` = joined `state.curators[].name` ("Gauntlet & Steakhouse"), null when unnamed —
+  never a raw address in member-facing UI.
 - Order preserved (TVL desc), capped at `VAULT_LIST_LIMIT`.
 
 ## Position enrichment (USD value + earnings)


### PR DESCRIPTION
Follow-up to #863/#864 (spec 050, issue #861). After the CSP fix, Rewards loads fine but the Lend view's vault query to `api.morpho.org/graphql` returned **HTTP 400**, so it stayed on the "temporarily unavailable" state.

## Root cause

The live Morpho API schema **no longer has the `whitelisted` vault field** the official docs' example query uses — the API rejects it with `Field "whitelisted" is not defined by type "VaultFilters". Did you mean "listed"?` (GraphQL validation → 400). Verified directly against the live endpoint.

## Changes

- **Vaults query**: filter `where: { chainId_in, listed: true }` and stop selecting `whitelisted`. Confirmed against the live API — returns 200 with real Polygon vaults (Compound USDC, Steakhouse High Yield USDT0, …). The positions-enrichment query validates unchanged.
- **Curator display**: the schema's scalar `state.curator` is a raw address; switched to `state.curators { name }` so members see "Managed by Gauntlet" / "Steakhouse Financial" instead of `0x9E33…` (multiple names joined, null when unnamed — never an address in member-facing UI).
- **Normalizer + tests**: curation = `listed` only; fixtures mirror the live schema; a new guard asserts the outgoing query never contains `whitelisted` again; curator-name joining covered. All 62 earn tests pass.
- **Spec artifact**: `specs/050-earn-lending-rewards/contracts/morpho-api.md` gains a schema-drift note documenting the divergence from Morpho's docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LizwRCtWZEqdsCobwCwApJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LizwRCtWZEqdsCobwCwApJ)_