### PR TITLE
Refresh operations documentation for the control plane

### DIFF
--- a/docs/developer-guide/frontend.md
+++ b/docs/developer-guide/frontend.md
@@ -45,7 +45,7 @@ frontend/src/
 | `/app` (aliases `/main`, `/fairwins`) | Dashboard | main workspace, inside `AppLayout` (Header + EntryGate + Footer) |
 | `/wallet` | WalletPage | Account Center: Account / Membership / Security / Preferences / Swap tabs |
 | `/friend-market/accept` | MarketAcceptancePage | QR / deep-link wager acceptance (`?marketId=N`) |
-| `/admin` | AdminPanel | role-gated (Guardian / Role Manager / Account Moderator / Admin) |
+| `/admin` | AdminPanel | the operations control plane, grouped by operator area; role-gated (Admin / Guardian / Account Moderator / Role Manager / Compliance Officer) — see `docs/runbooks/operations-control-plane.md` |
 | `*` | redirect to `/` | |
 
 ## Getting started

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -4,11 +4,26 @@ This directory contains step-by-step operational guides, integration procedures,
 
 ## Contents
 
-### Integration Guides
-- **[batch-operations.md](./batch-operations.md)** - Complete integration guide for batch processing APIs with examples in JavaScript, Python, and React
+### Operating the platform
+- **[operations-control-plane.md](./operations-control-plane.md)** - The operator console at `/admin`: every group and view, role gates, step-by-step how-tos, and troubleshooting
+- **[operator-onboarding.md](./operator-onboarding.md)** - Operator personas and responsibilities, role grant/verification procedure, offboarding
+- **[relayer-operations.md](./relayer-operations.md)** - Gasless intent relayer (spec 036): gateway/engine components, hot-key management, killswitch, OpenSea/Polymarket proxy ops, incident table
+- **[paymaster-operations.md](./paymaster-operations.md)** - Sponsored-gas paymaster (spec 050): deposit funding and runway, monitoring, killswitch, signer rotation, compromise response
+- **[callsigns-operations.md](./callsigns-operations.md)** - Deploy the `%callsign` naming registry, wire the frontend, grant operator roles, and moderate / tune / monitor it from the control plane (spec 054)
+- **[contract-upgrades.md](./contract-upgrades.md)** - UUPS proxy upgrade procedure: storage-layout gate, in-place upgrades, rollback
 
-### Deploy & Operations
-- **[callsigns-operations.md](./callsigns-operations.md)** - Deploy the `%callsign` naming registry, wire the frontend, grant operator roles, and moderate / tune / monitor it from the admin screen (spec 054)
+### Deploy
+- **[relayer-mordor-deploy.md](./relayer-mordor-deploy.md)** - First bring-up of the relayer stack on Mordor: GCP prerequisites, KMS keys, Cloud Run, origin lock, validation
+- **[zk-wager-pools-deploy.md](./zk-wager-pools-deploy.md)** - WagerPoolFactory (spec 034) append-only deploy, wiring matrix, subgraph publish
+- **[safe-proposal-hub-deploy.md](./safe-proposal-hub-deploy.md)** - SafeProposalHub (spec 043) events-only helper deploy
+
+### Integration & user-facing procedures
+- **[batch-operations.md](./batch-operations.md)** - Complete integration guide for batch processing APIs with examples in JavaScript, Python, and React
+- **[passkey-account-recovery.md](./passkey-account-recovery.md)** - End-user recovery paths for passkey smart-wallet accounts
+
+The full inventory of administrative control surfaces (on-chain, service, and
+frontend) and the gap analysis behind the control plane's structure live in
+[docs/system-overview/control-surface-audit.md](../system-overview/control-surface-audit.md).
 
 ## Purpose
 

--- a/docs/runbooks/callsigns-operations.md
+++ b/docs/runbooks/callsigns-operations.md
@@ -86,9 +86,10 @@ operator roles gate the work:
 Grant them to your operators from the admin screen (below) or directly. Follow
 least-privilege: give moderators only `MODERATOR_ROLE`, not admin.
 
-## Operate: the AdminPanel "Callsigns" tab
+## Operate: the control plane's Callsigns view
 
