### PR TITLE
feat(skill): fairwins-infra — bring gasless Cloud Run services up/down for cost

### DIFF
--- a/.claude/skills/fairwins-infra/SKILL.md
+++ b/.claude/skills/fairwins-infra/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: fairwins-infra
+description: Bring the FairWins gasless Cloud Run infrastructure (the alto ERC-4337 bundler and the relay/paymaster signer gateway on Polygon) up or down to control cost, and check its status, health, and config. Use whenever the user wants to start/stop/turn on/turn off the bundler, gateway, paymaster, relayer, or "signers"; ask whether they're running; scale them to zero to save money; or bring them up before testing passkey gasless transactions. The SPA runs itself and is out of scope.
+---
+
+# FairWins gasless infra control
+
+The FairWins app (SPA) runs cheaply on its own and scales to zero. Two **always-on**
+Cloud Run services back the gasless (passkey / ERC-4337) flows and are the expensive
+part — each runs `min-instances=1` with `cpu-throttling=false`, i.e. a **full vCPU
+allocated 24/7**. When we aren't actively testing or serving gasless traffic, scale
+them to zero; bring them back up on demand.
+
+| Alias     | Cloud Run service        | Role |
+|-----------|--------------------------|------|
+| `bundler` | `fairwins-alto-bundler`  | ERC-4337 bundler (alto) — submits UserOperations |
+| `gateway` | `fairwins-relay-gateway` | ERC-7677 paymaster (sponsorship signer) + EIP-3009 relay |
+
+Both are in project `chippr-bots-site-wp`, region `us-central1`.
+
+**Out of scope — never touch these:** the SPA (`prediction-dao-research`, already
+scales to zero) and other projects' services (`clearpath-*`, `fukuii-*`, `kings-edge-*`).
+The KMS signing keys are cheap and must never be deleted — this skill only toggles the
+Cloud Run services that *use* them.
+
+## How to run
+
+The script is `manage.sh` next to this file. Run it from the repo root:
+
+```bash
+bash .claude/skills/fairwins-infra/manage.sh status          # both services: state + health + bundler config
+bash .claude/skills/fairwins-infra/manage.sh up              # warm both (min=1) + health check
+bash .claude/skills/fairwins-infra/manage.sh down            # scale both to zero (min=0)
+bash .claude/skills/fairwins-infra/manage.sh up bundler      # just the bundler
+bash .claude/skills/fairwins-infra/manage.sh down gateway    # just the gateway
+```
+
+- **`down`** sets `min-instances=0`. The service scales to zero and idle cost drops to
+  ~$0; it still cold-starts (a few seconds) to serve an on-demand request. This is the
+  cost-saving state.
+- **`up`** sets `min-instances=1` (kept warm) and prints a health check. Use before an
+  active testing session or when serving real gasless traffic, so users don't eat cold
+  starts.
+- **`status`** shows each service's current scale state, `Ready` condition, a live
+  health ping, and — for the bundler — its critical env config.
+
+Scaling changes **do not** alter env vars, so `up`/`down` are safe and reversible.
+
+## Typical flow
+
+1. `... up` before a gasless test session → wait for `healthy` → tell the user to go.
+2. `... down` when done → confirms scale-to-zero.
+3. `... status` any time to answer "is the bundler running?" / "are the signers up?".
+
+## Config-drift guard (important for this project)
+
+`status`/`up` also read the bundler's env and warn if it drifted, because an
+**automated deploy** (the compute service account applying the repo `service.yaml`)
+has silently reverted the working config mid-session. The correct live config is:
+
+- `ALTO_RPC_URL` → a QuickNode endpoint (NOT `publicnode` — that 403s archive reads and breaks receipts)
+- `ALTO_DEPLOY_SIMULATIONS_CONTRACT` → `true` (else bundle-build fails before broadcast; executor nonce freezes)
+- `ALTO_GAS_PRICE_MULTIPLIERS` → set, e.g. `400,500,600` (public RPCs report a stale ~30 gwei priority; Polygon congestion needs 100+ gwei)
+
+If the guard reports drift, the fix is not in this skill — redeploy those env vars (or
+merge PR #895, which makes the manifest match and stops the clobber). See the
+`polygon-gasless-bundler-stall` memory for the full history.
+
+## Notes
+
+- Requires an authenticated `gcloud` with access to `chippr-bots-site-wp`.
+- Health URLs: bundler `https://bundler.fairwins.app` (JSON-RPC `eth_supportedEntryPoints`),
+  gateway `https://relay.fairwins.app` (any HTTP response = reachable; it's origin-locked so
+  a 404 on `/` is normal).
+- The executor gas wallet (`0x7C6d…`) and the paymaster deposit are funded separately;
+  scaling to zero does not affect on-chain balances.

--- a/.claude/skills/fairwins-infra/manage.sh
+++ b/.claude/skills/fairwins-infra/manage.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# FairWins gasless-infra control — bring the always-on Cloud Run services UP (warm)
+# or DOWN (scale-to-zero) to control cost, and check status/health/config.
+#
+# Manages ONLY the two gasless-stack services (both run min=1 + cpu-throttling=false,
+# i.e. a full vCPU allocated 24/7 — that is the cost we're toggling):
+#   - fairwins-alto-bundler   (the ERC-4337 bundler)
+#   - fairwins-relay-gateway  (the ERC-7677 paymaster + EIP-3009 relay signer)
+#
+# It NEVER touches the SPA (prediction-dao-research, already scales to zero) or any
+# other project's services (clearpath-*, fukuii-*, kings-edge-*).
+#
+# "Down" sets min-instances=0: the service scales to zero and costs ~$0 when idle,
+# but still cold-starts to serve an on-demand request. "Up" sets min-instances=1
+# (warm) for active testing/use. Scaling changes do NOT alter env vars.
+#
+# Usage:
+#   ./manage.sh status [bundler|gateway|all]     # default: all
+#   ./manage.sh up      [bundler|gateway|all]     # warm (min=1) + health check
+#   ./manage.sh down    [bundler|gateway|all]     # scale to zero (min=0)
+#
+set -euo pipefail
+
+PROJECT="chippr-bots-site-wp"
+REGION="us-central1"
+
+BUNDLER_SVC="fairwins-alto-bundler"
+GATEWAY_SVC="fairwins-relay-gateway"
+BUNDLER_HEALTH_URL="https://bundler.fairwins.app"
+GATEWAY_HEALTH_URL="https://relay.fairwins.app"
+
+# --- helpers ---------------------------------------------------------------
+
+svc_name() {  # alias -> Cloud Run service name
+  case "$1" in
+    bundler) echo "$BUNDLER_SVC" ;;
+    gateway) echo "$GATEWAY_SVC" ;;
+    *) echo "" ;;
+  esac
+}
+
+targets() {  # "all"|"bundler"|"gateway" -> alias list
+  case "${1:-all}" in
+    all|"") echo "bundler gateway" ;;
+    bundler) echo "bundler" ;;
+    gateway) echo "gateway" ;;
+    *) echo "ERR" ;;
+  esac
+}
+
+get_min() {  # current minScale for a service name ("" -> 0)
+  local n; n=$(gcloud run services describe "$1" --project="$PROJECT" --region="$REGION" \
+    --format='value(spec.template.metadata.annotations["autoscaling.knative.dev/minScale"])' 2>/dev/null || true)
+  echo "${n:-0}"
+}
+
+get_ready() {  # Ready condition for a service name
+  gcloud run services describe "$1" --project="$PROJECT" --region="$REGION" \
+    --format='value(status.conditions[0].status)' 2>/dev/null || echo "?"
+}
+
+set_min() {  # service-name min-instances
+  gcloud run services update "$1" --project="$PROJECT" --region="$REGION" \
+    --min-instances="$2" --quiet >/dev/null
+}
+
+health() {  # alias -> prints a health line
+  local a="$1" code body
+  if [ "$a" = "bundler" ]; then
+    body=$(curl -s -m 10 -X POST "$BUNDLER_HEALTH_URL" -H 'content-type: application/json' \
+      --data '{"jsonrpc":"2.0","id":1,"method":"eth_supportedEntryPoints","params":[]}' 2>/dev/null || true)
+    if echo "$body" | grep -q '0x5FF137D4'; then echo "healthy (EntryPoint v0.6 responding)"; else echo "NOT responding (${body:0:60})"; fi
+  else
+    code=$(curl -s -o /dev/null -w "%{http_code}" -m 10 "$GATEWAY_HEALTH_URL/" 2>/dev/null || echo "000")
+    if [ "$code" = "000" ]; then echo "NOT reachable"; else echo "reachable (HTTP $code)"; fi
+  fi
+}
+
+bundler_config() {  # warn if the critical env vars have been clobbered (see the auto-deploy gotcha)
+  gcloud run services describe "$BUNDLER_SVC" --project="$PROJECT" --region="$REGION" --format=json 2>/dev/null \
+  | python3 -c '
+import sys,json
+d=json.load(sys.stdin); env={}
+for c in d["spec"]["template"]["spec"]["containers"]:
+    if c.get("name")=="alto":
+        for e in c.get("env",[]): env[e["name"]]=e.get("value")
+rpc=env.get("ALTO_RPC_URL",""); sim=env.get("ALTO_DEPLOY_SIMULATIONS_CONTRACT",""); mul=env.get("ALTO_GAS_PRICE_MULTIPLIERS","")
+warn=[]
+if "publicnode" in rpc: warn.append("RPC is publicnode (archive-403 breaks receipts)")
+if sim!="true": warn.append("DEPLOY_SIMULATIONS_CONTRACT!=true (bundle-build fails)")
+if not mul or mul=="100,100,100": warn.append("no gas-price multiplier (underprices during congestion)")
+print("     RPC:", rpc)
+print("     sim-contract:", sim, " gas-multipliers:", mul or "(default)")
+if warn:
+    print("     ⚠ CONFIG DRIFT — likely clobbered by the auto-deploy; merge/redeploy PR #895:")
+    for w in warn: print("        -",w)
+else:
+    print("     ✓ config looks correct (QuickNode RPC, sim=true, multiplier set)")
+' 2>/dev/null || echo "     (config read failed)"
+}
+
+# --- commands --------------------------------------------------------------
+
+cmd_status() {
+  for a in $(targets "${1:-all}"); do
+    local n; n=$(svc_name "$a")
+    local min ready
+    min=$(get_min "$n"); ready=$(get_ready "$n")
+    local state="DOWN (scale-to-zero)"; [ "$min" != "0" ] && state="UP (warm, min=$min)"
+    printf '%-8s %-24s  %s  ready=%s  health=%s\n' "$a" "$n" "$state" "$ready" "$(health "$a")"
+    if [ "$a" = "bundler" ]; then bundler_config; fi
+  done
+}
+
+cmd_scale() {  # up|down [target]
+  local dir="$1" tgt="${2:-all}" min
+  [ "$dir" = "up" ] && min=1 || min=0
+  local list; list=$(targets "$tgt")
+  [ "$list" = "ERR" ] && { echo "unknown target: $tgt (use bundler|gateway|all)"; exit 2; }
+  for a in $list; do
+    local n; n=$(svc_name "$a")
+    echo "==> ${dir^^} $a ($n): setting min-instances=$min ..."
+    set_min "$n" "$min"
+  done
+  echo
+  if [ "$dir" = "up" ]; then
+    echo "Warming up — verifying health:"
+    cmd_status "$tgt"
+    echo
+    echo "Note: 'up' does not change env vars. If the bundler config shows drift above, redeploy the fixes (or merge PR #895)."
+  else
+    echo "Scaled to zero. Idle cost ~\$0; the service still cold-starts to serve an on-demand request."
+    cmd_status "$tgt"
+  fi
+}
+
+usage() {
+  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+main() {
+  local cmd="${1:-status}"; shift || true
+  case "$cmd" in
+    status)     cmd_status "${1:-all}" ;;
+    up)         cmd_scale up "${1:-all}" ;;
+    down)       cmd_scale down "${1:-all}" ;;
+    -h|--help|help) usage ;;
+    *) echo "unknown command: $cmd"; echo; usage; exit 2 ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Why
The SPA runs cheaply and scales to zero, but the two gasless-stack Cloud Run services run `min-instances=1` with `cpu-throttling=false` — a **full vCPU allocated 24/7**, which is the recurring cost. We want to bring the bundler + signer gateway up and down on demand instead of paying for them full-time.

