### PR TITLE
Wire Backup &amp; Security settings for passkey accounts

### DIFF
--- a/frontend/src/components/account/BackupPanel.jsx
+++ b/frontend/src/components/account/BackupPanel.jsx
@@ -28,8 +28,9 @@ function BackupPanel() {
       <h3 id="backup-heading" className="backup-title">Data backup</h3>
       <p className="backup-intro">
         Back up your address book, preferences, and activity history as a single <strong>encrypted</strong> file
-        on IPFS, located by a trustless on-chain pointer. Only your wallet can read it — restore on any device
-        with the same wallet. This is an explicit step; nothing leaves your device until you back up.
+        on IPFS, located by a trustless on-chain pointer. Only your account can read it — restore on any device
+        where you sign in to the same account (wallet or passkey). This is an explicit step; nothing leaves your
+        device until you back up.
       </p>
 
       {!available ? (

--- a/frontend/src/components/account/ControllersPanel.jsx
+++ b/frontend/src/components/account/ControllersPanel.jsx
@@ -29,6 +29,9 @@ import { extractAddressFromScan } from '../../lib/addressBook/scanAddress'
 
 const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/
 
+// User-facing guide for how losing/replacing passkeys and recovery via a linked wallet work.
+const RECOVERY_DOCS_URL = 'https://docs.FairWins.app/user-guide/account-recovery/'
+
 function ControllersPanel({ deps = {} }) {
   const { address, sendCalls, provider, chainId } = useWallet()
   const account = usePasskeyAccount(deps)
@@ -141,6 +144,13 @@ function ControllersPanel({ deps = {} }) {
   return (
     <section className="controllers-panel" aria-label="Account controllers">
       <h3>Devices &amp; controllers</h3>
+      <p className="controllers-panel__intro">
+        Passkeys and linked wallets that can control this account. Keep at least two so losing one device never
+        locks you out.{' '}
+        <a href={RECOVERY_DOCS_URL} target="_blank" rel="noopener noreferrer">
+          Learn how account recovery works →
+        </a>
+      </p>
       {!account.deployed && (
         <p className="controllers-panel__counterfactual" role="note">
           Your account is ready to receive funds and activates on-chain with your first action.
@@ -157,14 +167,22 @@ function ControllersPanel({ deps = {} }) {
 
       <ul className="controllers-panel__list">
         {account.controllers.map((c) => (
-          <li key={String(c.index)} data-testid={`controller-${c.index}`}>
-            <span>{c.label}</span>
-            <span className="controllers-panel__kind">{c.kind}</span>
-            {c.kind === 'wallet' && <code>{c.address}</code>}
-            {c.isThisDevice && <em> (this device)</em>}
+          <li key={String(c.index)} data-testid={`controller-${c.index}`} className="controllers-panel__item">
+            <div className="controllers-panel__item-info">
+              <div className="controllers-panel__item-head">
+                <span className="controllers-panel__label">{c.label}</span>
+                <span className="controllers-panel__kind" data-kind={c.kind}>
+                  {c.kind === 'wallet' ? 'Wallet' : 'Passkey'}
+                </span>
+                {c.isThisDevice && <span className="controllers-panel__badge">(this device)</span>}
+              </div>
+              {c.kind === 'wallet' && c.address && (
+                <code className="controllers-panel__address">{c.address}</code>
+              )}
+            </div>
             <button
               type="button"
-              className="btn btn-small"
+              className="btn btn-small controllers-panel__remove"
               disabled={busy || account.controllerCount <= 1}
               onClick={() => removeController(c)}
               aria-label={`Remove ${c.label}`}

--- a/frontend/src/components/account/RecoverAccountPanel.jsx
+++ b/frontend/src/components/account/RecoverAccountPanel.jsx
@@ -30,6 +30,9 @@ const RECOVERY_ABI = [
 
 const isHexAddress = (s) => /^0x[0-9a-fA-F]{40}$/.test(s.trim())
 
+// User-facing guide for how passkey account recovery via a linked wallet works.
+const RECOVERY_DOCS_URL = 'https://docs.FairWins.app/user-guide/account-recovery/'
+
 function RecoverAccountPanel({ deps = {} }) {
   const { address: walletAddress, signer, provider, loginMethod, isConnected } = useWallet()
   const [accountAddress, setAccountAddress] = useState('')
@@ -113,7 +116,10 @@ function RecoverAccountPanel({ deps = {} }) {
       <h3>Recover a passkey account</h3>
       <p className="section-description">
         Lost your passkeys? If this wallet was linked to your passkey account as a controller, it can
-        authorize a new passkey — no FairWins involvement required.
+        authorize a new passkey — no FairWins involvement required.{' '}
+        <a href={RECOVERY_DOCS_URL} target="_blank" rel="noopener noreferrer">
+          Learn how account recovery works →
+        </a>
       </p>
 
       <label htmlFor="recover-account-address">Passkey account address</label>

--- a/frontend/src/components/account/RecoveryCodesPanel.jsx
+++ b/frontend/src/components/account/RecoveryCodesPanel.jsx
@@ -38,13 +38,13 @@ export default function RecoveryCodesPanel() {
   let body
   if (!canUse) {
     body = (
-      <p className="fm-hint">Connect your wallet to recover the open-challenge codes you saved on this device.</p>
+      <p className="fm-hint">Sign in to recover the open-challenge codes you saved on this device.</p>
     )
   } else if (entries == null) {
     body = (
       <>
         <p className="fm-hint">
-          Codes you chose to back up are stored encrypted on this device, readable only with this wallet.
+          Codes you chose to back up are stored encrypted on this device, readable only by this account.
           Unlock to recover a forgotten code. (Codes saved on other devices won&apos;t appear here.)
         </p>
         {error && <div className="fm-error-banner" role="alert">{error}</div>}

--- a/frontend/src/components/account/__tests__/RecoveryCodesPanel.test.jsx
+++ b/frontend/src/components/account/__tests__/RecoveryCodesPanel.test.jsx
@@ -22,10 +22,10 @@ describe('RecoveryCodesPanel (recovery codes in Security)', () => {
     expect(screen.getByRole('heading', { name: /recovery codes/i })).toBeInTheDocument()
   })
 
-  it('prompts to connect a wallet when the vault is unavailable', () => {
+  it('prompts to sign in when the vault is unavailable', () => {
     vault = { ...vault, canUse: false }
     render(<RecoveryCodesPanel />)
-    expect(screen.getByText(/connect your wallet to recover/i)).toBeInTheDocument()
+    expect(screen.getByText(/sign in to recover/i)).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /unlock/i })).toBeNull()
   })
 

--- a/frontend/src/hooks/useDataBackup.js
+++ b/frontend/src/hooks/useDataBackup.js
@@ -16,32 +16,61 @@ import { useNotification } from './useUI'
 import { getNetwork } from '../config/networks'
 import { uploadJson, fetchByCid } from '../utils/ipfsService'
 import { getUserPreference, saveUserPreference, removeUserPreference } from '../utils/userStorage'
-import { deriveKey, encryptBundle, decryptBundle } from '../lib/backup/backupCrypto'
+import { deriveKey, deriveKeyFromSeed, encryptBundle, decryptBundle } from '../lib/backup/backupCrypto'
 import { buildBundle, parseBundle, applyBundle } from '../lib/backup/backupBundle'
-import { readPointer, writePointer, isBackupAvailable, CANONICAL_CHAIN_ID } from '../lib/backup/backupRegistry'
+import { readPointer, writePointer, buildSetPointerCall, isBackupAvailable, CANONICAL_CHAIN_ID } from '../lib/backup/backupRegistry'
+import { resolveMasterSeed } from '../lib/passkey/encryption'
+import { readSession } from '../connectors/passkey'
 
 const SIZE_WARN_BYTES = 1024 * 1024 // ~1 MB soft cap (FR-021)
 const LAST_BACKUP_KEY = 'data_backup_last_at'
 
 // Session-only key cache (in-memory; cleared on reload or account change) so a backup+restore in one session
-// doesn't double-prompt for the signature. Never persisted to disk.
+// doesn't double-prompt for the signature/ceremony. Never persisted to disk.
 let keyCache = { account: null, key: null }
 function cachedKey(account) {
   const a = account ? String(account).toLowerCase() : null
   return keyCache.account === a ? keyCache.key : null
 }
-async function keyFor(signer, account) {
+
+// Derive (and cache) the backup key for the active session, login-method agnostic:
+//  - classic wallet: one signature over the fixed domain message (deriveKey);
+//  - passkey account: one WebAuthn PRF ceremony → the account's master seed → deriveKeyFromSeed.
+// Both are deterministic per account, so a backup made under either controller restores under any controller
+// that holds the same account's key material.
+async function keyFor({ signer, account, loginMethod }) {
   const a = account ? String(account).toLowerCase() : null
   const hit = cachedKey(a)
   if (hit) return hit
-  const key = await deriveKey(signer)
+  let key
+  if (loginMethod === 'passkey') {
+    const credentialId = readSession()?.credentialId
+    const seed = await resolveMasterSeed({ account, credentialId })
+    key = deriveKeyFromSeed(seed)
+  } else {
+    key = await deriveKey(signer) // wallet signature prompt
+  }
   keyCache = { account: a, key }
   return key
 }
 
 export function useDataBackup() {
-  const { account, signer, chainId, isConnected, switchNetwork } = useWallet()
+  const { account, signer, chainId, isConnected, switchNetwork, loginMethod, sendCalls } = useWallet()
   const { showNotification } = useNotification()
+
+  // A passkey account signs through sendCalls / a PRF ceremony, not an ethers signer — so "can we write?"
+  // is "is an account connected with a usable signing path", never "is there a signer object".
+  const isPasskey = loginMethod === 'passkey'
+  const canSign = Boolean(account) && (Boolean(signer) || isPasskey)
+
+  // Persist the pointer on the canonical network, using the session's signing path.
+  const persistPointer = useCallback(async (cid) => {
+    if (isPasskey) {
+      await sendCalls([buildSetPointerCall(cid)])
+    } else {
+      await writePointer(signer, cid)
+    }
+  }, [isPasskey, sendCalls, signer])
 
   const [status, setStatus] = useState('idle') // 'idle' | 'backing-up' | 'restoring' | 'error'
   const [lastBackupAt, setLastBackupAt] = useState(null)
@@ -91,21 +120,21 @@ export function useDataBackup() {
   }, [onCanonical, switchNetwork, showNotification, canonicalName])
 
   const backup = useCallback(async () => {
-    if (!signer || !account) { showNotification('Connect a wallet to back up.', 'warning'); return false }
+    if (!canSign) { showNotification('Connect your account to back up.', 'warning'); return false }
     if (!available) { showNotification('Backup is not available on this network yet.', 'warning'); return false }
     if (!requireCanonical()) return false
     setStatus('backing-up')
     try {
-      const key = await keyFor(signer, account) // wallet signature prompt (cached for the session)
+      const key = await keyFor({ signer, account, loginMethod }) // signature / PRF ceremony (cached for the session)
       const bundle = buildBundle(account, Date.now())
       const envelope = encryptBundle(key, bundle)
       const size = new TextEncoder().encode(JSON.stringify(envelope)).length
       if (size > SIZE_WARN_BYTES) {
         showNotification('Your backup is over 1 MB — it may take longer to store, but will still proceed.', 'warning')
       }
-      showNotification('Storing your encrypted backup, then recording the pointer — confirm the prompts in your wallet…', 'info', 0)
+      showNotification('Storing your encrypted backup, then recording the pointer — confirm the prompts on your device…', 'info', 0)
       const { cid } = await uploadJson(envelope, { namePrefix: 'data-backup' }) // pin (await)
-      await writePointer(signer, cid) // pointer tx (await confirm)
+      await persistPointer(cid) // pointer tx (await confirm)
       const now = Date.now()
       saveUserPreference(account, LAST_BACKUP_KEY, now, true)
       setLastBackupAt(now)
@@ -118,11 +147,11 @@ export function useDataBackup() {
       showNotification(e?.shortMessage || e?.reason || e?.message || 'Backup failed — your local data is unchanged.', 'error')
       return false // local data never written during backup
     }
-  }, [signer, account, available, requireCanonical, showNotification])
+  }, [canSign, signer, account, loginMethod, available, requireCanonical, persistPointer, showNotification])
 
   // mode: 'merge' (additive, default, non-destructive) | 'replace'
   const restore = useCallback(async (mode = 'merge') => {
-    if (!signer || !account) { showNotification('Connect a wallet to restore.', 'warning'); return { restored: false, reason: 'no-wallet' } }
+    if (!canSign) { showNotification('Connect your account to restore.', 'warning'); return { restored: false, reason: 'no-wallet' } }
     if (!available) { showNotification('Backup is not available on this network yet.', 'warning'); return { restored: false, reason: 'unavailable' } }
     setStatus('restoring')
     try {
@@ -143,7 +172,7 @@ export function useDataBackup() {
       }
       let bundle
       try {
-        const key = await keyFor(signer, account)
+        const key = await keyFor({ signer, account, loginMethod })
         bundle = parseBundle(decryptBundle(key, envelope))
       } catch {
         setStatus('idle')
@@ -167,15 +196,15 @@ export function useDataBackup() {
       showNotification(e?.shortMessage || e?.message || 'Restore failed — your local data is unchanged.', 'error')
       return { restored: false, reason: 'error' }
     }
-  }, [signer, account, available, showNotification])
+  }, [canSign, signer, account, loginMethod, available, showNotification])
 
   const remove = useCallback(async () => {
-    if (!signer || !account) { showNotification('Connect a wallet.', 'warning'); return false }
+    if (!canSign) { showNotification('Connect your account.', 'warning'); return false }
     if (!available) return false
     if (!requireCanonical()) return false
     setStatus('backing-up')
     try {
-      await writePointer(signer, '') // clear the pointer
+      await persistPointer('') // clear the pointer
       removeUserPreference(account, LAST_BACKUP_KEY)
       setLastBackupAt(null)
       setHasRemote(false)
@@ -187,7 +216,7 @@ export function useDataBackup() {
       showNotification(e?.shortMessage || e?.message || 'Could not remove your backup.', 'error')
       return false
     }
-  }, [signer, account, available, requireCanonical, showNotification])
+  }, [canSign, account, available, requireCanonical, persistPointer, showNotification])
 
   return {
     available,

--- a/frontend/src/hooks/useOpenChallengeCodeVault.js
+++ b/frontend/src/hooks/useOpenChallengeCodeVault.js
@@ -3,11 +3,14 @@ import { WalletContext } from '../contexts/WalletContext'
 import {
   CODE_VAULT_SIGN_MESSAGE,
   deriveVaultKey,
+  deriveVaultKeyFromSeed,
   addEntry,
   readEntries,
   removeEntry,
   hasVault,
 } from '../lib/openChallenge/codeVault'
+import { resolveMasterSeed } from '../lib/passkey/encryption'
+import { readSession } from '../connectors/passkey'
 
 /**
  * Recover-an-open-challenge-code vault (feature 024 follow-up).
@@ -23,18 +26,30 @@ export function useOpenChallengeCodeVault() {
   const account = ctx?.account || null
   const signer = ctx?.signer || null
   const chainId = ctx?.chainId ?? null
+  const loginMethod = ctx?.loginMethod || null
   const keyRef = useRef(null)
   const [busy, setBusy] = useState(false)
 
-  // Derive (and cache) the vault key, prompting one signature the first time.
+  // Derive (and cache) the vault key with one ceremony the first time, login-method agnostic:
+  //  - classic wallet: a signature over the fixed unlock message;
+  //  - passkey account: one WebAuthn PRF ceremony → the account's master seed.
+  // Both are deterministic per account, so the same account always unlocks the same on-device vault.
   const getKey = useCallback(async () => {
     if (keyRef.current) return keyRef.current
-    if (!signer) throw new Error('Connect your wallet to use code backups.')
-    const sig = await signer.signMessage(CODE_VAULT_SIGN_MESSAGE)
-    const key = deriveVaultKey(sig)
+    let key
+    if (loginMethod === 'passkey') {
+      if (!account) throw new Error('Connect your account to use code backups.')
+      const credentialId = readSession()?.credentialId
+      const seed = await resolveMasterSeed({ account, credentialId })
+      key = deriveVaultKeyFromSeed(seed)
+    } else {
+      if (!signer) throw new Error('Connect your wallet to use code backups.')
+      const sig = await signer.signMessage(CODE_VAULT_SIGN_MESSAGE)
+      key = deriveVaultKey(sig)
+    }
     keyRef.current = key
     return key
-  }, [signer])
+  }, [loginMethod, account, signer])
 
   // Save (or refresh) one code backup. `entry` carries the code + light metadata for the recovery list.
   const saveCode = useCallback(async (entry) => {

--- a/frontend/src/lib/backup/backupCrypto.js
+++ b/frontend/src/lib/backup/backupCrypto.js
@@ -3,7 +3,7 @@
 // message is DISTINCT from the wager/address-book messages so the backup key can never coincide with another
 // key the wallet derives. The envelope mirrors the address-book backup shape; header is bound via AEAD AAD.
 
-import { getBytes, keccak256, toUtf8Bytes } from 'ethers'
+import { concat, getBytes, keccak256, toUtf8Bytes } from 'ethers'
 import { encryptJson, decryptJson, utf8ToBytes } from '../../utils/crypto/primitives'
 
 export const DATA_BACKUP_MESSAGE_V1 = 'FairWins Data Backup v1'
@@ -21,6 +21,18 @@ export function deriveKeyFromSignature(signature) {
 export async function deriveKey(signer) {
   const signature = await signer.signMessage(DATA_BACKUP_MESSAGE_V1)
   return deriveKeyFromSignature(signature)
+}
+
+/**
+ * Derive the 32-byte backup key from a passkey account's PRF master seed (spec 041) — the login-method-
+ * agnostic twin of {@link deriveKey}. The seed is deterministic per account (same seed on every controller
+ * with key material), and domain-separating with the fixed backup message keeps this key independent from the
+ * X25519/X-Wing keys the same seed derives. Pure + deterministic (no ceremony here; the caller resolves the
+ * seed once via one WebAuthn assertion).
+ * @param {Uint8Array} seed - 32-byte master seed
+ */
+export function deriveKeyFromSeed(seed) {
+  return getBytes(keccak256(concat([seed, toUtf8Bytes(DATA_BACKUP_MESSAGE_V1)])))
 }
 
 /** Encrypt a bundle object into the storable envelope. */

--- a/frontend/src/lib/backup/backupRegistry.js
+++ b/frontend/src/lib/backup/backupRegistry.js
@@ -42,3 +42,14 @@ export async function writePointer(signer, cid) {
   const tx = await c.setPointer(cid)
   return tx.wait()
 }
+
+/**
+ * Encode the `setPointer(cid)` call for passkey (smart-account) sessions, which write through `sendCalls`
+ * rather than an ethers signer. Returns a `{ target, data }` call the caller batches into one ceremony.
+ * `cid` "" clears the pointer, mirroring {@link writePointer}.
+ */
+export function buildSetPointerCall(cid) {
+  if (!isBackupAvailable()) throw new Error('Backup registry is not available on the canonical network yet')
+  const iface = new ethers.Interface(BACKUP_POINTER_REGISTRY_ABI)
+  return { target: registryAddress(), data: iface.encodeFunctionData('setPointer', [cid]) }
+}

--- a/frontend/src/lib/openChallenge/codeVault.js
+++ b/frontend/src/lib/openChallenge/codeVault.js
@@ -11,7 +11,7 @@
  * (the same approach as the address-book backup, lib/addressBook/addressBookCrypto.js).
  */
 
-import { keccak256, toUtf8Bytes, getBytes } from 'ethers'
+import { keccak256, toUtf8Bytes, getBytes, concat } from 'ethers'
 import { encryptJson, decryptJson, utf8ToBytes } from '../../utils/crypto/primitives'
 
 const STORAGE_PREFIX = 'fairwins.ocCodeVault.'
@@ -30,6 +30,17 @@ export const CODE_VAULT_SIGN_MESSAGE =
 export function deriveVaultKey(signature) {
   if (!signature) throw new Error('deriveVaultKey: signature required')
   return getBytes(keccak256(toUtf8Bytes(VAULT_KEY_DOMAIN + signature)))
+}
+
+/**
+ * Derive the 32-byte vault key from a passkey account's PRF master seed (spec 041) — the login-method-agnostic
+ * twin of {@link deriveVaultKey}. Same domain tag keeps it independent from other seed-derived keys, and the
+ * seed is deterministic per account so the same passkey account always unlocks the same on-device vault.
+ * @param {Uint8Array} seed - 32-byte master seed
+ */
+export function deriveVaultKeyFromSeed(seed) {
+  if (!seed) throw new Error('deriveVaultKeyFromSeed: seed required')
+  return getBytes(keccak256(concat([toUtf8Bytes(VAULT_KEY_DOMAIN), seed])))
 }
 
 function storageKey(address) {

--- a/frontend/src/pages/WalletPage.css
+++ b/frontend/src/pages/WalletPage.css
@@ -747,6 +747,98 @@
   line-height: 1.5;
 }
 
+.controllers-panel__intro {
+  margin: 0 0 16px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--color-text-secondary);
+}
+
+.controllers-panel__intro a {
+  color: var(--color-primary, #36B37E);
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.controllers-panel__intro a:hover {
+  text-decoration: underline;
+}
+
+.controllers-panel__list {
+  list-style: none;
+  margin: 0 0 16px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.controllers-panel__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  background: var(--color-surface-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+}
+
+.controllers-panel__item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0; /* allow the address to truncate instead of overflowing the row */
+}
+
+.controllers-panel__item-head {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.controllers-panel__label {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.controllers-panel__kind {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--color-surface, rgba(255, 255, 255, 0.06));
+  border: 1px solid var(--color-border);
+  color: var(--color-text-secondary);
+}
+
+.controllers-panel__kind[data-kind='passkey'] {
+  color: var(--color-primary, #36B37E);
+  border-color: var(--color-primary, #36B37E);
+}
+
+.controllers-panel__badge {
+  font-size: 12px;
+  font-style: italic;
+  color: var(--color-text-secondary);
+}
+
+.controllers-panel__address {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  overflow-wrap: anywhere;
+  word-break: break-all;
+}
+
+.controllers-panel__remove {
+  flex-shrink: 0;
+}
+
 .controllers-panel__link {
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -76,7 +76,8 @@ const POLYMARKET_CATEGORY_OPTIONS = [
 ]
 
 function WalletPage() {
-  const { address, isConnected, provider, signer, openConnectModal } = useWallet()
+  const { address, isConnected, provider, signer, loginMethod, openConnectModal } = useWallet()
+  const isPasskey = loginMethod === 'passkey'
   const { showModal, hideModal } = useModal()
   const { roles, hasRole } = useWalletRoles()
   const { isInitialized, isInitializing, ensureInitialized } = useEncryption()
@@ -135,8 +136,11 @@ function WalletPage() {
   }, [address, provider])
 
   const handleRegisterKey = useCallback(async () => {
-    if (!signer || !address) {
-      setKeyError('Wallet not connected. Please reconnect.')
+    // Passkey sessions have no ethers signer — keys derive from the WebAuthn PRF master seed and the
+    // on-chain registration is submitted through the smart account (sendCalls), all inside
+    // ensureInitialized(). Classic wallets keep the signer path (sign the derivation message → register tx).
+    if (!address || (!signer && !isPasskey)) {
+      setKeyError('Not connected. Please sign in again.')
       return
     }
     setKeyRegisterLoading(true)
@@ -145,6 +149,21 @@ function WalletPage() {
       const result = await ensureInitialized()
       if (!result?.publicKey) {
         throw new Error('Failed to derive encryption keys')
+      }
+      if (isPasskey) {
+        // ensureInitialized() already kicked off the on-chain registration (non-blocking, via sendCalls).
+        // Reflect it honestly: poll the registry briefly so the UI flips to "Registered" once it lands,
+        // and otherwise tell the user it's finishing rather than claiming failure.
+        let registered = await hasRegisteredKey(address, provider)
+        for (let i = 0; !registered && i < 5; i++) {
+          await new Promise((r) => setTimeout(r, 2000))
+          registered = await hasRegisteredKey(address, provider)
+        }
+        setKeyRegistered(registered)
+        if (!registered) {
+          setKeyError('Encryption key setup submitted — it can take a moment to finish. Use “Check Status” shortly.')
+        }
+        return
       }
       // ensureKeyRegistered checks on-chain first, only registers if needed
       const wasNewlyRegistered = await ensureKeyRegistered(signer, address, result.publicKey)
@@ -165,7 +184,7 @@ function WalletPage() {
     } finally {
       setKeyRegisterLoading(false)
     }
-  }, [ensureInitialized, signer, address])
+  }, [ensureInitialized, signer, address, isPasskey, provider])
 
   // Auto-check key status when Security tab is shown
   useEffect(() => {
@@ -354,7 +373,8 @@ function WalletPage() {
                     <div className="section">
                       <h3>Encryption Key</h3>
                       <p className="section-description">
-                        Your encryption key allows you to send and receive encrypted wagers. It is derived from your wallet signature and registered on-chain.
+                        Your encryption key allows you to send and receive encrypted wagers. It is derived from
+                        {isPasskey ? ' your passkey' : ' your wallet signature'} and registered on-chain.
                       </p>
 
                       <div className="key-status-card">

--- a/frontend/src/test/backup/backupCrypto.test.js
+++ b/frontend/src/test/backup/backupCrypto.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { deriveKeyFromSignature, encryptBundle, decryptBundle, DATA_BACKUP_MESSAGE_V1 } from '../../lib/backup/backupCrypto'
+import { deriveKeyFromSignature, deriveKeyFromSeed, encryptBundle, decryptBundle, DATA_BACKUP_MESSAGE_V1 } from '../../lib/backup/backupCrypto'
 
 // Spec 032 — backup encryption: deterministic signature-derived key, encrypt/decrypt round-trip, and honest
 // failure (wrong key / tampered / foreign envelope throws → "no usable backup", local never overwritten).
@@ -42,5 +42,22 @@ describe('backupCrypto', () => {
 
   it('uses a distinct domain message', () => {
     expect(DATA_BACKUP_MESSAGE_V1).toBe('FairWins Data Backup v1')
+  })
+
+  it('derives a deterministic 32-byte key from a passkey master seed (spec 041)', () => {
+    const seed = new Uint8Array(32).fill(7)
+    const seedKey = deriveKeyFromSeed(seed)
+    expect(seedKey).toBeInstanceOf(Uint8Array)
+    expect(seedKey.length).toBe(32)
+    expect(deriveKeyFromSeed(new Uint8Array(32).fill(7))).toEqual(seedKey) // same seed → same key
+    expect(deriveKeyFromSeed(new Uint8Array(32).fill(8))).not.toEqual(seedKey) // different seed → different key
+  })
+
+  it('round-trips a bundle encrypted under a seed-derived key', () => {
+    const seedKey = deriveKeyFromSeed(new Uint8Array(32).fill(7))
+    const env = encryptBundle(seedKey, bundle)
+    expect(decryptBundle(seedKey, env)).toEqual(bundle)
+    // A signature-derived key (even numerically identical seed bytes as a string) must NOT open it.
+    expect(() => decryptBundle(deriveKeyFromSignature('0xsignature-aaaa'), env)).toThrow()
   })
 })

--- a/frontend/src/test/backup/useDataBackup.backup.test.jsx
+++ b/frontend/src/test/backup/useDataBackup.backup.test.jsx
@@ -4,7 +4,7 @@ import { renderHook, act } from '@testing-library/react'
 // Spec 032 US1 — backup(): build→encrypt→pin→writePointer; success ONLY after both pin and pointer-tx;
 // honest failure leaves local data unchanged; blocked off the canonical network.
 
-const h = vi.hoisted(() => ({ wallet: {}, showNotification: vi.fn(), uploadJson: vi.fn(), fetchByCid: vi.fn(), readPointer: vi.fn(), writePointer: vi.fn(), available: true }))
+const h = vi.hoisted(() => ({ wallet: {}, showNotification: vi.fn(), uploadJson: vi.fn(), fetchByCid: vi.fn(), readPointer: vi.fn(), writePointer: vi.fn(), buildSetPointerCall: vi.fn(), resolveMasterSeed: vi.fn(), available: true }))
 vi.mock('../../hooks/useWalletManagement', () => ({ useWallet: () => h.wallet }))
 vi.mock('../../hooks/useUI', () => ({ useNotification: () => ({ showNotification: h.showNotification }) }))
 vi.mock('../../utils/ipfsService', () => ({ uploadJson: (...a) => h.uploadJson(...a), fetchByCid: (...a) => h.fetchByCid(...a) }))
@@ -12,8 +12,11 @@ vi.mock('../../lib/backup/backupRegistry', () => ({
   isBackupAvailable: () => h.available,
   readPointer: (...a) => h.readPointer(...a),
   writePointer: (...a) => h.writePointer(...a),
+  buildSetPointerCall: (...a) => h.buildSetPointerCall(...a),
   CANONICAL_CHAIN_ID: 137,
 }))
+vi.mock('../../lib/passkey/encryption', () => ({ resolveMasterSeed: (...a) => h.resolveMasterSeed(...a) }))
+vi.mock('../../connectors/passkey', () => ({ readSession: () => ({ credentialId: 'cred-passkey-1' }) }))
 
 import { useDataBackup } from '../../hooks/useDataBackup'
 import { saveAddressBook } from '../../lib/addressBook/addressBookStore'
@@ -28,6 +31,8 @@ beforeEach(() => {
   h.showNotification.mockReset()
   h.uploadJson.mockReset().mockResolvedValue({ cid: 'bafytest' })
   h.writePointer.mockReset().mockResolvedValue({})
+  h.buildSetPointerCall.mockReset().mockImplementation((cid) => ({ target: '0xREGISTRY', data: `0xset:${cid}` }))
+  h.resolveMasterSeed.mockReset().mockResolvedValue(new Uint8Array(32).fill(9))
   h.readPointer.mockReset().mockResolvedValue('')
   h.available = true
   saveAddressBook(ACCT, { schemaVersion: 1, contacts: [{ id: 'c1', nickname: 'A', addresses: [{ address: '0x1111111111111111111111111111111111111111', chainId: 137, notes: '', addedAt: 1 }], createdAt: 1, updatedAt: 1 }], updatedAt: 1 })
@@ -81,5 +86,21 @@ describe('useDataBackup.backup', () => {
     await act(async () => { ok = await result.current.backup() })
     expect(ok).toBe(false)
     expect(h.uploadJson).not.toHaveBeenCalled()
+  })
+
+  it('passkey session backs up via sendCalls (no ethers signer) — PRF seed key + pointer call', async () => {
+    // Passkey: no signer, loginMethod 'passkey', writes go through sendCalls (spec 041).
+    const sendCalls = vi.fn(async () => ({ txHash: '0xpk' }))
+    h.wallet = { account: ACCT, signer: null, chainId: 137, isConnected: true, switchNetwork: vi.fn(), loginMethod: 'passkey', sendCalls }
+    const { result } = renderHook(() => useDataBackup())
+    let ok
+    await act(async () => { ok = await result.current.backup() })
+    expect(ok).toBe(true)
+    expect(h.resolveMasterSeed).toHaveBeenCalledWith({ account: ACCT, credentialId: 'cred-passkey-1' })
+    expect(h.uploadJson).toHaveBeenCalled()
+    expect(h.writePointer).not.toHaveBeenCalled() // never the signer path for a passkey
+    expect(h.buildSetPointerCall).toHaveBeenCalledWith('bafytest')
+    expect(sendCalls).toHaveBeenCalledWith([{ target: '0xREGISTRY', data: '0xset:bafytest' }])
+    expect(h.showNotification).toHaveBeenCalledWith('Your data is backed up.', 'success')
   })
 })

--- a/frontend/src/test/claimCode/codeVault.test.js
+++ b/frontend/src/test/claimCode/codeVault.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import {
   deriveVaultKey,
+  deriveVaultKeyFromSeed,
   addEntry,
   readEntries,
   removeEntry,
@@ -63,5 +64,18 @@ describe('open-challenge code vault', () => {
     const ADDR2 = '0x2222222222222222222222222222222222222222'
     addEntry(ADDR, key, { code: 'aaa bbb ccc ddd', wagerId: '1' })
     expect(readEntries(ADDR2, key)).toEqual([])
+  })
+
+  it('derives a deterministic key from a passkey master seed (spec 041) that round-trips', () => {
+    const seedKey = deriveVaultKeyFromSeed(new Uint8Array(32).fill(5))
+    expect(seedKey).toBeInstanceOf(Uint8Array)
+    expect(seedKey.length).toBe(32)
+    expect(deriveVaultKeyFromSeed(new Uint8Array(32).fill(5))).toEqual(seedKey) // same seed → same key
+    expect(deriveVaultKeyFromSeed(new Uint8Array(32).fill(6))).not.toEqual(seedKey)
+    // A passkey-derived key encrypts and decrypts its own vault just like the wallet path.
+    addEntry(ADDR, seedKey, { code: 'passkey word word word', wagerId: '3' })
+    expect(readEntries(ADDR, seedKey)[0]).toMatchObject({ code: 'passkey word word word', wagerId: '3' })
+    // ...and the wallet-signature key cannot open the passkey-encrypted vault.
+    expect(() => readEntries(ADDR, key)).toThrow(/different wallet/i)
   })
 })


### PR DESCRIPTION
## Summary

The **Backup & Security** panel gated every action on an ethers `signer`. Passkey sessions sign through `sendCalls` / a WebAuthn PRF ceremony and have **no signer**, so every feature threw a misleading *"connect a wallet"* warning even though the passkey account was fully connected (see the reported screenshots). Each feature is now routed through the session's login method, so passkey users can actually use these settings.

## What changed

**Passkey wiring (the core fix)**
- **Data backup** (`useDataBackup`) — derives the backup key from the passkey account's PRF master seed (`deriveKeyFromSeed`) and records the on-chain pointer via `sendCalls` (`buildSetPointerCall`), keeping the existing signer path for classic wallets. Gating is now *"is an account connected with a usable signing path"* rather than *"is there a signer object"*. Copy: *"Connect a wallet to back up."* → *"Connect your account to back up."*
- **Encryption Key** (`WalletPage`) — for passkey sessions, keys derive and register through `ensureInitialized()` (PRF seed → `sendCalls`), and on-chain registration status is reflected honestly instead of erroring *"Wallet not connected. Please reconnect."*
- **Open-challenge recovery codes** (`useOpenChallengeCodeVault`) — unlocks the device-local vault with a passkey-seed-derived key (`deriveVaultKeyFromSeed`) instead of failing on the missing signer.

Both seed-derived keys are deterministic per account and domain-separated from the account's other seed-derived keys, so a backup/vault made under any controller opens under any controller that holds the same account's key material.

**Devices & controllers readability**
- Each controller row is now a labelled card: name, a passkey/wallet type pill, a *(this device)* badge, and the linked wallet address on its own line (monospace, wraps instead of overflowing). Previously the label, kind and address ran together (e.g. `New devicepasskey (this device)`, `Linked walletwallet0x525…`).

**Recovery documentation**
- Added a *"Learn how account recovery works →"* link to both the Devices & controllers panel and the wallet-recovery panel.

Copy throughout the section is now login-method neutral.

## Testing

- `npm run build` — passes.
- Added unit tests for the seed-derived backup key, the seed-derived vault key (round-trip + isolation from the signature-derived key), and the passkey backup path (asserts `sendCalls` + PRF seed, never the signer path).
- Full affected suite green (backup, claim-code/vault, account panels, WalletPage, usePasskeyAccount): 129 passing. Lint clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRSw1GKG1AET211Y76MhGx

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRSw1GKG1AET211Y76MhGx)_