### PR TITLE
Home create-a-challenge: inline compact resolution, drop timeline, one-line actions

### DIFF
--- a/frontend/src/components/fairwins/CreateChallengePanel.jsx
+++ b/frontend/src/components/fairwins/CreateChallengePanel.jsx
@@ -10,21 +10,13 @@ import QRScanner from '../ui/QRScanner'
 import AmountKeypad from '../ui/AmountKeypad'
 import PolymarketBrowser from './PolymarketBrowser'
 import ClaimCodeResultPanel from './ClaimCodeResultPanel'
-import DeadlineTimeline from './DeadlineTimeline'
-import { toDatetimeLocal, fromDatetimeLocal, formatTimelineSpan, HOUR_MS, DAY_MS } from './wagerTimeline'
+import { toDatetimeLocal, fromDatetimeLocal, HOUR_MS } from './wagerTimeline'
 import { deriveOracleChallengeTimeline } from '../../lib/openChallenge/oracleTimeline'
 import PillSelect from '../ui/PillSelect'
 import InfoTip from '../ui/InfoTip'
 import { EitherSideIcon, ThirdPartyIcon, OracleIcon } from './resolutionIcons'
 import './FriendMarketsModal.css'
 import './OpenChallengeModal.css'
-
-// Deadline bounds (unchanged from the previous slider-based timeline):
-// acceptance window caps at the open-challenge contract's MAX_ACCEPT_WINDOW
-// (30 days); the resolve window caps comfortably under the 180-day contract
-// resolve window.
-const ACCEPT_MAX_MS = 30 * DAY_MS
-const RESOLVE_MAX_GAP_MS = 90 * DAY_MS
 
 const BackIcon = () => (
   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -74,10 +66,11 @@ function CreateChallengePanel({ embedded = false, onClose, onDone, initialResolu
   const [step, setStep] = useState(() =>
     Number(initialResolutionType) === OPEN_RESOLUTION_TYPES.Polymarket && polymarketAvailable ? 'market' : 'form'
   )
-  // Deadlines (feature 024): the maker sets the accept/resolve windows for the
-  // self/arbitrator paths. Stored as datetime-local strings, unix seconds on submit.
-  const [acceptBy, setAcceptBy] = useState(() => toDatetimeLocal(Date.now() + 48 * HOUR_MS))
-  const [resolveBy, setResolveBy] = useState(() => toDatetimeLocal(Date.now() + (48 + 24 * 7) * HOUR_MS))
+  // Deadlines (feature 024): fixed sensible defaults for the self/arbitrator paths — 48h to take,
+  // then +7d to settle. No longer edited in the create view (spec 053: the slider timeline was
+  // dropped to stop the sheet scrolling). Converted to unix seconds on submit.
+  const [acceptBy] = useState(() => toDatetimeLocal(Date.now() + 48 * HOUR_MS))
+  const [resolveBy] = useState(() => toDatetimeLocal(Date.now() + (48 + 24 * 7) * HOUR_MS))
   const [nowMs] = useState(() => Date.now())
   const [error, setError] = useState(null)
   const [progress, setProgress] = useState(null)
@@ -109,40 +102,9 @@ function CreateChallengePanel({ embedded = false, onClose, onDone, initialResolu
       : (description.trim().length > 0 && arbitratorValid && deadlinesValid)
   )
 
-  // Milestones for the shared DeadlineTimeline control (self/arbitrator paths only).
-  const timelineMilestones = [
-    {
-      key: 'accept',
-      label: 'Open for acceptance until',
-      tileHead: 'Open until',
-      value: Number.isFinite(acceptMs) ? acceptMs : nowMs + 48 * HOUR_MS,
-      min: nowMs + HOUR_MS,
-      max: nowMs + ACCEPT_MAX_MS,
-      editable: true,
-      hint: 'After this, the challenge can no longer be taken and your stake is refundable.',
-      segmentColor: 'var(--timeline-accept)',
-      dotClass: 'is-accept',
-      tileClass: 'is-accept',
-    },
-    {
-      key: 'resolve',
-      label: 'Must be resolved by',
-      tileHead: 'Resolve by',
-      value: Number.isFinite(resolveMs) ? resolveMs : (Number.isFinite(acceptMs) ? acceptMs : nowMs + 48 * HOUR_MS) + 7 * DAY_MS,
-      min: (Number.isFinite(acceptMs) ? acceptMs : nowMs + 48 * HOUR_MS) + HOUR_MS,
-      max: (Number.isFinite(acceptMs) ? acceptMs : nowMs + 48 * HOUR_MS) + RESOLVE_MAX_GAP_MS,
-      editable: true,
-      hint: 'The outcome must be submitted before this time.',
-      segmentColor: 'var(--timeline-active)',
-      dotClass: 'is-resolve',
-      tileClass: 'is-resolve',
-    },
-  ]
-  const handleTimelineChange = (key, ms) => {
-    const str = toDatetimeLocal(ms)
-    if (key === 'accept') setAcceptBy(str)
-    else if (key === 'resolve') setResolveBy(str)
-  }
+  // The accept/resolve windows use sensible defaults (48h to take · +7d to settle) and are no
+  // longer editable in the create view (spec 053 feedback: drop the slider timeline to stop the
+  // sheet scrolling). The default state above still flows to the submit call as valid deadlines.
 
   const handleResolutionChange = (value) => {
     setResolutionType(value)
@@ -284,6 +246,33 @@ function CreateChallengePanel({ embedded = false, onClose, onDone, initialResolu
         />
       </div>
 
+      {/* Resolution selector — minimal icons, compact and inline right under the number pad
+          (spec 053 feedback). Short labels keep the three options on as few rows as possible. */}
+      <div className="fm-form-group fm-form-full fm-pay-resolution">
+        <PillSelect
+          label={<>How is it resolved? <span className="fm-required">*</span></>}
+          info={(
+            <InfoTip label="About: How is it resolved?">
+              Single-party self-resolution isn&apos;t available for open challenges — the taker is unknown when you post it.
+            </InfoTip>
+          )}
+          options={[
+            { value: String(OPEN_RESOLUTION_TYPES.Either), label: 'Either side', icon: <EitherSideIcon /> },
+            { value: String(OPEN_RESOLUTION_TYPES.ThirdParty), label: 'Arbitrator', icon: <ThirdPartyIcon /> },
+            {
+              value: String(OPEN_RESOLUTION_TYPES.Polymarket),
+              label: 'Oracle',
+              icon: <OracleIcon />,
+              disabled: !polymarketAvailable,
+              disabledReason: 'Requires a Polymarket-enabled network. Switch networks to settle from a market.',
+            },
+          ]}
+          value={resolutionType}
+          onChange={handleResolutionChange}
+          disabled={busy}
+        />
+      </div>
+
       {isOracle ? (
         // Oracle path: the picked market + your side stand in for the free memo
         // (the description is auto-composed from them).
@@ -368,70 +357,22 @@ function CreateChallengePanel({ embedded = false, onClose, onDone, initialResolu
         </div>
       )}
 
-      {/* Remaining controls grouped as compact "details" below the hero. */}
-      <div className="fm-pay-details">
-        <div className="fm-form-group fm-form-full">
-          <PillSelect
-            label={<>How is it resolved? <span className="fm-required">*</span></>}
-            info={(
-              <InfoTip label="About: How is it resolved?">
-                Single-party self-resolution isn&apos;t available for open challenges — the taker is unknown when you post it.
-              </InfoTip>
-            )}
-            options={[
-              { value: String(OPEN_RESOLUTION_TYPES.Either), label: 'Either side submits the outcome', icon: <EitherSideIcon /> },
-              { value: String(OPEN_RESOLUTION_TYPES.ThirdParty), label: 'A named third-party arbitrator decides', icon: <ThirdPartyIcon /> },
-              {
-                value: String(OPEN_RESOLUTION_TYPES.Polymarket),
-                label: 'An oracle settles it (Polymarket)',
-                icon: <OracleIcon />,
-                disabled: !polymarketAvailable,
-                disabledReason: 'Requires a Polymarket-enabled network. Switch networks to settle from a market.',
-              },
-            ]}
-            value={resolutionType}
-            onChange={handleResolutionChange}
-            disabled={busy}
-          />
-        </div>
+      {/* Arbitrator entry only when the third-party path is chosen. */}
+      {isThirdParty && (
+        <ArbitratorField
+          value={arbitrator}
+          onChange={setArbitrator}
+          onResolvedChange={setArbitratorResolved}
+          disabled={busy}
+        />
+      )}
 
-        {isThirdParty && (
-          <ArbitratorField
-            value={arbitrator}
-            onChange={setArbitrator}
-            onResolvedChange={setArbitratorResolved}
-            disabled={busy}
-          />
-        )}
-
-        {isOracle ? (
-          market && oracleTimeline?.eligible && (
-            <p className="fm-hint">
-              Takeable until the market closes (up to 30 days) · settles when Polymarket resolves it.
-            </p>
-          )
-        ) : (
-          <>
-            {/* Time constraints: the shared deadline timeline — drag a dot to pick each
-                time, or tap a tile to open the exact date & time modal. */}
-            <DeadlineTimeline
-              milestones={timelineMilestones}
-              onChange={handleTimelineChange}
-              disabled={busy}
-              idPrefix="oc"
-              summary={deadlinesValid
-                ? `Open ${formatTimelineSpan(new Date(nowMs), new Date(acceptMs))} for a taker · ` +
-                  `then up to ${formatTimelineSpan(new Date(acceptMs), new Date(resolveMs))} to settle`
-                : null}
-            />
-            {!deadlinesValid && (acceptBy || resolveBy) && (
-              <p className="fm-hint oc-deadline-warn" role="alert">
-                Pick an acceptance time in the future and a resolve time after it.
-              </p>
-            )}
-          </>
-        )}
-      </div>
+      {/* Oracle timeline is set by the event, not edited here — one compact line. */}
+      {isOracle && market && oracleTimeline?.eligible && (
+        <p className="fm-hint fm-pay-oracle-hint">
+          Takeable until the market closes (up to 30 days) · settles when Polymarket resolves it.
+        </p>
+      )}
 
       {progress && <p className="fm-hint" role="status">{progress.message}</p>}
       {error && <div className="fm-error-banner" role="alert">{error}</div>}

--- a/frontend/src/components/fairwins/FriendMarketsModal.css
+++ b/frontend/src/components/fairwins/FriendMarketsModal.css
@@ -554,6 +554,27 @@
   border-top: 1px solid var(--border-color, #23303D);
 }
 
+/* Compact, inline resolution selector directly under the number pad (spec 053 feedback):
+   minimal icons + short labels on a single wrapping row instead of a tall stacked list. */
+.fm-pay-resolution {
+  gap: 0.3rem;
+}
+
+.fm-pay-resolution .pill-select {
+  gap: 0.4rem;
+}
+
+.fm-pay-resolution .pill-select-option {
+  flex: 1 1 auto;
+  justify-content: center;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.85rem;
+}
+
+.fm-pay-oracle-hint {
+  text-align: center;
+}
+
 /* Multi-token select under the amount hero (1v1 surface) — compact, centered,
    sits directly beneath the amount rather than inline with a text input. */
 .fm-pay-hero .fm-pay-token-select {

--- a/frontend/src/components/fairwins/HomeScreen.css
+++ b/frontend/src/components/fairwins/HomeScreen.css
@@ -49,9 +49,3 @@
 .home-ticker {
   margin-top: 0.25rem;
 }
-
-@media (max-width: 480px) {
-  .home-actions {
-    grid-template-columns: 1fr;
-  }
-}

--- a/frontend/src/test/CreateChallengePanel.test.jsx
+++ b/frontend/src/test/CreateChallengePanel.test.jsx
@@ -69,13 +69,13 @@ describe('CreateChallengePanel (spec 053 — shared create panel)', () => {
   it('locks the oracle resolution option where Polymarket is unavailable', () => {
     capsHolder.capabilities = { polymarketSidebets: false }
     render(<CreateChallengePanel embedded onClose={() => {}} />)
-    const oracle = screen.getByRole('radio', { name: /an oracle settles it/i })
+    const oracle = screen.getByRole('radio', { name: /^oracle$/i })
     expect(oracle).toHaveAttribute('aria-disabled', 'true')
   })
 
   it('opens the market-search step when oracle is chosen, then returns with a side picker', () => {
     render(<CreateChallengePanel embedded onClose={() => {}} />)
-    fireEvent.click(screen.getByRole('radio', { name: /an oracle settles it/i }))
+    fireEvent.click(screen.getByRole('radio', { name: /^oracle$/i }))
     // Swaps to the market-search sub-view.
     expect(screen.getByTestId('pm-browser')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /pick eligible/i }))

--- a/frontend/src/test/claimCode/OpenChallengeModal.test.jsx
+++ b/frontend/src/test/claimCode/OpenChallengeModal.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
 // Mock the create flow so the modal renders deterministically (no chain/IPFS).
 const createOpenChallenge = vi.fn()
@@ -72,44 +72,11 @@ describe('OpenChallengeModal (create-only; taking moved to the unified lookup, s
     expect(form.acceptDeadline).toBeGreaterThan(Math.floor(Date.now() / 1000))
   })
 
-  it('Maker: deadlines use the shared timeline element — draggable dots plus tap-to-set modal', () => {
-    render(<OpenChallengeModal isOpen onClose={() => {}} />)
-    const acceptDot = screen.getByRole('slider', { name: /open for acceptance until/i })
-    const resolveDot = screen.getByRole('slider', { name: /must be resolved by/i })
-    expect(acceptDot).toBeInTheDocument()
-    expect(resolveDot).toBeInTheDocument()
-    // No native picker field or "type a date" link anywhere in the form (FR-005).
-    expect(document.querySelector('input[type="datetime-local"]')).toBeNull()
-    expect(screen.queryByText(/tap to type a date/i)).toBeNull()
-
-    // Stepping the accept dot's keyboard control drags the resolve deadline
-    // with it, keeping the original gap (legacy slider behavior, preserved).
-    const before = resolveDot.getAttribute('aria-valuenow')
-    fireEvent.keyDown(acceptDot, { key: 'ArrowRight', shiftKey: true })
-    expect(Number(resolveDot.getAttribute('aria-valuenow'))).toBe(Number(before) + 60 * 60 * 1000)
-
-    // Tapping a tile opens the shared set-time modal, not an inline input.
-    fireEvent.click(screen.getByRole('button', { name: /resolve by:/i }))
-    expect(screen.getByRole('dialog', { name: /set date and time/i })).toBeInTheDocument()
-  })
-
-  it('Maker: the set-time modal rejects a resolve time outside the allowed range', () => {
-    render(<OpenChallengeModal isOpen onClose={() => {}} />)
-    fireEvent.change(screen.getByLabelText(/what's the wager/i, { selector: 'input' }), { target: { value: 'Will it rain?' } })
-    tapAmount('10')
-    const createBtn = screen.getByRole('button', { name: /create & generate code/i })
-    expect(createBtn).toBeEnabled()
-
-    // Tap the Resolve-by tile and try to type a time before the allowed window.
-    fireEvent.click(screen.getByRole('button', { name: /resolve by:/i }))
-    const dialog = screen.getByRole('dialog', { name: /set date and time/i })
-    const input = within(dialog).getByLabelText(/must be resolved by/i)
-    fireEvent.change(input, { target: { value: '2000-01-01T00:00' } })
-    expect(within(dialog).getByRole('alert')).toHaveTextContent(/pick a time between/i)
-    expect(within(dialog).getByRole('button', { name: 'Set' })).toBeDisabled()
-    // Out-of-range input never reaches form state, so create stays enabled.
-    expect(createBtn).toBeEnabled()
-  })
+  // The editable deadline timeline (draggable dots + tap-to-set modal) was removed
+  // in the round-4 home redesign to reach the no-scroll goal; deadlines now submit
+  // from fixed sensible defaults (still asserted by the "passes the chosen
+  // accept/resolve deadlines" test above). The former timeline UI tests were
+  // dropped along with the control.
 
   it('Maker: the stake is entered on the payments-style number pad (hero amount + USDC token, spec 052)', () => {
     render(<OpenChallengeModal isOpen onClose={() => {}} />)


### PR DESCRIPTION
## What & why

Round-4 UX feedback on the create-a-challenge home screen (spec 053), pushing toward the **no-scroll goal** the redesign is chasing. From two annotated screenshots:

1. **The "who settles" choice should show a minimal icon and sit inline with the number pad.**
2. **The editable timeline with sliders is no longer needed — remove it.**
3. **"Accept a challenge" and "My rewards" should be on the same line to save space.**

## Changes

- **Compact, inline resolution selector.** Moved the "How is it resolved?" selector directly under the number-pad hero and shrank it: minimal icons with short labels (`Either side` / `Arbitrator` / `Oracle`) so the three options sit on as few rows as possible instead of full-width stacked pills. Oracle stays network-gated (disabled + reason when Polymarket isn't available). New `.fm-pay-resolution` compact styling in `FriendMarketsModal.css`.
- **Removed the editable deadline timeline** (draggable dots + tap-to-set tiles) from the open-challenge create panel. Accept/resolve deadlines now submit from fixed sensible defaults (48h to accept, then +7d to resolve). The `DeadlineTimeline` control itself is untouched and still used by the group-pool flow.
- **One-line secondary actions.** Dropped the mobile single-column stacking so "Accept a challenge" and "My rewards" stay side-by-side at all viewports (`HomeScreen.css`).

## Tests

- Repointed the oracle pill query to the shortened `Oracle` label.
- Dropped the two timeline-UI tests (`draggable dots plus tap-to-set modal`, `set-time modal rejects out-of-range`) along with the removed control; the fixed-default deadline submission stays asserted by the surviving "passes the chosen accept/resolve deadlines" test.
- `CreateChallengePanel`, `HomeScreen`, `OpenChallengeModal`, `Dashboard`, and `FriendMarketsModal` suites pass locally (111 tests); lint clean. Full suite runs in CI.

Front-end presentation only — no wager/take/rewards logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr18WCoEWMNiy4a4YKD6E5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kr18WCoEWMNiy4a4YKD6E5)_