### PR TITLE
Update Reporting tool UX for the multichain, multi-use ledger

### DIFF
--- a/frontend/src/components/wallet/TaxReportsPanel.jsx
+++ b/frontend/src/components/wallet/TaxReportsPanel.jsx
@@ -1,22 +1,26 @@
 /**
- * TaxReportsPanel — the "Tax Reports" tab content in My Account
- * (spec 016-wager-tax-report; contracts/reports-ui.md). Wires the period
- * selector, generation state machine, result/empty/error states, downloads,
- * and the saved-report history together.
+ * TaxReportsPanel — the "Reporting" tab content in My Account
+ * (spec 016-wager-tax-report, extended by spec 051; contracts/reports-ui.md).
+ * Wires the "export current month" quick action, the period selector, the
+ * generation state machine, result/empty/error states, downloads, and the
+ * saved-report history together. Reports cover every activity class the unified
+ * ledger tracks (wager/transfer/earn/pool/membership) on the connected network.
  */
 
 import { useTaxReport, REPORT_STATUS } from '../../hooks/useTaxReport'
+import { PERIOD_KINDS } from '../../utils/reportPeriods'
 import ReportPeriodSelector from './ReportPeriodSelector'
 import ReportHistoryList from './ReportHistoryList'
 
-function Totals({ totals }) {
+function Totals({ totals, showByClass = false }) {
+  const byClass = showByClass && totals.byClass ? Object.values(totals.byClass) : []
   return (
     <div className="report-totals">
-      <h4>Totals</h4>
+      <h4>Totals by token</h4>
       <ul>
         {Object.values(totals.byTicker).map((t) => (
           <li key={t.ticker}>
-            {t.ticker}: net {t.net} ({t.count} transfers) — USD {t.usdValue.toFixed(2)}
+            {t.ticker}: net {t.net} ({t.count} entries) — USD {t.usdValue.toFixed(2)}
           </li>
         ))}
         <li>
@@ -24,6 +28,18 @@ function Totals({ totals }) {
           {totals.overall.feesNativeSymbol}
         </li>
       </ul>
+      {byClass.length > 0 && (
+        <>
+          <h4>Totals by activity type</h4>
+          <ul>
+            {byClass.map((c) => (
+              <li key={c.class}>
+                {c.class}: {c.count} entr{c.count === 1 ? 'y' : 'ies'} — USD {c.usdValue.toFixed(2)}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
     </div>
   )
 }
@@ -36,21 +52,34 @@ export default function TaxReportsPanel({ hookOptions } = {}) {
 
   const generating = status === REPORT_STATUS.GENERATING
 
+  // One-click: build the current month-to-date report and download it as a PDF.
+  const exportCurrentMonth = async () => {
+    const built = await generate({ kind: PERIOD_KINDS.CURRENT_MONTH })
+    if (built) downloadPdf(built)
+  }
+
   if (!account) {
     return (
       <div className="tax-reports-section">
-        <p>Connect your wallet to generate a wager activity / tax report.</p>
+        <p>Connect your wallet to generate an activity report.</p>
       </div>
     )
   }
 
   return (
     <div className="tax-reports-section">
-      <h3>Wager activity / tax report</h3>
+      <h3>Reporting</h3>
       <p className="tax-reports-intro">
-        Generate a downloadable record of every wager-related stablecoin transfer for a chosen
-        period. This is an informational record, not tax advice.
+        Generate a downloadable record of your on-chain activity — wagers, transfers, pools, earn,
+        and membership — for a chosen period on the connected network. This is an informational
+        record, not tax advice.
       </p>
+
+      <div className="report-quick-actions">
+        <button type="button" className="report-quick-btn" onClick={exportCurrentMonth} disabled={generating}>
+          Export current month (PDF)
+        </button>
+      </div>
 
       <ReportPeriodSelector onGenerate={generate} disabled={generating} />
 
@@ -90,7 +119,7 @@ export default function TaxReportsPanel({ hookOptions } = {}) {
                   {`Could not refresh: ${report.staleClasses.join(', ')} — entries for these classes may be missing.`}
                 </p>
               )}
-              <Totals totals={report.totals} />
+              <Totals totals={report.totals} showByClass={report.source === 'ledger'} />
             </>
           )}
           <div className="report-download-actions">

--- a/frontend/src/data/reports/README.md
+++ b/frontend/src/data/reports/README.md
@@ -1,7 +1,12 @@
-# Wager tax/activity report module (spec 016-wager-tax-report)
+# Reporting module (spec 016-wager-tax-report, extended by spec 051)
 
-Frontend-only generation of a user's wager activity / tax report. No backend,
-no contract or subgraph changes. See `specs/016-wager-tax-report/`.
+Frontend-only generation of a user's **FairWins activity report** — a
+downloadable, multichain, multi-use record of on-chain activity across every
+ledger class (wager, transfer, earn, pool, membership). The primary path reads
+the unified activity ledger (spec 051) so the report and the Account tab can
+never disagree; a legacy wager-only path is kept for older callers/tests. No
+backend, no contract or subgraph changes. See `specs/016-wager-tax-report/` and
+`specs/051-unified-activity-ledger/`.
 
 ## Why on-chain receipts (not the subgraph)
 

--- a/frontend/src/data/reports/csvReport.js
+++ b/frontend/src/data/reports/csvReport.js
@@ -118,9 +118,10 @@ export function lineItemToRow(item, report) {
  */
 export function render(report) {
   const preamble = [
-    ['Activity / Tax Report'],
+    ['FairWins Activity Report'],
     ['Account', report.account],
     ['Network', `${report.networkName}${report.isTestnet ? ' (testnet)' : ''}`],
+    ['Chain ID', String(report.chainId ?? '')],
     ['Period', report.period.label],
     ['Generated', new Date(report.generatedAt).toISOString()],
     ['Valuation', report.valuationNote],
@@ -150,6 +151,23 @@ export function render(report) {
       `USD ${t.usdValue.toFixed(2)}`,
     ])
   }
+
+  // Collated per-activity breakdown — the multi-use view the flat table cannot
+  // give (spec 051 classes). Only the ledger path carries real class labels.
+  const byClass = report.totals?.byClass
+  if (report.source === 'ledger' && byClass && Object.keys(byClass).length) {
+    totals.push([], ['Totals by activity type (settled activity only)'])
+    for (const c of Object.values(byClass)) {
+      totals.push([
+        c.class,
+        `entries ${c.count}`,
+        `in USD ${c.inUsd.toFixed(2)}`,
+        `out USD ${c.outUsd.toFixed(2)}`,
+        `USD ${c.usdValue.toFixed(2)}`,
+      ])
+    }
+  }
+
   totals.push([
     'Overall',
     `USD ${report.totals.overall.usdValue.toFixed(2)}`,
@@ -159,9 +177,15 @@ export function render(report) {
   return Papa.unparse([...preamble, ...table, ...totals])
 }
 
-/** Suggested download file name (FR-007). */
+/**
+ * Suggested download file name (FR-007). The unified ledger export is
+ * multi-use, so it names itself by activity, not "wager"; the legacy
+ * wager-only path keeps its historical name for stable tooling.
+ */
 export function fileName(report) {
   const from = new Date(report.period.from).toISOString().slice(0, 10)
   const to = new Date(report.period.to).toISOString().slice(0, 10)
-  return `wager-report_${report.networkName.replace(/\s+/g, '-')}_${from}_${to}.csv`
+  const net = report.networkName.replace(/\s+/g, '-')
+  const stem = report.source === 'ledger' ? 'fairwins-activity' : 'wager-report'
+  return `${stem}_${net}_${from}_${to}.csv`
 }

--- a/frontend/src/data/reports/pdfReport.js
+++ b/frontend/src/data/reports/pdfReport.js
@@ -22,13 +22,14 @@ export function render(report) {
   let y = 40
 
   doc.setFontSize(16)
-  doc.text('Wager Activity / Tax Report', marginX, y)
+  // The ledger export spans every activity class; the legacy path is wager-only.
+  doc.text(report.source === 'ledger' ? 'FairWins Activity Report' : 'Wager Activity / Tax Report', marginX, y)
   y += 20
 
   doc.setFontSize(9)
   const headerLines = [
     `Account: ${report.account}`,
-    `Network: ${report.networkName}${report.isTestnet ? ' (testnet)' : ''}`,
+    `Network: ${report.networkName}${report.isTestnet ? ' (testnet)' : ''} · chain ${report.chainId}`,
     `Period: ${report.period.label}`,
     `Generated: ${new Date(report.generatedAt).toISOString()}`,
   ]
@@ -58,7 +59,7 @@ export function render(report) {
 
   let afterTableY = (doc.lastAutoTable?.finalY || y) + 18
   doc.setFontSize(9)
-  doc.text('Totals by stablecoin', marginX, afterTableY)
+  doc.text('Totals by token', marginX, afterTableY)
   afterTableY += 13
   doc.setFontSize(8)
   for (const t of Object.values(report.totals.byTicker)) {
@@ -69,6 +70,25 @@ export function render(report) {
     )
     afterTableY += 12
   }
+
+  // Collated per-activity breakdown for the multi-use ledger export.
+  const byClass = report.totals?.byClass
+  if (report.source === 'ledger' && byClass && Object.keys(byClass).length) {
+    afterTableY += 6
+    doc.setFontSize(9)
+    doc.text('Totals by activity type', marginX, afterTableY)
+    afterTableY += 13
+    doc.setFontSize(8)
+    for (const c of Object.values(byClass)) {
+      doc.text(
+        `${c.class}: ${c.count} entr${c.count === 1 ? 'y' : 'ies'}, in USD ${c.inUsd.toFixed(2)}, out USD ${c.outUsd.toFixed(2)}, USD ${c.usdValue.toFixed(2)}`,
+        marginX,
+        afterTableY,
+      )
+      afterTableY += 12
+    }
+  }
+
   const o = report.totals.overall
   doc.text(`Overall: USD ${o.usdValue.toFixed(2)}, fees ${o.feesNative} ${o.feesNativeSymbol}`, marginX, afterTableY)
   afterTableY += 18
@@ -84,9 +104,11 @@ export function render(report) {
   return doc.output('blob')
 }
 
-/** Suggested download file name (FR-007). */
+/** Suggested download file name (FR-007), mirroring the CSV naming split. */
 export function fileName(report) {
   const from = new Date(report.period.from).toISOString().slice(0, 10)
   const to = new Date(report.period.to).toISOString().slice(0, 10)
-  return `wager-report_${report.networkName.replace(/\s+/g, '-')}_${from}_${to}.pdf`
+  const net = report.networkName.replace(/\s+/g, '-')
+  const stem = report.source === 'ledger' ? 'fairwins-activity' : 'wager-report'
+  return `${stem}_${net}_${from}_${to}.pdf`
 }

--- a/frontend/src/data/reports/reportBuilder.js
+++ b/frontend/src/data/reports/reportBuilder.js
@@ -25,8 +25,9 @@ import { valueTransfer, PAR_VALUATION_NOTE } from './valuation'
 import { resolveTokenMeta } from './tokenMeta'
 
 export const REPORT_DISCLAIMER =
-  'This is an informational record of your on-chain wager activity, not tax advice. ' +
-  'The platform does not compute tax owed. Consult a qualified professional.'
+  'This is an informational record of your on-chain FairWins activity — wagers, ' +
+  'transfers, pools, earn, and membership — not tax advice. The platform does not ' +
+  'compute tax owed. Consult a qualified professional.'
 
 function eq(a, b) {
   return String(a).toLowerCase() === String(b).toLowerCase()
@@ -41,6 +42,9 @@ function isParty(wager, account) {
  *  Failed entries are listed but NEVER totaled (spec 051 FR-003). */
 function computeTotals(lineItems, nativeSymbol) {
   const byTicker = {}
+  // Collate settled activity by class (wager/transfer/earn/pool/membership) so
+  // the multi-use ledger reads as a per-activity breakdown, not one flat list.
+  const byClass = {}
   let overallUsd = 0
   let overallFees = 0
   let failedCount = 0
@@ -57,6 +61,17 @@ function computeTotals(lineItems, nativeSymbol) {
     else if (it.direction === 'refund') t.refunds += it.amountNumber
     t.usdValue += it.usdValue
     t.count += 1
+
+    const clsKey = it.class || 'wager'
+    const c = (byClass[clsKey] ||= { class: clsKey, count: 0, inUsd: 0, outUsd: 0, usdValue: 0 })
+    c.count += 1
+    c.usdValue += it.usdValue
+    // Ledger entries carry a value direction; wager kinds map onto it so the
+    // in/out split stays meaningful across every class.
+    const inward = it.direction === 'in' || it.direction === 'payout' || it.direction === 'refund'
+    if (inward) c.inUsd += it.usdValue
+    else c.outUsd += it.usdValue
+
     overallUsd += it.usdValue
     if (typeof it.feeNative === 'number') overallFees += it.feeNative
   }
@@ -65,6 +80,7 @@ function computeTotals(lineItems, nativeSymbol) {
   }
   return {
     byTicker,
+    byClass,
     overall: {
       usdValue: overallUsd,
       feesNative: overallFees,

--- a/frontend/src/pages/WalletPage.css
+++ b/frontend/src/pages/WalletPage.css
@@ -680,15 +680,31 @@
 }
 
 .reports-section .generate-report-btn,
+.reports-section .report-quick-btn,
 .reports-section .report-download-actions button {
   padding: 8px 16px;
   border-radius: 6px;
   cursor: pointer;
 }
 
-.reports-section .generate-report-btn:disabled {
+.reports-section .generate-report-btn:disabled,
+.reports-section .report-quick-btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.reports-section .report-quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 16px;
+}
+
+.reports-section .report-quick-btn {
+  background: var(--color-primary, #4338ca);
+  color: #fff;
+  border: 1px solid var(--color-primary, #4338ca);
+  font-weight: 600;
 }
 
 .reports-section .report-download-actions {

--- a/frontend/src/test/reports/TaxReportsPanel.test.jsx
+++ b/frontend/src/test/reports/TaxReportsPanel.test.jsx
@@ -44,6 +44,18 @@ describe('TaxReportsPanel (Story 1 + Story 2)', () => {
     await waitFor(() => expect(screen.getByText(/saved reports/i)).toBeInTheDocument())
   })
 
+  it('exports the current month in one click (generates + downloads a PDF)', async () => {
+    const saveAs = vi.fn()
+    render(<TaxReportsPanel hookOptions={hookOptions(saveAs)} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /export current month/i }))
+
+    // The current month-to-date (Jun 2026) covers the fixture activity, so a
+    // report is generated on screen and a single PDF download is triggered.
+    await waitFor(() => expect(saveAs).toHaveBeenCalledTimes(1))
+    expect(screen.getByText(/current month \(jun 2026\)/i)).toBeInTheDocument()
+  })
+
   it('shows a "no activity" empty state for an empty period', async () => {
     render(<TaxReportsPanel hookOptions={hookOptions(vi.fn())} />)
     fireEvent.click(screen.getByLabelText('Last calendar year'))

--- a/frontend/src/test/reports/reportParity.test.js
+++ b/frontend/src/test/reports/reportParity.test.js
@@ -159,6 +159,21 @@ describe('report ↔ Account tab parity (spec 051 US2)', () => {
     for (const cls of ['wager', 'transfer', 'earn', 'membership']) expect(csv).toContain(cls)
   })
 
+  it('collates settled activity by class for the multi-use ledger export', async () => {
+    const report = await build()
+    const byClass = report.totals.byClass
+    // Every settled class is represented; the failed transfer is not counted.
+    expect(byClass.wager.count).toBe(2)
+    expect(byClass.transfer.count).toBe(1) // the failed send is excluded (FR-003)
+    expect(byClass.earn.count).toBe(1)
+    expect(byClass.membership.count).toBe(1)
+    // Wager payout (190) is inbound; deposit (100) is outbound.
+    expect(byClass.wager.inUsd).toBeCloseTo(190)
+    expect(byClass.wager.outUsd).toBeCloseTo(100)
+    // The CSV surfaces the collated breakdown.
+    expect(renderCsv(report)).toContain('Totals by activity type')
+  })
+
   it('entries outside the period are excluded from both surfaces identically', async () => {
     const ledger = makeLedger()
     const narrow = { fromMs: T0 + 90 * 60_000, toMs: T0 + 150 * 60_000 } // only the settled send

--- a/frontend/src/test/reports/reportPeriods.test.js
+++ b/frontend/src/test/reports/reportPeriods.test.js
@@ -21,6 +21,13 @@ describe('reportPeriods presets (UTC boundaries)', () => {
     ])
   })
 
+  it('current_month resolves to the 1st of the current UTC month through now', () => {
+    const r = resolvePreset(PERIOD_KINDS.CURRENT_MONTH, NOW)
+    expect(new Date(r.from).toISOString()).toBe('2026-06-01T00:00:00.000Z')
+    expect(r.to).toBe(NOW)
+    expect(r.label).toBe('Current month (Jun 2026)')
+  })
+
   it('last_month resolves to the previous calendar month in UTC', () => {
     const r = resolvePreset(PERIOD_KINDS.LAST_MONTH, NOW)
     expect(new Date(r.from).toISOString()).toBe('2026-05-01T00:00:00.000Z')

--- a/frontend/src/utils/reportPeriods.js
+++ b/frontend/src/utils/reportPeriods.js
@@ -13,6 +13,7 @@
 
 export const PERIOD_KINDS = Object.freeze({
   CUSTOM: 'custom',
+  CURRENT_MONTH: 'current_month',
   LAST_MONTH: 'last_month',
   LAST_QUARTER: 'last_quarter',
   LAST_YEAR: 'last_year',
@@ -55,6 +56,18 @@ export function resolvePreset(kind, nowMs) {
   const m = now.getUTCMonth() // 0-11
 
   switch (kind) {
+    case PERIOD_KINDS.CURRENT_MONTH: {
+      // Month-to-date: the 1st of the current UTC month through "now" (FR-002).
+      // Powers the one-click "Export current month" quick action.
+      const from = Date.UTC(y, m, 1)
+      const to = nowMs
+      return {
+        kind,
+        from,
+        to,
+        label: `Current month (${MONTH_NAMES[m]} ${y})`,
+      }
+    }
     case PERIOD_KINDS.LAST_MONTH: {
       const from = Date.UTC(y, m - 1, 1)
       const to = endOfRange(Date.UTC(y, m, 1))


### PR DESCRIPTION
## Summary

The Reporting tab (`My Account → Reporting`) was still framed as a wager-only tax report, even though the app-wide ledger now spans multiple chains and activity classes (spec 051). This updates the tool's UX and its exports to match the new data model, and adds a one-click current-month export.

## Changes

**Panel (`TaxReportsPanel.jsx`)**
- Title changed to **"Reporting"**.
- Descriptive text rewritten to cover on-chain activity across **wagers, transfers, pools, earn, and membership** on the connected network (dropping the wager-only framing).
- Added an **"Export current month (PDF)"** quick action that builds the month-to-date report and downloads it in one click.
- The on-screen totals now include a **by-activity-type** breakdown for ledger-backed reports.
- Disconnected-state copy generalized to "activity report".

**Periods (`utils/reportPeriods.js`)**
- Added a `CURRENT_MONTH` preset resolving to the 1st of the current UTC month through "now", powering the quick action.

**Reports (`reportBuilder.js`, `csvReport.js`, `pdfReport.js`)**
- Collate settled activity **by ledger class** (`byClass` totals: count + in/out USD + total USD) and surface it in the panel, CSV ("Totals by activity type"), and PDF for the ledger path.
- Generalized the report title (**"FairWins Activity Report"**), the disclaimer, and the download file name (`fairwins-activity_*`) for the ledger export, while keeping the legacy wager-only naming (`wager-report_*`) byte-compatible for existing callers/tests.
- Added **Chain ID** to the CSV and PDF headers to make the multichain scope explicit.

**Styling (`WalletPage.css`)**
- Styling for the new quick-action button.

## Tests

- New coverage for the `CURRENT_MONTH` preset, the one-click export flow, and by-class collation.
- Full reports + nav suites pass (`115 passed`), lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZ4F7kVWfbLk7pYHQQZZot

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ4F7kVWfbLk7pYHQQZZot)_