### PR TITLE
fix: preferences toggle switches render as squares on mobile

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -705,7 +705,7 @@ svg {
   }
 
   /* Ensure touch targets are at least 44x44px on mobile */
-  button,
+  button:not([role="switch"]),
   .tab-button,
   .view-button,
   .trade-button,

--- a/frontend/src/components/account/NotificationPreferencesPanel.css
+++ b/frontend/src/components/account/NotificationPreferencesPanel.css
@@ -55,6 +55,8 @@
   position: relative;
   width: 44px;
   height: 24px;
+  min-width: 44px;
+  min-height: 24px;
   padding: 0;
   border: none;
   border-radius: 12px;

--- a/frontend/src/components/account/PortfolioPreferencesPanel.css
+++ b/frontend/src/components/account/PortfolioPreferencesPanel.css
@@ -34,6 +34,8 @@
   cursor: pointer;
   flex: none;
   height: 24px;
+  min-height: 24px;
+  min-width: 44px;
   padding: 0;
   position: relative;
   transition: background 0.15s ease;

--- a/frontend/src/components/account/PrivacyPreferencesPanel.css
+++ b/frontend/src/components/account/PrivacyPreferencesPanel.css
@@ -34,6 +34,8 @@
   cursor: pointer;
   flex: none;
   height: 24px;
+  min-height: 24px;
+  min-width: 44px;
   padding: 0;
   position: relative;
   transition: background 0.15s ease;

--- a/frontend/src/components/account/QuickAccessCardsPanel.css
+++ b/frontend/src/components/account/QuickAccessCardsPanel.css
@@ -50,6 +50,8 @@
   position: relative;
   width: 44px;
   height: 24px;
+  min-width: 44px;
+  min-height: 24px;
   padding: 0;
   border: none;
   border-radius: 12px;


### PR DESCRIPTION
## Summary
- On mobile, the toggle switches on the Preferences tab (Quick access cards, Portfolio, Privacy, Notifications) rendered as 44x44 squares instead of 44x24 pill sliders.
- Root cause: `App.css`'s mobile touch-target rule (`button { min-height: 44px; min-width: 44px }`) stretched every `<button>` switch, since a plain `height: 24px` declaration on the switch classes doesn't override a separately-cascaded `min-height`.
- Fix: exclude `button[role="switch"]` from the global touch-target rule, and pin explicit `min-height`/`min-width` on each of the four switch classes so they can't be re-stretched by similar rules elsewhere.

## Test plan
- [x] `npx vitest run src/test/QuickAccessCardsPanel.test.jsx src/test/portfolio/PortfolioPreferencesPanel.test.jsx src/test/privacy/PrivacyPreferencesPanel.test.jsx src/test/NotificationPreferencesPanel.test.jsx` — 24 tests passing


---
_Generated by [Claude Code](https://claude.ai/code/session_01DDQTAdEPzcojKub8RZQKhh)_