### PR TITLE
Earn: network-transparent vaults, positions & rewards — auto-switch on submit

### DIFF
--- a/docs/developer-guide/earn-integration.md
+++ b/docs/developer-guide/earn-integration.md
@@ -14,11 +14,20 @@ lib/earn/morphoApi.js          Morpho GraphQL: vault discovery + position enrich
 lib/earn/merkl.js              Merkl REST: reward balances + claim-arg builder
 lib/earn/vaultActions.js       ethers v6 ERC-4626 reads/validators/deposit/withdraw
 lib/earn/earnActivityBuffer.js queues user actions for the activity source
-hooks/useEarnVaults|Positions|Rewards.js
+hooks/useEarnVaults|Positions|Rewards.js   multi-network (all earn chains at once)
+hooks/useEarnSend.js           network-transparent sending: auto-switches to the
+                               target chain on submit, then routes via sendCalls
 components/earn/*              EarnPanel (hub) / EarnLendView / VaultSheet /
                                EarnRewardsView / EarnPositionsList
 data/notifications/sources/earnSource.js   spec-031 activity source
 ```
+
+Network selection is TRANSPARENT, like the portfolio: vaults, positions, and rewards from
+every earn-enabled network render together with network badges (shared `AssetLogo` artwork),
+independent of the wallet's active chain. Submitting a transaction on another chain switches
+automatically as part of the confirmation (`useEarnSend`) — there is no in-app "switch
+network" step. Passkey sessions are gated honestly to chains with an ERC-4337 rail
+(`NETWORKS[chainId].passkey`).
 
 Data flow is honest-state throughout (constitution III): vault lists and APY come live from
 Morpho's API (explicit `unavailable` on failure — deposits disabled, never stale numbers);
@@ -42,9 +51,10 @@ claims are safe no-ops.
 
 ## Vault curation
 
-No hand-maintained vault lists. The client queries `vaults(where: { chainId_in, whitelisted:
-true })`, requires `listed: true` (vaults shown on the Morpho app itself), keeps API TVL
-ordering, and caps at `VAULT_LIST_LIMIT`. Only Morpho **Vault V1 (MetaMorpho)** is surfaced in
+No hand-maintained vault lists. The client queries `vaults(where: { chainId_in, listed: true })`
+— `listed` = vaults shown on the Morpho app itself; the docs' `whitelisted` field was removed
+from the live schema — in ONE query across every earn-enabled chain, keeps API TVL ordering,
+and caps at `VAULT_LIST_LIMIT`. Only Morpho **Vault V1 (MetaMorpho)** is surfaced in
 this cut: V1 implements the full ERC-4626 surface including honest `maxDeposit`/`maxWithdraw`
 (Vault V2 returns 0 from `max*` by design, which breaks honest limit display).
 

--- a/docs/user-guide/earn.md
+++ b/docs/user-guide/earn.md
@@ -6,9 +6,11 @@ time. You stay in control the whole time: deposits go straight from your own wal
 never holds your money, and you can withdraw whenever you like.
 
 !!! note "Where Earn works"
-    Lending is available on **Ethereum** and **Polygon**. On other networks the Earn section
-    stays visible and tells you where earning is available — switch networks from
-    My Account → Network to use it.
+    Lending is available on **Ethereum** and **Polygon**, and the Earn section shows vaults
+    from both together — each row carries a small network badge, just like your portfolio.
+    You never manage networks yourself: when you confirm a deposit, withdrawal, or claim,
+    the app moves to the right network automatically (a browser wallet may ask you to
+    approve the network change in the wallet itself).
 
 ## What lending is (in plain terms)
 
@@ -23,7 +25,8 @@ plain-language explanation.
 ## Lending step by step
 
 1. Open the menu and choose **Earn** in the Finance group, then open **Lend**.
-2. Browse the vault list. For each vault you can see:
+2. Browse the vault list — vaults from every supported network appear together, each with
+   its network badge. For each vault you can see:
     - the asset it accepts (for example USDC),
     - the estimated **yearly rate (APY)** — an estimate, not a promise; rates change constantly,
     - how much everyone has deposited in total,

--- a/frontend/src/components/earn/Earn.css
+++ b/frontend/src/components/earn/Earn.css
@@ -238,11 +238,35 @@
 .earn-reward-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 0.75rem;
   padding: 0.75rem 1rem;
   border: 1px solid var(--border-color, rgba(128, 128, 128, 0.35));
   border-radius: 10px;
+}
+
+.earn-reward-row .earn-reward-values {
+  margin-left: auto;
+}
+
+/* Per-network reward groups (network-transparent rewards). */
+.earn-rewards-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.earn-rewards-network {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+/* Position rows: network context under the vault name. */
+.earn-position-network {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  font-weight: 400;
 }
 
 .earn-reward-token {

--- a/frontend/src/components/earn/EarnLendView.jsx
+++ b/frontend/src/components/earn/EarnLendView.jsx
@@ -1,15 +1,21 @@
 /**
- * EarnLendView (spec 050, US1) — the curated lending vault list for the
- * active network plus the member's open positions. Selecting a vault opens
- * VaultSheet for deposit/withdraw. Honest states: loading, explicit
- * "temporarily unavailable" (deposits disabled — never stale numbers), and a
- * plain empty state. `tokenFilter` (from portfolio deep links) narrows the
- * list to vaults accepting that asset, with a one-tap clear.
+ * EarnLendView (spec 050, US1) — the curated lending vault list across every
+ * earn-enabled network plus the member's open positions. Network selection is
+ * transparent, exactly like the portfolio: every row carries the hosting
+ * network's badge (the shared AssetLogo artwork) and name, and submitting a
+ * transaction handles any needed network switch automatically. Selecting a
+ * vault opens VaultSheet for deposit/withdraw. Honest states: loading,
+ * explicit "temporarily unavailable" (deposits disabled — never stale
+ * numbers), and a plain empty state. `tokenFilter` (from portfolio deep
+ * links) narrows the list to vaults accepting that asset, with a one-tap
+ * clear.
  */
 import { useMemo, useState } from 'react'
 import { useEarnVaults } from '../../hooks/useEarnVaults'
-import { useEarnPositions } from '../../hooks/useEarnPositions'
+import { useEarnPositions, positionKey } from '../../hooks/useEarnPositions'
+import { NETWORKS } from '../../config/networks'
 import InfoTip from '../ui/InfoTip'
+import AssetLogo from '../wallet/AssetLogo'
 import VaultSheet from './VaultSheet'
 import EarnPositionsList from './EarnPositionsList'
 import { EARN_TIPS } from '../../lib/earn/earnCopy'
@@ -28,7 +34,7 @@ export default function EarnLendView({ tokenFilter: initialTokenFilter = null })
   }, [vaults, tokenFilter])
 
   const selectedState = selectedVault
