### PR TITLE
Home polish: natural currency selector, drop redundant address-book label, declutter wager memo

### DIFF
--- a/frontend/src/components/fairwins/CreateChallengePanel.jsx
+++ b/frontend/src/components/fairwins/CreateChallengePanel.jsx
@@ -383,15 +383,11 @@ function CreateChallengePanel({
         </>
       ) : (
         // Wager description demoted to a Venmo/Cash-App-style memo below the amount.
+        // No label/InfoTip — the placeholder itself explains the intent (design feedback).
         <div className="fm-form-group fm-form-full fm-pay-memo">
-          <span className="fm-label-row">
-            <label htmlFor="oc-desc">What&apos;s the wager? <span className="fm-required">*</span></label>
-            <InfoTip label="About: What's the wager?">
-              Phrase it so it&apos;s clear which side you&apos;re on; the taker takes the opposite.
-            </InfoTip>
-          </span>
+          <label htmlFor="oc-desc" className="sr-only">What&apos;s the wager?</label>
           <input
-            id="oc-desc" type="text" maxLength={200} className="fm-pay-memo-input"
+            id="oc-desc" type="text" maxLength={200} className="fm-pay-memo-input" required
             placeholder="Add a note — e.g. I'm betting NO that it rains in Denver tomorrow"
             value={description} onChange={(e) => setDescription(e.target.value)} disabled={busy}
           />

--- a/frontend/src/components/fairwins/PayPanel.jsx
+++ b/frontend/src/components/fairwins/PayPanel.jsx
@@ -263,13 +263,14 @@ function PayPanel({ onSuccess }) {
         <label className="fm-label" htmlFor="pay-to">To</label>
         <div className="fm-input-with-action">
           <div className="fm-address-input-wrap">
+            {/* No inline address-book addon — the icon button beside the field
+                is the single address-book affordance (design feedback). */}
             <AddressInput
               id="pay-to"
               value={toRaw}
               onChange={(e) => setToRaw(e.target.value)}
               onResolvedChange={(addr) => setToResolved(addr || '')}
               chainId={connectedChainId}
-              enableAddressBook
               placeholder="0x…, %callsign, or ENS name"
               disabled={busy}
             />

--- a/frontend/src/components/ui/AmountKeypad.css
+++ b/frontend/src/components/ui/AmountKeypad.css
@@ -85,6 +85,36 @@
   justify-content: center;
 }
 
+/* A currency <select> in the slot reads as a natural part of the hero — no
+   hard pill border or fill, just the muted symbol + caret, matching the old
+   token label. (The browser's default select border/background is removed
+   here since .fm-token-select only strips the native appearance/arrow.) */
+.amount-keypad .amount-keypad-token-slot select {
+  border: none;
+  background-color: transparent;
+  box-shadow: none;
+  min-width: 0;
+  width: auto;
+  padding: 0.1rem 1.35rem 0.1rem 0.5rem;
+  color: var(--text-secondary, #7A8590);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  text-align: center;
+  text-align-last: center;
+}
+
+.amount-keypad .amount-keypad-token-slot select:hover:not(:disabled) {
+  color: var(--text-primary, #E6EDF3);
+}
+
+.amount-keypad .amount-keypad-token-slot select:focus-visible {
+  outline: 2px solid var(--brand-primary, #36B37E);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
 /* ── Number pad ────────────────────────────────────────────────────── */
 .amount-keypad-pad {
   display: grid;


### PR DESCRIPTION
## Summary

Three small visual-polish tweaks to the Pay / Request / Wager home from testing feedback. Frontend-only, no behavior or value-path changes.

1. **Currency selector reads as part of the screen.** The in-hero dropdown no longer shows a hard pill border or fill — just the muted uppercase symbol + caret, matching the old static token label. (The browser's default `select` border/background was showing because `.fm-token-select` only stripped the native appearance/arrow; now explicitly transparent/borderless in the `AmountKeypad` token slot, with a proper focus ring.)
2. **Pay "To" field — single address-book affordance.** Dropped the redundant inline "Address book" **text** button (removed `enableAddressBook` from `AddressInput`); the **icon** `AddressBookButton` beside the field remains. No effect on other screens that use the inline addon.
3. **Wager view — decluttered memo.** Removed the "What's the wager?" label and info tooltip; the input placeholder already explains the intent. Kept a visually-hidden (`sr-only`) label + `required` so the accessible name and validation parity are preserved.

## Tests

Affected suites pass (`PayPanel`, `CreateChallengePanel`, `AmountKeypad`, `home.axe`), including the accessibility audits — the sr-only labels keep the `To`, `Currency`, and wager inputs named. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Gr7WYVb89TScjTe49btkg

---
_Generated by [Claude Code](https://claude.ai/code/session_019Gr7WYVb89TScjTe49btkg)_