### PR TITLE
Consolidate admin panel into an operations control plane

### DIFF
--- a/docs/system-overview/control-surface-audit.md
+++ b/docs/system-overview/control-surface-audit.md
@@ -1,0 +1,160 @@
+# Platform Control-Surface Audit & Operations Control Plane
+
+**Date:** 2026-07-18 · **Scope:** every administrative/operator control on the
+platform — on-chain contracts, off-chain services, and the frontend admin panel
+— plus the gap analysis that drove the admin panel's consolidation into an
+operations control plane.
+
+This document is the inventory of record. The panel itself lives at `/admin`
+(`frontend/src/components/AdminPanel.jsx`); per-procedure detail stays in
+`docs/runbooks/`.
+
+---
+
+## 1. Control-surface inventory
+
+### 1.1 On-chain roles and who holds what
+
+| Role | Contract(s) | Authority | Operator persona |
+|---|---|---|---|
+| `DEFAULT_ADMIN_ROLE` | all UUPS contracts, SanctionsGuard | config, wiring, treasury withdrawal, role admin | Protocol Administrator (floppy keystore) |
+| `UPGRADER_ROLE` | all `UUPSManaged` adopters | UUPS upgrades + `setIntentExtension` (upgrade-equivalent) | Release Engineer (floppy keystore) |
+| `GUARDIAN_ROLE` | WagerRegistry | `pause()` / `unpause()` | Incident Commander |
+| `ACCOUNT_MODERATOR_ROLE` | WagerRegistry | `freezeAccount` / `unfreezeAccount` | Trust & Safety |
+| `ROLE_MANAGER_ROLE` | MembershipManager | grant/revoke memberships out-of-band | Member Support |
+| `SANCTIONS_ADMIN_ROLE` | SanctionsGuard | discretionary deny-list (`setDenied`) | Compliance Officer |
+| `TOKEN_ISSUER_ROLE` | TokenFactory | token issuance entrypoints | Token Operations |
+| `REGISTRY_CURATOR_ROLE` / `MODERATOR_ROLE` / `VERIFIER_ROLE` | CallsignRegistry | reserve / suspend / verify callsigns | Identity Moderation |
+| `Ownable` owner | oracle adapters, FairWinsVerifyingPaymaster | oracle condition config; paymaster deposit/signer | Oracle Operator / Paymaster Operator |
+
+### 1.2 On-chain admin functions (by contract)
+
+- **WagerRegistry** (UUPS, pausable): `pause`/`unpause` (GUARDIAN),
+  `freezeAccount`/`unfreezeAccount` (ACCOUNT_MODERATOR), `setMembershipManager`,
+  `setPolymarketAdapter`, `setSanctionsGuard`, `setOracleAdapter(type, addr)`,
+  `setTokenAllowed(token, bool)` (all DEFAULT_ADMIN), `setIntentExtension`
+  (UPGRADER). Readouts: `paused()`, `isFrozen`, `isTokenAllowed`,
+  `membershipManager()`, `polymarketAdapter()`, `sanctionsGuard()`,
+  `oracleAdapters(type)`, `intentExtension()`.
+- **WagerRegistryIntents** (facet, same proxy): `setFeeNetting` (DEFAULT_ADMIN);
+  **permissionless maintenance**: `batchExpireOpen(uint256[])`,
+  `autoResolveFromPolymarket(id)`, `autoResolveFromOracle(id)`.
+- **MembershipManager** (UUPS): `setTier`, `setTreasury`, `setPaymentToken`,
+  `setAuthorizedCaller`, `setSanctionsGuard`, `setVoucher`, `setFeeNetting`,
+  `withdrawFees` (all DEFAULT_ADMIN); `grantMembership`/`revokeMembership`
+  (ROLE_MANAGER).
+- **SanctionsGuard** (non-upgradeable): `setDenied` (SANCTIONS_ADMIN),
+  `setSanctionsOracle` (DEFAULT_ADMIN; `address(0)` disables oracle screening —
+  deny-list still applies).
+- **CallsignRegistry** (UUPS): `setReserved` (CURATOR), `setSuspended`
+  (MODERATOR), `setVerified` (VERIFIER), `setPolicyParams` (bounded),
+  `setMembershipGate` (floored at Gold), `setMembershipManager`,
+  `setSanctionsGuard` (DEFAULT_ADMIN).
+- **WagerPoolFactory** (UUPS): `setTemplate`, `setAllowedToken`,
+  `setSanctionsGuard`, `setMembershipManager` (DEFAULT_ADMIN).
+- **TokenFactory** (UUPS): `setTemplate`/`setV2Template`, `setSanctionsGuard`
+  (DEFAULT_ADMIN); `create*` (TOKEN_ISSUER).
+- **FairWinsVerifyingPaymaster** (Ownable): `deposit()` (permissionless
+  top-up), `getDeposit()`, `withdrawTo` (owner), `setVerifyingSigner` (owner),
+  `addStake`/`unlockStake`/`withdrawStake` (owner).
+- **Oracle adapters** (Ownable): Chainlink Data Feed `setFeedAllowed`,
+  `registerCondition`, `linkMarket`; Chainlink Functions `registerCondition`,
+  `linkMarket`; UMA `registerCondition`, `linkMarket`; Polymarket
+  `addCTFContract`/`removeCTFContract`/`updatePrimaryCTF`,
+  `linkMarketToPolymarket*`, `unlinkMarket`.
+- **No admin surface by design** (funds can never be drained or redirected by
+  an operator): `WagerPool` clones, `MembershipVoucher` (royalty bps only),
+  `VoucherBatchMinter`, `KeyRegistry`, `BackupPointerRegistry`,
+  `SafeProposalHub`, `SafePolicyGuard` (the Safe itself is the only authority).
+
+### 1.3 Off-chain / service controls (relay-gateway, oz-relayer, alto)
+
+All are env/config/signal-driven — the gateway deliberately has **no remote
+admin API** (worst case is refusing gas; it can censor, never steal):
+
+- **Gateway killswitch**: `KILL_SWITCH` env or `kill -USR2 <pid>`; halts
+  intents, paymaster sponsorship, OpenSea and Polymarket proxy routes. All
+  flows degrade to client self-submit (never-stranded rule).
+- **Quotas / backpressure / spend caps**: `SIGNER_QUOTA_PER_MIN`,
+  `GLOBAL_QUOTA_PER_MIN`, `MAX_QUEUE_DEPTH`, `GAS_SPEND_CAP_WEI_<id>`,
+  `PM_*` paymaster ceilings — env only.
+- **Polymarket builder fee**: `POLYMARKET_BUILDER_*` env, hard caps enforced at
+  boot (100/50 bps); fee changes rate-limited by Polymarket (1 per 7 days).
+- **oz-relayer**: per-chain `paused`, `gas_price_cap`, `whitelist_receivers`,
+  `min_balance` in `services/oz-relayer/config/config.json` + restart.
+- **Telemetry**: gateway `GET /status` returns `{status, chains: {<id>:
+  {rpc, gasWalletRunwayHrs, paymasterDepositRunwayHrs}}, killSwitch}` —
+  operator fields disclosed only with a valid `X-Origin-Auth` header (injected
+  zone-wide by Cloudflare in production).
+- **CLI scripts** (floppy-signed where they mutate state): `scripts/admin/*`
+  (roles, tier pricing, treasury limits), `scripts/operations/*` (lockdown,
+  fee netting, relayer funding), `scripts/deploy/*` (upgrades, storage-layout
+  gate), `scripts/cron/*` (funding settlement + health checks).
+
+---
+
+## 2. Gap analysis — controls that had no admin-panel surface
+
+The pre-consolidation panel covered: pause/unpause, tier config,
+membership grant/revoke, freeze/unfreeze, four admin roles, fee withdrawal,
+three oracle adapters, deny-list, callsigns. Everything below was **invisible
+or unreachable from the panel**:
+
+| # | Gap | Severity | Disposition |
+|---|---|---|---|
+| G1 | Protocol wiring (`setOracleAdapter`, `setSanctionsGuard`, `setMembershipManager`, `setPolymarketAdapter`, stake-token allowlist, `setTreasury`, `setPaymentToken`, `setAuthorizedCaller`, `setSanctionsOracle`) had no UI and **no readout** — an operator could not even verify current wiring | High | **Built** — Protocol Config view (readout + admin-gated setters) |
+| G2 | Paymaster operations (deposit runway = the loss cap per spec 050; `deposit`, `withdrawTo`, `setVerifyingSigner`) were CLI-only; deposit balance not visible anywhere | High | **Built** — Paymaster card in Infrastructure view; `verifyingPaymaster` added to the frontend address book |
+| G3 | Gateway/relayer health (killswitch state, per-chain RPC, gas-wallet runway, paymaster runway) never surfaced to operators despite `/status` existing | High | **Built** — Service Health card (Overview + Infrastructure), read-only by design |
+| G4 | Maintenance sweeps (`batchExpireOpen`, `autoResolveFrom*`) — permissionless, but no surface to run them | Medium | **Built** — Maintenance view |
+| G5 | `SANCTIONS_ADMIN_ROLE` existed on-chain but not in the frontend role model; the deny-list tab was gated on DEFAULT_ADMIN instead of the actual role, so a compliance officer without full admin could not reach their own tool | Medium | **Built** — `SANCTIONS_ADMIN` added to the role model; Compliance group gated on it |
+| G6 | Role management could not grant/revoke `SANCTIONS_ADMIN_ROLE` (SanctionsGuard) or `TOKEN_ISSUER_ROLE` (TokenFactory) | Medium | **Built** — Admin Roles view extended, role→contract routing made explicit |
+| G7 | Pool/token factory config (`setTemplate`, `setAllowedToken`, `setV2Template`) has no UI | Low | **Documented** — template swaps are deploy-coupled (new implementation address); keep on the scripted path (`scripts/deploy/set-pool-template.js`), where the storage-layout gate lives |
+| G8 | Gateway killswitch/quotas cannot be *toggled* from a browser | By design | **Documented** — the gateway has no admin API on purpose (an authenticated web killswitch would be a new attack surface); panel shows state + links the runbook |
+| G9 | `NullifierTab` is orphaned dead code targeting the **legacy v1** market factory; `RoleManagementAdmin.css` is a stranded stylesheet | Low | **Documented** — recommend removal or a v2 migration spec; not re-wired (would resurrect a legacy surface) |
+| G10 | Oracle admin lacks the Polymarket adapter (`addCTFContract`, `linkMarketToPolymarket`, `unlinkMarket`) | Low | **Deferred** — adapter is Ownable by the deploy EOA; follow-up alongside an ownership-to-role migration |
+
+---
+
+## 3. The operations control plane
+
+The `/admin` route is now a grouped control plane (`PortalNav` grouped rail).
+Each view is still gated by the on-chain role it requires; a group only renders
+if the operator holds at least one role inside it.
+
+| Group | Views | Gate |
+|---|---|---|
+| **Control Room** | Overview (protocol + service status tiles, membership/treasury metrics, contract addresses) | any operator role |
+| **Incident Response** | Emergency (pause/unpause + gateway killswitch readout), Account Moderation (freeze/unfreeze) | GUARDIAN / ACCOUNT_MODERATOR |
+| **Compliance** | Deny-list | SANCTIONS_ADMIN or ADMIN |
+| **Membership & Revenue** | Tiers, Members, Treasury | ADMIN / ROLE_MANAGER |
+| **Protocol Config** | Wiring & Tokens, Oracle Adapters, Maintenance | ADMIN (Maintenance: any operator — the calls are permissionless) |
+| **Identity** | Callsigns | ADMIN (per-action roles inside) |
+| **Access Control** | Admin Roles | ADMIN |
+| **Infrastructure** | Services (gateway health, relayer runway, paymaster ops) | ADMIN / GUARDIAN |
+
+Positive control is demonstrated by the Control Room: one screen answering
+"is the protocol live, is the gateway live, is sponsorship funded, is anything
+paused or killswitched, and who am I signed in as with which powers".
+
+### Operator role recommendations
+
+Current on-chain roles are sufficient — no new roles need deploying. What
+changed is that the frontend now models all of them:
+
+1. **Compliance Officer** = `SANCTIONS_ADMIN_ROLE` (now a first-class panel
+   role; grant via Admin Roles → SanctionsGuard).
+2. **Token Operations** = `TOKEN_ISSUER_ROLE` (grantable from the panel;
+   issuance UI remains a follow-up).
+3. Future candidates (documented, not built): a **Treasurer** split
+   (`withdrawFees` today requires full DEFAULT_ADMIN — a dedicated
+   `TREASURER_ROLE` would need a contract upgrade) and role-based ownership of
+   the oracle adapters (currently single-owner EOAs).
+
+### Explicitly out of the control plane
+
+- Anything requiring the floppy keystore (upgrades, `UPGRADER_ROLE` actions)
+  — air-gapped by policy; see `docs/runbooks/contract-upgrades.md`.
+- Gateway env/config mutation (killswitch toggle, quotas, builder fee) — see
+  `docs/runbooks/relayer-operations.md`.
+- Legacy v1 (`FriendGroupMarketFactory`, nullifier registry) — no live network
+  configures it.

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -15,25 +15,14 @@ import OracleAdaptersTab from './admin/OracleAdaptersTab'
 import DenyListAdmin from './admin/DenyListAdmin'
 import CallsignRegistryAdmin from './admin/CallsignRegistryAdmin'
 import MembershipTreasuryOverview from './admin/MembershipTreasuryOverview'