-    ? positionsApi.userStates?.get(selectedVault.address.toLowerCase()) || null
+    ? positionsApi.userStates?.get(positionKey(selectedVault.chainId, selectedVault.address)) || null
     : null
 
   return (
@@ -70,23 +76,28 @@ export default function EarnLendView({ tokenFilter: initialTokenFilter = null })
       {status === 'ready' && shownVaults.length === 0 && (
         <p className="earn-state">
           {tokenFilter
-            ? `No vaults accept ${tokenFilter} on this network right now.`
-            : 'No vaults are available on this network right now.'}
+            ? `No vaults accept ${tokenFilter} right now.`
+            : 'No vaults are available right now.'}
         </p>
       )}
 
       {status === 'ready' && shownVaults.length > 0 && (
         <ul className="earn-vault-list">
           {shownVaults.map((vault) => (
-            <li key={vault.address}>
+            <li key={`${vault.chainId}:${vault.address}`}>
               <button
                 type="button"
                 className="earn-vault-row"
                 onClick={() => setSelectedVault(vault)}
               >
+                {/* Shared portfolio artwork: asset glyph + hosting-network
+                    badge, so where a vault lives is always visible. */}
+                <AssetLogo symbol={vault.asset.symbol} chainId={vault.chainId} showBadge size={32} />
                 <span className="earn-vault-main">
                   <span className="earn-vault-name">{vault.name}</span>
-                  <span className="earn-vault-asset">Deposits {vault.asset.symbol}</span>
+                  <span className="earn-vault-asset">
+                    Deposits {vault.asset.symbol} · on {NETWORKS[vault.chainId]?.name || 'unknown network'}
+                  </span>
                   {vault.curator && (
                     <span className="earn-vault-curator">Managed by {vault.curator}</span>
                   )}

--- a/frontend/src/components/earn/EarnPanel.jsx
+++ b/frontend/src/components/earn/EarnPanel.jsx
@@ -1,39 +1,40 @@
 /**
  * EarnPanel (spec 050, issue #861) — the Finance → Earn section hub.
  *
- * A member-friendly gateway to passive earning: live area (Lend via Morpho
- * vaults) plus honest "not yet available" areas (Staking, Bridges), the
- * member's rewards, protocol attribution + risk disclosure, and a link to the
- * user guide. Every DeFi term carries an InfoTip (FR-011). On networks
- * without earn support the panel explains where earning IS available instead
- * of dead-ending (FR-008).
+ * A member-friendly gateway to passive earning: live areas (Lend via Morpho
+ * vaults, Rewards via Merkl) plus honest "not yet available" areas (Staking,
+ * Bridges), protocol attribution + risk disclosure, and a link to the user
+ * guide. Every DeFi term carries an InfoTip (FR-011).
  *
- * Deep links: /wallet?tab=earn[&view=lend|rewards][&chain=<id>][&token=<sym>]
- * — `chain` is a hint (prompts a switch when it differs from the active
- * network), `token` prefilters the vault list (used by the portfolio's Earn
- * action).
+ * Network selection is TRANSPARENT, like the portfolio: vaults, positions,
+ * and rewards from every earn-enabled network render together with network
+ * badges, regardless of the wallet's active network — and submitting a
+ * transaction switches networks automatically when needed (useEarnSend).
+ * There is no "switch network" banner and no per-network gating here.
+ *
+ * Deep links: /wallet?tab=earn[&view=lend|rewards][&token=<sym>] — `token`
+ * prefilters the vault list (used by the portfolio's Earn action). A legacy
+ * `chain` param is accepted and ignored: the list already spans all earn
+ * networks.
  */
 import { useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { useWallet } from '../../hooks/useWalletManagement'
-import { getNetwork, isEarnAvailable, getEarnConfig, getEarnNetworks, NETWORKS } from '../../config/networks'
+import { getEarnNetworks } from '../../config/networks'
 import InfoTip from '../ui/InfoTip'
 import EarnLendView from './EarnLendView'
 import EarnRewardsView from './EarnRewardsView'
-import { EARN_TIPS, EARN_DISCLOSURE, EARN_AREAS_FUTURE, earnUnavailableCopy } from '../../lib/earn/earnCopy'
+import { EARN_TIPS, EARN_DISCLOSURE, EARN_AREAS_FUTURE } from '../../lib/earn/earnCopy'
 import './Earn.css'
 
 const EARN_DOCS_URL = 'https://docs.FairWins.app/user-guide/earn/'
 const VIEWS = ['home', 'lend', 'rewards']
 
 export default function EarnPanel() {
-  const { chainId, switchNetwork } = useWallet() || {}
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const supported = isEarnAvailable(chainId)
-  const network = getNetwork(chainId)
-  const earnConfig = getEarnConfig(chainId)
-  const earnNetworkNames = useMemo(() => getEarnNetworks().map((n) => n.name), [])
+  // Provider identity + legacy link are the same on every earn network —
+  // resolve from the canonical earn config, independent of the active chain.
+  const earnConfig = useMemo(() => getEarnNetworks()[0]?.earn ?? null, [])
 
   // View selection is derived from ?view= so nav/portfolio deep links land
   // directly and back/forward keep working — no duplicated state.
@@ -47,10 +48,6 @@ export default function EarnPanel() {
     setSearchParams(params, { replace: true })
   }
 
-  // ?chain= hint from deep links: when it names a different earn-enabled
-  // network, offer the switch honestly instead of silently ignoring it.
-  const chainHint = Number(searchParams.get('chain')) || null
-  const hintNetwork = chainHint && chainHint !== chainId ? NETWORKS[chainHint] : null
   const tokenFilter = searchParams.get('token') || null
 
   return (
@@ -68,58 +65,20 @@ export default function EarnPanel() {
         </p>
       </div>
 
-      {hintNetwork && (
-        <div className="earn-switch-note" role="note">
-          <p>
-            You followed a link for {hintNetwork.name}, but your wallet is on{' '}
-            {network?.name || 'another network'}.
-          </p>
-          {typeof switchNetwork === 'function' && (
-            <button
-              type="button"
-              className="earn-btn secondary"
-              onClick={() => switchNetwork(chainHint)}
-            >
-              Switch to {hintNetwork.name}
-            </button>
-          )}
-        </div>
-      )}
-
-      {!supported && (
-        <div className="earn-unavailable" role="note">
-          <p>{earnUnavailableCopy(network?.name, earnNetworkNames)}</p>
-        </div>
-      )}
-
       {view === 'home' && (
         <div className="earn-areas" aria-label="Earning opportunities">
-          <button
-            type="button"
-            className="earn-area-card"
-            disabled={!supported}
-            title={supported ? undefined : earnUnavailableCopy(network?.name, earnNetworkNames)}
-            onClick={() => openView('lend')}
-          >
+          <button type="button" className="earn-area-card" onClick={() => openView('lend')}>
             <span className="earn-area-name">Lend</span>
             <span className="earn-area-desc">
               Deposit into a managed lending vault and earn interest. Withdraw any time.
             </span>
-            {!supported && <span className="earn-area-flag">Not on this network</span>}
           </button>
 
-          <button
-            type="button"
-            className="earn-area-card"
-            disabled={!supported}
-            title={supported ? undefined : earnUnavailableCopy(network?.name, earnNetworkNames)}
-            onClick={() => openView('rewards')}
-          >
+          <button type="button" className="earn-area-card" onClick={() => openView('rewards')}>
             <span className="earn-area-name">Rewards</span>
             <span className="earn-area-desc">
               See bonus tokens your deposits have earned and claim them to your wallet.
             </span>
-            {!supported && <span className="earn-area-flag">Not on this network</span>}
           </button>
 
           {/* Future areas render honestly disabled — same pattern as the
@@ -154,10 +113,8 @@ export default function EarnPanel() {
         </button>
       )}
 
-      {/* The not-supported explanation renders once above (FR-008), so the
-          sub-views simply stay absent on non-earn networks. */}
-      {view === 'lend' && supported && <EarnLendView tokenFilter={tokenFilter} />}
-      {view === 'rewards' && supported && <EarnRewardsView />}
+      {view === 'lend' && <EarnLendView tokenFilter={tokenFilter} />}
+      {view === 'rewards' && <EarnRewardsView />}
 
       <footer className="earn-footer">
         {earnConfig?.provider && (

--- a/frontend/src/components/earn/EarnPositionsList.jsx
+++ b/frontend/src/components/earn/EarnPositionsList.jsx
@@ -6,7 +6,9 @@
  */
 import { formatUnits } from 'ethers'
 import InfoTip from '../ui/InfoTip'
+import AssetLogo from '../wallet/AssetLogo'
 import SensitiveValue from '../common/SensitiveValue'
+import { NETWORKS } from '../../config/networks'
 import { EARN_TIPS } from '../../lib/earn/earnCopy'
 
 function formatUsd(n) {
@@ -31,13 +33,24 @@ export default function EarnPositionsList({ positions, status, onSelect }) {
       </h3>
       <ul className="earn-positions-list">
         {positions.map((position) => (
-          <li key={position.vault.address}>
+          <li key={`${position.vault.chainId}:${position.vault.address}`}>
             <button
               type="button"
               className="earn-position-row"
               onClick={() => onSelect?.(position)}
             >
-              <span className="earn-position-name">{position.vault.name}</span>
+              <AssetLogo
+                symbol={position.vault.asset.symbol}
+                chainId={position.vault.chainId}
+                showBadge
+                size={28}
+              />
+              <span className="earn-position-name">
+                {position.vault.name}
+                <span className="earn-position-network">
+                  on {NETWORKS[position.vault.chainId]?.name || 'unknown network'}
+                </span>
+              </span>
               <span className="earn-position-values">
                 <SensitiveValue className="earn-position-assets">
                   {formatAssets(position)}

--- a/frontend/src/components/earn/EarnRewardsView.jsx
+++ b/frontend/src/components/earn/EarnRewardsView.jsx
@@ -1,15 +1,23 @@
 /**
  * EarnRewardsView (spec 050, US2) — bonus reward tokens the member's lending
- * has earned (Merkl program), with a single claim action.
+ * has earned (Merkl program), across every earn-enabled network at once
+ * (network-transparent, like the portfolio). Rewards are grouped per network
+ * with the shared badge artwork; each group claims in one action, and the
+ * app switches to that network automatically as part of the confirmation —
+ * the member never manages networks by hand.
  *
  * Honest states: an unreachable rewards service is an explicit "temporarily
- * unavailable" (never a fabricated zero); figures carry their refresh cadence
- * ("updates every few hours"); the claim button never prompts the wallet when
- * nothing is claimable. Claim success is reported from the tx receipt.
+ * unavailable" (never a fabricated zero); a partially unreachable one names
+ * the networks that couldn't be checked; figures carry their refresh cadence
+ * ("updates every few hours"); a claim button never prompts the wallet when
+ * nothing is claimable. Claim success is reported from the tx outcome.
  */
+import { useMemo } from 'react'
 import { formatUnits } from 'ethers'
 import { useEarnRewards } from '../../hooks/useEarnRewards'
+import { NETWORKS } from '../../config/networks'
 import InfoTip from '../ui/InfoTip'
+import AssetLogo from '../wallet/AssetLogo'
 import SensitiveValue from '../common/SensitiveValue'
 import { EARN_TIPS } from '../../lib/earn/earnCopy'
 
@@ -19,8 +27,34 @@ function fmtToken(amountBig, token) {
 }
 
 export default function EarnRewardsView() {
-  const { rewards, status, fetchedAt, totalClaimable, claim, claimState, legacyRewardsUrl, refresh } =
-    useEarnRewards()
+  const {
+    rewards,
+    failedNetworks,
+    status,
+    fetchedAt,
+    claim,
+    claimState,
+    canTransactOn,
+    cannotTransactReason,
+    legacyRewardsUrl,
+    refresh,
+  } = useEarnRewards()
+
+  // Group rewards per network so each group can claim on its own chain.
+  const groups = useMemo(() => {
+    const byChain = new Map()
+    for (const reward of rewards) {
+      const list = byChain.get(reward.chainId) || []
+      list.push(reward)
+      byChain.set(reward.chainId, list)
+    }
+    return [...byChain.entries()].map(([chainId, list]) => ({
+      chainId,
+      network: NETWORKS[chainId]?.name || String(chainId),
+      rewards: list,
+      claimableCount: list.filter((r) => r.claimable > 0n).length,
+    }))
+  }, [rewards])
 
   return (
     <div className="earn-rewards">
@@ -55,6 +89,13 @@ export default function EarnRewardsView() {
         </div>
       )}
 
+      {status === 'ready' && failedNetworks.length > 0 && (
+        <p className="earn-state" role="note">
+          Couldn&rsquo;t check {failedNetworks.join(' and ')} right now — rewards there are safe
+          and will show once the service responds.
+        </p>
+      )}
+
       {status === 'ready' && rewards.length === 0 && (
         <p className="earn-state">
           Nothing to claim yet. Rewards build up over time while you have money lent out in a vault
@@ -62,55 +103,77 @@ export default function EarnRewardsView() {
         </p>
       )}
 
-      {status === 'ready' && rewards.length > 0 && (
-        <>
-          <ul className="earn-rewards-list">
-            {rewards.map((reward) => (
-              <li key={reward.token.address} className="earn-reward-row">
-                <span className="earn-reward-token">{reward.token.symbol}</span>
-                <span className="earn-reward-values">
-                  <SensitiveValue className="earn-reward-claimable">
-                    {reward.claimable > 0n
-                      ? `${fmtToken(reward.claimable, reward.token)} ready to claim`
-                      : 'Nothing ready yet'}
-                  </SensitiveValue>
-                  {reward.pending > 0n && (
-                    <SensitiveValue className="earn-reward-pending">
-                      {`${fmtToken(reward.pending, reward.token)} building up`}
-                    </SensitiveValue>
-                  )}
-                </span>
-              </li>
-            ))}
-          </ul>
+      {status === 'ready' &&
+        groups.map((group) => {
+          const groupClaimState = claimState.chainId === group.chainId ? claimState : null
+          const transactable = canTransactOn(group.chainId)
+          return (
+            <section key={group.chainId} className="earn-rewards-group" aria-label={`Rewards on ${group.network}`}>
+              <h4 className="earn-rewards-network">On {group.network}</h4>
+              <ul className="earn-rewards-list">
+                {group.rewards.map((reward) => (
+                  <li key={`${group.chainId}:${reward.token.address}`} className="earn-reward-row">
+                    <AssetLogo symbol={reward.token.symbol} chainId={group.chainId} showBadge size={28} />
+                    <span className="earn-reward-token">{reward.token.symbol}</span>
+                    <span className="earn-reward-values">
+                      <SensitiveValue className="earn-reward-claimable">
+                        {reward.claimable > 0n
+                          ? `${fmtToken(reward.claimable, reward.token)} ready to claim`
+                          : 'Nothing ready yet'}
+                      </SensitiveValue>
+                      {reward.pending > 0n && (
+                        <SensitiveValue className="earn-reward-pending">
+                          {`${fmtToken(reward.pending, reward.token)} building up`}
+                        </SensitiveValue>
+                      )}
+                    </span>
+                  </li>
+                ))}
+              </ul>
 
-          {claimState.status === 'confirmed' ? (
-            <div className="earn-tx-done" role="status">
-              <p>Rewards claimed — they are in your wallet.</p>
-              {claimState.txUrl && (
-                <a href={claimState.txUrl} target="_blank" rel="noopener noreferrer">
-                  View transaction ↗
-                </a>
+              {groupClaimState?.status === 'confirmed' ? (
+                <div className="earn-tx-done" role="status">
+                  <p>Rewards claimed — they are in your wallet.</p>
+                  {groupClaimState.txUrl && (
+                    <a href={groupClaimState.txUrl} target="_blank" rel="noopener noreferrer">
+                      View transaction ↗
+                    </a>
+                  )}
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  className="earn-btn primary"
+                  onClick={() => claim(group.chainId)}
+                  disabled={
+                    group.claimableCount === 0 || groupClaimState?.status === 'pending' || !transactable
+                  }
+                  title={
+                    !transactable
+                      ? cannotTransactReason(group.chainId)
+                      : group.claimableCount === 0
+                        ? 'Nothing is ready to claim yet'
+                        : undefined
+                  }
+                >
+                  {groupClaimState?.status === 'pending'
+                    ? 'Waiting for confirmation…'
+                    : `Claim on ${group.network}`}
+                </button>
               )}
-            </div>
-          ) : (
-            <button
-              type="button"
-              className="earn-btn primary"
-              onClick={claim}
-              disabled={totalClaimable === 0 || claimState.status === 'pending'}
-              title={totalClaimable === 0 ? 'Nothing is ready to claim yet' : undefined}
-            >
-              {claimState.status === 'pending' ? 'Waiting for confirmation…' : 'Claim rewards'}
-            </button>
-          )}
-          {claimState.status === 'error' && (
-            <p className="earn-input-error" role="alert">
-              {claimState.error}
-            </p>
-          )}
-        </>
-      )}
+              {!transactable && (
+                <p className="earn-state" role="note">
+                  {cannotTransactReason(group.chainId)}
+                </p>
+              )}
+              {groupClaimState?.status === 'error' && (
+                <p className="earn-input-error" role="alert">
+                  {groupClaimState.error}
+                </p>
+              )}
+            </section>
+          )
+        })}
 
       {legacyRewardsUrl && (
         <p className="earn-legacy-note">

--- a/frontend/src/components/earn/VaultSheet.jsx
+++ b/frontend/src/components/earn/VaultSheet.jsx
@@ -3,11 +3,14 @@
  * vault. Bottom-sheet modal per repo convention (Escape + backdrop close,
  * focus managed).
  *
- * Writes go through WalletContext.sendCalls — the unified spec-041 rail — so
- * BOTH session kinds work: a passkey session authorizes the whole
- * approve+deposit batch with one WebAuthn ceremony (it has no ethers signer),
- * a classic wallet signs each step. Reads (allowance, dry-runs) use the
- * chain's read provider, never the signer.
+ * Writes go through useEarnSend → WalletContext.sendCalls — the unified
+ * spec-041 rail — so BOTH session kinds work: a passkey session authorizes
+ * the whole approve+deposit batch with one WebAuthn ceremony (it has no
+ * ethers signer), a classic wallet signs each step. Network selection is
+ * transparent (like the portfolio): the sheet names the vault's network, and
+ * submitting on a different active network switches automatically as part of
+ * the confirmation — no separate switch step. Reads (allowance, dry-runs)
+ * use the VAULT's chain read provider, never the signer.
  *
  * Non-intimidating by design: amounts are validated with member-facing
  * reasons BEFORE any wallet prompt; a first deposit explains up front how
@@ -19,6 +22,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { formatUnits, parseUnits } from 'ethers'
 import { useWallet } from '../../hooks/useWalletManagement'
+import { useEarnSend } from '../../hooks/useEarnSend'
 import { useActivityOptional } from '../../hooks/useActivity'
 import { getBlockscoutUrl } from '../../config/blockExplorer'
 import { NETWORKS } from '../../config/networks'
@@ -42,11 +46,13 @@ function fmt(amountBig, decimals, symbol) {
 }
 
 export default function VaultSheet({ vault, userState, onClose, onActionComplete }) {
-  const { address, chainId, sendCalls, loginMethod } = useWallet() || {}
-  const isPasskey = loginMethod === 'passkey'
+  const { address } = useWallet() || {}
+  const { sendOnChain, canTransactOn, cannotTransactReason, isPasskey } = useEarnSend()
   const activity = useActivityOptional()
   const sheetRef = useRef(null)
   const restoreFocusRef = useRef(null)
+  const vaultNetwork = NETWORKS[vault.chainId]
+  const canTransact = canTransactOn(vault.chainId)
 
   const [mode, setMode] = useState('deposit')
   const [amountText, setAmountText] = useState('')
@@ -114,27 +120,30 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
       return
     }
     setInputError(null)
-    // Never a silent no-op (constitution III): if this session has no write
-    // rail at all, say so instead of swallowing the tap.
-    if (!address || typeof sendCalls !== 'function') {
+    // Never a silent no-op (constitution III): sessions that can't transact
+    // on this vault's network see the reason instead of a dead tap.
+    if (!address || !canTransact) {
       setTxState({
         step: 'error',
         txUrl: null,
-        error: 'This session cannot send transactions right now — please reconnect and try again.',
+        error: !address
+          ? 'This session cannot send transactions right now — please reconnect and try again.'
+          : cannotTransactReason(vault.chainId),
       })
       return
     }
 
     try {
-      // Reads (allowance check, dry-runs) go over the chain's read provider —
-      // passkey sessions have no signer/provider of their own.
-      const provider = makeReadProvider(NETWORKS[chainId].rpcUrl, chainId)
+      // Reads (allowance check, dry-runs) go over the VAULT's chain read
+      // provider — independent of the wallet's active network.
+      const provider = makeReadProvider(vaultNetwork.rpcUrl, vault.chainId)
       let calls
       let message
+      let busyStep
       if (mode === 'deposit') {
         const built = await buildDepositCalls({ vault, account: address, amount, provider })
         calls = built.calls
-        setTxState({ step: built.requiresApproval ? 'approving' : 'confirming', txUrl: null, error: null })
+        busyStep = built.requiresApproval ? 'approving' : 'confirming'
         message = `Deposited ${fmt(amount, decimals, symbol)} into ${vault.name}`
       } else {
         // A full withdrawal redeems all shares so no dust strands.
@@ -149,13 +158,21 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
           provider,
         })
         calls = built.calls
-        setTxState({ step: 'confirming', txUrl: null, error: null })
+        busyStep = 'confirming'
         message = `Withdrew ${fmt(amount, decimals, symbol)} from ${vault.name}`
       }
 
-      // One passkey ceremony covers the whole batch; classic wallets prompt
-      // per call (approve, then the action) — the copy above sets expectations.
-      const sent = await sendCalls(calls)
+      // Network selection is managed for the member: if the wallet is on a
+      // different network, sendOnChain switches to the vault's network first
+      // (no separate in-app confirmation step), then submits. One passkey
+      // ceremony covers the whole batch; classic wallets prompt per call.
+      setTxState({ step: busyStep, txUrl: null, error: null })
+      const sent = await sendOnChain(vault.chainId, calls, {
+        onState: ({ step }) => {
+          if (step === 'switching') setTxState({ step: 'switching', txUrl: null, error: null })
+          if (step === 'sending') setTxState({ step: busyStep, txUrl: null, error: null })
+        },
+      })
       if (sent?.state === 'failed') {
         throw new Error(sent.reason || 'transaction failed')
       }
@@ -163,8 +180,8 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
       if (!txHash) throw new Error('Submitted, but no transaction reference was returned.')
       // Explorer links only for real tx hashes — a UserOp hash is not a page
       // on the block explorer.
-      const txUrl = sent?.txHash ? getBlockscoutUrl(chainId, sent.txHash, 'tx') : null
-      queueEarnAction(address, chainId, {
+      const txUrl = sent?.txHash ? getBlockscoutUrl(vault.chainId, sent.txHash, 'tx') : null
+      queueEarnAction(address, vault.chainId, {
         type: mode === 'deposit' ? 'earn-deposit' : 'earn-withdraw',
         refId: vault.address,
         message,
@@ -172,8 +189,9 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
         txUrl,
         at: Date.now(),
       })
-      // Durable audit entry in the unified activity ledger (spec 051).
-      captureEarnAction(address, chainId, {
+      // Durable audit entry in the unified activity ledger (spec 051),
+      // scoped to the VAULT's chain (network-transparent flows).
+      captureEarnAction(address, vault.chainId, {
         type: mode === 'deposit' ? 'earn-deposit' : 'earn-withdraw',
         txHash,
         at: Date.now(),
@@ -194,12 +212,14 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
         txUrl: null,
         error: rejected
           ? 'The confirmation was cancelled. Nothing was moved.'
-          : 'The transaction could not be completed. Nothing was moved — you can try again.',
+          : err?.message && /switch|network/i.test(err.message)
+            ? err.message
+            : 'The transaction could not be completed. Nothing was moved — you can try again.',
       })
     }
   }
 
-  const busy = txState.step === 'approving' || txState.step === 'confirming'
+  const busy = txState.step === 'approving' || txState.step === 'confirming' || txState.step === 'switching'
   const titleId = 'earn-vault-sheet-title'
 
   return (
@@ -223,7 +243,10 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
                 {EARN_TIPS.apy}
               </InfoTip>
             </p>
-            {vault.curator && <p className="earn-vault-sheet-meta">Managed by {vault.curator}</p>}
+            <p className="earn-vault-sheet-meta">
+              On {vaultNetwork?.name || 'its network'}
+              {vault.curator ? ` · Managed by ${vault.curator}` : ''}
+            </p>
           </div>
           <button type="button" className="asset-sheet-close" onClick={onClose}>
             Close
@@ -365,18 +388,33 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
               </p>
             )}
 
-            <button type="button" className="earn-btn primary earn-submit" onClick={submit} disabled={busy}>
-              {txState.step === 'approving'
-                ? isPasskey
-                  ? 'Confirm with your passkey…'
-                  : 'Approve, then confirm the deposit…'
-                : txState.step === 'confirming'
+            {/* Sessions that can't transact on this vault's network get the
+                reason up front instead of a doomed submit (constitution III). */}
+            {!canTransact && (
+              <p className="earn-summary" role="note">
+                {cannotTransactReason(vault.chainId)}
+              </p>
+            )}
+            <button
+              type="button"
+              className="earn-btn primary earn-submit"
+              onClick={submit}
+              disabled={busy || !canTransact}
+              title={canTransact ? undefined : cannotTransactReason(vault.chainId)}
+            >
+              {txState.step === 'switching'
+                ? `Switching to ${vaultNetwork?.name || 'the vault network'}…`
+                : txState.step === 'approving'
                   ? isPasskey
                     ? 'Confirm with your passkey…'
-                    : 'Waiting for confirmation…'
-                  : mode === 'deposit'
-                    ? `Deposit ${symbol}`
-                    : `Withdraw ${symbol}`}
+                    : 'Approve, then confirm the deposit…'
+                  : txState.step === 'confirming'
+                    ? isPasskey
+                      ? 'Confirm with your passkey…'
+                      : 'Waiting for confirmation…'
+                    : mode === 'deposit'
+                      ? `Deposit ${symbol}`
+                      : `Withdraw ${symbol}`}
             </button>
           </>
         )}

--- a/frontend/src/hooks/useEarnPositions.js
+++ b/frontend/src/hooks/useEarnPositions.js
@@ -1,45 +1,60 @@
 /**
- * useEarnPositions (spec 050) — the member's lending positions on the active
- * network. Authoritative state is on-chain (share balance + convertToAssets +
- * maxWithdraw over the chain's read provider); USD value and earned-so-far are
- * best-effort enrichment from the Morpho API that degrades honestly to "—"
- * when the API is down (position still shown — constitution III).
+ * useEarnPositions (spec 050) — the member's lending positions across every
+ * earn-enabled network. Like the portfolio, each vault is read over ITS OWN
+ * chain's read provider (independent of the wallet's active network), so the
+ * member sees all their positions at once with network badges. Authoritative
+ * state is on-chain (share balance + convertToAssets + maxWithdraw); USD
+ * value and earned-so-far are best-effort Morpho API enrichment that
+ * degrades honestly to "—" (position still shown — constitution III).
  *
  * Polls every POSITIONS_POLL_MS (60s, aligned with usePortfolio), scoped to
- * (account, chain) — a scope change resets synchronously so nothing leaks.
+ * the connected account — an account change resets synchronously.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useWallet } from './useWalletManagement'
-import { NETWORKS, isEarnAvailable } from '../config/networks'
+import { NETWORKS, getEarnNetworks } from '../config/networks'
 import { makeReadProvider } from '../utils/rpcProvider'
 import { POSITIONS_POLL_MS } from '../config/earn'
 import { readVaultUserState } from '../lib/earn/vaultActions'
 import { fetchPositionsEnrichment } from '../lib/earn/morphoApi'
 
-export function useEarnPositions(vaults) {
-  const { address, isConnected, chainId } = useWallet() || {}
-  const supported = isEarnAvailable(chainId)
+/** Cross-chain key for one vault position. */
+export function positionKey(chainId, vaultAddress) {
+  return `${chainId}:${String(vaultAddress).toLowerCase()}`
+}
 
-  const [userStates, setUserStates] = useState(null) // Map vaultAddrLc -> chain reads
+export function useEarnPositions(vaults) {
+  const { address, isConnected } = useWallet() || {}
+  const earnChainIds = useMemo(() => getEarnNetworks().map((net) => net.chainId), [])
+
+  const [userStates, setUserStates] = useState(null) // Map positionKey -> chain reads
   const [enrichment, setEnrichment] = useState({})
   const [status, setStatus] = useState('loading')
   const reqIdRef = useRef(0)
 
-  const provider = useMemo(
-    () => (supported ? makeReadProvider(NETWORKS[chainId].rpcUrl, chainId) : null),
-    [supported, chainId],
+  const providers = useMemo(
+    () => new Map(earnChainIds.map((id) => [id, makeReadProvider(NETWORKS[id].rpcUrl, id)])),
+    [earnChainIds],
   )
 
   const load = useCallback(async () => {
-    if (!supported || !isConnected || !address || !provider || !vaults?.length) return
+    if (!isConnected || !address || !vaults?.length) return
     const reqId = ++reqIdRef.current
     try {
-      const [settled, enriched] = await Promise.all([
+      const [settled, enrichedPerChain] = await Promise.all([
         Promise.allSettled(
-          vaults.map((vault) => readVaultUserState({ vault, account: address, provider })),
+          vaults.map((vault) =>
+            readVaultUserState({ vault, account: address, provider: providers.get(vault.chainId) }),
+          ),
         ),
         // Enrichment failure degrades to on-chain values only — never blocks.
-        fetchPositionsEnrichment(address, chainId).catch(() => ({})),
+        Promise.all(
+          earnChainIds.map((chainId) =>
+            fetchPositionsEnrichment(address, chainId)
+              .then((byVault) => ({ chainId, byVault }))
+              .catch(() => ({ chainId, byVault: {} })),
+          ),
+        ),
       ])
       if (reqId !== reqIdRef.current) return
       const next = new Map()
@@ -47,13 +62,19 @@ export function useEarnPositions(vaults) {
       settled.forEach((res, i) => {
         if (res.status === 'fulfilled') {
           anyOk = true
-          next.set(vaults[i].address.toLowerCase(), res.value)
+          next.set(positionKey(vaults[i].chainId, vaults[i].address), res.value)
         }
       })
       if (!anyOk) {
         setUserStates(null)
         setStatus('unavailable')
         return
+      }
+      const enriched = {}
+      for (const { chainId, byVault } of enrichedPerChain) {
+        for (const [vaultAddress, extra] of Object.entries(byVault)) {
+          enriched[positionKey(chainId, vaultAddress)] = extra
+        }
       }
       setUserStates(next)
       setEnrichment(enriched)
@@ -63,31 +84,31 @@ export function useEarnPositions(vaults) {
       setUserStates(null)
       setStatus('unavailable')
     }
-  }, [supported, isConnected, address, provider, chainId, vaults])
+  }, [isConnected, address, providers, earnChainIds, vaults])
 
-  // Scope change: hard reset so another account/chain's positions never render.
+  // Account change: hard reset so another account's positions never render.
   useEffect(() => {
     reqIdRef.current++
     setUserStates(null)
     setEnrichment({})
-    setStatus(supported && isConnected ? 'loading' : 'idle')
+    setStatus(isConnected ? 'loading' : 'idle')
     load()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [address, chainId, vaults])
+  }, [address, vaults])
 
   useEffect(() => {
-    if (!supported || !isConnected || !address) return undefined
+    if (!isConnected || !address) return undefined
     const id = setInterval(() => load(), POSITIONS_POLL_MS)
     return () => clearInterval(id)
-  }, [supported, isConnected, address, load])
+  }, [isConnected, address, load])
 
   return useMemo(() => {
     const positions = []
     if (userStates && vaults?.length) {
       for (const vault of vaults) {
-        const state = userStates.get(vault.address.toLowerCase())
+        const state = userStates.get(positionKey(vault.chainId, vault.address))
         if (!state || state.shares === 0n) continue
-        const extra = enrichment[vault.address.toLowerCase()] || {}
+        const extra = enrichment[positionKey(vault.chainId, vault.address)] || {}
         positions.push({
           vault,
           shares: state.shares,

--- a/frontend/src/hooks/useEarnRewards.js
+++ b/frontend/src/hooks/useEarnRewards.js
@@ -1,18 +1,20 @@
 /**
- * useEarnRewards (spec 050, US2) — the member's Merkl reward balances on the
- * active network plus the claim action.
+ * useEarnRewards (spec 050, US2) — the member's Merkl reward balances across
+ * every earn-enabled network, plus per-network claim actions. Like the
+ * portfolio, rewards are shown regardless of the wallet's active network;
+ * claiming auto-switches to the reward's network as part of the confirmation
+ * (useEarnSend) — the member never manages networks by hand.
  *
- * Honest-state: a failed fetch is an explicit 'unavailable' status (never a
- * fabricated zero); reward figures update on Merkl's ~8-hour cadence, so the
- * view carries `fetchedAt` freshness rather than implying real-time accrual.
- * Claim success is reported from the tx receipt, not from the API (which may
- * lag the chain); after a claim we re-fetch and the queued activity entry
- * carries the explorer link (FR-010).
+ * Honest-state: every chain failing is an explicit 'unavailable' (never a
+ * fabricated zero); a partial failure lists the networks that couldn't be
+ * checked; figures carry Merkl's ~8-hour cadence via `fetchedAt`. Claim
+ * success is reported from the tx outcome, not the API (which may lag).
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Interface, formatUnits } from 'ethers'
 import { useWallet } from './useWalletManagement'
-import { isEarnAvailable, getEarnConfig } from '../config/networks'
+import { useEarnSend } from './useEarnSend'
+import { getEarnNetworks, getEarnConfig, NETWORKS } from '../config/networks'
 import { getBlockscoutUrl } from '../config/blockExplorer'
 import { fetchRewards, buildClaimArgs } from '../lib/earn/merkl'
 import { MERKL_DISTRIBUTOR_ABI } from '../abis/MerklDistributor'
@@ -23,128 +25,142 @@ import { useActivityOptional } from './useActivity'
 const DISTRIBUTOR_IFACE = new Interface(MERKL_DISTRIBUTOR_ABI)
 
 export function useEarnRewards() {
-  // Writes go through sendCalls (spec 041's unified rail) so passkey sessions
-  // — which have no ethers signer — can claim too.
-  const { address, isConnected, chainId, sendCalls } = useWallet() || {}
+  const { address, isConnected } = useWallet() || {}
+  const { sendOnChain, canTransactOn, cannotTransactReason } = useEarnSend()
   const activity = useActivityOptional()
-  const supported = isEarnAvailable(chainId)
-  const earnConfig = getEarnConfig(chainId)
+  const earnNetworks = useMemo(() => getEarnNetworks(), [])
 
-  const [rewards, setRewards] = useState([])
+  const [rewards, setRewards] = useState([]) // tagged with chainId
+  const [failedNetworks, setFailedNetworks] = useState([])
   const [status, setStatus] = useState('loading')
   const [fetchedAt, setFetchedAt] = useState(null)
-  const [claimState, setClaimState] = useState({ status: 'idle', txUrl: null, error: null })
+  const [claimState, setClaimState] = useState({ status: 'idle', chainId: null, txUrl: null, error: null })
   const reqIdRef = useRef(0)
 
   const load = useCallback(async () => {
-    if (!supported || !isConnected || !address) return
+    if (!isConnected || !address || earnNetworks.length === 0) return
     const reqId = ++reqIdRef.current
     setStatus('loading')
-    try {
-      const list = await fetchRewards(address, chainId)
-      if (reqId !== reqIdRef.current) return
-      setRewards(list)
-      setFetchedAt(Date.now())
-      setStatus('ready')
-    } catch {
-      if (reqId !== reqIdRef.current) return
+    const results = await Promise.all(
+      earnNetworks.map((net) =>
+        fetchRewards(address, net.chainId)
+          .then((list) => ({ chainId: net.chainId, list, ok: true }))
+          .catch(() => ({ chainId: net.chainId, list: [], ok: false })),
+      ),
+    )
+    if (reqId !== reqIdRef.current) return
+    const anyOk = results.some((r) => r.ok)
+    if (!anyOk) {
       setRewards([])
+      setFailedNetworks(earnNetworks.map((n) => n.name))
       setStatus('unavailable')
+      return
     }
-  }, [supported, isConnected, address, chainId])
+    setRewards(
+      results.flatMap((r) => r.list.map((reward) => ({ ...reward, chainId: r.chainId }))),
+    )
+    setFailedNetworks(results.filter((r) => !r.ok).map((r) => NETWORKS[r.chainId]?.name || String(r.chainId)))
+    setFetchedAt(Date.now())
+    setStatus('ready')
+  }, [isConnected, address, earnNetworks])
 
   useEffect(() => {
     reqIdRef.current++
     setRewards([])
+    setFailedNetworks([])
     setFetchedAt(null)
-    setClaimState({ status: 'idle', txUrl: null, error: null })
-    setStatus(supported && isConnected ? 'loading' : 'idle')
+    setClaimState({ status: 'idle', chainId: null, txUrl: null, error: null })
+    setStatus(isConnected ? 'loading' : 'idle')
     load()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [address, chainId])
+  }, [address])
 
   const totalClaimable = useMemo(
     () => rewards.reduce((n, r) => n + (r.claimable > 0n ? 1 : 0), 0),
     [rewards],
   )
 
-  /** Claim every claimable reward in one distributor transaction. */
-  const claim = useCallback(async () => {
-    if (!address || !earnConfig?.merklDistributor) return
-    const args = buildClaimArgs(address, rewards)
-    if (!args) return // nothing claimable — never prompt the wallet for a no-op
-    if (typeof sendCalls !== 'function') {
-      // Never a silent no-op (constitution III).
-      setClaimState({
-        status: 'error',
-        txUrl: null,
-        error: 'This session cannot send transactions right now — please reconnect and try again.',
-      })
-      return
-    }
-    setClaimState({ status: 'pending', txUrl: null, error: null })
-    try {
-      const sent = await sendCalls([
-        {
-          target: earnConfig.merklDistributor,
-          data: DISTRIBUTOR_IFACE.encodeFunctionData('claim', [
-            args.users,
-            args.tokens,
-            args.amounts,
-            args.proofs,
-          ]),
-          value: 0n,
-        },
-      ])
-      if (sent?.state === 'failed') throw new Error(sent.reason || 'claim failed')
-      const txHash = sent?.txHash ?? sent?.userOpHash ?? null
-      if (!txHash) throw new Error('Submitted, but no transaction reference was returned.')
-      // Explorer links only for real tx hashes (a UserOp hash has no page).
-      const txUrl = sent?.txHash ? getBlockscoutUrl(chainId, sent.txHash, 'tx') : null
-      const summary = args.rewards
-        .map((r) => `${formatUnits(r.claimable, r.token.decimals)} ${r.token.symbol}`.trim())
-        .join(', ')
-      queueEarnAction(address, chainId, {
-        type: 'earn-rewards-claimed',
-        refId: args.tokens[0],
-        message: `Claimed earn rewards: ${summary}`,
-        txHash,
-        txUrl,
-        at: Date.now(),
-      })
-      // Durable audit entry in the unified activity ledger (spec 051).
-      captureEarnAction(address, chainId, {
-        type: 'earn-rewards-claimed',
-        txHash,
-        at: Date.now(),
-        tokenAddress: args.tokens[0] ?? null,
-        description: `Claimed earn rewards: ${summary}`,
-      })
-      activity?.refresh?.()
-      setClaimState({ status: 'confirmed', txUrl, error: null })
-      load()
-    } catch (err) {
-      const rejected = /rejected|denied|cancelled|not allowed|abort/i.test(err?.message || '')
-      setClaimState({
-        status: 'error',
-        txUrl: null,
-        error: rejected ? 'The confirmation was cancelled.' : 'Claim failed. Please try again.',
-      })
-    }
-  }, [sendCalls, address, chainId, rewards, earnConfig, activity, load])
+  /**
+   * Claim every claimable reward on one network in a single distributor
+   * transaction — switching to that network automatically first.
+   */
+  const claim = useCallback(
+    async (chainId) => {
+      const earnConfig = getEarnConfig(chainId)
+      if (!address || !earnConfig?.merklDistributor) return
+      const chainRewards = rewards.filter((r) => r.chainId === chainId)
+      const args = buildClaimArgs(address, chainRewards)
+      if (!args) return // nothing claimable — never prompt the wallet for a no-op
+      setClaimState({ status: 'pending', chainId, txUrl: null, error: null })
+      try {
+        const sent = await sendOnChain(chainId, [
+          {
+            target: earnConfig.merklDistributor,
+            data: DISTRIBUTOR_IFACE.encodeFunctionData('claim', [
+              args.users,
+              args.tokens,
+              args.amounts,
+              args.proofs,
+            ]),
+            value: 0n,
+          },
+        ])
+        if (sent?.state === 'failed') throw new Error(sent.reason || 'claim failed')
+        const txHash = sent?.txHash ?? sent?.userOpHash ?? null
+        if (!txHash) throw new Error('Submitted, but no transaction reference was returned.')
+        // Explorer links only for real tx hashes (a UserOp hash has no page).
+        const txUrl = sent?.txHash ? getBlockscoutUrl(chainId, sent.txHash, 'tx') : null
+        const summary = args.rewards
+          .map((r) => `${formatUnits(r.claimable, r.token.decimals)} ${r.token.symbol}`.trim())
+          .join(', ')
+        queueEarnAction(address, chainId, {
+          type: 'earn-rewards-claimed',
+          refId: args.tokens[0],
+          message: `Claimed earn rewards: ${summary}`,
+          txHash,
+          txUrl,
+          at: Date.now(),
+        })
+        // Durable audit entry in the unified activity ledger (spec 051),
+        // scoped to the reward's own chain.
+        captureEarnAction(address, chainId, {
+          type: 'earn-rewards-claimed',
+          txHash,
+          at: Date.now(),
+          tokenAddress: args.tokens[0] ?? null,
+          description: `Claimed earn rewards: ${summary}`,
+        })
+        activity?.refresh?.()
+        setClaimState({ status: 'confirmed', chainId, txUrl, error: null })
+        load()
+      } catch (err) {
+        const rejected = /rejected|denied|cancelled|not allowed|abort/i.test(err?.message || '')
+        setClaimState({
+          status: 'error',
+          chainId,
+          txUrl: null,
+          error: rejected ? 'The confirmation was cancelled.' : err?.message || 'Claim failed. Please try again.',
+        })
+      }
+    },
+    [sendOnChain, address, rewards, activity, load],
+  )
 
   return useMemo(
     () => ({
       rewards,
+      failedNetworks,
       status,
       fetchedAt,
       totalClaimable,
       claim,
       claimState,
-      legacyRewardsUrl: earnConfig?.legacyRewardsUrl || null,
+      canTransactOn,
+      cannotTransactReason,
+      legacyRewardsUrl: earnNetworks[0]?.earn?.legacyRewardsUrl || null,
       refresh: load,
     }),
-    [rewards, status, fetchedAt, totalClaimable, claim, claimState, earnConfig, load],
+    [rewards, failedNetworks, status, fetchedAt, totalClaimable, claim, claimState, canTransactOn, cannotTransactReason, earnNetworks, load],
   )
 }
 

--- a/frontend/src/hooks/useEarnSend.js
+++ b/frontend/src/hooks/useEarnSend.js
@@ -1,0 +1,107 @@
+/**
+ * useEarnSend (spec 050) — network-transparent transaction sending for the
+ * Earn section. Vaults and rewards span every earn-enabled network (like the
+ * portfolio), so the member never manages networks by hand: when a
+ * transaction targets a different chain than the active one, the switch
+ * happens automatically as part of submitting — no separate "switch network"
+ * step to confirm in the app. (A browser wallet may still show its own
+ * switch prompt; that surface belongs to the wallet, not us.)
+ *
+ * After switching we wait for the session to settle on the target chain —
+ * and, for classic wallets, for the signer to be rebuilt — before handing the
+ * batch to WalletContext.sendCalls, which reads the ACTIVE chain. A ref to
+ * the latest wallet snapshot avoids acting on a stale closure mid-switch.
+ */
+import { useCallback, useEffect, useRef } from 'react'
+import { useSwitchChain } from 'wagmi'
+import { useWallet } from './useWalletManagement'
+import { NETWORKS } from '../config/networks'
+
+const SETTLE_TIMEOUT_MS = 20_000
+const SETTLE_POLL_MS = 150
+
+export function useEarnSend() {
+  const wallet = useWallet() || {}
+  const { switchChainAsync } = useSwitchChain()
+  const isPasskey = wallet.loginMethod === 'passkey'
+
+  // Always-current wallet snapshot — the switch spans renders, so the send
+  // must use post-switch values, not the ones captured at tap time.
+  const latestRef = useRef({})
+  useEffect(() => {
+    latestRef.current = {
+      chainId: wallet.chainId,
+      signer: wallet.signer,
+      sendCalls: wallet.sendCalls,
+    }
+  })
+
+  /**
+   * Whether this session can transact on `chainId` at all. Passkey smart
+   * accounts need that chain's ERC-4337 rail (bundler) configured; classic
+   * wallets can transact anywhere they can switch to.
+   */
+  const canTransactOn = useCallback(
+    (chainId) => !isPasskey || Boolean(NETWORKS[chainId]?.passkey),
+    [isPasskey],
+  )
+
+  /**
+   * Member-facing reason when canTransactOn is false.
+   */
+  const cannotTransactReason = useCallback(
+    (chainId) =>
+      `Passkey accounts can't send transactions on ${NETWORKS[chainId]?.name || 'this network'} yet — connect a browser wallet to use it.`,
+    [],
+  )
+
+  /**
+   * Send `calls` on `targetChainId`, switching networks first when needed.
+   * `onState` receives { step: 'switching' | 'sending' }. Resolves with the
+   * sendCalls result. Throws with member-facing messages on failure.
+   */
+  const sendOnChain = useCallback(
+    async (targetChainId, calls, { onState } = {}) => {
+      const target = Number(targetChainId)
+      if (!canTransactOn(target)) throw new Error(cannotTransactReason(target))
+
+      if (Number(latestRef.current.chainId) !== target) {
+        onState?.({ step: 'switching' })
+        try {
+          await switchChainAsync({ chainId: target })
+        } catch {
+          throw new Error(
+            `Could not switch to ${NETWORKS[target]?.name || 'the required network'} — approve the network change and try again.`,
+          )
+        }
+        // Wait for the session to settle on the target chain. Classic
+        // wallets also need the chain-scoped signer rebuilt before sendCalls
+        // can route the batch correctly.
+        const deadline = Date.now() + SETTLE_TIMEOUT_MS
+        while (
+          Number(latestRef.current.chainId) !== target ||
+          (!isPasskey && !latestRef.current.signer)
+        ) {
+          if (Date.now() > deadline) {
+            throw new Error(
+              `The switch to ${NETWORKS[target]?.name || 'the required network'} did not complete — please try again.`,
+            )
+          }
+          await new Promise((resolve) => setTimeout(resolve, SETTLE_POLL_MS))
+        }
+      }
+
+      const send = latestRef.current.sendCalls
+      if (typeof send !== 'function') {
+        throw new Error('This session cannot send transactions right now — please reconnect and try again.')
+      }
+      onState?.({ step: 'sending' })
+      return send(calls)
+    },
+    [canTransactOn, cannotTransactReason, isPasskey, switchChainAsync],
+  )
+
+  return { sendOnChain, canTransactOn, cannotTransactReason, isPasskey }
+}
+
+export default useEarnSend

--- a/frontend/src/hooks/useEarnVaults.js
+++ b/frontend/src/hooks/useEarnVaults.js
@@ -1,31 +1,30 @@
 /**
- * useEarnVaults (spec 050) — the curated Morpho vault list for the active
- * network. Capability-gated: on chains without earn support it stays inert
- * with status 'unsupported' so the panel renders the honest unavailable state.
+ * useEarnVaults (spec 050) — the curated Morpho vault list across EVERY
+ * earn-enabled network, in one query. Like the portfolio, the list is
+ * independent of the wallet's active network — each vault carries its
+ * chainId and the UI badges it; submission handles any network switch.
  *
- * Status model (honest-state): 'unsupported' | 'loading' | 'ready' |
- * 'unavailable'. A fetch failure is an explicit 'unavailable' — the UI
- * disables deposit entry points instead of showing stale numbers.
+ * Status model (honest-state): 'loading' | 'ready' | 'unavailable'. A fetch
+ * failure is an explicit 'unavailable' — the UI disables deposit entry
+ * points instead of showing stale numbers.
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useWallet } from './useWalletManagement'
-import { isEarnAvailable } from '../config/networks'
+import { getEarnNetworks } from '../config/networks'
 import { fetchVaults } from '../lib/earn/morphoApi'
 
 export function useEarnVaults() {
-  const { chainId } = useWallet() || {}
-  const supported = isEarnAvailable(chainId)
+  const earnChainIds = useMemo(() => getEarnNetworks().map((net) => net.chainId), [])
 
   const [vaults, setVaults] = useState([])
   const [status, setStatus] = useState('loading')
   const reqIdRef = useRef(0)
 
   const load = useCallback(async () => {
-    if (!supported) return
+    if (earnChainIds.length === 0) return
     const reqId = ++reqIdRef.current
     setStatus('loading')
     try {
-      const list = await fetchVaults(chainId)
+      const list = await fetchVaults(earnChainIds)
       if (reqId !== reqIdRef.current) return
       setVaults(list)
       setStatus('ready')
@@ -34,25 +33,14 @@ export function useEarnVaults() {
       setVaults([])
       setStatus('unavailable')
     }
-  }, [supported, chainId])
+  }, [earnChainIds])
 
-  // Reset synchronously on chain change so another network's vaults never
-  // linger (per-chain data isolation).
   useEffect(() => {
-    reqIdRef.current++
-    setVaults([])
-    if (!supported) {
-      setStatus('unsupported')
-      return
-    }
     load()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chainId, supported])
+  }, [])
 
-  return useMemo(
-    () => ({ vaults, status, isSupported: supported, refresh: load }),
-    [vaults, status, supported, load],
-  )
+  return useMemo(() => ({ vaults, status, refresh: load }), [vaults, status, load])
 }
 
 export default useEarnVaults

--- a/frontend/src/lib/earn/earnCopy.js
+++ b/frontend/src/lib/earn/earnCopy.js
@@ -36,12 +36,6 @@ export const EARN_DISCLOSURE = {
   risk: 'Lending happens through Morpho, a third-party on-chain lending protocol, from your own wallet. Returns are variable and not guaranteed, and smart contracts carry risk. FairWins never holds your deposit and charges no fee on Earn.',
 }
 
-/** Honest unavailable-state copy for networks without earn support (FR-008). */
-export function earnUnavailableCopy(networkName, earnNetworkNames) {
-  const names = (earnNetworkNames || []).join(' and ')
-  return `Earning is not available on ${networkName || 'this network'} yet. Lending is available on ${names || 'supported networks'} — switch networks to use it.`
-}
-
 /** Honest "not yet" copy for future earning areas (FR-002). */
 export const EARN_AREAS_FUTURE = {
   staking: 'Staking is not available in the app yet.',

--- a/frontend/src/lib/earn/morphoApi.js
+++ b/frontend/src/lib/earn/morphoApi.js
@@ -86,12 +86,17 @@ function numOrNull(v) {
 
 /**
  * Normalize one API vault item; returns null for items that fail curation or
- * consistency guards (non-listed, foreign chain, missing coordinates).
+ * consistency guards (non-listed, chain outside the allowlist, missing
+ * coordinates). `chainIds` is the earn-enabled allowlist — vaults are tagged
+ * with their own chainId so the multi-network list stays unambiguous
+ * (network transparency, like the portfolio).
  */
-export function normalizeVault(item, chainId) {
+export function normalizeVault(item, chainIds) {
+  const allowed = Array.isArray(chainIds) ? chainIds.map(Number) : [Number(chainIds)]
   if (!item?.address || !item?.asset?.address) return null
   if (item.listed !== true) return null
-  if (Number(item.chain?.id) !== Number(chainId)) return null
+  const itemChainId = Number(item.chain?.id)
+  if (!allowed.includes(itemChainId)) return null
   const decimals = Number(item.asset.decimals)
   if (!Number.isInteger(decimals) || decimals < 0) return null
   // Human curator names ("Gauntlet", "Steakhouse Financial"); the schema's
@@ -101,7 +106,7 @@ export function normalizeVault(item, chainId) {
     .filter(Boolean)
   return {
     address: item.address,
-    chainId: Number(chainId),
+    chainId: itemChainId,
     name: item.name || item.symbol || 'Vault',
     symbol: item.symbol || '',
     asset: {
@@ -121,19 +126,22 @@ export function normalizeVault(item, chainId) {
 }
 
 /**
- * Curated vault list for one chain — TVL-ordered (API order preserved),
- * capped at VAULT_LIST_LIMIT. Throws MorphoApiError on failure.
+ * Curated vault list across the earn-enabled chains — one query, TVL-ordered
+ * (API order preserved), capped at VAULT_LIST_LIMIT. Each vault carries its
+ * own chainId so the UI can badge networks like the portfolio does.
+ * Throws MorphoApiError on failure.
  */
-export async function fetchVaults(chainId, { fetchImpl } = {}) {
+export async function fetchVaults(chainIds, { fetchImpl } = {}) {
+  const allowed = (Array.isArray(chainIds) ? chainIds : [chainIds]).map(Number)
   const data = await graphql(
     VAULTS_QUERY,
     // first is generous: curation drops non-listed items after the fetch.
-    { chainIds: [Number(chainId)], first: 100 },
+    { chainIds: allowed, first: 100 },
     { fetchImpl },
   )
   const items = data?.vaults?.items || []
   return items
-    .map((item) => normalizeVault(item, chainId))
+    .map((item) => normalizeVault(item, allowed))
     .filter(Boolean)
     .slice(0, VAULT_LIST_LIMIT)
 }

--- a/frontend/src/test/earn/EarnPanel.axe.test.jsx
+++ b/frontend/src/test/earn/EarnPanel.axe.test.jsx
@@ -1,6 +1,7 @@
 /**
- * Earn section WCAG 2.1 AA audits (spec 050, FR-015 / SC-007) — hub, lend
- * view with vaults + positions, vault sheet, and rewards view.
+ * Earn section WCAG 2.1 AA audits (spec 050, FR-015 / SC-007) — hub,
+ * network-transparent lend view (multi-network vaults + positions), vault
+ * sheet, and per-network rewards view.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, fireEvent, screen } from '@testing-library/react'
@@ -12,6 +13,12 @@ vi.mock('../../hooks/useWalletManagement', () => ({
   useWallet: () => mockWallet.current,
 }))
 
+const mockSend = vi.hoisted(() => ({ current: {} }))
+vi.mock('../../hooks/useEarnSend', () => ({
+  useEarnSend: () => mockSend.current,
+  default: () => mockSend.current,
+}))
+
 const mockVaults = vi.hoisted(() => ({ current: {} }))
 vi.mock('../../hooks/useEarnVaults', () => ({
   useEarnVaults: () => mockVaults.current,
@@ -19,10 +26,14 @@ vi.mock('../../hooks/useEarnVaults', () => ({
 }))
 
 const mockPositions = vi.hoisted(() => ({ current: {} }))
-vi.mock('../../hooks/useEarnPositions', () => ({
-  useEarnPositions: () => mockPositions.current,
-  default: () => mockPositions.current,
-}))
+vi.mock('../../hooks/useEarnPositions', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    positionKey: actual.positionKey,
+    useEarnPositions: () => mockPositions.current,
+    default: () => mockPositions.current,
+  }
+})
 
 const mockRewards = vi.hoisted(() => ({ current: {} }))
 vi.mock('../../hooks/useEarnRewards', () => ({
@@ -45,6 +56,13 @@ const VAULT = {
   totalAssetsUsd: 12_000_000,
   curator: 'Prime Curation',
 }
+const ETH_VAULT = {
+  ...VAULT,
+  address: '0x00000000000000000000000000000000000000a2',
+  chainId: 1,
+  name: 'Blue ETH Vault',
+  asset: { address: '0xweth', symbol: 'WETH', name: 'Wrapped Ether', decimals: 18 },
+}
 
 const USER_STATE = {
   shares: 10_000_000n,
@@ -55,17 +73,26 @@ const USER_STATE = {
 }
 
 beforeEach(() => {
-  mockWallet.current = { chainId: 137, address: '0xac', isConnected: true, signer: null, switchNetwork: vi.fn() }
-  mockVaults.current = { vaults: [VAULT], status: 'ready', isSupported: true, refresh: vi.fn() }
+  mockWallet.current = { chainId: 63, address: '0xac', isConnected: true }
+  mockSend.current = {
+    sendOnChain: vi.fn(),
+    canTransactOn: () => true,
+    cannotTransactReason: () => 'not available',
+    isPasskey: false,
+  }
+  mockVaults.current = { vaults: [VAULT, ETH_VAULT], status: 'ready', refresh: vi.fn() }
   mockPositions.current = {
-    positions: [{ vault: VAULT, shares: 10_000_000n, assets: 10_000_000n, maxWithdrawAssets: 8_000_000n, assetsUsd: 10.0, pnlUsd: 0.12 }],
-    userStates: new Map([[VAULT.address.toLowerCase(), USER_STATE]]),
+    positions: [
+      { vault: VAULT, shares: 10_000_000n, assets: 10_000_000n, maxWithdrawAssets: 8_000_000n, assetsUsd: 10.0, pnlUsd: 0.12 },
+    ],
+    userStates: new Map(),
     status: 'ready',
     refresh: vi.fn(),
   }
   mockRewards.current = {
     rewards: [
       {
+        chainId: 137,
         token: { address: '0xmorpho', symbol: 'MORPHO', decimals: 18 },
         amount: 2n,
         claimed: 1n,
@@ -75,11 +102,14 @@ beforeEach(() => {
         fetchedAt: 1,
       },
     ],
+    failedNetworks: [],
     status: 'ready',
     fetchedAt: 1,
     totalClaimable: 1,
     claim: vi.fn(),
-    claimState: { status: 'idle', txUrl: null, error: null },
+    claimState: { status: 'idle', chainId: null, txUrl: null, error: null },
+    canTransactOn: () => true,
+    cannotTransactReason: () => 'not available',
     legacyRewardsUrl: 'https://rewards-legacy.morpho.org/',
     refresh: vi.fn(),
   }
@@ -98,12 +128,12 @@ describe('Earn section accessibility (FR-015)', () => {
     expect(await axe(container)).toHaveNoViolations()
   })
 
-  it('lend view (vaults + positions) has no axe violations', async () => {
+  it('multi-network lend view (vaults + positions) has no axe violations', async () => {
     const { container } = renderAt('/wallet?tab=earn&view=lend')
     expect(await axe(container)).toHaveNoViolations()
   })
 
-  it('rewards view has no axe violations', async () => {
+  it('per-network rewards view has no axe violations', async () => {
     const { container } = renderAt('/wallet?tab=earn&view=rewards')
     expect(await axe(container)).toHaveNoViolations()
   })
@@ -117,10 +147,11 @@ describe('Earn section accessibility (FR-015)', () => {
     expect(await axe(container)).toHaveNoViolations()
   })
 
-  it('unavailable-network state has no axe violations', async () => {
-    mockWallet.current = { ...mockWallet.current, chainId: 63 }
-    mockVaults.current = { vaults: [], status: 'unsupported', isSupported: false, refresh: vi.fn() }
-    const { container } = renderAt('/wallet?tab=earn')
+  it('cannot-transact disclosure state has no axe violations', async () => {
+    mockSend.current = { ...mockSend.current, isPasskey: true, canTransactOn: () => false }
+    const { container } = render(
+      <VaultSheet vault={ETH_VAULT} userState={USER_STATE} onClose={vi.fn()} onActionComplete={vi.fn()} />,
+    )
     expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/frontend/src/test/earn/EarnPanel.test.jsx
+++ b/frontend/src/test/earn/EarnPanel.test.jsx
@@ -1,7 +1,8 @@
 /**
  * EarnPanel tests (spec 050 US1/US3) — hub areas, attribution + risk
- * disclosure + docs link, honest unavailable state on non-earn networks,
- * and deep-link consumption (?view=, ?chain=, ?token=).
+ * disclosure + docs link, network-transparent vault list (all earn networks
+ * shown with badges, regardless of the active wallet network — no switch
+ * banner), and deep-link consumption (?view=, ?token=).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
@@ -19,10 +20,14 @@ vi.mock('../../hooks/useEarnVaults', () => ({
 }))
 
 const mockPositions = vi.hoisted(() => ({ current: {} }))
-vi.mock('../../hooks/useEarnPositions', () => ({
-  useEarnPositions: () => mockPositions.current,
-  default: () => mockPositions.current,
-}))
+vi.mock('../../hooks/useEarnPositions', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    positionKey: actual.positionKey,
+    useEarnPositions: () => mockPositions.current,
+    default: () => mockPositions.current,
+  }
+})
 
 const mockRewards = vi.hoisted(() => ({ current: {} }))
 vi.mock('../../hooks/useEarnRewards', () => ({
@@ -47,6 +52,7 @@ const USDC_VAULT = {
 const ETH_VAULT = {
   ...USDC_VAULT,
   address: '0x00000000000000000000000000000000000000a2',
+  chainId: 1,
   name: 'Blue ETH Vault',
   asset: { address: '0xweth', symbol: 'WETH', name: 'Wrapped Ether', decimals: 18 },
 }
@@ -60,16 +66,21 @@ function renderPanel(path = '/wallet?tab=earn') {
 }
 
 beforeEach(() => {
-  mockWallet.current = { chainId: 137, address: '0xac', isConnected: true, signer: null, switchNetwork: vi.fn() }
-  mockVaults.current = { vaults: [USDC_VAULT, ETH_VAULT], status: 'ready', isSupported: true, refresh: vi.fn() }
+  // Active wallet network is MORDOR — earn is network-transparent, so the
+  // multi-network list must render regardless.
+  mockWallet.current = { chainId: 63, address: '0xac', isConnected: true }
+  mockVaults.current = { vaults: [USDC_VAULT, ETH_VAULT], status: 'ready', refresh: vi.fn() }
   mockPositions.current = { positions: [], userStates: new Map(), status: 'ready', refresh: vi.fn() }
   mockRewards.current = {
     rewards: [],
+    failedNetworks: [],
     status: 'ready',
     fetchedAt: Date.now(),
     totalClaimable: 0,
     claim: vi.fn(),
-    claimState: { status: 'idle', txUrl: null, error: null },
+    claimState: { status: 'idle', chainId: null, txUrl: null, error: null },
+    canTransactOn: () => true,
+    cannotTransactReason: () => 'not available',
     legacyRewardsUrl: 'https://rewards-legacy.morpho.org/',
     refresh: vi.fn(),
   }
@@ -95,23 +106,18 @@ describe('EarnPanel hub (US1)', () => {
       expect.stringContaining('docs.FairWins.app'),
     )
   })
-
-  it('opens the lend view from the Lend area card', () => {
-    renderPanel()
-    fireEvent.click(screen.getByRole('button', { name: /^Lend/ }))
-    expect(screen.getByText('Prime USDC Vault')).toBeInTheDocument()
-    expect(screen.getByText('Blue ETH Vault')).toBeInTheDocument()
-  })
 })
 
-describe('EarnPanel honest unavailable state (US1/AS5, FR-008)', () => {
-  it('explains unavailability and names earn-enabled networks on Mordor', () => {
-    mockWallet.current = { ...mockWallet.current, chainId: 63 }
-    mockVaults.current = { vaults: [], status: 'unsupported', isSupported: false, refresh: vi.fn() }
-    renderPanel()
-    expect(screen.getByText(/not available on Ethereum Classic Mordor/i)).toBeInTheDocument()
-    expect(screen.getByText(/Ethereum and Polygon/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /^Lend/ })).toBeDisabled()
+describe('EarnPanel network transparency (like the portfolio)', () => {
+  it('lists vaults from EVERY earn network with their network names — no switch banner', () => {
+    renderPanel('/wallet?tab=earn&view=lend')
+    expect(screen.getByText('Prime USDC Vault')).toBeInTheDocument()
+    expect(screen.getByText(/on Polygon/i)).toBeInTheDocument()
+    expect(screen.getByText('Blue ETH Vault')).toBeInTheDocument()
+    expect(screen.getByText(/on Ethereum/i)).toBeInTheDocument()
+    // The old "switch network" interstitial is gone for good.
+    expect(screen.queryByText(/your wallet is on/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /switch to/i })).not.toBeInTheDocument()
   })
 })
 
@@ -123,14 +129,6 @@ describe('EarnPanel deep links (US3)', () => {
     // Clearing the filter restores the full list.
     fireEvent.click(screen.getByRole('button', { name: /USDC only/i }))
     expect(screen.getByText('Blue ETH Vault')).toBeInTheDocument()
-  })
-
-  it('offers a network switch when ?chain= names a different network', () => {
-    renderPanel('/wallet?tab=earn&view=lend&chain=1&token=USDC')
-    expect(screen.getByText(/wallet is on Polygon/i)).toBeInTheDocument()
-    const switchBtn = screen.getByRole('button', { name: /switch to Ethereum/i })
-    fireEvent.click(switchBtn)
-    expect(mockWallet.current.switchNetwork).toHaveBeenCalledWith(1)
   })
 
   it('lands on the rewards view via ?view=rewards', () => {

--- a/frontend/src/test/earn/EarnRewardsView.test.jsx
+++ b/frontend/src/test/earn/EarnRewardsView.test.jsx
@@ -1,7 +1,8 @@
 /**
- * EarnRewardsView tests (spec 050 US2) — claimable/pending display,
- * freshness copy, claim disabled at zero, explicit unavailable state
- * (never a fabricated zero), empty-state education, legacy link.
+ * EarnRewardsView tests (spec 050 US2) — network-transparent rewards:
+ * per-network groups with claim actions, freshness copy, claim disabled at
+ * zero, explicit unavailable state (never a fabricated zero), partial-failure
+ * honesty, empty-state education, legacy link.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
@@ -15,6 +16,7 @@ vi.mock('../../hooks/useEarnRewards', () => ({
 import EarnRewardsView from '../../components/earn/EarnRewardsView'
 
 const MORPHO_REWARD = {
+  chainId: 137,
   token: { address: '0xmorpho', symbol: 'MORPHO', decimals: 18 },
   amount: 2_000_000_000_000_000_000n,
   claimed: 500_000_000_000_000_000n,
@@ -24,13 +26,22 @@ const MORPHO_REWARD = {
   fetchedAt: 1_752_000_000_000,
 }
 
+const ETH_REWARD = {
+  ...MORPHO_REWARD,
+  chainId: 1,
+  token: { address: '0xarb', symbol: 'WELL', decimals: 18 },
+}
+
 const baseApi = () => ({
-  rewards: [MORPHO_REWARD],
+  rewards: [MORPHO_REWARD, ETH_REWARD],
+  failedNetworks: [],
   status: 'ready',
   fetchedAt: 1_752_000_000_000,
-  totalClaimable: 1,
+  totalClaimable: 2,
   claim: vi.fn(),
-  claimState: { status: 'idle', txUrl: null, error: null },
+  claimState: { status: 'idle', chainId: null, txUrl: null, error: null },
+  canTransactOn: () => true,
+  cannotTransactReason: (id) => `Passkey accounts can't send transactions on chain ${id} yet`,
   legacyRewardsUrl: 'https://rewards-legacy.morpho.org/',
   refresh: vi.fn(),
 })
@@ -39,23 +50,27 @@ beforeEach(() => {
   mockRewards.current = baseApi()
 })
 
-describe('EarnRewardsView (US2)', () => {
-  it('lists claimable and pending amounts with freshness copy', () => {
+describe('EarnRewardsView (US2, network-transparent)', () => {
+  it('groups rewards per network with claimable/pending amounts and freshness copy', () => {
     render(<EarnRewardsView />)
-    expect(screen.getByText('MORPHO')).toBeInTheDocument()
-    expect(screen.getByText(/1\.5 MORPHO ready to claim/i)).toBeInTheDocument()
-    expect(screen.getByText(/0\.1 MORPHO building up/i)).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: /rewards on polygon/i })).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: /rewards on ethereum/i })).toBeInTheDocument()
+    expect(screen.getAllByText(/1\.5 (MORPHO|WELL) ready to claim/i)).toHaveLength(2)
     expect(screen.getByText(/updates every few hours/i)).toBeInTheDocument()
   })
 
-  it('claims via the hook and reflects confirmation from the tx receipt', () => {
+  it('claims per network — the hook handles any network switch itself', () => {
     render(<EarnRewardsView />)
-    fireEvent.click(screen.getByRole('button', { name: /claim rewards/i }))
-    expect(mockRewards.current.claim).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByRole('button', { name: /claim on ethereum/i }))
+    expect(mockRewards.current.claim).toHaveBeenCalledWith(1)
+    fireEvent.click(screen.getByRole('button', { name: /claim on polygon/i }))
+    expect(mockRewards.current.claim).toHaveBeenCalledWith(137)
+  })
 
+  it('reflects confirmation from the tx outcome on the claimed network only', () => {
     mockRewards.current = {
       ...baseApi(),
-      claimState: { status: 'confirmed', txUrl: 'https://polygonscan.com/tx/0xh', error: null },
+      claimState: { status: 'confirmed', chainId: 137, txUrl: 'https://polygonscan.com/tx/0xh', error: null },
     }
     render(<EarnRewardsView />)
     expect(screen.getByText(/rewards claimed/i)).toBeInTheDocument()
@@ -63,6 +78,8 @@ describe('EarnRewardsView (US2)', () => {
       'href',
       'https://polygonscan.com/tx/0xh',
     )
+    // The other network's group still offers its own claim.
+    expect(screen.getByRole('button', { name: /claim on ethereum/i })).toBeEnabled()
   })
 
   it('disables Claim when nothing is claimable (no wallet no-ops)', () => {
@@ -72,7 +89,14 @@ describe('EarnRewardsView (US2)', () => {
       totalClaimable: 0,
     }
     render(<EarnRewardsView />)
-    expect(screen.getByRole('button', { name: /claim rewards/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /claim on polygon/i })).toBeDisabled()
+  })
+
+  it('discloses when a passkey session cannot claim on a network', () => {
+    mockRewards.current = { ...baseApi(), rewards: [ETH_REWARD], canTransactOn: () => false }
+    render(<EarnRewardsView />)
+    expect(screen.getByRole('button', { name: /claim on ethereum/i })).toBeDisabled()
+    expect(screen.getByRole('note')).toHaveTextContent(/passkey accounts can't send transactions/i)
   })
 
   it('explains accrual in the empty state', () => {
@@ -82,13 +106,20 @@ describe('EarnRewardsView (US2)', () => {
     expect(screen.getByText(/build up over time/i)).toBeInTheDocument()
   })
 
-  it('shows an explicit unavailable state on fetch failure — never a zero (US2/AS4)', () => {
+  it('shows an explicit unavailable state on total failure — never a zero (US2/AS4)', () => {
     mockRewards.current = { ...baseApi(), rewards: [], status: 'unavailable', totalClaimable: 0 }
     render(<EarnRewardsView />)
     expect(screen.getByRole('alert')).toHaveTextContent(/temporarily unavailable/i)
     expect(screen.queryByText(/nothing to claim yet/i)).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /try again/i }))
     expect(mockRewards.current.refresh).toHaveBeenCalled()
+  })
+
+  it('names networks that could not be checked (partial failure honesty)', () => {
+    mockRewards.current = { ...baseApi(), rewards: [MORPHO_REWARD], failedNetworks: ['Ethereum'] }
+    render(<EarnRewardsView />)
+    expect(screen.getByText(/couldn.t check ethereum right now/i)).toBeInTheDocument()
+    expect(screen.getByRole('region', { name: /rewards on polygon/i })).toBeInTheDocument()
   })
 
   it('links to the legacy rewards page', () => {

--- a/frontend/src/test/earn/VaultSheet.test.jsx
+++ b/frontend/src/test/earn/VaultSheet.test.jsx
@@ -2,8 +2,10 @@
  * VaultSheet tests (spec 050 US1) — pre-wallet amount validation with
  * member-facing reasons, Max shortcut, session-aware confirmation copy,
  * honest withdraw liquidity bound, withdraw disabled without a position,
- * and the sendCalls write rail (passkey batch + honest no-rail error —
- * the tap must NEVER be a silent no-op).
+ * and the network-transparent write rail (useEarnSend): the vault's network
+ * is displayed, submission targets the VAULT's chain (switching handled
+ * inside the hook), sessions that can't transact on that chain see the
+ * reason, and a tap is NEVER a silent no-op.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
@@ -11,6 +13,12 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 const mockWallet = vi.hoisted(() => ({ current: {} }))
 vi.mock('../../hooks/useWalletManagement', () => ({
   useWallet: () => mockWallet.current,
+}))
+
+const mockSend = vi.hoisted(() => ({ current: {} }))
+vi.mock('../../hooks/useEarnSend', () => ({
+  useEarnSend: () => mockSend.current,
+  default: () => mockSend.current,
 }))
 
 // Batch builders are unit-tested in vaultActions.test.js; here they are mocked
@@ -37,6 +45,13 @@ const VAULT = {
   curator: 'Prime Curation',
 }
 
+const ETH_VAULT = {
+  ...VAULT,
+  address: '0x00000000000000000000000000000000000000a2',
+  chainId: 1,
+  name: 'Blue ETH Vault',
+}
+
 // 25 USDC wallet, 10 USDC position, 8 USDC withdrawable right now.
 const USER_STATE = {
   shares: 10_000_000n,
@@ -52,13 +67,19 @@ const DEPOSIT_CALLS = [
 ]
 
 beforeEach(() => {
-  mockWallet.current = { address: '0xac', chainId: 137, sendCalls: vi.fn(), loginMethod: 'wallet' }
+  mockWallet.current = { address: '0xac', chainId: 137 }
+  mockSend.current = {
+    sendOnChain: vi.fn().mockResolvedValue({ route: 'direct', txHash: '0xtx1' }),
+    canTransactOn: () => true,
+    cannotTransactReason: (chainId) => `Passkey accounts can't send transactions on chain ${chainId} yet`,
+    isPasskey: false,
+  }
   mockBuilders.deposit.mockReset().mockResolvedValue({ calls: DEPOSIT_CALLS, requiresApproval: true })
   mockBuilders.withdraw.mockReset().mockResolvedValue({ calls: [DEPOSIT_CALLS[1]] })
 })
 
-function renderSheet(userState = USER_STATE) {
-  return render(<VaultSheet vault={VAULT} userState={userState} onClose={vi.fn()} onActionComplete={vi.fn()} />)
+function renderSheet(userState = USER_STATE, vault = VAULT) {
+  return render(<VaultSheet vault={vault} userState={userState} onClose={vi.fn()} onActionComplete={vi.fn()} />)
 }
 
 describe('VaultSheet deposit validation (pre-wallet)', () => {
@@ -87,10 +108,11 @@ describe('VaultSheet deposit validation (pre-wallet)', () => {
     expect(screen.getByText(/two quick wallet confirmations/i)).toBeInTheDocument()
   })
 
-  it('shows wallet and existing-position balances', () => {
+  it('shows wallet and existing-position balances, and names the vault network', () => {
     renderSheet()
     expect(screen.getByText(/in your wallet/i)).toBeInTheDocument()
     expect(screen.getByText(/already in this vault/i)).toBeInTheDocument()
+    expect(screen.getByText(/on Polygon/i)).toBeInTheDocument()
   })
 })
 
@@ -121,49 +143,50 @@ describe('VaultSheet withdraw (honest liquidity bound)', () => {
   })
 })
 
-describe('VaultSheet write rail (sendCalls — passkey + classic)', () => {
-  it('passkey deposit sends ONE sendCalls batch (approve + deposit) and shows the success state', async () => {
-    const sendCalls = vi.fn().mockResolvedValue({ route: 'userop', state: 'included', txHash: '0xtx1' })
-    mockWallet.current = { address: '0xac', chainId: 137, sendCalls, loginMethod: 'passkey' }
+describe('VaultSheet network-transparent write rail (useEarnSend)', () => {
+  it('submits to the VAULT chain — the network switch is managed for the member', async () => {
+    // Wallet is on Polygon; the vault lives on Ethereum. No banner, no
+    // pre-confirmation: the hook switches as part of the submission.
+    mockWallet.current = { address: '0xac', chainId: 137 }
+    renderSheet(USER_STATE, ETH_VAULT)
+    expect(screen.getByText(/on Ethereum/i)).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '5' } })
+    fireEvent.click(screen.getByRole('button', { name: /deposit usdc/i }))
+    await waitFor(() => expect(screen.getByText(/deposit complete/i)).toBeInTheDocument())
+    expect(mockSend.current.sendOnChain).toHaveBeenCalledTimes(1)
+    expect(mockSend.current.sendOnChain).toHaveBeenCalledWith(1, DEPOSIT_CALLS, expect.anything())
+  })
+
+  it('passkey deposit sends ONE batch (approve + deposit) with one-ceremony copy', async () => {
+    mockSend.current = {
+      ...mockSend.current,
+      isPasskey: true,
+      sendOnChain: vi.fn().mockResolvedValue({ route: 'userop', state: 'included', txHash: '0xtx1' }),
+    }
     renderSheet()
-    // Passkey copy: one ceremony, not "two confirmations".
     expect(screen.getByText(/one passkey confirmation/i)).toBeInTheDocument()
     fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '5' } })
     fireEvent.click(screen.getByRole('button', { name: /deposit usdc/i }))
     await waitFor(() => expect(screen.getByText(/deposit complete/i)).toBeInTheDocument())
-    expect(sendCalls).toHaveBeenCalledTimes(1)
-    expect(sendCalls).toHaveBeenCalledWith(DEPOSIT_CALLS)
-    expect(mockBuilders.deposit).toHaveBeenCalledWith(
-      expect.objectContaining({ account: '0xac', amount: 5_000_000n }),
-    )
+    expect(mockSend.current.sendOnChain).toHaveBeenCalledWith(137, DEPOSIT_CALLS, expect.anything())
     expect(screen.getByRole('link', { name: /view transaction/i })).toHaveAttribute(
       'href',
       expect.stringContaining('0xtx1'),
     )
   })
 
-  it('classic wallet withdraw routes through sendCalls too', async () => {
-    const sendCalls = vi.fn().mockResolvedValue({ route: 'direct', txHash: '0xtx2' })
-    mockWallet.current = { address: '0xac', chainId: 137, sendCalls, loginMethod: 'wallet' }
-    renderSheet()
-    fireEvent.click(screen.getByRole('tab', { name: /withdraw/i }))
-    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '2' } })
-    fireEvent.click(screen.getByRole('button', { name: /withdraw usdc/i }))
-    await waitFor(() => expect(screen.getByText(/withdrawal complete/i)).toBeInTheDocument())
-    expect(sendCalls).toHaveBeenCalledTimes(1)
-  })
-
-  it('shows an honest error when the session has no write rail — never a silent no-op', async () => {
-    mockWallet.current = { address: '0xac', chainId: 137, sendCalls: undefined, loginMethod: 'passkey' }
-    renderSheet()
-    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '5' } })
-    fireEvent.click(screen.getByRole('button', { name: /deposit usdc/i }))
-    expect(await screen.findByRole('alert')).toHaveTextContent(/cannot send transactions/i)
+  it('discloses up front when this session cannot transact on the vault network', () => {
+    mockSend.current = { ...mockSend.current, isPasskey: true, canTransactOn: () => false }
+    renderSheet(USER_STATE, ETH_VAULT)
+    const submit = screen.getByRole('button', { name: /deposit usdc/i })
+    expect(submit).toBeDisabled()
+    expect(screen.getByRole('note')).toHaveTextContent(/passkey accounts can't send transactions/i)
   })
 
   it('surfaces a failed submission outcome instead of pretending success', async () => {
-    const sendCalls = vi.fn().mockResolvedValue({ route: 'userop', state: 'failed', reason: 'user operation reverted' })
-    mockWallet.current = { address: '0xac', chainId: 137, sendCalls, loginMethod: 'passkey' }
+    mockSend.current.sendOnChain = vi
+      .fn()
+      .mockResolvedValue({ route: 'userop', state: 'failed', reason: 'user operation reverted' })
     renderSheet()
     fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '5' } })
     fireEvent.click(screen.getByRole('button', { name: /deposit usdc/i }))

--- a/frontend/src/test/earn/morphoApi.test.js
+++ b/frontend/src/test/earn/morphoApi.test.js
@@ -48,9 +48,16 @@ describe('normalizeVault', () => {
     expect(vault.rewards).toEqual([{ assetSymbol: 'MORPHO', supplyApr: 0.012 }])
   })
 
-  it('drops non-listed and foreign-chain items', () => {
+  it('drops non-listed items and chains outside the earn allowlist', () => {
     expect(normalizeVault({ ...VAULT_ITEM, listed: false }, 137)).toBeNull()
-    expect(normalizeVault({ ...VAULT_ITEM, chain: { id: 1 } }, 137)).toBeNull()
+    expect(normalizeVault({ ...VAULT_ITEM, chain: { id: 8453 } }, [1, 137])).toBeNull()
+  })
+
+  it('tags each vault with its OWN chainId across a multi-network allowlist', () => {
+    const onPolygon = normalizeVault(VAULT_ITEM, [1, 137])
+    expect(onPolygon.chainId).toBe(137)
+    const onEthereum = normalizeVault({ ...VAULT_ITEM, chain: { id: 1 } }, [1, 137])
+    expect(onEthereum.chainId).toBe(1)
   })
 
   it('joins multiple curator names and yields null when none are named', () => {

--- a/frontend/src/test/earn/useEarnRewards.test.jsx
+++ b/frontend/src/test/earn/useEarnRewards.test.jsx
@@ -1,8 +1,9 @@
 /**
- * useEarnRewards claim tests (spec 050 US2) — the claim goes through
- * sendCalls (so passkey sessions work), encodes the distributor call with
- * CUMULATIVE amounts, reports honestly on failure, and never silently
- * no-ops when the session has no write rail.
+ * useEarnRewards claim tests (spec 050 US2) — rewards fetched across every
+ * earn network and tagged with their chainId; claims go through
+ * useEarnSend.sendOnChain (network switch managed for the member, passkey
+ * sessions supported), encode the distributor call with CUMULATIVE amounts,
+ * and report honestly on failure.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act, waitFor } from '@testing-library/react'
@@ -17,10 +18,23 @@ vi.mock('../../hooks/useActivity', () => ({
   useActivityOptional: () => null,
 }))
 
-const mockMerkl = vi.hoisted(() => ({ rewards: [] }))
+const mockSend = vi.hoisted(() => ({ current: {} }))
+vi.mock('../../hooks/useEarnSend', () => ({
+  useEarnSend: () => mockSend.current,
+  default: () => mockSend.current,
+}))
+
+const mockMerkl = vi.hoisted(() => ({ byChain: {} }))
 vi.mock('../../lib/earn/merkl', async (importOriginal) => {
   const actual = await importOriginal()
-  return { ...actual, fetchRewards: vi.fn(async () => mockMerkl.rewards) }
+  return {
+    ...actual,
+    fetchRewards: vi.fn(async (_address, chainId) => {
+      const entry = mockMerkl.byChain[chainId]
+      if (entry instanceof Error) throw entry
+      return entry || []
+    }),
+  }
 })
 
 import { useEarnRewards } from '../../hooks/useEarnRewards'
@@ -40,50 +54,63 @@ const REWARD = {
 }
 
 beforeEach(() => {
-  mockMerkl.rewards = [REWARD]
-  mockWallet.current = {
-    address: ACCOUNT,
-    isConnected: true,
-    chainId: 137,
-    sendCalls: vi.fn().mockResolvedValue({ route: 'userop', state: 'included', txHash: '0xtx' }),
+  mockMerkl.byChain = { 137: [REWARD], 1: [] }
+  mockWallet.current = { address: ACCOUNT, isConnected: true, chainId: 63 }
+  mockSend.current = {
+    sendOnChain: vi.fn().mockResolvedValue({ route: 'userop', state: 'included', txHash: '0xtx' }),
+    canTransactOn: () => true,
+    cannotTransactReason: () => 'not available',
+    isPasskey: false,
   }
   localStorage.clear()
 })
 
-describe('useEarnRewards claim (sendCalls rail)', () => {
-  it('claims via one distributor call with the CUMULATIVE amount', async () => {
+describe('useEarnRewards (network-transparent claim rail)', () => {
+  it('fetches every earn network and tags rewards with their chainId', async () => {
     const { result } = renderHook(() => useEarnRewards())
     await waitFor(() => expect(result.current.status).toBe('ready'))
-    await act(() => result.current.claim())
+    expect(result.current.rewards).toHaveLength(1)
+    expect(result.current.rewards[0].chainId).toBe(137)
+    expect(result.current.failedNetworks).toEqual([])
+  })
 
-    const sendCalls = mockWallet.current.sendCalls
-    expect(sendCalls).toHaveBeenCalledTimes(1)
-    const [calls] = sendCalls.mock.calls[0]
+  it('claims via sendOnChain for the reward network with the CUMULATIVE amount', async () => {
+    const { result } = renderHook(() => useEarnRewards())
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    await act(() => result.current.claim(137))
+
+    const { sendOnChain } = mockSend.current
+    expect(sendOnChain).toHaveBeenCalledTimes(1)
+    const [chainId, calls] = sendOnChain.mock.calls[0]
+    expect(chainId).toBe(137)
     expect(calls).toHaveLength(1)
     const decoded = DISTRIBUTOR_IFACE.decodeFunctionData('claim', calls[0].data)
     expect(decoded[0][0].toLowerCase()).toBe(ACCOUNT) // users
     expect(decoded[1][0].toLowerCase()).toBe(REWARD.token.address) // tokens
     expect(decoded[2][0]).toBe(REWARD.amount) // cumulative, NOT the difference
-    expect(result.current.claimState.status).toBe('confirmed')
+    expect(result.current.claimState).toMatchObject({ status: 'confirmed', chainId: 137 })
     expect(result.current.claimState.txUrl).toContain('0xtx')
   })
 
-  it('reports an honest error when the session has no write rail', async () => {
-    mockWallet.current = { ...mockWallet.current, sendCalls: undefined }
+  it('is unavailable only when EVERY network fails; partial failures are named', async () => {
+    mockMerkl.byChain = { 137: [REWARD], 1: new Error('merkl down') }
     const { result } = renderHook(() => useEarnRewards())
     await waitFor(() => expect(result.current.status).toBe('ready'))
-    await act(() => result.current.claim())
-    expect(result.current.claimState.status).toBe('error')
-    expect(result.current.claimState.error).toMatch(/cannot send transactions/i)
+    expect(result.current.failedNetworks).toEqual(['Ethereum'])
+    expect(result.current.rewards).toHaveLength(1)
+
+    mockMerkl.byChain = { 137: new Error('down'), 1: new Error('down') }
+    const { result: allFail } = renderHook(() => useEarnRewards())
+    await waitFor(() => expect(allFail.current.status).toBe('unavailable'))
   })
 
   it('surfaces a failed submission outcome', async () => {
-    mockWallet.current.sendCalls = vi
+    mockSend.current.sendOnChain = vi
       .fn()
       .mockResolvedValue({ route: 'userop', state: 'failed', reason: 'reverted' })
     const { result } = renderHook(() => useEarnRewards())
     await waitFor(() => expect(result.current.status).toBe('ready'))
-    await act(() => result.current.claim())
+    await act(() => result.current.claim(137))
     expect(result.current.claimState.status).toBe('error')
   })
 })

--- a/frontend/src/test/earn/useEarnSend.test.jsx
+++ b/frontend/src/test/earn/useEarnSend.test.jsx
@@ -1,0 +1,80 @@
+/**
+ * useEarnSend tests (spec 050 — network-transparent sending). The switch to
+ * a transaction's network happens automatically as part of submitting (no
+ * separate in-app confirmation), the send waits for the session to settle on
+ * the target chain, and passkey sessions are honestly gated to chains with
+ * an ERC-4337 rail.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+const mockWallet = vi.hoisted(() => ({ current: {} }))
+vi.mock('../../hooks/useWalletManagement', () => ({
+  useWallet: () => mockWallet.current,
+}))
+
+const mockSwitch = vi.hoisted(() => ({ switchChainAsync: vi.fn() }))
+vi.mock('wagmi', () => ({
+  useSwitchChain: () => ({ switchChainAsync: mockSwitch.switchChainAsync }),
+}))
+
+import { useEarnSend } from '../../hooks/useEarnSend'
+
+const CALLS = [{ target: '0x' + 'a'.repeat(40), data: '0x01', value: 0n }]
+
+beforeEach(() => {
+  mockWallet.current = {
+    chainId: 137,
+    signer: {},
+    sendCalls: vi.fn().mockResolvedValue({ route: 'direct', txHash: '0xtx' }),
+    loginMethod: 'wallet',
+  }
+  mockSwitch.switchChainAsync.mockReset().mockResolvedValue({})
+})
+
+describe('useEarnSend', () => {
+  it('sends directly with no switch when already on the target chain', async () => {
+    const { result } = renderHook(() => useEarnSend())
+    const sent = await act(() => result.current.sendOnChain(137, CALLS))
+    expect(mockSwitch.switchChainAsync).not.toHaveBeenCalled()
+    expect(mockWallet.current.sendCalls).toHaveBeenCalledWith(CALLS)
+    expect(sent.txHash).toBe('0xtx')
+  })
+
+  it('switches automatically, waits for the session to settle, then sends', async () => {
+    const states = []
+    const { result, rerender } = renderHook(() => useEarnSend())
+    const pending = result.current.sendOnChain(1, CALLS, { onState: (s) => states.push(s.step) })
+
+    // The switch was requested without any in-app confirmation step…
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(mockSwitch.switchChainAsync).toHaveBeenCalledWith({ chainId: 1 })
+
+    // …and the send waits until the wallet snapshot reflects the new chain
+    // (and, for classic wallets, a rebuilt signer).
+    mockWallet.current = { ...mockWallet.current, chainId: 1, signer: {} }
+    rerender()
+    const sent = await act(() => pending)
+    expect(states).toEqual(['switching', 'sending'])
+    expect(mockWallet.current.sendCalls).toHaveBeenCalledWith(CALLS)
+    expect(sent.txHash).toBe('0xtx')
+  })
+
+  it('fails with a member-facing message when the wallet refuses the switch', async () => {
+    mockSwitch.switchChainAsync.mockRejectedValue(new Error('user rejected'))
+    const { result } = renderHook(() => useEarnSend())
+    await expect(result.current.sendOnChain(1, CALLS)).rejects.toThrow(/could not switch to ethereum/i)
+  })
+
+  it('gates passkey sessions honestly on chains without an ERC-4337 rail', async () => {
+    mockWallet.current = { ...mockWallet.current, loginMethod: 'passkey', signer: null }
+    const { result } = renderHook(() => useEarnSend())
+    // Ethereum mainnet has no passkey bundler configured (spec 048 cut).
+    expect(result.current.canTransactOn(1)).toBe(false)
+    expect(result.current.cannotTransactReason(1)).toMatch(/passkey accounts can't send transactions on ethereum/i)
+    await expect(result.current.sendOnChain(1, CALLS)).rejects.toThrow(/passkey accounts/i)
+    expect(mockSwitch.switchChainAsync).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Follow-up to #863/#864/#867/#871 (spec 050, issue #861). Makes network selection on Earn transparent to the member, the way the portfolio already is.

## Before

Earn was scoped to the wallet's active network. Following the portfolio's Earn action for an Ethereum asset while on Polygon landed on a **"Switch to Ethereum"** interstitial plus an empty "No vaults accept ETH on this network" list — and that switch button was wired to `WalletContext.switchNetwork`, which ignores its argument and hardcodes Polygon, so it couldn't even work.

## After

- **Vault list**: one Morpho query across **all earn-enabled chains**; every row shows the hosting network via the shared portfolio `AssetLogo` badge artwork plus the network name. Positions and reward balances are read the same way — per-chain read providers, independent of the active wallet network (the `usePortfolio` pattern).
- **Submission manages the network** (`hooks/useEarnSend`): if the transaction targets a different chain, the app calls wagmi `switchChainAsync` automatically as part of the confirmation — no in-app "switch network" step, no banner. It then waits for the session to settle on the target chain (and, for classic wallets, for the chain-scoped signer to be rebuilt) before routing the batch through `sendCalls`. A browser wallet may still show its own switch prompt; that surface belongs to the wallet.
- **Passkey honesty**: passkey sessions can only transact on chains with an ERC-4337 rail (`NETWORKS[chainId].passkey`); the sheet and rewards view disclose that up front with a disabled control + reason instead of a doomed submit (Ethereum vaults remain browsable/viewable).
- **VaultSheet** names the vault's network and adds a "Switching to …" progress state; explorer links and activity entries are scoped to the vault's chain.
- **Rewards** group per network with a per-network claim button on the same auto-switch rail; partial fetch failures name the unreachable networks honestly instead of showing zeros.
- **EarnPanel**: the switch banner and per-network gating are gone; the legacy `?chain=` deep-link param is accepted and ignored (the list already spans all networks; `?token=` prefiltering is unchanged).

## Testing

81 earn tests pass, including a new `useEarnSend` suite (no-switch fast path, auto-switch + settle-wait, wallet-refused switch, passkey chain gating), multi-network list/positions/rewards coverage, per-network claim encoding, and refreshed axe WCAG audits. Docs (user + developer guides) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LizwRCtWZEqdsCobwCwApJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LizwRCtWZEqdsCobwCwApJ)_