### PR TITLE
chore(056): close out sell-side task list — T029 verified green in CI

### DIFF
--- a/specs/056-collectibles-sell-side/tasks.md
+++ b/specs/056-collectibles-sell-side/tasks.md
@@ -94,7 +94,7 @@
 - [x] T026 [P] [US2] [US3] Passkey ERC-1271 signing coverage in `frontend/src/test/collectibles/sellPasskey.test.jsx`: a passkey seller signs a listing over `replaySafeHash(orderHash)` via the injected `passkeyIntentSigner` deps (mock `readContract`/`replaySafeHash` + assertion), and where the account signature can't be validated the action resolves to the honest-unavailable state (FR-019 / SC-009) — never a failed submit
 - [x] T027 [P] Add the `OPENSEA_REFERRAL_ADDRESS` inline env entry to the gateway container in `services/oz-relayer/deploy/production/service.yaml` (public value, not a secret; alongside `PAYMASTER_ADDRESS_137`) and bump the gateway image tag past `collectibles-055`
 - [x] T028 [P] Update `docs/runbooks/relayer-operations.md`: document the `/v1/opensea/*` write routes, the referral beneficiary provisioning/rotation (public address), write quotas, and the "attribution off when unset" safe default
-- [ ] T029 Run quickstart §1 + §5 gates: full `services/relay-gateway` suite, full `frontend` suite (`--maxWorkers=2` to avoid OOM), and `npm run lint` (frontend) — all green; fix fallout
+- [x] T029 Run quickstart §1 + §5 gates: full `services/relay-gateway` suite, full `frontend` suite (`--maxWorkers=2` to avoid OOM), and `npm run lint` (frontend) — all green; fix fallout
 - [x] T030 Grep-audit per quickstart §4: no marketplace credential in `frontend/` source or `dist/`; the wallet is the only signer on the sell path (no gateway signing key in the write routes); `OPENSEA_REFERRAL_ADDRESS` only in config/manifest, never a secret
 
 ## Dependencies & Execution Order


### PR DESCRIPTION
## Summary

Follow-up to #907 (merged). Marks the final spec-056 task **T029** (full regression gates) complete — closing the sell-side task list at **30/30**.

The sell-side implementation itself landed in #907. This is a docs-only checkbox closeout: the T029 gate (full frontend suite + gateway suite + lint) is verified by CI, which ran green on the merged head `ad9680e` across **Frontend Unit Tests, Relay Gateway Tests, Frontend Lint, Frontend Build, Cypress Fast E2E, Smart Contract Tests, Coverage, Slither, and the axe + Lighthouse accessibility audits**.

### What shipped in #907 (for reference)
Phase 2 sell-side trading in the Collect section — **list**, **accept offer**, and **cancel** for owned collectibles through OpenSea's orderbook:
- Gateway: `/v1/opensea/*` write routes (publish signed listing, required-fees, offer-fulfillment, cancel), `client.post` (no 5xx retry), `attachReferral` no-user-cost seam, separate write quota; wallet is the only signer (no gateway signing key on the sell path).
- Frontend: hand-built Seaport order signed through the one `signTypedData` seam, `useCollectibleSell` state machine, `SellConfirm` with live net-proceeds + no-cost referral disclosure (never a surcharge), and Sell/Accept/Cancel in the detail sheet.
- Honest-state throughout: signing blocked when fees can't be confirmed, displayed net equals the signed seller-receipt, no custody.

### Passkey note (carried faithfully)
Passkey selling ships **wired-but-gated** behind end-to-end ERC-1271 validation (research D3): EOA sellers work now; passkey users see an honest "not available yet" until OpenSea's validation of our account is confirmed live, at which point it's a one-flag flip. The ERC-1271 signing mechanism is unit-tested.

No application code changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DysWbvbrFCwn8MhiymHz9Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01DysWbvbrFCwn8MhiymHz9Q)_