### PR TITLE
Wager asset selector: match the natural in-hero currency-selector style

### DIFF
--- a/frontend/src/components/fairwins/FriendMarketsModal.jsx
+++ b/frontend/src/components/fairwins/FriendMarketsModal.jsx
@@ -1485,6 +1485,22 @@ function FriendMarketsModal({
                         onChange={(v) => handleFormChange('stakeAmount', v)}
                         prefix={(formData.stakeTokenId === 'STABLE' || formData.stakeTokenId === 'CUSTOM') ? '$' : ''}
                         token={selectedStakeToken?.symbol || ''}
+                        tokenSlot={(
+                          <select
+                            id="fm-stake-token"
+                            aria-label="Stake Token"
+                            value={formData.stakeTokenId}
+                            onChange={(e) => handleFormChange('stakeTokenId', e.target.value)}
+                            disabled={submitting}
+                            className="fm-token-select fm-pay-token-select"
+                          >
+                            {STAKE_TOKEN_OPTIONS.map(token => (
+                              <option key={token.id} value={token.id}>
+                                {token.icon} {token.symbol}
+                              </option>
+                            ))}
+                          </select>
+                        )}
                         disabled={submitting}
                         ariaLabel="Stake amount"
                         id="fm-stake"
@@ -1503,20 +1519,6 @@ function FriendMarketsModal({
                             : `${selectedStakeToken?.name} from the active chain`}
                         </InfoTip>
                       </span>
-                      <select
-                        id="fm-stake-token"
-                        aria-label="Stake Token"
-                        value={formData.stakeTokenId}
-                        onChange={(e) => handleFormChange('stakeTokenId', e.target.value)}
-                        disabled={submitting}
-                        className="fm-token-select fm-pay-token-select"
-                      >
-                        {STAKE_TOKEN_OPTIONS.map(token => (
-                          <option key={token.id} value={token.id}>
-                            {token.icon} {token.symbol}
-                          </option>
-                        ))}
-                      </select>
                       {errors.stakeAmount && <span className="fm-error">{errors.stakeAmount}</span>}
                     </div>
 


### PR DESCRIPTION
## Summary

Follow-up to #925: apply the same natural, borderless in-hero styling to the **wager asset selector**.

The 1v1 / Make-an-Offer create (`FriendMarketsModal`) has a real stake-token `<select>` (STABLE / NATIVE / CUSTOM) that was styled with the old hard-outline pill (`.fm-pay-token-select`) as a **sibling** of the `AmountKeypad` — so #925's natural styling (scoped to the keypad's `tokenSlot`) never reached it.

This moves that `<select>` into the `AmountKeypad` `tokenSlot`, exactly like Pay and Request, so the asset selector now sits directly under the amount and inherits the borderless/transparent treatment (with the caret preserved). Options, `onChange`, the "Stake Amount" caption/InfoTip, and validation are unchanged.

## Tests

`FriendMarketsModal` (69) and `AmountKeypad` (6) suites pass — 75 total; the `Stake Token` / `Stake amount` accessible names are preserved. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Gr7WYVb89TScjTe49btkg

---
_Generated by [Claude Code](https://claude.ai/code/session_019Gr7WYVb89TScjTe49btkg)_