### PR TITLE
Predict: fix live data feed (correct Polymarket hosts) + crystal-ball icon

### DIFF
--- a/docs/developer-guide/predict-polymarket.md
+++ b/docs/developer-guide/predict-polymarket.md
@@ -35,6 +35,27 @@ in the confirm UI, never hidden and never described as free (`TradeConfirm.jsx`)
 | State machine | `frontend/src/hooks/usePredictTrade.js` (fee → build → sign → submit) |
 | Browse / positions / orders | `usePredictMarkets.js`, `usePredictPortfolio.js` + `components/predict/*` |
 
+### Upstream hosts
+
+Polymarket splits across three public hosts, and the gateway routes each read to the right one:
+
+- **Gamma API** (`gamma-api.polymarket.com`) — market **discovery/browse + search**, volume-ranked live
+  markets (the CLOB `/markets` endpoint returns mostly closed historical markets, so it is not used for
+  browse). Outcomes/prices/token-ids arrive as stringified JSON arrays that the normalizer zips.
+- **Data API** (`data-api.polymarket.com`) — the wallet's **positions** (public, no auth).
+- **CLOB** (`clob.polymarket.com`) — fee rate (`base_fee`), open orders (L2-authed), and order
+  submit/cancel. This is the only host that uses the operator L2 credentials.
+
+Hosts are configurable via `POLYMARKET_GAMMA_URL` / `POLYMARKET_DATA_URL` / `POLYMARKET_BASE_URL`.
+
+### Fees, honestly
+
+We control and state the **builder fee** exactly. Polymarket's **own taker fee** is computed by their
+engine at execution (a curve over price/size); `base_fee` is carried on the signed order's `feeRateBps`
+for validity, but we do **not** fabricate a dollar estimate for it — the confirm UI discloses it as a
+separate note ("Polymarket also charges its own taker fee, applied at execution"). This keeps
+"shown == charged" honest for the one fee we own.
+
 ### Signing
 
 The member's wallet signs the CLOB V2 order struct as EIP-712 typed data (domain

--- a/frontend/src/components/nav/NavIcon.jsx
+++ b/frontend/src/components/nav/NavIcon.jsx
@@ -45,8 +45,8 @@ const ICON_PATHS = {
   gem: <><path d="M7 4h10l4 6-9 10L3 10l4-6Z" /><path d="M3 10h18" /><path d="M9.5 10 12 4l2.5 6L12 20l-2.5-10Z" /></>,
   // Earn (spec 050) — a sprouting seedling: assets at rest, growing.
   sprout: <><path d="M12 20v-7" /><path d="M12 13c0-3.3-2.7-6-6-6H4.5v.5c0 3.3 2.7 6 6 6H12" /><path d="M12 11c0-2.8 2.2-5 5-5h2.5v.5c0 2.8-2.2 5-5 5H12" /><path d="M7.5 20h9" /></>,
-  // Predict (spec 057) — a target/bullseye: forecasting an outcome.
-  predict: <><circle cx="12" cy="12" r="8.5" /><circle cx="12" cy="12" r="4.3" /><circle cx="12" cy="12" r="0.9" /></>,
+  // Predict (spec 057) — a crystal ball on a stand: forecasting an outcome. Sphere + pedestal + glint.
+  predict: <><circle cx="12" cy="9.5" r="6.5" /><path d="M8.2 15.4 7 20h10l-1.2-4.6" /><path d="M5.5 20h13" /><path d="M9.4 7a3.2 3.2 0 0 0-1.2 2.5" /></>,
   // Share address as QR (spec 011 quick-share entry point) — the three QR
   // finder-pattern corners plus scattered data pixels, universally read as "QR".
   qrcode: <><rect x="4" y="4" width="6" height="6" rx="1" /><rect x="14" y="4" width="6" height="6" rx="1" /><rect x="4" y="14" width="6" height="6" rx="1" /><path d="M14 14h3v3" /><path d="M20 14v.01" /><path d="M14 20v.01" /><path d="M20 20v.01" /><path d="M17 17v.01" /></>,

--- a/frontend/src/components/predict/TradeConfirm.jsx
+++ b/frontend/src/components/predict/TradeConfirm.jsx
@@ -115,7 +115,7 @@ export default function TradeConfirm({ market, outcome, side = 'BUY', onClose })
                   </div>
                 ))}
                 <div className="trade-confirm-total">
-                  <dt>{isBuy ? 'Total cost' : 'You receive'}</dt>
+                  <dt>{isBuy ? 'Subtotal (incl. builder fee)' : 'You receive (before Polymarket fee)'}</dt>
                   <dd data-testid="trade-total">
                     {formatUnits(isBuy ? quote.totalCostUnits : quote.netProceedsUnits, 6)} USDC
                   </dd>
@@ -123,10 +123,11 @@ export default function TradeConfirm({ market, outcome, side = 'BUY', onClose })
               </dl>
             )}
 
-            {/* Honest builder-fee disclosure — states it IS a cost (the divergence from Collect). */}
+            {/* Honest disclosure — the builder fee IS a cost (the divergence from Collect), and
+                Polymarket's own taker fee is separate and charged at execution (not fabricated here). */}
             <p className="trade-confirm-fee-note">
-              FairWins charges a {bpsToPct(builderBps)} builder fee on this trade, added on top of
-              Polymarket&apos;s own fee. It&apos;s included in the total above.
+              FairWins charges a {bpsToPct(builderBps)} builder fee on this trade, included above.
+              Polymarket also charges its own taker fee, set by the market and applied at execution.
             </p>
 
             <div className="trade-confirm-actions">