-Everything below is a role-gated write from `/admin` → **Callsigns** (component
+Everything below is a role-gated write from `/admin` → **Identity →
+Callsigns** in the operations control plane (component
 `frontend/src/components/admin/CallsignRegistryAdmin.jsx`). Each control is enabled only if
 your connected wallet holds the matching role **on this contract** (read live via
 `hasRole`). Writes go through the standard admin `runTx` (plain signer — admin actions
@@ -175,7 +176,7 @@ on-chain with `setReserved` (CURATOR) — via the admin screen or directly.
 
 | Symptom | Cause / fix |
 |---------|-------------|
-| Admin tab shows "not deployed / configured on this network" | Address not synced. Run `npm run sync:frontend-contracts` after deploy. |
+| Callsigns view shows "not deployed / configured on this network" | Address not synced. Run `npm run sync:frontend-contracts` after deploy. |
 | A moderation button is disabled | Your wallet lacks that role on this contract. Have an admin grant CURATOR/MODERATOR/VERIFIER. |
 | Deploy aborts "already recorded" | `callsignRegistry` is already in the record — use an upgrade, not this script. |
 | Deploy aborts "No membershipManager" | The network's `-v2.json` record has no `membershipManager`; deploy the core stack first. |

--- a/docs/runbooks/operations-control-plane.md
+++ b/docs/runbooks/operations-control-plane.md
@@ -1,0 +1,149 @@
+# Runbook: The Operations Control Plane (`/admin`)
+
+The operations control plane is the grouped operator console at `/admin`
+(`frontend/src/components/AdminPanel.jsx`). It is where platform controls are
+performed, metrics read, and positive control demonstrated. Every view is
+gated by the on-chain role its actions require — a view (and its group) only
+renders if the connected wallet holds that role.
+
+All writes are **plain signer transactions** (operator actions are never
+gasless). Addresses resolve per-chain via `getContractAddressForChain`; a view
+soft-fails with an explanatory card when its contract is not deployed on the
+connected network.
+
+Related: [operator onboarding](operator-onboarding.md) ·
+[control-surface audit](../system-overview/control-surface-audit.md) ·
+[roles overview](../system-overview/roles-and-tiers.md)
+
+## Map: groups, views, and gates
+
+| Group | View | Requires | Acts on |
+|---|---|---|---|
+| Control Room | Overview | any operator role | read-only |
+| Incident Response | Emergency | `GUARDIAN_ROLE` | WagerRegistry |
+| Incident Response | Account Moderation | `ACCOUNT_MODERATOR_ROLE` | WagerRegistry |
+| Compliance | Deny-list | `SANCTIONS_ADMIN_ROLE` (or admin) | SanctionsGuard |
+| Membership & Revenue | Tiers | `DEFAULT_ADMIN_ROLE` | MembershipManager |
+| Membership & Revenue | Members | `ROLE_MANAGER_ROLE` | MembershipManager |
+| Membership & Revenue | Treasury | `DEFAULT_ADMIN_ROLE` | MembershipManager |
+| Protocol Config | Wiring & Tokens | `DEFAULT_ADMIN_ROLE` | WagerRegistry, MembershipManager, SanctionsGuard |
+| Protocol Config | Oracle Adapters | adapter `owner` | the three oracle adapters |
+| Protocol Config | Maintenance | none (permissionless calls) | WagerRegistry (intents facet) |
+| Identity | Callsigns | callsign registry roles | CallsignRegistry |
+| Access Control | Admin Roles | `DEFAULT_ADMIN_ROLE` | role-defining contracts |
+| Infrastructure | Services | admin or guardian | read-only + paymaster |
+
+## How-to: common procedures
+
+### Emergency-pause the protocol (Guardian)
+
+1. `/admin` → **Incident Response → Emergency**.
+2. Confirm the incident justifies a protocol-wide stop (see
+   [security](../system-overview/security.md)); pausing halts wager creation,
+   acceptance, and settlement. Draw/refund/claim exit paths stay open.
+3. **Pause Protocol** → sign. The header status dot and Overview flip to
+   *Paused* within one poll (≤30 s).
+4. The same screen shows the gasless-infrastructure health card: a full stop
+   is the on-chain pause **plus** the gateway killswitch — the latter is
+   runbook-operated ([relayer-operations](relayer-operations.md)), not a
+   button here, by design.
+5. After remediation, **Unpause Protocol** from the same view.
+
+### Freeze / unfreeze an account (Account Moderator)
+
+1. `/admin` → **Incident Response → Account Moderation**.
+2. Enter the address or ENS name and a **reason** — the reason is recorded
+   on-chain in the `AccountFrozen` event and is mandatory. Grounds and the
+   appeal path are in the
+   [account moderation policy](../system-overview/account-moderation.md).
+3. **Freeze Account** → sign. A frozen account cannot create, accept, cancel,
+   declare, claim, or refund on WagerRegistry. Unfreeze from the same view.
+
+### Deny-list an address (Compliance Officer)
+
+1. `/admin` → **Compliance → Deny-list**.
+2. Check current status first (the view reads `isDenied` / `isAllowed`).
+3. Set denied with a written reason → sign. The audit trail table below the
+   form is built from `DenyListUpdated` events.
+4. Note the split of powers: the deny-list is `SANCTIONS_ADMIN_ROLE`; pointing
+   the guard at a different Chainalysis oracle (or disabling oracle screening)
+   is `DEFAULT_ADMIN_ROLE` under **Protocol Config → Wiring & Tokens**.
+
+### Configure tiers, grant memberships, withdraw fees
+
+- **Tiers** (admin): set price / duration / monthly + concurrent caps per
+  tier; the active checkbox controls purchasability.
+- **Members** (role manager): grant a membership out-of-band (support, gifts,
+  dispute resolution) or revoke one. Revocation does not refund USDC.
+- **Treasury** (admin): withdraw accrued tier fees in USDC. The recipient
+  defaults to the configured on-chain treasury; the current accrued balance
+  and a **Max** shortcut are shown.
+
+### Rewire protocol config (admin — high consequence)
+
+`/admin` → **Protocol Config → Wiring & Tokens**.
+
+1. Read the **Live Wiring** card first — it shows every wired address
+   (membership manager, sanctions guards, oracle adapters, Polymarket
+   adapter, treasury, payment token, voucher, Chainalysis oracle) so you can
+   verify state before and after a change.
+2. Use **Rewire Address** for single-address slots. For guard slots,
+   `address(0)` **disables screening** and the form warns accordingly —
+   follow compliance sign-off before doing this.
+3. **Oracle Adapter Routing** maps a resolution type (Chainlink Data Feed /
+   Chainlink Functions / UMA) to its adapter.
+4. **Stake Token Allowlist**: check a token's current status, then allow or
+   disallow. Disallowing blocks new wagers only; existing escrow settles.
+5. The intents facet pointer is displayed read-only — swapping it is
+   `UPGRADER_ROLE` via the [upgrade runbook](contract-upgrades.md), never
+   from this screen.
+
+### Run maintenance sweeps (any operator)
+
+`/admin` → **Protocol Config → Maintenance**. Both calls are permissionless
+on-chain; the view exists so operators can act without CLI tooling.
+
+- **Expire Open Wagers** — enter wager IDs; expired Open wagers past their
+  accept deadline are refunded to creators and their concurrent slots freed.
+  Stale IDs are skipped harmlessly.
+- **Trigger Auto-Resolution** — nudge an oracle-resolvable wager (Polymarket
+  or a configured adapter) to settlement. The oracle outcome, not the
+  caller, decides the winner.
+
+### Monitor and fund the gasless infrastructure
+
+`/admin` → **Infrastructure → Services** (admin or guardian).
+
+- The **Gasless Infrastructure** card reads the relay-gateway `GET /status`:
+  gateway reachability, killswitch state, per-chain RPC, and — for
+  origin-authenticated callers — gas-wallet and paymaster-deposit runway
+  hours. It is read-only; the gateway has no web admin API by design.
+- The **Sponsored-Gas Paymaster** card (spec 050) shows the EntryPoint
+  deposit (the sponsorship loss cap), verifying signer, and owner. Anyone can
+  **top up** the deposit; **withdraw** and **rotate signer** are owner-only
+  and part of incident response
+  ([paymaster-operations](paymaster-operations.md)).
+- Controls that stay runbook-operated (killswitch, quotas, builder fee,
+  relayer per-chain pause) are listed on the same screen with their runbook
+  pointers.
+
+### Grant or revoke an operator role (admin)
+
+1. `/admin` → **Access Control → Admin Roles**.
+2. Pick the role — Guardian, Account Moderator, Role Manager, Compliance
+   Officer (`SANCTIONS_ADMIN_ROLE`, lives on SanctionsGuard), Token Issuer
+   (TokenFactory), or Default Admin (rare). The panel routes the grant to the
+   contract that defines the role.
+3. Enter the address or ENS name → **Grant Role** → sign. Follow the
+   least-privilege guidance in [operator onboarding](operator-onboarding.md).
+
+## Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---|---|
+| "Access Restricted" on `/admin` | Connected wallet holds no operator role on this chain. Roles are chain-scoped — check the network selector first. |
+| A group/view is missing from the rail | You lack the gating role; the rail only shows what you can use. |
+| A view shows "not deployed on this network" | Address not in the frontend address book for this chain — run `npm run sync:frontend-contracts` after deploy. |
+| Gasless card shows "No relay gateway configured" | `VITE_RELAYER_URL` unset in this build; gasless flows self-submit. Expected in local dev. |
+| Runway numbers missing from the health card | The gateway only discloses operator telemetry to origin-authenticated callers; the public subset (RPC up/down) still renders. |
+| A write reverts with an AccessControl error | The role lives on a different contract than you expect (e.g. `SANCTIONS_ADMIN_ROLE` is on SanctionsGuard, not the registry) or you hold it on another chain. |

--- a/docs/runbooks/operator-onboarding.md
+++ b/docs/runbooks/operator-onboarding.md
@@ -1,0 +1,84 @@
+# Runbook: Operator Onboarding & Role Responsibilities
+
+How to bring a new operator onto the platform, what each operator persona is
+responsible for, and how to offboard cleanly. Companion to the
+[operations control plane runbook](operations-control-plane.md) (the how-to
+for each console view) and the
+[roles overview](../system-overview/roles-and-tiers.md) (the authority /
+separation-of-powers reference).
+
+## Operator personas and responsibilities
+
+Grant the **narrowest role that covers the job**. One person may hold several
+roles, but each grant should be justified by a responsibility below.
+
+| Persona | On-chain role (contract) | Responsible for | Console home |
+|---|---|---|---|
+| Incident Commander | `GUARDIAN_ROLE` (WagerRegistry) | Emergency pause/unpause; watching protocol + gateway health; first responder on security incidents | Incident Response, Infrastructure |
+| Trust & Safety | `ACCOUNT_MODERATOR_ROLE` (WagerRegistry) | Freezing/unfreezing accounts per the [moderation policy](../system-overview/account-moderation.md); documenting reasons on-chain | Incident Response |
+| Compliance Officer | `SANCTIONS_ADMIN_ROLE` (SanctionsGuard) | The discretionary deny-list; reviewing the `DenyListUpdated` audit trail; escalating oracle-screening changes to the admin | Compliance |
+| Member Support | `ROLE_MANAGER_ROLE` (MembershipManager) | Out-of-band membership grants/revocations (support, gifts, dispute resolution) | Membership & Revenue |
+| Protocol Administrator | `DEFAULT_ADMIN_ROLE` (MembershipManager + WagerRegistry) | Tier/pricing config, treasury withdrawals, protocol wiring, and granting every other role. Highest-consequence key — multisig or floppy keystore only | all groups |
+| Token Operations | `TOKEN_ISSUER_ROLE` (TokenFactory) | Token issuance through the factory | Access Control (grants); issuance is CLI/spec-driven |
+| Identity Moderation | `REGISTRY_CURATOR_ROLE` / `MODERATOR_ROLE` / `VERIFIER_ROLE` (CallsignRegistry) | Reserving, suspending, verifying `%callsigns` ([runbook](callsigns-operations.md)) | Identity |
+| Release Engineer | `UPGRADER_ROLE` (all UUPS proxies) | Contract upgrades via the [upgrade runbook](contract-upgrades.md). Air-gapped floppy keystore; **never** exercised from the web console | — (CLI only) |
+| Infra Operator | none (GCP IAM instead) | Relay gateway, oz-relayer, alto bundler, paymaster funding cadence ([relayer](relayer-operations.md) / [paymaster](paymaster-operations.md) runbooks) | Infrastructure (read-only telemetry) |
+
+Standing duty for **every** operator: start each session on **Control Room →
+Overview** — protocol status, accrued fees, membership metrics, service
+health, and your own permissions on one screen. Anomalies (unexpected pause,
+killswitch active, runway warnings) go to the incident channel before
+anything else.
+
+## Onboarding a new operator
+
+### Prerequisites (the operator)
+
+1. A dedicated operator wallet — hardware-backed where the persona's blast
+   radius warrants it (Guardian, Compliance, and above: always). Never reuse
+   a personal trading wallet.
+2. The wallet funded with a small amount of native gas token on the target
+   chain — operator actions are plain signed transactions, never gasless.
+3. Read, for every persona: the [roles overview](../system-overview/roles-and-tiers.md)
+   and the [control plane runbook](operations-control-plane.md). Persona-specific:
+   Trust & Safety reads the [moderation policy](../system-overview/account-moderation.md);
+   Incident Commanders read [security](../system-overview/security.md) and the
+   [relayer runbook](relayer-operations.md) killswitch section.
+
+### Grant procedure (an existing admin)
+
+1. Verify the request: persona, justification, wallet address (confirmed
+   out-of-band — read it back over a second channel).
+2. `/admin` → **Access Control → Admin Roles** → select the role → paste the
+   address (or ENS) → **Grant Role** → sign. The panel routes the grant to
+   the contract that defines the role. Callsign roles are granted from
+   **Identity → Callsigns** instead.
+3. Record the grant (who, role, why, date) in the ops log. The transaction
+   itself is the on-chain audit record.
+
+### Verification (the new operator)
+
+1. Connect the operator wallet on the correct network and open `/admin`.
+2. Confirm the expected groups appear in the rail and **Overview → Your
+   Permissions** shows the role enabled. Roles are chain-scoped: wrong
+   network = missing views.
+3. Dry-run a read-only action from your console home (e.g. check an address
+   on the deny-list, read the live wiring) before any write.
+
+## Offboarding
+
+1. `/admin` → **Access Control → Admin Roles** → select the role → the
+   departing address → **Revoke Role** → sign. Repeat per role held
+   (callsign roles from **Identity → Callsigns**).
+2. Verify: the departing wallet's `/admin` now shows "Access Restricted"
+   (or the reduced group set).
+3. If the operator held infra access, revoke GCP IAM and rotate any shared
+   secrets per the [relayer runbook](relayer-operations.md) key-management
+   section. If a key may be compromised, treat as an incident: freeze what
+   the role could touch first, then revoke.
+
+## Emergency contact chain
+
+Pause (Guardian) and killswitch (infra) authority must be reachable
+24/7. Keep the on-call rotation and escalation order in the team's private
+ops channel — not in this public repo.

--- a/docs/runbooks/paymaster-operations.md
+++ b/docs/runbooks/paymaster-operations.md
@@ -48,6 +48,10 @@ The deposit **is** the sponsorship pool and the hard loss cap.
 ```
 - `entryPoint.balanceOf(paymaster)` = current pool.
 - **Never** overfund beyond the accepted exposure cap — top up on the runway alert instead.
+- UI path: the control plane's **Infrastructure → Services → Sponsored-Gas Paymaster** card
+  shows the live deposit, verifying signer, and owner, and offers a top-up form
+  (`deposit()` is permissionless) — see
+  [operations-control-plane.md](operations-control-plane.md).
 
 ## Monitoring (add to the existing gas-wallet dashboards)
 
@@ -67,7 +71,8 @@ it. Use for incident response or runaway burn.
 ## Rotate the sponsorship signer
 
 1. Create a new KMS key; derive its Ethereum address.
-2. `owner` (floppy) calls `setVerifyingSigner(newAddr)` on the paymaster.
+2. `owner` (floppy) calls `setVerifyingSigner(newAddr)` on the paymaster — via CLI, or the
+   control plane's paymaster card (the button is owner-gated; the tx reverts for anyone else).
 3. Swap `PM_SIGNER_KMS_KEY` in the gateway; redeploy. Boot check re-validates the match.
 
 In-flight approvals signed by the old key remain valid until their short TTL expires — no need to

--- a/docs/runbooks/relayer-operations.md
+++ b/docs/runbooks/relayer-operations.md
@@ -39,6 +39,11 @@ curl -s localhost:8788/healthz | jq
   transactions still track to inclusion (no accepted intent is dropped).
 - Per-chain stop: pause the chain's relayer in the engine config (`"paused": true`).
 - Full contract stop remains `pause()` on the registry (GUARDIAN_ROLE) — independent of the relayer.
+- Visibility: killswitch state, per-chain RPC health, and gas-wallet / paymaster runway from
+  `GET /status` render read-only in the operations control plane (**Infrastructure → Services**,
+  and on the Guardian's Emergency screen) — see
+  [operations-control-plane.md](operations-control-plane.md). Toggling stays here in the runbook
+  by design; the gateway has no web admin API.
 
 ## Collectibles read proxy (spec 055, `/v1/opensea/*`)
 

--- a/docs/system-overview/account-moderation.md
+++ b/docs/system-overview/account-moderation.md
@@ -19,6 +19,10 @@ This page focuses on **account moderation**, which is the per-account
 freeze/unfreeze power. For protocol-wide pausing, see
 [Operator powers in security.md](security.md#operator-powers).
 
+Moderators act from the operations control plane: `/admin` → **Incident
+Response → Account Moderation** (see the
+[control plane runbook](../runbooks/operations-control-plane.md)).
+
 ## What an account freeze does
 
 When an `ACCOUNT_MODERATOR_ROLE` holder calls

--- a/docs/system-overview/control-surface-audit.md
+++ b/docs/system-overview/control-surface-audit.md
@@ -6,8 +6,11 @@ platform — on-chain contracts, off-chain services, and the frontend admin pane
 operations control plane.
 
 This document is the inventory of record. The panel itself lives at `/admin`
-(`frontend/src/components/AdminPanel.jsx`); per-procedure detail stays in
-`docs/runbooks/`.
+(`frontend/src/components/AdminPanel.jsx`); how to operate each view is in
+[the control plane runbook](../runbooks/operations-control-plane.md), operator
+personas and grants are in
+[operator onboarding](../runbooks/operator-onboarding.md), and per-system
+procedure detail stays in `docs/runbooks/`.
 
 ---
 

--- a/docs/system-overview/roles-and-tiers.md
+++ b/docs/system-overview/roles-and-tiers.md
@@ -1,8 +1,15 @@
 # Roles and Tiers
 
-The protocol has **one user-purchasable role** and **five on-chain admin
-roles**. Every privileged action is gated by exactly one of the admin roles,
-enforced via OpenZeppelin AccessControl.
+The protocol has **one user-purchasable role** and **six core operator
+roles**, plus a handful of registry-scoped roles. Every privileged action is
+gated by exactly one role, enforced via OpenZeppelin AccessControl.
+
+Operators exercise these roles from the **operations control plane** at
+`/admin` — a grouped console (Control Room, Incident Response, Compliance,
+Membership & Revenue, Protocol Config, Identity, Access Control,
+Infrastructure) where each view appears only if the connected wallet holds
+the role it requires. The full inventory of what is controllable from where
+lives in [the control-surface audit](control-surface-audit.md).
 
 ## The user-purchasable role
 
@@ -45,24 +52,39 @@ time you create a wager after 30 days have elapsed since the last reset.
 Closed wagers (resolved, refunded, or cancelled) free up your concurrent
 slot.
 
-## The five admin roles
+## The six core operator roles
 
-All admin roles are bytes32 hashes enforced via OpenZeppelin AccessControl on
-either `MembershipManager` or `WagerRegistry`.
+All operator roles are bytes32 hashes enforced via OpenZeppelin AccessControl
+on the contract that defines them (`MembershipManager`, `WagerRegistry`, or
+`SanctionsGuard`). Grants and revocations are performed from the control
+plane's **Access Control → Admin Roles** view, which routes each grant to the
+contract that owns the role.
 
 | Constant | Contract | What it can do | Typical holder |
 |---|---|---|---|
-| `DEFAULT_ADMIN_ROLE` | both | Configure tiers, set treasury / payment token, authorise registry hooks, withdraw fees, and grant / revoke **all other admin roles** | Multisig |
+| `DEFAULT_ADMIN_ROLE` | MembershipManager + WagerRegistry | Configure tiers, set treasury / payment token, rewire protocol config (oracle adapters, sanctions guards, stake-token allowlist), withdraw fees, and grant / revoke **all other operator roles** | Multisig |
 | `GUARDIAN_ROLE` | WagerRegistry | `pause` and `unpause` WagerRegistry in response to security incidents | Multisig + on-call signer(s) |
 | `ACCOUNT_MODERATOR_ROLE` | WagerRegistry | `freezeAccount` / `unfreezeAccount` for individual accounts | Trust-and-safety multisig |
 | `ROLE_MANAGER_ROLE` | MembershipManager | `grantMembership` / `revokeMembership` outside the purchase flow (gifts, support, dispute resolution) | Ops multisig |
-| `UPGRADER_ROLE` | WagerRegistry | Replace the contract implementation behind the UUPS proxy (logic swaps, stable address). Separate from `DEFAULT_ADMIN_ROLE` for least privilege | Floppy-keystore admin |
+| `SANCTIONS_ADMIN_ROLE` | SanctionsGuard | Maintain the discretionary deny-list (`setDenied`, with an on-chain reason). Surfaced in the frontend as **Compliance Officer** and gates the control plane's Compliance group | Compliance multisig |
+| `UPGRADER_ROLE` | all UUPS proxies | Replace the contract implementation behind a UUPS proxy (logic swaps, stable address). Separate from `DEFAULT_ADMIN_ROLE` for least privilege | Floppy-keystore admin |
 
 The separation is deliberate: a guardian can stop the protocol but cannot
 seize an account; an account moderator can freeze an account but cannot pause
 the protocol or move treasury funds; a role manager can hand out memberships
-but cannot revoke admin roles; an upgrader can ship new logic behind the proxy
-but holds no other privilege and cannot grant itself one.
+but cannot revoke admin roles; a compliance officer can block an address from
+the protocol but holds no other privilege; an upgrader can ship new logic
+behind the proxy but holds no other privilege and cannot grant itself one.
+
+### Registry-scoped roles
+
+Beyond the core six, individual registries define narrow roles for their own
+surface, also grantable from the control plane:
+
+- `TOKEN_ISSUER_ROLE` (TokenFactory) — gate on the token `create*` entrypoints.
+- `REGISTRY_CURATOR_ROLE` / `MODERATOR_ROLE` / `VERIFIER_ROLE`
+  (CallsignRegistry) — reserve, suspend, and verify `%callsigns`; see the
+  [callsigns runbook](../runbooks/callsigns-operations.md).
 
 ## What each role can **not** do
 
@@ -72,10 +94,14 @@ but holds no other privilege and cannot grant itself one.
 | `GUARDIAN_ROLE` | Cannot freeze individual accounts; cannot configure tiers; cannot withdraw fees |
 | `ACCOUNT_MODERATOR_ROLE` | Cannot pause the protocol; cannot configure tiers; cannot withdraw fees; cannot seize funds |
 | `ROLE_MANAGER_ROLE` | Cannot grant or revoke admin roles; cannot pause; cannot freeze; cannot withdraw fees |
+| `SANCTIONS_ADMIN_ROLE` | Cannot pause; cannot freeze accounts on the registry; cannot configure tiers; cannot withdraw fees; cannot disable oracle screening (that is `DEFAULT_ADMIN_ROLE` on SanctionsGuard) |
 | `UPGRADER_ROLE` | Cannot grant or revoke admin roles; cannot pause; cannot freeze; cannot configure tiers; cannot withdraw fees; cannot move escrowed stakes |
 
 ## Related documents
 
+- [Control-surface audit](control-surface-audit.md) — the inventory of every
+  administrative control (on-chain, service-level, frontend) and the
+  operations control plane's structure.
 - [Account moderation policy](account-moderation.md) — the canonical reference
   for the freeze power, including grounds, audit trail, and unfreeze path.
 - [Security](security.md) — pause/unpause flow, threat model, and the custom

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,20 @@ nav:
     - Security Model: system-overview/security.md
     - Governance: system-overview/governance.md
     - Account Moderation Policy: system-overview/account-moderation.md
+    - Control-Surface Audit: system-overview/control-surface-audit.md
+  - Operations:
+    - Runbook Index: runbooks/README.md
+    - Operations Control Plane: runbooks/operations-control-plane.md
+    - Operator Onboarding: runbooks/operator-onboarding.md
+    - Relayer Operations: runbooks/relayer-operations.md
+    - Paymaster Operations: runbooks/paymaster-operations.md
+    - Callsign Operations: runbooks/callsigns-operations.md
+    - Contract Upgrades: runbooks/contract-upgrades.md
+    - Relayer Mordor Deploy: runbooks/relayer-mordor-deploy.md
+    - Wager Pools Deploy: runbooks/zk-wager-pools-deploy.md
+    - Safe Proposal Hub Deploy: runbooks/safe-proposal-hub-deploy.md
+    - Batch Operations: runbooks/batch-operations.md
+    - Passkey Account Recovery: runbooks/passkey-account-recovery.md
   - Architecture Decisions:
     - Overview: adr/README.md
     - ADR-001 Trail of Bits Toolchain: adr/001-trail-of-bits-toolchain.md


### PR DESCRIPTION
## Summary

Follow-up to #931: brings the operator-facing documentation in line with the merged operations control plane and fills the gaps around **onboarding, role responsibilities, runbooks, and how-to procedures**.

## What changed

### New runbooks
- **`docs/runbooks/operations-control-plane.md`** — the `/admin` console runbook: a map of every group/view and its role gate, step-by-step how-tos for the common procedures (emergency pause, freeze/unfreeze, deny-listing, tier/member/treasury management, protocol rewiring, maintenance sweeps, infra monitoring and paymaster funding, role grants), and a troubleshooting table.
- **`docs/runbooks/operator-onboarding.md`** — operator personas mapped to on-chain roles with explicit responsibilities (Incident Commander, Trust & Safety, Compliance Officer, Member Support, Protocol Administrator, Token Operations, Identity Moderation, Release Engineer, Infra Operator), wallet prerequisites, the grant/verification procedure, and offboarding.

### Updated for current state
- **`docs/system-overview/roles-and-tiers.md`** — now documents **six** core operator roles (adds `SANCTIONS_ADMIN_ROLE` / Compliance Officer, which the frontend models since #931), the registry-scoped roles (`TOKEN_ISSUER_ROLE`, callsign curator/moderator/verifier), the control-plane entry point, and an updated cannot-do table.
- **`docs/runbooks/README.md`** — the index listed 2 of 10 runbooks; it now lists all of them (including the two new ones), grouped by operating / deploy / integration, with a pointer to the control-surface audit.
- **`docs/runbooks/paymaster-operations.md`** — points the funding and signer-rotation steps at the new Infrastructure → Services paymaster card.
- **`docs/runbooks/relayer-operations.md`** — notes that `/status` telemetry (killswitch, RPC, runways) now renders read-only in the control plane, while toggling deliberately stays runbook-only.
- **`docs/runbooks/callsigns-operations.md`** — updated to the control plane's Identity → Callsigns path.
- **`docs/system-overview/account-moderation.md`** and **`docs/developer-guide/frontend.md`** — point at the control plane and its runbook.
- **`mkdocs.yml`** — adds an **Operations** nav section (the runbooks directory was entirely absent from the published site) and registers the control-surface audit under System Overview.

## Testing
- `mkdocs build` passes; the only warnings are pre-existing INFO-level anchor notices in unrelated files.
- Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTtFVwFXC738JYvU1jCFjc

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTtFVwFXC738JYvU1jCFjc)_