### PR TITLE
Reorganize drawer: move Wagers to Apps, combine Backup & Security

### DIFF
--- a/frontend/src/components/nav/AppNavDrawer.jsx
+++ b/frontend/src/components/nav/AppNavDrawer.jsx
@@ -6,13 +6,19 @@ import Footer from '../Footer'
 import { HOME_ITEM, WAGERS_ITEM, NAV_GROUPS, pathForNavItem } from '../../config/appNav'
 import './AppNavDrawer.css'
 
-// Deep-link alias parity with WalletPage (the Swap tab is now "Trade").
-const TAB_ALIASES = { swap: 'trade' }
+// Deep-link alias parity with WalletPage (the Swap tab is now "Trade"; the
+// old standalone Backup tab now lives inside the combined Security panel).
+const TAB_ALIASES = { swap: 'trade', backup: 'security' }
 
-// The drawer list = a top "Quick Access" group (Home) + the section groups.
+// The drawer list = a top "Quick Access" group (Home) + the section groups,
+// with Wagers moved down into the Apps group (it keeps its absolute /wagers route).
 const DRAWER_GROUPS = [
-  { label: 'Quick Access', items: [HOME_ITEM, WAGERS_ITEM] },
-  ...NAV_GROUPS,
+  { label: 'Quick Access', items: [HOME_ITEM] },
+  ...NAV_GROUPS.map((group) =>
+    group.label === 'Apps'
+      ? { ...group, items: [WAGERS_ITEM, ...group.items] }
+      : group,
+  ),
 ]
 
 // Which drawer entry reflects the current route, so the open menu highlights it.

--- a/frontend/src/config/appNav.js
+++ b/frontend/src/config/appNav.js
@@ -17,7 +17,8 @@
 export const HOME_ITEM = { id: 'home', label: 'Home', icon: 'home', to: '/app' }
 
 // Wagers (spec 053) — the relocated create-types + actions grid. Like Home, it is an absolute
-// top-level route (not a `/wallet?tab=` section), pinned near the top of the drawer.
+// top-level route (not a `/wallet?tab=` section); it lives in the drawer's Apps group
+// (see AppNavDrawer's DRAWER_GROUPS).
 export const WAGERS_ITEM = { id: 'wagers', label: 'Wagers', icon: 'ticket', to: '/wagers' }
 
 // Grouped section rail. `id` matches the WalletPage tab id; `icon` drives both
@@ -40,10 +41,10 @@ export const NAV_GROUPS = [
     label: 'Tools',
     items: [
       { id: 'addressbook', label: 'Address Book', icon: 'addressbook' },
-      { id: 'backup', label: 'Backup', icon: 'backup' },
+      // Backup + Security combined into one panel (tab id 'security'); the old
+      // 'backup' tab id is kept as a deep-link alias (see WalletPage TAB_ALIASES).
+      { id: 'security', label: 'Backup & Security', icon: 'lock' },
       { id: 'reports', label: 'Reporting', icon: 'reports' },
-      // Security relocated here from the former Admin group.
-      { id: 'security', label: 'Security', icon: 'lock' },
       { id: 'network', label: 'Network', icon: 'globe' },
     ],
   },

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -46,21 +46,21 @@ const WALLET_TABS = [
   { id: 'membership', label: 'Membership' },
   { id: 'network', label: 'Network' },
   { id: 'preferences', label: 'Preferences' },
-  { id: 'security', label: 'Security' },
+  { id: 'security', label: 'Backup & Security' },
   { id: 'portfolio', label: 'Portfolio' },
   { id: 'earn', label: 'Earn' },
   { id: 'trade', label: 'Trade' },
   { id: 'paytransfer', label: 'Pay & Transfer' },
   { id: 'custody', label: 'Protect' },
   { id: 'addressbook', label: 'Address Book' },
-  { id: 'backup', label: 'Backup' },
   { id: 'reports', label: 'Reporting' },
   { id: 'clearpath', label: 'ClearPath' },
   { id: 'tokens', label: 'Token Mint' },
 ]
 
-// Legacy deep-link aliases → canonical tab ids (the Swap tab is now "Trade").
-const TAB_ALIASES = { swap: 'trade' }
+// Legacy deep-link aliases → canonical tab ids (the Swap tab is now "Trade"; the
+// old standalone Backup tab is now part of the combined "Backup & Security" panel).
+const TAB_ALIASES = { swap: 'trade', backup: 'security' }
 
 // Canonical Polymarket category slugs — kept here to keep WalletPage
 // self-contained. Order matches PolymarketBrowser's quick-filter row.
@@ -288,12 +288,6 @@ function WalletPage() {
                   </div>
                 )}
 
-                {activeTab === 'backup' && (
-                  <div className="backup-section" role="tabpanel">
-                    <BackupPanel />
-                  </div>
-                )}
-
                 {activeTab === 'membership' && (
                   <div className="membership-section" role="tabpanel">
                     <CallsignPanel />
@@ -347,6 +341,9 @@ function WalletPage() {
 
                 {activeTab === 'security' && (
                   <div className="security-section" role="tabpanel">
+                    {/* Backup + Security combined into one panel: the data-backup
+                        controls sit above the account-security controls. */}
+                    <BackupPanel />
                     {/* Spec 045 US5/US6 — account controllers & recovery.
                         ControllersPanel renders for passkey sessions (add a
                         passkey / link a wallet as recovery); the recovery


### PR DESCRIPTION
## Summary

Rearranges two sections in the global left nav drawer per request:

1. **Wagers moved down to the Apps group.** It was pinned in the top "Quick Access" group next to Home; it now sits at the top of the **Apps** group. It keeps its absolute `/wagers` route (it is not a `?tab=` wallet section), so navigation and active-highlighting are unchanged.
2. **Backup + Security combined.** The Tools group's separate **Backup** and **Security** entries are now a single **"Backup & Security"** section (tab id `security`). The Backup panel renders above the account-security controls (controllers, recovery, encryption key, recovery codes) in one panel.

## Changes

- `frontend/src/config/appNav.js` — Tools group: replaced the `backup` + `security` items with one `security` item labeled "Backup & Security"; updated the Wagers comment.
- `frontend/src/components/nav/AppNavDrawer.jsx` — build `DRAWER_GROUPS` so Home alone is Quick Access and `WAGERS_ITEM` is injected into the Apps group; added `backup → security` deep-link alias.
- `frontend/src/pages/WalletPage.jsx` — removed the standalone `backup` tab/panel, render `BackupPanel` inside the `security` panel, relabeled the `security` tab "Backup & Security", and added the `backup → security` alias so existing `?tab=backup` deep links resolve to the combined section.

## Compatibility

- `NAV_GROUPS` (consumed by the mobile `SectionIconNav` and `groupForTab`) is left unchanged for Wagers — moving it in the drawer only avoids the mobile bottom-nav trying to route `/wallet?tab=wagers`.
- Old `?tab=backup` deep links still work via the alias.

## Testing

- `npx vitest run` on `PortalNav`, `SectionIconNav`, `appNav.wagers`, and `BackupPanel.accessibility` — 17 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuuHoGi1H6YdJ8FhFUWXBE)_