### PR TITLE
Add MORPHO, GRT, UNI, AAVE, LINK, ENS, PYUSD, BAT, WBTC, FIDD to the token registry

### DIFF
--- a/frontend/src/components/wallet/AssetLogo.jsx
+++ b/frontend/src/components/wallet/AssetLogo.jsx
@@ -26,6 +26,14 @@ const ASSET_GLYPHS = {
   USDT: { bg: '#26A17B', glyph: 'T', fg: '#ffffff' },
   USC: { bg: '#0F8A5F', glyph: '$', fg: '#ffffff' },
   FWMV: { bg: '#36B37E', glyph: 'clover', fg: '#ffffff' },
+  GRT: { bg: '#6747ED', glyph: 'G', fg: '#ffffff' },
+  ENS: { bg: '#5284FF', glyph: 'E', fg: '#ffffff' },
+  BAT: { bg: '#FF5000', glyph: 'B', fg: '#ffffff' },
+  UNI: { bg: '#FF007A', glyph: 'U', fg: '#ffffff' },
+  AAVE: { bg: '#B6509E', glyph: 'A', fg: '#ffffff' },
+  MORPHO: { bg: '#5A5FF0', glyph: 'M', fg: '#ffffff' },
+  PYUSD: { bg: '#0070E0', glyph: '$', fg: '#ffffff' },
+  FIDD: { bg: '#00754A', glyph: '$', fg: '#ffffff' },
 }
 
 // Per-network badge colors (chainId → fill). Testnets get a dashed ring so

