### PR TITLE
Spec 060: Configurable platform fee wrapper (FeeRouter)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/059-notification-profiles"
+  "feature_directory": "specs/060-platform-fee-wrapper"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,9 +133,22 @@ artifacts live under `specs/<feature>/`.
   never hidden, never "free". Resolve nothing through `wagerRegistry`. Builder code + fee are public
   config; the CLOB API key + L2 creds are gateway-only secrets. Boot fails loudly if the fee exceeds the
   caps. See `docs/developer-guide/predict-polymarket.md` + `specs/057-predict-polymarket/`.
+- **Platform fees (spec 060) have ONE source of truth: the `FeeRouter`** (UUPS proxy, deployment keys
+  `feeRouter` / `feeRouterImpl`, `contracts/fees/`). Every configurable fee lives there as a
+  `bytes32 serviceId` (keccak of e.g. `earn.lend`, `polymarket.taker`) with a per-service hard cap
+  (wrapped services ≤ 250 bps; Polymarket keeps its spec-057 caps) — never hardcode a bps value in
+  client or gateway code, and never invent a second fee-config store (the gateway stays stateless
+  and only READS the router via `services/relay-gateway/src/fees/onchain.js`, env bps are fallback).
+  Wrapped charging is atomic (`depositToVaultWithFee`: fee → treasury + net → ERC-4626 vault in one
+  tx) and every member surface MUST disclose the live rate before signature and pass the quoted bps
+  as `maxFeeBps` (members can never be charged above what they saw); zero fee ⇒ no fee line and
+  byte-identical pre-060 behavior. New integrations (Lido, Polygon LST, Uniswap) REGISTER a service
+  (config only) instead of building their own fee path. `FEE_ADMIN_ROLE` edits rates from the
+  AdminPanel Fees tab; history = `FeeBpsChanged` events. See
+  `docs/developer-guide/platform-fees.md` + `docs/runbooks/fee-operations.md` + `specs/060-platform-fee-wrapper/`.
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/059-notification-profiles/plan.md
+at specs/060-platform-fee-wrapper/plan.md
 <!-- SPECKIT END -->

--- a/contracts/fees/FeeRouter.sol
+++ b/contracts/fees/FeeRouter.sol
@@ -76,7 +76,10 @@ contract FeeRouter is IFeeRouter, UUPSManaged, ReentrancyGuardUpgradeable {
     }
 
     /// @notice Fee/net split for `grossAmount` at the service's live rate (floor — the
-    ///         member's favor; a fee that rounds to zero is charged as zero).
+    ///         member's favor; a fee that rounds to zero is charged as zero). Mirrors the
+    ///         charge path exactly, including the treasury-unset skip: when `treasury` is
+    ///         address(0) no fee is actually taken, so the quote reports zero too (an
+    ///         integrator UI never displays a fee the router would not charge).
     function quoteFee(bytes32 serviceId, uint256 grossAmount)
         public
         view
@@ -84,7 +87,7 @@ contract FeeRouter is IFeeRouter, UUPSManaged, ReentrancyGuardUpgradeable {
     {
         Service storage svc = _services[serviceId];
         if (svc.kind == ServiceKind.Unregistered) revert ServiceUnknown();
-        feeAmount = (grossAmount * svc.feeBps) / BPS_DENOMINATOR;
+        feeAmount = treasury == address(0) ? 0 : (grossAmount * svc.feeBps) / BPS_DENOMINATOR;
         netAmount = grossAmount - feeAmount;
     }
 
@@ -156,11 +159,19 @@ contract FeeRouter is IFeeRouter, UUPSManaged, ReentrancyGuardUpgradeable {
             emit FeeCharged(serviceId, msg.sender, address(asset), assets, feeAmount, vault, receiver);
         } else if (liveBps > 0 && to == address(0)) {
             emit FeeSkippedNoTreasury(serviceId, msg.sender, assets);
+        } else if (liveBps > 0) {
+            // Fee floored to zero on a small principal (treasury configured). Still record the
+            // wrapper action so off-chain reconciliation counts exactly one router event per
+            // successful deposit, never under-counting dust.
+            emit FeeCharged(serviceId, msg.sender, address(asset), assets, 0, vault, receiver);
         }
 
         uint256 netAmount = assets - feeAmount;
         asset.forceApprove(vault, netAmount);
         shares = IERC4626(vault).deposit(netAmount, receiver);
+        // The router pulled the member's principal and (may have) taken a fee; refuse to let a
+        // vault swallow it for zero shares — that would break the atomic fee-for-value guarantee.
+        if (shares == 0) revert ZeroShares();
         asset.forceApprove(vault, 0);
     }
 }

--- a/contracts/fees/FeeRouter.sol
+++ b/contracts/fees/FeeRouter.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import {UUPSManaged} from "../upgradeable/UUPSManaged.sol";
+import {IFeeRouter} from "./IFeeRouter.sol";
+
+/// @title FeeRouter
+/// @notice Single on-chain source of truth for FairWins' configurable platform fees
+///         (spec 060), and the atomic fee wrapper for external services with no native
+///         revenue share. Wrapped services (first: Earn lending, `earn.lend`) are
+///         charged here: the router pulls the member's principal, skims the configured
+///         fee (bps, floor) to the treasury, and forwards the remainder into the
+///         external protocol in the same transaction. ConfigOnly services (the
+///         Polymarket builder taker/maker rates) store rates that off-chain enforcers
+///         read; the router never charges them.
+/// @dev    The router holds no balances outside a transaction. Fee changes are gated by
+///         FEE_ADMIN_ROLE and capped per service at registration (wrapped caps are
+///         themselves capped at MAX_WRAPPED_FEE_BPS); every change emits FeeBpsChanged,
+///         which is the audit history the admin UI renders. `maxFeeBps` on the charge
+///         path pins members to the rate they were shown, so a concurrent admin raise
+///         can never overcharge an in-flight deposit.
+///         Fee-on-transfer / rebasing assets are NOT supported: the router assumes the
+///         pulled amount equals the requested amount (true for the curated vault assets,
+///         e.g. USDC).
+contract FeeRouter is IFeeRouter, UUPSManaged, ReentrancyGuardUpgradeable {
+    using SafeERC20 for IERC20;
+
+    /// @notice Holders may change service rates within their caps.
+    bytes32 public constant FEE_ADMIN_ROLE = keccak256("FEE_ADMIN_ROLE");
+
+    /// @notice Absolute ceiling for any Wrapped service's cap (2.5%).
+    uint16 public constant MAX_WRAPPED_FEE_BPS = 250;
+
+    uint256 private constant BPS_DENOMINATOR = 10_000;
+
+    /// @notice Per-network fee destination. address(0) => fees are skipped, never lost.
+    address public treasury;
+
+    mapping(bytes32 => Service) private _services;
+    bytes32[] private _serviceIds;
+
+    uint256[47] private __gap;
+
+    /// @param admin Granted DEFAULT_ADMIN_ROLE, UPGRADER_ROLE and FEE_ADMIN_ROLE.
+    /// @param treasury_ Fee destination; address(0) allowed for not-yet-configured
+    ///        networks (the charge path then skips fees rather than reverting).
+    function initialize(address admin, address treasury_) external initializer {
+        if (admin == address(0)) revert ZeroAddress();
+        __UUPSManaged_init(admin);
+        __ReentrancyGuard_init();
+        _grantRole(FEE_ADMIN_ROLE, admin);
+        treasury = treasury_;
+    }
+
+    // ---------------------------------------------------------------- reads
+
+    function getService(bytes32 serviceId) external view returns (Service memory) {
+        return _services[serviceId];
+    }
+
+    function feeBps(bytes32 serviceId) external view returns (uint16) {
+        return _services[serviceId].feeBps;
+    }
+
+    function serviceCount() external view returns (uint256) {
+        return _serviceIds.length;
+    }
+
+    function serviceAt(uint256 index) external view returns (bytes32) {
+        return _serviceIds[index];
+    }
+
+    /// @notice Fee/net split for `grossAmount` at the service's live rate (floor — the
+    ///         member's favor; a fee that rounds to zero is charged as zero).
+    function quoteFee(bytes32 serviceId, uint256 grossAmount)
+        public
+        view
+        returns (uint256 feeAmount, uint256 netAmount)
+    {
+        Service storage svc = _services[serviceId];
+        if (svc.kind == ServiceKind.Unregistered) revert ServiceUnknown();
+        feeAmount = (grossAmount * svc.feeBps) / BPS_DENOMINATOR;
+        netAmount = grossAmount - feeAmount;
+    }
+
+    // ---------------------------------------------------------------- admin
+
+    /// @notice Register a fee service. One-shot per id; the cap is fixed for the life
+    ///         of the entry (emergency lever is `setFeeBps(id, 0)`, not cap changes).
+    function registerService(bytes32 serviceId, uint16 capBps, ServiceKind kind)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        if (kind == ServiceKind.Unregistered) revert ServiceUnknown();
+        if (capBps == 0) revert CapZero();
+        if (kind == ServiceKind.Wrapped && capBps > MAX_WRAPPED_FEE_BPS) revert CapAboveMax();
+        if (_services[serviceId].kind != ServiceKind.Unregistered) revert AlreadyRegistered();
+
+        _services[serviceId] = Service({capBps: capBps, feeBps: 0, kind: kind});
+        _serviceIds.push(serviceId);
+        emit ServiceRegistered(serviceId, capBps, kind);
+    }
+
+    function setTreasury(address newTreasury) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (newTreasury == address(0)) revert ZeroAddress();
+        emit TreasuryChanged(treasury, newTreasury, msg.sender);
+        treasury = newTreasury;
+    }
+
+    function setFeeBps(bytes32 serviceId, uint16 newBps) external onlyRole(FEE_ADMIN_ROLE) {
+        Service storage svc = _services[serviceId];
+        if (svc.kind == ServiceKind.Unregistered) revert ServiceUnknown();
+        if (newBps > svc.capBps) revert CapExceeded();
+        emit FeeBpsChanged(serviceId, svc.feeBps, newBps, msg.sender);
+        svc.feeBps = newBps;
+    }
+
+    // ---------------------------------------------------------------- member action
+
+    /// @inheritdoc IFeeRouter
+    /// @dev Pull `assets` of the vault's underlying from the caller, transfer the fee to
+    ///      the treasury, deposit the remainder into the ERC-4626 vault for `receiver`.
+    ///      Atomic: any failing leg reverts the whole action, so the treasury never
+    ///      keeps a fee for a deposit that did not happen. Reverts FeeAboveQuoted when
+    ///      the live rate exceeds `maxFeeBps` (the rate the member consented to).
+    function depositToVaultWithFee(
+        bytes32 serviceId,
+        address vault,
+        uint256 assets,
+        address receiver,
+        uint16 maxFeeBps
+    ) external nonReentrant returns (uint256 shares) {
+        if (assets == 0) revert ZeroAmount();
+        if (vault == address(0) || receiver == address(0)) revert ZeroAddress();
+
+        Service storage svc = _services[serviceId];
+        if (svc.kind == ServiceKind.Unregistered) revert ServiceUnknown();
+        if (svc.kind != ServiceKind.Wrapped) revert ServiceNotWrapped();
+        uint16 liveBps = svc.feeBps;
+        if (liveBps > svc.capBps) revert CapExceeded(); // defense in depth
+        if (liveBps > maxFeeBps) revert FeeAboveQuoted();
+
+        address to = treasury;
+        uint256 feeAmount = to == address(0) ? 0 : (assets * liveBps) / BPS_DENOMINATOR;
+
+        IERC20 asset = IERC20(IERC4626(vault).asset());
+        asset.safeTransferFrom(msg.sender, address(this), assets);
+
+        if (feeAmount > 0) {
+            asset.safeTransfer(to, feeAmount);
+            emit FeeCharged(serviceId, msg.sender, address(asset), assets, feeAmount, vault, receiver);
+        } else if (liveBps > 0 && to == address(0)) {
+            emit FeeSkippedNoTreasury(serviceId, msg.sender, assets);
+        }
+
+        uint256 netAmount = assets - feeAmount;
+        asset.forceApprove(vault, netAmount);
+        shares = IERC4626(vault).deposit(netAmount, receiver);
+        asset.forceApprove(vault, 0);
+    }
+}

--- a/contracts/fees/IFeeRouter.sol
+++ b/contracts/fees/IFeeRouter.sol
@@ -44,6 +44,7 @@ interface IFeeRouter {
     error FeeAboveQuoted();
     error ZeroAmount();
     error ZeroAddress();
+    error ZeroShares();
 
     // --- reads ---
     function treasury() external view returns (address);

--- a/contracts/fees/IFeeRouter.sol
+++ b/contracts/fees/IFeeRouter.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title IFeeRouter
+/// @notice Unified platform-fee registry and atomic fee wrapper (spec 060).
+///         The router is the single on-chain source of truth for every configurable
+///         platform fee: wrapper services it charges itself (Wrapped) and rates that
+///         off-chain consumers read (ConfigOnly, e.g. the Polymarket builder fee served
+///         by the relay-gateway).
+interface IFeeRouter {
+    /// @notice How a registered service uses its fee entry.
+    enum ServiceKind {
+        Unregistered,
+        Wrapped, // chargeable through the router (e.g. earn.lend)
+        ConfigOnly // read-only rate for off-chain enforcement (e.g. polymarket.taker)
+    }
+
+    struct Service {
+        uint16 capBps; // hard ceiling for feeBps; 0 => unregistered
+        uint16 feeBps; // live rate, 0..capBps
+        ServiceKind kind;
+    }
+
+    event ServiceRegistered(bytes32 indexed serviceId, uint16 capBps, ServiceKind kind);
+    event FeeBpsChanged(bytes32 indexed serviceId, uint16 oldBps, uint16 newBps, address indexed actor);
+    event TreasuryChanged(address oldTreasury, address newTreasury, address indexed actor);
+    event FeeCharged(
+        bytes32 indexed serviceId,
+        address indexed payer,
+        address indexed asset,
+        uint256 grossAmount,
+        uint256 feeAmount,
+        address vault,
+        address receiver
+    );
+    event FeeSkippedNoTreasury(bytes32 indexed serviceId, address indexed payer, uint256 grossAmount);
+
+    error ServiceUnknown();
+    error ServiceNotWrapped();
+    error CapExceeded();
+    error CapAboveMax();
+    error CapZero();
+    error AlreadyRegistered();
+    error FeeAboveQuoted();
+    error ZeroAmount();
+    error ZeroAddress();
+
+    // --- reads ---
+    function treasury() external view returns (address);
+    function getService(bytes32 serviceId) external view returns (Service memory);
+    function feeBps(bytes32 serviceId) external view returns (uint16);
+    function serviceCount() external view returns (uint256);
+    function serviceAt(uint256 index) external view returns (bytes32);
+    function quoteFee(bytes32 serviceId, uint256 grossAmount)
+        external
+        view
+        returns (uint256 feeAmount, uint256 netAmount);
+
+    // --- admin ---
+    function registerService(bytes32 serviceId, uint16 capBps, ServiceKind kind) external;
+    function setTreasury(address newTreasury) external;
+    function setFeeBps(bytes32 serviceId, uint16 newBps) external;
+
+    // --- member action ---
+    function depositToVaultWithFee(
+        bytes32 serviceId,
+        address vault,
+        uint256 assets,
+        address receiver,
+        uint16 maxFeeBps
+    ) external returns (uint256 shares);
+}

--- a/contracts/mocks/FeeRouterUpgradeMock.sol
+++ b/contracts/mocks/FeeRouterUpgradeMock.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {FeeRouter} from "../fees/FeeRouter.sol";
+
+/// @title FeeRouterUpgradeMock
+/// @notice Test-only additive upgrade of {FeeRouter}: appends one state variable (drawn from the
+///         reserved `__gap`, so storage stays append-only and compatible) plus a trivial view and
+///         setter. Used to prove an in-place, state-preserving UUPS upgrade leaves the treasury,
+///         service registry, and rates intact while activating new logic. NOT for production.
+contract FeeRouterUpgradeMock is FeeRouter {
+    /// @dev Appended AFTER all existing FeeRouter state (consumes a `__gap` slot). Never reorder.
+    uint256 public upgradeMarker;
+
+    function setUpgradeMarker(uint256 m) external {
+        upgradeMarker = m;
+    }
+
+    function upgradeProbe() external pure returns (string memory) {
+        return "v2";
+    }
+}

--- a/contracts/mocks/MockERC4626Vault.sol
+++ b/contracts/mocks/MockERC4626Vault.sol
@@ -10,6 +10,7 @@ import "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
  */
 contract MockERC4626Vault is ERC4626 {
     bool public revertOnDeposit;
+    bool public zeroShares;
 
     constructor(IERC20 asset_) ERC20("Mock Vault", "mVLT") ERC4626(asset_) {}
 
@@ -17,8 +18,16 @@ contract MockERC4626Vault is ERC4626 {
         revertOnDeposit = value;
     }
 
+    /// @notice When set, deposit accepts the call but returns zero shares — models a vault that
+    ///         (e.g. via inflation griefing) mints nothing for the assets, exercising the router's
+    ///         `ZeroShares` guard.
+    function setZeroShares(bool value) external {
+        zeroShares = value;
+    }
+
     function deposit(uint256 assets, address receiver) public override returns (uint256) {
         require(!revertOnDeposit, "MockERC4626Vault: deposit disabled");
+        if (zeroShares) return 0;
         return super.deposit(assets, receiver);
     }
 }

--- a/contracts/mocks/MockERC4626Vault.sol
+++ b/contracts/mocks/MockERC4626Vault.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+
+/**
+ * @title MockERC4626Vault
+ * @notice Minimal ERC-4626 vault for FeeRouter tests, with a settable revert mode so
+ *         atomicity (fee leg rolls back with a failed deposit) can be exercised.
+ */
+contract MockERC4626Vault is ERC4626 {
+    bool public revertOnDeposit;
+
+    constructor(IERC20 asset_) ERC20("Mock Vault", "mVLT") ERC4626(asset_) {}
+
+    function setRevertOnDeposit(bool value) external {
+        revertOnDeposit = value;
+    }
+
+    function deposit(uint256 assets, address receiver) public override returns (uint256) {
+        require(!revertOnDeposit, "MockERC4626Vault: deposit disabled");
+        return super.deposit(assets, receiver);
+    }
+}

--- a/contracts/mocks/MockReentrantERC4626Vault.sol
+++ b/contracts/mocks/MockReentrantERC4626Vault.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+
+interface IFeeRouterReenter {
+    function depositToVaultWithFee(bytes32, address, uint256, address, uint16) external returns (uint256);
+}
+
+/**
+ * @title MockReentrantERC4626Vault
+ * @notice Test-only ERC-4626 vault whose `deposit` re-enters the FeeRouter's fund-moving function,
+ *         so the router's `nonReentrant` guard can be exercised (a re-entrant deposit MUST revert).
+ */
+contract MockReentrantERC4626Vault is ERC4626 {
+    address public router;
+    bytes32 public serviceId;
+    bool private attacking;
+
+    constructor(IERC20 asset_) ERC20("Reentrant Vault", "rVLT") ERC4626(asset_) {}
+
+    function arm(address router_, bytes32 serviceId_) external {
+        router = router_;
+        serviceId = serviceId_;
+    }
+
+    function deposit(uint256 assets, address receiver) public override returns (uint256) {
+        if (router != address(0) && !attacking) {
+            attacking = true;
+            // Re-enter the router's only fund-moving function; ReentrancyGuard must reject this.
+            IFeeRouterReenter(router).depositToVaultWithFee(
+                serviceId,
+                address(this),
+                assets,
+                receiver,
+                type(uint16).max
+            );
+        }
+        return super.deposit(assets, receiver);
+    }
+}

--- a/docs/developer-guide/platform-fees.md
+++ b/docs/developer-guide/platform-fees.md
@@ -1,0 +1,125 @@
+# Platform Fees (FeeRouter)
+
+Spec 060. FairWins earns revenue on integrations two ways:
+
+1. **Native attribution programs** where the external service pays FairWins out of its own
+   economics — the OpenSea referral (specs 055/056, no member cost) and the Polymarket
+   builder-code fee (spec 057, a real, disclosed taker cost).
+2. **The platform fee wrapper** for services with no revenue-share program — Morpho lending
+   (Earn) today; Lido, Polygon liquid staking, Uniswap and other integrations later. FairWins
+   charges its own small fee, in basis points of the principal, **at entry only**.
+
+The **`FeeRouter`** contract (`contracts/fees/FeeRouter.sol`, UUPS proxy, deployment keys
+`feeRouter` / `feeRouterImpl`) unifies both: it is the single on-chain source of truth for every
+configurable fee rate, and the atomic charging wrapper for wrapped services.
+
+## Architecture
+
+```
+AdminPanel "Fees" tab ──setFeeBps/setTreasury (wallet tx)──▶ FeeRouter (per network)
+                                                              │  ▲
+Earn VaultSheet ──quote (eth_call feeBps/getService)──────────┘  │
+Earn deposit ──approve(router) + depositToVaultWithFee──▶ router ─┼─ fee ──▶ treasury
+                                                                  └─ net ──▶ ERC-4626 vault (receiver = member)
+relay-gateway /fee-rate ──cached eth_call (30 s TTL)──▶ FeeRouter@Polygon (polymarket.taker/.maker)
+Predict TradeConfirm ──fetchFeeRate──▶ /fee-rate (source: "chain" | "env-fallback")
+```
+
+- **Service registry.** Each fee is a `bytes32 serviceId = keccak256("<label>")` with a
+  `Service { capBps, feeBps, kind }`. `kind` is `Wrapped` (chargeable through the router) or
+  `ConfigOnly` (a stored rate that off-chain enforcers read — the Polymarket entries).
+- **Caps.** Wrapped caps are fixed at registration and bounded by `MAX_WRAPPED_FEE_BPS = 250`
+  (2.5%). The Polymarket entries carry their spec-057 caps (100 taker / 50 maker). `setFeeBps`
+  enforces `bps <= capBps` and the charge path re-checks it.
+- **Roles.** `FEE_ADMIN_ROLE` changes rates; `DEFAULT_ADMIN_ROLE` registers services and sets the
+  treasury; `UPGRADER_ROLE` (from `UUPSManaged`) upgrades. The AdminPanel gates the Fees tab on
+  `FEE_ADMIN` or `ADMIN`, but enforcement is always the contract.
+- **Atomic charging.** `depositToVaultWithFee(serviceId, vault, assets, receiver, maxFeeBps)`
+  pulls the member's principal, sends `floor(assets · bps / 10 000)` to the treasury, and deposits
+  the remainder into the ERC-4626 vault for the member — one transaction; any failing leg reverts
+  everything, so the treasury never keeps a fee for a deposit that did not happen. The router
+  holds no balance outside a transaction.
+- **Consent ceiling.** The frontend passes the **quoted** bps as `maxFeeBps`; if an admin raises
+  the rate while the member's action is in flight, the call reverts `FeeAboveQuoted()` instead of
+  overcharging. Never call the router with a `maxFeeBps` you did not display.
+- **Rounding.** Fee math floors (member's favor); a fee that rounds to zero in the asset's
+  smallest unit is charged as zero.
+- **Missing treasury.** `treasury == address(0)` skips the fee (full deposit, event
+  `FeeSkippedNoTreasury`) — an ops misconfiguration must never strand or lose member funds.
+- **Unsupported assets.** Fee-on-transfer / rebasing tokens are not supported by the wrapper; the
+  curated vault assets (USDC et al.) are plain ERC-20s.
+- **Audit trail.** `FeeBpsChanged(serviceId, oldBps, newBps, actor)` is the change history the
+  Fees tab renders; `FeeCharged` is the reconciliation record (its `feeAmount` equals the ERC-20
+  transfer to the treasury in the same tx).
+
+## Member disclosure rules
+
+Every fee-bearing confirm step shows a named **"FairWins platform fee"** line — live rate
+(percent), absolute amount, and the net amount reaching the service — with an info bubble, before
+any signature. A zero rate shows **no fee line**. If the live rate cannot be read on a network
+that has a router, the surface **blocks the action** (never proceeds on a possibly understated
+rate). See `frontend/src/lib/fees/feeQuote.js` and the Earn `VaultSheet` for the reference
+implementation, and Predict's `TradeConfirm` for the builder-fee line.
+
+## Gateway read path (Polymarket bps)
+
+`services/relay-gateway/src/fees/onchain.js` reads `feeBps(polymarket.taker/.maker)` through the
+gateway's failover providers, cached `FEE_ROUTER_CACHE_TTL_MS` (default 30 s), clamped to the
+spec-057 caps. `/v1/polymarket/:chainId/fee-rate` serves the result with
+`source: "chain" | "env-fallback"`; the env vars `POLYMARKET_BUILDER_*_FEE_BPS` are the fallback
+when the router is unset or unreachable. `GET /status` exposes a `fees` summary block. The
+gateway stays stateless: no admin API, no persistence — an admin edits on-chain and the gateway
+follows.
+
+Gateway env: `FEE_ROUTER_ADDRESS` (defaults to the deployment record's `feeRouter`; a
+contradicting override fails boot), `FEE_ROUTER_CHAIN_ID` (default 137),
+`FEE_ROUTER_CACHE_TTL_MS` (default 30000).
+
+## Registering a new service (e.g. Lido, Polygon LST, Uniswap)
+
+The fee system itself needs **no code change** for a new service. Steps:
+
+1. **Pick the label** — a stable, lowercase, dot-separated id, e.g. `stake.lido`. The service id
+   is `keccak256(label)` (`ethers.id(label)`).
+2. **Register on-chain** (DEFAULT_ADMIN, per network):
+   ```js
+   await feeRouter.registerService(ethers.id('stake.lido'), capBps, 1 /* Wrapped */)
+   ```
+   `capBps <= 250` for wrapped services. Registration is one-shot; the cap is fixed for the
+   entry's life. Add the registration to `scripts/deploy/deploy-fee-router.js`'s
+   `LAUNCH_SERVICES` for fresh networks.
+3. **Add the friendly label** to `KNOWN_SERVICES` in
+   `frontend/src/components/admin/FeesTab.jsx` (unknown ids still render, as truncated hashes)
+   and, if the surface quotes it, a constant in `frontend/src/lib/fees/feeQuote.js`
+   (`FEE_SERVICES`).
+4. **Wire the member surface**:
+   - quote with `fetchFeeQuote({ serviceId, chainId, provider })` — handle the three outcomes
+     (unavailable ⇒ fee-free, available ⇒ disclose, throw ⇒ block);
+   - for an ERC-4626-shaped deposit, reuse `depositToVaultWithFee` exactly as Earn does
+     (`frontend/src/lib/earn/vaultActions.js`);
+   - for a differently-shaped action (staking, swaps), add a purpose-built wrapped entrypoint to
+     the FeeRouter **in that feature's spec** — keep the same fee accounting, events, cap
+     re-check, `maxFeeBps` consent ceiling, and CEI/nonReentrant discipline; storage is
+     append-only (functions may be added in an in-place upgrade without storage changes).
+   - disclose per the rules above (named line + info bubble, zero ⇒ no line).
+5. **Set the rate** from the Fees tab (starts at 0 — nothing is charged until an operator acts).
+6. **Test**: extend `test/feeRouter.test.js` if you added an entrypoint; add UI tests for the
+   disclosure line; `npm run check:storage-layout` must stay green.
+
+## Deployment
+
+```bash
+npx hardhat run scripts/deploy/deploy-fee-router.js --network <net>   # appends feeRouter keys
+npm run sync:frontend-contracts                                        # frontend reads the address
+# gateway: set FEE_ROUTER_ADDRESS (or redeploy so the pinned record carries feeRouter)
+```
+
+Upgrades follow the standard UUPS runbook (`docs/runbooks/contract-upgrades.md`);
+`check:storage-layout` gates CI.
+
+## Related
+
+- Operations: [`docs/runbooks/fee-operations.md`](../runbooks/fee-operations.md)
+- Member-facing: `docs/user-guide/platform-fees.md`
+- Specs: `specs/060-platform-fee-wrapper/` (design), 050 (Earn), 056 (OpenSea referral),
+  057 (Polymarket builder fee)

--- a/docs/runbooks/fee-operations.md
+++ b/docs/runbooks/fee-operations.md
@@ -1,0 +1,100 @@
+# Runbook: Platform Fee Operations
+
+Spec 060. Operating the unified platform-fee system: the `FeeRouter` contract (per network),
+the AdminPanel **Fees** tab, and the relay-gateway's on-chain rate read for Predict.
+
+Roles: rate changes need `FEE_ADMIN_ROLE`; treasury changes and service registration need
+`DEFAULT_ADMIN_ROLE` (floppy-keystore flow for cold admin keys). The Fees tab uses the connected
+wallet — on-chain roles are the enforcement, the UI only pre-validates.
+
+## View current fees
+
+1. Operations control plane → **Fees** (visible with ADMIN or FEE_ADMIN).
+2. The tab shows: every registered service (live bps, hard cap, enforcement point), the
+   network's fee treasury, the Polymarket bps the gateway is actually serving (with its
+   `source`), and the OpenSea referral status (display-only, never a member cost).
+3. Cross-check the gateway directly: `curl -s $GATEWAY/status | jq .fees` — expect
+   `polymarket.source == "chain"` on a healthy Polygon setup. `"env-fallback"` means the router
+   is unset or unreadable (see Diagnostics).
+
+## Change a fee rate
+
+1. Fees tab → **Change a fee rate** → pick the service, enter the new bps (0..cap), confirm the
+   wallet transaction. The contract refuses above-cap rates (`CapExceeded`).
+2. **Verify** (all three within ~1 minute):
+   - the tab's table shows the new rate and a new **Change history** row (you, old → new);
+   - the member surface quotes it (Earn: open a vault deposit review — the fee line shows the
+     new rate; Predict: `curl -s "$GATEWAY/v1/polymarket/137/fee-rate?token_id=<id>"` shows the
+     new `builderTakerFeeBps` once the ~30 s gateway cache turns over);
+   - `FeeBpsChanged` is on the explorer (Fees tab → "Full history on the block explorer").
+3. In-flight member actions are protected: anyone quoted the old rate either pays at most the
+   quoted rate or their transaction reverts (`FeeAboveQuoted`) and they re-review. No follow-up
+   needed.
+
+## Emergency-zero a fee
+
+Use when a fee is mischarging, a disclosure mismatch is reported, or comms require it.
+
+1. Fees tab → set the affected service's rate to **0** → confirm. Effect is immediate for all
+   subsequent actions: no fee transfer, no fee line.
+2. If the UI is unavailable, from any FEE_ADMIN key:
+   ```bash
+   npx hardhat console --network <net>
+   > const r = await ethers.getContractAt('FeeRouter', '<feeRouter addr>')
+   > await r.setFeeBps(ethers.id('earn.lend'), 0)
+   ```
+   (Cold FEE_ADMIN key: follow the floppy-keystore signing flow, as for any admin action.)
+3. Verify as in "Change a fee rate". The change is recorded on-chain like any other.
+
+## Change the treasury destination
+
+1. Fees tab → **Change the fee treasury** (ADMIN only) → enter the new FairWins-controlled
+   address → confirm. The contract refuses the zero address; `TreasuryChanged` is emitted.
+2. Verify the next `FeeCharged` event's transfer lands at the new address.
+3. If a network's treasury was never set (`unset — fees are skipped` in the tab): fees on that
+   network are silently zero **by design** (never lost). Set it, then re-check member quotes
+   still match expectations.
+
+## Reconcile treasury receipts
+
+Monthly (or on demand):
+
+1. Export `FeeCharged` events for the period (explorer CSV, or
+   `feeRouter.queryFilter(feeRouter.filters.FeeCharged(), fromBlock, toBlock)`).
+2. Sum `feeAmount` per asset; compare against the treasury address's incoming ERC-20 transfers
+   **from the FeeRouter** for the same period. They must match exactly — every `FeeCharged`
+   equals one same-tx transfer.
+3. Any mismatch is an incident: freeze rate changes, capture the diverging txs, escalate per the
+   security process. (The contract's invariant makes divergence impossible without a bug or an
+   unexpected upgrade — check `feeRouterImpl` against `deployments/`.)
+4. Polymarket builder-fee revenue arrives via Polymarket's builder program, not the treasury —
+   reconcile it from Polymarket's builder dashboard as in the Predict runbook.
+
+## Diagnostics: disclosure/charge mismatch or wrong source
+
+Symptoms: member reports a fee different from the confirm screen; Predict shows
+`source: "env-fallback"` unexpectedly; Earn deposits blocked with "fee rate could not be
+confirmed".
+
+1. **Which layer?** Earn quotes read the chain directly from the browser; Predict reads the
+   gateway. `curl -s $GATEWAY/status | jq .fees` and compare with the Fees tab (direct chain
+   read).
+2. `source: "env-fallback"`:
+   - `FEE_ROUTER_ADDRESS` unset on the gateway → set it (or redeploy with a deployments record
+     containing `feeRouter`); the boot log fails loudly if it contradicts the record;
+   - Polygon RPC trouble → check the gateway's chain health in `/status.chains`; the reader
+     serves the last good value up to 10× the TTL, then falls back to env bps (which are the
+     spec-057-capped defaults — never higher than disclosed caps).
+3. Earn "deposits paused": the browser could not read the router on a network that has one —
+   almost always RPC. Confirm with the Fees tab on the same network; deposits self-restore when
+   the read succeeds. This is fail-safe behavior (never show an understated rate), not an outage
+   of member funds; withdrawals are unaffected.
+4. A member charged above the shown rate should be **impossible** (`maxFeeBps` + caps). Treat
+   any credible report as a security incident: emergency-zero the service, capture the tx hash,
+   compare the tx's `FeeCharged` args against the quoted rate, escalate.
+
+## Registering a new service
+
+Engineering-led — see the developer guide
+([platform-fees.md](../developer-guide/platform-fees.md)). Operations involvement: confirm the
+cap, set the initial rate (it registers at 0), and add the service to fee reconciliation.

--- a/docs/user-guide/platform-fees.md
+++ b/docs/user-guide/platform-fees.md
@@ -1,0 +1,30 @@
+# Platform Fees
+
+FairWins is honest about fees: **any fee you pay is shown to you, as its own line, before you
+confirm anything.** If you don't see a fee line, there is no fee.
+
+## Where fees can appear
+
+| Area | Fee | What you see |
+| --- | --- | --- |
+| **Earn** (lending) | A small FairWins platform fee may apply when your deposit goes in — a percentage of the amount (never more than **2.5%**, usually far less, sometimes zero). Withdrawing is always free. | A "FairWins platform fee" line on the deposit review: the rate, the exact amount, and what actually goes into the vault. |
+| **Predict** (prediction markets) | A FairWins builder fee on orders that take liquidity (capped at **1%**). | A fee line in the order confirmation with the rate and amount, included in the total shown. |
+| **Collect** (collectibles) | None from FairWins. FairWins may earn a referral reward from OpenSea, paid out of OpenSea's own fee — it never changes your price. | Your price is your price; the confirmation says so. |
+| Wagers, pools, sending money | No FairWins platform fee. | Network (gas) costs only, always shown. |
+
+## The rules we hold ourselves to
+
+- **Always shown first.** The live rate and the exact amount appear on the confirm screen before
+  you sign. Zero fee ⇒ no fee line.
+- **Never more than you were shown.** If the rate changes while your transaction is on its way,
+  it either completes at (or below) the rate you saw, or it safely fails and asks you to review
+  again. It can never complete at a higher rate.
+- **Hard caps.** Fees are set in basis points (1 bps = 0.01%) with caps built into the system
+  itself — 250 bps (2.5%) for platform fees on services like lending; 100 bps (1%) for the
+  Predict builder fee.
+- **Rounding favors you.** Fee amounts round down; a fee that rounds to zero is simply zero.
+- **Entry only.** Where a platform fee applies (like Earn), it applies once, when you put money
+  in — never on withdrawals or on what you earn.
+
+Rates can change over time (they are set transparently on-chain, with a public history), but the
+rules above never do: whatever the rate is, you see it before you commit.

--- a/frontend/src/abis/FeeRouter.js
+++ b/frontend/src/abis/FeeRouter.js
@@ -1,0 +1,33 @@
+/**
+ * FeeRouter ABI subset (spec 060 — unified platform-fee registry + atomic fee wrapper).
+ * Covers the reads the member surfaces and Fees admin tab need, the admin setters the
+ * Fees tab writes, the wrapped-deposit action the Earn flow routes through when a
+ * lending fee is configured, and the events the tab renders as change history.
+ * Human-readable fragments, ethers v6.
+ */
+export const FEE_ROUTER_ABI = [
+  // Reads
+  'function treasury() view returns (address)',
+  'function MAX_WRAPPED_FEE_BPS() view returns (uint16)',
+  'function FEE_ADMIN_ROLE() view returns (bytes32)',
+  'function getService(bytes32 serviceId) view returns (tuple(uint16 capBps, uint16 feeBps, uint8 kind))',
+  'function feeBps(bytes32 serviceId) view returns (uint16)',
+  'function serviceCount() view returns (uint256)',
+  'function serviceAt(uint256 index) view returns (bytes32)',
+  'function quoteFee(bytes32 serviceId, uint256 grossAmount) view returns (uint256 feeAmount, uint256 netAmount)',
+  'function hasRole(bytes32 role, address account) view returns (bool)',
+  // Admin
+  'function registerService(bytes32 serviceId, uint16 capBps, uint8 kind)',
+  'function setTreasury(address newTreasury)',
+  'function setFeeBps(bytes32 serviceId, uint16 newBps)',
+  // Member action (atomic fee + ERC-4626 deposit)
+  'function depositToVaultWithFee(bytes32 serviceId, address vault, uint256 assets, address receiver, uint16 maxFeeBps) returns (uint256 shares)',
+  // Events (change history + reconciliation)
+  'event ServiceRegistered(bytes32 indexed serviceId, uint16 capBps, uint8 kind)',
+  'event FeeBpsChanged(bytes32 indexed serviceId, uint16 oldBps, uint16 newBps, address indexed actor)',
+  'event TreasuryChanged(address oldTreasury, address newTreasury, address indexed actor)',
+  'event FeeCharged(bytes32 indexed serviceId, address indexed payer, address indexed asset, uint256 grossAmount, uint256 feeAmount, address vault, address receiver)',
+  'event FeeSkippedNoTreasury(bytes32 indexed serviceId, address indexed payer, uint256 grossAmount)',
+]
+
+export default FEE_ROUTER_ABI

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -16,6 +16,7 @@ import DenyListAdmin from './admin/DenyListAdmin'
 import CallsignRegistryAdmin from './admin/CallsignRegistryAdmin'
 import MembershipTreasuryOverview from './admin/MembershipTreasuryOverview'
 import ProtocolConfigTab from './admin/ProtocolConfigTab'
+import FeesTab from './admin/FeesTab'
 import MaintenanceTab from './admin/MaintenanceTab'
 import ServiceHealthCard from './admin/ServiceHealthCard'
 import PaymasterOpsCard from './admin/PaymasterOpsCard'
@@ -89,6 +90,7 @@ function AdminPanel() {
   const isAccountModerator = hasRole(ROLES.ACCOUNT_MODERATOR)
   const isRoleManager = hasRole(ROLES.ROLE_MANAGER)
   const isSanctionsAdmin = hasRole(ROLES.SANCTIONS_ADMIN)
+  const isFeeAdmin = hasRole(ROLES.FEE_ADMIN)
   const hasAdminAccess = hasAnyRole(ADMIN_ROLES)
 
   const [activeTab, setActiveTab] = useState('overview')
@@ -314,6 +316,7 @@ function AdminPanel() {
     isAccountModerator,
     isRoleManager,
     isSanctionsAdmin,
+    isFeeAdmin,
   })
   const adminTabs = flattenNavGroups(navGroups)
 
@@ -745,6 +748,18 @@ function AdminPanel() {
             chainId={chainId}
             runTx={runTx}
             pendingTx={pendingTx}
+          />
+        )}
+
+        {activeTab === 'fees' && (isAdmin || isFeeAdmin) && (
+          <FeesTab
+            signer={signer}
+            chainId={chainId}
+            provider={provider || getProvider(chainId)}
+            runTx={runTx}
+            pendingTx={pendingTx}
+            isAdmin={isAdmin}
+            isFeeAdmin={isFeeAdmin}
           />
         )}
 

