### PR TITLE
Fix callsign reservation for passkey wallets

### DIFF
--- a/frontend/src/components/account/CallsignPanel.jsx
+++ b/frontend/src/components/account/CallsignPanel.jsx
@@ -7,10 +7,12 @@
  * honest state). Membership below Gold sees an upgrade prompt, never a dead disabled control.
  *
  * All reads go straight to the on-chain CallsignRegistry (no subgraph, research R7); every write is a
- * plain self-submitted ethers v6 transaction against the connected wallet's signer — the same path the
- * sibling account panels use. Registration is a two-step commit -> reveal: the desired callsign + a random
- * salt are committed as a hash, then revealed after a short min-commit age so a pending pick can't be
- * front-run. The salt is persisted locally so a page reload between the two steps can still finish.
+ * self-call routed through the wallet's unified `sendCalls` (spec 041) — the same path the sibling account
+ * panels use — so it works identically for passkey smart-account sessions (which have no ethers signer and
+ * submit a UserOp) and classic injected wallets (a plain signer transaction). Registration is a two-step
+ * commit -> reveal: the desired callsign + a random salt are committed as a hash, then revealed after a
+ * short min-commit age so a pending pick can't be front-run. The salt is persisted locally so a page reload
+ * between the two steps can still finish.
  */
 
 import { useState, useEffect, useMemo, useCallback } from 'react'
