### PR TITLE
Home create view polish + fix gasless create/accept allowance deadlock

### DIFF
--- a/frontend/src/components/fairwins/CreateChallengePanel.jsx
+++ b/frontend/src/components/fairwins/CreateChallengePanel.jsx
@@ -39,7 +39,7 @@ const BackIcon = () => (
  *   - initialMarket: a Polymarket market to pre-select on the oracle path (e.g. a ticker click),
  *     skipping the market-search step.
  */
-function CreateChallengePanel({ embedded = false, onClose, onDone, initialResolutionType, initialMarket = null }) {
+function CreateChallengePanel({ embedded = false, onClose, onDone, onOracleModeChange, initialResolutionType, initialMarket = null }) {
   const { createOpenChallenge, busy } = useOpenChallengeCreate()
   const { capabilities } = useChainTokens()
   // Oracle settlement is only offered where the Polymarket CTF is reachable and
@@ -78,6 +78,13 @@ function CreateChallengePanel({ embedded = false, onClose, onDone, initialResolu
 
   const isThirdParty = Number(resolutionType) === OPEN_RESOLUTION_TYPES.ThirdParty
   const isOracle = Number(resolutionType) === OPEN_RESOLUTION_TYPES.Polymarket
+
+  // Let an embedding host react to the oracle path (the home screen hides its
+  // secondary actions while an oracle challenge is being composed — the market +
+  // side picker need the room and the goal is a no-scroll view).
+  useEffect(() => {
+    onOracleModeChange?.(isOracle)
+  }, [isOracle, onOracleModeChange])
   const arbitratorAddr = arbitratorResolved || arbitrator
   const arbitratorValid = !isThirdParty || isAddress(arbitratorAddr)
   const acceptMs = fromDatetimeLocal(acceptBy)

--- a/frontend/src/components/fairwins/FriendMarketsModal.css
+++ b/frontend/src/components/fairwins/FriendMarketsModal.css
@@ -564,25 +564,26 @@
   gap: 0.4rem;
 }
 
-/* Softened, borderless pills to match the borderless number pad — no hard
-   edges; a subtle fill carries the selected/hover state instead of an outline. */
+/* Borderless, fill-free pills to match the borderless number pad — no box and
+   no background tint; the green icon + label alone carry the selected state
+   (design feedback: "the colored text is enough"). */
 .fm-pay-resolution .pill-select-option {
   flex: 1 1 auto;
   justify-content: center;
   padding: 0.5rem 0.6rem;
   font-size: 0.85rem;
   border-color: transparent;
-  background: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.06);
+  background: transparent;
 }
 
 .fm-pay-resolution .pill-select-option:hover:not(:disabled) {
   border-color: transparent;
-  background: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.12);
+  background: transparent;
 }
 
 .fm-pay-resolution .pill-select-option.active {
   border-color: transparent;
-  background: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.16);
+  background: transparent;
 }
 
 .fm-pay-oracle-hint {

--- a/frontend/src/components/fairwins/HomeScreen.jsx
+++ b/frontend/src/components/fairwins/HomeScreen.jsx
@@ -40,6 +40,9 @@ function HomeScreen() {
   const [unifiedAutoResolve, setUnifiedAutoResolve] = useState(false)
   const [showMyWagers, setShowMyWagers] = useState(false)
   const [initialWagerId, setInitialWagerId] = useState(null)
+  // While the create panel is on its oracle path, hide the secondary actions so the
+  // taller oracle form (market + side picker) fits without scrolling (design feedback).
+  const [oracleMode, setOracleMode] = useState(false)
 
   // Feed → wager navigation (spec 012): open My Wagers on a specific wager, then clear state.
   useEffect(() => {
@@ -101,19 +104,23 @@ function HomeScreen() {
           embedded
           initialResolutionType={oraclePreselect ? OPEN_RESOLUTION_TYPES.Polymarket : undefined}
           initialMarket={oracleMarket}
+          onOracleModeChange={setOracleMode}
           onDone={handleCreated}
         />
       </section>
 
-      {/* Secondary actions: take a challenge, and view winnings/rewards. */}
-      <section className="home-actions" aria-label="Other actions">
-        <button type="button" className="fm-btn-secondary home-action" onClick={openAccept}>
-          Accept a challenge
-        </button>
-        <button type="button" className="fm-btn-secondary home-action" onClick={() => setShowMyWagers(true)}>
-          My rewards
-        </button>
-      </section>
+      {/* Secondary actions: take a challenge, and view winnings. Hidden on the oracle
+          path so the taller oracle form fits without scrolling (design feedback). */}
+      {!oracleMode && (
+        <section className="home-actions" aria-label="Other actions">
+          <button type="button" className="fm-btn-secondary home-action" onClick={openAccept}>
+            Accept a challenge
+          </button>
+          <button type="button" className="fm-btn-secondary home-action" onClick={() => setShowMyWagers(true)}>
+            My Wagers
+          </button>
+        </section>
+      )}
 
       {/* Polymarket ticker — picks route into the create view's oracle path. */}
       <section className="dashboard-section home-ticker">

--- a/frontend/src/components/ui/AmountKeypad.css
+++ b/frontend/src/components/ui/AmountKeypad.css
@@ -32,7 +32,7 @@
   font-weight: 700;
   line-height: 1;
   /* Scales down on narrow screens; stays large and glanceable on wide ones. */
-  font-size: clamp(2.75rem, 15vw, 4.5rem);
+  font-size: clamp(3.5rem, 19vw, 5.75rem);
   letter-spacing: -0.02em;
   overflow: hidden;
 }
@@ -82,7 +82,7 @@
 .amount-keypad-pad {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 0.4rem;
+  gap: 0.5rem;
 }
 
 /* Keys are deliberately wider than tall (short landscape keys) so the pad
@@ -95,14 +95,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 2.4rem;
+  min-height: 3rem;
   padding: 0.3rem;
   background: transparent;
   border: none;
   border-radius: var(--radius-full, 9999px);
   color: var(--text-primary, #E6EDF3);
   font-family: inherit;
-  font-size: 1.5rem;
+  font-size: 1.9rem;
   font-weight: 600;
   cursor: pointer;
   transition: background var(--transition-fast, 0.15s) ease,
@@ -135,8 +135,8 @@
 }
 
 .amount-keypad-key--fn svg {
-  width: 1.35rem;
-  height: 1.35rem;
+  width: 1.65rem;
+  height: 1.65rem;
 }
 
 /* Respect reduced-motion — drop the press-scale animation. */
@@ -151,10 +151,10 @@
 
 @media (max-width: 640px) {
   .amount-keypad-hero {
-    font-size: clamp(2.5rem, 17vw, 4rem);
+    font-size: clamp(3rem, 21vw, 5rem);
   }
   .amount-keypad-key {
-    min-height: 2.2rem;
-    font-size: 1.4rem;
+    min-height: 2.75rem;
+    font-size: 1.75rem;
   }
 }

--- a/frontend/src/hooks/useOpenChallengeAccept.js
+++ b/frontend/src/hooks/useOpenChallengeAccept.js
@@ -235,7 +235,15 @@ export function useOpenChallengeAccept() {
       try {
         await registry.acceptOpenWager.staticCall(wagerId, signature, { from: actor })
       } catch (sim) {
-        throw new Error(translateAcceptRevert(sim.reason || sim.shortMessage || sim.message || ''))
+        const raw = sim.reason || sim.shortMessage || sim.message || ''
+        // A not-yet-granted allowance is expected here: the approve above is batched with the
+        // accept and runs first, so the isolated pre-flight would spuriously revert on it and
+        // deadlock a fresh passkey taker. Only that case is swallowed; every real revert
+        // (expired, wrong signature, membership, …) is still surfaced.
+        const isAllowanceRevert = /(exceeds|insufficient) allowance/i.test(raw)
+        if (!(isAllowanceRevert && allowance < stake)) {
+          throw new Error(translateAcceptRevert(raw))
+        }
       }
       onProgress({ step: 'accept', message: 'Confirm acceptance in your wallet…' })
       calls.push({

--- a/frontend/src/hooks/useOpenChallengeCreate.js
+++ b/frontend/src/hooks/useOpenChallengeCreate.js
@@ -109,11 +109,23 @@ export function useOpenChallengeCreate() {
       ]
 
       // Pre-flight to surface a clear revert (e.g. Silver-tier gate) before the wallet prompt.
+      // The stake is pulled with transferFrom, so simulating createOpenWager in isolation also
+      // exercises the token allowance. When the stake token isn't approved yet the approve leg
+      // runs first — batched atomically for passkey/smart accounts, sequential for EOAs — so the
+      // allowance IS in place by the time create executes. Treat a not-yet-granted-allowance
+      // revert here as expected (never fatal): otherwise the isolated pre-flight would spuriously
+      // fail and permanently block first-time creators (a fresh passkey account has 0 allowance
+      // and no way to pre-approve, so it can never get past this check). Every other revert
+      // (Silver-tier gate, bad deadlines, resolved condition, …) is still surfaced for all users.
       onProgress({ step: 'create', message: 'Validating…' })
       try {
         await registry.createOpenWager.staticCall(...args, { from: actor })
       } catch (sim) {
-        throw new Error(translateOpenCreateRevert(sim.reason || sim.shortMessage || sim.message || ''))
+        const raw = sim.reason || sim.shortMessage || sim.message || ''
+        const isAllowanceRevert = /(exceeds|insufficient) allowance/i.test(raw)
+        if (!(isAllowanceRevert && allowance < stakeWei)) {
+          throw new Error(translateOpenCreateRevert(raw))
+        }
       }
 
       let receipt

--- a/frontend/src/test/HomeScreen.test.jsx
+++ b/frontend/src/test/HomeScreen.test.jsx
@@ -4,13 +4,14 @@ import { MemoryRouter } from 'react-router-dom'
 
 // Stub the heavy children to assert the HomeScreen wiring (not their internals).
 vi.mock('../components/fairwins/CreateChallengePanel', () => ({
-  default: ({ embedded, initialResolutionType, onDone }) => (
+  default: ({ embedded, initialResolutionType, onDone, onOracleModeChange }) => (
     <div
       data-testid="create-panel"
       data-embedded={String(!!embedded)}
       data-initial-resolution={initialResolutionType ?? ''}
     >
       <button type="button" onClick={() => onDone?.()}>done</button>
+      <button type="button" onClick={() => onOracleModeChange?.(true)}>enter oracle mode</button>
     </div>
   ),
 }))
@@ -61,11 +62,21 @@ describe('HomeScreen (spec 053) — the create-a-challenge landing', () => {
     expect(screen.getByTestId('unified-modal')).toBeInTheDocument()
   })
 
-  it('My rewards opens My Wagers (US3)', () => {
+  it('My Wagers opens the My Wagers modal (US3)', () => {
     renderHome()
     expect(screen.queryByTestId('my-wagers-modal')).toBeNull()
-    fireEvent.click(screen.getByRole('button', { name: /my rewards/i }))
+    fireEvent.click(screen.getByRole('button', { name: /my wagers/i }))
     expect(screen.getByTestId('my-wagers-modal')).toBeInTheDocument()
+  })
+
+  it('hides the secondary actions while the create panel is on its oracle path (design feedback)', () => {
+    renderHome()
+    expect(screen.getByRole('button', { name: /accept a challenge/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /my wagers/i })).toBeInTheDocument()
+    // The panel reports it switched to the oracle path → the secondary actions collapse.
+    fireEvent.click(screen.getByRole('button', { name: /enter oracle mode/i }))
+    expect(screen.queryByRole('button', { name: /accept a challenge/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /my wagers/i })).toBeNull()
   })
 
   it('a ticker pick routes the create view into its oracle path (US2)', () => {

--- a/frontend/src/test/useOpenChallengeAccept.test.jsx
+++ b/frontend/src/test/useOpenChallengeAccept.test.jsx
@@ -11,7 +11,7 @@ const ACCOUNT = '0x3333333333333333333333333333333333333333'
 const STAKE = 10_000_000n // 10 USDC (6 decimals)
 
 const { state, calls } = vi.hoisted(() => ({
-  state: { allowance: 0n, balance: 100_000_000n, wagerId: 0n, throwLookup: false, metadataUri: '', acceptArgs: null },
+  state: { allowance: 0n, balance: 100_000_000n, wagerId: 0n, throwLookup: false, metadataUri: '', acceptArgs: null, staticCallReject: null },
   calls: [],
 }))
 const wallet = vi.hoisted(() => ({
@@ -59,7 +59,10 @@ vi.mock('ethers', async () => {
         state.acceptArgs = a
         return Promise.resolve({ wait: () => Promise.resolve({ status: 1, hash: '0xtxhash' }) })
       }
-      acceptOpenWager.staticCall = () => Promise.resolve()
+      acceptOpenWager.staticCall = () =>
+        state.staticCallReject
+          ? Promise.reject(Object.assign(new Error(state.staticCallReject), { reason: state.staticCallReject }))
+          : Promise.resolve()
       return {
         interface: { encodeFunctionData: vi.fn(() => '0xacceptcalldata') },
         openWagerIdForClaim: () => state.throwLookup
@@ -104,6 +107,7 @@ describe('useOpenChallengeAccept.accept (funding flow)', () => {
     state.allowance = 0n
     state.balance = 100_000_000n
     state.acceptArgs = null
+    state.staticCallReject = null
     wallet.signer = {
       getAddress: () => Promise.resolve(ACCOUNT),
       provider: { getNetwork: () => Promise.resolve({ chainId: 63n }) },
@@ -171,6 +175,39 @@ describe('useOpenChallengeAccept.accept (funding flow)', () => {
     expect(wallet.sendCalls.mock.calls[0][0]).toHaveLength(2) // approve + accept
     expect(calls).toEqual([]) // no direct signer contract write path used
     expect(steps).toEqual(expect.arrayContaining(['check', 'approve', 'sign', 'accept']))
+  })
+
+  it('does not let the isolated pre-flight block a passkey taker on a not-yet-granted allowance', async () => {
+    // Same deadlock as create: a fresh passkey taker has 0 allowance and the approve is batched
+    // with accept, so the isolated pre-flight staticCall reverts on the allowance. It must not be
+    // fatal, or the taker can never accept their first challenge.
+    wallet.loginMethod = 'passkey'
+    state.allowance = 0n
+    state.staticCallReject = 'ERC20: transfer amount exceeds allowance'
+    const { result } = renderHook(() => useOpenChallengeAccept())
+    let res
+    await act(async () => {
+      res = await result.current.accept('river tiger kite zoo', 4n)
+    })
+    expect(res.txHash).toBe('0xpasskeytx')
+    expect(wallet.sendCalls).toHaveBeenCalledTimes(1)
+    expect(wallet.sendCalls.mock.calls[0][0]).toHaveLength(2) // approve + accept still submitted
+  })
+
+  it('still surfaces a real pre-flight revert (e.g. expired challenge) before sending', async () => {
+    // The pre-flight staticCall lives on the passkey/sendCalls branch; the EOA path pre-flights
+    // inside its own gasless seam.
+    wallet.loginMethod = 'passkey'
+    state.allowance = 0n
+    state.staticCallReject = 'AcceptExpired()'
+    const { result } = renderHook(() => useOpenChallengeAccept())
+    let err
+    await act(async () => {
+      try { await result.current.accept('river tiger kite zoo', 4n) } catch (e) { err = e }
+    })
+    expect(err?.message).toMatch(/expired/i)
+    expect(calls).toEqual([])
+    expect(wallet.sendCalls).not.toHaveBeenCalled()
   })
 })
 

--- a/frontend/src/test/useOpenChallengeCreate.test.jsx
+++ b/frontend/src/test/useOpenChallengeCreate.test.jsx
@@ -9,6 +9,8 @@ const h = vi.hoisted(() => ({
   allowance: 0n,
   balance: 100_000_000n,
   calls: [],
+  // When set, the createOpenWager pre-flight staticCall rejects with this reason.
+  staticCallReject: null,
   sendCalls: vi.fn(async () => ({ txHash: '0xpasskeytx' })),
   signer: { provider: { getNetwork: () => Promise.resolve({ chainId: 63n }) } },
   provider: {
@@ -61,7 +63,10 @@ vi.mock('ethers', async () => {
         h.calls.push('create')
         return Promise.resolve({ wait: () => Promise.resolve({ status: 1, hash: '0xcreate', logs: [] }) })
       }
-      createOpenWager.staticCall = () => Promise.resolve()
+      createOpenWager.staticCall = () =>
+        h.staticCallReject
+          ? Promise.reject(Object.assign(new Error(h.staticCallReject), { reason: h.staticCallReject }))
+          : Promise.resolve()
       return {
         interface: { encodeFunctionData: vi.fn(() => '0xcreatecalldata'), parseLog: () => null },
         createOpenWager,
@@ -94,6 +99,7 @@ describe('useOpenChallengeCreate', () => {
     h.allowance = 0n
     h.balance = 100_000_000n
     h.calls.length = 0
+    h.staticCallReject = null
     h.signer = { provider: { getNetwork: () => Promise.resolve({ chainId: 63n }) } }
     h.sendCalls.mockReset().mockResolvedValue({ txHash: '0xpasskeytx' })
     h.provider.getTransactionReceipt.mockReset().mockResolvedValue({ status: 1, hash: '0xpasskeytx', logs: [] })
@@ -122,5 +128,39 @@ describe('useOpenChallengeCreate', () => {
     expect(h.sendCalls).toHaveBeenCalledTimes(1)
     expect(h.sendCalls.mock.calls[0][0]).toHaveLength(2) // approve + create
     expect(h.calls).toEqual([])
+  })
+
+  it('does not let the isolated pre-flight block a passkey creator on a not-yet-granted allowance', async () => {
+    // A fresh passkey smart account has 0 allowance; the approve is batched with create,
+    // so the pre-flight staticCall reverts on the allowance. This must NOT be fatal —
+    // otherwise the account can never post its first challenge.
+    h.loginMethod = 'passkey'
+    h.allowance = 0n
+    h.staticCallReject = 'ERC20: transfer amount exceeds allowance'
+    const { result } = renderHook(() => useOpenChallengeCreate())
+    let out
+    await act(async () => {
+      out = await result.current.createOpenChallenge({ stake: '10', acceptDeadline: 1000, resolveDeadline: 2000 })
+    })
+    expect(out.txHash).toBe('0xpasskeytx')
+    // The batched approve + create still submits (the allowance is granted before create runs).
+    expect(h.sendCalls).toHaveBeenCalledTimes(1)
+    expect(h.sendCalls.mock.calls[0][0]).toHaveLength(2)
+  })
+
+  it('still surfaces a real pre-flight revert (e.g. membership gate) even before approve', async () => {
+    h.allowance = 0n
+    h.staticCallReject = 'InsufficientMembershipTier()'
+    const { result } = renderHook(() => useOpenChallengeCreate())
+    let err
+    await act(async () => {
+      try {
+        await result.current.createOpenChallenge({ stake: '10', acceptDeadline: 1000, resolveDeadline: 2000 })
+      } catch (e) { err = e }
+    })
+    expect(err?.message).toMatch(/silver/i)
+    // The gate stopped it before any write.
+    expect(h.calls).toEqual([])
+    expect(h.sendCalls).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## What & why

Next design-feedback pass on the create-a-challenge home screen (`/app`), plus a fix for the passkey gasless-transfer error reported in the same round.

## UI changes

- **Bigger pad + hero.** Enlarged the stake read-out and the number-pad keys (bigger digits, taller keys, roomier grid) so the pad reads as the centerpiece.
- **Hide secondary actions on the oracle path.** "Accept a challenge" / "My Wagers" now collapse while the create panel is composing an oracle challenge — the taller oracle form (market card + side picker) needs the vertical room and the goal is a no-scroll view. The panel reports its oracle mode up to the home screen via a new `onOracleModeChange` callback.
- **"My rewards" → "My Wagers".** Renamed the secondary entry.
- **Fill-free resolution pills.** Dropped the background tint behind the resolution options entirely — the green icon + label carry the selected state on their own ("the colored text is enough").

## Bug fix — gasless create/accept allowance deadlock

Passkey / smart-account users hit **"ERC20: transfer amount exceeds allowance"** and could never post (or take) their first open challenge.

**Root cause:** the create and accept hooks pre-flight the registry call with an isolated `staticCall` before submitting. Since the stake is pulled with `transferFrom`, that simulation also exercises the token allowance — but the `approve` leg only exists inside the not-yet-submitted batch (atomic `executeBatch` for passkey/smart accounts, sequential for EOAs). A fresh smart account has 0 allowance and no way to pre-approve, so the isolated pre-flight reverts on the allowance and the throw blocks the very batch that would have granted it. Permanent deadlock.

**Fix:** treat a not-yet-granted-allowance revert in the pre-flight as expected (never fatal) when the approve leg is about to run (`allowance < stake`). Every other revert — Silver-tier gate, bad deadlines, resolved condition, expired/wrong-signature on accept — is still surfaced for all users. The batched `approve` then establishes the allowance before the create/accept executes, exactly as intended. No contract change is required; the sponsored-UserOp batch already moves USDC correctly — only the isolated simulation was wrong. (A `createOpenWagerWithAuthorization` EIP-3009 twin would be a separate enhancement for EOA relayer parity, not needed for the passkey/sponsored-paymaster path.)

## Testing

- Affected suites pass locally: `HomeScreen` (incl. new oracle-mode hide test), `CreateChallengePanel`, `AmountKeypad`, `PillSelect`, `OpenChallengeModal`, and both `useOpenChallengeCreate` / `useOpenChallengeAccept` (new regression tests: deadlock unblocked, real reverts still surfaced).
- `npm run build` succeeds.
- Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr18WCoEWMNiy4a4YKD6E5