### PR TITLE
Home create view: larger pad, "Open wager" button, connect-in-flow, no banner

### DIFF
--- a/frontend/src/components/fairwins/CreateChallengePanel.jsx
+++ b/frontend/src/components/fairwins/CreateChallengePanel.jsx
@@ -39,7 +39,21 @@ const BackIcon = () => (
  *   - initialMarket: a Polymarket market to pre-select on the oracle path (e.g. a ticker click),
  *     skipping the market-search step.
  */
-function CreateChallengePanel({ embedded = false, onClose, onDone, onOracleModeChange, initialResolutionType, initialMarket = null }) {
+function CreateChallengePanel({
+  embedded = false,
+  onClose,
+  onDone,
+  onOracleModeChange,
+  // Connection is injected by the host so the panel stays presentational (and testable
+  // without a WalletProvider). Defaults to connected: hosts that only mount it post-connect
+  // (e.g. the modal opened from the dashboard) need no wiring. The home screen passes the
+  // live state + a connect handler so tapping the primary button opens the connect panel as
+  // part of the create flow (spec 053 feedback), then continues to create once connected.
+  isConnected = true,
+  onConnect,
+  initialResolutionType,
+  initialMarket = null,
+}) {
   const { createOpenChallenge, busy } = useOpenChallengeCreate()
   const { capabilities } = useChainTokens()
   // Oracle settlement is only offered where the Polymarket CTF is reachable and
@@ -75,6 +89,9 @@ function CreateChallengePanel({ embedded = false, onClose, onDone, onOracleModeC
   const [error, setError] = useState(null)
   const [progress, setProgress] = useState(null)
   const [result, setResult] = useState(null)
+  // Set when the user taps the primary button while disconnected: we open the connect panel,
+  // then auto-continue the create once the wallet connects (see the effect below).
+  const [pendingSubmit, setPendingSubmit] = useState(false)
 
   const isThirdParty = Number(resolutionType) === OPEN_RESOLUTION_TYPES.ThirdParty
   const isOracle = Number(resolutionType) === OPEN_RESOLUTION_TYPES.Polymarket
@@ -152,6 +169,18 @@ function CreateChallengePanel({ embedded = false, onClose, onDone, onOracleModeC
   const handleCreate = useCallback(async (e) => {
     e?.preventDefault?.()
     setError(null)
+    // Not signed in yet? Open the connect panel as part of this flow, then let the effect
+    // below resume the create once the wallet connects. If the host gave us no connect
+    // handler we fall through and let the create hook surface its own "connect" error.
+    if (!isConnected && onConnect) {
+      setPendingSubmit(true)
+      try {
+        await onConnect()
+      } catch {
+        setPendingSubmit(false)
+      }
+      return
+    }
     // Normalize the pad string (e.g. "10." → "10", "10.50" → "10.5").
     const cleanStake = Number(stake) > 0 ? String(Number(stake)) : stake
     try {
@@ -191,7 +220,15 @@ function CreateChallengePanel({ embedded = false, onClose, onDone, onOracleModeC
     } finally {
       setProgress(null)
     }
-  }, [isOracle, composedDescription, stake, market, side, oracleTimeline, description, resolutionType, isThirdParty, arbitratorAddr, acceptMs, resolveMs, createOpenChallenge]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isConnected, onConnect, isOracle, composedDescription, stake, market, side, oracleTimeline, description, resolutionType, isThirdParty, arbitratorAddr, acceptMs, resolveMs, createOpenChallenge]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Resume a create that was waiting on the wallet: the moment the connection lands, continue.
+  useEffect(() => {
+    if (pendingSubmit && isConnected) {
+      setPendingSubmit(false)
+      handleCreate()
+    }
+  }, [pendingSubmit, isConnected, handleCreate])
 
   if (result) {
     return (
@@ -386,7 +423,7 @@ function CreateChallengePanel({ embedded = false, onClose, onDone, onOracleModeC
 
       <div className="fm-success-actions">
         <button type="submit" className="fm-btn-primary" disabled={!canCreate}>
-          {busy ? 'Creating…' : 'Create & generate code'}
+          {busy ? 'Opening…' : 'Open wager'}
         </button>
       </div>
     </form>

--- a/frontend/src/components/fairwins/HomeScreen.css
+++ b/frontend/src/components/fairwins/HomeScreen.css
@@ -11,25 +11,6 @@
   padding: 1rem;
 }
 
-/* Connect prompt (disconnected) — the create view still renders; this gates the action. */
-.home-connect-cta {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  flex-wrap: wrap;
-  padding: 0.6rem 0.9rem;
-  border: 1px solid var(--border-color, #23303D);
-  border-radius: var(--radius-md, 12px);
-  background: var(--bg-secondary, #141C24);
-  color: var(--text-secondary, #AAB6C2);
-  font-size: 0.85rem;
-}
-
-.home-connect-btn {
-  flex: 0 0 auto;
-}
-
 .home-create {
   /* The inline create panel provides its own spacing; keep the hero centered. */
   display: flex;

--- a/frontend/src/components/fairwins/HomeScreen.jsx
+++ b/frontend/src/components/fairwins/HomeScreen.jsx
@@ -88,20 +88,15 @@ function HomeScreen() {
 
   return (
     <div className="dashboard-container home-screen">
-      {!isConnected && (
-        <div className="home-connect-cta" role="note">
-          <span>Connect your wallet to create a challenge.</span>
-          <button type="button" className="fm-btn-primary home-connect-btn" onClick={() => connectWallet()}>
-            Connect wallet
-          </button>
-        </div>
-      )}
-
-      {/* Primary content: the inline open-challenge create view. */}
+      {/* Primary content: the inline open-challenge create view. No disconnected banner —
+          tapping the panel's primary button opens the connect panel as part of the create
+          flow (spec 053 feedback), then continues once the wallet connects. */}
       <section className="home-create" aria-label="Create a challenge">
         <CreateChallengePanel
           key={createKey}
           embedded
+          isConnected={isConnected}
+          onConnect={connectWallet}
           initialResolutionType={oraclePreselect ? OPEN_RESOLUTION_TYPES.Polymarket : undefined}
           initialMarket={oracleMarket}
           onOracleModeChange={setOracleMode}

--- a/frontend/src/components/ui/AmountKeypad.css
+++ b/frontend/src/components/ui/AmountKeypad.css
@@ -32,7 +32,7 @@
   font-weight: 700;
   line-height: 1;
   /* Scales down on narrow screens; stays large and glanceable on wide ones. */
-  font-size: clamp(3.5rem, 19vw, 5.75rem);
+  font-size: clamp(4.25rem, 23vw, 7rem);
   letter-spacing: -0.02em;
   overflow: hidden;
 }
@@ -82,7 +82,7 @@
 .amount-keypad-pad {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 
 /* Keys are deliberately wider than tall (short landscape keys) so the pad
@@ -95,14 +95,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  min-height: 3rem;
+  min-height: 3.6rem;
   padding: 0.3rem;
   background: transparent;
   border: none;
   border-radius: var(--radius-full, 9999px);
   color: var(--text-primary, #E6EDF3);
   font-family: inherit;
-  font-size: 1.9rem;
+  font-size: 2.3rem;
   font-weight: 600;
   cursor: pointer;
   transition: background var(--transition-fast, 0.15s) ease,
@@ -135,8 +135,8 @@
 }
 
 .amount-keypad-key--fn svg {
-  width: 1.65rem;
-  height: 1.65rem;
+  width: 2rem;
+  height: 2rem;
 }
 
 /* Respect reduced-motion — drop the press-scale animation. */
@@ -151,10 +151,10 @@
 
 @media (max-width: 640px) {
   .amount-keypad-hero {
-    font-size: clamp(3rem, 21vw, 5rem);
+    font-size: clamp(3.75rem, 26vw, 6.25rem);
   }
   .amount-keypad-key {
-    min-height: 2.75rem;
-    font-size: 1.75rem;
+    min-height: 3.2rem;
+    font-size: 2.1rem;
   }
 }

--- a/frontend/src/test/CreateChallengePanel.test.jsx
+++ b/frontend/src/test/CreateChallengePanel.test.jsx
@@ -55,7 +55,7 @@ describe('CreateChallengePanel (spec 053 — shared create panel)', () => {
     createOpenChallenge.mockResolvedValue({ code: 'river tiger kite zoo', wagerId: 1n, txHash: '0x1' })
     const onDone = vi.fn()
     render(<CreateChallengePanel embedded onClose={() => {}} onDone={onDone} />)
-    const createBtn = screen.getByRole('button', { name: /create & generate code/i })
+    const createBtn = screen.getByRole('button', { name: /open wager/i })
     expect(createBtn).toBeDisabled()
     fireEvent.change(screen.getByLabelText(/what's the wager/i, { selector: 'input' }), { target: { value: 'Will it rain?' } })
     tapAmount('10')
@@ -64,6 +64,25 @@ describe('CreateChallengePanel (spec 053 — shared create panel)', () => {
     await waitFor(() => expect(createOpenChallenge).toHaveBeenCalled())
     expect(createOpenChallenge.mock.calls[0][0].resolutionType).toBe(OPEN_RESOLUTION_TYPES.Either)
     expect(await screen.findByText('river tiger kite zoo')).toBeInTheDocument()
+  })
+
+  it('opens the connect flow from the primary button when disconnected, then resumes the create once connected', async () => {
+    const onConnect = vi.fn()
+    const { rerender } = render(
+      <CreateChallengePanel embedded onClose={() => {}} isConnected={false} onConnect={onConnect} />
+    )
+    fireEvent.change(screen.getByLabelText(/what's the wager/i, { selector: 'input' }), { target: { value: 'Will it rain?' } })
+    tapAmount('10')
+    const openBtn = screen.getByRole('button', { name: /open wager/i })
+    expect(openBtn).toBeEnabled()
+    // Disconnected → tapping opens the connect panel and does NOT create yet.
+    fireEvent.click(openBtn)
+    await waitFor(() => expect(onConnect).toHaveBeenCalled())
+    expect(createOpenChallenge).not.toHaveBeenCalled()
+    // The wallet connects → the pending create resumes on its own (no second tap).
+    createOpenChallenge.mockResolvedValue({ code: 'river tiger kite zoo', wagerId: 1n, txHash: '0x1' })
+    rerender(<CreateChallengePanel embedded onClose={() => {}} isConnected onConnect={onConnect} />)
+    await waitFor(() => expect(createOpenChallenge).toHaveBeenCalled())
   })
 
   it('locks the oracle resolution option where Polymarket is unavailable', () => {

--- a/frontend/src/test/HomeScreen.test.jsx
+++ b/frontend/src/test/HomeScreen.test.jsx
@@ -4,14 +4,16 @@ import { MemoryRouter } from 'react-router-dom'
 
 // Stub the heavy children to assert the HomeScreen wiring (not their internals).
 vi.mock('../components/fairwins/CreateChallengePanel', () => ({
-  default: ({ embedded, initialResolutionType, onDone, onOracleModeChange }) => (
+  default: ({ embedded, initialResolutionType, onDone, onOracleModeChange, isConnected, onConnect }) => (
     <div
       data-testid="create-panel"
       data-embedded={String(!!embedded)}
       data-initial-resolution={initialResolutionType ?? ''}
+      data-connected={String(!!isConnected)}
     >
       <button type="button" onClick={() => onDone?.()}>done</button>
       <button type="button" onClick={() => onOracleModeChange?.(true)}>enter oracle mode</button>
+      <button type="button" onClick={() => onConnect?.()}>panel connect</button>
     </div>
   ),
 }))
@@ -29,10 +31,10 @@ vi.mock('../components/fairwins/PolymarketTickerCrawler', () => ({
   ),
 }))
 
-const walletHolder = { isConnected: true }
+const walletHolder = { isConnected: true, connectWallet: vi.fn() }
 vi.mock('../hooks', () => ({
   useWallet: () => ({ isConnected: walletHolder.isConnected, account: '0xabc' }),
-  useWalletConnection: () => ({ connectWallet: vi.fn() }),
+  useWalletConnection: () => ({ connectWallet: walletHolder.connectWallet }),
 }))
 vi.mock('../hooks/useUI', () => ({ useModal: () => ({ showModal: vi.fn(), hideModal: vi.fn() }) }))
 vi.mock('../contexts/FriendMarketsContext.js', () => ({ useFriendMarkets: () => ({ friendMarkets: [] }) }))
@@ -44,7 +46,7 @@ const renderHome = (entries = ['/app']) =>
   render(<MemoryRouter initialEntries={entries}><HomeScreen /></MemoryRouter>)
 
 describe('HomeScreen (spec 053) — the create-a-challenge landing', () => {
-  beforeEach(() => { walletHolder.isConnected = true })
+  beforeEach(() => { walletHolder.isConnected = true; walletHolder.connectWallet = vi.fn() })
 
   it('opens on the inline create view as the primary content — no quick-action grid (US1)', () => {
     renderHome()
@@ -94,10 +96,19 @@ describe('HomeScreen (spec 053) — the create-a-challenge landing', () => {
     expect(modal).toHaveAttribute('data-auto', 'true')
   })
 
-  it('shows a connect prompt when disconnected — the create view still renders, action gated (FR-013)', () => {
+  it('shows no connect banner when disconnected — the create panel handles connect in its own flow', () => {
     walletHolder.isConnected = false
     renderHome()
-    expect(screen.getByTestId('create-panel')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /connect wallet/i })).toBeInTheDocument()
+    // The create view still renders as the landing content…
+    const panel = screen.getByTestId('create-panel')
+    expect(panel).toBeInTheDocument()
+    // …but there is no standalone "connect your wallet" message/button anymore.
+    expect(screen.queryByText(/connect your wallet to create/i)).toBeNull()
+    expect(screen.queryByRole('button', { name: /connect wallet/i })).toBeNull()
+    // The panel is told it's disconnected and handed the connect handler so its primary
+    // button can open the connect panel as part of the create flow.
+    expect(panel).toHaveAttribute('data-connected', 'false')
+    fireEvent.click(screen.getByRole('button', { name: /panel connect/i }))
+    expect(walletHolder.connectWallet).toHaveBeenCalled()
   })
 })

--- a/frontend/src/test/claimCode/OpenChallengeCodeBackup.test.jsx
+++ b/frontend/src/test/claimCode/OpenChallengeCodeBackup.test.jsx
@@ -46,7 +46,7 @@ describe('OpenChallengeModal — encrypted code backup & recovery (feature 024)'
     // Create the challenge.
     fireEvent.change(screen.getByLabelText(/what's the wager/i, { selector: 'input' }), { target: { value: 'Will it rain?' } })
     tapAmount('10')
-    fireEvent.click(screen.getByRole('button', { name: /create & generate code/i }))
+    fireEvent.click(screen.getByRole('button', { name: /open wager/i }))
     await screen.findByText('river tiger kite zoo')
 
     // The encrypted backup saves automatically — no button press (testing feedback).

--- a/frontend/src/test/claimCode/OpenChallengeModal.test.jsx
+++ b/frontend/src/test/claimCode/OpenChallengeModal.test.jsx
@@ -37,7 +37,7 @@ describe('OpenChallengeModal (create-only; taking moved to the unified lookup, s
   it('Maker: gates create until description + stake, then shows the generated code + a scannable QR', async () => {
     createOpenChallenge.mockResolvedValue({ code: 'river tiger kite zoo', wagerId: 9n, txHash: '0xabc' })
     render(<OpenChallengeModal isOpen onClose={() => {}} />)
-    const createBtn = screen.getByRole('button', { name: /create & generate code/i })
+    const createBtn = screen.getByRole('button', { name: /open wager/i })
     expect(createBtn).toBeDisabled()
     fireEvent.change(screen.getByLabelText(/what's the wager/i, { selector: 'input' }), { target: { value: 'Will it rain?' } })
     // Description alone isn't enough — a positive stake is still required (FR-016).
@@ -63,7 +63,7 @@ describe('OpenChallengeModal (create-only; taking moved to the unified lookup, s
     render(<OpenChallengeModal isOpen onClose={() => {}} />)
     fireEvent.change(screen.getByLabelText(/what's the wager/i, { selector: 'input' }), { target: { value: 'Will it rain?' } })
     tapAmount('10')
-    fireEvent.click(screen.getByRole('button', { name: /create & generate code/i }))
+    fireEvent.click(screen.getByRole('button', { name: /open wager/i }))
     await waitFor(() => expect(createOpenChallenge).toHaveBeenCalled())
     const form = createOpenChallenge.mock.calls[0][0]
     expect(typeof form.acceptDeadline).toBe('number')
@@ -126,7 +126,7 @@ describe('OpenChallengeModal explainers behind info icons (spec 039 US1)', () =>
     render(<OpenChallengeModal isOpen onClose={() => {}} />)
     fireEvent.change(screen.getByLabelText(/what's the wager/i, { selector: 'input' }), { target: { value: 'Will it rain?' } })
     tapAmount('10')
-    fireEvent.click(screen.getByRole('button', { name: /create & generate code/i }))
+    fireEvent.click(screen.getByRole('button', { name: /open wager/i }))
     await waitFor(() => expect(createOpenChallenge).toHaveBeenCalled())
     await screen.findByText('river tiger kite zoo')
 


### PR DESCRIPTION
## What & why

Next design-feedback pass on the create-a-challenge home screen (`/app`).

## Changes

- **Larger pad + value.** Enlarged the stake hero and number-pad keys again so the amount + keypad dominate the view.
- **"Open wager" button.** Renamed the primary action from "Create & generate code" to **Open wager** (busy label "Opening…").
- **No disconnected banner.** Removed the standalone "Connect your wallet to create a challenge" message/button.
- **Connect as part of the flow.** Connection is now injected into `CreateChallengePanel` by the host (`isConnected` + `onConnect`, defaulting to connected so the modal and existing callers are unaffected). When a disconnected user taps **Open wager**, the panel opens the connect panel as part of the flow and **auto-resumes the create once the wallet connects** — no second tap, no separate prompt.

Presentation plus a small connection-state lift; no wager/take/rewards logic changed.

## Testing

- Affected suites pass locally (39 tests): `HomeScreen` (rewritten disconnected test), `CreateChallengePanel` (new connect-then-create test), `AmountKeypad`, `OpenChallengeModal`, `OpenChallengeCodeBackup`. Button-label test queries updated to "Open wager".
- `npm run build` succeeds.
- Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr18WCoEWMNiy4a4YKD6E5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kr18WCoEWMNiy4a4YKD6E5)_