### PR TITLE
fix(057): wire POLYMARKET_API_ADDRESS from secret in gateway manifest

### DIFF
--- a/docs/runbooks/relayer-operations.md
+++ b/docs/runbooks/relayer-operations.md
@@ -91,8 +91,14 @@ signer and Polymarket's protocol settles. A total outage never touches any value
 - **Credentials (secrets)**: `POLYMARKET_API_KEY` + `POLYMARKET_API_SECRET` + `POLYMARKET_API_PASSPHRASE`
   are the L2 HMAC creds, **derived once offline via L1** (`POST /auth/api-key` signed by the operator
   wallet) and stored in Secret Manager — so no signing key lives in the gateway. `POLYMARKET_API_ADDRESS`
-  is the operator wallet (public). Any missing secret ⇒ routes fail closed (`503 predict_unconfigured`)
-  and the tab hides. To rotate: re-derive the L2 creds offline, update the three secrets, redeploy.
+  is the operator wallet (public, wired from a same-named secret for consistency). Any missing secret ⇒
+  routes fail closed (`503 predict_unconfigured`) and the tab hides. To rotate: re-derive the L2 creds
+  offline, update the secrets, redeploy.
+  - **One-time IAM prerequisite:** the gateway runtime SA
+    (`fairwins-relay-engine@chippr-bots-site-wp.iam.gserviceaccount.com`) needs
+    `roles/secretmanager.secretAccessor` on all four `POLYMARKET_*` secrets, or the new revision
+    boot-fails to mount them. Grant once per secret with
+    `gcloud secrets add-iam-policy-binding <SECRET> --member="serviceAccount:<SA>" --role=roles/secretmanager.secretAccessor`.
 - **Builder code + fee** (public config, inline `value:` in the manifest — not secrets):
   `POLYMARKET_BUILDER_CODE` (bytes32), `POLYMARKET_BUILDER_TAKER_FEE_BPS` (default `50`),
   `POLYMARKET_BUILDER_MAKER_FEE_BPS` (default `0`). The builder fee is **additive** on Polymarket's

--- a/services/oz-relayer/deploy/production/service.yaml
+++ b/services/oz-relayer/deploy/production/service.yaml
@@ -83,9 +83,13 @@ spec:
             - name: POLYMARKET_API_PASSPHRASE
               valueFrom:
                 secretKeyRef: { name: POLYMARKET_API_PASSPHRASE, key: latest }
-            # The operator wallet the API creds belong to (POLY_ADDRESS header). PUBLIC address.
+            # The operator wallet the API creds belong to (POLY_ADDRESS header). PUBLIC address,
+            # stored as a secret for operational consistency with the other three L2 creds. Required
+            # for the authed order/cancel path (empty => Polymarket 401s the signed requests); the
+            # public read feed (markets/detail/positions/fee-rate) works without it.
             - name: POLYMARKET_API_ADDRESS
-              value: ""
+              valueFrom:
+                secretKeyRef: { name: POLYMARKET_API_ADDRESS, key: latest }
             # FairWins builder code (spec 057). PUBLIC bytes32, not a secret. Empty => orders post
             # unattributed (never stranded). The builder fee is additive and disclosed honestly in the UI.
             - name: POLYMARKET_BUILDER_CODE


### PR DESCRIPTION
## What

Reconciles the committed production gateway manifest (`services/oz-relayer/deploy/production/service.yaml`) with the live `predict-057` revision that fixed the Predict feed.

## Why

The Predict feed was returning **404 on every route** in the app because the live `fairwins-relay-gateway` was still running the old `collectibles-055` image (no `/v1/polymarket/*` routes) — #909/#910 shipped the code but the gateway was never redeployed. Redeploying `predict-057` fixed the feed.

While deploying, two gaps surfaced that this PR closes in the committed config:

1. **`POLYMARKET_API_ADDRESS` was empty inline (`value: ""`)** in the committed manifest. The public read feed (markets/detail/positions/fee-rate) works without it, but the **authed order/cancel path** uses it as the `POLY_ADDRESS` header — empty ⇒ Polymarket 401s the signed requests, so trading would silently fail. The deployed revision wires it from the same-named Secret Manager secret (consistent with the other three L2 creds). Leaving `main` on `""` is the #895 drift hazard: the next `services replace` from `main` would drop the address and re-break trading. This makes `main` match live.

2. **Runbook note**: the gateway runtime SA needs `roles/secretmanager.secretAccessor` on all four `POLYMARKET_*` secrets or the new revision boot-fails to mount them (this was the actual deploy blocker). Documented as a one-time prerequisite.

## Verification (live, after deploy)

- `GET /v1/polymarket/137/markets` → real volume-ranked tradable markets, builder code `0x6e03…` attached ✅
- `GET /v1/polymarket/137/markets?q=trump` → search works ✅
- `GET /v1/polymarket/137/markets/:conditionId` → market detail ✅
- `GET /v1/polymarket/137/fee-rate?token_id=<real>` → `feeRateBps` + builder fee (50/0 bps) ✅
- `GET /v1/polymarket/137/positions?address=…` → data-api positions ✅
- Live revision `fairwins-relay-gateway-00019-6ph` running `predict-057`, 100% traffic ✅

No code changes — manifest + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)