### PR TITLE
Enter-a-phrase: four word boxes with wordlist type-ahead + per-word validity

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.css
+++ b/frontend/src/components/fairwins/FriendMarketsModal.css
@@ -586,6 +586,88 @@
   background: transparent;
 }
 
+/* Four-word phrase entry (spec 037 feedback): one box per word with BIP-39 type-ahead
+   completion + per-word validity, so a mistyped word is caught before all four are entered. */
+.phrase-words {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+}
+
+@media (min-width: 480px) {
+  .phrase-words {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.phrase-word {
+  position: relative;
+}
+
+.phrase-word-input {
+  width: 100%;
+  padding-right: 1.6rem;
+  text-align: center;
+}
+
+.phrase-word-input.is-valid {
+  border-color: var(--brand-primary, #36B37E);
+}
+
+.phrase-word-input.is-invalid {
+  border-color: var(--semantic-loss, #E5533D);
+}
+
+.phrase-word-check {
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--brand-primary, #36B37E);
+  font-size: 0.9rem;
+  font-weight: 700;
+  pointer-events: none;
+}
+
+.phrase-suggestions {
+  position: absolute;
+  z-index: 5;
+  left: 0;
+  right: auto;
+  top: calc(100% + 3px);
+  margin: 0;
+  padding: 0.25rem;
+  list-style: none;
+  min-width: 100%;
+  width: max-content;
+  max-width: 220px;
+  background: var(--bg-secondary, #141C24);
+  border: 1px solid var(--border-color, #23303D);
+  border-radius: var(--radius-md, 12px);
+  box-shadow: var(--shadow-md, 0 6px 20px rgba(0, 0, 0, 0.25));
+  max-height: 12rem;
+  overflow-y: auto;
+}
+
+.phrase-suggestion {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 0.4rem 0.6rem;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: var(--text-primary, #E6EDF3);
+  font: inherit;
+  cursor: pointer;
+}
+
+.phrase-suggestion:hover,
+.phrase-suggestion.is-active {
+  background: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.14);
+  color: var(--brand-primary, #36B37E);
+}
+
 .fm-pay-oracle-hint {
   text-align: center;
 }

--- a/frontend/src/components/fairwins/PhraseWordInputs.jsx
+++ b/frontend/src/components/fairwins/PhraseWordInputs.jsx
@@ -1,0 +1,148 @@
+import { useRef, useState } from 'react'
+import { isValidWord, suggestWords } from '../../utils/claimCode/wordlist'
+
+const SLOTS = 4
+const MAX_SUGGESTIONS = 6
+
+/**
+ * Four-word phrase entry (spec 037 feedback). One box per word instead of a single free-text
+ * field, with BIP-39 type-ahead completion and per-word validity feedback, so a mistyped word
+ * is caught and correctable before all four are entered.
+ *
+ * Controlled: `words` is a 4-slot string array; `onChange(nextWords)` replaces it. Word-boundary
+ * input (space / paste of a full phrase) distributes across slots and advances focus.
+ *
+ * @param {{ words: string[], onChange: (next: string[]) => void, disabled?: boolean, idPrefix?: string }} props
+ */
+export default function PhraseWordInputs({ words, onChange, disabled = false, idPrefix = 'phrase-word' }) {
+  const inputRefs = useRef([])
+  const [focused, setFocused] = useState(-1)
+  const [activeSuggestion, setActiveSuggestion] = useState(0)
+
+  const focusSlot = (i) => {
+    const el = inputRefs.current[i]
+    if (el) el.focus()
+  }
+
+  const setWord = (i, value) => {
+    const next = words.slice()
+    next[i] = value
+    onChange(next)
+  }
+
+  // Put `word` in slot `i` and advance to the next slot (used by suggestion clicks + space/enter).
+  const acceptWord = (i, word) => {
+    const next = words.slice()
+    next[i] = word
+    onChange(next)
+    setActiveSuggestion(0)
+    if (i < SLOTS - 1) focusSlot(i + 1)
+  }
+
+  const suggestionsFor = (i) => (focused === i ? suggestWords(words[i], MAX_SUGGESTIONS) : [])
+
+  const handleChange = (i, raw) => {
+    // A space finalizes the current word and jumps to the next slot.
+    if (/\s/.test(raw)) {
+      const head = raw.split(/\s+/)[0]
+      setWord(i, head.toLowerCase())
+      if (head && i < SLOTS - 1) focusSlot(i + 1)
+      return
+    }
+    setWord(i, raw.toLowerCase())
+    setActiveSuggestion(0)
+  }
+
+  // Pasting a whole phrase into any slot spreads its words across the remaining slots.
+  const handlePaste = (i, e) => {
+    const text = e.clipboardData?.getData('text') || ''
+    const tokens = text
+      .normalize('NFKC').toLowerCase().replace(/[-_]+/g, ' ').trim()
+      .split(/\s+/).filter(Boolean)
+    if (tokens.length <= 1) return // single word → let the default paste land in this box
+    e.preventDefault()
+    const next = words.slice()
+    for (let k = 0; k < tokens.length && i + k < SLOTS; k += 1) next[i + k] = tokens[k]
+    onChange(next)
+    focusSlot(Math.min(i + tokens.length, SLOTS - 1))
+  }
+
+  const handleKeyDown = (i, e) => {
+    const sugg = suggestionsFor(i)
+    if (e.key === 'ArrowDown' && sugg.length) {
+      e.preventDefault(); setActiveSuggestion((a) => (a + 1) % sugg.length); return
+    }
+    if (e.key === 'ArrowUp' && sugg.length) {
+      e.preventDefault(); setActiveSuggestion((a) => (a - 1 + sugg.length) % sugg.length); return
+    }
+    if (e.key === ' ') {
+      // Space accepts the highlighted suggestion (or the exact word) and advances.
+      e.preventDefault()
+      const pick = sugg[activeSuggestion] || (isValidWord(words[i]) ? words[i] : sugg[0])
+      if (pick) acceptWord(i, pick)
+      return
+    }
+    if (e.key === 'Enter' && sugg.length && !isValidWord(words[i])) {
+      // Don't submit a partial word — complete it from the highlighted suggestion instead.
+      e.preventDefault()
+      acceptWord(i, sugg[activeSuggestion] || sugg[0])
+      return
+    }
+    if (e.key === 'Backspace' && words[i] === '' && i > 0) {
+      e.preventDefault(); focusSlot(i - 1)
+    }
+  }
+
+  return (
+    <div className="phrase-words" role="group" aria-label="Four-word phrase">
+      {words.map((w, i) => {
+        const valid = isValidWord(w)
+        const sugg = suggestionsFor(i)
+        // While the user is still typing a completable prefix, stay neutral; flag invalid once
+        // the box is blurred, or when nothing in the list can complete what's typed.
+        const showInvalid = w.trim() !== '' && !valid && (focused !== i || sugg.length === 0)
+        return (
+          <div className="phrase-word" key={i}>
+            <input
+              ref={(el) => { inputRefs.current[i] = el }}
+              id={`${idPrefix}-${i}`}
+              type="text"
+              autoComplete="off"
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck="false"
+              className={`phrase-word-input${valid ? ' is-valid' : ''}${showInvalid ? ' is-invalid' : ''}`}
+              aria-label={`Word ${i + 1}`}
+              aria-invalid={showInvalid || undefined}
+              value={w}
+              disabled={disabled}
+              placeholder={String(i + 1)}
+              onChange={(e) => handleChange(i, e.target.value)}
+              onKeyDown={(e) => handleKeyDown(i, e)}
+              onPaste={(e) => handlePaste(i, e)}
+              onFocus={() => { setFocused(i); setActiveSuggestion(0) }}
+              onBlur={() => setFocused((f) => (f === i ? -1 : f))}
+            />
+            {valid && <span className="phrase-word-check" aria-hidden="true">✓</span>}
+            {sugg.length > 0 && (
+              <ul className="phrase-suggestions" role="listbox" aria-label={`Suggestions for word ${i + 1}`}>
+                {sugg.map((s, si) => (
+                  <li key={s} role="option" aria-selected={si === activeSuggestion}>
+                    <button
+                      type="button"
+                      className={`phrase-suggestion${si === activeSuggestion ? ' is-active' : ''}`}
+                      // mousedown (not click) so it fires before the input's blur clears the list.
+                      onMouseDown={(e) => { e.preventDefault(); acceptWord(i, s) }}
+                    >
+                      {s}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/fairwins/UnifiedLookupModal.jsx
+++ b/frontend/src/components/fairwins/UnifiedLookupModal.jsx
@@ -2,11 +2,19 @@ import { useEffect, useState, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useUnifiedLookup } from '../../hooks/useUnifiedLookup'
 import { normalizePhrase } from '../../lib/lookup/resolvePhraseLookup.js'
+import { isValidWord } from '../../utils/claimCode/wordlist'
 import TakeChallengePanel from './TakeChallengePanel'
 import JoinPoolPanel from './JoinPoolPanel'
+import PhraseWordInputs from './PhraseWordInputs'
 import InfoTip from '../ui/InfoTip'
 import './FriendMarketsModal.css'
 import './OpenChallengeModal.css'
+
+// Split a raw phrase into exactly four editable slots (pad/truncate) for the per-word inputs.
+const toWordSlots = (phrase) => {
+  const parts = normalizePhrase(phrase || '').split(' ').filter(Boolean).slice(0, 4)
+  return [0, 1, 2, 3].map((i) => parts[i] || '')
+}
 
 const CloseIcon = () => (
   <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
@@ -25,8 +33,11 @@ const CloseIcon = () => (
 export default function UnifiedLookupModal({ isOpen, onClose, onBuyMembership, initialPhrase = '', autoResolve = false }) {
   const { status, result, submit, reset } = useUnifiedLookup()
   const navigate = useNavigate()
-  const [phrase, setPhrase] = useState(initialPhrase)
+  const [words, setWords] = useState(() => toWordSlots(initialPhrase))
   const [choice, setChoice] = useState(null) // collision disambiguation: 'challenge' | 'pool'
+
+  const phrase = words.join(' ').trim()
+  const allWordsValid = words.every(isValidWord)
 
   useEffect(() => {
     if (!isOpen) return undefined
@@ -38,7 +49,7 @@ export default function UnifiedLookupModal({ isOpen, onClose, onBuyMembership, i
   // Deep-link prefill + auto-resolve (FR-013): a shared ?oc=take&code= link opens here pre-resolved.
   useEffect(() => {
     if (isOpen && autoResolve && initialPhrase) {
-      setPhrase(initialPhrase)
+      setWords(toWordSlots(initialPhrase))
       submit(initialPhrase)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -46,9 +57,10 @@ export default function UnifiedLookupModal({ isOpen, onClose, onBuyMembership, i
 
   const onSubmit = useCallback((e) => {
     e.preventDefault()
+    if (!allWordsValid) return
     setChoice(null)
     submit(phrase)
-  }, [submit, phrase])
+  }, [submit, phrase, allWordsValid])
 
   const searchAgain = useCallback(() => { setChoice(null); reset() }, [reset])
 
@@ -153,17 +165,18 @@ export default function UnifiedLookupModal({ isOpen, onClose, onBuyMembership, i
               <form className="fm-form" onSubmit={onSubmit}>
                 <div className="fm-form-group fm-form-full">
                   <span className="fm-label-row">
-                    <label htmlFor="unified-phrase-input">Four-word phrase <span className="fm-required">*</span></label>
+                    <label htmlFor="phrase-word-0">Four-word phrase <span className="fm-required">*</span></label>
                     <InfoTip label="About: Four-word phrase">
-                      We’ll find whatever the words point to — a challenge or a pool.
+                      We’ll find whatever the words point to — a challenge or a pool. Type each word and
+                      pick from the suggestions — a mistyped word is flagged before you finish.
                     </InfoTip>
                   </span>
-                  <input
-                    id="unified-phrase-input" type="text" autoComplete="off" spellCheck="false"
-                    placeholder="e.g. crystal orbit harbor violet"
-                    value={phrase} onChange={(e) => setPhrase(e.target.value)}
+                  <PhraseWordInputs
+                    words={words}
+                    onChange={setWords}
                     disabled={status === 'resolving'}
                   />
+                  <span className="fm-hint">e.g. crystal orbit harbor violet</span>
                 </div>
 
                 {status === 'result' && result?.kind === 'format-error' && (
@@ -183,7 +196,7 @@ export default function UnifiedLookupModal({ isOpen, onClose, onBuyMembership, i
                 )}
 
                 <div className="fm-success-actions">
-                  <button type="submit" className="fm-btn-primary" disabled={status === 'resolving' || phrase.trim() === ''}>
+                  <button type="submit" className="fm-btn-primary" disabled={status === 'resolving' || !allWordsValid}>
                     {status === 'resolving' ? 'Looking up…' : 'Find'}
                   </button>
                 </div>

--- a/frontend/src/test/PhraseWordInputs.test.jsx
+++ b/frontend/src/test/PhraseWordInputs.test.jsx
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { useState } from 'react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import PhraseWordInputs from '../components/fairwins/PhraseWordInputs'
+
+// PhraseWordInputs is controlled; drive it through a tiny stateful harness.
+function Harness({ initial = ['', '', '', ''] }) {
+  const [words, setWords] = useState(initial)
+  return (
+    <>
+      <PhraseWordInputs words={words} onChange={setWords} />
+      <output data-testid="phrase">{words.join('|')}</output>
+    </>
+  )
+}
+
+const boxes = () => [0, 1, 2, 3].map((i) => screen.getByRole('textbox', { name: `Word ${i + 1}` }))
+
+describe('PhraseWordInputs (four-word phrase entry with type-ahead)', () => {
+  it('renders four labeled word boxes', () => {
+    render(<Harness />)
+    expect(boxes()).toHaveLength(4)
+  })
+
+  it('offers wordlist completions once typing starts and none for an empty box', () => {
+    render(<Harness />)
+    const [first] = boxes()
+    fireEvent.focus(first)
+    // Empty → no suggestion list.
+    expect(screen.queryByRole('listbox')).toBeNull()
+    fireEvent.change(first, { target: { value: 'ri' } })
+    const list = screen.getByRole('listbox', { name: /suggestions for word 1/i })
+    const options = within(list).getAllByRole('option')
+    expect(options.length).toBeGreaterThan(0)
+    expect(options.every((o) => o.textContent.startsWith('ri'))).toBe(true)
+  })
+
+  it('picking a suggestion fills that word and moves focus to the next box', () => {
+    render(<Harness />)
+    const [first, second] = boxes()
+    fireEvent.focus(first)
+    fireEvent.change(first, { target: { value: 'rive' } })
+    const option = within(screen.getByRole('listbox')).getByText('river')
+    fireEvent.mouseDown(option)
+    expect(screen.getByTestId('phrase')).toHaveTextContent('river|||')
+    expect(second).toHaveFocus()
+  })
+
+  it('a space finalizes the current word and advances', () => {
+    render(<Harness />)
+    const [first, second] = boxes()
+    fireEvent.focus(first)
+    fireEvent.change(first, { target: { value: 'amber ' } })
+    expect(screen.getByTestId('phrase')).toHaveTextContent('amber|||')
+    expect(second).toHaveFocus()
+  })
+
+  it('flags a mistyped word as invalid as soon as nothing can complete it', () => {
+    render(<Harness />)
+    const [first] = boxes()
+    fireEvent.focus(first)
+    fireEvent.change(first, { target: { value: 'zzzz' } })
+    expect(first).toHaveClass('is-invalid')
+    expect(first).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('marks a complete, valid word (and shows its check)', () => {
+    render(<Harness />)
+    const [first] = boxes()
+    fireEvent.change(first, { target: { value: 'river' } })
+    expect(first).toHaveClass('is-valid')
+    expect(first).not.toHaveClass('is-invalid')
+  })
+
+  it('pasting a full phrase spreads the words across all four boxes', () => {
+    render(<Harness />)
+    const [first] = boxes()
+    fireEvent.paste(first, { clipboardData: { getData: () => 'crystal orbit harbor violet' } })
+    expect(screen.getByTestId('phrase')).toHaveTextContent('crystal|orbit|harbor|violet')
+  })
+})

--- a/frontend/src/test/claimCode/claimCode.test.js
+++ b/frontend/src/test/claimCode/claimCode.test.js
@@ -7,7 +7,7 @@ import { verifyTypedData } from 'ethers'
 const TAKER_A = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
 const TAKER_B = '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC'
 const VERIFYING_CONTRACT = '0x5FbDB2315678afecb367f032d93F642f64180aa3'
-import { generateCode, normalizeCode, isValidCode } from '../../utils/claimCode/wordlist.js'
+import { generateCode, normalizeCode, isValidCode, isValidWord, suggestWords } from '../../utils/claimCode/wordlist.js'
 import { deriveFromCode, signOpenAccept, OPEN_ACCEPT_TYPES } from '../../utils/claimCode/deriveFromCode.js'
 import {
   encryptEnvelopeCode,
@@ -40,6 +40,28 @@ describe('claimCode/wordlist', () => {
     expect(isValidCode('river amber tiger kite extra')).toBe(false) // 5 words
     expect(isValidCode('river amber tiger zzzznotaword')).toBe(false)
     expect(isValidCode('')).toBe(false)
+  })
+
+  it('isValidWord: accepts a single BIP-39 word (normalized), rejects everything else', () => {
+    expect(isValidWord('river')).toBe(true)
+    expect(isValidWord('  River  ')).toBe(true) // trimmed + lowercased
+    expect(isValidWord('zzzznotaword')).toBe(false)
+    expect(isValidWord('river amber')).toBe(false) // more than one word
+    expect(isValidWord('')).toBe(false)
+    expect(isValidWord(null)).toBe(false)
+  })
+
+  it('suggestWords: returns list-order completions for a prefix, bounded by the limit', () => {
+    const s = suggestWords('ri', 6)
+    expect(s.length).toBeGreaterThan(0)
+    expect(s.length).toBeLessThanOrEqual(6)
+    expect(s.every((w) => w.startsWith('ri'))).toBe(true)
+    // A full word is its own first completion.
+    expect(suggestWords('river', 3)).toContain('river')
+    // No prefix / no match → nothing (never dump the whole list).
+    expect(suggestWords('')).toEqual([])
+    expect(suggestWords('   ')).toEqual([])
+    expect(suggestWords('zzzz')).toEqual([])
   })
 })
 

--- a/frontend/src/utils/claimCode/wordlist.js
+++ b/frontend/src/utils/claimCode/wordlist.js
@@ -44,6 +44,49 @@ export function isValidCode(input) {
 }
 
 /**
+ * @param {string} word
+ * @returns {boolean} true iff `word` normalizes to a single word in the BIP-39 English list.
+ * Used for the per-word validity feedback in the phrase entry inputs.
+ */
+export function isValidWord(word) {
+  if (typeof word !== 'string') return false
+  const w = word.normalize('NFKC').toLowerCase().trim()
+  if (!w || /\s/.test(w)) return false
+  return WORDLIST.getWordIndex(w) >= 0
+}
+
+// The full 2048-word list, materialized once for prefix suggestions (BIP-39 is sorted).
+let cachedWords = null
+function allWords() {
+  if (!cachedWords) {
+    cachedWords = new Array(LIST_SIZE)
+    for (let i = 0; i < LIST_SIZE; i += 1) cachedWords[i] = WORDLIST.getWord(i)
+  }
+  return cachedWords
+}
+
+/**
+ * Up to `limit` wordlist words that start with `prefix` (case-insensitive), in list order.
+ * An empty/whitespace prefix returns nothing (so we never dump the whole list). Powers the
+ * type-ahead completion in the phrase inputs so a word is corrected before all four are entered.
+ * @param {string} prefix
+ * @param {number} [limit=6]
+ * @returns {string[]}
+ */
+export function suggestWords(prefix, limit = 6) {
+  const p = typeof prefix === 'string' ? prefix.normalize('NFKC').toLowerCase().trim() : ''
+  if (!p) return []
+  const out = []
+  for (const w of allWords()) {
+    if (w.startsWith(p)) {
+      out.push(w)
+      if (out.length >= limit) break
+    }
+  }
+  return out
+}
+
+/**
  * Generate a fresh four-word claim code using the platform CSPRNG.
  * Uses rejection sampling on 16-bit reads to map uniformly onto the 2048-word list (no modulo bias).
  * @returns {string} e.g. "river amber tiger kite"


### PR DESCRIPTION
## What & why

The "Enter a phrase" lookup sheet (the "Accept a challenge" flow) used a single free-text field for all four words. That's error-prone: a mistyped word isn't caught until all four are entered and the lookup fails. This makes phrase entry guided and self-correcting.

## Changes

- **New `PhraseWordInputs` control** — one box per word, with:
  - **BIP-39 type-ahead completion** as you type (a dropdown of matching words).
  - **Per-word validity** feedback: a green check when a box holds a valid word, and a red flag the moment nothing in the wordlist can complete what's typed (or on blur).
  - Ergonomics: **space** or **picking a suggestion** finalizes the word and advances to the next box; **pasting a full phrase** spreads its words across all four boxes; **backspace on an empty box** steps back.
- **`UnifiedLookupModal`** uses the new control and only enables **Find** once all four words are valid — an invalid phrase can no longer be submitted.
- **`wordlist.js`** gains `isValidWord` and `suggestWords` (prefix completions from the materialized 2048-word list), powering the above. Existing `normalizeCode` / `isValidCode` / `generateCode` are untouched.

Front-end presentation + input ergonomics; the lookup/resolution logic and claim-code crypto are unchanged (the assembled phrase flows through the same `submit`).

## Testing

- New tests: `wordlist` helpers (`isValidWord`, `suggestWords`) and the `PhraseWordInputs` control (suggestions appear, pick-to-fill advances focus, space-advance, invalid flagging, paste-spread). `HomeScreen` / `Dashboard` (which mount the modal) still green — 57 tests across the affected files.
- `npm run build` succeeds.
- Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kr18WCoEWMNiy4a4YKD6E5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kr18WCoEWMNiy4a4YKD6E5)_