### PR TITLE
fix(pwa): shorten install name to 🍀Fairwins

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,7 +17,7 @@
     <!-- iOS standalone support (Safari ignores the manifest for home-screen installs) -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="🍀Fairwins" />
+    <meta name="apple-mobile-web-app-title" content="🍀FairWins" />
     <link rel="apple-touch-icon" href="/assets/fairwins_no-text_logo.svg" />
     <title>FairWins - Prediction Markets for Friends</title>
     

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,7 +17,7 @@
     <!-- iOS standalone support (Safari ignores the manifest for home-screen installs) -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="FairWins" />
+    <meta name="apple-mobile-web-app-title" content="🍀Fairwins" />
     <link rel="apple-touch-icon" href="/assets/fairwins_no-text_logo.svg" />
     <title>FairWins - Prediction Markets for Friends</title>
     

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "🍀Fairwins",
-  "short_name": "🍀Fairwins",
+  "name": "🍀FairWins",
+  "short_name": "FairWins",
   "description": "Open prediction markets where anyone can create, join, and resolve markets. Fair participation, transparent resolution, and privacy-preserving mechanisms for collective wisdom.",
   "id": "/",
   "start_url": "/?source=pwa",

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "FairWins — Prediction Markets for Friends",
-  "short_name": "FairWins",
+  "name": "🍀Fairwins",
+  "short_name": "🍀Fairwins",
   "description": "Open prediction markets where anyone can create, join, and resolve markets. Fair participation, transparent resolution, and privacy-preserving mechanisms for collective wisdom.",
   "id": "/",
   "start_url": "/?source=pwa",


### PR DESCRIPTION
## Summary
- The PWA install prompt truncated the app name (e.g. `FairWins - Predic...`) when installed locally, because `manifest.webmanifest`'s `name`/`short_name` and `index.html`'s `apple-mobile-web-app-title` were the long-form "FairWins — Prediction Markets for Friends" / "FairWins".
- Shortened all three to `🍀Fairwins` so the installed app name displays cleanly.

## Test plan
- [x] Confirmed no other frontend code, tests, or Lighthouse config reference the old manifest `name`/`short_name` strings.
- [ ] Manually reinstall the PWA locally and verify the install prompt/home-screen icon now shows `🍀Fairwins` without truncation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KGMUDB3raiEz5VGzRCb11f)_