--- a/frontend/src/components/admin/FeesTab.jsx
+++ b/frontend/src/components/admin/FeesTab.jsx
@@ -1,0 +1,430 @@
+/**
+ * FeesTab (spec 060) — unified platform-fee management for the operations
+ * control plane.
+ *
+ * One screen for every platform-fee system:
+ *   - Wrapper services on the FeeRouter (earn.lend today) — live bps, hard cap,
+ *     treasury destination; editable on-chain via the connected wallet
+ *     (FEE_ADMIN_ROLE for rates, DEFAULT_ADMIN_ROLE for the treasury). The
+ *     contract enforces caps and roles; the UI validates first for clear errors.
+ *   - The Polymarket builder fee (spec 057) — its taker/maker entries live on
+ *     the SAME FeeRouter (ConfigOnly kind); the relay-gateway reads them, so an
+ *     edit here is live in Predict within the gateway cache TTL (~30 s).
+ *   - The OpenSea referral (spec 056) — display-only: a no-cost attribution
+ *     program with no rate to edit (beneficiary is deployment-managed).
+ *
+ * Change history renders from FeeBpsChanged events (actor / old → new), the
+ * on-chain audit trail — bounded lookback with an explorer link for the rest.
+ */
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import { ethers } from 'ethers'
+import { getContractAddressForChain } from '../../config/contracts'
+import { FEE_ROUTER_ABI } from '../../abis/FeeRouter'
+import { gatewayBaseUrl } from '../../hooks/useGatewayStatus'
+import { getBlockscoutUrl } from '../../config/blockExplorer'
+
+// Friendly names for known service ids (keccak256 of the registered label).
+const KNOWN_SERVICES = {
+  [ethers.id('earn.lend')]: { label: 'Earn — vault lending (Morpho)', surface: 'Earn deposits' },
+  [ethers.id('polymarket.taker')]: { label: 'Predict — Polymarket builder fee (taker)', surface: 'Predict orders' },
+  [ethers.id('polymarket.maker')]: { label: 'Predict — Polymarket builder fee (maker)', surface: 'Predict orders' },
+  [ethers.id('stake.lido')]: { label: 'Stake — Lido', surface: 'Staking (future)' },
+  [ethers.id('stake.polygon')]: { label: 'Stake — Polygon liquid staking', surface: 'Staking (future)' },
+  [ethers.id('swap.uniswap')]: { label: 'Swap — Uniswap', surface: 'Swaps (future)' },
+}
+
+const KIND_NAMES = { 1: 'Charged on-chain (wrapper)', 2: 'Read by the gateway (config-only)' }
+const HISTORY_LOOKBACK_BLOCKS = 200_000
+const HISTORY_LIMIT = 25
+
+function shortAddr(a) {
+  return a && a !== ethers.ZeroAddress ? `${a.substring(0, 6)}...${a.substring(a.length - 4)}` : ''
+}
+
+function bpsPct(bps) {
+  return `${(Number(bps) / 100).toFixed(2)}%`
+}
+
+export default function FeesTab({ signer, chainId, provider, runTx, pendingTx, isAdmin, isFeeAdmin }) {
+  const routerAddr = getContractAddressForChain('feeRouter', chainId)
+  const canEditFees = Boolean(isAdmin || isFeeAdmin)
+
+  const [services, setServices] = useState(null) // null = loading; [] = none
+  const [treasury, setTreasury] = useState(undefined)
+  const [maxWrappedCap, setMaxWrappedCap] = useState(null)
+  const [readError, setReadError] = useState(null)
+  const [history, setHistory] = useState({ entries: null, truncated: false, error: null })
+  const [gatewayFees, setGatewayFees] = useState(null) // /status fees block, null until loaded
+  const [feeForm, setFeeForm] = useState({ serviceId: '', bps: '' })
+  const [treasuryForm, setTreasuryForm] = useState('')
+  const [formError, setFormError] = useState(null)
+
+  const routerRead = useMemo(
+    () => (routerAddr && provider ? new ethers.Contract(routerAddr, FEE_ROUTER_ABI, provider) : null),
+    [routerAddr, provider]
+  )
+
+  const fetchServices = useCallback(async () => {
+    if (!routerRead) return
+    try {
+      setReadError(null)
+      const [count, treasuryAddr, maxCap] = await Promise.all([
+        routerRead.serviceCount(),
+        routerRead.treasury(),
+        routerRead.MAX_WRAPPED_FEE_BPS(),
+      ])
+      const ids = await Promise.all(
+        Array.from({ length: Number(count) }, (_, i) => routerRead.serviceAt(i))
+      )
+      const entries = await Promise.all(
+        ids.map(async (id) => {
+          const svc = await routerRead.getService(id)
+          return {
+            serviceId: id,
+            label: KNOWN_SERVICES[id]?.label || `Service ${id.substring(0, 10)}…`,
+            surface: KNOWN_SERVICES[id]?.surface || '—',
+            feeBps: Number(svc.feeBps),
+            capBps: Number(svc.capBps),
+            kind: Number(svc.kind),
+          }
+        })
+      )
+      setServices(entries)
+      setTreasury(treasuryAddr)
+      setMaxWrappedCap(Number(maxCap))
+    } catch (e) {
+      setReadError(`Could not read the FeeRouter: ${e?.message || e}`)
+    }
+  }, [routerRead])
+
+  const fetchHistory = useCallback(async () => {
+    if (!routerRead || !provider) return
+    try {
+      const latest = await provider.getBlockNumber()
+      const fromBlock = Math.max(0, Number(latest) - HISTORY_LOOKBACK_BLOCKS)
+      const events = await routerRead.queryFilter(routerRead.filters.FeeBpsChanged(), fromBlock, 'latest')
+      const recent = events.slice(-HISTORY_LIMIT).reverse()
+      const entries = await Promise.all(
+        recent.map(async (ev) => {
+          const block = await provider.getBlock(ev.blockNumber).catch(() => null)
+          return {
+            serviceId: ev.args.serviceId,
+            label: KNOWN_SERVICES[ev.args.serviceId]?.label || `${ev.args.serviceId.substring(0, 10)}…`,
+            oldBps: Number(ev.args.oldBps),
+            newBps: Number(ev.args.newBps),
+            actor: ev.args.actor,
+            at: block ? new Date(block.timestamp * 1000) : null,
+            txHash: ev.transactionHash,
+          }
+        })
+      )
+      setHistory({ entries, truncated: fromBlock > 0, error: null })
+    } catch (e) {
+      // Some RPCs bound log ranges — the full history stays available on the explorer.
+      setHistory({ entries: [], truncated: true, error: e?.message || String(e) })
+    }
+  }, [routerRead, provider])
+
+  useEffect(() => {
+    fetchServices()
+    fetchHistory()
+  }, [fetchServices, fetchHistory])
+
+  // Gateway-enforced fee systems (read-only telemetry): Polymarket bps source + OpenSea referral.
+  useEffect(() => {
+    const base = gatewayBaseUrl()
+    if (!base) return
+    let cancelled = false
+    fetch(`${base}/status`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!cancelled) setGatewayFees(data?.fees ?? null)
+      })
+      .catch(() => {
+        if (!cancelled) setGatewayFees(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const refresh = () => {
+    fetchServices()
+    fetchHistory()
+  }
+
+  const selectedService = services?.find((s) => s.serviceId === feeForm.serviceId) || null
+
+  const handleSetFeeBps = () => {
+    setFormError(null)
+    if (!selectedService) {
+      setFormError('Pick a service first.')
+      return
+    }
+    const bps = Number.parseInt(feeForm.bps, 10)
+    if (!Number.isInteger(bps) || bps < 0) {
+      setFormError('Enter the new rate in basis points (whole number, 0 or more).')
+      return
+    }
+    if (bps > selectedService.capBps) {
+      setFormError(
+        `${bps} bps is above this service's hard cap of ${selectedService.capBps} bps — the contract will refuse it.`
+      )
+      return
+    }
+    runTx(
+      () => new ethers.Contract(routerAddr, FEE_ROUTER_ABI, signer).setFeeBps(feeForm.serviceId, bps),
+      `${selectedService.label} fee set to ${bps} bps (${bpsPct(bps)})`
+    ).then(refresh)
+  }
+
+  const handleSetTreasury = () => {
+    setFormError(null)
+    const value = treasuryForm.trim()
+    if (!ethers.isAddress(value) || value === ethers.ZeroAddress) {
+      setFormError('Enter a valid, nonzero treasury address — fees would otherwise be skipped or lost.')
+      return
+    }
+    runTx(
+      () => new ethers.Contract(routerAddr, FEE_ROUTER_ABI, signer).setTreasury(value),
+      `Fee treasury set to ${shortAddr(value)}`
+    ).then(refresh)
+  }
+
+  if (!routerAddr) {
+    return (
+      <div className="admin-tab-content" role="tabpanel">
+        <div className="admin-card">
+          <h3>Platform Fees</h3>
+          <p className="card-info">
+            No FeeRouter is deployed on this network, so no platform fees are active here — member
+            flows behave exactly as if the fee system did not exist. Deploy it with{' '}
+            <code>scripts/deploy/deploy-fee-router.js</code> (see the fee operations runbook).
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="admin-tab-content" role="tabpanel">
+      <div className="admin-card">
+        <div className="admin-card-header">
+          <h3>Platform Fees</h3>
+          <button type="button" className="refresh-btn" onClick={refresh} aria-label="Refresh fees">↻</button>
+        </div>
+        {readError && <p className="card-info error">{readError}</p>}
+        <div className="status-details">
+          <div className="status-row">
+            <span className="status-label">FeeRouter</span>
+            <span className="status-value"><code title={routerAddr}>{shortAddr(routerAddr)}</code></span>
+          </div>
+          <div className="status-row">
+            <span className="status-label">Fee treasury (this network)</span>
+            <span className="status-value">
+              {treasury === undefined ? '…'
+                : treasury && treasury !== ethers.ZeroAddress
+                  ? <code title={treasury}>{shortAddr(treasury)}</code>
+                  : <span className="status-value paused">unset — fees are skipped, not charged</span>}
+            </span>
+          </div>
+          {maxWrappedCap != null && (
+            <div className="status-row">
+              <span className="status-label">Wrapper-fee hard cap</span>
+              <span className="status-value">{maxWrappedCap} bps ({bpsPct(maxWrappedCap)})</span>
+            </div>
+          )}
+        </div>
+
+        {services == null && !readError ? (
+          <p className="card-info">Loading fee services…</p>
+        ) : services?.length === 0 ? (
+          <p className="card-info">No fee services are registered on this network yet.</p>
+        ) : services?.length > 0 ? (
+          <table className="admin-table" aria-label="Registered fee services">
+            <thead>
+              <tr>
+                <th scope="col">Service</th>
+                <th scope="col">Live rate</th>
+                <th scope="col">Hard cap</th>
+                <th scope="col">Enforcement</th>
+              </tr>
+            </thead>
+            <tbody>
+              {services.map((s) => (
+                <tr key={s.serviceId}>
+                  <td>{s.label}<div className="hint">{s.surface}</div></td>
+                  <td>{s.feeBps} bps ({bpsPct(s.feeBps)})</td>
+                  <td>{s.capBps} bps</td>
+                  <td>{KIND_NAMES[s.kind] || '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : null}
+        <p className="card-info">
+          Rates are read live by member surfaces — the confirm step always shows the rate in force,
+          and a member is never charged more than the rate they were shown. A rate of 0 shows no
+          fee line at all.
+        </p>
+      </div>
+
+      <div className="admin-card">
+        <h3>Other fee programs</h3>
+        <div className="status-details">
+          <div className="status-row">
+            <span className="status-label">Polymarket builder fee — gateway source</span>
+            <span className="status-value">
+              {gatewayFees?.polymarket
+                ? `${gatewayFees.polymarket.takerBps} bps taker / ${gatewayFees.polymarket.makerBps} bps maker · ${
+                    gatewayFees.polymarket.source === 'chain'
+                      ? 'live from the FeeRouter'
+                      : 'env fallback (router not read)'
+                  }`
+                : 'gateway unreachable — showing nothing rather than a stale rate'}
+            </span>
+          </div>
+          <div className="status-row">
+            <span className="status-label">OpenSea referral (Collect)</span>
+            <span className="status-value">
+              {gatewayFees?.opensea
+                ? gatewayFees.opensea.referralConfigured
+                  ? `configured${gatewayFees.opensea.beneficiary ? ` · ${shortAddr(gatewayFees.opensea.beneficiary)}` : ''} · no member cost`
+                  : 'not configured · no member cost either way'
+                : 'gateway unreachable'}
+            </span>
+          </div>
+        </div>
+        <p className="card-info">
+          The Polymarket taker/maker rates are edited below like any other service (they live on the
+          FeeRouter; the gateway re-reads them within ~30 s). The OpenSea referral has no rate to
+          edit — it never costs the member anything, and its beneficiary is deployment-managed.
+        </p>
+      </div>
+
+      {canEditFees && (
+        <div className="admin-card">
+          <h3>Change a fee rate</h3>
+          <p>
+            Takes effect for all subsequent member actions (in-flight actions are protected by the
+            rate they were quoted). The contract refuses rates above a service's hard cap.
+          </p>
+          <div className="admin-form">
+            <label>
+              Service
+              <select
+                value={feeForm.serviceId}
+                onChange={(e) => setFeeForm((f) => ({ ...f, serviceId: e.target.value }))}
+              >
+                <option value="">Choose a service…</option>
+                {(services || []).map((s) => (
+                  <option key={s.serviceId} value={s.serviceId}>
+                    {s.label} (now {s.feeBps} bps, cap {s.capBps})
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              New rate (bps)
+              <input
+                type="number"
+                min="0"
+                max={selectedService?.capBps ?? undefined}
+                value={feeForm.bps}
+                onChange={(e) => setFeeForm((f) => ({ ...f, bps: e.target.value }))}
+                placeholder={selectedService ? `0 – ${selectedService.capBps}` : 'bps'}
+              />
+            </label>
+            {selectedService && (
+              <span className="hint">
+                {feeForm.bps !== '' && Number.isInteger(Number(feeForm.bps))
+                  ? `${feeForm.bps} bps = ${bpsPct(Number(feeForm.bps))} of each amount`
+                  : `Cap: ${selectedService.capBps} bps (${bpsPct(selectedService.capBps)})`}
+              </span>
+            )}
+            {formError && <p className="card-info error" role="alert">{formError}</p>}
+            <button
+              type="button"
+              className="confirm-btn primary"
+              onClick={handleSetFeeBps}
+              disabled={pendingTx || !signer}
+            >
+              Set fee rate
+            </button>
+          </div>
+        </div>
+      )}
+
+      {isAdmin && (
+        <div className="admin-card">
+          <h3>Change the fee treasury</h3>
+          <p>
+            Where wrapper fees on this network are sent. Must be a FairWins-controlled address; the
+            contract refuses the zero address.
+          </p>
+          <div className="admin-form">
+            <label>
+              Treasury address
+              <input
+                type="text"
+                value={treasuryForm}
+                onChange={(e) => setTreasuryForm(e.target.value)}
+                placeholder="0x…"
+              />
+            </label>
+            <button
+              type="button"
+              className="confirm-btn danger"
+              onClick={handleSetTreasury}
+              disabled={pendingTx || !signer}
+            >
+              Set treasury
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="admin-card">
+        <h3>Change history</h3>
+        {history.entries == null ? (
+          <p className="card-info">Loading history…</p>
+        ) : history.entries.length === 0 ? (
+          <p className="card-info">
+            {history.error
+              ? 'This RPC bounds event lookups — view the full history on the block explorer.'
+              : 'No fee changes recorded in the recent lookback window.'}
+          </p>
+        ) : (
+          <table className="admin-table" aria-label="Fee change history">
+            <thead>
+              <tr>
+                <th scope="col">When</th>
+                <th scope="col">Service</th>
+                <th scope="col">Change</th>
+                <th scope="col">By</th>
+              </tr>
+            </thead>
+            <tbody>
+              {history.entries.map((h) => (
+                <tr key={h.txHash + h.serviceId}>
+                  <td>{h.at ? h.at.toLocaleString() : '—'}</td>
+                  <td>{h.label}</td>
+                  <td>{h.oldBps} → {h.newBps} bps</td>
+                  <td><code title={h.actor}>{shortAddr(h.actor)}</code></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+        <p className="card-info">
+          Every change is an on-chain event (who, when, old → new).{' '}
+          {getBlockscoutUrl(chainId, routerAddr, 'address') && (
+            <a href={getBlockscoutUrl(chainId, routerAddr, 'address')} target="_blank" rel="noopener noreferrer">
+              Full history on the block explorer ↗
+            </a>
+          )}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/admin/adminNav.js
+++ b/frontend/src/components/admin/adminNav.js
@@ -17,6 +17,7 @@ export const ADMIN_TAB_ICONS = {
   tiers: 'layers',
   members: 'users',
   treasury: 'bank',
+  fees: 'coin',
   'protocol-config': 'settings',
   'oracle-adapters': 'broadcast',
   maintenance: 'sliders',
@@ -31,6 +32,7 @@ export function buildAdminNavGroups({
   isAccountModerator,
   isRoleManager,
   isSanctionsAdmin,
+  isFeeAdmin,
 }) {
   const item = (id, label) => ({ id, label, icon: ADMIN_TAB_ICONS[id] })
 
@@ -58,6 +60,8 @@ export function buildAdminNavGroups({
         isAdmin && item('tiers', 'Tiers'),
         isRoleManager && item('members', 'Members'),
         isAdmin && item('treasury', 'Treasury'),
+        // Unified platform-fee management (spec 060): FEE_ADMIN edits rates; ADMIN also enters.
+        (isAdmin || isFeeAdmin) && item('fees', 'Fees'),
       ].filter(Boolean),
     },
     {

--- a/frontend/src/components/earn/VaultSheet.jsx
+++ b/frontend/src/components/earn/VaultSheet.jsx
@@ -35,6 +35,7 @@ import {
   buildDepositCalls,
   buildWithdrawCalls,
 } from '../../lib/earn/vaultActions'
+import { fetchFeeQuote, splitFee, bpsToPercent, FEE_SERVICES } from '../../lib/fees/feeQuote'
 import { queueEarnAction } from '../../lib/earn/earnActivityBuffer'
 import { captureEarnAction } from '../../data/ledger'
 import { formatApy } from '../../lib/earn/format'
@@ -59,6 +60,25 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
   const [inputError, setInputError] = useState(null)
   // idle | approving | confirming | done | error
   const [txState, setTxState] = useState({ step: 'idle', txUrl: null, error: null })
+  // Live platform-fee quote (spec 060). null = loading; { failed: true } = the
+  // router exists but the rate could not be read — deposits are blocked rather
+  // than shown a possibly-understated rate (FR-015).
+  const [feeQuote, setFeeQuote] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const provider = makeReadProvider(vaultNetwork.rpcUrl, vault.chainId)
+    fetchFeeQuote({ serviceId: FEE_SERVICES.EARN_LEND, chainId: vault.chainId, provider })
+      .then((quote) => {
+        if (!cancelled) setFeeQuote(quote)
+      })
+      .catch(() => {
+        if (!cancelled) setFeeQuote({ failed: true, available: false, bps: 0 })
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [vault.chainId, vaultNetwork.rpcUrl])
 
   useEffect(() => {
     restoreFocusRef.current = document.activeElement
@@ -113,6 +133,13 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
       : validateWithdrawAmount({ amount, maxWithdrawAssets: userState?.maxWithdrawAssets ?? null })
   }
 
+  // The fee applies only to deposits, only when the router quotes a nonzero
+  // live rate. `feeBlocked` = we KNOW a router exists but couldn't read the
+  // rate — never proceed on a rate we can't stand behind (FR-015).
+  const feeApplies = mode === 'deposit' && Boolean(feeQuote?.available && feeQuote.bps > 0)
+  const feeBlocked = mode === 'deposit' && Boolean(feeQuote?.failed)
+  const feeSplit = feeApplies && amount != null && amount > 0n ? splitFee(amount, feeQuote.bps) : null
+
   const submit = async () => {
     const check = validate()
     if (!check.ok) {
@@ -120,6 +147,15 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
       return
     }
     setInputError(null)
+    if (feeBlocked) {
+      setTxState({
+        step: 'error',
+        txUrl: null,
+        error:
+          'The platform fee rate could not be confirmed right now, so deposits are paused. Nothing was moved — please try again shortly.',
+      })
+      return
+    }
     // Never a silent no-op (constitution III): sessions that can't transact
     // on this vault's network see the reason instead of a dead tap.
     if (!address || !canTransact) {
@@ -141,7 +177,13 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
       let message
       let busyStep
       if (mode === 'deposit') {
-        const built = await buildDepositCalls({ vault, account: address, amount, provider })
+        const built = await buildDepositCalls({
+          vault,
+          account: address,
+          amount,
+          provider,
+          feeQuote: feeApplies ? feeQuote : null,
+        })
         calls = built.calls
         busyStep = built.requiresApproval ? 'approving' : 'confirming'
         message = `Deposited ${fmt(amount, decimals, symbol)} into ${vault.name}`
@@ -316,6 +358,23 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
                       <dd>{fmt(userState.assets, decimals, symbol)}</dd>
                     </div>
                   )}
+                  {feeApplies && (
+                    <>
+                      <div>
+                        <dt>
+                          FairWins platform fee ({bpsToPercent(feeQuote.bps)})
+                          <InfoTip label="About the platform fee" className="earn-info">
+                            {EARN_TIPS.platformFee}
+                          </InfoTip>
+                        </dt>
+                        <dd>{feeSplit ? fmt(feeSplit.feeAmount, decimals, symbol) : '—'}</dd>
+                      </div>
+                      <div>
+                        <dt>Goes into the vault</dt>
+                        <dd>{feeSplit ? fmt(feeSplit.netAmount, decimals, symbol) : '—'}</dd>
+                      </div>
+                    </>
+                  )}
                 </>
               ) : (
                 <>
@@ -388,6 +447,16 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
               </p>
             )}
 
+            {/* The live rate could not be read while a fee router exists on
+                this network — pause deposits rather than risk showing a rate
+                lower than what would be charged (spec 060, FR-015). */}
+            {feeBlocked && (
+              <p className="earn-input-error" role="alert">
+                The platform fee rate could not be confirmed right now, so deposits are paused.
+                Withdrawals are unaffected — please try again shortly.
+              </p>
+            )}
+
             {/* Sessions that can't transact on this vault's network get the
                 reason up front instead of a doomed submit (constitution III). */}
             {!canTransact && (
@@ -399,7 +468,7 @@ export default function VaultSheet({ vault, userState, onClose, onActionComplete
               type="button"
               className="earn-btn primary earn-submit"
               onClick={submit}
-              disabled={busy || !canTransact}
+              disabled={busy || !canTransact || (mode === 'deposit' && (feeQuote == null || feeBlocked))}
               title={canTransact ? undefined : cannotTransactReason(vault.chainId)}
             >
               {txState.step === 'switching'

--- a/frontend/src/contexts/RoleContext.js
+++ b/frontend/src/contexts/RoleContext.js
@@ -21,6 +21,7 @@ export const ROLES = {
   ACCOUNT_MODERATOR: 'ACCOUNT_MODERATOR',  // ACCOUNT_MODERATOR_ROLE — freeze
   ROLE_MANAGER: 'ROLE_MANAGER',            // ROLE_MANAGER_ROLE — grant/revoke memberships
   SANCTIONS_ADMIN: 'SANCTIONS_ADMIN',      // SANCTIONS_ADMIN_ROLE — deny-list (on SanctionsGuard)
+  FEE_ADMIN: 'FEE_ADMIN',                  // FEE_ADMIN_ROLE — platform-fee rates (on FeeRouter, spec 060)
 }
 
 export const ROLE_INFO = {
@@ -60,6 +61,12 @@ export const ROLE_INFO = {
     premium: false,
     isAdminRole: true
   },
+  [ROLES.FEE_ADMIN]: {
+    name: 'Fee Administrator',
+    description: 'Set platform-fee rates (within their hard caps) on the FeeRouter — wrapper services and the Polymarket builder fee',
+    premium: false,
+    isAdminRole: true
+  },
 }
 
 /**
@@ -72,6 +79,7 @@ export const ADMIN_ROLES = [
   ROLES.ACCOUNT_MODERATOR,
   ROLES.ROLE_MANAGER,
   ROLES.SANCTIONS_ADMIN,
+  ROLES.FEE_ADMIN,
 ]
 
 export function isAdminRole(role) {

--- a/frontend/src/contexts/WalletContext.jsx
+++ b/frontend/src/contexts/WalletContext.jsx
@@ -308,7 +308,7 @@ export function WalletProvider({ children }) {
    */
   const syncRolesWithBlockchain = useCallback(async (walletAddress, localRoles, activeChainId) => {
     const premiumRoles = ['WAGER_PARTICIPANT']
-    const adminRoles = ['ADMIN', 'GUARDIAN', 'ACCOUNT_MODERATOR', 'ROLE_MANAGER', 'SANCTIONS_ADMIN']
+    const adminRoles = ['ADMIN', 'GUARDIAN', 'ACCOUNT_MODERATOR', 'ROLE_MANAGER', 'SANCTIONS_ADMIN', 'FEE_ADMIN']
     const allSyncedRoles = [...premiumRoles, ...adminRoles]
     const updatedRoles = []
     let hasChanges = false

--- a/frontend/src/lib/earn/earnCopy.js
+++ b/frontend/src/lib/earn/earnCopy.js
@@ -28,12 +28,14 @@ export const EARN_TIPS = {
     'Reward figures are recalculated by the rewards program every few hours, so what you see updates on that schedule — not every second.',
   positions:
     'Your active positions: what your deposit is worth right now in each vault. The value includes the return earned so far.',
+  platformFee:
+    'FairWins charges this small platform fee when your deposit goes in — it is taken from the amount once, sent to the FairWins treasury, and the rest goes into the vault. The rate is always shown here before you confirm, and withdrawing is free.',
 }
 
 /** Powered-by attribution + risk disclosure (FR-012; Morpho integration terms). */
 export const EARN_DISCLOSURE = {
   attribution: 'Powered by Morpho',
-  risk: 'Lending happens through Morpho, a third-party on-chain lending protocol, from your own wallet. Returns are variable and not guaranteed, and smart contracts carry risk. FairWins never holds your deposit and charges no fee on Earn.',
+  risk: 'Lending happens through Morpho, a third-party on-chain lending protocol, from your own wallet. Returns are variable and not guaranteed, and smart contracts carry risk. FairWins never holds your deposit; if a FairWins platform fee applies to a deposit, it is always shown before you confirm.',
 }
 
 /** Honest "not yet" copy for future earning areas (FR-002). */

--- a/frontend/src/lib/earn/vaultActions.js
+++ b/frontend/src/lib/earn/vaultActions.js
@@ -18,6 +18,8 @@
  */
 import { Contract, Interface } from 'ethers'
 import { ERC4626_VAULT_ABI } from '../../abis/ERC4626Vault'
+import { FEE_ROUTER_ABI } from '../../abis/FeeRouter'
+import { FEE_SERVICES } from '../fees/feeQuote'
 
 const ERC20_MIN_ABI = [
   'function balanceOf(address) view returns (uint256)',
@@ -27,6 +29,7 @@ const ERC20_MIN_ABI = [
 
 const VAULT_IFACE = new Interface(ERC4626_VAULT_ABI)
 const ERC20_IFACE = new Interface(ERC20_MIN_ABI)
+const FEE_ROUTER_IFACE = new Interface(FEE_ROUTER_ABI)
 
 /**
  * Read the member's state against one vault over a read provider:
@@ -92,30 +95,64 @@ export function validateWithdrawAmount({ amount, maxWithdrawAssets }) {
  * member's address so vault-side rejections (cap reached, paused) surface
  * before anything is signed. Reads go over the chain's read `provider` — a
  * signer is never needed here.
+ *
+ * When a platform fee applies (spec 060: `feeQuote.available && feeQuote.bps
+ * > 0`), the deposit routes through the FeeRouter instead of the vault:
+ * approve the ROUTER for the gross amount, then
+ * `depositToVaultWithFee(earn.lend, vault, amount, account, quotedBps)` —
+ * fee to treasury and net deposit for the member in one atomic call, pinned
+ * to the quoted rate (FR-005). With no fee the batch is byte-identical to the
+ * pre-fee behavior.
  * Returns { calls, requiresApproval }.
  */
-export async function buildDepositCalls({ vault, account, amount, provider }) {
+export async function buildDepositCalls({ vault, account, amount, provider, feeQuote = null }) {
+  const feeApplies = Boolean(feeQuote?.available && feeQuote.bps > 0 && feeQuote.routerAddress)
+  const spender = feeApplies ? feeQuote.routerAddress : vault.address
   const token = new Contract(vault.asset.address, ERC20_MIN_ABI, provider)
-  const allowance = await token.allowance(account, vault.address)
+  const allowance = await token.allowance(account, spender)
   const requiresApproval = allowance < amount
   const calls = []
   if (requiresApproval) {
     calls.push({
       target: vault.asset.address,
-      data: ERC20_IFACE.encodeFunctionData('approve', [vault.address, amount]),
+      data: ERC20_IFACE.encodeFunctionData('approve', [spender, amount]),
       value: 0n,
     })
-  } else {
+  } else if (feeApplies) {
     // Only dry-runnable when the allowance already covers the deposit — with
     // an approval leg in the batch the simulation would revert on allowance.
+    const router = new Contract(feeQuote.routerAddress, FEE_ROUTER_ABI, provider)
+    await router.depositToVaultWithFee.staticCall(
+      FEE_SERVICES.EARN_LEND,
+      vault.address,
+      amount,
+      account,
+      feeQuote.bps,
+      { from: account }
+    )
+  } else {
     const vaultContract = new Contract(vault.address, ERC4626_VAULT_ABI, provider)
     await vaultContract.deposit.staticCall(amount, account, { from: account })
   }
-  calls.push({
-    target: vault.address,
-    data: VAULT_IFACE.encodeFunctionData('deposit', [amount, account]),
-    value: 0n,
-  })
+  if (feeApplies) {
+    calls.push({
+      target: feeQuote.routerAddress,
+      data: FEE_ROUTER_IFACE.encodeFunctionData('depositToVaultWithFee', [
+        FEE_SERVICES.EARN_LEND,
+        vault.address,
+        amount,
+        account,
+        feeQuote.bps,
+      ]),
+      value: 0n,
+    })
+  } else {
+    calls.push({
+      target: vault.address,
+      data: VAULT_IFACE.encodeFunctionData('deposit', [amount, account]),
+      value: 0n,
+    })
+  }
   return { calls, requiresApproval }
 }
 

--- a/frontend/src/lib/fees/feeQuote.js
+++ b/frontend/src/lib/fees/feeQuote.js
@@ -1,0 +1,68 @@
+/**
+ * Platform-fee quotes for wrapper services (spec 060).
+ *
+ * The FeeRouter contract is the single on-chain source of truth for platform
+ * fees; member surfaces quote the LIVE rate from it before any signature and
+ * pass that quoted rate back as `maxFeeBps`, so a member can never be charged
+ * more than the rate they were shown (FR-005). Networks with no router
+ * deployed quote `{ available: false, bps: 0 }` — surfaces then behave exactly
+ * as before the fee system existed (no fee, no fee line). A FAILED read on a
+ * network that HAS a router is different: the caller must block the action
+ * rather than proceed on a possibly-understated rate (FR-015).
+ */
+import { Contract, id as keccakId } from 'ethers'
+import { FEE_ROUTER_ABI } from '../../abis/FeeRouter'
+import { getContractAddressForChain } from '../../config/contracts'
+
+/** Launch wrapper service ids (bytes32 = keccak256 of the label). */
+export const FEE_SERVICES = {
+  EARN_LEND: keccakId('earn.lend'),
+  POLYMARKET_TAKER: keccakId('polymarket.taker'),
+  POLYMARKET_MAKER: keccakId('polymarket.maker'),
+}
+
+const BPS_DENOMINATOR = 10_000n
+
+/** Floor fee/net split — mirrors the contract math exactly (member's favor). */
+export function splitFee(grossAmount, bps) {
+  const gross = BigInt(grossAmount)
+  const feeAmount = (gross * BigInt(bps)) / BPS_DENOMINATOR
+  return { feeAmount, netAmount: gross - feeAmount }
+}
+
+/** "0.50%" for 50 bps — the display form of a rate. */
+export function bpsToPercent(bps) {
+  return `${(Number(bps) / 100).toFixed(2)}%`
+}
+
+/**
+ * Quote the live rate for one wrapper service on one chain.
+ *
+ * Returns:
+ *   { available: false, bps: 0, routerAddress: null }  — no router on this
+ *     chain (fee system not deployed): proceed WITHOUT a fee, like today.
+ *   { available: true, bps, capBps, routerAddress }    — live rate obtained:
+ *     disclose it and pass `bps` as maxFeeBps.
+ * Throws on a failed read when a router IS configured — callers must treat
+ * that as "cannot quote" and block the fee-bearing action (FR-015), never
+ * fall back to assuming zero.
+ */
+export async function fetchFeeQuote({ serviceId, chainId, provider }) {
+  const routerAddress = getContractAddressForChain('feeRouter', chainId)
+  if (!routerAddress) {
+    return { available: false, bps: 0, capBps: 0, routerAddress: null }
+  }
+  const router = new Contract(routerAddress, FEE_ROUTER_ABI, provider)
+  const service = await router.getService(serviceId)
+  const kind = Number(service.kind)
+  if (kind === 0) {
+    // Router deployed but the service is not registered yet — honestly no fee.
+    return { available: false, bps: 0, capBps: 0, routerAddress }
+  }
+  return {
+    available: true,
+    bps: Number(service.feeBps),
+    capBps: Number(service.capBps),
+    routerAddress,
+  }
+}

--- a/frontend/src/test/FeesTab.axe.test.jsx
+++ b/frontend/src/test/FeesTab.axe.test.jsx
@@ -1,0 +1,80 @@
+/**
+ * FeesTab WCAG 2.1 AA audit (spec 060) — the unified fee screen with tables,
+ * forms, and history must pass axe in its loaded state.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import { ethers } from 'ethers'
+
+const m = vi.hoisted(() => ({ routerAddr: null, reads: {} }))
+
+vi.mock('../config/contracts', () => ({
+  getContractAddressForChain: vi.fn(() => m.routerAddr),
+}))
+vi.mock('../hooks/useGatewayStatus', () => ({ gatewayBaseUrl: () => '' }))
+vi.mock('../config/blockExplorer', () => ({
+  getBlockscoutUrl: () => 'https://explorer.example/address/0xrouter',
+}))
+vi.mock('ethers', async (orig) => {
+  const actual = await orig()
+  function FakeContract() {
+    return new Proxy(
+      {},
+      {
+        get(_t, prop) {
+          if (prop === 'then') return undefined
+          if (prop === 'filters') return { FeeBpsChanged: () => ({}) }
+          const key = String(prop)
+          return (...args) => {
+            const f = m.reads[key]
+            if (!f) throw new Error('unmocked contract method: ' + key)
+            return f(...args)
+          }
+        },
+      },
+    )
+  }
+  return { ...actual, ethers: { ...actual.ethers, Contract: FakeContract }, Contract: FakeContract }
+})
+
+import FeesTab from '../components/admin/FeesTab'
+
+const EARN_LEND = ethers.id('earn.lend')
+
+beforeEach(() => {
+  m.routerAddr = '0x00000000000000000000000000000000000000f1'
+  m.reads = {
+    serviceCount: async () => 1n,
+    serviceAt: async () => EARN_LEND,
+    getService: async () => ({ capBps: 250n, feeBps: 50n, kind: 1n }),
+    treasury: async () => '0x1111111111111111111111111111111111111111',
+    MAX_WRAPPED_FEE_BPS: async () => 250n,
+    queryFilter: async () => [
+      {
+        args: { serviceId: EARN_LEND, oldBps: 0n, newBps: 50n, actor: '0x1111111111111111111111111111111111111111' },
+        blockNumber: 1,
+        transactionHash: '0xabc',
+      },
+    ],
+  }
+})
+
+describe('FeesTab accessibility', () => {
+  it('has no WCAG 2.1 AA violations in the loaded state (tables + forms + history)', async () => {
+    const { container } = render(
+      <FeesTab
+        signer={{}}
+        chainId={137}
+        provider={{ getBlockNumber: async () => 100, getBlock: async () => ({ timestamp: 1_752_800_000 }) }}
+        runTx={vi.fn()}
+        pendingTx={false}
+        isAdmin
+        isFeeAdmin
+      />,
+    )
+    await screen.findAllByText(/earn — vault lending/i)
+    await screen.findByText('0 → 50 bps')
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/FeesTab.test.jsx
+++ b/frontend/src/test/FeesTab.test.jsx
@@ -1,0 +1,180 @@
+/**
+ * FeesTab tests (spec 060, US2) — the unified fee screen renders every fee
+ * system with live rates and caps, gates edits by role, validates caps
+ * client-side before any transaction, renders the on-chain change history,
+ * and is honest when no router is deployed or the gateway is unreachable.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { ethers } from 'ethers'
+
+const m = vi.hoisted(() => ({ routerAddr: null, reads: {}, writes: {} }))
+
+vi.mock('../config/contracts', () => ({
+  getContractAddressForChain: vi.fn(() => m.routerAddr),
+}))
+vi.mock('../hooks/useGatewayStatus', () => ({
+  gatewayBaseUrl: () => '', // gateway rows exercise the unreachable path by default
+}))
+vi.mock('../config/blockExplorer', () => ({
+  getBlockscoutUrl: () => 'https://explorer.example/address/0xrouter',
+}))
+
+// One fake Contract serves reads (provider) and writes (signer): methods come
+// from m.reads / m.writes, plus the queryFilter/filters event surface.
+vi.mock('ethers', async (orig) => {
+  const actual = await orig()
+  function FakeContract(_addr, _abi, signerOrProvider) {
+    const table = signerOrProvider?.isSigner ? m.writes : m.reads
+    return new Proxy(
+      {},
+      {
+        get(_t, prop) {
+          if (prop === 'then') return undefined
+          if (prop === 'filters') return { FeeBpsChanged: () => ({}) }
+          const key = String(prop)
+          return (...args) => {
+            const f = table[key]
+            if (!f) throw new Error('unmocked contract method: ' + key)
+            return f(...args)
+          }
+        },
+      },
+    )
+  }
+  return { ...actual, ethers: { ...actual.ethers, Contract: FakeContract }, Contract: FakeContract }
+})
+
+import FeesTab from '../components/admin/FeesTab'
+
+const EARN_LEND = ethers.id('earn.lend')
+const PM_TAKER = ethers.id('polymarket.taker')
+const TREASURY = '0x1111111111111111111111111111111111111111'
+
+const PROVIDER = { getBlockNumber: async () => 500_000, getBlock: async () => ({ timestamp: 1_752_800_000 }) }
+const SIGNER = { isSigner: true }
+
+function seedReads({ feeBps = { [EARN_LEND]: 50, [PM_TAKER]: 40 }, events = [] } = {}) {
+  const ids = [EARN_LEND, PM_TAKER]
+  const svc = {
+    [EARN_LEND]: { capBps: 250n, feeBps: BigInt(feeBps[EARN_LEND] ?? 0), kind: 1n },
+    [PM_TAKER]: { capBps: 100n, feeBps: BigInt(feeBps[PM_TAKER] ?? 0), kind: 2n },
+  }
+  m.reads = {
+    serviceCount: async () => 2n,
+    serviceAt: async (i) => ids[i],
+    getService: async (id) => svc[id],
+    treasury: async () => TREASURY,
+    MAX_WRAPPED_FEE_BPS: async () => 250n,
+    queryFilter: async () => events,
+  }
+}
+
+function renderTab({ isAdmin = true, isFeeAdmin = false, runTx } = {}) {
+  const tx = runTx ?? vi.fn(async (fn) => fn())
+  render(
+    <FeesTab
+      signer={SIGNER}
+      chainId={137}
+      provider={PROVIDER}
+      runTx={tx}
+      pendingTx={false}
+      isAdmin={isAdmin}
+      isFeeAdmin={isFeeAdmin}
+    />,
+  )
+  return tx
+}
+
+beforeEach(() => {
+  m.routerAddr = '0x00000000000000000000000000000000000000f1'
+  m.writes = { setFeeBps: vi.fn(async () => ({})), setTreasury: vi.fn(async () => ({})) }
+  seedReads()
+})
+
+describe('FeesTab rendering', () => {
+  it('lists every registered service with live rate, cap, and enforcement', async () => {
+    renderTab()
+    expect((await screen.findAllByText(/earn — vault lending/i)).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/polymarket builder fee \(taker\)/i).length).toBeGreaterThan(0)
+    expect(screen.getByText('50 bps (0.50%)')).toBeInTheDocument()
+    expect(screen.getByText('40 bps (0.40%)')).toBeInTheDocument()
+    expect(screen.getByText(/charged on-chain \(wrapper\)/i)).toBeInTheDocument()
+    expect(screen.getByText(/read by the gateway/i)).toBeInTheDocument()
+    // Treasury + OpenSea display-only row + unreachable-gateway honesty.
+    expect(screen.getByText('0x1111...1111')).toBeInTheDocument()
+    expect(screen.getByText('OpenSea referral (Collect)')).toBeInTheDocument()
+    expect(screen.getAllByText(/gateway unreachable/i).length).toBeGreaterThan(0)
+  })
+
+  it('is honest when no FeeRouter is deployed on the network', async () => {
+    m.routerAddr = null
+    renderTab()
+    expect(
+      await screen.findByText(/no feerouter is deployed on this network/i),
+    ).toBeInTheDocument()
+  })
+
+  it('renders the change history from FeeBpsChanged events', async () => {
+    seedReads({
+      events: [
+        {
+          args: { serviceId: EARN_LEND, oldBps: 0n, newBps: 50n, actor: TREASURY },
+          blockNumber: 499_000,
+          transactionHash: '0xabc',
+        },
+      ],
+    })
+    renderTab()
+    expect(await screen.findByText('0 → 50 bps')).toBeInTheDocument()
+  })
+})
+
+describe('FeesTab editing & gating', () => {
+  it('sends setFeeBps through runTx for an in-cap change', async () => {
+    const tx = renderTab({ isAdmin: false, isFeeAdmin: true })
+    await screen.findAllByText(/earn — vault lending/i)
+    fireEvent.change(screen.getByLabelText('Service'), { target: { value: EARN_LEND } })
+    fireEvent.change(screen.getByLabelText(/new rate/i), { target: { value: '75' } })
+    fireEvent.click(screen.getByRole('button', { name: /set fee rate/i }))
+    await waitFor(() => expect(m.writes.setFeeBps).toHaveBeenCalledWith(EARN_LEND, 75))
+    expect(tx).toHaveBeenCalled()
+  })
+
+  it('blocks an above-cap rate client-side with a clear error (contract would refuse too)', async () => {
+    renderTab()
+    await screen.findAllByText(/earn — vault lending/i)
+    fireEvent.change(screen.getByLabelText('Service'), { target: { value: EARN_LEND } })
+    fireEvent.change(screen.getByLabelText(/new rate/i), { target: { value: '300' } })
+    fireEvent.click(screen.getByRole('button', { name: /set fee rate/i }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/above this service's hard cap/i)
+    expect(m.writes.setFeeBps).not.toHaveBeenCalled()
+  })
+
+  it('hides the rate editor entirely without the fee-admin capability', async () => {
+    renderTab({ isAdmin: false, isFeeAdmin: false })
+    await screen.findAllByText(/earn — vault lending/i)
+    expect(screen.queryByRole('button', { name: /set fee rate/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /set treasury/i })).not.toBeInTheDocument()
+  })
+
+  it('treasury changes are admin-only and validate the address', async () => {
+    renderTab({ isAdmin: true })
+    await screen.findAllByText(/earn — vault lending/i)
+    fireEvent.change(screen.getByLabelText(/treasury address/i), { target: { value: 'nonsense' } })
+    fireEvent.click(screen.getByRole('button', { name: /set treasury/i }))
+    expect(await screen.findByText(/valid, nonzero treasury address/i)).toBeInTheDocument()
+    expect(m.writes.setTreasury).not.toHaveBeenCalled()
+
+    fireEvent.change(screen.getByLabelText(/treasury address/i), { target: { value: TREASURY } })
+    fireEvent.click(screen.getByRole('button', { name: /set treasury/i }))
+    await waitFor(() => expect(m.writes.setTreasury).toHaveBeenCalledWith(TREASURY))
+  })
+
+  it('fee admins without full admin cannot change the treasury', async () => {
+    renderTab({ isAdmin: false, isFeeAdmin: true })
+    await screen.findAllByText(/earn — vault lending/i)
+    expect(screen.getByRole('button', { name: /set fee rate/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /set treasury/i })).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/adminNav.test.js
+++ b/frontend/src/test/adminNav.test.js
@@ -11,6 +11,7 @@ const NO_ROLES = {
   isAccountModerator: false,
   isRoleManager: false,
   isSanctionsAdmin: false,
+  isFeeAdmin: false,
 }
 
 const ids = (groups) => flattenNavGroups(groups).map((i) => i.id)
@@ -65,6 +66,19 @@ describe('buildAdminNavGroups', () => {
   it('a compliance officer without full admin reaches the deny-list', () => {
     const groups = buildAdminNavGroups({ ...NO_ROLES, isSanctionsAdmin: true })
     expect(ids(groups)).toContain('deny-list')
+  })
+
+  it('a fee admin without full admin reaches the Fees view (spec 060)', () => {
+    const groups = buildAdminNavGroups({ ...NO_ROLES, isFeeAdmin: true })
+    const flat = ids(groups)
+    expect(flat).toContain('fees')
+    expect(flat).not.toContain('tiers')
+    expect(flat).not.toContain('treasury')
+  })
+
+  it('full admin also sees the Fees view without the dedicated role', () => {
+    const groups = buildAdminNavGroups({ ...NO_ROLES, isAdmin: true })
+    expect(ids(groups)).toContain('fees')
   })
 
   it('role manager sees Members but not Tiers/Treasury (admin-only)', () => {

--- a/frontend/src/test/earn/VaultSheet.test.jsx
+++ b/frontend/src/test/earn/VaultSheet.test.jsx
@@ -34,6 +34,14 @@ vi.mock('../../lib/earn/vaultActions', async (importOriginal) => {
 })
 vi.mock('../../utils/rpcProvider', () => ({ makeReadProvider: () => ({}) }))
 
+// The live platform-fee quote (spec 060) is mocked so tests control whether a
+// fee applies; default = no fee system on the chain (pre-060 behavior).
+const mockFee = vi.hoisted(() => ({ impl: null }))
+vi.mock('../../lib/fees/feeQuote', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, fetchFeeQuote: (...args) => mockFee.impl(...args) }
+})
+
 import VaultSheet from '../../components/earn/VaultSheet'
 
 const VAULT = {
@@ -76,15 +84,24 @@ beforeEach(() => {
   }
   mockBuilders.deposit.mockReset().mockResolvedValue({ calls: DEPOSIT_CALLS, requiresApproval: true })
   mockBuilders.withdraw.mockReset().mockResolvedValue({ calls: [DEPOSIT_CALLS[1]] })
+  mockFee.impl = vi.fn().mockResolvedValue({ available: false, bps: 0, capBps: 0, routerAddress: null })
 })
+
+/** Deposits are gated until the live fee quote resolves (spec 060, FR-015). */
+async function depositQuoteReady() {
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: /deposit usdc/i })).not.toBeDisabled(),
+  )
+}
 
 function renderSheet(userState = USER_STATE, vault = VAULT) {
   return render(<VaultSheet vault={vault} userState={userState} onClose={vi.fn()} onActionComplete={vi.fn()} />)
 }
 
 describe('VaultSheet deposit validation (pre-wallet)', () => {
-  it('rejects zero, junk, and over-balance amounts with plain reasons', () => {
+  it('rejects zero, junk, and over-balance amounts with plain reasons', async () => {
     renderSheet()
+    await depositQuoteReady()
     const input = screen.getByLabelText(/amount/i)
     const submit = screen.getByRole('button', { name: /deposit usdc/i })
 
@@ -149,6 +166,7 @@ describe('VaultSheet network-transparent write rail (useEarnSend)', () => {
     // pre-confirmation: the hook switches as part of the submission.
     mockWallet.current = { address: '0xac', chainId: 137 }
     renderSheet(USER_STATE, ETH_VAULT)
+    await depositQuoteReady()
     expect(screen.getByText(/on Ethereum/i)).toBeInTheDocument()
     fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '5' } })
     fireEvent.click(screen.getByRole('button', { name: /deposit usdc/i }))
@@ -164,6 +182,7 @@ describe('VaultSheet network-transparent write rail (useEarnSend)', () => {
       sendOnChain: vi.fn().mockResolvedValue({ route: 'userop', state: 'included', txHash: '0xtx1' }),
     }
     renderSheet()
+    await depositQuoteReady()
     expect(screen.getByText(/one passkey confirmation/i)).toBeInTheDocument()
     fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '5' } })
     fireEvent.click(screen.getByRole('button', { name: /deposit usdc/i }))
@@ -188,8 +207,55 @@ describe('VaultSheet network-transparent write rail (useEarnSend)', () => {
       .fn()
       .mockResolvedValue({ route: 'userop', state: 'failed', reason: 'user operation reverted' })
     renderSheet()
+    await depositQuoteReady()
     fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '5' } })
     fireEvent.click(screen.getByRole('button', { name: /deposit usdc/i }))
     expect(await screen.findByRole('alert')).toHaveTextContent(/could not be completed/i)
+  })
+})
+
+describe('VaultSheet platform-fee disclosure (spec 060)', () => {
+  const ROUTER = '0x00000000000000000000000000000000000000f1'
+  const FEE_QUOTE = { available: true, bps: 50, capBps: 250, routerAddress: ROUTER }
+
+  it('shows the fee line — rate, amount, and net — before any signature', async () => {
+    mockFee.impl = vi.fn().mockResolvedValue(FEE_QUOTE)
+    renderSheet()
+    await depositQuoteReady()
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '20' } })
+    expect(screen.getByText(/fairwins platform fee \(0\.50%\)/i)).toBeInTheDocument()
+    // 20 USDC at 50 bps: 0.1 fee, 19.9 into the vault.
+    expect(screen.getByText(/^0\.1 USDC$/)).toBeInTheDocument()
+    expect(screen.getByText(/goes into the vault/i)).toBeInTheDocument()
+    expect(screen.getByText(/^19\.9 USDC$/)).toBeInTheDocument()
+  })
+
+  it('passes the quote through to the deposit batch builder (consent ceiling)', async () => {
+    mockFee.impl = vi.fn().mockResolvedValue(FEE_QUOTE)
+    renderSheet()
+    await depositQuoteReady()
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '5' } })
+    fireEvent.click(screen.getByRole('button', { name: /deposit usdc/i }))
+    await waitFor(() => expect(mockBuilders.deposit).toHaveBeenCalledTimes(1))
+    expect(mockBuilders.deposit.mock.calls[0][0].feeQuote).toEqual(FEE_QUOTE)
+  })
+
+  it('shows NO fee line when no fee applies (zero-fee parity with pre-060 UX)', async () => {
+    renderSheet()
+    await depositQuoteReady()
+    fireEvent.change(screen.getByLabelText(/amount/i), { target: { value: '20' } })
+    expect(screen.queryByText(/platform fee/i)).not.toBeInTheDocument()
+  })
+
+  it('pauses deposits (never an understated rate) when the quote cannot be read', async () => {
+    mockFee.impl = vi.fn().mockRejectedValue(new Error('rpc down'))
+    renderSheet()
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/fee rate could not be confirmed/i),
+    )
+    expect(screen.getByRole('button', { name: /deposit usdc/i })).toBeDisabled()
+    // Withdrawals stay available — the fee never applies to exits.
+    fireEvent.click(screen.getByRole('tab', { name: /withdraw/i }))
+    expect(screen.getByRole('button', { name: /withdraw usdc/i })).not.toBeDisabled()
   })
 })

--- a/frontend/src/test/earn/vaultActions.test.js
+++ b/frontend/src/test/earn/vaultActions.test.js
@@ -44,10 +44,13 @@ import {
   buildWithdrawCalls,
 } from '../../lib/earn/vaultActions'
 import { ERC4626_VAULT_ABI } from '../../abis/ERC4626Vault'
+import { FEE_ROUTER_ABI } from '../../abis/FeeRouter'
+import { FEE_SERVICES } from '../../lib/fees/feeQuote'
 import { formatApy, formatTvl } from '../../lib/earn/format'
 
 const VAULT_IFACE = new Interface(ERC4626_VAULT_ABI)
 const ERC20_IFACE = new Interface(['function approve(address spender, uint256 value) returns (bool)'])
+const FEE_ROUTER_TEST_IFACE = new Interface(FEE_ROUTER_ABI)
 
 const ACCOUNT = '0x00000000000000000000000000000000000000ac'
 const VAULT = {
@@ -149,6 +152,76 @@ describe('buildDepositCalls (sendCalls batch)', () => {
     await expect(
       buildDepositCalls({ vault: VAULT, account: ACCOUNT, amount: 5_000_000n, provider: {} }),
     ).rejects.toThrow(/vault paused/)
+  })
+})
+
+describe('buildDepositCalls with a platform fee (spec 060)', () => {
+  const ROUTER = '0x00000000000000000000000000000000000000f1'
+  const FEE_QUOTE = { available: true, bps: 50, capBps: 250, routerAddress: ROUTER }
+
+  beforeEach(() => {
+    m.fns = {}
+  })
+
+  it('routes through the FeeRouter with the quoted rate as the consent ceiling', async () => {
+    m.fns.allowance = async () => 0n
+    const { calls, requiresApproval } = await buildDepositCalls({
+      vault: VAULT,
+      account: ACCOUNT,
+      amount: 5_000_000n,
+      provider: {},
+      feeQuote: FEE_QUOTE,
+    })
+    expect(requiresApproval).toBe(true)
+    expect(calls).toHaveLength(2)
+    // The ROUTER (not the vault) is approved for the exact gross amount.
+    expect(calls[0].target).toBe(VAULT.asset.address)
+    const approve = ERC20_IFACE.decodeFunctionData('approve', calls[0].data)
+    expect(approve[0].toLowerCase()).toBe(ROUTER)
+    expect(approve[1]).toBe(5_000_000n)
+    // The deposit is depositToVaultWithFee(earn.lend, vault, gross, member, quotedBps).
+    expect(calls[1].target).toBe(ROUTER)
+    const args = FEE_ROUTER_TEST_IFACE.decodeFunctionData('depositToVaultWithFee', calls[1].data)
+    expect(args[0]).toBe(FEE_SERVICES.EARN_LEND)
+    expect(args[1].toLowerCase()).toBe(VAULT.address)
+    expect(args[2]).toBe(5_000_000n)
+    expect(args[3].toLowerCase()).toBe(ACCOUNT)
+    expect(args[4]).toBe(50n)
+  })
+
+  it('dry-runs the router call when the allowance already covers the deposit', async () => {
+    m.fns.allowance = async () => 10_000_000n
+    const dryRun = vi.fn(async () => 5_000_000n)
+    m.fns['depositToVaultWithFee.staticCall'] = dryRun
+    const { calls, requiresApproval } = await buildDepositCalls({
+      vault: VAULT,
+      account: ACCOUNT,
+      amount: 5_000_000n,
+      provider: {},
+      feeQuote: FEE_QUOTE,
+    })
+    expect(requiresApproval).toBe(false)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].target).toBe(ROUTER)
+    expect(dryRun).toHaveBeenCalled()
+  })
+
+  it('keeps the pre-fee direct path byte-identical when the fee is zero or unavailable', async () => {
+    m.fns.allowance = async () => 0n
+    for (const feeQuote of [null, { available: false, bps: 0, routerAddress: null }, { ...FEE_QUOTE, bps: 0 }]) {
+      const { calls } = await buildDepositCalls({
+        vault: VAULT,
+        account: ACCOUNT,
+        amount: 5_000_000n,
+        provider: {},
+        feeQuote,
+      })
+      expect(calls[0].target).toBe(VAULT.asset.address)
+      const approve = ERC20_IFACE.decodeFunctionData('approve', calls[0].data)
+      expect(approve[0].toLowerCase()).toBe(VAULT.address) // vault, not router
+      expect(calls[1].target).toBe(VAULT.address)
+      VAULT_IFACE.decodeFunctionData('deposit', calls[1].data) // still a plain deposit
+    }
   })
 })
 

--- a/frontend/src/test/fees/feeQuote.test.js
+++ b/frontend/src/test/fees/feeQuote.test.js
@@ -1,0 +1,95 @@
+/**
+ * Platform-fee quote tests (spec 060) — the quote math mirrors the contract
+ * (floor, member's favor), display formatting is honest, and fetchFeeQuote
+ * distinguishes "no fee system on this chain" (proceed fee-free) from "rate
+ * unreadable" (throw — callers must block, FR-015).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const m = vi.hoisted(() => ({ fns: {}, address: null }))
+
+vi.mock('ethers', async (orig) => {
+  const actual = await orig()
+  function FakeContract() {
+    return new Proxy(
+      {},
+      {
+        get(_t, prop) {
+          if (prop === 'then') return undefined
+          const key = String(prop)
+          return (...args) => {
+            const f = m.fns[key]
+            if (!f) throw new Error('unmocked contract method: ' + key)
+            return f(...args)
+          }
+        },
+      },
+    )
+  }
+  return { ...actual, Contract: vi.fn(FakeContract) }
+})
+
+vi.mock('../../config/contracts', () => ({
+  getContractAddressForChain: vi.fn(() => m.address),
+}))
+
+import { splitFee, bpsToPercent, fetchFeeQuote, FEE_SERVICES } from '../../lib/fees/feeQuote'
+
+describe('splitFee', () => {
+  it('floors the fee in the member’s favor', () => {
+    expect(splitFee(100_000_000n, 50)).toEqual({ feeAmount: 500_000n, netAmount: 99_500_000n })
+    // 199 * 50 / 10000 = 0.995 → 0
+    expect(splitFee(199n, 50)).toEqual({ feeAmount: 0n, netAmount: 199n })
+    expect(splitFee(100n, 0)).toEqual({ feeAmount: 0n, netAmount: 100n })
+  })
+})
+
+describe('bpsToPercent', () => {
+  it('formats bps as a percentage', () => {
+    expect(bpsToPercent(50)).toBe('0.50%')
+    expect(bpsToPercent(250)).toBe('2.50%')
+    expect(bpsToPercent(0)).toBe('0.00%')
+  })
+})
+
+describe('fetchFeeQuote', () => {
+  beforeEach(() => {
+    m.fns = {}
+    m.address = null
+  })
+
+  it('quotes unavailable (fee-free) when no router is deployed on the chain', async () => {
+    const quote = await fetchFeeQuote({ serviceId: FEE_SERVICES.EARN_LEND, chainId: 63, provider: {} })
+    expect(quote).toEqual({ available: false, bps: 0, capBps: 0, routerAddress: null })
+  })
+
+  it('quotes unavailable when the router exists but the service is unregistered', async () => {
+    m.address = '0x00000000000000000000000000000000000000f1'
+    m.fns.getService = async () => ({ capBps: 0n, feeBps: 0n, kind: 0n })
+    const quote = await fetchFeeQuote({ serviceId: FEE_SERVICES.EARN_LEND, chainId: 137, provider: {} })
+    expect(quote.available).toBe(false)
+    expect(quote.bps).toBe(0)
+  })
+
+  it('returns the live rate and cap for a registered service', async () => {
+    m.address = '0x00000000000000000000000000000000000000f1'
+    m.fns.getService = async () => ({ capBps: 250n, feeBps: 50n, kind: 1n })
+    const quote = await fetchFeeQuote({ serviceId: FEE_SERVICES.EARN_LEND, chainId: 137, provider: {} })
+    expect(quote).toEqual({
+      available: true,
+      bps: 50,
+      capBps: 250,
+      routerAddress: '0x00000000000000000000000000000000000000f1',
+    })
+  })
+
+  it('throws when a configured router cannot be read (callers must block, not assume zero)', async () => {
+    m.address = '0x00000000000000000000000000000000000000f1'
+    m.fns.getService = async () => {
+      throw new Error('rpc down')
+    }
+    await expect(
+      fetchFeeQuote({ serviceId: FEE_SERVICES.EARN_LEND, chainId: 137, provider: {} }),
+    ).rejects.toThrow(/rpc down/)
+  })
+})

--- a/frontend/src/utils/blockchainService.js
+++ b/frontend/src/utils/blockchainService.js
@@ -656,6 +656,7 @@ const ROLE_NAME_TO_HASH = {
   'ACCOUNT_MODERATOR': ethers.keccak256(ethers.toUtf8Bytes('ACCOUNT_MODERATOR_ROLE')),
   'ROLE_MANAGER': ethers.keccak256(ethers.toUtf8Bytes('ROLE_MANAGER_ROLE')),
   'SANCTIONS_ADMIN': ethers.keccak256(ethers.toUtf8Bytes('SANCTIONS_ADMIN_ROLE')),
+  'FEE_ADMIN': ethers.keccak256(ethers.toUtf8Bytes('FEE_ADMIN_ROLE')),
 }
 
 // Minimal ABI for role manager contract
@@ -1021,6 +1022,10 @@ export async function hasRoleOnChain(userAddress, roleName, chainId) {
     if (addr) candidates.push(addr)
   } else if (roleName === 'SANCTIONS_ADMIN') {
     const addr = resolveAddress('sanctionsGuard')
+    if (addr) candidates.push(addr)
+  } else if (roleName === 'FEE_ADMIN') {
+    // FEE_ADMIN lives on the FeeRouter (spec 060); no router deployed => nobody holds it here.
+    const addr = resolveAddress('feeRouter')
     if (addr) candidates.push(addr)
   } else {
     const wager = resolveAddress('wagerRegistry')

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
     - Open Challenges: user-guide/open-challenges.md
     - Membership Vouchers: user-guide/membership-vouchers.md
     - Earn (Lending & Rewards): user-guide/earn.md
+    - Platform Fees: user-guide/platform-fees.md
     - Resolving a Wager: user-guide/resolve-wager.md
     - Private Wager Encryption: user-guide/private-market-encryption.md
     - Address Book & Screening: user-guide/address-book.md
@@ -104,6 +105,7 @@ nav:
     - Frontend Development: developer-guide/frontend.md
     - ClearPath Multi-Network DAOs: developer-guide/clearpath-multi-network.md
     - Earn Integration: developer-guide/earn-integration.md
+    - Platform Fees (FeeRouter): developer-guide/platform-fees.md
     - Encryption Architecture: developer-guide/encryption-architecture.md
     - Envelope Encryption Spec: developer-guide/envelope-encryption-spec.md
     - Ethereum Security Agent: developer-guide/ethereum-security-agent.md
@@ -137,6 +139,7 @@ nav:
     - Relayer Operations: runbooks/relayer-operations.md
     - Paymaster Operations: runbooks/paymaster-operations.md
     - Callsign Operations: runbooks/callsigns-operations.md
+    - Fee Operations: runbooks/fee-operations.md
     - Contract Upgrades: runbooks/contract-upgrades.md
     - Relayer Mordor Deploy: runbooks/relayer-mordor-deploy.md
     - Wager Pools Deploy: runbooks/zk-wager-pools-deploy.md

--- a/scripts/deploy/check-storage-layout.js
+++ b/scripts/deploy/check-storage-layout.js
@@ -24,6 +24,7 @@ const UPGRADEABLE_CONTRACTS = [
   { name: "ExternalDAORegistry", deploymentsKey: "externalDAORegistry" }, // spec 030 — ClearPath external-DAO registry
   { name: "WagerPoolFactory", deploymentsKey: "wagerPoolFactory" }, // spec 034 — WagerPools factory (address-based)
   { name: "CallsignRegistry", deploymentsKey: "callsignRegistry" }, // spec 054 — in-house %callsign naming registry
+  { name: "FeeRouter", deploymentsKey: "feeRouter" }, // spec 060 — unified platform-fee registry + wrapper
 ];
 
 function loadDeployedImpl(deploymentsKey) {

--- a/scripts/deploy/deploy-fee-router.js
+++ b/scripts/deploy/deploy-fee-router.js
@@ -23,12 +23,7 @@ const path = require("path");
 
 const { saveDeployment, getDeploymentFilename } = require("./lib/helpers");
 const { deployProxy } = require("./lib/upgradeable");
-
-const LAUNCH_SERVICES = [
-  { label: "earn.lend", capBps: 250, kind: 1 /* Wrapped */ },
-  { label: "polymarket.taker", capBps: 100, kind: 2 /* ConfigOnly */ },
-  { label: "polymarket.maker", capBps: 50, kind: 2 /* ConfigOnly */ },
-];
+const { LAUNCH_FEE_SERVICES } = require("./lib/feeServices");
 
 async function main() {
   const network = await ethers.provider.getNetwork();
@@ -72,15 +67,8 @@ async function main() {
     initArgs: [deployer.address, treasury],
   });
 
-  // Register launch services (rates start at 0; enable from the Fees admin tab).
-  const router = proxy.contract;
-  for (const svc of LAUNCH_SERVICES) {
-    const id = ethers.keccak256(ethers.toUtf8Bytes(svc.label));
-    await (await router.registerService(id, svc.capBps, svc.kind)).wait();
-    console.log(`  ✓ registered ${svc.label} (cap ${svc.capBps} bps, kind ${svc.kind})`);
-  }
-
-  // APPEND to the record (preserve everything already there).
+  // Persist the proxy address IMMEDIATELY (before the registration loop) so an interrupted run —
+  // e.g. an RPC timeout on a registerService tx — leaves a RECORDED proxy rather than an orphan.
   contracts.feeRouter = proxy.proxy;
   contracts.feeRouterImpl = proxy.implementation;
   record.constructorArgs = record.constructorArgs || {};
@@ -88,11 +76,31 @@ async function main() {
   record.feeRouterDeployedAt = new Date().toISOString();
   saveDeployment(filename, record);
 
+  // Register launch services idempotently (rates start at 0; enable from the Fees admin tab). A
+  // resumed run skips services already registered (AlreadyRegistered), so re-running finishes setup.
+  const router = proxy.contract;
+  for (const svc of LAUNCH_FEE_SERVICES) {
+    const id = ethers.keccak256(ethers.toUtf8Bytes(svc.label));
+    const existing = await router.getService(id);
+    if (Number(existing.kind) !== 0) {
+      console.log(`  • ${svc.label} already registered — skipping`);
+      continue;
+    }
+    await (await router.registerService(id, svc.capBps, svc.kind)).wait();
+    console.log(`  ✓ registered ${svc.label} (cap ${svc.capBps} bps, kind ${svc.kind})`);
+  }
+
   console.log("\n" + "=".repeat(60));
   console.log("Appended to deployments/" + filename);
   console.log("=".repeat(60));
   console.log(`  feeRouter     ${contracts.feeRouter}`);
   console.log(`  feeRouterImpl ${contracts.feeRouterImpl}`);
+  console.log("\n" + "!".repeat(60));
+  console.log("ADMIN HANDOFF (do NOT skip): the deployer EOA currently holds DEFAULT_ADMIN_ROLE,");
+  console.log("UPGRADER_ROLE and FEE_ADMIN_ROLE on a value-bearing UUPS router. Transfer these to");
+  console.log("the designated multisig/timelock and renounce the deployer's roles per the fee");
+  console.log("operations runbook before this router carries production fees.");
+  console.log("!".repeat(60));
   console.log(`\nNext: npm run sync:frontend-contracts, then set FEE_ROUTER_ADDRESS on the relay-gateway.`);
 }
 

--- a/scripts/deploy/deploy-fee-router.js
+++ b/scripts/deploy/deploy-fee-router.js
@@ -1,0 +1,104 @@
+/**
+ * Targeted spec-060 deploy: add the FeeRouter (unified platform-fee registry + atomic ERC-4626
+ * fee wrapper) to an ALREADY-deployed network WITHOUT touching existing core contracts. Reuses the
+ * network's recorded treasury address and APPENDS the new addresses to its
+ * `deployments/<net>-chain<id>-v2.json` record (never overwrites).
+ *
+ * Registers the launch fee services with their hard caps (rates all start at 0 — fees are enabled
+ * later from the AdminPanel Fees tab):
+ *   earn.lend         Wrapped     cap 250 bps  (Earn/Morpho vault deposits, spec 050 consumer)
+ *   polymarket.taker  ConfigOnly  cap 100 bps  (relay-gateway reads; spec 057 cap)
+ *   polymarket.maker  ConfigOnly  cap  50 bps  (relay-gateway reads; spec 057 cap)
+ *
+ *   npx hardhat run scripts/deploy/deploy-fee-router.js --network polygon
+ *   GAS_PRICE_WEI=100000000000 npx hardhat run scripts/deploy/deploy-fee-router.js --network mordor
+ *
+ * Then: npm run sync:frontend-contracts  (frontend picks up the feeRouter address), and set
+ * FEE_ROUTER_ADDRESS on the relay-gateway so Predict serves the on-chain Polymarket bps.
+ */
+const hre = require("hardhat");
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+
+const { saveDeployment, getDeploymentFilename } = require("./lib/helpers");
+const { deployProxy } = require("./lib/upgradeable");
+
+const LAUNCH_SERVICES = [
+  { label: "earn.lend", capBps: 250, kind: 1 /* Wrapped */ },
+  { label: "polymarket.taker", capBps: 100, kind: 2 /* ConfigOnly */ },
+  { label: "polymarket.maker", capBps: 50, kind: 2 /* ConfigOnly */ },
+];
+
+async function main() {
+  const network = await ethers.provider.getNetwork();
+  const networkName = hre.network.name;
+  const chainId = Number(network.chainId);
+  const [deployer] = await ethers.getSigners();
+
+  console.log("=".repeat(60));
+  console.log("Fee Router (spec 060) — targeted deploy");
+  console.log("=".repeat(60));
+  console.log(`Network:  ${networkName} (chainId ${chainId})`);
+  console.log(`Deployer: ${deployer.address}`);
+
+  const filename = getDeploymentFilename(network, "v2");
+  const filepath = path.join(process.cwd(), "deployments", filename);
+  if (!fs.existsSync(filepath)) {
+    throw new Error(`No existing deployment record at deployments/${filename}. Run the core deploy first.`);
+  }
+  const record = JSON.parse(fs.readFileSync(filepath, "utf8"));
+  const contracts = record.contracts || (record.contracts = {});
+
+  // Fee destination: the network's recorded treasury (TREASURY env overrides). Zero is allowed —
+  // the charge path then skips fees (never lost funds) until setTreasury is called.
+  const treasury =
+    process.env.TREASURY && ethers.isAddress(process.env.TREASURY)
+      ? process.env.TREASURY
+      : record.treasury && ethers.isAddress(record.treasury)
+        ? record.treasury
+        : ethers.ZeroAddress;
+  console.log(`Treasury: ${treasury === ethers.ZeroAddress ? "(unset — fees skipped until setTreasury)" : treasury}`);
+
+  if (contracts.feeRouter) {
+    console.log(`\n⚠️  feeRouter already recorded (${contracts.feeRouter}). To change logic,`);
+    console.log(`   run an in-place upgrade (lib/upgradeable.js upgradeProxy), not this script. Aborting.`);
+    return;
+  }
+
+  console.log("\nDeploying FeeRouter behind a UUPS proxy...");
+  const proxy = await deployProxy({
+    name: "FeeRouter",
+    initArgs: [deployer.address, treasury],
+  });
+
+  // Register launch services (rates start at 0; enable from the Fees admin tab).
+  const router = proxy.contract;
+  for (const svc of LAUNCH_SERVICES) {
+    const id = ethers.keccak256(ethers.toUtf8Bytes(svc.label));
+    await (await router.registerService(id, svc.capBps, svc.kind)).wait();
+    console.log(`  ✓ registered ${svc.label} (cap ${svc.capBps} bps, kind ${svc.kind})`);
+  }
+
+  // APPEND to the record (preserve everything already there).
+  contracts.feeRouter = proxy.proxy;
+  contracts.feeRouterImpl = proxy.implementation;
+  record.constructorArgs = record.constructorArgs || {};
+  record.constructorArgs.feeRouterImpl = [];
+  record.feeRouterDeployedAt = new Date().toISOString();
+  saveDeployment(filename, record);
+
+  console.log("\n" + "=".repeat(60));
+  console.log("Appended to deployments/" + filename);
+  console.log("=".repeat(60));
+  console.log(`  feeRouter     ${contracts.feeRouter}`);
+  console.log(`  feeRouterImpl ${contracts.feeRouterImpl}`);
+  console.log(`\nNext: npm run sync:frontend-contracts, then set FEE_ROUTER_ADDRESS on the relay-gateway.`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/scripts/deploy/lib/feeServices.js
+++ b/scripts/deploy/lib/feeServices.js
@@ -1,0 +1,17 @@
+/**
+ * Canonical launch fee-service table for the spec-060 FeeRouter, shared by the deploy script and
+ * its test so the two can never drift (security review nit). Each entry is registered at 0 bps;
+ * rates are enabled later from the AdminPanel Fees tab.
+ *
+ * kind: 1 = Wrapped (chargeable via depositToVaultWithFee), 2 = ConfigOnly (rate read off-chain).
+ * Wrapped caps must be <= MAX_WRAPPED_FEE_BPS (250); the Polymarket entries keep their spec-057 caps.
+ */
+const ServiceKind = { Wrapped: 1, ConfigOnly: 2 };
+
+const LAUNCH_FEE_SERVICES = [
+  { label: "earn.lend", capBps: 250, kind: ServiceKind.Wrapped }, // Earn/Morpho vault deposits (spec 050)
+  { label: "polymarket.taker", capBps: 100, kind: ServiceKind.ConfigOnly }, // relay-gateway reads; spec-057 cap
+  { label: "polymarket.maker", capBps: 50, kind: ServiceKind.ConfigOnly }, // relay-gateway reads; spec-057 cap
+];
+
+module.exports = { LAUNCH_FEE_SERVICES, ServiceKind };

--- a/scripts/utils/sync-frontend-contracts.js
+++ b/scripts/utils/sync-frontend-contracts.js
@@ -192,6 +192,7 @@ function main() {
         backupPointerRegistry: deployed.backupPointerRegistry, // spec 032 — encrypted-backup pointer registry
         wagerPoolFactory: deployed.wagerPoolFactory, // spec 034 — WagerPools factory, address-based (only where deployed)
         callsignRegistry: deployed.callsignRegistry, // spec 054 — %callsign naming registry (only where deployed)
+        feeRouter: deployed.feeRouter, // spec 060 — unified platform-fee registry + wrapper (only where deployed)
         safeProposalHub: deployed.safeProposalHub, // spec 043 — Safe custody proposal broadcaster (only where deployed)
         safePolicyGuard: deployed.safePolicyGuard, // spec 049 — multisig policy engine guard (only where deployed)
         policyGuardSetup: deployed.policyGuardSetup, // spec 049 — Safe.setup policy attach helper (only where deployed)

--- a/services/relay-gateway/.env.example
+++ b/services/relay-gateway/.env.example
@@ -101,5 +101,12 @@ KILL_SWITCH=false
 # The builder fee is ADDITIVE on top of Polymarket's platform taker fee (a real user cost, disclosed
 # honestly in the UI). Hard-capped at 100 bps taker / 50 bps maker — out-of-range fails boot.
 #POLYMARKET_BUILDER_CODE=0x6e0316783960e149b53466f0f2c5fdbaf5ce11ba15669491de980f6dedc493a3
-#POLYMARKET_BUILDER_TAKER_FEE_BPS=50       # 0.50% on taker orders (default)
-#POLYMARKET_BUILDER_MAKER_FEE_BPS=0        # makers kept whole (default)
+#POLYMARKET_BUILDER_TAKER_FEE_BPS=50       # 0.50% on taker orders (default; FALLBACK since spec 060 — the FeeRouter is the live source)
+#POLYMARKET_BUILDER_MAKER_FEE_BPS=0        # makers kept whole (default; fallback since spec 060)
+
+# FeeRouter (spec 060): on-chain source of truth for the Polymarket builder bps. Defaults to the
+# deployment record's feeRouter for FEE_ROUTER_CHAIN_ID; an override contradicting the record
+# fails boot. Unset + not in the record => env-fallback mode (the two bps values above).
+#FEE_ROUTER_ADDRESS=
+#FEE_ROUTER_CHAIN_ID=137
+#FEE_ROUTER_CACHE_TTL_MS=30000             # bounds how long an admin rate change takes to go live

--- a/services/relay-gateway/src/config/index.js
+++ b/services/relay-gateway/src/config/index.js
@@ -57,8 +57,17 @@
  *   POLYMARKET_WRITE_QUOTA_GLOBAL      order/cancel writes/min across all callers (default 100)
  *   POLYMARKET_BUILDER_CODE    FairWins bytes32 builder code (spec 057, public; unset => unattributed,
  *                              orders still post — never stranded). Attaches to every order for fee + rewards.
- *   POLYMARKET_BUILDER_TAKER_FEE_BPS  builder fee on taker orders (default 50; hard cap 100 — fails boot if over)
- *   POLYMARKET_BUILDER_MAKER_FEE_BPS  builder fee on maker orders (default 0; hard cap 50 — fails boot if over)
+ *   POLYMARKET_BUILDER_TAKER_FEE_BPS  builder fee on taker orders (default 50; hard cap 100 — fails boot if over).
+ *                              Since spec 060 this is the FALLBACK served when the FeeRouter is
+ *                              unset/unreachable; the on-chain rate is the source of truth.
+ *   POLYMARKET_BUILDER_MAKER_FEE_BPS  builder fee on maker orders (default 0; hard cap 50 — fails boot if over).
+ *                              Fallback since spec 060, same as the taker fee.
+ *   FEE_ROUTER_ADDRESS         FeeRouter proxy (spec 060) serving the LIVE polymarket.taker/.maker bps.
+ *                              Defaults to the deployment record's feeRouter for FEE_ROUTER_CHAIN_ID;
+ *                              a set value that CONTRADICTS the record fails boot loudly. Unset and not
+ *                              in the record => env-fallback mode (pre-060 behavior).
+ *   FEE_ROUTER_CHAIN_ID        chain the FeeRouter is read on (default 137)
+ *   FEE_ROUTER_CACHE_TTL_MS    on-chain rate cache TTL (default 30000 — bounds admin-change latency)
  *
  * The gateway NEVER holds the gas key — that is the engine's (Secret-Manager-held) concern.
  */
@@ -367,6 +376,29 @@ export function loadConfig(env = process.env, opts = {}) {
         return bps
       })(),
     },
+    // FeeRouter (spec 060): the on-chain source of truth for the Polymarket builder bps. The env
+    // takerFeeBps/makerFeeBps above become the FALLBACK when the router is unset or unreachable.
+    // The address defaults to the deployment record's feeRouter (same pinning philosophy as
+    // FR-025); an env override that CONTRADICTS the record fails boot loudly.
+    feeRouter: (() => {
+      const chainId = int(env, 'FEE_ROUTER_CHAIN_ID', 137)
+      const cacheTtlMs = int(env, 'FEE_ROUTER_CACHE_TTL_MS', 30_000)
+      const envAddress = opt(env, 'FEE_ROUTER_ADDRESS', null)
+      if (envAddress && !ADDRESS_RE.test(envAddress)) {
+        throw new Error('[relay-gateway] FEE_ROUTER_ADDRESS is not an address')
+      }
+      const deployment = loadDeployment(deploymentsDir, chainId)
+      const recorded = deployment?.contracts?.feeRouter && ADDRESS_RE.test(deployment.contracts.feeRouter)
+        ? deployment.contracts.feeRouter
+        : null
+      if (envAddress && recorded && envAddress.toLowerCase() !== recorded.toLowerCase()) {
+        throw new Error(
+          `[relay-gateway] FEE_ROUTER_ADDRESS=${envAddress} contradicts the deployment record's feeRouter ` +
+            `${recorded} for chain ${chainId} (${deployment.file}). Refusing to start.`
+        )
+      }
+      return { address: envAddress || recorded, chainId, cacheTtlMs }
+    })(),
     maxQueueDepth: int(env, 'MAX_QUEUE_DEPTH', 100),
     spendWindowMs: int(env, 'SPEND_WINDOW_MS', 3_600_000),
     defaultGasLimit: bigInt(env, 'DEFAULT_GAS_LIMIT', 300_000n),

--- a/services/relay-gateway/src/fees/onchain.js
+++ b/services/relay-gateway/src/fees/onchain.js
@@ -1,0 +1,97 @@
+/**
+ * FeeRouter on-chain rate reader (spec 060).
+ *
+ * The FeeRouter contract is the single source of truth for FairWins' configurable platform fees;
+ * the gateway READS the Polymarket builder taker/maker bps from it so an admin's on-chain change is
+ * live on every member surface within the cache TTL — with no gateway redeploy and no new gateway
+ * mutability (the gateway stays stateless; this is a cached eth_call, nothing more).
+ *
+ * Honesty rules:
+ *   - values read from chain are CLAMPED to the spec-057 caps (100 taker / 50 maker) before being
+ *     served — the contract enforces the caps too, so a clamp firing is logged as a warning;
+ *   - on a read failure the last good value is served while it is still fresh-ish (<= 10x TTL),
+ *     else null — callers fall back to the env-configured bps and mark `source: 'env-fallback'`;
+ *   - a router that is not configured at all returns null immediately (pre-060 behavior).
+ */
+import { ethers } from 'ethers'
+
+const FEE_BPS_IFACE = new ethers.Interface(['function feeBps(bytes32 serviceId) view returns (uint16)'])
+
+export const FEE_SERVICE_IDS = {
+  polymarketTaker: ethers.id('polymarket.taker'),
+  polymarketMaker: ethers.id('polymarket.maker'),
+}
+
+// Spec-057 hard caps, re-applied at read time (defense in depth).
+const TAKER_CAP_BPS = 100
+const MAKER_CAP_BPS = 50
+
+// How long a stale cached value may still be served during an RPC outage before
+// callers drop to env fallback (bounded staleness beats flapping).
+const STALE_FACTOR = 10
+
+/**
+ * @param {object} config gateway config (reads .feeRouter)
+ * @param {Record<number, {call: Function}>} providers per-chain read providers
+ * @param {{now?: () => number, log?: (msg: string) => void}} [opts]
+ * @returns {{ enabled: boolean, address: string|null, getPolymarketBps: () => Promise<{takerBps:number, makerBps:number}|null> }}
+ */
+export function createFeeRouterReader(config, providers, opts = {}) {
+  const now = opts.now ?? Date.now
+  const log = opts.log ?? ((msg) => console.warn(msg))
+  const fr = config.feeRouter || {}
+  const provider = fr.address ? providers?.[fr.chainId] : null
+  const enabled = Boolean(fr.address && provider)
+
+  let cached = null // { takerBps, makerBps, fetchedAt }
+  let inflight = null
+
+  async function readBps(serviceId, capBps, label) {
+    const data = FEE_BPS_IFACE.encodeFunctionData('feeBps', [serviceId])
+    const ret = await provider.call({ to: fr.address, data })
+    const [bps] = FEE_BPS_IFACE.decodeFunctionResult('feeBps', ret)
+    const value = Number(bps)
+    if (value > capBps) {
+      // The contract enforces per-service caps, so this should be impossible — clamp and shout.
+      log(`[relay-gateway] FeeRouter ${label} bps ${value} exceeds the ${capBps} cap; clamping (investigate!)`)
+      return capBps
+    }
+    return value
+  }
+
+  async function refresh() {
+    const [takerBps, makerBps] = await Promise.all([
+      readBps(FEE_SERVICE_IDS.polymarketTaker, TAKER_CAP_BPS, 'polymarket.taker'),
+      readBps(FEE_SERVICE_IDS.polymarketMaker, MAKER_CAP_BPS, 'polymarket.maker'),
+    ])
+    cached = { takerBps, makerBps, fetchedAt: now() }
+    return cached
+  }
+
+  /**
+   * Live Polymarket builder bps, or null when the gateway must fall back to env values.
+   */
+  async function getPolymarketBps() {
+    if (!enabled) return null
+    if (cached && now() - cached.fetchedAt < fr.cacheTtlMs) {
+      return { takerBps: cached.takerBps, makerBps: cached.makerBps }
+    }
+    if (!inflight) {
+      inflight = refresh().finally(() => {
+        inflight = null
+      })
+    }
+    try {
+      const fresh = await inflight
+      return { takerBps: fresh.takerBps, makerBps: fresh.makerBps }
+    } catch (err) {
+      log(`[relay-gateway] FeeRouter read failed: ${err?.message || err}`)
+      if (cached && now() - cached.fetchedAt < fr.cacheTtlMs * STALE_FACTOR) {
+        return { takerBps: cached.takerBps, makerBps: cached.makerBps }
+      }
+      return null
+    }
+  }
+
+  return { enabled, address: fr.address ?? null, getPolymarketBps }
+}

--- a/services/relay-gateway/src/polymarket/routes.js
+++ b/services/relay-gateway/src/polymarket/routes.js
@@ -35,7 +35,7 @@ import {
  *   killSwitch: {isActive: () => boolean},
  * }} deps
  */
-export function createPolymarketRouter(config, { client, gammaClient, dataClient, cache, quotas, writeQuotas, killSwitch }) {
+export function createPolymarketRouter(config, { client, gammaClient, dataClient, cache, quotas, writeQuotas, killSwitch, feeRates }) {
   const pm = config.polymarket
   const gamma = gammaClient ?? client // browse/search host (public)
   const data = dataClient ?? client // positions host (public)
@@ -178,7 +178,13 @@ export function createPolymarketRouter(config, { client, gammaClient, dataClient
         // The builder code + fee are OUR config and are ALWAYS known — trading must never be blocked
         // by a CLOB fee-rate quirk (FR-015). Polymarket's own taker fee (base_fee → the order's
         // feeRateBps) is best-effort: fetched for the signed order, null if the CLOB has none.
-        const builder = attachBuilderCode(config, { chainId: 137 })
+        // Since spec 060 the bps come LIVE from the FeeRouter contract (admin-editable on-chain);
+        // the env values remain the honest fallback when the router is unset/unreachable.
+        const live = feeRates ? await feeRates.getPolymarketBps() : null
+        const effectiveConfig = live
+          ? { ...config, polymarket: { ...pm, takerFeeBps: live.takerBps, makerFeeBps: live.makerBps } }
+          : config
+        const builder = attachBuilderCode(effectiveConfig, { chainId: 137 })
         let platform = null
         try {
           platform = normalizeFeeRate(await client.get('/fee-rate', { query: { token_id: tokenId } }), tokenId)
@@ -192,6 +198,8 @@ export function createPolymarketRouter(config, { client, gammaClient, dataClient
           builderCode: builder.builderCode,
           builderTakerFeeBps: builder.takerFeeBps,
           builderMakerFeeBps: builder.makerFeeBps,
+          // Where the bps came from: the on-chain FeeRouter, or the env fallback.
+          source: live ? 'chain' : 'env-fallback',
         }
       })
       respond(res, result)

--- a/services/relay-gateway/src/server.js
+++ b/services/relay-gateway/src/server.js
@@ -18,6 +18,7 @@ import express from 'express'
 import helmet from 'helmet'
 import { loadConfig } from './config/index.js'
 import { buildProviders } from './config/providers.js'
+import { createFeeRouterReader } from './fees/onchain.js'
 import { parseIntent, verifyIntent } from './intent/verify.js'
 import { createIntentStore } from './intent/store.js'
 import { createSanctionsScreen } from './policy/sanctions.js'
@@ -110,6 +111,8 @@ export function createApp(config, deps = {}) {
   const now = deps.now ?? (() => Math.floor(Date.now() / 1000))
   const killSwitch = deps.killSwitch ?? createKillSwitch(config.killSwitch)
   const audit = createAuditLogger(deps.auditSink ? { sink: deps.auditSink } : {})
+  // Live platform-fee rates from the FeeRouter contract (spec 060); env bps are the fallback.
+  const feeRates = deps.feeRates ?? createFeeRouterReader(config, providers)
 
   const nowMs = () => now() * 1000
   const store = createIntentStore({ now: nowMs })
@@ -267,7 +270,25 @@ export function createApp(config, deps = {}) {
     for (const [id, c] of Object.entries(healthCache.chains || {})) {
       chains[id] = disclose ? c : { rpc: c.rpc }
     }
-    res.json({ status: 'ok', chains, killSwitch: killSwitch.isActive() })
+    // Platform-fee summary (spec 060): where each fee system's live rate comes from. Public,
+    // read-only telemetry — rates are already public on-chain and in every confirm UI; the
+    // Fees admin tab renders this for the gateway-enforced rows.
+    const liveBps = await feeRates.getPolymarketBps()
+    const fees = {
+      feeRouter: feeRates.address,
+      polymarket: {
+        takerBps: liveBps?.takerBps ?? config.polymarket.takerFeeBps,
+        makerBps: liveBps?.makerBps ?? config.polymarket.makerFeeBps,
+        source: liveBps ? 'chain' : 'env-fallback',
+      },
+      opensea: {
+        referralConfigured: Boolean(
+          config.opensea.referralAddress || Object.keys(config.opensea.referralAddressByChain || {}).length
+        ),
+        beneficiary: config.opensea.referralAddress ?? null,
+      },
+    }
+    res.json({ status: 'ok', chains, killSwitch: killSwitch.isActive(), fees })
   }
   app.get('/healthz', healthHandler)
   app.get('/status', healthHandler)
@@ -590,6 +611,7 @@ export function createApp(config, deps = {}) {
       quotas: pmReadQuotas,
       writeQuotas: pmWriteQuotas,
       killSwitch,
+      feeRates,
     })
   )
 

--- a/services/relay-gateway/test/fees.test.js
+++ b/services/relay-gateway/test/fees.test.js
@@ -1,0 +1,172 @@
+/**
+ * Spec 060 — unified platform-fee surfaces on the gateway.
+ *
+ * The FeeRouter contract is the source of truth for the Polymarket builder bps; the gateway reads
+ * it via a cached eth_call and serves `source: "chain"`, falling back to the env-configured bps
+ * (`source: "env-fallback"`) when the router is unset or unreachable. `/status` gains a public
+ * read-only `fees` summary for the Fees admin tab.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import request from 'supertest'
+import { ethers } from 'ethers'
+import { createApp } from '../src/server.js'
+import { createFeeRouterReader, FEE_SERVICE_IDS } from '../src/fees/onchain.js'
+import { testConfig, mockProviders, mockEngine, ORIGIN_SECRET, TEST_NOW } from './helpers.js'
+
+const ROUTER = '0x00000000000000000000000000000000000000F1'
+const TOKEN = '71321045679252212594626385532706912750332728571942532289631379312455583992563'
+const FEE_PATH = `/v1/polymarket/137/fee-rate?token_id=${TOKEN}`
+
+const PM_ENV = {
+  POLYMARKET_API_KEY: 'test-pm-key',
+  POLYMARKET_API_SECRET: Buffer.from('test-secret').toString('base64url'),
+  POLYMARKET_API_PASSPHRASE: 'test-pass',
+  POLYMARKET_API_ADDRESS: '0x1111111111111111111111111111111111111111',
+  POLYMARKET_BUILDER_CODE: '0x6e0316783960e149b53466f0f2c5fdbaf5ce11ba15669491de980f6dedc493a3',
+}
+
+const IFACE = new ethers.Interface(['function feeBps(bytes32 serviceId) view returns (uint16)'])
+const encodeBps = (n) => IFACE.encodeFunctionResult('feeBps', [n])
+
+/** A provider whose FeeRouter answers come from a per-service bps map (throws when `fail`). */
+function feeRouterProvider(bpsByService, state = {}) {
+  return {
+    calls: 0,
+    async call(tx) {
+      this.calls += 1
+      if (state.fail) throw new Error('rpc down')
+      const [serviceId] = IFACE.decodeFunctionData('feeBps', tx.data)
+      return encodeBps(bpsByService[serviceId] ?? 0)
+    },
+  }
+}
+
+function readerConfig(overrides = {}) {
+  return {
+    feeRouter: { address: ROUTER, chainId: 137, cacheTtlMs: 30_000, ...overrides },
+  }
+}
+
+describe('createFeeRouterReader', () => {
+  it('is disabled (null) when no router address is configured', async () => {
+    const reader = createFeeRouterReader({ feeRouter: { address: null, chainId: 137, cacheTtlMs: 30_000 } }, {})
+    expect(reader.enabled).toBe(false)
+    expect(await reader.getPolymarketBps()).toBeNull()
+  })
+
+  it('reads live taker/maker bps from the router and caches within the TTL', async () => {
+    const provider = feeRouterProvider({
+      [FEE_SERVICE_IDS.polymarketTaker]: 40,
+      [FEE_SERVICE_IDS.polymarketMaker]: 10,
+    })
+    let t = 1_000_000
+    const reader = createFeeRouterReader(readerConfig(), { 137: provider }, { now: () => t })
+    expect(await reader.getPolymarketBps()).toEqual({ takerBps: 40, makerBps: 10 })
+    expect(provider.calls).toBe(2) // one per service
+    // Inside the TTL: served from cache, no new calls.
+    t += 10_000
+    await reader.getPolymarketBps()
+    expect(provider.calls).toBe(2)
+    // Past the TTL: re-read.
+    t += 30_000
+    await reader.getPolymarketBps()
+    expect(provider.calls).toBe(4)
+  })
+
+  it('clamps above-cap chain values to the spec-057 caps and warns', async () => {
+    const log = vi.fn()
+    const provider = feeRouterProvider({
+      [FEE_SERVICE_IDS.polymarketTaker]: 120, // above the 100 cap — "impossible", clamp + shout
+      [FEE_SERVICE_IDS.polymarketMaker]: 60, // above the 50 cap
+    })
+    const reader = createFeeRouterReader(readerConfig(), { 137: provider }, { log })
+    expect(await reader.getPolymarketBps()).toEqual({ takerBps: 100, makerBps: 50 })
+    expect(log).toHaveBeenCalledTimes(2)
+  })
+
+  it('serves the last good value during a short outage, null once it is too stale', async () => {
+    const state = { fail: false }
+    const provider = feeRouterProvider({ [FEE_SERVICE_IDS.polymarketTaker]: 40 }, state)
+    let t = 1_000_000
+    const reader = createFeeRouterReader(readerConfig(), { 137: provider }, { now: () => t, log: () => {} })
+    expect((await reader.getPolymarketBps()).takerBps).toBe(40)
+    state.fail = true
+    t += 60_000 // past the TTL but within the bounded-staleness window
+    expect((await reader.getPolymarketBps()).takerBps).toBe(40)
+    t += 600_000 // way past — env fallback takes over
+    expect(await reader.getPolymarketBps()).toBeNull()
+  })
+})
+
+// ---- routes -------------------------------------------------------------------------------------
+
+const jsonRes = (body) => ({ ok: true, status: 200, async json() { return body }, async text() { return JSON.stringify(body) } })
+const pmFetch = () => async (url) => (String(url).includes('/fee-rate') ? jsonRes({ base_fee: 1000 }) : jsonRes({ data: [] }))
+
+function build({ feeRates } = {}) {
+  const config = testConfig(PM_ENV)
+  const { app } = createApp(config, {
+    providers: mockProviders(config),
+    engineClient: mockEngine(),
+    now: () => TEST_NOW,
+    polymarketFetch: pmFetch(),
+    ...(feeRates ? { feeRates } : {}),
+  })
+  return { app, config }
+}
+
+const get = (app, path) => request(app).get(path).set('X-Origin-Auth', ORIGIN_SECRET)
+
+describe('GET fee-rate with the FeeRouter as source (spec 060)', () => {
+  it('serves the on-chain bps with source "chain" when the reader has a live value', async () => {
+    const feeRates = {
+      enabled: true,
+      address: ROUTER,
+      getPolymarketBps: async () => ({ takerBps: 40, makerBps: 0 }),
+    }
+    const res = await get(build({ feeRates }).app, FEE_PATH)
+    expect(res.status).toBe(200)
+    expect(res.body.builderTakerFeeBps).toBe(40)
+    expect(res.body.builderMakerFeeBps).toBe(0)
+    expect(res.body.source).toBe('chain')
+  })
+
+  it('falls back to the env bps with source "env-fallback" when the reader has no value', async () => {
+    const feeRates = { enabled: false, address: null, getPolymarketBps: async () => null }
+    const res = await get(build({ feeRates }).app, FEE_PATH)
+    expect(res.status).toBe(200)
+    expect(res.body.builderTakerFeeBps).toBe(50) // POLYMARKET_BUILDER_TAKER_FEE_BPS default
+    expect(res.body.source).toBe('env-fallback')
+  })
+
+  it('defaults to env-fallback with no FeeRouter recorded for the chain (pre-060 parity)', async () => {
+    const res = await get(build().app, FEE_PATH)
+    expect(res.status).toBe(200)
+    expect(res.body.builderTakerFeeBps).toBe(50)
+    expect(res.body.source).toBe('env-fallback')
+  })
+})
+
+describe('GET /status fees block (spec 060)', () => {
+  it('summarizes every fee system: feeRouter, polymarket bps + source, opensea referral', async () => {
+    const feeRates = {
+      enabled: true,
+      address: ROUTER,
+      getPolymarketBps: async () => ({ takerBps: 40, makerBps: 0 }),
+    }
+    const res = await get(build({ feeRates }).app, '/status')
+    expect(res.status).toBe(200)
+    expect(res.body.fees).toEqual({
+      feeRouter: ROUTER,
+      polymarket: { takerBps: 40, makerBps: 0, source: 'chain' },
+      opensea: { referralConfigured: false, beneficiary: null },
+    })
+  })
+
+  it('reports env-fallback rates when no router is configured', async () => {
+    const res = await get(build().app, '/status')
+    expect(res.status).toBe(200)
+    expect(res.body.fees.feeRouter).toBeNull()
+    expect(res.body.fees.polymarket).toEqual({ takerBps: 50, makerBps: 0, source: 'env-fallback' })
+  })
+})

--- a/specs/060-platform-fee-wrapper/checklists/requirements.md
+++ b/specs/060-platform-fee-wrapper/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Configurable Platform Fee Wrapper
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The four scope-shaping decisions (fee basis, legacy-fee editability, first consumer, hard cap)
+  were resolved directly with the requester before drafting, so no [NEEDS CLARIFICATION] markers
+  were needed.

--- a/specs/060-platform-fee-wrapper/contracts/fee-router.md
+++ b/specs/060-platform-fee-wrapper/contracts/fee-router.md
@@ -1,0 +1,65 @@
+# Interface Contract: `FeeRouter` (spec 060)
+
+Solidity interface exposed by `contracts/fees/FeeRouter.sol` (UUPS proxy, deployment
+keys `feeRouter` / `feeRouterImpl`). See [data-model.md](../data-model.md) for storage,
+events, and errors.
+
+```solidity
+interface IFeeRouter {
+    enum ServiceKind { Unregistered, Wrapped, ConfigOnly }
+
+    struct Service {
+        uint16 capBps;   // hard cap; 0 => unregistered
+        uint16 feeBps;   // live rate, 0..capBps
+        ServiceKind kind;
+    }
+
+    // --- reads (member surfaces + admin tab) ---
+    function treasury() external view returns (address);
+    function getService(bytes32 serviceId) external view returns (Service memory);
+    function feeBps(bytes32 serviceId) external view returns (uint16);
+    function serviceCount() external view returns (uint256);
+    function serviceAt(uint256 index) external view returns (bytes32);
+    function quoteFee(bytes32 serviceId, uint256 grossAmount)
+        external view returns (uint256 feeAmount, uint256 netAmount);
+    function MAX_WRAPPED_FEE_BPS() external view returns (uint16); // 250
+
+    // --- admin (DEFAULT_ADMIN_ROLE) ---
+    function registerService(bytes32 serviceId, uint16 capBps, ServiceKind kind) external;
+    function setTreasury(address newTreasury) external;
+
+    // --- admin (FEE_ADMIN_ROLE) ---
+    function setFeeBps(bytes32 serviceId, uint16 newBps) external;
+
+    // --- member action (Wrapped services) ---
+    /// Pulls `assets` of `IERC4626(vault).asset()` from msg.sender, transfers the fee
+    /// (floor(assets * feeBps / 10_000)) to `treasury`, deposits the remainder into
+    /// `vault` for `receiver`. Reverts entirely if any leg fails (atomic).
+    /// Reverts FeeAboveQuoted() if live feeBps > maxFeeBps (the rate the member saw).
+    /// treasury == address(0) => fee skipped (FeeSkippedNoTreasury), full deposit.
+    /// nonReentrant; checks-effects-interactions.
+    function depositToVaultWithFee(
+        bytes32 serviceId,
+        address vault,
+        uint256 assets,
+        address receiver,
+        uint16 maxFeeBps
+    ) external returns (uint256 shares);
+}
+```
+
+`initialize(address admin, address treasury_)` — one-time; calls
+`__UUPSManaged_init(admin)` first (grants DEFAULT_ADMIN + UPGRADER + FEE_ADMIN), sets
+treasury (zero allowed at init for not-yet-configured networks — charge path then skips
+fees).
+
+## Invariants
+
+1. Router token balance is zero outside a transaction (no accrual custody).
+2. `feeAmount + netAmount == assets` for every charge; `netAmount` shares go to
+   `receiver`, never the router.
+3. A `FeeCharged` event's `feeAmount` equals the ERC-20 transfer to `treasury` in the
+   same tx (reconciliation basis, FR-020).
+4. No path charges `feeBps > min(capBps, maxFeeBps)`.
+5. Registration is one-shot per id (`AlreadyRegistered`); caps never change post-
+   registration in v1.

--- a/specs/060-platform-fee-wrapper/contracts/gateway-fees.md
+++ b/specs/060-platform-fee-wrapper/contracts/gateway-fees.md
@@ -1,0 +1,58 @@
+# Interface Contract: relay-gateway fee surfaces (spec 060)
+
+No new writable endpoints. The gateway stays stateless; changes are read-path only.
+
+## Changed: `GET /v1/polymarket/:chainId/fee-rate?token_id=…`
+
+Response (extended — existing fields unchanged for compatibility):
+
+```json
+{
+  "tokenId": "…",
+  "feeRateBps": 0,
+  "builderCode": "0x6e03…93a3",
+  "builderTakerFeeBps": 40,
+  "builderMakerFeeBps": 0,
+  "source": "chain"
+}
+```
+
+- `builderTakerFeeBps` / `builderMakerFeeBps` now come from the FeeRouter on Polygon
+  (`polymarket.taker` / `polymarket.maker`), cached `FEE_ROUTER_CACHE_TTL_MS`
+  (default 30 000 ms).
+- `source`: `"chain"` (live on-chain read) or `"env-fallback"` (router unreachable /
+  `FEE_ROUTER_ADDRESS` unset — serves the env values exactly as today).
+- Chain values are clamped to the spec-057 caps (100 taker / 50 maker) before serving.
+
+## Changed: `GET /status`
+
+Gains a `fees` block (public, read-only telemetry — same disclosure class as existing
+fields):
+
+```json
+{
+  "fees": {
+    "feeRouter": "0x… | null",
+    "polymarket": { "takerBps": 40, "makerBps": 0, "source": "chain" },
+    "opensea": { "referralConfigured": true, "beneficiary": "0x… | null" }
+  }
+}
+```
+
+Consumed by the AdminPanel Fees tab for the gateway-enforced rows.
+
+## New config (env, boot-validated — unchanged philosophy)
+
+| Var | Meaning | Default |
+|---|---|---|
+| `FEE_ROUTER_ADDRESS` | FeeRouter proxy on Polygon; unset ⇒ env-fallback mode. Cross-checked against `deployments/…#feeRouter` at boot (fail loud on mismatch). | unset |
+| `FEE_ROUTER_CHAIN_ID` | Chain the router is read from | `137` |
+| `FEE_ROUTER_CACHE_TTL_MS` | On-chain read cache TTL | `30000` |
+| `POLYMARKET_BUILDER_TAKER_FEE_BPS` | **Demoted to fallback**; boot cap 100 unchanged | `50` |
+| `POLYMARKET_BUILDER_MAKER_FEE_BPS` | **Demoted to fallback**; boot cap 50 unchanged | `0` |
+
+## Order-attachment consistency
+
+`attachBuilderCode` (used by `/fee-rate` and `builder-sign`) reads the same cached chain
+value, so the bps disclosed and the bps attached to orders always come from one read
+path (FR-016; no disclosure/charge divergence within a TTL window).

--- a/specs/060-platform-fee-wrapper/data-model.md
+++ b/specs/060-platform-fee-wrapper/data-model.md
@@ -1,0 +1,91 @@
+# Data Model: Configurable Platform Fee Wrapper (spec 060)
+
+## On-chain — `FeeRouter` (per network, UUPS)
+
+### Storage (append-only, trailing `__gap`)
+
+| Field | Type | Notes |
+|---|---|---|
+| `treasury` | `address` | Per-network fee destination. Set in `initialize`, changeable via `setTreasury` (DEFAULT_ADMIN). Zero ⇒ charge path skips the fee (emits `FeeSkippedNoTreasury`). |
+| `_services` | `mapping(bytes32 => Service)` | Registry of fee services. |
+| `_serviceIds` | `bytes32[]` | Enumeration for the admin UI (`serviceCount()` / `serviceAt(i)`). |
+| `__gap` | `uint256[47]` | Reserved. |
+
+### `Service` struct
+
+| Field | Type | Notes |
+|---|---|---|
+| `capBps` | `uint16` | Fixed-after-registration hard cap. Wrapped: ≤ `MAX_WRAPPED_FEE_BPS` (250). ConfigOnly: set at registration (Polymarket 100/50). `0` cap ⇒ unregistered sentinel. |
+| `feeBps` | `uint16` | Live rate, `0..capBps`. Default 0. |
+| `kind` | `uint8` enum `{Unregistered, Wrapped, ConfigOnly}` | `Wrapped` is chargeable via the deposit entrypoint; `ConfigOnly` is read-only config. |
+
+### Constants / roles
+
+- `MAX_WRAPPED_FEE_BPS = 250` (FR-004)
+- `BPS_DENOMINATOR = 10_000`
+- `FEE_ADMIN_ROLE = keccak256("FEE_ADMIN_ROLE")` — rate changes
+- `DEFAULT_ADMIN_ROLE` — register services, set treasury, grant roles
+- `UPGRADER_ROLE` — from `UUPSManaged`
+
+### Launch service ids
+
+| id | derivation | kind | cap |
+|---|---|---|---|
+| Earn lending | `keccak256("earn.lend")` | Wrapped | 250 |
+| Polymarket taker | `keccak256("polymarket.taker")` | ConfigOnly | 100 |
+| Polymarket maker | `keccak256("polymarket.maker")` | ConfigOnly | 50 |
+
+(Future: `stake.lido`, `stake.polygon`, `swap.uniswap` — registration only, no code.)
+
+### Events (= audit history, FR-012/020, SC-006)
+
+- `ServiceRegistered(bytes32 indexed serviceId, uint16 capBps, uint8 kind)`
+- `FeeBpsChanged(bytes32 indexed serviceId, uint16 oldBps, uint16 newBps, address indexed actor)`
+- `TreasuryChanged(address oldTreasury, address newTreasury, address indexed actor)`
+- `FeeCharged(bytes32 indexed serviceId, address indexed payer, address indexed asset, uint256 grossAmount, uint256 feeAmount, address vault, address receiver)`
+- `FeeSkippedNoTreasury(bytes32 indexed serviceId, address indexed payer, uint256 grossAmount)`
+
+### Errors
+
+`ServiceUnknown()`, `ServiceNotWrapped()`, `CapExceeded()`, `CapAboveMax()`, `CapZero()`,
+`AlreadyRegistered()`, `FeeAboveQuoted()` (maxFeeBps consent, FR-005), `ZeroAmount()`,
+`ZeroAddress()`.
+
+### State transitions
+
+```
+Unregistered --registerService(id, cap, kind) [DEFAULT_ADMIN]--> Registered(feeBps=0)
+Registered   --setFeeBps(id, bps<=cap) [FEE_ADMIN]-->            Registered(feeBps=bps)   (emits FeeBpsChanged)
+(no deregistration in v1; emergency = setFeeBps(id, 0))
+```
+
+## Gateway (in-memory only — no new persistence)
+
+- **FeeRouterReader** (`src/fees/onchain.js`): `{ address, chainId, cacheTtlMs }` +
+  cached `{ takerBps, makerBps, fetchedAt }`. Read failure ⇒ served-if-fresh-ish else
+  null ⇒ env fallback.
+- **/fee-rate response (extended)**: `{ tokenId, feeRateBps, builderCode,
+  builderTakerFeeBps, builderMakerFeeBps, source: "chain"|"env-fallback" }` — chain
+  values clamped to spec-057 caps.
+- **/status.fees (new block)**: `{ feeRouter, polymarket: { takerBps, makerBps, source },
+  opensea: { referralConfigured, beneficiary } }`.
+
+## Frontend
+
+- **FeeQuote** (`lib/fees/feeQuote.js`): `{ available, bps, capBps, routerAddress }` +
+  `splitFee(gross, bps)` (floor) + `bpsToPercent`. The quoted `bps` is passed as
+  `maxFeeBps` (consent ceiling, FR-005).
+- **Fees tab row**: `{ serviceId, label, surface, feeBps, capBps, kind }` + history
+  entries `{ actor, at, oldBps, newBps }` from `FeeBpsChanged`.
+- **RoleContext**: adds `FEE_ADMIN` (resolved on the FeeRouter) for tab gating;
+  enforcement stays on-chain.
+
+## Validation rules (cross-layer)
+
+1. `bps <= capBps` — enforced in `setFeeBps` (revert) and re-checked at charge time.
+2. `capBps <= 250` for Wrapped — enforced at registration.
+3. `bps <= maxFeeBps` (member consent) — enforced at charge time only.
+4. `fee = gross * bps / 10_000` floor; `fee == 0` ⇒ no transfer (FR-006).
+5. `treasury == 0` ⇒ fee skipped, event emitted (never revert, never lose funds).
+6. Gateway clamps chain-read bps to spec-057 caps before serving.
+7. UI blocks the action when no live rate is obtainable (FR-015).

--- a/specs/060-platform-fee-wrapper/plan.md
+++ b/specs/060-platform-fee-wrapper/plan.md
@@ -1,0 +1,137 @@
+# Implementation Plan: Configurable Platform Fee Wrapper
+
+**Branch**: `feat/platform-fee-wrapper` | **Date**: 2026-07-18 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/060-platform-fee-wrapper/spec.md`
+
+## Summary
+
+Add a single on-chain **`FeeRouter`** contract (UUPS, per network) that is both the
+**source of truth for every configurable platform fee** and the **atomic fee-charging
+wrapper** for external services with no native revenue share. Services are registered as
+`bytes32` service ids with a per-service hard cap (wrapper services ≤ 250 bps; the
+Polymarket taker/maker entries keep their spec-057 caps of 100/50); a `FEE_ADMIN_ROLE`
+sets rates 0..cap; every change emits an attributable event (the change history).
+The first wrapper consumer is **Earn lending** (spec 050): when the lending fee is
+nonzero, the frontend routes vault deposits through
+`FeeRouter.depositToVaultWithFee(serviceId, vault, assets, receiver, maxFeeBps)` — pull
+principal, skim fee to the per-network treasury, deposit the remainder into the ERC-4626
+vault for the member, atomically; `maxFeeBps` pins the member to the rate they were shown
+(FR-005). With a zero fee (or no router deployed on the chain) the existing direct
+approve+deposit path is unchanged. The **Polymarket builder fee** moves its source of
+truth on-chain: the relay-gateway's `/fee-rate` endpoint reads the FeeRouter entries on
+Polygon (short-TTL cache, env values demoted to fallback/caps), so an admin bps change is
+live in Predict's existing confirm UI with **no gateway redeploy and no new gateway
+mutability** — the gateway stays stateless with no admin API, per its design. A new
+role-gated **Fees tab** in the AdminPanel (pattern: `ProtocolConfigTab`) lists all fee
+systems — wrapper services, Polymarket taker/maker, OpenSea referral (display-only,
+no-cost) — with live rates, caps, treasury, per-network availability, and on-chain
+change history, and writes changes via the wallet (`runTx`, on-chain role = auth).
+Docs: developer guide (how to register a future service: Lido, Polygon LST, Uniswap),
+operations runbook (change/verify/emergency-zero/reconcile), and a member-facing fees
+page. Decision log: [research.md](research.md).
+
+## Technical Context
+
+**Language/Version**: Solidity 0.8.x + Hardhat (contracts); JavaScript ESM — Node ≥20
+(relay-gateway, Express 4), Node ≥22 + React 19 + Vite (frontend)
+
+**Primary Dependencies**: contracts: OpenZeppelin upgradeable (`UUPSManaged` base,
+`AccessControlUpgradeable`, `SafeERC20`, `ReentrancyGuardUpgradeable`), ERC-4626 vault
+interface (no new dep); gateway: ethers v6 (already present) for the on-chain fee read —
+no new npm dep; frontend: ethers v6 + existing wagmi/`sendCalls` rail — no new dep
+
+**Storage**: on-chain FeeRouter storage (append-only + `__gap`); no new off-chain
+persistence — the gateway keeps its stateless, env-at-boot design and only gains a
+short-TTL in-memory cache for the on-chain fee read; fee change history = contract events
+
+**Testing**: Hardhat unit tests (`test/feeRouter.test.js`), upgrade/storage tests
+(`test/upgradeable/FeeRouter.upgrade.test.js`), integration with a mock ERC-4626 vault;
+gateway Vitest + Supertest with injected provider mock (`test/fees.test.js`); frontend
+Vitest + Testing Library + vitest-axe (VaultSheet fee line, Fees tab)
+
+**Target Platform**: EVM networks in `deployments/` (Polygon first; router deployable
+per network); relay-gateway on Cloud Run; frontend SPA
+
+**Project Type**: web application — `contracts/` + `services/relay-gateway/` +
+`frontend/` + `docs/`; no subgraph changes
+
+**Performance Goals**: fee quote (rate read) resolves with the vault detail load (one
+extra `eth_call`, cacheable); admin change visible on member surfaces within one block +
+gateway cache TTL (≤ 60 s, satisfies SC-003's 1-minute bound)
+
+**Constraints**: gateway must remain stateless (no durable store, no admin HTTP API);
+member is never charged above the disclosed rate (`maxFeeBps` enforced on-chain); fee
+math rounds down (member's favor); zero-fee and router-undeployed paths must be
+byte-identical to today's behavior
+
+**Scale/Scope**: 1 new contract (+1 mock), ~3 service ids at launch (`earn.lend`,
+`polymarket.taker`, `polymarket.maker`), 1 new admin tab, 1 gateway read-path change,
+1 Earn call-path change, 3 docs artifacts
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Security-first contracts | PASS (design gate) | FeeRouter is value-bearing (custodies funds transiently within one tx). CEI + `nonReentrant` on `depositToVaultWithFee`; `SafeERC20` everywhere; fee transfer and vault deposit in one tx (atomicity FR-003); caps enforced in the setter **and** re-checked at charge time; `maxFeeBps` protects members from admin front-running; role-gated setters (`FEE_ADMIN_ROLE`), upgrade gated `UPGRADER_ROLE` via `UUPSManaged`. Slither + security-agent review before merge; fund-custody reasoning recorded here and in research.md R2. |
+| II. Test-first, comprehensive | PASS | Unit tests for fee math (incl. rounding-to-zero, cap rejection, maxFeeBps revert, treasury-unset ⇒ zero fee), atomic-revert test (vault deposit reverts ⇒ fee reverts), upgrade/storage-layout test, gateway `/fee-rate` on-chain-source tests (incl. RPC-failure fallback), frontend tests for fee line, zero-fee path, and Fees tab (incl. axe). |
+| III. Honest state, no mocks in shipped paths | PASS | Disclosed rate is read live from the same contract the admin writes; gateway falls back to env caps only with an explicit `source` marker; UI never shows a rate it can't honor (maxFeeBps); mock vault lives in `contracts/mocks/` only. |
+| IV. Fail loudly in CI | PASS | New tests join existing gates; `check:storage-layout` extended to FeeRouter; no `continue-on-error`. |
+| V. Accessible, consistent frontend | PASS | Fees tab follows AdminPanel/PortalNav pattern; fee line follows the spec-057 disclosure pattern with info bubble; axe tests; addresses only via `getContractAddressForChain` from sync artifacts. |
+| Constraints (stack, keys, deployments) | PASS | No new core tech. Admin actions use wallet-as-auth on-chain roles (floppy keystore flow unchanged). Deployment via `scripts/deploy/lib/upgradeable.js` `deployProxy`, recorded keys `feeRouter`/`feeRouterImpl` in `deployments/`. |
+
+**Post-design re-check (after Phase 1)**: PASS — the one YAGNI trade-off (no `…WithSig`
+intent twins on `depositToVaultWithFee` in v1) is logged in Complexity Tracking.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/060-platform-fee-wrapper/
+├── spec.md
+├── plan.md              # This file
+├── research.md          # Phase 0 decisions
+├── data-model.md        # Phase 1 entities/storage
+├── quickstart.md        # Phase 1 validation guide
+├── contracts/
+│   ├── fee-router.md
+│   └── gateway-fees.md
+├── checklists/requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+contracts/fees/{FeeRouter,IFeeRouter}.sol           # NEW — UUPS registry + atomic wrapper
+contracts/mocks/{MockERC4626Vault,FeeRouterUpgradeMock}.sol  # NEW (test-only)
+test/feeRouter.test.js + test/upgradeable/FeeRouter.upgrade.test.js  # NEW
+test/helpers/proxy.js                                # EXTEND — deployFeeRouter
+scripts/deploy/deploy-fee-router.js                  # NEW
+scripts/deploy/check-storage-layout.js               # EXTEND
+scripts/utils/sync-frontend-contracts.js             # EXTEND
+services/relay-gateway/src/fees/onchain.js           # NEW — FeeRouter reader + TTL cache
+services/relay-gateway/src/{config/index,polymarket/routes,server}.js  # EXTEND
+frontend/src/abis/FeeRouter.js                       # NEW
+frontend/src/lib/fees/feeQuote.js                    # NEW
+frontend/src/lib/earn/vaultActions.js                # EXTEND — fee path
+frontend/src/components/earn/VaultSheet.jsx          # EXTEND — fee line
+frontend/src/components/admin/FeesTab.jsx            # NEW
+frontend/src/components/admin/adminNav.js + AdminPanel.jsx  # EXTEND
+frontend/src/contexts/{RoleContext,WalletContext}.jsx + utils/blockchainService.js  # EXTEND — FEE_ADMIN
+docs/developer-guide/platform-fees.md + docs/runbooks/fee-operations.md + docs/user-guide/platform-fees.md  # NEW
+```
+
+**Structure Decision**: web-application layout already in place; this feature adds one
+contract module (`contracts/fees/`), one gateway module (`src/fees/`), one admin tab, and
+extends the Earn call path — all inside existing directories and conventions.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| New value-bearing contract (FeeRouter) | FR-003 atomicity: fee + external-service leg must revert together; a frontend-batched fee transfer is not atomic for classic wallets (separate txs ⇒ treasury could keep a fee for a failed deposit) | "Batch a treasury transfer client-side" rejected — violates FR-003/FR-005 and honest-state; no cap or consent ceiling enforceable on-chain |
+| No `…WithSig` intent twins on `depositToVaultWithFee` in v1 | Earn deposits already ride the spec-041 `sendCalls` rail (passkey UserOps get gasless via spec-050 paymaster); adding twins forces the three-way intentTypes sync for a path with no relayer consumer today | Kept out per YAGNI; documented so a future spec can add twins without storage changes (functions only) |

--- a/specs/060-platform-fee-wrapper/quickstart.md
+++ b/specs/060-platform-fee-wrapper/quickstart.md
@@ -1,0 +1,71 @@
+# Quickstart Validation: Configurable Platform Fee Wrapper (spec 060)
+
+Runnable scenarios proving the feature end-to-end. Interfaces:
+[contracts/fee-router.md](contracts/fee-router.md),
+[contracts/gateway-fees.md](contracts/gateway-fees.md); entities:
+[data-model.md](data-model.md).
+
+## Prerequisites
+
+```bash
+npm ci && npm run compile
+(cd services/relay-gateway && npm ci)
+(cd frontend && npm ci)
+```
+
+## 1. Contract suite (fee math, atomicity, caps, consent, roles)
+
+```bash
+npx hardhat test test/feeRouter.test.js test/upgradeable/FeeRouter.upgrade.test.js
+npm run check:storage-layout
+```
+
+Expected: all green. Covers — 50 bps on 100 USDC ⇒ 0.50 fee / 99.50 deposited;
+floor-rounding to zero charges nothing; `setFeeBps` above cap reverts `CapExceeded`;
+live rate above `maxFeeBps` reverts `FeeAboveQuoted`; vault revert rolls back the fee;
+zero treasury ⇒ full deposit + `FeeSkippedNoTreasury`; non-FEE_ADMIN `setFeeBps` reverts;
+`FeeBpsChanged` carries actor/old/new; storage layout registered and clean.
+
+## 2. Gateway (live bps from chain, honest fallback)
+
+```bash
+cd services/relay-gateway && npx vitest run test/fees.test.js test/polymarket.test.js test/gateway.test.js
+```
+
+Expected: `/fee-rate` returns chain-sourced bps with `source: "chain"`; provider failure
+⇒ env values with `source: "env-fallback"`; above-cap chain value clamped + warned;
+`/status` includes the `fees` block.
+
+## 3. Frontend (disclosure, zero-fee parity, admin tab)
+
+```bash
+npm run test:frontend
+```
+
+Expected: VaultSheet shows the "FairWins platform fee" line only when bps > 0 and blocks
+deposit when the quote is unavailable; `buildDepositCalls` emits approve+`depositToVault
+WithFee` when bps > 0 and today's approve+deposit when 0; FeesTab renders all rows, gates
+edits by role, validates caps client-side; axe passes.
+
+## 4. Manual end-to-end (local chain)
+
+```bash
+npx hardhat node &
+npx hardhat run scripts/deploy/deploy.js --network localhost
+npx hardhat run scripts/deploy/deploy-fee-router.js --network localhost
+npm run sync:frontend-contracts && npm run frontend
+```
+
+1. AdminPanel → Fees: see `earn.lend 0/250`, `polymarket.taker 50/100`,
+   `polymarket.maker 0/50`, treasury. Set `earn.lend` to 50 bps → history row appears.
+2. Earn → vault → deposit 100: review shows "FairWins platform fee 0.50% · 0.50",
+   net 99.50; confirm; treasury +0.50, vault position 99.50.
+3. Set fee back to 0 → new deposit shows no fee line, full amount deposited.
+4. Try 300 bps → rejected before send and reverts on-chain if forced.
+
+## 5. Docs artifacts
+
+- `docs/developer-guide/platform-fees.md` — following only its "register a new service"
+  steps yields a working new fee entry (SC-005).
+- `docs/runbooks/fee-operations.md` — the emergency-zero procedure works as written.
+- `docs/user-guide/platform-fees.md` renders on the docs site build.

--- a/specs/060-platform-fee-wrapper/research.md
+++ b/specs/060-platform-fee-wrapper/research.md
@@ -1,0 +1,131 @@
+# Research & Decisions: Configurable Platform Fee Wrapper (spec 060)
+
+Format per Spec Kit: Decision / Rationale / Alternatives considered.
+
+## R1 — Where does the unified fee configuration live?
+
+**Decision**: On-chain, in a single `FeeRouter` contract per network (UUPS via
+`UUPSManaged`). It is the source of truth for wrapper-service rates **and** the
+Polymarket builder taker/maker bps. The relay-gateway *reads* it; nothing writes config
+off-chain.
+
+**Rationale**:
+- The relay-gateway is deliberately **stateless and has no admin HTTP API** — all config
+  is env-at-boot (`services/relay-gateway/src/config/index.js`), state is in-memory, and
+  the only runtime toggle is the SIGUSR2 killswitch. Building a writable admin API +
+  durable store on Cloud Run would reverse that design and invent a new auth model.
+- Every existing admin surface already uses **wallet-as-auth against on-chain roles**
+  (`PaymasterOpsCard`, `MaintenanceTab`, `ProtocolConfigTab` write via ethers + `runTx`).
+  An on-chain fee registry gets admin auth, attribution, and history for free.
+- FR-012's attributable change history falls out of events (`FeeBpsChanged`), and
+  FR-010's "no redeploy" holds because the gateway re-reads the chain.
+
+**Alternatives considered**:
+- *Gateway runtime config store + authenticated admin endpoints*: rejected — needs new
+  persistence (none exists), new auth (none exists), contradicts the gateway's design,
+  and splits fee truth across two systems.
+- *Keep env-only Polymarket bps (read-only dashboard)*: rejected by the requester
+  (clarification: legacy fees become fully editable).
+
+## R2 — Wrapper mechanics: how is the fee charged atomically?
+
+**Decision**: `FeeRouter.depositToVaultWithFee(serviceId, vault, assets, receiver,
+maxFeeBps)`: pull `assets` (SafeERC20), compute `fee = assets * bps / 10_000` (floor),
+transfer `fee` to treasury, approve the vault for `assets - fee`, call
+`IERC4626(vault).deposit(assets - fee, receiver)`, in one transaction guarded by
+`nonReentrant` and CEI. Any leg reverts ⇒ everything reverts (FR-003). The router holds
+funds only transiently within the tx.
+
+**Rationale**: Earn today deposits **directly** into the Morpho vault (approve +
+`deposit`, no intermediary). A client-side "extra transfer in the batch" is not atomic
+for classic wallets (per-call txs), so the treasury could keep a fee for a failed
+deposit — forbidden by FR-003. Only a contract makes fee+deposit atomic for every wallet.
+
+**Alternatives considered**: client-batched treasury transfer (rejected — atomicity, cap,
+consent unenforceable); per-service ERC-1167 clones (rejected — services are stateless
+pass-throughs, one router with service ids is simpler); charging on yield/at exit
+(rejected by the requester — fee basis = principal at entry).
+
+## R3 — Member consent ceiling (FR-005)
+
+**Decision**: The frontend passes the **quoted** bps as `maxFeeBps`; the router reverts
+`FeeAboveQuoted()` if the live rate exceeds it at execution time. Withdrawals never touch
+the router.
+
+**Rationale**: an admin raising the rate between quote and execution otherwise silently
+over-charges; a revert forces an honest re-review. Mirrors slippage-protection UX.
+
+## R4 — Service identity, caps, and registration
+
+**Decision**: `bytes32 serviceId = keccak256("<domain>")` with launch ids
+`earn.lend` (Wrapped, cap 250), `polymarket.taker` (ConfigOnly, cap 100),
+`polymarket.maker` (ConfigOnly, cap 50). `DEFAULT_ADMIN_ROLE` registers via
+`registerService(serviceId, capBps, kind)`; wrapped caps are themselves capped by
+`MAX_WRAPPED_FEE_BPS = 250`. `FEE_ADMIN_ROLE` sets rates via `setFeeBps` with `bps <=
+capBps` enforced in the setter **and** re-checked at charge time. ConfigOnly entries have
+no charging path — the gateway/Predict reads them.
+
+**Rationale**: future services register without fee-system code changes (FR-007, SC-005);
+ConfigOnly lets the Polymarket bps live in the same registry without pretending the
+router charges them; cap-at-registration preserves the spec-057 caps.
+
+## R5 — Treasury destination
+
+**Decision**: `treasury` is a per-network address, set at `initialize` and by
+`setTreasury` (DEFAULT_ADMIN), zero rejected on set. If treasury is unset the charge path
+treats the fee as **zero** (full deposit) and emits `FeeSkippedNoTreasury`. Deployment
+default: the existing `treasury` key already recorded in `deployments/*-v2.json`.
+
+**Rationale**: matches MembershipManager's recorded-treasury precedent and the
+deployments-as-source-of-truth rule; fee-to-zero beats reverting member deposits over an
+ops mistake — funds are never lost.
+
+**Alternatives**: accrue-in-contract + `withdrawFees` (rejected — direct-to-treasury
+keeps the router balance-free, nicer audit surface, one-address reconciliation).
+
+## R6 — How the gateway serves live Polymarket bps without redeploy
+
+**Decision**: `services/relay-gateway/src/fees/onchain.js` reads
+`feeBps('polymarket.taker'/'polymarket.maker')` from the FeeRouter on Polygon via the
+gateway's existing ethers provider, cached with a short TTL (default 30 000 ms).
+`attachBuilderCode` and `/fee-rate` consume it. Env `POLYMARKET_BUILDER_*_FEE_BPS` become
+the **fallback** when the router is unreachable/undeployed; the spec-057 boot caps remain,
+and on-chain values are clamped to those caps at read time. `/fee-rate` gains
+`source: "chain" | "env-fallback"`; `/status` gains a `fees` block for the admin tab.
+
+**Rationale**: keeps the gateway stateless and read-only (its design), meets FR-010/015
+(admin change live ≤ TTL + 1 block ≤ 1 min, SC-003), and the existing Predict confirm UI
+(`TradeConfirm` ← `usePredictTrade.loadFee` ← `fetchFeeRate`) needs no data-path change.
+
+## R7 — Frontend Earn wiring & disclosure
+
+**Decision**: `lib/fees/feeQuote.js` reads the lending rate; `buildDepositCalls` gains
+the fee path (approve router + `depositToVaultWithFee` when bps > 0; today's direct path
+when 0). `VaultSheet` adds the "FairWins platform fee" line (rate %, amount, net) with an
+info bubble only when bps > 0; the quote is fetched with vault state so the rate is live.
+On a failed read the sheet blocks deposit with an honest error (FR-015). Withdrawals
+untouched (FR-002).
+
+## R8 — Admin Fees tab
+
+**Decision**: `FeesTab.jsx` registered as `fees` in `adminNav.js`, gated `isAdmin ||
+isFeeAdmin` (`FEE_ADMIN` role added to `RoleContext`, resolved on the FeeRouter). Reads
+the FeeRouter services table + gateway `/status` fees block (Polymarket source + OpenSea
+referral display-only). Writes `setFeeBps`/`setTreasury` via `runTx`. History from
+`queryFilter(FeeBpsChanged)` with bounded lookback + explorer fallback. Copies the
+`ProtocolConfigTab` read/write shape.
+
+## R9 — Docs & runbook placement
+
+**Decision**: `docs/developer-guide/platform-fees.md`, `docs/runbooks/fee-operations.md`,
+`docs/user-guide/platform-fees.md`, registered in `mkdocs.yml`; CLAUDE.md gains a
+guardrail making the FeeRouter the single fee-config source of truth.
+
+## R10 — Testing strategy
+
+Contract: fee math incl. floor-to-zero, cap enforcement (setter + charge), `maxFeeBps`
+revert, treasury-unset skip, atomic revert with `MockERC4626Vault` revert mode, role
+gating, events, `deployFeeRouter` helper; upgrade/storage test via OZ plugin; register in
+`check:storage-layout`. Gateway: `/fee-rate` chain source, provider-failure fallback,
+above-cap clamp, `/status.fees`. Frontend: `vaultActions` fee vs direct path, VaultSheet
+fee line/hide/blocked, FeesTab render + role gating + axe.

--- a/specs/060-platform-fee-wrapper/spec.md
+++ b/specs/060-platform-fee-wrapper/spec.md
@@ -1,0 +1,332 @@
+# Feature Specification: Configurable Platform Fee Wrapper
+
+**Feature Branch**: `feat/platform-fee-wrapper`
+
+**Created**: 2026-07-18
+
+**Status**: Draft
+
+**Input**: User description: "Configurable platform fee wrapper for external service integrations.
+Several services FairWins integrates with (or plans to) do not offer native fee-sharing /
+revenue-share programs — examples: Morpho lending vaults (Earn, spec 050), Lido staking, Polygon
+liquid staking, Uniswap swaps, and other future integrations. For these, FairWins needs its own
+configurable fee wrapper that takes a platform fee (set in basis points) on the relevant action and
+routes it to the FairWins treasury. Fees are configurable per service from the admin screen,
+transparently disclosed to the user with live rates, denominated in bps with hard caps. The two
+previously shipped independent fee systems — OpenSea referral (specs 055/056) and Polymarket
+builder-code fee (spec 057) — must be brought under this unified fee management. Documentation and
+operational runbooks for the fee system must be added."
+
+## User Scenarios & Testing *(mandatory)*
+
+FairWins earns revenue on integrations two ways. Where the external service offers a native
+attribution program (OpenSea referral rewards, Polymarket builder codes), FairWins uses it. Where
+the service offers nothing (Morpho lending, Lido staking, Polygon liquid staking, Uniswap swaps),
+FairWins currently earns nothing. This feature adds FairWins' own **platform fee wrapper**: when a
+member enters one of these wrapped services, a small platform fee — set in basis points, capped,
+and configured per service by an operator — is taken from the principal at entry and routed to the
+FairWins treasury. The member always sees the live fee, in plain terms, before confirming; a
+zero-fee service shows no fee line. All platform fees — wrapper fees and the previously shipped
+OpenSea/Polymarket programs — become visible and manageable from one **Fees** screen in the
+operations control plane.
+
+### User Story 1 - Member sees and pays a transparent platform fee on Earn deposits (Priority: P1)
+
+A member opens Earn → Lend (spec 050) and deposits into a Morpho vault. Before confirming, the
+review step shows a clearly labeled "FairWins platform fee" line with the live rate (e.g.
+"0.50% · 0.50 USDC") alongside the amount that will actually be deposited (e.g. "99.50 USDC").
+The member confirms once; the fee goes to the FairWins treasury and the remainder enters the
+vault, all in the same action. If the operator has set the fee to zero, no fee line appears and
+the full amount is deposited. The position and activity views reflect the actually-deposited
+amount, never silently absorbing the fee.
+
+**Why this priority**: This is the revenue-generating core of the request and the only part that
+touches member funds — it must exist (with its disclosure) before anything else matters. Earn is
+the one shipped integration without a revenue program today.
+
+**Independent Test**: With a wrapper fee of 50 bps configured for the lending service, deposit
+100 USDC into a vault; verify the treasury receives 0.50 USDC, the vault position reflects
+99.50 USDC, and the confirm step disclosed both numbers before signing. Repeat with 0 bps and
+verify no fee line and a full 100 USDC deposit.
+
+**Acceptance Scenarios**:
+
+1. **Given** a lending fee of 50 bps, **When** a member reviews a 100 USDC vault deposit, **Then**
+   the review step shows a "FairWins platform fee" line of 0.50 USDC (0.50%), the net deposit of
+   99.50 USDC, and an info bubble explaining the fee — before any signature is requested.
+2. **Given** a confirmed deposit with a 50 bps fee, **When** the transaction completes, **Then**
+   the treasury has received exactly the disclosed fee and the member's vault position reflects
+   exactly the disclosed net amount, in a single member-confirmed action.
+3. **Given** a lending fee of 0 bps, **When** a member deposits, **Then** no fee line is shown and
+   the full amount is deposited with no fee transfer.
+4. **Given** a member who was shown a 50 bps fee, **When** the operator raises the fee before the
+   member's transaction executes, **Then** the member is never charged more than the rate they
+   were shown — the action either honors the disclosed rate or fails safely and asks them to
+   re-review.
+5. **Given** a withdrawal of an existing position, **When** the member withdraws, **Then** no
+   platform fee is taken (fees apply to principal at entry only).
+
+---
+
+### User Story 2 - Operator manages every platform fee from one screen (Priority: P2)
+
+An operator with the appropriate admin role opens a new **Fees** view in the operations control
+plane. It lists every platform-fee system in one table: the wrapper-fee services (lending today;
+staking and swaps when they ship), the Polymarket builder fee (spec 057), and the OpenSea referral
+(specs 055/056). For each entry the operator sees the service, the fee basis, the live rate in
+bps, the hard cap, the treasury/beneficiary destination, and where the fee is enforced. The
+operator edits a wrapper fee (e.g. lending 0 → 50 bps) or the Polymarket builder-fee bps within
+its existing caps, confirms, and the change takes effect without a redeploy or service restart.
+Changes above the hard cap are rejected with a clear error. Every change is attributable (who,
+when, old → new).
+
+**Why this priority**: Configurability from the admin screen is the second half of the core
+request — without it, fees are hardcoded and the unified management requirement is unmet. It
+depends on the fee systems existing (Story 1) but not the reverse.
+
+**Independent Test**: As an admin, open the Fees view, change the lending wrapper fee from 0 to
+50 bps and the Polymarket taker fee from 50 to 40 bps; verify both take effect live (next member
+quote reflects them) with no redeploy, and that a value above the cap is rejected.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator with the fee-admin role, **When** they open the Fees view, **Then** they
+   see all platform-fee systems — wrapper services, Polymarket builder fee, OpenSea referral —
+   with live rates, caps, basis, and destinations in one place.
+2. **Given** the Fees view, **When** the operator sets the lending wrapper fee to 50 bps and
+   confirms, **Then** the next member deposit quote reflects 50 bps without any redeploy.
+3. **Given** the Fees view, **When** the operator attempts to set a wrapper fee above the 250 bps
+   hard cap (or a Polymarket fee above its spec-057 caps), **Then** the change is rejected with a
+   clear message and the prior rate remains in force.
+4. **Given** a completed fee change, **When** anyone reviews the change history, **Then** the
+   change shows who made it, when, and the old and new values.
+5. **Given** an operator without the fee-admin role, **When** they open the control plane,
+   **Then** the Fees view is either hidden or read-only for them and every change path is denied.
+
+---
+
+### User Story 3 - Unified fee disclosure across existing surfaces (Priority: P3)
+
+The Polymarket builder fee (Predict) and the OpenSea referral (Collect) join the unified system
+without changing what members were promised. Predict's confirm UI keeps its honest builder-fee
+line but now reads the live rate from the same fee management the admin edits — an admin change
+to the Polymarket bps is reflected in the next order's disclosure. Collect continues to disclose
+that its referral costs the member nothing. Anywhere a platform fee applies, the disclosure
+pattern is the same: a named fee line, the live rate, the absolute amount, and an info bubble —
+never hidden, never stale.
+
+**Why this priority**: Valuable consistency and honesty win, but both surfaces already disclose
+correctly today with static config; this story re-points them at the unified source.
+
+**Independent Test**: Change the Polymarket taker-fee bps in the Fees view; verify the Predict
+confirm UI shows the new rate on the next order without a frontend or gateway redeploy, and that
+Collect's disclosure still shows the no-cost referral.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Polymarket taker fee is changed from 50 to 40 bps in the Fees view, **When** a
+   member reviews their next Predict order, **Then** the fee line shows 0.40% and the charged fee
+   matches the disclosure.
+2. **Given** any surface with a platform fee, **When** a member reaches the final confirm step,
+   **Then** the fee appears as its own named line with rate and amount, with an info bubble, and a
+   zero fee shows either no line or an explicit "no fee" — never a hidden charge.
+3. **Given** the fee management source is unreachable, **When** a member reaches a fee-bearing
+   confirm step, **Then** the flow either uses a safe, honestly-labeled known rate or blocks the
+   action — it never proceeds while displaying a rate that may understate the charge.
+
+---
+
+### User Story 4 - Future integrations plug into the wrapper, and operators can run it (Priority: P4)
+
+Lido staking, Polygon liquid staking, Uniswap swaps, and other future integrations adopt the same
+wrapper: each new service is registered with its own fee entry (0..cap bps), inherits the same
+admin management, member disclosure pattern, and treasury routing, without redesigning fees each
+time. Developer documentation explains how to wire a new service in; an operations runbook covers
+setting/adjusting fees, verifying treasury receipts, the change history, emergency zeroing of a
+fee, and what to check when disclosures and charges disagree.
+
+**Why this priority**: This is the "wrapper is a platform primitive" payoff and the documentation
+requirement — necessary for the stated future services, but nothing member-facing ships in this
+story beyond the docs.
+
+**Independent Test**: Following only the developer guide, register a hypothetical new service in a
+test environment with a 25 bps fee; verify it appears in the Fees admin view and produces correct
+quotes. Verify the runbook's fee-change and emergency-zero procedures work as written.
+
+**Acceptance Scenarios**:
+
+1. **Given** the developer guide, **When** a developer registers a new wrapped service, **Then**
+   it appears in the Fees view with its own rate, cap, and destination, and member disclosure
+   works with no fee-system code changes.
+2. **Given** the runbook, **When** an operator follows the emergency procedure to zero a fee,
+   **Then** the fee is 0 for all subsequent member actions and the change is recorded.
+3. **Given** the documentation site, **When** a member looks up platform fees, **Then** a plain-
+   language page explains what fees FairWins charges, where they appear, and that rates are always
+   shown before confirming.
+
+---
+
+### Edge Cases
+
+- Fee rounding: a fee computed on a tiny principal rounds to zero in the asset's smallest unit —
+  the deposit proceeds with a zero fee (never over-charges, never blocks).
+- Rate change in flight: an admin changes the fee between the member's quote and execution — the
+  member pays at most the disclosed rate (Story 1, scenario 4).
+- Treasury destination unset or invalid for a network — fee-bearing actions on that network must
+  not send funds to a dead address: the fee falls back to zero (with the discrepancy surfaced to
+  operators) or the action is blocked; funds are never lost.
+- The service the wrapper fronts fails after the fee leg (e.g. vault deposit reverts) — the
+  member's whole action reverts atomically; the treasury must not keep a fee for an action that
+  did not happen.
+- Fee config source unreachable on a member surface — disclosure never silently shows a stale
+  lower rate while a higher one is charged (Story 3, scenario 3).
+- Two operators edit the same fee concurrently — last write wins, both changes appear in history;
+  no state where cap enforcement is bypassed.
+- A network where the wrapper is not yet deployed — member surfaces behave as today (no fee, no
+  fee line); the admin view shows the service as not available on that network rather than
+  implying a fee is active.
+- Non-member or sanctioned wallet attempts a wrapped action — existing eligibility rules (spec
+  050 and platform screening) are unchanged by the fee wrapper; the fee never bypasses them.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Wrapper fee on member actions**
+
+- **FR-001**: The system MUST be able to charge a FairWins platform fee, denominated in basis
+  points of the principal, at entry into a wrapped external service, routing the fee to the
+  FairWins treasury and the remainder into the external service in a single member-confirmed
+  action.
+- **FR-002**: Fees MUST apply to principal at entry only. Exits (withdrawals, unstaking, claim of
+  rewards) MUST NOT incur a platform fee in this feature.
+- **FR-003**: The fee-and-forward action MUST be atomic: if the external-service leg fails, the
+  entire action (including the fee transfer) reverts; the treasury never retains a fee for an
+  action that did not complete.
+- **FR-004**: Each wrapped service MUST have its own independently configurable rate from 0 bps up
+  to a hard cap of **250 bps**, enforced at the point where the fee is charged (not only in the
+  admin UI). A configured rate of 0 MUST result in no fee transfer at all.
+- **FR-005**: A member MUST never be charged a higher rate than the one disclosed to them at
+  confirmation time, even if an operator raises the rate while their action is in flight; the
+  action either honors the disclosed rate or fails safely.
+- **FR-006**: Fee amounts MUST round in the member's favor (round down) in the asset's smallest
+  unit; a fee that rounds to zero is charged as zero.
+- **FR-007**: In this feature, the wrapper MUST be wired into the existing Earn lending flow
+  (spec 050 vault deposits) as its first consumer. Lido staking, Polygon liquid staking, and
+  Uniswap swaps are explicitly out of scope to build, but the wrapper MUST NOT assume anything
+  lending-specific that would prevent those services from registering later with only
+  configuration and service-specific glue.
+- **FR-008**: The wrapper MUST NOT weaken existing eligibility and screening rules on wrapped
+  actions (membership roles, sanctions screening, network scoping); it composes with them,
+  never bypasses them.
+
+**Unified fee management (admin)**
+
+- **FR-009**: The operations control plane MUST gain a Fees view listing every platform-fee
+  system — wrapper services, the Polymarket builder fee (spec 057), and the OpenSea referral
+  (specs 055/056) — showing for each: service, fee basis, live rate in bps, hard cap, beneficiary/
+  treasury destination, enforcement point, and per-network availability.
+- **FR-010**: Operators with the fee-admin capability MUST be able to change wrapper-service rates
+  and the Polymarket builder-fee rates (within the spec-057 caps of 100 bps taker / 50 bps maker)
+  from the Fees view, with changes taking effect for subsequent member actions without a redeploy
+  or restart. The OpenSea referral has no rate (no-cost program); its beneficiary and status are
+  displayed, and its beneficiary MAY remain deployment-managed.
+- **FR-011**: Fee changes MUST be restricted to an explicit fee-admin capability; viewing MAY be
+  granted more broadly. Unauthorized change attempts MUST be denied at the enforcement layer, not
+  merely hidden in the UI.
+- **FR-012**: Every fee change MUST be recorded and reviewable: actor, timestamp, service,
+  old value, new value. Attempts to exceed a hard cap MUST be rejected with a clear error and
+  MUST NOT alter the effective rate.
+- **FR-013**: The treasury/beneficiary destination for wrapper fees MUST be configurable per
+  network by the same admin capability, with validation that prevents routing fees to an obviously
+  invalid destination (unset, zero, or malformed). Networks with no valid destination MUST charge
+  no fee rather than lose funds.
+
+**Member transparency**
+
+- **FR-014**: Every fee-bearing confirm step MUST disclose, before any signature: a named
+  "FairWins platform fee" (or equivalent) line, the live rate (percent), the absolute fee amount
+  in the asset, and the net amount reaching the external service, with a plain-language info
+  bubble. Zero-fee actions show no fee line (or an explicit "no fee") and MUST NOT show a fee.
+- **FR-015**: Disclosed rates MUST be live: sourced from the same configuration the admin edits,
+  such that an admin change is reflected in the next quote on every surface (Earn, Predict)
+  without redeploying. If the live rate cannot be obtained, the surface MUST NOT proceed on a
+  possibly-understated rate (block, or use a rate that is provably an upper bound and label it).
+- **FR-016**: The Predict builder-fee disclosure (spec 057) and Collect referral disclosure
+  (spec 056) MUST be preserved in meaning and prominence while re-pointing at the unified fee
+  source; existing promises to members (e.g. Collect referral costs the member nothing) MUST NOT
+  change.
+- **FR-017**: The public documentation site MUST gain a plain-language page describing FairWins
+  platform fees: which surfaces have them, how rates are shown, and the caps.
+
+**Documentation & operations**
+
+- **FR-018**: A developer guide MUST document the fee system end to end: architecture, how fees
+  are charged and capped, how disclosure works, and the exact steps to register a future service
+  (e.g. Lido, Polygon liquid staking, Uniswap) with the wrapper.
+- **FR-019**: An operations runbook MUST cover: viewing current fees, changing a fee (including
+  verification steps), changing the treasury destination, emergency-zeroing a fee, reconciling
+  treasury receipts against expected fees, and diagnosing disclosure/charge mismatches.
+- **FR-020**: Fee totals MUST be observable by operators: for wrapper fees, the treasury
+  destination's receipts per service are verifiable from recorded events/records sufficient for
+  the runbook's reconciliation procedure.
+
+### Key Entities
+
+- **Fee Service (wrapped service)**: An external integration fronted by the wrapper — lending
+  (Morpho, first consumer), later staking and swaps. Attributes: identifier, display name, fee
+  basis (principal-at-entry), rate (bps), hard cap (250 bps), per-network availability, treasury
+  destination.
+- **Fee Schedule / Rate**: The live bps value for one service (and, for Polymarket, the
+  taker/maker pair with spec-057 caps). Editable by fee-admins; readable by all member surfaces.
+- **Fee Change Record**: An attributable history entry — actor, time, service, old → new value.
+- **Treasury Destination**: The per-network FairWins account receiving wrapper fees.
+- **Fee Disclosure (quote)**: What the member sees at confirm time — rate, absolute fee, net
+  amount — and the ceiling the member actually consents to (FR-005).
+- **Attribution Programs (existing)**: Polymarket builder fee (real member cost, editable bps)
+  and OpenSea referral (no member cost, display/status) — managed and displayed alongside wrapper
+  fees.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With a nonzero lending fee configured, 100% of completed Earn deposits transfer
+  exactly the disclosed fee to the treasury and exactly the disclosed net amount into the vault
+  (verified across the test matrix including rounding edge cases).
+- **SC-002**: 100% of fee-bearing confirm flows show the fee line (rate, amount, net) before any
+  signature; zero-fee flows never show a fee. Verified by automated UI tests on Earn and Predict.
+- **SC-003**: An operator can view every platform-fee system and change any editable rate from
+  one screen in under 2 minutes, with the new rate live on member surfaces in under 1 minute,
+  with no redeploy.
+- **SC-004**: No member action can ever be charged above the disclosed rate or above the hard cap
+  — attempts are rejected in tests at both the admin layer and the enforcement layer.
+- **SC-005**: A developer following only the guide can register a new test service with a fee and
+  see it correctly quoted and managed, without modifying the fee system itself.
+- **SC-006**: 100% of fee changes appear in the reviewable history with actor, time, and
+  old → new values.
+
+## Assumptions
+
+- **Fee basis**: Confirmed by the requester — fees are charged on principal at entry (deposit /
+  stake / swap input amount), not on yield or at exit.
+- **Hard cap**: Confirmed by the requester — 250 bps (2.5%) for wrapper services. Polymarket
+  builder-fee caps stay as shipped in spec 057 (100 taker / 50 maker) since they are enforced by
+  that integration's own rules.
+- **Legacy systems become editable**: Confirmed by the requester — Polymarket builder-fee bps
+  move from deploy-time-only settings to live admin-editable configuration (within caps). The
+  OpenSea referral has no rate to edit; it is displayed in the unified view.
+- **Scope of consumers**: Confirmed by the requester — this feature builds the framework and
+  wires it into the existing Earn/Morpho lending flow only. Lido, Polygon liquid staking, and
+  Uniswap adopt the wrapper in their own future specs.
+- **Treasury**: Wrapper fees route to a FairWins-controlled treasury destination configured per
+  network, consistent with the existing deployments-as-source-of-truth practice; this feature
+  does not introduce treasury governance changes.
+- **Who administers fees**: Fee administration is an operator capability in the existing
+  operations control plane role model; this feature adds a fee-admin capability rather than a new
+  admin surface.
+- **Earn UX baseline**: Spec 050's Earn flow (deposit review step, info bubbles, activity views)
+  exists and is the surface this feature extends; Earn's current behavior with no fee configured
+  is unchanged.
+- **No retroactive fees**: Existing positions entered before a fee is configured are never
+  charged retroactively; fees apply only to new entries after the rate is set.

--- a/specs/060-platform-fee-wrapper/tasks.md
+++ b/specs/060-platform-fee-wrapper/tasks.md
@@ -1,0 +1,83 @@
+# Tasks: Configurable Platform Fee Wrapper
+
+**Input**: Design documents from `/specs/060-platform-fee-wrapper/`
+
+**Tests**: Included — the constitution makes test-first non-negotiable (Principle II).
+
+**Organization**: Grouped by user story; each is an independently testable increment.
+US1 (fee wrapper + Earn) is the MVP.
+
+## Phase 1: Setup
+
+- [X] T001 `contracts/fees/IFeeRouter.sol` — interface (enum, struct, reads, setters,
+      `depositToVaultWithFee`, events, errors)
+- [X] T002 [P] `contracts/mocks/MockERC4626Vault.sol` — minimal ERC-4626 with a settable
+      revert mode
+
+## Phase 2: Foundational (blocking all stories)
+
+- [X] T003 `contracts/fees/FeeRouter.sol` — UUPS via `UUPSManaged`; append-only storage;
+      `initialize`; `MAX_WRAPPED_FEE_BPS`; `FEE_ADMIN_ROLE`; register/setTreasury/setFeeBps
+      with cap+role guards; `quoteFee`; atomic `depositToVaultWithFee` (nonReentrant, CEI,
+      maxFeeBps consent, treasury-unset skip)
+- [X] T004 `test/feeRouter.test.js` — fee math incl. floor-to-zero, cap enforcement,
+      maxFeeBps revert, treasury-unset skip, atomic revert, role gating, events, enumeration,
+      ConfigOnly rejects deposit
+- [X] T005 [P] `test/helpers/proxy.js` — `deployFeeRouter` helper
+- [X] T006 [P] `test/upgradeable/FeeRouter.upgrade.test.js` + register FeeRouter in
+      `scripts/deploy/check-storage-layout.js`
+- [X] T007 `scripts/deploy/deploy-fee-router.js` — deploy + register launch services + append
+      `feeRouter`/`feeRouterImpl`
+- [X] T008 [P] map `feeRouter` in `scripts/utils/sync-frontend-contracts.js` +
+      `frontend/src/abis/FeeRouter.js`
+- [X] T009 `npm run compile && npx hardhat test … && npm run check:storage-layout` green
+
+## Phase 3: US1 — Member fee on Earn deposits (P1) 🎯 MVP
+
+- [X] T010 [P] `frontend/src/lib/fees/feeQuote.js` — live rate quote (floor math, three
+      outcomes)
+- [X] T011 `frontend/src/lib/earn/vaultActions.js` — `buildDepositCalls` fee path
+- [X] T012 `frontend/src/components/earn/VaultSheet.jsx` — fee line + info bubble + block on
+      failed quote + earnCopy tip
+- [X] T013 [P] frontend tests: `vaultActions.test.js` fee path, `VaultSheet.test.jsx` fee
+      line/hide/blocked, `feeQuote.test.js`
+- [X] T014 verify local (deposit with 50 bps → treasury +0.50 / vault 99.50; 0 bps → parity)
+
+## Phase 4: US2 — Admin Fees tab (P2)
+
+- [X] T015 [P] `FEE_ADMIN` in `RoleContext.js`, `WalletContext.jsx`, `blockchainService.js`
+- [X] T016 `frontend/src/components/admin/FeesTab.jsx` — services table, gateway rows,
+      edit forms, change history
+- [X] T017 register in `adminNav.js` (fees item + icon + param) + `AdminPanel.jsx`
+- [X] T018 [P] `FeesTab.test.jsx` + `FeesTab.axe.test.jsx` + `adminNav.test.js`
+- [X] T019 `npm run test:frontend`
+
+## Phase 5: US3 — Live disclosure across surfaces (P3)
+
+- [X] T020 [P] `services/relay-gateway/src/fees/onchain.js` — FeeRouter reader + TTL cache +
+      clamp + fallback
+- [X] T021 `services/relay-gateway/src/config/index.js` — `FEE_ROUTER_*` + deployment pinning
+- [X] T022 `polymarket/routes.js` + `server.js` — `/fee-rate` source, `/status.fees`
+- [X] T023 [P] `services/relay-gateway/test/fees.test.js`
+- [X] T024 Predict UI needs no data-path change (verified); gateway + frontend suites green
+
+## Phase 6: US4 — Docs & runbook (P4)
+
+- [X] T025 [P] `docs/developer-guide/platform-fees.md`
+- [X] T026 [P] `docs/runbooks/fee-operations.md`
+- [X] T027 [P] `docs/user-guide/platform-fees.md` + mkdocs nav
+- [X] T028 SC-005 register-a-service walkthrough validated against the guide
+
+## Phase 7: Polish & cross-cutting
+
+- [X] T029 [P] CLAUDE.md guardrail + SPECKIT plan pointer
+- [X] T030 [P] `.env.example` FEE_ROUTER_* + demoted POLYMARKET_BUILDER_* fallback
+- [ ] T031 full gates: compile + test + check:storage-layout + test:frontend + gateway vitest;
+      Slither on `contracts/fees/` (slither not installed locally — run in CI)
+- [ ] T032 security pass against `.github/agents/smart-contract-security.agent.md`
+      (reentrancy, CEI, access control, fee-math, token edge cases) — record in PR
+
+## Notes
+
+Reconstructed after a mid-session environment teleport discarded the original sandbox
+branch; all code recreated in `feat/platform-fee-wrapper` off `origin/main` and pushed.

--- a/specs/060-platform-fee-wrapper/tasks.md
+++ b/specs/060-platform-fee-wrapper/tasks.md
@@ -72,10 +72,14 @@ US1 (fee wrapper + Earn) is the MVP.
 
 - [X] T029 [P] CLAUDE.md guardrail + SPECKIT plan pointer
 - [X] T030 [P] `.env.example` FEE_ROUTER_* + demoted POLYMARKET_BUILDER_* fallback
-- [ ] T031 full gates: compile + test + check:storage-layout + test:frontend + gateway vitest;
-      Slither on `contracts/fees/` (slither not installed locally — run in CI)
-- [ ] T032 security pass against `.github/agents/smart-contract-security.agent.md`
-      (reentrancy, CEI, access control, fee-math, token edge cases) — record in PR
+- [X] T031 full gates: compile + test + check:storage-layout + test:frontend + gateway vitest
+      all green in CI (Slither included); local frontend needs `npm install` for the uniswap SDK
+- [X] T032 security pass against `.github/agents/smart-contract-security.agent.md` — adversarial
+      multi-agent review: APPROVE WITH NITS, EthTrust-SL L2, nothing above Informational survived.
+      All actionable findings applied in the hardening commit (ZeroShares guard, treasury-aware
+      quoteFee, one-event-per-deposit, reentrancy/boundary/dust/launch-table tests, deploy hygiene);
+      review posted to PR #936. Remaining pre-mainnet: Slither/Medusa asset sign-off, treasury set
+      per network, admin-role handoff to multisig.
 
 ## Notes
 

--- a/test/feeRouter.test.js
+++ b/test/feeRouter.test.js
@@ -1,0 +1,289 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+const { deployFeeRouter } = require("./helpers/proxy");
+
+// spec 060 — unified platform-fee registry + atomic ERC-4626 fee wrapper.
+describe("FeeRouter", function () {
+  const EARN_LEND = ethers.keccak256(ethers.toUtf8Bytes("earn.lend"));
+  const PM_TAKER = ethers.keccak256(ethers.toUtf8Bytes("polymarket.taker"));
+  const UNKNOWN = ethers.keccak256(ethers.toUtf8Bytes("nope"));
+  const Kind = { Unregistered: 0, Wrapped: 1, ConfigOnly: 2 };
+  const USDC = (n) => ethers.parseUnits(n, 6);
+
+  let admin, feeAdmin, member, treasury, stranger;
+  let router, usdc, vault;
+
+  beforeEach(async function () {
+    [admin, feeAdmin, member, treasury, stranger] = await ethers.getSigners();
+
+    router = await deployFeeRouter([admin.address, treasury.address]);
+    await router.connect(admin).grantRole(await router.FEE_ADMIN_ROLE(), feeAdmin.address);
+
+    const MockERC20 = await ethers.getContractFactory("MockERC20");
+    usdc = await MockERC20.deploy("USD Coin", "USDC", 0);
+    const MockVault = await ethers.getContractFactory("MockERC4626Vault");
+    vault = await MockVault.deploy(await usdc.getAddress());
+
+    await router.connect(admin).registerService(EARN_LEND, 250, Kind.Wrapped);
+    await router.connect(admin).registerService(PM_TAKER, 100, Kind.ConfigOnly);
+
+    await usdc.mint(member.address, USDC("1000"));
+    await usdc.connect(member).approve(await router.getAddress(), USDC("1000"));
+  });
+
+  describe("initialize", function () {
+    it("grants admin the three roles and sets the treasury", async function () {
+      expect(await router.hasRole(await router.DEFAULT_ADMIN_ROLE(), admin.address)).to.equal(true);
+      expect(await router.hasRole(await router.UPGRADER_ROLE(), admin.address)).to.equal(true);
+      expect(await router.hasRole(await router.FEE_ADMIN_ROLE(), admin.address)).to.equal(true);
+      expect(await router.treasury()).to.equal(treasury.address);
+    });
+
+    it("rejects a zero admin", async function () {
+      const Impl = await ethers.getContractFactory("FeeRouter");
+      const impl = await Impl.deploy();
+      const initData = Impl.interface.encodeFunctionData("initialize", [ethers.ZeroAddress, treasury.address]);
+      const Proxy = await ethers.getContractFactory("ERC1967Proxy");
+      await expect(Proxy.deploy(await impl.getAddress(), initData)).to.be.revertedWithCustomError(
+        Impl,
+        "ZeroAddress"
+      );
+    });
+
+    it("allows a zero treasury at init (fees will be skipped)", async function () {
+      const bare = await deployFeeRouter([admin.address, ethers.ZeroAddress]);
+      expect(await bare.treasury()).to.equal(ethers.ZeroAddress);
+    });
+  });
+
+  describe("registerService", function () {
+    it("registers with cap and kind, enumerable, fee starts at 0", async function () {
+      expect(await router.serviceCount()).to.equal(2n);
+      expect(await router.serviceAt(0)).to.equal(EARN_LEND);
+      const svc = await router.getService(EARN_LEND);
+      expect(svc.capBps).to.equal(250);
+      expect(svc.feeBps).to.equal(0);
+      expect(svc.kind).to.equal(Kind.Wrapped);
+    });
+
+    it("emits ServiceRegistered", async function () {
+      const id = ethers.keccak256(ethers.toUtf8Bytes("stake.lido"));
+      await expect(router.connect(admin).registerService(id, 200, Kind.Wrapped))
+        .to.emit(router, "ServiceRegistered")
+        .withArgs(id, 200, Kind.Wrapped);
+    });
+
+    it("rejects wrapped caps above MAX_WRAPPED_FEE_BPS (250)", async function () {
+      const id = ethers.keccak256(ethers.toUtf8Bytes("swap.uniswap"));
+      await expect(
+        router.connect(admin).registerService(id, 251, Kind.Wrapped)
+      ).to.be.revertedWithCustomError(router, "CapAboveMax");
+    });
+
+    it("allows ConfigOnly caps above 250 (external programs keep their own caps)", async function () {
+      const id = ethers.keccak256(ethers.toUtf8Bytes("some.external"));
+      await router.connect(admin).registerService(id, 300, Kind.ConfigOnly);
+      expect((await router.getService(id)).capBps).to.equal(300);
+    });
+
+    it("rejects zero caps, Unregistered kind, and duplicate ids", async function () {
+      const id = ethers.keccak256(ethers.toUtf8Bytes("x"));
+      await expect(router.connect(admin).registerService(id, 0, Kind.Wrapped)).to.be.revertedWithCustomError(
+        router,
+        "CapZero"
+      );
+      await expect(
+        router.connect(admin).registerService(id, 10, Kind.Unregistered)
+      ).to.be.revertedWithCustomError(router, "ServiceUnknown");
+      await expect(
+        router.connect(admin).registerService(EARN_LEND, 10, Kind.Wrapped)
+      ).to.be.revertedWithCustomError(router, "AlreadyRegistered");
+    });
+
+    it("is DEFAULT_ADMIN gated (fee admin cannot register)", async function () {
+      const id = ethers.keccak256(ethers.toUtf8Bytes("y"));
+      await expect(router.connect(feeAdmin).registerService(id, 10, Kind.Wrapped)).to.be.revertedWithCustomError(
+        router,
+        "AccessControlUnauthorizedAccount"
+      );
+    });
+  });
+
+  describe("setFeeBps", function () {
+    it("sets within cap and emits actor/old/new (the audit history)", async function () {
+      await expect(router.connect(feeAdmin).setFeeBps(EARN_LEND, 50))
+        .to.emit(router, "FeeBpsChanged")
+        .withArgs(EARN_LEND, 0, 50, feeAdmin.address);
+      expect(await router.feeBps(EARN_LEND)).to.equal(50);
+      await expect(router.connect(feeAdmin).setFeeBps(EARN_LEND, 25))
+        .to.emit(router, "FeeBpsChanged")
+        .withArgs(EARN_LEND, 50, 25, feeAdmin.address);
+    });
+
+    it("rejects above-cap rates and unknown services", async function () {
+      await expect(router.connect(feeAdmin).setFeeBps(EARN_LEND, 251)).to.be.revertedWithCustomError(
+        router,
+        "CapExceeded"
+      );
+      await expect(router.connect(feeAdmin).setFeeBps(PM_TAKER, 101)).to.be.revertedWithCustomError(
+        router,
+        "CapExceeded"
+      );
+      await expect(router.connect(feeAdmin).setFeeBps(UNKNOWN, 1)).to.be.revertedWithCustomError(
+        router,
+        "ServiceUnknown"
+      );
+    });
+
+    it("is FEE_ADMIN gated", async function () {
+      await expect(router.connect(stranger).setFeeBps(EARN_LEND, 1)).to.be.revertedWithCustomError(
+        router,
+        "AccessControlUnauthorizedAccount"
+      );
+    });
+  });
+
+  describe("setTreasury", function () {
+    it("changes the destination and emits, rejects zero, is admin gated", async function () {
+      await expect(router.connect(admin).setTreasury(stranger.address))
+        .to.emit(router, "TreasuryChanged")
+        .withArgs(treasury.address, stranger.address, admin.address);
+      expect(await router.treasury()).to.equal(stranger.address);
+      await expect(router.connect(admin).setTreasury(ethers.ZeroAddress)).to.be.revertedWithCustomError(
+        router,
+        "ZeroAddress"
+      );
+      await expect(router.connect(feeAdmin).setTreasury(stranger.address)).to.be.revertedWithCustomError(
+        router,
+        "AccessControlUnauthorizedAccount"
+      );
+    });
+  });
+
+  describe("quoteFee", function () {
+    it("floors in the member's favor", async function () {
+      await router.connect(feeAdmin).setFeeBps(EARN_LEND, 50);
+      let [fee, net] = await router.quoteFee(EARN_LEND, USDC("100"));
+      expect(fee).to.equal(USDC("0.5"));
+      expect(net).to.equal(USDC("99.5"));
+      // 199 units * 50 / 10000 = 0.995 -> floors to 0
+      [fee, net] = await router.quoteFee(EARN_LEND, 199n);
+      expect(fee).to.equal(0n);
+      expect(net).to.equal(199n);
+    });
+
+    it("reverts for unknown services", async function () {
+      await expect(router.quoteFee(UNKNOWN, 1n)).to.be.revertedWithCustomError(router, "ServiceUnknown");
+    });
+  });
+
+  describe("depositToVaultWithFee", function () {
+    beforeEach(async function () {
+      await router.connect(feeAdmin).setFeeBps(EARN_LEND, 50);
+    });
+
+    it("splits fee to treasury and deposits net for the receiver, atomically", async function () {
+      await expect(
+        router.connect(member).depositToVaultWithFee(EARN_LEND, await vault.getAddress(), USDC("100"), member.address, 50)
+      )
+        .to.emit(router, "FeeCharged")
+        .withArgs(
+          EARN_LEND,
+          member.address,
+          await usdc.getAddress(),
+          USDC("100"),
+          USDC("0.5"),
+          await vault.getAddress(),
+          member.address
+        );
+
+      expect(await usdc.balanceOf(treasury.address)).to.equal(USDC("0.5"));
+      expect(await vault.maxWithdraw(member.address)).to.equal(USDC("99.5"));
+      // The router never keeps a balance outside a transaction.
+      expect(await usdc.balanceOf(await router.getAddress())).to.equal(0n);
+      expect(await usdc.allowance(await router.getAddress(), await vault.getAddress())).to.equal(0n);
+    });
+
+    it("charges nothing at 0 bps (no fee event, full deposit)", async function () {
+      await router.connect(feeAdmin).setFeeBps(EARN_LEND, 0);
+      const tx = await router
+        .connect(member)
+        .depositToVaultWithFee(EARN_LEND, await vault.getAddress(), USDC("100"), member.address, 0);
+      const receipt = await tx.wait();
+      const events = receipt.logs.filter((l) => l.address === router.target);
+      expect(events).to.have.length(0);
+      expect(await usdc.balanceOf(treasury.address)).to.equal(0n);
+      expect(await vault.maxWithdraw(member.address)).to.equal(USDC("100"));
+    });
+
+    it("charges zero when the fee floors to zero on a tiny principal", async function () {
+      await router.connect(member).depositToVaultWithFee(EARN_LEND, await vault.getAddress(), 199n, member.address, 50);
+      expect(await usdc.balanceOf(treasury.address)).to.equal(0n);
+      expect(await vault.maxWithdraw(member.address)).to.equal(199n);
+    });
+
+    it("pins the member to the quoted rate (FeeAboveQuoted)", async function () {
+      // Member was quoted 50; admin raises to 100 before execution.
+      await router.connect(feeAdmin).setFeeBps(EARN_LEND, 100);
+      await expect(
+        router.connect(member).depositToVaultWithFee(EARN_LEND, await vault.getAddress(), USDC("100"), member.address, 50)
+      ).to.be.revertedWithCustomError(router, "FeeAboveQuoted");
+      // A lower live rate than quoted is fine (member pays less).
+      await router.connect(feeAdmin).setFeeBps(EARN_LEND, 25);
+      await router
+        .connect(member)
+        .depositToVaultWithFee(EARN_LEND, await vault.getAddress(), USDC("100"), member.address, 50);
+      expect(await usdc.balanceOf(treasury.address)).to.equal(USDC("0.25"));
+    });
+
+    it("skips the fee (and flags it) when no treasury is configured", async function () {
+      const bare = await deployFeeRouter([admin.address, ethers.ZeroAddress]);
+      await bare.connect(admin).registerService(EARN_LEND, 250, Kind.Wrapped);
+      await bare.connect(admin).setFeeBps(EARN_LEND, 50);
+      await usdc.connect(member).approve(await bare.getAddress(), USDC("100"));
+      await expect(
+        bare.connect(member).depositToVaultWithFee(EARN_LEND, await vault.getAddress(), USDC("100"), member.address, 50)
+      )
+        .to.emit(bare, "FeeSkippedNoTreasury")
+        .withArgs(EARN_LEND, member.address, USDC("100"));
+      expect(await vault.maxWithdraw(member.address)).to.equal(USDC("100"));
+    });
+
+    it("reverts the fee leg when the vault deposit fails (atomicity)", async function () {
+      await vault.setRevertOnDeposit(true);
+      await expect(
+        router.connect(member).depositToVaultWithFee(EARN_LEND, await vault.getAddress(), USDC("100"), member.address, 50)
+      ).to.be.revertedWith("MockERC4626Vault: deposit disabled");
+      // Nothing moved: no fee kept for a deposit that did not happen.
+      expect(await usdc.balanceOf(treasury.address)).to.equal(0n);
+      expect(await usdc.balanceOf(member.address)).to.equal(USDC("1000"));
+    });
+
+    it("rejects unknown, config-only, zero-amount and zero-address calls", async function () {
+      const v = await vault.getAddress();
+      await expect(
+        router.connect(member).depositToVaultWithFee(UNKNOWN, v, 1n, member.address, 50)
+      ).to.be.revertedWithCustomError(router, "ServiceUnknown");
+      await expect(
+        router.connect(member).depositToVaultWithFee(PM_TAKER, v, 1n, member.address, 50)
+      ).to.be.revertedWithCustomError(router, "ServiceNotWrapped");
+      await expect(
+        router.connect(member).depositToVaultWithFee(EARN_LEND, v, 0n, member.address, 50)
+      ).to.be.revertedWithCustomError(router, "ZeroAmount");
+      await expect(
+        router.connect(member).depositToVaultWithFee(EARN_LEND, ethers.ZeroAddress, 1n, member.address, 50)
+      ).to.be.revertedWithCustomError(router, "ZeroAddress");
+      await expect(
+        router.connect(member).depositToVaultWithFee(EARN_LEND, v, 1n, ethers.ZeroAddress, 50)
+      ).to.be.revertedWithCustomError(router, "ZeroAddress");
+    });
+
+    it("supports depositing on behalf of a different receiver", async function () {
+      await router
+        .connect(member)
+        .depositToVaultWithFee(EARN_LEND, await vault.getAddress(), USDC("100"), stranger.address, 50);
+      expect(await vault.maxWithdraw(stranger.address)).to.equal(USDC("99.5"));
+      expect(await vault.maxWithdraw(member.address)).to.equal(0n);
+    });
+  });
+});

--- a/test/feeRouter.test.js
+++ b/test/feeRouter.test.js
@@ -1,6 +1,7 @@
 const { expect } = require("chai");
 const { ethers } = require("hardhat");
 const { deployFeeRouter } = require("./helpers/proxy");
+const { LAUNCH_FEE_SERVICES } = require("../scripts/deploy/lib/feeServices");
 
 // spec 060 — unified platform-fee registry + atomic ERC-4626 fee wrapper.
 describe("FeeRouter", function () {
@@ -141,6 +142,14 @@ describe("FeeRouter", function () {
         "AccessControlUnauthorizedAccount"
       );
     });
+
+    it("accepts a rate at exactly the cap (inclusive boundary)", async function () {
+      // Guards against an off-by-one regression to `>=` on the maximum fee the platform can charge.
+      await router.connect(feeAdmin).setFeeBps(EARN_LEND, 250);
+      expect(await router.feeBps(EARN_LEND)).to.equal(250);
+      await router.connect(feeAdmin).setFeeBps(PM_TAKER, 100);
+      expect(await router.feeBps(PM_TAKER)).to.equal(100);
+    });
   });
 
   describe("setTreasury", function () {
@@ -174,6 +183,35 @@ describe("FeeRouter", function () {
 
     it("reverts for unknown services", async function () {
       await expect(router.quoteFee(UNKNOWN, 1n)).to.be.revertedWithCustomError(router, "ServiceUnknown");
+    });
+
+    it("reports zero fee when no treasury is configured (mirrors the charge path)", async function () {
+      const bare = await deployFeeRouter([admin.address, ethers.ZeroAddress]);
+      await bare.connect(admin).registerService(EARN_LEND, 250, Kind.Wrapped);
+      await bare.connect(admin).setFeeBps(EARN_LEND, 50);
+      const [fee, net] = await bare.quoteFee(EARN_LEND, USDC("100"));
+      expect(fee).to.equal(0n);
+      expect(net).to.equal(USDC("100"));
+    });
+  });
+
+  describe("launch fee-service table (deploy config)", function () {
+    it("registers exactly the intended services with the right kind and cap", async function () {
+      // Locks scripts/deploy/lib/feeServices.js against drift (the deploy script uses the same table).
+      const fresh = await deployFeeRouter([admin.address, treasury.address]);
+      for (const svc of LAUNCH_FEE_SERVICES) {
+        const id = ethers.keccak256(ethers.toUtf8Bytes(svc.label));
+        await fresh.connect(admin).registerService(id, svc.capBps, svc.kind);
+        const got = await fresh.getService(id);
+        expect(got.kind, `${svc.label} kind`).to.equal(svc.kind);
+        expect(got.capBps, `${svc.label} cap`).to.equal(svc.capBps);
+        expect(got.feeBps, `${svc.label} starts at 0`).to.equal(0);
+      }
+      // The flagship wrapped consumer must be chargeable; the Polymarket entries must not be.
+      const earn = await fresh.getService(ethers.keccak256(ethers.toUtf8Bytes("earn.lend")));
+      expect(earn.kind).to.equal(Kind.Wrapped);
+      const taker = await fresh.getService(ethers.keccak256(ethers.toUtf8Bytes("polymarket.taker")));
+      expect(taker.kind).to.equal(Kind.ConfigOnly);
     });
   });
 
@@ -220,6 +258,34 @@ describe("FeeRouter", function () {
       await router.connect(member).depositToVaultWithFee(EARN_LEND, await vault.getAddress(), 199n, member.address, 50);
       expect(await usdc.balanceOf(treasury.address)).to.equal(0n);
       expect(await vault.maxWithdraw(member.address)).to.equal(199n);
+    });
+
+    it("emits FeeCharged with zero fee on a dust deposit (exactly one event per deposit)", async function () {
+      await expect(
+        router.connect(member).depositToVaultWithFee(EARN_LEND, await vault.getAddress(), 199n, member.address, 50)
+      )
+        .to.emit(router, "FeeCharged")
+        .withArgs(EARN_LEND, member.address, await usdc.getAddress(), 199n, 0n, await vault.getAddress(), member.address);
+    });
+
+    it("reverts if the vault mints zero shares (no fee for nothing)", async function () {
+      await vault.setZeroShares(true);
+      await expect(
+        router.connect(member).depositToVaultWithFee(EARN_LEND, await vault.getAddress(), USDC("100"), member.address, 50)
+      ).to.be.revertedWithCustomError(router, "ZeroShares");
+      // The whole action rolled back — no fee kept, member made whole.
+      expect(await usdc.balanceOf(treasury.address)).to.equal(0n);
+      expect(await usdc.balanceOf(member.address)).to.equal(USDC("1000"));
+    });
+
+    it("rejects a re-entrant vault via the nonReentrant guard", async function () {
+      const Reentrant = await ethers.getContractFactory("MockReentrantERC4626Vault");
+      const evil = await Reentrant.deploy(await usdc.getAddress());
+      await evil.arm(await router.getAddress(), EARN_LEND);
+      await expect(
+        router.connect(member).depositToVaultWithFee(EARN_LEND, await evil.getAddress(), USDC("100"), member.address, 50)
+      ).to.be.revertedWithCustomError(router, "ReentrancyGuardReentrantCall");
+      expect(await usdc.balanceOf(treasury.address)).to.equal(0n);
     });
 
     it("pins the member to the quoted rate (FeeAboveQuoted)", async function () {

--- a/test/helpers/proxy.js
+++ b/test/helpers/proxy.js
@@ -150,10 +150,28 @@ async function deployTokenFactoryV2({ adminSigner, sanctionsGuard = ethers.ZeroA
   return { factory, templates, v2 };
 }
 
+/// Deploy FeeRouter behind an ERC1967 UUPS proxy and return the contract bound to the proxy address
+/// (spec 060). `initArgs` is `[admin, treasury]` (treasury may be the zero address — the charge path
+/// then skips fees). Same rationale as deployWagerRegistry: manual proxy wiring keeps the suite fast;
+/// the plugin's storage-layout/safety validation runs in test/upgradeable/ and `npm run check:storage-layout`.
+async function deployFeeRouter(initArgs) {
+  const Impl = await ethers.getContractFactory("FeeRouter");
+  const impl = await Impl.deploy();
+  await impl.waitForDeployment();
+
+  const initData = Impl.interface.encodeFunctionData("initialize", initArgs);
+  const Proxy = await ethers.getContractFactory("ERC1967Proxy");
+  const proxy = await Proxy.deploy(await impl.getAddress(), initData);
+  await proxy.waitForDeployment();
+
+  return Impl.attach(await proxy.getAddress());
+}
+
 module.exports = {
   mergeAbis,
   deployWagerRegistry,
   deployMembershipManager,
+  deployFeeRouter,
   deployTokenTemplates,
   deployTokenFactory,
   deployTokenTemplatesV2,

--- a/test/upgradeable/FeeRouter.upgrade.test.js
+++ b/test/upgradeable/FeeRouter.upgrade.test.js
@@ -1,0 +1,84 @@
+const { expect } = require("chai");
+const { ethers, upgrades } = require("hardhat");
+
+// Upgrade lifecycle for the real FeeRouter behind a UUPS proxy (spec 060): deploy with current
+// logic, then an in-place upgrade preserves the address AND the treasury/service-registry/rate
+// state; only UPGRADER_ROLE may upgrade; re-init is rejected; a bare implementation cannot be
+// initialized. Uses the hardhat-upgrades plugin so storage-layout safety validation runs on every
+// deploy/upgrade (fast manual wiring lives in test/helpers/proxy.js#deployFeeRouter).
+
+const EARN_LEND = ethers.keccak256(ethers.toUtf8Bytes("earn.lend"));
+const PM_TAKER = ethers.keccak256(ethers.toUtf8Bytes("polymarket.taker"));
+const UPGRADER_ROLE = ethers.keccak256(ethers.toUtf8Bytes("UPGRADER_ROLE"));
+const Kind = { Unregistered: 0, Wrapped: 1, ConfigOnly: 2 };
+
+async function setup() {
+  const [admin, outsider, treasury] = await ethers.getSigners();
+  const Router = await ethers.getContractFactory("FeeRouter");
+  const router = await upgrades.deployProxy(Router, [admin.address, treasury.address], { kind: "uups" });
+  await router.waitForDeployment();
+  await router.connect(admin).registerService(EARN_LEND, 250, Kind.Wrapped);
+  await router.connect(admin).registerService(PM_TAKER, 100, Kind.ConfigOnly);
+  await router.connect(admin).setFeeBps(EARN_LEND, 50);
+  await router.connect(admin).setFeeBps(PM_TAKER, 40);
+  return { admin, outsider, treasury, router };
+}
+
+describe("FeeRouter — UUPS upgrade lifecycle", function () {
+  it("deploys behind a proxy; upgrade preserves address, treasury, services and rates", async function () {
+    const { router, admin, treasury } = await setup();
+    const proxyAddress = await router.getAddress();
+
+    const V2 = await ethers.getContractFactory("FeeRouterUpgradeMock");
+    // The mock adds no roles/config needing re-initialization, so the plugin's
+    // "missing-initializer" heuristic is a false positive here (same as the other upgrade mocks).
+    const upgraded = await upgrades.upgradeProxy(proxyAddress, V2.connect(admin), {
+      kind: "uups",
+      unsafeAllow: ["missing-initializer"],
+    });
+
+    expect(await upgraded.getAddress()).to.equal(proxyAddress);
+    expect(await upgraded.upgradeProbe()).to.equal("v2");
+    expect(await upgraded.treasury()).to.equal(treasury.address);
+    expect(await upgraded.serviceCount()).to.equal(2n);
+    expect(await upgraded.feeBps(EARN_LEND)).to.equal(50);
+    expect(await upgraded.feeBps(PM_TAKER)).to.equal(40);
+    const svc = await upgraded.getService(EARN_LEND);
+    expect(svc.capBps).to.equal(250);
+    expect(svc.kind).to.equal(Kind.Wrapped);
+
+    await upgraded.setUpgradeMarker(7n);
+    expect(await upgraded.upgradeMarker()).to.equal(7n);
+  });
+
+  it("rejects upgrade attempts from non-UPGRADER accounts", async function () {
+    const { router, outsider } = await setup();
+    const V2 = await ethers.getContractFactory("FeeRouterUpgradeMock", outsider);
+    await expect(
+      upgrades.upgradeProxy(await router.getAddress(), V2, {
+        kind: "uups",
+        unsafeAllow: ["missing-initializer"],
+      })
+    ).to.be.revertedWithCustomError(router, "AccessControlUnauthorizedAccount");
+    expect(await router.hasRole(UPGRADER_ROLE, outsider.address)).to.equal(false);
+  });
+
+  it("rejects re-initialization of the proxy", async function () {
+    const { router, admin, treasury } = await setup();
+    await expect(router.initialize(admin.address, treasury.address)).to.be.revertedWithCustomError(
+      router,
+      "InvalidInitialization"
+    );
+  });
+
+  it("locks initialization of the bare implementation", async function () {
+    const [admin, , treasury] = await ethers.getSigners();
+    const Router = await ethers.getContractFactory("FeeRouter");
+    const impl = await Router.deploy();
+    await impl.waitForDeployment();
+    await expect(impl.initialize(admin.address, treasury.address)).to.be.revertedWithCustomError(
+      impl,
+      "InvalidInitialization"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a single on-chain **`FeeRouter`** (UUPS, per network) that is both the **source of truth for every configurable platform fee** and the **atomic fee-charging wrapper** for external services with no native revenue share. First wrapper consumer: **Earn/Morpho lending** (spec 050). Brings the existing **Polymarket builder fee** (spec 057) and **OpenSea referral** (spec 056) under one admin surface. Spec Kit: `specs/060-platform-fee-wrapper/`.

Requested scope (all four decisions confirmed with the requester up front): fee on **principal at entry**; **250 bps** wrapped hard cap; legacy Polymarket bps become **live-editable**; framework **+ Morpho Earn** wired now (Lido / Polygon LST / Uniswap register later with config only).

## What's in it
- **Contract** `contracts/fees/{FeeRouter,IFeeRouter}.sol` — service registry (`Wrapped`/`ConfigOnly` `bytes32` ids, per-service caps, `FEE_ADMIN_ROLE`), atomic `depositToVaultWithFee` (pull principal → skim fee to treasury → deposit net for the member; `maxFeeBps` consent ceiling; treasury-unset ⇒ fee skipped, never lost; `nonReentrant` + CEI + SafeERC20). 27 unit + upgrade-lifecycle tests; registered in `check:storage-layout`.
- **Earn** — `buildDepositCalls` routes through the router when a fee applies; `VaultSheet` shows a live "FairWins platform fee" line (rate, amount, net) before signing, pauses deposits if the rate can't be read, and stays byte-identical to spec 050 at zero fee.
- **Admin Fees tab** — every fee system in one screen (wrapper services, Polymarket bps + source, OpenSea no-cost referral), on-chain rate/treasury edits via the wallet, `FeeBpsChanged` change history. New `FEE_ADMIN` role (resolved on the FeeRouter).
- **Gateway** — `src/fees/onchain.js` cached reader serves live Polymarket bps to `/fee-rate` (`source: chain|env-fallback`, spec-057 cap clamp, env fallback); `/status` gains a `fees` block. Gateway stays stateless (no admin API). 9 new tests.
- **Docs** — developer guide (incl. register-a-new-service steps), operations runbook, member-facing fees page, CLAUDE.md guardrail.

## Testing
- Contracts: `npx hardhat test test/feeRouter.test.js test/upgradeable/FeeRouter.upgrade.test.js` → 27 passing; `npm run check:storage-layout` clean.
- Gateway: `npx vitest run` → 144 passing (9 new).
- Frontend: 54 spec-060 tests passing (feeQuote, vaultActions, VaultSheet, FeesTab, FeesTab axe, adminNav); full suite run for regressions.

## Deploy (not run here)
`scripts/deploy/deploy-fee-router.js` registers `earn.lend` (250) / `polymarket.taker` (100) / `polymarket.maker` (50) at 0 bps and appends `feeRouter`/`feeRouterImpl`; then `sync:frontend-contracts` + set gateway `FEE_ROUTER_ADDRESS`. Contract security review (Slither + `.github/agents/smart-contract-security.agent.md`) still gates any mainnet deploy.

> Note: this branch was reconstructed after a mid-session environment change discarded the original sandbox branch; all code was recreated off `origin/main` and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)