### PR TITLE
chore(057): pin gateway image to predict-058 (builder-sign live)

### DIFF
--- a/services/oz-relayer/deploy/production/service.yaml
+++ b/services/oz-relayer/deploy/production/service.yaml
@@ -18,8 +18,9 @@ spec:
       containers:
         # ---- ingress: FairWins policy gateway (public, port 8788) ----
         - name: gateway
-          # predict-057: adds the /v1/polymarket/* Predict proxy (spec 057) on top of the 055/056 OpenSea routes
-          image: us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway:predict-057
+          # predict-058 (main 0c697064, PR #912): adds POST /v1/polymarket/:chainId/builder-sign
+          # (Option A builder attribution) on top of the predict-057 /v1/polymarket/* read proxy.
+          image: us-central1-docker.pkg.dev/chippr-bots-site-wp/cloud-run-source-deploy/prediction-dao-research/fairwins-relay-gateway:predict-058
           ports:
             - name: http1
               containerPort: 8788


### PR DESCRIPTION
Reflects the out-of-band gateway redeploy so the repo manifest matches production.

**Deployed:** `fairwins-relay-gateway` now serves **predict-058** (built from main `0c697064`), adding `POST /v1/polymarket/:chainId/builder-sign` (Option A builder attribution, #912) on top of the predict-057 read proxy.

- Built via Cloud Build from merged main; deployed via `gcloud run services replace services/oz-relayer/deploy/production/service.yaml`.
- Serving revision **`fairwins-relay-gateway-00020-dbw`** @ 100% traffic, `Ready=True`.
- **Verified live:** `/status` → both chains up (`killSwitch:false`); `POST /v1/polymarket/137/builder-sign` → HTTP 200 returning signed `POLY_BUILDER_*` headers.

Manifest-only change (image tag `predict-057` → `predict-058`) so the next `services replace` from main doesn't revert the gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)