### PR TITLE
Spec 059: Signal-style notification profiles

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/058-send-request-home"
+  "feature_directory": "specs/059-notification-profiles"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,5 +137,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/058-send-request-home/plan.md
+at specs/059-notification-profiles/plan.md
 <!-- SPECKIT END -->

--- a/docs/developer-guide/notification-profiles.md
+++ b/docs/developer-guide/notification-profiles.md
@@ -1,0 +1,98 @@
+# Notification Profiles (spec 059)
+
+Signal-style interruption modes layered over the spec-031 client-side
+notification stack. A profile is a named allow-list over the notification
+domains plus two always-break-through exceptions and an optional weekly
+schedule; at most one profile is active at a time. While active, only allowed
+updates interrupt (toast/OS push) — everything still lands in the durable
+activity feed.
+
+## Layering
+
+```
+ActivityProvider.poll()  — appends ALL fresh entries to the feed, then per entry:
+  resolveEntryDelivery(entry)            lib/notifications/notificationProfiles.js
+    ├─ no active profile      → resolveDelivery(domain)     (bit-identical to pre-059)
+    ├─ domain allow-listed    → resolveDelivery(domain)
+    ├─ exception match        → resolveDelivery(domain), 'silent' upgraded to 'app'
+    └─ otherwise              → 'silent' (feed only)
+  resolveDelivery(domain)                lib/notifications/deliveryPreferences.js
+    the untouched base layer: per-category push/app/silent + master push flag
+```
+
+Exception matches: `entry.actionable === true` ("Always allow action-required
+items") and `entry.type ∈ DEADLINE_REMINDER_TYPES` (`warn-acceptance`,
+`warn-resolution` from `deadlineWarnings.js` — "Always allow deadline
+reminders"). Both default ON for new profiles: in a wagering app, missed
+approvals and deadlines cost money, so the safety-preserving default wins over
+strict Signal symmetry (Signal defaults mentions OFF).
+
+## Storage
+
+`localStorage['fairwins_notif_profiles_v1']` — device-scoped (like
+`fairwins_notif_delivery_v1`; a phone's interruption rules are per-device, and
+there is no backend to sync through):
+
+```json
+{
+  "version": 1,
+  "profiles": [{
+    "id": "p_…", "name": "Sleep", "emoji": "😴",
+    "allowedDomains": ["wagers"],
+    "allowActionRequired": true, "allowDeadlineReminders": true,
+    "schedule": { "enabled": true, "start": "21:00", "end": "07:00", "days": [0,1,2,3,4,5,6] },
+    "createdAt": 0, "updatedAt": 0
+  }],
+  "override": { "kind": "enabled", "profileId": "p_…", "until": null, "at": 0 }
+}
+```
+
+Reads normalize aggressively (corrupt/foreign data ⇒ empty store, never
+throws). Activation is a single `override` record — `enabled` (manual on,
+optional `until` expiry) or `disabled` (suppresses one scheduled window) —
+replaced wholesale on every enable, which structurally guarantees a single
+active profile. `getActiveStatus(nowMs)` evaluates lazily (manual > schedule,
+latest window start wins, expired overrides pruned on read), so correctness
+never depends on a timer: the state is right on next open even if the app was
+closed across a boundary. Schedules are device-local wall time; `end <= start`
+spans midnight and the window belongs to its start day.
+
+## Surfaces
+
+- **Settings** — `components/account/NotificationProfilesPanel.jsx`, rendered
+  above the base-layer `NotificationPreferencesPanel` in Wallet → Preferences →
+  Notifications. Hosts the 4-step `ProfileWizard` (name+emoji presets →
+  allow-list+exceptions → schedule → confirmation) and the inline editor.
+  Deep links: `/wallet?tab=preferences#notification-profiles` (scroll) and
+  `…#notification-profiles-new` (open wizard).
+- **Quick access** — `components/notifications/profiles/ProfileQuickAccess.jsx`,
+  pinned atop the `ActivityFeed` panel (the chat-list analog of Signal's
+  sheet): per-profile On / "For 1 hour" / "Until <schedule end>" / Turn off,
+  plus New profile / View settings.
+- **React binding** — `hooks/useNotificationProfiles.js`: store subscription +
+  a 30 s status tick (display only; the gate never needs it).
+
+## Signal mapping
+
+| Signal | FairWins |
+|---|---|
+| Allowed people & groups | Allow-list over the six notification domains (`NOTIFICATION_CATEGORIES`) |
+| Allow all calls | Always allow action-required items (default ON) |
+| Notify for all mentions | Always allow deadline reminders (default ON — money beats symmetry) |
+| Chat-list sheet | `ProfileQuickAccess` in the bell's feed panel |
+| Cross-device sync | Out of scope (no backend; per-device like delivery prefs) |
+
+## Invariants (tested)
+
+- With no profile active, delivery is byte-identical to the base layer — the
+  pre-059 delivery test suite passes unmodified (`ActivityProvider.delivery`,
+  `deliveryPreferences`, `NotificationPreferencesPanel`).
+- The feed append path is untouched: silenced entries persist and count unread.
+- The silent→app upgrade applies to exception matches ONLY; profiles never
+  upgrade normal delivery.
+- A schedule can never be saved enabled with zero days.
+
+Tests: `src/test/notificationProfiles.test.js`,
+`ActivityProvider.profiles.test.jsx`, `ProfileWizard.test.jsx`,
+`NotificationProfilesPanel.test.jsx`, `ProfileQuickAccess.test.jsx`.
+Spec: `specs/059-notification-profiles/`.

--- a/frontend/src/components/account/NotificationProfilesPanel.css
+++ b/frontend/src/components/account/NotificationProfilesPanel.css
@@ -1,0 +1,286 @@
+/* NotificationProfilesPanel — Signal-style notification profiles on the
+   Preferences tab (spec 059). Sits above NotificationPreferencesPanel and
+   reuses its switch look (.notif-pref-switch) for on/off controls. */
+
+.notif-profiles-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.notif-profiles-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.notif-profiles-hint {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.notif-profiles-empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  padding: 0.5rem 0;
+}
+
+.notif-profiles-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.notif-profiles-row {
+  border-bottom: 1px solid var(--border-color);
+  padding: 0.6rem 0;
+}
+
+.notif-profiles-row:last-child {
+  border-bottom: none;
+}
+
+.notif-profiles-row-main {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.notif-profiles-emoji {
+  font-size: 1.3rem;
+  width: 1.75rem;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.notif-profiles-row-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.notif-profiles-name {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.notif-profiles-status {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.notif-profiles-edit {
+  appearance: none;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  padding: 0.3rem 0.8rem;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.notif-profiles-edit:hover,
+.notif-profiles-edit:focus-visible {
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+  outline: none;
+}
+
+.notif-profiles-new {
+  appearance: none;
+  align-self: flex-start;
+  border: 1px dashed var(--border-color);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  font-weight: 500;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  margin-top: 0.5rem;
+}
+
+.notif-profiles-new:hover,
+.notif-profiles-new:focus-visible {
+  border-color: var(--brand-primary);
+  color: var(--brand-primary);
+  outline: none;
+}
+
+/* Inline editor */
+.notif-profile-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+}
+
+.notif-profile-editor-name input[type='text'] {
+  width: 100%;
+  padding: 0.5rem 0.7rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+}
+
+.notif-profile-editor-name input[type='text']:focus-visible {
+  outline: 2px solid var(--brand-primary);
+  outline-offset: -1px;
+}
+
+.notif-profile-editor-emojis {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.notif-profile-emoji-btn {
+  appearance: none;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 50%;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  font-size: 1.1rem;
+  cursor: pointer;
+}
+
+.notif-profile-emoji-btn.selected {
+  border-color: var(--brand-primary);
+  box-shadow: 0 0 0 1px var(--brand-primary);
+}
+
+.notif-profile-emoji-btn:focus-visible {
+  outline: 2px solid var(--brand-primary);
+  outline-offset: 2px;
+}
+
+.notif-profile-editor-heading {
+  margin: 0.4rem 0 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-secondary);
+}
+
+.notif-profile-editor-domains {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+  gap: 0.2rem;
+}
+
+.notif-profile-editor-domain {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  padding: 0.25rem 0;
+  cursor: pointer;
+}
+
+.notif-profile-editor-domain input[type='checkbox'] {
+  accent-color: var(--brand-primary);
+  width: 1rem;
+  height: 1rem;
+}
+
+.notif-profile-editor-exception {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  padding: 0.3rem 0;
+}
+
+.notif-profile-editor-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.notif-profile-editor-spacer {
+  flex: 1;
+}
+
+.notif-profile-save-btn {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: var(--brand-primary);
+  color: #fff;
+  cursor: pointer;
+}
+
+.notif-profile-save-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.notif-profile-cancel-btn {
+  appearance: none;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  font-size: 0.85rem;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.notif-profile-delete-btn {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  font-size: 0.85rem;
+  background: transparent;
+  color: var(--color-error, #b91c1c);
+  cursor: pointer;
+}
+
+.notif-profile-delete-btn:hover,
+.notif-profile-delete-btn:focus-visible {
+  background: color-mix(in srgb, var(--color-error, #b91c1c) 10%, transparent);
+  outline: none;
+}
+
+.notif-profile-delete-confirm-text {
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.notif-profile-save-btn:focus-visible,
+.notif-profile-cancel-btn:focus-visible {
+  outline: 2px solid var(--brand-primary);
+  outline-offset: 2px;
+}

--- a/frontend/src/components/account/NotificationProfilesPanel.jsx
+++ b/frontend/src/components/account/NotificationProfilesPanel.jsx
@@ -1,0 +1,281 @@
+import { useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import { useNotificationProfiles } from '../../hooks/useNotificationProfiles'
+import {
+  PROFILE_EMOJI_PRESETS,
+  MAX_PROFILE_NAME_LENGTH,
+  DEFAULT_SCHEDULE,
+  isScheduleDraftValid,
+} from '../../lib/notifications/notificationProfiles'
+import { NOTIFICATION_CATEGORIES } from '../../lib/notifications/deliveryPreferences'
+import ProfileWizard from '../notifications/profiles/ProfileWizard'
+import ProfileScheduleFields from '../notifications/profiles/ProfileScheduleFields'
+import { profileStatusText } from '../notifications/profiles/statusText'
+import './NotificationProfilesPanel.css'
+
+/**
+ * Inline edit surface for one profile (spec 059 US5): rename, emoji, category
+ * allow-list, exceptions, schedule, delete. Draft state is local; Save writes
+ * through the store in one update.
+ */
+function ProfileEditor({ profile, onSave, onDelete, onClose }) {
+  const [name, setName] = useState(profile.name)
+  const [emoji, setEmoji] = useState(profile.emoji)
+  const [allowed, setAllowed] = useState(() => new Set(profile.allowedDomains))
+  const [allowActionRequired, setAllowActionRequired] = useState(profile.allowActionRequired)
+  const [allowDeadlineReminders, setAllowDeadlineReminders] = useState(profile.allowDeadlineReminders)
+  const [schedule, setSchedule] = useState(() => profile.schedule || { ...DEFAULT_SCHEDULE })
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+
+  const nameValid = name.trim().length > 0 && name.trim().length <= MAX_PROFILE_NAME_LENGTH
+  const valid = nameValid && isScheduleDraftValid(schedule)
+
+  const toggleDomain = (domain) => {
+    setAllowed((prev) => {
+      const next = new Set(prev)
+      if (next.has(domain)) next.delete(domain)
+      else next.add(domain)
+      return next
+    })
+  }
+
+  const save = () => {
+    onSave({
+      name,
+      emoji,
+      allowedDomains: [...allowed],
+      allowActionRequired,
+      allowDeadlineReminders,
+      schedule: schedule.enabled ? schedule : null,
+    })
+  }
+
+  return (
+    <div className="notif-profile-editor" role="group" aria-label={`Edit profile ${profile.name}`}>
+      <div className="notif-profile-editor-name">
+        <label>
+          <span className="sr-only">Profile name</span>
+          <input
+            type="text"
+            value={name}
+            maxLength={MAX_PROFILE_NAME_LENGTH}
+            placeholder="Profile name"
+            onChange={(e) => setName(e.target.value)}
+          />
+        </label>
+      </div>
+
+      <div className="notif-profile-editor-emojis" role="group" aria-label="Profile emoji">
+        {PROFILE_EMOJI_PRESETS.map((preset) => (
+          <button
+            key={preset.name}
+            type="button"
+            aria-pressed={emoji === preset.emoji}
+            aria-label={`${preset.name} emoji`}
+            className={`notif-profile-emoji-btn ${emoji === preset.emoji ? 'selected' : ''}`}
+            onClick={() => setEmoji(emoji === preset.emoji ? null : preset.emoji)}
+          >
+            {preset.emoji}
+          </button>
+        ))}
+      </div>
+
+      <h5 className="notif-profile-editor-heading">Allowed notifications</h5>
+      <ul className="notif-profile-editor-domains">
+        {NOTIFICATION_CATEGORIES.map((category) => (
+          <li key={category.domain}>
+            <label className="notif-profile-editor-domain">
+              <input
+                type="checkbox"
+                checked={allowed.has(category.domain)}
+                onChange={() => toggleDomain(category.domain)}
+              />
+              <span>{category.label}</span>
+            </label>
+          </li>
+        ))}
+      </ul>
+
+      <h5 className="notif-profile-editor-heading">Exceptions</h5>
+      <div className="notif-profile-editor-exception">
+        <span id={`edit-${profile.id}-action`}>Always allow action-required items</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={allowActionRequired}
+          aria-labelledby={`edit-${profile.id}-action`}
+          className={`notif-pref-switch ${allowActionRequired ? 'on' : ''}`}
+          onClick={() => setAllowActionRequired((v) => !v)}
+        >
+          <span className="sr-only">{allowActionRequired ? 'On' : 'Off'}</span>
+        </button>
+      </div>
+      <div className="notif-profile-editor-exception">
+        <span id={`edit-${profile.id}-deadline`}>Always allow deadline reminders</span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={allowDeadlineReminders}
+          aria-labelledby={`edit-${profile.id}-deadline`}
+          className={`notif-pref-switch ${allowDeadlineReminders ? 'on' : ''}`}
+          onClick={() => setAllowDeadlineReminders((v) => !v)}
+        >
+          <span className="sr-only">{allowDeadlineReminders ? 'On' : 'Off'}</span>
+        </button>
+      </div>
+
+      <h5 className="notif-profile-editor-heading">Schedule</h5>
+      <ProfileScheduleFields value={schedule} onChange={setSchedule} idPrefix={`edit-${profile.id}`} />
+
+      <div className="notif-profile-editor-actions">
+        {confirmingDelete ? (
+          <>
+            <span className="notif-profile-delete-confirm-text">Delete this profile?</span>
+            <button type="button" className="notif-profile-delete-btn" onClick={onDelete}>
+              Delete
+            </button>
+            <button type="button" className="notif-profile-cancel-btn" onClick={() => setConfirmingDelete(false)}>
+              Keep
+            </button>
+          </>
+        ) : (
+          <>
+            <button type="button" className="notif-profile-delete-btn" onClick={() => setConfirmingDelete(true)}>
+              Delete profile
+            </button>
+            <span className="notif-profile-editor-spacer" />
+            <button type="button" className="notif-profile-cancel-btn" onClick={onClose}>
+              Cancel
+            </button>
+            <button type="button" className="notif-profile-save-btn" disabled={!valid} onClick={save}>
+              Save
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * NotificationProfilesPanel — the "Notification profiles" area of the
+ * Preferences tab (spec 059). Lists this device's profiles with truthful
+ * active state, offers per-profile on/off, editing, deletion, and hosts the
+ * 4-step creation wizard. Renders above the base-layer
+ * NotificationPreferencesPanel, which keeps deciding HOW allowed updates are
+ * delivered.
+ */
+function NotificationProfilesPanel() {
+  const {
+    profiles,
+    activeStatus,
+    updateProfile,
+    deleteProfile,
+    enableProfile,
+    disableActiveProfile,
+  } = useNotificationProfiles()
+  const location = useLocation()
+  const [wizardOpen, setWizardOpen] = useState(() => location.hash === '#notification-profiles-new')
+  const [editingId, setEditingId] = useState(null)
+
+  // Deep links from the quick-access surface: #notification-profiles scrolls
+  // here; #notification-profiles-new also opens the wizard (covers hash
+  // changes after mount — the initial hash is handled by the lazy state).
+  useEffect(() => {
+    const hash = location.hash
+    if (hash !== '#notification-profiles' && hash !== '#notification-profiles-new') return
+    const id = window.setTimeout(() => {
+      if (hash === '#notification-profiles-new') setWizardOpen(true)
+      document.getElementById('notification-profiles')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }, 50)
+    return () => window.clearTimeout(id)
+  }, [location.hash])
+
+  const toggleProfile = (profile, isActive) => {
+    if (isActive) disableActiveProfile()
+    else enableProfile(profile.id)
+  }
+
+  return (
+    <div className="notif-profiles-panel" id="notification-profiles">
+      <h3 className="notif-profiles-title">Notification profiles</h3>
+      <p className="notif-profiles-hint">
+        Profiles decide when you get interrupted: while one is on, only the
+        updates it allows will notify you — everything else waits quietly in
+        your activity feed. Turn profiles on manually or on a schedule.
+      </p>
+
+      {wizardOpen ? (
+        <ProfileWizard onClose={() => setWizardOpen(false)} />
+      ) : (
+        <>
+          {profiles.length === 0 ? (
+            <p className="notif-profiles-empty">
+              No profiles yet. Create one — like Sleep or Work — to control
+              when FairWins can interrupt you.
+            </p>
+          ) : (
+            <ul className="notif-profiles-list">
+              {profiles.map((profile) => {
+                const isActive = activeStatus.profile?.id === profile.id
+                const editing = editingId === profile.id
+                return (
+                  <li key={profile.id} className="notif-profiles-row">
+                    <div className="notif-profiles-row-main">
+                      <span className="notif-profiles-emoji" aria-hidden="true">
+                        {profile.emoji || '🔔'}
+                      </span>
+                      <div className="notif-profiles-row-text">
+                        <span className="notif-profiles-name">{profile.name}</span>
+                        <span className="notif-profiles-status">
+                          {profileStatusText(profile, activeStatus)}
+                        </span>
+                      </div>
+                      <button
+                        type="button"
+                        className="notif-profiles-edit"
+                        aria-expanded={editing}
+                        onClick={() => setEditingId(editing ? null : profile.id)}
+                      >
+                        {editing ? 'Close' : 'Edit'}
+                      </button>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={isActive}
+                        aria-label={`${profile.name} profile ${isActive ? 'on' : 'off'}`}
+                        className={`notif-pref-switch ${isActive ? 'on' : ''}`}
+                        onClick={() => toggleProfile(profile, isActive)}
+                      >
+                        <span className="sr-only">{isActive ? 'On' : 'Off'}</span>
+                      </button>
+                    </div>
+                    {editing && (
+                      <ProfileEditor
+                        profile={profile}
+                        onSave={(patch) => {
+                          updateProfile(profile.id, patch)
+                          setEditingId(null)
+                        }}
+                        onDelete={() => {
+                          deleteProfile(profile.id)
+                          setEditingId(null)
+                        }}
+                        onClose={() => setEditingId(null)}
+                      />
+                    )}
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+          <button type="button" className="notif-profiles-new" onClick={() => setWizardOpen(true)}>
+            + New profile
+          </button>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default NotificationProfilesPanel

--- a/frontend/src/components/notifications/ActivityFeed.jsx
+++ b/frontend/src/components/notifications/ActivityFeed.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useActivity } from '../../hooks/useActivity'
 import { domainLabel } from '../../data/notifications/domains'
+import ProfileQuickAccess from './profiles/ProfileQuickAccess'
 import './ActivityFeed.css'
 
 const SEVERITY_ICONS = { success: '✓', warning: '⚠', error: '✗', info: 'ℹ' }
@@ -85,6 +86,9 @@ function ActivityFeed({ onClose }) {
           </button>
         )}
       </div>
+
+      {/* Signal-style notification profiles quick access (spec 059). */}
+      <ProfileQuickAccess onClose={onClose} />
 
       {domains.length > 1 && (
         <div className="activity-feed-filters" role="group" aria-label="Filter activity by domain">

--- a/frontend/src/components/notifications/profiles/ProfileQuickAccess.css
+++ b/frontend/src/components/notifications/profiles/ProfileQuickAccess.css
@@ -1,0 +1,159 @@
+/* ProfileQuickAccess — Signal-style profile sheet pinned atop the ActivityFeed
+   panel (spec 059). Follows ActivityFeed.css visual language. */
+
+.profile-qa {
+  border-bottom: 1px solid var(--border-color);
+  padding: 0.5rem 0.75rem;
+}
+
+.profile-qa-headline {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.profile-qa-emoji {
+  font-size: 1.2rem;
+  flex-shrink: 0;
+}
+
+.profile-qa-headline-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.05rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.profile-qa-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.profile-qa-status {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+}
+
+.profile-qa-expand {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.7rem;
+  cursor: pointer;
+  padding: 0.35rem 0.5rem;
+  border-radius: 6px;
+  flex-shrink: 0;
+}
+
+.profile-qa-expand:hover,
+.profile-qa-expand:focus-visible {
+  color: var(--text-primary);
+  background: var(--border-color);
+  outline: none;
+}
+
+.profile-qa-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding-top: 0.5rem;
+}
+
+.profile-qa-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.profile-qa-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.profile-qa-row-name {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.profile-qa-row-actions {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.profile-qa-action {
+  appearance: none;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  padding: 0.25rem 0.7rem;
+  cursor: pointer;
+}
+
+.profile-qa-action:hover,
+.profile-qa-action:focus-visible {
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+  outline: none;
+}
+
+.profile-qa-footer {
+  display: flex;
+  gap: 0.5rem;
+  padding-top: 0.25rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.profile-qa-link,
+.profile-qa-new {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--brand-primary);
+  font-size: 0.78rem;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 0.35rem 0.25rem;
+  border-radius: 6px;
+}
+
+.profile-qa-link:hover,
+.profile-qa-link:focus-visible,
+.profile-qa-new:hover,
+.profile-qa-new:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}
+
+.profile-qa-new {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  width: 100%;
+  text-align: left;
+  color: var(--text-primary);
+}
+
+.profile-qa-new-plus {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  background: var(--border-color);
+  font-size: 0.9rem;
+}

--- a/frontend/src/components/notifications/profiles/ProfileQuickAccess.jsx
+++ b/frontend/src/components/notifications/profiles/ProfileQuickAccess.jsx
@@ -1,0 +1,118 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useNotificationProfiles } from '../../../hooks/useNotificationProfiles'
+import { getNextScheduleEnd, oneHourFrom } from '../../../lib/notifications/notificationProfiles'
+import { formatTime, profileStatusText } from './statusText'
+import './ProfileQuickAccess.css'
+
+/**
+ * ProfileQuickAccess — the Signal-style quick sheet for notification profiles
+ * (spec 059 US3), pinned at the top of the ActivityFeed panel (FairWins'
+ * chat-list analog). Shows the active/first profile at a glance; expanding it
+ * reveals every profile with manual on/off durations (on, "For 1 hour",
+ * "Until <schedule end>"), plus "New profile" and "View settings" links into
+ * the Preferences tab.
+ *
+ * @param {{ onClose: () => void }} props onClose closes the parent feed panel
+ *   before navigating away.
+ */
+function ProfileQuickAccess({ onClose }) {
+  const navigate = useNavigate()
+  const { profiles, activeStatus, enableProfile, disableActiveProfile } = useNotificationProfiles()
+  const [expanded, setExpanded] = useState(false)
+
+  const go = (hash) => {
+    onClose()
+    navigate(`/wallet?tab=preferences${hash}`)
+  }
+
+  const headline = activeStatus.profile || profiles[0] || null
+
+  if (!headline) {
+    return (
+      <div className="profile-qa">
+        <button type="button" className="profile-qa-new" onClick={() => go('#notification-profiles-new')}>
+          <span className="profile-qa-new-plus" aria-hidden="true">+</span> New notification profile
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="profile-qa">
+      <div className="profile-qa-headline">
+        <span className="profile-qa-emoji" aria-hidden="true">{headline.emoji || '🔔'}</span>
+        <div className="profile-qa-headline-text">
+          <span className="profile-qa-name">{headline.name}</span>
+          <span className="profile-qa-status">{profileStatusText(headline, activeStatus)}</span>
+        </div>
+        <button
+          type="button"
+          className="profile-qa-expand"
+          aria-expanded={expanded}
+          aria-label={expanded ? 'Hide notification profiles' : 'Show notification profiles'}
+          onClick={() => setExpanded((v) => !v)}
+        >
+          {expanded ? '▲' : '▼'}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="profile-qa-body">
+          <ul className="profile-qa-list">
+            {profiles.map((profile) => {
+              const isActive = activeStatus.profile?.id === profile.id
+              const scheduleEnd = getNextScheduleEnd(profile)
+              return (
+                <li key={profile.id} className="profile-qa-row">
+                  <span className="profile-qa-row-name">
+                    <span aria-hidden="true">{profile.emoji || '🔔'}</span> {profile.name}
+                  </span>
+                  <div className="profile-qa-row-actions" role="group" aria-label={`Turn ${profile.name} on or off`}>
+                    {isActive ? (
+                      <button type="button" className="profile-qa-action" onClick={() => disableActiveProfile()}>
+                        Turn off
+                      </button>
+                    ) : (
+                      <>
+                        <button type="button" className="profile-qa-action" onClick={() => enableProfile(profile.id)}>
+                          On
+                        </button>
+                        <button
+                          type="button"
+                          className="profile-qa-action"
+                          onClick={() => enableProfile(profile.id, { until: oneHourFrom() })}
+                        >
+                          For 1 hour
+                        </button>
+                        {scheduleEnd != null && (
+                          <button
+                            type="button"
+                            className="profile-qa-action"
+                            onClick={() => enableProfile(profile.id, { until: scheduleEnd })}
+                          >
+                            Until {formatTime(scheduleEnd)}
+                          </button>
+                        )}
+                      </>
+                    )}
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+          <div className="profile-qa-footer">
+            <button type="button" className="profile-qa-link" onClick={() => go('#notification-profiles-new')}>
+              New profile
+            </button>
+            <button type="button" className="profile-qa-link" onClick={() => go('#notification-profiles')}>
+              View settings
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ProfileQuickAccess

--- a/frontend/src/components/notifications/profiles/ProfileScheduleFields.jsx
+++ b/frontend/src/components/notifications/profiles/ProfileScheduleFields.jsx
@@ -1,0 +1,105 @@
+import { DEFAULT_SCHEDULE } from '../../../lib/notifications/notificationProfiles'
+
+const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+const DAY_INITIALS = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
+
+function parseMinutes(hhmm) {
+  const [h, m] = String(hhmm).split(':').map(Number)
+  return h * 60 + m
+}
+
+/**
+ * Shared weekly-schedule editor (spec 059) used by the creation wizard and the
+ * profile edit surface. Mirrors Signal's "Add a schedule" step: an enable
+ * switch, native start/end time inputs (locale-aware for free), and an
+ * S M T W T F S day-toggle row. End at or before start spans midnight; a
+ * schedule cannot be saved enabled with zero days (parents gate on
+ * isScheduleDraftValid).
+ *
+ * @param {{ value: object|null, onChange: (schedule) => void, idPrefix: string }} props
+ */
+function ProfileScheduleFields({ value, onChange, idPrefix }) {
+  const schedule = value || DEFAULT_SCHEDULE
+  const overnight = parseMinutes(schedule.end) <= parseMinutes(schedule.start)
+  const needsDays = schedule.enabled && schedule.days.length === 0
+
+  const patch = (fields) => onChange({ ...schedule, ...fields })
+
+  const toggleDay = (day) => {
+    const days = schedule.days.includes(day)
+      ? schedule.days.filter((d) => d !== day)
+      : [...schedule.days, day].sort((a, b) => a - b)
+    patch({ days })
+  }
+
+  return (
+    <div className="profile-schedule-fields">
+      <div className="profile-schedule-master">
+        <span className="profile-schedule-label" id={`${idPrefix}-schedule-label`}>
+          Schedule
+        </span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={schedule.enabled}
+          aria-labelledby={`${idPrefix}-schedule-label`}
+          className={`notif-pref-switch ${schedule.enabled ? 'on' : ''}`}
+          onClick={() => patch({ enabled: !schedule.enabled })}
+        >
+          <span className="sr-only">{schedule.enabled ? 'Schedule on' : 'Schedule off'}</span>
+        </button>
+      </div>
+
+      <div className={`profile-schedule-times ${schedule.enabled ? '' : 'muted'}`}>
+        <label className="profile-schedule-time">
+          <span>Start</span>
+          <input
+            type="time"
+            value={schedule.start}
+            onChange={(e) => e.target.value && patch({ start: e.target.value })}
+          />
+        </label>
+        <label className="profile-schedule-time">
+          <span>End</span>
+          <input
+            type="time"
+            value={schedule.end}
+            onChange={(e) => e.target.value && patch({ end: e.target.value })}
+          />
+        </label>
+      </div>
+      {overnight && (
+        <p className="profile-schedule-note">Ends the next day (overnight schedule).</p>
+      )}
+
+      <div
+        className={`profile-schedule-days ${schedule.enabled ? '' : 'muted'}`}
+        role="group"
+        aria-label="Days of week"
+      >
+        {DAY_INITIALS.map((initial, day) => {
+          const selected = schedule.days.includes(day)
+          return (
+            <button
+              key={DAY_NAMES[day]}
+              type="button"
+              aria-pressed={selected}
+              aria-label={DAY_NAMES[day]}
+              className={`profile-schedule-day ${selected ? 'selected' : ''}`}
+              onClick={() => toggleDay(day)}
+            >
+              {initial}
+            </button>
+          )
+        })}
+      </div>
+      {needsDays && (
+        <p className="profile-schedule-warn" role="alert">
+          Pick at least one day to enable the schedule.
+        </p>
+      )}
+    </div>
+  )
+}
+
+export default ProfileScheduleFields

--- a/frontend/src/components/notifications/profiles/ProfileWizard.css
+++ b/frontend/src/components/notifications/profiles/ProfileWizard.css
@@ -1,0 +1,348 @@
+/* ProfileWizard — 4-step notification-profile creation flow (spec 059).
+   Rendered inline inside the Preferences panel; visual language follows
+   NotificationPreferencesPanel.css. Shared schedule-field styles live here
+   because the wizard and the edit surface both mount ProfileScheduleFields. */
+
+.profile-wizard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background: var(--surface-secondary, transparent);
+}
+
+.profile-wizard-top {
+  display: flex;
+  justify-content: space-between;
+  min-height: 1.5rem;
+}
+
+.profile-wizard-back,
+.profile-wizard-close,
+.profile-wizard-clear {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 8px;
+}
+
+.profile-wizard-back:hover,
+.profile-wizard-close:hover,
+.profile-wizard-clear:hover {
+  color: var(--text-primary);
+  background: var(--border-color);
+}
+
+.profile-wizard-close {
+  margin-left: auto;
+}
+
+.profile-wizard-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  text-align: center;
+}
+
+.profile-wizard-title:focus {
+  outline: none;
+}
+
+.profile-wizard-step {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.profile-wizard-hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+/* Step 1 — name + emoji */
+.profile-wizard-name-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.profile-wizard-emoji {
+  font-size: 1.5rem;
+}
+
+.profile-wizard-name-label {
+  flex: 1;
+  min-width: 0;
+}
+
+.profile-wizard-name-row input[type='text'] {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 0.95rem;
+}
+
+.profile-wizard-name-row input[type='text']:focus-visible {
+  outline: 2px solid var(--brand-primary);
+  outline-offset: -1px;
+}
+
+.profile-wizard-presets {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.profile-wizard-presets button {
+  appearance: none;
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 0.95rem;
+  padding: 0.65rem 0.25rem;
+  border-bottom: 1px solid var(--border-color);
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.profile-wizard-presets li:last-child button {
+  border-bottom: none;
+}
+
+.profile-wizard-presets button:hover,
+.profile-wizard-presets button:focus-visible {
+  background: var(--border-color);
+  outline: none;
+}
+
+/* Step 2 — allow-list + exceptions */
+.profile-wizard-domains {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.profile-wizard-domain {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.5rem 0.25rem;
+  cursor: pointer;
+}
+
+.profile-wizard-domain input[type='checkbox'] {
+  margin-top: 0.2rem;
+  accent-color: var(--brand-primary);
+  width: 1rem;
+  height: 1rem;
+}
+
+.profile-wizard-domain-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.profile-wizard-domain-label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.profile-wizard-domain-desc {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.profile-wizard-subheading {
+  margin: 0.5rem 0 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.profile-wizard-exception {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.profile-wizard-exception:last-of-type {
+  border-bottom: none;
+}
+
+.profile-wizard-exception-label {
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+.profile-wizard-warn {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--color-warning, #b45309);
+}
+
+/* Step 4 — confirmation */
+.profile-wizard-done {
+  align-items: center;
+  text-align: center;
+}
+
+.profile-wizard-done-emoji {
+  font-size: 2.5rem;
+}
+
+.profile-wizard-done-hints {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+/* Actions */
+.profile-wizard-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+}
+
+.profile-wizard-next {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.55rem 1.4rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  background: var(--brand-primary);
+  color: #fff;
+  cursor: pointer;
+}
+
+.profile-wizard-next:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.profile-wizard-next:focus-visible {
+  outline: 2px solid var(--brand-primary);
+  outline-offset: 2px;
+}
+
+/* Shared schedule fields (wizard + edit surface) */
+.profile-schedule-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.profile-schedule-master {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.profile-schedule-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.profile-schedule-times {
+  display: flex;
+  gap: 1rem;
+}
+
+.profile-schedule-times.muted,
+.profile-schedule-days.muted {
+  opacity: 0.6;
+}
+
+.profile-schedule-time {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.profile-schedule-time input[type='time'] {
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 0.95rem;
+}
+
+.profile-schedule-time input[type='time']:focus-visible {
+  outline: 2px solid var(--brand-primary);
+  outline-offset: -1px;
+}
+
+.profile-schedule-note {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.profile-schedule-days {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.profile-schedule-day {
+  appearance: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  border: 1px solid var(--border-color);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.profile-schedule-day.selected {
+  background: var(--brand-primary);
+  border-color: var(--brand-primary);
+  color: #fff;
+  font-weight: 600;
+}
+
+.profile-schedule-day:focus-visible {
+  outline: 2px solid var(--brand-primary);
+  outline-offset: 2px;
+}
+
+.profile-schedule-warn {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--color-warning, #b45309);
+}

--- a/frontend/src/components/notifications/profiles/ProfileWizard.jsx
+++ b/frontend/src/components/notifications/profiles/ProfileWizard.jsx
@@ -1,0 +1,277 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  PROFILE_EMOJI_PRESETS,
+  MAX_PROFILE_NAME_LENGTH,
+  DEFAULT_SCHEDULE,
+  createProfile,
+  isScheduleDraftValid,
+} from '../../../lib/notifications/notificationProfiles'
+import { NOTIFICATION_CATEGORIES } from '../../../lib/notifications/deliveryPreferences'
+import ProfileScheduleFields from './ProfileScheduleFields'
+import './ProfileWizard.css'
+
+const STEP_TITLES = ['Name your profile', 'Allowed notifications', 'Add a schedule', 'Profile created']
+
+/**
+ * Four-step notification-profile creation flow (spec 059), mirroring Signal's:
+ * (1) name + emoji with one-tap presets, (2) category allow-list + the two
+ * always-break-through exceptions, (3) optional weekly schedule (skippable),
+ * (4) confirmation with usage hints. State survives back/forward navigation;
+ * the profile is persisted when the member continues past step 3.
+ *
+ * @param {{ onClose: (createdProfile?: object) => void }} props
+ */
+function ProfileWizard({ onClose }) {
+  const [step, setStep] = useState(0)
+  const [name, setName] = useState('')
+  const [emoji, setEmoji] = useState(null)
+  const [allowed, setAllowed] = useState(() => new Set())
+  const [allowActionRequired, setAllowActionRequired] = useState(true)
+  const [allowDeadlineReminders, setAllowDeadlineReminders] = useState(true)
+  const [schedule, setSchedule] = useState(() => ({ ...DEFAULT_SCHEDULE }))
+  const [created, setCreated] = useState(null)
+  const headingRef = useRef(null)
+
+  // Move focus to the step heading on every step change so keyboard and
+  // screen-reader users land at the top of the new step.
+  useEffect(() => {
+    headingRef.current?.focus()
+  }, [step])
+
+  const nameValid = name.trim().length > 0 && name.trim().length <= MAX_PROFILE_NAME_LENGTH
+  const scheduleValid = isScheduleDraftValid(schedule)
+  const nothingAllowed = allowed.size === 0 && !allowActionRequired && !allowDeadlineReminders
+
+  const applyPreset = (preset) => {
+    setName(preset.name)
+    setEmoji(preset.emoji)
+  }
+
+  const toggleDomain = (domain) => {
+    setAllowed((prev) => {
+      const next = new Set(prev)
+      if (next.has(domain)) next.delete(domain)
+      else next.add(domain)
+      return next
+    })
+  }
+
+  const finishScheduleStep = () => {
+    const profile = createProfile({
+      name,
+      emoji,
+      allowedDomains: [...allowed],
+      allowActionRequired,
+      allowDeadlineReminders,
+      schedule: schedule.enabled ? schedule : null,
+    })
+    setCreated(profile)
+    setStep(3)
+  }
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Escape') {
+      event.stopPropagation()
+      onClose(created || undefined)
+    }
+  }
+
+  return (
+    <div
+      className="profile-wizard"
+      role="dialog"
+      aria-label="New notification profile"
+      onKeyDown={handleKeyDown}
+    >
+      <div className="profile-wizard-top">
+        {step > 0 && step < 3 && (
+          <button
+            type="button"
+            className="profile-wizard-back"
+            aria-label="Back"
+            onClick={() => setStep(step - 1)}
+          >
+            ←
+          </button>
+        )}
+        {step < 3 && (
+          <button
+            type="button"
+            className="profile-wizard-close"
+            aria-label="Cancel new profile"
+            onClick={() => onClose()}
+          >
+            ✕
+          </button>
+        )}
+      </div>
+
+      <h3 className="profile-wizard-title" tabIndex={-1} ref={headingRef}>
+        {STEP_TITLES[step]}
+      </h3>
+      <p className="sr-only" aria-live="polite">{`Step ${step + 1} of 4`}</p>
+
+      {step === 0 && (
+        <div className="profile-wizard-step">
+          <div className="profile-wizard-name-row">
+            <span className="profile-wizard-emoji" aria-hidden="true">
+              {emoji || '🔔'}
+            </span>
+            <label className="profile-wizard-name-label">
+              <span className="sr-only">Profile name</span>
+              <input
+                type="text"
+                value={name}
+                maxLength={MAX_PROFILE_NAME_LENGTH}
+                placeholder="Profile name"
+                onChange={(e) => setName(e.target.value)}
+              />
+            </label>
+            {name && (
+              <button
+                type="button"
+                className="profile-wizard-clear"
+                aria-label="Clear name"
+                onClick={() => {
+                  setName('')
+                  setEmoji(null)
+                }}
+              >
+                ✕
+              </button>
+            )}
+          </div>
+          <ul className="profile-wizard-presets">
+            {PROFILE_EMOJI_PRESETS.map((preset) => (
+              <li key={preset.name}>
+                <button type="button" onClick={() => applyPreset(preset)}>
+                  <span aria-hidden="true">{preset.emoji}</span> {preset.name}
+                </button>
+              </li>
+            ))}
+          </ul>
+          <div className="profile-wizard-actions">
+            <button
+              type="button"
+              className="profile-wizard-next"
+              disabled={!nameValid}
+              onClick={() => setStep(1)}
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === 1 && (
+        <div className="profile-wizard-step">
+          <p className="profile-wizard-hint">
+            Choose the updates that can notify you while this profile is on.
+            Everything else stays quiet but is kept in your activity feed.
+          </p>
+          <ul className="profile-wizard-domains">
+            {NOTIFICATION_CATEGORIES.map((category) => {
+              const checked = allowed.has(category.domain)
+              return (
+                <li key={category.domain}>
+                  <label className="profile-wizard-domain">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleDomain(category.domain)}
+                    />
+                    <span className="profile-wizard-domain-text">
+                      <span className="profile-wizard-domain-label">{category.label}</span>
+                      <span className="profile-wizard-domain-desc">{category.description}</span>
+                    </span>
+                  </label>
+                </li>
+              )
+            })}
+          </ul>
+
+          <h4 className="profile-wizard-subheading">Exceptions</h4>
+          <div className="profile-wizard-exception">
+            <span id="pw-exc-action" className="profile-wizard-exception-label">
+              Always allow action-required items
+            </span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={allowActionRequired}
+              aria-labelledby="pw-exc-action"
+              className={`notif-pref-switch ${allowActionRequired ? 'on' : ''}`}
+              onClick={() => setAllowActionRequired((v) => !v)}
+            >
+              <span className="sr-only">{allowActionRequired ? 'On' : 'Off'}</span>
+            </button>
+          </div>
+          <div className="profile-wizard-exception">
+            <span id="pw-exc-deadline" className="profile-wizard-exception-label">
+              Always allow deadline reminders
+            </span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={allowDeadlineReminders}
+              aria-labelledby="pw-exc-deadline"
+              className={`notif-pref-switch ${allowDeadlineReminders ? 'on' : ''}`}
+              onClick={() => setAllowDeadlineReminders((v) => !v)}
+            >
+              <span className="sr-only">{allowDeadlineReminders ? 'On' : 'Off'}</span>
+            </button>
+          </div>
+          {nothingAllowed && (
+            <p className="profile-wizard-warn">
+              Nothing is allowed — while this profile is on you will get no
+              notifications at all. Updates still appear in your activity feed.
+            </p>
+          )}
+          <div className="profile-wizard-actions">
+            <button type="button" className="profile-wizard-next" onClick={() => setStep(2)}>
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === 2 && (
+        <div className="profile-wizard-step">
+          <p className="profile-wizard-hint">
+            Set up a schedule to enable this notification profile automatically.
+          </p>
+          <ProfileScheduleFields value={schedule} onChange={setSchedule} idPrefix="pw" />
+          <div className="profile-wizard-actions">
+            <button
+              type="button"
+              className="profile-wizard-next"
+              disabled={!scheduleValid}
+              onClick={finishScheduleStep}
+            >
+              {schedule.enabled ? 'Next' : 'Skip'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {step === 3 && (
+        <div className="profile-wizard-step profile-wizard-done">
+          <span className="profile-wizard-done-emoji" aria-hidden="true">
+            {created?.emoji || '🔔'}
+          </span>
+          <ul className="profile-wizard-done-hints">
+            <li>You can turn your profile on or off from the activity panel in the header.</li>
+            <li>{created?.schedule ? 'Your schedule will turn it on automatically.' : 'Add a schedule in settings to automate your profile.'}</li>
+          </ul>
+          <div className="profile-wizard-actions">
+            <button type="button" className="profile-wizard-next" onClick={() => onClose(created || undefined)}>
+              Done
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ProfileWizard

--- a/frontend/src/components/notifications/profiles/emojiPresets.js
+++ b/frontend/src/components/notifications/profiles/emojiPresets.js
@@ -1,0 +1,6 @@
+/**
+ * One-tap profile presets for the creation flow (spec 059), mirrored from
+ * Signal's "Name your profile" screen. Re-exported from the store module so
+ * UI and logic share a single list.
+ */
+export { PROFILE_EMOJI_PRESETS } from '../../../lib/notifications/notificationProfiles'

--- a/frontend/src/components/notifications/profiles/statusText.js
+++ b/frontend/src/components/notifications/profiles/statusText.js
@@ -1,0 +1,31 @@
+import { getNextScheduleStart } from '../../../lib/notifications/notificationProfiles'
+
+/** Locale-aware short time, e.g. "6:00 PM" / "18:00". */
+export function formatTime(ms) {
+  return new Date(ms).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+}
+
+/** Locale-aware weekday + time, e.g. "Mon 9:00 PM". */
+export function formatDayTime(ms) {
+  return new Date(ms).toLocaleString([], { weekday: 'short', hour: 'numeric', minute: '2-digit' })
+}
+
+/**
+ * One-line truthful status for a profile (spec 059 FR-014): whether it is on,
+ * how it was activated (manual vs scheduled), when it turns off if known, and
+ * — for off profiles with a schedule — when it next turns on.
+ * @param {object} profile
+ * @param {{ profile: object|null, source: string|null, until: number|null }} activeStatus
+ * @param {number} [nowMs]
+ */
+export function profileStatusText(profile, activeStatus, nowMs = Date.now()) {
+  const isActive = activeStatus.profile?.id === profile.id
+  if (isActive) {
+    const how = activeStatus.source === 'schedule' ? 'Scheduled' : 'Manual'
+    if (activeStatus.until != null) return `On until ${formatTime(activeStatus.until)} · ${how}`
+    return `On · ${how}`
+  }
+  const nextStart = getNextScheduleStart(profile, nowMs)
+  if (nextStart != null) return `Off · Turns on ${formatDayTime(nextStart)}`
+  return 'Off'
+}

--- a/frontend/src/contexts/ActivityProvider.jsx
+++ b/frontend/src/contexts/ActivityProvider.jsx
@@ -16,7 +16,7 @@ import { useNotification } from '../hooks/useUI'
 import { activitySources } from '../data/notifications/sources'
 import { defaultStore, loadStore, saveStore, appendEntries, markRead, setSourceSlice } from '../data/notifications/activityStore'
 import { detectAll, countActionNeeded } from '../data/notifications/activityEngine'
-import { resolveDelivery } from '../lib/notifications/deliveryPreferences'
+import { resolveEntryDelivery } from '../lib/notifications/notificationProfiles'
 import { showSystemNotification } from '../lib/notifications/pushDelivery'
 
 const MAX_TOASTS_PER_CYCLE = 3
@@ -103,19 +103,22 @@ export function ActivityProvider({ children, sources = activitySources }) {
       const isCatchUp = firstPollRef.current
       firstPollRef.current = false
       if (!isCatchUp && added.length > 0) {
-        // Route each fresh entry by its domain's delivery mode (per-device
-        // preference): 'silent' → feed only (already persisted above);
-        // 'app' → in-app toast; 'push' → in-app toast + a system notification on
-        // this device. The toast cap applies to non-silent entries; system
-        // notifications are capped the same way so a busy cycle can't spam.
-        const toastable = added.filter((e) => resolveDelivery(e.domain || 'wagers') !== 'silent')
+        // Route each fresh entry through the profile-aware gate (spec 059):
+        // an active notification profile silences non-allowed domains (with
+        // action-required/deadline exceptions breaking through); otherwise the
+        // per-device domain mode applies as before. 'silent' → feed only
+        // (already persisted above); 'app' → in-app toast; 'push' → in-app
+        // toast + a system notification on this device. The toast cap applies
+        // to non-silent entries; system notifications are capped the same way
+        // so a busy cycle can't spam.
+        const toastable = added.filter((e) => resolveEntryDelivery(e) !== 'silent')
         for (const entry of toastable.slice(0, MAX_TOASTS_PER_CYCLE)) {
           showNotification(entry.message, entry.severity, TOAST_DURATION_MS)
         }
         if (toastable.length > MAX_TOASTS_PER_CYCLE) {
           showNotification(`+${toastable.length - MAX_TOASTS_PER_CYCLE} more updates in activity`, 'info', TOAST_DURATION_MS)
         }
-        const pushable = added.filter((e) => resolveDelivery(e.domain || 'wagers') === 'push')
+        const pushable = added.filter((e) => resolveEntryDelivery(e) === 'push')
         for (const entry of pushable.slice(0, MAX_TOASTS_PER_CYCLE)) {
           showSystemNotification(entry)
         }

--- a/frontend/src/hooks/useNotificationProfiles.js
+++ b/frontend/src/hooks/useNotificationProfiles.js
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  getProfiles,
+  getActiveStatus,
+  createProfile as storeCreateProfile,
+  updateProfile as storeUpdateProfile,
+  deleteProfile as storeDeleteProfile,
+  enableProfile as storeEnableProfile,
+  disableActiveProfile as storeDisableActiveProfile,
+  subscribe,
+} from '../lib/notifications/notificationProfiles'
+
+/** How often displayed active-state ("On until 6:00 PM") is re-evaluated. */
+const STATUS_TICK_MS = 30_000
+
+/**
+ * React binding for the device-scoped notification profiles
+ * (lib/notifications/notificationProfiles.js). Re-renders on any store change
+ * from anywhere (settings panel, quick access, delivery path pruning) and on a
+ * 30 s tick so schedule boundaries and manual expiries flip the displayed
+ * status without interaction. The delivery gate itself never depends on this
+ * tick — getActiveStatus() is evaluated lazily at read time.
+ */
+export function useNotificationProfiles() {
+  const [profiles, setProfiles] = useState(getProfiles)
+  const [activeStatus, setActiveStatus] = useState(() => getActiveStatus())
+
+  useEffect(() => {
+    const sync = () => {
+      setProfiles(getProfiles())
+      setActiveStatus(getActiveStatus())
+    }
+    const unsubscribe = subscribe(sync)
+    const interval = setInterval(sync, STATUS_TICK_MS)
+    // Catch any change that landed between the initial render and this effect.
+    sync()
+    return () => {
+      unsubscribe()
+      clearInterval(interval)
+    }
+  }, [])
+
+  const createProfile = useCallback((input) => storeCreateProfile(input), [])
+  const updateProfile = useCallback((id, patch) => storeUpdateProfile(id, patch), [])
+  const deleteProfile = useCallback((id) => storeDeleteProfile(id), [])
+  const enableProfile = useCallback((id, options) => storeEnableProfile(id, options), [])
+  const disableActiveProfile = useCallback(() => storeDisableActiveProfile(), [])
+
+  return { profiles, activeStatus, createProfile, updateProfile, deleteProfile, enableProfile, disableActiveProfile }
+}
+
+export default useNotificationProfiles

--- a/frontend/src/lib/notifications/notificationProfiles.js
+++ b/frontend/src/lib/notifications/notificationProfiles.js
@@ -1,0 +1,413 @@
+/**
+ * Notification Profiles (spec 059) — Signal-style interruption modes layered
+ * over the per-category delivery preferences (deliveryPreferences.js).
+ *
+ * A profile is a named allow-list over the notification domains plus two
+ * always-break-through exceptions (action-required items, deadline reminders)
+ * and an optional weekly schedule. At most one profile is active at a time:
+ * a single activation override (manual on with optional expiry, or manual off
+ * suppressing one scheduled window) layers over lazy schedule evaluation, so
+ * the active state is always computed correctly at read time — no timer has
+ * to fire for the gate to be right after the app was closed at a boundary.
+ *
+ * While a profile is active, resolveEntryDelivery() decides per fresh entry:
+ * allowed domain → the base-layer mode; exception match → base-layer mode but
+ * never below 'app' (a break-through that stays invisible isn't one); anything
+ * else → 'silent' (durable feed only — nothing is ever dropped). With no
+ * active profile the result is bit-identical to resolveDelivery(domain).
+ *
+ * Device-scoped, same never-throws localStorage + pub/sub pattern as
+ * deliveryPreferences.js; separate key so the two stores version independently.
+ */
+
+import { NOTIFICATION_CATEGORIES, resolveDelivery } from './deliveryPreferences'
+
+const PROFILES_KEY = 'fairwins_notif_profiles_v1'
+const STORE_VERSION = 1
+
+/** One-tap presets mirrored from Signal's creation flow. */
+export const PROFILE_EMOJI_PRESETS = [
+  { name: 'Work', emoji: '💪' },
+  { name: 'Sleep', emoji: '😴' },
+  { name: 'Driving', emoji: '🚗' },
+  { name: 'Downtime', emoji: '😊' },
+  { name: 'Focus', emoji: '💡' },
+]
+
+/**
+ * Entry `type`s emitted by data/notifications/deadlineWarnings.js — the
+ * "deadline reminder" exception matches exactly these.
+ */
+export const DEADLINE_REMINDER_TYPES = ['warn-acceptance', 'warn-resolution']
+
+export const MAX_PROFILE_NAME_LENGTH = 32
+
+/** Signal's schedule defaults: 9 AM – 5 PM, no days preselected. */
+export const DEFAULT_SCHEDULE = Object.freeze({ enabled: false, start: '09:00', end: '17:00', days: [] })
+
+const KNOWN_DOMAINS = NOTIFICATION_CATEGORIES.map((c) => c.domain)
+const HHMM_RE = /^([01]\d|2[0-3]):[0-5]\d$/
+const HOUR_MS = 3_600_000
+const DAY_MIN = 1440
+
+const listeners = new Set()
+
+function notify() {
+  listeners.forEach((listener) => {
+    try {
+      listener()
+    } catch (error) {
+      console.warn('Error in notification profile listener:', error)
+    }
+  })
+}
+
+function readRaw() {
+  try {
+    const saved = localStorage.getItem(PROFILES_KEY)
+    if (!saved) return {}
+    const parsed = JSON.parse(saved)
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch (error) {
+    console.warn('Error reading notification profiles:', error)
+    return {}
+  }
+}
+
+function writeRaw(store) {
+  try {
+    localStorage.setItem(PROFILES_KEY, JSON.stringify({ ...store, version: STORE_VERSION }))
+  } catch (error) {
+    // Private browsing / quota: session-only state; listeners still fire so
+    // open surfaces stay consistent.
+    console.warn('Error saving notification profiles:', error)
+  }
+}
+
+function normalizeName(name) {
+  if (typeof name !== 'string') return null
+  const trimmed = name.trim()
+  if (!trimmed || trimmed.length > MAX_PROFILE_NAME_LENGTH) return null
+  return trimmed
+}
+
+function normalizeSchedule(raw) {
+  if (!raw || typeof raw !== 'object') return null
+  const start = HHMM_RE.test(raw.start) ? raw.start : DEFAULT_SCHEDULE.start
+  const end = HHMM_RE.test(raw.end) ? raw.end : DEFAULT_SCHEDULE.end
+  const days = [...new Set(Array.isArray(raw.days) ? raw.days : [])]
+    .filter((d) => Number.isInteger(d) && d >= 0 && d <= 6)
+    .sort((a, b) => a - b)
+  // A schedule can never be enabled with zero days (spec FR-005).
+  const enabled = raw.enabled === true && days.length > 0
+  return { enabled, start, end, days }
+}
+
+function normalizeProfile(raw) {
+  if (!raw || typeof raw !== 'object') return null
+  if (typeof raw.id !== 'string' || !raw.id) return null
+  const name = normalizeName(raw.name)
+  if (!name) return null
+  return {
+    id: raw.id,
+    name,
+    emoji: typeof raw.emoji === 'string' && raw.emoji ? raw.emoji : null,
+    allowedDomains: [...new Set(Array.isArray(raw.allowedDomains) ? raw.allowedDomains : [])].filter((d) =>
+      KNOWN_DOMAINS.includes(d)
+    ),
+    allowActionRequired: raw.allowActionRequired !== false,
+    allowDeadlineReminders: raw.allowDeadlineReminders !== false,
+    schedule: normalizeSchedule(raw.schedule),
+    createdAt: Number.isFinite(raw.createdAt) ? raw.createdAt : 0,
+    updatedAt: Number.isFinite(raw.updatedAt) ? raw.updatedAt : 0,
+  }
+}
+
+function normalizeOverride(raw, profiles) {
+  if (!raw || typeof raw !== 'object') return null
+  if (!profiles.some((p) => p.id === raw.profileId)) return null
+  if (raw.kind === 'enabled') {
+    return {
+      kind: 'enabled',
+      profileId: raw.profileId,
+      until: Number.isFinite(raw.until) ? raw.until : null,
+      at: Number.isFinite(raw.at) ? raw.at : 0,
+    }
+  }
+  if (raw.kind === 'disabled') {
+    return { kind: 'disabled', profileId: raw.profileId, at: Number.isFinite(raw.at) ? raw.at : 0 }
+  }
+  return null
+}
+
+/**
+ * Fully normalized store — safe on missing, corrupt, or future-versioned data.
+ * @returns {{ profiles: Array, override: object|null }}
+ */
+function readStore() {
+  const raw = readRaw()
+  const profiles = (Array.isArray(raw.profiles) ? raw.profiles : []).map(normalizeProfile).filter(Boolean)
+  return { profiles, override: normalizeOverride(raw.override, profiles) }
+}
+
+// ---------------------------------------------------------------------------
+// Schedule math (device-local wall time)
+// ---------------------------------------------------------------------------
+
+function parseMinutes(hhmm) {
+  const [h, m] = hhmm.split(':').map(Number)
+  return h * 60 + m
+}
+
+/** Window length in minutes; end <= start spans midnight (end === start ⇒ 24 h). */
+function windowDurationMin(schedule) {
+  return ((parseMinutes(schedule.end) - parseMinutes(schedule.start)) + DAY_MIN) % DAY_MIN || DAY_MIN
+}
+
+/** Start of the window beginning on the calendar day containing `dayMs`, or null if that weekday isn't selected. */
+function windowStartOnDay(schedule, dayMs) {
+  const day = new Date(dayMs)
+  day.setHours(0, 0, 0, 0)
+  if (!schedule.days.includes(day.getDay())) return null
+  return day.getTime() + parseMinutes(schedule.start) * 60_000
+}
+
+/**
+ * The schedule window containing `atMs`, if any. Overnight windows belong to
+ * their start day, so both today's and yesterday's starts are candidates.
+ * @returns {{ startMs: number, endMs: number } | null}
+ */
+function windowAt(schedule, atMs) {
+  if (!schedule?.enabled) return null
+  const durationMs = windowDurationMin(schedule) * 60_000
+  for (const offsetMs of [0, -86_400_000]) {
+    const startMs = windowStartOnDay(schedule, atMs + offsetMs)
+    if (startMs == null) continue
+    const endMs = startMs + durationMs
+    if (atMs >= startMs && atMs < endMs) return { startMs, endMs }
+  }
+  return null
+}
+
+/**
+ * ms timestamp of the profile's next scheduled activation strictly after
+ * `nowMs` (up to a week out), or null without an enabled schedule.
+ */
+export function getNextScheduleStart(profile, nowMs = Date.now()) {
+  const schedule = profile?.schedule
+  if (!schedule?.enabled) return null
+  for (let dayOffset = 0; dayOffset <= 7; dayOffset += 1) {
+    const startMs = windowStartOnDay(schedule, nowMs + dayOffset * 86_400_000)
+    if (startMs != null && startMs > nowMs) return startMs
+  }
+  return null
+}
+
+/**
+ * End of the profile's current window (when inside one) or of its next window
+ * — feeds the "Until <end>" manual option and status lines. Null without an
+ * enabled schedule.
+ */
+export function getNextScheduleEnd(profile, nowMs = Date.now()) {
+  const schedule = profile?.schedule
+  if (!schedule?.enabled) return null
+  const current = windowAt(schedule, nowMs)
+  if (current) return current.endMs
+  const nextStart = getNextScheduleStart(profile, nowMs)
+  return nextStart == null ? null : nextStart + windowDurationMin(schedule) * 60_000
+}
+
+// ---------------------------------------------------------------------------
+// CRUD
+// ---------------------------------------------------------------------------
+
+/** All profiles, normalized (creation order). */
+export function getProfiles() {
+  return readStore().profiles
+}
+
+/** @returns {object|null} */
+export function getProfile(id) {
+  return readStore().profiles.find((p) => p.id === id) || null
+}
+
+function generateId() {
+  return `p_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
+}
+
+/**
+ * Create and persist a profile. Exceptions default ON (missing a custody
+ * approval or a claim deadline costs real money — see spec 059 research R3).
+ * @returns {object|null} the created profile, or null for an invalid name
+ */
+export function createProfile(input = {}) {
+  const name = normalizeName(input.name)
+  if (!name) return null
+  const now = Date.now()
+  const profile = normalizeProfile({
+    ...input,
+    id: generateId(),
+    name,
+    createdAt: now,
+    updatedAt: now,
+  })
+  const store = readStore()
+  writeRaw({ profiles: [...store.profiles, profile], override: store.override })
+  notify()
+  return profile
+}
+
+/**
+ * Shallow-merge a validated patch into an existing profile.
+ * @returns {object|null} the updated profile, or null (unknown id / invalid patch)
+ */
+export function updateProfile(id, patch = {}) {
+  const store = readStore()
+  const existing = store.profiles.find((p) => p.id === id)
+  if (!existing) return null
+  if ('name' in patch && !normalizeName(patch.name)) return null
+  const updated = normalizeProfile({ ...existing, ...patch, id, updatedAt: Date.now(), createdAt: existing.createdAt })
+  writeRaw({
+    profiles: store.profiles.map((p) => (p.id === id ? updated : p)),
+    override: store.override,
+  })
+  notify()
+  return updated
+}
+
+/** Remove a profile; an activation override referencing it is pruned too. */
+export function deleteProfile(id) {
+  const store = readStore()
+  if (!store.profiles.some((p) => p.id === id)) return
+  writeRaw({
+    profiles: store.profiles.filter((p) => p.id !== id),
+    override: store.override?.profileId === id ? null : store.override,
+  })
+  notify()
+}
+
+// ---------------------------------------------------------------------------
+// Activation
+// ---------------------------------------------------------------------------
+
+/**
+ * Manually turn a profile on, replacing any prior override wholesale — at most
+ * one profile is ever active (FR-008).
+ * @param {string} id
+ * @param {{ until?: number|null }} [options] absolute ms expiry ("For 1 hour",
+ *   "Until <schedule end>") or null/omitted for indefinite
+ */
+export function enableProfile(id, { until = null } = {}) {
+  const store = readStore()
+  if (!store.profiles.some((p) => p.id === id)) return
+  writeRaw({
+    profiles: store.profiles,
+    override: { kind: 'enabled', profileId: id, until: Number.isFinite(until) ? until : null, at: Date.now() },
+  })
+  notify()
+}
+
+/**
+ * Turn the currently active profile off. If it is inside a scheduled window,
+ * a 'disabled' override suppresses just that window (it reactivates at the
+ * next scheduled start); otherwise the manual override is simply cleared.
+ */
+export function disableActiveProfile(nowMs = Date.now()) {
+  const { profile } = getActiveStatus(nowMs)
+  if (!profile) return
+  const store = readStore()
+  const inWindow = windowAt(profile.schedule, nowMs) != null
+  writeRaw({
+    profiles: store.profiles,
+    override: inWindow ? { kind: 'disabled', profileId: profile.id, at: nowMs } : null,
+  })
+  notify()
+}
+
+/** Prune an override that no longer applies; returns the live override (or null). */
+function pruneOverride(store, nowMs) {
+  const ov = store.override
+  if (!ov) return null
+  const profile = store.profiles.find((p) => p.id === ov.profileId)
+  let live = ov
+  if (!profile) live = null
+  else if (ov.kind === 'enabled' && ov.until != null && ov.until <= nowMs) live = null
+  else if (ov.kind === 'disabled') {
+    const window = windowAt(profile.schedule, ov.at)
+    if (!window || nowMs >= window.endMs) live = null
+  }
+  if (live !== ov) {
+    writeRaw({ profiles: store.profiles, override: live })
+    notify()
+  }
+  return live
+}
+
+/**
+ * The single source of truth for "which profile is interrupting right now".
+ * Lazy: correct at any call time with no timer dependency; expired overrides
+ * are pruned (persist + notify only when something actually changed).
+ * @returns {{ profile: object|null, source: 'manual'|'schedule'|null, until: number|null }}
+ */
+export function getActiveStatus(nowMs = Date.now()) {
+  const store = readStore()
+  const override = pruneOverride(store, nowMs)
+
+  if (override?.kind === 'enabled') {
+    const profile = store.profiles.find((p) => p.id === override.profileId)
+    return { profile, source: 'manual', until: override.until }
+  }
+
+  // Pure schedule evaluation; a live 'disabled' override suppresses only its profile.
+  let best = null
+  for (const profile of store.profiles) {
+    if (override?.kind === 'disabled' && override.profileId === profile.id) continue
+    const window = windowAt(profile.schedule, nowMs)
+    if (window && (!best || window.startMs > best.window.startMs)) best = { profile, window }
+  }
+  if (best) return { profile: best.profile, source: 'schedule', until: best.window.endMs }
+  return { profile: null, source: null, until: null }
+}
+
+/** Convenience for the quick-access "For 1 hour" action. */
+export function oneHourFrom(nowMs = Date.now()) {
+  return nowMs + HOUR_MS
+}
+
+// ---------------------------------------------------------------------------
+// Delivery gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve how a fresh activity entry should be delivered right now, composing
+ * the active profile (if any) over the base per-category preference. With no
+ * active profile this is exactly resolveDelivery(entry.domain) — the
+ * no-profile path must stay bit-identical to the pre-profile behavior.
+ * @param {{ domain?: string, type?: string, actionable?: boolean }} entry
+ * @returns {'push'|'app'|'silent'}
+ */
+export function resolveEntryDelivery(entry, nowMs = Date.now()) {
+  const domain = entry?.domain || 'wagers'
+  const { profile } = getActiveStatus(nowMs)
+  if (!profile) return resolveDelivery(domain)
+  if (profile.allowedDomains.includes(domain)) return resolveDelivery(domain)
+  const isException =
+    (profile.allowActionRequired && entry?.actionable === true) ||
+    (profile.allowDeadlineReminders && DEADLINE_REMINDER_TYPES.includes(entry?.type))
+  if (isException) {
+    // Break-throughs are never left invisible: 'silent' base upgrades to 'app'
+    // for exception matches only (spec FR-010).
+    const mode = resolveDelivery(domain)
+    return mode === 'silent' ? 'app' : mode
+  }
+  return 'silent'
+}
+
+/**
+ * Subscribe to profile/activation changes. Returns an unsubscribe function.
+ * @param {() => void} listener
+ */
+export function subscribe(listener) {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}

--- a/frontend/src/lib/notifications/notificationProfiles.js
+++ b/frontend/src/lib/notifications/notificationProfiles.js
@@ -45,6 +45,11 @@ export const MAX_PROFILE_NAME_LENGTH = 32
 /** Signal's schedule defaults: 9 AM – 5 PM, no days preselected. */
 export const DEFAULT_SCHEDULE = Object.freeze({ enabled: false, start: '09:00', end: '17:00', days: [] })
 
+/** Whether a draft schedule may be saved: enabled requires at least one day (FR-005). */
+export function isScheduleDraftValid(schedule) {
+  return !schedule?.enabled || (schedule.days?.length || 0) > 0
+}
+
 const KNOWN_DOMAINS = NOTIFICATION_CATEGORIES.map((c) => c.domain)
 const HHMM_RE = /^([01]\d|2[0-3]):[0-5]\d$/
 const HOUR_MS = 3_600_000

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -22,6 +22,7 @@ import AccountDashboard from '../components/account/AccountDashboard'
 import ControllersPanel from '../components/account/ControllersPanel'
 import RecoverAccountPanel from '../components/account/RecoverAccountPanel'
 import NotificationPreferencesPanel from '../components/account/NotificationPreferencesPanel'
+import NotificationProfilesPanel from '../components/account/NotificationProfilesPanel'
 import QuickAccessCardsPanel from '../components/account/QuickAccessCardsPanel'
 import HomePreferencesPanel from '../components/account/HomePreferencesPanel'
 import WalletDisplayPreferencesPanel from '../components/account/WalletDisplayPreferencesPanel'
@@ -484,6 +485,9 @@ function WalletPage() {
                     </div>
 
                     <h2 className="preferences-group-heading">Notifications</h2>
+                    <div className="section">
+                      <NotificationProfilesPanel />
+                    </div>
                     <div className="section">
                       <NotificationPreferencesPanel />
                     </div>

--- a/frontend/src/test/ActivityProvider.profiles.test.jsx
+++ b/frontend/src/test/ActivityProvider.profiles.test.jsx
@@ -1,0 +1,125 @@
+/**
+ * ActivityProvider × notification profiles (spec 059). Verifies the poll
+ * loop's delivery gate honors the active profile: blocked domains are feed-only
+ * (still appended, still unread), allowed domains keep their base-layer mode,
+ * exceptions (actionable / deadline warn-*) break through — upgrading a silent
+ * base to an in-app toast — and the no-profile path matches the pre-profile
+ * behavior exactly.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { ActivityProvider } from '../contexts/ActivityProvider'
+import { setDeliveryMode, setPushEnabled } from '../lib/notifications/deliveryPreferences'
+import { createProfile, enableProfile, updateProfile } from '../lib/notifications/notificationProfiles'
+import { loadStore } from '../data/notifications/activityStore'
+
+const NOW = 1765432100000
+const ACC = '0xAAA0000000000000000000000000000000000aaa'
+
+const h = vi.hoisted(() => ({
+  wallet: { account: '', chainId: 0 },
+  showNotification: vi.fn(),
+  showSystem: vi.fn(),
+}))
+vi.mock('../hooks/useWalletManagement', () => ({ useWallet: () => h.wallet }))
+vi.mock('../hooks/useUI', () => ({ useNotification: () => ({ showNotification: h.showNotification }) }))
+vi.mock('../lib/notifications/pushDelivery', () => ({
+  showSystemNotification: (...args) => h.showSystem(...args),
+}))
+
+function entry(id, domain, over = {}) {
+  return { id, domain, refId: id, type: 't', message: `msg-${id}`, severity: 'info', actionable: false, createdAt: NOW, read: false, ...over }
+}
+// call 1 = catch-up (feed-only, empty); call 2 = live poll emitting `entries`.
+function twoPhaseSource(key, entries) {
+  let call = 0
+  return {
+    key,
+    label: key,
+    detect: vi.fn(async () => {
+      call += 1
+      return { ok: true, entries: call === 1 ? [] : entries, nextSnapshots: {}, nextAux: {}, currentIds: [], actionNeededById: {} }
+    }),
+  }
+}
+const tick = (ms) => act(async () => { await vi.advanceTimersByTimeAsync(ms) })
+
+async function runLive(sources) {
+  render(<ActivityProvider sources={sources} />)
+  await tick(0) // catch-up
+  await tick(30_000) // live
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  h.wallet = { account: ACC, chainId: 137 }
+  h.showNotification.mockReset()
+  h.showSystem.mockReset()
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+})
+afterEach(() => vi.useRealTimers())
+
+describe('ActivityProvider with an active notification profile', () => {
+  it('blocked domain: no toast, no push — but appended to the feed unread', async () => {
+    const p = createProfile({ name: 'Sleep', allowedDomains: ['wagers'], allowActionRequired: false, allowDeadlineReminders: false })
+    enableProfile(p.id)
+    setDeliveryMode('dao', 'push')
+    setPushEnabled(true)
+    await runLive([twoPhaseSource('dao', [entry('d1', 'dao')])])
+    expect(h.showNotification).not.toHaveBeenCalled()
+    expect(h.showSystem).not.toHaveBeenCalled()
+    const persisted = loadStore(ACC.toLowerCase(), 137)
+    expect(persisted.entries.map((e) => e.id)).toContain('d1')
+    expect(persisted.entries.find((e) => e.id === 'd1').read).toBe(false)
+  })
+
+  it('allowed domain: delivered per its base mode (push)', async () => {
+    const p = createProfile({ name: 'Sleep', allowedDomains: ['wagers'] })
+    enableProfile(p.id)
+    setDeliveryMode('wagers', 'push')
+    setPushEnabled(true)
+    await runLive([twoPhaseSource('wagers', [entry('w1', 'wagers')])])
+    expect(h.showNotification).toHaveBeenCalledWith('msg-w1', 'info', 6000)
+    expect(h.showSystem).toHaveBeenCalledTimes(1)
+  })
+
+  it('action-required entry from a blocked domain breaks through; toggle off silences it', async () => {
+    const p = createProfile({ name: 'Sleep', allowedDomains: ['wagers'] })
+    enableProfile(p.id)
+    setDeliveryMode('custody', 'app')
+    await runLive([twoPhaseSource('custody', [entry('c1', 'custody', { actionable: true })])])
+    expect(h.showNotification).toHaveBeenCalledWith('msg-c1', 'info', 6000)
+
+    h.showNotification.mockReset()
+    updateProfile(p.id, { allowActionRequired: false, allowDeadlineReminders: false })
+    await runLive([twoPhaseSource('custody', [entry('c2', 'custody', { actionable: true })])])
+    expect(h.showNotification).not.toHaveBeenCalled()
+  })
+
+  it('deadline warn-* entry breaks through even from a blocked domain', async () => {
+    const p = createProfile({ name: 'Sleep', allowedDomains: [], allowActionRequired: false })
+    enableProfile(p.id)
+    setDeliveryMode('wagers', 'app')
+    await runLive([twoPhaseSource('wagers', [entry('w1', 'wagers', { type: 'warn-acceptance', actionable: true, severity: 'warning' })])])
+    expect(h.showNotification).toHaveBeenCalledWith('msg-w1', 'warning', 6000)
+  })
+
+  it('exception over a silent base category upgrades to an in-app toast (no push)', async () => {
+    const p = createProfile({ name: 'Sleep', allowedDomains: [] })
+    enableProfile(p.id)
+    setDeliveryMode('custody', 'silent')
+    await runLive([twoPhaseSource('custody', [entry('c1', 'custody', { actionable: true })])])
+    expect(h.showNotification).toHaveBeenCalledWith('msg-c1', 'info', 6000)
+    expect(h.showSystem).not.toHaveBeenCalled()
+  })
+
+  it('profiles saved but none active: behavior identical to base layer', async () => {
+    createProfile({ name: 'Sleep', allowedDomains: [] }) // never enabled
+    setDeliveryMode('wagers', 'push')
+    setPushEnabled(true)
+    await runLive([twoPhaseSource('wagers', [entry('w1', 'wagers')])])
+    expect(h.showNotification).toHaveBeenCalledWith('msg-w1', 'info', 6000)
+    expect(h.showSystem).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/test/NotificationProfilesPanel.test.jsx
+++ b/frontend/src/test/NotificationProfilesPanel.test.jsx
@@ -1,0 +1,115 @@
+/**
+ * NotificationProfilesPanel tests (spec 059 US1 + US5): empty state, wizard
+ * entry, listing with truthful status, per-profile on/off, editing every
+ * attribute, and deletion (including the active profile).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import NotificationProfilesPanel from '../components/account/NotificationProfilesPanel'
+import {
+  createProfile,
+  enableProfile,
+  getProfiles,
+  getProfile,
+  getActiveStatus,
+} from '../lib/notifications/notificationProfiles'
+
+// Tue 2026-07-14 12:00 local.
+const NOW = new Date(2026, 6, 14, 12, 0, 0).getTime()
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+})
+afterEach(() => vi.useRealTimers())
+
+const renderPanel = () =>
+  render(
+    <MemoryRouter>
+      <NotificationProfilesPanel />
+    </MemoryRouter>
+  )
+
+describe('NotificationProfilesPanel', () => {
+  it('shows the empty state and opens the wizard from "New profile"', () => {
+    renderPanel()
+    expect(screen.getByText(/No profiles yet/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /New profile/i }))
+    expect(screen.getByRole('heading', { name: 'Name your profile' })).toBeInTheDocument()
+  })
+
+  it('lists created profiles with name, emoji, and Off status', () => {
+    createProfile({ name: 'Sleep', emoji: '😴' })
+    renderPanel()
+    expect(screen.getByText('Sleep')).toBeInTheDocument()
+    expect(screen.getByText('😴')).toBeInTheDocument()
+    expect(screen.getByText('Off', { selector: '.notif-profiles-status' })).toBeInTheDocument()
+  })
+
+  it('per-profile switch enables and disables the profile', () => {
+    const p = createProfile({ name: 'Sleep' })
+    renderPanel()
+    const toggle = screen.getByRole('switch', { name: /Sleep profile off/i })
+    fireEvent.click(toggle)
+    expect(getActiveStatus().profile?.id).toBe(p.id)
+    expect(screen.getByText(/On · Manual/)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('switch', { name: /Sleep profile on/i }))
+    expect(getActiveStatus().profile).toBeNull()
+  })
+
+  it('shows scheduled status truthfully (on until end, off with next start)', () => {
+    createProfile({
+      name: 'Work',
+      schedule: { enabled: true, start: '09:00', end: '17:00', days: [1, 2, 3, 4, 5] },
+    })
+    renderPanel()
+    expect(screen.getByText(/On until .*Scheduled/)).toBeInTheDocument()
+  })
+
+  it('edits every attribute through the inline editor', () => {
+    const p = createProfile({ name: 'Work', emoji: '💪', allowedDomains: ['wagers'] })
+    renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    const editor = screen.getByRole('group', { name: /Edit profile Work/ })
+    fireEvent.change(within(editor).getByPlaceholderText('Profile name'), { target: { value: 'Deep Work' } })
+    fireEvent.click(within(editor).getByRole('button', { name: 'Focus emoji' }))
+    fireEvent.click(within(editor).getByLabelText('Custody'))
+    fireEvent.click(within(editor).getByRole('switch', { name: /action-required/i }))
+    // Add a schedule.
+    fireEvent.click(within(editor).getByRole('switch', { name: 'Schedule' }))
+    fireEvent.click(within(editor).getByRole('button', { name: 'Tuesday' }))
+    fireEvent.click(within(editor).getByRole('button', { name: 'Save' }))
+    expect(getProfile(p.id)).toMatchObject({
+      name: 'Deep Work',
+      emoji: '💡',
+      allowedDomains: ['wagers', 'custody'],
+      allowActionRequired: false,
+      schedule: { enabled: true, days: [2] },
+    })
+    // Schedule covering now (Tue 09:00–17:00) makes it active immediately.
+    expect(getActiveStatus().profile?.id).toBe(p.id)
+  })
+
+  it('deleting the active profile clears activation and the row', () => {
+    const p = createProfile({ name: 'Sleep' })
+    enableProfile(p.id)
+    renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete profile' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    expect(getProfiles()).toHaveLength(0)
+    expect(getActiveStatus().profile).toBeNull()
+    expect(screen.getByText(/No profiles yet/i)).toBeInTheDocument()
+  })
+
+  it('Save is blocked while the schedule is enabled with no days', () => {
+    createProfile({ name: 'Work' })
+    renderPanel()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+    const editor = screen.getByRole('group', { name: /Edit profile Work/ })
+    fireEvent.click(within(editor).getByRole('switch', { name: 'Schedule' }))
+    expect(within(editor).getByRole('button', { name: 'Save' })).toBeDisabled()
+  })
+})

--- a/frontend/src/test/ProfileQuickAccess.test.jsx
+++ b/frontend/src/test/ProfileQuickAccess.test.jsx
@@ -1,0 +1,142 @@
+/**
+ * ProfileQuickAccess tests (spec 059 US3 + US4): status display for
+ * off/manual/scheduled states, duration actions ("On", "For 1 hour",
+ * "Until <end>"), single-active flip, immediate revert on turn-off, the
+ * no-profiles state, navigation links, and the schedule-boundary status flip
+ * driven by the 30 s tick.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act, within } from '@testing-library/react'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import ProfileQuickAccess from '../components/notifications/profiles/ProfileQuickAccess'
+import {
+  createProfile,
+  enableProfile,
+  getActiveStatus,
+} from '../lib/notifications/notificationProfiles'
+
+// Tue 2026-07-14 12:00 local.
+const NOW = new Date(2026, 6, 14, 12, 0, 0).getTime()
+const HOUR = 3_600_000
+
+let lastLocation = null
+function LocationProbe() {
+  lastLocation = useLocation()
+  return null
+}
+
+const renderQa = (onClose = vi.fn()) => {
+  const view = render(
+    <MemoryRouter initialEntries={['/']}>
+      <Routes>
+        <Route path="*" element={<><ProfileQuickAccess onClose={onClose} /><LocationProbe /></>} />
+      </Routes>
+    </MemoryRouter>
+  )
+  return { view, onClose }
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  lastLocation = null
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+})
+afterEach(() => vi.useRealTimers())
+
+describe('ProfileQuickAccess', () => {
+  it('with no profiles: offers only "New notification profile" and navigates', () => {
+    const { onClose } = renderQa()
+    const btn = screen.getByRole('button', { name: /New notification profile/i })
+    fireEvent.click(btn)
+    expect(onClose).toHaveBeenCalled()
+    expect(lastLocation.pathname + lastLocation.search + lastLocation.hash).toBe(
+      '/wallet?tab=preferences#notification-profiles-new'
+    )
+  })
+
+  it('shows the first profile "Off" collapsed; expanding reveals actions', () => {
+    createProfile({ name: 'Sleep', emoji: '😴' })
+    renderQa()
+    expect(screen.getByText('Sleep')).toBeInTheDocument()
+    expect(screen.getByText('Off')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Show notification profiles/i }))
+    expect(screen.getByRole('button', { name: 'On' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'For 1 hour' })).toBeInTheDocument()
+    // No schedule → no "Until" option.
+    expect(screen.queryByRole('button', { name: /^Until / })).toBeNull()
+  })
+
+  it('"For 1 hour" enables with an expiry and shows it; turn off reverts immediately', () => {
+    const p = createProfile({ name: 'Sleep', emoji: '😴' })
+    renderQa()
+    fireEvent.click(screen.getByRole('button', { name: /Show notification profiles/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'For 1 hour' }))
+    expect(getActiveStatus()).toMatchObject({ profile: { id: p.id }, source: 'manual', until: NOW + HOUR })
+    expect(screen.getByText(/On until .*Manual/)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Turn off' }))
+    expect(getActiveStatus().profile).toBeNull()
+    expect(screen.getByText('Off')).toBeInTheDocument()
+  })
+
+  it('scheduled profile offers "Until <end>" and honors it', () => {
+    const p = createProfile({
+      name: 'Work',
+      schedule: { enabled: true, start: '13:00', end: '17:00', days: [2] }, // starts later today
+    })
+    renderQa()
+    fireEvent.click(screen.getByRole('button', { name: /Show notification profiles/i }))
+    const until = screen.getByRole('button', { name: /^Until / })
+    fireEvent.click(until)
+    const end = new Date(2026, 6, 14, 17, 0, 0).getTime()
+    expect(getActiveStatus()).toMatchObject({ profile: { id: p.id }, until: end })
+  })
+
+  it('enabling one profile turns the other off (single active)', () => {
+    const a = createProfile({ name: 'A' })
+    const b = createProfile({ name: 'B' })
+    enableProfile(a.id)
+    renderQa()
+    fireEvent.click(screen.getByRole('button', { name: /Show notification profiles/i }))
+    // Row B still shows enable actions; enable it.
+    const rowB = screen.getByRole('group', { name: /Turn B on or off/i })
+    fireEvent.click(within(rowB).getByRole('button', { name: 'On' }))
+    expect(getActiveStatus().profile?.id).toBe(b.id)
+    // Row A now offers enable again, row B offers Turn off.
+    expect(screen.getByRole('group', { name: /Turn A on or off/i })).toBeInTheDocument()
+  })
+
+  it('headline is the ACTIVE profile even when it is not first', () => {
+    createProfile({ name: 'First' })
+    const second = createProfile({ name: 'Second', emoji: '💡' })
+    enableProfile(second.id)
+    renderQa()
+    expect(screen.getByText('Second')).toBeInTheDocument()
+    expect(screen.getByText(/On · Manual/)).toBeInTheDocument()
+  })
+
+  it('status flips at a schedule boundary via the 30 s tick, no interaction', async () => {
+    createProfile({
+      name: 'Work',
+      schedule: { enabled: true, start: '12:30', end: '17:00', days: [2] },
+    })
+    renderQa()
+    expect(screen.getByText(/Off · Turns on/)).toBeInTheDocument()
+    // Cross 12:30 and let the status tick fire.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(31 * 60_000)
+    })
+    expect(screen.getByText(/On until .*Scheduled/)).toBeInTheDocument()
+  })
+
+  it('"View settings" closes the panel and deep-links to the profiles section', () => {
+    createProfile({ name: 'Sleep' })
+    const { onClose } = renderQa()
+    fireEvent.click(screen.getByRole('button', { name: /Show notification profiles/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'View settings' }))
+    expect(onClose).toHaveBeenCalled()
+    expect(lastLocation.pathname + lastLocation.search + lastLocation.hash).toBe(
+      '/wallet?tab=preferences#notification-profiles'
+    )
+  })
+})

--- a/frontend/src/test/ProfileWizard.test.jsx
+++ b/frontend/src/test/ProfileWizard.test.jsx
@@ -1,0 +1,127 @@
+/**
+ * ProfileWizard tests (spec 059 US1): the 4-step Signal-style creation flow —
+ * presets fill name+emoji, name required, state survives back navigation,
+ * schedule skippable, zero-days schedule can't be saved enabled, and Done
+ * persists exactly the chosen shape.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ProfileWizard from '../components/notifications/profiles/ProfileWizard'
+import { getProfiles } from '../lib/notifications/notificationProfiles'
+
+// Tue 2026-07-14 12:00 local.
+const NOW = new Date(2026, 6, 14, 12, 0, 0).getTime()
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+})
+afterEach(() => vi.useRealTimers())
+
+const next = () => fireEvent.click(screen.getByRole('button', { name: /next|skip/i }))
+
+describe('ProfileWizard', () => {
+  it('preset fills name and emoji, then Next advances', () => {
+    render(<ProfileWizard onClose={vi.fn()} />)
+    expect(screen.getByRole('heading', { name: 'Name your profile' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Sleep/ }))
+    expect(screen.getByPlaceholderText('Profile name')).toHaveValue('Sleep')
+    next()
+    expect(screen.getByRole('heading', { name: 'Allowed notifications' })).toBeInTheDocument()
+  })
+
+  it('blocks continuing with an empty name', () => {
+    render(<ProfileWizard onClose={vi.fn()} />)
+    expect(screen.getByRole('button', { name: 'Next' })).toBeDisabled()
+    fireEvent.change(screen.getByPlaceholderText('Profile name'), { target: { value: 'Focus time' } })
+    expect(screen.getByRole('button', { name: 'Next' })).toBeEnabled()
+  })
+
+  it('keeps step state across back/forward navigation', () => {
+    render(<ProfileWizard onClose={vi.fn()} />)
+    fireEvent.change(screen.getByPlaceholderText('Profile name'), { target: { value: 'Work' } })
+    next()
+    fireEvent.click(screen.getByLabelText(/Wagers/))
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    expect(screen.getByPlaceholderText('Profile name')).toHaveValue('Work')
+    next()
+    expect(screen.getByLabelText(/Wagers/)).toBeChecked()
+  })
+
+  it('skipping the schedule creates a manual-only profile with chosen allow-list', () => {
+    const onClose = vi.fn()
+    render(<ProfileWizard onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: /Sleep/ }))
+    next()
+    fireEvent.click(screen.getByLabelText(/Wagers/))
+    // Turn one exception off to prove toggles persist.
+    fireEvent.click(screen.getByRole('switch', { name: /action-required/i }))
+    next()
+    expect(screen.getByRole('heading', { name: 'Add a schedule' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }))
+    expect(screen.getByRole('heading', { name: 'Profile created' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+    expect(onClose).toHaveBeenCalled()
+    const [profile] = getProfiles()
+    expect(profile).toMatchObject({
+      name: 'Sleep',
+      emoji: '😴',
+      allowedDomains: ['wagers'],
+      allowActionRequired: false,
+      allowDeadlineReminders: true,
+      schedule: null,
+    })
+  })
+
+  it('an enabled schedule with zero days blocks continuing until a day is picked', () => {
+    render(<ProfileWizard onClose={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /Focus/ }))
+    next()
+    next()
+    fireEvent.click(screen.getByRole('switch', { name: 'Schedule' }))
+    const goBtn = screen.getByRole('button', { name: 'Next' }) // label flips from Skip when enabled
+    expect(goBtn).toBeDisabled()
+    expect(screen.getByRole('alert')).toHaveTextContent(/at least one day/i)
+    fireEvent.click(screen.getByRole('button', { name: 'Monday' }))
+    expect(goBtn).toBeEnabled()
+    fireEvent.click(goBtn)
+    expect(screen.getByRole('heading', { name: 'Profile created' })).toBeInTheDocument()
+    const [profile] = getProfiles()
+    expect(profile.schedule).toMatchObject({ enabled: true, start: '09:00', end: '17:00', days: [1] })
+  })
+
+  it('stores a custom overnight schedule', () => {
+    render(<ProfileWizard onClose={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /Sleep/ }))
+    next()
+    next()
+    fireEvent.click(screen.getByRole('switch', { name: 'Schedule' }))
+    fireEvent.change(screen.getByLabelText('Start'), { target: { value: '21:00' } })
+    fireEvent.change(screen.getByLabelText('End'), { target: { value: '07:00' } })
+    for (const day of ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']) {
+      fireEvent.click(screen.getByRole('button', { name: day }))
+    }
+    expect(screen.getByText(/overnight/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }))
+    const [profile] = getProfiles()
+    expect(profile.schedule).toMatchObject({ enabled: true, start: '21:00', end: '07:00', days: [0, 1, 2, 3, 4, 5, 6] })
+  })
+
+  it('warns plainly when nothing at all is allowed', () => {
+    render(<ProfileWizard onClose={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /Focus/ }))
+    next()
+    fireEvent.click(screen.getByRole('switch', { name: /action-required/i }))
+    fireEvent.click(screen.getByRole('switch', { name: /deadline/i }))
+    expect(screen.getByText(/no notifications at all/i)).toBeInTheDocument()
+  })
+
+  it('cancel closes without creating anything', () => {
+    const onClose = vi.fn()
+    render(<ProfileWizard onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel new profile' }))
+    expect(onClose).toHaveBeenCalled()
+    expect(getProfiles()).toHaveLength(0)
+  })
+})

--- a/frontend/src/test/notificationProfiles.test.js
+++ b/frontend/src/test/notificationProfiles.test.js
@@ -1,0 +1,305 @@
+/**
+ * Notification profile store tests (spec 059): CRUD + validation, corrupt
+ * storage fallback, activation overrides (manual durations, window
+ * suppression), schedule window math incl. overnight spans, and the
+ * resolveEntryDelivery gate matrix — including bit-parity with the base layer
+ * when no profile is active.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  PROFILE_EMOJI_PRESETS,
+  DEADLINE_REMINDER_TYPES,
+  MAX_PROFILE_NAME_LENGTH,
+  getProfiles,
+  getProfile,
+  createProfile,
+  updateProfile,
+  deleteProfile,
+  enableProfile,
+  disableActiveProfile,
+  getActiveStatus,
+  getNextScheduleStart,
+  getNextScheduleEnd,
+  oneHourFrom,
+  resolveEntryDelivery,
+  subscribe,
+} from '../lib/notifications/notificationProfiles'
+import { setDeliveryMode, setPushEnabled, resolveDelivery } from '../lib/notifications/deliveryPreferences'
+
+// Tue 2026-07-14 12:00:00 local time (getDay() === 2).
+const NOW = new Date(2026, 6, 14, 12, 0, 0).getTime()
+const HOUR = 3_600_000
+const DAY = 86_400_000
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.useFakeTimers()
+  vi.setSystemTime(NOW)
+})
+afterEach(() => vi.useRealTimers())
+
+const entry = (over = {}) => ({ id: 'e1', domain: 'wagers', type: 't', actionable: false, ...over })
+
+describe('CRUD + validation', () => {
+  it('creates with defaults: exceptions on, empty allow-list, no schedule', () => {
+    const p = createProfile({ name: 'Sleep', emoji: '😴' })
+    expect(p).toMatchObject({
+      name: 'Sleep',
+      emoji: '😴',
+      allowedDomains: [],
+      allowActionRequired: true,
+      allowDeadlineReminders: true,
+      schedule: null,
+    })
+    expect(p.id).toBeTruthy()
+    expect(getProfiles()).toHaveLength(1)
+    expect(getProfile(p.id)).toMatchObject({ name: 'Sleep' })
+  })
+
+  it('rejects empty and over-long names', () => {
+    expect(createProfile({ name: '' })).toBeNull()
+    expect(createProfile({ name: '   ' })).toBeNull()
+    expect(createProfile({ name: 'x'.repeat(MAX_PROFILE_NAME_LENGTH + 1) })).toBeNull()
+    expect(getProfiles()).toHaveLength(0)
+  })
+
+  it('drops unknown domains and dedupes the allow-list', () => {
+    const p = createProfile({ name: 'Work', allowedDomains: ['wagers', 'wagers', 'nope', 'dao'] })
+    expect(p.allowedDomains).toEqual(['wagers', 'dao'])
+  })
+
+  it('updates fields and rejects invalid patches', () => {
+    const p = createProfile({ name: 'Work' })
+    const updated = updateProfile(p.id, { name: 'Deep Work', allowedDomains: ['custody'] })
+    expect(updated).toMatchObject({ name: 'Deep Work', allowedDomains: ['custody'] })
+    expect(updateProfile(p.id, { name: '' })).toBeNull()
+    expect(getProfile(p.id).name).toBe('Deep Work')
+    expect(updateProfile('missing', { name: 'X' })).toBeNull()
+  })
+
+  it('normalizes schedules: zero days can never be enabled', () => {
+    const p = createProfile({ name: 'S', schedule: { enabled: true, start: '21:00', end: '07:00', days: [] } })
+    expect(p.schedule.enabled).toBe(false)
+    const q = updateProfile(p.id, { schedule: { enabled: true, start: '21:00', end: '07:00', days: [2, 2, 9, -1] } })
+    expect(q.schedule).toEqual({ enabled: true, start: '21:00', end: '07:00', days: [2] })
+  })
+
+  it('deletes profiles and notifies subscribers on changes', () => {
+    const listener = vi.fn()
+    const unsub = subscribe(listener)
+    const p = createProfile({ name: 'Work' })
+    deleteProfile(p.id)
+    expect(getProfiles()).toHaveLength(0)
+    expect(listener).toHaveBeenCalledTimes(2)
+    unsub()
+  })
+
+  it('exposes the five Signal-style presets', () => {
+    expect(PROFILE_EMOJI_PRESETS.map((p) => p.name)).toEqual(['Work', 'Sleep', 'Driving', 'Downtime', 'Focus'])
+  })
+})
+
+describe('corrupt/foreign storage', () => {
+  it('degrades to an empty store on garbage JSON', () => {
+    localStorage.setItem('fairwins_notif_profiles_v1', '{bad json')
+    expect(getProfiles()).toEqual([])
+    expect(getActiveStatus().profile).toBeNull()
+  })
+
+  it('drops malformed profiles and dangling overrides', () => {
+    localStorage.setItem(
+      'fairwins_notif_profiles_v1',
+      JSON.stringify({
+        version: 99,
+        profiles: [{ id: 'ok', name: 'Fine' }, { name: 'no-id' }, { id: 'x2' }, 42, null],
+        override: { kind: 'enabled', profileId: 'ghost', until: null, at: 0 },
+      })
+    )
+    expect(getProfiles().map((p) => p.name)).toEqual(['Fine'])
+    expect(getActiveStatus().profile).toBeNull()
+  })
+})
+
+describe('activation overrides', () => {
+  it('manual indefinite enable stays on and reports no expiry', () => {
+    const p = createProfile({ name: 'Focus' })
+    enableProfile(p.id)
+    expect(getActiveStatus()).toMatchObject({ profile: { id: p.id }, source: 'manual', until: null })
+    expect(getActiveStatus(NOW + 7 * DAY).profile.id).toBe(p.id)
+  })
+
+  it('"for 1 hour" expires and prunes lazily', () => {
+    const p = createProfile({ name: 'Focus' })
+    enableProfile(p.id, { until: oneHourFrom(NOW) })
+    expect(getActiveStatus(NOW + HOUR - 1000).profile.id).toBe(p.id)
+    expect(getActiveStatus(NOW + HOUR).profile).toBeNull()
+    // Pruned: a later read at an earlier time no longer sees the override.
+    expect(getActiveStatus(NOW).profile).toBeNull()
+  })
+
+  it('at most one profile is active — enabling B replaces A', () => {
+    const a = createProfile({ name: 'A' })
+    const b = createProfile({ name: 'B' })
+    enableProfile(a.id)
+    enableProfile(b.id)
+    expect(getActiveStatus().profile.id).toBe(b.id)
+  })
+
+  it('enable of an unknown id is a no-op', () => {
+    enableProfile('ghost')
+    expect(getActiveStatus().profile).toBeNull()
+  })
+
+  it('deleting the active profile deactivates it', () => {
+    const p = createProfile({ name: 'A' })
+    enableProfile(p.id)
+    deleteProfile(p.id)
+    expect(getActiveStatus().profile).toBeNull()
+  })
+
+  it('disabling a manually enabled profile turns it fully off', () => {
+    const p = createProfile({ name: 'A' })
+    enableProfile(p.id)
+    disableActiveProfile()
+    expect(getActiveStatus().profile).toBeNull()
+  })
+})
+
+describe('schedule evaluation', () => {
+  const workdays = { enabled: true, start: '09:00', end: '17:00', days: [1, 2, 3, 4, 5] }
+
+  it('is active inside the window on a selected day, inactive outside', () => {
+    const p = createProfile({ name: 'Work', schedule: workdays })
+    expect(getActiveStatus(NOW)).toMatchObject({ profile: { id: p.id }, source: 'schedule' })
+    // until = today 17:00
+    expect(getActiveStatus(NOW).until).toBe(new Date(2026, 6, 14, 17, 0, 0).getTime())
+    expect(getActiveStatus(new Date(2026, 6, 14, 8, 59, 0).getTime()).profile).toBeNull()
+    expect(getActiveStatus(new Date(2026, 6, 14, 17, 0, 0).getTime()).profile).toBeNull()
+  })
+
+  it('is inactive on an unselected day', () => {
+    createProfile({ name: 'Work', schedule: workdays })
+    // Sat 2026-07-18 12:00
+    expect(getActiveStatus(new Date(2026, 6, 18, 12, 0, 0).getTime()).profile).toBeNull()
+  })
+
+  it('overnight windows span midnight and belong to the start day', () => {
+    const p = createProfile({ name: 'Sleep', schedule: { enabled: true, start: '21:00', end: '07:00', days: [2] } })
+    // Tue 23:00 — inside
+    expect(getActiveStatus(new Date(2026, 6, 14, 23, 0, 0).getTime()).profile.id).toBe(p.id)
+    // Wed 06:00 — still inside Tuesday's window
+    const wedSix = new Date(2026, 6, 15, 6, 0, 0).getTime()
+    expect(getActiveStatus(wedSix)).toMatchObject({ profile: { id: p.id }, source: 'schedule' })
+    expect(getActiveStatus(wedSix).until).toBe(new Date(2026, 6, 15, 7, 0, 0).getTime())
+    // Wed 23:00 — Wednesday not selected
+    expect(getActiveStatus(new Date(2026, 6, 15, 23, 0, 0).getTime()).profile).toBeNull()
+  })
+
+  it('manual off inside a window suppresses only that window', () => {
+    const p = createProfile({ name: 'Work', schedule: workdays })
+    disableActiveProfile(NOW)
+    expect(getActiveStatus(new Date(2026, 6, 14, 16, 0, 0).getTime()).profile).toBeNull()
+    // Next day 10:00 — window reactivates
+    expect(getActiveStatus(new Date(2026, 6, 15, 10, 0, 0).getTime()).profile.id).toBe(p.id)
+  })
+
+  it('manual enable beats another profile\'s schedule; expiry re-evaluates schedules', () => {
+    const work = createProfile({ name: 'Work', schedule: workdays })
+    const focus = createProfile({ name: 'Focus' })
+    enableProfile(focus.id, { until: NOW + HOUR })
+    expect(getActiveStatus(NOW).profile.id).toBe(focus.id)
+    // After expiry, Work's still-open window takes back over.
+    expect(getActiveStatus(NOW + HOUR + 1000).profile.id).toBe(work.id)
+  })
+
+  it('overlapping schedules: the most recent start wins', () => {
+    createProfile({ name: 'AllDay', schedule: { enabled: true, start: '08:00', end: '18:00', days: [2] } })
+    const later = createProfile({ name: 'Lunch', schedule: { enabled: true, start: '11:00', end: '13:00', days: [2] } })
+    expect(getActiveStatus(NOW).profile.id).toBe(later.id)
+  })
+
+  it('getNextScheduleStart / getNextScheduleEnd', () => {
+    const p = createProfile({ name: 'Work', schedule: workdays })
+    // Inside Tuesday's window: end is today 17:00; next start is Wed 09:00.
+    expect(getNextScheduleEnd(p, NOW)).toBe(new Date(2026, 6, 14, 17, 0, 0).getTime())
+    expect(getNextScheduleStart(p, NOW)).toBe(new Date(2026, 6, 15, 9, 0, 0).getTime())
+    // Friday 18:00 → next start Monday 09:00.
+    const friEve = new Date(2026, 6, 17, 18, 0, 0).getTime()
+    expect(getNextScheduleStart(p, friEve)).toBe(new Date(2026, 6, 20, 9, 0, 0).getTime())
+    expect(getNextScheduleEnd(p, friEve)).toBe(new Date(2026, 6, 20, 17, 0, 0).getTime())
+    // No schedule → null.
+    const bare = createProfile({ name: 'Bare' })
+    expect(getNextScheduleStart(bare, NOW)).toBeNull()
+    expect(getNextScheduleEnd(bare, NOW)).toBeNull()
+  })
+})
+
+describe('resolveEntryDelivery gate', () => {
+  it('no active profile ⇒ identical to the base layer', () => {
+    for (const mode of ['push', 'app', 'silent']) {
+      setDeliveryMode('wagers', mode)
+      setPushEnabled(mode === 'push')
+      expect(resolveEntryDelivery(entry())).toBe(resolveDelivery('wagers'))
+    }
+    expect(resolveEntryDelivery({})).toBe(resolveDelivery('wagers')) // domain fallback
+  })
+
+  it('allowed domain ⇒ base-layer mode', () => {
+    const p = createProfile({ name: 'W', allowedDomains: ['wagers'] })
+    enableProfile(p.id)
+    setDeliveryMode('wagers', 'push')
+    setPushEnabled(true)
+    expect(resolveEntryDelivery(entry())).toBe('push')
+    setDeliveryMode('wagers', 'silent')
+    expect(resolveEntryDelivery(entry())).toBe('silent') // allowed ≠ upgraded
+  })
+
+  it('blocked domain without exception ⇒ silent', () => {
+    const p = createProfile({ name: 'W', allowedDomains: ['wagers'] })
+    enableProfile(p.id)
+    setDeliveryMode('dao', 'push')
+    setPushEnabled(true)
+    expect(resolveEntryDelivery(entry({ domain: 'dao' }))).toBe('silent')
+  })
+
+  it('action-required exception breaks through; toggle respected', () => {
+    const p = createProfile({ name: 'W', allowedDomains: [] })
+    enableProfile(p.id)
+    setDeliveryMode('custody', 'app')
+    expect(resolveEntryDelivery(entry({ domain: 'custody', actionable: true }))).toBe('app')
+    updateProfile(p.id, { allowActionRequired: false })
+    expect(resolveEntryDelivery(entry({ domain: 'custody', actionable: true }))).toBe('silent')
+  })
+
+  it('deadline-reminder exception matches the warn types; toggle respected', () => {
+    const p = createProfile({ name: 'W', allowedDomains: [], allowActionRequired: false })
+    enableProfile(p.id)
+    for (const type of DEADLINE_REMINDER_TYPES) {
+      expect(resolveEntryDelivery(entry({ type, actionable: true }))).toBe('app')
+    }
+    updateProfile(p.id, { allowDeadlineReminders: false })
+    expect(resolveEntryDelivery(entry({ type: 'warn-acceptance', actionable: true }))).toBe('silent')
+  })
+
+  it('exception on a silent base category upgrades to app — exceptions only', () => {
+    const p = createProfile({ name: 'W', allowedDomains: [] })
+    enableProfile(p.id)
+    setDeliveryMode('custody', 'silent')
+    expect(resolveEntryDelivery(entry({ domain: 'custody', actionable: true }))).toBe('app')
+    // Non-exception on the same silent category stays silent.
+    expect(resolveEntryDelivery(entry({ domain: 'custody' }))).toBe('silent')
+  })
+
+  it('empty allow-list with both exceptions off ⇒ total silence', () => {
+    const p = createProfile({
+      name: 'DND',
+      allowedDomains: [],
+      allowActionRequired: false,
+      allowDeadlineReminders: false,
+    })
+    enableProfile(p.id)
+    setDeliveryMode('wagers', 'push')
+    setPushEnabled(true)
+    expect(resolveEntryDelivery(entry({ actionable: true, type: 'warn-acceptance' }))).toBe('silent')
+  })
+})

--- a/specs/059-notification-profiles/checklists/requirements.md
+++ b/specs/059-notification-profiles/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Notification Profiles
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Signal's per-contact allow-list and cross-device sync are deliberately adapted
+  (categories) / excluded (sync) — documented in Assumptions.
+- SC-005 pins the no-regression guarantee for members who never touch profiles.
+- References to "polling cadence" in SC-006/Assumptions describe the existing
+  product behavior boundary, not an implementation choice made by this spec.

--- a/specs/059-notification-profiles/contracts/profile-store.md
+++ b/specs/059-notification-profiles/contracts/profile-store.md
@@ -1,0 +1,84 @@
+# Contract: notificationProfiles module + delivery gate
+
+**Feature**: 059-notification-profiles
+**Module**: `frontend/src/lib/notifications/notificationProfiles.js`
+**Consumers**: `ActivityProvider.jsx` (gate), `useNotificationProfiles.js`
+(UI binding), profile components, tests.
+
+This is a UI-application internal contract (no external API). Shapes are
+defined in [data-model.md](../data-model.md).
+
+## Constants
+
+```js
+export const PROFILE_EMOJI_PRESETS  // [{ name: 'Work', emoji: '💪' }, Sleep 😴, Driving 🚗, Downtime 😊, Focus 💡]
+export const DEADLINE_REMINDER_TYPES // ['warn-acceptance', 'warn-resolution']
+export const MAX_PROFILE_NAME_LENGTH // 32
+export const DEFAULT_SCHEDULE       // { enabled: false, start: '09:00', end: '17:00', days: [] }
+```
+
+## Store CRUD (all synchronous, never throw)
+
+| Function | Signature | Behavior |
+|----------|-----------|----------|
+| `getProfiles` | `() => NotificationProfile[]` | Normalized list; `[]` on missing/corrupt storage. |
+| `getProfile` | `(id) => NotificationProfile \| null` | |
+| `createProfile` | `(input) => NotificationProfile` | `input: { name, emoji?, allowedDomains?, allowActionRequired?, allowDeadlineReminders?, schedule? }`. Trims/validates name (1–32 chars — returns `null` on invalid), fills defaults (exceptions `true`, `allowedDomains: []`, `schedule: null`), generates `id`, persists, notifies listeners. |
+| `updateProfile` | `(id, patch) => NotificationProfile \| null` | Shallow-merges validated fields; bumps `updatedAt`; `null` if id unknown or patch invalid. |
+| `deleteProfile` | `(id) => void` | Removes profile; prunes an `override` referencing it; notifies. |
+| `subscribe` | `(listener) => unsubscribe` | Same semantics as `deliveryPreferences.subscribe`. Fires after any persisted change (CRUD + activation). |
+
+## Activation
+
+| Function | Signature | Behavior |
+|----------|-----------|----------|
+| `enableProfile` | `(id, { until } = {}) => void` | Sets `override = { kind: 'enabled', profileId: id, until: until ?? null, at: now }` (replaces any prior override — FR-008). No-op for unknown id. |
+| `disableActiveProfile` | `(nowMs?) => void` | If a profile is active: scheduled ⇒ `{ kind: 'disabled', … }` suppressing the current window; manual ⇒ clears the override. No-op when nothing active. |
+| `getActiveStatus` | `(nowMs?) => ActiveProfileStatus` | Pure lazy evaluation per data-model; prunes expired overrides as a side effect (persist + notify only when something actually changed). |
+| `getNextScheduleEnd` | `(profile, nowMs?) => number \| null` | ms timestamp of the profile's current/next window end — feeds the "Until 5:00 PM" manual option and status line; `null` when no enabled schedule. |
+
+## Delivery gate
+
+| Function | Signature | Behavior |
+|----------|-----------|----------|
+| `resolveEntryDelivery` | `(entry, nowMs?) => 'push' \| 'app' \| 'silent'` | Per data-model §Entry delivery. MUST return exactly `resolveDelivery(entry.domain \|\| 'wagers')` when no profile is active (SC-005). Never throws (corrupt storage ⇒ no active profile). |
+
+### ActivityProvider integration (behavioral contract)
+
+- `poll()` continues to append **all** fresh entries to the feed before any
+  delivery decision (FR-009).
+- The toastable filter becomes `resolveEntryDelivery(e) !== 'silent'`; the
+  pushable filter becomes `resolveEntryDelivery(e) === 'push'`. Toast cap,
+  "+N more" overflow, catch-up (first-poll) suppression, and push→app
+  degradation via the base layer are unchanged.
+
+## Guarantees
+
+1. **No-profile parity (SC-005)**: with `fairwins_notif_profiles_v1` absent,
+   every exported read returns empty/inactive defaults and
+   `resolveEntryDelivery ≡ resolveDelivery` — the existing delivery test
+   suite passes without behavioral edits.
+2. **Never-throw storage**: read/write failures degrade exactly like
+   `deliveryPreferences.js` (session-only state, listeners still fire).
+3. **Single active profile**: no sequence of calls can yield two active
+   profiles (`override` is a single record, wholesale-replaced).
+4. **Lazy correctness**: `getActiveStatus`/`resolveEntryDelivery` are correct
+   at any call time without any timer having fired (app-closed-at-boundary
+   edge case).
+5. **Feed integrity**: the module never touches the activity store, unread
+   counts, or entry contents.
+
+## Hook contract — `useNotificationProfiles()`
+
+```js
+{
+  profiles,            // NotificationProfile[]
+  activeStatus,        // ActiveProfileStatus (re-evaluated on store change + 30 s tick)
+  createProfile, updateProfile, deleteProfile,
+  enableProfile,       // (id, { until }) — callers build `until` via getNextScheduleEnd / +1 h
+  disableActiveProfile,
+}
+```
+
+Re-render triggers: store `subscribe` events and a 30-second interval tick
+(status display only). Unmount cleans both.

--- a/specs/059-notification-profiles/data-model.md
+++ b/specs/059-notification-profiles/data-model.md
@@ -1,0 +1,126 @@
+# Data Model: Notification Profiles
+
+**Feature**: 059-notification-profiles | **Date**: 2026-07-17
+
+All data is device-scoped, stored under one new localStorage key:
+
+```
+Key:   fairwins_notif_profiles_v1
+Value: ProfilesStore (plain JSON)
+```
+
+## ProfilesStore
+
+| Field      | Type                   | Rules |
+|------------|------------------------|-------|
+| `version`  | `1`                    | Bump on breaking shape change. Unknown/absent version or non-object payload ⇒ treat as empty store (never crash). |
+| `profiles` | `NotificationProfile[]`| Order = creation order (render order). May be empty. |
+| `override` | `ActivationOverride \| null` | At most one; pruned lazily when expired/stale. |
+
+Normalization on every read (mirrors `getNotificationPrefs()`): coerce bad
+fields to defaults, drop profiles without a valid `id`/`name`, drop `override`
+referencing a missing profile.
+
+## NotificationProfile
+
+| Field                    | Type              | Rules |
+|--------------------------|-------------------|-------|
+| `id`                     | `string`          | Required, unique, opaque (`p_<timestamp>_<rand>`). Identity — names may duplicate. |
+| `name`                   | `string`          | Required, 1–32 chars after trim. |
+| `emoji`                  | `string \| null`  | Optional single emoji; `null` ⇒ neutral default icon. |
+| `allowedDomains`         | `string[]`        | Subset of the six known domains (`wagers`, `pools`, `membership`, `dao`, `token`, `custody`); unknown entries dropped on read. Empty = full DND (valid). |
+| `allowActionRequired`    | `boolean`         | Default `true`. Exception: entries with `actionable === true` break through. |
+| `allowDeadlineReminders` | `boolean`         | Default `true`. Exception: entries with `type ∈ DEADLINE_REMINDER_TYPES` break through. |
+| `schedule`               | `ProfileSchedule \| null` | `null` ⇒ manual-only profile. |
+| `createdAt` / `updatedAt`| `number` (ms)     | Bookkeeping only. |
+
+`DEADLINE_REMINDER_TYPES = ['warn-acceptance', 'warn-resolution']`
+(the types emitted by `data/notifications/deadlineWarnings.js`), exported as a
+constant so gate + tests share one source of truth.
+
+## ProfileSchedule
+
+| Field     | Type       | Rules |
+|-----------|------------|-------|
+| `enabled` | `boolean`  | Cannot be saved `true` with `days` empty (UI blocks; store normalizes to `enabled: false`). |
+| `start`   | `'HH:MM'`  | 24-h device-local wall time. Default `'09:00'`. |
+| `end`     | `'HH:MM'`  | Default `'17:00'`. `end <= start` ⇒ window crosses midnight into the next day. |
+| `days`    | `number[]` | 0 = Sunday … 6 = Saturday; the day a window **starts**. Default `[]`. |
+
+**Window semantics**: for each selected day `d`, the window is
+`[d start, d start + duration)` where `duration = end - start` (mod 24 h,
+overnight when `end <= start`). A Mon 21:00–07:00 schedule covers Tue 00:00–07:00
+only via Monday's selection.
+
+## ActivationOverride
+
+Discriminated union on `kind`:
+
+| Variant | Fields | Meaning |
+|---------|--------|---------|
+| `enabled`  | `profileId: string`, `until: number \| null` (ms), `at: number` | Manual on. `until = null` ⇒ indefinite (until turned off / another profile enabled). `until` set from "For 1 hour" (`now + 3600e3`) or "Until <schedule end>" (next end boundary). Expired (`until <= now`) ⇒ pruned on read, schedule evaluation resumes. |
+| `disabled` | `profileId: string`, `at: number` | Manual off during that profile's scheduled window. Suppresses only that window; pruned once the window containing `at` ends (profile reactivates at next scheduled start). If the profile wasn't in a window (indefinite-enable turned off), pruned immediately — recorded uniformly for simplicity. |
+
+Invariant: enabling any profile **replaces** the override wholesale ⇒ at most
+one profile can ever be active (FR-008).
+
+## Derived (never stored)
+
+### ActiveProfileStatus — `getActiveStatus(nowMs)`
+
+```
+{ profile: NotificationProfile | null,
+  source: 'manual' | 'schedule' | null,
+  until: number | null }   // ms when it will turn off, if known
+```
+
+Evaluation order:
+1. `override.kind === 'enabled'` and (`until` null or `> now`) ⇒ that profile,
+   `source: 'manual'`, `until` = override.until ?? (profile's current window
+   end if inside one, else null).
+2. Else, among profiles with `schedule.enabled` whose window contains `now`
+   (excluding one suppressed by a live `disabled` override), the one with the
+   most recent window start ⇒ `source: 'schedule'`, `until` = window end.
+3. Else `{ profile: null, source: null, until: null }`.
+
+### Entry delivery — `resolveEntryDelivery(entry, nowMs?)`
+
+```
+'push' | 'app' | 'silent'
+```
+
+1. No active profile ⇒ `resolveDelivery(entry.domain || 'wagers')` (today's
+   behavior, bit-identical).
+2. Active + domain ∈ `allowedDomains` ⇒ `resolveDelivery(domain)`.
+3. Active + exception match (`allowActionRequired && entry.actionable`, or
+   `allowDeadlineReminders && DEADLINE_REMINDER_TYPES.includes(entry.type)`)
+   ⇒ `resolveDelivery(domain)`, upgraded `'silent'` → `'app'` (FR-010
+   carve-out; exception matches only).
+4. Otherwise ⇒ `'silent'` (feed-only).
+
+## Relationships
+
+```
+ProfilesStore 1 ── * NotificationProfile 1 ── 0..1 ProfileSchedule
+       │ 0..1
+       └── ActivationOverride ── references ── NotificationProfile.id
+ActiveProfileStatus  = f(ProfilesStore, now)          [derived]
+resolveEntryDelivery = f(ActiveProfileStatus, entry,
+                         deliveryPreferences base layer)  [derived]
+```
+
+Base-layer stores (`fairwins_notif_delivery_v1`, activity store) are
+**unchanged** — profiles reference domains by the same keys but own no copy of
+mode data.
+
+## State transitions
+
+```
+(no override, outside windows)  ──schedule start──▶  active (schedule)
+active (schedule)  ──schedule end──▶  inactive
+active (schedule)  ──user turns off──▶  override {disabled} → inactive until window ends
+inactive           ──user enables (∞ | 1h | until-end)──▶  override {enabled} → active (manual)
+active (manual)    ──until expires──▶  override pruned → re-evaluate schedules
+active (any)       ──user enables other profile──▶  override {enabled, other} (old one off)
+active (any)       ──profile deleted──▶  override pruned → inactive
+```

--- a/specs/059-notification-profiles/plan.md
+++ b/specs/059-notification-profiles/plan.md
@@ -1,0 +1,167 @@
+# Implementation Plan: Notification Profiles
+
+**Branch**: `claude/notification-profiles-migration-h59dr6` | **Date**: 2026-07-17 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/059-notification-profiles/spec.md`
+
+## Summary
+
+Adopt Signal's notification-profiles pattern on top of the existing spec-031
+client-side notification stack. A new device-scoped store
+(`lib/notifications/notificationProfiles.js`, same localStorage + pub/sub
+pattern as `deliveryPreferences.js`) holds named profiles (name, emoji,
+category allow-list, action-required/deadline exceptions, optional weekly
+schedule) plus a single activation record (manual on/off overrides layered
+over schedule evaluation, at most one active profile). The
+`ActivityProvider.poll()` delivery gate swaps its per-domain
+`resolveDelivery(domain)` calls for a per-entry `resolveEntryDelivery(entry)`
+that first consults the active profile (allow-list + exceptions) and then
+falls through to the untouched base-layer preferences. UI: a 4-step creation
+wizard + profile list/editor in the Wallet → Preferences Notifications group,
+and a quick-access section at the top of the `ActivityFeed` panel (the app's
+analog of Signal's chat-list sheet) for manual on/off with durations. No
+contracts, no backend, no schema changes to the activity store.
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES2022), React 18 (JSX), Node 20 toolchain
+
+**Primary Dependencies**: React + Vite; existing notification stack: `lib/notifications/deliveryPreferences.js`, `lib/notifications/pushDelivery.js`, `contexts/ActivityProvider.jsx`, `data/notifications/*` (spec 031). No new packages.
+
+**Storage**: `localStorage`, device-scoped, new key `fairwins_notif_profiles_v1` (same never-throws pattern as `fairwins_notif_delivery_v1`). Activity feed storage untouched.
+
+**Testing**: Vitest (`npm run test:frontend`), jsdom + Testing Library, fake timers for schedule/duration tests (existing pattern in `ActivityProvider.delivery.test.jsx`)
+
+**Target Platform**: Browser/PWA (desktop + mobile web)
+
+**Project Type**: Web frontend only — `frontend/` workspace; zero contract/subgraph/services changes
+
+**Performance Goals**: Gate adds O(1) work per fresh entry per poll cycle; schedule evaluation is pure arithmetic on a ≤ handful of profiles; no extra timers beyond one lightweight interval for UI status refresh
+
+**Constraints**: Behavior with zero profiles must be bit-identical to today (SC-005); nothing ever dropped from the durable feed (Constitution III); WCAG 2.1 AA for all new surfaces; storage corruption degrades to defaults
+
+**Scale/Scope**: ~1 new lib module, 1 new hook, ~4 new components + CSS, 3 edited files (`ActivityProvider.jsx`, `ActivityFeed.jsx`, `WalletPage.jsx`), ~5 new test files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment | Status |
+|-----------|------------|--------|
+| I. Security-first contracts | No `contracts/` changes; feature is entirely client-side UI/preferences. Slither/Medusa/security review not applicable. | PASS (N/A) |
+| II. Test-first, comprehensive coverage | Vitest unit tests for the profile store (schedule math, overrides, gate) and component tests for wizard/panel/quick-access; `ActivityProvider` delivery tests extended for profile gating; existing delivery suite must keep passing unmodified in behavior (SC-005). | PASS |
+| III. Honest state, no mocks in shipped paths | Profiles only gate *interruptions* (toast/push); every entry still lands in the durable feed with real unread state. No fabricated data; active-state UI shows computed truth ("On until 6:00 PM"). No catch-up toasts invented for silenced periods (catch-up polls stay feed-only, as today). | PASS |
+| IV. Fail loudly in CI | No CI changes; new tests run in the existing `test:frontend` gate. | PASS |
+| V. Accessible, consistent frontend | Wizard/panel/quick-access follow existing panel patterns (`role="switch"`, `radiogroup`, labelled controls, focus management like `ActivityFeed`); FR-017 requires keyboard + SR operability; axe/Lighthouse CI unchanged. | PASS |
+| Simplicity (workflow §4) | One new store module mirroring an existing pattern; no context provider added (module pub/sub + hook, like `useNotificationPreferences`); no new deps. | PASS |
+
+**Post-design re-check (after Phase 1)**: PASS — design introduces no backend,
+no new technology, no contract surface; storage versioned (`version: 1`) with
+corrupt-data fallback; base layer untouched.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/059-notification-profiles/
+├── spec.md
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── profile-store.md # Module API + delivery-gate contract
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/
+├── lib/notifications/
+│   ├── deliveryPreferences.js        # UNCHANGED base layer
+│   ├── pushDelivery.js               # UNCHANGED
+│   └── notificationProfiles.js      # NEW — profile store, schedule eval,
+│                                     #        activation record, resolveEntryDelivery()
+├── hooks/
+│   ├── useNotificationPreferences.js # UNCHANGED
+│   └── useNotificationProfiles.js    # NEW — React binding + status tick
+├── contexts/
+│   └── ActivityProvider.jsx          # EDIT — gate via resolveEntryDelivery(entry)
+├── components/
+│   ├── notifications/
+│   │   ├── ActivityFeed.jsx          # EDIT — mount ProfileQuickAccess at top
+│   │   └── profiles/
+│   │       ├── ProfileQuickAccess.jsx    # NEW — Signal-style sheet section
+│   │       ├── ProfileQuickAccess.css
+│   │       ├── ProfileWizard.jsx         # NEW — 4-step creation flow
+│   │       ├── ProfileWizard.css
+│   │       ├── ProfileScheduleFields.jsx # NEW — shared schedule editor (wizard + edit)
+│   │       └── emojiPresets.js           # NEW — Work/Sleep/Driving/Downtime/Focus
+│   └── account/
+│       ├── NotificationPreferencesPanel.jsx  # UNCHANGED (base layer)
+│       ├── NotificationProfilesPanel.jsx     # NEW — list/edit/delete + wizard entry
+│       └── NotificationProfilesPanel.css
+├── pages/
+│   └── WalletPage.jsx                # EDIT — render NotificationProfilesPanel
+└── test/
+    ├── notificationProfiles.test.js          # NEW — store/schedule/override/gate
+    ├── ActivityProvider.profiles.test.jsx    # NEW — end-to-end gating
+    ├── NotificationProfilesPanel.test.jsx    # NEW
+    ├── ProfileWizard.test.jsx                # NEW
+    ├── ProfileQuickAccess.test.jsx           # NEW
+    └── ActivityProvider.delivery.test.jsx    # UNCHANGED — must keep passing (SC-005)
+```
+
+**Structure Decision**: Frontend-only change inside the existing `frontend/src`
+layout. New profile UI lives beside the notification components it extends
+(`components/notifications/profiles/`), the settings panel beside the existing
+preferences panel (`components/account/`), and all logic in one new lib module
+mirroring `deliveryPreferences.js` so the two device-scoped stores stay
+side-by-side and independently versioned.
+
+## Key Design Decisions
+
+1. **Gate composition, not replacement.** `resolveEntryDelivery(entry)` is the
+   single new decision point: `(no active profile) → resolveDelivery(domain)`
+   unchanged; `(active, domain allowed) → resolveDelivery(domain)`;
+   `(active, exception match) → resolveDelivery(domain)` upgraded from
+   `silent` to `app` (FR-010 carve-out, exception matches only);
+   `(active, otherwise) → 'silent'`. `ActivityProvider.poll()` swaps its two
+   `resolveDelivery(e.domain)` call sites for `resolveEntryDelivery(e)` —
+   the only provider change.
+2. **Exception matching.** Action-required ⇔ `entry.actionable === true`
+   (already stamped by every source). Deadline reminders ⇔ `entry.type ∈
+   {'warn-acceptance', 'warn-resolution'}` (the deadlineWarnings.js types),
+   exported as a shared constant from `notificationProfiles.js`.
+3. **Activation model (Signal semantics).** Stored `override` record:
+   `{ kind: 'enabled', profileId, until: ms|null }` (manual on; `until` from
+   "For 1 hour" / "Until <schedule end>") or `{ kind: 'disabled', profileId,
+   at: ms }` (manual off inside that profile's schedule window — suppresses it
+   until the window ends) or `null` (pure schedule evaluation).
+   `getActiveProfile(nowMs)` evaluates lazily at every call — correctness never
+   depends on a timer firing; expired overrides are pruned on read.
+   Overlapping schedules: latest start wins; enabling any profile clears the
+   prior override (at most one active).
+4. **Schedule math in device-local time.** Times stored as `'HH:MM'` strings +
+   `days: [0..6]` (Sunday-first, matching the S M T W T F S row). End ≤ start
+   spans midnight: the window belongs to its *start* day (a Mon 21:00–07:00
+   schedule is active Tue 06:00 only if Monday is selected — Signal behavior).
+5. **UI status refresh.** `useNotificationProfiles` subscribes to the store and
+   re-evaluates on a 30 s interval so "On until 6:00 PM" flips without
+   interaction; the delivery gate itself never relies on that tick.
+6. **Settings placement.** `NotificationProfilesPanel` renders *above* the
+   untouched `NotificationPreferencesPanel` in WalletPage's Preferences →
+   Notifications group: profiles are the headline; the base grid remains as
+   "How each category is delivered". Wizard opens in-panel (no new route);
+   quick-access "View settings" deep-links to the Preferences tab.
+7. **No migration needed.** New storage key, absent by default ⇒ FR-016
+   (existing users unchanged) is satisfied structurally; corrupt/foreign data
+   degrades to `{ profiles: [], override: null }`.
+
+## Complexity Tracking
+
+No constitution violations — table intentionally empty.

--- a/specs/059-notification-profiles/quickstart.md
+++ b/specs/059-notification-profiles/quickstart.md
@@ -1,0 +1,79 @@
+# Quickstart: Notification Profiles
+
+**Feature**: 059-notification-profiles
+
+Validation guide for the profile layer on top of the spec-031 notification
+stack. Shapes: [data-model.md](./data-model.md) · API:
+[contracts/profile-store.md](./contracts/profile-store.md).
+
+## Prerequisites
+
+```bash
+cd frontend && npm install   # repo root: npm install if not yet done
+```
+
+## Automated validation
+
+```bash
+# Full frontend suite (from repo root)
+npm run test:frontend
+
+# Feature-focused runs (from frontend/)
+npx vitest run src/test/notificationProfiles.test.js       # store, schedule math, overrides, gate
+npx vitest run src/test/ActivityProvider.profiles.test.jsx # end-to-end gating in the poll loop
+npx vitest run src/test/ProfileWizard.test.jsx             # 4-step creation flow
+npx vitest run src/test/NotificationProfilesPanel.test.jsx # list/edit/delete settings surface
+npx vitest run src/test/ProfileQuickAccess.test.jsx        # feed-panel quick access
+
+# Regression guarantee (SC-005): pre-existing delivery tests, unmodified behavior
+npx vitest run src/test/ActivityProvider.delivery.test.jsx src/test/deliveryPreferences.test.js src/test/NotificationPreferencesPanel.test.jsx
+```
+
+Expected: all pass; the three regression files pass **without behavioral
+edits**.
+
+## Manual validation
+
+```bash
+npm run frontend   # Vite dev server
+```
+
+1. **Create (Story 1)** — Wallet → Preferences → Notifications → "New
+   profile". Tap the **Sleep** preset (name + 😴 fill in) → Next → allow only
+   **Wagers**, leave both exceptions on → Next → enable the schedule, set
+   21:00–07:00, select all days → Next → confirmation screen → Done. Profile
+   listed with name, emoji, and schedule. Reload — still there.
+2. **Silencing (Story 2)** — enable the profile, then trigger fresh activity
+   in a blocked domain (e.g. a DAO proposal on a local chain, or temporarily
+   drive a source in dev): no toast/push; bell unread count increments; entry
+   in feed. A wager update still toasts per its base mode.
+3. **Quick access (Story 3)** — open the bell's Activity panel: profile
+   section pinned on top shows "Sleep — Off". Expand → "For 1 hour" →
+   status shows the off time; second profile enable flips the first off;
+   "Turn off" reverts immediately. "View settings" lands on the Preferences
+   tab; "New profile" opens the wizard.
+4. **Schedule (Story 4)** — set a schedule covering the current time/day,
+   reload: profile shows active with "until <end>" without any tap. Turn it
+   off mid-window: stays off; change device clock past the next start (or
+   wait): reactivates. Overnight window active before 07:00.
+5. **Edit/delete (Story 5)** — from settings, rename, change allow-list, add/
+   remove schedule — each persists across reload. Delete the active profile:
+   status clears, base-layer behavior resumes.
+6. **Base parity (FR-011/016)** — in a fresh browser profile (no localStorage
+   key): notification behavior identical to production today; the
+   Push/In-app/Silent grid and master push toggle work unchanged.
+7. **Accessibility (FR-017)** — walk the wizard and quick access with
+   keyboard only (Tab/Space/Enter/Escape); verify toggles announce state
+   (`role="switch"`/`aria-pressed`), the wizard traps focus like existing
+   dialogs, and axe reports no new violations.
+
+## Storage inspection (DevTools)
+
+```js
+JSON.parse(localStorage.getItem('fairwins_notif_profiles_v1'))
+// { version: 1, profiles: [...], override: {...}|null }
+localStorage.removeItem('fairwins_notif_profiles_v1') // reset feature only
+```
+
+Corruption drill: `localStorage.setItem('fairwins_notif_profiles_v1', '{bad')`
+→ reload → app loads, zero profiles, base behavior intact (FR-015).

--- a/specs/059-notification-profiles/research.md
+++ b/specs/059-notification-profiles/research.md
@@ -1,0 +1,142 @@
+# Research: Notification Profiles
+
+**Feature**: 059-notification-profiles | **Date**: 2026-07-17
+
+No NEEDS CLARIFICATION markers remained in the Technical Context; research
+consolidated the Signal reference behavior and the existing codebase seams.
+
+## R1. Signal's notification-profiles pattern (reference behavior)
+
+- **Decision**: Mirror Signal Android / Desktop 7.76 semantics: multiple named
+  profiles (name + emoji, presets Work 💪 / Sleep 😴 / Driving 🚗 / Downtime 😊 /
+  Focus 💡), an allow-list, always-break-through exceptions, optional weekly
+  schedule (start, end, days), manual enable with durations (indefinite /
+  "For 1 hour" / "Until <schedule end>"), single active profile, quick-access
+  sheet on the main list surface, 4-step creation flow ending in a
+  confirmation screen with "turn on manually" and "add a schedule" hints.
+- **Rationale**: Confirmed against the provided flow screenshots (chat-list
+  sheet, "Name your profile", "Allowed notifications" with Allow-all-calls ON /
+  Notify-for-all-mentions OFF defaults, "Add a schedule" with 9:00 AM–5:00 PM
+  defaults and no-days-preselected, "Profile created") and the linked article
+  (aboutsignal.com, Signal Desktop 7.76 beta): profiles control "how, when,
+  and from whom", schedules support weekday/weekend/time-block automation,
+  manual + scheduled activation, active profile surfaced atop the chat list.
+- **Alternatives considered**: iOS Focus-mode style system integration —
+  rejected: web app has no OS focus APIs; Signal's in-app model matches our
+  in-app delivery pipeline.
+
+## R2. Mapping Signal's people/groups allow-list to FairWins
+
+- **Decision**: Allow-list over the six existing notification categories
+  (`wagers`, `pools`, `membership`, `dao`, `token`, `custody`) from
+  `NOTIFICATION_CATEGORIES` in `deliveryPreferences.js`.
+- **Rationale**: FairWins notifications are derived per-domain by
+  ActivitySources (spec 031); there is no per-contact notification source, so
+  categories are the only meaningful allow-list axis. Reusing
+  `NOTIFICATION_CATEGORIES` keeps the wizard and the base-layer grid showing
+  the identical category set (labels + descriptions).
+- **Alternatives considered**: Per-wager/per-pool allow-listing — rejected as
+  speculative scope (no user ask, no precedent in the feed model); can layer
+  later without storage breakage (versioned store).
+
+## R3. Mapping Signal's exceptions ("Allow all calls", "Notify for all mentions")
+
+- **Decision**: Two exception switches: **Always allow action-required items**
+  (matches `entry.actionable === true`) and **Always allow deadline
+  reminders** (matches `entry.type ∈ {'warn-acceptance','warn-resolution'}`).
+  Both default ON for new profiles.
+- **Rationale**: In a wagering app the money-critical interrupts are "you must
+  act" (custody approvals, votes, claims — sources already stamp
+  `actionable: true`) and "a deadline is about to pass"
+  (`deadlineWarnings.js` emits exactly the two `warn-*` types, at most one per
+  wager/window/day). Signal defaults calls ON — the analogous
+  safety-preserving default is both ON. Signal defaults mentions OFF, but
+  defaulting deadline reminders OFF would let a "Sleep" profile eat a
+  He-must-claim-by-8AM warning — money beats symmetry; the switch remains for
+  users who want total silence.
+- **Alternatives considered**: severity-based exception (`severity ===
+  'warning'`) — rejected: severity is presentation, `actionable`/`warn-*` are
+  semantic; a single combined "critical only" switch — rejected: loses
+  Signal's two-switch mental model and the ability to silence deadlines but
+  keep approvals.
+
+## R4. Storage pattern
+
+- **Decision**: New module `lib/notifications/notificationProfiles.js`, key
+  `fairwins_notif_profiles_v1`, device-scoped, `{ version: 1, profiles: [],
+  override: null }`, plain-JSON localStorage, never-throws read/write,
+  module-level listener set with `subscribe()` — the exact
+  `deliveryPreferences.js` pattern.
+- **Rationale**: Spec mandates client-side/device-scoped parity with delivery
+  preferences; the pattern is proven (private-browsing fallback, cross-
+  component sync); a separate key keeps the two stores independently
+  versioned and makes FR-016 (no migration) automatic.
+- **Alternatives considered**: extending `fairwins_notif_delivery_v1` —
+  rejected: entangles versioning and risks corrupting the existing store on
+  rollback; per-account `userStorage` scoping — rejected: interruption
+  preferences are a device concern (mirrors existing decision for delivery
+  prefs, and Signal profiles are per-device unless synced — sync is out of
+  scope with no backend).
+
+## R5. Activation/override semantics
+
+- **Decision**: Lazy evaluation `getActiveProfile(nowMs)` over
+  `{ profiles, override }`: manual-enabled (with optional `until`) beats
+  schedules; manual-disabled suppresses one profile until its current window
+  ends; otherwise the scheduled profile whose start is most recent wins;
+  expired overrides are pruned on read. No background timer required for
+  correctness.
+- **Rationale**: The app has no persistent background process (PWA, tab may be
+  closed at boundaries — spec edge case). Lazy evaluation guarantees the
+  correct state on next open and on every poll cycle; a UI-only 30 s tick
+  refreshes displayed status. Matches Signal's observed behavior (manual off
+  during a scheduled window stays off until next window).
+- **Alternatives considered**: storing a boolean `active` flag flipped by
+  timers — rejected: wrong after sleep/close (dishonest state, Constitution
+  III); scheduling via service worker alarms — rejected: no reliable
+  cross-browser API, unnecessary.
+
+## R6. Gate integration point
+
+- **Decision**: Single choke point in `ActivityProvider.poll()`: replace the
+  two `resolveDelivery(e.domain || 'wagers')` call sites (toastable filter,
+  pushable filter) with `resolveEntryDelivery(entry)` exported from
+  `notificationProfiles.js`, which internally calls the untouched
+  `resolveDelivery(domain)` for the base layer.
+- **Rationale**: Keeps `deliveryPreferences.js` byte-identical (SC-005), keeps
+  the feed append path untouched (FR-009 — silenced entries still persist +
+  count unread), and preserves the existing toast cap, catch-up suppression,
+  and push degradation for free since they sit around the same filter.
+- **Alternatives considered**: gating inside `showSystemNotification` —
+  rejected: wouldn't stop toasts; a React context for profiles — rejected:
+  the poll callback is easier and less invasive with a plain module import
+  (same as `resolveDelivery` today).
+
+## R7. Quick-access surface
+
+- **Decision**: A `ProfileQuickAccess` section pinned at the top of the
+  existing `ActivityFeed` panel (opened from the `NotificationBell`),
+  showing the active/first profile with expand-to-reveal duration actions
+  ("For 1 hour", "Until <end>", off), plus "View settings" and "New profile".
+- **Rationale**: The bell's feed panel is FairWins' chat-list analog — the one
+  always-reachable notification surface on every page; Signal pins its sheet
+  to the chat list the same way. Reuses the panel's focus/Escape handling
+  (a11y) and avoids a new global UI region.
+- **Alternatives considered**: header-level standalone menu — rejected
+  (crowds the header, duplicates bell affordance); floating action on Home —
+  rejected (Home is already dense; profiles are notification-scoped).
+
+## R8. Time/schedule representation
+
+- **Decision**: `'HH:MM'` 24-h strings + `days: number[]` (0 = Sunday);
+  native `<input type="time">` + seven day-toggle buttons
+  (`aria-pressed`), rendered S M T W T F S; display via
+  `toLocaleTimeString` for 12/24-h locale correctness. End ≤ start spans
+  midnight and belongs to the start day.
+- **Rationale**: Native time inputs are accessible, mobile-friendly, and
+  locale-aware for free; string storage avoids timezone bugs (evaluated
+  against device-local time per spec edge case); Signal's picker defaults
+  (9:00 AM – 5:00 PM, no days preselected) are kept.
+- **Alternatives considered**: minutes-since-midnight integers — equivalent
+  but less debuggable in storage; a custom picker component — rejected
+  (YAGNI, a11y cost).

--- a/specs/059-notification-profiles/spec.md
+++ b/specs/059-notification-profiles/spec.md
@@ -1,0 +1,386 @@
+# Feature Specification: Notification Profiles
+
+**Feature Branch**: `claude/notification-profiles-migration-h59dr6`
+
+**Created**: 2026-07-17
+
+**Status**: Draft
+
+**Input**: User description: "Replace the current per-category notification delivery settings (the 'Notifications' panel in Wallet → Preferences with a master Mobile push toggle and per-category Push/In-app/Silent segmented controls) with Signal-style Notification Profiles. Following Signal's pattern (Signal Desktop 7.76 / Android): a user can create multiple named notification profiles, each with a name and emoji (with quick-pick presets like Work, Sleep, Driving, Downtime, Focus), an allow-list of notification categories the profile lets through, exceptions that always break through, and an optional schedule (start time, end time, days of week) that turns the profile on automatically. Profiles can also be toggled manually from a quick-access surface: enable indefinitely, 'for 1 hour', or 'until <next schedule boundary>', and turned off. When a profile is active, only allowed notifications notify; everything else is silenced (still recorded in the activity feed). When no profile is active, existing per-category delivery preferences continue to apply. Creation flow mirrors Signal's 4 steps. All storage stays client-side/device-scoped."
+
+## Overview
+
+FairWins currently offers one flat notification setting: a master push toggle plus a
+per-category choice of Push / In-app / Silent. That answers "how does each kind of
+update reach me?" but not "when do I want to be interrupted at all?". A member who
+wants quiet evenings but must never miss a wager deadline has no way to express
+that today.
+
+Notification Profiles adopt the pattern Signal introduced on Android and Desktop
+7.76: named, reusable "interruption modes" (Sleep, Work, Focus…) that a member
+turns on manually or on a weekly schedule. While a profile is on, only the
+notification categories that profile allows may interrupt the member; everything
+else lands silently in the activity feed. Deadline-critical and action-required
+updates can be marked as exceptions that always break through, because in a
+wagering app a missed acceptance or claim deadline costs real money.
+
+Signal's allow-list is people and groups; FairWins has no per-contact
+notifications, so the allow-list is adapted to FairWins' notification categories
+(Wagers, Wager Pools, Membership, Governance, Token, Custody), and Signal's
+"allow all calls / all mentions" exceptions are adapted to FairWins'
+money-safety equivalents ("always allow action-required items" and "always allow
+deadline reminders").
+
+The existing per-category Push / In-app / Silent selector remains the base
+layer: it still decides *how* an allowed notification is delivered. Profiles add
+a layer above it that decides *whether* a notification may interrupt at all.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Create a notification profile (Priority: P1)
+
+A member opens their notification settings, starts "New profile", and walks a
+four-step flow mirrored on Signal's: (1) name the profile and pick an emoji, with
+one-tap presets (Work 💪, Sleep 😴, Driving 🚗, Downtime 😊, Focus 💡); (2) choose
+which notification categories are allowed to notify while the profile is on, and
+set the exceptions ("Always allow action-required items" — on by default — and
+"Always allow deadline reminders"); (3) optionally add a weekly schedule (start
+time, end time, days of week) that turns the profile on automatically, or skip;
+(4) see a confirmation that the profile was created, with hints on how to turn it
+on manually and where to edit the schedule.
+
+**Why this priority**: Nothing else in the feature is usable until a profile can
+be created. Creating a profile with a category allow-list and exceptions is the
+minimum viable slice: even without schedules or a quick-access surface, a member
+can create and enable a profile from settings and get the core value (selective
+quiet).
+
+**Independent Test**: Can be fully tested by walking the creation flow end to
+end and confirming the profile appears in the settings list with the chosen
+name, emoji, allowed categories, exceptions, and (if set) schedule — all
+surviving a page reload.
+
+**Acceptance Scenarios**:
+
+1. **Given** a member with no profiles, **When** they start "New profile" and tap
+   the "Sleep" preset, **Then** the name field is filled with "Sleep" and the 😴
+   emoji is selected, and they can continue.
+2. **Given** the name step, **When** the member tries to continue with an empty
+   name, **Then** the flow blocks continuation and indicates a name is required.
+3. **Given** the allowed-notifications step, **When** the member allows only
+   "Wagers" and leaves "Always allow action-required items" on, **Then** the
+   created profile records exactly that allow-list and exception.
+4. **Given** the schedule step, **When** the member skips it, **Then** the profile
+   is created with no schedule and can only be turned on manually.
+5. **Given** the schedule step, **When** the member enables the schedule, sets
+   9:00 PM – 7:00 AM on all seven days, and continues, **Then** the confirmation
+   step appears and the created profile stores that schedule.
+6. **Given** the confirmation step, **When** the member finishes, **Then** they
+   return to the notification settings where the new profile is listed.
+
+---
+
+### User Story 2 - Profile silences non-allowed notifications (Priority: P1)
+
+While a profile is on, a notification from a category the profile does not allow
+is recorded in the activity feed but produces no toast and no device push. A
+notification from an allowed category is delivered exactly as the existing
+per-category Push / In-app / Silent preference dictates. Notifications matching
+an enabled exception (action-required items, deadline reminders) break through
+even if their category is not allowed.
+
+**Why this priority**: This is the behavioral heart of the feature — a profile
+that doesn't actually gate interruptions is just a saved form. Ships together
+with Story 1 as the MVP.
+
+**Independent Test**: With a profile active that allows only "Wagers", simulate
+fresh activity in an allowed category, a blocked category, and a blocked
+category with an action-required item; verify toast/push behavior for each and
+that all three appear in the activity feed.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active profile allowing only Wagers, **When** a new Governance
+   update arrives, **Then** no toast or device push is shown and the update
+   appears in the activity feed as unread.
+2. **Given** an active profile allowing only Wagers, **When** a new Wagers update
+   arrives and the Wagers base preference is "Push", **Then** the member gets the
+   toast and the device push as today.
+3. **Given** an active profile allowing only Wagers with "Always allow
+   action-required items" on, **When** a Custody approval request (action
+   required) arrives, **Then** it notifies despite Custody not being allowed.
+4. **Given** an active profile with "Always allow deadline reminders" on,
+   **When** a wager deadline warning arrives, **Then** it notifies even if Wagers
+   is not in the allow-list.
+5. **Given** no active profile, **When** any update arrives, **Then** delivery is
+   identical to today's behavior (per-category Push / In-app / Silent).
+
+---
+
+### User Story 3 - Manual on/off from a quick-access surface (Priority: P2)
+
+From the notification bell's feed panel (the app's equivalent of Signal's chat
+list), the member can see their profiles and the active one at a glance, and
+toggle a profile with duration choices: on indefinitely, on "For 1 hour", or —
+when the profile has a schedule — on "Until <next schedule end>". They can turn
+the active profile off at any time, and reach profile settings ("View settings")
+and profile creation ("New profile") from the same surface.
+
+**Why this priority**: Manual control from settings alone (Story 1) is workable;
+the quick-access surface is what makes profiles habitual. It builds directly on
+Stories 1–2.
+
+**Independent Test**: With two profiles saved, open the quick-access surface,
+enable one "For 1 hour", verify it reports active with an expiry, verify the
+other cannot be simultaneously active, turn it off, and verify normal delivery
+resumes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a saved profile that is off, **When** the member enables it "For 1
+   hour", **Then** it becomes active, displays that it is on with the time it
+   turns off, and deactivates itself after one hour.
+2. **Given** a profile with a schedule ending at 5:00 PM today, **When** the
+   member enables it manually at 2:00 PM choosing "Until 5:00 PM", **Then** it
+   deactivates at 5:00 PM.
+3. **Given** profile A is active, **When** the member enables profile B, **Then**
+   profile A turns off — at most one profile is active at a time.
+4. **Given** an active profile, **When** the member turns it off, **Then**
+   delivery immediately reverts to the base per-category preferences.
+5. **Given** the quick-access surface, **When** the member has no profiles,
+   **Then** it offers "New profile" and leads into the creation flow.
+
+---
+
+### User Story 4 - Scheduled activation (Priority: P2)
+
+A profile with a schedule turns itself on at the scheduled start time on the
+selected days and off at the end time, with no member action. Overnight ranges
+(e.g. 9:00 PM – 7:00 AM) span midnight correctly. A member can manually override
+a scheduled activation — turning the profile off before the end time keeps it
+off until the next scheduled start; turning a profile on outside its schedule
+works like any manual enable.
+
+**Why this priority**: Schedules are what make "Sleep" set-and-forget, but the
+feature is fully usable manually without them.
+
+**Independent Test**: Create a profile scheduled for the current time window and
+day, reload the app, and verify it reports active without interaction; verify a
+manual off keeps it off within the same window; verify it does not activate on
+an unselected day.
+
+**Acceptance Scenarios**:
+
+1. **Given** a profile scheduled 9:00 AM – 5:00 PM on Monday–Friday, **When** the
+   member uses the app at 10:00 AM on a Tuesday, **Then** the profile is active.
+2. **Given** the same profile, **When** the member uses the app at 10:00 AM on a
+   Saturday, **Then** the profile is not active.
+3. **Given** a profile scheduled 9:00 PM – 7:00 AM daily, **When** the member uses
+   the app at 6:00 AM, **Then** the profile is active (overnight span).
+4. **Given** a scheduled profile currently active, **When** the member turns it
+   off at 3:00 PM (before its 5:00 PM end), **Then** it stays off for the rest of
+   that window and reactivates at the next scheduled start.
+5. **Given** a schedule with no days selected, **When** the member tries to save
+   the schedule as enabled, **Then** saving is blocked until at least one day is
+   chosen.
+
+---
+
+### User Story 5 - Manage existing profiles (Priority: P3)
+
+From notification settings, the member can open any saved profile to rename it,
+change its emoji, edit its allowed categories and exceptions, add/edit/remove
+its schedule, or delete the profile. The settings surface also presents the
+existing base-layer controls (master push toggle and per-category
+Push / In-app / Silent) so the whole notification experience is managed in one
+place.
+
+**Why this priority**: Editing rounds out the lifecycle; until it ships, a member
+can delete and recreate a profile as a workaround.
+
+**Independent Test**: Edit each attribute of a saved profile and verify
+persistence across reload; delete a profile and verify it disappears and, if it
+was active, that delivery reverts to base behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** a saved profile, **When** the member renames it and changes its
+   allowed categories, **Then** the changes persist across a reload.
+2. **Given** an active profile, **When** the member deletes it, **Then** it is
+   removed, no profile is active, and delivery reverts to base preferences.
+3. **Given** a profile without a schedule, **When** the member adds one from the
+   edit surface, **Then** scheduled activation starts working for it.
+
+---
+
+### Edge Cases
+
+- Two profiles have overlapping schedules: the profile whose scheduled start is
+  most recent wins; enabling one profile always deactivates any other.
+- A manual "For 1 hour" enable on a profile whose schedule would start within
+  that hour: the manual duration wins; when it expires, the schedule is
+  re-evaluated (so the profile may remain on because its schedule window is now
+  open).
+- The member's device clock/timezone changes (travel): schedules are evaluated
+  in the device's current local time.
+- The app is closed at a schedule boundary: on next open, the correct
+  active/inactive state is computed from the schedule and any manual override —
+  no "catch-up" toasts for updates that were silenced while a profile was on.
+- Deleting the active profile, or the active profile's manual duration expiring
+  while the settings surface is open: the UI reflects the change without a
+  reload.
+- All categories un-ticked in the allow-list: allowed — the profile silences
+  everything except enabled exceptions (a true Do-Not-Disturb).
+- Both exceptions disabled and no categories allowed: allowed, with the
+  consequence stated plainly in the flow (total silence; feed still records
+  everything).
+- Emoji is skipped: the profile falls back to a neutral default icon; emoji is
+  optional, name is required.
+- Duplicate profile names: allowed (profiles are identified internally, not by
+  name), matching Signal's behavior.
+- Profile storage is corrupted or from a newer version: settings load with an
+  empty/default profile list rather than crashing; base preferences still apply.
+- Browser/device push permission revoked while a profile is on: allowed
+  notifications degrade from push to in-app exactly as today's base layer does.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Members MUST be able to create multiple named notification
+  profiles, each with a required name (up to 32 characters) and an optional
+  emoji, including one-tap presets: Work 💪, Sleep 😴, Driving 🚗, Downtime 😊,
+  Focus 💡.
+- **FR-002**: Each profile MUST hold an allow-list over the notification
+  categories already exposed in notification settings (Wagers, Wager Pools,
+  Membership, Governance, Token, Custody); categories not on the allow-list are
+  silenced while the profile is active. An empty allow-list is valid.
+- **FR-003**: Each profile MUST hold two exception switches — "Always allow
+  action-required items" (default on for new profiles) and "Always allow
+  deadline reminders" (default on for new profiles) — which let matching
+  updates notify even when their category is not allowed.
+- **FR-004**: Profile creation MUST follow a four-step guided flow: name & emoji
+  → allowed notifications & exceptions → optional schedule (skippable) →
+  confirmation, with back navigation between steps and no data lost while
+  moving between steps.
+- **FR-005**: Each profile MAY have one weekly schedule consisting of an on/off
+  switch, a start time, an end time, and a set of days of week (default
+  9:00 AM – 5:00 PM with no days preselected). A schedule cannot be saved as
+  enabled with zero days selected. End-before-start ranges are treated as
+  spanning midnight into the next day.
+- **FR-006**: A profile with an enabled schedule MUST activate automatically at
+  its start time on selected days and deactivate at its end time, evaluated in
+  the device's local time, including while the app was closed (correct state on
+  next open).
+- **FR-007**: Members MUST be able to manually turn any profile on
+  (indefinitely, "For 1 hour", or — when the profile has an enabled schedule —
+  "Until <next schedule end>") and manually turn the active profile off.
+  Manual actions override the schedule until the next schedule boundary.
+- **FR-008**: At most one profile can be active at any moment; activating a
+  profile deactivates any other.
+- **FR-009**: While a profile is active, updates from non-allowed categories
+  that match no enabled exception MUST produce no toast and no device push, but
+  MUST still be recorded in the activity feed (including unread state) exactly
+  as today.
+- **FR-010**: While a profile is active, updates from allowed categories (or
+  matching an enabled exception) MUST be delivered according to the existing
+  base per-category Push / In-app / Silent preference — profiles never upgrade
+  delivery (an exception breaking through a "Silent" base category is delivered
+  at least in-app so it is actually noticeable; this is the single deliberate
+  carve-out and MUST be limited to exception matches).
+- **FR-011**: When no profile is active, notification behavior MUST be
+  byte-for-byte today's behavior: master push toggle plus per-category
+  Push / In-app / Silent.
+- **FR-012**: A quick-access surface reachable from the notification bell's
+  feed panel MUST show the profiles, indicate the active one and when it turns
+  off (e.g. "Off", "On until 6:00 PM"), offer the manual on/off choices of
+  FR-007, and link to "View settings" and "New profile".
+- **FR-013**: The notification settings area MUST list all profiles with their
+  active state, allow editing every profile attribute (name, emoji, allow-list,
+  exceptions, schedule) and deleting profiles, and continue to expose the
+  base-layer master push toggle and per-category mode controls.
+- **FR-014**: While a profile is active, the settings and quick-access surfaces
+  MUST make the state visible (profile name/emoji and how it was activated —
+  manual or scheduled — and when it will turn off, if known).
+- **FR-015**: All profile data and active-state MUST be stored client-side on
+  the device, alongside (and with the same durability/versioning approach as)
+  the existing delivery preferences; no backend or on-chain storage. Corrupt or
+  unrecognized stored data MUST degrade to defaults without crashing.
+- **FR-016**: Existing members' current settings MUST carry forward unchanged:
+  on first load after the update, no profile exists, nothing is active, and the
+  base preferences keep working with no member action required.
+- **FR-017**: All new surfaces MUST be operable by keyboard and screen reader
+  (labelled controls, announced state changes) consistent with the app's
+  accessibility standard.
+
+### Key Entities
+
+- **Notification Profile**: A named interruption mode. Attributes: identifier,
+  name, optional emoji, allow-list of notification categories, exception
+  switches (action-required, deadline reminders), optional weekly schedule,
+  created/updated timestamps.
+- **Profile Schedule**: Part of a profile: enabled flag, start time, end time,
+  set of days of week. Interpreted in device-local time; end ≤ start means the
+  window crosses midnight.
+- **Active Profile State**: Device-wide record of which profile (if any) is
+  currently active and why: manual-indefinite, manual-until-<time>, or
+  scheduled; plus any manual override suppressing a schedule window. Drives the
+  notification gate and the status shown in the UI.
+- **Notification Category**: The existing per-domain grouping of updates
+  (Wagers, Wager Pools, Membership, Governance, Token, Custody) that profiles
+  allow-list over and base preferences assign modes to.
+- **Exception Match**: An update flagged as action-required, or a deadline
+  reminder, which enabled exceptions let through regardless of category
+  allow-listing.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A member can create a "Sleep" profile from presets — including a
+  nightly schedule — in under 60 seconds and fewer than 12 taps/clicks.
+- **SC-002**: With a profile active that allows one category, 100% of simulated
+  updates from other categories produce zero toasts and zero device pushes
+  while 100% still appear in the activity feed.
+- **SC-003**: With "Always allow action-required items" on, 100% of simulated
+  action-required updates notify regardless of the profile's allow-list.
+- **SC-004**: A scheduled profile reports the correct active/inactive state on
+  app open in 100% of tested boundary cases (before start, inside window,
+  after end, overnight span, unselected day, manual override).
+- **SC-005**: Members with no profiles see zero change in notification
+  behavior after the update (verified by the existing delivery test suite
+  passing unmodified in behavior).
+- **SC-006**: Turning a profile on or off from the quick-access surface takes
+  effect on the very next detected update (no reload, no delay beyond the
+  existing polling cadence).
+- **SC-007**: All new settings and quick-access surfaces pass the project's
+  automated accessibility checks with zero new violations.
+
+## Assumptions
+
+- FairWins has no per-contact or per-group notification source, so Signal's
+  "add people or groups" allow-list maps to FairWins' six notification
+  categories; Signal's "Allow all calls" / "Notify for all mentions" exceptions
+  map to "Always allow action-required items" / "Always allow deadline
+  reminders" — the money-critical equivalents in a wagering app.
+- Profiles gate *interruptions* only (toasts and device push). The durable
+  activity feed and its unread counts are intentionally unaffected, matching
+  the product's "honest state" principle — nothing is ever dropped.
+- "Replace the current notification setting" means the settings surface is
+  rebuilt around profiles as the headline concept; the per-category
+  Push / In-app / Silent grid and master push toggle are retained beneath as
+  the base delivery layer (per the feature description), not removed.
+- Storage remains per-device (like today's delivery preferences), not synced
+  per-account; Signal's cross-device profile sync is out of scope because
+  FairWins has no notification backend to sync through.
+- Scheduling precision follows the app's existing detection cadence (~30 s
+  polling while the tab is visible); a schedule boundary takes effect on the
+  next evaluation tick, which is within the product's tolerance.
+- The quick-access surface lives in the notification bell's feed panel — the
+  closest FairWins analog to Signal's chat-list sheet — rather than a new
+  global UI region.
+- The `intents` and `earn` activity domains are not exposed in today's
+  preferences panel and stay out of the profile allow-list for parity; adding
+  them later is a follow-up.
+- Localized 12/24-hour time display follows the device locale, as elsewhere in
+  the app.

--- a/specs/059-notification-profiles/tasks.md
+++ b/specs/059-notification-profiles/tasks.md
@@ -1,0 +1,122 @@
+# Tasks: Notification Profiles
+
+**Input**: Design documents from `/specs/059-notification-profiles/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/profile-store.md, quickstart.md
+
+**Tests**: Included — Constitution Principle II (test-first) is non-negotiable; every behavior lands with Vitest coverage in the same phase.
+
+**Organization**: Grouped by user story. All paths are under `frontend/src/` unless noted.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1 (create), US2 (gating), US3 (quick access), US4 (schedule), US5 (manage)
+
+## Phase 1: Setup
+
+- [x] T001 Verify frontend toolchain and green baseline: run `npm run test:frontend` from repo root; record any pre-existing failures in the PR notes (none expected)
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The profile store module and its exhaustive unit tests — every story consumes it. Schedule evaluation (US4 logic) lives here because the store's activation model is inseparable from it; US4's phase then covers only its UI/status surface.
+
+- [x] T002 Create `lib/notifications/notificationProfiles.js` per contracts/profile-store.md: constants (`PROFILE_EMOJI_PRESETS`, `DEADLINE_REMINDER_TYPES`, `MAX_PROFILE_NAME_LENGTH`, `DEFAULT_SCHEDULE`), never-throw versioned storage (`fairwins_notif_profiles_v1`, normalize-on-read per data-model.md), CRUD (`getProfiles`/`getProfile`/`createProfile`/`updateProfile`/`deleteProfile`), pub/sub `subscribe` — mirror the `deliveryPreferences.js` pattern exactly
+- [x] T003 Implement activation + schedule evaluation in `lib/notifications/notificationProfiles.js`: window math ('HH:MM' + days, overnight spans owned by start day), `enableProfile(id, { until })`, `disableActiveProfile()`, `getActiveStatus(nowMs)` (manual > schedule, latest-start wins, lazy pruning of expired/stale overrides, persist+notify only on actual change), `getNextScheduleEnd(profile, nowMs)`
+- [x] T004 Implement `resolveEntryDelivery(entry, nowMs)` in `lib/notifications/notificationProfiles.js` per data-model.md §Entry delivery: no-active → base `resolveDelivery`; allowed domain → base; exception match (`allowActionRequired && entry.actionable`, `allowDeadlineReminders && DEADLINE_REMINDER_TYPES.includes(entry.type)`) → base with silent→app upgrade; else `'silent'`
+- [x] T005 Write `test/notificationProfiles.test.js` covering: CRUD + validation (name 1–32, unknown domains dropped, defaults), corrupt/foreign storage → empty store, single-active invariant, manual durations (indefinite/1 h/until-end, expiry re-evaluates schedule), disabled-override suppresses only current window, schedule boundaries (before/inside/after, overnight, unselected day, zero-days normalization), gate matrix (all four branches incl. silent→app upgrade for exceptions only) and no-profile parity with `resolveDelivery`
+- [x] T006 Create `hooks/useNotificationProfiles.js` per contracts/profile-store.md hook contract: state from store + `subscribe`, `activeStatus` re-evaluated on change and on a 30 s interval, stable action callbacks, cleanup on unmount
+
+**Checkpoint**: `npx vitest run src/test/notificationProfiles.test.js` green; no UI changes yet.
+
+## Phase 3: User Story 1 — Create a notification profile (P1) 🎯 MVP (with US2)
+
+**Goal**: 4-step wizard (name+emoji presets → allowed categories + exceptions → optional schedule → confirmation) reachable from a new profiles panel in Wallet → Preferences.
+
+**Independent test**: Walk the wizard end-to-end; profile appears in the settings list with all chosen attributes and survives reload (quickstart §Manual 1).
+
+- [x] T007 [P] [US1] Create `components/notifications/profiles/emojiPresets.js` re-exporting `PROFILE_EMOJI_PRESETS` (Work 💪, Sleep 😴, Driving 🚗, Downtime 😊, Focus 💡) for UI use
+- [x] T008 [P] [US1] Create `components/notifications/profiles/ProfileScheduleFields.jsx` — shared schedule editor: enable `role="switch"`, native `<input type="time">` start/end (defaults 09:00/17:00), S M T W T F S day toggles (`aria-pressed`), blocks enabled-with-zero-days, overnight hint when end ≤ start
+- [x] T009 [US1] Create `components/notifications/profiles/ProfileWizard.jsx` + `ProfileWizard.css` — 4 steps with back navigation and state retention: (1) required name (≤32) + optional emoji + preset chips that fill both; (2) category allow-list from `NOTIFICATION_CATEGORIES` + two exception switches defaulting ON, with plain-language total-silence consequence when nothing is allowed; (3) `ProfileScheduleFields` with Skip; (4) confirmation ("Profile created", manual-toggle + schedule hints) → Done calls `createProfile` (schedule step 3 already captured) — dialog semantics, focus trap, Escape closes per existing app dialogs
+- [x] T010 [US1] Create `components/account/NotificationProfilesPanel.jsx` + `NotificationProfilesPanel.css` — "Notification profiles" headline section: profile list (emoji, name, status line), "New profile" button opening `ProfileWizard`, empty-state copy; wire into `pages/WalletPage.jsx` Preferences → Notifications group ABOVE the untouched `NotificationPreferencesPanel`
+- [x] T011 [P] [US1] Write `test/ProfileWizard.test.jsx` — preset fills name+emoji, empty-name blocked, step state survives back/forward, skip-schedule creates schedule-less profile, zero-days schedule cannot be saved enabled, Done persists exactly the chosen shape (assert via `getProfiles()`)
+- [x] T012 [P] [US1] Write `test/NotificationProfilesPanel.test.jsx` (creation slice) — empty state, New-profile opens wizard, created profile listed with name/emoji
+
+**Checkpoint**: Wizard + panel functional and tested; profiles persist. No behavior change to delivery yet.
+
+## Phase 4: User Story 2 — Profile silences non-allowed notifications (P1) 🎯 MVP
+
+**Goal**: Active profile gates toasts/push in the poll loop; feed untouched; base layer bit-identical when no profile active.
+
+**Independent test**: With a profile active allowing only Wagers, fresh entries from allowed/blocked/exception categories toast-or-not per the matrix while all land in the feed (quickstart §Automated).
+
+- [x] T013 [US2] Edit `contexts/ActivityProvider.jsx`: import `resolveEntryDelivery` from `lib/notifications/notificationProfiles`; replace the two `resolveDelivery(e.domain || 'wagers')` call sites (toastable filter line ~111, pushable filter line ~118) with `resolveEntryDelivery(e)`; feed append, toast cap, "+N more", catch-up suppression unchanged; update the routing comment
+- [x] T014 [US2] Write `test/ActivityProvider.profiles.test.jsx` — with an enabled profile: blocked-domain entry → no toast/no `showSystemNotification`, still appended + unread; allowed-domain entry → toasts per base mode; actionable entry from blocked domain with exception ON → notifies, OFF → silent; deadline `warn-*` entry likewise; silent-base + exception → in-app toast (upgrade); no-profile run → identical to existing delivery behavior (reuse harness/mocks from `test/ActivityProvider.delivery.test.jsx`)
+- [x] T015 [US2] Run regression set unmodified (SC-005): `npx vitest run src/test/ActivityProvider.delivery.test.jsx src/test/deliveryPreferences.test.js src/test/NotificationPreferencesPanel.test.jsx` — must pass with zero behavioral edits to those files
+
+**Checkpoint**: MVP complete — profiles can be created (settings) and actually gate delivery.
+
+## Phase 5: User Story 3 — Manual on/off from quick access (P2)
+
+**Goal**: Signal-style section pinned atop the bell's `ActivityFeed` panel: status, expand for durations, off, View settings, New profile.
+
+**Independent test**: Quickstart §Manual 3 — enable "For 1 hour" shows expiry, enabling B turns A off, off reverts immediately, links land correctly.
+
+- [x] T016 [US3] Create `components/notifications/profiles/ProfileQuickAccess.jsx` + `ProfileQuickAccess.css` — uses `useNotificationProfiles`; collapsed row: emoji, name, status ("Off" / "On until 6:00 PM" / "On" with manual/scheduled wording per FR-014, locale time via `toLocaleTimeString`); expandable (`aria-expanded`) actions: enable indefinitely, "For 1 hour" (`until: now+3600e3`), "Until <end>" only when `getNextScheduleEnd` non-null, "Turn off" when active; footer "New profile" and "View settings" buttons; no-profiles state = just "New profile"
+- [x] T017 [US3] Edit `components/notifications/ActivityFeed.jsx` — render `ProfileQuickAccess` between header and filters; wire "View settings" to close the panel and navigate to the Wallet Preferences tab (reuse the page's existing tab-targeting mechanism; add a `?tab=preferences` search-param read in `pages/WalletPage.jsx` only if none exists); "New profile" navigates there and opens the wizard (pass intent via router state consumed by `NotificationProfilesPanel`)
+- [x] T018 [P] [US3] Write `test/ProfileQuickAccess.test.jsx` — status rendering for off/manual-until/indefinite/scheduled, duration actions call `enableProfile` with right `until`, single-active flip (enable B → A off), turn-off reverts `getActiveStatus` to null, empty-profile state, keyboard operability (expand/collapse, Escape bubbles to panel close)
+
+**Checkpoint**: Profiles switchable without leaving any page.
+
+## Phase 6: User Story 4 — Scheduled activation (P2)
+
+**Goal**: Surface scheduled state truthfully everywhere (engine shipped in Phase 2); status flips without interaction.
+
+**Independent test**: Quickstart §Manual 4 — schedule covering now → active on reload with "until <end>"; manual off stays off within window; inactive on unselected day.
+
+- [x] T019 [US4] In `components/account/NotificationProfilesPanel.jsx` + `ProfileQuickAccess.jsx`, verify/finish scheduled-status display: "On until <end> · Scheduled", next-activation hint for off scheduled profiles ("Turns on Mon 9:00 PM") via a small helper exported from `lib/notifications/notificationProfiles.js` (`getNextScheduleStart`), 30 s tick already provided by the hook
+- [x] T020 [US4] Extend `test/notificationProfiles.test.js` with `getNextScheduleStart` cases (later today, next selected day, overnight) and extend `test/ProfileQuickAccess.test.jsx` with fake-timer flip: schedule boundary crossing updates status text without user interaction
+
+**Checkpoint**: Set-and-forget schedules visibly working.
+
+## Phase 7: User Story 5 — Manage existing profiles (P3)
+
+**Goal**: Edit every attribute; delete (including active); all from the settings panel.
+
+**Independent test**: Quickstart §Manual 5 — each attribute edit persists across reload; deleting the active profile clears status and reverts delivery.
+
+- [x] T021 [US5] Extend `components/account/NotificationProfilesPanel.jsx` with an edit surface (expand-in-place or dialog reusing wizard step components and `ProfileScheduleFields`): rename, emoji change, allow-list + exception toggles, add/edit/remove schedule, per-profile on/off convenience toggle, Delete with confirm — wired to `updateProfile`/`deleteProfile`/`enableProfile`/`disableActiveProfile`
+- [x] T022 [US5] Extend `test/NotificationProfilesPanel.test.jsx` — edits persist via `getProfiles()`, deleting active profile clears `getActiveStatus()` and removes row, schedule added via edit activates scheduling (assert `getActiveStatus` with fake time), a11y roles/labels on all new controls
+
+**Checkpoint**: Full lifecycle complete.
+
+## Phase 8: Polish & Cross-Cutting
+
+- [ ] T023 [P] Accessibility pass over all new surfaces (wizard, panel, quick access): keyboard-only walk, focus trap/restore, `role`/`aria-*` audit against existing patterns; fix findings (FR-017, SC-007)
+- [ ] T024 [P] Verify styling in light/dark and mobile widths matches existing panel patterns (`NotificationPreferencesPanel.css`, `ActivityFeed.css` conventions); ensure no horizontal overflow in the feed panel with quick access mounted
+- [x] T025 Update docs: add profiles section to the notifications developer guide (create `docs/developer-guide/notification-profiles.md` if no existing guide covers spec 031) documenting storage key, gate order, and Signal mapping; cross-link from `specs/059-notification-profiles/`
+- [ ] T026 Full-suite gate: `npm run test:frontend` green and `npm run lint` (frontend ESLint) clean; run quickstart.md manual + corruption drill; mark checklists complete
+
+## Dependencies & Execution Order
+
+- **Phase 2 blocks everything** (T002→T003→T004 sequential in one file; T005 after T004; T006 after T003).
+- **US1 (Phase 3)** needs only Phase 2. T007/T008 parallel; T009 after both; T010 after T009; T011/T012 parallel after T010.
+- **US2 (Phase 4)** needs only Phase 2 — can proceed in parallel with US1 (different files). T013→T014→T015.
+- **US3 (Phase 5)** needs Phase 2 + T010 (settings destination for "View settings"). T016→T017; T018 parallel with T017.
+- **US4 (Phase 6)** needs US3 surfaces (T016) + Phase 2.
+- **US5 (Phase 7)** needs T010.
+- **Phase 8** last.
+
+```
+Phase 2 ──┬── Phase 3 (US1) ──┬── Phase 5 (US3) ── Phase 6 (US4) ──┐
+          └── Phase 4 (US2) ──┤                                    ├── Phase 8
+                              └── Phase 7 (US5) ───────────────────┘
+```
+
+## Parallel Example
+
+After Phase 2: one track runs T007+T008 → T009 (US1 UI) while another runs T013 (US2 gate) — disjoint files. Test tasks T011/T012/T018 are parallel-safe (separate new files).
+
+## Implementation Strategy
+
+**MVP = Phase 2 + US1 + US2**: create profiles in settings and have them gate delivery. Quick access (US3), schedule surfacing (US4), and editing (US5) layer on incrementally; each checkpoint leaves the app shippable with the base layer untouched.


### PR DESCRIPTION
## Summary

Replaces the flat notification settings with **Signal-style Notification Profiles** (per the shared flow screenshots and Signal Desktop 7.76 announcement), layered over — not replacing — the existing per-category Push/In-app/Silent delivery preferences.

- **Full Spec Kit chain** under `specs/059-notification-profiles/`: spec, plan, research (Signal-pattern mapping), data model, module contract, quickstart, tasks.
- **Store + engine** (`frontend/src/lib/notifications/notificationProfiles.js`): device-scoped localStorage store (`fairwins_notif_profiles_v1`, same never-throws pub/sub pattern as `deliveryPreferences.js`) holding named profiles (name, emoji, category allow-list, action-required/deadline exceptions, optional weekly schedule) and a single activation override (manual on with optional expiry / manual off suppressing one scheduled window). Lazy evaluation — active state is correct on next open even if the app was closed across a schedule boundary. Overnight schedules span midnight and belong to their start day.
- **Delivery gate**: `ActivityProvider.poll()` now routes fresh entries through `resolveEntryDelivery(entry)` — active profile allow-list + exceptions first, then the untouched base layer. Silenced entries still land in the durable feed unread (nothing is ever dropped). Exceptions upgrade a silent base to in-app only for exception matches.
- **UI**: 4-step creation wizard mirroring Signal (name+emoji presets Work/Sleep/Driving/Downtime/Focus → allowed notifications + exceptions → optional schedule → confirmation); profile list/editor in Wallet → Preferences above the existing preferences panel; Signal-style quick-access sheet pinned atop the activity feed panel (On / For 1 hour / Until &lt;schedule end&gt; / Turn off, New profile, View settings).
- **Docs**: `docs/developer-guide/notification-profiles.md`.

## Key guarantees

- **No-profile parity (SC-005)**: with no profiles, behavior is bit-identical to today — the pre-existing delivery test suite passes unmodified.
- Signal's people/groups allow-list maps to FairWins' six notification domains; "Allow all calls"/"Notify for all mentions" map to "Always allow action-required items"/"Always allow deadline reminders" (both default ON — missed approvals/deadlines cost money).
- Frontend-only; no contracts, no backend, no new dependencies.

## Testing

- 52 new Vitest tests: store/schedule/override/gate matrix (29), provider gating end-to-end (6), wizard (8), settings panel (7 incl. edit/delete), quick access (8 incl. schedule-boundary status flip).
- SC-005 regression set (`ActivityProvider.delivery`, `deliveryPreferences`, `NotificationPreferencesPanel`) passes with zero edits.
- ESLint clean on all new/changed files. Full suite delegated to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnX9oGQjfeHFFLX9xCfzxx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnX9oGQjfeHFFLX9xCfzxx)_