### PR TITLE
Crawler feedback: light-mode contrast, market pre-select, sub-market groups, oracle gating

### DIFF
--- a/frontend/src/components/fairwins/Dashboard.jsx
+++ b/frontend/src/components/fairwins/Dashboard.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useWallet, useWalletRoles, useWalletConnection } from '../../hooks'
+import { useChainTokens } from '../../hooks/useChainTokens'
 import { useUserPreferences } from '../../hooks/useUserPreferences'
 import { useModal } from '../../hooks/useUI'
 import { useWagerActivityOptional } from '../../hooks/useWagerActivity'
@@ -69,6 +70,12 @@ function QuickActionCard({ action, onAction }) {
 
 function QuickActions({ onAction, actionNeededCount = 0 }) {
   const navigate = useNavigate()
+  // Oracle features (Open Oracle Challenge + the Polymarket ticker) only make
+  // sense on chains with an on-chain oracle. On chains without one, hide the
+  // Open Oracle Challenge card entirely (the plain Open Challenge stays) — the
+  // ticker self-hides on the same capability.
+  const { capabilities } = useChainTokens()
+  const oracleAvailable = Boolean(capabilities?.polymarketSidebets)
   // Quick access card visibility (spec 038 US5) — re-render when the
   // Preferences panel changes it, even from a different mounted instance.
   const [, forceRender] = useState(0)
@@ -253,7 +260,15 @@ function QuickActions({ onAction, actionNeededCount = 0 }) {
 
   // Filter by the user's quick access card preference (spec 038 US5); a
   // group header only renders when it still has a visible card under it.
-  const visibleCreateActions = createActions.filter((a) => isCardVisible(a.id))
+  // Networks without an on-chain oracle can't settle from Polymarket, so the
+  // oracle-open-challenge card is hidden there and the plain Open Challenge
+  // takes its place as the default create-challenge entry point (even though it
+  // is otherwise default-hidden).
+  const visibleCreateActions = createActions.filter((a) => {
+    if (a.id === 'oracle-open-challenge') return isCardVisible(a.id) && oracleAvailable
+    if (a.id === 'open-challenge') return isCardVisible(a.id) || !oracleAvailable
+    return isCardVisible(a.id)
+  })
   const visibleUtilityActions = utilityActions.filter((a) => isCardVisible(a.id))
 
   if (visibleCreateActions.length === 0 && visibleUtilityActions.length === 0) {
@@ -485,6 +500,9 @@ function Dashboard() {
   const [showCreateWager, setShowCreateWager] = useState(false)
   const [showOpenChallenge, setShowOpenChallenge] = useState(false)
   const [showOracleOpenChallenge, setShowOracleOpenChallenge] = useState(false)
+  // A Polymarket market pre-selected via the ticker crawler (null when the flow
+  // is opened from the quick-action card and the picker starts empty).
+  const [oracleInitialMarket, setOracleInitialMarket] = useState(null)
   const [showGroupPool, setShowGroupPool] = useState(false)
   // Unified phrase lookup (spec 037): one entry point for taking a challenge or joining a pool.
   const [showUnifiedLookup, setShowUnifiedLookup] = useState(false)
@@ -556,6 +574,7 @@ function Dashboard() {
         setShowOpenChallenge(true)
         break
       case 'oracle-open-challenge':
+        setOracleInitialMarket(null)
         setShowOracleOpenChallenge(true)
         break
       case 'create-pool':
@@ -580,7 +599,8 @@ function Dashboard() {
     }
   }, [navigate])
 
-  const handlePolymarketTickerClick = useCallback(() => {
+  const handlePolymarketTickerClick = useCallback((market) => {
+    setOracleInitialMarket(market || null)
     setShowOracleOpenChallenge(true)
   }, [])
 
@@ -703,7 +723,11 @@ function Dashboard() {
       <OracleOpenChallengeModal
         key={showOracleOpenChallenge ? 'ooc-open' : 'ooc-closed'}
         isOpen={showOracleOpenChallenge}
-        onClose={() => setShowOracleOpenChallenge(false)}
+        initialMarket={oracleInitialMarket}
+        onClose={() => {
+          setShowOracleOpenChallenge(false)
+          setOracleInitialMarket(null)
+        }}
       />
 
       {/* Unified phrase lookup (spec 037) — one entry point: enter four words to take a challenge or join a pool. */}

--- a/frontend/src/components/fairwins/OracleOpenChallengeModal.jsx
+++ b/frontend/src/components/fairwins/OracleOpenChallengeModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useOpenChallengeCreate, OPEN_RESOLUTION_TYPES } from '../../hooks/useOpenChallengeCreate'
 import { useChainTokens } from '../../hooks/useChainTokens'
 import { ResolutionType, isOracleModelExposed } from '../../constants/wagerDefaults'
@@ -26,7 +26,7 @@ const CloseIcon = () => (
  * market closes, settle after it resolves; both capped to the contract windows). Reuses
  * the feature-024 claim-code machinery unchanged (ClaimCodeResultPanel).
  */
-function OracleOpenChallengeModal({ isOpen, onClose }) {
+function OracleOpenChallengeModal({ isOpen, onClose, initialMarket = null }) {
   useEffect(() => {
     if (!isOpen) return
     const onKey = (e) => { if (e.key === 'Escape') onClose() }
@@ -70,7 +70,7 @@ function OracleOpenChallengeModal({ isOpen, onClose }) {
 
         <div className="fm-content">
           <div className="fm-panel">
-            <OracleMakerPanel onClose={onClose} />
+            <OracleMakerPanel onClose={onClose} initialMarket={initialMarket} />
           </div>
         </div>
       </div>
@@ -81,7 +81,7 @@ function OracleOpenChallengeModal({ isOpen, onClose }) {
 // ---------------------------------------------------------------------------
 // Maker — pick market → pick side → stake → create (timeline derived, not edited)
 // ---------------------------------------------------------------------------
-function OracleMakerPanel({ onClose }) {
+function OracleMakerPanel({ onClose, initialMarket = null }) {
   const { createOpenChallenge, busy } = useOpenChallengeCreate()
   const { capabilities } = useChainTokens()
   const polymarketAvailable =
@@ -118,6 +118,16 @@ function OracleMakerPanel({ onClose }) {
     setMarket(m)
     setSide('')
   }, [])
+
+  // Pre-select a market handed in from the ticker crawler (FR: clicking a market
+  // opens this view with it already selected). Seed once, and only while the
+  // picker is still empty, so re-picks and the Change affordance aren't clobbered.
+  const seededRef = useRef(false)
+  useEffect(() => {
+    if (seededRef.current || !initialMarket) return
+    seededRef.current = true
+    handleSelectMarket(initialMarket)
+  }, [initialMarket, handleSelectMarket])
 
   const clearMarket = useCallback(() => {
     setMarket(null)

--- a/frontend/src/components/fairwins/PolymarketTickerCrawler.css
+++ b/frontend/src/components/fairwins/PolymarketTickerCrawler.css
@@ -1,9 +1,18 @@
+/* Polymarket ticker crawler. Colors are driven by the shared theme variables
+   (which flip with .theme-light / .theme-dark) so the row stays legible in both
+   modes — the earlier hard-coded near-white values were invisible on the light
+   porcelain background. */
+.pm-ticker-root {
+  position: relative;
+  width: 100%;
+}
+
 .pm-ticker {
   overflow: hidden;
   width: 100%;
   padding: 0.35rem 0;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color);
   -webkit-mask-image: linear-gradient(to right, transparent, #000 8%, #000 92%, transparent);
   mask-image: linear-gradient(to right, transparent, #000 8%, #000 92%, transparent);
 }
@@ -15,7 +24,8 @@
 }
 
 .pm-ticker:hover .pm-ticker-track,
-.pm-ticker:focus-within .pm-ticker-track {
+.pm-ticker:focus-within .pm-ticker-track,
+.pm-ticker--paused .pm-ticker-track {
   animation-play-state: paused;
 }
 
@@ -32,7 +42,7 @@
 }
 
 .pm-ticker-label {
-  color: rgba(123, 220, 181, 0.75);
+  color: var(--brand-primary);
   font-size: 0.7rem;
   font-weight: 700;
   letter-spacing: 0.1em;
@@ -40,9 +50,12 @@
 }
 
 .pm-ticker-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   background: transparent;
   border: none;
-  color: rgba(230, 237, 243, 0.72);
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 0.82rem;
   padding: 0;
@@ -54,7 +67,86 @@
 
 .pm-ticker-item:hover,
 .pm-ticker-item:focus-visible {
-  color: rgba(230, 237, 243, 0.98);
+  color: var(--text-primary);
+}
+
+/* Group entries carry a count pill and don't select directly — no underline so
+   they read as "expand" rather than "pick". */
+.pm-ticker-item--group {
+  text-decoration: none;
+}
+
+.pm-ticker-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.15rem;
+  height: 1.15rem;
+  padding: 0 0.35rem;
+  border-radius: var(--radius-full);
+  background: rgba(var(--brand-primary-rgb), 0.16);
+  color: var(--brand-primary);
+  font-size: 0.62rem;
+  font-weight: 700;
+  line-height: 1;
+  text-decoration: none;
+}
+
+/* Sub-market panel — a small card floating above the ticker row. */
+.pm-ticker-submarkets {
+  position: absolute;
+  bottom: 100%;
+  left: 0.5rem;
+  z-index: 20;
+  max-width: min(28rem, calc(100% - 1rem));
+  margin-bottom: 0.4rem;
+  padding: 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background: var(--surface-color);
+  box-shadow: var(--shadow-lg);
+}
+
+.pm-ticker-submarket-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 14rem;
+  overflow-y: auto;
+}
+
+.pm-ticker-submarket {
+  display: block;
+  width: 100%;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 0.82rem;
+  padding: 0.4rem 0.5rem;
+  text-align: left;
+  white-space: normal;
+}
+
+.pm-ticker-submarket:hover,
+.pm-ticker-submarket:focus-visible {
+  background: rgba(var(--brand-primary-rgb), 0.12);
+  color: var(--brand-primary);
+}
+
+/* The group title sits beneath the sub-market list (spec: "submarkets as a list
+   above the market title"). */
+.pm-ticker-submarkets-title {
+  margin: 0.4rem 0.15rem 0.1rem;
+  padding-top: 0.4rem;
+  border-top: 1px solid var(--border-color);
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 600;
 }
 
 @keyframes pm-ticker-crawl {

--- a/frontend/src/components/fairwins/PolymarketTickerCrawler.jsx
+++ b/frontend/src/components/fairwins/PolymarketTickerCrawler.jsx
@@ -1,50 +1,153 @@
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { useChainTokens } from '../../hooks/useChainTokens'
 import { usePolymarketTopMarkets } from '../../hooks/usePolymarketSearch'
 import './PolymarketTickerCrawler.css'
 
+/**
+ * Horizontally-scrolling ticker of top Polymarket markets on the dashboard.
+ * Clicking a single-market entry opens the Open Oracle Challenge flow with that
+ * market pre-selected (onSelectMarket). Entries backed by an event with several
+ * sub-markets (e.g. a race with many candidates) don't select directly — they
+ * open a small panel above the ticker listing the sub-markets so the user can
+ * pick the exact one.
+ *
+ * The row is rendered twice and the track translated by -50% so the marquee
+ * loops seamlessly; the second copy is aria-hidden and non-interactive so
+ * assistive tech and clicks only ever hit each market once. The crawl pauses on
+ * hover/focus (so entries are clickable) and while a sub-market panel is open,
+ * and stops entirely under prefers-reduced-motion. Self-gates on chain
+ * capability — renders nothing on networks without Polymarket support.
+ */
 function PolymarketTickerCrawler({ onSelectMarket, limit = 12 }) {
   const { capabilities } = useChainTokens()
   const polymarketSidebetsEnabled = Boolean(capabilities?.polymarketSidebets)
   const { results } = usePolymarketTopMarkets({ limit })
+  // Which event's sub-market panel is open (null = none). Only one at a time.
+  const [openEventId, setOpenEventId] = useState(null)
+  const rootRef = useRef(null)
+
+  // Dismiss the sub-market panel on outside click or Escape.
+  useEffect(() => {
+    if (openEventId == null) return undefined
+    const onPointerDown = (e) => {
+      if (rootRef.current && !rootRef.current.contains(e.target)) setOpenEventId(null)
+    }
+    const onKey = (e) => { if (e.key === 'Escape') setOpenEventId(null) }
+    document.addEventListener('mousedown', onPointerDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [openEventId])
+
+  const handleSelect = useCallback((market) => {
+    setOpenEventId(null)
+    onSelectMarket?.(market)
+  }, [onSelectMarket])
 
   if (!polymarketSidebetsEnabled || !results?.length) return null
 
   const items = results
     .map((event) => {
-      const market = event?.markets?.[0]
-      const title = event?.title || market?.question || market?.label
-      if (!market || !title) return null
-      return { market, title }
+      const markets = Array.isArray(event?.markets) ? event.markets : []
+      const title = event?.title || markets[0]?.question || markets[0]?.label
+      if (!markets.length || !title) return null
+      return { id: event.id, title, markets }
     })
     .filter(Boolean)
 
   if (!items.length) return null
 
+  const openItem = items.find((item) => item.id === openEventId) || null
+
+  // A single ticker entry. Clones are static (non-interactive) so the marquee's
+  // duplicate copy never fires a second selection or panel.
+  const renderEntry = (item, clone) => {
+    const isGroup = item.markets.length > 1
+
+    if (clone) {
+      return (
+        <span className={`pm-ticker-item${isGroup ? ' pm-ticker-item--group' : ''}`}>
+          {item.title}
+          {isGroup && <span className="pm-ticker-count" aria-hidden="true">{item.markets.length}</span>}
+        </span>
+      )
+    }
+
+    if (!isGroup) {
+      const market = item.markets[0]
+      return (
+        <button
+          type="button"
+          className="pm-ticker-item"
+          onClick={() => handleSelect(market)}
+        >
+          {item.title}
+        </button>
+      )
+    }
+
+    const isOpen = openEventId === item.id
+    return (
+      <button
+        type="button"
+        className="pm-ticker-item pm-ticker-item--group"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        onClick={() => setOpenEventId((cur) => (cur === item.id ? null : item.id))}
+      >
+        {item.title}
+        <span className="pm-ticker-count" aria-hidden="true">{item.markets.length}</span>
+      </button>
+    )
+  }
+
   const renderGroup = (clone) => (
     <ul className="pm-ticker-group" aria-hidden={clone || undefined}>
       <li className="pm-ticker-label">Polymarket</li>
       {items.map((item, index) => (
-        <li key={`${clone ? 'clone' : 'item'}-${index}-${item.market.conditionId}`}>
-          <button
-            type="button"
-            className="pm-ticker-item"
-            tabIndex={clone ? -1 : undefined}
-            onClick={() => onSelectMarket?.(item.market)}
-          >
-            {item.title}
-          </button>
+        <li key={`${clone ? 'clone' : 'item'}-${index}-${item.id}`}>
+          {renderEntry(item, clone)}
         </li>
       ))}
     </ul>
   )
 
   return (
-    <section className="pm-ticker" aria-label="Polymarket ticker crawler">
-      <div className="pm-ticker-track">
-        {renderGroup(false)}
-        {renderGroup(true)}
-      </div>
-    </section>
+    <div className="pm-ticker-root" ref={rootRef}>
+      {/* Sub-market list for the open group — sits above the ticker (outside the
+          clipped track) so it can't be masked, with the group title beneath it. */}
+      {openItem && (
+        <div className="pm-ticker-submarkets" role="menu" aria-label={`${openItem.title} markets`}>
+          <ul className="pm-ticker-submarket-list">
+            {openItem.markets.map((market) => (
+              <li key={market.conditionId}>
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="pm-ticker-submarket"
+                  onClick={() => handleSelect(market)}
+                >
+                  {market.label || market.question}
+                </button>
+              </li>
+            ))}
+          </ul>
+          <p className="pm-ticker-submarkets-title">{openItem.title}</p>
+        </div>
+      )}
+
+      <section
+        className={`pm-ticker${openEventId != null ? ' pm-ticker--paused' : ''}`}
+        aria-label="Polymarket ticker crawler"
+      >
+        <div className="pm-ticker-track">
+          {renderGroup(false)}
+          {renderGroup(true)}
+        </div>
+      </section>
+    </div>
   )
 }
 

--- a/frontend/src/test/Dashboard.test.jsx
+++ b/frontend/src/test/Dashboard.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import { useChainId } from 'wagmi'
 import Dashboard from '../components/fairwins/Dashboard'
 import { UserPreferencesContext, WalletContext, FriendMarketsContext, UIContext, DexContext } from '../contexts'
 import { setCardVisible } from '../utils/quickAccessPreference'
@@ -23,7 +24,12 @@ vi.mock('../components/fairwins/FriendMarketsModal', () => ({
 // Stub the oracle open challenge modal (spec 041) to assert the Dashboard card wiring
 // without the picker/create internals (covered by OracleOpenChallengeModal.test.jsx).
 vi.mock('../components/fairwins/OracleOpenChallengeModal', () => ({
-  default: ({ isOpen }) => isOpen ? <div data-testid="oracle-open-challenge-modal" /> : null,
+  default: ({ isOpen, initialMarket }) => isOpen ? (
+    <div
+      data-testid="oracle-open-challenge-modal"
+      data-initial-market={initialMarket?.conditionId || ''}
+    />
+  ) : null,
 }))
 
 vi.mock('../components/fairwins/UnifiedLookupModal', () => ({
@@ -34,7 +40,7 @@ vi.mock('../components/fairwins/UnifiedLookupModal', () => ({
 
 vi.mock('../components/fairwins/PolymarketTickerCrawler', () => ({
   default: ({ onSelectMarket }) => (
-    <button type="button" onClick={() => onSelectMarket?.()}>
+    <button type="button" onClick={() => onSelectMarket?.({ conditionId: '0xticker' })}>
       Ticker: Will event happen?
     </button>
   ),
@@ -159,6 +165,10 @@ describe('Dashboard Component', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default the dashboard onto a Polymarket-enabled chain (Polygon) so the
+    // oracle card + ticker render; individual tests override for the
+    // no-on-chain-oracle case.
+    useChainId.mockReturnValue(137)
     localStorage.removeItem('fairwins_quickaccess_v1')
   })
 
@@ -390,19 +400,25 @@ describe('Dashboard Component', () => {
       expect(screen.getByText(/share a code — Polymarket settles it automatically/i)).toBeInTheDocument()
     })
 
-    it('clicking the card opens the oracle open challenge modal (not the 1v1 flow)', () => {
+    it('clicking the card opens the oracle open challenge modal (not the 1v1 flow) with an empty picker', () => {
       renderWithProviders(<Dashboard />)
       expect(screen.queryByTestId('oracle-open-challenge-modal')).toBeNull()
       fireEvent.click(screen.getByText('Open Oracle Challenge'))
-      expect(screen.getByTestId('oracle-open-challenge-modal')).toBeInTheDocument()
+      const modal = screen.getByTestId('oracle-open-challenge-modal')
+      expect(modal).toBeInTheDocument()
+      // Opened from the card → no market pre-selected.
+      expect(modal).toHaveAttribute('data-initial-market', '')
       expect(screen.queryByTestId('friend-modal')).toBeNull()
     })
 
-    it('clicking a ticker title opens the oracle open challenge modal', () => {
+    it('clicking a ticker market opens the oracle open challenge modal with that market pre-selected', () => {
       renderWithProviders(<Dashboard />)
       expect(screen.queryByTestId('oracle-open-challenge-modal')).toBeNull()
       fireEvent.click(screen.getByText('Ticker: Will event happen?'))
-      expect(screen.getByTestId('oracle-open-challenge-modal')).toBeInTheDocument()
+      const modal = screen.getByTestId('oracle-open-challenge-modal')
+      expect(modal).toBeInTheDocument()
+      // The ticker forwards the picked market's conditionId into the modal.
+      expect(modal).toHaveAttribute('data-initial-market', '0xticker')
     })
 
     it('the card is toggleable via quick-access preferences like any other (spec 038 US5)', () => {
@@ -420,6 +436,27 @@ describe('Dashboard Component', () => {
       // the card itself is an h4, the modal title an h2.
       expect(screen.queryByTestId('oracle-open-challenge-modal')).toBeNull()
       expect(screen.getByRole('heading', { level: 2, name: 'Open Challenge' })).toBeInTheDocument()
+    })
+  })
+
+  // Networks without an on-chain oracle (no Polymarket) hide the oracle open
+  // challenge card while keeping the plain Open Challenge available. The ticker
+  // crawler self-hides on the same capability (covered by its own test).
+  describe('Networks without an on-chain oracle', () => {
+    it('hides the Open Oracle Challenge card', () => {
+      useChainId.mockReturnValue(63) // Ethereum Classic Mordor — no Polymarket
+      setCardVisible('oracle-open-challenge', true)
+      renderWithProviders(<Dashboard />)
+      expect(screen.queryByText('Open Oracle Challenge')).toBeNull()
+    })
+
+    it('surfaces the plain Open Challenge card by default (replacing the hidden oracle card)', () => {
+      useChainId.mockReturnValue(63)
+      // No setCardVisible: open-challenge is otherwise default-hidden, but a
+      // network without an on-chain oracle promotes it to the default entry.
+      renderWithProviders(<Dashboard />)
+      expect(screen.getByText('Open Challenge')).toBeInTheDocument()
+      expect(screen.queryByText('Open Oracle Challenge')).toBeNull()
     })
   })
 })

--- a/frontend/src/test/PolymarketTickerCrawler.test.jsx
+++ b/frontend/src/test/PolymarketTickerCrawler.test.jsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+
+// Chain capability gate — flip per-test via this holder.
+const capsHolder = { capabilities: { polymarketSidebets: true } }
+vi.mock('../hooks/useChainTokens', () => ({
+  useChainTokens: () => capsHolder,
+}))
+
+// Top-markets feed — controlled per-test.
+const topHolder = { results: [] }
+vi.mock('../hooks/usePolymarketSearch', () => ({
+  usePolymarketTopMarkets: () => topHolder,
+}))
+
+import PolymarketTickerCrawler from '../components/fairwins/PolymarketTickerCrawler'
+
+const singleEvent = {
+  id: 'evt-single',
+  title: 'Will ETH flip BTC?',
+  markets: [
+    { conditionId: '0xsingle', question: 'Will ETH flip BTC?', label: 'Will ETH flip BTC?', endDate: '2030-01-01' },
+  ],
+}
+
+const groupEvent = {
+  id: 'evt-group',
+  title: 'F1 Drivers’ Champion',
+  markets: [
+    { conditionId: '0xham', question: 'Will Hamilton win?', label: 'Hamilton', endDate: '2030-01-01' },
+    { conditionId: '0xver', question: 'Will Verstappen win?', label: 'Verstappen', endDate: '2030-01-01' },
+    { conditionId: '0xnor', question: 'Will Norris win?', label: 'Norris', endDate: '2030-01-01' },
+  ],
+}
+
+describe('<PolymarketTickerCrawler />', () => {
+  beforeEach(() => {
+    capsHolder.capabilities = { polymarketSidebets: true }
+    topHolder.results = []
+  })
+
+  it('renders nothing on a network without an on-chain oracle', () => {
+    capsHolder.capabilities = { polymarketSidebets: false }
+    topHolder.results = [singleEvent]
+    const { container } = render(<PolymarketTickerCrawler onSelectMarket={vi.fn()} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when there are no markets', () => {
+    topHolder.results = []
+    const { container } = render(<PolymarketTickerCrawler onSelectMarket={vi.fn()} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('clicking a single-market entry selects that market', () => {
+    const onSelectMarket = vi.fn()
+    topHolder.results = [singleEvent]
+    render(<PolymarketTickerCrawler onSelectMarket={onSelectMarket} />)
+
+    // The interactive (non-clone) copy is a button; the aria-hidden clone is a span.
+    fireEvent.click(screen.getByRole('button', { name: 'Will ETH flip BTC?' }))
+    expect(onSelectMarket).toHaveBeenCalledTimes(1)
+    expect(onSelectMarket.mock.calls[0][0].conditionId).toBe('0xsingle')
+  })
+
+  it('clicking a market group reveals its sub-markets as a list above the title', () => {
+    const onSelectMarket = vi.fn()
+    topHolder.results = [groupEvent]
+    render(<PolymarketTickerCrawler onSelectMarket={onSelectMarket} />)
+
+    // Group entry does not select directly — it expands.
+    expect(screen.queryByRole('menu')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: /F1 Drivers’ Champion/ }))
+    expect(onSelectMarket).not.toHaveBeenCalled()
+
+    const menu = screen.getByRole('menu')
+    // Each sub-market is a menu item, listed by its short label.
+    expect(within(menu).getByRole('menuitem', { name: 'Hamilton' })).toBeInTheDocument()
+    expect(within(menu).getByRole('menuitem', { name: 'Verstappen' })).toBeInTheDocument()
+    expect(within(menu).getByRole('menuitem', { name: 'Norris' })).toBeInTheDocument()
+
+    // Picking a sub-market selects it and closes the panel.
+    fireEvent.click(within(menu).getByRole('menuitem', { name: 'Verstappen' }))
+    expect(onSelectMarket).toHaveBeenCalledTimes(1)
+    expect(onSelectMarket.mock.calls[0][0].conditionId).toBe('0xver')
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
+  it('shows each market once for assistive tech — the marquee clone is aria-hidden and non-interactive', () => {
+    topHolder.results = [singleEvent]
+    render(<PolymarketTickerCrawler onSelectMarket={vi.fn()} />)
+    // One interactive button (real copy); the clone renders as static text.
+    expect(screen.getAllByRole('button', { name: 'Will ETH flip BTC?' })).toHaveLength(1)
+  })
+})

--- a/frontend/src/test/claimCode/OracleOpenChallengeModal.test.jsx
+++ b/frontend/src/test/claimCode/OracleOpenChallengeModal.test.jsx
@@ -59,6 +59,24 @@ describe('OracleOpenChallengeModal (spec 041, US1)', () => {
     expect(screen.getByRole('button', { name: /create & generate code/i })).toBeDisabled()
   })
 
+  it('pre-selects a market handed in via initialMarket (ticker crawler entry), skipping the picker', () => {
+    render(<OracleOpenChallengeModal isOpen onClose={() => {}} initialMarket={eligibleMarket} />)
+    // The picker is bypassed: the selected-market summary + side picker show immediately.
+    expect(screen.queryByTestId('pm-browser')).toBeNull()
+    expect(screen.getByText('Will ETH flip BTC?')).toBeInTheDocument()
+    expect(screen.getByText(/your side of the bet/i)).toBeInTheDocument()
+    // Change goes back to the picker.
+    fireEvent.click(screen.getByRole('button', { name: /change/i }))
+    expect(screen.getByTestId('pm-browser')).toBeInTheDocument()
+  })
+
+  it('an ineligible (too-soon) initialMarket falls back to the picker with a reason', () => {
+    render(<OracleOpenChallengeModal isOpen onClose={() => {}} initialMarket={soonMarket} />)
+    expect(screen.getByRole('alert')).toHaveTextContent(/too soon/i)
+    expect(screen.getByTestId('pm-browser')).toBeInTheDocument()
+    expect(screen.queryByText(/your side of the bet/i)).toBeNull()
+  })
+
   it('shows a locked explanation (not a silent blank) on chains without Polymarket support (FR-004)', () => {
     capsHolder.capabilities = { polymarketSidebets: false }
     render(<OracleOpenChallengeModal isOpen onClose={() => {}} />)


### PR DESCRIPTION
Addresses the four rounds of feedback on the home-screen Polymarket ticker crawler.

## Changes

### 1. Light-mode contrast
The ticker used hard-coded near-white `rgba(...)` values that were invisible on the light porcelain background. All colors now come from the shared theme variables (`--text-secondary`/`--text-primary`, `--border-color`, `--brand-primary`), so the row is legible in both light and dark and stays in sync with any future theme tuning.

### 2. Clicking a market pre-selects it in the oracle challenge
Clicking a market now opens the **Open Oracle Challenge** view with that market already selected. The crawler's `onSelectMarket` is threaded through `Dashboard` into `OracleOpenChallengeModal` as a new `initialMarket` prop, seeded through the existing eligibility check (an ineligible/too-soon market falls back to the picker with the usual reason, so the flow is never stranded).

### 3. Market groups expand their sub-markets
Clicking a market group backed by several sub-markets (e.g. a race with many candidates) no longer selects blindly — it opens a small panel **above** the group title listing each sub-market, and picking one selects that exact market and continues into the challenge flow. The panel sits outside the clipped marquee track, dismisses on outside-click/Escape, and pauses the crawl while open.

### 4. Oracle features hidden on networks without an on-chain oracle
On networks without an on-chain oracle (no Polymarket support), the **Open Oracle Challenge** card is hidden and the plain **Open Challenge** takes its place as the default create-challenge entry point (even though it is otherwise default-hidden). The crawler already self-hides on the same `polymarketSidebets` capability.

## Testing
- New `PolymarketTickerCrawler.test.jsx`: capability self-hide, single-market select, group→sub-market expansion, and marquee-clone non-interactivity.
- `Dashboard.test.jsx`: ticker click forwards the picked market's `conditionId`; card-open starts with an empty picker; oracle card hidden + Open Challenge promoted on a non-oracle network.
- `OracleOpenChallengeModal.test.jsx`: `initialMarket` pre-selects (skipping the picker) and an ineligible one falls back to the picker.
- Full frontend suite: no new failures (the 11 pre-existing failures in `quickAccessPreference`/`ProposalBuilder`/`useTransfer.balances` are present on the base branch and untouched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YHim8Mnp3PQhgHUG8NnUwf)_