### PR TITLE
Fix passkey gasless sends: build UserOp for the FairWins-factory address (not viem's Coinbase factory)

### DIFF
--- a/frontend/src/lib/passkey/__tests__/sendBatch.fallback.test.js
+++ b/frontend/src/lib/passkey/__tests__/sendBatch.fallback.test.js
@@ -57,6 +57,10 @@ describe('sendPasskeyBatch never-stranded fallback (spec 050)', () => {
     // second build forced self-funding
     expect(buildAccount).toHaveBeenCalledTimes(2)
     expect(buildAccount.mock.calls[1][0].deps.noPaymaster).toBe(true)
+    // both builds pin the sender to the SESSION address (the FairWins-factory address the user funded),
+    // never viem's empty Coinbase-factory address (the factory-mismatch fix).
+    expect(buildAccount.mock.calls[0][0].accountAddress).toBe(ADDRESS)
+    expect(buildAccount.mock.calls[1][0].accountAddress).toBe(ADDRESS)
     expect(onState).toHaveBeenCalledWith(expect.objectContaining({ state: LIFECYCLE.DRAFT, sponsored: false }))
   })
 
@@ -82,5 +86,11 @@ describe('sendPasskeyBatch never-stranded fallback (spec 050)', () => {
     expect(isSponsorshipUnavailable(new Error('AA23 reverted: account validation'))).toBe(false)
     expect(isSponsorshipUnavailable(new Error('execution reverted'))).toBe(false)
     expect(isSponsorshipUnavailable(new Error('AA21 didn\'t pay prefund'))).toBe(false)
+    // The insufficient-balance revert (empty sender) is an OP problem — surface it, don't mask it as
+    // a self-funded AA21 (the confusing symptom the factory-mismatch fix resolves).
+    expect(
+      isSponsorshipUnavailable(new Error('UserOperation reverted during simulation with reason: transfer amount exceeds balance'))
+    ).toBe(false)
+    expect(isSponsorshipUnavailable(new Error('ERC20: transfer amount exceeds balance'))).toBe(false)
   })
 })

--- a/frontend/src/lib/passkey/__tests__/smartAccount.test.js
+++ b/frontend/src/lib/passkey/__tests__/smartAccount.test.js
@@ -45,13 +45,18 @@ vi.mock('viem/account-abstraction', async () => {
   return {
     ...actual,
     toWebAuthnAccount: vi.fn(() => ({ type: 'webAuthnAccount' })),
-    toCoinbaseSmartAccount: vi.fn(async () => ({ address: '0xACC0000000000000000000000000000000000001' })),
+    // Echo the pinned `address` param (the factory-mismatch fix pins the sender) and expose an
+    // isDeployed the getFactoryArgs override consults; default counterfactual.
+    toCoinbaseSmartAccount: vi.fn(async (params) => ({
+      address: params?.address ?? '0xACC0000000000000000000000000000000000001',
+      isDeployed: vi.fn().mockResolvedValue(false),
+    })),
     createBundlerClient: vi.fn((opts) => opts),
     createPaymasterClient: vi.fn((opts) => ({ __isPaymasterClient: true, ...opts })),
   }
 })
 
