### PR TITLE
chore(054): record WagerTagRegistry Polygon mainnet deploy

### DIFF
--- a/.openzeppelin/polygon.json
+++ b/.openzeppelin/polygon.json
@@ -19,6 +19,11 @@
     {
       "address": "0x420aEC3c76859eB74ab21c769c16AcdAB221f723",
       "kind": "uups"
+    },
+    {
+      "address": "0xF7370780F13eCEb2f65c21d38b7bd53f25509a9F",
+      "txHash": "0xee4ee61c10890b1af713f24b0b5fdbc1a0fc74d14ec7cc35ae56f9fc03984c19",
+      "kind": "uups"
     }
   ],
   "impls": {
@@ -2328,6 +2333,456 @@
         "0x2ad0F9Fe788F35F8edbaCA35346Da22792c5d18e",
         "0x754d8aa4785Ec4bEE7c921f8d032D5E3a78d9308"
       ]
+    },
+    "b8cbc4e7c5a33f55f829f541bc3d007ae169e02703722e0bd09ea61066a37822": {
+      "address": "0x72BC0c361Ea54720F25Dc8E519f70a4d7F6a41A0",
+      "txHash": "0x3d6d37c1f65a6786cad4d84958cae305bb79ac6f84a4277d4674060b337f3e8d",
+      "layout": {
+        "solcVersion": "0.8.24",
+        "storage": [
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSManaged",
+            "src": "contracts/upgradeable/UUPSManaged.sol:46"
+          },
+          {
+            "label": "membershipManager",
+            "offset": 0,
+            "slot": "50",
+            "type": "t_contract(IMembershipManager)31576",
+            "contract": "WagerTagRegistry",
+            "src": "contracts/naming/WagerTagRegistry.sol:71"
+          },
+          {
+            "label": "sanctionsGuard",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_contract(ISanctionsGuard)31733",
+            "contract": "WagerTagRegistry",
+            "src": "contracts/naming/WagerTagRegistry.sol:72"
+          },
+          {
+            "label": "membershipRole",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_bytes32",
+            "contract": "WagerTagRegistry",
+            "src": "contracts/naming/WagerTagRegistry.sol:73"
+          },
+          {
+            "label": "minTier",
+            "offset": 0,
+            "slot": "53",
+            "type": "t_enum(Tier)31429",
+            "contract": "WagerTagRegistry",
+            "src": "contracts/naming/WagerTagRegistry.sol:74"
+          },
+          {
+            "label": "minCommitmentAge",
+            "offset": 1,
+            "slot": "53",
+            "type": "t_uint64",
+            "contract": "WagerTagRegistry",
+            "src": "contracts/naming/WagerTagRegistry.sol:76"
+          },
+          {
+            "label": "maxCommitmentAge",
+            "offset": 9,
+            "slot": "53",
+            "type": "t_uint64",
+            "contract": "WagerTagRegistry",
+            "src": "contracts/naming/WagerTagRegistry.sol:77"
+          },
+          {
+            "label": "quarantinePeriod",
+            "offset": 17,
+            "slot": "53",
+            "type": "t_uint64",
+            "contract": "WagerTagRegistry",
+            "src": "contracts/naming/WagerTagRegistry.sol:78"
+          },
+          {
+            "label": "changeCooldown",
+            "offset": 0,
+            "slot": "54",
+            "type": "t_uint64",
+            "contract": "WagerTagRegistry",
+            "src": "contracts/naming/WagerTagRegistry.sol:79"
+          },
+          {
+            "label": "repointDelay",
+            "offset": 8,
+            "slot": "54",
+            "type": "t_uint64",
+            "contract": "WagerTagRegistry",
+            "src": "contracts/naming/WagerTagRegistry.sol:80"
+          },
+          {
+            "label": "lapseGrace",
+            "offset": 16,
+            "slot": "54",
+            "type": "t_uint64",
+            "contract": "WagerTagRegistry",
+            "src": "contracts/naming/WagerTagRegistry.sol:81"
+          },
+          {
+            "label": "_records",
+            "offset": 0,
+            "slot": "55",
+            "type": "t_mapping(t_bytes32,t_struct(TagRecord)34248_storage)",
+            "contract": "WagerTagRegistry",
+            "src": "contracts/naming/WagerTagRegistry.sol:83"
+          },
+          {
+            "label": "tagHashOf",
+            "offset": 0,
+            "slot": "56",
+            "type": "t_mapping(t_address,t_bytes32)",
+            "contract": "WagerTagRegistry",
+            "src": "contracts/naming/WagerTagRegistry.sol:84"
+          },
+          {
+            "label": "quarantinedUntil",
+            "offset": 0,
+            "slot": "57",
+            "type": "t_mapping(t_bytes32,t_uint64)",
+            "contract": "WagerTagRegistry",
+            "src": "contracts/naming/WagerTagRegistry.sol:85"
+          },
+          {
+            "label": "reserved",
+            "offset": 0,
+            "slot": "58",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "WagerTagRegistry",
+            "src": "contracts/naming/WagerTagRegistry.sol:86"
+          },
+          {
+            "label": "commitments",
+            "offset": 0,
+            "slot": "59",
+            "type": "t_mapping(t_bytes32,t_uint64)",
+            "contract": "WagerTagRegistry",
+            "src": "contracts/naming/WagerTagRegistry.sol:87"
+          },
+          {
+            "label": "lastChangeAt",
+            "offset": 0,
+            "slot": "60",
+            "type": "t_mapping(t_address,t_uint64)",
+            "contract": "WagerTagRegistry",
+            "src": "contracts/naming/WagerTagRegistry.sol:88"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "61",
+            "type": "t_array(t_uint256)43_storage",
+            "contract": "WagerTagRegistry",
+            "src": "contracts/naming/WagerTagRegistry.sol:90"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_bytes32,t_bool))": {
+            "label": "mapping(address => mapping(bytes32 => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)973_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlStorage)983_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)973_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(EIP712Storage)2321_storage": {
+            "label": "struct EIP712Upgradeable.EIP712Storage",
+            "members": [
+              {
+                "label": "_hashedName",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_hashedVersion",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "_version",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(InitializableStorage)1258_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)973_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(SignerIntentStorage)17745_storage": {
+            "label": "struct SignerIntentBase.SignerIntentStorage",
+            "members": [
+              {
+                "label": "used",
+                "type": "t_mapping(t_address,t_mapping(t_bytes32,t_bool))",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_array(t_uint256)43_storage": {
+            "label": "uint256[43]",
+            "numberOfBytes": "1376"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_contract(IMembershipManager)31576": {
+            "label": "contract IMembershipManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ISanctionsGuard)31733": {
+            "label": "contract ISanctionsGuard",
+            "numberOfBytes": "20"
+          },
+          "t_enum(Tier)31429": {
+            "label": "enum IMembershipManager.Tier",
+            "members": [
+              "None",
+              "Bronze",
+              "Silver",
+              "Gold",
+              "Platinum"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bytes32)": {
+            "label": "mapping(address => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint64)": {
+            "label": "mapping(address => uint64)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(TagRecord)34248_storage)": {
+            "label": "mapping(bytes32 => struct WagerTagRegistry.TagRecord)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint64)": {
+            "label": "mapping(bytes32 => uint64)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(TagRecord)34248_storage": {
+            "label": "struct WagerTagRegistry.TagRecord",
+            "members": [
+              {
+                "label": "owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "tag",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "registeredAt",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "pendingOwner",
+                "type": "t_address",
+                "offset": 8,
+                "slot": "2"
+              },
+              {
+                "label": "repointEffectiveAt",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "suspended",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "3"
+              },
+              {
+                "label": "verified",
+                "type": "t_bool",
+                "offset": 9,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
+          "erc7201:fairwins.storage.SignerIntentBase": [
+            {
+              "contract": "SignerIntentBase",
+              "label": "used",
+              "type": "t_mapping(t_address,t_mapping(t_bytes32,t_bool))",
+              "src": "contracts/upgradeable/SignerIntentBase.sol:33",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.EIP712": [
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedName",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:38",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedVersion",
+              "type": "t_bytes32",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:40",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_name",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:42",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_version",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol:43",
+              "offset": 0,
+              "slot": "3"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)973_storage)",
+              "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:62",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/deployments/polygon-chain137-v2.json
+++ b/deployments/polygon-chain137-v2.json
@@ -37,7 +37,9 @@
     "backupPointerRegistry": "0x664ACAd4d604c626A6160948Df9C10FE38010E11",
     "safePolicyGuard": "0xa0F188776a65794cc06777412432e47dcB0d0c4B",
     "policyGuardSetup": "0xD0CB9D0ca2E56e9552cb833eC6D16F86ce818C2b",
-    "safeProposalHub": "0x94b5b38C247CE51F7C42C83B63115998b7e970E7"
+    "safeProposalHub": "0x94b5b38C247CE51F7C42C83B63115998b7e970E7",
+    "wagerTagRegistry": "0xF7370780F13eCEb2f65c21d38b7bd53f25509a9F",
+    "wagerTagRegistryImpl": "0x72BC0c361Ea54720F25Dc8E519f70a4d7F6a41A0"
   },
   "mocks": null,
   "constructorArgs": {
@@ -80,7 +82,8 @@
     "backupPointerRegistry": [],
     "safePolicyGuard": [],
     "policyGuardSetup": [],
-    "safeProposalHub": []
+    "safeProposalHub": [],
+    "wagerTagRegistryImpl": []
   },
   "saltPrefix": "FairWins-P2P-v2.0-",
   "timestamp": "2026-07-05T20:05:10.649Z",
@@ -99,5 +102,6 @@
     "safePolicyGuard": 90120723,
     "policyGuardSetup": 90120725,
     "safeProposalHub": 90120743
-  }
+  },
+  "wagerTagRegistryDeployedAt": "2026-07-13T03:02:00.347Z"
 }

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -115,7 +115,7 @@ const POLYGON_CONTRACTS = {
   safeProposalHub: '0x94b5b38C247CE51F7C42C83B63115998b7e970E7',
   safePolicyGuard: '0xa0F188776a65794cc06777412432e47dcB0d0c4B',
   policyGuardSetup: '0xD0CB9D0ca2E56e9552cb833eC6D16F86ce818C2b',
-  wagerTagRegistry: '', // spec 054 — %tag naming registry (synced after deploy)
+  wagerTagRegistry: '0xF7370780F13eCEb2f65c21d38b7bd53f25509a9F', // spec 054 — %tag naming registry (synced after deploy)
 }
 
 const NETWORK_CONTRACTS = {


### PR DESCRIPTION
## Summary

Deploys the spec-054 **%tag naming registry** (`WagerTagRegistry`, UUPS proxy) to **Polygon mainnet (chainId 137)** from the admin account `0x52502d…F6e1`, and records the result. This is the deploy-artifact PR only — the feature code already merged via #898.

| | Address |
|---|---|
| `wagerTagRegistry` (proxy) | `0xF7370780F13eCEb2f65c21d38b7bd53f25509a9F` |
| `wagerTagRegistryImpl` | `0x72BC0c361Ea54720F25Dc8E519f70a4d7F6a41A0` |

## What the deploy did
- Reused the network's recorded **MembershipManager** (`0xEfd1a880…`) for the Gold-tier gate on `WAGER_PARTICIPANT_ROLE`, and **SanctionsGuard** (`0x2Dc53d91…`).
- Seeded **41 reserved terms** (FR-004) via `setReserved` after self-granting `REGISTRY_CURATOR_ROLE`.
- Deployed at a pinned 350 gwei legacy gas price (Polygon was at ~285 gwei base; the pin avoids the priority-floor "underpriced" failure).

## On-chain verification (read-only, post-deploy)
- `membershipManager()` / `sanctionsGuard()` → match recorded addresses ✓
- `membershipRole()` = `WAGER_PARTICIPANT_ROLE` ✓ · `minTier()` = 3 (Gold) ✓
- admin holds `DEFAULT_ADMIN_ROLE` + `REGISTRY_CURATOR_ROLE` ✓
- `reserved[]` true for fairwins/admin/treasury ✓
- ERC1967 implementation slot = `0x72BC0c36…` ✓

## Files
- `deployments/polygon-chain137-v2.json` — appends `wagerTagRegistry` + `wagerTagRegistryImpl` (existing core contracts untouched).
- `.openzeppelin/polygon.json` — OZ upgrades manifest (storage layout for future validated upgrades).
- `frontend/src/config/contracts.js` — `POLYGON_CONTRACTS.wagerTagRegistry` populated; other networks stay empty (not deployed there).

## Follow-ups (not in this PR)
- Explorer verification: `npm run verify:polygon` (Etherscan V2).
- Other networks (Mordor/Amoy) remain undeployed by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)