### PR TITLE
Spec 059 follow-up: single Notifications section (embed delivery controls under profiles)

### DIFF
--- a/docs/developer-guide/notification-profiles.md
+++ b/docs/developer-guide/notification-profiles.md
@@ -59,10 +59,14 @@ spans midnight and the window belongs to its start day.
 
 ## Surfaces
 
-- **Settings** — `components/account/NotificationProfilesPanel.jsx`, rendered
-  above the base-layer `NotificationPreferencesPanel` in Wallet → Preferences →
-  Notifications. Hosts the 4-step `ProfileWizard` (name+emoji presets →
-  allow-list+exceptions → schedule → confirmation) and the inline editor.
+- **Settings** — `components/account/NotificationProfilesPanel.jsx`, the
+  single Notifications section in Wallet → Preferences. Hosts the 4-step
+  `ProfileWizard` (name+emoji presets → allow-list+exceptions → schedule →
+  confirmation) and the inline editor. The base-layer
+  `NotificationPreferencesPanel` (master push toggle + per-category
+  push/app/silent grid) no longer stands alone — it renders inside this
+  panel's collapsed "Delivery settings" disclosure (`embedded` prop) so there
+  is one notifications surface, profiles-first.
   Deep links: `/wallet?tab=preferences#notification-profiles` (scroll) and
   `…#notification-profiles-new` (open wizard).
 - **Quick access** — `components/notifications/profiles/ProfileQuickAccess.jsx`,

--- a/frontend/src/components/account/NotificationPreferencesPanel.jsx
+++ b/frontend/src/components/account/NotificationPreferencesPanel.jsx
@@ -19,14 +19,17 @@ const MODE_HINTS = {
 }
 
 /**
- * NotificationPreferencesPanel — the "Notifications" area of the Preferences tab
- * (My Account / Wallet). Lets a user (1) enable mobile push and (2) choose, per
- * notification category, whether it's pushed to the device, shown in-app only,
- * or kept silent (feed only). Device-scoped (a phone's push permission is
+ * NotificationPreferencesPanel — the base-layer delivery controls: (1) enable
+ * mobile push and (2) choose, per notification category, whether it's pushed
+ * to the device, shown in-app only, or kept silent (feed only). Since spec 059
+ * this no longer stands alone on the Preferences tab — it renders inside the
+ * NotificationProfilesPanel's "Delivery settings" disclosure (`embedded`),
+ * which suppresses the standalone heading/hint so the page has a single
+ * Notifications section. Device-scoped (a phone's push permission is
  * per-device), so no wallet is required. Persisted via
  * lib/notifications/deliveryPreferences.js.
  */