-import { createBundlerClient, createPaymasterClient } from 'viem/account-abstraction'
+import { createBundlerClient, createPaymasterClient, toCoinbaseSmartAccount } from 'viem/account-abstraction'
 import {
   publicKeyToOwnerBytes,
   addressToOwnerBytes,
@@ -217,6 +222,74 @@ describe('buildAccount sponsoring-paymaster wiring (spec 050)', () => {
     const bundlerOpts = createBundlerClient.mock.calls[0][0]
     expect(bundlerOpts.paymaster).toBe(injected)
     expect(out.sponsored).toBe(true)
+  })
+})
+
+describe('buildAccount FairWins-factory address pinning (factory-mismatch fix)', () => {
+  const credential = { credentialId: 'c1', publicKey: { x: X, y: Y } }
+  const ownerBytes = publicKeyToOwnerBytes({ x: X, y: Y })
+  const FUNDED = '0xF1F269F7ABF9C94963692D53A0D9386DB36EA4C0'
+
+  beforeEach(() => {
+    toCoinbaseSmartAccount.mockClear()
+  })
+
+  it('pins the viem sender to the caller-supplied account address (never viem’s Coinbase-factory address)', async () => {
+    const publicClient = { readContract: vi.fn(), getCode: vi.fn() }
+    const out = await buildAccount({
+      chainId: 137,
+      credential,
+      accountAddress: FUNDED,
+      ownerIndex: 0,
+      deps: { publicClient },
+    })
+    // viem is told the address explicitly — it must NOT query its own (wrong) factory to derive it.
+    expect(toCoinbaseSmartAccount.mock.calls[0][0].address).toBe(FUNDED)
+    expect(publicClient.readContract).not.toHaveBeenCalled()
+    expect(out.account.address).toBe(FUNDED)
+  })
+
+  it('derives the sender from the FairWins factory (getAddress) when the caller omits it', async () => {
+    const publicClient = { readContract: vi.fn().mockResolvedValue(FUNDED), getCode: vi.fn() }
+    await buildAccount({ chainId: 137, credential, ownerIndex: 0, deps: { publicClient } })
+    // deriveAddress → getAddress on the FairWins-deployed factory (0xFAC7…), with the credential’s owner bytes.
+    const call = publicClient.readContract.mock.calls[0][0]
+    expect(call.functionName).toBe('getAddress')
+    expect(call.address).toMatch(/^0xFAC7/i)
+    expect(call.args).toEqual([[ownerBytes], 0n])
+    // …and that derived address is what viem is pinned to.
+    expect(toCoinbaseSmartAccount.mock.calls[0][0].address).toBe(FUNDED)
+  })
+
+  it('overrides getFactoryArgs to deploy via the FairWins factory while counterfactual', async () => {
+    const publicClient = { readContract: vi.fn(), getCode: vi.fn() }
+    const out = await buildAccount({
+      chainId: 137,
+      credential,
+      accountAddress: FUNDED,
+      ownerIndex: 0,
+      deps: { publicClient },
+    })
+    const args = await out.account.getFactoryArgs()
+    // The FairWins factory (0xFAC7…), NOT viem’s hardwired Coinbase factory (0x0ba5ed0c…).
+    expect(args.factory).toMatch(/^0xFAC7/i)
+    expect(args.factory.toLowerCase()).not.toBe('0x0ba5ed0c6aa8c49038f819e587e2633c4a9f428a')
+    // createAccount([ownerBytes], 0) calldata carries the initial owner bytes.
+    expect(args.factoryData.toLowerCase()).toContain('11'.repeat(32) + '22'.repeat(32))
+  })
+
+  it('emits NO initCode once the account is deployed (preserves viem’s isDeployed guard)', async () => {
+    const publicClient = { readContract: vi.fn(), getCode: vi.fn() }
+    const out = await buildAccount({
+      chainId: 137,
+      credential,
+      accountAddress: FUNDED,
+      ownerIndex: 0,
+      deps: { publicClient },
+    })
+    out.account.isDeployed.mockResolvedValue(true)
+    const args = await out.account.getFactoryArgs()
+    expect(args).toEqual({ factory: undefined, factoryData: undefined })
   })
 })
 

--- a/frontend/src/lib/passkey/sendBatch.js
+++ b/frontend/src/lib/passkey/sendBatch.js
@@ -110,7 +110,9 @@ export async function sendPasskeyBatch({
     deps,
   })
   const build = deps.buildAccount ?? buildAccount
-  let acct = await build({ chainId, credential, ownerIndex, deps })
+  // Pass the SESSION address (the FairWins-factory address the user funded) so buildAccount pins the
+  // UserOp sender to it — never viem's hardwired Coinbase-factory address, which is empty.
+  let acct = await build({ chainId, credential, accountAddress: address, ownerIndex, deps })
   const { calls: shaped } = buildAction(calls)
 
   // Sponsored attempt with a never-stranded self-funded fallback (spec 050 / FR-007): if a paymaster
