### PR TITLE
Admin Overview: app-wide membership statistics + treasury growth

### DIFF
--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -14,6 +14,7 @@ import { MEMBERSHIP_MANAGER_ABI } from '../abis/MembershipManager'
 import OracleAdaptersTab from './admin/OracleAdaptersTab'
 import DenyListAdmin from './admin/DenyListAdmin'
 import CallsignRegistryAdmin from './admin/CallsignRegistryAdmin'
+import MembershipTreasuryOverview from './admin/MembershipTreasuryOverview'
 import PortalNav from './ui/PortalNav'
 import SectionIconNav from './nav/SectionIconNav'
 import './AdminPanel.css'
@@ -433,6 +434,13 @@ function AdminPanel() {
                   </div>
                 </div>
               </div>
+
+              <MembershipTreasuryOverview
+                provider={provider || getProvider(chainId)}
+                chainId={chainId}
+                address={membershipManagerAddr}
+                accruedFees={contractState.accruedFees}
+              />
 
               <div className="admin-card full-width">
                 <div className="admin-card-header"><h3>Contract Addresses</h3></div>

--- a/frontend/src/components/admin/MembershipTreasuryOverview.css
+++ b/frontend/src/components/admin/MembershipTreasuryOverview.css
@@ -1,0 +1,176 @@
+/* MembershipTreasuryOverview — app-wide membership stats + treasury growth on Admin → Overview.
+   Theme-aware via the shared CSS custom properties; single brand hue for the revenue sparkline. */
+
+.mto-muted {
+  margin: 0 0 1rem;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.mto-muted code {
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+}
+
+.mto-error {
+  margin: 0 0 1rem;
+  font-size: 0.875rem;
+  color: var(--danger-color);
+}
+
+.mto-note {
+  margin: 1rem 0 0;
+  padding: 0.75rem 1rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+}
+
+.mto-subhead {
+  margin: 1.5rem 0 0.75rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+/* ---- Stat tiles ---- */
+.mto-tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.mto-tiles--dense {
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.mto-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.875rem 1rem;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+}
+
+.mto-tile--accent {
+  border-color: var(--brand-primary);
+}
+
+.mto-tile__value {
+  font-size: 1.375rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1.1;
+  font-variant-numeric: tabular-nums;
+}
+
+.mto-tile--accent .mto-tile__value {
+  color: var(--brand-primary);
+}
+
+.mto-tile__label {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+/* ---- Revenue sparkline (single-series, single hue) ---- */
+.mto-spark {
+  margin: 1.25rem 0 0;
+}
+
+.mto-spark__svg {
+  display: block;
+  width: 100%;
+  height: 64px;
+}
+
+.mto-spark__area {
+  fill: rgba(var(--brand-primary-rgb), 0.14);
+  stroke: none;
+}
+
+.mto-spark__line {
+  fill: none;
+  stroke: var(--brand-primary);
+  stroke-width: 2;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.mto-spark__dot {
+  fill: var(--brand-primary);
+  stroke: var(--bg-secondary);
+  stroke-width: 2;
+}
+
+.mto-spark__caption {
+  margin: 0.375rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.mto-spark__caption strong {
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.mto-spark__hint {
+  color: var(--text-muted);
+}
+
+/* ---- Horizontal breakdown bars ---- */
+.mto-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.mto-bar-row {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr auto;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.mto-bar-label {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.mto-bar-track {
+  position: relative;
+  height: 8px;
+  background: var(--bg-primary);
+  border-radius: var(--radius-full, 999px);
+  overflow: hidden;
+}
+
+.mto-bar-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  height: 100%;
+  min-width: 2px;
+  background: var(--brand-primary);
+  border-radius: inherit;
+  transition: width var(--transition-fast, 0.15s) ease;
+}
+
+.mto-bar-value {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 520px) {
+  .mto-bar-row {
+    grid-template-columns: 4.5rem 1fr auto;
+    gap: 0.5rem;
+  }
+}

--- a/frontend/src/components/admin/MembershipTreasuryOverview.jsx
+++ b/frontend/src/components/admin/MembershipTreasuryOverview.jsx
@@ -1,0 +1,217 @@
+import { useEffect, useMemo } from 'react'
+import { ethers } from 'ethers'
+import { useMembershipTreasuryStats, fmtUsdc } from '../../hooks/useMembershipTreasuryStats'
+import './MembershipTreasuryOverview.css'
+
+/**
+ * MembershipTreasuryOverview — the app-wide membership statistics + treasury-growth panel that anchors
+ * the Admin → Overview tab. Reads are aggregated client-side from a bounded MembershipManager event
+ * scan (see useMembershipTreasuryStats) because the contract exposes no aggregate counters and there is
+ * no backend/subgraph for it. The scan is explicit (Refresh), cache-backed, and honestly flags a
+ * truncated window.
+ *
+ * Props:
+ *   provider   — ethers provider for the read scan
+ *   chainId    — connected chain (drives the cache key + address resolution)
+ *   address    — MembershipManager address on this chain ('' when undeployed)
+ *   accruedFees — live undrawn balance (USDC string) already read by the parent AdminPanel
+ */
+
+const TIER_NAMES = { 1: 'Bronze', 2: 'Silver', 3: 'Gold', 4: 'Platinum' }
+const USD = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 2 })
+
+function usd(v) {
+  const n = typeof v === 'bigint' ? Number(fmtUsdc(v)) : Number(v || 0)
+  return USD.format(Number.isFinite(n) ? n : 0)
+}
+
+const shortAddr = (a) => (a && ethers.isAddress(a) ? `${a.slice(0, 6)}…${a.slice(-4)}` : a || '—')
+
+/**
+ * Compact single-series cumulative-revenue sparkline (magnitude over the sequence of revenue events).
+ * One hue (brand), thin line + soft area fill, recessive baseline, latest value direct-labelled. Block
+ * numbers are the x clock the logs carry — labelled as such, never claimed to be calendar time.
+ */
+function RevenueSparkline({ series }) {
+  const points = useMemo(
+    () => series.map((p) => ({ x: p.block, y: Number(fmtUsdc(p.cumulative)) })),
+    [series],
+  )
+  if (points.length < 2) return null
+
+  const W = 320
+  const H = 64
+  const PAD = 4
+  const xs = points.map((p) => p.x)
+  const ys = points.map((p) => p.y)
+  const minX = Math.min(...xs)
+  const maxX = Math.max(...xs)
+  const maxY = Math.max(...ys)
+  const spanX = maxX - minX || 1
+  const spanY = maxY || 1
+
+  const sx = (x) => PAD + ((x - minX) / spanX) * (W - PAD * 2)
+  const sy = (y) => H - PAD - (y / spanY) * (H - PAD * 2)
+
+  const line = points.map((p, i) => `${i === 0 ? 'M' : 'L'}${sx(p.x).toFixed(1)},${sy(p.y).toFixed(1)}`).join(' ')
+  const area = `${line} L${sx(maxX).toFixed(1)},${(H - PAD).toFixed(1)} L${sx(minX).toFixed(1)},${(H - PAD).toFixed(1)} Z`
+  const last = points[points.length - 1]
+
+  return (
+    <figure className="mto-spark" aria-label={`Cumulative membership revenue reaching ${usd(last.y)} over the scanned block window`}>
+      <svg viewBox={`0 0 ${W} ${H}`} role="img" preserveAspectRatio="none" className="mto-spark__svg">
+        <path d={area} className="mto-spark__area" />
+        <path d={line} className="mto-spark__line" />
+        <circle cx={sx(last.x)} cy={sy(last.y)} r="3" className="mto-spark__dot" />
+      </svg>
+      <figcaption className="mto-spark__caption">
+        Cumulative membership revenue → <strong>{usd(last.y)}</strong>
+        <span className="mto-spark__hint"> (over scanned blocks)</span>
+      </figcaption>
+    </figure>
+  )
+}
+
+function Tile({ label, value, tone }) {
+  return (
+    <div className={`mto-tile${tone ? ` mto-tile--${tone}` : ''}`}>
+      <span className="mto-tile__value">{value}</span>
+      <span className="mto-tile__label">{label}</span>
+    </div>
+  )
+}
+
+export default function MembershipTreasuryOverview({ provider, chainId, address, accruedFees }) {
+  const configured = Boolean(address && ethers.isAddress(address))
+  const stats = useMembershipTreasuryStats({ provider, chainId, address })
+
+  // Initial (cache-backed) scan when the panel mounts on a configured network.
+  useEffect(() => {
+    if (configured && provider) stats.refresh()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [configured, provider, chainId, address])
+
+  if (!configured) {
+    return (
+      <div className="admin-card full-width">
+        <div className="admin-card-header"><h3>Membership &amp; Treasury</h3></div>
+        <p role="status" className="mto-muted">
+          MembershipManager is not deployed / configured on this network — no app-wide statistics to show.
+        </p>
+      </div>
+    )
+  }
+
+  const d = stats.data
+
+  return (
+    <>
+      {/* -------------------- Membership statistics -------------------- */}
+      <div className="admin-card full-width">
+        <div className="admin-card-header">
+          <h3>Membership Statistics</h3>
+          <button
+            type="button"
+            className="confirm-btn"
+            onClick={() => stats.refresh({ force: true })}
+            disabled={stats.loading}
+          >
+            {stats.loading ? 'Scanning…' : 'Refresh'}
+          </button>
+        </div>
+        <p className="mto-muted">
+          App-wide across all members, aggregated from the MembershipManager event log
+          (<code title={address}>{shortAddr(address)}</code>).
+        </p>
+        {stats.error && <p role="alert" className="mto-error">Scan failed: {stats.error}</p>}
+        {!d && !stats.loading && !stats.error && <p role="status" className="mto-muted">No statistics loaded yet.</p>}
+        {d && (
+          <>
+            <div className="mto-tiles" aria-label="Active membership summary">
+              <Tile label={d.truncated ? 'Active members (window)' : 'Active members'} value={d.members.active} tone="accent" />
+              {[1, 2, 3, 4].map((t) => (
+                <Tile key={t} label={`${TIER_NAMES[t]} active`} value={d.members.byTier[t]} />
+              ))}
+              <Tile label="Unique members (ever)" value={d.members.everMembers} />
+            </div>
+
+            <h4 className="mto-subhead">Lifetime activity {d.truncated ? '(scanned window)' : ''}</h4>
+            <div className="mto-tiles mto-tiles--dense" aria-label="Lifetime membership events">
+              <Tile label="Purchases" value={d.counts.purchased} />
+              <Tile label="Admin grants" value={d.counts.granted} />
+              <Tile label="Voucher redemptions" value={d.counts.redeemed} />
+              <Tile label="Extensions" value={d.counts.extended} />
+              <Tile label="Upgrades" value={d.counts.upgraded} />
+              <Tile label="Revocations" value={d.counts.revoked} />
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* -------------------- Treasury growth -------------------- */}
+      <div className="admin-card full-width">
+        <div className="admin-card-header"><h3>Treasury Growth</h3></div>
+        <p className="mto-muted">
+          Two streams fund the treasury: paid <strong>membership</strong> revenue (purchases, extensions,
+          upgrades) and the <strong>fees</strong> withdrawn from the MembershipManager to the treasury
+          address. Admin grants and voucher redemptions are free at this contract and add nothing here.
+        </p>
+        {d && (
+          <>
+            <div className="mto-tiles" aria-label="Treasury growth summary">
+              <Tile label={d.truncated ? 'Membership revenue (window)' : 'Membership revenue'} value={usd(d.revenue.total)} tone="accent" />
+              <Tile label="Withdrawn to treasury" value={usd(d.revenue.withdrawn)} />
+              <Tile label="Accrued (undrawn, live)" value={usd(accruedFees)} />
+            </div>
+
+            <RevenueSparkline series={d.series} />
+
+            <h4 className="mto-subhead">Revenue by stream</h4>
+            <div className="mto-bars" aria-label="Membership revenue by stream">
+              {[
+                { key: 'purchases', label: 'Purchases' },
+                { key: 'extensions', label: 'Extensions' },
+                { key: 'upgrades', label: 'Upgrades' },
+              ].map(({ key, label }) => {
+                const val = Number(fmtUsdc(d.revenue[key]))
+                const total = Number(fmtUsdc(d.revenue.total)) || 1
+                const pct = Math.max(0, Math.min(100, (val / total) * 100))
+                return (
+                  <div className="mto-bar-row" key={key}>
+                    <span className="mto-bar-label">{label}</span>
+                    <span className="mto-bar-track"><span className="mto-bar-fill" style={{ width: `${pct}%` }} /></span>
+                    <span className="mto-bar-value">{usd(d.revenue[key])}</span>
+                  </div>
+                )
+              })}
+            </div>
+
+            <h4 className="mto-subhead">Membership revenue by tier</h4>
+            <div className="mto-bars" aria-label="Membership revenue by tier">
+              {[1, 2, 3, 4].map((t) => {
+                const val = Number(fmtUsdc(d.revenueByTier[t]))
+                const total = Number(fmtUsdc(d.revenue.total)) || 1
+                const pct = Math.max(0, Math.min(100, (val / total) * 100))
+                return (
+                  <div className="mto-bar-row" key={t}>
+                    <span className="mto-bar-label">{TIER_NAMES[t]}</span>
+                    <span className="mto-bar-track"><span className="mto-bar-fill" style={{ width: `${pct}%` }} /></span>
+                    <span className="mto-bar-value">{usd(d.revenueByTier[t])}</span>
+                  </div>
+                )
+              })}
+            </div>
+
+            {d.truncated && (
+              <p role="note" className="mto-note">
+                Showing the most recent block window only — lifetime tallies and revenue are for the
+                scanned range, not all-time. The live accrued balance above is exact; query the chain
+                directly (or a future subgraph) for full history.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/hooks/useMembershipTreasuryStats.js
+++ b/frontend/src/hooks/useMembershipTreasuryStats.js
@@ -1,0 +1,231 @@
+/**
+ * useMembershipTreasuryStats — derives app-wide membership statistics and treasury growth for the
+ * platform Admin → Overview from a bounded, resilient client-side event scan of the MembershipManager.
+ *
+ * The MembershipManager exposes only point-lookup views (per-user `getMembership`, a single
+ * `accruedFees` counter) — no enumeration, no aggregate revenue counters — and the subgraph does not
+ * index it. Under the repo's no-backend footprint, event-log scanning is the only aggregate source,
+ * exactly like `useCallsignRegistryMetrics` (spec 054). We reduce the membership lifecycle events into:
+ *   • membership statistics — lifetime event counts + currently-active members (net, by tier), and
+ *   • treasury growth — gross membership revenue (paid purchases + extensions + upgrades) plus the
+ *     amount already withdrawn to the treasury (`FeesWithdrawn`), the two streams that fund the treasury.
+ *
+ * The scan is bounded (a MAX_SPAN backward lookback, never from genesis — public RPCs reject wide
+ * eth_getLogs), chunked, and degrades on provider range-caps via `getLogsRange` (bisect-on-reject).
+ * Results are cached per (chain, address) with a short TTL so remounts don't re-scan. Triggered
+ * explicitly (a Refresh button), never auto-polled. When the lookback is capped, `truncated` is true
+ * and lifetime tallies / revenue are honestly "within the scanned window", not all-time.
+ */
+import { useCallback, useState } from 'react'
+import { ethers } from 'ethers'
+import { MEMBERSHIP_MANAGER_ABI } from '../abis/MembershipManager'
+import { getLogsRange } from '../components/clearpath/connectors/ozGovernor'
+
+const CHUNK = 45_000
+const MAX_SPAN = 3_000_000
+const CACHE_TTL_MS = 60_000
+const RECENT_LIMIT = 25
+const USDC_DECIMALS = 6
+
+const cacheByKey = new Map() // `${chainId}:${address}` -> { at, data }
+
+// Format a USDC (6-decimal) bigint as a plain decimal string for display.
+function fmtUsdc(v) {
+  return ethers.formatUnits(v ?? 0n, USDC_DECIMALS)
+}
+
+/**
+ * Pure reducer: fold parsed MembershipManager events into app-wide membership + treasury metrics.
+ * Exported for unit testing. All USDC sums are returned as bigint (6-decimal base units); the caller
+ * formats. `nowSec` (unix seconds) decides which memberships are still active — pass the current time.
+ *
+ * @param {Array<{name:string,args:object,blockNumber:number,logIndex:number}>} events parsed log events
+ * @param {boolean} truncated whether the scan window was capped (older history not loaded)
+ * @param {number} nowSec current time in unix seconds (memberships with expiresAt > nowSec are active)
+ */
+export function reduceMembershipTreasuryStats(events, truncated = false, nowSec = 0) {
+  // Replay in chain order so per-member tier/expiry state and cumulative revenue are correct.
+  const ordered = [...events].sort(
+    (a, b) => a.blockNumber - b.blockNumber || a.logIndex - b.logIndex,
+  )
+
+  const counts = { purchased: 0, granted: 0, redeemed: 0, extended: 0, upgraded: 0, revoked: 0 }
+  const revenue = { purchases: 0n, extensions: 0n, upgrades: 0n, withdrawn: 0n }
+  const revenueByTier = { 1: 0n, 2: 0n, 3: 0n, 4: 0n }
+
+  // Per (user,role) membership state, replayed last-write-wins. A member holds at most one active
+  // membership per role, so keying by user+role de-dupes repeat purchases/extensions into one member.
+  const members = new Map() // `${user}:${role}` -> { tier, expiresAt, revoked }
+  const memberKey = (user, role) => `${String(user).toLowerCase()}:${role}`
+
+  // Cumulative membership-revenue series (magnitude over the sequence of revenue events). Block
+  // numbers are the only monotonic clock the logs carry (events don't include timestamps), so the
+  // series is honestly "cumulative revenue vs. block", not calendar time.
+  const series = []
+  let cumulative = 0n
+
+  const addRevenue = (bucket, tier, amount) => {
+    if (!amount) return
+    revenue[bucket] += amount
+    if (tier >= 1 && tier <= 4) revenueByTier[tier] += amount
+    cumulative += amount
+  }
+
+  for (const ev of ordered) {
+    const { name, args, blockNumber } = ev
+    switch (name) {
+      case 'MembershipPurchased': {
+        counts.purchased++
+        const tier = Number(args.tier)
+        members.set(memberKey(args.user, args.role), { tier, expiresAt: Number(args.expiresAt), revoked: false })
+        addRevenue('purchases', tier, BigInt(args.price ?? 0))
+        series.push({ block: blockNumber, cumulative })
+        break
+      }
+      case 'MembershipGranted': {
+        counts.granted++
+        // Admin grant — free (no price paid to the contract), so it funds no treasury growth.
+        members.set(memberKey(args.user, args.role), { tier: Number(args.tier), expiresAt: Number(args.expiresAt), revoked: false })
+        break
+      }
+      case 'MembershipRedeemed': {
+        counts.redeemed++
+        // Voucher redemption — already paid for at voucher mint, no price at redeem time.
+        members.set(memberKey(args.user, args.role), { tier: Number(args.tier), expiresAt: Number(args.expiresAt), revoked: false })
+        break
+      }
+      case 'MembershipExtended': {
+        counts.extended++
+        const cur = members.get(memberKey(args.user, args.role))
+        const tier = cur ? cur.tier : 0
+        if (cur) cur.expiresAt = Number(args.expiresAt)
+        else members.set(memberKey(args.user, args.role), { tier: 0, expiresAt: Number(args.expiresAt), revoked: false })
+        addRevenue('extensions', tier, BigInt(args.price ?? 0))
+        series.push({ block: blockNumber, cumulative })
+        break
+      }
+      case 'MembershipUpgraded': {
+        counts.upgraded++
+        const cur = members.get(memberKey(args.user, args.role))
+        const toTier = Number(args.toTier)
+        if (cur) cur.tier = toTier
+        else members.set(memberKey(args.user, args.role), { tier: toTier, expiresAt: 0, revoked: false })
+        addRevenue('upgrades', toTier, BigInt(args.delta ?? 0))
+        series.push({ block: blockNumber, cumulative })
+        break
+      }
+      case 'MembershipRevoked': {
+        counts.revoked++
+        const cur = members.get(memberKey(args.user, args.role))
+        if (cur) cur.revoked = true
+        break
+      }
+      case 'FeesWithdrawn': {
+        revenue.withdrawn += BigInt(args.amount ?? 0)
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  revenue.total = revenue.purchases + revenue.extensions + revenue.upgrades
+
+  // Active members: still within their term (expiresAt > now) and not revoked. Grants/redemptions
+  // carry an expiry too, so they count while live. `everMembers` is every unique (user,role) seen.
+  const byTier = { 1: 0, 2: 0, 3: 0, 4: 0 }
+  let active = 0
+  for (const m of members.values()) {
+    if (m.revoked) continue
+    if (m.expiresAt > nowSec) {
+      active++
+      if (m.tier >= 1 && m.tier <= 4) byTier[m.tier]++
+    }
+  }
+
+  const recent = [...ordered]
+    .reverse()
+    .slice(0, RECENT_LIMIT)
+    .map((ev) => ({
+      type: ev.name,
+      user: ev.args.user || ev.args.to || null,
+      tier: ev.args.tier != null ? Number(ev.args.tier) : (ev.args.toTier != null ? Number(ev.args.toTier) : null),
+      amount:
+        ev.args.price != null ? BigInt(ev.args.price)
+          : ev.args.delta != null ? BigInt(ev.args.delta)
+            : ev.args.amount != null ? BigInt(ev.args.amount)
+              : null,
+      block: ev.blockNumber,
+    }))
+
+  return {
+    counts,
+    revenue,
+    revenueByTier,
+    members: { active, everMembers: members.size, byTier },
+    series,
+    recent,
+    truncated,
+    totalEvents: events.length,
+  }
+}
+
+/**
+ * @param {{ provider: any, chainId: number, address: string }} args
+ * @returns {{ loading, error, data, truncated, refresh }}
+ */
+export function useMembershipTreasuryStats({ provider, chainId, address } = {}) {
+  const [state, setState] = useState({ loading: false, error: null, data: null, truncated: false })
+
+  const refresh = useCallback(
+    async ({ force = false } = {}) => {
+      if (!provider || !address || !ethers.isAddress(address)) {
+        setState({ loading: false, error: null, data: null, truncated: false })
+        return
+      }
+      const key = `${chainId}:${address.toLowerCase()}`
+      const cached = cacheByKey.get(key)
+      if (!force && cached && Date.now() - cached.at < CACHE_TTL_MS) {
+        setState({ loading: false, error: null, data: cached.data, truncated: cached.data.truncated })
+        return
+      }
+      setState((s) => ({ ...s, loading: true, error: null }))
+      try {
+        const iface = new ethers.Interface(MEMBERSHIP_MANAGER_ABI)
+        const latest = await provider.getBlockNumber()
+        const floor = Math.max(0, latest - MAX_SPAN)
+        const rawLogs = []
+        let to = latest
+        while (to >= floor) {
+          const from = Math.max(floor, to - CHUNK + 1)
+          // No topic filter → all MembershipManager events in the range; getLogsRange bisects on RPC caps.
+          const batch = await getLogsRange(provider, address, from, to, 2000, [])
+          rawLogs.push(...batch)
+          if (from === floor) break
+          to = from - 1
+        }
+        const parsed = []
+        for (const log of rawLogs) {
+          try {
+            const p = iface.parseLog({ topics: log.topics, data: log.data })
+            if (p) parsed.push({ name: p.name, args: p.args, blockNumber: log.blockNumber, logIndex: log.index ?? log.logIndex })
+          } catch {
+            /* not one of our events — skip */
+          }
+        }
+        const nowSec = Math.floor(Date.now() / 1000)
+        const data = reduceMembershipTreasuryStats(parsed, floor > 0, nowSec)
+        cacheByKey.set(key, { at: Date.now(), data })
+        setState({ loading: false, error: null, data, truncated: data.truncated })
+      } catch (err) {
+        setState({ loading: false, error: err?.message || String(err), data: null, truncated: false })
+      }
+    },
+    [provider, chainId, address],
+  )
+
+  return { ...state, refresh }
+}
+
+export { fmtUsdc }
+export default useMembershipTreasuryStats

--- a/frontend/src/test/MembershipTreasuryOverview.test.jsx
+++ b/frontend/src/test/MembershipTreasuryOverview.test.jsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// Mock the stats hook so we render the panel without a live MembershipManager scan.
+vi.mock('../hooks/useMembershipTreasuryStats', async () => {
+  const actual = await vi.importActual('../hooks/useMembershipTreasuryStats')
+  return { ...actual, useMembershipTreasuryStats: vi.fn() }
+})
+
+import { useMembershipTreasuryStats } from '../hooks/useMembershipTreasuryStats'
+import MembershipTreasuryOverview from '../components/admin/MembershipTreasuryOverview'
+
+const ADDRESS = '0x1111111111111111111111111111111111111111'
+const usdc = (n) => BigInt(Math.round(n * 1e6))
+
+const DATA = {
+  counts: { purchased: 12, granted: 3, redeemed: 2, extended: 5, upgraded: 1, revoked: 1 },
+  revenue: { purchases: usdc(24), extensions: usdc(10), upgrades: usdc(6), total: usdc(40), withdrawn: usdc(30) },
+  revenueByTier: { 1: usdc(20), 2: usdc(14), 3: usdc(6), 4: 0n },
+  members: { active: 14, everMembers: 18, byTier: { 1: 8, 2: 4, 3: 2, 4: 0 } },
+  series: [
+    { block: 10, cumulative: usdc(24) },
+    { block: 20, cumulative: usdc(34) },
+    { block: 30, cumulative: usdc(40) },
+  ],
+  recent: [],
+  truncated: false,
+  totalEvents: 24,
+}
+
+const provider = { getBlockNumber: vi.fn() }
+const baseProps = { provider, chainId: 137, address: ADDRESS, accruedFees: '10' }
+
+describe('MembershipTreasuryOverview (admin overview: membership + treasury)', () => {
+  beforeEach(() => {
+    useMembershipTreasuryStats.mockReset()
+  })
+
+  it('shows a not-configured notice when MembershipManager is undeployed on this network', () => {
+    useMembershipTreasuryStats.mockReturnValue({ loading: false, error: null, data: null, truncated: false, refresh: vi.fn() })
+    render(<MembershipTreasuryOverview {...baseProps} address="" />)
+    expect(screen.getByText(/not deployed \/ configured on this network/i)).toBeInTheDocument()
+    expect(screen.queryByText('Membership Statistics')).not.toBeInTheDocument()
+  })
+
+  it('renders membership statistics and treasury growth from the scanned data', () => {
+    const refresh = vi.fn()
+    useMembershipTreasuryStats.mockReturnValue({ loading: false, error: null, data: DATA, truncated: false, refresh })
+    render(<MembershipTreasuryOverview {...baseProps} />)
+
+    // Headline membership tiles
+    expect(screen.getByText('Membership Statistics')).toBeInTheDocument()
+    expect(screen.getByText('Active members')).toBeInTheDocument()
+    expect(screen.getByText('14')).toBeInTheDocument() // active members
+    expect(screen.getByText('Silver active')).toBeInTheDocument()
+
+    // Lifetime counts ("Purchases" also labels a revenue bar, so allow multiple)
+    expect(screen.getAllByText('Purchases').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('12')).toBeInTheDocument()
+
+    // Treasury growth headline (revenue total $40, withdrawn $30, accrued live $10).
+    // $40.00 also appears in the sparkline caption (latest cumulative), so allow multiple.
+    expect(screen.getByText('Treasury Growth')).toBeInTheDocument()
+    expect(screen.getAllByText('$40.00').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('$30.00')).toBeInTheDocument()
+    // $10.00 is both the live accrued tile and the extensions revenue bar.
+    expect(screen.getAllByText('$10.00').length).toBeGreaterThanOrEqual(1)
+
+    // Sparkline caption reflects the latest cumulative value
+    expect(screen.getByText(/Cumulative membership revenue/)).toBeInTheDocument()
+  })
+
+  it('surfaces the truncated-window disclosure and scan errors', () => {
+    useMembershipTreasuryStats.mockReturnValue({
+      loading: false,
+      error: 'rpc range too wide',
+      data: { ...DATA, truncated: true },
+      truncated: true,
+      refresh: vi.fn(),
+    })
+    render(<MembershipTreasuryOverview {...baseProps} />)
+    expect(screen.getByText(/Scan failed: rpc range too wide/)).toBeInTheDocument()
+    expect(screen.getByText(/most recent block window only/i)).toBeInTheDocument()
+    expect(screen.getByText('Active members (window)')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/useMembershipTreasuryStats.test.js
+++ b/frontend/src/test/useMembershipTreasuryStats.test.js
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import { reduceMembershipTreasuryStats } from '../hooks/useMembershipTreasuryStats'
+
+// Role hash is opaque to the reducer — any distinct string keys a (user,role) member.
+const ROLE = '0x' + 'w'.charCodeAt(0).toString(16).repeat(64).slice(0, 64)
+const A = '0x' + 'a'.repeat(40)
+const B = '0x' + 'b'.repeat(40)
+const C = '0x' + 'c'.repeat(40)
+
+// USDC (6-decimal) helper.
+const usdc = (n) => BigInt(Math.round(n * 1e6))
+
+const NOW = 1_000_000
+const FUTURE = NOW + 10_000 // still active
+const PAST = NOW - 10_000 // expired
+
+describe('reduceMembershipTreasuryStats (admin overview: membership + treasury)', () => {
+  it('tallies lifetime event counts across the membership lifecycle', () => {
+    const events = [
+      { name: 'MembershipPurchased', args: { user: A, role: ROLE, tier: 1, price: usdc(2), expiresAt: FUTURE }, blockNumber: 10, logIndex: 0 },
+      { name: 'MembershipGranted', args: { user: B, role: ROLE, tier: 3, expiresAt: FUTURE }, blockNumber: 11, logIndex: 0 },
+      { name: 'MembershipRedeemed', args: { user: C, role: ROLE, tier: 2, voucherId: 7, expiresAt: FUTURE }, blockNumber: 12, logIndex: 0 },
+      { name: 'MembershipExtended', args: { user: A, role: ROLE, durationDays: 30, price: usdc(2), expiresAt: FUTURE }, blockNumber: 13, logIndex: 0 },
+      { name: 'MembershipUpgraded', args: { user: A, role: ROLE, fromTier: 1, toTier: 2, delta: usdc(6) }, blockNumber: 14, logIndex: 0 },
+    ]
+    const d = reduceMembershipTreasuryStats(events, false, NOW)
+    expect(d.counts).toEqual({ purchased: 1, granted: 1, redeemed: 1, extended: 1, upgraded: 1, revoked: 0 })
+    expect(d.totalEvents).toBe(5)
+    expect(d.truncated).toBe(false)
+  })
+
+  it('sums membership revenue only from paid streams (grants/redemptions are free)', () => {
+    const events = [
+      { name: 'MembershipPurchased', args: { user: A, role: ROLE, tier: 1, price: usdc(2), expiresAt: FUTURE }, blockNumber: 10, logIndex: 0 },
+      { name: 'MembershipGranted', args: { user: B, role: ROLE, tier: 4, expiresAt: FUTURE }, blockNumber: 11, logIndex: 0 },
+      { name: 'MembershipRedeemed', args: { user: C, role: ROLE, tier: 2, voucherId: 1, expiresAt: FUTURE }, blockNumber: 12, logIndex: 0 },
+      { name: 'MembershipExtended', args: { user: A, role: ROLE, durationDays: 30, price: usdc(2), expiresAt: FUTURE }, blockNumber: 13, logIndex: 0 },
+      { name: 'MembershipUpgraded', args: { user: A, role: ROLE, fromTier: 1, toTier: 2, delta: usdc(6) }, blockNumber: 14, logIndex: 0 },
+    ]
+    const d = reduceMembershipTreasuryStats(events, false, NOW)
+    expect(d.revenue.purchases).toBe(usdc(2))
+    expect(d.revenue.extensions).toBe(usdc(2))
+    expect(d.revenue.upgrades).toBe(usdc(6))
+    expect(d.revenue.total).toBe(usdc(10)) // grant + voucher contribute nothing
+    expect(d.revenue.withdrawn).toBe(0n)
+  })
+
+  it('attributes revenue to the member current tier, including extensions and upgrades', () => {
+    const events = [
+      // A buys Bronze ($2), extends at Bronze ($2), then upgrades to Silver ($6 delta).
+      { name: 'MembershipPurchased', args: { user: A, role: ROLE, tier: 1, price: usdc(2), expiresAt: FUTURE }, blockNumber: 10, logIndex: 0 },
+      { name: 'MembershipExtended', args: { user: A, role: ROLE, durationDays: 30, price: usdc(2), expiresAt: FUTURE }, blockNumber: 11, logIndex: 0 },
+      { name: 'MembershipUpgraded', args: { user: A, role: ROLE, fromTier: 1, toTier: 2, delta: usdc(6) }, blockNumber: 12, logIndex: 0 },
+    ]
+    const d = reduceMembershipTreasuryStats(events, false, NOW)
+    // Bronze: purchase $2 + extension $2 (extension attributed to current tier at that block = Bronze)
+    expect(d.revenueByTier[1]).toBe(usdc(4))
+    // Silver: upgrade delta $6 attributed to toTier
+    expect(d.revenueByTier[2]).toBe(usdc(6))
+    expect(d.revenueByTier[3]).toBe(0n)
+  })
+
+  it('counts active members by tier using expiry and de-dupes repeat events per user', () => {
+    const events = [
+      { name: 'MembershipPurchased', args: { user: A, role: ROLE, tier: 1, price: usdc(2), expiresAt: FUTURE }, blockNumber: 10, logIndex: 0 },
+      // A upgrades to Silver — still ONE member, now Silver.
+      { name: 'MembershipUpgraded', args: { user: A, role: ROLE, fromTier: 1, toTier: 2, delta: usdc(6) }, blockNumber: 11, logIndex: 0 },
+      { name: 'MembershipGranted', args: { user: B, role: ROLE, tier: 3, expiresAt: FUTURE }, blockNumber: 12, logIndex: 0 },
+      // C's membership is already expired.
+      { name: 'MembershipPurchased', args: { user: C, role: ROLE, tier: 1, price: usdc(2), expiresAt: PAST }, blockNumber: 13, logIndex: 0 },
+    ]
+    const d = reduceMembershipTreasuryStats(events, false, NOW)
+    expect(d.members.everMembers).toBe(3) // A, B, C
+    expect(d.members.active).toBe(2) // A (Silver), B (Gold); C expired
+    expect(d.members.byTier).toEqual({ 1: 0, 2: 1, 3: 1, 4: 0 })
+  })
+
+  it('drops revoked members from the active set', () => {
+    const events = [
+      { name: 'MembershipPurchased', args: { user: A, role: ROLE, tier: 2, price: usdc(8), expiresAt: FUTURE }, blockNumber: 10, logIndex: 0 },
+      { name: 'MembershipRevoked', args: { user: A, role: ROLE, by: B }, blockNumber: 11, logIndex: 0 },
+    ]
+    const d = reduceMembershipTreasuryStats(events, false, NOW)
+    expect(d.counts.revoked).toBe(1)
+    expect(d.members.active).toBe(0)
+    expect(d.members.byTier[2]).toBe(0)
+  })
+
+  it('accumulates withdrawals to the treasury from FeesWithdrawn', () => {
+    const events = [
+      { name: 'MembershipPurchased', args: { user: A, role: ROLE, tier: 4, price: usdc(100), expiresAt: FUTURE }, blockNumber: 10, logIndex: 0 },
+      { name: 'FeesWithdrawn', args: { to: B, amount: usdc(60) }, blockNumber: 11, logIndex: 0 },
+      { name: 'FeesWithdrawn', args: { to: B, amount: usdc(40) }, blockNumber: 12, logIndex: 0 },
+    ]
+    const d = reduceMembershipTreasuryStats(events, false, NOW)
+    expect(d.revenue.total).toBe(usdc(100))
+    expect(d.revenue.withdrawn).toBe(usdc(100))
+  })
+
+  it('builds a monotonic cumulative revenue series ordered by block', () => {
+    const events = [
+      { name: 'MembershipUpgraded', args: { user: A, role: ROLE, fromTier: 1, toTier: 2, delta: usdc(6) }, blockNumber: 30, logIndex: 0 },
+      { name: 'MembershipPurchased', args: { user: A, role: ROLE, tier: 1, price: usdc(2), expiresAt: FUTURE }, blockNumber: 10, logIndex: 0 },
+      { name: 'MembershipExtended', args: { user: A, role: ROLE, durationDays: 30, price: usdc(2), expiresAt: FUTURE }, blockNumber: 20, logIndex: 0 },
+    ]
+    const d = reduceMembershipTreasuryStats(events, false, NOW)
+    // Reordered by block: purchase(2) → extend(4) → upgrade(10).
+    expect(d.series.map((p) => p.block)).toEqual([10, 20, 30])
+    expect(d.series.map((p) => p.cumulative)).toEqual([usdc(2), usdc(4), usdc(10)])
+  })
+
+  it('orders the recent feed newest-first and honors the truncated flag', () => {
+    const events = [
+      { name: 'MembershipPurchased', args: { user: A, role: ROLE, tier: 1, price: usdc(2), expiresAt: FUTURE }, blockNumber: 5, logIndex: 0 },
+      { name: 'MembershipRevoked', args: { user: A, role: ROLE, by: B }, blockNumber: 30, logIndex: 2 },
+      { name: 'MembershipGranted', args: { user: B, role: ROLE, tier: 2, expiresAt: FUTURE }, blockNumber: 30, logIndex: 1 },
+    ]
+    const d = reduceMembershipTreasuryStats(events, true, NOW)
+    expect(d.truncated).toBe(true)
+    expect(d.recent.map((r) => r.type)).toEqual(['MembershipRevoked', 'MembershipGranted', 'MembershipPurchased'])
+    expect(d.recent[0].block).toBe(30)
+  })
+
+  it('handles an empty event set', () => {
+    const d = reduceMembershipTreasuryStats([], false, NOW)
+    expect(d.counts).toEqual({ purchased: 0, granted: 0, redeemed: 0, extended: 0, upgraded: 0, revoked: 0 })
+    expect(d.revenue.total).toBe(0n)
+    expect(d.members.active).toBe(0)
+    expect(d.series).toEqual([])
+    expect(d.recent).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

The Admin → Overview tab now surfaces **app-wide membership statistics** and **treasury growth from fees and memberships** — previously it only showed system status, the connected admin's permissions, and contract addresses.

Because `MembershipManager` exposes only point-lookup views (per-user `getMembership`, a single `accruedFees` counter — no aggregate revenue/member counters) and is not indexed by the subgraph, the aggregates are derived client-side from a **bounded, chunked, range-cap-resilient event-log scan**, mirroring the spec-054 callsign operator metrics (`useCallsignRegistryMetrics`). No new contracts, backend, or subgraph work.

## What's new

**`useMembershipTreasuryStats` hook** (+ pure, unit-tested `reduceMembershipTreasuryStats` reducer)
- Scans the MembershipManager lifecycle events over a bounded backward window (`getLogsRange` bisects on RPC caps), cached per (chain, address), refreshed explicitly.
- Folds events into: lifetime counts (purchases / grants / redemptions / extensions / upgrades / revocations); **currently-active members by tier** (expiry- and revocation-aware, de-duped per user so repeat events count as one member); **gross membership revenue** by stream and by tier; a cumulative-revenue series; **total withdrawn to treasury** (`FeesWithdrawn`); and a recent-activity feed.
- Grants and voucher redemptions are correctly **excluded from revenue** (free at this contract), so treasury growth reflects only real inflows.

**`MembershipTreasuryOverview` component** — two new Overview cards:
- *Membership Statistics* — stat tiles for active members (total + per tier), unique members ever, and lifetime activity counts.
- *Treasury Growth* — tiles for membership revenue, withdrawn-to-treasury, and the **exact live accrued (undrawn) balance**; a single-hue cumulative-revenue sparkline; and per-stream / per-tier revenue breakdown bars.
- Explicit cache-backed **Refresh**, honest **truncated-window** disclosure, and a soft-fail "not deployed on this network" notice when MembershipManager is unconfigured.

## Testing

- `useMembershipTreasuryStats.test.js` — 9 reducer tests (counts, paid-stream revenue, tier attribution incl. extensions/upgrades, active-by-tier with expiry, revocation, withdrawals, cumulative series ordering, recent feed, empty set).
- `MembershipTreasuryOverview.test.jsx` — 3 render tests (not-configured notice, populated stats + treasury growth, truncated/error disclosure).
- `npm run build` passes; ESLint clean on all changed files.

## Notes

- Theme-aware (shared CSS custom properties); the sparkline uses a single brand hue for a single-series magnitude-over-sequence form. Block numbers are the x clock (events carry no timestamps), labelled honestly as such.
- No contract/ABI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AnZAMt4EKWPG6TYT1ANrub)_