### PR TITLE
Fix passkey gasless transfer/create reporting phantom success on stalled UserOps

### DIFF
--- a/frontend/src/components/wallet/TransferForm.jsx
+++ b/frontend/src/components/wallet/TransferForm.jsx
@@ -93,10 +93,19 @@ export default function TransferForm({ onSent }) {
     setFormError(null)
     try {
       const res = await send({ kind, to: toResolved, amount })
-      showNotification(
-        `Sent ${amount} ${m.symbol} to ${short(toResolved)}${res.route === 'gasless' ? ' (gasless)' : ''}.`,
-        'success'
-      )
+      if (res?.pending) {
+        // Submitted but not yet confirmed on-chain (a stalled/never-included UserOp): tell the truth
+        // rather than claiming it cleared. It stays "In process" in Activity until it settles.
+        showNotification(
+          `Submitted ${amount} ${m.symbol} to ${short(toResolved)} — still confirming on-chain. It will show as complete in Activity once settled.`,
+          'info'
+        )
+      } else {
+        showNotification(
+          `Sent ${amount} ${m.symbol} to ${short(toResolved)}${res.route === 'gasless' ? ' (gasless)' : ''}.`,
+          'success'
+        )
+      }
       resetForm()
       onSent?.(res)
     } catch (err) {

--- a/frontend/src/contexts/WalletContext.jsx
+++ b/frontend/src/contexts/WalletContext.jsx
@@ -114,7 +114,7 @@ export function WalletProvider({ children }) {
    * Each call: { target, data, value? }.
    */
   const sendCalls = useCallback(
-    async (calls) => {
+    async (calls, { onState } = {}) => {
       if (!calls?.length) throw new Error('sendCalls: empty batch')
       if (loginMethod === 'passkey') {
         const [{ sendPasskeyBatch }, { readSession }] = await Promise.all([
@@ -123,8 +123,9 @@ export function WalletProvider({ children }) {
         ])
         // Pin the ceremony to the credential this session signed in with —
         // never a different passkey that happens to share the address book
-        // (spec 045 US3/FR-008).
-        return sendPasskeyBatch({ chainId, address, calls, credentialId: readSession()?.credentialId })
+        // (spec 045 US3/FR-008). `onState` (optional) surfaces the honest
+        // submitted→included|failed|stalled lifecycle to the caller's UI.
+        return sendPasskeyBatch({ chainId, address, calls, credentialId: readSession()?.credentialId, onState })
       }
       if (!signer) throw new Error('No signer available')
       const receipts = []

--- a/frontend/src/hooks/useOpenChallengeCreate.js
+++ b/frontend/src/hooks/useOpenChallengeCreate.js
@@ -9,6 +9,10 @@ import { deriveFromCode } from '../utils/claimCode/deriveFromCode.js'
 import { encryptEnvelopeCode } from '../utils/crypto/envelopeEncryption.js'
 import { getCurrentDocument } from '../utils/legalDocs'
 
+// Honest passkey-UserOp lifecycle states as returned by sendCalls (mirrors LIFECYCLE in
+// lib/passkey/submission.js — kept as literals here to avoid pulling the relay graph into this hook).
+const OP_STATE = Object.freeze({ SUBMITTED: 'submitted', INCLUDED: 'included', FAILED: 'failed' })
+
 const ERC20_ABI = [
   'function balanceOf(address owner) view returns (uint256)',
   'function allowance(address owner, address spender) view returns (uint256)',
@@ -146,8 +150,25 @@ export function useOpenChallengeCreate() {
           data: registry.interface.encodeFunctionData('createOpenWager', args),
           value: 0n,
         })
-        const sent = await sendCalls(calls)
-        const txHash = sent?.txHash ?? sent?.userOpHash ?? sent?.intentId
+        const sent = await sendCalls(calls, {
+          onState: (s) => {
+            if (s?.state === OP_STATE.SUBMITTED) onProgress({ step: 'create', message: 'Submitted — confirming on-chain…' })
+          },
+        })
+        // Honest terminal state (spec 041 FR-017): a passkey batch resolves to included | failed | stalled
+        // and sendCalls NEVER throws on a stalled/never-included UserOp. A userOpHash is NOT a transaction
+        // hash — reconciling it via getTransactionReceipt polls forever and would then hand out a one-time
+        // claim code for a challenge that was never created on-chain. So branch on the state honestly.
+        if (sent?.state === OP_STATE.FAILED) {
+          throw new Error(sent.reason || 'Creation reverted on-chain.')
+        }
+        if (sent?.state && sent.state !== OP_STATE.INCLUDED) {
+          throw new Error(
+            'Your challenge was submitted but hasn’t confirmed on-chain yet. Check “My Wagers” in a moment — if it doesn’t appear there, you can safely retry.'
+          )
+        }
+        // Included (or a legacy/classic-shaped result carrying a real txHash): use the on-chain hash.
+        const txHash = sent?.state === OP_STATE.INCLUDED ? sent.txHash : (sent?.txHash ?? sent?.userOpHash ?? sent?.intentId)
         if (!txHash) throw new Error('Creation submitted but no transaction hash was returned.')
         for (let i = 0; i < 20; i += 1) {
           receipt = await readProvider.getTransactionReceipt(txHash)

--- a/frontend/src/hooks/useTransfer.js
+++ b/frontend/src/hooks/useTransfer.js
@@ -58,6 +58,10 @@ function mirrorToLedger(account, record, patch = null, suffix = null) {
 
 export const TRANSFER_KIND = Object.freeze({ NATIVE: 'native', STABLE: 'stable' })
 
+// Honest passkey-UserOp lifecycle states as returned by sendCalls (mirrors LIFECYCLE in
+// lib/passkey/submission.js — kept as literals here to avoid pulling the relay graph into this hook).
+const OP_STATE = Object.freeze({ SUBMITTED: 'submitted', INCLUDED: 'included', FAILED: 'failed' })
+
 const ERC20_IFACE = new ethers.Interface(TRANSFER_ABI)
 
 export function useTransfer() {
@@ -213,12 +217,42 @@ export function useTransfer() {
               ? [{ target: m.address, data: ERC20_IFACE.encodeFunctionData('transfer', [to, value]), value: 0n }]
               : [{ target: to, data: '0x', value }]
           setStatus('submitting')
-          const res = await sendCalls(calls)
-          txHash = res?.txHash ?? res?.userOpHash ?? res?.intentId ?? null
+          // Reflect the honest lifecycle while the batch is tracked to inclusion (spec 041 FR-017):
+          // a passkey UserOp is "submitted" for up to ~90s before it is "included", so flip the button
+          // to a truthful pending state instead of a frozen "Sending…".
+          const res = await sendCalls(calls, {
+            onState: (s) => {
+              if (s?.state === OP_STATE.SUBMITTED) setStatus('pending')
+            },
+          })
           // Honest route: reflect whether the batch was ACTUALLY sponsored. sendCalls falls back to a
           // self-funded UserOp when sponsorship is unavailable (spec 050), so trust its `sponsored`
           // flag rather than assuming gasless.
           route = res?.sponsored === false ? 'self' : res?.sponsored === true || passkeySponsored ? 'gasless' : 'self'
+
+          // A passkey batch resolves to an honest terminal state — included | failed | stalled — and
+          // sendCalls NEVER throws on a stalled/never-included UserOp (submission.js#trackToInclusion).
+          // We MUST branch on that state: only an on-chain inclusion is a real transfer, and a
+          // userOpHash is NOT a transaction hash (block explorers cannot resolve it), so it must never
+          // be recorded or displayed as one (Constitution III, honest-state). This is the fix for a
+          // stalled sponsored UserOp being force-marked "complete" with its userOpHash as the txHash.
+          if (res?.state === OP_STATE.FAILED) {
+            throw new Error(res.reason || 'The transfer reverted on-chain and was not sent.')
+          }
+          if (res?.state && res.state !== OP_STATE.INCLUDED) {
+            // Submitted but not yet confirmed (stalled): keep it truthfully "in process" with the
+            // UserOp reference for later reconciliation — do NOT mark complete or fabricate a txHash.
+            const ref = res.userOpHash ?? res.intentId ?? null
+            updateTransfer(address, entry.id, { status: TRANSFER_STATUS.IN_PROCESS, route, userOpHash: ref })
+            mirrorToLedger(address, entry, { status: TRANSFER_STATUS.IN_PROCESS, route }, 'submitted')
+            setStatus('pending')
+            const pending = { txHash: null, userOpHash: ref, route, id: entry.id, pending: true }
+            setLastResult(pending)
+            refreshBalances()
+            return pending
+          }
+          // Included: use the REAL on-chain transaction hash only.
+          txHash = res?.txHash ?? null
         } else if (kind === TRANSFER_KIND.STABLE && stableDomainVersion != null && hasRelayer) {
           // Classic EOA, gasless: sign an EIP-3009 authorization; a relayer submits + pays gas.
           const auth = await signTransferAuthorization({

--- a/frontend/src/test/TransferForm.test.jsx
+++ b/frontend/src/test/TransferForm.test.jsx
@@ -85,6 +85,27 @@ describe('TransferForm', () => {
     await waitFor(() => expect(showNotification).toHaveBeenCalled())
   })
 
+  it('reports a stalled (pending) passkey transfer honestly — info notice, not a "success"', async () => {
+    // A sponsored UserOp submitted but not yet confirmed on-chain: send() resolves with { pending: true }
+    // and no real txHash. The form must NOT claim it cleared.
+    send.mockResolvedValueOnce({ txHash: null, userOpHash: '0xuop', route: 'gasless', id: 't1', pending: true })
+    const user = userEvent.setup()
+    render(<TransferForm />)
+
+    await user.type(screen.getByLabelText('To'), '0xBbBb000000000000000000000000000000000002')
+    await user.type(screen.getByLabelText('Amount'), '10')
+    const preview = screen.getByRole('button', { name: 'Preview' })
+    await waitFor(() => expect(preview).toBeEnabled())
+    await user.click(preview)
+    await user.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => expect(showNotification).toHaveBeenCalled())
+    const [message, type] = showNotification.mock.calls.at(-1)
+    expect(type).toBe('info')
+    expect(message).toMatch(/still confirming on-chain/i)
+    expect(message).not.toMatch(/^Sent /)
+  })
+
   it('blocks Preview when the amount exceeds the balance', async () => {
     const user = userEvent.setup()
     render(<TransferForm />)

--- a/frontend/src/test/useOpenChallengeCreate.test.jsx
+++ b/frontend/src/test/useOpenChallengeCreate.test.jsx
@@ -123,4 +123,41 @@ describe('useOpenChallengeCreate', () => {
     expect(h.sendCalls.mock.calls[0][0]).toHaveLength(2) // approve + create
     expect(h.calls).toEqual([])
   })
+
+  it('uses the real on-chain hash for an included passkey UserOp', async () => {
+    h.loginMethod = 'passkey'
+    h.sendCalls.mockResolvedValue({ state: 'included', txHash: '0xrealtxhash', userOpHash: '0xuop' })
+    h.provider.getTransactionReceipt.mockResolvedValue({ status: 1, hash: '0xrealtxhash', logs: [] })
+    const { result } = renderHook(() => useOpenChallengeCreate())
+    let out
+    await act(async () => {
+      out = await result.current.createOpenChallenge({ stake: '10', acceptDeadline: 1000, resolveDeadline: 2000 })
+    })
+    expect(out.txHash).toBe('0xrealtxhash')
+    // Only the real tx hash is ever used to reconcile — never the userOpHash.
+    expect(h.provider.getTransactionReceipt).toHaveBeenCalledWith('0xrealtxhash')
+    expect(h.provider.getTransactionReceipt).not.toHaveBeenCalledWith('0xuop')
+  })
+
+  it('does NOT present a stalled passkey UserOp as a created challenge (no phantom code, no userOpHash poll)', async () => {
+    h.loginMethod = 'passkey'
+    // A sponsored UserOp that was submitted but never landed on-chain: no txHash, only a userOpHash.
+    h.sendCalls.mockResolvedValue({ state: 'stalled', userOpHash: '0xuop', lastKnown: { state: 'pending' } })
+    const { result } = renderHook(() => useOpenChallengeCreate())
+    await expect(
+      result.current.createOpenChallenge({ stake: '10', acceptDeadline: 1000, resolveDeadline: 2000 })
+    ).rejects.toThrow(/hasn.t confirmed on-chain/i)
+    // The userOpHash must never be polled as if it were a transaction hash.
+    expect(h.provider.getTransactionReceipt).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the revert reason for a failed passkey UserOp', async () => {
+    h.loginMethod = 'passkey'
+    h.sendCalls.mockResolvedValue({ state: 'failed', reason: 'user operation reverted', userOpHash: '0xuop' })
+    const { result } = renderHook(() => useOpenChallengeCreate())
+    await expect(
+      result.current.createOpenChallenge({ stake: '10', acceptDeadline: 1000, resolveDeadline: 2000 })
+    ).rejects.toThrow(/reverted/i)
+    expect(h.provider.getTransactionReceipt).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Problem

Sending a gasless transaction from a **passkey** account via **Transfer & Pay** (and, per a follow-up report, the home **Create-a-challenge** flow) hangs and then lies:

- The button sits on **"Sending…" / "Creating…"** and never settles.
- Navigate away and a notification says the transaction **cleared**, and it appears in the **Activity log / a claim code is issued**.
- On the block explorer, **the transaction does not exist**.

This is a critical blocker for transfers.

## Root cause

A sponsored passkey UserOp is deliberately tracked to an **honest terminal state** — `included | failed | stalled` — and the submission layer (`lib/passkey/submission.js#trackToInclusion`) **never throws** on a stalled/never-included op; it *returns* `stalled`.

Both consumers ignored that state:

- `useTransfer.send()` unconditionally marked the transfer `COMPLETE` / `success` and recorded `res.userOpHash` **as if it were a transaction hash** (`txHash = res.txHash ?? res.userOpHash ?? …`).
- `useOpenChallengeCreate` fell back to the `userOpHash`, then polled `getTransactionReceipt(userOpHash)` (which never resolves) for ~30s and finally handed out a **one-time claim code for a challenge that was never created**.

So a UserOp that was submitted but never mined got reported as a cleared transaction, with a `userOpHash` shown where a real tx hash belongs — which is exactly why the explorer finds nothing. The ~90s inclusion poll also runs *inside* the awaited `sendCalls`, so the button hangs with no progress feedback.

## Changes

- **`useTransfer` (Transfer & Pay):** branch on the returned lifecycle state — `included` records the **real on-chain tx hash**; `failed` surfaces the revert reason; `stalled` keeps the transfer truthfully **in process** (no `COMPLETE`, no fabricated `txHash`) and returns a `pending` result. Wire an `onState` observer so the button reflects a pending/submitted state instead of a frozen "Sending…".
- **`TransferForm`:** show an honest **"still confirming on-chain"** info notice for a pending result instead of a false "Sent … (gasless)" success toast.
- **`useOpenChallengeCreate` (home create-a-challenge):** same honest branching. A stalled UserOp no longer polls a receipt on a `userOpHash` and no longer presents an unconfirmed challenge (with its claim code) as created; `included` uses the real tx hash.
- **`WalletContext.sendCalls`:** accepts an optional `{ onState }` to relay the `submitted → included | failed | stalled` lifecycle to callers' UIs. Backward compatible with every existing positional caller.

The Activity list already guards explorer links to real 66-char tx hashes, so a pending record renders "In process" with no link — no further change needed there.

## Scope note

This makes the UI **honest** and unblocks the stuck button. If sponsored UserOps are *genuinely* never landing on-chain, that points to a separate **paymaster/bundler infrastructure** issue (spec 050, `docs/runbooks/paymaster-operations.md`) rather than the frontend — transfers will now truthfully show "in process / not confirmed" instead of a phantom success. Happy to investigate that rail next if UserOps still aren't being included.

## Testing

- New regression tests cover `included` / `failed` / `stalled` outcomes for both flows (`useOpenChallengeCreate.test.jsx`, `TransferForm.test.jsx`), asserting a `userOpHash` is never polled or shown as a tx hash and a stalled op is never reported as success.
- Affected suites pass: `TransferForm`, `useOpenChallengeCreate`, `CreateChallengePanel`, `sendBatch`, `WalletContext.passkey`, `HomeScreen`, `Dashboard`, `useVouchers.passkey` (35 + 46 tests green). Lint clean (0 errors) on changed files.
- Pre-existing note: `useTransfer.balances.test.jsx` fails on a stale `config/networks` mock (missing `getCurrentChainId`) on a clean checkout too — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018odpumso5zS5r92b4KM8GA)_