### PR TITLE
SPA: enable gasless passkey transfers on Polygon (wire VITE_SPONSOR_PAYMASTER_POLYGON)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ ARG VITE_RELAYER_URL
 # Passkey ERC-4337 bundler URL(s), comma-separated (spec 041). Unset => passkeyConfig(137) is null,
 # so passkey smart accounts stay disabled on Polygon.
 ARG VITE_BUNDLER_URLS_POLYGON
+# Sponsored-paymaster endpoint (spec 050): the relay-gateway's /v1/paymaster. Set => passkey UserOps
+# are gasless (FairWins sponsors gas); unset => the account self-funds and the UI discloses honestly.
+ARG VITE_SPONSOR_PAYMASTER_POLYGON
 
 # Set environment variables from build args
 ENV VITE_WALLETCONNECT_PROJECT_ID=${VITE_WALLETCONNECT_PROJECT_ID}
@@ -39,6 +42,7 @@ ENV VITE_SUBGRAPH_URL=${VITE_SUBGRAPH_URL}
 ENV VITE_WAGER_SOURCE=${VITE_WAGER_SOURCE}
 ENV VITE_RELAYER_URL=${VITE_RELAYER_URL}
 ENV VITE_BUNDLER_URLS_POLYGON=${VITE_BUNDLER_URLS_POLYGON}
+ENV VITE_SPONSOR_PAYMASTER_POLYGON=${VITE_SPONSOR_PAYMASTER_POLYGON}
 
 # Build the application
 RUN npm run build

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -30,12 +30,18 @@ steps:
       - 'VITE_WAGER_SOURCE=subgraph'
       # Passkey smart accounts (spec 041): self-hosted alto ERC-4337 bundler, colocated with the
       # relay gateway (SC-009). Baked in at build; passkeyConfig(137) is null without it, so passkey
-      # accounts stay disabled on Polygon until this is set. EntryPoint v0.6; FairWins sponsors no gas.
+      # accounts stay disabled on Polygon until this is set. EntryPoint v0.6.
       - '--build-arg'
       # Cloudflare-fronted edge host (origin-lock ARMED 2026-07-06). Cloudflare injects X-Origin-Auth on
       # *.fairwins.app; the bare run.app URL now 403s (no header), so the SPA MUST use this host. CSP
       # connect-src already allows it (frontend/nginx.conf).
       - 'VITE_BUNDLER_URLS_POLYGON=https://bundler.fairwins.app'
+      - '--build-arg'
+      # Sponsored paymaster (spec 050): FairWins sponsors passkey UserOp gas on Polygon via the
+      # relay-gateway's /v1/paymaster (verifying paymaster 0xe14554D14eB5DeC47f7824ebeeDa6C9f3A50d105,
+      # KMS signer). Set => passkey transfers are gasless; unset => the account self-funds and the
+      # confirm UI discloses the native fee honestly (never a false "sponsored").
+      - 'VITE_SPONSOR_PAYMASTER_POLYGON=https://relay.fairwins.app/v1/paymaster'
       - '-t'
       - 'us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/prediction-dao-research:$COMMIT_SHA'
       - '-t'


### PR DESCRIPTION
Points the SPA at the now-live `/v1/paymaster` gateway so passkey UserOps are FairWins-sponsored (gasless) on Polygon. The gateway (verifying paymaster `0xe14554…d105` + KMS signer) was deployed and **verified end-to-end** (policy + live Cloud KMS signing → a signature that recovers to the on-chain `verifyingSigner`) before this change, so there's no dishonest-badge window. Adds `VITE_SPONSOR_PAYMASTER_POLYGON` to the prod `Dockerfile` (ARG+ENV) + `cloudbuild.yaml`. CSP already allows `relay.fairwins.app`; never-stranded self-submit fallback preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)