@@ -139,7 +141,12 @@ function extractRevert(err, iface) {
 }
 
 function describeError(err, iface) {
-  if (err?.code === 'ACTION_REJECTED' || /reject|denied/i.test(err?.message || '')) {
+  // A dismissed passkey ceremony (spec 041) is a clean abort, not a failure.
+  if (
+    err?.name === 'CeremonyCancelled' ||
+    err?.code === 'ACTION_REJECTED' ||
+    /reject|denied/i.test(err?.message || '')
+  ) {
     return 'Transaction was rejected.'
   }
   const revert = extractRevert(err, iface)
@@ -188,7 +195,7 @@ function safeNormalize(input) {
 }
 
 export default function CallsignPanel() {
-  const { address: account, signer, provider, chainId, isConnected } = useWallet()
+  const { address: account, sendCalls, provider, chainId, isConnected } = useWallet()
   const navigate = useNavigate()
 
   // Current-user membership tier (read via the shared role-details hook).
@@ -339,20 +346,20 @@ export default function CallsignPanel() {
         setNotice({ kind: 'error', text: 'That callsign is not valid yet.' })
         return
       }
-      if (!registryAddress || !signer) {
+      if (!registryAddress || !account || !readRegistry) {
         setNotice({ kind: 'error', text: 'Connect a wallet to continue.' })
         return
       }
       setBusy(true)
       try {
         const salt = ethers.hexlify(ethers.randomBytes(32))
-        const write = new ethers.Contract(registryAddress, CALLSIGN_REGISTRY_ABI, signer)
-        const commitment = await write.makeCommitment(canonical, account, salt)
+        // makeCommitment is a pure view — resolve it over the read transport so passkey
+        // sessions (which have no signer) can compute it too.
+        const commitment = await readRegistry.makeCommitment(canonical, account, salt)
         // Persist BEFORE sending so a reload after signing can still reveal.
         const record = { mode, callsign: canonical, salt, commitment, committedAt: Date.now() }
         savePending(chainId, account, record)
-        const tx = await write.commit(commitment)
-        await tx.wait()
+        await sendCalls([{ target: registryAddress, data: iface.encodeFunctionData('commit', [commitment]) }])
         // Anchor the countdown to the mined moment.
         const mined = { ...record, committedAt: Date.now() }
         savePending(chainId, account, mined)
@@ -369,20 +376,19 @@ export default function CallsignPanel() {
         setBusy(false)
       }
     },
-    [desiredCallsign, registryAddress, signer, account, chainId, iface],
+    [desiredCallsign, registryAddress, account, readRegistry, sendCalls, chainId, iface],
   )
 
   const completeReveal = useCallback(async () => {
-    if (!pending || !registryAddress || !signer) return
+    if (!pending || !registryAddress || !account) return
     setNotice(null)
     setBusy(true)
     try {
-      const write = new ethers.Contract(registryAddress, CALLSIGN_REGISTRY_ABI, signer)
-      const tx =
+      const data =
         pending.mode === 'change'
-          ? await write.changeCallsign(pending.callsign, pending.salt)
-          : await write.register(pending.callsign, pending.salt)
-      await tx.wait()
+          ? iface.encodeFunctionData('changeCallsign', [pending.callsign, pending.salt])
+          : iface.encodeFunctionData('register', [pending.callsign, pending.salt])
+      await sendCalls([{ target: registryAddress, data }])
       clearPending(chainId, account)
       rememberOwned(chainId, account, pending.callsign)
       setPending(null)
@@ -397,7 +403,7 @@ export default function CallsignPanel() {
     } finally {
       setBusy(false)
     }
-  }, [pending, registryAddress, signer, account, chainId, iface, loadCallsign])
+  }, [pending, registryAddress, account, sendCalls, chainId, iface, loadCallsign])
 
   const discardPending = useCallback(() => {
     clearPending(chainId, account)
@@ -409,13 +415,11 @@ export default function CallsignPanel() {
   }, [chainId, account])
 
   const doRelease = useCallback(async () => {
-    if (!registryAddress || !signer) return
+    if (!registryAddress || !account) return
     setNotice(null)
     setBusy(true)
     try {
-      const write = new ethers.Contract(registryAddress, CALLSIGN_REGISTRY_ABI, signer)
-      const tx = await write.release()
-      await tx.wait()
+      await sendCalls([{ target: registryAddress, data: iface.encodeFunctionData('release', []) }])
       clearOwned(chainId, account)
       setOpenAction(null)
       setNotice({
@@ -428,7 +432,7 @@ export default function CallsignPanel() {
     } finally {
       setBusy(false)
     }
-  }, [registryAddress, signer, chainId, account, iface, loadCallsign])
+  }, [registryAddress, account, sendCalls, chainId, iface, loadCallsign])
 
   const requestRepoint = useCallback(async () => {
     const to = repointAddress.trim()
@@ -440,13 +444,13 @@ export default function CallsignPanel() {
       setNotice({ kind: 'error', text: 'That is already the callsign’s address.' })
       return
     }
-    if (!registryAddress || !signer) return
+    if (!registryAddress || !account) return
     setNotice(null)
     setBusy(true)
     try {
-      const write = new ethers.Contract(registryAddress, CALLSIGN_REGISTRY_ABI, signer)
-      const tx = await write.requestRepoint(to)
-      await tx.wait()
+      await sendCalls([
+        { target: registryAddress, data: iface.encodeFunctionData('requestRepoint', [to]) },
+      ])
       setOpenAction(null)
       setRepointAddress('')
       setNotice({
@@ -459,16 +463,16 @@ export default function CallsignPanel() {
     } finally {
       setBusy(false)
     }
-  }, [repointAddress, account, registryAddress, signer, iface, loadCallsign])
+  }, [repointAddress, account, registryAddress, sendCalls, iface, loadCallsign])
 
   const cancelRepoint = useCallback(async () => {
-    if (!registryAddress || !signer) return
+    if (!registryAddress || !account) return
     setNotice(null)
     setBusy(true)
     try {
-      const write = new ethers.Contract(registryAddress, CALLSIGN_REGISTRY_ABI, signer)
-      const tx = await write.cancelRepoint()
-      await tx.wait()
+      await sendCalls([
+        { target: registryAddress, data: iface.encodeFunctionData('cancelRepoint', []) },
+      ])
       setNotice({ kind: 'success', text: 'Address change cancelled. Your callsign stays put.' })
       await loadCallsign()
     } catch (e) {
@@ -476,7 +480,7 @@ export default function CallsignPanel() {
     } finally {
       setBusy(false)
     }
-  }, [registryAddress, signer, iface, loadCallsign])
+  }, [registryAddress, account, sendCalls, iface, loadCallsign])
 
   // ------------------------------------------------------------- derived UI
   const canonical = safeNormalize(desiredCallsign)

--- a/frontend/src/components/account/__tests__/CallsignPanel.passkey.test.jsx
+++ b/frontend/src/components/account/__tests__/CallsignPanel.passkey.test.jsx
@@ -1,0 +1,143 @@
+/**
+ * Regression (spec 054 + spec 041): a passkey smart-account session has NO ethers
+ * signer — every write must route through the wallet's unified `sendCalls` (a UserOp
+ * self-call), exactly like the sibling account panels. The original CallsignPanel
+ * gated its writes on `signer`, so a connected passkey wallet hit the dead
+ * "Connect a wallet to continue." branch even though the account was fully connected
+ * and Gold-tier. These tests pin the fix: reserve/commit and the register reveal both
+ * fire `sendCalls` and never surface the connect-wallet error when only the signer
+ * (not the wallet) is absent.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ethers } from 'ethers'
+import { CALLSIGN_REGISTRY_ABI } from '../../../abis/callsignRegistry'
+
+const REGISTRY = '0x00000000000000000000000000000000000c0de5'
+const ACCOUNT = '0x1111111111111111111111111111111111111111'
+const COMMITMENT = '0x' + 'ab'.repeat(32)
+
+// Read transport used by readRegistry (isAvailable / makeCommitment / callsignOf).
+// A passkey session's `provider` is a plain RPC read provider — reads work, there is
+// simply no signer for writes.
+const readContract = {
+  isAvailable: vi.fn(async () => true),
+  makeCommitment: vi.fn(async () => COMMITMENT),
+  callsignOf: vi.fn(async () => ''),
+  resolve: vi.fn(async () => ({})),
+}
+
+// Keep the real ethers surface (Interface, randomBytes, hexlify, isAddress) and only
+// stub Contract so the panel's read calls resolve without a live chain.
+vi.mock('ethers', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    ethers: {
+      ...actual.ethers,
+      // Regular function so `new ethers.Contract(...)` works (arrows can't construct);
+      // returning an object from a constructor yields that object.
+      Contract: vi.fn(function () {
+        return readContract
+      }),
+    },
+  }
+})
+
+let walletState
+vi.mock('../../../hooks/useWalletManagement', () => ({ useWallet: () => walletState }))
+
+let membershipState
+vi.mock('../../../hooks/useRoleDetails', () => ({
+  default: () => ({ getRoleDetails: () => membershipState }),
+  MembershipTier: { NONE: 0, BRONZE: 1, SILVER: 2, GOLD: 3, PLATINUM: 4 },
+}))
+
+vi.mock('../../../config/contracts', () => ({
+  getContractAddressForChain: () => REGISTRY,
+}))
+
+import CallsignPanel from '../CallsignPanel'
+
+const iface = new ethers.Interface(CALLSIGN_REGISTRY_ABI)
+const commitData = iface.encodeFunctionData('commit', [COMMITMENT])
+
+function renderPanel() {
+  return render(
+    <MemoryRouter>
+      <CallsignPanel />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  localStorage.clear()
+  readContract.isAvailable.mockResolvedValue(true)
+  readContract.makeCommitment.mockResolvedValue(COMMITMENT)
+  readContract.callsignOf.mockResolvedValue('')
+  // Passkey session: connected + Gold, `provider` is a read transport, NO signer.
+  walletState = {
+    address: ACCOUNT,
+    provider: {},
+    chainId: 137,
+    isConnected: true,
+    sendCalls: vi.fn(async () => ({ route: 'passkey', userOpHash: '0x1' })),
+  }
+  membershipState = { isActive: true, tier: 3 /* Gold */ }
+})
+
+describe('CallsignPanel — passkey (no-signer) write path', () => {
+  it('reserves a callsign through sendCalls, not a signer transaction', async () => {
+    renderPanel()
+
+    // Wait out the initial callsign load before the chooser renders.
+    fireEvent.change(await screen.findByLabelText(/choose a callsign/i), {
+      target: { value: 'dontpanic' },
+    })
+
+    // Availability resolves → the Reserve button enables.
+    const reserve = await screen.findByRole('button', { name: /reserve callsign/i })
+    await waitFor(() => expect(reserve).toBeEnabled())
+
+    fireEvent.click(reserve)
+
+    await waitFor(() => expect(walletState.sendCalls).toHaveBeenCalledTimes(1))
+    const batch = walletState.sendCalls.mock.calls[0][0]
+    expect(batch).toHaveLength(1)
+    expect(batch[0].target).toBe(REGISTRY)
+    expect(batch[0].data).toBe(commitData)
+
+    // The commitment came from the read transport — a passkey session has no signer.
+    expect(readContract.makeCommitment).toHaveBeenCalledWith('dontpanic', ACCOUNT, expect.any(String))
+    // The dead "connect a wallet" branch must never appear for a connected passkey wallet.
+    expect(screen.queryByText(/connect a wallet to continue/i)).toBeNull()
+  })
+
+  it('completes the reveal step through sendCalls', async () => {
+    const salt = '0x' + '11'.repeat(32)
+    // A pending commit already persisted (post-commit reload); its min-commit age has
+    // elapsed, so the reveal button is live immediately.
+    const key = `fairwins:callsign:pending:137:${ACCOUNT.toLowerCase()}`
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        mode: 'register',
+        callsign: 'dontpanic',
+        salt,
+        commitment: COMMITMENT,
+        committedAt: Date.now() - 120_000, // well past the 60s min-commit age
+      }),
+    )
+    renderPanel()
+
+    const complete = await screen.findByRole('button', { name: /complete registration/i })
+    fireEvent.click(complete)
+
+    await waitFor(() => expect(walletState.sendCalls).toHaveBeenCalledTimes(1))
+    const batch = walletState.sendCalls.mock.calls[0][0]
+    expect(batch[0].target).toBe(REGISTRY)
+    expect(batch[0].data).toBe(iface.encodeFunctionData('register', ['dontpanic', salt]))
+  })
+})