## What
A Claude skill at `.claude/skills/fairwins-infra/`:

```
bash .claude/skills/fairwins-infra/manage.sh status        # state + health + bundler config
bash .claude/skills/fairwins-infra/manage.sh up   [target] # warm (min=1) + health check
bash .claude/skills/fairwins-infra/manage.sh down [target] # scale to zero (min=0)
# target = bundler | gateway | all (default all)
```

- **down** → `min-instances=0`: scales to zero, ~$0 idle, still cold-starts to serve an on-demand request.
- **up** → `min-instances=1`: kept warm for an active session; prints a health check.
- **status** → scale state, `Ready`, a live health ping, and a **bundler config-drift guard**.

Manages **only** `fairwins-alto-bundler` + `fairwins-relay-gateway` (us-central1). Never touches the SPA (`prediction-dao-research`, already scales to zero), other projects' services (`clearpath-*`, `fukuii-*`, `kings-edge-*`), or the KMS signing keys — only the Cloud Run services that use them. Scaling changes don't alter env vars.

## Config-drift guard
`status`/`up` read the bundler env and warn if it drifted, because an automated deploy (the compute service account re-applying the repo `service.yaml`) has silently reverted the working config mid-session. It checks `ALTO_RPC_URL` (not publicnode), `ALTO_DEPLOY_SIMULATIONS_CONTRACT=true`, and `ALTO_GAS_PRICE_MULTIPLIERS` set. The drift *fix* is merging the infra PR (#895), not this skill.

## Tested
`status` runs clean (exit 0) against the live project:
```
bundler  fairwins-alto-bundler   UP (warm, min=1)  ready=True  health=healthy (EntryPoint v0.6 responding)
     RPC: https://rpc-mainnet.matic.quiknode.pro   sim-contract: true  gas-multipliers: 400,500,600
     ✓ config looks correct
gateway  fairwins-relay-gateway  UP (warm, min=1)  ready=True  health=reachable (HTTP 404)
```

Requires an authenticated `gcloud` with access to `chippr-bots-site-wp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)