--- a/frontend/src/config/assetTaxonomy.js
+++ b/frontend/src/config/assetTaxonomy.js
@@ -119,6 +119,14 @@ export const UNDERLYING_META = {
   DAI: { name: 'Dai Stablecoin', homeChainId: null },
   USC: { name: 'Classic USD', homeChainId: null },
   FWMV: { name: 'FairWins Membership Voucher', homeChainId: null },
+  GRT: { name: 'The Graph', homeChainId: null },
+  ENS: { name: 'Ethereum Name Service', homeChainId: null },
+  BAT: { name: 'Basic Attention Token', homeChainId: null },
+  UNI: { name: 'Uniswap', homeChainId: null },
+  AAVE: { name: 'Aave', homeChainId: null },
+  MORPHO: { name: 'Morpho', homeChainId: null },
+  PYUSD: { name: 'PayPal USD', homeChainId: null },
+  FIDD: { name: 'Fidelity Digital Dollar', homeChainId: null },
 }
 
 export function getUnderlyingMeta(symbol) {
@@ -160,6 +168,99 @@ const CURATED_REGISTRY = {
       decimals: 18,
       categoryId: 'payment-stablecoins',
     },
+    {
+      // Wrapped Bitcoin on Ethereum mainnet — canonical custodial-wrapped BTC.
+      address: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
+      symbol: 'WBTC',
+      name: 'Wrapped BTC',
+      decimals: 8,
+      categoryId: 'digital-commodities',
+      baselineSymbol: 'BTC',
+    },
+    {
+      // Chainlink token on Ethereum mainnet — protocol utility (oracle payment),
+      // no yield/capital-raising function.
+      address: '0x514910771AF9Ca656af840dff83E8264EcF986CA',
+      symbol: 'LINK',
+      name: 'ChainLink Token',
+      decimals: 18,
+      categoryId: 'digital-tools',
+    },
+    {
+      // The Graph — indexing-protocol utility token (query fees/curation), no
+      // capital-raising function.
+      address: '0xc944E90C64B2c07662A292be6244BDf05Cda44a7',
+      symbol: 'GRT',
+      name: 'Graph Token',
+      decimals: 18,
+      categoryId: 'digital-tools',
+    },
+    {
+      // ENS DAO governance token — ties to name-service domain identity, the
+      // Digital Tools category's textbook case.
+      address: '0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72',
+      symbol: 'ENS',
+      name: 'Ethereum Name Service',
+      decimals: 18,
+      categoryId: 'digital-tools',
+    },
+    {
+      // Basic Attention Token — Brave browser attention/ad utility token.
+      address: '0x0D8775F648430679A709E98d2b0Cb6250d2887EF',
+      symbol: 'BAT',
+      name: 'Basic Attention Token',
+      decimals: 18,
+      categoryId: 'digital-tools',
+    },
+    {
+      // Uniswap governance token — vote-weight/fee-switch characteristics of
+      // an investment contract.
+      address: '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
+      symbol: 'UNI',
+      name: 'Uniswap',
+      decimals: 18,
+      categoryId: 'digital-securities',
+    },
+    {
+      // Aave governance token — vote-weight plus a Safety Module staking
+      // program; investment-contract characteristics.
+      address: '0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9',
+      symbol: 'AAVE',
+      name: 'Aave Token',
+      decimals: 18,
+      categoryId: 'digital-securities',
+    },
+    {
+      // Morpho governance token — vote-weight over protocol/fee parameters;
+      // investment-contract characteristics. No Polygon deployment of the
+      // governance token exists (Morpho's multichain "infrastructure mode"
+      // deploys the lending stack, not this token) — mainnet only.
+      address: '0x58D97B57BB95320F9a05dC918Aef65434969c2B2',
+      symbol: 'MORPHO',
+      name: 'Morpho Token',
+      decimals: 18,
+      categoryId: 'digital-securities',
+    },
+    {
+      // PayPal USD — transactional stablecoin by known issuer (PayPal/Paxos).
+      // Ethereum only; not deployed on Polygon.
+      address: '0x6c3ea9036406852006290770BEdFcAbA0e23A0e8',
+      symbol: 'PYUSD',
+      name: 'PayPal USD',
+      decimals: 6,
+      categoryId: 'payment-stablecoins',
+    },
+    {
+      // Fidelity Digital Dollar — transactional stablecoin by known issuer
+      // (Fidelity Digital Assets, launched Feb 2026). Address sourced from
+      // Etherscan at add-time; re-verify on-chain before relying on it, the
+      // same convention as networks.js's Mordor-address caveat.
+      address: '0x7C135549504245B5eAe64fc0E99Fa5ebabb8e35D',
+      symbol: 'FIDD',
+      name: 'Fidelity Digital Dollar',
+      decimals: 18,
+      categoryId: 'payment-stablecoins',
+    },
   ],
   137: [
     {
@@ -196,6 +297,38 @@ const CURATED_REGISTRY = {
       name: 'Tether USD',
       decimals: 6,
       categoryId: 'payment-stablecoins',
+    },
+    {
+      // The Graph on Polygon PoS (official PoS-bridge child token).
+      address: '0xaa35915966E20B94Fb131b8fFfd8799518827c32',
+      symbol: 'GRT',
+      name: 'Graph Token',
+      decimals: 18,
+      categoryId: 'digital-tools',
+    },
+    {
+      // Basic Attention Token on Polygon PoS.
+      address: '0x3Cef98bb43d732E2F285eE605a8158cDE967D219',
+      symbol: 'BAT',
+      name: 'Basic Attention Token',
+      decimals: 18,
+      categoryId: 'digital-tools',
+    },
+    {
+      // Uniswap governance token on Polygon PoS (bridged).
+      address: '0xb33eaad8d922b1083446dc23f610c2567fb5180f',
+      symbol: 'UNI',
+      name: 'Uniswap',
+      decimals: 18,
+      categoryId: 'digital-securities',
+    },
+    {
+      // Aave governance token on Polygon PoS (bridged).
+      address: '0xD6DF932A45C0f255f85145f286eA0b292B21C90B',
+      symbol: 'AAVE',
+      name: 'Aave Token',
+      decimals: 18,
+      categoryId: 'digital-securities',
     },
   ],
 }