+import ProtocolConfigTab from './admin/ProtocolConfigTab'
+import MaintenanceTab from './admin/MaintenanceTab'
+import ServiceHealthCard from './admin/ServiceHealthCard'
+import PaymasterOpsCard from './admin/PaymasterOpsCard'
+import { buildAdminNavGroups, flattenNavGroups } from './admin/adminNav'
 import PortalNav from './ui/PortalNav'
 import SectionIconNav from './nav/SectionIconNav'
 import './AdminPanel.css'
-
-// Icons for the mobile bottom quick-nav (SectionIconNav). Desktop uses the
-// text rail; mobile pins these so admins can hop between sections one-handed.
-// Values are NavIcon names (flat line glyphs), not emoji.
-const ADMIN_TAB_ICONS = {
-  overview: 'grid',
-  emergency: 'alert',
-  tiers: 'layers',
-  members: 'users',
-  moderation: 'shieldOff',
-  'admin-roles': 'key',
-  treasury: 'bank',
-  'oracle-adapters': 'broadcast',
-  'deny-list': 'ban',
-  'callsigns': 'ticket',
-}
 
 const TIER_NAMES = { 1: 'Bronze', 2: 'Silver', 3: 'Gold', 4: 'Platinum' }
 const USDC_DECIMALS = 6
@@ -43,6 +32,8 @@ const ROLE_HASHES = {
   GUARDIAN: ethers.keccak256(ethers.toUtf8Bytes('GUARDIAN_ROLE')),
   ACCOUNT_MODERATOR: ethers.keccak256(ethers.toUtf8Bytes('ACCOUNT_MODERATOR_ROLE')),
   ROLE_MANAGER: ethers.keccak256(ethers.toUtf8Bytes('ROLE_MANAGER_ROLE')),
+  SANCTIONS_ADMIN: ethers.keccak256(ethers.toUtf8Bytes('SANCTIONS_ADMIN_ROLE')),
+  TOKEN_ISSUER: ethers.keccak256(ethers.toUtf8Bytes('TOKEN_ISSUER_ROLE')),
   DEFAULT_ADMIN: ethers.ZeroHash,
 }
 
