### PR TITLE
Spec 058 follow-up: home-screen testing fixes (currency dropdown, connect modal, QR modal, nav overlap)

### DIFF
--- a/frontend/src/components/fairwins/HomeScreen.css
+++ b/frontend/src/components/fairwins/HomeScreen.css
@@ -53,11 +53,13 @@
   gap: 0.4rem;
 }
 
-/* Reserve room for the mobile bottom bar (plus the device safe area) so no
-   mode's primary button is obscured; keeps each mode non-scrolling at 320px. */
+/* Reserve room for the fixed mobile bottom bar (plus the device safe area) so
+   the whole view — including the wager ticker docked at the column bottom —
+   scrolls clear of the nav instead of hiding behind it. The double class
+   outranks `.dashboard-container`'s own mobile padding on the same element. */
 @media (max-width: 768px) {
-  .home-screen {
-    padding-bottom: calc(4.25rem + env(safe-area-inset-bottom, 0px));
+  .dashboard-container.home-screen {
+    padding-bottom: calc(5rem + env(safe-area-inset-bottom, 0px));
   }
 }
 
@@ -98,36 +100,4 @@
 
 .fm-pay-status {
   text-align: center;
-}
-
-.request-result {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-/* White quiet-zone card behind the request QR (scannability contract from
-   the address-QR work: dark-on-white, no embedded imagery). */
-.request-qr-frame {
-  background: #ffffff;
-  padding: 0.75rem;
-  border-radius: 12px;
-  line-height: 0;
-}
-
-.request-note-text {
-  margin: 0;
-  font-size: 0.95rem;
-  text-align: center;
-  overflow-wrap: anywhere;
-}
-
-.request-scan-hint {
-  text-align: center;
-}
-
-.request-result-actions {
-  width: 100%;
-  max-width: 320px;
 }

--- a/frontend/src/components/fairwins/PayPanel.jsx
+++ b/frontend/src/components/fairwins/PayPanel.jsx
@@ -5,7 +5,7 @@ import AmountKeypad from '../ui/AmountKeypad'
 import AddressInput from '../ui/AddressInput'
 import AddressBookButton from '../ui/AddressBookButton'
 import QRScanner from '../ui/QRScanner'
-import { useWallet, useWalletConnection } from '../../hooks'
+import { useWallet } from '../../hooks'
 import { useTransfer, TRANSFER_KIND } from '../../hooks/useTransfer'
 import { useAddressScreening } from '../../hooks/useAddressScreening'
 import { useNotification } from '../../hooks/useUI'
@@ -33,8 +33,7 @@ function formatUnitsForKeypad(units, decimals) {
  * Contract: specs/058-send-request-home/contracts/home-mode-components.md
  */
 function PayPanel({ onSuccess }) {
-  const { isConnected, chainId } = useWallet()
-  const { connectWallet } = useWalletConnection()
+  const { isConnected, chainId, openConnectModal } = useWallet()
   const { send, status, error: sendError, quoteGasless, balanceOf, refreshBalances, tokens } = useTransfer()
   const { screenOne } = useAddressScreening()
   const { showNotification } = useNotification()
@@ -228,30 +227,35 @@ function PayPanel({ onSuccess }) {
 
   return (
     <div className="fm-form fm-pay-form pay-panel">
-      {/* Amount hero — the shared payments-style keypad; the token pill under
-          the amount switches the currency kind, showing the network's REAL
-          symbols (honest state — no fake "USDC" on networks without it). */}
+      {/* Amount hero — the shared payments-style keypad; the currency dropdown
+          sits directly under the amount (in place of a static pill) and shows
+          the network's REAL symbols (honest state — no fake "USDC" on networks
+          without it). */}
       <div className="fm-pay-hero">
         <AmountKeypad
           value={amount}
           onChange={setAmount}
           prefix="$"
           token={symbol}
+          tokenSlot={(
+            <>
+              <label className="sr-only" htmlFor="pay-token">Currency</label>
+              <select
+                id="pay-token"
+                className="fm-token-select fm-pay-token-select"
+                value={kind}
+                onChange={(e) => setKind(e.target.value)}
+                disabled={busy}
+              >
+                <option value={TRANSFER_KIND.STABLE}>{tokens.stable}</option>
+                <option value={TRANSFER_KIND.NATIVE}>{tokens.native}</option>
+              </select>
+            </>
+          )}
           disabled={busy}
           ariaLabel="Amount to pay"
           id="pay-amount"
         />
-        <label className="sr-only" htmlFor="pay-token">Currency</label>
-        <select
-          id="pay-token"
-          className="fm-token-select fm-pay-token-select"
-          value={kind}
-          onChange={(e) => setKind(e.target.value)}
-          disabled={busy}
-        >
-          <option value={TRANSFER_KIND.STABLE}>{tokens.stable}</option>
-          <option value={TRANSFER_KIND.NATIVE}>{tokens.native}</option>
-        </select>
       </div>
 
       {/* Recipient — the standard address entry stack (typed/pasted + book + scan). */}
@@ -326,7 +330,7 @@ function PayPanel({ onSuccess }) {
 
       <div className="fm-success-actions">
         {!isConnected ? (
-          <button type="button" className="fm-btn-primary" onClick={connectWallet}>
+          <button type="button" className="fm-btn-primary" onClick={() => openConnectModal()}>
             Connect wallet
           </button>
         ) : chainMismatch ? (

--- a/frontend/src/components/fairwins/RequestPanel.jsx
+++ b/frontend/src/components/fairwins/RequestPanel.jsx
@@ -1,50 +1,35 @@
 import { useCallback, useState } from 'react'
-import { QRCodeSVG } from 'qrcode.react'
 import AmountKeypad from '../ui/AmountKeypad'
-import { useWallet, useWalletConnection } from '../../hooks'
+import RequestQRModal from './RequestQRModal'
+import { useWallet } from '../../hooks'
 import { useChainTokens } from '../../hooks/useChainTokens'
-import { useClipboard } from '../../hooks/useClipboard'
-import { getQRColorPreference, getQRColorEntry } from '../../utils/qrColorPreference'
 import { getDefaultCurrencyKind } from '../../utils/homePreference'
 import { buildPaymentRequestUri, NOTE_MAX_LENGTH } from '../../lib/payments/paymentRequest'
 
 /**
  * RequestPanel (spec 058 US2) — ask someone for value: the same amount hero +
- * note layout, and a "Request" action that renders a standard EIP-681 payment
- * request as a QR code (recipient = the connected wallet's address, amount,
- * currency, network; the note rides as an additive `message` param and is
- * ALSO shown as plain text, since third-party wallets ignore the param).
- * Copy/Share cover the remote-payer case. Requests are ephemeral — displayed,
- * never persisted.
+ * note layout, and a "Request" action that builds a standard EIP-681 payment
+ * request (recipient = the connected wallet's address, amount, currency,
+ * network; the note rides as an additive `message` param). The QR is shown in
+ * the shared branded QR dialog (RequestQRModal) — the same surface the app
+ * uses for receive-address QRs — so the panel stays compact. Requests are
+ * ephemeral — displayed, never persisted.
  *
  * Contract: specs/058-send-request-home/contracts/home-mode-components.md
  */
 function RequestPanel() {
-  const { address, isConnected } = useWallet()
-  const { connectWallet } = useWalletConnection()
+  const { address, isConnected, openConnectModal } = useWallet()
   const tokens = useChainTokens()
-  const { copied, copy } = useClipboard()
 
-  const [kind, setKindState] = useState(getDefaultCurrencyKind)
-  const [amount, setAmountState] = useState('')
-  const [note, setNoteState] = useState('')
-  // The generated request remembers the inputs it was built from; it only
-  // renders while they still match, so a stale QR asking for the wrong
-  // amount/network can never stay on screen.
-  const [generatedRaw, setGenerated] = useState(null) // { uri, note, chainId, address } | null
+  const [kind, setKind] = useState(getDefaultCurrencyKind)
+  const [amount, setAmount] = useState('')
+  const [note, setNote] = useState('')
+  const [generated, setGenerated] = useState(null) // { uri, note, amount, symbol } | null
   const [formError, setFormError] = useState(null)
 
   const symbol = kind === 'stable' ? tokens.stable : tokens.native
   const amountValid = Number.isFinite(Number(amount)) && Number(amount) > 0
   const stableUnavailable = kind === 'stable' && !tokens.stableAddress
-  const generated = generatedRaw && generatedRaw.chainId === tokens.chainId && generatedRaw.address === address
-    ? generatedRaw
-    : null
-
-  // Editing any input invalidates a displayed code.
-  const setAmount = useCallback((v) => { setAmountState(v); setGenerated(null); setFormError(null) }, [])
-  const setNote = useCallback((v) => { setNoteState(v); setGenerated(null); setFormError(null) }, [])
-  const setKind = useCallback((v) => { setKindState(v); setGenerated(null); setFormError(null) }, [])
 
   const handleRequest = useCallback(() => {
     setFormError(null)
@@ -58,29 +43,26 @@ function RequestPanel() {
         amount,
         note,
       })
-      setGenerated({ uri, note: note.trim(), chainId: tokens.chainId, address })
+      setGenerated({ uri, note: note.trim(), amount, symbol })
     } catch (err) {
       setFormError(err?.message || 'Could not create the request.')
     }
-  }, [tokens, address, kind, amount, note])
+  }, [tokens, address, kind, amount, note, symbol])
 
-  const handleShare = useCallback(async () => {
-    if (!generated) return
-    const shareText = generated.note
-      ? `${generated.note}\nPay me ${amount} ${symbol} with FairWins:\n${generated.uri}`
-      : `Pay me ${amount} ${symbol} with FairWins:\n${generated.uri}`
-    if (typeof navigator.share === 'function') {
-      try {
-        await navigator.share({ text: shareText })
-      } catch (err) {
-        if (err?.name !== 'AbortError') console.warn('Share failed:', err)
-      }
-    } else {
-      copy(shareText)
-    }
-  }, [generated, amount, symbol, copy])
-
-  const { fg } = getQRColorEntry(getQRColorPreference())
+  const currencySelect = (
+    <>
+      <label className="sr-only" htmlFor="request-token">Currency</label>
+      <select
+        id="request-token"
+        className="fm-token-select fm-pay-token-select"
+        value={kind}
+        onChange={(e) => setKind(e.target.value)}
+      >
+        <option value="stable">{tokens.stable}</option>
+        <option value="native">{tokens.native}</option>
+      </select>
+    </>
+  )
 
   return (
     <div className="fm-form fm-pay-form request-panel">
@@ -90,19 +72,10 @@ function RequestPanel() {
           onChange={setAmount}
           prefix="$"
           token={symbol}
+          tokenSlot={currencySelect}
           ariaLabel="Amount to request"
           id="request-amount"
         />
-        <label className="sr-only" htmlFor="request-token">Currency</label>
-        <select
-          id="request-token"
-          className="fm-token-select fm-pay-token-select"
-          value={kind}
-          onChange={(e) => setKind(e.target.value)}
-        >
-          <option value="stable">{tokens.stable}</option>
-          <option value="native">{tokens.native}</option>
-        </select>
       </div>
 
       <div className="fm-form-group fm-form-full fm-pay-memo">
@@ -123,51 +96,31 @@ function RequestPanel() {
       )}
       {formError && <div className="fm-error-banner" role="alert">{formError}</div>}
 
-      {generated ? (
-        <div className="request-result" data-testid="request-result">
-          <div className="request-qr-frame">
-            <QRCodeSVG
-              value={generated.uri}
-              size={200}
-              level="H"
-              marginSize={2}
-              fgColor={fg}
-              bgColor="#FFFFFF"
-              role="img"
-              aria-label={`Payment request QR code for ${amount} ${symbol}`}
-            />
-          </div>
-          {generated.note && <p className="request-note-text">{generated.note}</p>}
-          <p className="fm-hint request-scan-hint">
-            Scannable from the FairWins Pay view — or by any wallet that reads payment QR codes.
-          </p>
-          <div className="request-result-actions">
-            <button type="button" className="fm-btn-secondary" onClick={() => copy(generated.uri)}>
-              {copied ? 'Copied!' : 'Copy'}
-            </button>
-            <button type="button" className="fm-btn-secondary" onClick={handleShare}>
-              Share
-            </button>
-          </div>
-        </div>
-      ) : (
-        <div className="fm-success-actions">
-          {!isConnected || !address ? (
-            <button type="button" className="fm-btn-primary" onClick={connectWallet}>
-              Connect wallet
-            </button>
-          ) : (
-            <button
-              type="button"
-              className="fm-btn-primary"
-              onClick={handleRequest}
-              disabled={!amountValid || stableUnavailable}
-            >
-              Request
-            </button>
-          )}
-        </div>
-      )}
+      <div className="fm-success-actions">
+        {!isConnected || !address ? (
+          <button type="button" className="fm-btn-primary" onClick={() => openConnectModal()}>
+            Connect wallet
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="fm-btn-primary"
+            onClick={handleRequest}
+            disabled={!amountValid || stableUnavailable}
+          >
+            Request
+          </button>
+        )}
+      </div>
+
+      <RequestQRModal
+        isOpen={Boolean(generated)}
+        onClose={() => setGenerated(null)}
+        uri={generated?.uri}
+        amount={generated?.amount}
+        symbol={generated?.symbol}
+        note={generated?.note}
+      />
     </div>
   )
 }

--- a/frontend/src/components/fairwins/RequestPanel.jsx
+++ b/frontend/src/components/fairwins/RequestPanel.jsx
@@ -21,15 +21,28 @@ function RequestPanel() {
   const { address, isConnected, openConnectModal } = useWallet()
   const tokens = useChainTokens()
 
-  const [kind, setKind] = useState(getDefaultCurrencyKind)
-  const [amount, setAmount] = useState('')
-  const [note, setNote] = useState('')
-  const [generated, setGenerated] = useState(null) // { uri, note, amount, symbol } | null
+  const [kind, setKindState] = useState(getDefaultCurrencyKind)
+  const [amount, setAmountState] = useState('')
+  const [note, setNoteState] = useState('')
+  const [generated, setGenerated] = useState(null) // { uri, note, amount, symbol, address, chainId } | null
   const [formError, setFormError] = useState(null)
 
   const symbol = kind === 'stable' ? tokens.stable : tokens.native
   const amountValid = Number.isFinite(Number(amount)) && Number(amount) > 0
   const stableUnavailable = kind === 'stable' && !tokens.stableAddress
+
+  // A generated request is only valid for the wallet + network it was built
+  // for: if the user switches account or chain while the modal is open, the
+  // guard nulls it out so the QR can never pay the previous address/network.
+  const safeGenerated = generated && generated.address === address && generated.chainId === tokens.chainId
+    ? generated
+    : null
+
+  // Any input change invalidates a displayed code (belt-and-braces alongside
+  // the modal's focus trap, so a stale QR is never shown after an edit).
+  const setKind = useCallback((v) => { setKindState(v); setGenerated(null); setFormError(null) }, [])
+  const setAmount = useCallback((v) => { setAmountState(v); setGenerated(null); setFormError(null) }, [])
+  const setNote = useCallback((v) => { setNoteState(v); setGenerated(null); setFormError(null) }, [])
 
   const handleRequest = useCallback(() => {
     setFormError(null)
@@ -43,7 +56,7 @@ function RequestPanel() {
         amount,
         note,
       })
-      setGenerated({ uri, note: note.trim(), amount, symbol })
+      setGenerated({ uri, note: note.trim(), amount, symbol, address, chainId: tokens.chainId })
     } catch (err) {
       setFormError(err?.message || 'Could not create the request.')
     }
@@ -114,12 +127,12 @@ function RequestPanel() {
       </div>
 
       <RequestQRModal
-        isOpen={Boolean(generated)}
+        isOpen={Boolean(safeGenerated)}
         onClose={() => setGenerated(null)}
-        uri={generated?.uri}
-        amount={generated?.amount}
-        symbol={generated?.symbol}
-        note={generated?.note}
+        uri={safeGenerated?.uri}
+        amount={safeGenerated?.amount}
+        symbol={safeGenerated?.symbol}
+        note={safeGenerated?.note}
       />
     </div>
   )

--- a/frontend/src/components/fairwins/RequestQRModal.jsx
+++ b/frontend/src/components/fairwins/RequestQRModal.jsx
@@ -22,6 +22,7 @@ function RequestQRModal({ isOpen, onClose, uri, amount, symbol, note }) {
   const { copied, error: copyError, copy } = useClipboard()
   const closeButtonRef = useRef(null)
   const triggerRef = useRef(null)
+  const dialogRef = useRef(null)
 
   const shareText = note
     ? `${note}\nPay me ${amount} ${symbol} with FairWins:\n${uri}`
@@ -51,10 +52,32 @@ function RequestQRModal({ isOpen, onClose, uri, amount, symbol, note }) {
     }
   }, [isOpen])
 
-  // Escape closes.
+  // Escape closes; Tab is trapped inside the dialog so keyboard users can't
+  // reach the amount/currency controls behind the modal and leave a stale QR.
   useEffect(() => {
     if (!isOpen) return undefined
-    const handleKeyDown = (e) => { if (e.key === 'Escape') onClose() }
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') { onClose(); return }
+      if (e.key !== 'Tab') return
+      const root = dialogRef.current
+      if (!root) return
+      const focusable = root.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )
+      if (focusable.length === 0) return
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault()
+        first.focus()
+      } else if (!root.contains(document.activeElement)) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [isOpen, onClose])
@@ -75,7 +98,7 @@ function RequestQRModal({ isOpen, onClose, uri, amount, symbol, note }) {
       aria-modal="true"
       aria-labelledby="request-qr-title"
     >
-      <div className="address-qr-modal">
+      <div className="address-qr-modal" ref={dialogRef}>
         <button
           ref={closeButtonRef}
           className="address-qr-close"

--- a/frontend/src/components/fairwins/RequestQRModal.jsx
+++ b/frontend/src/components/fairwins/RequestQRModal.jsx
@@ -1,0 +1,132 @@
+import { useEffect, useRef } from 'react'
+import { QRCodeSVG } from 'qrcode.react'
+import { useClipboard } from '../../hooks/useClipboard'
+import { getQRColorPreference, getQRColorEntry } from '../../utils/qrColorPreference'
+import '../ui/AddressQRModal.css'
+
+/**
+ * RequestQRModal (spec 058 US2) — presents a generated payment request as a
+ * scannable QR in the SAME branded dialog chrome as AddressQRModal (the app's
+ * existing "show a QR" surface), rather than inline in the panel. This keeps
+ * the Request view compact (nothing pushed under the bottom nav) and matches
+ * the receive-address modal users already know.
+ *
+ * Props:
+ *  - isOpen (bool): nothing renders when false.
+ *  - onClose (fn): close button, backdrop, and Escape.
+ *  - uri (string): the EIP-681 payment-request URI to encode.
+ *  - amount (string) / symbol (string): for the human-readable caption.
+ *  - note (string): optional; shown as plain text under the code.
+ */
+function RequestQRModal({ isOpen, onClose, uri, amount, symbol, note }) {
+  const { copied, error: copyError, copy } = useClipboard()
+  const closeButtonRef = useRef(null)
+  const triggerRef = useRef(null)
+
+  const shareText = note
+    ? `${note}\nPay me ${amount} ${symbol} with FairWins:\n${uri}`
+    : `Pay me ${amount} ${symbol} with FairWins:\n${uri}`
+
+  const handleShare = async () => {
+    if (typeof navigator.share === 'function') {
+      try {
+        await navigator.share({ text: shareText })
+      } catch (err) {
+        if (err?.name !== 'AbortError') console.warn('Share failed:', err)
+      }
+    } else {
+      copy(shareText)
+    }
+  }
+
+  // Move focus into the dialog on open; return it to the trigger on close.
+  useEffect(() => {
+    if (!isOpen) return undefined
+    triggerRef.current = document.activeElement
+    closeButtonRef.current?.focus()
+    return () => {
+      if (triggerRef.current && typeof triggerRef.current.focus === 'function') {
+        triggerRef.current.focus()
+      }
+    }
+  }, [isOpen])
+
+  // Escape closes.
+  useEffect(() => {
+    if (!isOpen) return undefined
+    const handleKeyDown = (e) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  const { fg } = getQRColorEntry(getQRColorPreference())
+
+  const handleBackdropClick = (e) => {
+    if (e.target === e.currentTarget) onClose()
+  }
+
+  return (
+    <div
+      className="address-qr-backdrop"
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="request-qr-title"
+    >
+      <div className="address-qr-modal">
+        <button
+          ref={closeButtonRef}
+          className="address-qr-close"
+          onClick={onClose}
+          aria-label="Close payment request dialog"
+        >
+          ×
+        </button>
+
+        <h2 id="request-qr-title" className="address-qr-title">
+          Request {amount} {symbol}
+        </h2>
+
+        <div className="address-qr-content">
+          <div className="address-qr-frame">
+            <QRCodeSVG
+              value={uri}
+              size={240}
+              level="H"
+              marginSize={2}
+              fgColor={fg}
+              bgColor="#FFFFFF"
+              role="img"
+              aria-label={`Payment request QR code for ${amount} ${symbol}`}
+            />
+          </div>
+
+          <p className="address-qr-wordmark" aria-hidden="true">FairWins</p>
+
+          {note && <p className="address-qr-address">{note}</p>}
+
+          <div className="address-qr-actions">
+            <button type="button" className="address-qr-action-btn" onClick={() => copy(uri)}>
+              {copied ? 'Copied!' : 'Copy'}
+            </button>
+            <button
+              type="button"
+              className="address-qr-action-btn address-qr-share-btn"
+              onClick={handleShare}
+            >
+              Share
+            </button>
+          </div>
+
+          <p className="address-qr-status" role="status" aria-live="polite">
+            {copyError || (copied ? 'Request copied to clipboard.' : 'Scannable from the FairWins Pay view — or any wallet that reads payment QR codes.')}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default RequestQRModal

--- a/frontend/src/components/ui/AmountKeypad.css
+++ b/frontend/src/components/ui/AmountKeypad.css
@@ -78,6 +78,13 @@
   text-transform: uppercase;
 }
 
+/* Host-provided currency control slotted under the amount, in place of the
+   static token pill (spec 058 feedback). Centers whatever the host renders. */
+.amount-keypad-token-slot {
+  display: flex;
+  justify-content: center;
+}
+
 /* ── Number pad ────────────────────────────────────────────────────── */
 .amount-keypad-pad {
   display: grid;

--- a/frontend/src/components/ui/AmountKeypad.jsx
+++ b/frontend/src/components/ui/AmountKeypad.jsx
@@ -63,6 +63,7 @@ function AmountKeypad({
   onChange,
   prefix = '$',
   token = null,
+  tokenSlot = null,
   disabled = false,
   maxFractionDigits = 2,
   id,
@@ -114,7 +115,12 @@ function AmountKeypad({
           {prefix && <span className="amount-keypad-prefix">{prefix}</span>}
           <span className="amount-keypad-value">{displayValue}</span>
         </div>
-        {token && <span className="amount-keypad-token">{token}</span>}
+        {/* A host can slot an interactive currency control (e.g. a token
+            dropdown) directly under the amount in place of the static pill;
+            the sr-only announcement still uses `token` for the live value. */}
+        {tokenSlot
+          ? <div className="amount-keypad-token-slot">{tokenSlot}</div>
+          : token && <span className="amount-keypad-token">{token}</span>}
         <span className="sr-only" role="status" aria-live="polite">{announced}</span>
       </div>
 

--- a/frontend/src/components/ui/__tests__/AmountKeypad.test.jsx
+++ b/frontend/src/components/ui/__tests__/AmountKeypad.test.jsx
@@ -117,6 +117,22 @@ describe('AmountKeypad', () => {
     expect(live).toHaveTextContent(/USDC/)
   })
 
+  it('renders a host-provided tokenSlot in place of the static token pill (spec 058)', () => {
+    const { container } = render(
+      <Harness
+        prefix="$"
+        token="USDC"
+        initial="5"
+        tokenSlot={<button type="button">pick currency</button>}
+      />,
+    )
+    // The interactive slot renders; the static pill does not.
+    expect(screen.getByRole('button', { name: 'pick currency' })).toBeInTheDocument()
+    expect(container.querySelector('.amount-keypad-token')).toBeNull()
+    // The token still drives the sr-only live announcement.
+    expect(screen.getByRole('status')).toHaveTextContent(/USDC/)
+  })
+
   it('accepts hardware keyboard digits, decimal and backspace', () => {
     render(<Harness />)
     const group = screen.getByRole('group')

--- a/frontend/src/test/PayPanel.test.jsx
+++ b/frontend/src/test/PayPanel.test.jsx
@@ -5,10 +5,14 @@ const USDC = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'
 const RECIPIENT = '0x2222222222222222222222222222222222222222'
 const BOOK_ADDR = '0x3333333333333333333333333333333333333333'
 
-const walletHolder = { isConnected: true, connectWallet: vi.fn() }
+const walletHolder = { isConnected: true, openConnectModal: vi.fn() }
 vi.mock('../hooks', () => ({
-  useWallet: () => ({ isConnected: walletHolder.isConnected, address: '0xabc', chainId: 137 }),
-  useWalletConnection: () => ({ connectWallet: walletHolder.connectWallet }),
+  useWallet: () => ({
+    isConnected: walletHolder.isConnected,
+    address: '0xabc',
+    chainId: 137,
+    openConnectModal: walletHolder.openConnectModal,
+  }),
 }))
 
 const transferHolder = {}
@@ -93,19 +97,19 @@ describe('PayPanel (spec 058 US1)', () => {
     localStorage.clear()
     resetTransferHolder()
     walletHolder.isConnected = true
-    walletHolder.connectWallet = vi.fn()
+    walletHolder.openConnectModal = vi.fn()
     screeningHolder.result = 'clear'
     notifyHolder.showNotification = vi.fn()
     switchHolder.switchChainAsync = vi.fn(async () => {})
   })
 
-  it('defaults the hero to the stablecoin (USDC) and shows honest symbols in the currency pill', () => {
-    const { container } = render(<PayPanel />)
-    expect(container.querySelector('.amount-keypad-token')).toHaveTextContent('USDC')
-    const pill = screen.getByLabelText('Currency')
-    expect(pill).toHaveValue('stable')
-    fireEvent.change(pill, { target: { value: 'native' } })
-    expect(container.querySelector('.amount-keypad-token')).toHaveTextContent('POL')
+  it('defaults the hero to the stablecoin (USDC) and shows honest symbols in the currency dropdown', () => {
+    render(<PayPanel />)
+    const select = screen.getByLabelText('Currency')
+    expect(select).toHaveValue('stable')
+    expect(screen.getByRole('option', { name: 'USDC' }).selected).toBe(true)
+    fireEvent.change(select, { target: { value: 'native' } })
+    expect(screen.getByRole('option', { name: 'POL' }).selected).toBe(true)
   })
 
   it('starts on the preferred currency kind from the device preference', async () => {
@@ -143,12 +147,12 @@ describe('PayPanel (spec 058 US1)', () => {
     expect(payButton()).toBeDisabled()
   })
 
-  it('shows a connect prompt instead of Pay when disconnected', () => {
+  it('opens the connect modal instead of Pay when disconnected', () => {
     walletHolder.isConnected = false
     render(<PayPanel />)
     const connect = screen.getByRole('button', { name: /connect wallet/i })
     fireEvent.click(connect)
-    expect(walletHolder.connectWallet).toHaveBeenCalled()
+    expect(walletHolder.openConnectModal).toHaveBeenCalled()
   })
 
   it('prefills the recipient from an address-book pick', () => {

--- a/frontend/src/test/RequestPanel.test.jsx
+++ b/frontend/src/test/RequestPanel.test.jsx
@@ -119,6 +119,29 @@ describe('RequestPanel (spec 058 US2)', () => {
     expect(requestButton()).toBeInTheDocument()
   })
 
+  it('invalidates a generated request when the connected account changes (no stale payee)', () => {
+    const { rerender } = render(<RequestPanel />)
+    typeAmount(['5'])
+    fireEvent.click(requestButton())
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    // The wallet switches to a different account: the modal must drop the
+    // now-stale request rather than keep paying the previous address.
+    walletHolder.address = ethers.getAddress('0x9999999999999999999999999999999999999999')
+    rerender(<RequestPanel />)
+    expect(screen.queryByRole('dialog')).toBeNull()
+    expect(screen.queryByTestId('request-qr')).toBeNull()
+  })
+
+  it('invalidates a generated request when the network changes', () => {
+    const { rerender } = render(<RequestPanel />)
+    typeAmount(['5'])
+    fireEvent.click(requestButton())
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    tokensHolder.chainId = 1
+    rerender(<RequestPanel />)
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
   it('blocks a stablecoin request honestly when the network has none configured', () => {
     tokensHolder.stableAddress = null
     tokensHolder.stable = 'USC'

--- a/frontend/src/test/RequestPanel.test.jsx
+++ b/frontend/src/test/RequestPanel.test.jsx
@@ -5,16 +5,19 @@ import { ethers } from 'ethers'
 const MY_ADDRESS = ethers.getAddress('0x5555555555555555555555555555555555555555')
 const USDC = '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'
 
-const walletHolder = { isConnected: true, address: MY_ADDRESS, connectWallet: vi.fn() }
+const walletHolder = { isConnected: true, address: MY_ADDRESS, openConnectModal: vi.fn() }
 vi.mock('../hooks', () => ({
-  useWallet: () => ({ isConnected: walletHolder.isConnected, address: walletHolder.address }),
-  useWalletConnection: () => ({ connectWallet: walletHolder.connectWallet }),
+  useWallet: () => ({
+    isConnected: walletHolder.isConnected,
+    address: walletHolder.address,
+    openConnectModal: walletHolder.openConnectModal,
+  }),
 }))
 
 const tokensHolder = {}
 vi.mock('../hooks/useChainTokens', () => ({ useChainTokens: () => tokensHolder }))
 
-const clipboardHolder = { copied: false, copy: vi.fn() }
+const clipboardHolder = { copied: false, error: null, copy: vi.fn() }
 vi.mock('../hooks/useClipboard', () => ({ useClipboard: () => clipboardHolder }))
 
 vi.mock('qrcode.react', () => ({
@@ -36,8 +39,9 @@ describe('RequestPanel (spec 058 US2)', () => {
     localStorage.clear()
     walletHolder.isConnected = true
     walletHolder.address = MY_ADDRESS
-    walletHolder.connectWallet = vi.fn()
+    walletHolder.openConnectModal = vi.fn()
     clipboardHolder.copied = false
+    clipboardHolder.error = null
     clipboardHolder.copy = vi.fn()
     Object.assign(tokensHolder, {
       chainId: 137, networkName: 'Polygon',
@@ -53,17 +57,16 @@ describe('RequestPanel (spec 058 US2)', () => {
     expect(requestButton()).toBeEnabled()
   })
 
-  it('prompts to connect before a code can be generated (US2 scenario 4)', () => {
+  it('opens the connect modal before a code can be generated (US2 scenario 4)', () => {
     walletHolder.isConnected = false
     walletHolder.address = null
     render(<RequestPanel />)
     typeAmount(['4'])
-    const connect = screen.getByRole('button', { name: /connect wallet/i })
-    fireEvent.click(connect)
-    expect(walletHolder.connectWallet).toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: /connect wallet/i }))
+    expect(walletHolder.openConnectModal).toHaveBeenCalled()
   })
 
-  it('generates a valid EIP-681 QR carrying address, amount, currency, network, and note (FR-006/FR-007)', () => {
+  it('generates a valid EIP-681 QR in a modal carrying address, amount, currency, network, and note (FR-006/FR-007)', () => {
     render(<RequestPanel />)
     typeAmount(['1', '2', '.', '5'])
     fireEvent.change(screen.getByLabelText(/what's it for/i), { target: { value: 'pizza night' } })
@@ -71,12 +74,14 @@ describe('RequestPanel (spec 058 US2)', () => {
     const expected = buildPaymentRequestUri({
       chainId: 137, to: MY_ADDRESS, kind: 'stable', tokenAddress: USDC, decimals: 6, amount: '12.5', note: 'pizza night',
     })
+    // The QR is presented in the shared branded dialog.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
     expect(screen.getByTestId('request-qr')).toHaveAttribute('data-value', expected)
-    // The note is ALSO plain text beside the code (third-party wallets ignore the param).
+    // The note is ALSO plain text under the code (third-party wallets ignore the param).
     expect(screen.getByText('pizza night')).toBeInTheDocument()
   })
 
-  it('generates a native-coin request when the currency pill is on the native kind', () => {
+  it('generates a native-coin request when the currency dropdown is on the native kind', () => {
     render(<RequestPanel />)
     fireEvent.change(screen.getByLabelText('Currency'), { target: { value: 'native' } })
     typeAmount(['2'])
@@ -87,7 +92,7 @@ describe('RequestPanel (spec 058 US2)', () => {
     expect(screen.getByTestId('request-qr')).toHaveAttribute('data-value', expected)
   })
 
-  it('copies the request URI', () => {
+  it('copies the request URI from the modal', () => {
     render(<RequestPanel />)
     typeAmount(['3'])
     fireEvent.click(requestButton())
@@ -104,13 +109,14 @@ describe('RequestPanel (spec 058 US2)', () => {
     expect(clipboardHolder.copy).toHaveBeenCalledWith(expect.stringContaining('ethereum:'))
   })
 
-  it('clears a displayed code the moment any input changes (stale-QR prevention)', () => {
+  it('closes the QR modal, returning to the editable form', () => {
     render(<RequestPanel />)
     typeAmount(['3'])
     fireEvent.click(requestButton())
     expect(screen.getByTestId('request-qr')).toBeInTheDocument()
-    typeAmount(['0'])
+    fireEvent.click(screen.getByRole('button', { name: /close payment request/i }))
     expect(screen.queryByTestId('request-qr')).toBeNull()
+    expect(requestButton()).toBeInTheDocument()
   })
 
   it('blocks a stablecoin request honestly when the network has none configured', () => {

--- a/frontend/src/test/home.axe.test.jsx
+++ b/frontend/src/test/home.axe.test.jsx
@@ -18,7 +18,7 @@ vi.mock('../components/fairwins/PolymarketTickerCrawler', () => ({
 }))
 
 vi.mock('../hooks', () => ({
-  useWallet: () => ({ isConnected: true, address: '0x5555555555555555555555555555555555555555', chainId: 137 }),
+  useWallet: () => ({ isConnected: true, address: '0x5555555555555555555555555555555555555555', chainId: 137, openConnectModal: vi.fn() }),
   useWalletConnection: () => ({ connectWallet: vi.fn() }),
 }))
 vi.mock('../hooks/useUI', () => ({

--- a/frontend/src/test/paymentRequestRoundTrip.test.jsx
+++ b/frontend/src/test/paymentRequestRoundTrip.test.jsx
@@ -17,8 +17,7 @@ const TOKENS = {
 }
 
 vi.mock('../hooks', () => ({
-  useWallet: () => ({ isConnected: true, address: REQUESTER, chainId: 137 }),
-  useWalletConnection: () => ({ connectWallet: vi.fn() }),
+  useWallet: () => ({ isConnected: true, address: REQUESTER, chainId: 137, openConnectModal: vi.fn() }),
 }))
 vi.mock('../hooks/useChainTokens', () => ({ useChainTokens: () => TOKENS }))
 vi.mock('../hooks/useClipboard', () => ({ useClipboard: () => ({ copied: false, copy: vi.fn() }) }))


### PR DESCRIPTION
## Summary

Follow-up to the merged spec 058 (#921), addressing tester feedback on the live Pay / Request / Wager home. Four UI fixes; frontend-only, no contract or value-path changes.

| # | Feedback | Fix |
|---|----------|-----|
| 1 | Duplicate "USDC" — a static pill under the amount **and** a dropdown below the numpad | Added an optional `tokenSlot` to the shared `AmountKeypad`; the currency **dropdown** now renders directly under the amount in place of the pill. One control, not two. |
| 2 | "Connect wallet" button non-functional | Root cause: `onClick={connectWallet}` passed the click **event** as a connector id, so `connectWallet` took the "find connector" path and threw instead of opening the modal. Now calls `openConnectModal()` (the app's canonical connect surface, as `WalletButton` uses). |
| 4 | Receive QR should use the app's existing modal | New `RequestQRModal` reuses `AddressQRModal`'s branded dialog chrome (focus trap, Escape, copy, share); the Request QR opens there instead of rendering inline. |
| 5 | Ticker/crawler rendered under the bottom nav | The mobile scroll container (`.dashboard-container.home-screen`) now reserves enough bottom padding — raised and made specific enough to outrank `.dashboard-container` — so the whole view, including the wager ticker docked at the column bottom, clears the fixed bottom nav. |

## Not included — issue #3 (passkey "no longer a controller" after reconnect)

The reported error ("This passkey is no longer a controller of the account") is thrown by `lib/passkey/smartAccount.js#resolveController` during signing, when the resolved smart-account's on-chain controllers don't include the reconnected passkey credential. This is **passkey account/controller-lifecycle logic (specs 041/045)** — the same error would surface from the wallet's existing Pay & Transfer tab, not something this home feature introduced. Because it's custody-adjacent, I've left it out of this UI-fix PR pending a decision on scope (see the PR discussion). Diagnosis: on reconnect the account address is derived from the credential, but if that account's passkey owner was rotated/removed on-chain, the restored session still maps to it — needs a dedicated look with a security review.

## Tests

Updated `PayPanel`, `RequestPanel`, `paymentRequestRoundTrip`, and `home.axe` suites for the connect-modal and QR-modal flows, plus a new `AmountKeypad` `tokenSlot` case. All affected suites pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Gr7WYVb89TScjTe49btkg

---
_Generated by [Claude Code](https://claude.ai/code/session_019Gr7WYVb89TScjTe49btkg)_