### PR TITLE
Trade screen redesign: brokerage-style ticket with account selection, price/order types, passkey + gasless rails

### DIFF
--- a/frontend/src/components/fairwins/TradePanel.css
+++ b/frontend/src/components/fairwins/TradePanel.css
@@ -1,14 +1,27 @@
 /* Trade panel — a compact, professional order-ticket for on-chain swaps.
-   Colors come from the app theme tokens so it tracks light/dark automatically. */
+   All colors alias the app theme tokens (theme.css) so the panel tracks
+   light/dark automatically, the same way Portfolio and Earn do. */
 
 .trade-panel {
+  --trade-surface: var(--surface-color, #ffffff);
+  --trade-surface-2: var(--bg-secondary, #f5f6f8);
+  --trade-text: var(--text-primary, #111827);
+  --trade-text-2: var(--text-secondary, #6b7280);
+  --trade-text-3: var(--text-muted, #9ca3af);
+  --trade-border: var(--border-color, #e5e7eb);
+  --trade-accent: var(--brand-primary, #36b37e);
+  --trade-accent-hover: var(--primary-button-hover, var(--brand-secondary, #2e9e6b));
+  --trade-success: var(--success-color, #48bb78);
+  --trade-warning: var(--warning-color, #d69e2e);
+  --trade-danger: var(--danger-color, #e5533d);
+
   max-width: 480px;
   margin: 1.5rem auto;
   padding: 1.25rem;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
+  background: var(--trade-surface);
+  border: 1px solid var(--trade-border);
   border-radius: 16px;
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--shadow-md, 0 8px 28px rgba(0, 0, 0, 0.06));
 }
 
 /* Header */
@@ -28,7 +41,7 @@
   font-size: 1.4rem;
   font-weight: 700;
   letter-spacing: -0.01em;
-  color: var(--color-text);
+  color: var(--trade-text);
 }
 
 .trade-venue {
@@ -36,9 +49,9 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--color-text-secondary);
-  background: var(--color-surface-secondary);
-  border: 1px solid var(--color-border);
+  color: var(--trade-text-2);
+  background: var(--trade-surface-2);
+  border: 1px solid var(--trade-border);
   border-radius: 999px;
   padding: 0.2rem 0.6rem;
 }
@@ -46,15 +59,106 @@
 .trade-subtitle {
   margin: 0.35rem 0 0;
   font-size: 0.82rem;
-  color: var(--color-text-secondary);
+  color: var(--trade-text-2);
 }
 
 /* Empty / disconnected states */
 .trade-empty {
   padding: 2rem 1rem;
   text-align: center;
-  color: var(--color-text-secondary);
+  color: var(--trade-text-2);
   font-size: 0.9rem;
+}
+
+/* Account block — whose money the ticket trades */
+.trade-account {
+  margin-bottom: 1rem;
+  padding: 0.85rem 0.95rem;
+  background: var(--trade-surface-2);
+  border: 1px solid var(--trade-border);
+  border-radius: 12px;
+}
+
+.trade-account-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.45rem;
+}
+
+.trade-account-select {
+  width: 100%;
+  padding: 0.5rem 0.6rem;
+  background: var(--trade-surface);
+  border: 1px solid var(--trade-border);
+  border-radius: 9px;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--trade-text);
+  cursor: pointer;
+}
+
+.trade-account-rows {
+  margin: 0.65rem 0 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.trade-account-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.4rem 0;
+  border-bottom: 1px solid var(--trade-border);
+}
+
+.trade-account-row:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.trade-account-row dt {
+  font-size: 0.8rem;
+  color: var(--trade-text-2);
+}
+
+.trade-account-row dd {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--trade-text);
+}
+
+.trade-account-note {
+  margin: 0.6rem 0 0;
+  font-size: 0.76rem;
+  color: var(--trade-text-2);
+}
+
+/* Session/fee badges */
+.trade-badge {
+  flex-shrink: 0;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid var(--trade-border);
+  color: var(--trade-text-2);
+  background: var(--trade-surface);
+}
+
+.trade-badge-gasless {
+  color: var(--trade-success);
+  border-color: var(--trade-success);
+}
+
+.trade-badge-proposal {
+  color: var(--trade-accent);
+  border-color: var(--trade-accent);
 }
 
 /* Mode selector (segmented control) */
@@ -62,10 +166,10 @@
   display: flex;
   gap: 0.25rem;
   margin-bottom: 1rem;
-  background: var(--color-surface-secondary);
+  background: var(--trade-surface-2);
   padding: 0.25rem;
   border-radius: 10px;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--trade-border);
 }
 
 .trade-mode-btn {
@@ -77,18 +181,74 @@
   cursor: pointer;
   font-size: 0.85rem;
   font-weight: 600;
-  color: var(--color-text-secondary);
+  color: var(--trade-text-2);
   transition: background 0.15s, color 0.15s;
 }
 
 .trade-mode-btn:hover {
-  color: var(--color-text);
+  color: var(--trade-text);
 }
 
 .trade-mode-btn.active {
-  background: var(--color-surface);
-  color: var(--color-text);
+  background: var(--trade-surface);
+  color: var(--trade-text);
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+/* Order controls grid (order type / price type / limit price / term) */
+.trade-order-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem 0.9rem;
+  margin-bottom: 0.85rem;
+}
+
+.trade-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
+.trade-field-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--trade-text-2);
+}
+
+.trade-field-select,
+.trade-field-input {
+  width: 100%;
+  padding: 0.5rem 0.6rem;
+  background: var(--trade-surface-2);
+  border: 1px solid var(--trade-border);
+  border-radius: 9px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--trade-text);
+}
+
+.trade-field-select {
+  cursor: pointer;
+}
+
+.trade-field-input:focus,
+.trade-field-select:focus,
+.trade-account-select:focus {
+  outline: none;
+  border-color: var(--trade-accent);
+}
+
+.trade-field-static {
+  padding: 0.5rem 0.1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--trade-text);
 }
 
 /* Order ticket legs */
@@ -100,14 +260,14 @@
 
 .trade-leg {
   padding: 0.85rem 0.95rem;
-  background: var(--color-surface-secondary);
-  border: 1px solid var(--color-border);
+  background: var(--trade-surface-2);
+  border: 1px solid var(--trade-border);
   border-radius: 12px;
   transition: border-color 0.15s;
 }
 
 .trade-leg:focus-within {
-  border-color: var(--color-primary);
+  border-color: var(--trade-accent);
 }
 
 .trade-leg-top {
@@ -122,12 +282,12 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--color-text-secondary);
+  color: var(--trade-text-2);
 }
 
 .trade-balance {
   font-size: 0.75rem;
-  color: var(--color-text-tertiary, var(--color-text-secondary));
+  color: var(--trade-text-3);
 }
 
 .trade-leg-body {
@@ -143,7 +303,7 @@
   font-size: 1.5rem;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
-  color: var(--color-text);
+  color: var(--trade-text);
   border: none;
   background: transparent;
   padding: 0;
@@ -154,7 +314,7 @@
 }
 
 .trade-amount-input::placeholder {
-  color: var(--color-text-tertiary, var(--color-text-secondary));
+  color: var(--trade-text-3);
 }
 
 .trade-receive-value {
@@ -168,12 +328,12 @@
 .trade-token-static {
   flex-shrink: 0;
   padding: 0.4rem 0.7rem;
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
+  background: var(--trade-surface);
+  border: 1px solid var(--trade-border);
   border-radius: 999px;
   font-weight: 700;
   font-size: 0.85rem;
-  color: var(--color-text);
+  color: var(--trade-text);
 }
 
 .trade-token-select {
@@ -184,8 +344,8 @@
   flex-shrink: 0;
   padding: 0.35rem 0.6rem;
   background: transparent;
-  color: var(--color-primary);
-  border: 1px solid var(--color-border);
+  color: var(--trade-accent);
+  border: 1px solid var(--trade-border);
   border-radius: 7px;
   font-size: 0.68rem;
   font-weight: 700;
@@ -195,8 +355,8 @@
 }
 
 .trade-max-btn:hover {
-  background: var(--color-surface);
-  border-color: var(--color-primary);
+  background: var(--trade-surface);
+  border-color: var(--trade-accent);
 }
 
 /* Switch direction control, overlapping the two legs */
@@ -216,13 +376,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--color-surface);
-  border: 3px solid var(--color-surface);
-  outline: 1px solid var(--color-border);
+  background: var(--trade-surface);
+  border: 3px solid var(--trade-surface);
+  outline: 1px solid var(--trade-border);
   border-radius: 10px;
   font-size: 0.9rem;
   font-weight: 700;
