### PR TITLE
Declutter Trade panel and open asset selectors to the full portfolio

### DIFF
--- a/frontend/src/components/fairwins/TradePanel.css
+++ b/frontend/src/components/fairwins/TradePanel.css
@@ -15,13 +15,16 @@
   --trade-warning: var(--warning-color, #d69e2e);
   --trade-danger: var(--danger-color, #e5533d);
 
-  max-width: 480px;
-  margin: 1.5rem auto;
-  padding: 1.25rem;
-  background: var(--trade-surface);
-  border: 1px solid var(--trade-border);
-  border-radius: 16px;
-  box-shadow: var(--shadow-md, 0 8px 28px rgba(0, 0, 0, 0.06));
+  /* The panel is a frameless layout container — its parent tab already supplies
+     the page padding, and the inner blocks (account, legs, summary) carry their
+     own cards, so an extra outer frame + padding just crowds the content. */
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
 }
 
 /* Header */
@@ -161,40 +164,6 @@
   border-color: var(--trade-accent);
 }
 
-/* Mode selector (segmented control) */
-.trade-modes {
-  display: flex;
-  gap: 0.25rem;
-  margin-bottom: 1rem;
-  background: var(--trade-surface-2);
-  padding: 0.25rem;
-  border-radius: 10px;
-  border: 1px solid var(--trade-border);
-}
-
-.trade-mode-btn {
-  flex: 1;
-  padding: 0.55rem 0.5rem;
-  background: transparent;
-  border: none;
-  border-radius: 7px;
-  cursor: pointer;
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--trade-text-2);
-  transition: background 0.15s, color 0.15s;
-}
-
-.trade-mode-btn:hover {
-  color: var(--trade-text);
-}
-
-.trade-mode-btn.active {
-  background: var(--trade-surface);
-  color: var(--trade-text);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
-}
-
 /* Order controls grid (order type / price type / limit price / term) */
 .trade-order-grid {
   display: grid;
@@ -324,8 +293,7 @@
 }
 
 /* Token pill */
-.trade-token-select,
-.trade-token-static {
+.trade-token-select {
   flex-shrink: 0;
   padding: 0.4rem 0.7rem;
   background: var(--trade-surface);
@@ -334,9 +302,6 @@
   font-weight: 700;
   font-size: 0.85rem;
   color: var(--trade-text);
-}
-
-.trade-token-select {
   cursor: pointer;
 }
 
@@ -368,8 +333,7 @@
   z-index: 1;
 }
 
