### PR TITLE
Passkey support across all transaction-signing surfaces (spec 041/050)

### DIFF
--- a/frontend/src/components/clearpath/ExternalDaoView.jsx
+++ b/frontend/src/components/clearpath/ExternalDaoView.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { ethers } from 'ethers'
 import { getNetwork } from '../../config/networks'
 import { useNotification } from '../../hooks/useUI'
+import { useWallet } from '../../hooks/useWalletManagement'
 import { useAddressScreening } from '../../hooks/useAddressScreening'
 import { useActiveAccount } from '../../hooks/useActiveAccount'
 import { DAO_FRAMEWORK_LABEL, PROPOSAL_STATE_LABEL, VOTE_SUPPORT } from '../../abis/externalDAORegistry'
@@ -108,6 +109,10 @@ function CopyableId({ id }) {
 export default function ExternalDaoView({ record, reader, signer, account, chainId, usdcAddress, onBack }) {
   const { showNotification } = useNotification()
   const { screenOne } = useAddressScreening()
+  // Spec 041/050: a passkey smart-account session has no ethers signer — its writes go through `sendCalls`
+  // (one sponsored ERC-4337 UserOp) instead of `signer`. `loginMethod` picks the rail.
+  const { sendCalls, loginMethod } = useWallet()
+  const isPasskey = loginMethod === 'passkey'
   // Spec 043 (US3, FR-022a): acting on a DAO while operating as a vault becomes a threshold-gated vault proposal.
   const { isVault: operatingAsVault, canActAsVault, submit: submitAsActive } = useActiveAccount()
   const net = getNetwork(chainId)
@@ -228,7 +233,8 @@ export default function ExternalDaoView({ record, reader, signer, account, chain
   // confirmed, so callers can gate success-only UI (e.g. the proposal builder must not reset/close on a reverted
   // propose — that would imply a success the chain didn't give).
   async function run(label, makeTx) {
-    if (!signer) {
+    // A passkey session has no `signer` but can still act via `sendCalls`; only block when neither rail exists.
+    if (!isPasskey && !signer) {
       showNotification('Connect a wallet to act on this DAO.', 'warning')
       return false
     }
@@ -283,6 +289,16 @@ export default function ExternalDaoView({ record, reader, signer, account, chain
       }
       const { to, data } = connector.encode(record.dao, action, encodeArgs)
       return submitAsActive({ to, value: 0n, data })
+    }
+    // Spec 041/050 passkey rail: reuse the connector's exact calldata encoding (castVote/queue/execute), then
+    // send it as one sponsored UserOp via `sendCalls` instead of the signer. `sendCalls` already awaits
+    // inclusion, so the returned `wait` is a no-op that keeps `run()`'s `tx.wait(...)` from crashing.
+    if (isPasskey) {
+      if (typeof connector.encode !== 'function') throw new Error('This DAO framework does not support passkey accounts yet.')
+      if (typeof sendCalls !== 'function') throw new Error('This wallet cannot act on the current transaction rail.')
+      const { to, data } = connector.encode(record.dao, action, encodeArgs)
+      const sent = await sendCalls([{ target: to, data, value: 0n }])
+      return { hash: sent?.txHash ?? sent?.userOpHash ?? sent?.intentId, wait: async () => {} }
     }
     return personalFn()
   }

--- a/frontend/src/components/clearpath/ProposalBuilder.jsx
+++ b/frontend/src/components/clearpath/ProposalBuilder.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ethers } from 'ethers'
+import { useWallet } from '../../hooks/useWalletManagement'
 import { ERC20_BALANCE_ABI } from '../../abis/externalDAORegistry'
 import { ACTION_TYPE, newAction, assemble, predictProposalId } from './proposalEncoding'
 import CpAddressField from './CpAddressField'
@@ -16,6 +17,10 @@ const EXECUTE_TREASURY_SELECTOR = EXECUTE_TREASURY_IFACE.getFunction('executeTre
 const short = (a) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '—')
 
 export default function ProposalBuilder({ record, connector, signer, reader, account, usdcAddress, nativeSymbol, treasuries = [], fundingSources = [], proposals = [], run, busy, onSubmitted }) {
+  // Spec 041/050: a passkey smart-account session has no ethers signer — propose goes through `sendCalls`
+  // (one sponsored ERC-4337 UserOp) instead of `connector.propose(signer, ...)`. `loginMethod` picks the rail.
+  const { sendCalls, loginMethod } = useWallet()
+  const isPasskey = loginMethod === 'passkey'
   const [open, setOpen] = useState(false)
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
@@ -132,9 +137,20 @@ export default function ProposalBuilder({ record, connector, signer, reader, acc
     // Route through the DAO's own connector so the framework-correct propose() is used (OZ:
     // targets/values/calldatas/description; Bravo: adds the parallel `signatures` array). Only reset/close/reload
     // on a CONFIRMED tx — a reverted propose must not look like success (US5 #9).
-    run('Propose', () =>
-      connector.propose(signer, record.dao, { targets: A.targets, values: A.values, calldatas: A.calldatas, description: A.description })
-    ).then((ok) => { if (ok) { reset(); setOpen(false); onSubmitted?.() } })
+    const proposal = { targets: A.targets, values: A.values, calldatas: A.calldatas, description: A.description }
+    // Spec 041/050 passkey rail: `connector.encode` yields the SAME framework-correct propose calldata as the
+    // signer path (the connector owns the OZ vs Bravo signature), sent as one sponsored UserOp via `sendCalls`.
+    // `sendCalls` already awaits inclusion, so the returned `wait` is a no-op that keeps `run()`'s wait happy.
+    const makeTx = isPasskey
+      ? async () => {
+          if (typeof connector.encode !== 'function') throw new Error('This DAO framework does not support passkey accounts yet.')
+          if (typeof sendCalls !== 'function') throw new Error('This wallet cannot act on the current transaction rail.')
+          const { to, data } = connector.encode(record.dao, 'propose', proposal)
+          const sent = await sendCalls([{ target: to, data, value: 0n }])
+          return { hash: sent?.txHash ?? sent?.userOpHash ?? sent?.intentId, wait: async () => {} }
+        }
+      : () => connector.propose(signer, record.dao, proposal)
+    run('Propose', makeTx).then((ok) => { if (ok) { reset(); setOpen(false); onSubmitted?.() } })
   }
 
   // "Fund from treasury" is offered FIRST when the DAO has a governable (executor-gated) vault; the generic
@@ -224,7 +240,7 @@ ${dupId ? `proposalId: ${dupId}` : ''}`}
         </details>
 
         <div className="cp-row-actions" style={{ marginTop: '0.6rem' }}>
-          {signer ? (
+          {(signer || isPasskey) ? (
             <button type="button" className="cp-btn cp-btn-primary" disabled={!valid || busy || isDuplicate} aria-disabled={!valid || busy || isDuplicate} onClick={submit}>Submit proposal</button>
           ) : (
             <span className="cp-notice">Connect a wallet to propose.</span>

--- a/frontend/src/components/clearpath/__tests__/ClearPathPanel.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ClearPathPanel.test.jsx
@@ -23,6 +23,11 @@ const cp = {
 }
 vi.mock('../useClearPath', () => ({ useClearPath: () => cp }))
 vi.mock('../../../hooks/useUI', () => ({ useNotification: () => ({ showNotification: vi.fn() }) }))
+// ExternalDaoView (rendered within) now reads sendCalls/loginMethod from useWallet (passkey rail);
+// these tests drive the classic signer-prop path, so return a non-passkey session.
+vi.mock('../../../hooks/useWalletManagement', () => ({
+  useWallet: () => ({ loginMethod: 'injected', sendCalls: undefined }),
+}))
 
 const conn = { validateGovernor: vi.fn(), readGovernorSummary: vi.fn(), fetchGovernorProposals: vi.fn(), readTreasuries: vi.fn(), readVoterState: vi.fn(), readProposalEta: vi.fn(), detectTreasuryFunding: vi.fn() }
 vi.mock('../governorConnector', () => ({

--- a/frontend/src/components/clearpath/__tests__/ExternalDaoView.notifications.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ExternalDaoView.notifications.test.jsx
@@ -18,6 +18,11 @@ const h = vi.hoisted(() => ({
 }))
 
 vi.mock('../../../hooks/useUI', () => ({ useNotification: () => ({ showNotification: h.showNotification }) }))
+// The view now reads sendCalls/loginMethod from useWallet (passkey rail); these tests drive the
+// classic signer-prop path, so return a non-passkey session.
+vi.mock('../../../hooks/useWalletManagement', () => ({
+  useWallet: () => ({ loginMethod: 'injected', sendCalls: undefined }),
+}))
 vi.mock('../governorConnector', () => ({
   readGovernorSummary: (...a) => h.readGovernorSummary(...a),
   readTreasuries: (...a) => h.readTreasuries(...a),

--- a/frontend/src/components/clearpath/__tests__/ProposalBuilder.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ProposalBuilder.test.jsx
@@ -4,6 +4,12 @@ import userEvent from '@testing-library/user-event'
 import { axe } from 'vitest-axe'
 import { ethers } from 'ethers'
 import ProposalBuilder from '../ProposalBuilder'
+
+// The component now reads sendCalls/loginMethod from useWallet (passkey rail, spec 041/050); these
+// tests drive the classic signer-prop path, so return a non-passkey session.
+vi.mock('../../../hooks/useWalletManagement', () => ({
+  useWallet: () => ({ loginMethod: 'injected', sendCalls: undefined }),
+}))
 import { ACTION_TYPE, newAction, assemble, predictProposalId } from '../proposalEncoding'
 
 // Spec 030 (US5, FR-023/024) — the rich proposal builder: compose a Governor proposal without hand-writing

--- a/frontend/src/components/clearpath/connectors/governorBravo.js
+++ b/frontend/src/components/clearpath/connectors/governorBravo.js
@@ -235,14 +235,22 @@ export async function detectTreasuryFunding() {
 }
 
 // Spec 043 (US3, FR-022a): encode a management action's calldata (to the governor) so it can be proposed as a
-// vault transaction when operating as a Safe. Bravo queue/execute take only the proposal id. Returns {to,data}.
+// vault transaction when operating as a Safe. Spec 041/050 reuses the same encoding for the passkey smart-account
+// rail (sendCalls). Bravo queue/execute take only the proposal id; Bravo `propose` carries the extra
+// `signatures` array (defaulted to empty strings, mirroring the signer `propose()` above). Returns {to,data}.
 export function encodeManagementAction(governor, action, args) {
   const iface = new ethers.Interface(BRAVO_WRITE_ABI)
   let data
   if (action === 'castVote') data = iface.encodeFunctionData('castVote', [args.proposalId, args.support])
   else if (action === 'queue') data = iface.encodeFunctionData('queue', [args.p.id])
   else if (action === 'execute') data = iface.encodeFunctionData('execute', [args.p.id])
-  else throw new Error(`Unsupported vault governance action: ${action}`)
+  else if (action === 'propose') {
+    const sigs =
+      Array.isArray(args.signatures) && args.signatures.length === args.targets.length
+        ? args.signatures
+        : args.targets.map(() => '')
+    data = iface.encodeFunctionData('propose', [args.targets, args.values, sigs, args.calldatas, args.description])
+  } else throw new Error(`Unsupported vault governance action: ${action}`)
   return { to: governor, data }
 }
 

--- a/frontend/src/components/clearpath/connectors/ozGovernor.js
+++ b/frontend/src/components/clearpath/connectors/ozGovernor.js
@@ -383,13 +383,16 @@ export function proposeAction(signer, governor, { targets, values, calldatas, de
 }
 
 // Spec 043 (US3, FR-022a): encode a management action's calldata (to the governor) so it can be proposed as a
-// vault transaction when operating as a Safe. Returns { to, data }.
+// vault transaction when operating as a Safe. Spec 041/050 reuses the same encoding for the passkey smart-account
+// rail (sendCalls). `propose` is included so the ProposalBuilder's passkey path can encode the framework-correct
+// OZ propose(targets, values, calldatas, description) without re-deriving the signature. Returns { to, data }.
 export function encodeManagementAction(governor, action, args) {
   const iface = new ethers.Interface(GOVERNOR_WRITE_ABI)
   let data
   if (action === 'castVote') data = iface.encodeFunctionData('castVote', [args.proposalId, args.support])
   else if (action === 'queue') data = iface.encodeFunctionData('queue', [args.p.targets, args.p.values, args.p.calldatas, args.p.descriptionHash])
   else if (action === 'execute') data = iface.encodeFunctionData('execute', [args.p.targets, args.p.values, args.p.calldatas, args.p.descriptionHash])
+  else if (action === 'propose') data = iface.encodeFunctionData('propose', [args.targets, args.values, args.calldatas, args.description])
   else throw new Error(`Unsupported vault governance action: ${action}`)
   return { to: governor, data }
 }

--- a/frontend/src/components/clearpath/useClearPath.js
+++ b/frontend/src/components/clearpath/useClearPath.js
@@ -49,7 +49,10 @@ function cachedReadProvider(rpcUrl, chainId) {
  * network's public RPC with a wallet-managed routing option (FR-019); writes always use the wallet signer.
  */
 export function useClearPath() {
-  const { account, signer, provider, chainId, isConnected } = useWallet()
+  // Spec 041/050: passkey smart-account sessions have no `signer`; their writes go through `sendCalls`
+  // (one sponsored ERC-4337 UserOp). `loginMethod` picks the rail for the on-chain register write.
+  const { account, signer, provider, chainId, isConnected, sendCalls, loginMethod } = useWallet()
+  const isPasskey = loginMethod === 'passkey'
   const { showNotification } = useNotification()
 
   const net = getNetwork(chainId)
@@ -154,9 +157,30 @@ export function useClearPath() {
         showNotification('This network has no on-chain DAO registry.', 'warning')
         throw new Error('no registry')
       }
-      if (!signer) {
+      // A passkey session has no `signer` but can register via `sendCalls`; only block when neither rail exists.
+      if (!isPasskey && !signer) {
         showNotification('Connect a wallet to register a DAO.', 'warning')
         throw new Error('no signer')
+      }
+      // Spec 041/050 passkey rail: encode the same registerExternalDAO calldata and send it as one sponsored
+      // UserOp via `sendCalls` (which already awaits inclusion) instead of a signer-backed contract call.
+      if (isPasskey) {
+        if (typeof sendCalls !== 'function') {
+          showNotification('This wallet cannot register a DAO on the current transaction rail.', 'error')
+          throw new Error('no sendCalls')
+        }
+        try {
+          showNotification('Register DAO: confirm in your wallet…', 'info', 0)
+          const data = new ethers.Interface(EXTERNAL_DAO_REGISTRY_ABI).encodeFunctionData('registerExternalDAO', [dao, framework, label])
+          const sent = await sendCalls([{ target: registryAddress, data, value: 0n }])
+          const txHash = sent?.txHash ?? sent?.userOpHash ?? sent?.intentId
+          const ref = txHash ? ` · tx ${String(txHash).slice(0, 6)}…${String(txHash).slice(-4)}` : ''
+          showNotification(`Registered ${label || 'DAO'}.${ref}`, 'success')
+          return sent
+        } catch (e) {
+          showNotification(e?.shortMessage || e?.reason || e?.message || 'Register failed.', 'error')
+          throw e
+        }
       }
       const reg = new ethers.Contract(registryAddress, EXTERNAL_DAO_REGISTRY_ABI, signer)
       try {
@@ -176,7 +200,7 @@ export function useClearPath() {
         throw e
       }
     },
-    [hasRegistry, signer, registryAddress, showNotification]
+    [hasRegistry, isPasskey, sendCalls, signer, registryAddress, showNotification]
   )
 
   /**

--- a/frontend/src/components/fairwins/MarketAcceptanceModal.jsx
+++ b/frontend/src/components/fairwins/MarketAcceptanceModal.jsx
@@ -80,7 +80,8 @@ function MarketAcceptanceModal({
   contractABI
 }) {
   const { isConnected, account } = useWallet()
-  const { signer, isCorrectNetwork, switchNetwork, chainId } = useWeb3()
+  const { signer, isCorrectNetwork, switchNetwork, chainId, sendCalls, loginMethod, provider } = useWeb3()
+  const isPasskey = loginMethod === 'passkey'
   // Spec 043 (US3): accepting a wager while operating as a vault becomes a threshold-gated vault proposal.
   const { isVault: operatingAsVault, canActAsVault, submit: submitAsActive } = useActiveAccount()
   const {
@@ -311,7 +312,7 @@ function MarketAcceptanceModal({
   }
 
   const handleAccept = async () => {
-    if (!signer) {
+    if (!isPasskey && !signer) {
       setError('Please connect your wallet')
       return
     }
@@ -334,10 +335,12 @@ function MarketAcceptanceModal({
         throw new Error('The acceptance deadline has passed. This offer can no longer be accepted.')
       }
 
+      // Reads use the signer when present, else the session read provider (a passkey session has no
+      // signer, but WalletContext exposes an RPC reader). Calldata encoding needs no signer.
       const contract = new ethers.Contract(
         contractAddress,
         contractABI,
-        signer
+        signer || provider
       )
 
       // v2: ERC20-only stakes. Pull on-chain wager to get authoritative stake amounts.
@@ -358,7 +361,7 @@ function MarketAcceptanceModal({
           'function symbol() view returns (string)',
           'function decimals() view returns (uint8)',
         ],
-        signer
+        signer || provider
       )
 
       // Spec 043 (US3, FR-021): accepting AS a vault → batch [approve, acceptWager] as a threshold-gated
@@ -392,6 +395,34 @@ function MarketAcceptanceModal({
           `Have ${ethers.formatUnits(balance, tokenDecimals)}, ` +
           `need ${ethers.formatUnits(stakeAmount, tokenDecimals)}.`
         )
+      }
+
+      // Passkey rail (spec 041/050): batch [approve?(exact stake), acceptWager] into ONE sponsored
+      // UserOp via sendCalls (no signer). Mirrors the useOpenChallengeAccept template.
+      if (isPasskey) {
+        if (typeof sendCalls !== 'function') {
+          throw new Error('This wallet cannot accept on the current transaction rail.')
+        }
+        const calls = []
+        const allowance = await tokenContract.allowance(account, contractAddress)
+        if (allowance < stakeAmount) {
+          calls.push({
+            target: stakeTokenAddress,
+            data: tokenContract.interface.encodeFunctionData('approve', [contractAddress, stakeAmount]),
+            value: 0n,
+          })
+        }
+        calls.push({
+          target: contractAddress,
+          data: contract.interface.encodeFunctionData('acceptWager', [marketId]),
+          value: 0n,
+        })
+        const sent = await sendCalls(calls)
+        const txHash = sent?.txHash ?? sent?.userOpHash ?? sent?.intentId
+        if (txHash) setTxHash(txHash)
+        setStep('success')
+        if (onAccepted) onAccepted(marketId)
+        return
       }
 
       // Gasless-or-self-submit acceptance: the self-submit closure keeps the existing
@@ -508,7 +539,7 @@ function MarketAcceptanceModal({
   })
 
   const handleDecline = async () => {
-    if (!signer) {
+    if (!isPasskey && !signer) {
       setError('Please connect your wallet')
       return
     }
@@ -526,7 +557,17 @@ function MarketAcceptanceModal({
     setError(null)
 
     try {
-      const result = await declineWagerTx.run(marketId)
+      let result
+      if (isPasskey) {
+        if (typeof sendCalls !== 'function') {
+          throw new Error('This wallet cannot decline on the current transaction rail.')
+        }
+        const data = new ethers.Interface(contractABI).encodeFunctionData('declineWager', [marketId])
+        const sent = await sendCalls([{ target: contractAddress, data, value: 0n }])
+        result = { txHash: sent?.txHash ?? sent?.userOpHash ?? sent?.intentId }
+      } else {
+        result = await declineWagerTx.run(marketId)
+      }
       if (result?.error) throw result.error
       if (result?.txHash) setTxHash(result.txHash)
       setStep('declined')

--- a/frontend/src/components/fairwins/MyMarketsModal.jsx
+++ b/frontend/src/components/fairwins/MyMarketsModal.jsx
@@ -30,6 +30,22 @@ import './MyMarketsModal.css'
 import './WagerCard.css'
 
 /**
+ * Passkey rail for a single WagerRegistry write (spec 041/050): a passkey smart-account session has
+ * no ethers signer, so its writes go through WalletContext.sendCalls as one sponsored UserOp instead
+ * of the useGaslessWrite/signer path. Returns the same `{ txHash }` shape the classic `.run()` yields,
+ * so callers stay branch-light. Claim/refund/resolve are single calls (no token approval).
+ */
+async function sendRegistryCall(sendCalls, chainId, method, args) {
+  if (typeof sendCalls !== 'function') {
+    throw new Error('This wallet cannot submit this action on the current transaction rail.')
+  }
+  const registryAddr = getContractAddressForChain('wagerRegistry', chainId)
+  const data = new ethers.Interface(WAGER_REGISTRY_ABI).encodeFunctionData(method, args)
+  const sent = await sendCalls([{ target: registryAddr, data, value: 0n }])
+  return { txHash: sent?.txHash ?? sent?.userOpHash ?? sent?.intentId }
+}
+
+/**
  * MyMarketsModal Component
  *
  * A comprehensive modal for users to manage their wagers:
@@ -49,7 +65,8 @@ function MyMarketsModal({
   initialSelectedMarketId = null
 }) {
   const { isConnected, account, chainId } = useWallet()
-  const { signer, isCorrectNetwork, switchNetwork } = useWeb3()
+  const { signer, isCorrectNetwork, switchNetwork, sendCalls, loginMethod } = useWeb3()
+  const isPasskey = loginMethod === 'passkey'
   // Spec 043 (US3, FR-022c): a vault-won payout claim is a threshold-gated vault transaction (the registry
   // binds the claimer to the winner). Refunds stay single-owner and need no change.
   const { isVault: operatingAsVault, canActAsVault, submit: submitAsActive } = useActiveAccount()
@@ -718,18 +735,24 @@ function MyMarketsModal({
     const userAddr = account?.toLowerCase()
     const isCreator = userAddr && market.creator?.toLowerCase() === userAddr
 
-    if (isCreator && signer) {
+    if (isCreator && (signer || isPasskey)) {
       try {
         if (!isCorrectNetwork) {
           try { await switchNetwork() } catch { /* user declined */ }
         }
-        const registry = new ethers.Contract(
-          getContractAddressForChain('wagerRegistry', chainId),
-          WAGER_REGISTRY_ABI,
-          signer
-        )
-        const tx = await registry.claimRefund(market.wagerId ?? market.id)
-        await tx.wait()
+        if (isPasskey) {
+          // Passkey creator reclaims the stake over the sendCalls rail (no signer to reclaim it
+          // otherwise strands the funds and only dismisses the row locally).
+          await sendRegistryCall(sendCalls, chainId, 'claimRefund', [market.wagerId ?? market.id])
+        } else {
+          const registry = new ethers.Contract(
+            getContractAddressForChain('wagerRegistry', chainId),
+            WAGER_REGISTRY_ABI,
+            signer
+          )
+          const tx = await registry.claimRefund(market.wagerId ?? market.id)
+          await tx.wait()
+        }
       } catch (err) {
         const reason = err?.reason || err?.shortMessage || err?.message || ''
         const userRejected = err?.code === 'ACTION_REJECTED' ||
@@ -742,7 +765,7 @@ function MyMarketsModal({
     }
 
     dismissMarket(market.id)
-  }, [account, signer, isCorrectNetwork, switchNetwork, dismissMarket, chainId])
+  }, [account, signer, isPasskey, sendCalls, isCorrectNetwork, switchNetwork, dismissMarket, chainId])
 
   const handleClearAllExpired = useCallback((markets) => {
     dismissMarkets(markets.map(m => m.id))
@@ -773,7 +796,7 @@ function MyMarketsModal({
   })
 
   const handleClaimPayout = useCallback(async (market) => {
-    if (!signer) return
+    if (!isPasskey && !signer) return
     const id = String(market.id)
 
     if (!isCorrectNetwork) {
@@ -800,7 +823,9 @@ function MyMarketsModal({
         fireToast('Vault claim proposed — awaiting co-owner approval')
         return
       }
-      const result = await claimPayoutTx.run(wagerId)
+      const result = isPasskey
+        ? await sendRegistryCall(sendCalls, chainId, 'claimPayout', [wagerId])
+        : await claimPayoutTx.run(wagerId)
       if (result?.error) throw result.error
       // Pull fresh on-chain data so the claimed wager flips to paid (which
       // hides the Claim affordances) and clear its unread activity.
@@ -826,7 +851,7 @@ function MyMarketsModal({
     } finally {
       setClaimingId(null)
     }
-  }, [signer, isCorrectNetwork, switchNetwork, markWagerRead, refreshFriendMarkets, fireToast, claimPayoutTx, operatingAsVault, canActAsVault, submitAsActive, chainId])
+  }, [signer, isPasskey, sendCalls, isCorrectNetwork, switchNetwork, markWagerRead, refreshFriendMarkets, fireToast, claimPayoutTx, operatingAsVault, canActAsVault, submitAsActive, chainId])
 
   // Participant reclaims their stake on a wager that ran past its resolution
   // window without a winner being declared (the "refundable" state). Mirrors
@@ -852,7 +877,7 @@ function MyMarketsModal({
   })
 
   const handleClaimRefund = useCallback(async (market) => {
-    if (!signer) return
+    if (!isPasskey && !signer) return
     const id = String(market.id)
 
     if (!isCorrectNetwork) {
@@ -868,7 +893,10 @@ function MyMarketsModal({
     setRefundError(null)
 
     try {
-      const result = await claimRefundRowTx.run(market.wagerId ?? market.id)
+      const wagerId = market.wagerId ?? market.id
+      const result = isPasskey
+        ? await sendRegistryCall(sendCalls, chainId, 'claimRefund', [wagerId])
+        : await claimRefundRowTx.run(wagerId)
       if (result?.error) throw result.error
       // Pull fresh on-chain data so the refunded wager leaves the list and clear
       // its unread activity.
@@ -892,7 +920,7 @@ function MyMarketsModal({
     } finally {
       setRefundingId(null)
     }
-  }, [signer, isCorrectNetwork, switchNetwork, markWagerRead, refreshFriendMarkets, fireToast, claimRefundRowTx])
+  }, [signer, isPasskey, sendCalls, chainId, isCorrectNetwork, switchNetwork, markWagerRead, refreshFriendMarkets, fireToast, claimRefundRowTx])
 
   if (!isOpen) return null
 
@@ -1420,7 +1448,8 @@ function MarketDetailView({
 
   // Active chain id so explorer links resolve to the right network
   // (Polygon mainnet vs Amoy testnet) instead of a hardcoded testnet URL.
-  const { chainId } = useWeb3()
+  const { chainId, sendCalls, loginMethod } = useWeb3()
+  const isPasskey = loginMethod === 'passkey'
 
   const [withdrawing, setWithdrawing] = useState(false)
   const [withdrawError, setWithdrawError] = useState(null)
@@ -1444,7 +1473,7 @@ function MarketDetailView({
   })
 
   const handleWithdraw = async () => {
-    if (!signer) return
+    if (!isPasskey && !signer) return
 
     if (!isCorrectNetwork) {
       try {
@@ -1459,7 +1488,10 @@ function MarketDetailView({
     setWithdrawError(null)
 
     try {
-      const result = await cancelOpenTx.run(market.wagerId ?? market.id)
+      const wagerId = market.wagerId ?? market.id
+      const result = isPasskey
+        ? await sendRegistryCall(sendCalls, chainId, 'cancelOpen', [wagerId])
+        : await cancelOpenTx.run(wagerId)
       if (result?.error) throw result.error
       if (result?.txHash) {
         setWithdrawTxHash(result.txHash)
@@ -1495,7 +1527,7 @@ function MarketDetailView({
   const isParticipant = market.participants?.some(
     p => p.toLowerCase() === account?.toLowerCase()
   )
-  const showRefundButton = isParticipant && signer &&
+  const showRefundButton = isParticipant && (signer || isPasskey) &&
     status === MarketStatus.PENDING_RESOLUTION && !refundSuccess
 
   // Gasless claimRefund (spec 035/036): relayed where available, transparent self-submit otherwise.
@@ -1514,7 +1546,7 @@ function MarketDetailView({
   })
 
   const handleClaimRefund = async () => {
-    if (!signer) return
+    if (!isPasskey && !signer) return
 
     if (!isCorrectNetwork) {
       try {
@@ -1529,7 +1561,10 @@ function MarketDetailView({
     setRefundError(null)
 
     try {
-      const result = await claimRefundTx.run(market.wagerId ?? market.id)
+      const wagerId = market.wagerId ?? market.id
+      const result = isPasskey
+        ? await sendRegistryCall(sendCalls, chainId, 'claimRefund', [wagerId])
+        : await claimRefundTx.run(wagerId)
       if (result?.error) throw result.error
       if (result?.txHash) {
         setRefundTxHash(result.txHash)
@@ -1907,7 +1942,8 @@ function ResolutionModal({
   // counterparty); the second SETTLES. Detected from the WagerDrawn event below.
   const [drawSettled, setDrawSettled] = useState(false)
   // Chain-aware explorer link for the payout receipt (avoids a hardcoded testnet host).
-  const { chainId } = useWeb3()
+  const { chainId, sendCalls, loginMethod, provider } = useWeb3()
+  const isPasskey = loginMethod === 'passkey'
 
   // Canonical outcome keys preserve the on-chain mapping:
   //   outcomes[0] => creator wins, outcomes[1] => opponent wins.
@@ -2033,7 +2069,7 @@ function ResolutionModal({
       return
     }
 
-    if (!signer) {
+    if (!isPasskey && !signer) {
       setError('Please connect your wallet to resolve this wager.')
       return
     }
@@ -2048,10 +2084,12 @@ function ResolutionModal({
     setError(null)
 
     const registryAddress = getContractAddressForChain('wagerRegistry', chainId)
+    // Reads (getWager for the winner address) use the signer when present, else the session read
+    // provider — a passkey session has no signer but WalletContext exposes an RPC reader.
     const registry = new ethers.Contract(
       registryAddress,
       WAGER_REGISTRY_ABI,
-      signer
+      signer || provider
     )
 
     try {
@@ -2059,7 +2097,9 @@ function ResolutionModal({
       // first call only proposes (awaiting the counterparty); the second settles.
       // The self-submit closure inspects the WagerDrawn event to set drawSettled.
       if (isDrawSelected) {
-        const result = await declareDrawTx.run(market.id)
+        const result = isPasskey
+          ? await sendRegistryCall(sendCalls, chainId, 'declareDraw', [market.id])
+          : await declareDrawTx.run(market.id)
         if (result?.error) throw result.error
         if (result?.txHash) setTxHash(result.txHash)
         setStep('success')
@@ -2079,7 +2119,9 @@ function ResolutionModal({
         notes: resolutionNotes,
       })
 
-      const result = await declareWinnerTx.run(market.id, winner)
+      const result = isPasskey
+        ? await sendRegistryCall(sendCalls, chainId, 'declareWinner', [market.id, winner])
+        : await declareWinnerTx.run(market.id, winner)
       if (result?.error) throw result.error
       if (result?.txHash) setTxHash(result.txHash)
 

--- a/frontend/src/components/tokens/TokenDetailView.jsx
+++ b/frontend/src/components/tokens/TokenDetailView.jsx
@@ -28,7 +28,10 @@ const ROLE_LABELS = [
 ]
 
 export default function TokenDetailView({ token, onBack }) {
-  const { signer } = useWallet()
+  const { signer, sendCalls, loginMethod } = useWallet()
+  // Passkey smart-account sessions (spec 041/050) have NO ethers signer; their writes go through
+  // sendCalls (one sponsored ERC-4337 UserOp) instead of a signer-bound contract call.
+  const isPasskey = loginMethod === 'passkey'
   const { detectCapabilities, readTokenLive, reader, chainId } = useTokenFactory()
   const { showNotification } = useNotification()
 
@@ -76,9 +79,28 @@ export default function TokenDetailView({ token, onBack }) {
 
   const run = useCallback(
     async (label, fn) => {
-      if (!signer) return showNotification('Connect a wallet to administer this token.', 'warning')
+      if (!isPasskey && !signer) return showNotification('Connect a wallet to administer this token.', 'warning')
       setStatus('working')
       try {
+        // Passkey smart-account (no ethers signer): reuse the SAME `fn(c) => c.method(...)` closure the
+        // classic path uses, but hand it a populating contract so it yields the {to,data} calldata instead
+        // of sending, then route that as one sponsored ERC-4337 UserOp via sendCalls.
+        if (isPasskey) {
+          if (typeof sendCalls !== 'function') {
+            throw new Error('This wallet cannot administer tokens on the current transaction rail.')
+          }
+          const populated = await fn(populatingContract(contractFor(false)))
+          showNotification(`${label} submitted — awaiting confirmation…`, 'info')
+          await sendCalls([{
+            target: populated?.to ?? token.tokenAddress,
+            data: populated.data,
+            value: populated?.value ?? 0n,
+          }])
+          setStatus('idle')
+          showNotification(`${label} confirmed.`, 'success')
+          setRefresh((n) => n + 1)
+          return
+        }
         const tx = await fn(contractFor(true))
         showNotification(`${label} submitted — awaiting confirmation…`, 'info')
         await tx.wait()
@@ -90,7 +112,7 @@ export default function TokenDetailView({ token, onBack }) {
         showNotification(e?.shortMessage || e?.reason || e?.message || `${label} failed.`, 'error')
       }
     },
-    [signer, contractFor, showNotification]
+    [isPasskey, signer, sendCalls, contractFor, token, showNotification]
   )
 
   const tabs = useMemo(() => {
@@ -211,6 +233,22 @@ export default function TokenDetailView({ token, onBack }) {
 }
 
 // ---- helpers ----
+// Wrap a read-only (signer-less) contract so that calling a write method returns its populated
+// { to, data, value } transaction request (ethers populateTransaction) instead of trying to send it.
+// This lets the passkey rail reuse the EXACT SAME `fn(c) => c.method(...)` closures the classic signer
+// path uses, turning them into ERC-4337 batch calls without ever needing a signer to encode.
+function populatingContract(contract) {
+  return new Proxy(contract, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver)
+      if (typeof value === 'function' && typeof value.populateTransaction === 'function') {
+        return (...args) => value.populateTransaction(...args)
+      }
+      return value
+    },
+  })
+}
+
 function short(a) { return a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '' }
 function badgeClass(std) {
   if (std === TOKEN_STANDARD.OPEN_ERC721) return 'tm-badge-erc721'

--- a/frontend/src/components/tokens/useTokenFactory.js
+++ b/frontend/src/components/tokens/useTokenFactory.js
@@ -35,7 +35,10 @@ export function v1AbiForStandard(standard) {
  * honest pending/confirmed/failed state (FR-006/FR-024 — no token is surfaced before its tx confirms).
  */
 export function useTokenFactory() {
-  const { account, signer, provider, chainId, isConnected } = useWallet()
+  const { account, signer, provider, chainId, isConnected, sendCalls, loginMethod } = useWallet()
+  // Passkey smart-account sessions (spec 041/050) have NO ethers signer; their writes go through
+  // sendCalls (one sponsored ERC-4337 UserOp). loginMethod is informational — the batch rail is authoritative.
+  const isPasskey = loginMethod === 'passkey'
   // Spec 043 (US3): creating a token while operating as a vault becomes a threshold-gated vault proposal.
   const { isVault: operatingAsVault, canActAsVault, submit: submitAsActive } = useActiveAccount()
 
@@ -240,11 +243,12 @@ export function useTokenFactory() {
   const runCreate = useCallback(
     async (method, args) => {
       if (!isSupported) throw new Error('Token issuance is not available on this network.')
-      if (!signer) throw new Error('Connect a wallet to create a token.')
+      if (!isPasskey && !signer) throw new Error('Connect a wallet to create a token.')
       setStatus('creating')
       setError(null)
       setLastTxHash(null)
       try {
+        // Encoding needs no signer (interface only), so this contract is safe to build on the passkey rail.
         const factory = new ethers.Contract(factoryAddress, TOKEN_FACTORY_ABI, signer)
         // Spec 043 (US3, FR-022a): create AS a vault → propose the factory call as a threshold-gated vault
         // transaction (the Safe becomes the token issuer). Only in the vault queue until executed.
@@ -254,6 +258,24 @@ export function useTokenFactory() {
           const res = await submitAsActive({ to: factoryAddress, value: 0n, data })
           setStatus('success')
           return { proposed: true, safeTxHash: res.safeTxHash }
+        }
+        // Passkey smart-account operating personally (not as vault): route the factory call through the
+        // batched, sponsored ERC-4337 UserOp. No receipt logs come back, so the created address is resolved
+        // later by re-reading the registry — the tx hash is the honest confirmation signal here.
+        if (isPasskey) {
+          if (typeof sendCalls !== 'function') {
+            throw new Error('This wallet cannot create tokens on the current transaction rail.')
+          }
+          const call = {
+            target: factoryAddress,
+            data: factory.interface.encodeFunctionData(method, args),
+            value: 0n,
+          }
+          const sent = await sendCalls([call])
+          const txHash = sent?.txHash ?? sent?.userOpHash ?? sent?.intentId ?? null
+          setLastTxHash(txHash)
+          setStatus('success')
+          return { txHash }
         }
         const tx = await factory[method](...args)
         setLastTxHash(tx.hash)
@@ -281,7 +303,7 @@ export function useTokenFactory() {
         throw e
       }
     },
-    [isSupported, factoryAddress, signer, operatingAsVault, canActAsVault, submitAsActive]
+    [isSupported, factoryAddress, signer, isPasskey, sendCalls, operatingAsVault, canActAsVault, submitAsActive]
   )
 
   const createOpenERC20 = useCallback(

--- a/frontend/src/contexts/DexContext.jsx
+++ b/frontend/src/contexts/DexContext.jsx
@@ -23,7 +23,10 @@ const ZERO = '0x0000000000000000000000000000000000000000'
  * provider via `dexProvider` from the returned context.
  */
 export function DexProvider({ children }) {
-  const { provider, signer, address, isConnected } = useWallet()
+  const { provider, signer, address, isConnected, sendCalls, loginMethod } = useWallet()
+  // Passkey smart-account sessions (spec 041/050) have NO ethers signer — their writes go through
+  // `sendCalls(calls)` (one sponsored ERC-4337 UserOp per batch) while reads use the RPC read `provider`.
+  const isPasskey = loginMethod === 'passkey'
   // Spec 043 (US3): swapping while operating as a vault becomes a threshold-gated vault proposal.
   const { isVault: operatingAsVault, canActAsVault, identity: activeIdentity, submit: submitAsActive } = useActiveAccount()
   const wagmiChainId = useChainId()
@@ -174,15 +177,31 @@ export function DexProvider({ children }) {
   }, [isConnected, fetchBalances])
 
   const wrapNative = useCallback(async (amount) => {
-    if (!signer || !contracts) {
+    if ((!isPasskey && !signer) || !contracts) {
       throw new Error('Wallet not connected')
     }
 
     try {
       setLoading(true)
-      const wnativeWithSigner = contracts.wnative.connect(signer)
       const amountWei = ethers.parseEther(amount)
 
+      // Passkey session (no signer): wrap via one sponsored ERC-4337 UserOp — deposit() with the
+      // native amount as the call value, addressed to the WNATIVE contract.
+      if (isPasskey) {
+        if (typeof sendCalls !== 'function') {
+          throw new Error('This wallet cannot wrap on the current transaction rail.')
+        }
+        const wnativeAddress = contracts.wnative.target
+        const sent = await sendCalls([{
+          target: wnativeAddress,
+          data: contracts.wnative.interface.encodeFunctionData('deposit', []),
+          value: amountWei,
+        }])
+        await fetchBalances()
+        return sent
+      }
+
+      const wnativeWithSigner = contracts.wnative.connect(signer)
       const tx = await wnativeWithSigner.deposit({ value: amountWei })
       await tx.wait()
 
@@ -194,18 +213,34 @@ export function DexProvider({ children }) {
     } finally {
       setLoading(false)
     }
-  }, [signer, contracts, fetchBalances])
+  }, [signer, contracts, fetchBalances, isPasskey, sendCalls])
 
   const unwrapNative = useCallback(async (amount) => {
-    if (!signer || !contracts) {
+    if ((!isPasskey && !signer) || !contracts) {
       throw new Error('Wallet not connected')
     }
 
     try {
       setLoading(true)
-      const wnativeWithSigner = contracts.wnative.connect(signer)
       const amountWei = ethers.parseEther(amount)
 
+      // Passkey session (no signer): unwrap via one sponsored ERC-4337 UserOp — withdraw(amount) with
+      // zero call value, addressed to the WNATIVE contract.
+      if (isPasskey) {
+        if (typeof sendCalls !== 'function') {
+          throw new Error('This wallet cannot unwrap on the current transaction rail.')
+        }
+        const wnativeAddress = contracts.wnative.target
+        const sent = await sendCalls([{
+          target: wnativeAddress,
+          data: contracts.wnative.interface.encodeFunctionData('withdraw', [amountWei]),
+          value: 0n,
+        }])
+        await fetchBalances()
+        return sent
+      }
+
+      const wnativeWithSigner = contracts.wnative.connect(signer)
       const tx = await wnativeWithSigner.withdraw(amountWei)
       await tx.wait()
 
@@ -217,7 +252,7 @@ export function DexProvider({ children }) {
     } finally {
       setLoading(false)
     }
-  }, [signer, contracts, fetchBalances])
+  }, [signer, contracts, fetchBalances, isPasskey, sendCalls])
 
   // Decimals lookup for a token by address used in quote/swap calls below.
   // Defaults to 18 (native/wrapped) when the token isn't in our known set.
@@ -364,7 +399,7 @@ export function DexProvider({ children }) {
   }, [contracts, decimalsOf, symbolOf, chainId, slippage])
 
   const swap = useCallback(async (tokenIn, tokenOut, amountIn) => {
-    if (!signer || !contracts || !address) {
+    if ((!isPasskey && !signer) || !contracts || !address) {
       throw new Error('Wallet not connected')
     }
 
@@ -404,6 +439,44 @@ export function DexProvider({ children }) {
         return { proposed: true, safeTxHash: res.safeTxHash }
       }
 
+      // Personal passkey session (no signer): batch [approve?, exactInputSingle] into one sponsored
+      // ERC-4337 UserOp. Reads (allowance) go through the RPC read `provider`; the swap value mirrors the
+      // classic personal path, which passes NO native value to exactInputSingle (tokenIn is always an
+      // ERC20 here — the UI wraps native to WNATIVE first), so every call carries value 0n.
+      if (isPasskey) {
+        if (typeof sendCalls !== 'function') {
+          throw new Error('This wallet cannot swap on the current transaction rail.')
+        }
+        const calls = []
+        const erc20Iface = new ethers.Interface(ERC20_ABI)
+        const tokenInReader = new ethers.Contract(tokenIn, ERC20_ABI, provider)
+        const passkeyAllowance = await tokenInReader.allowance(address, addresses.SWAP_ROUTER_02)
+        if (passkeyAllowance < amountInWei) {
+          calls.push({
+            target: tokenIn,
+            data: erc20Iface.encodeFunctionData('approve', [addresses.SWAP_ROUTER_02, amountInWei]),
+            value: 0n,
+          })
+        }
+        const passkeyParams = {
+          tokenIn,
+          tokenOut,
+          fee: quote.feeTier,
+          recipient: address,
+          amountIn: amountInWei,
+          amountOutMinimum: minAmountOutWei,
+          sqrtPriceLimitX96: 0,
+        }
+        calls.push({
+          target: addresses.SWAP_ROUTER_02,
+          data: contracts.swapRouter.interface.encodeFunctionData('exactInputSingle', [passkeyParams]),
+          value: 0n,
+        })
+        const sent = await sendCalls(calls)
+        await fetchBalances()
+        return sent
+      }
+
       const tokenInContract = new ethers.Contract(tokenIn, ERC20_ABI, signer)
       const allowance = await tokenInContract.allowance(address, addresses.SWAP_ROUTER_02)
 
@@ -437,7 +510,7 @@ export function DexProvider({ children }) {
     } finally {
       setLoading(false)
     }
-  }, [signer, contracts, address, getBestQuote, fetchBalances, decimalsOf, addresses, operatingAsVault, canActAsVault, activeIdentity, submitAsActive])
+  }, [signer, contracts, address, getBestQuote, fetchBalances, decimalsOf, addresses, operatingAsVault, canActAsVault, activeIdentity, submitAsActive, isPasskey, sendCalls, provider])
 
   const value = {
     balances,

--- a/frontend/src/hooks/useCustodyVaults.js
+++ b/frontend/src/hooks/useCustodyVaults.js
@@ -35,7 +35,8 @@ async function readPolicyBadge(vaultAddress, chainId, provider) {
 }
 
 export function useCustodyVaults() {
-  const { address, chainId, signer, provider } = useWallet()
+  const { address, chainId, signer, provider, sendCalls, loginMethod } = useWallet()
+  const isPasskey = loginMethod === 'passkey'
   const [vaults, setVaults] = useState([])
   const [activeAddress, setActiveAddress] = useState(null)
   const [loading, setLoading] = useState(false)
@@ -107,16 +108,23 @@ export function useCustodyVaults() {
    * attaches a policy guard atomically at creation. */
   const createVault = useCallback(
     async ({ owners, threshold, saltNonce, label = '', policySetup }, nowMs = 0) => {
-      if (!signer) throw new Error('Connect a wallet to create a vault')
+      if (!isPasskey && !signer) throw new Error('Connect a wallet to create a vault')
       setError(null)
-      const { address: vaultAddress, txHash } = await createVaultTx({
-        signer,
-        chainId,
-        owners,
-        threshold,
-        saltNonce,
-        policySetup,
-      })
+      let vaultAddress
+      let txHash
+      if (isPasskey) {
+        // Passkey rail: send createProxyWithNonce as ONE sponsored UserOp. A UserOp receipt has no
+        // parseable ProxyCreation log, so the deterministic CREATE2 address (predictedAddress) is
+        // authoritative for the deployed vault.
+        const tx = await buildCreateVaultTx({ chainId, owners, threshold, saltNonce, policySetup, provider })
+        const sent = await sendCalls([{ target: tx.to, data: tx.data, value: tx.value ?? 0n }])
+        vaultAddress = tx.predictedAddress
+        txHash = sent?.txHash ?? sent?.userOpHash ?? sent?.intentId
+      } else {
+        const res = await createVaultTx({ signer, chainId, owners, threshold, saltNonce, policySetup })
+        vaultAddress = res.address
+        txHash = res.txHash
+      }
       upsertVaultReference(
         address,
         { chainId: Number(chainId), address: vaultAddress, label, role: 'owner' },
@@ -126,7 +134,7 @@ export function useCustodyVaults() {
       setActiveAddress(vaultAddress)
       return { address: vaultAddress, txHash }
     },
-    [signer, address, chainId, refresh],
+    [isPasskey, signer, sendCalls, provider, address, chainId, refresh],
   )
 
   /** Preview the deterministic address a new vault would deploy to (before signing, FR US1). */

--- a/frontend/src/hooks/useFriendMarketCreation.js
+++ b/frontend/src/hooks/useFriendMarketCreation.js
@@ -111,7 +111,8 @@ export const clearPendingTransaction = () => {
  *    reverts, the UI surfaces a buy-tier prompt.
  */
 export function useFriendMarketCreation({ onMarketCreated } = {}) {
-  const { signer } = useWeb3()
+  const { signer, sendCalls, loginMethod, provider, address, chainId } = useWeb3()
+  const isPasskey = loginMethod === 'passkey'
   // Spec 043 (US3): when operating as a vault, wager creation becomes a threshold-gated vault proposal.
   const { isVault: operatingAsVault, canActAsVault, submit: submitAsActive } = useActiveAccount()
 
@@ -143,7 +144,10 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
 
   const createFriendMarket = useCallback(async (data, modalSigner) => {
     const activeSigner = modalSigner || signer
-    if (!activeSigner) throw new Error('Please connect your wallet to create a wager')
+    if (!isPasskey && !activeSigner) throw new Error('Please connect your wallet to create a wager')
+    // Passkey sessions have no signer: reads and calldata encoding run over the session read provider,
+    // the write goes out as one sponsored UserOp (approve+create) via sendCalls further below.
+    const readRunner = activeSigner || provider
 
     const onProgress = data.data?.onProgress || (() => {})
     savePendingTransaction({
@@ -165,9 +169,11 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
       // signer can't report its network.
       let executionChainId
       try {
-        executionChainId = Number((await activeSigner.provider.getNetwork()).chainId)
+        executionChainId = activeSigner
+          ? Number((await activeSigner.provider.getNetwork()).chainId)
+          : chainId
       } catch {
-        executionChainId = undefined
+        executionChainId = chainId
       }
       const resolve = (name) =>
         executionChainId != null ? getContractAddressForChain(name, executionChainId) : getContractAddress(name)
@@ -186,9 +192,9 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
         throw new Error('A stake token (USDC or WMATIC) is required. Native MATIC is not supported.')
       }
 
-      const userAddress = await activeSigner.getAddress()
-      const registry = new ethers.Contract(wagerRegistryAddress, WAGER_REGISTRY_ABI, activeSigner)
-      const stakeToken = new ethers.Contract(stakeTokenAddress, ERC20_ABI, activeSigner)
+      const userAddress = activeSigner ? await activeSigner.getAddress() : address
+      const registry = new ethers.Contract(wagerRegistryAddress, WAGER_REGISTRY_ABI, readRunner)
+      const stakeToken = new ethers.Contract(stakeTokenAddress, ERC20_ABI, readRunner)
       const tokenDecimals = Number(await stakeToken.decimals())
       const tokenSymbol = await stakeToken.symbol().catch(() => 'tokens')
 
@@ -478,16 +484,49 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
         return minedReceipt
       }
 
-      // Gasless-or-self-submit send (spec 035/036). Params mirror the CreateWagerIntent struct; the
-      // creator is auto-filled from the signer. The relayer only serves EIP-3009 chains — everywhere
-      // else this transparently self-submits with identical on-chain effect.
-      const runResult = await createWagerTx.run({
-        opponent, arbitrator, stakeTokenAddress, creatorStakeWei, opponentStakeWei,
-        acceptDeadline, resolveDeadline, resolutionType, polymarketConditionId,
-        creatorIsYes, metadataHash, metadataReference,
-        termsVersionHash: termsBytes32 || ethers.ZeroHash,
-        performSelfSubmit,
-      })
+      // Passkey rail (spec 041/050): batch [approve?(exact stake), createWager] into ONE sponsored
+      // UserOp via sendCalls. Mirrors the vault batch above but self-executed (not a Safe proposal).
+      // Flows into the shared receipt/WagerCreated parsing below via a txHash-only runResult.
+      let runResult
+      if (isPasskey) {
+        if (typeof sendCalls !== 'function') {
+          throw new Error('This wallet cannot create a wager on the current transaction rail.')
+        }
+        const calls = []
+        const currentAllowance = await stakeToken.allowance(userAddress, wagerRegistryAddress)
+        if (currentAllowance < creatorStakeWei) {
+          calls.push({
+            target: stakeTokenAddress,
+            data: stakeToken.interface.encodeFunctionData('approve', [wagerRegistryAddress, creatorStakeWei]),
+            value: 0n,
+          })
+        }
+        try {
+          onProgress({ step: 'create', message: 'Validating transaction...' })
+          await registry[createMethod].staticCall(...createArgs, { from: userAddress })
+        } catch (simError) {
+          throw new Error(translateRevert(simError.reason || simError.shortMessage || simError.message || ''))
+        }
+        calls.push({
+          target: wagerRegistryAddress,
+          data: registry.interface.encodeFunctionData(createMethod, createArgs),
+          value: 0n,
+        })
+        onProgress({ step: 'create', message: 'Confirm with your passkey…' })
+        const sent = await sendCalls(calls)
+        runResult = { txHash: sent?.txHash ?? sent?.userOpHash ?? sent?.intentId, via: 'userop' }
+      } else {
+        // Gasless-or-self-submit send (spec 035/036). Params mirror the CreateWagerIntent struct; the
+        // creator is auto-filled from the signer. The relayer only serves EIP-3009 chains — everywhere
+        // else this transparently self-submits with identical on-chain effect.
+        runResult = await createWagerTx.run({
+          opponent, arbitrator, stakeTokenAddress, creatorStakeWei, opponentStakeWei,
+          acceptDeadline, resolveDeadline, resolutionType, polymarketConditionId,
+          creatorIsYes, metadataHash, metadataReference,
+          termsVersionHash: termsBytes32 || ethers.ZeroHash,
+          performSelfSubmit,
+        })
+      }
       if (runResult?.error) throw runResult.error
 
       // Only the self-submit leg guarantees a mined receipt in hand; treat a missing/failed one as a
@@ -504,8 +543,8 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
       let receipt = minedReceipt
       if (!receipt && runResult?.txHash) {
         try {
-          receipt = await activeSigner.provider.getTransactionReceipt(runResult.txHash)
-        } catch { /* relayer still landing it; wager id resolves once mined */ }
+          receipt = await (activeSigner?.provider || provider).getTransactionReceipt(runResult.txHash)
+        } catch { /* relayer/bundler still landing it; wager id resolves once mined */ }
       }
 
       // Parse WagerCreated event
@@ -568,7 +607,7 @@ export function useFriendMarketCreation({ onMarketCreated } = {}) {
       }
       throw error
     }
-  }, [signer, onMarketCreated, createWagerTx, operatingAsVault, canActAsVault, submitAsActive])
+  }, [signer, isPasskey, sendCalls, provider, address, chainId, onMarketCreated, createWagerTx, operatingAsVault, canActAsVault, submitAsActive])
 
   return { createFriendMarket, loadPendingTransaction, clearPendingTransaction }
 }

--- a/frontend/src/hooks/useVaultProposals.js
+++ b/frontend/src/hooks/useVaultProposals.js
@@ -4,7 +4,7 @@
 // once per owner on-chain (idempotent); non-owners get read-only.
 
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { Contract, getAddress } from 'ethers'
+import { Contract, Interface, getAddress } from 'ethers'
 import { useWallet } from '.'
 import { SAFE_ABI } from '../abis/Safe'
 import { getContractAddressForChain, getDeploymentBlockForChain } from '../config/contracts'
@@ -14,11 +14,20 @@ import {
   buildPrevalidatedSignatures,
   encodeExecTransaction,
 } from '../lib/custody/vaultTransaction'
-import { emitProposal, cancelProposal, readVerifiedProposals } from '../lib/custody/proposalHub'
+import {
+  emitProposal,
+  cancelProposal,
+  emitProposalCall,
+  cancelProposalCall,
+  readVerifiedProposals,
+} from '../lib/custody/proposalHub'
 import { deriveProposalStatus, isQueued, STATUS } from '../lib/custody/proposalStatus'
 
+const safeIface = new Interface(SAFE_ABI)
+
 export function useVaultProposals(vault) {
-  const { chainId, signer, provider } = useWallet()
+  const { chainId, signer, provider, sendCalls, loginMethod } = useWallet()
+  const isPasskey = loginMethod === 'passkey'
   const [proposals, setProposals] = useState([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
@@ -109,57 +118,85 @@ export function useVaultProposals(vault) {
    *  attach flow: configureRules at N, setGuard at N+1 — the chain then enforces the order). */
   const propose = useCallback(
     async ({ to, value = 0n, data = '0x', operation = 0, nonce: nonceOverride }) => {
-      if (!signer) throw new Error('Connect a wallet to propose')
+      if (!isPasskey && !signer) throw new Error('Connect a wallet to propose')
       if (!hubAddress) throw new Error('Custody proposals are not configured on this network')
-      const safe = new Contract(vaultAddress, SAFE_ABI, signer)
+      // Nonce is a read: use the signer when present, else the session read provider (passkey).
+      const safe = new Contract(vaultAddress, SAFE_ABI, signer || provider)
       const nonce = nonceOverride ?? (await safe.nonce())
       const safeTx = buildSafeTx({ to, value, data, operation, nonce })
       const safeTxHash = computeSafeTxHash(vaultAddress, chainId, safeTx)
-      await emitProposal({ hubAddress, safe: vaultAddress, safeTx, safeTxHash, signer })
-      const approveTx = await safe.approveHash(safeTxHash)
-      await approveTx.wait()
+      if (isPasskey) {
+        // Passkey rail: broadcast the preimage AND record the proposer's approval in ONE sponsored
+        // UserOp — same two on-chain effects as the classic path, batched.
+        const calls = [
+          emitProposalCall({ hubAddress, safe: vaultAddress, safeTx, safeTxHash }),
+          { target: vaultAddress, data: safeIface.encodeFunctionData('approveHash', [safeTxHash]), value: 0n },
+        ]
+        await sendCalls(calls)
+      } else {
+        await emitProposal({ hubAddress, safe: vaultAddress, safeTx, safeTxHash, signer })
+        const approveTx = await safe.approveHash(safeTxHash)
+        await approveTx.wait()
+      }
       await refresh()
       return { safeTxHash, nonce: Number(nonce) }
     },
-    [signer, vaultAddress, hubAddress, chainId, refresh],
+    [isPasskey, signer, sendCalls, provider, vaultAddress, hubAddress, chainId, refresh],
   )
 
   /** Record the connected owner's approval for a proposal (idempotent on-chain). */
   const approve = useCallback(
     async (safeTxHash) => {
-      if (!signer) throw new Error('Connect a wallet to approve')
-      const safe = new Contract(vaultAddress, SAFE_ABI, signer)
-      const tx = await safe.approveHash(safeTxHash)
-      await tx.wait()
+      if (!isPasskey && !signer) throw new Error('Connect a wallet to approve')
+      if (isPasskey) {
+        await sendCalls([
+          { target: vaultAddress, data: safeIface.encodeFunctionData('approveHash', [safeTxHash]), value: 0n },
+        ])
+      } else {
+        const safe = new Contract(vaultAddress, SAFE_ABI, signer)
+        const tx = await safe.approveHash(safeTxHash)
+        await tx.wait()
+      }
       await refresh()
     },
-    [signer, vaultAddress, refresh],
+    [isPasskey, signer, sendCalls, vaultAddress, refresh],
   )
 
   /** Execute a proposal that has reached threshold, using pre-validated (on-chain approval) signatures. */
   const execute = useCallback(
     async (proposal) => {
-      if (!signer) throw new Error('Connect a wallet to execute')
+      if (!isPasskey && !signer) throw new Error('Connect a wallet to execute')
       if (proposal.status !== STATUS.READY) throw new Error('Proposal is not ready to execute')
-      const safe = new Contract(vaultAddress, SAFE_ABI, signer)
       const signatures = buildPrevalidatedSignatures(proposal.approvers)
       const args = encodeExecTransaction(proposal.safeTx, signatures)
+      if (isPasskey) {
+        const sent = await sendCalls([
+          { target: vaultAddress, data: safeIface.encodeFunctionData('execTransaction', args), value: 0n },
+        ])
+        await refresh()
+        return { txHash: sent?.txHash ?? sent?.userOpHash ?? sent?.intentId }
+      }
+      const safe = new Contract(vaultAddress, SAFE_ABI, signer)
       const tx = await safe.execTransaction(...args)
       const receipt = await tx.wait()
       await refresh()
       return { txHash: receipt.hash }
     },
-    [signer, vaultAddress, refresh],
+    [isPasskey, signer, sendCalls, vaultAddress, refresh],
   )
 
   const cancel = useCallback(
     async (safeTxHash) => {
-      if (!signer) throw new Error('Connect a wallet to cancel')
+      if (!isPasskey && !signer) throw new Error('Connect a wallet to cancel')
       if (!hubAddress) throw new Error('Custody proposals are not configured on this network')
-      await cancelProposal({ hubAddress, safe: vaultAddress, safeTxHash, signer })
+      if (isPasskey) {
+        await sendCalls([cancelProposalCall({ hubAddress, safe: vaultAddress, safeTxHash })])
+      } else {
+        await cancelProposal({ hubAddress, safe: vaultAddress, safeTxHash, signer })
+      }
       await refresh()
     },
-    [signer, hubAddress, vaultAddress, refresh],
+    [isPasskey, signer, sendCalls, hubAddress, vaultAddress, refresh],
   )
 
   const queue = proposals.filter((p) => isQueued(p.status))

--- a/frontend/src/hooks/useVouchers.js
+++ b/frontend/src/hooks/useVouchers.js
@@ -25,7 +25,12 @@ import { useGaslessWrite } from '../lib/relay/useGaslessWrite'
  * network, {voucherAvailable} is false and the UI surfaces that honestly rather than implying it works.
  */
 export function useVouchers() {
-  const { account, signer, provider, chainId } = useWallet()
+  const { account, signer, provider, chainId, sendCalls, loginMethod } = useWallet()
+  // Passkey smart-account sessions have no ethers signer (spec 041): their writes go through
+  // WalletContext.sendCalls (one sponsored ERC-4337 UserOp, approve+action batched), exactly like
+  // the transfer/earn/pool surfaces. Reads use the session read `provider` (a live RPC reader for
+  // passkey on supported chains). Classic wallets keep the signer path unchanged.
+  const isPasskey = loginMethod === 'passkey'
   const [status, setStatus] = useState('idle') // idle | minting | redeeming | transferring | listing | success | error
   const [error, setError] = useState(null)
   const [lastTxHash, setLastTxHash] = useState(null)
@@ -64,7 +69,7 @@ export function useVouchers() {
    */
   const mintVouchers = useCallback(
     async (roleHash, tierId, quantity = 1, recipient = '') => {
-      if (!signer) throw new Error('Connect a wallet to buy a voucher.')
+      if (!isPasskey && !signer) throw new Error('Connect a wallet to buy a voucher.')
       if (!voucherAvailable) throw new Error('Membership vouchers are not available on this network yet.')
 
       const qty = Math.max(1, Math.floor(Number(quantity) || 1))
@@ -77,6 +82,39 @@ export function useVouchers() {
       setError(null)
       setLastTxHash(null)
       try {
+        if (isPasskey) {
+          // Passkey rail: batch approve (only if the allowance is short) + the mint into ONE
+          // sponsored UserOp. Reads over the session read provider; encoding needs no signer.
+          if (needsHelper && !batchMintAvailable) {
+            throw new Error('Buying multiple vouchers or gifting isn’t available on this network yet.')
+          }
+          const manager = new ethers.Contract(managerAddress, MEMBERSHIP_MANAGER_ABI, provider)
+          const cfg = await manager.getTierConfig(roleHash, tierId)
+          if (!cfg.active) throw new Error('That tier is not available for purchase.')
+          const price = cfg.priceUSDC
+          const spender = needsHelper ? batchMinterAddress : voucherAddress
+          const amount = needsHelper ? price * BigInt(qty) : price
+          const token = new ethers.Contract(paymentTokenAddress, ERC20_ABI, provider)
+          const allowance = await token.allowance(account, spender)
+          const calls = []
+          if (allowance < amount) {
+            calls.push({ target: paymentTokenAddress, data: token.interface.encodeFunctionData('approve', [spender, amount]), value: 0n })
+          }
+          if (needsHelper) {
+            const minter = new ethers.Contract(batchMinterAddress, VOUCHER_BATCH_MINTER_ABI, provider)
+            calls.push({ target: batchMinterAddress, data: minter.interface.encodeFunctionData('mintBatch', [roleHash, tierId, qty, to]), value: 0n })
+          } else {
+            const voucher = new ethers.Contract(voucherAddress, MEMBERSHIP_VOUCHER_ABI, provider)
+            calls.push({ target: voucherAddress, data: voucher.interface.encodeFunctionData('mint', [roleHash, tierId]), value: 0n })
+          }
+          const res = await sendCalls(calls)
+          const txHash = res?.txHash ?? res?.userOpHash ?? null
+          setLastTxHash(txHash)
+          setStatus('success')
+          // tokenId isn't parsed from a UserOp receipt; the holdings refresh reads it back on-chain.
+          return { count: qty, recipient: to, gift: isGift, tokenId: needsHelper ? undefined : null, txHash }
+        }
+
         const manager = new ethers.Contract(managerAddress, MEMBERSHIP_MANAGER_ABI, signer)
         const cfg = await manager.getTierConfig(roleHash, tierId)
         if (!cfg.active) throw new Error('That tier is not available for purchase.')
@@ -132,7 +170,7 @@ export function useVouchers() {
         throw e
       }
     },
-    [signer, account, voucherAvailable, batchMintAvailable, voucherAddress, managerAddress, batchMinterAddress, paymentTokenAddress]
+    [isPasskey, provider, sendCalls, signer, account, voucherAvailable, batchMintAvailable, voucherAddress, managerAddress, batchMinterAddress, paymentTokenAddress]
   )
 
   /**
@@ -142,7 +180,7 @@ export function useVouchers() {
    */
   const transferVoucher = useCallback(
     async (tokenId, to) => {
-      if (!signer) throw new Error('Connect a wallet to transfer a voucher.')
+      if (!isPasskey && !signer) throw new Error('Connect a wallet to transfer a voucher.')
       if (!voucherAvailable) throw new Error('Membership vouchers are not available on this network yet.')
       const dest = (to || '').trim()
       if (!ethers.isAddress(dest)) throw new Error('Enter a valid recipient address.')
@@ -153,9 +191,19 @@ export function useVouchers() {
       setError(null)
       setLastTxHash(null)
       try {
-        const voucher = new ethers.Contract(voucherAddress, MEMBERSHIP_VOUCHER_ABI, signer)
         // The voucher overloads safeTransferFrom; pick the 3-arg (no data) form explicitly.
-        const tx = await voucher['safeTransferFrom(address,address,uint256)'](account, dest, tokenId)
+        const SIG = 'safeTransferFrom(address,address,uint256)'
+        if (isPasskey) {
+          const iface = new ethers.Interface(MEMBERSHIP_VOUCHER_ABI)
+          const data = iface.encodeFunctionData(SIG, [account, dest, tokenId])
+          const res = await sendCalls([{ target: voucherAddress, data, value: 0n }])
+          const txHash = res?.txHash ?? res?.userOpHash ?? null
+          setLastTxHash(txHash)
+          setStatus('success')
+          return { tokenId, to: dest, txHash }
+        }
+        const voucher = new ethers.Contract(voucherAddress, MEMBERSHIP_VOUCHER_ABI, signer)
+        const tx = await voucher[SIG](account, dest, tokenId)
         setLastTxHash(tx.hash)
         await tx.wait()
         setStatus('success')
@@ -166,18 +214,29 @@ export function useVouchers() {
         throw e
       }
     },
-    [signer, account, voucherAvailable, voucherAddress]
+    [isPasskey, sendCalls, signer, account, voucherAvailable, voucherAddress]
   )
 
   /** Redeem voucher `tokenId` into a soulbound membership for the connected wallet. `termsHash` may be 0x0. */
   const redeemVoucher = useCallback(
     async (tokenId, termsHash) => {
-      if (!signer) throw new Error('Connect a wallet to redeem.')
+      if (!isPasskey && !signer) throw new Error('Connect a wallet to redeem.')
       if (!voucherAvailable) throw new Error('Membership vouchers are not available on this network yet.')
       setStatus('redeeming')
       setError(null)
       setLastTxHash(null)
       try {
+        if (isPasskey) {
+          // Passkey rail: redeemVoucher as one sponsored UserOp (the 035 relay/intent path is
+          // signer-only). The redeemer is the smart account — the connected passkey session.
+          const iface = new ethers.Interface(MEMBERSHIP_MANAGER_ABI)
+          const data = iface.encodeFunctionData('redeemVoucher', [tokenId, termsHash || ethers.ZeroHash])
+          const res = await sendCalls([{ target: managerAddress, data, value: 0n }])
+          const txHash = res?.txHash ?? res?.userOpHash ?? null
+          setLastTxHash(txHash)
+          setStatus('success')
+          return { txHash }
+        }
         const result = await voucherTx.run(tokenId, termsHash)
         if (result?.error) throw result.error
         setLastTxHash(result.txHash || lastTxHash)
@@ -189,7 +248,7 @@ export function useVouchers() {
         throw e
       }
     },
-    [signer, voucherAvailable, voucherTx, lastTxHash]
+    [isPasskey, sendCalls, managerAddress, signer, voucherAvailable, voucherTx, lastTxHash]
   )
 
   /**

--- a/frontend/src/lib/custody/proposalHub.js
+++ b/frontend/src/lib/custody/proposalHub.js
@@ -29,6 +29,35 @@ export async function cancelProposal({ hubAddress, safe, safeTxHash, signer }) {
   return hub.cancel(getAddress(safe), safeTxHash)
 }
 
+/**
+ * Pure calldata for `hub.propose(...)` — a `{target,data,value}` call for the passkey rail (sendCalls).
+ * Byte-identical to what `emitProposal` sends, minus the signer/broadcast.
+ */
+export function emitProposalCall({ hubAddress, safe, safeTx, safeTxHash }) {
+  return {
+    target: getAddress(hubAddress),
+    data: hubIface.encodeFunctionData('propose', [
+      getAddress(safe),
+      safeTx.to,
+      safeTx.value,
+      safeTx.data,
+      safeTx.operation,
+      safeTx.nonce,
+      safeTxHash,
+    ]),
+    value: 0n,
+  }
+}
+
+/** Pure calldata for `hub.cancel(...)` — a `{target,data,value}` call for the passkey rail (sendCalls). */
+export function cancelProposalCall({ hubAddress, safe, safeTxHash }) {
+  return {
+    target: getAddress(hubAddress),
+    data: hubIface.encodeFunctionData('cancel', [getAddress(safe), safeTxHash]),
+    value: 0n,
+  }
+}
+
 /** Reconstruct a full SafeTx + metadata from decoded `Proposed` event args. Pure. */
 export function reconstructProposal(args) {
   const safeTx = buildSafeTx({

--- a/frontend/src/test/useVouchers.passkey.test.jsx
+++ b/frontend/src/test/useVouchers.passkey.test.jsx
@@ -1,0 +1,103 @@
+/**
+ * useVouchers — passkey rail (spec 041/050). A passkey smart-account session has no ethers signer,
+ * so buy/gift/redeem/transfer must route through WalletContext.sendCalls (one sponsored UserOp,
+ * approve+action batched) instead of throwing "Connect a wallet". Reads use the session read provider.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+vi.mock('../hooks/useWalletManagement', () => ({ useWallet: vi.fn() }))
+vi.mock('../config/contracts', () => ({
+  getContractAddressForChain: vi.fn(
+    (key) =>
+      ({
+        membershipVoucher: '0x' + 'a1'.repeat(20),
+        membershipManager: '0x' + 'b2'.repeat(20),
+        voucherBatchMinter: '0x' + 'c3'.repeat(20),
+        paymentToken: '0x' + 'd4'.repeat(20),
+      }[key] ?? null)
+  ),
+  getDeploymentBlockForChain: vi.fn(() => 0),
+}))
+// The redeem gasless seam is signer-only; stub it so the passkey branch (which bypasses it) is isolated.
+vi.mock('../lib/relay/useGaslessWrite', () => ({ useGaslessWrite: () => ({ run: vi.fn() }) }))
+
+// Mock only ethers.Contract reads; keep Interface/isAddress/ZeroHash real so calldata is genuinely
+// encoded. A real `function` (not an arrow) so `new ethers.Contract(...)` constructs, and `.interface`
+// is a real Interface for encodeFunctionData.
+vi.mock('ethers', async () => {
+  const actual = await vi.importActual('ethers')
+  const RealInterface = actual.ethers.Interface
+  function FakeContract(_addr, abi) {
+    this.getTierConfig = vi.fn().mockResolvedValue({ active: true, priceUSDC: 1_000000n })
+    this.allowance = vi.fn().mockResolvedValue(0n)
+    this.interface = new RealInterface(abi)
+  }
+  return { ...actual, ethers: { ...actual.ethers, Contract: FakeContract } }
+})
+
+import { useWallet } from '../hooks/useWalletManagement'
+import { useVouchers } from '../hooks/useVouchers'
+
+const MANAGER = '0x' + 'b2'.repeat(20)
+const VOUCHER = '0x' + 'a1'.repeat(20)
+const MINTER = '0x' + 'c3'.repeat(20)
+const TOKEN = '0x' + 'd4'.repeat(20)
+const ACCOUNT = '0x' + '11'.repeat(20)
+const OTHER = '0x' + '22'.repeat(20)
+const ROLE = '0x' + '00'.repeat(31) + '01'
+
+function passkeyWallet(sendCalls) {
+  return { account: ACCOUNT, signer: null, provider: {}, chainId: 137, sendCalls, loginMethod: 'passkey' }
+}
+
+describe('useVouchers passkey rail (sendCalls, no signer)', () => {
+  let sendCalls
+  beforeEach(() => {
+    sendCalls = vi.fn().mockResolvedValue({ txHash: '0xdead', sponsored: true })
+    useWallet.mockReturnValue(passkeyWallet(sendCalls))
+  })
+
+  it('buy one for yourself → sendCalls([approve, mint]); never "Connect a wallet"', async () => {
+    const { result } = renderHook(() => useVouchers())
+    let res
+    await act(async () => {
+      res = await result.current.mintVouchers(ROLE, 1, 1, '')
+    })
+    expect(sendCalls).toHaveBeenCalledTimes(1)
+    const calls = sendCalls.mock.calls[0][0]
+    expect(calls).toHaveLength(2)
+    expect(calls[0].target).toBe(TOKEN) // approve
+    expect(calls[1].target).toBe(VOUCHER) // mint on the immutable voucher
+    expect(res.txHash).toBe('0xdead')
+    expect(res.gift).toBe(false)
+  })
+
+  it('gift / quantity>1 → sendCalls([approve(minter), mintBatch])', async () => {
+    const { result } = renderHook(() => useVouchers())
+    await act(async () => {
+      await result.current.mintVouchers(ROLE, 1, 2, OTHER)
+    })
+    const calls = sendCalls.mock.calls[0][0]
+    expect(calls[0].target).toBe(TOKEN) // approve the batch minter
+    expect(calls[1].target).toBe(MINTER) // mintBatch
+  })
+
+  it('redeem → sendCalls([redeemVoucher on the manager])', async () => {
+    const { result } = renderHook(() => useVouchers())
+    await act(async () => {
+      await result.current.redeemVoucher('7', undefined)
+    })
+    expect(sendCalls).toHaveBeenCalledTimes(1)
+    expect(sendCalls.mock.calls[0][0][0].target).toBe(MANAGER)
+  })
+
+  it('transfer → sendCalls([safeTransferFrom on the voucher])', async () => {
+    const { result } = renderHook(() => useVouchers())
+    await act(async () => {
+      await result.current.transferVoucher('7', OTHER)
+    })
+    expect(sendCalls).toHaveBeenCalledTimes(1)
+    expect(sendCalls.mock.calls[0][0][0].target).toBe(VOUCHER)
+  })
+})


### PR DESCRIPTION
## What & why

After the passkey UserOp factory fix (#872) made gasless **transfers** work, a broad audit found the same class of bug across most write surfaces: they implemented only the **classic-EOA rail** (`useGaslessWrite` / `submitAsActive` / raw `signer`) and hard-rejected passkey smart-account sessions with `if(!signer) throw`/silent no-op. This PR extends the proven transfer/pool pattern to **every user-facing signing surface**.

**The pattern (additive everywhere):** passkey (`loginMethod === 'passkey'`, no `signer`) → build `{target,data,value}` calls → `WalletContext.sendCalls` (one sponsored ERC-4337 UserOp, `approve`+action batched). Classic + vault (`submitAsActive`) paths are untouched; `if(!signer)` guards relax to `!isPasskey && !signer`; reads use the WalletContext read provider (a live RPC reader for passkey).

## Surfaces fixed

| Area | Surfaces |
|---|---|
| **Membership vouchers** | `useVouchers` buy / gift / redeem / transfer (was the reported "buy a voucher" failure) |
| **Wagers** | `MyMarketsModal` claim payout, claim refund (×2), withdraw offer, clear-expired reclaim, declare draw/winner; `MarketAcceptanceModal` accept + decline; `useFriendMarketCreation` create |
| **Tokens** | `useTokenFactory` create; `TokenDetailView` all admin writes (mint/burn/pause/transfer/roles/compliance); `DistributePanel` (via parent) |
| **Swap** | `DexContext` swap / wrap / unwrap |
| **DAO** | `ExternalDaoView` vote/queue/execute; `ProposalBuilder` propose; `useClearPath` register (connectors gain a `propose` encoder) |
| **Custody** | `useVaultProposals` propose/approve/execute/cancel; `useCustodyVaults` createVault (all raw ethers → sendCalls; createVault uses the deterministic CREATE2 address) |

Notable techniques: a shared `sendRegistryCall` helper for wagers; a `populateTransaction` Proxy in `TokenDetailView` that reuses the existing `fn(c)=>c.method()` closures as calldata (no signer/RPC — verified against ethers v6); custody's propose batches `emitProposal`+`approveHash` into one UserOp.

## Already correct (no change)
`useTransfer`, `usePools`, `useOpenChallenge*`, `VaultSheet` (Morpho deposit), `useEarnRewards`, `PremiumPurchaseModal` (direct membership purchase), `ControllersPanel`, `useEncryption` already handle both rails. **The Morpho deposit + direct membership purchase are passkey-correct in code** — if they still fail at runtime it's a 2-call sponsored-batch issue to diagnose from the actual error, not a missing branch.

## Out of scope (flagged, not silently converted)
- **Admin** (AdminPanel / DenyList / Oracle / Nullifier / Treasury) — EOA-operator surfaces by design.
- **Off-chain `signMessage`-derived flows** (recovery codes, encrypted backups, address-book backup) — a fundamentally different problem for passkey (no `signMessage` equivalent), needs its own design.

## Testing
Every locally-runnable suite passes: vouchers (+ new `useVouchers.passkey` test), tokens, MarketAcceptanceModal/FriendMarkets, all clearpath (DAO) and custody suites. Clearpath component tests gained a `useWallet` mock (the components now read the rail from it). Lint clean across all changed files. Three files (`MyMarketsModal`, `DexContext`, `FriendMarketsModal` test files) can't load locally due to a missing CI-only dep (`@uniswap/sdk-core`) — pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)