-function NotificationPreferencesPanel() {
+function NotificationPreferencesPanel({ embedded = false }) {
   const { prefs, permission, setMode, enablePush, disablePush } = useNotificationPreferences()
   const supported = isPushSupported()
   const blocked = permission === 'denied'
@@ -42,7 +45,7 @@ function NotificationPreferencesPanel() {
 
   return (
     <div className="notif-pref-panel">
-      <h3 className="notif-pref-title">Notifications</h3>
+      {!embedded && <h3 className="notif-pref-title">Notifications</h3>}
       <p className="notif-pref-hint">
         Choose how each kind of update reaches you. Turn on mobile push to get
         device notifications for new activity while FairWins is open.

--- a/frontend/src/components/account/NotificationProfilesPanel.css
+++ b/frontend/src/components/account/NotificationProfilesPanel.css
@@ -284,3 +284,41 @@
   outline: 2px solid var(--brand-primary);
   outline-offset: 2px;
 }
+
+/* Base-layer delivery controls disclosure (former standalone section) */
+.notif-profiles-delivery {
+  margin-top: 0.75rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.notif-profiles-delivery-toggle {
+  appearance: none;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  border: none;
+  background: transparent;
+  padding: 0.75rem 0.25rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  cursor: pointer;
+  border-radius: 6px;
+}
+
+.notif-profiles-delivery-toggle:hover,
+.notif-profiles-delivery-toggle:focus-visible {
+  background: var(--border-color);
+  outline: none;
+}
+
+.notif-profiles-delivery-chevron {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+}
+
+.notif-profiles-delivery-body {
+  padding: 0.25rem 0.25rem 0.5rem;
+}

--- a/frontend/src/components/account/NotificationProfilesPanel.jsx
+++ b/frontend/src/components/account/NotificationProfilesPanel.jsx
@@ -11,6 +11,7 @@ import { NOTIFICATION_CATEGORIES } from '../../lib/notifications/deliveryPrefere
 import ProfileWizard from '../notifications/profiles/ProfileWizard'
 import ProfileScheduleFields from '../notifications/profiles/ProfileScheduleFields'
 import { profileStatusText } from '../notifications/profiles/statusText'
+import NotificationPreferencesPanel from './NotificationPreferencesPanel'
 import './NotificationProfilesPanel.css'
 
 /**
@@ -158,12 +159,13 @@ function ProfileEditor({ profile, onSave, onDelete, onClose }) {
 }
 
 /**
- * NotificationProfilesPanel — the "Notification profiles" area of the
+ * NotificationProfilesPanel — the single "Notifications" area of the
  * Preferences tab (spec 059). Lists this device's profiles with truthful
  * active state, offers per-profile on/off, editing, deletion, and hosts the
- * 4-step creation wizard. Renders above the base-layer
- * NotificationPreferencesPanel, which keeps deciding HOW allowed updates are
- * delivered.
+ * 4-step creation wizard. The base-layer NotificationPreferencesPanel (which
+ * keeps deciding HOW allowed updates are delivered) is embedded below in a
+ * "Delivery settings" disclosure so the tab has exactly one notifications
+ * section.
  */
 function NotificationProfilesPanel() {
   const {
@@ -177,6 +179,7 @@ function NotificationProfilesPanel() {
   const location = useLocation()
   const [wizardOpen, setWizardOpen] = useState(() => location.hash === '#notification-profiles-new')
   const [editingId, setEditingId] = useState(null)
+  const [deliveryOpen, setDeliveryOpen] = useState(false)
 
   // Deep links from the quick-access surface: #notification-profiles scrolls
   // here; #notification-profiles-new also opens the wizard (covers hash
@@ -272,6 +275,30 @@ function NotificationProfilesPanel() {
           <button type="button" className="notif-profiles-new" onClick={() => setWizardOpen(true)}>
             + New profile
           </button>
+
+          {/* Base-layer delivery controls (spec 059 consolidation): the former
+              standalone Notifications section lives here so the Preferences
+              tab has exactly one notifications surface. Profiles decide WHEN
+              you're interrupted; these decide HOW allowed updates arrive. */}
+          <div className="notif-profiles-delivery">
+            <button
+              type="button"
+              className="notif-profiles-delivery-toggle"
+              aria-expanded={deliveryOpen}
+              aria-controls="notif-profiles-delivery-body"
+              onClick={() => setDeliveryOpen((v) => !v)}
+            >
+              <span>Delivery settings</span>
+              <span className="notif-profiles-delivery-chevron" aria-hidden="true">
+                {deliveryOpen ? '▲' : '▼'}
+              </span>
+            </button>
+            {deliveryOpen && (
+              <div id="notif-profiles-delivery-body" className="notif-profiles-delivery-body">
+                <NotificationPreferencesPanel embedded />
+              </div>
+            )}
+          </div>
         </>
       )}
     </div>

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -21,7 +21,6 @@ import ClearPathPanel from '../components/clearpath/ClearPathPanel'
 import AccountDashboard from '../components/account/AccountDashboard'
 import ControllersPanel from '../components/account/ControllersPanel'
 import RecoverAccountPanel from '../components/account/RecoverAccountPanel'
-import NotificationPreferencesPanel from '../components/account/NotificationPreferencesPanel'
 import NotificationProfilesPanel from '../components/account/NotificationProfilesPanel'
 import QuickAccessCardsPanel from '../components/account/QuickAccessCardsPanel'
 import HomePreferencesPanel from '../components/account/HomePreferencesPanel'
@@ -487,9 +486,6 @@ function WalletPage() {
                     <h2 className="preferences-group-heading">Notifications</h2>
                     <div className="section">
                       <NotificationProfilesPanel />
-                    </div>
-                    <div className="section">
-                      <NotificationPreferencesPanel />
                     </div>
 
                     <h2 className="preferences-group-heading">Markets</h2>

--- a/frontend/src/test/NotificationProfilesPanel.test.jsx
+++ b/frontend/src/test/NotificationProfilesPanel.test.jsx
@@ -104,6 +104,19 @@ describe('NotificationProfilesPanel', () => {
     expect(screen.getByText(/No profiles yet/i)).toBeInTheDocument()
   })
 
+  it('embeds the base-layer delivery controls behind a "Delivery settings" disclosure', () => {
+    renderPanel()
+    const toggle = screen.getByRole('button', { name: /Delivery settings/i })
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    // Collapsed: base-layer controls hidden; no duplicate standalone heading anywhere.
+    expect(screen.queryByText('Mobile push notifications')).toBeNull()
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Mobile push notifications')).toBeInTheDocument()
+    // Embedded mode drops the old panel's own "Notifications" heading.
+    expect(screen.queryByRole('heading', { name: 'Notifications' })).toBeNull()
+  })
+
   it('Save is blocked while the schedule is enabled with no days', () => {
     createProfile({ name: 'Work' })
     renderPanel()

--- a/specs/059-notification-profiles/quickstart.md
+++ b/specs/059-notification-profiles/quickstart.md
@@ -61,7 +61,8 @@ npm run frontend   # Vite dev server
    status clears, base-layer behavior resumes.
 6. **Base parity (FR-011/016)** — in a fresh browser profile (no localStorage
    key): notification behavior identical to production today; the
-   Push/In-app/Silent grid and master push toggle work unchanged.
+   Push/In-app/Silent grid and master push toggle work unchanged, now under
+   the "Delivery settings" disclosure inside the profiles section.
 7. **Accessibility (FR-017)** — walk the wizard and quick access with
    keyboard only (Tab/Space/Enter/Escape); verify toggles announce state
    (`role="switch"`/`aria-pressed`), the wizard traps focus like existing

--- a/specs/059-notification-profiles/spec.md
+++ b/specs/059-notification-profiles/spec.md
@@ -295,10 +295,13 @@ was active, that delivery reverts to base behavior.
   feed panel MUST show the profiles, indicate the active one and when it turns
   off (e.g. "Off", "On until 6:00 PM"), offer the manual on/off choices of
   FR-007, and link to "View settings" and "New profile".
-- **FR-013**: The notification settings area MUST list all profiles with their
-  active state, allow editing every profile attribute (name, emoji, allow-list,
-  exceptions, schedule) and deleting profiles, and continue to expose the
-  base-layer master push toggle and per-category mode controls.
+- **FR-013**: The notification settings area MUST be a single section that
+  lists all profiles with their active state, allows editing every profile
+  attribute (name, emoji, allow-list, exceptions, schedule) and deleting
+  profiles, and continues to expose the base-layer master push toggle and
+  per-category mode controls — tucked behind a "Delivery settings" disclosure
+  within the same section rather than as a separate, potentially confusing
+  second notifications block.
 - **FR-014**: While a profile is active, the settings and quick-access surfaces
   MUST make the state visible (profile name/emoji and how it was activated —
   manual or scheduled — and when it will turn off, if known).
@@ -368,8 +371,10 @@ was active, that delivery reverts to base behavior.
   the product's "honest state" principle — nothing is ever dropped.
 - "Replace the current notification setting" means the settings surface is
   rebuilt around profiles as the headline concept; the per-category
-  Push / In-app / Silent grid and master push toggle are retained beneath as
-  the base delivery layer (per the feature description), not removed.
+  Push / In-app / Silent grid and master push toggle are retained as the base
+  delivery layer, folded into the profiles section behind a "Delivery
+  settings" disclosure — the old standalone Notifications block is removed to
+  avoid two competing notification sections.
 - Storage remains per-device (like today's delivery preferences), not synced
   per-account; Signal's cross-device profile sync is out of scope because
   FairWins has no notification backend to sync through.


### PR DESCRIPTION
## Summary

Follow-up to #924. The Preferences tab previously showed **two** notification blocks — the new profiles panel and the old standalone per-category panel — which was confusing. This removes the standalone section and folds the base-layer controls into the profiles panel:

- `WalletPage` no longer renders `NotificationPreferencesPanel` as its own section; the Notifications group is just `NotificationProfilesPanel`.
- `NotificationProfilesPanel` gains a collapsed **"Delivery settings"** disclosure (`aria-expanded` toggle) that embeds the base-layer panel — master mobile-push toggle + per-category Push/In-app/Silent grid — so push enablement and per-category modes remain fully reachable, just no longer duplicated at the top level.
- `NotificationPreferencesPanel` gains an `embedded` prop that suppresses its standalone "Notifications" heading when hosted inside the disclosure; standalone rendering (and its existing tests) are unchanged.
- Spec 059 (`spec.md` FR-013 + assumption, `quickstart.md`) and `docs/developer-guide/notification-profiles.md` updated to match.

No delivery-behavior changes — this is purely a settings-surface consolidation.

## Testing

- New panel test: disclosure starts collapsed, expands to reveal the delivery controls, and the embedded panel renders without a duplicate heading.
- `NotificationProfilesPanel`, `NotificationPreferencesPanel`, and `WalletPage` suites pass (22 tests); ESLint clean on all touched files. Full suite in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnX9oGQjfeHFFLX9xCfzxx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnX9oGQjfeHFFLX9xCfzxx)_