@@ -137,7 +138,7 @@ export default function TradeConfirm({ market, outcome, side = 'BUY', onClose })
                 type="button"
                 className="trade-confirm-submit"
                 disabled={!canSign || busy}
-                onClick={() => trade.submit(params, { builder: trade.fee?.builderCode })}
+                onClick={() => trade.submit(params, { builder: trade.fee?.builderCode, negRisk: Boolean(market?.negRisk) })}
               >
                 {busy ? 'Submitting…' : `Sign ${isBuy ? 'buy' : 'sell'} (no gas)`}
               </button>

--- a/frontend/src/lib/predict/clobOrder.js
+++ b/frontend/src/lib/predict/clobOrder.js
@@ -53,11 +53,14 @@ export function polymarketExchange(negRisk = false) {
 }
 
 /**
- * Notional (USDC base units) for a price∈[0,1] and a share size, plus fee split and the honest total.
- * Floor division in bigint — no float drift. Platform fee is the venue's (estimated live from
- * feeRateBps); the builder fee is FairWins' exact, additive amount.
+ * Notional (USDC base units) for a price∈[0,1] and a share size, plus the FairWins builder fee — the
+ * one fee we control and can state exactly. Floor division in bigint — no float drift.
  *
- * @returns {{ notionalUnits: bigint, platformFeeUnits: bigint, builderFeeUnits: bigint,
+ * Polymarket's OWN taker fee is charged by their engine at execution (a curve over price/size); we
+ * carry its rate on the signed order (`feeRateBps`) for validity but do NOT fabricate a dollar estimate
+ * for it here — it is disclosed honestly as a separate note in the confirm UI. Makers pay no builder fee.
+ *
+ * @returns {{ notionalUnits: bigint, builderFeeUnits: bigint, platformFeeRateBps: number,
  *   totalCostUnits: bigint, netProceedsUnits: bigint, feeLines: Array, currency: 'USDC' }}
  */
 export function computeCost({ price, size, side, isMaker = false }, feeBreakdown) {
@@ -66,26 +69,24 @@ export function computeCost({ price, size, side, isMaker = false }, feeBreakdown
   // notional = price × size, both 6-dec → divide out one scale factor.
   const notionalUnits = (priceUnits * sizeUnits) / 10n ** BigInt(USDC_DECIMALS)
 
-  // Makers pay neither the platform fee (Polymarket makers are fee-free) nor the builder fee.
-  const platformBps = isMaker ? 0 : Number(feeBreakdown?.feeRateBps ?? 0)
+  // Makers pay no builder fee (Polymarket keeps makers whole).
   const builderBps = isMaker ? Number(feeBreakdown?.builderMakerFeeBps ?? 0) : Number(feeBreakdown?.builderTakerFeeBps ?? 0)
-  const platformFeeUnits = feeUnits(notionalUnits, platformBps)
   const builderFeeUnits = feeUnits(notionalUnits, builderBps)
 
-  const totalCostUnits = notionalUnits + platformFeeUnits + builderFeeUnits
-  const netProceedsUnits = notionalUnits - platformFeeUnits - builderFeeUnits
+  // Our guaranteed side of the math: notional ± our builder fee. Polymarket's fee is additional and
+  // charged at execution (disclosed, not fabricated).
+  const totalCostUnits = notionalUnits + builderFeeUnits
+  const netProceedsUnits = notionalUnits - builderFeeUnits
 
   const feeLines = [
-    // Platform fee is the venue's, labelled as an estimate (Polymarket computes the exact curve at match).
-    feeLine("Polymarket fee", platformFeeUnits, { estimated: true }),
     // FairWins' builder fee — always its own honest line when it applies (never hidden, FR-012).
     feeLine('FairWins builder fee', builderFeeUnits),
   ].filter(Boolean)
 
   return {
     notionalUnits,
-    platformFeeUnits,
     builderFeeUnits,
+    platformFeeRateBps: isMaker ? 0 : Number(feeBreakdown?.feeRateBps ?? 0),
     totalCostUnits,
     netProceedsUnits: netProceedsUnits < 0n ? 0n : netProceedsUnits,
     feeLines,

--- a/frontend/src/test/predict/TradeConfirm.test.jsx
+++ b/frontend/src/test/predict/TradeConfirm.test.jsx
@@ -19,18 +19,16 @@ const MARKET = { question: 'Will it rain tomorrow?', polymarketUrl: 'https://pol
 const OUTCOME = { name: 'Yes', tokenId: '123456789', price: '0.5' }
 const FEE = { feeRateBps: 100, builderTakerFeeBps: 50, builderMakerFeeBps: 0, builderCode: '0x6e03' }
 
-// A preview matching computeCost for 100 shares @ 0.50: notional 50, platform 0.5, builder 0.25.
+// A preview matching computeCost for 100 shares @ 0.50: notional 50, builder 0.25 (platform fee is
+// Polymarket's, disclosed as a note — not a fabricated dollar line).
 const QUOTE = {
   notionalUnits: 50_000000n,
-  platformFeeUnits: 500000n,
   builderFeeUnits: 250000n,
-  totalCostUnits: 50_750000n,
-  netProceedsUnits: 49_250000n,
+  platformFeeRateBps: 100,
+  totalCostUnits: 50_250000n,
+  netProceedsUnits: 49_750000n,
   currency: 'USDC',
-  feeLines: [
-    { label: 'Polymarket fee', amount: '0.5', currency: 'USDC', estimated: true },
-    { label: 'FairWins builder fee', amount: '0.25', currency: 'USDC' },
-  ],
+  feeLines: [{ label: 'FairWins builder fee', amount: '0.25', currency: 'USDC' }],
 }
 
 function makeHook(over = {}) {
@@ -60,15 +58,16 @@ describe('TradeConfirm', () => {
     render(<TradeConfirm market={MARKET} outcome={OUTCOME} side="BUY" onClose={() => {}} />)
     fireEvent.change(screen.getByLabelText(/shares to buy/i), { target: { value: '100' } })
     expect(screen.getByText('FairWins builder fee')).toBeInTheDocument()
-    // Total cost includes the additive builder fee (50 + 0.5 + 0.25 = 50.75).
-    expect(screen.getByTestId('trade-total')).toHaveTextContent('50.75 USDC')
+    // Subtotal includes the exact builder fee (50 + 0.25 = 50.25).
+    expect(screen.getByTestId('trade-total')).toHaveTextContent('50.25 USDC')
   })
 
-  it('discloses the builder fee as a real cost — not free', () => {
+  it('discloses the builder fee as a real cost and Polymarket fee as separate — not free', () => {
     render(<TradeConfirm market={MARKET} outcome={OUTCOME} side="BUY" onClose={() => {}} />)
-    const note = screen.getByText(/builder fee on this trade/i)
+    const note = screen.getByText(/builder fee/i)
     expect(note).toHaveTextContent(/0\.50%/)
-    expect(note).toHaveTextContent(/added on top of/i)
+    // Discloses Polymarket's own taker fee is separate.
+    expect(note).toHaveTextContent(/Polymarket also charges/i)
     // It must NOT claim to be free (the Collect divergence).
     expect(note.textContent).not.toMatch(/costs you nothing|free/i)
   })

--- a/frontend/src/test/predict/clobOrder.test.js
+++ b/frontend/src/test/predict/clobOrder.test.js
@@ -13,29 +13,28 @@ const MAKER = '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'
 const FEE = { feeRateBps: 100, builderTakerFeeBps: 50, builderMakerFeeBps: 0 }
 
 describe('computeCost', () => {
-  it('includes the additive builder fee in a taker BUY total (shown == charged)', () => {
-    // 100 shares @ 0.50 = 50 USDC notional. Platform 1% = 0.5, builder 0.5% = 0.25.
+  it('includes the exact builder fee in a taker BUY total (shown == charged)', () => {
+    // 100 shares @ 0.50 = 50 USDC notional. Builder 0.5% = 0.25. Polymarket's own fee is separate.
     const c = computeCost({ price: '0.5', size: '100', side: 'BUY', isMaker: false }, FEE)
     expect(c.notionalUnits).toBe(50_000000n)
-    expect(c.platformFeeUnits).toBe(500000n) // 0.50 USDC
     expect(c.builderFeeUnits).toBe(250000n) // 0.25 USDC
-    expect(c.totalCostUnits).toBe(50_750000n) // 50.75 USDC
-    // Both fees appear as their own labelled lines; the builder fee is never hidden.
+    expect(c.totalCostUnits).toBe(50_250000n) // 50.25 USDC (notional + our builder fee)
+    expect(c.platformFeeRateBps).toBe(100) // carried on the order, not fabricated as a dollar line
+    // The builder fee is its own labelled line; we never fabricate a platform-fee dollar amount.
     const labels = c.feeLines.map((l) => l.label)
-    expect(labels).toContain('FairWins builder fee')
-    expect(labels).toContain('Polymarket fee')
-    expect(c.feeLines.find((l) => l.label === 'FairWins builder fee').amount).toBe('0.25')
+    expect(labels).toEqual(['FairWins builder fee'])
+    expect(c.feeLines[0].amount).toBe('0.25')
   })
 
-  it('charges a taker SELL its fees against net proceeds', () => {
+  it('charges a taker SELL the builder fee against net proceeds', () => {
     const c = computeCost({ price: '0.5', size: '100', side: 'SELL', isMaker: false }, FEE)
-    expect(c.netProceedsUnits).toBe(49_250000n) // 50 - 0.5 - 0.25
+    expect(c.netProceedsUnits).toBe(49_750000n) // 50 - 0.25
   })
 
-  it('charges makers NO platform fee and NO builder fee', () => {
+  it('charges makers NO builder fee (and no platform rate on the order)', () => {
     const c = computeCost({ price: '0.5', size: '100', side: 'BUY', isMaker: true }, FEE)
-    expect(c.platformFeeUnits).toBe(0n)
     expect(c.builderFeeUnits).toBe(0n)
+    expect(c.platformFeeRateBps).toBe(0)
     expect(c.totalCostUnits).toBe(50_000000n)
     expect(c.feeLines).toHaveLength(0) // no fee lines to show
   })
@@ -51,7 +50,8 @@ describe('buildOrder', () => {
     expect(built.message.maker).toBe(MAKER)
     expect(built.message.tokenId).toBe(TOKEN)
     expect(built.message.side).toBe(0) // BUY
-    expect(built.totalCost).toBe('50.75')
+    expect(built.message.feeRateBps).toBe('100') // platform rate carried on the order
+    expect(built.totalCost).toBe('50.25')
     expect(built.domain).toMatchObject({ name: 'Polymarket CTF Exchange', version: '2', chainId: 137 })
     expect(built.types).toBe(CLOB_ORDER_TYPES)
     // BUY: maker gives USDC notional, takes shares.

--- a/frontend/src/test/predict/usePredictTrade.test.jsx
+++ b/frontend/src/test/predict/usePredictTrade.test.jsx
@@ -57,7 +57,7 @@ describe('usePredictTrade', () => {
     const { result } = renderHook(() => usePredictTrade({ deps }), { wrapper: wrapperFor() })
     await act(async () => { await result.current.loadFee(TOKEN) })
     const p = result.current.preview(BUY)
-    expect(p.totalCostUnits).toBe(50_750000n)
+    expect(p.totalCostUnits).toBe(50_250000n)
     expect(p.feeLines.map((l) => l.label)).toContain('FairWins builder fee')
   })
 

--- a/services/relay-gateway/.env.example
+++ b/services/relay-gateway/.env.example
@@ -86,6 +86,10 @@ KILL_SWITCH=false
 #POLYMARKET_API_PASSPHRASE=
 #POLYMARKET_API_ADDRESS=0x...              # the operator wallet the API creds belong to
 #POLYMARKET_BASE_URL=https://clob.polymarket.com
+# Polymarket splits across three public hosts: CLOB (orders/fees/auth), Gamma (market discovery +
+# search), Data API (positions). Browse hits Gamma, positions hit Data — both public (no L2 creds).
+#POLYMARKET_GAMMA_URL=https://gamma-api.polymarket.com
+#POLYMARKET_DATA_URL=https://data-api.polymarket.com
 #POLYMARKET_TIMEOUT_MS=5000
 #POLYMARKET_RETRIES=1
 #POLYMARKET_CACHE_TTL_MS=15000             # market/fee read cache (prices move fast)

--- a/services/relay-gateway/src/config/index.js
+++ b/services/relay-gateway/src/config/index.js
@@ -328,6 +328,11 @@ export function loadConfig(env = process.env, opts = {}) {
         return a
       })(),
       baseUrl: opt(env, 'POLYMARKET_BASE_URL', 'https://clob.polymarket.com'),
+      // Polymarket splits across three public hosts: the CLOB (orders/fees/auth), the Gamma API
+      // (market discovery + search), and the Data API (positions). Browse hits Gamma, positions hit
+      // Data — both public (no L2 creds); only the CLOB path is authed.
+      gammaBaseUrl: opt(env, 'POLYMARKET_GAMMA_URL', 'https://gamma-api.polymarket.com'),
+      dataBaseUrl: opt(env, 'POLYMARKET_DATA_URL', 'https://data-api.polymarket.com'),
       timeoutMs: int(env, 'POLYMARKET_TIMEOUT_MS', 5000),
       retries: int(env, 'POLYMARKET_RETRIES', 1),
       cacheTtlMs: int(env, 'POLYMARKET_CACHE_TTL_MS', 15_000),

--- a/services/relay-gateway/src/polymarket/normalize.js
+++ b/services/relay-gateway/src/polymarket/normalize.js
@@ -75,6 +75,7 @@ export function normalizeMarket(raw) {
     outcomes,
     volume: usdcQuote(raw.volume ?? raw.volume_num ?? null),
     endDate: typeof raw.end_date_iso === 'string' ? raw.end_date_iso : (typeof raw.endDate === 'string' ? raw.endDate : null),
+    negRisk: Boolean(raw.neg_risk ?? raw.negRisk),
     // Non-tradable markets show an honest state instead of a buy/sell affordance that would fail.
     tradable: !closed && outcomes.length > 0,
     polymarketUrl: polymarketMarketUrl(slug),
@@ -86,6 +87,66 @@ export function normalizeMarketPage(body) {
   const list = Array.isArray(body?.data) ? body.data : Array.isArray(body) ? body : []
   const markets = list.map(normalizeMarket).filter(Boolean)
   const next = typeof body?.next_cursor === 'string' && body.next_cursor !== '' && body.next_cursor !== 'LTE=' ? body.next_cursor : null
+  return { markets, next }
+}
+
+/** Parse a Gamma stringified-JSON array field (outcomes/outcomePrices/clobTokenIds) -> array, or []. */
+function parseJsonArray(v) {
+  if (Array.isArray(v)) return v
+  if (typeof v !== 'string') return []
+  try {
+    const parsed = JSON.parse(v)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * One Gamma API market -> Market DTO (the discovery/browse source; live tradable markets by volume,
+ * with search). Gamma encodes outcomes/prices/token-ids as stringified JSON arrays that we zip
+ * together; field names are camelCase. Returns null when unusable.
+ */
+export function normalizeGammaMarket(raw) {
+  if (!raw) return null
+  const conditionId = raw.conditionId ?? raw.condition_id
+  if (typeof conditionId !== 'string' || conditionId === '') return null
+  const names = parseJsonArray(raw.outcomes)
+  const tokenIds = parseJsonArray(raw.clobTokenIds)
+  const prices = parseJsonArray(raw.outcomePrices)
+  const outcomes = names
+    .map((name, i) => {
+      const tokenId = String(tokenIds[i] ?? '')
+      if (!isTokenId(tokenId)) return null
+      return { name: typeof name === 'string' ? name : `Outcome ${i + 1}`, tokenId, price: normalizePrice(prices[i]) }
+    })
+    .filter(Boolean)
+  const closed = Boolean(raw.closed) || raw.active === false
+  const slug = typeof raw.slug === 'string' ? raw.slug : null
+  return {
+    conditionId,
+    question: typeof raw.question === 'string' && raw.question !== '' ? raw.question : (raw.title ?? conditionId),
+    category: typeof raw.category === 'string' ? raw.category : null,
+    slug,
+    outcomes,
+    volume: usdcQuote(raw.volumeNum ?? raw.volume ?? null),
+    endDate: typeof raw.endDate === 'string' ? raw.endDate : null,
+    negRisk: Boolean(raw.negRisk),
+    tradable: !closed && outcomes.length > 0,
+    polymarketUrl: polymarketMarketUrl(slug),
+  }
+}
+
+/**
+ * Assemble a Gamma market page. `q` filters by question text (Gamma /markets has no free-text param, so
+ * we filter the volume-ranked page server-side); `next` is the next offset when the page was full.
+ */
+export function normalizeGammaPage(body, { q = '', offset = 0, limit = 100 } = {}) {
+  const list = Array.isArray(body) ? body : Array.isArray(body?.data) ? body.data : []
+  let markets = list.map(normalizeGammaMarket).filter(Boolean).filter((m) => m.tradable)
+  const needle = q.trim().toLowerCase()
+  if (needle) markets = markets.filter((m) => m.question.toLowerCase().includes(needle))
+  const next = list.length >= limit ? String(offset + limit) : null
   return { markets, next }
 }
 
@@ -106,7 +167,7 @@ export function normalizeFeeRate(body, tokenId) {
   }
 }
 
-/** One position -> {tokenId, conditionId, outcome, size, value}, or null. */
+/** One Data-API position -> {tokenId, conditionId, outcome, size, value, bestBid, negRisk}, or null. */
 export function normalizePosition(raw) {
   if (!raw) return null
   const tokenId = String(raw.asset ?? raw.token_id ?? raw.tokenId ?? '')
@@ -118,8 +179,10 @@ export function normalizePosition(raw) {
     conditionId: typeof raw.conditionId === 'string' ? raw.conditionId : (raw.condition_id ?? null),
     outcome: typeof raw.outcome === 'string' ? raw.outcome : null,
     size: String(size),
-    value: usdcQuote(raw.current_value ?? raw.value ?? null),
+    // Data-API uses camelCase currentValue + curPrice (the current mark, our sell-price proxy).
+    value: usdcQuote(raw.currentValue ?? raw.current_value ?? raw.value ?? null),
     bestBid: usdcQuote(raw.curPrice ?? raw.price ?? null),
+    negRisk: Boolean(raw.negativeRisk ?? raw.negRisk),
   }
 }
 

--- a/services/relay-gateway/src/polymarket/routes.js
+++ b/services/relay-gateway/src/polymarket/routes.js
@@ -18,7 +18,8 @@ import {
   isTokenId,
   isCursor,
   normalizeMarket,
-  normalizeMarketPage,
+  normalizeGammaMarket,
+  normalizeGammaPage,
   normalizeFeeRate,
   normalizePositionsList,
   normalizeOpenOrdersList,
@@ -36,9 +37,13 @@ import {
  *   killSwitch: {isActive: () => boolean},
  * }} deps
  */
-export function createPolymarketRouter(config, { client, cache, quotas, writeQuotas, killSwitch }) {
+export function createPolymarketRouter(config, { client, gammaClient, dataClient, cache, quotas, writeQuotas, killSwitch }) {
   const pm = config.polymarket
+  const gamma = gammaClient ?? client // browse/search host (public)
+  const data = dataClient ?? client // positions host (public)
   const router = express.Router()
+
+  const GAMMA_PAGE = 100 // markets fetched per Gamma page (volume-ranked; q filters this set)
 
   /** Killswitch + fail-closed key (shared by reads and writes). */
   function requireLive() {
@@ -96,26 +101,32 @@ export function createPolymarketRouter(config, { client, cache, quotas, writeQuo
       .json({ error: { code: 'upstream_unavailable', reason: 'prediction-market data is temporarily unavailable; try again later' } })
   }
 
-  // ---- GET /v1/polymarket/:chainId/markets (list/search) --------------------------------------
+  // ---- GET /v1/polymarket/:chainId/markets (browse/search via Gamma) --------------------------
+  // Live, tradable markets ranked by volume (the CLOB /markets endpoint returns mostly closed
+  // historical markets). `q` filters the volume-ranked page by question text; `next` is an offset.
   router.get('/v1/polymarket/:chainId/markets', async (req, res) => {
     try {
       requirePolygon(req.params.chainId)
       const next = req.query.next ?? null
       const search = typeof req.query.q === 'string' ? req.query.q.slice(0, 128) : ''
-      const category = typeof req.query.category === 'string' ? req.query.category.slice(0, 64) : ''
       if (!isCursor(next)) throw new GatewayError(400, 'invalid_cursor', 'malformed pagination cursor')
-      guard(`markets:${search}:${category}`)
+      const offset = Number.parseInt(next ?? '0', 10) || 0
+      guard(`markets:${search}:${offset}`)
 
-      const result = await cache.fetchThrough(
-        `markets:${search}:${category}:${next ?? ''}`,
-        pm.cacheTtlMs,
-        async () => {
-          const body = await client.get('/markets', {
-            query: { ...(next ? { next_cursor: next } : {}), ...(search ? { q: search } : {}), ...(category ? { category } : {}) },
-          })
-          return normalizeMarketPage(body)
-        }
-      )
+      const result = await cache.fetchThrough(`markets:${search}:${offset}`, pm.cacheTtlMs, async () => {
+        const body = await gamma.get('/markets', {
+          query: {
+            active: 'true',
+            closed: 'false',
+            archived: 'false',
+            limit: String(GAMMA_PAGE),
+            offset: String(offset),
+            order: 'volumeNum',
+            ascending: 'false',
+          },
+        })
+        return normalizeGammaPage(body, { q: search, offset, limit: GAMMA_PAGE })
+      })
       respond(res, result)
     } catch (err) {
       handleError(res, err)
@@ -133,8 +144,9 @@ export function createPolymarketRouter(config, { client, cache, quotas, writeQuo
       guard(`market:${conditionId}`)
 
       const result = await cache.fetchThrough(`market:${conditionId}`, pm.cacheTtlMs, async () => {
-        const body = await client.get(`/markets/${conditionId}`)
-        const market = normalizeMarket(body?.market ?? body)
+        const body = await gamma.get('/markets', { query: { condition_ids: conditionId } })
+        const raw = Array.isArray(body) ? body[0] : (body?.data?.[0] ?? body?.market ?? body)
+        const market = normalizeGammaMarket(raw) ?? normalizeMarket(raw)
         if (!market) throw new PolymarketRequestError(404, 'market not present upstream')
         return market
       })
@@ -155,16 +167,20 @@ export function createPolymarketRouter(config, { client, cache, quotas, writeQuo
       guard(`fee:${tokenId}`)
 
       const result = await cache.fetchThrough(`fee:${tokenId}`, pm.cacheTtlMs, async () => {
-        const body = await client.get('/fee-rate', { query: { token_id: tokenId } })
-        const fee = normalizeFeeRate(body, tokenId)
-        // No confirmable schedule -> block signing with a retryable state, never a guessed/hardcoded
-        // fee (FR-010). 503 (try again) rather than 404 (not_found) because the market itself exists.
-        if (!fee) throw new GatewayError(503, 'fee_unavailable', 'could not confirm the fee schedule; try again')
-        // Echo the configured builder fee + code so the client shows the honest additive total
-        // (FR-012) and embeds the code in the order it signs (the gateway re-validates it on submit).
+        // The builder code + fee are OUR config and are ALWAYS known — trading must never be blocked
+        // by a CLOB fee-rate quirk (FR-015). Polymarket's own taker fee (base_fee → the order's
+        // feeRateBps) is best-effort: fetched for the signed order, null if the CLOB has none.
         const builder = attachBuilderCode(config, { chainId: 137 })
+        let platform = null
+        try {
+          platform = normalizeFeeRate(await client.get('/fee-rate', { query: { token_id: tokenId } }), tokenId)
+        } catch {
+          platform = null
+        }
         return {
-          ...fee,
+          tokenId,
+          // Platform fee rate the order must carry (bps); null when the CLOB reports none.
+          feeRateBps: platform?.feeRateBps ?? null,
           builderCode: builder.builderCode,
           builderTakerFeeBps: builder.takerFeeBps,
           builderMakerFeeBps: builder.makerFeeBps,
@@ -185,7 +201,8 @@ export function createPolymarketRouter(config, { client, cache, quotas, writeQuo
       guard(address.toLowerCase())
 
       const result = await cache.fetchThrough(`positions:${address.toLowerCase()}`, pm.cacheTtlMs, async () => {
-        const body = await client.get('/positions', { query: { user: address }, auth: true })
+        // Positions live on the public Data API (not the CLOB), keyed by the wallet — no L2 auth.
+        const body = await data.get('/positions', { query: { user: address, sizeThreshold: '0.1', limit: '100' } })
         return normalizePositionsList(body)
       })
       respond(res, result)

--- a/services/relay-gateway/src/server.js
+++ b/services/relay-gateway/src/server.js
@@ -571,12 +571,21 @@ export function createApp(config, deps = {}) {
     windowMs: config.polymarket.quotaWindowMs,
     now: nowMs,
   })
+  const pmFetch = deps.polymarketFetch ? { fetchImpl: deps.polymarketFetch } : {}
   const polymarketClient =
-    deps.polymarketClient ??
-    createPolymarketClient({ ...config.polymarket, now: nowMs, ...(deps.polymarketFetch ? { fetchImpl: deps.polymarketFetch } : {}) })
+    deps.polymarketClient ?? createPolymarketClient({ ...config.polymarket, now: nowMs, ...pmFetch })
+  // Discovery (Gamma) + positions (Data API) hosts — both PUBLIC, so no creds (no L2 auth headers).
+  const polymarketGammaClient =
+    deps.polymarketGammaClient ??
+    createPolymarketClient({ baseUrl: config.polymarket.gammaBaseUrl, timeoutMs: config.polymarket.timeoutMs, retries: config.polymarket.retries, now: nowMs, ...pmFetch })
+  const polymarketDataClient =
+    deps.polymarketDataClient ??
+    createPolymarketClient({ baseUrl: config.polymarket.dataBaseUrl, timeoutMs: config.polymarket.timeoutMs, retries: config.polymarket.retries, now: nowMs, ...pmFetch })
   app.use(
     createPolymarketRouter(config, {
       client: polymarketClient,
+      gammaClient: polymarketGammaClient,
+      dataClient: polymarketDataClient,
       cache: deps.polymarketCache ?? createTtlCache({ now: nowMs }),
       quotas: pmReadQuotas,
       writeQuotas: pmWriteQuotas,

--- a/services/relay-gateway/test/polymarket.test.js
+++ b/services/relay-gateway/test/polymarket.test.js
@@ -13,6 +13,7 @@ import {
   isSupportedChain,
   isTokenId,
   normalizeMarket,
+  normalizeGammaMarket,
   normalizeFeeRate,
   normalizePosition,
   validateOrderBody,
@@ -26,6 +27,7 @@ const CONDITION = '0x' + 'ab'.repeat(32)
 
 // ---- upstream fixtures (Polymarket CLOB shapes) -------------------------------------------------
 
+// CLOB /markets shape (used by the normalizeMarket unit test).
 const MARKETS_BODY = {
   data: [
     {
@@ -35,6 +37,7 @@ const MARKETS_BODY = {
       market_slug: 'will-it-rain-tomorrow',
       closed: false,
       volume: '12345.67',
+      neg_risk: false,
       tokens: [
         { token_id: TOKEN, outcome: 'Yes', price: '0.55' },
         { token_id: '1', outcome: 'No', price: '0.45' },
@@ -44,11 +47,28 @@ const MARKETS_BODY = {
   ],
   next_cursor: 'cursor-2',
 }
-const MARKET_DETAIL_BODY = { market: MARKETS_BODY.data[0] }
-const FEE_BODY = { fd: { r: 100, e: 2, to: true } }
-const POSITIONS_BODY = {
-  data: [{ asset: TOKEN, size: '10', outcome: 'Yes', current_value: '5.5', curPrice: '0.55', conditionId: CONDITION }],
-}
+// Gamma /markets shape (the browse/detail source): outcomes/prices/token-ids are stringified arrays.
+const GAMMA_MARKETS = [
+  {
+    conditionId: CONDITION,
+    question: 'Will it rain tomorrow?',
+    slug: 'will-it-rain-tomorrow',
+    category: 'Weather',
+    active: true,
+    closed: false,
+    negRisk: false,
+    volumeNum: 12345.67,
+    outcomes: JSON.stringify(['Yes', 'No']),
+    clobTokenIds: JSON.stringify([TOKEN, '1']),
+    outcomePrices: JSON.stringify(['0.55', '0.45']),
+  },
+  { foo: 'junk' }, // unusable -> dropped
+]
+const FEE_BODY = { base_fee: 1000 } // real CLOB /fee-rate shape
+// Data-API positions shape (public; camelCase currentValue/curPrice/negativeRisk).
+const POSITIONS_BODY = [
+  { asset: TOKEN, size: 10, outcome: 'Yes', currentValue: 5.5, curPrice: 0.55, conditionId: CONDITION, negativeRisk: false },
+]
 const OPEN_ORDERS_BODY = {
   data: [{ id: '0xorder1', asset_id: TOKEN, side: 'BUY', price: '0.5', original_size: '10', size_remaining: '4' }],
 }
@@ -94,13 +114,13 @@ function mockPolymarketFetch(overrides = {}) {
     for (const [needle, resp] of Object.entries(overrides)) {
       if (url.includes(needle)) return typeof resp === 'function' ? resp(url) : jsonRes(resp)
     }
+    // Host-routed: Gamma (discovery), Data-API (positions), CLOB (everything else).
+    if (url.includes('gamma-api')) return jsonRes(GAMMA_MARKETS)
+    if (url.includes('data-api')) return jsonRes(POSITIONS_BODY)
     if (url.includes('/order/cancel')) return jsonRes(CANCEL_RESPONSE)
     if (url.includes('/order')) return jsonRes(ORDER_POST_RESPONSE)
     if (url.includes('/data/orders')) return jsonRes(OPEN_ORDERS_BODY)
-    if (url.includes('/positions')) return jsonRes(POSITIONS_BODY)
     if (url.includes('/fee-rate')) return jsonRes(FEE_BODY)
-    if (url.includes('/markets/')) return jsonRes(MARKET_DETAIL_BODY)
-    if (url.includes('/markets')) return jsonRes(MARKETS_BODY)
     return jsonRes({ error: 'not found' }, 404)
   }
   impl.calls = calls
@@ -166,14 +186,33 @@ describe('polymarket normalize', () => {
     expect(normalizeMarket({ junk: true })).toBeNull()
   })
 
-  it('reads the platform fee live (never hardcoded) and returns null when absent', () => {
-    expect(normalizeFeeRate(FEE_BODY, TOKEN)).toMatchObject({ tokenId: TOKEN, feeRateBps: 100, takerOnly: true })
+  it('reads the platform fee live (base_fee) and returns null when absent', () => {
+    expect(normalizeFeeRate(FEE_BODY, TOKEN)).toMatchObject({ tokenId: TOKEN, feeRateBps: 1000 })
     expect(normalizeFeeRate({}, TOKEN)).toBeNull()
   })
 
-  it('maps a position, dropping zero-size records', () => {
-    expect(normalizePosition(POSITIONS_BODY.data[0])).toMatchObject({ tokenId: TOKEN, size: '10', outcome: 'Yes' })
+  it('maps a Data-API position, dropping zero-size records', () => {
+    expect(normalizePosition(POSITIONS_BODY[0])).toMatchObject({
+      tokenId: TOKEN,
+      size: '10',
+      outcome: 'Yes',
+      value: { amount: '5.5', currency: 'USDC' },
+      bestBid: { amount: '0.55', currency: 'USDC' },
+    })
     expect(normalizePosition({ asset: TOKEN, size: '0' })).toBeNull()
+  })
+
+  it('maps a Gamma market, zipping outcomes/token-ids/prices and dropping untradable', () => {
+    const m = normalizeGammaMarket(GAMMA_MARKETS[0])
+    expect(m.conditionId).toBe(CONDITION)
+    expect(m.outcomes).toEqual([
+      { name: 'Yes', tokenId: TOKEN, price: '0.55' },
+      { name: 'No', tokenId: '1', price: '0.45' },
+    ])
+    expect(m.tradable).toBe(true)
+    expect(m.negRisk).toBe(false)
+    expect(normalizeGammaMarket({ foo: 'junk' })).toBeNull()
+    expect(normalizeGammaMarket({ conditionId: CONDITION, closed: true, outcomes: '[]', clobTokenIds: '[]' }).tradable).toBe(false)
   })
 
   it('rejects a malformed order and a stripped/altered builder code', () => {
@@ -270,39 +309,47 @@ describe('predict proxy cross-cutting', () => {
 // ---- reads --------------------------------------------------------------------------------------
 
 describe('predict reads', () => {
-  it('lists markets, dropping unusable records', async () => {
-    const { app } = build()
+  it('lists live tradable markets from Gamma, dropping unusable records', async () => {
+    const { app, polymarketFetch } = build()
     const res = await get(app, MARKETS_PATH).expect(200)
     expect(res.body.markets).toHaveLength(1)
     expect(res.body.markets[0].conditionId).toBe(CONDITION)
-    expect(res.body.next).toBe('cursor-2')
+    expect(res.body.markets[0].outcomes[0]).toMatchObject({ name: 'Yes', tokenId: TOKEN })
     expect(res.body.stale).toBe(false)
+    // Browse hits the Gamma host, not the CLOB.
+    expect(polymarketFetch.calls.some((c) => c.url.includes('gamma-api') && c.url.includes('/markets'))).toBe(true)
   })
 
-  it('returns a market detail', async () => {
+  it('returns a market detail from Gamma', async () => {
     const { app } = build()
     const res = await get(app, MARKET_PATH).expect(200)
     expect(res.body.question).toBe('Will it rain tomorrow?')
   })
 
-  it('returns the live fee rate plus the configured builder fee (honest additive total)', async () => {
+  it('returns the configured builder fee + code with the live platform rate', async () => {
     const { app } = build()
     const res = await get(app, FEE_PATH).expect(200)
-    expect(res.body).toMatchObject({ feeRateBps: 100, builderTakerFeeBps: 50, builderMakerFeeBps: 0 })
+    expect(res.body).toMatchObject({ feeRateBps: 1000, builderTakerFeeBps: 50, builderMakerFeeBps: 0, builderCode: BUILDER_CODE })
   })
 
-  it('blocks (503) when the fee schedule is unavailable rather than guessing', async () => {
+  it('still returns builder info (no block) when the CLOB fee rate is unavailable — trading not stranded', async () => {
     const { app } = build({ polymarketFetch: mockPolymarketFetch({ '/fee-rate': {} }) })
-    await get(app, FEE_PATH).expect(503)
+    const res = await get(app, FEE_PATH).expect(200)
+    expect(res.body).toMatchObject({ feeRateBps: null, builderTakerFeeBps: 50, builderCode: BUILDER_CODE })
   })
 
-  it('reads positions and open orders with L2 auth headers', async () => {
+  it('reads positions from the public Data API (no auth) and open orders from the CLOB (L2 auth)', async () => {
     const { app, polymarketFetch } = build()
-    await get(app, POSITIONS_PATH).expect(200)
+    const posRes = await get(app, POSITIONS_PATH).expect(200)
+    expect(posRes.body.positions[0]).toMatchObject({ tokenId: TOKEN, outcome: 'Yes' })
     await get(app, ORDERS_PATH).expect(200)
-    const authed = polymarketFetch.calls.find((c) => c.url.includes('/positions'))
-    expect(authed.headers.POLY_API_KEY).toBe('test-pm-key')
-    expect(authed.headers.POLY_SIGNATURE).toBeDefined()
+    // Positions: public Data API, no POLY auth headers.
+    const posCall = polymarketFetch.calls.find((c) => c.url.includes('data-api') && c.url.includes('/positions'))
+    expect(posCall.headers.POLY_API_KEY).toBeUndefined()
+    // Open orders: CLOB, L2-authed.
+    const ordersCall = polymarketFetch.calls.find((c) => c.url.includes('/data/orders'))
+    expect(ordersCall.headers.POLY_API_KEY).toBe('test-pm-key')
+    expect(ordersCall.headers.POLY_SIGNATURE).toBeDefined()
   })
 })
 


### PR DESCRIPTION
## Summary

Follow-up to the merged Predict feature (#909). The browse feed came up empty/degraded on device because the gateway routed reads to the **wrong Polymarket hosts** — I built the proxy from API research without hitting the live endpoints. Polymarket splits across three public hosts; this PR routes each read correctly (verified against the live APIs), plus swaps the nav icon.

## Feed fixes

| Read | Was (broken) | Now |
|---|---|---|
| Browse / search | CLOB `/markets` → mostly **closed historical** markets | **Gamma API** (`gamma-api`): live tradable markets ranked by volume, with search |
| Positions | CLOB host (wrong) | **Data API** (`data-api`), public, correct camelCase shape (`currentValue`/`curPrice`/`negativeRisk`) |
| Fee rate | 503-blocked trading if the CLOB had no rate | returns the builder code/fee (our config) always; platform `base_fee` best-effort — never strands trading (FR-015) |

- `normalizeGammaMarket` zips Gamma's stringified `outcomes`/`clobTokenIds`/`outcomePrices` arrays into outcomes; browse filters to tradable and by question text.
- **`negRisk`** threaded from the market into the order builder so the correct "Polymarket CTF Exchange" contract (standard vs. neg-risk) is used.
- Hosts are configurable: `POLYMARKET_GAMMA_URL` / `POLYMARKET_DATA_URL` / `POLYMARKET_BASE_URL`.

## Fee honesty

We state the **FairWins builder fee exactly** (the fee we control). Polymarket's **own taker fee** is a curve their engine computes at execution and can't be reliably converted to a dollar amount from `base_fee`, so instead of fabricating a number we carry its rate on the signed order (`feeRateBps`) for validity and disclose it as a separate note in the confirm UI ("Polymarket also charges its own taker fee, applied at execution"). This keeps "shown == charged" honest for the fee we own.

## Icon

Predict nav glyph changed from a target/bullseye to a **crystal ball** (sphere + pedestal + glint).

## Note on the empty feed in production

Correcting these endpoints is necessary but not sufficient to light up the feed: the `fairwins-relay-gateway` service must be **redeployed** with this code and the `POLYMARKET_*` secrets (merging doesn't deploy; the service is currently scaled to zero on an older revision). Once deployed + warmed, browse/positions/orders resolve.

## Test plan

Gateway **138 tests** (updated for host-aware mock, Gamma/Data shapes, no-block fee-rate) + frontend **39 tests** (cost model, disclosure) — all green; lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016e1tUHGuNJ2in4c1qBtV39

---
_Generated by [Claude Code](https://claude.ai/code/session_016e1tUHGuNJ2in4c1qBtV39)_