--- a/frontend/src/test/callsigns.axe.test.jsx
+++ b/frontend/src/test/callsigns.axe.test.jsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { axe } from 'vitest-axe'
 
 // ---- CallsignPanel dependencies (mocked so we can render each gate state without a live wallet) ----
-const walletState = { address: null, signer: null, provider: null, chainId: 137, isConnected: false }
+const walletState = { address: null, sendCalls: () => {}, provider: null, chainId: 137, isConnected: false }
 const membershipState = { isActive: false, tier: 0 }
 let registryAddress = '0x0000000000000000000000000000000000000abc'
 
@@ -43,7 +43,7 @@ function renderPanel() {
 
 describe('Callsign surfaces — accessibility (spec 054, WCAG 2.1 AA)', () => {
   beforeEach(() => {
-    Object.assign(walletState, { address: null, signer: null, provider: null, chainId: 137, isConnected: false })
+    Object.assign(walletState, { address: null, sendCalls: () => {}, provider: null, chainId: 137, isConnected: false })
     Object.assign(membershipState, { isActive: false, tier: 0 })
     Object.assign(ensState, { resolvedAddress: null, isLoading: false, error: null, isEns: false, isAddress: false })
     Object.assign(callsignState, { isCallsign: false, address: null, status: null, verified: false, isLoading: false, message: null })


### PR DESCRIPTION
## Problem

Testers with a connected passkey wallet couldn't reserve a callsign. Despite the wallet being fully connected (PREMIUM roles, Active membership, an available `%callsign`), clicking **Reserve callsign** surfaced the erroneous message **"Connect a wallet to continue."**

![reported bug](https://github.com/chippr-robotics/prediction-dao-research/assets/placeholder)

## Root cause

`CallsignPanel` (spec 054) was written for classic injected wallets only. Every write built an `ethers.Contract` bound to the wallet **`signer`** and gated on `!signer`:

```js
if (!registryAddress || !signer) {
  setNotice({ kind: 'error', text: 'Connect a wallet to continue.' })
  return
}
```

But a **passkey smart-account session** (spec 041) has **no ethers signer** — `WalletContext` sets `signer = null` and routes all writes through the unified **`sendCalls`** abstraction (a batched UserOp self-call). Reads still work because the exposed `provider` is a read transport, which is why availability (`%dontpanic is available`) rendered correctly while the write path hit the dead branch.

## Fix

Route **all** `CallsignPanel` writes through `sendCalls`, encoding calldata via the registry `Interface` — the same pattern the sibling `ControllersPanel` already uses. This works identically for passkey UserOps and classic signer transactions (never-stranded rule).

- `commit`, `register`/`changeCallsign` reveal, `release`, `requestRepoint`, `cancelRepoint` → `sendCalls([{ target: registryAddress, data }])`
- The pure `makeCommitment` view is now resolved over the read transport (`readRegistry`), which passkey sessions have — no signer required
- Write guards changed from `!signer` to `!account` (the panel body already gates on `isConnected && account`)
- A dismissed passkey ceremony (`CeremonyCancelled`) is now treated as a clean "Transaction was rejected." abort, matching the sibling panels

## Tests

- **New** `CallsignPanel.passkey.test.jsx` — a regression test that renders a connected, Gold-tier, **signer-less** passkey session and asserts that reserving a callsign fires `sendCalls` (with the correct `commit` calldata) and never shows "Connect a wallet to continue"; plus the register reveal step routing through `sendCalls`.
- Updated `callsigns.axe.test.jsx` wallet mock to the current context shape (`sendCalls` in place of the removed `signer`).
- All existing callsign tests pass (`callsigns.axe`, `CallsignRegistryAdmin`, `AddressInput.callsign`, `ReportCallsignButton`, `lib/callsigns`).

## Scope

The operator-only `CallsignRegistryAdmin` panel intentionally uses a plain signer via its parent `runTx` and is unchanged. No contract or ABI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBNqZsnMXX6eQB25k2mkG8)_