### PR TITLE
ClearPath: list known DAOs across every network, gate writes behind a switch

### DIFF
--- a/docs/developer-guide/clearpath-multi-network.md
+++ b/docs/developer-guide/clearpath-multi-network.md
@@ -1,10 +1,15 @@
 # ClearPath: network-agnostic multi-network DAOs
 
 ClearPath (spec 030) is the platform's DAO governance module — a registry, dashboard, and
-action-router embedded as a My Account tab. Spec **042** made it **network-agnostic**: it can
-discover, track, and (where authorized) act on governance DAOs on chains beyond the app's wager
-networks — starting with **Ethereum mainnet** (ENS, Uniswap), with Base/Arbitrum/Optimism as
-config-only follow-ons.
+action-router embedded as a My Account tab. Spec **042** opened it to chains beyond the app's
+wager networks — starting with **Ethereum mainnet** (ENS, Uniswap), with Base/Arbitrum/Optimism
+as config-only follow-ons. A network-agnostic-listing follow-up (mirroring the cross-chain
+Portfolio pattern, `usePortfolio.js`) then made the **panel itself** network-agnostic: it lists
+known/tracked DAOs from **every** `clearpath`-capable network **at once**, over each network's own
+read provider, independent of the wallet's currently connected chain. A member only needs to
+switch networks when they take a **write** action (register, track-on-a-registry-network, vote,
+queue, execute, propose) — the same "Switch to X" pattern `TransferForm.jsx` uses for portfolio
+assets on another chain.
 
 This is a **frontend-only** capability: there is **no new or changed on-chain contract**. The
 existing `ExternalDAORegistry` remains deployed only where it already is (Mordor); everywhere