@@ -125,7 +127,7 @@ export async function sendPasskeyBatch({
   } catch (err) {
     if (sponsored && isSponsorshipUnavailable(err)) {
       onState?.({ state: LIFECYCLE.DRAFT, route, sponsored: false })
-      acct = await build({ chainId, credential, ownerIndex, deps: { ...deps, noPaymaster: true } })
+      acct = await build({ chainId, credential, accountAddress: address, ownerIndex, deps: { ...deps, noPaymaster: true } })
       sponsored = false
       bundlerClient = acct.bundlerClient
       hash = await bundlerClient.sendUserOperation({ calls: shaped })
@@ -155,7 +157,15 @@ export async function sendPasskeyBatch({
  */
 export function isSponsorshipUnavailable(err) {
   const msg = String(err?.details || err?.shortMessage || err?.message || err || '').toLowerCase()
-  if (/aa1[0-9]|aa2[0-9]|execution reverted|reverted with|account validation|out of gas|invalid userop/.test(msg)) {
+  // An op that reverts in bundler simulation (e.g. "reverted during simulation ... transfer amount
+  // exceeds balance") is a USER-OP problem: a self-funded retry reverts identically and only masks the
+  // real reason behind a confusing AA21. Surface it. Only genuine sponsorship/transport failures below
+  // fall through to the self-funded retry.
+  if (
+    /aa1[0-9]|aa2[0-9]|execution reverted|reverted with|reverted during simulation|exceeds balance|transfer amount|account validation|out of gas|invalid userop/.test(
+      msg
+    )
+  ) {
     return false
   }
   // Paymaster AA3x, our endpoint's refusals, and HTTP/RPC/transport failures all mean sponsorship

--- a/frontend/src/lib/passkey/smartAccount.js
+++ b/frontend/src/lib/passkey/smartAccount.js
@@ -182,8 +182,8 @@ export async function resolveOwnerIndex({ chainId, accountAddress, credential, d
  * `credential` = { credentialId, publicKey: {x, y} } from credentials.js.
  * `signPayload` lets the connector own the ceremony UX (deps-injectable).
  */
-export async function buildAccount({ chainId, credential, ownersBytes, ownerIndex, nonce = 0n, deps = {} }) {
-  const { entryPoint, bundlerUrls, sponsorPaymasterUrl } = requirePasskeySupport(chainId)
+export async function buildAccount({ chainId, credential, accountAddress, ownerIndex, nonce = 0n, deps = {} }) {
+  const { entryPoint, bundlerUrls, sponsorPaymasterUrl, factory } = requirePasskeySupport(chainId)
   const client = deps.publicClient ?? defaultPublicClient(chainId)
 
   // Refuse incomplete records BEFORE any ceremony — an undefined id/key here
@@ -204,14 +204,27 @@ export async function buildAccount({ chainId, credential, ownersBytes, ownerInde
       return result
     })
 
+  const initialOwnerBytes = publicKeyToOwnerBytes(credential.publicKey)
+
   const owner = toWebAuthnAccount({
     credential: {
       id: credential.credentialId,
-      publicKey: publicKeyToOwnerBytes(credential.publicKey),
+      publicKey: initialOwnerBytes,
     },
     getFn,
     rpId: deps.rpId,
   })
+
+  // The account address is a pure function of (initial owners, nonce) and the FairWins-DEPLOYED
+  // factory — the one the connector's `deriveAddress` uses and the address the user funds (their
+  // displayed balance). viem's `toCoinbaseSmartAccount` instead hardwires the canonical Coinbase
+  // factory (0x0ba5ed0c), which derives a DIFFERENT counterfactual address. Left unpinned, every
+  // UserOp was built for that empty Coinbase-factory address — the transfer reverted "exceeds
+  // balance" (sponsored) or the sender couldn't prefund gas → AA21 (self-funded). Pin viem to the
+  // FairWins address so the sender is the account that actually holds the funds.
+  const address =
+    accountAddress ??
+    (await deriveAddress({ chainId, ownersBytes: [initialOwnerBytes], nonce, deps: { publicClient: client } }))
 
   const account = await toCoinbaseSmartAccount({
     client,
@@ -221,8 +234,28 @@ export async function buildAccount({ chainId, credential, ownersBytes, ownerInde
     // slot. Controller additions never reindex (append-only).
     ownerIndex: ownerIndex ?? deps.ownerIndex ?? 0,
     nonce,
-    ...(ownersBytes ? {} : {}),
+    // Pin the sender: viem returns this verbatim from getAddress() instead of querying its
+    // own (wrong) factory. Signing (replaySafeHash/ERC-1271) binds this same address + chainId.
+    address,
   })
+
+  // First-use deployment must land the account code at `address`, so the initCode MUST call the
+  // FairWins factory's createAccount — not viem's hardwired Coinbase factory (which would deploy a
+  // different address and revert AA14). Override viem's getFactoryArgs, preserving its isDeployed
+  // guard so a deployed account emits no initCode. Owners here mirror `deriveAddress` exactly, so
+  // the deployed address equals `address`. (For counterfactual accounts the connecting credential
+  // is always the sole initial owner — controllers can only be added post-deployment.)
+  account.getFactoryArgs = async () => {
+    if (await account.isDeployed()) return { factory: undefined, factoryData: undefined }
+    return {
+      factory,
+      factoryData: encodeFunctionData({
+        abi: FACTORY_ABI,
+        functionName: 'createAccount',
+        args: [[initialOwnerBytes], nonce],
+      }),
+    }
+  }
 
   // FairWins-sponsored paymaster (spec 050): when a sponsor endpoint is configured for this network,
   // the bundler client fetches a signed sponsorship automatically so the account never needs a


### PR DESCRIPTION
## The bug

Passkey **gasless transfers fail for accounts that hold POL and USDC** — the UI shows the balance, but the send fails with *"Smart Account does not have sufficient funds"* (self-funded path) or an ERC20 *"transfer amount exceeds balance"* revert (sponsored path).

## Root cause — an account-address mismatch between two factories

Two code paths derive the smart-account address from **two different factories**:

| Path | Factory | Address |
|---|---|---|
| Connector / balance display (`deriveAddress`) | **FairWins-deployed** `0xd519C25e…` | **X** — where funds actually are |
| Send path (`buildAccount` → viem `toCoinbaseSmartAccount`) | viem's **hardwired Coinbase** `0x0ba5ed0c…` (no override param) | **Y** — empty, counterfactual |

Same owners + nonce, different factory → different CREATE2 address. Proven on-chain (live Polygon): the FairWins factory returns `0xC73368EA…`, viem's returns `0xD30E185D…`.

So **every UserOp was built for an empty Coinbase-factory address (Y)** while the user's funds sit at the FairWins-factory address (X):
- **Sponsored:** paymaster pays gas, but `USDC.transfer` from Y reverts — Y holds nothing.
- **Self-funded:** empty Y can't prefund gas → **AA21** — the exact symptom that originally motivated the spec-050 sponsored paymaster.

The paymaster work was still needed (zero-MATIC users genuinely require sponsorship) — but it treated a *symptom*. This is the disease.

## The fix (`frontend/src/lib/passkey`)

- **`buildAccount`** pins viem's account to the **FairWins-factory address** — the session address the connector derived (or `deriveAddress` when omitted) — and overrides `getFactoryArgs` so first-use deployment calls the **FairWins factory's `createAccount`**, preserving viem's `isDeployed` guard (deployed → no initCode). Signing (`replaySafeHash`/ERC-1271) binds this same address, so signatures stay valid.
- **`sendBatch`** threads the session address into both `build()` calls (sponsored + self-funded retry).
- **`isSponsorshipUnavailable`** no longer misclassifies a simulation/ERC20 balance revert as a sponsorship failure — it surfaces the real reason instead of masking it behind a self-funded AA21.

**No contract / gateway / paymaster change.** The frontend simply builds the UserOp for the correct (funded) sender; the gateway signs whatever initCode it's given.

## Verification

- **Real viem + live Polygon RPC:** pinned `account.address` == the funded FairWins address `0xC73368EA…`; `getFactoryArgs` → FairWins factory + `createAccount` initCode; override sticks (account not frozen).
- **Unit tests:** 101 passing across `src/lib/passkey` + `src/connectors`, including new coverage for the address pin, the `getFactoryArgs` override (counterfactual + deployed), address threading through the retry, and the revert-classification fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)