### PR TITLE
Remove info tooltip above resolution path selector

### DIFF
--- a/frontend/src/components/fairwins/CreateChallengePanel.jsx
+++ b/frontend/src/components/fairwins/CreateChallengePanel.jsx
@@ -295,11 +295,6 @@ function CreateChallengePanel({
       <div className="fm-form-group fm-form-full fm-pay-resolution">
         <PillSelect
           label={<>How is it resolved? <span className="fm-required">*</span></>}
-          info={(
-            <InfoTip label="About: How is it resolved?">
-              Single-party self-resolution isn&apos;t available for open challenges — the taker is unknown when you post it.
-            </InfoTip>
-          )}
           options={[
             { value: String(OPEN_RESOLUTION_TYPES.Either), label: 'Either side', icon: <EitherSideIcon /> },
             { value: String(OPEN_RESOLUTION_TYPES.ThirdParty), label: 'Arbitrator', icon: <ThirdPartyIcon /> },

--- a/frontend/src/test/accessibility.test.jsx
+++ b/frontend/src/test/accessibility.test.jsx
@@ -253,7 +253,9 @@ describe('OpenChallengeModal Accessibility (feature 024, WCAG 2.1 AA)', () => {
 
   it('has no axe violations with an info bubble open (spec 039 FR-007)', async () => {
     const { container } = render(<OpenChallengeModal isOpen onClose={() => {}} />)
-    fireEvent.click(screen.getByRole('button', { name: 'About: How is it resolved?' }))
+    // The "How is it resolved?" InfoTip was removed (spec 054); use a surviving
+    // field explainer to exercise the info-bubble-open a11y state.
+    fireEvent.click(screen.getByRole('button', { name: "About: What's the wager?" }))
     expect(screen.getByRole('note')).toBeInTheDocument()
     expect(await axe(container)).toHaveNoViolations()
   })

--- a/frontend/src/test/claimCode/OpenChallengeModal.test.jsx
+++ b/frontend/src/test/claimCode/OpenChallengeModal.test.jsx
@@ -112,13 +112,11 @@ describe('OpenChallengeModal explainers behind info icons (spec 039 US1)', () =>
     expect(screen.queryByText(/the taker takes the opposite/i)).toBeNull()
     expect(screen.queryByText(/single-party self-resolution/i)).toBeNull()
 
-    // The stake caption + its InfoTip were removed to conserve space (spec 052 feedback);
-    // the remaining field explainers still reveal one at a time from their icons.
+    // The stake caption + its InfoTip, and the "How is it resolved?" InfoTip, were removed
+    // to conserve space (specs 052/054 feedback); the remaining field explainer still
+    // reveals from its icon.
     fireEvent.click(screen.getByRole('button', { name: "About: What's the wager?" }))
     expect(screen.getByRole('note')).toHaveTextContent(/the taker takes the opposite/i)
-
-    fireEvent.click(screen.getByRole('button', { name: 'About: How is it resolved?' }))
-    expect(screen.getByRole('note')).toHaveTextContent(/single-party self-resolution/i)
   })
 
   it('keeps dynamic text inline on the success screen: security warning visible, backup explainer behind its icon', async () => {


### PR DESCRIPTION
## Summary
- Remove the "How is it resolved?" `InfoTip` (small circled-`i` button) that rendered above the resolution-path pills (Either side / Arbitrator / Event) on the create-challenge screen — the pill icons/labels are already self-explanatory and the tooltip text isn't needed.
- Update tests that exercised that specific InfoTip to instead exercise a surviving field explainer (the "What's the wager?" InfoTip), preserving coverage of the info-bubble a11y behavior without depending on the removed control.

## Test plan
- [x] `npx vitest run src/test/accessibility.test.jsx src/test/claimCode/OpenChallengeModal.test.jsx src/test/CreateChallengePanel.test.jsx` — 46 tests passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01DsjJbBtntvaqBAXmqPVEPU)_