### PR TITLE
Fix silent no-op on Earn deposit/withdraw/claim for passkey sessions

### DIFF
--- a/docs/developer-guide/earn-integration.md
+++ b/docs/developer-guide/earn-integration.md
@@ -67,8 +67,13 @@ constitution III.
 
 - Pure validators (`validateDepositAmount`/`validateWithdrawAmount`) reject zero/junk/over-limit
   amounts with member-facing reasons **before** any wallet prompt.
-- Deposits: exact-amount `approve` (no unlimited allowances) → `previewDeposit` quote →
-  `deposit.staticCall` dry-run → transaction.
+- Writes are `{ target, data, value }` batches submitted through
+  **`WalletContext.sendCalls`** (spec 041's unified rail) — never a raw ethers signer. Passkey
+  sessions (which have no signer) authorize the whole approve+deposit batch with ONE WebAuthn
+  ceremony via UserOp; classic wallets sign sequentially. Reads (allowance, dry-runs) use the
+  chain's read provider.
+- Deposits: exact-amount `approve` leg when the allowance is short (no unlimited allowances);
+  spendable deposits are dry-run with `staticCall` from the member's address before signing.
 - Withdrawals: bounded by `maxWithdraw` (vault liquidity, surfaced in the UI); full exits use
   `redeem(shares)` so share dust never strands.
 

--- a/docs/user-guide/earn.md
+++ b/docs/user-guide/earn.md
@@ -30,9 +30,10 @@ plain-language explanation.
     - who manages the vault.
 3. Pick a vault and enter an amount (or tap **Max**). The app checks your amount before your
    wallet is ever involved and explains any problem in plain language.
-4. Confirm in your wallet. **Your first deposit takes two quick confirmations**: the first gives
-   the vault permission to take exactly the amount you typed, the second makes the deposit. This
-   is standard for on-chain tokens — you never approve more than you typed.
+4. Confirm the deposit. **With a browser wallet, a first deposit takes two quick
+   confirmations**: the first gives the vault permission to take exactly the amount you typed,
+   the second makes the deposit — you never approve more than you typed. **With a passkey
+   account, one passkey confirmation covers both steps.**
 5. Your position appears under **Your positions** with its current value, which includes the
    return earned so far.
 

--- a/frontend/src/components/earn/VaultSheet.jsx
+++ b/frontend/src/components/earn/VaultSheet.jsx
@@ -3,27 +3,33 @@
  * vault. Bottom-sheet modal per repo convention (Escape + backdrop close,
  * focus managed).
  *
+ * Writes go through WalletContext.sendCalls — the unified spec-041 rail — so
+ * BOTH session kinds work: a passkey session authorizes the whole
+ * approve+deposit batch with one WebAuthn ceremony (it has no ethers signer),
+ * a classic wallet signs each step. Reads (allowance, dry-runs) use the
+ * chain's read provider, never the signer.
+ *
  * Non-intimidating by design: amounts are validated with member-facing
- * reasons BEFORE any wallet prompt; a first deposit explains the two wallet
- * confirmations (approval + deposit) up front; a plain-English summary states
- * exactly what will happen; withdrawal honors the vault's honest liquidity
- * bound (maxWithdraw). Every completed action is queued for the activity
- * feed with its transaction link (FR-010).
+ * reasons BEFORE any wallet prompt; a first deposit explains up front how
+ * many confirmations to expect for the session kind; a plain-English summary
+ * states exactly what will happen; withdrawal honors the vault's honest
+ * liquidity bound (maxWithdraw). Every completed action is queued for the
+ * activity feed with its transaction link (FR-010).
  */
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { formatUnits, parseUnits } from 'ethers'
 import { useWallet } from '../../hooks/useWalletManagement'
 import { useActivityOptional } from '../../hooks/useActivity'
 import { getBlockscoutUrl } from '../../config/blockExplorer'
+import { NETWORKS } from '../../config/networks'
+import { makeReadProvider } from '../../utils/rpcProvider'
 import InfoTip from '../ui/InfoTip'
 import { EARN_TIPS } from '../../lib/earn/earnCopy'
 import {
   validateDepositAmount,
   validateWithdrawAmount,
-  needsApproval,
-  approveDeposit,
-  depositToVault,
-  withdrawFromVault,
+  buildDepositCalls,
+  buildWithdrawCalls,
 } from '../../lib/earn/vaultActions'
 import { queueEarnAction } from '../../lib/earn/earnActivityBuffer'
 import { formatApy } from '../../lib/earn/format'
@@ -35,7 +41,8 @@ function fmt(amountBig, decimals, symbol) {
 }
 
 export default function VaultSheet({ vault, userState, onClose, onActionComplete }) {
-  const { address, chainId, signer } = useWallet() || {}
+  const { address, chainId, sendCalls, loginMethod } = useWallet() || {}
+  const isPasskey = loginMethod === 'passkey'
   const activity = useActivityOptional()
   const sheetRef = useRef(null)
   const restoreFocusRef = useRef(null)
@@ -106,43 +113,61 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
       return
     }
     setInputError(null)
-    if (!signer || !address) return
+    // Never a silent no-op (constitution III): if this session has no write
+    // rail at all, say so instead of swallowing the tap.
+    if (!address || typeof sendCalls !== 'function') {
+      setTxState({
+        step: 'error',
+        txUrl: null,
+        error: 'This session cannot send transactions right now — please reconnect and try again.',
+      })
+      return
+    }
 
     try {
-      let receipt
+      // Reads (allowance check, dry-runs) go over the chain's read provider —
+      // passkey sessions have no signer/provider of their own.
+      const provider = makeReadProvider(NETWORKS[chainId].rpcUrl, chainId)
+      let calls
       let message
       if (mode === 'deposit') {
-        const provider = signer.provider
-        const requiresApproval = await needsApproval({ vault, account: address, amount, provider })
-        if (requiresApproval) {
-          setTxState({ step: 'approving', txUrl: null, error: null })
-          await approveDeposit({ vault, amount, signer })
-        }
-        setTxState({ step: 'confirming', txUrl: null, error: null })
-        ;({ receipt } = await depositToVault({ vault, account: address, amount, signer }))
+        const built = await buildDepositCalls({ vault, account: address, amount, provider })
+        calls = built.calls
+        setTxState({ step: built.requiresApproval ? 'approving' : 'confirming', txUrl: null, error: null })
         message = `Deposited ${fmt(amount, decimals, symbol)} into ${vault.name}`
       } else {
-        setTxState({ step: 'confirming', txUrl: null, error: null })
         // A full withdrawal redeems all shares so no dust strands.
         const isFullExit =
           userState?.maxWithdrawAssets != null && amount === userState.maxWithdrawAssets &&
           userState?.shares != null
-        ;({ receipt } = await withdrawFromVault({
+        const built = await buildWithdrawCalls({
           vault,
           account: address,
           amount,
           redeemAllShares: isFullExit ? userState.shares : null,
-          signer,
-        }))
+          provider,
+        })
+        calls = built.calls
+        setTxState({ step: 'confirming', txUrl: null, error: null })
         message = `Withdrew ${fmt(amount, decimals, symbol)} from ${vault.name}`
       }
 
-      const txUrl = getBlockscoutUrl(chainId, receipt.hash, 'tx')
+      // One passkey ceremony covers the whole batch; classic wallets prompt
+      // per call (approve, then the action) — the copy above sets expectations.
+      const sent = await sendCalls(calls)
+      if (sent?.state === 'failed') {
+        throw new Error(sent.reason || 'transaction failed')
+      }
+      const txHash = sent?.txHash ?? sent?.userOpHash ?? null
+      if (!txHash) throw new Error('Submitted, but no transaction reference was returned.')
+      // Explorer links only for real tx hashes — a UserOp hash is not a page
+      // on the block explorer.
+      const txUrl = sent?.txHash ? getBlockscoutUrl(chainId, sent.txHash, 'tx') : null
       queueEarnAction(address, chainId, {
         type: mode === 'deposit' ? 'earn-deposit' : 'earn-withdraw',
         refId: vault.address,
         message,
-        txHash: receipt.hash,
+        txHash,
         txUrl,
         at: Date.now(),
       })
@@ -150,12 +175,12 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
       setTxState({ step: 'done', txUrl, error: null })
       onActionComplete?.()
     } catch (err) {
-      const rejected = /rejected|denied/i.test(err?.message || '')
+      const rejected = /rejected|denied|cancelled|not allowed|abort/i.test(err?.message || '')
       setTxState({
         step: 'error',
         txUrl: null,
         error: rejected
-          ? 'Transaction was cancelled in your wallet. Nothing was moved.'
+          ? 'The confirmation was cancelled. Nothing was moved.'
           : 'The transaction could not be completed. Nothing was moved — you can try again.',
       })
     }
@@ -305,9 +330,11 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
             {mode === 'deposit' && (
               <p className="earn-summary">
                 Your {symbol} moves from your wallet into this vault and starts earning. You can
-                withdraw it whenever you like. A first deposit asks for two quick wallet
-                confirmations.
-                <InfoTip label="Why two confirmations?" className="earn-info">
+                withdraw it whenever you like.{' '}
+                {isPasskey
+                  ? 'One passkey confirmation covers the whole deposit — including the spending permission on a first deposit.'
+                  : 'A first deposit asks for two quick wallet confirmations.'}
+                <InfoTip label="About the spending permission" className="earn-info">
                   {EARN_TIPS.approval}
                 </InfoTip>
               </p>
@@ -327,9 +354,13 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
 
             <button type="button" className="earn-btn primary earn-submit" onClick={submit} disabled={busy}>
               {txState.step === 'approving'
-                ? 'Waiting for approval…'
+                ? isPasskey
+                  ? 'Confirm with your passkey…'
+                  : 'Approve, then confirm the deposit…'
                 : txState.step === 'confirming'
-                  ? 'Waiting for confirmation…'
+                  ? isPasskey
+                    ? 'Confirm with your passkey…'
+                    : 'Waiting for confirmation…'
                   : mode === 'deposit'
                     ? `Deposit ${symbol}`
                     : `Withdraw ${symbol}`}

--- a/frontend/src/hooks/useEarnRewards.js
+++ b/frontend/src/hooks/useEarnRewards.js
@@ -10,7 +10,7 @@
  * carries the explorer link (FR-010).
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Contract, formatUnits } from 'ethers'
+import { Interface, formatUnits } from 'ethers'
 import { useWallet } from './useWalletManagement'
 import { isEarnAvailable, getEarnConfig } from '../config/networks'
 import { getBlockscoutUrl } from '../config/blockExplorer'
@@ -19,8 +19,12 @@ import { MERKL_DISTRIBUTOR_ABI } from '../abis/MerklDistributor'
 import { queueEarnAction } from '../lib/earn/earnActivityBuffer'
 import { useActivityOptional } from './useActivity'
 
+const DISTRIBUTOR_IFACE = new Interface(MERKL_DISTRIBUTOR_ABI)
+
 export function useEarnRewards() {
-  const { address, isConnected, chainId, signer } = useWallet() || {}
+  // Writes go through sendCalls (spec 041's unified rail) so passkey sessions
+  // — which have no ethers signer — can claim too.
+  const { address, isConnected, chainId, sendCalls } = useWallet() || {}
   const activity = useActivityOptional()
   const supported = isEarnAvailable(chainId)
   const earnConfig = getEarnConfig(chainId)
@@ -65,15 +69,37 @@ export function useEarnRewards() {
 
   /** Claim every claimable reward in one distributor transaction. */
   const claim = useCallback(async () => {
-    if (!signer || !address || !earnConfig?.merklDistributor) return
+    if (!address || !earnConfig?.merklDistributor) return
     const args = buildClaimArgs(address, rewards)
     if (!args) return // nothing claimable — never prompt the wallet for a no-op
+    if (typeof sendCalls !== 'function') {
+      // Never a silent no-op (constitution III).
+      setClaimState({
+        status: 'error',
+        txUrl: null,
+        error: 'This session cannot send transactions right now — please reconnect and try again.',
+      })
+      return
+    }
     setClaimState({ status: 'pending', txUrl: null, error: null })
     try {
-      const distributor = new Contract(earnConfig.merklDistributor, MERKL_DISTRIBUTOR_ABI, signer)
-      const tx = await distributor.claim(args.users, args.tokens, args.amounts, args.proofs)
-      const receipt = await tx.wait()
-      const txUrl = getBlockscoutUrl(chainId, receipt.hash, 'tx')
+      const sent = await sendCalls([
+        {
+          target: earnConfig.merklDistributor,
+          data: DISTRIBUTOR_IFACE.encodeFunctionData('claim', [
+            args.users,
+            args.tokens,
+            args.amounts,
+            args.proofs,
+          ]),
+          value: 0n,
+        },
+      ])
+      if (sent?.state === 'failed') throw new Error(sent.reason || 'claim failed')
+      const txHash = sent?.txHash ?? sent?.userOpHash ?? null
+      if (!txHash) throw new Error('Submitted, but no transaction reference was returned.')
+      // Explorer links only for real tx hashes (a UserOp hash has no page).
+      const txUrl = sent?.txHash ? getBlockscoutUrl(chainId, sent.txHash, 'tx') : null
       const summary = args.rewards
         .map((r) => `${formatUnits(r.claimable, r.token.decimals)} ${r.token.symbol}`.trim())
         .join(', ')
@@ -81,7 +107,7 @@ export function useEarnRewards() {
         type: 'earn-rewards-claimed',
         refId: args.tokens[0],
         message: `Claimed earn rewards: ${summary}`,
-        txHash: receipt.hash,
+        txHash,
         txUrl,
         at: Date.now(),
       })
@@ -89,14 +115,14 @@ export function useEarnRewards() {
       setClaimState({ status: 'confirmed', txUrl, error: null })
       load()
     } catch (err) {
-      const rejected = /rejected|denied/i.test(err?.message || '')
+      const rejected = /rejected|denied|cancelled|not allowed|abort/i.test(err?.message || '')
       setClaimState({
         status: 'error',
         txUrl: null,
-        error: rejected ? 'Transaction was cancelled in your wallet.' : 'Claim failed. Please try again.',
+        error: rejected ? 'The confirmation was cancelled.' : 'Claim failed. Please try again.',
       })
     }
-  }, [signer, address, chainId, rewards, earnConfig, activity, load])
+  }, [sendCalls, address, chainId, rewards, earnConfig, activity, load])
 
   return useMemo(
     () => ({

--- a/frontend/src/lib/earn/vaultActions.js
+++ b/frontend/src/lib/earn/vaultActions.js
@@ -1,16 +1,22 @@
 /**
  * ERC-4626 vault reads + actions for the Earn section (spec 050).
  *
- * Deposits and withdrawals run directly from the member's own wallet against
- * curated Morpho vaults — FairWins never takes custody. Safety rails
- * (research.md R1/R9):
+ * Deposits and withdrawals run from the member's own account against curated
+ * Morpho vaults — FairWins never takes custody. Writes are expressed as
+ * `{ target, data, value }` call batches for WalletContext.sendCalls (spec
+ * 041's unified rail): passkey sessions authorize the WHOLE batch (approve +
+ * deposit) with ONE ceremony via UserOp; classic wallets sign sequentially.
+ * A raw ethers signer is never required — passkey sessions don't have one.
+ *
+ * Safety rails (research.md R1/R9):
  *   - pure validators reject bad amounts BEFORE any wallet prompt;
- *   - deposits are quoted with previewDeposit and dry-run with staticCall
- *     before the real transaction;
+ *   - actions that are spendable now are dry-run with staticCall (from the
+ *     member's address) before anything is signed;
+ *   - approvals are for the exact amount (no unlimited allowances);
  *   - withdrawals are bounded by maxWithdraw (the vault's honest liquidity
  *     limit), full exits use redeem(shares) so dust never strands.
  */
-import { Contract } from 'ethers'
+import { Contract, Interface } from 'ethers'
 import { ERC4626_VAULT_ABI } from '../../abis/ERC4626Vault'
 
 const ERC20_MIN_ABI = [
@@ -18,6 +24,9 @@ const ERC20_MIN_ABI = [
   'function allowance(address owner, address spender) view returns (uint256)',
   'function approve(address spender, uint256 value) returns (bool)',
 ]
+
+const VAULT_IFACE = new Interface(ERC4626_VAULT_ABI)
+const ERC20_IFACE = new Interface(ERC20_MIN_ABI)
 
 /**
  * Read the member's state against one vault over a read provider:
@@ -77,52 +86,54 @@ export function validateWithdrawAmount({ amount, maxWithdrawAssets }) {
 }
 
 /**
- * Whether a deposit of `amount` needs an approval transaction first.
+ * Build the sendCalls batch for a deposit: an exact-amount approval when the
+ * current allowance is short, then the deposit itself. When the deposit is
+ * already spendable (no approval leg), it is dry-run with staticCall from the
+ * member's address so vault-side rejections (cap reached, paused) surface
+ * before anything is signed. Reads go over the chain's read `provider` — a
+ * signer is never needed here.
+ * Returns { calls, requiresApproval }.
  */
-export async function needsApproval({ vault, account, amount, provider }) {
+export async function buildDepositCalls({ vault, account, amount, provider }) {
   const token = new Contract(vault.asset.address, ERC20_MIN_ABI, provider)
   const allowance = await token.allowance(account, vault.address)
-  return allowance < amount
-}
-
-/**
- * Send the approval for exactly `amount` (no unlimited allowances — the
- * member approves what they are depositing). Returns the tx receipt.
- */
-export async function approveDeposit({ vault, amount, signer }) {
-  const token = new Contract(vault.asset.address, ERC20_MIN_ABI, signer)
-  const tx = await token.approve(vault.address, amount)
-  return tx.wait()
-}
-
-/**
- * Quote then execute a deposit. The staticCall dry-run surfaces vault-side
- * rejections (cap reached, paused) before the member pays gas.
- * Returns { receipt, expectedShares }.
- */
-export async function depositToVault({ vault, account, amount, signer }) {
-  const vaultContract = new Contract(vault.address, ERC4626_VAULT_ABI, signer)
-  const expectedShares = await vaultContract.previewDeposit(amount)
-  await vaultContract.deposit.staticCall(amount, account)
-  const tx = await vaultContract.deposit(amount, account)
-  const receipt = await tx.wait()
-  return { receipt, expectedShares }
-}
-
-/**
- * Withdraw `amount` of the underlying, or the full position via redeem when
- * `redeemAllShares` is set (so share dust never strands). Returns { receipt }.
- */
-export async function withdrawFromVault({ vault, account, amount, redeemAllShares, signer }) {
-  const vaultContract = new Contract(vault.address, ERC4626_VAULT_ABI, signer)
-  let tx
-  if (redeemAllShares != null && redeemAllShares > 0n) {
-    await vaultContract.redeem.staticCall(redeemAllShares, account, account)
-    tx = await vaultContract.redeem(redeemAllShares, account, account)
+  const requiresApproval = allowance < amount
+  const calls = []
+  if (requiresApproval) {
+    calls.push({
+      target: vault.asset.address,
+      data: ERC20_IFACE.encodeFunctionData('approve', [vault.address, amount]),
+      value: 0n,
+    })
   } else {
-    await vaultContract.withdraw.staticCall(amount, account, account)
-    tx = await vaultContract.withdraw(amount, account, account)
+    // Only dry-runnable when the allowance already covers the deposit — with
+    // an approval leg in the batch the simulation would revert on allowance.
+    const vaultContract = new Contract(vault.address, ERC4626_VAULT_ABI, provider)
+    await vaultContract.deposit.staticCall(amount, account, { from: account })
   }
-  const receipt = await tx.wait()
-  return { receipt }
+  calls.push({
+    target: vault.address,
+    data: VAULT_IFACE.encodeFunctionData('deposit', [amount, account]),
+    value: 0n,
+  })
+  return { calls, requiresApproval }
+}
+
+/**
+ * Build the sendCalls batch for a withdrawal: `withdraw(assets)` for partial
+ * exits, `redeem(shares)` for full exits (so share dust never strands). The
+ * call is dry-run with staticCall from the member's address first.
+ * Returns { calls }.
+ */
+export async function buildWithdrawCalls({ vault, account, amount, redeemAllShares, provider }) {
+  const vaultContract = new Contract(vault.address, ERC4626_VAULT_ABI, provider)
+  let data
+  if (redeemAllShares != null && redeemAllShares > 0n) {
+    await vaultContract.redeem.staticCall(redeemAllShares, account, account, { from: account })
+    data = VAULT_IFACE.encodeFunctionData('redeem', [redeemAllShares, account, account])
+  } else {
+    await vaultContract.withdraw.staticCall(amount, account, account, { from: account })
+    data = VAULT_IFACE.encodeFunctionData('withdraw', [amount, account, account])
+  }
+  return { calls: [{ target: vault.address, data, value: 0n }] }
 }

--- a/frontend/src/test/earn/VaultSheet.test.jsx
+++ b/frontend/src/test/earn/VaultSheet.test.jsx
@@ -1,15 +1,30 @@
 /**
  * VaultSheet tests (spec 050 US1) — pre-wallet amount validation with
- * member-facing reasons, Max shortcut, two-prompt approval explanation,
- * honest withdraw liquidity bound, and withdraw disabled without a position.
+ * member-facing reasons, Max shortcut, session-aware confirmation copy,
+ * honest withdraw liquidity bound, withdraw disabled without a position,
+ * and the sendCalls write rail (passkey batch + honest no-rail error —
+ * the tap must NEVER be a silent no-op).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
 const mockWallet = vi.hoisted(() => ({ current: {} }))
 vi.mock('../../hooks/useWalletManagement', () => ({
   useWallet: () => mockWallet.current,
 }))
+
+// Batch builders are unit-tested in vaultActions.test.js; here they are mocked
+// so no read-provider RPC is constructed. Validators stay real.
+const mockBuilders = vi.hoisted(() => ({ deposit: vi.fn(), withdraw: vi.fn() }))
+vi.mock('../../lib/earn/vaultActions', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    buildDepositCalls: (...args) => mockBuilders.deposit(...args),
+    buildWithdrawCalls: (...args) => mockBuilders.withdraw(...args),
+  }
+})
+vi.mock('../../utils/rpcProvider', () => ({ makeReadProvider: () => ({}) }))
 
 import VaultSheet from '../../components/earn/VaultSheet'
 
@@ -31,8 +46,15 @@ const USER_STATE = {
   maxDepositAssets: 0n,
 }
 
+const DEPOSIT_CALLS = [
+  { target: '0xusdc', data: '0xapprove', value: 0n },
+  { target: VAULT.address, data: '0xdeposit', value: 0n },
+]
+
 beforeEach(() => {
-  mockWallet.current = { address: '0xac', chainId: 137, signer: null }
+  mockWallet.current = { address: '0xac', chainId: 137, sendCalls: vi.fn(), loginMethod: 'wallet' }
+  mockBuilders.deposit.mockReset().mockResolvedValue({ calls: DEPOSIT_CALLS, requiresApproval: true })
+  mockBuilders.withdraw.mockReset().mockResolvedValue({ calls: [DEPOSIT_CALLS[1]] })
 })
 
 function renderSheet(userState = USER_STATE) {
@@ -96,5 +118,55 @@ describe('VaultSheet withdraw (honest liquidity bound)', () => {
     const withdrawTab = screen.getByRole('tab', { name: /withdraw/i })
     expect(withdrawTab).toBeDisabled()
     expect(withdrawTab).toHaveAttribute('title', expect.stringMatching(/nothing in this vault/i))
+  })
+})
+
+describe('VaultSheet write rail (sendCalls — passkey + classic)', () => {
+  it('passkey deposit sends ONE sendCalls batch (approve + deposit) and shows the success state', async () => {
+    const sendCalls = vi.fn().mockResolvedValue({ route: 'userop', state: 'included', txHash: '0xtx1' })
+    mockWallet.current = { address: '0xac', chainId: 137, sendCalls, loginMethod: 'passkey' }
+    renderSheet()
+    // Passkey copy: one ceremony, not "two confirmations".
+    expect(screen.getByText(/one passkey confirmation/i)).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '5' } })
+    fireEvent.click(screen.getByRole('button', { name: /deposit usdc/i }))
+    await waitFor(() => expect(screen.getByText(/deposit complete/i)).toBeInTheDocument())
+    expect(sendCalls).toHaveBeenCalledTimes(1)
+    expect(sendCalls).toHaveBeenCalledWith(DEPOSIT_CALLS)
+    expect(mockBuilders.deposit).toHaveBeenCalledWith(
+      expect.objectContaining({ account: '0xac', amount: 5_000_000n }),
+    )
+    expect(screen.getByRole('link', { name: /view transaction/i })).toHaveAttribute(
+      'href',
+      expect.stringContaining('0xtx1'),
+    )
+  })
+
+  it('classic wallet withdraw routes through sendCalls too', async () => {
+    const sendCalls = vi.fn().mockResolvedValue({ route: 'direct', txHash: '0xtx2' })
+    mockWallet.current = { address: '0xac', chainId: 137, sendCalls, loginMethod: 'wallet' }
+    renderSheet()
+    fireEvent.click(screen.getByRole('tab', { name: /withdraw/i }))
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '2' } })
+    fireEvent.click(screen.getByRole('button', { name: /withdraw usdc/i }))
+    await waitFor(() => expect(screen.getByText(/withdrawal complete/i)).toBeInTheDocument())
+    expect(sendCalls).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows an honest error when the session has no write rail — never a silent no-op', async () => {
+    mockWallet.current = { address: '0xac', chainId: 137, sendCalls: undefined, loginMethod: 'passkey' }
+    renderSheet()
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '5' } })
+    fireEvent.click(screen.getByRole('button', { name: /deposit usdc/i }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/cannot send transactions/i)
+  })
+
+  it('surfaces a failed submission outcome instead of pretending success', async () => {
+    const sendCalls = vi.fn().mockResolvedValue({ route: 'userop', state: 'failed', reason: 'user operation reverted' })
+    mockWallet.current = { address: '0xac', chainId: 137, sendCalls, loginMethod: 'passkey' }
+    renderSheet()
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '5' } })
+    fireEvent.click(screen.getByRole('button', { name: /deposit usdc/i }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/could not be completed/i)
   })
 })

--- a/frontend/src/test/earn/useEarnRewards.test.jsx
+++ b/frontend/src/test/earn/useEarnRewards.test.jsx
@@ -1,0 +1,89 @@
+/**
+ * useEarnRewards claim tests (spec 050 US2) — the claim goes through
+ * sendCalls (so passkey sessions work), encodes the distributor call with
+ * CUMULATIVE amounts, reports honestly on failure, and never silently
+ * no-ops when the session has no write rail.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { Interface } from 'ethers'
+
+const mockWallet = vi.hoisted(() => ({ current: {} }))
+vi.mock('../../hooks/useWalletManagement', () => ({
+  useWallet: () => mockWallet.current,
+}))
+vi.mock('../../hooks/useActivity', () => ({
+  useActivity: () => null,
+  useActivityOptional: () => null,
+}))
+
+const mockMerkl = vi.hoisted(() => ({ rewards: [] }))
+vi.mock('../../lib/earn/merkl', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, fetchRewards: vi.fn(async () => mockMerkl.rewards) }
+})
+
+import { useEarnRewards } from '../../hooks/useEarnRewards'
+import { MERKL_DISTRIBUTOR_ABI } from '../../abis/MerklDistributor'
+
+const DISTRIBUTOR_IFACE = new Interface(MERKL_DISTRIBUTOR_ABI)
+const ACCOUNT = '0x00000000000000000000000000000000000000ac'
+
+const REWARD = {
+  token: { address: '0x00000000000000000000000000000000000000d1', symbol: 'MORPHO', decimals: 18 },
+  amount: 2_000_000_000_000_000_000n,
+  claimed: 500_000_000_000_000_000n,
+  claimable: 1_500_000_000_000_000_000n,
+  pending: 0n,
+  proofs: ['0x' + 'aa'.repeat(32)],
+  fetchedAt: 1,
+}
+
+beforeEach(() => {
+  mockMerkl.rewards = [REWARD]
+  mockWallet.current = {
+    address: ACCOUNT,
+    isConnected: true,
+    chainId: 137,
+    sendCalls: vi.fn().mockResolvedValue({ route: 'userop', state: 'included', txHash: '0xtx' }),
+  }
+  localStorage.clear()
+})
+
+describe('useEarnRewards claim (sendCalls rail)', () => {
+  it('claims via one distributor call with the CUMULATIVE amount', async () => {
+    const { result } = renderHook(() => useEarnRewards())
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    await act(() => result.current.claim())
+
+    const sendCalls = mockWallet.current.sendCalls
+    expect(sendCalls).toHaveBeenCalledTimes(1)
+    const [calls] = sendCalls.mock.calls[0]
+    expect(calls).toHaveLength(1)
+    const decoded = DISTRIBUTOR_IFACE.decodeFunctionData('claim', calls[0].data)
+    expect(decoded[0][0].toLowerCase()).toBe(ACCOUNT) // users
+    expect(decoded[1][0].toLowerCase()).toBe(REWARD.token.address) // tokens
+    expect(decoded[2][0]).toBe(REWARD.amount) // cumulative, NOT the difference
+    expect(result.current.claimState.status).toBe('confirmed')
+    expect(result.current.claimState.txUrl).toContain('0xtx')
+  })
+
+  it('reports an honest error when the session has no write rail', async () => {
+    mockWallet.current = { ...mockWallet.current, sendCalls: undefined }
+    const { result } = renderHook(() => useEarnRewards())
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    await act(() => result.current.claim())
+    expect(result.current.claimState.status).toBe('error')
+    expect(result.current.claimState.error).toMatch(/cannot send transactions/i)
+  })
+
+  it('surfaces a failed submission outcome', async () => {
+    mockWallet.current.sendCalls = vi
+      .fn()
+      .mockResolvedValue({ route: 'userop', state: 'failed', reason: 'reverted' })
+    const { result } = renderHook(() => useEarnRewards())
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    await act(() => result.current.claim())
+    expect(result.current.claimState.status).toBe('error')
+  })
+})

--- a/frontend/src/test/earn/vaultActions.test.js
+++ b/frontend/src/test/earn/vaultActions.test.js
@@ -1,11 +1,59 @@
 /**
- * Vault action validator tests (spec 050, US1 edge cases) — every bad amount
- * is rejected with a member-facing reason BEFORE any wallet prompt, and the
- * display formatters stay honest about missing data.
+ * Vault action tests (spec 050, US1 edge cases) — every bad amount is
+ * rejected with a member-facing reason BEFORE any wallet prompt, the
+ * sendCalls batch builders produce correct approve/deposit/withdraw/redeem
+ * calldata (signer-free, so passkey sessions work), and the display
+ * formatters stay honest about missing data.
  */
-import { describe, it, expect } from 'vitest'
-import { validateDepositAmount, validateWithdrawAmount } from '../../lib/earn/vaultActions'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const m = vi.hoisted(() => ({ fns: {} }))
+
+vi.mock('ethers', async (orig) => {
+  const actual = await orig()
+  function FakeContract() {
+    return new Proxy(
+      {},
+      {
+        get(_t, prop) {
+          if (prop === 'then') return undefined
+          const key = String(prop)
+          const fn = (...args) => {
+            const f = m.fns[key]
+            if (!f) throw new Error('unmocked contract method: ' + key)
+            return f(...args)
+          }
+          fn.staticCall = (...args) => {
+            const f = m.fns[`${key}.staticCall`]
+            if (!f) throw new Error('unmocked staticCall: ' + key)
+            return f(...args)
+          }
+          return fn
+        },
+      },
+    )
+  }
+  return { ...actual, Contract: vi.fn(FakeContract) }
+})
+
+import { Interface } from 'ethers'
+import {
+  validateDepositAmount,
+  validateWithdrawAmount,
+  buildDepositCalls,
+  buildWithdrawCalls,
+} from '../../lib/earn/vaultActions'
+import { ERC4626_VAULT_ABI } from '../../abis/ERC4626Vault'
 import { formatApy, formatTvl } from '../../lib/earn/format'
+
+const VAULT_IFACE = new Interface(ERC4626_VAULT_ABI)
+const ERC20_IFACE = new Interface(['function approve(address spender, uint256 value) returns (bool)'])
+
+const ACCOUNT = '0x00000000000000000000000000000000000000ac'
+const VAULT = {
+  address: '0x00000000000000000000000000000000000000a1',
+  asset: { address: '0x00000000000000000000000000000000000000c0', symbol: 'USDC', decimals: 6 },
+}
 
 const BALANCE = 1_000_000n // 1 USDC at 6 decimals
 
@@ -50,6 +98,89 @@ describe('validateWithdrawAmount', () => {
 
   it('accepts up to the available liquidity bound', () => {
     expect(validateWithdrawAmount({ amount: BALANCE, maxWithdrawAssets: BALANCE }).ok).toBe(true)
+  })
+})
+
+describe('buildDepositCalls (sendCalls batch)', () => {
+  beforeEach(() => {
+    m.fns = {}
+  })
+
+  it('prepends an exact-amount approval when the allowance is short', async () => {
+    m.fns.allowance = async () => 0n
+    const { calls, requiresApproval } = await buildDepositCalls({
+      vault: VAULT,
+      account: ACCOUNT,
+      amount: 5_000_000n,
+      provider: {},
+    })
+    expect(requiresApproval).toBe(true)
+    expect(calls).toHaveLength(2)
+    expect(calls[0].target).toBe(VAULT.asset.address)
+    const approve = ERC20_IFACE.decodeFunctionData('approve', calls[0].data)
+    expect(approve[0].toLowerCase()).toBe(VAULT.address)
+    expect(approve[1]).toBe(5_000_000n) // exact amount — never unlimited
+    expect(calls[1].target).toBe(VAULT.address)
+    const deposit = VAULT_IFACE.decodeFunctionData('deposit', calls[1].data)
+    expect(deposit[0]).toBe(5_000_000n)
+    expect(deposit[1].toLowerCase()).toBe(ACCOUNT)
+  })
+
+  it('skips the approval and dry-runs the deposit when the allowance covers it', async () => {
+    m.fns.allowance = async () => 10_000_000n
+    const dryRun = vi.fn(async () => 5_000_000n)
+    m.fns['deposit.staticCall'] = dryRun
+    const { calls, requiresApproval } = await buildDepositCalls({
+      vault: VAULT,
+      account: ACCOUNT,
+      amount: 5_000_000n,
+      provider: {},
+    })
+    expect(requiresApproval).toBe(false)
+    expect(calls).toHaveLength(1)
+    expect(dryRun).toHaveBeenCalled()
+  })
+
+  it('propagates a dry-run revert so nothing is signed for a doomed deposit', async () => {
+    m.fns.allowance = async () => 10_000_000n
+    m.fns['deposit.staticCall'] = async () => {
+      throw new Error('vault paused')
+    }
+    await expect(
+      buildDepositCalls({ vault: VAULT, account: ACCOUNT, amount: 5_000_000n, provider: {} }),
+    ).rejects.toThrow(/vault paused/)
+  })
+})
+
+describe('buildWithdrawCalls (sendCalls batch)', () => {
+  beforeEach(() => {
+    m.fns = {}
+  })
+
+  it('encodes withdraw(assets) for partial exits after a dry-run', async () => {
+    m.fns['withdraw.staticCall'] = async () => 1n
+    const { calls } = await buildWithdrawCalls({
+      vault: VAULT,
+      account: ACCOUNT,
+      amount: 2_000_000n,
+      redeemAllShares: null,
+      provider: {},
+    })
+    const decoded = VAULT_IFACE.decodeFunctionData('withdraw', calls[0].data)
+    expect(decoded[0]).toBe(2_000_000n)
+  })
+
+  it('encodes redeem(shares) for full exits so dust never strands', async () => {
+    m.fns['redeem.staticCall'] = async () => 1n
+    const { calls } = await buildWithdrawCalls({
+      vault: VAULT,
+      account: ACCOUNT,
+      amount: 8_000_000n,
+      redeemAllShares: 10_000_000n,
+      provider: {},
+    })
+    const decoded = VAULT_IFACE.decodeFunctionData('redeem', calls[0].data)
+    expect(decoded[0]).toBe(10_000_000n)
   })
 })
 


### PR DESCRIPTION
Follow-up to #863/#864/#867 (spec 050, issue #861). With vaults now loading, tapping **Deposit USDC** did nothing for a passkey member — no error, no request.

## Root cause

The Earn write flows required a raw ethers signer: `VaultSheet.submit()` and the rewards claim both bailed on `if (!signer) return`. Passkey sessions have **no ethers signer** (WalletContext sets it to null for `loginMethod === 'passkey'`), so the tap was a silent dead button — a constitution III violation on top of a broken flow.

## Fix

All Earn writes now go through **`WalletContext.sendCalls`** — the spec-041 unified rail the rest of the app uses (same pattern as `useOpenChallengeAccept`):

- **`lib/earn/vaultActions.js`**: the signer-based approve/deposit/withdraw helpers become `buildDepositCalls` / `buildWithdrawCalls`, producing `{ target, data, value }` batches — an exact-amount approval leg only when the allowance is short, `staticCall` dry-runs from the member's address, `redeem(shares)` for full exits. Reads use the chain's read provider (passkey sessions have no provider of their own).
- **`VaultSheet`**: one `sendCalls` batch per action. A passkey session authorizes approve+deposit with **one WebAuthn ceremony** (UserOp, sponsored where available); classic wallets keep their sequential prompts. Confirmation copy is session-aware ("one passkey confirmation" vs "two quick wallet confirmations"). A session with no write rail now gets an honest error instead of a silent return; failed submission outcomes surface; explorer links render only for real tx hashes (never a bare UserOp hash).
- **`useEarnRewards.claim`**: distributor claim encoded via `Interface` and sent through `sendCalls`, same honest-rail/failure handling.
- **Docs**: user guide (passkey = one confirmation) and developer guide (sendCalls rail) updated.

## Testing

74 earn tests pass, including new coverage: passkey deposit sends exactly one batch (approve+deposit) and shows success with the tx link; no-rail sessions get a visible error (the silent no-op is now impossible); failed UserOp outcomes surface; batch calldata is decoded and asserted (exact-amount approval, redeem full-exit); a direct `useEarnRewards` hook test verifies the claim call carries the cumulative amounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LizwRCtWZEqdsCobwCwApJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LizwRCtWZEqdsCobwCwApJ)_