-.trade-switch-btn,
-.trade-switch-static {
+.trade-switch-btn {
   width: 34px;
   height: 34px;
   margin-top: -17px;
@@ -383,9 +347,6 @@
   font-size: 0.9rem;
   font-weight: 700;
   color: var(--trade-text);
-}
-
-.trade-switch-btn {
   cursor: pointer;
   transition: color 0.15s, outline-color 0.15s;
 }
@@ -604,15 +565,9 @@ button.trade-rate .trade-summary-val {
 
 /* Responsive */
 @media (max-width: 768px) {
-  .trade-panel {
-    margin: 1rem;
-    padding: 1rem;
-  }
-
-  .trade-order-grid {
-    grid-template-columns: 1fr;
-  }
-
+  /* Order Type / Price Type stay side-by-side on narrow screens — two compact
+     selects fit a phone width comfortably and reading them on one line matches
+     a brokerage ticket. */
   .trade-amount-input,
   .trade-receive-value {
     font-size: 1.3rem;

--- a/frontend/src/components/fairwins/TradePanel.jsx
+++ b/frontend/src/components/fairwins/TradePanel.jsx
@@ -18,10 +18,6 @@ import SensitiveValue from '../common/SensitiveValue'
 import InfoTip from '../ui/InfoTip'
 import './TradePanel.css'
 
-const FROM_NATIVE = 'NATIVE'
-const FROM_WNATIVE = 'WNATIVE'
-const FROM_STABLE = 'STABLE'
-
 // Price impact bands used to color the trade summary, mirroring the thresholds
 // mainstream V3 clients use to warn a trader.
 const IMPACT_WARN = 1 // %
@@ -40,19 +36,19 @@ const shortAddress = (addr) =>
 const fmtBalance = (value) =>
   Number(value || 0).toLocaleString(undefined, { maximumSignificantDigits: 8 })
 
+const sameAddr = (a, b) => Boolean(a) && Boolean(b) && a.toLowerCase() === b.toLowerCase()
+
 function TradePanel() {
   const {
     balances,
     loading,
     quotingPrice,
-    wrapNative,
-    unwrapNative,
     swap,
     getBestQuote,
     slippage,
     setSlippage,
     addresses,
-    tokens,
+    tradeTokens,
     isDexAvailable,
     dexProvider,
     network,
@@ -91,48 +87,51 @@ function TradePanel() {
     : `Powered by ${providerName} · Uniswap v3 protocol`
 
   const wnativeSymbol = nativeSymbol ? `W${nativeSymbol}` : 'WNATIVE'
-  const labelFor = (key) => {
-    if (key === FROM_NATIVE) return nativeSymbol
-    if (key === FROM_WNATIVE) return wnativeSymbol
-    return stableSymbol
-  }
 
-  const [mode, setMode] = useState('trade')
-  const [fromToken, setFromToken] = useState(FROM_WNATIVE)
-  const [toToken, setToToken] = useState(FROM_STABLE)
+  // The tradeable set for the active chain (wrapped-native, the stablecoin, and
+  // every curated portfolio asset with a routeable pair here). Keyed by address.
+  const assets = useMemo(() => tradeTokens || [], [tradeTokens])
+  const tokenFor = useCallback(
+    (addr) => assets.find((t) => sameAddr(t.address, addr)) || null,
+    [assets],
+  )
+  const symbolFor = useCallback((addr) => tokenFor(addr)?.symbol || '—', [tokenFor])
+  const balanceFor = useCallback(
+    (addr) => balances.tokens?.[addr?.toLowerCase?.()] ?? '0',
+    [balances],
+  )
+
+  const [fromToken, setFromToken] = useState(addresses.WNATIVE)
+  const [toToken, setToToken] = useState(addresses.STABLECOIN)
+  // Re-seed the pair to the chain default (sell wrapped-native for the
+  // stablecoin) whenever the active chain changes, without an effect: adjust
+  // state during render keyed on the chain's core addresses (React-endorsed),
+  // so a mid-chain token pick is never clobbered by a re-render.
+  const [chainKey, setChainKey] = useState(addresses.WNATIVE)
+  if (chainKey !== addresses.WNATIVE) {
+    setChainKey(addresses.WNATIVE)
+    setFromToken(addresses.WNATIVE)
+    setToToken(addresses.STABLECOIN)
+  }
   const [orderType, setOrderType] = useState('sell')
   const [priceType, setPriceType] = useState('market')
   const [limitPrice, setLimitPrice] = useState('')
   const [amount, setAmount] = useState('')
   const [quote, setQuote] = useState(null)
-  const [wrapOutput, setWrapOutput] = useState('')
   const [rateInverted, setRateInverted] = useState(false)
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
 
-  const addrFor = useCallback(
-    (key) => (key === FROM_WNATIVE ? addresses.WNATIVE : addresses.STABLECOIN),
-    [addresses],
-  )
-
   const isPerpsOrder = orderType === 'sell_short' || orderType === 'buy_to_cover'
 
-  // Live quoting — debounced. Trade mode routes through the DEX; wrap/unwrap is
-  // always 1:1 so we mirror the input.
+  // Live quoting — debounced. Routes through the DEX for the selected pair.
   useEffect(() => {
     if (!amount || parseFloat(amount) <= 0) {
       setQuote(null)
-      setWrapOutput('')
       return
     }
 
-    if (mode !== 'trade') {
-      setWrapOutput(amount)
-      setQuote(null)
-      return
-    }
-
-    if (fromToken === toToken || isPerpsOrder) {
+    if (!fromToken || !toToken || sameAddr(fromToken, toToken) || isPerpsOrder) {
       setQuote(null)
       return
     }
@@ -140,7 +139,7 @@ function TradePanel() {
     let cancelled = false
     const timeoutId = setTimeout(async () => {
       try {
-        const result = await getBestQuote(addrFor(fromToken), addrFor(toToken), amount)
+        const result = await getBestQuote(fromToken, toToken, amount)
         if (!cancelled) {
           setQuote(result)
           setError('')
@@ -157,34 +156,15 @@ function TradePanel() {
       cancelled = true
       clearTimeout(timeoutId)
     }
-  }, [amount, fromToken, toToken, mode, isPerpsOrder, getBestQuote, addrFor])
+  }, [amount, fromToken, toToken, isPerpsOrder, getBestQuote])
 
-  const handleModeChange = (next) => {
-    setMode(next)
-    setAmount('')
-    setQuote(null)
-    setWrapOutput('')
-    setError('')
-    setSuccess('')
-
-    if (next === 'wrap') {
-      setFromToken(FROM_NATIVE)
-      setToToken(FROM_WNATIVE)
-    } else if (next === 'unwrap') {
-      setFromToken(FROM_WNATIVE)
-      setToToken(FROM_NATIVE)
-    } else {
-      setFromToken(FROM_WNATIVE)
-      setToToken(FROM_STABLE)
-      setOrderType('sell')
-    }
-  }
-
-  // Spot order type maps onto the pair direction: Buy receives the network
-  // asset, Sell pays it away. The two stay in sync in both directions.
+  // Spot order type maps onto the pair direction relative to cash: paying the
+  // stablecoin to receive an asset is a Buy; paying an asset for the stablecoin
+  // is a Sell. Asset-for-asset pairs leave the order type unchanged.
   const deriveOrderType = (from, to) => {
-    if (to === FROM_WNATIVE && from === FROM_STABLE) return 'buy'
-    if (from === FROM_WNATIVE && to === FROM_STABLE) return 'sell'
+    const stable = addresses.STABLECOIN
+    if (sameAddr(to, stable) && !sameAddr(from, stable)) return 'sell'
+    if (sameAddr(from, stable) && !sameAddr(to, stable)) return 'buy'
     return null
   }
 
@@ -194,11 +174,11 @@ function TradePanel() {
     setError('')
     setSuccess('')
     if (next === 'buy') {
-      setFromToken(FROM_STABLE)
-      setToToken(FROM_WNATIVE)
+      setFromToken(addresses.STABLECOIN)
+      setToToken(addresses.WNATIVE)
     } else if (next === 'sell') {
-      setFromToken(FROM_WNATIVE)
-      setToToken(FROM_STABLE)
+      setFromToken(addresses.WNATIVE)
+      setToToken(addresses.STABLECOIN)
     }
   }
 
@@ -236,8 +216,7 @@ function TradePanel() {
 
   // A Limit order's floor: limit price (output per 1 unit paid) × quantity,
   // enforced on-chain as the swap's minimum received.
-  const outDecimals =
-    toToken === FROM_STABLE ? tokens?.STABLE?.decimals ?? 6 : 18
+  const outDecimals = tokenFor(toToken)?.decimals ?? 18
   const limitFloor = useMemo(() => {
     if (priceType !== 'limit') return null
     const qty = parseFloat(amount)
@@ -259,63 +238,32 @@ function TradePanel() {
       setError('Enter an amount to trade')
       return
     }
-    if (mode === 'trade' && priceType === 'limit' && !limitFloor) {
+    if (priceType === 'limit' && !limitFloor) {
       setError('Enter a limit price to place a limit order')
       return
     }
 
     try {
       const proposedNote = `Proposed to ${identity.label || 'the multisig'} — owners approve before it executes.`
-      if (mode === 'wrap') {
-        const res = await wrapNative(amount)
-        setSuccess(
-          res?.proposed
-            ? proposedNote
-            : `Wrapped ${amount} ${nativeSymbol} → ${wnativeSymbol}`,
-        )
-      } else if (mode === 'unwrap') {
-        const res = await unwrapNative(amount)
-        setSuccess(
-          res?.proposed
-            ? proposedNote
-            : `Unwrapped ${amount} ${wnativeSymbol} → ${nativeSymbol}`,
-        )
-      } else {
-        const res =
-          priceType === 'limit'
-            ? await swap(addrFor(fromToken), addrFor(toToken), amount, {
-                limitMinOutWei: limitFloor.wei,
-              })
-            : await swap(addrFor(fromToken), addrFor(toToken), amount)
-        setSuccess(
-          res?.proposed
-            ? proposedNote
-            : `Swapped ${amount} ${labelFor(fromToken)} → ${labelFor(toToken)}`,
-        )
-      }
+      const res =
+        priceType === 'limit'
+          ? await swap(fromToken, toToken, amount, { limitMinOutWei: limitFloor.wei })
+          : await swap(fromToken, toToken, amount)
+      setSuccess(
+        res?.proposed
+          ? proposedNote
+          : `Swapped ${amount} ${symbolFor(fromToken)} → ${symbolFor(toToken)}`,
+      )
       setAmount('')
       setQuote(null)
-      setWrapOutput('')
     } catch (err) {
       console.error('Trade error:', err)
       setError(err.message || 'Transaction failed')
     }
   }
 
-  const balanceFor = (key) => {
-    if (key === FROM_NATIVE) return balances.native
-    if (key === FROM_WNATIVE) return balances.wnative
-    return balances.stable
-  }
-
   const handleSetMax = () => {
-    if (fromToken === FROM_NATIVE) {
-      // Leave a little native for gas.
-      const maxAmount = Math.max(0, parseFloat(balances.native) - 0.01)
-      setAmount(maxAmount.toString())
-    } else {
-      setAmount(balanceFor(fromToken))
-    }
+    setAmount(balanceFor(fromToken))
   }
 
   if (!isConnected) {
@@ -323,7 +271,7 @@ function TradePanel() {
       <div className="trade-panel">
         <div className="trade-header">
           <h2>Trade</h2>
-          <p className="trade-subtitle">Swap, wrap and unwrap on {networkName}</p>
+          <p className="trade-subtitle">Trade on {networkName}</p>
         </div>
         <div className="trade-empty">
           <p>Connect your wallet to start trading.</p>
@@ -350,14 +298,11 @@ function TradePanel() {
     )
   }
 
-  const isTrade = mode === 'trade'
-  const receiveValue = isTrade
-    ? quotingPrice
-      ? '…'
-      : quote?.amountOut
-        ? Number(quote.amountOut).toLocaleString(undefined, { maximumSignificantDigits: 8 })
-        : '0.0'
-    : wrapOutput || '0.0'
+  const receiveValue = quotingPrice
+    ? '…'
+    : quote?.amountOut
+      ? Number(quote.amountOut).toLocaleString(undefined, { maximumSignificantDigits: 8 })
+      : '0.0'
 
   const severity = impactSeverity(quote?.priceImpactPercent)
   const canExecute =
@@ -366,8 +311,8 @@ function TradePanel() {
     !isPerpsOrder &&
     amount &&
     parseFloat(amount) > 0 &&
-    (!isTrade || Boolean(quote)) &&
-    (!isTrade || priceType !== 'limit' || Boolean(limitFloor))
+    Boolean(quote) &&
+    (priceType !== 'limit' || Boolean(limitFloor))
 
   const rateLabel =
     quote && !rateInverted
@@ -423,7 +368,7 @@ function TradePanel() {
         </select>
         <dl className="trade-account-rows">
           <div className="trade-account-row">
-            <dt>Available to trade ({labelFor(fromToken)})</dt>
+            <dt>Available to trade ({symbolFor(fromToken)})</dt>
             <dd>
               <SensitiveValue>{fmtBalance(balanceFor(fromToken))}</SensitiveValue>
             </dd>
@@ -449,120 +394,92 @@ function TradePanel() {
         )}
       </section>
 
-      <div className="trade-modes" role="tablist" aria-label="Trade mode">
-        <button
-          role="tab"
-          aria-selected={mode === 'trade'}
-          className={`trade-mode-btn ${mode === 'trade' ? 'active' : ''}`}
-          onClick={() => handleModeChange('trade')}
-        >
-          Swap
-        </button>
-        <button
-          role="tab"
-          aria-selected={mode === 'wrap'}
-          className={`trade-mode-btn ${mode === 'wrap' ? 'active' : ''}`}
-          onClick={() => handleModeChange('wrap')}
-        >
-          Wrap
-        </button>
-        <button
-          role="tab"
-          aria-selected={mode === 'unwrap'}
-          className={`trade-mode-btn ${mode === 'unwrap' ? 'active' : ''}`}
-          onClick={() => handleModeChange('unwrap')}
-        >
-          Unwrap
-        </button>
-      </div>
-
-      {/* Order ticket controls — order type, price type, term (brokerage-style). */}
-      {isTrade && (
-        <div className="trade-order-grid">
-          <div className="trade-field">
-            <span className="trade-field-label">
-              <label htmlFor="trade-order-type">Order Type</label>
-              <InfoTip label="About order types" className="trade-info">
-                Buy receives {wnativeSymbol} for {stableSymbol}; Sell does the reverse.
-                Sell Short and Buy to Cover appear on networks with a perpetuals venue —
-                {perpsVenue ? ` ${perpsVenue.name} on this network.` : ' none of the supported networks has one yet.'}
-              </InfoTip>
-            </span>
-            <select
-              id="trade-order-type"
-              className="trade-field-select"
-              value={orderType}
-              onChange={(e) => handleOrderTypeChange(e.target.value)}
-            >
-              {SPOT_ORDER_TYPES.map((o) => (
+      {/* Order ticket controls — order type + price type share a row, with the
+          limit price / term beneath (brokerage-style). */}
+      <div className="trade-order-grid">
+        <div className="trade-field">
+          <span className="trade-field-label">
+            <label htmlFor="trade-order-type">Order Type</label>
+            <InfoTip label="About order types" className="trade-info">
+              Buy receives {wnativeSymbol} for {stableSymbol}; Sell does the reverse.
+              Sell Short and Buy to Cover appear on networks with a perpetuals venue —
+              {perpsVenue ? ` ${perpsVenue.name} on this network.` : ' none of the supported networks has one yet.'}
+            </InfoTip>
+          </span>
+          <select
+            id="trade-order-type"
+            className="trade-field-select"
+            value={orderType}
+            onChange={(e) => handleOrderTypeChange(e.target.value)}
+          >
+            {SPOT_ORDER_TYPES.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+            {perpsVenue &&
+              PERPS_ORDER_TYPES.map((o) => (
                 <option key={o.value} value={o.value}>
                   {o.label}
                 </option>
               ))}
-              {perpsVenue &&
-                PERPS_ORDER_TYPES.map((o) => (
-                  <option key={o.value} value={o.value}>
-                    {o.label}
-                  </option>
-                ))}
-            </select>
-          </div>
-
-          <div className="trade-field">
-            <span className="trade-field-label">
-              <label htmlFor="trade-price-type">Price Type</label>
-              <InfoTip label="About price types" className="trade-info">
-                Market fills at the best routed price within your slippage tolerance.
-                Limit fills at your price or better, or not at all — orders don’t rest
-                on a book.
-              </InfoTip>
-            </span>
-            <select
-              id="trade-price-type"
-              className="trade-field-select"
-              value={priceType}
-              onChange={(e) => {
-                setPriceType(e.target.value)
-                setError('')
-              }}
-            >
-              {PRICE_TYPES.map((p) => (
-                <option key={p.value} value={p.value}>
-                  {p.label}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          {priceType === 'limit' && (
-            <div className="trade-field">
-              <label className="trade-field-label" htmlFor="trade-limit-price">
-                Limit Price ({labelFor(toToken)} per {labelFor(fromToken)})
-              </label>
-              <input
-                id="trade-limit-price"
-                className="trade-field-input"
-                type="number"
-                inputMode="decimal"
-                min="0"
-                step="0.000001"
-                placeholder="0.0"
-                value={limitPrice}
-                onChange={(e) => setLimitPrice(e.target.value)}
-              />
-            </div>
-          )}
-
-          <div className="trade-field">
-            <span className="trade-field-label">Term</span>
-            <span className="trade-field-static">
-              {priceType === 'limit' ? 'Fill at limit or cancel' : 'Immediate'}
-            </span>
-          </div>
+          </select>
         </div>
-      )}
 
-      {isTrade && isPerpsOrder && (
+        <div className="trade-field">
+          <span className="trade-field-label">
+            <label htmlFor="trade-price-type">Price Type</label>
+            <InfoTip label="About price types" className="trade-info">
+              Market fills at the best routed price within your slippage tolerance.
+              Limit fills at your price or better, or not at all — orders don’t rest
+              on a book.
+            </InfoTip>
+          </span>
+          <select
+            id="trade-price-type"
+            className="trade-field-select"
+            value={priceType}
+            onChange={(e) => {
+              setPriceType(e.target.value)
+              setError('')
+            }}
+          >
+            {PRICE_TYPES.map((p) => (
+              <option key={p.value} value={p.value}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {priceType === 'limit' && (
+          <div className="trade-field">
+            <label className="trade-field-label" htmlFor="trade-limit-price">
+              Limit Price ({symbolFor(toToken)} per {symbolFor(fromToken)})
+            </label>
+            <input
+              id="trade-limit-price"
+              className="trade-field-input"
+              type="number"
+              inputMode="decimal"
+              min="0"
+              step="0.000001"
+              placeholder="0.0"
+              value={limitPrice}
+              onChange={(e) => setLimitPrice(e.target.value)}
+            />
+          </div>
+        )}
+
+        <div className="trade-field">
+          <span className="trade-field-label">Term</span>
+          <span className="trade-field-static">
+            {priceType === 'limit' ? 'Fill at limit or cancel' : 'Immediate'}
+          </span>
+        </div>
+      </div>
+
+      {isPerpsOrder && (
         <div className="trade-message trade-error" role="alert">
           {perpsVenue
             ? `${orderType === 'sell_short' ? 'Sell Short' : 'Buy to Cover'} orders route to ${perpsVenue.name}, which isn’t wired into in-app execution yet.`
@@ -591,19 +508,18 @@ function TradePanel() {
               inputMode="decimal"
               className="trade-amount-input"
             />
-            {isTrade ? (
-              <select
-                aria-label="Token to sell"
-                value={fromToken}
-                onChange={(e) => handlePairChange('from', e.target.value)}
-                className="trade-token-select"
-              >
-                <option value={FROM_WNATIVE}>{wnativeSymbol}</option>
-                <option value={FROM_STABLE}>{stableSymbol}</option>
-              </select>
-            ) : (
-              <span className="trade-token-static">{labelFor(fromToken)}</span>
-            )}
+            <select
+              aria-label="Token to sell"
+              value={fromToken}
+              onChange={(e) => handlePairChange('from', e.target.value)}
+              className="trade-token-select"
+            >
+              {assets.map((t) => (
+                <option key={t.address} value={t.address}>
+                  {t.symbol}
+                </option>
+              ))}
+            </select>
             <button type="button" onClick={handleSetMax} className="trade-max-btn">
               MAX
             </button>
@@ -611,18 +527,14 @@ function TradePanel() {
         </div>
 
         <div className="trade-switch-row">
-          {isTrade ? (
-            <button
-              type="button"
-              onClick={handleFlipTokens}
-              className="trade-switch-btn"
-              aria-label="Switch direction"
-            >
-              ↓↑
-            </button>
-          ) : (
-            <span className="trade-switch-static" aria-hidden="true">↓</span>
-          )}
+          <button
+            type="button"
+            onClick={handleFlipTokens}
+            className="trade-switch-btn"
+            aria-label="Switch direction"
+          >
+            ↓↑
+          </button>
         </div>
 
         {/* Receive leg */}
@@ -637,25 +549,24 @@ function TradePanel() {
             <div className="trade-receive-value" aria-live="polite">
               <SensitiveValue>{receiveValue}</SensitiveValue>
             </div>
-            {isTrade ? (
-              <select
-                aria-label="Token to buy"
-                value={toToken}
-                onChange={(e) => handlePairChange('to', e.target.value)}
-                className="trade-token-select"
-              >
-                <option value={FROM_WNATIVE}>{wnativeSymbol}</option>
-                <option value={FROM_STABLE}>{stableSymbol}</option>
-              </select>
-            ) : (
-              <span className="trade-token-static">{labelFor(toToken)}</span>
-            )}
+            <select
+              aria-label="Token to buy"
+              value={toToken}
+              onChange={(e) => handlePairChange('to', e.target.value)}
+              className="trade-token-select"
+            >
+              {assets.map((t) => (
+                <option key={t.address} value={t.address}>
+                  {t.symbol}
+                </option>
+              ))}
+            </select>
           </div>
         </div>
       </div>
 
       {/* Trade summary — the capital-markets read-out */}
-      {isTrade && quote && (
+      {quote && (
         <div className="trade-summary" role="group" aria-label="Trade details">
           <button
             type="button"
@@ -723,7 +634,7 @@ function TradePanel() {
         </div>
       )}
 
-      {isTrade && severity === 'high' && (
+      {severity === 'high' && (
         <div className="trade-impact-warning" role="alert">
           High price impact — you may receive substantially less than the market rate.
         </div>
@@ -737,17 +648,13 @@ function TradePanel() {
       >
         {loading
           ? 'Processing…'
-          : mode === 'wrap'
-            ? `Wrap ${nativeSymbol}`
-            : mode === 'unwrap'
-              ? `Unwrap ${wnativeSymbol}`
-              : quotingPrice
-                ? 'Fetching best price…'
-                : quote
-                  ? priceType === 'limit'
-                    ? `Place limit order — ${labelFor(fromToken)} for ${labelFor(toToken)}`
-                    : `Swap ${labelFor(fromToken)} for ${labelFor(toToken)}`
-                  : 'Enter an amount'}
+          : quotingPrice
+            ? 'Fetching best price…'
+            : quote
+              ? priceType === 'limit'
+                ? `Place limit order — ${symbolFor(fromToken)} for ${symbolFor(toToken)}`
+                : `Swap ${symbolFor(fromToken)} for ${symbolFor(toToken)}`
+              : 'Enter an amount'}
       </button>
 
       {isPasskey && passkeyReady && !isVault && (

--- a/frontend/src/contexts/DexContext.jsx
+++ b/frontend/src/contexts/DexContext.jsx
@@ -5,6 +5,7 @@ import { useWallet } from '../hooks/useWalletManagement'
 import { useActiveAccount } from '../hooks/useActiveAccount'
 import { FEE_TIERS, DEFAULT_SLIPPAGE } from '../constants/dex'
 import { getNetwork, getCurrentChainId } from '../config/networks'
+import { getPortfolioRegistry } from '../config/assetTaxonomy'
 import { ERC20_ABI } from '../abis/ERC20'
 import { WNATIVE_ABI } from '../abis/WNative'
 import { SWAP_ROUTER_02_ABI } from '../abis/SwapRouter02'
@@ -100,10 +101,38 @@ export function DexProvider({ children }) {
     },
   }), [addresses, stableConfig, nativeConfig])
 
+  // The tradeable universe for the active chain: every fungible ERC-20 the
+  // portfolio registry knows about on this network (wrapped native + stablecoin
+  // from app-config, plus curated commodities/tools/stables) — i.e. the
+  // portfolio assets that have a routeable pair on a chain we support. Native
+  // coins (must be wrapped first) and NFT credentials are excluded. Swaps
+  // execute on the active chain, so the list is per-chain (honest-state: we only
+  // offer what can actually route here). Falls back to []/no-DEX cleanly.
+  const tradeTokens = useMemo(() => {
+    if (!isDexAvailable) return []
+    return getPortfolioRegistry(chainId)
+      .filter((entry) => entry.kind === 'erc20' && entry.address)
+      .map((entry) => ({
+        address: entry.address,
+        symbol: entry.symbol,
+        name: entry.name,
+        decimals: entry.decimals,
+      }))
+  }, [chainId, isDexAvailable])
+
+  // Address → metadata lookup so quote/swap math uses the right decimals and
+  // ticker for any tradeable token, not just wrapped-native and the stablecoin.
+  const tokenMeta = useMemo(() => {
+    const map = new Map()
+    for (const t of tradeTokens) map.set(t.address.toLowerCase(), t)
+    return map
+  }, [tradeTokens])
+
   const [balances, setBalances] = useState({
     native: '0',
     wnative: '0',
     stable: '0',
+    tokens: {},
   })
 
   const [balanceHistory, setBalanceHistory] = useState([])
@@ -160,6 +189,33 @@ export function DexProvider({ children }) {
         stable: ethers.formatUnits(stableBalance, tokens.STABLE.decimals),
       }
 
+      // Balances for the rest of the tradeable set (curated commodities/tools/
+      // stables) so the ticket's "available to trade" line is accurate for any
+      // selected asset, not just wrapped-native/stablecoin. Read-only, a handful
+      // of tokens per chain, tolerant of per-token failure.
+      const wnativeLower = addresses.WNATIVE.toLowerCase()
+      const stableLower = addresses.STABLECOIN.toLowerCase()
+      const tokenBalances = {
+        [wnativeLower]: newBalances.wnative,
+        [stableLower]: newBalances.stable,
+      }
+      const extraTokens = tradeTokens.filter((t) => {
+        const lower = t.address.toLowerCase()
+        return lower !== wnativeLower && lower !== stableLower
+      })
+      await Promise.all(
+        extraTokens.map(async (t) => {
+          try {
+            const erc20 = new ethers.Contract(t.address, ERC20_ABI, readProvider)
+            const bal = await erc20.balanceOf(tradingAddress)
+            tokenBalances[t.address.toLowerCase()] = ethers.formatUnits(bal, t.decimals)
+          } catch {
+            tokenBalances[t.address.toLowerCase()] = '0'
+          }
+        }),
+      )
+      newBalances.tokens = tokenBalances
+
       setBalances(newBalances)
 
       setBalanceHistory(prev => [
@@ -174,12 +230,12 @@ export function DexProvider({ children }) {
     } finally {
       setLoading(false)
     }
-  }, [readProvider, tradingAddress, contracts, stableContract, tokens.STABLE.decimals])
+  }, [readProvider, tradingAddress, contracts, stableContract, tokens.STABLE.decimals, tradeTokens, addresses])
 
   // Reset balances when the chain or the active account changes so the user
   // doesn't see stale numbers (e.g. personal balances while operating as a vault).
   useEffect(() => {
-    setBalances({ native: '0', wnative: '0', stable: '0' })
+    setBalances({ native: '0', wnative: '0', stable: '0', tokens: {} })
     setBalanceHistory([])
   }, [chainId, tradingAddress])
 
@@ -263,8 +319,8 @@ export function DexProvider({ children }) {
     const lower = tokenAddress?.toLowerCase?.()
     if (lower === addresses.STABLECOIN.toLowerCase()) return tokens.STABLE.decimals
     if (lower === addresses.WNATIVE.toLowerCase()) return 18
-    return 18
-  }, [addresses, tokens.STABLE.decimals])
+    return tokenMeta.get(lower)?.decimals ?? 18
+  }, [addresses, tokens.STABLE.decimals, tokenMeta])
 
   // Symbol lookup for a token by address, used to label SDK Token instances so
   // the trade surface reads the right ticker on every chain.
@@ -272,8 +328,8 @@ export function DexProvider({ children }) {
     const lower = tokenAddress?.toLowerCase?.()
     if (lower === addresses.STABLECOIN.toLowerCase()) return tokens.STABLE.symbol
     if (lower === addresses.WNATIVE.toLowerCase()) return tokens.WNATIVE.symbol
-    return 'TOKEN'
-  }, [addresses, tokens.STABLE.symbol, tokens.WNATIVE.symbol])
+    return tokenMeta.get(lower)?.symbol ?? 'TOKEN'
+  }, [addresses, tokens.STABLE.symbol, tokens.WNATIVE.symbol, tokenMeta])
 
   const getQuote = useCallback(async (tokenIn, tokenOut, amountIn, feeTier = FEE_TIERS.MEDIUM) => {
     if (!contracts) {
@@ -515,6 +571,7 @@ export function DexProvider({ children }) {
     setSlippage,
 
     tokens,
+    tradeTokens,
     addresses,
     isDexAvailable,
     dexProvider,

--- a/frontend/src/test/TradePanel.test.jsx
+++ b/frontend/src/test/TradePanel.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 
 // TradePanel is the brokerage-style order ticket for on-chain swaps. It must:
 //  - name/link the DEX provider for the active network (ETCswap on the ETC
@@ -63,9 +63,34 @@ const SAMPLE_QUOTE = {
   tokenOutSymbol: 'USDC',
 }
 
+// Tradeable-token universe (spec: the selectors list every portfolio asset with
+// a routeable pair on the active chain). Keyed by address; wrapped-native and
+// the stablecoin lead, followed by curated commodities/tools.
+const ETC_TOKENS = [
+  { address: ETC_ADDRESSES.WNATIVE, symbol: 'WETC', name: 'Wrapped Ethereum Classic', decimals: 18 },
+  { address: ETC_ADDRESSES.STABLECOIN, symbol: 'USC', name: 'Classic USD', decimals: 6 },
+]
+const POLYGON_TOKENS = [
+  { address: POLYGON_ADDRESSES.WNATIVE, symbol: 'WPOL', name: 'Wrapped POL', decimals: 18 },
+  { address: POLYGON_ADDRESSES.STABLECOIN, symbol: 'USDC', name: 'USD Coin', decimals: 6 },
+  { address: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619', symbol: 'WETH', name: 'Wrapped Ether', decimals: 18 },
+  { address: '0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6', symbol: 'WBTC', name: 'Wrapped BTC', decimals: 8 },
+  { address: '0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39', symbol: 'LINK', name: 'ChainLink Token', decimals: 18 },
+  { address: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F', symbol: 'USDT', name: 'Tether USD', decimals: 6 },
+]
+
+const balancesFor = (tokenList) => ({
+  native: '10',
+  wnative: '5',
+  stable: '100',
+  tokens: Object.fromEntries(
+    tokenList.map((t) => [t.address.toLowerCase(), t.symbol === 'USC' || t.symbol === 'USDC' ? '100' : '5']),
+  ),
+})
+
 function dexValue(overrides = {}) {
   return {
-    balances: { native: '10', wnative: '5', stable: '100' },
+    balances: balancesFor(ETC_TOKENS),
     loading: false,
     quotingPrice: false,
     wrapNative: vi.fn(),
@@ -76,6 +101,7 @@ function dexValue(overrides = {}) {
     setSlippage: vi.fn(),
     addresses: ETC_ADDRESSES,
     tokens: { STABLE: { decimals: 6, symbol: 'USC' }, WNATIVE: { decimals: 18, symbol: 'WETC' } },
+    tradeTokens: ETC_TOKENS,
     isDexAvailable: true,
     dexProvider: { name: 'ETCswap', url: 'https://v3.etcswap.org' },
     network: { name: 'Ethereum Classic', chainId: 61 },
@@ -85,8 +111,10 @@ function dexValue(overrides = {}) {
 
 const polygonDex = (overrides = {}) =>
   dexValue({
+    balances: balancesFor(POLYGON_TOKENS),
     addresses: POLYGON_ADDRESSES,
     tokens: { STABLE: { decimals: 6, symbol: 'USDC' }, WNATIVE: { decimals: 18, symbol: 'WPOL' } },
+    tradeTokens: POLYGON_TOKENS,
     dexProvider: { name: 'Uniswap', url: 'https://app.uniswap.org/swap?chain=polygon' },
     network: { name: 'Polygon', chainId: 137 },
     ...overrides,
@@ -224,13 +252,25 @@ describe('TradePanel — SDK-driven trade read-out', () => {
     )
   })
 
-  it('offers Swap, Wrap and Unwrap modes', () => {
+  it('has no swap/wrap/unwrap mode selector', () => {
     mockUseDex.mockReturnValue(polygonDex())
     render(<TradePanel />)
 
-    expect(screen.getByRole('tab', { name: 'Swap' })).toBeInTheDocument()
-    expect(screen.getByRole('tab', { name: 'Wrap' })).toBeInTheDocument()
-    expect(screen.getByRole('tab', { name: 'Unwrap' })).toBeInTheDocument()
+    expect(screen.queryByRole('tablist', { name: 'Trade mode' })).toBeNull()
+    expect(screen.queryByRole('tab', { name: 'Wrap' })).toBeNull()
+    expect(screen.queryByRole('tab', { name: 'Unwrap' })).toBeNull()
+  })
+
+  it('lists every tradeable portfolio asset in both selectors', () => {
+    mockUseDex.mockReturnValue(polygonDex())
+    render(<TradePanel />)
+
+    const sell = screen.getByLabelText('Token to sell')
+    const buy = screen.getByLabelText('Token to buy')
+    for (const symbol of ['WPOL', 'USDC', 'WETH', 'WBTC', 'LINK', 'USDT']) {
+      expect(within(sell).getByRole('option', { name: symbol })).toBeInTheDocument()
+      expect(within(buy).getByRole('option', { name: symbol })).toBeInTheDocument()
+    }
   })
 })
 
@@ -309,12 +349,13 @@ describe('TradePanel — order & price types', () => {
     expect(screen.getByLabelText(/Order Type/).value).toBe('sell')
 
     fireEvent.change(screen.getByLabelText(/Order Type/), { target: { value: 'buy' } })
-    expect(screen.getByLabelText('Token to sell').value).toBe('STABLE')
-    expect(screen.getByLabelText('Token to buy').value).toBe('WNATIVE')
+    // Buy pays the stablecoin to receive the wrapped-native asset.
+    expect(screen.getByLabelText('Token to sell').value).toBe(POLYGON_ADDRESSES.STABLECOIN)
+    expect(screen.getByLabelText('Token to buy').value).toBe(POLYGON_ADDRESSES.WNATIVE)
 
     // Flipping the pair back flips the order type too.
-    fireEvent.change(screen.getByLabelText('Token to sell'), { target: { value: 'WNATIVE' } })
-    fireEvent.change(screen.getByLabelText('Token to buy'), { target: { value: 'STABLE' } })
+    fireEvent.change(screen.getByLabelText('Token to sell'), { target: { value: POLYGON_ADDRESSES.WNATIVE } })
+    fireEvent.change(screen.getByLabelText('Token to buy'), { target: { value: POLYGON_ADDRESSES.STABLECOIN } })
     expect(screen.getByLabelText(/Order Type/).value).toBe('sell')
   })
 


### PR DESCRIPTION
Continuing the trading-view work. Four changes to the Trade panel per the screenshot feedback:

## What changed

**1. Removed the outer padding / card frame**
The panel sat inside three nested paddings (tab content → panel card → inner blocks), leaving the actual inputs cramped. The `.trade-panel` is now a frameless layout container (no padding/margin/border/shadow); the inner blocks (account, legs, summary) keep their own cards, so the ticket fills the available width.

**2. Removed the Swap / Wrap / Unwrap selector**
The segmented mode control is gone — the panel is now a single swap ticket. The wrap/unwrap code paths, `mode` state, and their dead CSS were removed.

**3. Order Type and Price Type on one line**
Removed the mobile single-column collapse of `.trade-order-grid`, so the two selects stay side-by-side (Limit Price / Term flow beneath when a limit order is selected).

**4. Asset selectors list the full tradeable portfolio**
Both token selectors now list every fungible ERC-20 with a routeable pair on the active chain — wrapped-native, the stablecoin, and the curated commodities/tools/stables from the portfolio registry (`getPortfolioRegistry`) — keyed by address. To make that actually tradeable, `DexContext` now:
- exposes `tradeTokens` (the per-chain tradeable set),
- makes quote/swap `decimalsOf` / `symbolOf` token-aware via a per-chain metadata map (so decimals/tickers are correct for WBTC, USDT, LINK, etc., not just wrapped-native/stablecoin),
- reads balances for the whole tradeable set, so "Available to trade" and the pay-leg balance are accurate for any selected asset.

Swaps execute on the active chain, so the list is per-chain (honest-state: only assets that can actually route here are offered — the ETC chains, whose curated registry is empty, still show just wrapped-native + the stablecoin).

## Testing
- `frontend/src/test/TradePanel.test.jsx` updated: removed the modes assertion, added coverage that both selectors list every tradeable asset and that Buy/Sell stays in sync with the (now address-keyed) pair direction.
- Full frontend Vitest suite passes; lint clean on the changed files (one pre-existing warning on the debounced quote effect, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ks9XcTdTrbF9qBGJ17B6mv)_