--- a/frontend/src/config/priceFeeds.js
+++ b/frontend/src/config/priceFeeds.js
@@ -21,10 +21,16 @@ export const CHAINLINK_FEEDS = {
     // Canonical Ethereum mainnet feeds (spec 048). Ethereum mainnet has no in-app
     // `dex` config, so the DEX-spot fallback cannot run there — these feeds are the
     // required price source for native ETH and WETH (WETH resolves via the ETH
-    // underlying). Stablecoins (USDC/USDT/DAI) value at par $1 and are not listed.
+    // underlying; WBTC resolves via the BTC underlying). Stablecoins (USDC/USDT/DAI/
+    // PYUSD/FIDD) value at par $1 and are not listed. GRT and MORPHO have no
+    // established mainnet USD feed at add-time and stay honestly unpriced there.
     ETH: import.meta.env?.VITE_FEED_MAINNET_ETH_USD || '0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419',
     BTC: import.meta.env?.VITE_FEED_MAINNET_BTC_USD || '0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c',
     LINK: import.meta.env?.VITE_FEED_MAINNET_LINK_USD || '0x2c1d072e956AFFC0D435Cb7AC38EF18d24d9127c',
+    UNI: import.meta.env?.VITE_FEED_MAINNET_UNI_USD || '0x553303d460EE0afB37EdFf9be42922D8FF63220e',
+    AAVE: import.meta.env?.VITE_FEED_MAINNET_AAVE_USD || '0x547a514d5e3769680Ce22B2361c10Ea13619e8a9',
+    BAT: import.meta.env?.VITE_FEED_MAINNET_BAT_USD || '0x9441D7556e7820B5cA42082cfa99487D56AcA958',
+    ENS: import.meta.env?.VITE_FEED_MAINNET_ENS_USD || '0x5C00128d4d1c2F4f652C267d7bcdD7aC99C16E16',
   },
   137: {
     MATIC: import.meta.env?.VITE_FEED_POLYGON_MATIC_USD || '0xAB594600376Ec9fD91F8e885dADF0CE036862dE0',

--- a/frontend/src/test/portfolio/assetTaxonomy.test.js
+++ b/frontend/src/test/portfolio/assetTaxonomy.test.js
@@ -142,6 +142,44 @@ describe('getPortfolioRegistry', () => {
     expect(bySymbol.USDT.source).toBe('curated-registry')
   })
 
+  it('includes the newly curated tokens on mainnet, each with a valid address/decimals', () => {
+    const registry = getPortfolioRegistry(1)
+    const bySymbol = Object.fromEntries(registry.map((e) => [e.symbol, e]))
+    const expected = {
+      MORPHO: 'digital-securities',
+      GRT: 'digital-tools',
+      UNI: 'digital-securities',
+      AAVE: 'digital-securities',
+      LINK: 'digital-tools',
+      ENS: 'digital-tools',
+      BAT: 'digital-tools',
+      WBTC: 'digital-commodities',
+      PYUSD: 'payment-stablecoins',
+      FIDD: 'payment-stablecoins',
+    }
+    for (const [symbol, categoryId] of Object.entries(expected)) {
+      expect(bySymbol[symbol], `${symbol} missing from mainnet registry`).toBeTruthy()
+      expect(bySymbol[symbol].categoryId).toBe(categoryId)
+      expect(bySymbol[symbol].address).toMatch(/^0x[0-9a-fA-F]{40}$/)
+      expect(bySymbol[symbol].decimals).toBeGreaterThan(0)
+    }
+    // WBTC wraps the SEC-baseline BTC commodity, so baseline precedence wins.
+    expect(bySymbol.WBTC.source).toBe('sec-baseline')
+  })
+
+  it('includes the newly curated tokens on Polygon that have an established bridged deployment', () => {
+    const registry = getPortfolioRegistry(137)
+    const bySymbol = Object.fromEntries(registry.map((e) => [e.symbol, e]))
+    for (const symbol of ['GRT', 'BAT', 'UNI', 'AAVE']) {
+      expect(bySymbol[symbol], `${symbol} missing from Polygon registry`).toBeTruthy()
+      expect(bySymbol[symbol].address).toMatch(/^0x[0-9a-fA-F]{40}$/)
+    }
+    // No official Polygon deployment of the MORPHO governance token, ENS, PYUSD, or FIDD.
+    for (const symbol of ['MORPHO', 'ENS', 'PYUSD', 'FIDD']) {
+      expect(bySymbol[symbol]).toBeUndefined()
+    }
+  })
+
   it('covers Sepolia: baseline-commodity native ETH plus Circle USDC', () => {
     const registry = getPortfolioRegistry(11155111)
     const native = registry.find((e) => e.kind === 'native')


### PR DESCRIPTION
## Summary
- Adds MORPHO, The Graph (GRT), Uniswap (UNI), Aave (AAVE), Chainlink (LINK), ENS, PayPal USD (PYUSD), Basic Attention Token (BAT), Wrapped Bitcoin (WBTC), and Fidelity Digital Dollar (FIDD) to the curated asset registry (`frontend/src/config/assetTaxonomy.js`) — the single source consumed by the Portfolio tab, Send/Transfer, and DEX/Trade panel.
- New entries land on Ethereum mainnet (chain 1) plus Polygon (chain 137) wherever an established bridged deployment exists (GRT, UNI, AAVE, BAT). MORPHO's governance token, ENS, PYUSD, and FIDD have no confirmed official Polygon deployment, so they're mainnet-only.
- Adds Chainlink USD price feeds for UNI, AAVE, BAT, and ENS on mainnet (`frontend/src/config/priceFeeds.js`) — mainnet has no in-app DEX fallback, so these were previously the only path to a priced value. WBTC prices via the existing BTC feed (baseline commodity). GRT and MORPHO have no established mainnet Chainlink feed and stay honestly unpriced there per the app's existing "no source → unpriced" convention; PYUSD/FIDD value at par $1 like other stablecoins.
- Adds inline SVG logo glyphs for the new symbols in `frontend/src/components/wallet/AssetLogo.jsx` so they render with a proper badge instead of falling back to the generic grey-disc placeholder.
- Extends `frontend/src/test/portfolio/assetTaxonomy.test.js` with coverage asserting each new token's presence, category, address format, and decimals on both chains.

## Scope decisions (confirmed with the requester)
- **"Fidelity coin"** was resolved to Fidelity Digital Dollar (FIDD), a USD stablecoin Fidelity Digital Assets reportedly launched in Feb 2026. Its contract address was sourced via web search cross-referencing at add-time (post-dates my training data) — **please verify the address on-chain before this ships**, per the requester's own request.
- **WZEC and WSOL were intentionally left out.** Neither has a single canonical bridged contract (multiple bridges issue different wrapped variants with different addresses), and this app has zero existing Zcash/Solana chain support. Picking the wrong bridge variant risks routing funds to the wrong token, so these were deferred pending an explicit address from the requester.
- **Address books need no changes** — `frontend/src/lib/addressBook/` is purely contact/address storage with no token allowlist, so every new token is already usable with any saved contact.
- **Wager stake currency selection** (`FriendMarketsModal.jsx`) already supports pasting any ERC-20 address as a custom stake token, so these tokens are reachable there without additional wiring — the curated dropdown itself intentionally stays narrow (stable/wrapped-native/native + custom).

## Test plan
- [x] `npx vitest run src/test/portfolio/` — 117/117 passing, including new coverage for the added tokens on both chains
- [x] `npx eslint` on all changed files — clean
- [ ] Full frontend suite (`npx vitest run`) — kicked off in CI; changes are scoped to config + one presentational component so no cross-cutting impact is expected


---
_Generated by [Claude Code](https://claude.ai/code/session_01V91csPAysy8o24pbkbGHHR)_