### PR TITLE
Add QR share icon to wallet dropdown header

### DIFF
--- a/frontend/src/components/nav/NavIcon.jsx
+++ b/frontend/src/components/nav/NavIcon.jsx
@@ -43,6 +43,9 @@ const ICON_PATHS = {
   trending: <><path d="M4 15.5 9.5 10l3.5 3.5L20 6" /><path d="M15.5 6H20v4.5" /></>,
   // Earn (spec 050) — a sprouting seedling: assets at rest, growing.
   sprout: <><path d="M12 20v-7" /><path d="M12 13c0-3.3-2.7-6-6-6H4.5v.5c0 3.3 2.7 6 6 6H12" /><path d="M12 11c0-2.8 2.2-5 5-5h2.5v.5c0 2.8-2.2 5-5 5H12" /><path d="M7.5 20h9" /></>,
+  // Share address as QR (spec 011 quick-share entry point) — the three QR
+  // finder-pattern corners plus scattered data pixels, universally read as "QR".
+  qrcode: <><rect x="4" y="4" width="6" height="6" rx="1" /><rect x="14" y="4" width="6" height="6" rx="1" /><rect x="4" y="14" width="6" height="6" rx="1" /><path d="M14 14h3v3" /><path d="M20 14v.01" /><path d="M14 20v.01" /><path d="M20 20v.01" /><path d="M17 17v.01" /></>,
 }
 
 export default function NavIcon({ name, size = 18, className = '' }) {

--- a/frontend/src/components/wallet/WalletButton.css
+++ b/frontend/src/components/wallet/WalletButton.css
@@ -130,6 +130,38 @@
   display: flex;
   flex-direction: column;
   gap: 0rem 0rem;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* Quick "share address as QR" entry point (spec 011), sitting at the end of
+   the dropdown header row next to the address/balance/network stack. */
+.account-qr-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  margin-left: auto;
+  background: transparent;
+  border: 1px solid var(--border-color, #333);
+  border-radius: 8px;
+  color: var(--text-secondary, #888);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.account-qr-btn:hover {
+  background: var(--surface-hover, #2a2a2a);
+  border-color: var(--brand-primary, #36B37E);
+  color: var(--brand-primary, #36B37E);
+}
+
+.account-qr-btn:focus-visible {
+  outline: 2px solid var(--brand-primary, #36B37E);
+  outline-offset: 1px;
 }
 
 .account-address-full {

--- a/frontend/src/components/wallet/WalletButton.jsx
+++ b/frontend/src/components/wallet/WalletButton.jsx
@@ -15,6 +15,7 @@ import { WAGER_DEFAULTS } from '../../constants/wagerDefaults'
 import BlockiesAvatar from '../ui/BlockiesAvatar'
 import NavIcon from '../nav/NavIcon'
 import PremiumPurchaseModal from '../ui/PremiumPurchaseModal'
+import AddressQRModal from '../ui/AddressQRModal'
 import { RoleDetailsSection } from './RoleDetailsCard'
 import walletIcon from '../../assets/wallet_no_text.svg'
 import './WalletButton.css'
@@ -33,6 +34,7 @@ import './RoleDetailsCard.css'
 
 function WalletButton({ className = '' }) {
   const [isOpen, setIsOpen] = useState(false)
+  const [showAddressQR, setShowAddressQR] = useState(false)
   const { address, isConnected } = useAccount()
   const { openConnectModal, disconnectWallet } = useWallet()
   const chainId = useChainId()
@@ -123,6 +125,11 @@ function WalletButton({ className = '' }) {
     await Promise.all([refreshRoles(), refreshRoleDetails()])
   }
 
+  const handleOpenAddressQR = () => {
+    setIsOpen(false)
+    setShowAddressQR(true)
+  }
+
   const handleNavigateToAdmin = () => {
     setIsOpen(false)
     navigate('/admin')
@@ -197,6 +204,15 @@ function WalletButton({ className = '' }) {
                     </span>
                     <span className="network-info">{network?.name || `Chain ${chainId}`}</span>
                   </div>
+                  <button
+                    type="button"
+                    className="account-qr-btn"
+                    onClick={handleOpenAddressQR}
+                    aria-label="Show wallet address QR code"
+                    title="Share address via QR code"
+                  >
+                    <NavIcon name="qrcode" size={18} />
+                  </button>
                 </div>
               </div>
 
@@ -300,6 +316,17 @@ function WalletButton({ className = '' }) {
         </>
       )}
 
+      {/* Address QR Modal (spec 011) — quick variant: clean QR using the
+          persisted Account-page color, no color options, no visible address.
+          Mounted per open so the preference is re-read each time. */}
+      {showAddressQR && (
+        <AddressQRModal
+          isOpen
+          onClose={() => setShowAddressQR(false)}
+          address={address}
+          variant="quick"
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/test/WalletButton.test.jsx
+++ b/frontend/src/test/WalletButton.test.jsx
@@ -72,6 +72,18 @@ vi.mock('../components/ui/PremiumPurchaseModal', () => ({
   )
 }))
 
+vi.mock('../components/ui/AddressQRModal', () => ({
+  default: ({ isOpen, onClose, address, variant }) => (
+    isOpen
+      ? (
+        <div role="dialog" aria-label="Address QR Modal" data-variant={variant} data-address={address}>
+          <button onClick={onClose}>Close</button>
+        </div>
+      )
+      : null
+  )
+}))
+
 import { useAccount, useConnect, useDisconnect, useChainId } from 'wagmi'
 import { useWalletRoles, useWeb3 } from '../hooks'
 import { useDex } from '../hooks/useDex'
@@ -293,6 +305,27 @@ describe('WalletButton Component - Wagers', () => {
       expect(await navigator.clipboard.readText()).toBe(
         '0x1234567890123456789012345678901234567890'
       )
+    })
+
+    it('opens the address QR modal from the dropdown header and closes the dropdown', async () => {
+      const user = userEvent.setup()
+      renderWithProviders(<WalletButton />)
+
+      await user.click(screen.getByRole('button', { name: /wallet account/i }))
+      await screen.findByRole('menu')
+
+      const qrButton = screen.getByRole('button', { name: /show wallet address qr code/i })
+      await user.click(qrButton)
+
+      const qrModal = await screen.findByRole('dialog', { name: /address qr modal/i })
+      expect(qrModal).toHaveAttribute('data-variant', 'quick')
+      expect(qrModal).toHaveAttribute('data-address', '0x1234567890123456789012345678901234567890')
+
+      // Opening the QR modal closes the account dropdown.
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+
+      await user.click(screen.getByRole('button', { name: 'Close' }))
+      expect(screen.queryByRole('dialog', { name: /address qr modal/i })).not.toBeInTheDocument()
     })
 
     it('hides Create Prediction Market button (removed feature)', async () => {


### PR DESCRIPTION
## Summary
- Add a `qrcode` glyph to the shared `NavIcon` set (matches the existing flat, stroke-based icon style).
- Add a QR icon button to the wallet dropdown header (`WalletButton.jsx`), next to the address/balance/network row, so users can quickly share their address without navigating to Account settings.
- Wire the button to open the existing `AddressQRModal` in its `quick` variant (same component already used by the Dashboard's "Share Account" quick-access card), closing the account dropdown when it opens.
- Style the new button (`.account-qr-btn`) to match the existing icon-button conventions in `WalletButton.css`.

## Test plan
- [x] `npx vitest run src/test/WalletButton.test.jsx` — 9/9 passing, including a new test asserting the QR button opens `AddressQRModal` (quick variant, correct address) and closes the dropdown.
- [x] `npx vitest run src/test/AddressQRModal.test.jsx src/test/Dashboard.test.jsx` — no regressions (54/54 passing).
- [x] `npx eslint` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019uPzdFLdx9hAtZtG3CqohK)_