### PR TITLE
fix(open-challenge): let passkey takers connect + accept, render terms as prose

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.css
+++ b/frontend/src/components/fairwins/FriendMarketsModal.css
@@ -634,7 +634,9 @@
   z-index: 5;
   left: 0;
   right: auto;
-  top: calc(100% + 3px);
+  /* Open ABOVE the input: on mobile the on-screen keyboard covers the area below the
+     box, hiding a downward list. Anchoring to the input's top keeps suggestions visible. */
+  bottom: calc(100% + 3px);
   margin: 0;
   padding: 0.25rem;
   list-style: none;

--- a/frontend/src/components/fairwins/PhraseWordInputs.jsx
+++ b/frontend/src/components/fairwins/PhraseWordInputs.jsx
@@ -116,7 +116,7 @@ export default function PhraseWordInputs({ words, onChange, disabled = false, id
               aria-invalid={showInvalid || undefined}
               value={w}
               disabled={disabled}
-              placeholder={String(i + 1)}
+              placeholder={`word #${i + 1}`}
               onChange={(e) => handleChange(i, e.target.value)}
               onKeyDown={(e) => handleKeyDown(i, e)}
               onPaste={(e) => handlePaste(i, e)}

--- a/frontend/src/components/fairwins/TakeChallengePanel.css
+++ b/frontend/src/components/fairwins/TakeChallengePanel.css
@@ -1,6 +1,24 @@
 /* Take-a-challenge bet summary additions (spec 041). Meaning is carried by text +
    icon, never color alone (WCAG); layered over FriendMarketsModal/OpenChallengeModal css. */
 
+/* The challenge, rendered as plain readable prose (not a JSON code block). */
+.tc-terms-text {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 1rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.tc-terms-text--empty {
+  font-style: italic;
+  opacity: 0.75;
+}
+
 .tc-stake {
   padding: 10px 12px;
   border-radius: 10px;

--- a/frontend/src/components/fairwins/TakeChallengePanel.jsx
+++ b/frontend/src/components/fairwins/TakeChallengePanel.jsx
@@ -4,6 +4,7 @@ import { usePolymarketMarket } from '../../hooks/usePolymarketMarket'
 import { useChainTokens } from '../../hooks/useChainTokens'
 import { ResolutionType } from '../../constants/wagerDefaults'
 import { UIContext } from '../../contexts/UIContext'
+import { WalletContext } from '../../contexts/WalletContext'
 import InfoTip from '../ui/InfoTip'
 import SensitiveValue from '../common/SensitiveValue'
 import './FriendMarketsModal.css'
@@ -22,6 +23,14 @@ export default function TakeChallengePanel({ code, match, onClose, onBuyMembersh
   // Access the notification system directly (optional) so this panel still renders in tests without a
   // UIProvider, while routing the take-success event into the app's notification toasts (spec 037).
   const ui = useContext(UIContext)
+  // Wallet connection surface (spec 045). Read directly (optional) so the panel still renders in
+  // tests without a WalletProvider. A passkey/EOA session is "connected" once it has an address; if
+  // there's no connected account we show a Connect affordance instead of dead-ending the accept with
+  // "Connect your wallet to accept." — the exact error passkey takers hit opening a shared link.
+  const wallet = useContext(WalletContext)
+  const connectedAddress = wallet?.address || wallet?.account || null
+  const isConnected = Boolean(connectedAddress)
+  const openConnectModal = wallet?.openConnectModal
   const [phase, setPhase] = useState('found')
   const [progress, setProgress] = useState(null)
   const [txHash, setTxHash] = useState(null)
@@ -76,14 +85,14 @@ export default function TakeChallengePanel({ code, match, onClose, onBuyMembersh
   return (
     <div className="fm-form">
       <div className="fm-form-group fm-form-full">
-        <label>Challenge terms</label>
+        <label>The challenge</label>
         {found.termsUnavailable ? (
           <div className="oc-notice oc-notice--warn" role="alert">
             Terms unavailable — the encrypted details couldn&apos;t be retrieved. You can still accept; the
             on-chain wager is unaffected. Keep your code to read the terms later.
           </div>
         ) : (
-          <pre className="oc-terms-body">{formatTerms(found.terms)}</pre>
+          <ChallengeText terms={found.terms} />
         )}
       </div>
 
@@ -129,7 +138,11 @@ export default function TakeChallengePanel({ code, match, onClose, onBuyMembersh
           )}
           <div className="fm-success-actions">
             <span className="fm-label-row">
-              <button type="button" className="fm-btn-primary" onClick={handleAccept} disabled={busy || blockedResolved}>{busy ? (progress ? `${stepLabel(progress.step)}…` : 'Accepting…') : 'Accept challenge'}</button>
+              {isConnected ? (
+                <button type="button" className="fm-btn-primary" onClick={handleAccept} disabled={busy || blockedResolved}>{busy ? (progress ? `${stepLabel(progress.step)}…` : 'Locking in…') : 'Lock In!'}</button>
+              ) : (
+                <button type="button" className="fm-btn-primary" onClick={() => openConnectModal?.()} disabled={blockedResolved}>Connect wallet to Lock In</button>
+              )}
               <InfoTip label="About accepting">
                 Accepting binds you as the opponent and escrows your equal stake. Save your code to re-read the terms later.
               </InfoTip>
@@ -359,10 +372,28 @@ function formatDeadline(value) {
   }
 }
 
-function formatTerms(terms) {
+/**
+ * Render the challenge as readable prose, never raw JSON. The sealed terms are a small object
+ * ({ description, createdAt, oracle? }); the taker only cares about the human description. Anything
+ * that isn't a plain description (legacy shapes, missing text) degrades to a neutral note rather than
+ * dumping the object — the on-chain bet summary below already carries the authoritative details.
+ */
+function ChallengeText({ terms }) {
+  const text = challengeText(terms)
+  if (!text) {
+    return <p className="tc-terms-text tc-terms-text--empty">No description was included with this challenge.</p>
+  }
+  return <p className="tc-terms-text">{text}</p>
+}
+
+function challengeText(terms) {
   if (terms == null) return ''
-  if (typeof terms === 'string') return terms
-  try { return JSON.stringify(terms, null, 2) } catch { return String(terms) }
+  if (typeof terms === 'string') return terms.trim()
+  if (typeof terms === 'object') {
+    const desc = terms.description ?? terms.text ?? terms.title
+    if (typeof desc === 'string') return desc.trim()
+  }
+  return ''
 }
 
 function shorten(hash) {

--- a/frontend/src/components/fairwins/__tests__/TakeChallengePanel.test.jsx
+++ b/frontend/src/components/fairwins/__tests__/TakeChallengePanel.test.jsx
@@ -8,25 +8,57 @@ vi.mock('../../../hooks/useOpenChallengeAccept', () => ({
 
 import TakeChallengePanel from '../TakeChallengePanel'
 import { UIContext } from '../../../contexts/UIContext'
+import { WalletContext } from '../../../contexts/WalletContext'
 
 const matchOpen = { wagerId: 4n, wager: {}, terms: { description: 'Will it snow?' }, termsUnavailable: false, needsMembership: false }
 
+// A connected taker — the take flow needs an address, so most cases render with one.
+const connectedWallet = { address: '0xTaker', account: '0xTaker', openConnectModal: vi.fn() }
+
+function renderPanel(ui, wallet = connectedWallet) {
+  return render(<WalletContext.Provider value={wallet}>{ui}</WalletContext.Provider>)
+}
+
 describe('TakeChallengePanel (spec 037, US1)', () => {
-  beforeEach(() => { accept.mockReset() })
+  beforeEach(() => { accept.mockReset(); connectedWallet.openConnectModal.mockReset() })
 
   it('shows terms + funding steps and accepts (onProgress passed through)', async () => {
     accept.mockResolvedValue({ txHash: '0xdef' })
-    render(<TakeChallengePanel code="river tiger kite zoo" match={matchOpen} onClose={() => {}} />)
+    renderPanel(<TakeChallengePanel code="river tiger kite zoo" match={matchOpen} onClose={() => {}} />)
     expect(screen.getByText(/Will it snow/)).toBeInTheDocument()
     expect(screen.getByText(/Approve the stake token/i)).toBeInTheDocument()
     expect(screen.getByText(/Sign to authorize acceptance/i)).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: /accept challenge/i }))
+    fireEvent.click(screen.getByRole('button', { name: /lock in/i }))
     await waitFor(() => expect(accept).toHaveBeenCalledWith('river tiger kite zoo', 4n, expect.any(Function)))
     expect(await screen.findByText(/taken the challenge/i)).toBeInTheDocument()
   })
 
+  it('renders the challenge as plain prose, not a JSON code block', () => {
+    renderPanel(<TakeChallengePanel code="river tiger kite zoo" match={matchOpen} onClose={() => {}} />)
+    const text = screen.getByText('Will it snow?')
+    // Readable paragraph, never the raw `{ "description": … }` dump.
+    expect(text.tagName).toBe('P')
+    expect(text).toHaveClass('tc-terms-text')
+    expect(screen.queryByText(/"description"/)).toBeNull()
+  })
+
+  it('offers a Connect affordance instead of dead-ending accept when no wallet is connected', () => {
+    const openConnectModal = vi.fn()
+    renderPanel(
+      <TakeChallengePanel code="river tiger kite zoo" match={matchOpen} onClose={() => {}} />,
+      { address: null, account: null, openConnectModal }
+    )
+    // No "Lock In!" accept button while disconnected — a connect prompt instead.
+    expect(screen.queryByRole('button', { name: /^lock in!$/i })).toBeNull()
+    const connectBtn = screen.getByRole('button', { name: /connect wallet to lock in/i })
+    fireEvent.click(connectBtn)
+    expect(openConnectModal).toHaveBeenCalled()
+    // Never silently calls accept without a wallet.
+    expect(accept).not.toHaveBeenCalled()
+  })
+
   it('moves the accept explainer and save-code note behind an info icon (spec 039 US2)', () => {
-    render(<TakeChallengePanel code="river tiger kite zoo" match={matchOpen} onClose={() => {}} />)
+    renderPanel(<TakeChallengePanel code="river tiger kite zoo" match={matchOpen} onClose={() => {}} />)
     expect(screen.queryByText(/binds you as the opponent/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/save your code to re-read/i)).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'About accepting' }))
@@ -37,34 +69,34 @@ describe('TakeChallengePanel (spec 037, US1)', () => {
 
   it('prompts for membership when the taker is not a member (no accept button)', () => {
     const onBuyMembership = vi.fn()
-    render(<TakeChallengePanel code="river tiger kite zoo" match={{ ...matchOpen, needsMembership: true }} onClose={() => {}} onBuyMembership={onBuyMembership} />)
-    expect(screen.queryByRole('button', { name: /accept challenge/i })).toBeNull()
+    renderPanel(<TakeChallengePanel code="river tiger kite zoo" match={{ ...matchOpen, needsMembership: true }} onClose={() => {}} onBuyMembership={onBuyMembership} />)
+    expect(screen.queryByRole('button', { name: /lock in/i })).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: /membership/i }))
     expect(onBuyMembership).toHaveBeenCalled()
   })
 
   it('shows terms-unavailable but still allows accept', () => {
-    render(<TakeChallengePanel code="river tiger kite zoo" match={{ ...matchOpen, terms: null, termsUnavailable: true }} onClose={() => {}} />)
+    renderPanel(<TakeChallengePanel code="river tiger kite zoo" match={{ ...matchOpen, terms: null, termsUnavailable: true }} onClose={() => {}} />)
     expect(screen.getByText(/terms unavailable/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /accept challenge/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /lock in/i })).toBeInTheDocument()
   })
 
   it('surfaces a clean revert error without crashing (e.g. no-longer-open)', async () => {
     accept.mockRejectedValue(new Error('This challenge is no longer open — someone may have already taken it.'))
-    render(<TakeChallengePanel code="river tiger kite zoo" match={matchOpen} onClose={() => {}} />)
-    fireEvent.click(screen.getByRole('button', { name: /accept challenge/i }))
+    renderPanel(<TakeChallengePanel code="river tiger kite zoo" match={matchOpen} onClose={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: /lock in/i }))
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/no longer open/i))
   })
 
   it('routes a success toast into the notification system (spec 037)', async () => {
     accept.mockResolvedValue({ txHash: '0xdef' })
     const showNotification = vi.fn()
-    render(
+    renderPanel(
       <UIContext.Provider value={{ showNotification }}>
         <TakeChallengePanel code="river tiger kite zoo" match={matchOpen} onClose={() => {}} />
       </UIContext.Provider>
     )
-    fireEvent.click(screen.getByRole('button', { name: /accept challenge/i }))
+    fireEvent.click(screen.getByRole('button', { name: /lock in/i }))
     await waitFor(() => expect(showNotification).toHaveBeenCalledWith(expect.stringMatching(/taken the challenge/i), 'success', expect.any(Number)))
   })
 })

--- a/frontend/src/test/claimCode/TakeChallengePanel.oracle.test.jsx
+++ b/frontend/src/test/claimCode/TakeChallengePanel.oracle.test.jsx
@@ -19,8 +19,12 @@ vi.mock('../../hooks/useChainTokens', () => ({
 }))
 
 import TakeChallengePanel from '../../components/fairwins/TakeChallengePanel'
+import { WalletContext } from '../../contexts/WalletContext'
 
 const CONDITION = '0xc0ffee00000000000000000000000000000000000000000000000000000000ab'
+
+// A connected taker — the "Lock In!" accept button only renders with a wallet address.
+const connectedWallet = { address: '0xTaker', account: '0xTaker', openConnectModal: () => {} }
 
 const oracleWager = (over = {}) => ({
   resolutionType: 4n, // Polymarket
@@ -62,11 +66,13 @@ const liveMarket = (over = {}) => ({
 
 function renderPanel({ wager = oracleWager(), terms = sealedTerms(), termsUnavailable = false, needsMembership = false } = {}) {
   return render(
-    <TakeChallengePanel
-      code="river tiger kite zoo"
-      match={{ wagerId: 1n, wager, terms, termsUnavailable, needsMembership }}
-      onClose={() => {}}
-    />
+    <WalletContext.Provider value={connectedWallet}>
+      <TakeChallengePanel
+        code="river tiger kite zoo"
+        match={{ wagerId: 1n, wager, terms, termsUnavailable, needsMembership }}
+        onClose={() => {}}
+      />
+    </WalletContext.Provider>
   )
 }
 
@@ -117,7 +123,7 @@ describe('TakeChallengePanel — oracle bet summary (spec 041, US2)', () => {
 
     expect(screen.getByText('Will ETH flip BTC?')).toBeInTheDocument()
     expect(screen.getByText(/live market info unavailable/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /accept challenge/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /lock in/i })).toBeEnabled()
   })
 
   it('side labels follow on-chain creatorIsYes in both directions (D6)', () => {
@@ -147,13 +153,13 @@ describe('TakeChallengePanel — oracle bet summary (spec 041, US2)', () => {
     liveHolder.market = liveMarket({ closed: true, outcomes: [{ name: 'Yes', price: 0.7 }, { name: 'No', price: 0.3 }] })
     renderPanel()
     expect(screen.getByText(/already closed/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /accept challenge/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /lock in/i })).toBeEnabled()
   })
 
   it('blocks acceptance with an explanation when the outcome is already public (FR-015/D8)', () => {
     liveHolder.market = liveMarket({ closed: true, outcomes: [{ name: 'Yes', price: 1 }, { name: 'No', price: 0 }] })
     renderPanel()
-    const btn = screen.getByRole('button', { name: /accept challenge/i })
+    const btn = screen.getByRole('button', { name: /lock in/i })
     expect(btn).toBeDisabled()
     expect(screen.getByText(/can no longer be taken fairly/i)).toBeInTheDocument()
     expect(screen.getByText(/can no longer be taken fairly/i).parentElement).toHaveTextContent(/Yes/)
@@ -167,6 +173,6 @@ describe('TakeChallengePanel — oracle bet summary (spec 041, US2)', () => {
     expect(screen.queryByText(/settled automatically by/i)).toBeNull()
     expect(screen.queryByRole('status')).toBeNull()
     expect(screen.getByLabelText(/stake and payout/i)).toHaveTextContent(/10 USDC/)
-    expect(screen.getByRole('button', { name: /accept challenge/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /lock in/i })).toBeEnabled()
   })
 })


### PR DESCRIPTION
## Problem

Passkey users couldn't accept an open wager from a shared phrase link. The take panel always rendered an **"Accept challenge"** button, and clicking it with no connected wallet threw a dead-end error banner: *"Connect your wallet to accept."* — with no way to actually connect. This is exactly what happens when a passkey user opens a shared `fairwins.app` challenge link in a fresh (in-app) browser where no wallet session is present.

Two secondary complaints from the same screen:
- The challenge details were dumped as raw JSON (`{ "description": "...", "createdAt": "..." }`) in a monospace code block instead of readable text.
- The accept button label should read **"Lock In!"**.

## Changes

- **`TakeChallengePanel.jsx`**
  - Reads wallet connection state (optionally, so the panel still renders in tests without a `WalletProvider`). When no account is connected, it renders an enabled **"Connect wallet to Lock In"** button that opens the unified connect modal (spec 045) so a passkey user can authenticate and then take the challenge — instead of a button that throws a confusing error.
  - Once connected, the button becomes **"Lock In!"** (and **"Locking in…"** while busy) and runs the unchanged accept flow.
  - Renders the challenge as plain readable prose (the human `description`) via a new `ChallengeText` component, never a JSON dump; degrades to a neutral note when no description is present. The `<label>` is now "The challenge".
- **`TakeChallengePanel.css`** — adds `.tc-terms-text` styling for the prose block (replaces the monospace `oc-terms-body` for this view).

## Tests

- Updated the panel and oracle tests for the new **"Lock In!"** label and to render within a connected `WalletContext`.
- Added coverage for: the disconnected → **"Connect wallet to Lock In"** affordance (opens the connect modal, never silently calls accept), and the challenge rendering as a `<p class="tc-terms-text">` rather than a JSON code block.
- `useOpenChallengeAccept`, `TakeChallengePanel`, and oracle-summary suites pass (28 tests). The one unrelated pre-existing failure in `UnifiedLookupModal.test.jsx` (phrase-input submit) was confirmed present on the unmodified tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnAmoSM5eiwYT5SaULSxFZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnAmoSM5eiwYT5SaULSxFZ)_