-  color: var(--color-text);
+  color: var(--trade-text);
 }
 
 .trade-switch-btn {
@@ -231,16 +391,16 @@
 }
 
 .trade-switch-btn:hover {
-  color: var(--color-primary);
-  outline-color: var(--color-primary);
+  color: var(--trade-accent);
+  outline-color: var(--trade-accent);
 }
 
 /* Summary read-out */
 .trade-summary {
   margin-top: 0.85rem;
   padding: 0.5rem 0.85rem;
-  background: var(--color-surface-secondary);
-  border: 1px solid var(--color-border);
+  background: var(--trade-surface-2);
+  border: 1px solid var(--trade-border);
   border-radius: 12px;
   display: flex;
   flex-direction: column;
@@ -253,7 +413,7 @@
   gap: 0.75rem;
   padding: 0.4rem 0;
   font-size: 0.8rem;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--trade-border);
 }
 
 .trade-summary-row:last-child {
@@ -261,17 +421,17 @@
 }
 
 .trade-summary-key {
-  color: var(--color-text-secondary);
+  color: var(--trade-text-2);
   font-weight: 500;
 }
 
 .trade-summary-note {
-  color: var(--color-text-tertiary, var(--color-text-secondary));
+  color: var(--trade-text-3);
   font-weight: 400;
 }
 
 .trade-summary-val {
-  color: var(--color-text);
+  color: var(--trade-text);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   text-align: right;
@@ -281,13 +441,13 @@ button.trade-rate {
   width: 100%;
   background: transparent;
   border: none;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--trade-border);
   cursor: pointer;
   font: inherit;
 }
 
 button.trade-rate .trade-summary-val {
-  color: var(--color-primary);
+  color: var(--trade-accent);
 }
 
 .trade-route {
@@ -299,35 +459,35 @@ button.trade-rate .trade-summary-val {
 .trade-route-fee {
   font-size: 0.68rem;
   font-weight: 600;
-  color: var(--color-text-secondary);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
+  color: var(--trade-text-2);
+  background: var(--trade-surface);
+  border: 1px solid var(--trade-border);
   border-radius: 999px;
   padding: 0.1rem 0.45rem;
 }
 
 /* Price-impact coloring */
 .impact-low {
-  color: var(--color-success, #48bb78);
+  color: var(--trade-success);
 }
 .impact-warn {
-  color: var(--color-warning, #d69e2e);
+  color: var(--trade-warning);
 }
 .impact-high {
-  color: var(--color-error, #e5533d);
+  color: var(--trade-danger);
 }
 .impact-unknown {
-  color: var(--color-text-secondary);
+  color: var(--trade-text-2);
 }
 
 .trade-slippage-select {
   padding: 0.3rem 0.5rem;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--trade-border);
   border-radius: 7px;
-  background: var(--color-surface);
+  background: var(--trade-surface);
   cursor: pointer;
   font-size: 0.8rem;
-  color: var(--color-text);
+  color: var(--trade-text);
 }
 
 .trade-impact-warning {
@@ -335,9 +495,9 @@ button.trade-rate .trade-summary-val {
   padding: 0.6rem 0.8rem;
   font-size: 0.78rem;
   border-radius: 9px;
-  background: var(--color-error-bg, rgba(229, 83, 61, 0.1));
-  color: var(--color-error, #e5533d);
-  border: 1px solid var(--color-error, #e5533d);
+  background: color-mix(in srgb, var(--trade-danger) 10%, transparent);
+  color: var(--trade-danger);
+  border: 1px solid var(--trade-danger);
 }
 
 /* Execute */
@@ -345,7 +505,7 @@ button.trade-rate .trade-summary-val {
   width: 100%;
   margin-top: 0.85rem;
   padding: 0.95rem;
-  background: var(--color-primary);
+  background: var(--trade-accent);
   color: var(--primary-button-text, #ffffff);
   border: none;
   border-radius: 12px;
@@ -356,16 +516,24 @@ button.trade-rate .trade-summary-val {
 }
 
 .trade-execute-btn:hover:not(:disabled) {
-  background: var(--color-primary-dark);
+  background: var(--trade-accent-hover);
   transform: translateY(-1px);
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.1);
 }
 
 .trade-execute-btn:disabled {
-  background: var(--color-border);
-  color: var(--color-text-secondary);
+  background: var(--trade-border);
+  color: var(--trade-text-2);
   cursor: not-allowed;
   opacity: 0.7;
+}
+
+/* Session note under the execute button (passkey ceremony + sponsorship) */
+.trade-session-note {
+  margin: 0.6rem 0 0;
+  font-size: 0.76rem;
+  color: var(--trade-text-2);
+  text-align: center;
 }
 
 /* Messages */
@@ -378,22 +546,22 @@ button.trade-rate .trade-summary-val {
 }
 
 .trade-error {
-  background: var(--color-error-bg, rgba(229, 83, 61, 0.1));
-  color: var(--color-error, #e5533d);
-  border-color: var(--color-error, #e5533d);
+  background: color-mix(in srgb, var(--trade-danger) 10%, transparent);
+  color: var(--trade-danger);
+  border-color: var(--trade-danger);
 }
 
 .trade-success {
-  background: var(--color-success-bg, rgba(72, 187, 120, 0.1));
-  color: var(--color-success, #48bb78);
-  border-color: var(--color-success, #48bb78);
+  background: color-mix(in srgb, var(--trade-success) 10%, transparent);
+  color: var(--trade-success);
+  border-color: var(--trade-success);
 }
 
 /* Footer — subtle attribution + venue links */
 .trade-footer {
   margin-top: 1.1rem;
   padding-top: 0.85rem;
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--trade-border);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -407,15 +575,15 @@ button.trade-rate .trade-summary-val {
   gap: 0.4rem;
   font-size: 0.72rem;
   font-weight: 500;
-  color: var(--color-text-secondary);
+  color: var(--trade-text-2);
 }
 
 .trade-attribution-dot {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: var(--color-primary);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 20%, transparent);
+  background: var(--trade-accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--trade-accent) 20%, transparent);
 }
 
 .trade-links {
@@ -426,7 +594,7 @@ button.trade-rate .trade-summary-val {
 .trade-link {
   font-size: 0.72rem;
   font-weight: 600;
-  color: var(--color-primary);
+  color: var(--trade-accent);
   text-decoration: none;
 }
 
@@ -439,6 +607,10 @@ button.trade-rate .trade-summary-val {
   .trade-panel {
     margin: 1rem;
     padding: 1rem;
+  }
+
+  .trade-order-grid {
+    grid-template-columns: 1fr;
   }
 
   .trade-amount-input,

--- a/frontend/src/components/fairwins/TradePanel.jsx
+++ b/frontend/src/components/fairwins/TradePanel.jsx
@@ -1,10 +1,21 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { parseUnits } from 'ethers'
 import { useDex } from '../../hooks/useDex'
-import { SLIPPAGE_OPTIONS, getExplorerUrl } from '../../constants/dex'
+import {
+  SLIPPAGE_OPTIONS,
+  PRICE_TYPES,
+  SPOT_ORDER_TYPES,
+  PERPS_ORDER_TYPES,
+  getPerpsVenue,
+  getExplorerUrl,
+} from '../../constants/dex'
 import { feeTierLabel } from '../../lib/uniswap/trade'
 import { useWallet } from '../../hooks'
 import { useChainTokens } from '../../hooks/useChainTokens'
+import { useActiveAccount } from '../../hooks/useActiveAccount'
+import { useCustodyVaults } from '../../hooks/useCustodyVaults'
 import SensitiveValue from '../common/SensitiveValue'
+import InfoTip from '../ui/InfoTip'
 import './TradePanel.css'
 
 const FROM_NATIVE = 'NATIVE'
@@ -23,6 +34,12 @@ function impactSeverity(pct) {
   return 'low'
 }
 
+const shortAddress = (addr) =>
+  addr && addr.length > 10 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr || ''
+
+const fmtBalance = (value) =>
+  Number(value || 0).toLocaleString(undefined, { maximumSignificantDigits: 8 })
+
 function TradePanel() {
   const {
     balances,
@@ -35,13 +52,31 @@ function TradePanel() {
     slippage,
     setSlippage,
     addresses,
+    tokens,
     isDexAvailable,
     dexProvider,
     network,
   } = useDex()
 
-  const { isConnected, chainId } = useWallet()
+  const { isConnected, chainId, address, loginMethod } = useWallet()
   const { native: nativeSymbol, stable: stableSymbol } = useChainTokens()
+
+  // Account selection (spec 043): trade as the personal wallet or as one of the
+  // member's saved multisig vaults. Selecting a vault turns every order into a
+  // threshold-gated proposal; balances shown below always follow the selection.
+  const { identity, isVault, operateAsVault, operateAsPersonal } = useActiveAccount()
+  const { vaults } = useCustodyVaults()
+
+  // Session rails: passkey accounts transact through their smart account —
+  // gasless (FairWins-sponsored) where the network has a sponsor paymaster
+  // (spec 050), self-funded otherwise. Classic wallets pay network fees.
+  const isPasskey = loginMethod === 'passkey'
+  const passkeyReady = !isPasskey || Boolean(network?.passkey)
+  const passkeySponsored = isPasskey && Boolean(network?.passkey?.sponsorPaymasterUrl)
+
+  // Perpetuals order types only exist where the network has a perps venue.
+  // No supported network configures one yet, so these stay off — honest-state.
+  const perpsVenue = getPerpsVenue(network)
 
   // Network-aware DEX provider identity (ETC family → ETCswap; else Uniswap).
   const providerName = dexProvider?.name || 'the DEX'
@@ -65,6 +100,9 @@ function TradePanel() {
   const [mode, setMode] = useState('trade')
   const [fromToken, setFromToken] = useState(FROM_WNATIVE)
   const [toToken, setToToken] = useState(FROM_STABLE)
+  const [orderType, setOrderType] = useState('sell')
+  const [priceType, setPriceType] = useState('market')
+  const [limitPrice, setLimitPrice] = useState('')
   const [amount, setAmount] = useState('')
   const [quote, setQuote] = useState(null)
   const [wrapOutput, setWrapOutput] = useState('')
@@ -76,6 +114,8 @@ function TradePanel() {
     (key) => (key === FROM_WNATIVE ? addresses.WNATIVE : addresses.STABLECOIN),
     [addresses],
   )
+
+  const isPerpsOrder = orderType === 'sell_short' || orderType === 'buy_to_cover'
 
   // Live quoting — debounced. Trade mode routes through the DEX; wrap/unwrap is
   // always 1:1 so we mirror the input.
@@ -92,7 +132,7 @@ function TradePanel() {
       return
     }
 
-    if (fromToken === toToken) {
+    if (fromToken === toToken || isPerpsOrder) {
       setQuote(null)
       return
     }
@@ -117,7 +157,7 @@ function TradePanel() {
       cancelled = true
       clearTimeout(timeoutId)
     }
-  }, [amount, fromToken, toToken, mode, getBestQuote, addrFor])
+  }, [amount, fromToken, toToken, mode, isPerpsOrder, getBestQuote, addrFor])
 
   const handleModeChange = (next) => {
     setMode(next)
@@ -136,16 +176,80 @@ function TradePanel() {
     } else {
       setFromToken(FROM_WNATIVE)
       setToToken(FROM_STABLE)
+      setOrderType('sell')
     }
   }
 
+  // Spot order type maps onto the pair direction: Buy receives the network
+  // asset, Sell pays it away. The two stay in sync in both directions.
+  const deriveOrderType = (from, to) => {
+    if (to === FROM_WNATIVE && from === FROM_STABLE) return 'buy'
+    if (from === FROM_WNATIVE && to === FROM_STABLE) return 'sell'
+    return null
+  }
+
+  const handleOrderTypeChange = (next) => {
+    setOrderType(next)
+    setQuote(null)
+    setError('')
+    setSuccess('')
+    if (next === 'buy') {
+      setFromToken(FROM_STABLE)
+      setToToken(FROM_WNATIVE)
+    } else if (next === 'sell') {
+      setFromToken(FROM_WNATIVE)
+      setToToken(FROM_STABLE)
+    }
+  }
+
+  const handlePairChange = (side, value) => {
+    const from = side === 'from' ? value : fromToken
+    const to = side === 'to' ? value : toToken
+    if (side === 'from') setFromToken(value)
+    else setToToken(value)
+    const derived = deriveOrderType(from, to)
+    if (derived) setOrderType(derived)
+    setQuote(null)
+    setError('')
+  }
+
   const handleFlipTokens = () => {
+    const derived = deriveOrderType(toToken, fromToken)
     setFromToken(toToken)
     setToToken(fromToken)
+    if (derived) setOrderType(derived)
     setAmount('')
     setQuote(null)
     setError('')
   }
+
+  const handleAccountChange = (value) => {
+    setSuccess('')
+    setError('')
+    if (value === 'personal') {
+      operateAsPersonal()
+      return
+    }
+    const vault = vaults.find((v) => v.address === value)
+    if (vault) operateAsVault(vault)
+  }
+
+  // A Limit order's floor: limit price (output per 1 unit paid) × quantity,
+  // enforced on-chain as the swap's minimum received.
+  const outDecimals =
+    toToken === FROM_STABLE ? tokens?.STABLE?.decimals ?? 6 : 18
+  const limitFloor = useMemo(() => {
+    if (priceType !== 'limit') return null
+    const qty = parseFloat(amount)
+    const px = parseFloat(limitPrice)
+    if (!Number.isFinite(qty) || !Number.isFinite(px) || qty <= 0 || px <= 0) return null
+    const text = (qty * px).toFixed(outDecimals)
+    try {
+      return { wei: parseUnits(text, outDecimals), text }
+    } catch {
+      return null
+    }
+  }, [priceType, amount, limitPrice, outDecimals])
 
   const handleExecute = async () => {
     setError('')
@@ -155,17 +259,39 @@ function TradePanel() {
       setError('Enter an amount to trade')
       return
     }
+    if (mode === 'trade' && priceType === 'limit' && !limitFloor) {
+      setError('Enter a limit price to place a limit order')
+      return
+    }
 
     try {
+      const proposedNote = `Proposed to ${identity.label || 'the multisig'} — owners approve before it executes.`
       if (mode === 'wrap') {
-        await wrapNative(amount)
-        setSuccess(`Wrapped ${amount} ${nativeSymbol} → ${wnativeSymbol}`)
+        const res = await wrapNative(amount)
+        setSuccess(
+          res?.proposed
+            ? proposedNote
+            : `Wrapped ${amount} ${nativeSymbol} → ${wnativeSymbol}`,
+        )
       } else if (mode === 'unwrap') {
-        await unwrapNative(amount)
-        setSuccess(`Unwrapped ${amount} ${wnativeSymbol} → ${nativeSymbol}`)
+        const res = await unwrapNative(amount)
+        setSuccess(
+          res?.proposed
+            ? proposedNote
+            : `Unwrapped ${amount} ${wnativeSymbol} → ${nativeSymbol}`,
+        )
       } else {
-        await swap(addrFor(fromToken), addrFor(toToken), amount)
-        setSuccess(`Swapped ${amount} ${labelFor(fromToken)} → ${labelFor(toToken)}`)
+        const res =
+          priceType === 'limit'
+            ? await swap(addrFor(fromToken), addrFor(toToken), amount, {
+                limitMinOutWei: limitFloor.wei,
+              })
+            : await swap(addrFor(fromToken), addrFor(toToken), amount)
+        setSuccess(
+          res?.proposed
+            ? proposedNote
+            : `Swapped ${amount} ${labelFor(fromToken)} → ${labelFor(toToken)}`,
+        )
       }
       setAmount('')
       setQuote(null)
@@ -235,7 +361,13 @@ function TradePanel() {
 
   const severity = impactSeverity(quote?.priceImpactPercent)
   const canExecute =
-    !loading && amount && parseFloat(amount) > 0 && (!isTrade || Boolean(quote))
+    !loading &&
+    passkeyReady &&
+    !isPerpsOrder &&
+    amount &&
+    parseFloat(amount) > 0 &&
+    (!isTrade || Boolean(quote)) &&
+    (!isTrade || priceType !== 'limit' || Boolean(limitFloor))
 
   const rateLabel =
     quote && !rateInverted
@@ -243,6 +375,13 @@ function TradePanel() {
       : quote
         ? `1 ${quote.tokenOutSymbol} = ${quote.executionPriceInverted} ${quote.tokenInSymbol}`
         : null
+
+  const accountValue = isVault ? identity.vaultAddress : 'personal'
+  const feeBadge = isVault
+    ? { className: 'trade-badge-proposal', text: 'Multisig proposal' }
+    : passkeySponsored
+      ? { className: 'trade-badge-gasless', text: '⚡ Gasless · sponsored' }
+      : { className: 'trade-badge-fee', text: 'Network fee applies' }
 
   return (
     <div className="trade-panel">
@@ -257,6 +396,58 @@ function TradePanel() {
           Best-execution swaps routed across {providerName} liquidity
         </p>
       </div>
+
+      {/* Account — the personal wallet or a saved multisig; the available
+          figures below always belong to the selected account. */}
+      <section className="trade-account" aria-label="Trading account">
+        <div className="trade-account-top">
+          <label className="trade-field-label" htmlFor="trade-account-select">
+            Account
+          </label>
+          <span className={`trade-badge ${feeBadge.className}`}>{feeBadge.text}</span>
+        </div>
+        <select
+          id="trade-account-select"
+          className="trade-account-select"
+          value={accountValue}
+          onChange={(e) => handleAccountChange(e.target.value)}
+        >
+          <option value="personal">
+            Personal wallet{address ? ` · ${shortAddress(address)}` : ''}
+          </option>
+          {vaults.map((v) => (
+            <option key={v.address} value={v.address}>
+              {(v.label || shortAddress(v.address)) + ' · Multisig'}
+            </option>
+          ))}
+        </select>
+        <dl className="trade-account-rows">
+          <div className="trade-account-row">
+            <dt>Available to trade ({labelFor(fromToken)})</dt>
+            <dd>
+              <SensitiveValue>{fmtBalance(balanceFor(fromToken))}</SensitiveValue>
+            </dd>
+          </div>
+          <div className="trade-account-row">
+            <dt>Cash available ({stableSymbol})</dt>
+            <dd>
+              <SensitiveValue>{fmtBalance(balances.stable)}</SensitiveValue>
+            </dd>
+          </div>
+        </dl>
+        {isVault && (
+          <p className="trade-account-note">
+            Orders from this account are proposed to the multisig and execute once enough
+            owners approve.
+          </p>
+        )}
+        {!passkeyReady && (
+          <p className="trade-account-note" role="note">
+            Passkey accounts can’t send transactions on {networkName} yet — connect a
+            browser wallet to trade here.
+          </p>
+        )}
+      </section>
 
       <div className="trade-modes" role="tablist" aria-label="Trade mode">
         <button
@@ -285,13 +476,107 @@ function TradePanel() {
         </button>
       </div>
 
+      {/* Order ticket controls — order type, price type, term (brokerage-style). */}
+      {isTrade && (
+        <div className="trade-order-grid">
+          <div className="trade-field">
+            <span className="trade-field-label">
+              <label htmlFor="trade-order-type">Order Type</label>
+              <InfoTip label="About order types" className="trade-info">
+                Buy receives {wnativeSymbol} for {stableSymbol}; Sell does the reverse.
+                Sell Short and Buy to Cover appear on networks with a perpetuals venue —
+                {perpsVenue ? ` ${perpsVenue.name} on this network.` : ' none of the supported networks has one yet.'}
+              </InfoTip>
+            </span>
+            <select
+              id="trade-order-type"
+              className="trade-field-select"
+              value={orderType}
+              onChange={(e) => handleOrderTypeChange(e.target.value)}
+            >
+              {SPOT_ORDER_TYPES.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+              {perpsVenue &&
+                PERPS_ORDER_TYPES.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+            </select>
+          </div>
+
+          <div className="trade-field">
+            <span className="trade-field-label">
+              <label htmlFor="trade-price-type">Price Type</label>
+              <InfoTip label="About price types" className="trade-info">
+                Market fills at the best routed price within your slippage tolerance.
+                Limit fills at your price or better, or not at all — orders don’t rest
+                on a book.
+              </InfoTip>
+            </span>
+            <select
+              id="trade-price-type"
+              className="trade-field-select"
+              value={priceType}
+              onChange={(e) => {
+                setPriceType(e.target.value)
+                setError('')
+              }}
+            >
+              {PRICE_TYPES.map((p) => (
+                <option key={p.value} value={p.value}>
+                  {p.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {priceType === 'limit' && (
+            <div className="trade-field">
+              <label className="trade-field-label" htmlFor="trade-limit-price">
+                Limit Price ({labelFor(toToken)} per {labelFor(fromToken)})
+              </label>
+              <input
+                id="trade-limit-price"
+                className="trade-field-input"
+                type="number"
+                inputMode="decimal"
+                min="0"
+                step="0.000001"
+                placeholder="0.0"
+                value={limitPrice}
+                onChange={(e) => setLimitPrice(e.target.value)}
+              />
+            </div>
+          )}
+
+          <div className="trade-field">
+            <span className="trade-field-label">Term</span>
+            <span className="trade-field-static">
+              {priceType === 'limit' ? 'Fill at limit or cancel' : 'Immediate'}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {isTrade && isPerpsOrder && (
+        <div className="trade-message trade-error" role="alert">
+          {perpsVenue
+            ? `${orderType === 'sell_short' ? 'Sell Short' : 'Buy to Cover'} orders route to ${perpsVenue.name}, which isn’t wired into in-app execution yet.`
+            : `Short selling needs a perpetuals venue, and ${networkName} doesn’t have one yet.`}
+        </div>
+      )}
+
       <div className="trade-ticket">
         {/* Pay leg */}
         <div className="trade-leg">
           <div className="trade-leg-top">
             <label htmlFor="trade-amount">You pay</label>
             <span className="trade-balance">
-              Balance: <SensitiveValue>{Number(balanceFor(fromToken)).toLocaleString(undefined, { maximumSignificantDigits: 8 })}</SensitiveValue>
+              Balance: <SensitiveValue>{fmtBalance(balanceFor(fromToken))}</SensitiveValue>
             </span>
           </div>
           <div className="trade-leg-body">
@@ -310,7 +595,7 @@ function TradePanel() {
               <select
                 aria-label="Token to sell"
                 value={fromToken}
-                onChange={(e) => setFromToken(e.target.value)}
+                onChange={(e) => handlePairChange('from', e.target.value)}
                 className="trade-token-select"
               >
                 <option value={FROM_WNATIVE}>{wnativeSymbol}</option>
@@ -345,7 +630,7 @@ function TradePanel() {
           <div className="trade-leg-top">
             <label>You receive</label>
             <span className="trade-balance">
-              Balance: <SensitiveValue>{Number(balanceFor(toToken)).toLocaleString(undefined, { maximumSignificantDigits: 8 })}</SensitiveValue>
+              Balance: <SensitiveValue>{fmtBalance(balanceFor(toToken))}</SensitiveValue>
             </span>
           </div>
           <div className="trade-leg-body">
@@ -356,7 +641,7 @@ function TradePanel() {
               <select
                 aria-label="Token to buy"
                 value={toToken}
-                onChange={(e) => setToToken(e.target.value)}
+                onChange={(e) => handlePairChange('to', e.target.value)}
                 className="trade-token-select"
               >
                 <option value={FROM_WNATIVE}>{wnativeSymbol}</option>
@@ -394,10 +679,18 @@ function TradePanel() {
           <div className="trade-summary-row">
             <span className="trade-summary-key">
               Minimum received
-              <span className="trade-summary-note"> after {(slippage / 100).toFixed(2)}% slippage</span>
+              {priceType === 'limit' ? (
+                <span className="trade-summary-note"> at your limit price</span>
+              ) : (
+                <span className="trade-summary-note"> after {(slippage / 100).toFixed(2)}% slippage</span>
+              )}
             </span>
             <span className="trade-summary-val">
-              <SensitiveValue>{Number(quote.minimumReceived).toLocaleString(undefined, { maximumSignificantDigits: 8 })}</SensitiveValue>{' '}
+              <SensitiveValue>
+                {priceType === 'limit' && limitFloor
+                  ? fmtBalance(limitFloor.text)
+                  : fmtBalance(quote.minimumReceived)}
+              </SensitiveValue>{' '}
               {quote.tokenOutSymbol}
             </span>
           </div>
@@ -408,23 +701,25 @@ function TradePanel() {
               <span className="trade-route-fee">{feeTierLabel(quote.feeTier)} pool</span>
             </span>
           </div>
-          <div className="trade-summary-row trade-slippage">
-            <label htmlFor="trade-slippage-select" className="trade-summary-key">
-              Slippage tolerance
-            </label>
-            <select
-              id="trade-slippage-select"
-              value={slippage}
-              onChange={(e) => setSlippage(parseInt(e.target.value))}
-              className="trade-slippage-select"
-            >
-              {SLIPPAGE_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </div>
+          {priceType !== 'limit' && (
+            <div className="trade-summary-row trade-slippage">
+              <label htmlFor="trade-slippage-select" className="trade-summary-key">
+                Slippage tolerance
+              </label>
+              <select
+                id="trade-slippage-select"
+                value={slippage}
+                onChange={(e) => setSlippage(parseInt(e.target.value))}
+                className="trade-slippage-select"
+              >
+                {SLIPPAGE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
         </div>
       )}
 
@@ -449,9 +744,19 @@ function TradePanel() {
               : quotingPrice
                 ? 'Fetching best price…'
                 : quote
-                  ? `Swap ${labelFor(fromToken)} for ${labelFor(toToken)}`
+                  ? priceType === 'limit'
+                    ? `Place limit order — ${labelFor(fromToken)} for ${labelFor(toToken)}`
+                    : `Swap ${labelFor(fromToken)} for ${labelFor(toToken)}`
                   : 'Enter an amount'}
       </button>
+
+      {isPasskey && passkeyReady && !isVault && (
+        <p className="trade-session-note">
+          One passkey confirmation covers the whole order — including the spending
+          permission when it’s needed.
+          {passkeySponsored ? ' FairWins sponsors the network fee.' : ''}
+        </p>
+      )}
 
       {error && (
         <div className="trade-message trade-error" role="alert">

--- a/frontend/src/constants/dex.js
+++ b/frontend/src/constants/dex.js
@@ -106,6 +106,35 @@ export const SLIPPAGE_OPTIONS = [
 // Default slippage (0.5%)
 export const DEFAULT_SLIPPAGE = 50
 
+// Price types the order ticket offers — the execution styles Uniswap V3
+// actually supports through SwapRouter02. "Market" fills at the routed price
+// within the slippage tolerance; "Limit" is an immediate-or-cancel order that
+// enforces the member's price as the on-chain minimum received (amountOutMinimum)
+// — it fills at the limit or better, or not at all. There is no resting order
+// book, so we never pretend an unfilled limit is "working".
+export const PRICE_TYPES = [
+  { value: 'market', label: 'Market' },
+  { value: 'limit', label: 'Limit' },
+]
+
+// Order types for the spot ticket. Direction maps onto the swap pair: buying
+// receives the network asset, selling pays it away.
+export const SPOT_ORDER_TYPES = [
+  { value: 'buy', label: 'Buy' },
+  { value: 'sell', label: 'Sell' },
+]
+
+// Order types that only exist where a perpetuals venue is configured for the
+// network (`network.perps` in config/networks.js). No supported network has
+// one today, so these stay hidden — honest-state over dead buttons.
+export const PERPS_ORDER_TYPES = [
+  { value: 'sell_short', label: 'Sell Short' },
+  { value: 'buy_to_cover', label: 'Buy to Cover' },
+]
+
+// The perpetuals venue for a network, or null when the network has none.
+export const getPerpsVenue = (network) => network?.perps || null
+
 // Time horizon options for balance charts (in seconds)
 export const TIME_HORIZONS = {
   '1H': 3600,

--- a/frontend/src/contexts/DexContext.jsx
+++ b/frontend/src/contexts/DexContext.jsx
@@ -11,6 +11,7 @@ import { SWAP_ROUTER_02_ABI } from '../abis/SwapRouter02'
 import { QUOTER_V2_ABI } from '../abis/QuoterV2'
 import { DexContext } from './DexContext'
 import { toSdkToken, buildTradeMetrics, ROUTED_FEE_TIERS } from '../lib/uniswap/trade'
+import { makeReadProvider } from '../utils/rpcProvider'
 import logger from '../utils/logger'
 
 const ZERO = '0x0000000000000000000000000000000000000000'
@@ -23,12 +24,28 @@ const ZERO = '0x0000000000000000000000000000000000000000'
  * provider via `dexProvider` from the returned context.
  */
 export function DexProvider({ children }) {
-  const { provider, signer, address, isConnected } = useWallet()
+  const { provider, address, isConnected, sendCalls } = useWallet()
   // Spec 043 (US3): swapping while operating as a vault becomes a threshold-gated vault proposal.
   const { isVault: operatingAsVault, canActAsVault, identity: activeIdentity, submit: submitAsActive } = useActiveAccount()
   const wagmiChainId = useChainId()
   const chainId = wagmiChainId || getCurrentChainId()
   const network = getNetwork(chainId)
+
+  // Reads must not depend on a wallet signer-provider: passkey sessions have
+  // none (WalletContext leaves provider/signer null), yet they still need
+  // balances and quotes. Fall back to the chain's public read provider, the
+  // same pattern Portfolio and Earn use.
+  const readProvider = useMemo(() => {
+    if (provider) return provider
+    if (!network?.rpcUrl) return null
+    return makeReadProvider(network.rpcUrl, chainId)
+  }, [provider, network?.rpcUrl, chainId])
+
+  // The account whose funds the trade ticket represents: the vault when the
+  // member operates as one (on the vault's own network), else the connected
+  // wallet. Balances and swap recipients follow this address so "available to
+  // trade" is accurate for the selected account (Spec 043).
+  const tradingAddress = operatingAsVault && canActAsVault ? activeIdentity.vaultAddress : address
 
   const dexConfig = network?.dex || null
   const stableConfig = network?.stablecoin || null
@@ -96,45 +113,45 @@ export function DexProvider({ children }) {
 
   // Stablecoin contract for balance reads — available even when DEX is not.
   const stableContract = useMemo(() => {
-    if (!provider || !stableConfig?.address) return null
-    return new ethers.Contract(stableConfig.address, ERC20_ABI, provider)
-  }, [provider, stableConfig])
+    if (!readProvider || !stableConfig?.address) return null
+    return new ethers.Contract(stableConfig.address, ERC20_ABI, readProvider)
+  }, [readProvider, stableConfig])
 
   const contracts = useMemo(() => {
-    if (!provider || !isDexAvailable) return null
+    if (!readProvider || !isDexAvailable) return null
 
     return {
-      wnative: new ethers.Contract(addresses.WNATIVE, WNATIVE_ABI, provider),
-      stable: new ethers.Contract(addresses.STABLECOIN, ERC20_ABI, provider),
-      swapRouter: new ethers.Contract(addresses.SWAP_ROUTER_02, SWAP_ROUTER_02_ABI, provider),
-      quoter: new ethers.Contract(addresses.QUOTER_V2, QUOTER_V2_ABI, provider),
+      wnative: new ethers.Contract(addresses.WNATIVE, WNATIVE_ABI, readProvider),
+      stable: new ethers.Contract(addresses.STABLECOIN, ERC20_ABI, readProvider),
+      swapRouter: new ethers.Contract(addresses.SWAP_ROUTER_02, SWAP_ROUTER_02_ABI, readProvider),
+      quoter: new ethers.Contract(addresses.QUOTER_V2, QUOTER_V2_ABI, readProvider),
     }
-  }, [provider, isDexAvailable, addresses])
+  }, [readProvider, isDexAvailable, addresses])
 
   const fetchBalances = useCallback(async () => {
     if (import.meta.env.VITE_SKIP_BLOCKCHAIN_CALLS === 'true') {
       return
     }
 
-    if (!provider || !address) return
+    if (!readProvider || !tradingAddress) return
     // Need at least stableContract or full DEX contracts to fetch anything useful
     if (!stableContract && !contracts) return
 
     try {
       setLoading(true)
 
-      const nativeBalance = await provider.getBalance(address)
+      const nativeBalance = await readProvider.getBalance(tradingAddress)
 
       // Fetch wnative only when DEX contracts are available
       const wnativeBalance = contracts
-        ? await contracts.wnative.balanceOf(address)
+        ? await contracts.wnative.balanceOf(tradingAddress)
         : 0n
 
       // Fetch stable balance from DEX contracts if available, otherwise
       // fall back to the standalone stableContract
       const stableReader = contracts?.stable || stableContract
       const stableBalance = stableReader
-        ? await stableReader.balanceOf(address)
+        ? await stableReader.balanceOf(tradingAddress)
         : 0n
 
       const newBalances = {
@@ -157,13 +174,14 @@ export function DexProvider({ children }) {
     } finally {
       setLoading(false)
     }
-  }, [provider, address, contracts, stableContract, tokens.STABLE.decimals])
+  }, [readProvider, tradingAddress, contracts, stableContract, tokens.STABLE.decimals])
 
-  // Reset balances when chain changes so the user doesn't see stale numbers.
+  // Reset balances when the chain or the active account changes so the user
+  // doesn't see stale numbers (e.g. personal balances while operating as a vault).
   useEffect(() => {
     setBalances({ native: '0', wnative: '0', stable: '0' })
     setBalanceHistory([])
-  }, [chainId])
+  }, [chainId, tradingAddress])
 
   useEffect(() => {
     if (isConnected) {
@@ -173,51 +191,71 @@ export function DexProvider({ children }) {
     }
   }, [isConnected, fetchBalances])
 
+  // Wrap/unwrap ride the unified spec-041 write rail (WalletContext.sendCalls)
+  // so BOTH session kinds work: passkey sessions authorize with one WebAuthn
+  // ceremony (they have no ethers signer), classic wallets sign per call.
+  // Operating as a vault turns the action into a threshold-gated proposal.
   const wrapNative = useCallback(async (amount) => {
-    if (!signer || !contracts) {
-      throw new Error('Wallet not connected')
+    if (!contracts) {
+      throw new Error('DEX is not available on the current network')
     }
 
     try {
       setLoading(true)
-      const wnativeWithSigner = contracts.wnative.connect(signer)
       const amountWei = ethers.parseEther(amount)
+      const data = contracts.wnative.interface.encodeFunctionData('deposit', [])
+      const call = { to: addresses.WNATIVE, value: amountWei, data }
 
-      const tx = await wnativeWithSigner.deposit({ value: amountWei })
-      await tx.wait()
+      if (operatingAsVault) {
+        if (!canActAsVault) throw new Error("Switch to the vault's network to act as the vault.")
+        const res = await submitAsActive({ batch: [call] })
+        return { proposed: true, safeTxHash: res.safeTxHash }
+      }
+
+      if (typeof sendCalls !== 'function') throw new Error('Wallet not connected')
+      const res = await sendCalls([call])
+      if (res?.state === 'failed') throw new Error(res.reason || 'Transaction failed')
 
       await fetchBalances()
-      return tx
+      return res
     } catch (error) {
       console.error('Error wrapping native:', error)
       throw error
     } finally {
       setLoading(false)
     }
-  }, [signer, contracts, fetchBalances])
+  }, [contracts, addresses, operatingAsVault, canActAsVault, submitAsActive, sendCalls, fetchBalances])
 
   const unwrapNative = useCallback(async (amount) => {
-    if (!signer || !contracts) {
-      throw new Error('Wallet not connected')
+    if (!contracts) {
+      throw new Error('DEX is not available on the current network')
     }
 
     try {
       setLoading(true)
-      const wnativeWithSigner = contracts.wnative.connect(signer)
       const amountWei = ethers.parseEther(amount)
+      const data = contracts.wnative.interface.encodeFunctionData('withdraw', [amountWei])
+      const call = { to: addresses.WNATIVE, value: 0n, data }
 
-      const tx = await wnativeWithSigner.withdraw(amountWei)
-      await tx.wait()
+      if (operatingAsVault) {
+        if (!canActAsVault) throw new Error("Switch to the vault's network to act as the vault.")
+        const res = await submitAsActive({ batch: [call] })
+        return { proposed: true, safeTxHash: res.safeTxHash }
+      }
+
+      if (typeof sendCalls !== 'function') throw new Error('Wallet not connected')
+      const res = await sendCalls([call])
+      if (res?.state === 'failed') throw new Error(res.reason || 'Transaction failed')
 
       await fetchBalances()
-      return tx
+      return res
     } catch (error) {
       console.error('Error unwrapping native:', error)
       throw error
     } finally {
       setLoading(false)
     }
-  }, [signer, contracts, fetchBalances])
+  }, [contracts, addresses, operatingAsVault, canActAsVault, submitAsActive, sendCalls, fetchBalances])
 
   // Decimals lookup for a token by address used in quote/swap calls below.
   // Defaults to 18 (native/wrapped) when the token isn't in our known set.
@@ -363,8 +401,17 @@ export function DexProvider({ children }) {
     }
   }, [contracts, decimalsOf, symbolOf, chainId, slippage])
 
-  const swap = useCallback(async (tokenIn, tokenOut, amountIn) => {
-    if (!signer || !contracts || !address) {
+  /**
+   * Execute (or, as a vault, propose) a swap.
+   *
+   * `opts.limitMinOutWei` — a Limit order's floor: the member's limit price
+   * expressed as the minimum output amount. Uniswap V3 enforces it on-chain
+   * via `amountOutMinimum`, making the order immediate-or-cancel — it fills at
+   * the limit or better, or not at all. We pre-check against the fresh quote
+   * so an unfillable limit fails with a plain reason before any wallet prompt.
+   */
+  const swap = useCallback(async (tokenIn, tokenOut, amountIn, opts = {}) => {
+    if (!contracts || !tradingAddress) {
       throw new Error('Wallet not connected')
     }
 
@@ -377,24 +424,34 @@ export function DexProvider({ children }) {
 
       const decIn = decimalsOf(tokenIn)
       const amountInWei = ethers.parseUnits(amountIn, decIn)
-      const minAmountOutWei = quote.minimumReceivedWei
+      const isLimit = opts.limitMinOutWei != null
+      const minAmountOutWei = isLimit ? BigInt(opts.limitMinOutWei) : quote.minimumReceivedWei
+
+      if (isLimit && quote.amountOutWei < minAmountOutWei) {
+        throw new Error(
+          'The market is below your limit price right now — the order was not placed. Nothing was moved.'
+        )
+      }
+
+      const erc20 = new ethers.Interface(ERC20_ABI)
+      const swapParams = (recipient) => ({
+        tokenIn,
+        tokenOut,
+        fee: quote.feeTier,
+        recipient,
+        amountIn: amountInWei,
+        amountOutMinimum: minAmountOutWei,
+        sqrtPriceLimitX96: 0,
+      })
 
       // Spec 043 (US3, FR-022a): swap AS a vault → batch [approve, exactInputSingle] with recipient = the
       // vault, proposed as a threshold-gated vault transaction. Only in the vault queue until executed.
       if (operatingAsVault) {
         if (!canActAsVault) throw new Error("Switch to the vault's network to swap as the vault.")
-        const erc20 = new ethers.Interface(ERC20_ABI)
         const approveData = erc20.encodeFunctionData('approve', [addresses.SWAP_ROUTER_02, amountInWei])
-        const vaultParams = {
-          tokenIn,
-          tokenOut,
-          fee: quote.feeTier,
-          recipient: activeIdentity.vaultAddress,
-          amountIn: amountInWei,
-          amountOutMinimum: minAmountOutWei,
-          sqrtPriceLimitX96: 0,
-        }
-        const swapData = contracts.swapRouter.interface.encodeFunctionData('exactInputSingle', [vaultParams])
+        const swapData = contracts.swapRouter.interface.encodeFunctionData('exactInputSingle', [
+          swapParams(activeIdentity.vaultAddress),
+        ])
         const res = await submitAsActive({
           batch: [
             { to: tokenIn, value: 0n, data: approveData },
@@ -404,40 +461,43 @@ export function DexProvider({ children }) {
         return { proposed: true, safeTxHash: res.safeTxHash }
       }
 
-      const tokenInContract = new ethers.Contract(tokenIn, ERC20_ABI, signer)
-      const allowance = await tokenInContract.allowance(address, addresses.SWAP_ROUTER_02)
+      // Personal mode rides the unified spec-041 write rail: one batch through
+      // sendCalls covers approval (only when needed, for the exact amount) and
+      // the swap — a single WebAuthn ceremony for passkey sessions, sequential
+      // signed transactions for classic wallets.
+      if (typeof sendCalls !== 'function') throw new Error('Wallet not connected')
 
+      const tokenInContract = new ethers.Contract(tokenIn, ERC20_ABI, readProvider)
+      const allowance = await tokenInContract.allowance(tradingAddress, addresses.SWAP_ROUTER_02)
+
+      const calls = []
       if (allowance < amountInWei) {
-        const approveTx = await tokenInContract.approve(
-          addresses.SWAP_ROUTER_02,
-          ethers.MaxUint256
-        )
-        await approveTx.wait()
+        calls.push({
+          to: tokenIn,
+          value: 0n,
+          data: erc20.encodeFunctionData('approve', [addresses.SWAP_ROUTER_02, amountInWei]),
+        })
       }
+      calls.push({
+        to: addresses.SWAP_ROUTER_02,
+        value: 0n,
+        data: contracts.swapRouter.interface.encodeFunctionData('exactInputSingle', [
+          swapParams(tradingAddress),
+        ]),
+      })
 
-      const swapRouterWithSigner = contracts.swapRouter.connect(signer)
-      const params = {
-        tokenIn,
-        tokenOut,
-        fee: quote.feeTier,
-        recipient: address,
-        amountIn: amountInWei,
-        amountOutMinimum: minAmountOutWei,
-        sqrtPriceLimitX96: 0,
-      }
-
-      const tx = await swapRouterWithSigner.exactInputSingle(params)
-      await tx.wait()
+      const res = await sendCalls(calls)
+      if (res?.state === 'failed') throw new Error(res.reason || 'Transaction failed')
 
       await fetchBalances()
-      return tx
+      return res
     } catch (error) {
       console.error('Error performing swap:', error)
       throw error
     } finally {
       setLoading(false)
     }
-  }, [signer, contracts, address, getBestQuote, fetchBalances, decimalsOf, addresses, operatingAsVault, canActAsVault, activeIdentity, submitAsActive])
+  }, [contracts, tradingAddress, readProvider, getBestQuote, fetchBalances, decimalsOf, addresses, operatingAsVault, canActAsVault, activeIdentity, submitAsActive, sendCalls])
 
   const value = {
     balances,
@@ -460,6 +520,7 @@ export function DexProvider({ children }) {
     dexProvider,
     chainId,
     network,
+    tradingAddress,
   }
 
   return (

--- a/frontend/src/hooks/useActiveAccount.js
+++ b/frontend/src/hooks/useActiveAccount.js
@@ -18,6 +18,7 @@ export function useActiveAccount() {
   const custody = useContext(CustodyContext)
   const active = custody?.active ?? PERSONAL
   const operateAsPersonal = custody?.operateAsPersonal ?? NOOP
+  const operateAsVault = custody?.operateAsVault ?? NOOP
   const { chainId, signer, provider } = useWallet()
   const isVault = active.mode === 'vault'
 
@@ -42,7 +43,7 @@ export function useActiveAccount() {
   // Whether a vault action can currently be sent (connected to the vault's network).
   const canActAsVault = isVault && Number(chainId) === Number(active.chainId)
 
-  return { identity: active, isVault, canActAsVault, submit, operateAsPersonal }
+  return { identity: active, isVault, canActAsVault, submit, operateAsPersonal, operateAsVault }
 }
 
 export default useActiveAccount

--- a/frontend/src/test/TradePanel.test.jsx
+++ b/frontend/src/test/TradePanel.test.jsx
@@ -1,23 +1,40 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
-// TradePanel is the renamed, SDK-driven successor to SwapPanel. It must:
+// TradePanel is the brokerage-style order ticket for on-chain swaps. It must:
 //  - name/link the DEX provider for the active network (ETCswap on the ETC
 //    family, Uniswap elsewhere) while subtly attributing the Uniswap V3 protocol
 //    that powers routing (Spec 033 provider-awareness, preserved);
 //  - present a professional trade read-out (rate, price impact, minimum
-//    received, route) fed by getBestQuote().
-// We mock the DEX/wallet/token hooks so the component is exercised in isolation.
+//    received, route) fed by getBestQuote();
+//  - let the member trade as their personal wallet or as a saved multisig
+//    vault (Spec 043), with balances that follow the selected account;
+//  - offer the price types Uniswap V3 actually supports (Market, and Limit as
+//    immediate-or-cancel via amountOutMinimum) and gate perpetuals order types
+//    (Sell Short / Buy to Cover) on a per-network perps venue — hidden where
+//    none exists (honest-state).
+// We mock the DEX/wallet/token/account hooks so the component is exercised in
+// isolation.
 
-const { mockUseDex, mockUseWallet, mockUseChainTokens } = vi.hoisted(() => ({
+const {
+  mockUseDex,
+  mockUseWallet,
+  mockUseChainTokens,
+  mockUseActiveAccount,
+  mockUseCustodyVaults,
+} = vi.hoisted(() => ({
   mockUseDex: vi.fn(),
   mockUseWallet: vi.fn(),
   mockUseChainTokens: vi.fn(),
+  mockUseActiveAccount: vi.fn(),
+  mockUseCustodyVaults: vi.fn(),
 }))
 
 vi.mock('../hooks/useDex', () => ({ useDex: mockUseDex }))
 vi.mock('../hooks', () => ({ useWallet: mockUseWallet }))
 vi.mock('../hooks/useChainTokens', () => ({ useChainTokens: mockUseChainTokens }))
+vi.mock('../hooks/useActiveAccount', () => ({ useActiveAccount: mockUseActiveAccount }))
+vi.mock('../hooks/useCustodyVaults', () => ({ useCustodyVaults: mockUseCustodyVaults }))
 
 import TradePanel from '../components/fairwins/TradePanel'
 
@@ -58,6 +75,7 @@ function dexValue(overrides = {}) {
     slippage: 50,
     setSlippage: vi.fn(),
     addresses: ETC_ADDRESSES,
+    tokens: { STABLE: { decimals: 6, symbol: 'USC' }, WNATIVE: { decimals: 18, symbol: 'WETC' } },
     isDexAvailable: true,
     dexProvider: { name: 'ETCswap', url: 'https://v3.etcswap.org' },
     network: { name: 'Ethereum Classic', chainId: 61 },
@@ -68,14 +86,32 @@ function dexValue(overrides = {}) {
 const polygonDex = (overrides = {}) =>
   dexValue({
     addresses: POLYGON_ADDRESSES,
+    tokens: { STABLE: { decimals: 6, symbol: 'USDC' }, WNATIVE: { decimals: 18, symbol: 'WPOL' } },
     dexProvider: { name: 'Uniswap', url: 'https://app.uniswap.org/swap?chain=polygon' },
     network: { name: 'Polygon', chainId: 137 },
     ...overrides,
   })
 
+function personalAccount(overrides = {}) {
+  return {
+    identity: { mode: 'personal' },
+    isVault: false,
+    canActAsVault: false,
+    submit: vi.fn(),
+    operateAsPersonal: vi.fn(),
+    operateAsVault: vi.fn(),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUseActiveAccount.mockReturnValue(personalAccount())
+  mockUseCustodyVaults.mockReturnValue({ vaults: [], supported: false })
+})
+
 describe('TradePanel — provider identity & attribution', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
     mockUseWallet.mockReturnValue({ isConnected: true, chainId: 61 })
     mockUseChainTokens.mockReturnValue({ native: 'ETC', stable: 'USC' })
   })
@@ -136,7 +172,6 @@ describe('TradePanel — provider identity & attribution', () => {
 
 describe('TradePanel — SDK-driven trade read-out', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
     mockUseWallet.mockReturnValue({ isConnected: true, chainId: 137 })
     mockUseChainTokens.mockReturnValue({ native: 'POL', stable: 'USDC' })
   })
@@ -196,5 +231,174 @@ describe('TradePanel — SDK-driven trade read-out', () => {
     expect(screen.getByRole('tab', { name: 'Swap' })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: 'Wrap' })).toBeInTheDocument()
     expect(screen.getByRole('tab', { name: 'Unwrap' })).toBeInTheDocument()
+  })
+})
+
+describe('TradePanel — account selection (spec 043)', () => {
+  beforeEach(() => {
+    mockUseWallet.mockReturnValue({
+      isConnected: true,
+      chainId: 137,
+      address: '0x1111222233334444555566667777888899990000',
+    })
+    mockUseChainTokens.mockReturnValue({ native: 'POL', stable: 'USDC' })
+    mockUseDex.mockReturnValue(polygonDex())
+  })
+
+  it('lists the personal wallet and every saved multisig, and shows account balances', () => {
+    mockUseCustodyVaults.mockReturnValue({
+      supported: true,
+      vaults: [
+        { address: '0xVaultAAA', chainId: 137, label: 'Ops Treasury' },
+        { address: '0xVaultBBB', chainId: 137, label: '' },
+      ],
+    })
+    render(<TradePanel />)
+
+    const picker = screen.getByLabelText('Account')
+    expect(picker).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /Personal wallet · 0x1111…0000/ })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: /Ops Treasury · Multisig/ })).toBeInTheDocument()
+
+    // Available-to-trade figures for the selected account (pay leg = WPOL).
+    expect(screen.getByText(/Available to trade \(WPOL\)/)).toBeInTheDocument()
+    expect(screen.getByText(/Cash available \(USDC\)/)).toBeInTheDocument()
+  })
+
+  it('switches the active identity when a multisig is selected', () => {
+    const operateAsVault = vi.fn()
+    const vault = { address: '0xVaultAAA', chainId: 137, label: 'Ops Treasury' }
+    mockUseActiveAccount.mockReturnValue(personalAccount({ operateAsVault }))
+    mockUseCustodyVaults.mockReturnValue({ supported: true, vaults: [vault] })
+    render(<TradePanel />)
+
+    fireEvent.change(screen.getByLabelText('Account'), { target: { value: '0xVaultAAA' } })
+    expect(operateAsVault).toHaveBeenCalledWith(vault)
+  })
+
+  it('discloses the proposal flow while operating as a multisig', () => {
+    mockUseActiveAccount.mockReturnValue(
+      personalAccount({
+        identity: { mode: 'vault', vaultAddress: '0xVaultAAA', chainId: 137, label: 'Ops Treasury' },
+        isVault: true,
+        canActAsVault: true,
+      }),
+    )
+    mockUseCustodyVaults.mockReturnValue({
+      supported: true,
+      vaults: [{ address: '0xVaultAAA', chainId: 137, label: 'Ops Treasury' }],
+    })
+    render(<TradePanel />)
+
+    expect(screen.getByText('Multisig proposal')).toBeInTheDocument()
+    expect(screen.getByText(/proposed to the multisig/)).toBeInTheDocument()
+  })
+})
+
+describe('TradePanel — order & price types', () => {
+  beforeEach(() => {
+    mockUseWallet.mockReturnValue({ isConnected: true, chainId: 137 })
+    mockUseChainTokens.mockReturnValue({ native: 'POL', stable: 'USDC' })
+  })
+
+  it('keeps order type and pair direction in sync (Buy receives the network asset)', () => {
+    mockUseDex.mockReturnValue(polygonDex())
+    render(<TradePanel />)
+
+    // Default direction WPOL → USDC reads as Sell.
+    expect(screen.getByLabelText(/Order Type/).value).toBe('sell')
+
+    fireEvent.change(screen.getByLabelText(/Order Type/), { target: { value: 'buy' } })
+    expect(screen.getByLabelText('Token to sell').value).toBe('STABLE')
+    expect(screen.getByLabelText('Token to buy').value).toBe('WNATIVE')
+
+    // Flipping the pair back flips the order type too.
+    fireEvent.change(screen.getByLabelText('Token to sell'), { target: { value: 'WNATIVE' } })
+    fireEvent.change(screen.getByLabelText('Token to buy'), { target: { value: 'STABLE' } })
+    expect(screen.getByLabelText(/Order Type/).value).toBe('sell')
+  })
+
+  it('offers Market and Limit price types and passes the limit floor to swap()', async () => {
+    const swap = vi.fn().mockResolvedValue({})
+    mockUseDex.mockReturnValue(polygonDex({ swap }))
+    render(<TradePanel />)
+
+    fireEvent.change(screen.getByLabelText(/Price Type/), { target: { value: 'limit' } })
+    fireEvent.change(screen.getByLabelText(/Limit Price/), { target: { value: '1.3' } })
+    fireEvent.change(screen.getByLabelText('You pay'), { target: { value: '1' } })
+
+    // Limit orders are immediate-or-cancel — the term row says so honestly.
+    expect(screen.getByText('Fill at limit or cancel')).toBeInTheDocument()
+
+    const execBtn = await screen.findByRole('button', { name: /Place limit order/ })
+    fireEvent.click(execBtn)
+
+    // 1 × 1.3 at 6 stable decimals → 1300000n enforced as amountOutMinimum.
+    await waitFor(() =>
+      expect(swap).toHaveBeenCalledWith(
+        POLYGON_ADDRESSES.WNATIVE,
+        POLYGON_ADDRESSES.STABLECOIN,
+        '1',
+        { limitMinOutWei: 1300000n },
+      ),
+    )
+  })
+
+  it('hides perpetuals order types on networks without a perps venue', () => {
+    mockUseDex.mockReturnValue(polygonDex())
+    render(<TradePanel />)
+
+    expect(screen.queryByRole('option', { name: 'Sell Short' })).toBeNull()
+    expect(screen.queryByRole('option', { name: 'Buy to Cover' })).toBeNull()
+  })
+
+  it('offers Sell Short / Buy to Cover only where the network has a perps venue', () => {
+    mockUseDex.mockReturnValue(
+      polygonDex({ network: { name: 'Polygon', chainId: 137, perps: { name: 'TestPerps' } } }),
+    )
+    render(<TradePanel />)
+
+    expect(screen.getByRole('option', { name: 'Sell Short' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'Buy to Cover' })).toBeInTheDocument()
+  })
+})
+
+describe('TradePanel — session rails (passkey & gasless)', () => {
+  beforeEach(() => {
+    mockUseChainTokens.mockReturnValue({ native: 'POL', stable: 'USDC' })
+  })
+
+  it('shows the sponsored-gasless badge for passkey sessions on sponsored networks', () => {
+    mockUseWallet.mockReturnValue({ isConnected: true, chainId: 137, loginMethod: 'passkey' })
+    mockUseDex.mockReturnValue(
+      polygonDex({
+        network: {
+          name: 'Polygon',
+          chainId: 137,
+          passkey: { sponsorPaymasterUrl: 'https://relay.example/v1/paymaster' },
+        },
+      }),
+    )
+    render(<TradePanel />)
+
+    expect(screen.getByText(/Gasless · sponsored/)).toBeInTheDocument()
+    expect(screen.getByText(/One passkey confirmation covers the whole order/)).toBeInTheDocument()
+  })
+
+  it('is honest when a passkey session cannot transact on this network', () => {
+    mockUseWallet.mockReturnValue({ isConnected: true, chainId: 61, loginMethod: 'passkey' })
+    mockUseDex.mockReturnValue(dexValue()) // network has no passkey rail
+    render(<TradePanel />)
+
+    expect(screen.getByText(/Passkey accounts can’t send transactions on Ethereum Classic yet/)).toBeInTheDocument()
+    expect(screen.getByText('Network fee applies')).toBeInTheDocument()
+  })
+
+  it('shows the fee badge for classic wallet sessions', () => {
+    mockUseWallet.mockReturnValue({ isConnected: true, chainId: 137 })
+    mockUseDex.mockReturnValue(polygonDex())
+    render(<TradePanel />)
+
+    expect(screen.getByText('Network fee applies')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

Redesigns the Trade screen into a brokerage-style order ticket (modeled on the reference screenshots) and brings it up to the standard set by the network-transparent Portfolio and Earn redesigns.

### Account selection & accurate available value (spec 043)
- New **Account** block at the top of the ticket: trade as the **personal wallet or any saved multisig vault**. Selecting a vault routes every order through the threshold-gated proposal flow (`operateAsVault`), with a plain-language disclosure and a "Multisig proposal" badge.
- **"Available to trade" / "Cash available" are now accurate for the selected account**: `DexContext` reads balances for the active identity (vault address when operating as a vault), not just the connected wallet, and resets them on account switch.

### Price & order types
- **Price Type: Market / Limit** — the execution styles Uniswap V3 actually supports. Limit is an honest **immediate-or-cancel** order: the member's limit price becomes the on-chain `amountOutMinimum`, pre-checked against a fresh quote so an unfillable limit fails with a clear reason before any wallet prompt. The Term row says so ("Fill at limit or cancel" vs "Immediate"); no pretend resting order book.
- **Order Type: Buy / Sell**, kept in two-way sync with the from/to pair (Buy receives the network asset). **Sell Short / Buy to Cover** appear only on networks that configure a perpetuals venue (`network.perps`) — none does today, so they stay hidden (honest-state), with an info bubble explaining when they'd appear.
- From/To pair selectors are kept as-is per the current multi-pair design.

### Passkey + gasless wiring (specs 041/050)
- Swaps, wraps and unwraps now ride the unified `WalletContext.sendCalls` rail. **Passkey sessions previously could not trade at all** — they have no ethers signer, so the old signer-based path (and even balance/quote reads, which used the wallet provider) silently didn't work. Reads now use the chain read provider; one WebAuthn ceremony covers the whole approve+swap batch, FairWins-sponsored where the network has a sponsor paymaster, with the fee/sponsorship state disclosed honestly (⚡ Gasless · sponsored / Network fee applies).
- Classic wallets keep signing per call; token approvals are now **exact-amount** instead of unlimited `MaxUint256`.

### Theme awareness
- `TradePanel.css` previously referenced `--color-*` variables that are defined nowhere in the project (the panel only rendered readably by accident). All surfaces now alias the real `theme.css` tokens (`--surface-color`, `--bg-secondary`, `--text-primary/secondary/muted`, `--border-color`, `--brand-primary`, semantic colors), so the ticket tracks light/dark like Portfolio and Earn.

## Test plan

- `TradePanel.test.jsx` extended from 8 → 18 tests: all spec-033 provider-identity and SDK read-out assertions preserved, plus new coverage for account listing/switching, multisig-proposal disclosure, order/pair sync, limit-floor passed to `swap()` (`{ limitMinOutWei }`), perps gating both ways, and the passkey sponsored/fee/cannot-transact states.
- `DexContext.test.jsx` (spec 033 provider awareness) still passes unchanged.
- Full frontend suite: no new failures — the only failing files (`quickAccessPreference`, `ClearPathPanel`, `ProposalBuilder`, `ExternalDaoView.notifications`, `useTransfer.balances` load error) fail identically on `main` in this environment (they depend on live RPC endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7B4Ncxep1WmHhHgHtj7Cz

---
_Generated by [Claude Code](https://claude.ai/code/session_01C7B4Ncxep1WmHhHgHtj7Cz)_