### PR TITLE
Home create view: dock ticker, drop footer, soften pads, green hero

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -42,11 +42,14 @@ import PwaInstallPrompt from './components/pwa/PwaInstallPrompt'
 import PwaUpdateNotification from './components/pwa/PwaUpdateNotification'
 
 function AppLayout() {
-  // The global nav drawer ("us") already carries the legal/policy footer, and the
-  // My Account screen is a dense tab host, so it omits the redundant page-level
-  // footer; every other in-app route keeps it.
+  // The global nav drawer ("us") already carries the legal/policy footer, so the
+  // page-level footer is redundant on the dense hosts: the My Account screen
+  // (/wallet) and the create-a-challenge home (/app, /main, /fairwins), where it
+  // also pushed the ticker off the bottom of the view. Every other in-app route
+  // keeps it.
   const { pathname } = useLocation()
-  const showPageFooter = pathname !== '/wallet'
+  const HIDE_PAGE_FOOTER = ['/wallet', '/app', '/main', '/fairwins']
+  const showPageFooter = !HIDE_PAGE_FOOTER.includes(pathname)
 
   return (
     /* Spec 031: platform-wide activity watcher scoped to the app-mode tree — the header bell and the views

--- a/frontend/src/components/fairwins/FriendMarketsModal.css
+++ b/frontend/src/components/fairwins/FriendMarketsModal.css
@@ -564,11 +564,25 @@
   gap: 0.4rem;
 }
 
+/* Softened, borderless pills to match the borderless number pad — no hard
+   edges; a subtle fill carries the selected/hover state instead of an outline. */
 .fm-pay-resolution .pill-select-option {
   flex: 1 1 auto;
   justify-content: center;
-  padding: 0.45rem 0.6rem;
+  padding: 0.5rem 0.6rem;
   font-size: 0.85rem;
+  border-color: transparent;
+  background: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.06);
+}
+
+.fm-pay-resolution .pill-select-option:hover:not(:disabled) {
+  border-color: transparent;
+  background: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.12);
+}
+
+.fm-pay-resolution .pill-select-option.active {
+  border-color: transparent;
+  background: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.16);
 }
 
 .fm-pay-oracle-hint {

--- a/frontend/src/components/fairwins/HomeScreen.css
+++ b/frontend/src/components/fairwins/HomeScreen.css
@@ -46,6 +46,10 @@
   width: 100%;
 }
 
+/* Dock the ticker to the bottom of the view: the auto top-margin absorbs any
+   spare vertical space in the full-height flex column, so the crawler stays
+   pinned at the bottom instead of floating mid-screen (design feedback). */
 .home-ticker {
-  margin-top: 0.25rem;
+  margin-top: auto;
+  padding-top: 0.5rem;
 }

--- a/frontend/src/components/ui/AmountKeypad.css
+++ b/frontend/src/components/ui/AmountKeypad.css
@@ -26,17 +26,20 @@
   justify-content: center;
   gap: 0.15rem;
   max-width: 100%;