@@ -78,16 +69,14 @@ function shortAddr(address) {
 }
 
 /**
- * Admin Panel — gated per-tab by the on-chain role each action requires.
+ * Operations Control Plane — the grouped admin portal at /admin.
  *
- * Tabs:
- *   Overview          (any admin role)
- *   Emergency         (GUARDIAN_ROLE)
- *   Tiers             (DEFAULT_ADMIN_ROLE)
- *   Members           (ROLE_MANAGER_ROLE)
- *   Account Moderation (ACCOUNT_MODERATOR_ROLE)
- *   Admin Roles       (DEFAULT_ADMIN_ROLE)
- *   Treasury          (DEFAULT_ADMIN_ROLE)
+ * Views are organized into operator groups (Control Room, Incident Response,
+ * Compliance, Membership & Revenue, Protocol Config, Identity, Access
+ * Control, Infrastructure); see components/admin/adminNav.js for the
+ * grouping/gating model and docs/system-overview/control-surface-audit.md
+ * for the audit that produced it. Every view remains gated by the on-chain
+ * role its actions require.
  */
 function AdminPanel() {
   const { hasRole, hasAnyRole } = useRoles()
@@ -99,6 +88,7 @@ function AdminPanel() {
   const isGuardian = hasRole(ROLES.GUARDIAN)
   const isAccountModerator = hasRole(ROLES.ACCOUNT_MODERATOR)
   const isRoleManager = hasRole(ROLES.ROLE_MANAGER)
+  const isSanctionsAdmin = hasRole(ROLES.SANCTIONS_ADMIN)
   const hasAdminAccess = hasAnyRole(ADMIN_ROLES)
 
   const [activeTab, setActiveTab] = useState('overview')
@@ -147,6 +137,17 @@ function AdminPanel() {
 
   const wagerRegistryAddr = getContractAddressForChain('wagerRegistry', chainId)
   const membershipManagerAddr = getContractAddressForChain('membershipManager', chainId)
+  const sanctionsGuardAddr = getContractAddressForChain('sanctionsGuard', chainId)
+  const tokenFactoryAddr = getContractAddressForChain('tokenFactory', chainId)
+
+  // Each grantable role lives on a specific contract; grants must be sent
+  // to the contract that defines the role, not blanket-sent to the registry.
+  const roleHomeContract = (role) => {
+    if (role === 'ROLE_MANAGER') return membershipManagerAddr
+    if (role === 'SANCTIONS_ADMIN') return sanctionsGuardAddr
+    if (role === 'TOKEN_ISSUER') return tokenFactoryAddr
+    return wagerRegistryAddr
+  }
 
   const wagerRegistryRead = useMemo(() => {
     if (!wagerRegistryAddr) return null
@@ -273,8 +274,8 @@ function AdminPanel() {
     const target = adminRoleEns.resolvedAddress || adminRoleForm.address
     if (!isValidEthereumAddress(target)) return showNotification('Invalid address', 'error')
     const roleHash = ROLE_HASHES[adminRoleForm.role]
-    // ROLE_MANAGER lives on MembershipManager; everything else on WagerRegistry
-    const addr = adminRoleForm.role === 'ROLE_MANAGER' ? membershipManagerAddr : wagerRegistryAddr
+    const addr = roleHomeContract(adminRoleForm.role)
+    if (!addr) return showNotification('Role contract not deployed on this network', 'error')
     return runTx(
       () => new ethers.Contract(addr, WAGER_REGISTRY_ADMIN_ABI, signer).grantRole(roleHash, target),
       `Granted ${adminRoleForm.role} to ${shortAddr(target)}`
@@ -285,7 +286,8 @@ function AdminPanel() {
     const target = adminRoleEns.resolvedAddress || adminRoleForm.address
     if (!isValidEthereumAddress(target)) return showNotification('Invalid address', 'error')
     const roleHash = ROLE_HASHES[adminRoleForm.role]
-    const addr = adminRoleForm.role === 'ROLE_MANAGER' ? membershipManagerAddr : wagerRegistryAddr
+    const addr = roleHomeContract(adminRoleForm.role)
+    if (!addr) return showNotification('Role contract not deployed on this network', 'error')
     return runTx(
       () => new ethers.Contract(addr, WAGER_REGISTRY_ADMIN_ABI, signer).revokeRole(roleHash, target),
       `Revoked ${adminRoleForm.role} from ${shortAddr(target)}`
@@ -303,20 +305,17 @@ function AdminPanel() {
     )
   }
 
-  // Role-gated section list for the left sidebar. Mirrors the per-tab role
-  // checks below — a tab only appears if the connected account can use it.
-  const adminTabs = [
-    { id: 'overview', label: 'Overview' },
-    isGuardian && { id: 'emergency', label: 'Emergency' },
-    isAdmin && { id: 'tiers', label: 'Tiers' },
-    isRoleManager && { id: 'members', label: 'Members' },
-    isAccountModerator && { id: 'moderation', label: 'Account Moderation' },
-    isAdmin && { id: 'admin-roles', label: 'Admin Roles' },
-    isAdmin && { id: 'treasury', label: 'Treasury' },
-    isAdmin && { id: 'oracle-adapters', label: 'Oracle Adapters' },
-    isAdmin && { id: 'deny-list', label: 'Deny-list' },
-    isAdmin && { id: 'callsigns', label: 'Callsigns' },
-  ].filter(Boolean)
+  // Grouped, role-gated section rail (see admin/adminNav.js). Mirrors the
+  // per-tab role checks below — a view only appears if the connected account
+  // can use it, and a group only appears if it has at least one usable view.
+  const navGroups = buildAdminNavGroups({
+    isAdmin,
+    isGuardian,
+    isAccountModerator,
+    isRoleManager,
+    isSanctionsAdmin,
+  })
+  const adminTabs = flattenNavGroups(navGroups)
 
   if (!hasAdminAccess) {
     return (
@@ -324,9 +323,10 @@ function AdminPanel() {
         <div className="admin-unauthorized">
           <div className="unauthorized-icon" aria-hidden="true">🔒</div>
           <h2>Access Restricted</h2>
-          <p>This admin panel is only accessible to users with administrative privileges.</p>
+          <p>The operations control plane is only accessible to users with operator privileges.</p>
           <p className="unauthorized-hint">
-            Administrative roles include: Administrator, Emergency Guardian, Account Moderator, and Role Manager.
+            Operator roles include: Administrator, Emergency Guardian, Account Moderator, Role
+            Manager, and Compliance Officer.
           </p>
         </div>
       </div>
@@ -338,16 +338,18 @@ function AdminPanel() {
       <header className="admin-panel-header">
         <div className="admin-panel-header-content">
           <div className="admin-panel-title-section">
-            <h1>Admin Panel</h1>
+            <h1>Operations</h1>
             <span className="admin-badge">
               {isAdmin ? 'Administrator' :
                 isGuardian ? 'Guardian' :
                   isAccountModerator ? 'Moderator' :
-                    isRoleManager ? 'Role Manager' : 'Admin'}
+                    isRoleManager ? 'Role Manager' :
+                      isSanctionsAdmin ? 'Compliance Officer' : 'Admin'}
             </span>
           </div>
           <p className="admin-panel-subtitle">
-            On-chain controls for the P2P wager protocol. Each tab is gated by the role it requires.
+            Control plane for the P2P wager protocol — protocol controls, metrics, and service
+            health in one place. Each view is gated by the on-chain role it requires.
           </p>
         </div>
         <div className="admin-panel-status">
@@ -363,10 +365,10 @@ function AdminPanel() {
       <div className={`portal-shell admin-portal-shell ${sidebarOpen ? '' : 'portal-collapsed'}`}>
         <aside className="portal-sidebar admin-portal-sidebar">
           <PortalNav
-            items={adminTabs}
+            groups={navGroups}
             activeId={activeTab}
             onSelect={setActiveTab}
-            ariaLabel="Admin sections"
+            ariaLabel="Operations sections"
           />
         </aside>
 
@@ -432,8 +434,14 @@ function AdminPanel() {
                     <span className="permission-icon">{isRoleManager ? '✓' : '×'}</span>
                     <span className="permission-name">Role Manager (grant / revoke memberships)</span>
                   </div>
+                  <div className={`permission-item ${isSanctionsAdmin ? 'enabled' : 'disabled'}`}>
+                    <span className="permission-icon">{isSanctionsAdmin ? '✓' : '×'}</span>
+                    <span className="permission-name">Compliance Officer (deny-list on SanctionsGuard)</span>
+                  </div>
                 </div>
               </div>
+
+              <ServiceHealthCard />
 
               <MembershipTreasuryOverview
                 provider={provider || getProvider(chainId)}
@@ -477,6 +485,10 @@ function AdminPanel() {
                 )}
               </div>
             </div>
+            {/* Incident commanders get the gasless-infra picture on the same
+                screen: the on-chain pause and the gateway killswitch are the
+                two halves of a full stop. */}
+            <ServiceHealthCard />
           </div>
         )}
 
@@ -647,6 +659,8 @@ function AdminPanel() {
                     <option value="GUARDIAN">Guardian — pause/unpause</option>
                     <option value="ACCOUNT_MODERATOR">Account Moderator — freeze/unfreeze</option>
                     <option value="ROLE_MANAGER">Role Manager — grant/revoke memberships</option>
+                    <option value="SANCTIONS_ADMIN">Compliance Officer — deny-list (SanctionsGuard)</option>
+                    <option value="TOKEN_ISSUER">Token Issuer — token creation (TokenFactory)</option>
                     <option value="DEFAULT_ADMIN">Default Admin — full control (rare)</option>
                   </select>
                 </label>
@@ -713,7 +727,7 @@ function AdminPanel() {
           />
         )}
 
-        {activeTab === 'deny-list' && isAdmin && (
+        {activeTab === 'deny-list' && (isSanctionsAdmin || isAdmin) && (
           <DenyListAdmin
             signer={signer}
             account={account}
@@ -733,14 +747,64 @@ function AdminPanel() {
             pendingTx={pendingTx}
           />
         )}
+
+        {activeTab === 'protocol-config' && isAdmin && (
+          <ProtocolConfigTab
+            signer={signer}
+            chainId={chainId}
+            provider={provider || getProvider(chainId)}
+            runTx={runTx}
+            pendingTx={pendingTx}
+          />
+        )}
+
+        {activeTab === 'maintenance' && (
+          <MaintenanceTab
+            signer={signer}
+            chainId={chainId}
+            runTx={runTx}
+            pendingTx={pendingTx}
+          />
+        )}
+
+        {activeTab === 'services' && (isAdmin || isGuardian) && (
+          <div className="admin-tab-content" role="tabpanel">
+            <div className="overview-grid">
+              <ServiceHealthCard />
+              <PaymasterOpsCard
+                signer={signer}
+                account={account}
+                provider={provider || getProvider(chainId)}
+                chainId={chainId}
+                nativeSymbol={nativeSymbol}
+                runTx={runTx}
+                pendingTx={pendingTx}
+              />
+            </div>
+            <div className="admin-card">
+              <h3>Off-chain Controls (runbook-operated)</h3>
+              <p>
+                The relay gateway deliberately has no web admin API — it can censor, never steal,
+                and its worst failure mode is refusing gas. These controls are operated via
+                deploy config and signals, documented in the runbooks:
+              </p>
+              <ul>
+                <li><strong>Gateway killswitch</strong> — <code>KILL_SWITCH</code> env or <code>SIGUSR2</code>; halts relaying, sponsorship, and the OpenSea/Polymarket proxies (docs/runbooks/relayer-operations.md).</li>
+                <li><strong>Relayer per-chain pause / gas caps / receiver allowlist</strong> — <code>services/oz-relayer/config/config.json</code>.</li>
+                <li><strong>Quotas, spend caps, paymaster ceilings</strong> — gateway env (<code>SIGNER_QUOTA_PER_MIN</code>, <code>GAS_SPEND_CAP_WEI_*</code>, <code>PM_*</code>).</li>
+                <li><strong>Polymarket builder fee</strong> — gateway env, hard-capped at boot; changes rate-limited by Polymarket (docs/developer-guide/predict-polymarket.md).</li>
+              </ul>
+            </div>
+          </div>
+        )}
           </main>
 
           {/* Mobile-only bottom quick-nav between admin sections. */}
           <SectionIconNav
-            items={adminTabs.map((tab) => ({ ...tab, icon: ADMIN_TAB_ICONS[tab.id] || '•' }))}
+            items={adminTabs}
             activeId={activeTab}
             onSelect={setActiveTab}
-            ariaLabel="Admin sections"
+            ariaLabel="Operations sections"
           />
         </div>
       </div>

--- a/frontend/src/components/admin/MaintenanceTab.jsx
+++ b/frontend/src/components/admin/MaintenanceTab.jsx
@@ -22,7 +22,12 @@ function parseIdList(text) {
     .split(/[,\s]+/)
     .map((s) => s.trim())
     .filter(Boolean)
-    .map((s) => BigInt(s))
+    .map((s) => {
+      // BigInt would happily parse "-1", which then fails uint256 ABI encoding
+      // downstream — reject anything but plain digits up front.
+      if (!/^\d+$/.test(s)) throw new Error(`invalid id: ${s}`)
+      return BigInt(s)
+    })
 }
 
 function MaintenanceTab({ signer, chainId, runTx, pendingTx }) {
@@ -50,14 +55,13 @@ function MaintenanceTab({ signer, chainId, runTx, pendingTx }) {
   }
 
   const handleAutoResolve = () => {
-    let id
-    try {
-      id = BigInt(resolveForm.id.trim())
-      setParseError('')
-    } catch {
-      setParseError('Wager ID must be an integer')
+    const raw = resolveForm.id.trim()
+    if (!/^\d+$/.test(raw)) {
+      setParseError('Wager ID must be a non-negative integer')
       return
     }
+    setParseError('')
+    const id = BigInt(raw)
     const fn = resolveForm.source === 'polymarket'
       ? () => write().autoResolveFromPolymarket(id)
       : () => write().autoResolveFromOracle(id)

--- a/frontend/src/components/admin/MaintenanceTab.jsx
+++ b/frontend/src/components/admin/MaintenanceTab.jsx
@@ -1,0 +1,120 @@
+import { useState } from 'react'
+import { ethers } from 'ethers'
+import { getContractAddressForChain } from '../../config/contracts'
+
+/**
+ * MaintenanceTab — permissionless housekeeping calls on the wager registry
+ * (they live on the intents facet, reached through the proxy).
+ *
+ * Anyone on-chain may call these; surfacing them here gives operators a
+ * one-click way to demonstrate active platform stewardship: sweeping expired
+ * open wagers (refunds creators, frees membership slots) and nudging
+ * oracle-resolvable wagers to settlement.
+ */
+const MAINTENANCE_ABI = [
+  'function batchExpireOpen(uint256[] wagerIds)',
+  'function autoResolveFromPolymarket(uint256 wagerId)',
+  'function autoResolveFromOracle(uint256 wagerId)',
+]
+
+function parseIdList(text) {
+  return text
+    .split(/[,\s]+/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => BigInt(s))
+}
+
+function MaintenanceTab({ signer, chainId, runTx, pendingTx }) {
+  const registryAddr = getContractAddressForChain('wagerRegistry', chainId)
+  const [expireIds, setExpireIds] = useState('')
+  const [resolveForm, setResolveForm] = useState({ id: '', source: 'polymarket' })
+  const [parseError, setParseError] = useState('')
+
+  const write = () => new ethers.Contract(registryAddr, MAINTENANCE_ABI, signer)
+
+  const handleBatchExpire = () => {
+    let ids
+    try {
+      ids = parseIdList(expireIds)
+      setParseError('')
+    } catch {
+      setParseError('Wager IDs must be integers (comma or space separated)')
+      return
+    }
+    if (ids.length === 0) return
+    runTx(
+      () => write().batchExpireOpen(ids),
+      `Expired ${ids.length} open wager${ids.length === 1 ? '' : 's'} — creators refunded`
+    )
+  }
+
+  const handleAutoResolve = () => {
+    let id
+    try {
+      id = BigInt(resolveForm.id.trim())
+      setParseError('')
+    } catch {
+      setParseError('Wager ID must be an integer')
+      return
+    }
+    const fn = resolveForm.source === 'polymarket'
+      ? () => write().autoResolveFromPolymarket(id)
+      : () => write().autoResolveFromOracle(id)
+    runTx(fn, `Auto-resolution triggered for wager #${resolveForm.id}`)
+  }
+
+  return (
+    <div className="admin-tab-content" role="tabpanel">
+      <div className="admin-card">
+        <h3>Expire Open Wagers</h3>
+        <p>
+          Sweeps Open wagers whose accept deadline has passed: refunds the creator's stake and
+          releases their concurrent-market slot. The call is permissionless and skips wagers
+          that are not actually expired, so a stale ID is harmless.
+        </p>
+        <div className="admin-form">
+          <label>
+            Wager IDs (comma or space separated)
+            <input type="text" placeholder="e.g. 12, 15, 33" value={expireIds}
+              onChange={(e) => setExpireIds(e.target.value)} />
+            {parseError && <span className="hint">{parseError}</span>}
+          </label>
+          <button className="confirm-btn primary" onClick={handleBatchExpire}
+            disabled={pendingTx || !signer || !expireIds.trim() || !registryAddr}>
+            {pendingTx ? 'Sweeping...' : 'Run Expiry Sweep'}
+          </button>
+        </div>
+      </div>
+
+      <div className="admin-card">
+        <h3>Trigger Auto-Resolution</h3>
+        <p>
+          Nudges an oracle-resolvable wager to settlement (Polymarket or a configured oracle
+          adapter). Permissionless — the oracle outcome, not the caller, decides the winner.
+        </p>
+        <div className="admin-form">
+          <label>
+            Wager ID
+            <input type="text" placeholder="e.g. 42" value={resolveForm.id}
+              onChange={(e) => setResolveForm({ ...resolveForm, id: e.target.value })} />
+          </label>
+          <label>
+            Resolution source
+            <select value={resolveForm.source}
+              onChange={(e) => setResolveForm({ ...resolveForm, source: e.target.value })}>
+              <option value="polymarket">Polymarket</option>
+              <option value="oracle">Oracle adapter (Chainlink / UMA)</option>
+            </select>
+          </label>
+          <button className="confirm-btn primary" onClick={handleAutoResolve}
+            disabled={pendingTx || !signer || !resolveForm.id.trim() || !registryAddr}>
+            {pendingTx ? 'Processing...' : 'Trigger Resolution'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default MaintenanceTab

--- a/frontend/src/components/admin/PaymasterOpsCard.jsx
+++ b/frontend/src/components/admin/PaymasterOpsCard.jsx
@@ -2,6 +2,19 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 import { ethers } from 'ethers'
 import { getContractAddressForChain } from '../../config/contracts'
 import { isValidEthereumAddress } from '../../utils/validation'
+import { useNotification } from '../../hooks/useUI'
+
+// parseEther throws on strings a number input can still produce (scientific
+// notation like "1e-6", trailing "."), and an uncaught throw would take down
+// the whole control plane — normalize to null and let callers surface it.
+function safeParseEther(value) {
+  try {
+    const parsed = ethers.parseEther(String(value || '0'))
+    return parsed > 0n ? parsed : null
+  } catch {
+    return null
+  }
+}
 
 /**
  * PaymasterOpsCard — FairWinsVerifyingPaymaster operations (spec 050).
@@ -28,6 +41,7 @@ function shortAddr(a) {
 
 function PaymasterOpsCard({ signer, account, provider, chainId, nativeSymbol, runTx, pendingTx }) {
   const paymasterAddr = getContractAddressForChain('verifyingPaymaster', chainId)
+  const { showNotification } = useNotification()
 
   const [info, setInfo] = useState({ deposit: null, verifyingSigner: '', owner: '' })
   const [depositAmount, setDepositAmount] = useState('')
@@ -73,8 +87,8 @@ function PaymasterOpsCard({ signer, account, provider, chainId, nativeSymbol, ru
   const write = () => new ethers.Contract(paymasterAddr, PAYMASTER_ABI, signer)
 
   const handleDeposit = () => {
-    const value = ethers.parseEther(String(depositAmount || '0'))
-    if (value === 0n) return
+    const value = safeParseEther(depositAmount)
+    if (value == null) return showNotification(`Enter a valid ${nativeSymbol} amount`, 'error')
     runTx(
       () => write().deposit({ value }),
       `Deposited ${depositAmount} ${nativeSymbol} to the paymaster's EntryPoint balance`
@@ -82,9 +96,9 @@ function PaymasterOpsCard({ signer, account, provider, chainId, nativeSymbol, ru
   }
 
   const handleWithdraw = () => {
-    if (!isValidEthereumAddress(withdrawForm.to)) return
-    const amount = ethers.parseEther(String(withdrawForm.amount || '0'))
-    if (amount === 0n) return
+    if (!isValidEthereumAddress(withdrawForm.to)) return showNotification('Invalid recipient address', 'error')
+    const amount = safeParseEther(withdrawForm.amount)
+    if (amount == null) return showNotification(`Enter a valid ${nativeSymbol} amount`, 'error')
     runTx(
       () => write().withdrawTo(withdrawForm.to, amount),
       `Withdrew ${withdrawForm.amount} ${nativeSymbol} from the paymaster deposit`
@@ -92,7 +106,7 @@ function PaymasterOpsCard({ signer, account, provider, chainId, nativeSymbol, ru
   }
 
   const handleRotateSigner = () => {
-    if (!isValidEthereumAddress(newSigner)) return
+    if (!isValidEthereumAddress(newSigner)) return showNotification('Invalid signer address', 'error')
     runTx(
       () => write().setVerifyingSigner(newSigner),
       `Verifying signer rotated to ${shortAddr(newSigner)}`

--- a/frontend/src/components/admin/PaymasterOpsCard.jsx
+++ b/frontend/src/components/admin/PaymasterOpsCard.jsx
@@ -1,0 +1,175 @@
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { ethers } from 'ethers'
+import { getContractAddressForChain } from '../../config/contracts'
+import { isValidEthereumAddress } from '../../utils/validation'
+
+/**
+ * PaymasterOpsCard — FairWinsVerifyingPaymaster operations (spec 050).
+ *
+ * The EntryPoint deposit IS the sponsorship loss cap: monitoring and topping
+ * it up is a routine operator duty (docs/runbooks/paymaster-operations.md).
+ * `deposit()` is deliberately permissionless on-chain (anyone may top up);
+ * `withdrawTo` / `setVerifyingSigner` are owner-only — the buttons stay
+ * visible so any operator can see the controls exist, but the transaction
+ * reverts unless the connected wallet is the paymaster owner.
+ */
+const PAYMASTER_ABI = [
+  'function getDeposit() view returns (uint256)',
+  'function verifyingSigner() view returns (address)',
+  'function owner() view returns (address)',
+  'function deposit() payable',
+  'function withdrawTo(address payable to, uint256 amount)',
+  'function setVerifyingSigner(address newSigner)',
+]
+
+function shortAddr(a) {
+  return a ? `${a.substring(0, 6)}...${a.substring(a.length - 4)}` : ''
+}
+
+function PaymasterOpsCard({ signer, account, provider, chainId, nativeSymbol, runTx, pendingTx }) {
+  const paymasterAddr = getContractAddressForChain('verifyingPaymaster', chainId)
+
+  const [info, setInfo] = useState({ deposit: null, verifyingSigner: '', owner: '' })
+  const [depositAmount, setDepositAmount] = useState('')
+  const [withdrawForm, setWithdrawForm] = useState({ to: '', amount: '' })
+  const [newSigner, setNewSigner] = useState('')
+
+  const readContract = useMemo(() => {
+    if (!paymasterAddr || !provider) return null
+    return new ethers.Contract(paymasterAddr, PAYMASTER_ABI, provider)
+  }, [paymasterAddr, provider])
+
+  const fetchInfo = useCallback(async () => {
+    if (!readContract) return
+    try {
+      const [deposit, vSigner, owner] = await Promise.all([
+        readContract.getDeposit().catch(() => null),
+        readContract.verifyingSigner().catch(() => ''),
+        readContract.owner().catch(() => ''),
+      ])
+      setInfo({ deposit, verifyingSigner: vSigner, owner })
+    } catch (err) {
+      console.warn('[PaymasterOpsCard] read failed:', err)
+    }
+  }, [readContract])
+
+  useEffect(() => {
+    fetchInfo()
+  }, [fetchInfo])
+
+  if (!paymasterAddr) {
+    return (
+      <div className="admin-card">
+        <div className="admin-card-header"><h3>Sponsored-Gas Paymaster</h3></div>
+        <p className="card-info">
+          No verifying paymaster is deployed on this network. Sponsorship (spec 050) is
+          Polygon-only; the passkey path self-funds elsewhere.
+        </p>
+      </div>
+    )
+  }
+
+  const isOwner = account && info.owner && account.toLowerCase() === info.owner.toLowerCase()
+  const write = () => new ethers.Contract(paymasterAddr, PAYMASTER_ABI, signer)
+
+  const handleDeposit = () => {
+    const value = ethers.parseEther(String(depositAmount || '0'))
+    if (value === 0n) return
+    runTx(
+      () => write().deposit({ value }),
+      `Deposited ${depositAmount} ${nativeSymbol} to the paymaster's EntryPoint balance`
+    ).then(fetchInfo)
+  }
+
+  const handleWithdraw = () => {
+    if (!isValidEthereumAddress(withdrawForm.to)) return
+    const amount = ethers.parseEther(String(withdrawForm.amount || '0'))
+    if (amount === 0n) return
+    runTx(
+      () => write().withdrawTo(withdrawForm.to, amount),
+      `Withdrew ${withdrawForm.amount} ${nativeSymbol} from the paymaster deposit`
+    ).then(fetchInfo)
+  }
+
+  const handleRotateSigner = () => {
+    if (!isValidEthereumAddress(newSigner)) return
+    runTx(
+      () => write().setVerifyingSigner(newSigner),
+      `Verifying signer rotated to ${shortAddr(newSigner)}`
+    ).then(fetchInfo)
+  }
+
+  return (
+    <div className="admin-card">
+      <div className="admin-card-header">
+        <h3>Sponsored-Gas Paymaster</h3>
+        <button type="button" className="refresh-btn" onClick={fetchInfo} aria-label="Refresh paymaster state">↻</button>
+      </div>
+      <div className="status-details">
+        <div className="status-row">
+          <span className="status-label">EntryPoint deposit (loss cap)</span>
+          <span className="status-value">
+            {info.deposit == null ? '—' : `${ethers.formatEther(info.deposit)} ${nativeSymbol}`}
+          </span>
+        </div>
+        <div className="status-row">
+          <span className="status-label">Verifying signer</span>
+          <span className="status-value"><code>{shortAddr(info.verifyingSigner) || '—'}</code></span>
+        </div>
+        <div className="status-row">
+          <span className="status-label">Owner</span>
+          <span className="status-value">
+            <code>{shortAddr(info.owner) || '—'}</code>{isOwner ? ' (you)' : ''}
+          </span>
+        </div>
+      </div>
+
+      <div className="admin-form">
+        <label>
+          Top up deposit ({nativeSymbol}) — permissionless, funds sponsorship runway
+          <input type="number" min="0" step="0.01" value={depositAmount}
+            onChange={(e) => setDepositAmount(e.target.value)} />
+        </label>
+        <button className="confirm-btn primary" onClick={handleDeposit}
+          disabled={pendingTx || !signer || !depositAmount}>
+          {pendingTx ? 'Processing...' : 'Deposit'}
+        </button>
+      </div>
+
+      <div className="admin-form">
+        <label>
+          Withdraw to (owner only)
+          <input type="text" placeholder="0x…" value={withdrawForm.to}
+            onChange={(e) => setWithdrawForm({ ...withdrawForm, to: e.target.value })} />
+        </label>
+        <label>
+          Amount ({nativeSymbol})
+          <input type="number" min="0" step="0.01" value={withdrawForm.amount}
+            onChange={(e) => setWithdrawForm({ ...withdrawForm, amount: e.target.value })} />
+        </label>
+        <button className="confirm-btn danger" onClick={handleWithdraw}
+          disabled={pendingTx || !signer || !isOwner || !withdrawForm.to || !withdrawForm.amount}>
+          {pendingTx ? 'Processing...' : 'Withdraw Deposit'}
+        </button>
+      </div>
+
+      <div className="admin-form">
+        <label>
+          Rotate verifying signer (owner only — incident response for a compromised KMS signer)
+          <input type="text" placeholder="0x… new signer" value={newSigner}
+            onChange={(e) => setNewSigner(e.target.value)} />
+        </label>
+        <button className="confirm-btn danger" onClick={handleRotateSigner}
+          disabled={pendingTx || !signer || !isOwner || !newSigner}>
+          {pendingTx ? 'Processing...' : 'Rotate Signer'}
+        </button>
+      </div>
+      <p className="card-info">
+        A compromised verifying signer can only spend deposit on gas — it cannot withdraw.
+        Full procedure: docs/runbooks/paymaster-operations.md.
+      </p>
+    </div>
+  )
+}
+
+export default PaymasterOpsCard

--- a/frontend/src/components/admin/ProtocolConfigTab.jsx
+++ b/frontend/src/components/admin/ProtocolConfigTab.jsx
@@ -167,7 +167,7 @@ function ProtocolConfigTab({ signer, chainId, provider, runTx, pendingTx }) {
   }
 
   const handleSetOracleAdapter = () => {
-    if (!isValidEthereumAddress(oracleForm.address)) return
+    if (!registryAddr || !isValidEthereumAddress(oracleForm.address)) return
     const typeLabel = ORACLE_TYPES.find((t) => t.value === oracleForm.type)?.label
     runTx(
       () => new ethers.Contract(registryAddr, REGISTRY_ABI, signer)
@@ -183,7 +183,7 @@ function ProtocolConfigTab({ signer, chainId, provider, runTx, pendingTx }) {
   }
 
   const handleSetTokenAllowed = () => {
-    if (!isValidEthereumAddress(tokenForm.address)) return
+    if (!registryAddr || !isValidEthereumAddress(tokenForm.address)) return
     runTx(
       () => new ethers.Contract(registryAddr, REGISTRY_ABI, signer)
         .setTokenAllowed(tokenForm.address, tokenForm.allowed),
@@ -192,7 +192,7 @@ function ProtocolConfigTab({ signer, chainId, provider, runTx, pendingTx }) {
   }
 
   const handleSetAuthorizedCaller = () => {
-    if (!isValidEthereumAddress(callerForm.address)) return
+    if (!membershipAddr || !isValidEthereumAddress(callerForm.address)) return
     runTx(
       () => new ethers.Contract(membershipAddr, MEMBERSHIP_ABI, signer)
         .setAuthorizedCaller(callerForm.address, callerForm.authorized),
@@ -276,7 +276,7 @@ function ProtocolConfigTab({ signer, chainId, provider, runTx, pendingTx }) {
               onChange={(e) => setOracleForm({ ...oracleForm, address: e.target.value })} />
           </label>
           <button className="confirm-btn primary" onClick={handleSetOracleAdapter}
-            disabled={pendingTx || !signer || !oracleForm.address}>
+            disabled={pendingTx || !signer || !oracleForm.address || !registryAddr}>
             {pendingTx ? 'Processing...' : 'Set Adapter'}
           </button>
         </div>
@@ -305,7 +305,7 @@ function ProtocolConfigTab({ signer, chainId, provider, runTx, pendingTx }) {
               Check Current
             </button>
             <button className="confirm-btn primary" onClick={handleSetTokenAllowed}
-              disabled={pendingTx || !signer || !tokenForm.address}>
+              disabled={pendingTx || !signer || !tokenForm.address || !registryAddr}>
               {pendingTx ? 'Processing...' : 'Apply'}
             </button>
           </div>
@@ -330,7 +330,7 @@ function ProtocolConfigTab({ signer, chainId, provider, runTx, pendingTx }) {
             Authorized
           </label>
           <button className="confirm-btn danger" onClick={handleSetAuthorizedCaller}
-            disabled={pendingTx || !signer || !callerForm.address}>
+            disabled={pendingTx || !signer || !callerForm.address || !membershipAddr}>
             {pendingTx ? 'Processing...' : 'Apply'}
           </button>
         </div>

--- a/frontend/src/components/admin/ProtocolConfigTab.jsx
+++ b/frontend/src/components/admin/ProtocolConfigTab.jsx
@@ -1,0 +1,342 @@
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { ethers } from 'ethers'
+import { getContractAddressForChain } from '../../config/contracts'
+import { isValidEthereumAddress } from '../../utils/validation'
+
+/**
+ * ProtocolConfigTab — the protocol wiring view of the operations control
+ * plane (DEFAULT_ADMIN_ROLE).
+ *
+ * Before this view existed, an operator could not even READ the live wiring
+ * (which sanctions guard, which oracle adapters, which stake tokens) without
+ * a block explorer. Every setter here is a high-consequence config change —
+ * each row shows the current value next to the input that replaces it.
+ */
+const REGISTRY_ABI = [
+  'function membershipManager() view returns (address)',
+  'function polymarketAdapter() view returns (address)',
+  'function sanctionsGuard() view returns (address)',
+  'function intentExtension() view returns (address)',
+  'function oracleAdapters(uint8) view returns (address)',
+  'function isTokenAllowed(address) view returns (bool)',
+  'function setMembershipManager(address)',
+  'function setPolymarketAdapter(address)',
+  'function setSanctionsGuard(address)',
+  'function setOracleAdapter(uint8 resolutionType, address adapter)',
+  'function setTokenAllowed(address token, bool allowed)',
+]
+
+const MEMBERSHIP_ABI = [
+  'function treasury() view returns (address)',
+  'function paymentToken() view returns (address)',
+  'function voucher() view returns (address)',
+  'function sanctionsGuard() view returns (address)',
+  'function setTreasury(address)',
+  'function setPaymentToken(address)',
+  'function setSanctionsGuard(address)',
+  'function setAuthorizedCaller(address caller, bool authorized)',
+  'function authorizedCallers(address) view returns (bool)',
+]
+
+const SANCTIONS_ABI = [
+  'function sanctionsOracle() view returns (address)',
+  'function setSanctionsOracle(address)',
+]
+
+// Oracle-routed subset of IWagerRegistryTypes.ResolutionType (indexes 5–7);
+// 0–4 resolve socially or via the dedicated Polymarket adapter slot.
+const ORACLE_TYPES = [
+  { value: 5, label: 'Chainlink Data Feed' },
+  { value: 6, label: 'Chainlink Functions' },
+  { value: 7, label: 'UMA Optimistic Oracle' },
+]
+
+function shortAddr(a) {
+  return a && a !== ethers.ZeroAddress ? `${a.substring(0, 6)}...${a.substring(a.length - 4)}` : ''
+}
+
+function WiringRow({ label, current, note }) {
+  return (
+    <div className="status-row">
+      <span className="status-label">{label}</span>
+      <span className="status-value">
+        {current === undefined ? '…'
+          : current && current !== ethers.ZeroAddress
+            ? <code title={current}>{shortAddr(current)}</code>
+            : <span className="status-value paused">{note || 'unset'}</span>}
+      </span>
+    </div>
+  )
+}
+
+function ProtocolConfigTab({ signer, chainId, provider, runTx, pendingTx }) {
+  const registryAddr = getContractAddressForChain('wagerRegistry', chainId)
+  const membershipAddr = getContractAddressForChain('membershipManager', chainId)
+  const sanctionsAddr = getContractAddressForChain('sanctionsGuard', chainId)
+
+  const [wiring, setWiring] = useState({})
+  const [addrForm, setAddrForm] = useState({ target: 'registry-sanctions', address: '' })
+  const [oracleForm, setOracleForm] = useState({ type: 5, address: '' })
+  const [tokenForm, setTokenForm] = useState({ address: '', allowed: true, status: null })
+  const [callerForm, setCallerForm] = useState({ address: '', authorized: true })
+
+  const registryRead = useMemo(
+    () => (registryAddr && provider ? new ethers.Contract(registryAddr, REGISTRY_ABI, provider) : null),
+    [registryAddr, provider]
+  )
+  const membershipRead = useMemo(
+    () => (membershipAddr && provider ? new ethers.Contract(membershipAddr, MEMBERSHIP_ABI, provider) : null),
+    [membershipAddr, provider]
+  )
+  const sanctionsRead = useMemo(
+    () => (sanctionsAddr && provider ? new ethers.Contract(sanctionsAddr, SANCTIONS_ABI, provider) : null),
+    [sanctionsAddr, provider]
+  )
+
+  const fetchWiring = useCallback(async () => {
+    if (!registryRead) return
+    const safe = (p) => p.catch(() => undefined)
+    const [mm, pm, sg, ext, cdf, cf, uma, treasury, payToken, voucher, mmSg, oracle] =
+      await Promise.all([
+        safe(registryRead.membershipManager()),
+        safe(registryRead.polymarketAdapter()),
+        safe(registryRead.sanctionsGuard()),
+        safe(registryRead.intentExtension()),
+        safe(registryRead.oracleAdapters(5)),
+        safe(registryRead.oracleAdapters(6)),
+        safe(registryRead.oracleAdapters(7)),
+        membershipRead ? safe(membershipRead.treasury()) : undefined,
+        membershipRead ? safe(membershipRead.paymentToken()) : undefined,
+        membershipRead ? safe(membershipRead.voucher()) : undefined,
+        membershipRead ? safe(membershipRead.sanctionsGuard()) : undefined,
+        sanctionsRead ? safe(sanctionsRead.sanctionsOracle()) : undefined,
+      ])
+    setWiring({ mm, pm, sg, ext, cdf, cf, uma, treasury, payToken, voucher, mmSg, oracle })
+  }, [registryRead, membershipRead, sanctionsRead])
+
+  useEffect(() => {
+    fetchWiring()
+  }, [fetchWiring])
+
+  // One form drives all single-address setters; this table routes each choice
+  // to the right contract + method and flags screening-disable cases.
+  const ADDRESS_TARGETS = {
+    'registry-sanctions': {
+      label: 'WagerRegistry → sanctions guard', addr: () => registryAddr, abi: REGISTRY_ABI,
+      method: 'setSanctionsGuard', danger: 'address(0) disables sanctions screening on the registry',
+    },
+    'registry-membership': {
+      label: 'WagerRegistry → membership manager', addr: () => registryAddr, abi: REGISTRY_ABI,
+      method: 'setMembershipManager',
+    },
+    'registry-polymarket': {
+      label: 'WagerRegistry → Polymarket adapter', addr: () => registryAddr, abi: REGISTRY_ABI,
+      method: 'setPolymarketAdapter',
+    },
+    'membership-treasury': {
+      label: 'MembershipManager → treasury', addr: () => membershipAddr, abi: MEMBERSHIP_ABI,
+      method: 'setTreasury', danger: 'all future fee withdrawals default to this address',
+    },
+    'membership-paytoken': {
+      label: 'MembershipManager → payment token', addr: () => membershipAddr, abi: MEMBERSHIP_ABI,
+      method: 'setPaymentToken',
+    },
+    'membership-sanctions': {
+      label: 'MembershipManager → sanctions guard', addr: () => membershipAddr, abi: MEMBERSHIP_ABI,
+      method: 'setSanctionsGuard', danger: 'address(0) disables sanctions screening on memberships',
+    },
+    'guard-oracle': {
+      label: 'SanctionsGuard → Chainalysis oracle', addr: () => sanctionsAddr, abi: SANCTIONS_ABI,
+      method: 'setSanctionsOracle', danger: 'address(0) disables oracle screening (deny-list still applies)',
+    },
+  }
+
+  const selectedTarget = ADDRESS_TARGETS[addrForm.target]
+
+  const handleSetAddress = () => {
+    const value = addrForm.address.trim()
+    // address(0) is a legitimate—but destructive—input for the guard slots, so
+    // accept it explicitly rather than through the generic validator.
+    const isClearing = value === ethers.ZeroAddress
+    if (!isClearing && !isValidEthereumAddress(value)) return
+    const target = selectedTarget
+    runTx(
+      () => new ethers.Contract(target.addr(), target.abi, signer)[target.method](value),
+      `${target.label} set to ${isClearing ? 'address(0)' : shortAddr(value)}`
+    ).then(fetchWiring)
+  }
+
+  const handleSetOracleAdapter = () => {
+    if (!isValidEthereumAddress(oracleForm.address)) return
+    const typeLabel = ORACLE_TYPES.find((t) => t.value === oracleForm.type)?.label
+    runTx(
+      () => new ethers.Contract(registryAddr, REGISTRY_ABI, signer)
+        .setOracleAdapter(oracleForm.type, oracleForm.address),
+      `${typeLabel} adapter set to ${shortAddr(oracleForm.address)}`
+    ).then(fetchWiring)
+  }
+
+  const handleCheckToken = async () => {
+    if (!registryRead || !isValidEthereumAddress(tokenForm.address)) return
+    const allowed = await registryRead.isTokenAllowed(tokenForm.address).catch(() => null)
+    setTokenForm((f) => ({ ...f, status: allowed }))
+  }
+
+  const handleSetTokenAllowed = () => {
+    if (!isValidEthereumAddress(tokenForm.address)) return
+    runTx(
+      () => new ethers.Contract(registryAddr, REGISTRY_ABI, signer)
+        .setTokenAllowed(tokenForm.address, tokenForm.allowed),
+      `Stake token ${shortAddr(tokenForm.address)} ${tokenForm.allowed ? 'allowed' : 'disallowed'}`
+    ).then(() => setTokenForm((f) => ({ ...f, status: f.allowed })))
+  }
+
+  const handleSetAuthorizedCaller = () => {
+    if (!isValidEthereumAddress(callerForm.address)) return
+    runTx(
+      () => new ethers.Contract(membershipAddr, MEMBERSHIP_ABI, signer)
+        .setAuthorizedCaller(callerForm.address, callerForm.authorized),
+      `Caller ${shortAddr(callerForm.address)} ${callerForm.authorized ? 'authorized' : 'deauthorized'} on MembershipManager`
+    )
+  }
+
+  return (
+    <div className="admin-tab-content" role="tabpanel">
+      <div className="admin-card">
+        <div className="admin-card-header">
+          <h3>Live Wiring</h3>
+          <button type="button" className="refresh-btn" onClick={fetchWiring} aria-label="Refresh wiring">↻</button>
+        </div>
+        <div className="status-details">
+          <WiringRow label="WagerRegistry → membership manager" current={wiring.mm} />
+          <WiringRow label="WagerRegistry → sanctions guard" current={wiring.sg} note="screening OFF" />
+          <WiringRow label="WagerRegistry → Polymarket adapter" current={wiring.pm} />
+          <WiringRow label="WagerRegistry → intents facet" current={wiring.ext} />
+          <WiringRow label="Oracle adapter: Chainlink Data Feed" current={wiring.cdf} />
+          <WiringRow label="Oracle adapter: Chainlink Functions" current={wiring.cf} />
+          <WiringRow label="Oracle adapter: UMA" current={wiring.uma} />
+          <WiringRow label="MembershipManager → treasury" current={wiring.treasury} />
+          <WiringRow label="MembershipManager → payment token" current={wiring.payToken} />
+          <WiringRow label="MembershipManager → voucher" current={wiring.voucher} />
+          <WiringRow label="MembershipManager → sanctions guard" current={wiring.mmSg} note="screening OFF" />
+          <WiringRow label="SanctionsGuard → Chainalysis oracle" current={wiring.oracle} note="oracle screening OFF" />
+        </div>
+        <p className="card-info">
+          The intents facet is set via <code>setIntentExtension</code> (UPGRADER_ROLE, floppy
+          keystore) and is shown read-only — swap it only through the upgrade runbook.
+        </p>
+      </div>
+
+      <div className="admin-card">
+        <h3>Rewire Address</h3>
+        <p>
+          Changes take effect immediately for all users. For guard slots,{' '}
+          <code>0x000…000</code> disables screening — this is logged on-chain and should follow
+          the compliance runbook.
+        </p>
+        <div className="admin-form">
+          <label>
+            Target
+            <select value={addrForm.target}
+              onChange={(e) => setAddrForm({ ...addrForm, target: e.target.value })}>
+              {Object.entries(ADDRESS_TARGETS).map(([key, t]) => (
+                <option key={key} value={key}>{t.label}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            New address
+            <input type="text" placeholder="0x…" value={addrForm.address}
+              onChange={(e) => setAddrForm({ ...addrForm, address: e.target.value })} />
+            {selectedTarget?.danger && (
+              <span className="hint">⚠ {selectedTarget.danger}</span>
+            )}
+          </label>
+          <button className="confirm-btn danger" onClick={handleSetAddress}
+            disabled={pendingTx || !signer || !addrForm.address || !selectedTarget?.addr()}>
+            {pendingTx ? 'Processing...' : 'Set Address'}
+          </button>
+        </div>
+      </div>
+
+      <div className="admin-card">
+        <h3>Oracle Adapter Routing</h3>
+        <p>Route a resolution type to its adapter contract on WagerRegistry.</p>
+        <div className="admin-form">
+          <label>
+            Resolution type
+            <select value={oracleForm.type}
+              onChange={(e) => setOracleForm({ ...oracleForm, type: Number(e.target.value) })}>
+              {ORACLE_TYPES.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
+            </select>
+          </label>
+          <label>
+            Adapter address
+            <input type="text" placeholder="0x…" value={oracleForm.address}
+              onChange={(e) => setOracleForm({ ...oracleForm, address: e.target.value })} />
+          </label>
+          <button className="confirm-btn primary" onClick={handleSetOracleAdapter}
+            disabled={pendingTx || !signer || !oracleForm.address}>
+            {pendingTx ? 'Processing...' : 'Set Adapter'}
+          </button>
+        </div>
+      </div>
+
+      <div className="admin-card">
+        <h3>Stake Token Allowlist</h3>
+        <p>Which ERC-20s can be escrowed as wager stakes. Disallowing a token blocks new wagers only — existing escrow settles normally.</p>
+        <div className="admin-form">
+          <label>
+            Token address
+            <input type="text" placeholder="0x…" value={tokenForm.address}
+              onChange={(e) => setTokenForm({ ...tokenForm, address: e.target.value, status: null })} />
+            {tokenForm.status != null && (
+              <span className="hint">Currently {tokenForm.status ? 'allowed' : 'not allowed'}</span>
+            )}
+          </label>
+          <label className="admin-checkbox">
+            <input type="checkbox" checked={tokenForm.allowed}
+              onChange={(e) => setTokenForm({ ...tokenForm, allowed: e.target.checked })} />
+            Allowed as stake token
+          </label>
+          <div className="emergency-actions">
+            <button type="button" className="confirm-btn secondary" onClick={handleCheckToken}
+              disabled={!tokenForm.address}>
+              Check Current
+            </button>
+            <button className="confirm-btn primary" onClick={handleSetTokenAllowed}
+              disabled={pendingTx || !signer || !tokenForm.address}>
+              {pendingTx ? 'Processing...' : 'Apply'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="admin-card">
+        <h3>Membership Hook Callers</h3>
+        <p>
+          Contracts authorized to record market open/close counts on MembershipManager
+          (normally just the WagerRegistry proxy). Only change during a registry migration.
+        </p>
+        <div className="admin-form">
+          <label>
+            Caller address
+            <input type="text" placeholder="0x…" value={callerForm.address}
+              onChange={(e) => setCallerForm({ ...callerForm, address: e.target.value })} />
+          </label>
+          <label className="admin-checkbox">
+            <input type="checkbox" checked={callerForm.authorized}
+              onChange={(e) => setCallerForm({ ...callerForm, authorized: e.target.checked })} />
+            Authorized
+          </label>
+          <button className="confirm-btn danger" onClick={handleSetAuthorizedCaller}
+            disabled={pendingTx || !signer || !callerForm.address}>
+            {pendingTx ? 'Processing...' : 'Apply'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ProtocolConfigTab

--- a/frontend/src/components/admin/ServiceHealthCard.jsx
+++ b/frontend/src/components/admin/ServiceHealthCard.jsx
@@ -1,0 +1,97 @@
+import { NETWORK_CONFIG } from '../../config/contracts'
+import { useGatewayStatus } from '../../hooks/useGatewayStatus'
+
+/**
+ * ServiceHealthCard — read-only gasless-infrastructure telemetry for the
+ * operations control plane (relay-gateway `/status`).
+ *
+ * Strictly display: the gateway has no remote admin API by design (killswitch
+ * and quotas are env/signal-driven — see docs/runbooks/relayer-operations.md).
+ */
+const CHAIN_NAMES = { 63: 'Mordor', 137: 'Polygon', 80002: 'Amoy', 1337: 'Hardhat' }
+
+function fmtRunway(hrs) {
+  if (hrs == null) return null
+  if (hrs >= 48) return { text: `${Math.round(hrs)}h`, tone: 'active' }
+  if (hrs >= 12) return { text: `${Math.round(hrs)}h`, tone: 'warning' }
+  return { text: `${Math.max(0, Math.round(hrs))}h`, tone: 'paused' }
+}
+
+function ServiceHealthCard() {
+  const { configured, loading, reachable, status, lastChecked, refresh } = useGatewayStatus()
+
+  return (
+    <div className="admin-card">
+      <div className="admin-card-header">
+        <h3>Gasless Infrastructure</h3>
+        <button
+          type="button"
+          className="refresh-btn"
+          onClick={refresh}
+          disabled={!configured || loading}
+          aria-label="Refresh service health"
+        >
+          ↻
+        </button>
+      </div>
+
+      {!configured && (
+        <p className="card-info">
+          No relay gateway configured (<code>VITE_RELAYER_URL</code> unset). Gasless flows fall
+          back to self-submit; nothing to monitor here.
+        </p>
+      )}
+
+      {configured && (
+        <div className="status-details">
+          <div className="status-row">
+            <span className="status-label">Relay gateway</span>
+            <span className={`status-value ${loading ? '' : reachable ? 'active' : 'paused'}`}>
+              {loading ? 'Checking…' : reachable ? 'Reachable' : 'Unreachable'}
+            </span>
+          </div>
+          {reachable && status && (
+            <div className="status-row">
+              <span className="status-label">Kill switch</span>
+              <span className={`status-value ${status.killSwitch ? 'paused' : 'active'}`}>
+                {status.killSwitch ? 'ACTIVE — relaying halted' : 'Off'}
+              </span>
+            </div>
+          )}
+          {reachable && status?.chains.map((c) => {
+            const gas = fmtRunway(c.gasWalletRunwayHrs)
+            const pm = fmtRunway(c.paymasterDepositRunwayHrs)
+            return (
+              <div key={c.chainId} className="status-row">
+                <span className="status-label">
+                  {CHAIN_NAMES[c.chainId] || `Chain ${c.chainId}`} RPC
+                </span>
+                <span className={`status-value ${c.rpc === 'up' ? 'active' : 'paused'}`}>
+                  {c.rpc === 'up' ? 'Up' : 'Down'}
+                  {gas && ` · gas ${gas.text}`}
+                  {pm && ` · paymaster ${pm.text}`}
+                </span>
+              </div>
+            )
+          })}
+          {reachable && status && !status.hasOperatorTelemetry && (
+            <p className="card-info">
+              Runway telemetry (gas wallet / paymaster deposit) is only disclosed to
+              origin-authenticated callers; showing the public subset.
+            </p>
+          )}
+          {lastChecked && (
+            <p className="card-info">
+              Last checked {new Date(lastChecked).toLocaleTimeString()} · network{' '}
+              {NETWORK_CONFIG.name}. Killswitch and quotas are operated via the runbook
+              (docs/runbooks/relayer-operations.md) — the gateway exposes no web admin API by
+              design.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ServiceHealthCard

--- a/frontend/src/components/admin/adminNav.js
+++ b/frontend/src/components/admin/adminNav.js
@@ -1,0 +1,94 @@
+/**
+ * Operations control plane navigation model.
+ *
+ * Pure function so the grouping/gating logic is unit-testable without
+ * rendering the panel. Each view is gated by the on-chain role it requires;
+ * a group renders only when the operator can use at least one view inside it.
+ *
+ * Icons are NavIcon glyph names (used by both PortalNav and the mobile
+ * SectionIconNav quick-nav).
+ */
+
+export const ADMIN_TAB_ICONS = {
+  overview: 'grid',
+  emergency: 'alert',
+  moderation: 'shieldOff',
+  'deny-list': 'ban',
+  tiers: 'layers',
+  members: 'users',
+  treasury: 'bank',
+  'protocol-config': 'settings',
+  'oracle-adapters': 'broadcast',
+  maintenance: 'sliders',
+  callsigns: 'ticket',
+  'admin-roles': 'key',
+  services: 'power',
+}
+
+export function buildAdminNavGroups({
+  isAdmin,
+  isGuardian,
+  isAccountModerator,
+  isRoleManager,
+  isSanctionsAdmin,
+}) {
+  const item = (id, label) => ({ id, label, icon: ADMIN_TAB_ICONS[id] })
+
+  const groups = [
+    {
+      label: 'Control Room',
+      items: [item('overview', 'Overview')],
+    },
+    {
+      label: 'Incident Response',
+      items: [
+        isGuardian && item('emergency', 'Emergency'),
+        isAccountModerator && item('moderation', 'Account Moderation'),
+      ].filter(Boolean),
+    },
+    {
+      label: 'Compliance',
+      items: [
+        (isSanctionsAdmin || isAdmin) && item('deny-list', 'Deny-list'),
+      ].filter(Boolean),
+    },
+    {
+      label: 'Membership & Revenue',
+      items: [
+        isAdmin && item('tiers', 'Tiers'),
+        isRoleManager && item('members', 'Members'),
+        isAdmin && item('treasury', 'Treasury'),
+      ].filter(Boolean),
+    },
+    {
+      label: 'Protocol Config',
+      items: [
+        isAdmin && item('protocol-config', 'Wiring & Tokens'),
+        isAdmin && item('oracle-adapters', 'Oracle Adapters'),
+        // Maintenance calls are permissionless on-chain; any operator may run them.
+        item('maintenance', 'Maintenance'),
+      ].filter(Boolean),
+    },
+    {
+      label: 'Identity',
+      items: [isAdmin && item('callsigns', 'Callsigns')].filter(Boolean),
+    },
+    {
+      label: 'Access Control',
+      items: [isAdmin && item('admin-roles', 'Admin Roles')].filter(Boolean),
+    },
+    {
+      label: 'Infrastructure',
+      items: [
+        (isAdmin || isGuardian) && item('services', 'Services'),
+      ].filter(Boolean),
+    },
+  ]
+
+  return groups.filter((g) => g.items.length > 0)
+}
+
+/** Flat item list (for the mobile SectionIconNav and default-tab checks). */
+export function flattenNavGroups(groups) {
+  return groups.flatMap((g) => g.items)
+}

--- a/frontend/src/config/contracts.js
+++ b/frontend/src/config/contracts.js
@@ -110,6 +110,7 @@ const POLYGON_CONTRACTS = {
   tokenFactory: '0x5806e76cA3c838524E7cF43db7625bdFBA0783a0',
   wagerPoolFactory: '0x420aEC3c76859eB74ab21c769c16AcdAB221f723',
   entryPoint: '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789',
+  verifyingPaymaster: '0xe14554D14eB5DeC47f7824ebeeDa6C9f3A50d105', // spec 050 — sponsored-gas paymaster (EntryPoint v0.6)
   accountFactory: '0xd519C25e9dEd0DAC586B764574100479CB318734',
   backupPointerRegistry: '0x664ACAd4d604c626A6160948Df9C10FE38010E11',
   safeProposalHub: '0x94b5b38C247CE51F7C42C83B63115998b7e970E7',

--- a/frontend/src/contexts/RoleContext.js
+++ b/frontend/src/contexts/RoleContext.js
@@ -20,6 +20,7 @@ export const ROLES = {
   GUARDIAN: 'GUARDIAN',                    // GUARDIAN_ROLE — pause/unpause
   ACCOUNT_MODERATOR: 'ACCOUNT_MODERATOR',  // ACCOUNT_MODERATOR_ROLE — freeze
   ROLE_MANAGER: 'ROLE_MANAGER',            // ROLE_MANAGER_ROLE — grant/revoke memberships
+  SANCTIONS_ADMIN: 'SANCTIONS_ADMIN',      // SANCTIONS_ADMIN_ROLE — deny-list (on SanctionsGuard)
 }
 
 export const ROLE_INFO = {
@@ -53,6 +54,12 @@ export const ROLE_INFO = {
     premium: false,
     isAdminRole: true
   },
+  [ROLES.SANCTIONS_ADMIN]: {
+    name: 'Compliance Officer',
+    description: 'Maintain the discretionary deny-list on SanctionsGuard (block/unblock addresses with an on-chain reason)',
+    premium: false,
+    isAdminRole: true
+  },
 }
 
 /**
@@ -64,6 +71,7 @@ export const ADMIN_ROLES = [
   ROLES.GUARDIAN,
   ROLES.ACCOUNT_MODERATOR,
   ROLES.ROLE_MANAGER,
+  ROLES.SANCTIONS_ADMIN,
 ]
 
 export function isAdminRole(role) {

--- a/frontend/src/contexts/WalletContext.jsx
+++ b/frontend/src/contexts/WalletContext.jsx
@@ -308,7 +308,7 @@ export function WalletProvider({ children }) {
    */
   const syncRolesWithBlockchain = useCallback(async (walletAddress, localRoles, activeChainId) => {
     const premiumRoles = ['WAGER_PARTICIPANT']
-    const adminRoles = ['ADMIN', 'GUARDIAN', 'ACCOUNT_MODERATOR', 'ROLE_MANAGER']
+    const adminRoles = ['ADMIN', 'GUARDIAN', 'ACCOUNT_MODERATOR', 'ROLE_MANAGER', 'SANCTIONS_ADMIN']
     const allSyncedRoles = [...premiumRoles, ...adminRoles]
     const updatedRoles = []
     let hasChanges = false

--- a/frontend/src/hooks/useGatewayStatus.js
+++ b/frontend/src/hooks/useGatewayStatus.js
@@ -1,0 +1,87 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+
+/**
+ * useGatewayStatus — poll the relay-gateway `GET /status` endpoint for the
+ * operations control plane.
+ *
+ * The gateway is GAS INFRASTRUCTURE with no admin API by design: this hook is
+ * strictly read-only telemetry. `/status` (not `/healthz` — Google's GFE
+ * intercepts that literal path on Cloud Run) returns:
+ *
+ *   { status: 'ok'|..., killSwitch: boolean,
+ *     chains: { <chainId>: { rpc: 'up'|'down',
+ *                            gasWalletRunwayHrs?, paymasterDepositRunwayHrs? } } }
+ *
+ * The runway fields are operator telemetry the gateway only discloses to
+ * callers presenting a valid X-Origin-Auth header (injected zone-wide by
+ * Cloudflare in production) — when absent we render the public subset.
+ */
+
+const POLL_MS = 60_000
+const FETCH_TIMEOUT_MS = 5_000
+
+export function gatewayBaseUrl() {
+  return (import.meta.env.VITE_RELAYER_URL || '').trim().replace(/\/$/, '')
+}
+
+/** Normalize a raw /status payload into what the control plane renders. */
+export function parseGatewayStatus(data) {
+  if (!data || typeof data !== 'object') return null
+  const chains = Object.entries(data.chains || {}).map(([chainId, c]) => ({
+    chainId: Number(chainId),
+    rpc: c?.rpc === 'up' ? 'up' : 'down',
+    gasWalletRunwayHrs: typeof c?.gasWalletRunwayHrs === 'number' ? c.gasWalletRunwayHrs : null,
+    paymasterDepositRunwayHrs:
+      typeof c?.paymasterDepositRunwayHrs === 'number' ? c.paymasterDepositRunwayHrs : null,
+  }))
+  return {
+    ok: data.status === 'ok',
+    killSwitch: data.killSwitch === true,
+    chains,
+    // Operator telemetry present only when the gateway trusted our origin.
+    hasOperatorTelemetry: chains.some(
+      (c) => c.gasWalletRunwayHrs != null || c.paymasterDepositRunwayHrs != null
+    ),
+  }
+}
+
+export function useGatewayStatus() {
+  const configured = Boolean(gatewayBaseUrl())
+  const [state, setState] = useState({
+    loading: configured,
+    reachable: false,
+    status: null,
+    lastChecked: null,
+  })
+  const timerRef = useRef(null)
+
+  const fetchStatus = useCallback(async () => {
+    const base = gatewayBaseUrl()
+    if (!base) return
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    try {
+      const res = await fetch(`${base}/status`, { method: 'GET', signal: controller.signal })
+      const data = res.ok ? await res.json().catch(() => null) : null
+      setState({
+        loading: false,
+        reachable: res.ok && data != null,
+        status: parseGatewayStatus(data),
+        lastChecked: Date.now(),
+      })
+    } catch {
+      setState({ loading: false, reachable: false, status: null, lastChecked: Date.now() })
+    } finally {
+      clearTimeout(timeout)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!configured) return undefined
+    fetchStatus()
+    timerRef.current = setInterval(fetchStatus, POLL_MS)
+    return () => clearInterval(timerRef.current)
+  }, [configured, fetchStatus])
+
+  return { configured, refresh: fetchStatus, ...state }
+}

--- a/frontend/src/test/accessibility.test.jsx
+++ b/frontend/src/test/accessibility.test.jsx
@@ -253,9 +253,10 @@ describe('OpenChallengeModal Accessibility (feature 024, WCAG 2.1 AA)', () => {
 
   it('has no axe violations with an info bubble open (spec 039 FR-007)', async () => {
     const { container } = render(<OpenChallengeModal isOpen onClose={() => {}} />)
-    // The "How is it resolved?" InfoTip was removed (spec 054); use a surviving
-    // field explainer to exercise the info-bubble-open a11y state.
-    fireEvent.click(screen.getByRole('button', { name: "About: What's the wager?" }))
+    // The per-field InfoTips were removed one by one to conserve space (specs 052/054/058);
+    // the modal-title explainer is the surviving info icon, so use it to exercise the
+    // info-bubble-open a11y state.
+    fireEvent.click(screen.getByRole('button', { name: 'About open challenges' }))
     expect(screen.getByRole('note')).toBeInTheDocument()
     expect(await axe(container)).toHaveNoViolations()
   })
@@ -263,13 +264,13 @@ describe('OpenChallengeModal Accessibility (feature 024, WCAG 2.1 AA)', () => {
   it('info icons are keyboard operable: focus, Enter opens, Escape closes and restores focus (spec 039 FR-007)', async () => {
     const user = userEvent.setup()
     render(<OpenChallengeModal isOpen onClose={() => {}} />)
-    // The stake caption + its InfoTip were removed to conserve space (spec 052); use a
-    // surviving field explainer to exercise keyboard operability of the info icons.
-    const icon = screen.getByRole('button', { name: "About: What's the wager?" })
+    // The per-field InfoTips were removed to conserve space (specs 052/054/058); the
+    // modal-title explainer is the surviving info icon for keyboard-operability coverage.
+    const icon = screen.getByRole('button', { name: 'About open challenges' })
     icon.focus()
     expect(icon).toHaveFocus()
     await user.keyboard('{Enter}')
-    expect(screen.getByRole('note')).toHaveTextContent(/the taker takes the opposite/i)
+    expect(screen.getByRole('note')).toHaveTextContent(/take the other side/i)
     await user.keyboard('{Escape}')
     expect(screen.queryByRole('note')).not.toBeInTheDocument()
     expect(icon).toHaveFocus()

--- a/frontend/src/test/adminNav.test.js
+++ b/frontend/src/test/adminNav.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildAdminNavGroups,
+  flattenNavGroups,
+  ADMIN_TAB_ICONS,
+} from '../components/admin/adminNav'
+
+const NO_ROLES = {
+  isAdmin: false,
+  isGuardian: false,
+  isAccountModerator: false,
+  isRoleManager: false,
+  isSanctionsAdmin: false,
+}
+
+const ids = (groups) => flattenNavGroups(groups).map((i) => i.id)
+const labels = (groups) => groups.map((g) => g.label)
+
+describe('buildAdminNavGroups', () => {
+  it('full admin sees every group', () => {
+    const groups = buildAdminNavGroups({
+      isAdmin: true,
+      isGuardian: true,
+      isAccountModerator: true,
+      isRoleManager: true,
+      isSanctionsAdmin: true,
+    })
+    expect(labels(groups)).toEqual([
+      'Control Room',
+      'Incident Response',
+      'Compliance',
+      'Membership & Revenue',
+      'Protocol Config',
+      'Identity',
+      'Access Control',
+      'Infrastructure',
+    ])
+    expect(ids(groups)).toContain('protocol-config')
+    expect(ids(groups)).toContain('services')
+    expect(ids(groups)).toContain('maintenance')
+  })
+
+  it('an operator with no roles still gets Overview and Maintenance (permissionless calls)', () => {
+    const groups = buildAdminNavGroups(NO_ROLES)
+    expect(ids(groups)).toEqual(['overview', 'maintenance'])
+  })
+
+  it('empty groups are dropped entirely', () => {
+    const groups = buildAdminNavGroups({ ...NO_ROLES, isGuardian: true })
+    expect(labels(groups)).not.toContain('Compliance')
+    expect(labels(groups)).not.toContain('Membership & Revenue')
+    expect(labels(groups)).not.toContain('Access Control')
+  })
+
+  it('guardian gets Incident Response and Infrastructure but not admin-only views', () => {
+    const groups = buildAdminNavGroups({ ...NO_ROLES, isGuardian: true })
+    const flat = ids(groups)
+    expect(flat).toContain('emergency')
+    expect(flat).toContain('services')
+    expect(flat).not.toContain('tiers')
+    expect(flat).not.toContain('admin-roles')
+    expect(flat).not.toContain('protocol-config')
+  })
+
+  it('a compliance officer without full admin reaches the deny-list', () => {
+    const groups = buildAdminNavGroups({ ...NO_ROLES, isSanctionsAdmin: true })
+    expect(ids(groups)).toContain('deny-list')
+  })
+
+  it('role manager sees Members but not Tiers/Treasury (admin-only)', () => {
+    const groups = buildAdminNavGroups({ ...NO_ROLES, isRoleManager: true })
+    const flat = ids(groups)
+    expect(flat).toContain('members')
+    expect(flat).not.toContain('tiers')
+    expect(flat).not.toContain('treasury')
+  })
+
+  it('every view carries a known NavIcon glyph for the mobile quick-nav', () => {
+    const groups = buildAdminNavGroups({
+      isAdmin: true,
+      isGuardian: true,
+      isAccountModerator: true,
+      isRoleManager: true,
+      isSanctionsAdmin: true,
+    })
+    for (const item of flattenNavGroups(groups)) {
+      expect(item.icon, `icon for ${item.id}`).toBe(ADMIN_TAB_ICONS[item.id])
+      expect(item.icon).toBeTruthy()
+    }
+  })
+})

--- a/frontend/src/test/claimCode/OpenChallengeModal.test.jsx
+++ b/frontend/src/test/claimCode/OpenChallengeModal.test.jsx
@@ -109,14 +109,15 @@ describe('OpenChallengeModal explainers behind info icons (spec 039 US1)', () =>
 
   it('hides the static field explainers by default and reveals each from its icon, one at a time', () => {
     render(<OpenChallengeModal isOpen onClose={() => {}} />)
-    expect(screen.queryByText(/the taker takes the opposite/i)).toBeNull()
+    expect(screen.queryByText(/take the other side/i)).toBeNull()
     expect(screen.queryByText(/single-party self-resolution/i)).toBeNull()
 
-    // The stake caption + its InfoTip, and the "How is it resolved?" InfoTip, were removed
-    // to conserve space (specs 052/054 feedback); the remaining field explainer still
-    // reveals from its icon.
-    fireEvent.click(screen.getByRole('button', { name: "About: What's the wager?" }))
-    expect(screen.getByRole('note')).toHaveTextContent(/the taker takes the opposite/i)
+    // The stake caption + its InfoTip, the "How is it resolved?" InfoTip, and the wager
+    // memo's field explainer were all removed to conserve space (specs 052/054/058
+    // feedback — the memo's placeholder now explains itself); the modal-title explainer
+    // is the surviving info icon and still reveals from its icon.
+    fireEvent.click(screen.getByRole('button', { name: 'About open challenges' }))
+    expect(screen.getByRole('note')).toHaveTextContent(/take the other side/i)
   })
 
   it('keeps dynamic text inline on the success screen: security warning visible, backup explainer behind its icon', async () => {

--- a/frontend/src/test/gatewayStatus.test.js
+++ b/frontend/src/test/gatewayStatus.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { parseGatewayStatus } from '../hooks/useGatewayStatus'
+
+describe('parseGatewayStatus', () => {
+  it('returns null for non-objects', () => {
+    expect(parseGatewayStatus(null)).toBeNull()
+    expect(parseGatewayStatus('nope')).toBeNull()
+    expect(parseGatewayStatus(undefined)).toBeNull()
+  })
+
+  it('parses a full operator-telemetry payload', () => {
+    const parsed = parseGatewayStatus({
+      status: 'ok',
+      killSwitch: false,
+      chains: {
+        137: { rpc: 'up', gasWalletRunwayHrs: 72.4, paymasterDepositRunwayHrs: 120 },
+        63: { rpc: 'down' },
+      },
+    })
+    expect(parsed.ok).toBe(true)
+    expect(parsed.killSwitch).toBe(false)
+    expect(parsed.hasOperatorTelemetry).toBe(true)
+    const polygon = parsed.chains.find((c) => c.chainId === 137)
+    expect(polygon).toMatchObject({
+      rpc: 'up',
+      gasWalletRunwayHrs: 72.4,
+      paymasterDepositRunwayHrs: 120,
+    })
+    const mordor = parsed.chains.find((c) => c.chainId === 63)
+    expect(mordor).toMatchObject({
+      rpc: 'down',
+      gasWalletRunwayHrs: null,
+      paymasterDepositRunwayHrs: null,
+    })
+  })
+
+  it('flags the public (unauthenticated) subset — no runway fields', () => {
+    const parsed = parseGatewayStatus({
+      status: 'ok',
+      killSwitch: false,
+      chains: { 137: { rpc: 'up' } },
+    })
+    expect(parsed.hasOperatorTelemetry).toBe(false)
+  })
+
+  it('surfaces an active killswitch and non-ok status', () => {
+    const parsed = parseGatewayStatus({ status: 'degraded', killSwitch: true, chains: {} })
+    expect(parsed.ok).toBe(false)
+    expect(parsed.killSwitch).toBe(true)
+    expect(parsed.chains).toEqual([])
+  })
+
+  it('treats unknown rpc values as down (fail-visible)', () => {
+    const parsed = parseGatewayStatus({
+      status: 'ok',
+      chains: { 137: { rpc: 'weird' } },
+    })
+    expect(parsed.chains[0].rpc).toBe('down')
+  })
+})

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -655,6 +655,7 @@ const ROLE_NAME_TO_HASH = {
   'GUARDIAN': ethers.keccak256(ethers.toUtf8Bytes('GUARDIAN_ROLE')),
   'ACCOUNT_MODERATOR': ethers.keccak256(ethers.toUtf8Bytes('ACCOUNT_MODERATOR_ROLE')),
   'ROLE_MANAGER': ethers.keccak256(ethers.toUtf8Bytes('ROLE_MANAGER_ROLE')),
+  'SANCTIONS_ADMIN': ethers.keccak256(ethers.toUtf8Bytes('SANCTIONS_ADMIN_ROLE')),
 }
 
 // Minimal ABI for role manager contract
@@ -1008,14 +1009,18 @@ export async function hasRoleOnChain(userAddress, roleName, chainId) {
 
   // Admin roles use OpenZeppelin AccessControl.hasRole. ADMIN /
   // ACCOUNT_MODERATOR / GUARDIAN live on WagerRegistry; ROLE_MANAGER lives
-  // on MembershipManager. DEFAULT_ADMIN_ROLE (ADMIN) is set on both — we
-  // check WagerRegistry first because it's the canonical operator surface.
+  // on MembershipManager; SANCTIONS_ADMIN lives on SanctionsGuard.
+  // DEFAULT_ADMIN_ROLE (ADMIN) is set on both core contracts — we check
+  // WagerRegistry first because it's the canonical operator surface.
   const accessControlAbi = [
     'function hasRole(bytes32 role, address account) view returns (bool)'
   ]
   const candidates = []
   if (roleName === 'ROLE_MANAGER') {
     const addr = resolveAddress('membershipManager')
+    if (addr) candidates.push(addr)
+  } else if (roleName === 'SANCTIONS_ADMIN') {
+    const addr = resolveAddress('sanctionsGuard')
     if (addr) candidates.push(addr)
   } else {
     const wager = resolveAddress('wagerRegistry')


### PR DESCRIPTION
## Summary

Audits every administrative control surface on the platform (contracts, off-chain services, frontend), documents the gaps, and consolidates the `/admin` panel into a grouped **operations control plane** where controls are performed, metrics read, and positive control of the platform demonstrated from one place.

The inventory of record and 10-item gap analysis live in **`docs/system-overview/control-surface-audit.md`**.

## What changed

### Information architecture
- The flat 10-tab panel is regrouped into operator groups via the existing `PortalNav` grouped rail: **Control Room · Incident Response · Compliance · Membership & Revenue · Protocol Config · Identity · Access Control · Infrastructure**.
- Grouping/gating logic extracted to a pure, unit-tested module (`frontend/src/components/admin/adminNav.js`). A group only renders if the operator holds a role that can use something inside it.

### Previously missing controls, now built
- **Protocol Config — Wiring & Tokens** (`ProtocolConfigTab.jsx`): live wiring readout (previously unreadable without a block explorer) + admin setters: sanctions guards (with explicit screening-disable warnings), oracle adapter routing (Chainlink Data Feed / Functions / UMA), Polymarket adapter, treasury, payment token, stake-token allowlist, membership hook callers.
- **Maintenance** (`MaintenanceTab.jsx`): permissionless `batchExpireOpen` expiry sweep and `autoResolveFromPolymarket`/`autoResolveFromOracle` triggers.
- **Infrastructure — Services**: relay-gateway `/status` telemetry (killswitch state, per-chain RPC, gas-wallet + paymaster-deposit runway) via a new `useGatewayStatus` hook (`ServiceHealthCard.jsx`, also shown on the Guardian's Emergency screen), plus spec-050 paymaster operations (`PaymasterOpsCard.jsx`): EntryPoint deposit/runway readout, permissionless top-up, owner-only withdraw and verifying-signer rotation. Runbook-operated controls (gateway killswitch, quotas, builder fee) are documented in-panel — the gateway deliberately has no web admin API.

### Operator roles
- **`SANCTIONS_ADMIN` (Compliance Officer)** promoted to a first-class frontend role: role model, chain sync, on-chain reader (checks SanctionsGuard), and portal access. The deny-list view is now gated on the real on-chain role instead of DEFAULT_ADMIN only.
- Admin Roles view can grant/revoke **SANCTIONS_ADMIN** (SanctionsGuard) and **TOKEN_ISSUER** (TokenFactory), routed to the contract that defines each role.
- No new on-chain roles required; future candidates (Treasurer split, oracle-adapter ownership migration) documented in the audit.

### Config
- `verifyingPaymaster` added to the Polygon address book (from `deployments/polygon-chain137-v2.json`).

## Testing
- 12 new unit tests (`adminNav.test.js`, `gatewayStatus.test.js`) pass.
- Targeted ESLint on all touched files: no errors (one pre-existing-pattern fetch-in-effect warning).
- `npm run build` passes.
- No contract changes; frontend + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTtFVwFXC738JYvU1jCFjc

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTtFVwFXC738JYvU1jCFjc)_