@@ -22,20 +27,33 @@ self-disclose as unavailable (`networkCapabilities.js` exposes a `clearpath` fea
 **Adding a network is pure config** — declare the entry (RPC, USDC, explorer) and set
 `clearpath: true`.
 
-### 2. Registry-optional tracking
+### 2. Registry-optional tracking, aggregated across every network
 
 ClearPath availability is **capability-driven, not registry-gated**:
-`useClearPath().isSupported = capabilities.clearpath && !!reader`. The on-chain
-`ExternalDAORegistry` is an **optional shared-discovery overlay** used where deployed. On a
-registry-less network a member tracks a DAO by address into a **device-local** store
-(`trackedDaoStore.js`, `localStorage` keyed by `chainId + wallet` — no backend, no cross-device
-sync in this cut). `listExternalDAOs()` merges, de-duplicated and strictly network-scoped:
+`useClearPath().isSupported = capabilities.clearpath && !!reader` (this reflects the *connected*
+chain — it gates write actions, not what's listed). The on-chain `ExternalDAORegistry` is an
+**optional shared-discovery overlay** used where deployed. On a registry-less network a member
+tracks a DAO by address into a **device-local** store (`trackedDaoStore.js`, `localStorage` keyed
+by `chainId + wallet` — no backend, no cross-device sync in this cut).
+
+`useClearPath().listExternalDAOs()` scans **every** `clearpath`-capable chain in parallel
+(`getClearPathChainIds()` in `config/networks.js`, mirroring `getPortfolioChainIds()`) via
+`Promise.allSettled` — an unreachable RPC on one chain degrades that chain honestly without
+blanking the others. For each chain it merges, de-duplicated and still strictly scoped to that one
+chain:
 
 ```
-on-chain registry entries  (iff a registry is deployed)
-+ device-local tracked DAOs (per chainId + wallet)
-+ curated known DAOs        (config/clearpath/knownDaos.js — ENS, Uniswap on mainnet)
+on-chain registry entries  (iff a registry is deployed on THAT chain)
++ device-local tracked DAOs (per chainId + wallet, on THAT chain)
++ curated known DAOs        (config/clearpath/knownDaos.js, on THAT chain)
 ```
+
+Every returned row carries its own `chainId`/`networkName`, badged in `ClearPathPanel.jsx`.
+Tracking (device-local) works on any chain regardless of the connected one — no tx, no switch.
+**Registering** on a registry network, and every **Governor action** (vote/queue/execute/propose in
+`ExternalDaoView.jsx`), can only be signed on that DAO's own chain: those surfaces compare
+`chainId` (the DAO's) against the connected chain and show a **"Switch to X"** button
+(`wagmi`'s `useSwitchChain().switchChainAsync`) in place of the action when they differ.
 
 ### 3. Pluggable per-framework connectors
 
@@ -65,8 +83,10 @@ is always signed by the connected wallet.
 
 ## Honesty, scoping & sanctions (unchanged invariants)
 
-- **Network-scoped**: every store, list, and read is keyed by `chainId` (tracked list also by
-  wallet) — nothing crosses networks.
+- **Network-scoped data, network-agnostic view**: every store and read is still keyed by `chainId`
+  (tracked list also by wallet) — a DAO tracked on one chain never leaks into another's scope. The
+  panel aggregates those per-chain scopes into one list for browsing; it never merges DAOs or
+  balances *across* chains the way a token portfolio would.
 - **Non-custodial**: ClearPath constructs actions the member signs against the DAO's own
   contract; it holds no keys, roles, or funds.
 - **Sanctions (FR-013)**: the action path screens the connected signer; a confirmed `restricted`
@@ -80,7 +100,12 @@ is always signed by the connected wallet.
   and a usable `rpcUrl` (+ USDC for treasury reads). Optionally seed known DAOs and subgraphs.
 - **New known DAO**: add `{ address, framework, label }` to `config/clearpath/knownDaos.js` —
   **verify the address on-chain first** (probe `COUNTING_MODE` for OZ, or
-  `proposalCount`+`quorumVotes` for Bravo); never guess.
+  `proposalCount`+`quorumVotes` for Bravo); never guess. Optionally add its governance subgraph id
+  to `daoSubgraphs.js` — but only a **verified, currently-synced** entry on The Graph's
+  decentralized-network gateway (`thegraph.com/explorer`); the ENS/Uniswap entries are
+  deliberately left empty today because no such live id could be confirmed (see the comment in
+  that file) — a wrong id is worse than none, since the router just falls back to the on-chain
+  live scan either way.
 - **New framework**: add `connectors/<framework>.js` implementing the interface and register it
   in `connectors/index.js#ORDERED`.
 

--- a/frontend/src/components/clearpath/ClearPathPanel.jsx
+++ b/frontend/src/components/clearpath/ClearPathPanel.jsx
@@ -1,26 +1,38 @@
 import { useCallback, useEffect, useState } from 'react'
 import './clearpath.css'
 import { getNetwork } from '../../config/networks'
+import { getContractAddressForChain } from '../../config/contracts'
 import { DAO_FRAMEWORK_LABEL } from '../../abis/externalDAORegistry'
 import { useClearPath } from './useClearPath'
 import RegisterExternalDao from './RegisterExternalDao'
 import ExternalDaoView from './ExternalDaoView'
 import ReadRouteToggle from './ReadRouteToggle'
 
-// Spec 030 — ClearPath module (external-DAO pillar), embedded as the My Account "ClearPath" tab. Lists DAOs
-// deployed by other platforms registered in the on-chain ExternalDAORegistry (read live over RPC — works on
-// subgraph-less Mordor, where Olympia lives), lets a member register a new one, and opens a per-DAO tracking
-// view. Network-scoped; self-disables truthfully where ClearPath isn't deployed (FR-016). Real on-chain only.
+// Spec 030/042 + network-agnostic follow-up — ClearPath module (external-DAO pillar), embedded as the My
+// Account "ClearPath" tab. Lists DAOs across EVERY clearpath-capable network at once (mirroring the Portfolio
+// tab's cross-chain pattern) — registered in an on-chain ExternalDAORegistry where deployed, else tracked
+// device-local, plus the curated known-DAO seed list. Each row is tagged with its network; opening one reads
+// live over that network's own RPC regardless of which chain the wallet is connected to. Real on-chain only —
+// acting on a DAO (register/vote/queue/execute) still requires the wallet to switch to that DAO's own network.
 
 const short = (a) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '')
 
 export default function ClearPathPanel() {
-  const { isSupported, hasRegistry, chainId, reader, signer, account, usdcAddress, readRoute, setReadRoute, listExternalDAOs, trackDAO, untrackDAO } = useClearPath()
-  // Tab label follows the mechanism: an on-chain register where a registry is deployed, else device-local track.
-  const TABS = [
-    { id: 'daos', label: 'DAOs' },
-    { id: 'register', label: hasRegistry ? 'Register' : 'Track' },
-  ]
+  const {
+    isSupported,
+    chainId,
+    chainIds,
+    hasRegistryFor,
+    reader,
+    readerFor,
+    signer,
+    account,
+    readRoute,
+    setReadRoute,
+    listExternalDAOs,
+    trackDAO,
+    untrackDAO,
+  } = useClearPath()
   const [tab, setTab] = useState('daos')
   const [loading, setLoading] = useState(true)
   const [daos, setDaos] = useState([])
@@ -28,10 +40,10 @@ export default function ClearPathPanel() {
   const [selected, setSelected] = useState(null)
   const net = getNetwork(chainId)
 
-  // Loads the registry over RPC. Does NOT setState synchronously (the first statement when supported is the
-  // async read) so it is safe to call from the effect; the Refresh button flips `loading` itself.
+  // Loads every clearpath network's DAOs in parallel (network-agnostic). Does NOT setState synchronously (the
+  // first statement is the async read) so it is safe to call from the effect; the Refresh button flips
+  // `loading` itself.
   const load = useCallback(async () => {
-    if (!isSupported) return
     try {
       const list = await listExternalDAOs()
       setDaos(list)
@@ -42,7 +54,7 @@ export default function ClearPathPanel() {
     } finally {
       setLoading(false)
     }
-  }, [isSupported, listExternalDAOs])
+  }, [listExternalDAOs])
 
   useEffect(() => {
     load()
@@ -53,91 +65,98 @@ export default function ClearPathPanel() {
     load()
   }
 
-  if (!isSupported) {
-    return (
-      <div className="clearpath">
-        <div className="cp-disabled" role="status">
-          ClearPath isn’t available on {net?.name || 'this network'}. Switch to a network that supports DAO
-          governance (e.g. Ethereum for ENS/Uniswap, or Ethereum Classic Mordor for Olympia) to track and
-          manage DAOs.
-        </div>
-      </div>
-    )
-  }
-
-  if (selected) {
-    return (
-      <div className="clearpath">
-        <ExternalDaoView record={selected} reader={reader} signer={signer} account={account} chainId={chainId} usdcAddress={usdcAddress} onBack={() => setSelected(null)} />
-      </div>
-    )
-  }
+  const openDao = (d) => setSelected(d)
 
   return (
     <div className="clearpath">
-      <p className="cp-intro">
-        ClearPath — track and manage DAOs across networks on {net?.name || 'this network'}. Add an existing DAO by
-        address — an OpenZeppelin Governor (e.g. ENS, Olympia) or a Governor Bravo DAO (e.g. Uniswap) — and inspect
-        its live governance + treasury.
-        {!hasRegistry && ' On this network, DAOs you add are tracked on this device.'}
-      </p>
-
-      <div className="cp-tabs" role="tablist">
-        {TABS.map((t) => (
-          <button key={t.id} type="button" role="tab" aria-selected={tab === t.id} className={`cp-tab ${tab === t.id ? 'active' : ''}`} onClick={() => setTab(t.id)}>
-            {t.label}
-          </button>
-        ))}
-      </div>
-
-      {tab === 'daos' && (
-        <div role="tabpanel">
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '0.6rem', flexWrap: 'wrap', marginBottom: '0.75rem' }}>
-            <span className="cp-row-sub">DAOs on {net?.name || 'this network'}</span>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem' }}>
-              <ReadRouteToggle value={readRoute} onChange={setReadRoute} />
-              <button type="button" className="cp-btn" onClick={refresh} disabled={loading}>{loading ? 'Loading…' : 'Refresh'}</button>
+      {selected ? (
+        <ExternalDaoView
+          record={selected}
+          reader={readerFor(selected.chainId)}
+          signer={signer}
+          account={account}
+          chainId={selected.chainId}
+          usdcAddress={getContractAddressForChain('paymentToken', selected.chainId)}
+          onBack={() => setSelected(null)}
+        />
+      ) : (
+        <>
+          <p className="cp-intro">
+            ClearPath — track and manage DAOs across every supported network: an OpenZeppelin Governor (e.g. ENS,
+            Olympia) or a Governor Bravo DAO (e.g. Uniswap). Every DAO is listed regardless of which network your
+            wallet is currently on — you'll be asked to switch networks only when you act (register, vote, queue,
+            execute).
+          </p>
+          {!isSupported && (
+            <div className="cp-notice" role="status">
+              Your wallet is on {net?.name || 'a network'}, which doesn't run ClearPath — you can still browse the
+              DAOs below; switch to a supported network to register, track, or act on one.
             </div>
-          </div>
-          {error && <div className="cp-error" role="alert">{error}</div>}
-          {!loading && daos.length === 0 && !error && (
-            <p className="cp-empty">No DAOs tracked yet. Use “{hasRegistry ? 'Register' : 'Track'}” to add one.</p>
           )}
-          {daos.map((d) => (
-            <div key={d.id} className="cp-row" role="button" tabIndex={0}
-              onClick={() => setSelected(d)} onKeyDown={(e) => { if (e.key === 'Enter') setSelected(d) }}>
-              <div style={{ minWidth: 0 }}>
-                <div className="cp-row-name">{d.label || 'External DAO'}</div>
-                <div className="cp-row-sub">{short(d.dao)}</div>
-              </div>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem' }}>
-                <span className="cp-badge cp-badge-ext">{DAO_FRAMEWORK_LABEL[d.framework] || 'Unknown'}</span>
-                {d.source === 'local' && (
-                  <button
-                    type="button"
-                    className="cp-btn-link"
-                    aria-label={`Untrack ${d.label || short(d.dao)}`}
-                    onClick={(e) => { e.stopPropagation(); untrackDAO(d.dao); load() }}
-                  >
-                    Untrack
-                  </button>
-                )}
-                <span aria-hidden="true" style={{ color: 'var(--cp-text-3)' }}>›</span>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
 
-      {tab === 'register' && (
-        <div role="tabpanel">
-          <RegisterExternalDao
-            reader={reader}
-            track={trackDAO}
-            hasRegistry={hasRegistry}
-            onRegistered={() => { setTab('daos'); load() }}
-          />
-        </div>
+          <div className="cp-tabs" role="tablist">
+            <button type="button" role="tab" aria-selected={tab === 'daos'} className={`cp-tab ${tab === 'daos' ? 'active' : ''}`} onClick={() => setTab('daos')}>
+              DAOs
+            </button>
+            <button type="button" role="tab" aria-selected={tab === 'register'} className={`cp-tab ${tab === 'register' ? 'active' : ''}`} onClick={() => setTab('register')}>
+              Register / Track
+            </button>
+          </div>
+
+          {tab === 'daos' && (
+            <div role="tabpanel">
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '0.6rem', flexWrap: 'wrap', marginBottom: '0.75rem' }}>
+                <span className="cp-row-sub">DAOs across every supported network</span>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem' }}>
+                  <ReadRouteToggle value={readRoute} onChange={setReadRoute} />
+                  <button type="button" className="cp-btn" onClick={refresh} disabled={loading}>{loading ? 'Loading…' : 'Refresh'}</button>
+                </div>
+              </div>
+              {error && <div className="cp-error" role="alert">{error}</div>}
+              {!loading && daos.length === 0 && !error && (
+                <p className="cp-empty">No DAOs tracked yet. Use “Register / Track” to add one.</p>
+              )}
+              {daos.map((d) => (
+                <div key={`${d.chainId}:${d.id}`} className="cp-row" role="button" tabIndex={0}
+                  onClick={() => openDao(d)} onKeyDown={(e) => { if (e.key === 'Enter') openDao(d) }}>
+                  <div style={{ minWidth: 0 }}>
+                    <div className="cp-row-name">{d.label || 'External DAO'}</div>
+                    <div className="cp-row-sub">{short(d.dao)}</div>
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem' }}>
+                    <span className="cp-badge" title={`Network: ${d.networkName}`}>{d.networkName}</span>
+                    <span className="cp-badge cp-badge-ext">{DAO_FRAMEWORK_LABEL[d.framework] || 'Unknown'}</span>
+                    {d.source === 'local' && (
+                      <button
+                        type="button"
+                        className="cp-btn-link"
+                        aria-label={`Untrack ${d.label || short(d.dao)}`}
+                        onClick={(e) => { e.stopPropagation(); untrackDAO(d.dao, d.chainId); load() }}
+                      >
+                        Untrack
+                      </button>
+                    )}
+                    <span aria-hidden="true" style={{ color: 'var(--cp-text-3)' }}>›</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {tab === 'register' && (
+            <div role="tabpanel">
+              <RegisterExternalDao
+                connectedChainId={chainId}
+                connectedReader={reader}
+                chainIds={chainIds}
+                hasRegistryFor={hasRegistryFor}
+                readerFor={readerFor}
+                track={trackDAO}
+                onRegistered={() => { setTab('daos'); load() }}
+              />
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/frontend/src/components/clearpath/ExternalDaoView.jsx
+++ b/frontend/src/components/clearpath/ExternalDaoView.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { ethers } from 'ethers'
+import { useSwitchChain } from 'wagmi'
 import { getNetwork } from '../../config/networks'
 import { useNotification } from '../../hooks/useUI'
 import { useWallet } from '../../hooks/useWalletManagement'
@@ -111,12 +112,25 @@ export default function ExternalDaoView({ record, reader, signer, account, chain
   const { screenOne } = useAddressScreening()
   // Spec 041/050: a passkey smart-account session has no ethers signer — its writes go through `sendCalls`
   // (one sponsored ERC-4337 UserOp) instead of `signer`. `loginMethod` picks the rail.
-  const { sendCalls, loginMethod } = useWallet()
+  // `chainId` here is the CONNECTED wallet's chain — `chainId` (the prop) is the DAO's own network, which may
+  // differ now that ClearPath lists DAOs across every network at once (network-agnostic). A write can only be
+  // signed on the connected chain, so every action below is gated on the two matching.
+  const { chainId: connectedChainId, sendCalls, loginMethod } = useWallet()
   const isPasskey = loginMethod === 'passkey'
+  const { switchChainAsync, isPending: switching } = useSwitchChain()
+  const onConnectedChain = Number(chainId) === Number(connectedChainId)
   // Spec 043 (US3, FR-022a): acting on a DAO while operating as a vault becomes a threshold-gated vault proposal.
   const { isVault: operatingAsVault, canActAsVault, submit: submitAsActive } = useActiveAccount()
   const net = getNetwork(chainId)
   const explorerBase = (net?.explorer?.baseUrl || '').replace(/\/$/, '')
+
+  const handleSwitch = useCallback(async () => {
+    try {
+      await switchChainAsync({ chainId })
+    } catch (e) {
+      showNotification(e?.shortMessage || e?.message || 'Could not switch network.', 'error')
+    }
+  }, [switchChainAsync, chainId, showNotification])
 
   // Resolve the per-framework connector. A registry entry may carry a coarse framework and a device-local entry
   // the detected one; if it's absent/unknown, detect it live. Fall back to the OZ connector (framework 0) while
@@ -238,6 +252,13 @@ export default function ExternalDaoView({ record, reader, signer, account, chain
       showNotification('Connect a wallet to act on this DAO.', 'warning')
       return false
     }
+    // A write can only be signed on the DAO's own chain — the UI already gates the buttons behind a "Switch to
+    // X" prompt, but a passkey session's `sendCalls` targets the wallet's account on whatever chain it's on, so
+    // this is checked again here as the last line of defense (never send a signed action to the wrong network).
+    if (!onConnectedChain) {
+      showNotification(`Switch your wallet to ${net?.name || 'this DAO’s network'} to act on this DAO.`, 'warning')
+      return false
+    }
     // Sanctions posture (FR-013, spec 042): screen the connected signer where a platform sanctions source exists.
     // A confirmed `restricted` result (only possible where a SanctionsGuard is deployed) blocks the action,
     // fail-closed. `uncertain` (no source on this network, e.g. Ethereum mainnet, or an unreadable guard) does
@@ -317,6 +338,14 @@ export default function ExternalDaoView({ record, reader, signer, account, chain
           Tracked on {net?.name || 'this network'}. ClearPath holds no authority over this DAO — it reads its
           on-chain state and (where your wallet is authorized by the DAO's own rules) lets you act on it, signed by you.
         </p>
+        {!onConnectedChain && (
+          <div className="cp-notice" role="status" style={{ marginTop: '0.6rem', display: 'flex', alignItems: 'center', gap: '0.6rem', flexWrap: 'wrap' }}>
+            <span>Your wallet is on a different network — switch to {net?.name || 'this DAO’s network'} to vote, queue, execute, or propose.</span>
+            <button type="button" className="cp-btn cp-btn-primary" onClick={handleSwitch} disabled={switching}>
+              {switching ? 'Switching…' : `Switch to ${net?.name || 'this network'}`}
+            </button>
+          </div>
+        )}
       </div>
 
       {sumLoading && <div className="cp-notice" role="status">Reading live DAO state…</div>}
@@ -373,23 +402,31 @@ export default function ExternalDaoView({ record, reader, signer, account, chain
           Actions are signed by your wallet and gated by the DAO's own rules.
         </p>
 
-        <ProposalBuilder
-          record={record}
-          connector={connector}
-          signer={signer}
-          reader={reader}
-          account={account}
-          usdcAddress={usdcAddress}
-          nativeSymbol={net?.nativeCurrency?.symbol}
-          treasuries={treasuries}
-          fundingSources={treasuries
-            .filter((t) => t.funding)
-            .map((t) => ({ executor: t.funding.executor, label: t.label, address: t.address, native: t.native }))}
-          proposals={props.proposals}
-          run={run}
-          busy={busy}
-          onSubmitted={loadProposals}
-        />
+        {onConnectedChain ? (
+          <ProposalBuilder
+            record={record}
+            connector={connector}
+            signer={signer}
+            reader={reader}
+            account={account}
+            usdcAddress={usdcAddress}
+            nativeSymbol={net?.nativeCurrency?.symbol}
+            treasuries={treasuries}
+            fundingSources={treasuries
+              .filter((t) => t.funding)
+              .map((t) => ({ executor: t.funding.executor, label: t.label, address: t.address, native: t.native }))}
+            proposals={props.proposals}
+            run={run}
+            busy={busy}
+            onSubmitted={loadProposals}
+          />
+        ) : (
+          <div style={{ marginBottom: '0.8rem' }}>
+            <button type="button" className="cp-btn cp-btn-primary" onClick={handleSwitch} disabled={switching}>
+              {switching ? 'Switching…' : `Switch to ${net?.name || 'this network'} to propose`}
+            </button>
+          </div>
+        )}
 
         {propsLoading && <div className="cp-notice" role="status">Indexing proposals on-chain…</div>}
         {!propsLoading && !props.ok && (
@@ -457,19 +494,19 @@ export default function ExternalDaoView({ record, reader, signer, account, chain
               <div className="cp-row-actions" style={{ marginTop: '0.6rem' }}>
                 {canVote && (
                   <>
-                    <button type="button" className="cp-btn cp-btn-primary" disabled={busy} onClick={() => run('Vote For', managedTx('castVote', { proposalId: p.id, support: VOTE_SUPPORT.For }, () => connector.castVote(signer, record.dao, p.id, VOTE_SUPPORT.For)))}>Vote For</button>
-                    <button type="button" className="cp-btn" disabled={busy} onClick={() => run('Vote Against', managedTx('castVote', { proposalId: p.id, support: VOTE_SUPPORT.Against }, () => connector.castVote(signer, record.dao, p.id, VOTE_SUPPORT.Against)))}>Against</button>
-                    <button type="button" className="cp-btn" disabled={busy} onClick={() => run('Vote Abstain', managedTx('castVote', { proposalId: p.id, support: VOTE_SUPPORT.Abstain }, () => connector.castVote(signer, record.dao, p.id, VOTE_SUPPORT.Abstain)))}>Abstain</button>
+                    <button type="button" className="cp-btn cp-btn-primary" disabled={busy || !onConnectedChain} title={onConnectedChain ? undefined : `Switch to ${net?.name || 'this network'} to vote`} onClick={() => run('Vote For', managedTx('castVote', { proposalId: p.id, support: VOTE_SUPPORT.For }, () => connector.castVote(signer, record.dao, p.id, VOTE_SUPPORT.For)))}>Vote For</button>
+                    <button type="button" className="cp-btn" disabled={busy || !onConnectedChain} title={onConnectedChain ? undefined : `Switch to ${net?.name || 'this network'} to vote`} onClick={() => run('Vote Against', managedTx('castVote', { proposalId: p.id, support: VOTE_SUPPORT.Against }, () => connector.castVote(signer, record.dao, p.id, VOTE_SUPPORT.Against)))}>Against</button>
+                    <button type="button" className="cp-btn" disabled={busy || !onConnectedChain} title={onConnectedChain ? undefined : `Switch to ${net?.name || 'this network'} to vote`} onClick={() => run('Vote Abstain', managedTx('castVote', { proposalId: p.id, support: VOTE_SUPPORT.Abstain }, () => connector.castVote(signer, record.dao, p.id, VOTE_SUPPORT.Abstain)))}>Abstain</button>
                   </>
                 )}
-                {p.state === 4 && <button type="button" className="cp-btn cp-btn-primary" disabled={busy} onClick={() => run('Queue', managedTx('queue', { p }, () => connector.queue(signer, record.dao, p)))}>Queue</button>}
+                {p.state === 4 && <button type="button" className="cp-btn cp-btn-primary" disabled={busy || !onConnectedChain} title={onConnectedChain ? undefined : `Switch to ${net?.name || 'this network'} to queue`} onClick={() => run('Queue', managedTx('queue', { p }, () => connector.queue(signer, record.dao, p)))}>Queue</button>}
                 {p.state === 5 && (
                   <button
                     type="button"
                     className="cp-btn cp-btn-primary"
-                    disabled={busy || !executeReady}
-                    aria-disabled={busy || !executeReady}
-                    title={executeReady ? undefined : 'Waiting for the timelock delay to elapse'}
+                    disabled={busy || !executeReady || !onConnectedChain}
+                    aria-disabled={busy || !executeReady || !onConnectedChain}
+                    title={!onConnectedChain ? `Switch to ${net?.name || 'this network'} to execute` : executeReady ? undefined : 'Waiting for the timelock delay to elapse'}
                     onClick={() => run('Execute', managedTx('execute', { p }, () => connector.execute(signer, record.dao, p)))}
                   >
                     Execute

--- a/frontend/src/components/clearpath/RegisterExternalDao.jsx
+++ b/frontend/src/components/clearpath/RegisterExternalDao.jsx
@@ -1,20 +1,36 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { ethers } from 'ethers'
+import { useSwitchChain } from 'wagmi'
+import { getNetwork } from '../../config/networks'
 import { DAO_FRAMEWORK_LABEL } from '../../abis/externalDAORegistry'
 import { detectFramework, getConnector } from './connectors'
 import CpAddressField from './CpAddressField'
 
-// Spec 030 + 042 — register/track an existing DAO deployed by another platform. Validation is framework-aware:
-// it detects OpenZeppelin Governor vs GovernorBravo client-side (a fast mirror of the on-chain probe) before
-// tracking. On a network with an on-chain registry (Mordor) tracking is a real register tx; on a registry-less
-// network (Ethereum mainnet) it is a device-local add — either way ClearPath takes no custody; you sign every
-// governance action. The contract / DAO's own rules remain the source of truth.
+// Spec 030 + 042, network-agnostic follow-up — register/track an existing DAO deployed by another platform, on
+// ANY clearpath-capable network (not just the one the wallet happens to be connected to). Validation always
+// reads over the target network's own RPC (no switch required). On a network with an on-chain registry
+// (Mordor) tracking is a real register tx, which — because a signer can only sign for its connected chain —
+// requires the wallet to actually switch to that network first; on a registry-less network (e.g. Ethereum
+// mainnet) tracking is a device-local add and needs no network switch at all. Either way ClearPath takes no
+// custody; you sign every governance action. The contract / DAO's own rules remain the source of truth.
 
-export default function RegisterExternalDao({ reader, track, hasRegistry, onRegistered }) {
+export default function RegisterExternalDao({ connectedChainId, connectedReader, chainIds = [], hasRegistryFor, readerFor, track, onRegistered }) {
+  const { switchChainAsync, isPending: switching } = useSwitchChain()
+  const [targetChainId, setTargetChainId] = useState(() =>
+    chainIds.includes(connectedChainId) ? connectedChainId : chainIds[0]
+  )
   const [addr, setAddr] = useState('')
   const [label, setLabel] = useState('')
   const [check, setCheck] = useState(null) // { ok, name, framework, reason }
   const [busy, setBusy] = useState(false)
+
+  const targetReader = useMemo(
+    () => (Number(targetChainId) === Number(connectedChainId) ? connectedReader : readerFor?.(targetChainId)),
+    [targetChainId, connectedChainId, connectedReader, readerFor]
+  )
+  const hasRegistry = Boolean(hasRegistryFor?.(targetChainId))
+  const onConnectedChain = Number(targetChainId) === Number(connectedChainId)
+  const needsSwitch = hasRegistry && !onConnectedChain
 
   async function doValidate() {
     setCheck(null)
@@ -23,14 +39,14 @@ export default function RegisterExternalDao({ reader, track, hasRegistry, onRegi
       setCheck({ ok: false, reason: 'Not a valid address.' })
       return
     }
-    const framework = await detectFramework(reader, target)
+    const framework = await detectFramework(targetReader, target)
     if (framework === 'unknown') {
       setCheck({ ok: false, reason: 'Not a recognized governance contract (OpenZeppelin Governor or Governor Bravo).' })
       return
     }
     // Use the matched connector's richer validate for the on-chain name, when available.
     const conn = getConnector(framework)
-    const result = conn?.validate ? await conn.validate(reader, target) : { ok: true, name: '' }
+    const result = conn?.validate ? await conn.validate(targetReader, target) : { ok: true, name: '' }
     const next = { ...result, ok: result.ok !== false, framework }
     setCheck(next)
     if (next.ok && !label) setLabel(next.name || '')
@@ -39,7 +55,7 @@ export default function RegisterExternalDao({ reader, track, hasRegistry, onRegi
   async function doTrack() {
     setBusy(true)
     try {
-      await track({ address: addr.trim(), framework: check?.framework ?? null, label: label.trim() })
+      await track({ address: addr.trim(), framework: check?.framework ?? null, label: label.trim(), chainId: targetChainId })
       setAddr('')
       setLabel('')
       setCheck(null)
@@ -51,6 +67,14 @@ export default function RegisterExternalDao({ reader, track, hasRegistry, onRegi
     }
   }
 
+  async function doSwitch() {
+    try {
+      await switchChainAsync({ chainId: targetChainId })
+    } catch {
+      /* the wallet's own reject/error UI already surfaces this */
+    }
+  }
+
   const valid = check?.ok === true
   const actionLabel = hasRegistry ? 'Register DAO' : 'Track DAO'
 
@@ -58,23 +82,45 @@ export default function RegisterExternalDao({ reader, track, hasRegistry, onRegi
     <div className="cp-card">
       <h4 style={{ marginBottom: '0.6rem' }}>{hasRegistry ? 'Register an external DAO' : 'Track a DAO'}</h4>
       <p className="cp-intro">
-        Track and (where authorized) act on a DAO deployed by another platform — an OpenZeppelin Governor (e.g.
-        ENS, Olympia) or a Governor Bravo DAO (e.g. Uniswap). ClearPath takes no custody or authority; you sign
-        every action.
+        Track and (where authorized) act on a DAO deployed by another platform, on any supported network — an
+        OpenZeppelin Governor (e.g. ENS, Olympia) or a Governor Bravo DAO (e.g. Uniswap). ClearPath takes no
+        custody or authority; you sign every action.
         {hasRegistry
           ? ' Registering records it on-chain for shared discovery (requires a Silver+ membership).'
           : ' This network has no on-chain registry, so the DAO is tracked on this device.'}
       </p>
+
+      <div className="cp-field">
+        <label className="cp-label" htmlFor="cp-dao-network">Network</label>
+        <select
+          id="cp-dao-network"
+          className="cp-input cp-select"
+          value={targetChainId}
+          onChange={(e) => { setTargetChainId(Number(e.target.value)); setCheck(null) }}
+          disabled={busy}
+        >
+          {chainIds.map((id) => (
+            <option key={id} value={id}>{getNetwork(id)?.name || id}</option>
+          ))}
+        </select>
+      </div>
+
       <CpAddressField id="cp-dao-addr" label="Governor address" value={addr} onChange={setAddr} disabled={busy} />
       <div className="cp-field">
         <label className="cp-label" htmlFor="cp-dao-label">Label (optional)</label>
         <input id="cp-dao-label" className="cp-input" value={label} onChange={(e) => setLabel(e.target.value)} placeholder="Uniswap" />
       </div>
       <div className="cp-row-actions">
-        <button type="button" className="cp-btn" disabled={!ethers.isAddress(addr.trim())} onClick={doValidate}>Validate</button>
-        <button type="button" className="cp-btn cp-btn-primary" disabled={!valid || busy} onClick={doTrack}>
-          {busy ? `${actionLabel.replace(/ DAO$/, '')}ing…` : actionLabel}
-        </button>
+        <button type="button" className="cp-btn" disabled={!ethers.isAddress(addr.trim()) || busy} onClick={doValidate}>Validate</button>
+        {needsSwitch ? (
+          <button type="button" className="cp-btn cp-btn-primary" disabled={!valid || busy || switching} onClick={doSwitch}>
+            {switching ? 'Switching…' : `Switch to ${getNetwork(targetChainId)?.name || 'this network'} to register`}
+          </button>
+        ) : (
+          <button type="button" className="cp-btn cp-btn-primary" disabled={!valid || busy} onClick={doTrack}>
+            {busy ? `${actionLabel.replace(/ DAO$/, '')}ing…` : actionLabel}
+          </button>
+        )}
       </div>
       {check && (
         check.ok

--- a/frontend/src/components/clearpath/__tests__/ClearPathPanel.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ClearPathPanel.test.jsx
@@ -3,15 +3,26 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import ClearPathPanel from '../ClearPathPanel'
 
-// Spec 030 (US3) — the ClearPath panel: lists external DAOs from the on-chain registry, opens a live tracking
-// view (Olympia), registers a new DAO, and self-disables truthfully on unsupported networks. No mock data in
-// the product — the tests mock the hook/connector to drive the components deterministically.
+// Spec 030/042 + network-agnostic follow-up — the ClearPath panel: lists external DAOs across every supported
+// network at once, opens a live tracking view (Olympia), registers/tracks a new DAO on a chosen network, and
+// shows a non-blocking switch prompt when the wallet isn't on a ClearPath-capable network (the list itself
+// never disables). No mock data in the product — the tests mock the hook/connector to drive the components
+// deterministically.
 
+const switchChainAsync = vi.fn().mockResolvedValue({})
+vi.mock('wagmi', () => ({ useSwitchChain: () => ({ switchChainAsync, isPending: false }) }))
+
+// A stable reader instance — `readerFor` must return the SAME reference across renders (like the real hook's
+// cached provider), or an effect keyed on `reader` identity re-fires every render and loops forever.
+const STABLE_READER = {}
 const cp = {
   isSupported: true,
-  hasRegistry: true,
   chainId: 63,
-  reader: {},
+  chainIds: [63],
+  hasRegistryFor: (id) => Number(id) === 63,
+  reader: STABLE_READER,
+  readerFor: () => STABLE_READER,
+  signer: {},
   account: '0xabc',
   isConnected: true,
   readRoute: 'public',
@@ -23,11 +34,11 @@ const cp = {
 }
 vi.mock('../useClearPath', () => ({ useClearPath: () => cp }))
 vi.mock('../../../hooks/useUI', () => ({ useNotification: () => ({ showNotification: vi.fn() }) }))
-// ExternalDaoView (rendered within) now reads sendCalls/loginMethod from useWallet (passkey rail);
-// these tests drive the classic signer-prop path, so return a non-passkey session.
-vi.mock('../../../hooks/useWalletManagement', () => ({
-  useWallet: () => ({ loginMethod: 'injected', sendCalls: undefined }),
-}))
+// ExternalDaoView (rendered within) now reads sendCalls/loginMethod/chainId from useWallet (passkey rail +
+// switch-to-act gating); these tests drive the classic signer-prop path on the SAME chain as the DAO (63) by
+// default — a `mockReturnValue` override lets one test move the wallet to a different chain.
+const useWalletMock = vi.fn(() => ({ loginMethod: 'injected', sendCalls: undefined, chainId: 63 }))
+vi.mock('../../../hooks/useWalletManagement', () => ({ useWallet: (...a) => useWalletMock(...a) }))
 
 const conn = { validateGovernor: vi.fn(), readGovernorSummary: vi.fn(), fetchGovernorProposals: vi.fn(), readTreasuries: vi.fn(), readVoterState: vi.fn(), readProposalEta: vi.fn(), detectTreasuryFunding: vi.fn() }
 vi.mock('../governorConnector', () => ({
@@ -87,6 +98,7 @@ vi.mock('../../../config/networks', () => ({
     nativeCurrency: { symbol: 'ETC' },
   }),
 }))
+vi.mock('../../../config/contracts', () => ({ getContractAddressForChain: () => null }))
 
 // CpAddressField (governor/recipient inputs) pulls in AddressBookButton → useWallet, which throws without a
 // WalletProvider. Stub the wallet-scoped hooks so register + tracking views render the real fields in tests.
@@ -94,12 +106,15 @@ vi.mock('../../../hooks/useAddressBook', () => ({ useAddressBook: () => ({ searc
 vi.mock('../../../hooks/useAddressScreening', () => ({ useAddressScreening: () => ({ getStatus: () => 'clear', screen: vi.fn(), screenOne: () => Promise.resolve('clear') }) }))
 
 const OLYMPIA = '0xB85dbc899472756470EF4033b9637ff8fa2FD23D'
-const olympiaRecord = { id: 1, dao: OLYMPIA, framework: 0, label: 'Olympia DAO', registrant: '0xabc', registeredAt: 1700000000 }
+const olympiaRecord = { id: 1, dao: OLYMPIA, framework: 0, label: 'Olympia DAO', registrant: '0xabc', registeredAt: 1700000000, chainId: 63, networkName: 'Ethereum Classic Mordor' }
 
-describe('ClearPathPanel (spec 030 / US3)', () => {
+describe('ClearPathPanel (spec 030/042, network-agnostic)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     cp.isSupported = true
+    cp.chainId = 63
+    cp.chainIds = [63]
+    useWalletMock.mockReturnValue({ loginMethod: 'injected', sendCalls: undefined, chainId: 63 })
     cp.listExternalDAOs.mockResolvedValue([olympiaRecord])
     conn.readGovernorSummary.mockResolvedValue({ clockMode: 'mode=blocknumber' })
     conn.fetchGovernorProposals.mockResolvedValue({ ok: true, proposals: [], scannedFrom: 16000000, scannedTo: 16500000, partial: false })
@@ -109,16 +124,18 @@ describe('ClearPathPanel (spec 030 / US3)', () => {
     conn.detectTreasuryFunding.mockResolvedValue(null)
   })
 
-  it('self-disables truthfully on an unsupported network', async () => {
+  it('shows a non-blocking switch notice on an unsupported network, but still lists DAOs from every network', async () => {
     cp.isSupported = false
     render(<ClearPathPanel />)
-    expect(screen.getByText(/ClearPath isn’t available/i)).toBeInTheDocument()
+    expect(screen.getByText(/doesn't run ClearPath/i)).toBeInTheDocument()
+    expect(await screen.findByText('Olympia DAO')).toBeInTheDocument()
   })
 
-  it('lists external DAOs from the on-chain registry', async () => {
+  it('lists external DAOs with a network badge', async () => {
     render(<ClearPathPanel />)
     expect(await screen.findByText('Olympia DAO')).toBeInTheDocument()
     expect(screen.getByText('OpenZeppelin Governor')).toBeInTheDocument()
+    expect(screen.getByText('Ethereum Classic Mordor')).toBeInTheDocument()
   })
 
   it('opens a live tracking view for a registered DAO', async () => {
@@ -168,8 +185,28 @@ describe('ClearPathPanel (spec 030 / US3)', () => {
     expect(screen.getByText('Active', { selector: '.cp-badge' })).toBeInTheDocument()
     // the proposal timeline surfaces the voting window position
     expect(screen.getByLabelText('Proposal timeline')).toBeInTheDocument()
-    // US5: an Active proposal offers vote actions
-    expect(screen.getByRole('button', { name: /vote for/i })).toBeInTheDocument()
+    // US5: an Active proposal offers vote actions, enabled since the wallet is on the DAO's own chain
+    const voteFor = screen.getByRole('button', { name: /vote for/i })
+    expect(voteFor).toBeInTheDocument()
+    expect(voteFor).not.toBeDisabled()
+  })
+
+  it('disables vote actions and offers a switch prompt when the wallet is on a different network', async () => {
+    conn.fetchGovernorProposals.mockResolvedValue({
+      ok: true, partial: false, scannedFrom: 16000000, scannedTo: 16500000,
+      proposals: [
+        { id: '42', proposer: '0xB85dbc899472756470EF4033b9637ff8fa2FD23D', description: 'Fund core dev', targets: [], values: [], calldatas: [], descriptionHash: '0x', voteStart: '1', voteEnd: '2', state: 1, votes: { for: '3', against: '1', abstain: '0' } },
+      ],
+    })
+    // Two networks in scope; the wallet is connected to the OTHER one (137, not the DAO's own 63).
+    cp.chainId = 137
+    cp.chainIds = [63, 137]
+    useWalletMock.mockReturnValue({ loginMethod: 'injected', sendCalls: undefined, chainId: 137 })
+    const user = userEvent.setup()
+    render(<ClearPathPanel />)
+    await user.click(await screen.findByText('Olympia DAO'))
+    expect(await screen.findByRole('button', { name: /^switch to ethereum classic mordor$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /vote for/i })).toBeDisabled()
   })
 
   it('shows the user vote receipt and hides vote buttons once they have voted', async () => {
@@ -218,9 +255,10 @@ describe('ClearPathPanel (spec 030 / US3)', () => {
     expect(await navigator.clipboard.readText()).toBe('123456789012345678')
   })
 
-  it('validates then registers a new external DAO', async () => {
+  it('validates then registers a new external DAO on the selected network', async () => {
     conn.validateGovernor.mockResolvedValue({ ok: true, name: 'OlympiaGovernor', reason: '' })
     cp.registerExternalDAO.mockResolvedValue({})
+    cp.trackDAO.mockResolvedValue({})
     const user = userEvent.setup()
     render(<ClearPathPanel />)
     await user.click(screen.getByRole('tab', { name: /register/i }))
@@ -229,8 +267,8 @@ describe('ClearPathPanel (spec 030 / US3)', () => {
     expect(await screen.findByText(/Recognized governance contract/i)).toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: /register dao/i }))
     await waitFor(() =>
-      expect(cp.registerExternalDAO).toHaveBeenCalledWith(
-        expect.objectContaining({ dao: OLYMPIA, framework: 0 })
+      expect(cp.trackDAO).toHaveBeenCalledWith(
+        expect.objectContaining({ address: OLYMPIA, framework: 0, chainId: 63 })
       )
     )
   })

--- a/frontend/src/components/clearpath/__tests__/ExternalDaoView.notifications.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/ExternalDaoView.notifications.test.jsx
@@ -18,11 +18,13 @@ const h = vi.hoisted(() => ({
 }))
 
 vi.mock('../../../hooks/useUI', () => ({ useNotification: () => ({ showNotification: h.showNotification }) }))
-// The view now reads sendCalls/loginMethod from useWallet (passkey rail); these tests drive the
-// classic signer-prop path, so return a non-passkey session.
-vi.mock('../../../hooks/useWalletManagement', () => ({
-  useWallet: () => ({ loginMethod: 'injected', sendCalls: undefined }),
-}))
+// The view now reads sendCalls/loginMethod/chainId from useWallet (passkey rail + switch-to-act gating); these
+// tests drive the classic signer-prop path on the SAME chain as the DAO (63, matching renderView below) by
+// default — a `mockReturnValue` override lets one test move the wallet to a different chain.
+const useWalletMock = vi.fn(() => ({ loginMethod: 'injected', sendCalls: undefined, chainId: 63 }))
+vi.mock('../../../hooks/useWalletManagement', () => ({ useWallet: (...a) => useWalletMock(...a) }))
+const switchChainAsync = vi.fn().mockResolvedValue({})
+vi.mock('wagmi', () => ({ useSwitchChain: () => ({ switchChainAsync, isPending: false }) }))
 vi.mock('../governorConnector', () => ({
   readGovernorSummary: (...a) => h.readGovernorSummary(...a),
   readTreasuries: (...a) => h.readTreasuries(...a),
@@ -96,6 +98,7 @@ function renderView(signer, account = '0x0000000000000000000000000000000000000Ac
 describe('ExternalDaoView notifications (spec 030 / US5)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    useWalletMock.mockReturnValue({ loginMethod: 'injected', sendCalls: undefined, chainId: 63 })
     h.screenStatus = 'clear'
     h.readGovernorSummary.mockResolvedValue({
       name: 'OlympiaGovernor', tokenAddr: '0x0000000000000000000000000000000000000111', tokenName: 'Olympia Member',
@@ -163,5 +166,24 @@ describe('ExternalDaoView notifications (spec 030 / US5)', () => {
     await waitFor(() => expect(screen.getByRole('button', { name: /vote for/i })).not.toBeDisabled())
     expect(h.showNotification).not.toHaveBeenCalledWith(expect.stringContaining('confirmed'), 'success')
     expect(h.showNotification).not.toHaveBeenCalledWith(expect.stringContaining('failed'), 'error')
+  })
+
+  it('network-agnostic follow-up: disables voting and offers a switch prompt when the wallet is on a different chain than the DAO', async () => {
+    useWalletMock.mockReturnValue({ loginMethod: 'injected', sendCalls: undefined, chainId: 137 }) // DAO is on 63 (renderView)
+    const user = userEvent.setup()
+    renderView({})
+    const voteFor = await screen.findByRole('button', { name: /vote for/i })
+    expect(voteFor).toBeDisabled()
+    expect(await screen.findByRole('button', { name: /^switch to ethereum classic mordor$/i })).toBeInTheDocument()
+    await user.click(voteFor)
+    expect(h.castVote).not.toHaveBeenCalled()
+  })
+
+  it('network-agnostic follow-up: the switch button calls switchChainAsync with the DAO’s own chain', async () => {
+    useWalletMock.mockReturnValue({ loginMethod: 'injected', sendCalls: undefined, chainId: 137 })
+    const user = userEvent.setup()
+    renderView({})
+    await user.click(await screen.findByRole('button', { name: /^switch to ethereum classic mordor$/i }))
+    expect(switchChainAsync).toHaveBeenCalledWith({ chainId: 63 })
   })
 })

--- a/frontend/src/components/clearpath/__tests__/RegisterExternalDao.test.jsx
+++ b/frontend/src/components/clearpath/__tests__/RegisterExternalDao.test.jsx
@@ -3,45 +3,61 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import RegisterExternalDao from '../RegisterExternalDao'
 
-// Spec 042 US2 — register/track flow. Client-side framework detection (OZ vs Bravo) gates validation; on a
-// registry-less network the submit routes to trackDAO (device-local). Invalid/unknown addresses are rejected
+// Spec 042 US2 + network-agnostic follow-up — register/track flow, now with an explicit target-network picker
+// (any clearpath-capable chain, not just the connected one). Client-side framework detection (OZ vs Bravo) gates
+// validation; on a registry-less TARGET network the submit routes to trackDAO (device-local) with no network
+// switch required. On a registry TARGET network, a wallet connected elsewhere is offered a "Switch to X" prompt
+// instead of Register — a signer can only write on its connected chain. Invalid/unknown addresses are rejected
 // with a truthful reason and nothing is tracked.
 
-const h = vi.hoisted(() => ({ detect: vi.fn(), track: vi.fn() }))
+const h = vi.hoisted(() => ({ detect: vi.fn(), track: vi.fn(), switchChainAsync: vi.fn().mockResolvedValue({}) }))
 
 vi.mock('../connectors', () => ({
   detectFramework: (...a) => h.detect(...a),
   getConnector: (fw) => ({ framework: fw, validate: async () => ({ ok: true, name: 'Uniswap Governor Bravo' }) }),
 }))
+vi.mock('wagmi', () => ({ useSwitchChain: () => ({ switchChainAsync: h.switchChainAsync, isPending: false }) }))
+vi.mock('../../../config/networks', () => ({ getNetwork: (id) => ({ name: `Network ${id}` }) }))
 // CpAddressField → AddressBookButton → wallet hooks would throw without a provider.
 vi.mock('../../../hooks/useAddressBook', () => ({ useAddressBook: () => ({ search: () => [] }) }))
 vi.mock('../../../hooks/useAddressScreening', () => ({ useAddressScreening: () => ({ getStatus: () => 'clear', screen: vi.fn() }) }))
 
 const ADDR = '0x408ED6354d4973f66138C91495F2f2FCbd8724C3'
+const STABLE_READER = {} // referential stability matters — see useClearPath's own cachedReadProvider comment
 
-function renderForm(hasRegistry = false) {
-  return render(<RegisterExternalDao reader={{}} track={h.track} hasRegistry={hasRegistry} onRegistered={() => {}} />)
+function renderForm({ hasRegistryChainIds = [], chainIds = [63], connectedChainId = 63 } = {}) {
+  return render(
+    <RegisterExternalDao
+      connectedChainId={connectedChainId}
+      connectedReader={STABLE_READER}
+      chainIds={chainIds}
+      hasRegistryFor={(id) => hasRegistryChainIds.includes(Number(id))}
+      readerFor={() => STABLE_READER}
+      track={h.track}
+      onRegistered={() => {}}
+    />
+  )
 }
 
-describe('RegisterExternalDao registry-less track (spec 042 US2)', () => {
+describe('RegisterExternalDao (spec 042 US2, network-agnostic)', () => {
   beforeEach(() => vi.clearAllMocks())
 
   it('detects the framework, then tracks device-local on a registry-less network', async () => {
     h.detect.mockResolvedValue(1) // GovernorBravo
     h.track.mockResolvedValue({ added: true })
     const user = userEvent.setup()
-    renderForm(false)
+    renderForm({ hasRegistryChainIds: [] })
     await user.type(screen.getByLabelText(/governor address/i), ADDR)
     await user.click(screen.getByRole('button', { name: /validate/i }))
     await waitFor(() => expect(screen.getByText(/Recognized Governor Bravo contract/i)).toBeInTheDocument())
     await user.click(screen.getByRole('button', { name: /track dao/i }))
-    await waitFor(() => expect(h.track).toHaveBeenCalledWith(expect.objectContaining({ address: ADDR, framework: 1 })))
+    await waitFor(() => expect(h.track).toHaveBeenCalledWith(expect.objectContaining({ address: ADDR, framework: 1, chainId: 63 })))
   })
 
   it('rejects an unrecognized contract with a truthful reason — nothing tracked', async () => {
     h.detect.mockResolvedValue('unknown')
     const user = userEvent.setup()
-    renderForm(false)
+    renderForm({ hasRegistryChainIds: [] })
     await user.type(screen.getByLabelText(/governor address/i), ADDR)
     await user.click(screen.getByRole('button', { name: /validate/i }))
     await waitFor(() => expect(screen.getByText(/Not a recognized governance contract/i)).toBeInTheDocument())
@@ -49,9 +65,31 @@ describe('RegisterExternalDao registry-less track (spec 042 US2)', () => {
     expect(h.track).not.toHaveBeenCalled()
   })
 
-  it('labels the primary action "Register DAO" on a registry network', async () => {
+  it('labels the primary action "Register DAO" on a registry network the wallet is already connected to', async () => {
     h.detect.mockResolvedValue(0)
-    renderForm(true)
+    renderForm({ hasRegistryChainIds: [63], chainIds: [63], connectedChainId: 63 })
     expect(screen.getByRole('button', { name: /register dao/i })).toBeInTheDocument()
+  })
+
+  it('defaults the network picker to the connected chain when it is in scope', () => {
+    renderForm({ hasRegistryChainIds: [], chainIds: [61, 63], connectedChainId: 63 })
+    expect(screen.getByLabelText(/network/i)).toHaveValue('63')
+  })
+
+  it('offers a Switch prompt instead of Register when the chosen network has a registry and the wallet is elsewhere', async () => {
+    h.detect.mockResolvedValue(0)
+    const user = userEvent.setup()
+    // Wallet is connected to 137; the DAO is registered on 63, which the member selects explicitly.
+    renderForm({ hasRegistryChainIds: [63], chainIds: [63, 137], connectedChainId: 137 })
+    await user.selectOptions(screen.getByLabelText(/network/i), '63')
+    expect(screen.queryByRole('button', { name: /^register dao$/i })).not.toBeInTheDocument()
+    const switchBtn = screen.getByRole('button', { name: /switch to network 63/i })
+    expect(switchBtn).toBeInTheDocument()
+    await user.type(screen.getByLabelText(/governor address/i), ADDR)
+    await user.click(screen.getByRole('button', { name: /validate/i }))
+    await waitFor(() => expect(screen.getByText(/Recognized/i)).toBeInTheDocument())
+    await user.click(screen.getByRole('button', { name: /switch to network 63/i }))
+    expect(h.switchChainAsync).toHaveBeenCalledWith({ chainId: 63 })
+    expect(h.track).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/clearpath/__tests__/useClearPath.multinetwork.test.js
+++ b/frontend/src/components/clearpath/__tests__/useClearPath.multinetwork.test.js
@@ -13,6 +13,9 @@ vi.mock('../../../hooks/useWalletManagement', () => ({
 }))
 // Isolate the tracked-list behavior from the curated known-DAO seeds (ENS/Uniswap) on mainnet.
 vi.mock('../../../config/clearpath/knownDaos', () => ({ knownDaosForChain: () => [] }))
+// No on-chain registry anywhere in this suite — keeps the network-agnostic aggregate scan (every clearpath
+// chain) from making a real registry contract read against a live RPC.
+vi.mock('../../../config/contracts', () => ({ getContractAddressForChain: () => null }))
 
 describe('useClearPath on a registry-less network (spec 042)', () => {
   beforeEach(() => window.localStorage.clear())
@@ -40,5 +43,37 @@ describe('useClearPath on a registry-less network (spec 042)', () => {
     act(() => result.current.setReadRoute('wallet'))
     expect(result.current.readRoute).toBe('wallet')
     expect(window.localStorage.getItem('clearpath.readRoute.v1')).toBe('wallet')
+  })
+})
+
+describe('useClearPath network-agnostic listing (network-agnostic follow-up to spec 042)', () => {
+  beforeEach(() => window.localStorage.clear())
+
+  it('exposes every clearpath-capable chain, not just the connected one', () => {
+    const { result } = renderHook(() => useClearPath())
+    expect(result.current.chainIds.length).toBeGreaterThan(1)
+    expect(result.current.chainIds).toContain(1) // the connected chain is always included
+  })
+
+  it('tracking a DAO on a network the wallet is NOT connected to needs no network switch (registry-less), and the aggregate list tags it with its own chain', async () => {
+    const { result } = renderHook(() => useClearPath())
+    await act(async () => {
+      await result.current.trackDAO({ address: '0xUNI000000000000000000000000000000000001', framework: 1, label: 'Uniswap', chainId: 137 })
+    })
+    const list = await result.current.listExternalDAOs()
+    const uni = list.find((d) => d.label === 'Uniswap')
+    expect(uni).toBeDefined()
+    expect(uni.chainId).toBe(137)
+    expect(uni.source).toBe('local')
+  })
+
+  it('scopes tracked DAOs strictly per chain — a DAO tracked on chain 137 never leaks into chain 1s scope', async () => {
+    const { result } = renderHook(() => useClearPath())
+    await act(async () => {
+      await result.current.trackDAO({ address: '0xUNI000000000000000000000000000000000001', framework: 1, label: 'Uniswap', chainId: 137 })
+    })
+    const list = await result.current.listExternalDAOs()
+    const onMainnet = list.filter((d) => d.chainId === 1)
+    expect(onMainnet.find((d) => d.label === 'Uniswap')).toBeUndefined()
   })
 })

--- a/frontend/src/components/clearpath/useClearPath.js
+++ b/frontend/src/components/clearpath/useClearPath.js
@@ -3,7 +3,7 @@ import { ethers } from 'ethers'
 import { useWallet } from '../../hooks/useWalletManagement'
 import { useNotification } from '../../hooks/useUI'
 import { getContractAddressForChain } from '../../config/contracts'
-import { getNetwork } from '../../config/networks'
+import { getNetwork, getClearPathChainIds } from '../../config/networks'
 import { makeReadProvider } from '../../utils/rpcProvider'
 import { EXTERNAL_DAO_REGISTRY_ABI } from '../../abis/externalDAORegistry'
 import * as trackedDaoStore from './trackedDaoStore'
@@ -38,15 +38,26 @@ function cachedReadProvider(rpcUrl, chainId) {
   return p
 }
 
+/** Whether an on-chain ExternalDAORegistry is deployed on `targetChainId`. */
+function hasRegistryOn(targetChainId) {
+  return ethers.isAddress(getContractAddressForChain('externalDAORegistry', targetChainId) || '')
+}
+
 /**
  * Spec 030 + 042 — ClearPath hook.
  *
- * Availability is now capability-driven (spec 042): ClearPath runs on any network that declares the `clearpath`
+ * Availability is capability-driven (spec 042): ClearPath runs on any network that declares the `clearpath`
  * capability AND has a live reader — it does NOT require a deployed ExternalDAORegistry. Where a registry exists
  * (e.g. Mordor) it is used as a shared-discovery overlay and MERGED with the member's device-local tracked list;
  * where it does not (e.g. Ethereum mainnet), the device-local list is the source and a member tracks a DAO by
- * address with no on-chain write. Everything stays strictly network-scoped (FR-014). Reads default to the
- * network's public RPC with a wallet-managed routing option (FR-019); writes always use the wallet signer.
+ * address with no on-chain write.
+ *
+ * Network-agnostic listing (follow-up to spec 042, mirroring the Portfolio pattern in usePortfolio.js):
+ * `listExternalDAOs()` scans EVERY `clearpath`-capable network in parallel over each network's own read
+ * provider, independent of which chain the wallet is connected to — so a member sees every known/tracked DAO
+ * across all networks at once. Reads degrade per-network (a bad RPC on one chain never blanks the others);
+ * writes are unaffected and still require the wallet to actually be on the target DAO's chain (checked by the
+ * caller before invoking `registerExternalDAO`, and by `ExternalDaoView` before a vote/queue/execute).
  */
 export function useClearPath() {
   // Spec 041/050: passkey smart-account sessions have no `signer`; their writes go through `sendCalls`
@@ -55,6 +66,7 @@ export function useClearPath() {
   const isPasskey = loginMethod === 'passkey'
   const { showNotification } = useNotification()
 
+  const chainIds = useMemo(() => getClearPathChainIds(), [])
   const net = getNetwork(chainId)
   const registryAddress = getContractAddressForChain('externalDAORegistry', chainId)
   const usdcAddress = getContractAddressForChain('paymentToken', chainId) // per-network USDC for treasury balances
@@ -63,13 +75,25 @@ export function useClearPath() {
 
   const [readRoute, setReadRouteState] = useState(readStoredRoute)
 
-  // Read routing (FR-019): 'public' → the network's own RPC (default; handles the wide eth_getLogs scans that
-  // injected/mobile wallet backends reject; `makeReadProvider` also disables batching on ETC/Mordor). 'wallet' →
-  // the connected wallet's provider. Writes ALWAYS use `signer`, independent of this setting.
+  // Read routing (FR-019) applies to the CONNECTED chain only: 'public' → the network's own RPC (default;
+  // handles the wide eth_getLogs scans that injected/mobile wallet backends reject; `makeReadProvider` also
+  // disables batching on ETC/Mordor). 'wallet' → the connected wallet's provider. Every OTHER network (scanned
+  // for the aggregated list) always reads via its own public RPC — there is no wallet provider for a chain the
+  // wallet isn't on. Writes ALWAYS use `signer`, independent of this setting.
   const reader = useMemo(() => {
     if (readRoute === 'wallet') return provider || signer?.provider || (net?.rpcUrl ? cachedReadProvider(net.rpcUrl, chainId) : null)
     return net?.rpcUrl ? cachedReadProvider(net.rpcUrl, chainId) : provider || signer?.provider || null
   }, [readRoute, provider, signer, net, chainId])
+
+  /** A read provider for any clearpath-capable chain, honoring the read-route setting on the connected chain. */
+  const readerFor = useCallback(
+    (targetChainId) => {
+      if (Number(targetChainId) === Number(chainId)) return reader
+      const targetNet = getNetwork(targetChainId)
+      return targetNet?.rpcUrl ? cachedReadProvider(targetNet.rpcUrl, targetChainId) : null
+    },
+    [chainId, reader]
+  )
 
   // Spec 042: available when the network declares ClearPath AND we have something to read with — NOT gated on a
   // deployed registry (its reads are pure client-side RPC/subgraph).
@@ -85,21 +109,19 @@ export function useClearPath() {
     setReadRouteState(next)
   }, [])
 
-  const registryReader = useCallback(() => {
-    if (!hasRegistry || !reader) return null
-    return new ethers.Contract(registryAddress, EXTERNAL_DAO_REGISTRY_ABI, reader)
-  }, [hasRegistry, registryAddress, reader])
-
-  /** On-chain registry entries for the active network (empty when no registry is deployed). */
-  const listRegistryDAOs = useCallback(async () => {
-    const reg = registryReader()
-    if (!reg) return []
+  /** On-chain registry entries for `targetChainId` (empty when no registry is deployed there, or on any read failure — never throws). */
+  const listRegistryDAOsFor = useCallback(async (targetChainId) => {
+    if (!hasRegistryOn(targetChainId)) return []
+    const targetReader = readerFor(targetChainId)
+    if (!targetReader) return []
+    const regAddr = getContractAddressForChain('externalDAORegistry', targetChainId)
+    const reg = new ethers.Contract(regAddr, EXTERNAL_DAO_REGISTRY_ABI, targetReader)
     const n = Number(await reg.externalCount())
     const out = []
     for (let id = n; id >= 1; id--) {
       const [dao, framework, label, registrant, registeredAt] = await reg.getExternalDAO(id)
       out.push({
-        id,
+        id: `${targetChainId}:${id}`,
         dao,
         framework: Number(framework),
         label,
@@ -109,48 +131,63 @@ export function useClearPath() {
       })
     }
     return out
-  }, [registryReader])
+  }, [readerFor])
 
   /**
-   * Every external DAO on the active network: on-chain registry entries (if a registry is deployed) MERGED with
-   * the member's device-local tracked list, de-duplicated by lowercased address (registry wins on conflict).
-   * Strictly network-scoped — nothing crosses chains or accounts.
+   * Every external DAO on `targetChainId`: on-chain registry entries (if deployed) MERGED with the member's
+   * device-local tracked list and the curated known-DAO seed list, de-duplicated by lowercased address
+   * (registry wins on conflict). Strictly network-scoped — nothing crosses chains or accounts.
+   */
+  const listExternalDAOsFor = useCallback(
+    async (targetChainId) => {
+      const registryList = await listRegistryDAOsFor(targetChainId).catch(() => [])
+      const localList = trackedDaoStore.list(targetChainId, account).map((e) => ({
+        id: `local:${targetChainId}:${String(e.address).toLowerCase()}`,
+        dao: e.address,
+        framework: e.framework,
+        label: e.label,
+        registrant: account,
+        registeredAt: e.addedAt,
+        source: 'local',
+      }))
+      // Curated, on-chain-verified DAOs for this network (e.g. ENS, Uniswap on mainnet) surface by default so a
+      // member doesn't have to paste an address to find them; still deduped against registry + local entries.
+      const knownList = knownDaosForChain(targetChainId).map((k) => ({
+        id: `known:${targetChainId}:${String(k.address).toLowerCase()}`,
+        dao: k.address,
+        framework: k.framework,
+        label: k.label,
+        registrant: null,
+        registeredAt: null,
+        source: 'known',
+      }))
+      const seen = new Set(registryList.map((d) => String(d.dao).toLowerCase()))
+      const merged = [...registryList]
+      for (const d of [...localList, ...knownList]) {
+        const lc = String(d.dao).toLowerCase()
+        if (!seen.has(lc)) {
+          merged.push(d)
+          seen.add(lc)
+        }
+      }
+      const targetNet = getNetwork(targetChainId)
+      return merged.map((d) => ({ ...d, chainId: targetChainId, networkName: targetNet?.name || String(targetChainId) }))
+    },
+    [listRegistryDAOsFor, account]
+  )
+
+  /**
+   * Every external DAO across EVERY clearpath-capable network (network-agnostic, mirrors usePortfolio). Each
+   * network is scanned independently via `Promise.allSettled` — an unreachable RPC on one chain never blanks the
+   * others (honest partial degradation). Rows are tagged with `chainId`/`networkName` so the UI can badge them
+   * and gate write actions on a network switch.
    */
   const listExternalDAOs = useCallback(async () => {
-    const registryList = await listRegistryDAOs()
-    const localList = trackedDaoStore.list(chainId, account).map((e) => ({
-      id: `local:${String(e.address).toLowerCase()}`,
-      dao: e.address,
-      framework: e.framework,
-      label: e.label,
-      registrant: account,
-      registeredAt: e.addedAt,
-      source: 'local',
-    }))
-    // Curated, on-chain-verified DAOs for this network (e.g. ENS, Uniswap on mainnet) surface by default so a
-    // member doesn't have to paste an address to find them; still deduped against registry + local entries.
-    const knownList = knownDaosForChain(chainId).map((k) => ({
-      id: `known:${String(k.address).toLowerCase()}`,
-      dao: k.address,
-      framework: k.framework,
-      label: k.label,
-      registrant: null,
-      registeredAt: null,
-      source: 'known',
-    }))
-    const seen = new Set(registryList.map((d) => String(d.dao).toLowerCase()))
-    const merged = [...registryList]
-    for (const d of [...localList, ...knownList]) {
-      const lc = String(d.dao).toLowerCase()
-      if (!seen.has(lc)) {
-        merged.push(d)
-        seen.add(lc)
-      }
-    }
-    return merged
-  }, [listRegistryDAOs, chainId, account])
+    const settled = await Promise.allSettled(chainIds.map((id) => listExternalDAOsFor(id)))
+    return settled.flatMap((r) => (r.status === 'fulfilled' ? r.value : []))
+  }, [chainIds, listExternalDAOsFor])
 
-  /** Register an external DAO on-chain (registry networks). Real tx; honest state + notifications. */
+  /** Register an external DAO on-chain (registry networks). Real tx, signed on the CONNECTED chain; honest state + notifications. */
   const registerExternalDAO = useCallback(
     async ({ dao, framework = 0, label = '' }) => {
       if (!hasRegistry) {
@@ -204,20 +241,27 @@ export function useClearPath() {
   )
 
   /**
-   * Track a DAO. On a registry network this is the on-chain register (above); on a registry-less network it is a
-   * device-local add (immediate, no tx) — honest "tracked on this device" note, duplicate → truthful notice, no
-   * phantom row. The caller validates + framework-detects before calling.
+   * Track a DAO on `targetChainId` (defaults to the connected chain). On a network with an on-chain registry
+   * this is a real register tx — the caller MUST have already confirmed the wallet is on that chain (e.g. via a
+   * "Switch to X" prompt), since a signer can only sign for its connected chain. On a registry-less network it
+   * is a device-local add (immediate, no tx, no network switch required) — honest "tracked on this device" note,
+   * duplicate → truthful notice, no phantom row.
    */
   const trackDAO = useCallback(
-    async ({ address, framework = null, label = '' }) => {
-      if (hasRegistry) {
+    async ({ address, framework = null, label = '', chainId: targetChainId = chainId }) => {
+      if (hasRegistryOn(targetChainId)) {
+        if (Number(targetChainId) !== Number(chainId)) {
+          const targetName = getNetwork(targetChainId)?.name || 'that network'
+          showNotification(`Switch your wallet to ${targetName} to register this DAO.`, 'warning')
+          throw new Error('wrong network')
+        }
         return registerExternalDAO({ dao: address, framework: framework ?? 0, label })
       }
       if (!account) {
         showNotification('Connect a wallet to track a DAO.', 'warning')
         throw new Error('no account')
       }
-      const res = trackedDaoStore.add(chainId, account, { address, framework, label })
+      const res = trackedDaoStore.add(targetChainId, account, { address, framework, label })
       if (!res.added && res.reason === 'exists') {
         showNotification('That DAO is already tracked.', 'warning')
         return res
@@ -229,25 +273,28 @@ export function useClearPath() {
       showNotification(`Tracking ${label || 'DAO'} on this device.`, 'success')
       return res
     },
-    [hasRegistry, registerExternalDAO, account, chainId, showNotification]
+    [chainId, registerExternalDAO, account, showNotification]
   )
 
-  /** Remove a device-local tracked DAO (on-chain registry entries are not removable here). */
+  /** Remove a device-local tracked DAO on `targetChainId` (defaults to the connected chain; on-chain registry entries are not removable here). */
   const untrackDAO = useCallback(
-    (address) => trackedDaoStore.remove(chainId, account, address),
+    (address, targetChainId = chainId) => trackedDaoStore.remove(targetChainId, account, address),
     [chainId, account]
   )
 
   return {
     isSupported,
     hasRegistry,
+    hasRegistryFor: hasRegistryOn,
     hasSanctionsSource,
     registryAddress,
     usdcAddress,
     chainId,
+    chainIds,
     account,
     isConnected,
     reader,
+    readerFor,
     signer,
     readRoute,
     setReadRoute,

--- a/frontend/src/config/clearpath/daoSubgraphs.js
+++ b/frontend/src/config/clearpath/daoSubgraphs.js
@@ -17,6 +17,16 @@ export function gatewayUrl(subgraphId) {
   return `https://gateway.thegraph.com/api/${GRAPH_KEY}/subgraphs/id/${subgraphId}`
 }
 
+// Researched for the two seeded mainnet DAOs (knownDaos.js) — deliberately left EMPTY, not guessed:
+//  - ENS Governor (0x323A76393544d5ecca80cd6ef2A560C6a395b7E3): Messari published an OZ-Governor-schema
+//    subgraph ("ens-governance") announced at https://discuss.ens.domains/t/new-ens-governance-subgraph-live/13898,
+//    but only ever on the now-deprecated hosted service (api.thegraph.com/subgraphs/name/...) — that host no
+//    longer serves live queries and no decentralized-network (gateway) subgraph id for it could be confirmed.
+//  - Uniswap Governor Bravo (0x408ED6354d4973f66138C91495F2f2FCbd8724C3): community subgraphs found
+//    (messari/uniswap-governance, arr00/uniswap-governance-v2) are unmaintained/hosted-service-only, and most
+//    target the older GovernorAlpha contract rather than this Bravo deployment.
+// Re-check https://thegraph.com/explorer for a live, actively-synced entry before adding an id here — a wrong
+// id is worse than no id (the router falls back to the on-chain live scan either way, never fabricates rows).
 /** @type {Record<number, Record<string, {subgraphId: string, idKind?: string}>>} */
 export const DAO_SUBGRAPHS = {
   // 1: { '0x…ens governor': { subgraphId: '…' }, '0x…uniswap governor': { subgraphId: '…' } },

--- a/frontend/src/config/networks.js
+++ b/frontend/src/config/networks.js
@@ -646,6 +646,21 @@ export function getSelectableNetworks() {
 }
 
 /**
+ * Every network where ClearPath (DAO governance) is available, mainnets first — mirrors
+ * `getPortfolioChainIds()` so the ClearPath panel can list known/tracked DAOs across every
+ * capable network in parallel (network-agnostic), independent of which chain the wallet is
+ * currently connected to. Only WRITE actions (register/vote/queue/execute) require the wallet
+ * to actually be on a given DAO's chain.
+ */
+export function getClearPathChainIds() {
+  return listSupportedChainIds()
+    .map((id) => NETWORKS[id])
+    .filter((net) => net?.capabilities?.clearpath)
+    .sort((a, b) => Number(a.isTestnet) - Number(b.isTestnet))
+    .map((net) => net.chainId)
+}
+
+/**
  * Pair of (testnet, mainnet) chain IDs used by the Testnet/Mainnet toggle.
  * Surfaced as a helper so UI code doesn't have to know the numeric values.
  */

--- a/frontend/src/test/clearpath.accessibility.test.jsx
+++ b/frontend/src/test/clearpath.accessibility.test.jsx
@@ -6,14 +6,23 @@ import ClearPathPanel from '../components/clearpath/ClearPathPanel'
 // Spec 030 (T057) — axe accessibility (WCAG 2.1 AA) over the ClearPath module surfaces. Picked up by the gating
 // CI step `npm test -- --run accessibility.test`.
 
+const STABLE_READER = {} // must be referentially stable across renders — see useClearPath's cachedReadProvider
 const cp = {
   isSupported: true,
   chainId: 63,
-  reader: {},
+  chainIds: [63],
+  hasRegistryFor: () => true,
+  reader: STABLE_READER,
+  readerFor: () => STABLE_READER,
+  signer: {},
   account: '0xabc',
   isConnected: true,
+  readRoute: 'public',
+  setReadRoute: vi.fn(),
   listExternalDAOs: vi.fn(),
   registerExternalDAO: vi.fn(),
+  trackDAO: vi.fn(),
+  untrackDAO: vi.fn(),
 }
 vi.mock('../components/clearpath/useClearPath', () => ({ useClearPath: () => cp }))
 vi.mock('../hooks/useUI', () => ({ useNotification: () => ({ showNotification: vi.fn() }) }))
@@ -46,7 +55,7 @@ describe('ClearPath accessibility (WCAG 2.1 AA)', () => {
     vi.clearAllMocks()
     cp.isSupported = true
     cp.listExternalDAOs.mockResolvedValue([
-      { id: 1, dao: '0xB85dbc899472756470EF4033b9637ff8fa2FD23D', framework: 0, label: 'Olympia DAO', registrant: '0xabc', registeredAt: 1700000000 },
+      { id: 1, dao: '0xB85dbc899472756470EF4033b9637ff8fa2FD23D', framework: 0, label: 'Olympia DAO', registrant: '0xabc', registeredAt: 1700000000, chainId: 63, networkName: 'Ethereum Classic Mordor' },
     ])
   })
 

--- a/frontend/src/test/networkCapabilities.clearpath.test.js
+++ b/frontend/src/test/networkCapabilities.clearpath.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getNetwork } from '../config/networks'
+import { getNetwork, getClearPathChainIds } from '../config/networks'
 import { getNetworkFeatures } from '../config/networkCapabilities'
 
 // Spec 042 — the `clearpath` per-chain capability + its Network-tab feature tag.
@@ -20,5 +20,17 @@ describe('clearpath capability (spec 042)', () => {
     expect(tag.deployed).toBe(true)
     const localTag = getNetworkFeatures(1337).find((f) => f.key === 'clearpath')
     expect(localTag.deployed).toBe(false)
+  })
+})
+
+describe('getClearPathChainIds (network-agnostic follow-up to spec 042)', () => {
+  it('returns every clearpath-capable chain, mainnets before testnets, and excludes non-clearpath chains', () => {
+    const ids = getClearPathChainIds()
+    expect(ids).toEqual(expect.arrayContaining([1, 61, 137, 63, 80002]))
+    expect(ids).not.toContain(1337) // local Hardhat sandbox
+    expect(ids).not.toContain(11155111) // Sepolia — clearpath off
+    expect(ids).not.toContain(560048) // Hoodi — clearpath off
+    const testnetStart = ids.findIndex((id) => getNetwork(id).isTestnet)
+    expect(ids.slice(testnetStart).every((id) => getNetwork(id).isTestnet)).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

ClearPath (DAO governance) previously listed DAOs only from the wallet's currently connected chain. This makes it network-agnostic, mirroring the pattern already shipped for the Portfolio tab:

- **`frontend/src/config/networks.js`** — new `getClearPathChainIds()`, mirroring `getPortfolioChainIds()`: every network with `capabilities.clearpath`, mainnets first.
- **`useClearPath.js`** — `listExternalDAOs()` now scans *every* clearpath-capable chain in parallel (`Promise.allSettled`, so one bad RPC never blanks the others), merging each chain's on-chain registry entries + device-local tracked DAOs + curated known-DAO seeds, tagged with `chainId`/`networkName`. Added `readerFor(chainId)` (a stable, cached per-chain read provider) and `hasRegistryFor(chainId)`. `trackDAO`/`untrackDAO` take an explicit target chain (default: connected) — device-local tracking needs no network switch since it's just `localStorage`.
- **`ClearPathPanel.jsx`** — the DAO list is no longer gated on the connected chain; it always shows DAOs from every network with a per-row network badge. A non-blocking banner explains when the connected chain doesn't run ClearPath. The Register/Track tab gained a network picker.
- **`ExternalDaoView.jsx`** — when the DAO's chain differs from the connected wallet chain, vote/queue/execute/propose are disabled and a **"Switch to X"** button (wagmi's `useSwitchChain().switchChainAsync`) takes their place — the same pattern `TransferForm.jsx` uses for portfolio assets on another chain. `run()` re-checks the chain match server-side as a last line of defense.
- **`RegisterExternalDao.jsx`** — gained a target-network `<select>`; on a chain with an on-chain registry, registering while connected elsewhere shows a Switch prompt instead of Register (validation still reads over the target chain's own RPC, no switch needed just to check).
- **`daoSubgraphs.js`** — researched subgraphs for the two seeded known DAOs (ENS, Uniswap Governor Bravo) per spec 042's open follow-ons (T026/T036). No verified, currently-synced decentralized-network subgraph could be confirmed for either (the leads found were the deprecated hosted service or unmaintained repos) — left empty with a comment documenting what was checked, rather than guessing an id. Both DAOs continue to serve via the on-chain live-scan fallback.
- Doc: `docs/developer-guide/clearpath-multi-network.md` updated to describe the aggregate listing + switch-to-act pattern.

## Test plan

- [x] `useClearPath.multinetwork.test.js` (extended) — exposes `chainIds`, tracks a DAO on a non-connected chain with no switch, scopes strictly per chain
- [x] `RegisterExternalDao.test.jsx` (rewritten) — network picker default, Switch-prompt-instead-of-Register when the wallet is elsewhere
- [x] `ClearPathPanel.test.jsx`, `ExternalDaoView.notifications.test.jsx`, `clearpath.accessibility.test.jsx` — updated mocks/fixtures for the new hook shape and connected-chain gating, plus new coverage for the switch-to-act banner/buttons
- [x] `networkCapabilities.clearpath.test.js` (extended) — `getClearPathChainIds()` ordering/membership
- [x] `npx eslint` clean on all touched files
- [x] Ran every test file that doesn't mount `ExternalDaoView` locally (50/50 passing); files that do mount it hang in this sandbox on **unmodified `main`** too (confirmed via `git stash`) — a pre-existing sandbox-specific issue unrelated to this change. Recent CI runs on `main` are green, so I'm relying on CI to execute those specific test files.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dph6zyagtz3q8X9nm46fmp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dph6zyagtz3q8X9nm46fmp)_