-  color: var(--text-primary, #E6EDF3);
+  /* The stake is the hero — big and brand-green ("Winning Green"), like a
+     payments app's amount read-out. */
+  color: var(--brand-primary, #36B37E);
   font-weight: 700;
   line-height: 1;
   /* Scales down on narrow screens; stays large and glanceable on wide ones. */
-  font-size: clamp(2rem, 10vw, 3rem);
+  font-size: clamp(2.75rem, 15vw, 4.5rem);
   letter-spacing: -0.02em;
   overflow: hidden;
 }
 
 .amount-keypad-prefix {
-  color: var(--text-secondary, #AAB6C2);
+  color: var(--brand-primary, #36B37E);
+  opacity: 0.8;
   font-weight: 600;
   font-size: 0.62em;
   align-self: center;
@@ -49,13 +52,15 @@
   min-width: 0;
 }
 
-/* Zero state — de-emphasized so it reads as "nothing entered yet" (FR-016). */
+/* Zero state — a faded tint of the same green so it reads as "nothing entered
+   yet" without losing the brand color (FR-016). */
 .amount-keypad-hero.is-zero {
-  color: var(--text-muted, #7A8590);
+  color: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.5);
 }
 
 .amount-keypad-hero.is-zero .amount-keypad-prefix {
-  color: var(--text-muted, #7A8590);
+  color: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.5);
+  opacity: 1;
 }
 
 .amount-keypad-token {
@@ -82,6 +87,9 @@
 
 /* Keys are deliberately wider than tall (short landscape keys) so the pad
    stays compact and the sheet doesn't scroll. */
+/* Borderless keys — no boxes, just the digits (Cash-App style). The tap target
+   stays generous; hover/press draws a soft circular highlight instead of a
+   hard-edged box. */
 .amount-keypad-key {
   appearance: none;
   display: flex;
@@ -89,35 +97,32 @@
   justify-content: center;
   min-height: 2.4rem;
   padding: 0.3rem;
-  background: var(--bg-primary, #0E141B);
-  border: 1px solid var(--border-color, #23303D);
-  border-radius: var(--radius-md, 12px);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-full, 9999px);
   color: var(--text-primary, #E6EDF3);
   font-family: inherit;
-  font-size: 1.35rem;
+  font-size: 1.5rem;
   font-weight: 600;
   cursor: pointer;
   transition: background var(--transition-fast, 0.15s) ease,
-              border-color var(--transition-fast, 0.15s) ease,
               transform var(--transition-fast, 0.15s) ease;
   -webkit-tap-highlight-color: transparent;
   user-select: none;
 }
 
 .amount-keypad-key:hover:not(:disabled) {
-  border-color: var(--brand-primary, #36B37E);
-  background: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.08);
+  background: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.1);
 }
 
 .amount-keypad-key:active:not(:disabled) {
   transform: scale(0.97);
-  background: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.14);
+  background: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.18);
 }
 
 .amount-keypad-key:focus-visible {
   outline: none;
-  border-color: var(--brand-primary, #36B37E);
-  box-shadow: 0 0 0 3px rgba(var(--brand-primary-rgb, 54, 179, 126), 0.25);
+  box-shadow: 0 0 0 3px rgba(var(--brand-primary-rgb, 54, 179, 126), 0.35);
 }
 
 .amount-keypad-key:disabled {
@@ -146,10 +151,10 @@
 
 @media (max-width: 640px) {
   .amount-keypad-hero {
-    font-size: clamp(1.75rem, 13vw, 2.75rem);
+    font-size: clamp(2.5rem, 17vw, 4rem);
   }
   .amount-keypad-key {
     min-height: 2.2rem;
-    font-size: 1.25rem;
+    font-size: 1.4rem;
   }
 }


### PR DESCRIPTION
## What & why

Design-feedback pass on the create-a-challenge home screen (`/app`), continuing the payments-app polish toward a clean, no-scroll landing.

## Changes

- **Ticker docked to the bottom.** The Polymarket crawler now pins to the bottom of the view (an auto top-margin absorbs spare space in the full-height flex column) instead of floating mid-screen with a dead gap beneath it.
- **Footer removed on the home routes** (`/app`, `/main`, `/fairwins`). The legal/policy links already live in the nav drawer, so the page-level footer was redundant — and it was pushing the ticker off the bottom. Mirrors the existing `/wallet` exclusion.
- **No more hard edges.** The number-pad keys are now borderless — bare digits with a soft circular hover/press highlight (Cash-App style) — and the resolution pills drop their outline for a subtle brand-tint fill.
- **Bigger, green hero.** The stake read-out is larger and uses the brand "Winning Green", with a faded-green zero state so `$0` still reads as empty.

CSS/presentation only — no wager/take/rewards logic changed.

## Testing

- Affected suites pass locally (46 tests): `AmountKeypad`, `PillSelect`, `CreateChallengePanel`, `HomeScreen`, `OpenChallengeModal`, `Footer`.
- `npm run build` succeeds.
- Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr18WCoEWMNiy4a4YKD6E5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kr18WCoEWMNiy4a4YKD6E5)_