### PR TITLE
feat(passkey): global signature→confirmation progress overlay

### DIFF
--- a/frontend/src/components/wallet/TxProgressOverlay.css
+++ b/frontend/src/components/wallet/TxProgressOverlay.css
@@ -1,0 +1,256 @@
+/* Global passkey transaction-progress overlay (spec 041 FR-017).
+   Fixed, non-blocking card that walks the user from signature to confirmation.
+   Uses theme variables so it tracks light/dark automatically. */
+
+.txp-overlay {
+  position: fixed;
+  z-index: 1200;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  width: min(420px, calc(100vw - 24px));
+  pointer-events: none; /* only the card is interactive */
+}
+
+.txp-card {
+  position: relative;
+  pointer-events: auto;
+  background: var(--surface-color, #fff);
+  color: var(--text-primary, #1f2933);
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-left: 4px solid var(--brand-primary, #36b37e);
+  border-radius: var(--radius-md, 8px);
+  box-shadow: var(--shadow-lg, 0 10px 15px rgba(0, 0, 0, 0.1));
+  padding: 14px 16px 12px;
+  animation: txp-rise 160ms ease-out;
+}
+
+.txp-card.is-confirmed {
+  border-left-color: var(--success-color, #22c55e);
+}
+.txp-card.is-failed {
+  border-left-color: var(--danger-color, #dc2626);
+}
+.txp-card.is-stalled {
+  border-left-color: var(--warning-color, #f59e0b);
+}
+
+@keyframes txp-rise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.txp-close {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted, #8a959e);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm, 4px);
+}
+.txp-close:hover {
+  color: var(--text-primary, #1f2933);
+}
+
+.txp-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding-right: 18px;
+}
+
+.txp-icon {
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 700;
+  margin-top: 1px;
+}
+.is-confirmed .txp-icon {
+  color: var(--success-color, #22c55e);
+}
+.is-failed .txp-icon {
+  color: var(--danger-color, #dc2626);
+}
+.is-stalled .txp-icon {
+  color: var(--warning-color, #f59e0b);
+}
+
+.txp-spinner {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(var(--brand-primary-rgb, 54, 179, 126), 0.25);
+  border-top-color: var(--brand-primary, #36b37e);
+  animation: txp-spin 0.7s linear infinite;
+}
+@keyframes txp-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.txp-titles {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.txp-title {
+  font-weight: 600;
+  font-size: 14px;
+}
+.txp-sub {
+  font-size: 12.5px;
+  color: var(--text-secondary, #5a6772);
+  margin-top: 2px;
+  line-height: 1.35;
+}
+.is-failed .txp-sub {
+  color: var(--danger-color, #dc2626);
+}
+
+.txp-elapsed {
+  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  color: var(--text-muted, #8a959e);
+  margin-top: 2px;
+}
+
+/* Step rail */
+.txp-steps {
+  list-style: none;
+  display: flex;
+  margin: 12px 0 4px;
+  padding: 0;
+}
+.txp-step {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  font-size: 11px;
+  color: var(--text-muted, #8a959e);
+}
+/* connector line between dots */
+.txp-step::before {
+  content: '';
+  position: absolute;
+  top: 5px;
+  left: -50%;
+  width: 100%;
+  height: 2px;
+  background: var(--border-color, #e3e7eb);
+  z-index: 0;
+}
+.txp-step:first-child::before {
+  display: none;
+}
+.txp-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--border-color, #e3e7eb);
+  border: 2px solid var(--surface-color, #fff);
+  box-shadow: 0 0 0 1px var(--border-color, #e3e7eb);
+  z-index: 1;
+  margin-bottom: 5px;
+}
+.txp-step-label {
+  white-space: nowrap;
+}
+.txp-step--done .txp-dot,
+.txp-step--current .txp-dot {
+  background: var(--brand-primary, #36b37e);
+  box-shadow: 0 0 0 1px var(--brand-primary, #36b37e);
+}
+.txp-step--done .txp-step::before,
+.txp-step--current::before {
+  background: var(--brand-primary, #36b37e);
+}
+.txp-step--current .txp-dot {
+  animation: txp-pulse 1.2s ease-in-out infinite;
+}
+.txp-step--current .txp-step-label {
+  color: var(--text-primary, #1f2933);
+  font-weight: 600;
+}
+.txp-step--error .txp-dot {
+  background: var(--danger-color, #dc2626);
+  box-shadow: 0 0 0 1px var(--danger-color, #dc2626);
+}
+@keyframes txp-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 1px var(--brand-primary, #36b37e);
+  }
+  50% {
+    box-shadow: 0 0 0 4px rgba(var(--brand-primary-rgb, 54, 179, 126), 0.3);
+  }
+}
+
+/* meta row: sponsorship truth + references/links */
+.txp-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  min-height: 4px;
+}
+.txp-meta:empty {
+  margin-top: 0;
+}
+.txp-badge {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+.txp-badge--gasless {
+  background: rgba(var(--brand-primary-rgb, 54, 179, 126), 0.14);
+  color: var(--brand-primary, #36b37e);
+}
+.txp-badge--self {
+  background: rgba(245, 166, 35, 0.16);
+  color: var(--warning-color, #f59e0b);
+}
+.txp-link {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--brand-primary, #36b37e);
+  text-decoration: none;
+}
+.txp-link:hover {
+  text-decoration: underline;
+}
+.txp-ref {
+  font-size: 11px;
+  color: var(--text-muted, #8a959e);
+  font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .txp-card {
+    animation: none;
+  }
+  .txp-spinner,
+  .txp-step--current .txp-dot {
+    animation: none;
+  }
+}

--- a/frontend/src/components/wallet/TxProgressOverlay.jsx
+++ b/frontend/src/components/wallet/TxProgressOverlay.jsx
@@ -1,0 +1,161 @@
+import { useSyncExternalStore, useEffect, useState, useRef } from 'react'
+import {
+  subscribe,
+  getSnapshot,
+  dismissTx,
+  PHASE,
+  STEPS,
+  PHASE_STEP,
+  isTerminalPhase,
+} from '../../lib/passkey/txProgressBus'
+import { getTransactionUrl } from '../../config/blockExplorer'
+import './TxProgressOverlay.css'
+
+// Honest, user-facing copy for each phase (spec 041 FR-017 / Constitution III:
+// never claim confirmed before inclusion; never freeze silently).
+const COPY = {
+  [PHASE.PREPARING]: { title: 'Preparing…', sub: 'Building your transaction.' },
+  [PHASE.SIGNING]: {
+    title: 'Confirm with your passkey',
+    sub: 'Approve the prompt on your device to authorize this action.',
+  },
+  [PHASE.SUBMITTING]: { title: 'Submitting…', sub: 'Handing your transaction to the network.' },
+  [PHASE.CONFIRMING]: {
+    title: 'Confirming on-chain…',
+    sub: 'Submitted. Waiting for it to be included in a block — usually a few seconds.',
+  },
+  [PHASE.CONFIRMED]: { title: 'Confirmed', sub: 'Your transaction is on-chain.' },
+  [PHASE.STALLED]: {
+    title: 'Taking longer than usual',
+    sub: "The network is congested. Your transaction is still being tracked — it's safe to wait, or check Activity later.",
+  },
+  [PHASE.FAILED]: { title: 'Transaction failed', sub: 'Nothing was sent. You can try again.' },
+}
+
+const AUTO_DISMISS_MS = 7000
+
+function shortHash(h) {
+  if (!h || typeof h !== 'string') return ''
+  return h.length > 14 ? `${h.slice(0, 8)}…${h.slice(-6)}` : h
+}
+
+/**
+ * TxProgressOverlay — one global, session-wide surface that renders the passkey
+ * batch lifecycle published by WalletContext.sendCalls (via txProgressBus). It
+ * replaces the frozen "Sending…" button state with a signature → submission →
+ * confirmation walk-through and an honest terminal state.
+ *
+ * Mounted once at the app root; renders nothing when no batch is in flight, so
+ * classic-wallet flows (which surface their own extension UI) are unaffected.
+ */
+export default function TxProgressOverlay() {
+  const progress = useSyncExternalStore(subscribe, getSnapshot, () => null)
+
+  const phase = progress?.phase
+  const seq = progress?.seq
+  const terminal = phase ? isTerminalPhase(phase) : false
+
+  // Live elapsed-seconds clock. Kept in state and advanced by an interval so the
+  // tick stays out of the app tree; Date.now() runs only inside the callback
+  // (never during render). Reset to 0 the instant a new batch starts via the
+  // "adjust state when an input changes" pattern (react.dev) so a stale count
+  // never flashes across batches.
+  const startedAt = progress?.startedAt
+  const [elapsed, setElapsed] = useState(0)
+  const [lastSeq, setLastSeq] = useState(seq)
+  const dismissTimer = useRef(null)
+  if (seq !== lastSeq) {
+    setLastSeq(seq)
+    setElapsed(0)
+  }
+
+  useEffect(() => {
+    if (!progress?.active || terminal || startedAt == null) return undefined
+    const id = setInterval(() => {
+      setElapsed(Math.max(0, Math.round((Date.now() - startedAt) / 1000)))
+    }, 1000)
+    return () => clearInterval(id)
+    // Re-arm per batch (startedAt changes with seq); a terminal phase freezes the clock.
+  }, [progress?.active, terminal, startedAt])
+
+  // Auto-dismiss only the happy terminal; failures/stalls stay until dismissed
+  // so the user can read the guidance and copy the reference.
+  useEffect(() => {
+    clearTimeout(dismissTimer.current)
+    if (phase === PHASE.CONFIRMED) {
+      dismissTimer.current = setTimeout(() => dismissTx(), AUTO_DISMISS_MS)
+    }
+    return () => clearTimeout(dismissTimer.current)
+  }, [phase, seq])
+
+  if (!progress?.active) return null
+
+  const copy = COPY[phase] || COPY[PHASE.PREPARING]
+  const activeStep = PHASE_STEP[phase] ?? 0
+  const failed = phase === PHASE.FAILED
+  const stalled = phase === PHASE.STALLED
+  const confirmed = phase === PHASE.CONFIRMED
+  const explorerUrl =
+    confirmed && progress.txHash && progress.chainId
+      ? getTransactionUrl(progress.chainId, progress.txHash)
+      : ''
+
+  const statusClass = failed ? 'is-failed' : stalled ? 'is-stalled' : confirmed ? 'is-confirmed' : 'is-active'
+
+  return (
+    <div className="txp-overlay" role="status" aria-live="polite">
+      <div className={`txp-card ${statusClass}`}>
+        <button className="txp-close" onClick={() => dismissTx()} aria-label="Dismiss">
+          ×
+        </button>
+
+        <div className="txp-head">
+          <span className="txp-icon" aria-hidden="true">
+            {confirmed ? '✓' : failed ? '✕' : stalled ? '⏳' : <span className="txp-spinner" />}
+          </span>
+          <div className="txp-titles">
+            <div className="txp-title">{copy.title}</div>
+            <div className="txp-sub">{failed && progress.reason ? progress.reason : copy.sub}</div>
+          </div>
+          {!terminal && <span className="txp-elapsed">{elapsed}s</span>}
+        </div>
+
+        {/* Step rail — Prepare · Sign · Submit · Confirm */}
+        <ol className="txp-steps" aria-hidden="true">
+          {STEPS.map((label, i) => {
+            const state =
+              failed && i === Math.max(activeStep, 0)
+                ? 'error'
+                : i < activeStep
+                  ? 'done'
+                  : i === activeStep
+                    ? 'current'
+                    : 'todo'
+            return (
+              <li key={label} className={`txp-step txp-step--${state}`}>
+                <span className="txp-dot" />
+                <span className="txp-step-label">{label}</span>
+              </li>
+            )
+          })}
+        </ol>
+
+        {/* Route / sponsorship truth + references */}
+        <div className="txp-meta">
+          {progress.sponsored === true && <span className="txp-badge txp-badge--gasless">Gas sponsored</span>}
+          {progress.sponsored === false && <span className="txp-badge txp-badge--self">You pay gas</span>}
+          {confirmed && explorerUrl && (
+            <a className="txp-link" href={explorerUrl} target="_blank" rel="noopener noreferrer">
+              View on explorer ↗
+            </a>
+          )}
+          {(stalled || (!confirmed && progress.userOpHash)) && progress.userOpHash && (
+            <span className="txp-ref" title={progress.userOpHash}>
+              Ref {shortHash(progress.userOpHash)}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/contexts/WalletContext.jsx
+++ b/frontend/src/contexts/WalletContext.jsx
@@ -11,6 +11,7 @@ import {
 } from '../utils/roleStorage'
 import { hasRoleOnChain } from '../utils/blockchainService'
 import { WalletContext } from './WalletContext'
+import { beginTx, publishLifecycle, failTx } from '../lib/passkey/txProgressBus'
 
 export function WalletProvider({ children }) {
   // Wagmi hooks for wallet connection
@@ -121,11 +122,42 @@ export function WalletProvider({ children }) {
           import('../lib/passkey/sendBatch'),
           import('../connectors/passkey'),
         ])
-        // Pin the ceremony to the credential this session signed in with —
-        // never a different passkey that happens to share the address book
-        // (spec 045 US3/FR-008). `onState` (optional) surfaces the honest
-        // submitted→included|failed|stalled lifecycle to the caller's UI.
-        return sendPasskeyBatch({ chainId, address, calls, credentialId: readSession()?.credentialId, onState })
+        // Publish the honest lifecycle to the global progress overlay so EVERY
+        // passkey write (transfer, vouchers, wagers, tokens, swap, DAO, custody)
+        // shows a signature → submission → confirmation walk-through instead of a
+        // frozen "Sending…". The caller's own `onState` (if any) still fires — the
+        // bus is additive, and a broken listener never breaks the batch.
+        beginTx({ chainId })
+        const observe = (s) => {
+          try {
+            publishLifecycle(s)
+          } catch {
+            /* progress is best-effort */
+          }
+          try {
+            onState?.(s)
+          } catch {
+            /* caller observer must not break submission */
+          }
+        }
+        try {
+          // Pin the ceremony to the credential this session signed in with —
+          // never a different passkey that happens to share the address book
+          // (spec 045 US3/FR-008).
+          return await sendPasskeyBatch({
+            chainId,
+            address,
+            calls,
+            credentialId: readSession()?.credentialId,
+            onState: observe,
+          })
+        } catch (err) {
+          // A throw (revert surfaced, or no submission path) never reaches the
+          // lifecycle observer — reflect it so the overlay shows the failure
+          // instead of vanishing mid-flight.
+          failTx(err?.shortMessage || err?.message || 'Transaction failed.')
+          throw err
+        }
       }
       if (!signer) throw new Error('No signer available')
       const receipts = []

--- a/frontend/src/lib/passkey/txProgressBus.js
+++ b/frontend/src/lib/passkey/txProgressBus.js
@@ -1,0 +1,148 @@
+/**
+ * txProgressBus — a tiny, dependency-free pub/sub that carries the honest
+ * passkey-batch lifecycle (spec 041 FR-017: draft → submitted → included |
+ * failed | stalled) from WalletContext.sendCalls to ONE global progress
+ * overlay, without threading an `onState` callback through every call site.
+ *
+ * Why a bus (not React context): sendCalls is invoked from ~30 surfaces
+ * (transfer, vouchers, wagers, tokens, swap, DAO, custody). Publishing progress
+ * through WalletContext's value would re-render every consumer on each ~3s poll
+ * tick. A module-level store keeps that churn isolated to the overlay, which
+ * subscribes via useSyncExternalStore.
+ *
+ * The overlay's job is to replace the frozen "Sending…" button state with a
+ * truthful signature → submission → confirmation walk-through.
+ */
+
+// Coarse, user-facing phases. NOT the raw LIFECYCLE literals — those describe
+// the submission engine; these describe what the person is waiting on.
+export const PHASE = Object.freeze({
+  PREPARING: 'preparing', // building the batch / resolving the account
+  SIGNING: 'signing', // the WebAuthn ceremony (device prompt) is up
+  SUBMITTING: 'submitting', // handed to the bundler/relayer
+  CONFIRMING: 'confirming', // in flight; waiting for on-chain inclusion
+  CONFIRMED: 'confirmed', // included on-chain (terminal, happy)
+  FAILED: 'failed', // reverted or could not be submitted (terminal)
+  STALLED: 'stalled', // submitted but not confirmed within the window (terminal-ish)
+})
+
+// The four visible steps in the overlay's progress rail, in order.
+export const STEPS = Object.freeze(['Prepare', 'Sign', 'Submit', 'Confirm'])
+
+// Which rail node is "active" for a given phase (index into STEPS; 4 = all done).
+export const PHASE_STEP = Object.freeze({
+  [PHASE.PREPARING]: 0,
+  [PHASE.SIGNING]: 1,
+  [PHASE.SUBMITTING]: 2,
+  [PHASE.CONFIRMING]: 3,
+  [PHASE.CONFIRMED]: 4,
+  [PHASE.STALLED]: 3,
+  [PHASE.FAILED]: -1,
+})
+
+export const isTerminalPhase = (phase) =>
+  phase === PHASE.CONFIRMED || phase === PHASE.FAILED || phase === PHASE.STALLED
+
+let current = null // the live snapshot (null = nothing in flight)
+let seq = 0
+const listeners = new Set()
+
+function emit(next) {
+  current = next
+  for (const fn of listeners) {
+    try {
+      fn()
+    } catch {
+      /* a bad listener must not break the batch */
+    }
+  }
+}
+
+/** useSyncExternalStore subscribe. */
+export function subscribe(listener) {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+/** useSyncExternalStore getSnapshot — stable reference until the next emit(). */
+export function getSnapshot() {
+  return current
+}
+
+/**
+ * Start tracking a new batch. Returns the sequence id so a caller could scope
+ * later updates, though publishLifecycle/failTx operate on the latest batch.
+ */
+export function beginTx({ chainId = null } = {}) {
+  seq += 1
+  emit({
+    active: true,
+    seq,
+    phase: PHASE.PREPARING,
+    route: null,
+    sponsored: null,
+    chainId,
+    startedAt: Date.now(),
+    txHash: null,
+    userOpHash: null,
+    reason: null,
+  })
+  return seq
+}
+
+/**
+ * Map one engine lifecycle event (submission.js LIFECYCLE) onto a user-facing
+ * phase and merge it into the live snapshot. Ignored if no batch is active
+ * (e.g. a stray late poll after dismissal).
+ */
+export function publishLifecycle(s) {
+  if (!current?.active || !s?.state) return
+  const patch = { ...current }
+  switch (s.state) {
+    case 'draft': // route chosen; the device prompt is imminent
+      patch.phase = PHASE.SIGNING
+      if (s.route != null) patch.route = s.route
+      if (s.sponsored != null) patch.sponsored = s.sponsored
+      break
+    case 'submitted': // accepted by bundler/relayer; now waiting for inclusion
+      patch.phase = PHASE.CONFIRMING
+      if (s.sponsored != null) patch.sponsored = s.sponsored
+      if (s.userOpHash) patch.userOpHash = s.userOpHash
+      if (s.intentId) patch.userOpHash = patch.userOpHash || s.intentId
+      break
+    case 'included':
+      patch.phase = PHASE.CONFIRMED
+      if (s.txHash) patch.txHash = s.txHash
+      break
+    case 'failed':
+      patch.phase = PHASE.FAILED
+      patch.reason = s.reason || 'The transaction reverted on-chain.'
+      break
+    case 'stalled':
+      patch.phase = PHASE.STALLED
+      if (s.lastKnown?.userOpHash) patch.userOpHash = s.lastKnown.userOpHash
+      break
+    default:
+      return // 'ceremony-signed' and unknowns don't move the visible phase
+  }
+  emit(patch)
+}
+
+/** Force the failed terminal (a thrown error before/around submission). */
+export function failTx(reason) {
+  if (!current?.active) return
+  emit({ ...current, phase: PHASE.FAILED, reason: reason || 'Transaction failed.' })
+}
+
+/** Clear the overlay (user dismiss, or auto-dismiss after a happy confirmation). */
+export function dismissTx() {
+  if (!current) return
+  emit(null)
+}
+
+// Test seam: reset module state between cases.
+export function __resetTxProgress() {
+  current = null
+  seq = 0
+  listeners.clear()
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -17,6 +17,7 @@ import {
   PrivacyProvider
 } from './contexts'
 import ErrorBoundary from './components/ui/ErrorBoundary'
+import TxProgressOverlay from './components/wallet/TxProgressOverlay'
 import { validateTheme } from './utils/validateTheme'
 import { registerServiceWorker } from './lib/pwa/serviceWorkerUpdate'
 
@@ -42,6 +43,10 @@ createRoot(document.getElementById('root')).render(
                       <UIProvider>
                         <PriceProvider>
                           <App />
+                          {/* Global passkey tx-progress overlay: renders the
+                              signature → submission → confirmation lifecycle for
+                              every sendCalls batch (spec 041 FR-017). */}
+                          <TxProgressOverlay />
                         </PriceProvider>
                       </UIProvider>
                     </DexProvider>

--- a/frontend/src/test/TxProgressOverlay.test.jsx
+++ b/frontend/src/test/TxProgressOverlay.test.jsx
@@ -1,0 +1,96 @@
+/**
+ * txProgressBus + TxProgressOverlay — the global passkey signature→confirmation
+ * progress surface (spec 041 FR-017). The bus maps engine LIFECYCLE events to
+ * user-facing phases; the overlay renders them and never claims "confirmed"
+ * before on-chain inclusion.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, act, cleanup } from '@testing-library/react'
+import {
+  beginTx,
+  publishLifecycle,
+  failTx,
+  getSnapshot,
+  __resetTxProgress,
+  PHASE,
+} from '../lib/passkey/txProgressBus'
+import TxProgressOverlay from '../components/wallet/TxProgressOverlay'
+
+describe('txProgressBus lifecycle mapping', () => {
+  beforeEach(() => __resetTxProgress())
+
+  it('beginTx starts in PREPARING and is active', () => {
+    beginTx({ chainId: 137 })
+    expect(getSnapshot()).toMatchObject({ active: true, phase: PHASE.PREPARING, chainId: 137 })
+  })
+
+  it('maps draft→signing, submitted→confirming, included→confirmed(txHash)', () => {
+    beginTx({ chainId: 137 })
+    publishLifecycle({ state: 'draft', route: 'userop', sponsored: true })
+    expect(getSnapshot()).toMatchObject({ phase: PHASE.SIGNING, route: 'userop', sponsored: true })
+
+    publishLifecycle({ state: 'submitted', userOpHash: '0xuo', sponsored: true })
+    expect(getSnapshot()).toMatchObject({ phase: PHASE.CONFIRMING, userOpHash: '0xuo' })
+
+    publishLifecycle({ state: 'included', txHash: '0xabc' })
+    expect(getSnapshot()).toMatchObject({ phase: PHASE.CONFIRMED, txHash: '0xabc' })
+  })
+
+  it('maps failed→failed(reason) and stalled→stalled', () => {
+    beginTx({ chainId: 137 })
+    publishLifecycle({ state: 'failed', reason: 'reverted' })
+    expect(getSnapshot()).toMatchObject({ phase: PHASE.FAILED, reason: 'reverted' })
+
+    __resetTxProgress()
+    beginTx({ chainId: 137 })
+    publishLifecycle({ state: 'stalled', lastKnown: { userOpHash: '0xuo' } })
+    expect(getSnapshot()).toMatchObject({ phase: PHASE.STALLED, userOpHash: '0xuo' })
+  })
+
+  it('ignores updates when no batch is active', () => {
+    publishLifecycle({ state: 'submitted', userOpHash: '0xuo' })
+    expect(getSnapshot()).toBeNull()
+  })
+
+  it('failTx forces the failed terminal', () => {
+    beginTx({ chainId: 137 })
+    failTx('boom')
+    expect(getSnapshot()).toMatchObject({ phase: PHASE.FAILED, reason: 'boom' })
+  })
+})
+
+describe('TxProgressOverlay rendering', () => {
+  beforeEach(() => __resetTxProgress())
+  afterEach(() => cleanup())
+
+  it('renders nothing when idle', () => {
+    const { container } = render(<TxProgressOverlay />)
+    expect(container.querySelector('.txp-card')).toBeNull()
+  })
+
+  it('shows the passkey prompt copy while signing, then an explorer link when confirmed', () => {
+    render(<TxProgressOverlay />)
+    act(() => {
+      beginTx({ chainId: 137 })
+      publishLifecycle({ state: 'draft', route: 'userop', sponsored: true })
+    })
+    expect(screen.getByText('Confirm with your passkey')).toBeInTheDocument()
+    expect(screen.getByText('Gas sponsored')).toBeInTheDocument()
+
+    act(() => publishLifecycle({ state: 'included', txHash: '0x' + 'a'.repeat(64) }))
+    expect(screen.getByText('Confirmed')).toBeInTheDocument()
+    const link = screen.getByRole('link', { name: /view on explorer/i })
+    expect(link).toHaveAttribute('href', expect.stringContaining('/tx/0x' + 'a'.repeat(64)))
+  })
+
+  it('surfaces the stall guidance and stays until dismissed', () => {
+    render(<TxProgressOverlay />)
+    act(() => {
+      beginTx({ chainId: 137 })
+      publishLifecycle({ state: 'stalled', lastKnown: {} })
+    })
+    expect(screen.getByText('Taking longer than usual')).toBeInTheDocument()
+    act(() => screen.getByLabelText('Dismiss').click())
+    expect(screen.queryByText('Taking longer than usual')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Why

Passkey users report the frontend **hangs at "Sending…"** with no feedback across every gasless surface (transfer, vouchers, wagers, tokens, swap, DAO, custody). The button is static from tap to (eventual) resolution — there's no indication whether the transaction is signing, submitting, or confirming, and no honest terminal state when the network is slow.

## Root cause of the *feedback gap*

`sendPasskeyBatch` already emits an honest lifecycle (`draft → submitted → included | failed | stalled`) via `onState`, but **only `useTransfer` consumed it** — every other surface calls `sendCalls(calls)` with no observer, so the lifecycle was emitted into the void and the UI stayed frozen.

## Fix — publish once, render once

Instead of threading a status pair through ~30 call sites, publish the lifecycle **centrally** from `WalletContext.sendCalls` to a tiny dependency-free pub/sub, and render it in **one global overlay**:

- **`lib/passkey/txProgressBus.js`** — module-level store mapping engine `LIFECYCLE` events to user-facing phases. A module store (not React context) keeps the ~3s poll-tick churn *off* the app tree.
- **`WalletContext.sendCalls`** — `beginTx` / `publishLifecycle` / `failTx` around the passkey batch. The caller's own `onState` still fires (additive; a broken listener never breaks submission).
- **`components/wallet/TxProgressOverlay.jsx/.css`** — subscribes via `useSyncExternalStore`; shows a **Prepare · Sign · Submit · Confirm** rail, a live elapsed clock, the honest **Gas sponsored / You pay gas** badge, an **explorer link** on inclusion, and truthful **stall guidance** ("still tracking — safe to wait, or check Activity later") instead of a frozen button. Never claims "confirmed" before on-chain inclusion (Constitution III).

Classic-wallet flows are untouched (they surface their own extension UI). Mounted once at the app root; renders nothing when idle.

## Tests
`src/test/TxProgressOverlay.test.jsx` — bus lifecycle mapping + overlay render/dismiss (8 cases, green). Lint clean.

## ⚠️ Separate infra blocker (not fixed here — needs your go-ahead)

While diagnosing, I found the alto bundler's upstream RPC (`ALTO_RPC_URL = https://polygon-bor-rpc.publicnode.com`, `services/alto-bundler/deploy/service.yaml:66`) now returns **HTTP 403 — "Archive requests require a personal token"** on ERC-4337 receipt/log resolution (`eth_getLogs` for `UserOperationEvent`). The UserOp *lands* (executor `0x7C6d…` funded 46 POL, nonce advancing) but alto **can't read the receipt back**, so confirmations never surface → this overlay would show "stalled" at 90s. **The real fix is pointing `ALTO_RPC_URL` at an archive-capable RPC** (paid allnodes token / Alchemy / Infura / drpc). That's a prod infra change — happy to prep it on your say-so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)