### PR TITLE
Fix Lock In button pushed off screen by oracle hint text

### DIFF
--- a/frontend/src/components/fairwins/CreateChallengePanel.jsx
+++ b/frontend/src/components/fairwins/CreateChallengePanel.jsx
@@ -408,13 +408,6 @@ function CreateChallengePanel({
         />
       )}
 
-      {/* Oracle timeline is set by the event, not edited here — one compact line. */}
-      {isOracle && market && oracleTimeline?.eligible && (
-        <p className="fm-hint fm-pay-oracle-hint">
-          Takeable until the market closes (up to 30 days) · settles when Polymarket resolves it.
-        </p>
-      )}
-
       {progress && <p className="fm-hint" role="status">{progress.message}</p>}
       {error && <div className="fm-error-banner" role="alert">{error}</div>}
 

--- a/frontend/src/components/fairwins/FriendMarketsModal.css
+++ b/frontend/src/components/fairwins/FriendMarketsModal.css
@@ -670,10 +670,6 @@
   color: var(--brand-primary, #36B37E);
 }
 
-.fm-pay-oracle-hint {
-  text-align: center;
-}
-
 /* Multi-token select under the amount hero (1v1 surface) — compact, centered,
    sits directly beneath the amount rather than inline with a text input. */
 .fm-pay-hero .fm-pay-token-select {


### PR DESCRIPTION
## Summary
- On the oracle (Polymarket) resolution path of the open-challenge create panel, the hint line "Takeable until the market closes (up to 30 days) · settles when Polymarket resolves it." added enough height on mobile to push the primary "Lock in!" submit button below the fold.
- Removed the hint paragraph in `CreateChallengePanel.jsx` and its now-unused `.fm-pay-oracle-hint` CSS rule in `FriendMarketsModal.css`.

## Test plan
- [x] `npx vitest run src/test/CreateChallengePanel.test.jsx` — 6 tests pass
- [x] `npx vitest run src/test/HomeScreen.test.jsx src/test/Dashboard.test.jsx` — 35 tests pass
- [x] `npx eslint src/components/fairwins/CreateChallengePanel.jsx` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01FXzGht5PFMn3sgGNzfQm1X)_