### PR TITLE
Move Portfolio from Finance to Quick Access nav group

### DIFF
--- a/frontend/src/components/nav/AppNavDrawer.jsx
+++ b/frontend/src/components/nav/AppNavDrawer.jsx
@@ -3,7 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom'
 import { useNavDrawer } from '../../contexts/NavDrawerContext.js'
 import PortalNav from '../ui/PortalNav'
 import Footer from '../Footer'
-import { HOME_ITEM, WAGERS_ITEM, NAV_GROUPS, pathForNavItem, visibleNavGroups } from '../../config/appNav'
+import { HOME_ITEM, PORTFOLIO_ITEM, WAGERS_ITEM, NAV_GROUPS, pathForNavItem, visibleNavGroups } from '../../config/appNav'
 import { useChainTokens } from '../../hooks/useChainTokens'
 import { collectiblesGatewayUrl } from '../../lib/collectibles/gatewayClient'
 import { predictGatewayUrl } from '../../lib/predict/predictClient'
@@ -13,13 +13,14 @@ import './AppNavDrawer.css'
 // old standalone Backup tab now lives inside the combined Security panel).
 const TAB_ALIASES = { swap: 'trade', backup: 'security' }
 
-// The drawer list = a top "Quick Access" group (Home) + the section groups,
-// with Wagers moved down into the Apps group (it keeps its absolute /wagers route).
-// Built per render because item visibility is chain-aware (spec 055: Collectibles
-// hides entirely on networks OpenSea doesn't serve or with no gateway configured).
+// The drawer list = a top "Quick Access" group (Home, Portfolio) + the section
+// groups, with Wagers moved down into the Apps group (it keeps its absolute
+// /wagers route). Built per render because item visibility is chain-aware
+// (spec 055: Collectibles hides entirely on networks OpenSea doesn't serve or
+// with no gateway configured).
 function buildDrawerGroups(visibility) {
   return [
-    { label: 'Quick Access', items: [HOME_ITEM] },
+    { label: 'Quick Access', items: [HOME_ITEM, PORTFOLIO_ITEM] },
     ...visibleNavGroups(visibility, NAV_GROUPS).map((group) =>
       group.label === 'Apps'
         ? { ...group, items: [WAGERS_ITEM, ...group.items] }

--- a/frontend/src/config/appNav.js
+++ b/frontend/src/config/appNav.js
@@ -16,6 +16,11 @@
 // name (see components/nav/NavIcon.jsx) — flat line glyphs, not emoji.
 export const HOME_ITEM = { id: 'home', label: 'Home', icon: 'home', to: '/app' }
 
+// Portfolio — pinned into Quick Access alongside Home (not a Finance section
+// item), so it keeps its 'portfolio' tab id / `/wallet?tab=portfolio` route but
+// is absent from the Finance group's bottom icon nav (see groupForTab).
+export const PORTFOLIO_ITEM = { id: 'portfolio', label: 'Portfolio', icon: 'trending' }
+
 // Wagers (spec 053) — the relocated create-types + actions grid. Like Home, it is an absolute
 // top-level route (not a `/wallet?tab=` section); it lives in the drawer's Apps group
 // (see AppNavDrawer's DRAWER_GROUPS).
@@ -27,7 +32,6 @@ export const NAV_GROUPS = [
   {
     label: 'Finance',
     items: [
-      { id: 'portfolio', label: 'Portfolio', icon: 'trending' },
       // Earn — lending & rewards (spec 050). Always present; the panel
       // self-discloses per-network availability.
       { id: 'earn', label: 'Earn', icon: 'sprout' },

--- a/frontend/src/test/AppNavDrawer.test.jsx
+++ b/frontend/src/test/AppNavDrawer.test.jsx
@@ -60,6 +60,29 @@ describe('AppNavDrawer (global nav drawer)', () => {
     expect(screen.queryByRole('button', { name: 'Account' })).not.toBeInTheDocument()
   })
 
+  it('lists Portfolio under Quick Access with Home, not under Finance', () => {
+    const { container } = renderDrawer()
+
+    expect(screen.getByRole('button', { name: 'Portfolio' })).toBeInTheDocument()
+
+    // Portfolio sits between the Quick Access and Finance group labels, i.e.
+    // it belongs to Quick Access rather than Finance's item list.
+    const labels = Array.from(
+      container.querySelectorAll('.portal-nav-group-label, .portal-nav-item-label')
+    ).map((el) => el.textContent)
+    const quickAccessIdx = labels.indexOf('Quick Access')
+    const financeIdx = labels.indexOf('Finance')
+    const portfolioIdx = labels.indexOf('Portfolio')
+    expect(portfolioIdx).toBeGreaterThan(quickAccessIdx)
+    expect(portfolioIdx).toBeLessThan(financeIdx)
+  })
+
+  it('routes Portfolio to its wallet tab', () => {
+    renderDrawer()
+    fireEvent.click(screen.getByRole('button', { name: 'Portfolio' }))
+    expect(screen.getByTestId('loc')).toHaveTextContent('/wallet?tab=portfolio')
+  })
+
   it('routes Home to the dashboard', () => {
     renderDrawer('/wallet?tab=trade')
     fireEvent.click(screen.getByRole('button', { name: /home/i }))


### PR DESCRIPTION
## Summary
- Move the Portfolio item from the Finance group into the drawer's "Quick Access" group, alongside Home
- Removing Portfolio from `NAV_GROUPS`'s Finance items also removes it from the Finance section's mobile bottom icon nav (`SectionIconNav`), since both surfaces are driven by the same `appNav.js` config (`groupForTab`)
- Portfolio keeps its existing `portfolio` tab id and `/wallet?tab=portfolio` route — only its position in the nav config/UI changed

## Test plan
- [x] `npx vitest run src/test/AppNavDrawer.test.jsx src/test/appNav.wagers.test.js src/test/collectibles/navVisibility.test.jsx src/test/SectionIconNav.test.jsx` — all pass
- [x] `npx vitest run src/test/portfolio src/test/Dashboard.test.jsx` — all pass
- [x] Added drawer tests asserting Portfolio renders under "Quick Access" (before the Finance group label) and routes to `/wallet?tab=portfolio`


---
_Generated by [Claude Code](https://claude.ai/code/session_01E8BC2rfxMTPaogcWHRW821)_