### PR TITLE
Spec 061: Bitcoin transactions — native BTC portfolio, send/receive with address rotation, Stamps protection, taproot

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/060-platform-fee-wrapper"
+  "feature_directory": "specs/061-bitcoin-transactions"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,23 @@ artifacts live under `specs/<feature>/`.
   (config only) instead of building their own fee path. `FEE_ADMIN_ROLE` edits rates from the
   AdminPanel Fees tab; history = `FeeBpsChanged` events. See
   `docs/developer-guide/platform-fees.md` + `docs/runbooks/fee-operations.md` + `specs/060-platform-fee-wrapper/`.
+- **Bitcoin (spec 061) is the FIRST NON-EVM network — portfolio/send/receive ONLY.** Bitcoin
+  networks are STRING ids (`'bitcoin'`, `'bitcoin-testnet'` = testnet4) in
+  `frontend/src/config/bitcoinNetworks.js`, parallel to (never inside) the numeric `NETWORKS`
+  map — never assign Bitcoin a numeric chainId and never pass its ids to
+  `getContractAddressForChain`/wagmi/subgraph code (guard boundaries with `isBitcoinNetworkId`).
+  Keys derive client-side from the spec-041 passkey master seed per
+  `specs/061-bitcoin-transactions/contracts/key-derivation-btc.md` — those constants
+  (HKDF info `fairwins-btc-seed-v1`, BIP84/BIP86 paths) are **wallet-breaking** if changed;
+  key material/xpubs never leave the client (gateway sees bare addresses + signed raw txs only).
+  Receive addresses ROTATE (never reissued; gap-limit-20 discovery rebuilds on recovery; cursor
+  never decreases). Stamps handling is FAIL-SAFE: a UTXO is spendable only when positively
+  verified stamp-free — degraded recognition ⇒ protected, never spent. Fee quotes expire (60s)
+  and the member-confirmed fee is a hard signing ceiling (`FeeOverrunError`); BTC sends are
+  NEVER gasless and the confirm UI must say the member pays the network fee. The gateway module
+  (`services/relay-gateway/src/bitcoin/`, `BTC_*` env) is optional — unset/disabled ⇒ every
+  Bitcoin surface hides/degrades honestly. See `docs/developer-guide/bitcoin.md` +
+  `docs/runbooks/bitcoin-operations.md` + `specs/061-bitcoin-transactions/`.
 
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,5 +150,5 @@ artifacts live under `specs/<feature>/`.
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan
-at specs/060-platform-fee-wrapper/plan.md
+at specs/061-bitcoin-transactions/plan.md
 <!-- SPECKIT END -->

--- a/docs/developer-guide/bitcoin.md
+++ b/docs/developer-guide/bitcoin.md
@@ -1,0 +1,77 @@
+# Bitcoin (spec 061)
+
+Native BTC support — the platform's first non-EVM network. Members get a
+non-custodial Bitcoin wallet inside their existing passkey account: portfolio,
+send, and receive only. No wagers, pools, membership, gasless, contracts, or
+subgraph on Bitcoin, ever disclosed otherwise.
+
+## Architecture
+
+```
+passkey master seed (spec 041, PRF-recoverable, memory-only)
+  └─ HKDF("fairwins-btc-seed-v1") → BIP32 root            frontend/src/lib/bitcoin/derivation.js
+       ├─ m/84'/{coin}'/0' native segwit (bc1q…, default)
+       └─ m/86'/{coin}'/0' taproot      (bc1p…, opt-in)
+frontend/src/lib/bitcoin/     pure libs: addresses, coinSelection, psbt, send,
+                              wallet (rotation ledger + gap-limit discovery),
+                              portfolioSource, gatewayClient
+frontend/src/hooks/useBitcoinWallet.js   orchestration (unlock/receive/send)
+frontend/src/config/bitcoinNetworks.js   string-keyed non-EVM registry
+services/relay-gateway/src/bitcoin/      /v1/bitcoin/* Esplora + Stamps proxy
+```
+
+Normative contracts live in `specs/061-bitcoin-transactions/contracts/`:
+`key-derivation-btc.md` (constants are **wallet-breaking** if changed),
+`bitcoin-gateway-api.md`, `network-registry.md`.
+
+## Key rules
+
+- **No numeric chainId.** Bitcoin networks are string ids (`'bitcoin'`,
+  `'bitcoin-testnet'` = testnet4) in `bitcoinNetworks.js`, parallel to —
+  never inside — `NETWORKS`. Guard every shared boundary with
+  `isBitcoinNetworkId()`; these ids must never reach
+  `getContractAddressForChain`, wagmi, or subgraph routing.
+- **Non-custodial, client-side keys.** Private keys, xpubs, and descriptors
+  never leave the client; the gateway sees bare addresses (≤50/batch) and
+  signed raw transactions only. Key material is memory-only — never persisted
+  or logged.
+- **Availability = passkey + PRF + gateway.** Injected/WalletConnect wallets
+  and non-PRF authenticators get an honest `unavailable` state (matrix in the
+  derivation contract). `BTC_ENABLED=false` keeps the whole feature dark.
+- **Address rotation.** Fresh receive address per request (never repeated);
+  the persisted ledger is a cache — gap-limit-20 discovery rebuilds addresses
+  and the never-decreasing cursor on any device (recovery needs no
+  Bitcoin-specific backup).
+- **Stamps fail-safe.** A coin is spendable only when positively verified
+  stamp-free. Degraded/unavailable Stamps recognition ⇒ coins classify
+  `unverified` and are protected (excluded from sends and spendable balance,
+  shown as protected value). Over-protection beats accidental destruction.
+- **Fee honesty.** Quotes (sat/vB tiers) expire after 60s; the confirmed fee
+  is a hard ceiling — `buildAndSignTx` refuses to sign above it
+  (`FeeOverrunError`). Sub-dust change folds into the fee; sends are RBF-
+  signaled. Bitcoin sends are never gasless — the confirm UI says so.
+- **Honest state.** Pending (mempool/unconfirmed) value is never presented as
+  final; balance-source failure renders stale/failed (`failedAssets`), never
+  zero; testnet4 and mainnet never mix (paired with the app's toggle).
+
+## Portfolio integration
+
+`getBitcoinPortfolioAsset(networkId)` (assetTaxonomy) yields the native-BTC
+instance (`baselineSymbol: 'BTC'`, category digital-commodities, decimals 8);
+`usePortfolio` feeds it from `lib/bitcoin/portfolioSource.js` and the existing
+aggregation rolls native BTC + WBTC into one "Bitcoin" row. Pricing reuses the
+configured Chainlink BTC/USD feeds — no new price infrastructure.
+
+## Testing
+
+- `npm run test:frontend -- --run src/lib/bitcoin src/config/__tests__/bitcoinNetworks.test.js`
+  — derivation vectors (BIP32/84/86 + pinned FairWins vectors), codecs,
+  selection properties, PSBT, rotation/discovery, send pipeline.
+- `cd services/relay-gateway && npx vitest run` — gateway module route tests.
+- End-to-end validation guide: `specs/061-bitcoin-transactions/quickstart.md`
+  (testnet4).
+
+## Operations
+
+See `docs/runbooks/bitcoin-operations.md` (upstream swap, killswitch, quotas,
+stamps-indexer degradation, testnet4 notes).

--- a/docs/runbooks/bitcoin-operations.md
+++ b/docs/runbooks/bitcoin-operations.md
@@ -1,0 +1,64 @@
+# Runbook: Bitcoin Operations (spec 061)
+
+The bitcoin module of the relay-gateway proxies public Bitcoin data
+(balances/UTXOs, fees, broadcast, tx status, Stamps) behind
+`/v1/bitcoin/:network/*` with quotas, TTL caches, and a killswitch. It is
+stateless — no wallet data, no keys — and optional: disabled, the frontend
+hides/degrades every Bitcoin surface honestly.
+
+## Config (relay-gateway env — see `.env.example`)
+
+| Var | Default | Notes |
+|---|---|---|
+| `BTC_ENABLED` | `false` | master switch; `false` ⇒ all routes 503 `bitcoin_disabled` |
+| `BTC_ESPLORA_URL` | `https://mempool.space/api` | mainnet Esplora-compatible upstream |
+| `BTC_ESPLORA_TESTNET_URL` | `https://mempool.space/testnet4/api` | testnet4 upstream |
+| `BTC_STAMPS_URL` | unset | Stamps indexer (stampchain.io-compatible); unset ⇒ stamps endpoint `degraded: true` |
+| `BTC_MAX_FEE_RATE` | `500` | sat/vB clamp on fee responses |
+| `BTC_QUOTA_PER_IP` / `BTC_QUOTA_GLOBAL` | polymarket parity | read quotas; writes (broadcast) are tighter |
+| `BTC_KILLSWITCH` | `false` | ops kill: all routes 503 `bitcoin_killed` |
+| `BTC_TIMEOUT_MS` / `BTC_RETRIES` | `5000` / `1` | upstream tuning; broadcasts are never retried |
+
+Boot fails loudly on malformed URLs or nonsensical clamps when
+`BTC_ENABLED=true` — a bad deploy dies visibly, not silently.
+
+## Playbooks
+
+**Kill Bitcoin now** (incident): set `BTC_KILLSWITCH=true` and restart (or the
+global runtime killswitch if the whole gateway is implicated). Frontend
+surfaces degrade to honest unavailable states; member funds are unaffected
+(keys are client-side; self-custody continues in any external wallet via the
+same standard derivation paths).
+
+**Swap upstream** (rate-limited / down / self-host): point
+`BTC_ESPLORA_URL`(+`_TESTNET_`) at any Esplora-compatible API — public
+alternatives (blockstream.info) or self-hosted mempool/electrs. No code
+change; the client-side fee-dialect fallback handles both mempool.space
+`fees/recommended` and Esplora `fee-estimates` shapes.
+
+**Stamps indexer degraded/down**: no action is strictly required — the
+frontend fails SAFE (all unverified coins are protected; members see a
+degraded-recognition banner and reduced spendable balance, never a lost
+Stamp). Restore or swap `BTC_STAMPS_URL` to clear it. Degraded results cache
+only 30s, so recovery is fast.
+
+**Fee spikes**: quotes are clamped to `BTC_MAX_FEE_RATE` and expire client-side
+after 60s; raise the clamp only deliberately (it caps what members can be
+quoted, and the confirmed quote is a hard signing ceiling).
+
+**Quota exhaustion (429s)**: raise `BTC_QUOTA_*` or lower portfolio poll
+pressure; balance lookups batch ≤50 addresses per call and cache 15s, so
+sustained 429s usually mean abuse, not organic load.
+
+**Testnet4 notes**: `'bitcoin-testnet'` is testnet4 (testnet3 is deprecated).
+Faucets: mempool.space testnet4 faucet. If testnet4 resets or the upstream
+drops it, swap the testnet URL (signet is the fallback candidate — one env
+change, but note coinType stays 1' so derived addresses are unchanged).
+
+## Monitoring
+
+- 502 `upstream_unavailable` rate — upstream health (portfolio shows stale,
+  sends block honestly; prolonged ⇒ swap upstream).
+- 400 `broadcast_rejected` reasons — surfaced verbatim to members; spikes may
+  indicate fee-estimation drift (check `BTC_MAX_FEE_RATE` vs mempool).
+- stamps `degraded: true` ratio — indexer health (drives protected-balance UX).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,8 @@
         "@noble/hashes": "^1.5.0",
         "@noble/post-quantum": "^0.2.0",
         "@polymarket/clob-client": "^5.8.1",
+        "@scure/bip32": "2.2.0",
+        "@scure/btc-signer": "2.2.0",
         "@tanstack/react-query": "^5.101.2",
         "@uniswap/sdk-core": "^7.18.0",
         "@uniswap/v3-sdk": "^3.31.0",
@@ -3965,6 +3967,20 @@
         "viem": ">=2.45.0"
       }
     },
+    "node_modules/@reown/appkit-controllers/node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@reown/appkit-controllers/node_modules/@walletconnect/core": {
       "version": "2.23.7",
       "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.7.tgz",
@@ -4214,6 +4230,20 @@
         "valtio": "2.1.7"
       }
     },
+    "node_modules/@reown/appkit-utils/node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@reown/appkit-utils/node_modules/@walletconnect/core": {
       "version": "2.23.7",
       "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.7.tgz",
@@ -4405,6 +4435,20 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@reown/appkit/node_modules/@walletconnect/core": {
@@ -4991,15 +5035,51 @@
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
-      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.2.0.tgz",
+      "integrity": "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~1.9.0",
-        "@noble/hashes": "~1.8.0",
-        "@scure/base": "~1.2.5"
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
       },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -5012,6 +5092,72 @@
       "dependencies": {
         "@noble/hashes": "~1.8.0",
         "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/btc-signer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/btc-signer/-/btc-signer-2.2.0.tgz",
+      "integrity": "sha512-ZXZ08sZqSZKEcOuEQnxTF66ouHtl6+UA6U/QfQM06K9WiOlEkXF4LviZCaSgkdiFh9cyMt9+xdup7JtEv3p0fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~2.2.0",
+        "@noble/hashes": "~2.2.0",
+        "@scure/base": "~2.2.0",
+        "micro-packed": "~0.9.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/btc-signer/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/btc-signer/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/btc-signer/node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/btc-signer/node_modules/micro-packed": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/micro-packed/-/micro-packed-0.9.0.tgz",
+      "integrity": "sha512-gFdaWTxEXOwtSOcpxulO4AuXVtp3HWIRmB8eq8+3m1Zku0ubgva0UGpi03YhcvsTJasHngG9gTIUK5kHNKdesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@scure/base": "~2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -7368,6 +7514,20 @@
         "detect-browser": "5.3.0",
         "ox": "0.9.3",
         "uint8arrays": "3.1.1"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@walletconnect/utils/node_modules/abitype": {
@@ -13044,6 +13204,21 @@
         }
       }
     },
+    "node_modules/ox/node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -15496,6 +15671,20 @@
       },
       "engines": {
         "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,8 @@
     "@noble/hashes": "^1.5.0",
     "@noble/post-quantum": "^0.2.0",
     "@polymarket/clob-client": "^5.8.1",
+    "@scure/bip32": "2.2.0",
+    "@scure/btc-signer": "2.2.0",
     "@tanstack/react-query": "^5.101.2",
     "@uniswap/sdk-core": "^7.18.0",
     "@uniswap/v3-sdk": "^3.31.0",

--- a/frontend/src/components/account/WalletDisplayPreferencesPanel.jsx
+++ b/frontend/src/components/account/WalletDisplayPreferencesPanel.jsx
@@ -8,9 +8,15 @@ import './WalletDisplayPreferencesPanel.css'
  * Pool phrase language and the address QR code (color picker included, via
  * AddressQRModal's variant="full") relocated here from the Account tab so
  * they sit with other settings instead of crowding the account stats.
+ *
+ * Spec 061: also the entry point for the Bitcoin receive surface — the same
+ * modal in mode="bitcoin" shows the member's rotating Bitcoin address (the
+ * modal itself handles the honest unavailable/locked states for non-passkey
+ * accounts, so the button is always safe to offer).
  */
 function WalletDisplayPreferencesPanel({ address }) {
   const [isQROpen, setQROpen] = useState(false)
+  const [isBtcOpen, setBtcOpen] = useState(false)
 
   return (
     <div className="wallet-display-prefs">
@@ -23,9 +29,20 @@ function WalletDisplayPreferencesPanel({ address }) {
         <button type="button" className="account-utilities-btn" onClick={() => setQROpen(true)}>
           Show QR Code
         </button>
+        <button type="button" className="account-utilities-btn" onClick={() => setBtcOpen(true)}>
+          Receive Bitcoin
+        </button>
       </div>
       {isQROpen && (
         <AddressQRModal isOpen onClose={() => setQROpen(false)} address={address} />
+      )}
+      {isBtcOpen && (
+        <AddressQRModal
+          isOpen
+          onClose={() => setBtcOpen(false)}
+          address={address}
+          mode="bitcoin"
+        />
       )}
     </div>
   )

--- a/frontend/src/components/collectibles/BitcoinStampsSection.jsx
+++ b/frontend/src/components/collectibles/BitcoinStampsSection.jsx
@@ -1,0 +1,79 @@
+import { useState } from 'react'
+import { useBitcoinStamps } from '../../hooks/useBitcoinStamps'
+import './CollectiblesPanel.css'
+
+function StampCard({ stamp }) {
+  const [imageFailed, setImageFailed] = useState(false)
+  return (
+    <li className="collectible-card bitcoin-stamp-card">
+      <div className="collectible-card-button bitcoin-stamp-body">
+        <span className="collectible-card-media">
+          {stamp.imageUrl && !imageFailed ? (
+            <img src={stamp.imageUrl} alt="" loading="lazy" onError={() => setImageFailed(true)} />
+          ) : (
+            <span className="collectible-card-placeholder" aria-hidden="true">
+              🖼
+            </span>
+          )}
+          <span className="bitcoin-stamp-protected-badge">Protected</span>
+        </span>
+        <span className="collectible-card-name">{stamp.stampId}</span>
+        <span className="collectible-card-collection">Bitcoin Stamp</span>
+      </div>
+    </li>
+  )
+}
+
+/**
+ * BitcoinStampsSection (spec 061, T031 — FR-017/FR-018/FR-019) — the
+ * "Bitcoin Stamps" section of the Collect surface, following the spec-055
+ * section pattern. Bitcoin's `collect: 'stamps-only'` capability means this
+ * section renders WITHOUT any OpenSea integration: stamps are display-only
+ * (v1 recognizes, displays, and protects — no transfer/mint).
+ *
+ * Honest states: hidden when the member has no bitcoin ledger (or the module
+ * is off); an explicit degraded notice when recognition is unavailable —
+ * never an endless spinner, never a confident partial gallery.
+ */
+export default function BitcoinStampsSection() {
+  const { status, stamps, refresh } = useBitcoinStamps()
+
+  // No bitcoin footprint, module off, or recognition healthy with zero
+  // stamps: nothing to disclose — the section stays out of the page.
+  if (status === 'hidden' || status === 'empty' || status === 'loading') return null
+
+  return (
+    <section className="bitcoin-stamps-section" aria-label="Bitcoin Stamps">
+      <div className="collectibles-panel-header">
+        <div>
+          <h4>Bitcoin Stamps</h4>
+          <p className="collectibles-panel-subtitle">
+            Collectibles held in your Bitcoin wallet. Their value is protected: ordinary BTC sends can
+            never spend the coins a Stamp travels with, so this value is excluded from your spendable
+            balance.
+          </p>
+        </div>
+      </div>
+
+      {status === 'degraded' ? (
+        <div className="collectibles-degraded" role="status">
+          <p>
+            Stamps recognition is temporarily degraded. Your Stamps are safe on-chain — until
+            recognition recovers, unverified coins are treated as protected and cannot be spent.
+          </p>
+          <div className="collectibles-degraded-actions">
+            <button type="button" onClick={refresh}>
+              Try again
+            </button>
+          </div>
+        </div>
+      ) : (
+        <ul className="collectibles-grid">
+          {stamps.map((stamp) => (
+            <StampCard key={`${stamp.outpoint?.txid}:${stamp.outpoint?.vout}:${stamp.stampId}`} stamp={stamp} />
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/components/collectibles/CollectiblesPanel.css
+++ b/frontend/src/components/collectibles/CollectiblesPanel.css
@@ -170,3 +170,24 @@
   cursor: default;
   opacity: 0.6;
 }
+
+/* Bitcoin Stamps section (spec 061): spec-055 card pattern, display-only. */
+.bitcoin-stamps-section {
+  margin-top: 24px;
+}
+
+.bitcoin-stamp-body {
+  cursor: default;
+}
+
+.bitcoin-stamp-protected-badge {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 999px;
+  color: #fff;
+  background: rgba(15, 118, 110, 0.9);
+}

--- a/frontend/src/components/collectibles/CollectiblesPanel.jsx
+++ b/frontend/src/components/collectibles/CollectiblesPanel.jsx
@@ -3,6 +3,7 @@ import { useWallet } from '../../hooks/useWalletManagement'
 import { useCollectibles } from '../../hooks/useCollectibles'
 import EmptyState from '../account/EmptyState'
 import CollectibleDetailSheet from './CollectibleDetailSheet'
+import BitcoinStampsSection from './BitcoinStampsSection'
 import './CollectiblesPanel.css'
 
 const OPENSEA_EXPLORE_URL = 'https://opensea.io'
@@ -129,6 +130,11 @@ export default function CollectiblesPanel() {
           )}
         </>
       )}
+
+      {/* Bitcoin Stamps (spec 061, `collect: 'stamps-only'`): independent of
+          the OpenSea-backed grid above — it renders (or hides) on its own
+          bitcoin ledger + gateway state, with no OpenSea integration. */}
+      <BitcoinStampsSection />
 
       <CollectibleDetailSheet
         key={openItem ? `${openItem.contract}:${openItem.identifier}` : 'closed'}

--- a/frontend/src/components/ui/AddressInput.jsx
+++ b/frontend/src/components/ui/AddressInput.jsx
@@ -5,7 +5,17 @@ import { formatCallsign, isValidCallsign, normalizeCallsign } from '../../lib/ca
 import { CallsignStatus } from '../../lib/callsigns/resolveCallsign'
 import ReportCallsignButton from '../callsigns/ReportCallsignButton'
 import AddressInputBookAddon from './AddressInputBookAddon'
+import { classifyAddress } from '../../lib/bitcoin/addresses'
 import styles from './AddressInput.module.css'
+
+// Member-facing labels for recognized Bitcoin destination types (spec 061).
+const BTC_TYPE_LABEL = {
+  p2pkh: 'Legacy',
+  p2sh: 'Script (P2SH)',
+  p2wpkh: 'SegWit',
+  p2wsh: 'SegWit script',
+  p2tr: 'Taproot',
+}
 
 /**
  * AddressInput Component
@@ -31,6 +41,11 @@ import styles from './AddressInput.module.css'
  * @param {string} props.errorMessage - External error message to display
  * @param {string} props.ariaDescribedBy - ID of description element
  * @param {boolean} props.showResolvedAddress - Show resolved address preview
+ * @param {string} props.bitcoinNetworkId - Bitcoin mode (spec 061): validate as a
+ *   Bitcoin destination for this network id ('bitcoin' | 'bitcoin-testnet')
+ *   instead of the EVM/ENS/callsign stack. Accepts every standard type
+ *   (legacy, P2SH, bech32, bech32m/taproot) with per-reason rejection
+ *   messages; the recognized type is surfaced as a tag.
  */
 const AddressInput = forwardRef(({
   value = '',
@@ -48,8 +63,16 @@ const AddressInput = forwardRef(({
   label,
   enableAddressBook = false,
   chainId,
+  bitcoinNetworkId = null,
   ...props
 }, ref) => {
+  // Bitcoin mode (spec 061): pure synchronous validation via classifyAddress.
+  // The EVM resolver hooks below still mount (rules of hooks) but are fed
+  // empty input so they stay inert.
+  const isBitcoinMode = Boolean(bitcoinNetworkId)
+  const btcTrimmed = isBitcoinMode ? (value || '').trim() : ''
+  const btc = isBitcoinMode && btcTrimmed ? classifyAddress(btcTrimmed, bitcoinNetworkId) : null
+
   // Use ENS resolution hook
   const {
     resolvedAddress,
@@ -57,20 +80,22 @@ const AddressInput = forwardRef(({
     error: resolutionError,
     isEns,
     isAddress
-  } = useEnsResolution(value)
+  } = useEnsResolution(isBitcoinMode ? '' : value)
 
   // Use reverse lookup to show ENS name for addresses
   const {
     ensName,
     isLoading: isLookingUp
-  } = useEnsReverseLookup(isAddress ? value?.trim() : null)
+  } = useEnsReverseLookup(!isBitcoinMode && isAddress ? value?.trim() : null)
 
   // Callsign forward-resolution (spec 054). Additive: only engages for callsign-shaped input that is
   // neither an address nor an ENS name. A resolved ACTIVE callsign becomes the effective resolved address;
   // any other status is surfaced as a non-committable message (FR-011/022). Registry unreachable → soft
   // no-op, raw-address entry unaffected (FR-013).
-  const callsignRes = useCallsignResolution(value, { chainId })
-  const effectiveResolvedAddress = (callsignRes.isCallsign && callsignRes.address) ? callsignRes.address : resolvedAddress
+  const callsignRes = useCallsignResolution(isBitcoinMode ? '' : value, { chainId })
+  const effectiveResolvedAddress = isBitcoinMode
+    ? (btc?.valid ? btcTrimmed : null)
+    : ((callsignRes.isCallsign && callsignRes.address) ? callsignRes.address : resolvedAddress)
 
   // Notify parent of resolved address changes (callsign-resolved address included)
   useEffect(() => {
@@ -93,9 +118,10 @@ const AddressInput = forwardRef(({
 
   // Determine error state. A callsign-shaped input suppresses the ENS "invalid address/name" error and
   // instead surfaces the callsign's own status ("No such callsign", "address changing", etc.) when non-ACTIVE.
-  const callsignError = callsignRes.isCallsign && !callsignRes.isLoading && !!callsignRes.message && callsignRes.status !== CallsignStatus.ACTIVE
-  const hasError = externalError || callsignError || (value && !isLoading && !callsignRes.isCallsign && resolutionError)
-  const displayError = externalErrorMessage || (callsignError ? callsignRes.message : (!callsignRes.isCallsign ? resolutionError : undefined))
+  const callsignError = !isBitcoinMode && callsignRes.isCallsign && !callsignRes.isLoading && !!callsignRes.message && callsignRes.status !== CallsignStatus.ACTIVE
+  const bitcoinError = isBitcoinMode && Boolean(btc) && !btc.valid
+  const hasError = externalError || bitcoinError || callsignError || (!isBitcoinMode && value && !isLoading && !callsignRes.isCallsign && resolutionError)
+  const displayError = externalErrorMessage || (bitcoinError ? btc.message : (callsignError ? callsignRes.message : (!callsignRes.isCallsign ? resolutionError : undefined)))
 
   // Determine status indicator
   const showLoading = isLoading || isLookingUp || callsignRes.isLoading
@@ -183,6 +209,11 @@ const AddressInput = forwardRef(({
           )}
           {showEnsLabel && !showLoading && (
             <span className={styles.ensLabel} role="img" aria-label="ENS name detected">ENS</span>
+          )}
+          {isBitcoinMode && btc?.valid && (
+            <span className={styles.ensLabel} role="img" aria-label={`Bitcoin ${BTC_TYPE_LABEL[btc.type]} address`}>
+              {BTC_TYPE_LABEL[btc.type]}
+            </span>
           )}
         </div>
       </div>

--- a/frontend/src/components/ui/AddressQRModal.css
+++ b/frontend/src/components/ui/AddressQRModal.css
@@ -310,3 +310,64 @@
     height: 200px;
   }
 }
+
+/* ---- Bitcoin mode (spec 061, FR-007) --------------------------------------
+   The Bitcoin receive view must be visually AND textually distinct from the
+   EVM address view so the two can never be confused: an explicit labeled
+   network badge (Bitcoin orange, but never color-only — the text carries the
+   meaning) and a matching accent on the address text. */
+
+.address-qr-network-badge {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 4px 12px;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+}
+
+.address-qr-network-badge--bitcoin {
+  border-color: #f7931a;
+  color: #b36400;
+  background: rgba(247, 147, 26, 0.12);
+}
+
+.address-qr-address--bitcoin {
+  border-left: 3px solid #f7931a;
+}
+
+.address-qr-type-toggle {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 10px 14px;
+  margin: 4px 0 0;
+  width: 100%;
+  text-align: left;
+}
+
+.address-qr-type-toggle legend {
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0 6px;
+  color: var(--text-secondary, var(--text-primary));
+}
+
+.address-qr-type-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.address-qr-type-option input:focus-visible {
+  outline: 2px solid var(--brand-primary);
+  outline-offset: 2px;
+}

--- a/frontend/src/components/ui/AddressQRModal.jsx
+++ b/frontend/src/components/ui/AddressQRModal.jsx
@@ -1,12 +1,198 @@
 import { useEffect, useRef, useState } from 'react'
 import AddressQRCode from './AddressQRCode'
 import { useClipboard } from '../../hooks/useClipboard'
+import { useBitcoinWallet } from '../../hooks/useBitcoinWallet'
+import { getBitcoinNetwork } from '../../config/bitcoinNetworks'
 import {
   QR_COLOR_PALETTE,
   getQRColorPreference,
   setQRColorPreference,
 } from '../../utils/qrColorPreference'
 import './AddressQRModal.css'
+
+/**
+ * Bitcoin receive surface (spec 061, US1/FR-004…FR-007) — rendered inside the
+ * modal when mode="bitcoin". A separate component so the useBitcoinWallet hook
+ * only mounts in bitcoin mode: the EVM address view stays byte-for-byte
+ * unchanged (FR-022) and never touches the wallet-context requirement.
+ *
+ * Honest states: 'unavailable' renders the reason with no dead buttons;
+ * 'locked' offers exactly one action — unlocking with the passkey (one PRF
+ * ceremony). Ready shows a fresh rotating address as text + BIP-21 QR, a
+ * "New address" affordance, and the segwit/taproot preference toggle.
+ */
+function BitcoinReceiveContent({ paletteId }) {
+  const btc = useBitcoinWallet()
+  const { copied, error: copyError, copy } = useClipboard()
+  const [unlocking, setUnlocking] = useState(false)
+  const [unlockError, setUnlockError] = useState(null)
+
+  const { status, reason, networkId, receive, unlock } = btc
+  const network = getBitcoinNetwork(networkId)
+  const networkLabel = network?.isTestnet ? 'Bitcoin — Testnet4' : 'Bitcoin — Mainnet'
+  const current = receive.current
+  const hasCurrent = Boolean(current)
+
+  // Show an address as soon as the wallet is ready: re-shows this session's
+  // address for the preferred type, or issues a fresh one (rotation, FR-004).
+  useEffect(() => {
+    if (status === 'ready' && !hasCurrent) {
+      receive.select(receive.preferredType)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status, hasCurrent])
+
+  const handleUnlock = async () => {
+    setUnlocking(true)
+    setUnlockError(null)
+    try {
+      const res = await unlock()
+      if (!res?.ok) {
+        setUnlockError(res?.message || 'Could not unlock your Bitcoin wallet — try again.')
+      }
+    } finally {
+      setUnlocking(false)
+    }
+  }
+
+  const handleTypeChange = (type) => {
+    receive.setPreferredType(type)
+    receive.select(type)
+  }
+
+  const shareText = current
+    ? `My Bitcoin address (${network?.name || 'Bitcoin'}):\n${current.address}`
+    : ''
+
+  const handleShare = async () => {
+    if (typeof navigator.share === 'function') {
+      try {
+        await navigator.share({ text: shareText })
+      } catch (err) {
+        if (err?.name !== 'AbortError') {
+          console.warn('Share failed:', err)
+        }
+      }
+    } else {
+      copy(shareText)
+    }
+  }
+
+  return (
+    <div className="address-qr-content">
+      {/* Explicit Bitcoin + network labeling, visually distinct from the EVM
+          address view (FR-007) — text label, never color alone. */}
+      <p className="address-qr-network-badge address-qr-network-badge--bitcoin">
+        <span aria-hidden="true">₿</span> {networkLabel}
+      </p>
+
+      {status === 'unavailable' && (
+        <p className="address-qr-connect-prompt" role="status">
+          {reason || 'Bitcoin is unavailable for this account.'}
+        </p>
+      )}
+
+      {status === 'locked' && (
+        <>
+          <p className="address-qr-connect-prompt">
+            Your Bitcoin wallet is locked. Unlock it with your passkey to derive your receive
+            addresses — nothing leaves this device.
+          </p>
+          <div className="address-qr-actions">
+            <button
+              type="button"
+              className="address-qr-action-btn"
+              onClick={handleUnlock}
+              disabled={unlocking}
+            >
+              {unlocking ? 'Unlocking…' : 'Unlock with your passkey'}
+            </button>
+          </div>
+          <p className="address-qr-status" role="status" aria-live="polite">
+            {unlockError || ''}
+          </p>
+        </>
+      )}
+
+      {status === 'ready' && !current && (
+        <p className="address-qr-connect-prompt" role="status">
+          Preparing a fresh Bitcoin address…
+        </p>
+      )}
+
+      {status === 'ready' && current && (
+        <>
+          <div className="address-qr-frame">
+            <AddressQRCode
+              value={receive.uri}
+              paletteId={paletteId}
+              size={240}
+              ariaLabel={`QR code for your Bitcoin address ${current.address.slice(0, 8)}…${current.address.slice(-6)}`}
+            />
+          </div>
+
+          <p className="address-qr-wordmark" aria-hidden="true">
+            FairWins
+          </p>
+
+          <p className="address-qr-address address-qr-address--bitcoin">{current.address}</p>
+
+          <div className="address-qr-actions">
+            <button
+              type="button"
+              className="address-qr-action-btn"
+              onClick={() => copy(current.address)}
+            >
+              {copied ? 'Copied!' : 'Copy Address'}
+            </button>
+            <button
+              type="button"
+              className="address-qr-action-btn address-qr-share-btn"
+              onClick={handleShare}
+            >
+              Share
+            </button>
+            <button
+              type="button"
+              className="address-qr-action-btn"
+              onClick={() => receive.nextReceiveAddress(receive.preferredType)}
+            >
+              New address
+            </button>
+          </div>
+
+          <p className="address-qr-status" role="status" aria-live="polite">
+            {copyError || (copied ? 'Address copied to clipboard.' : '')}
+          </p>
+
+          <fieldset className="address-qr-type-toggle">
+            <legend>Address type</legend>
+            <label className="address-qr-type-option">
+              <input
+                type="radio"
+                name="btc-address-type"
+                value="segwit"
+                checked={receive.preferredType === 'segwit'}
+                onChange={() => handleTypeChange('segwit')}
+              />
+              <span>Native SegWit (recommended)</span>
+            </label>
+            <label className="address-qr-type-option">
+              <input
+                type="radio"
+                name="btc-address-type"
+                value="taproot"
+                checked={receive.preferredType === 'taproot'}
+                onChange={() => handleTypeChange('taproot')}
+              />
+              <span>Taproot</span>
+            </label>
+          </fieldset>
+        </>
+      )}
+    </div>
+  )
+}
 
 /**
  * Branded dialog presenting the connected wallet address as a scannable QR
@@ -24,9 +210,13 @@ import './AddressQRModal.css'
  *    options (the persisted Account-page choice applies) and no visible
  *    address text. The address is revealed only as the copy-failure
  *    fallback so the manual-copy escape hatch (contract M5) survives.
+ *  - mode ('evm' | 'bitcoin'): 'bitcoin' (spec 061) swaps the content for the
+ *    member's rotating Bitcoin receive address (BitcoinReceiveContent above);
+ *    the default 'evm' view is untouched.
  */
-function AddressQRModal({ isOpen, onClose, address, variant = 'full' }) {
+function AddressQRModal({ isOpen, onClose, address, variant = 'full', mode = 'evm' }) {
   const isQuick = variant === 'quick'
+  const isBitcoin = mode === 'bitcoin'
   // Lazy initializer reads the persisted choice when the modal mounts; the
   // parent mounts it per open (FR-007), so every open reflects storage.
   const [paletteId, setPaletteId] = useState(getQRColorPreference)
@@ -116,10 +306,12 @@ function AddressQRModal({ isOpen, onClose, address, variant = 'full' }) {
         </button>
 
         <h2 id="address-qr-title" className="address-qr-title">
-          Your wallet address
+          {isBitcoin ? 'Your Bitcoin address' : 'Your wallet address'}
         </h2>
 
-        {!address ? (
+        {isBitcoin ? (
+          <BitcoinReceiveContent paletteId={paletteId} />
+        ) : !address ? (
           <p className="address-qr-connect-prompt">
             Connect a wallet to display your address as a QR code.
           </p>

--- a/frontend/src/components/wallet/AssetDetailSheet.jsx
+++ b/frontend/src/components/wallet/AssetDetailSheet.jsx
@@ -25,6 +25,30 @@ function formatAmount(holding) {
   return formatAssetAmount(holding.balance, holding.asset.symbol, holding.asset.kind)
 }
 
+/**
+ * Bitcoin instance disclosures (spec 061, FR-009/FR-018): pending value is
+ * never presented as final, and Stamps-protected value explains why
+ * total ≠ spendable. Only rendered for holdings carrying `holding.bitcoin`
+ * (native BTC from the bitcoin balance source) — EVM instances are untouched.
+ */
+function bitcoinInstanceNotes(holding) {
+  const btc = holding.bitcoin
+  if (!btc) return []
+  const notes = []
+  if (btc.pendingSats) {
+    const sign = btc.pendingSats > 0 ? '+' : '−'
+    notes.push(`${sign}${formatAssetAmount(Math.abs(btc.pendingSats) / 1e8, 'BTC')} pending`)
+  }
+  if (btc.protectedSats > 0) {
+    notes.push(
+      `${formatAssetAmount(btc.protectedSats / 1e8, 'BTC')} protected (${
+        btc.stampsDegraded ? 'Stamps check degraded — treated as protected' : 'Bitcoin Stamps'
+      })`,
+    )
+  }
+  return notes
+}
+
 // Action eligibility per instance — actions the app cannot perform render
 // disabled with a reason, never as dead buttons (constitution III).
 function actionsFor(instance) {
@@ -179,6 +203,11 @@ export default function AssetDetailSheet({ aggregate, onClose }) {
                   <span className="asset-sheet-instance-meta">
                     {holding.network} · {SOURCE_LABELS[holding.asset.source] || holding.asset.source}
                   </span>
+                  {bitcoinInstanceNotes(holding).map((note) => (
+                    <span key={note} className="asset-sheet-instance-meta asset-sheet-instance-bitcoin">
+                      {note}
+                    </span>
+                  ))}
                 </span>
                 <span className="asset-sheet-instance-values">
                   <SensitiveValue className="asset-sheet-instance-balance">{formatAmount(holding)}</SensitiveValue>

--- a/frontend/src/components/wallet/BitcoinSendPanel.jsx
+++ b/frontend/src/components/wallet/BitcoinSendPanel.jsx
@@ -1,0 +1,290 @@
+import { useCallback, useState } from 'react'
+import AddressInput from '../ui/AddressInput'
+import QRScanner from '../ui/QRScanner'
+import SensitiveValue from '../common/SensitiveValue'
+import { useNotification } from '../../hooks/useUI'
+import { extractBitcoinFromScan } from '../../lib/addressBook/scanAddress'
+import { isQuoteFresh } from '../../lib/bitcoin/send'
+import { getBitcoinNetwork } from '../../config/bitcoinNetworks'
+
+const short = (a) => (a ? `${a.slice(0, 10)}…${a.slice(-6)}` : '')
+const satsToBtc = (sats) => (sats ?? 0) / 1e8
+
+/** Exact satoshis for a BTC-decimal string; null when malformed (>8 dp etc.). */
+function parseBtcAmount(amount) {
+  const m = /^(\d+)(?:\.(\d{1,8}))?$/.exec(String(amount).trim())
+  if (!m) return null
+  const sats = Number(m[1]) * 1e8 + Number((m[2] || '').padEnd(8, '0'))
+  return Number.isSafeInteger(sats) && sats > 0 ? sats : null
+}
+
+const SEND_ERROR_TEXT = {
+  invalid_destination: null, // classify message is surfaced verbatim
+  stale_fee_quote: 'The network fee quote expired — review the refreshed fee before sending.',
+  amount_below_dust: 'That amount is below the Bitcoin dust limit for this destination type.',
+  insufficient_funds: null, // detailed shortfall composed inline
+  missing_change_address: 'Could not prepare a change address — try again.',
+  signing_failed: 'Signing failed — nothing was sent.',
+  broadcast_rejected: null, // upstream reason surfaced verbatim
+}
+
+/**
+ * Bitcoin send flow (spec 061, US3 — FR-011…FR-016). Rendered by TransferForm
+ * when the Bitcoin asset is selected; a fully parallel pipeline that never
+ * touches the EVM routing (useTransfer). The member always pays the Bitcoin
+ * network fee — nothing here may ever claim gasless (FR-015).
+ *
+ * @param {object} btc       useBitcoinWallet() instance (owned by TransferForm)
+ * @param {number|null} usdPerBtc  BTC/USD for fee/amount context lines (null ⇒ omitted, never faked)
+ * @param {function} onSent  optional callback after a successful broadcast
+ */
+export default function BitcoinSendPanel({ btc, usdPerBtc = null, onSent }) {
+  const { showNotification } = useNotification()
+  const [toRaw, setToRaw] = useState('')
+  const [toResolved, setToResolved] = useState('')
+  const [amount, setAmount] = useState('')
+  const [isMax, setIsMax] = useState(false)
+  const [feeTier, setFeeTier] = useState('normal')
+  const [quote, setQuote] = useState(null)
+  const [plan, setPlan] = useState(null)
+  const [formError, setFormError] = useState(null)
+  const [busy, setBusy] = useState(false)
+  const [scanOpen, setScanOpen] = useState(false)
+
+  const { networkId, balances, stampsDegraded } = btc
+  const network = getBitcoinNetwork(networkId)
+  const spendableBtc = satsToBtc(balances.spendableSats)
+  const protectedSats = balances.protectedSats ?? 0
+
+  const usd = (sats) =>
+    usdPerBtc != null ? ` (~$${(satsToBtc(sats) * usdPerBtc).toFixed(2)})` : ''
+
+  const applyScan = useCallback((decodedText) => {
+    const parsed = extractBitcoinFromScan(decodedText, networkId)
+    if (parsed) {
+      setToRaw(parsed.address)
+      setToResolved(parsed.address)
+      if (parsed.amountSats) {
+        setAmount(String(satsToBtc(parsed.amountSats)))
+        setIsMax(false)
+      }
+    }
+    setScanOpen(false)
+  }, [networkId])
+
+  const describePrepareError = (res) => {
+    if (res.error === 'invalid_destination') return res.message
+    if (res.error === 'insufficient_funds') {
+      const shortfall = res.shortfallSats != null ? ` You are ${satsToBtc(res.shortfallSats)} BTC short, network fee included.` : ''
+      return `Amount plus the network fee exceeds your spendable Bitcoin balance.${shortfall}`
+    }
+    if (res.error === 'broadcast_rejected') return `The Bitcoin network rejected the transaction: ${res.message}`
+    return SEND_ERROR_TEXT[res.error] || res.message || 'Could not prepare the send.'
+  }
+
+  const handlePreview = useCallback(async () => {
+    setFormError(null)
+    setBusy(true)
+    try {
+      const quoted = await btc.send.getFeeQuote()
+      if (!quoted?.ok) {
+        setFormError('Bitcoin network fees are unavailable right now — try again shortly.')
+        return
+      }
+      setQuote(quoted.quote)
+      const amountSats = isMax ? 'max' : parseBtcAmount(amount)
+      if (!isMax && amountSats == null) {
+        setFormError('Enter a valid BTC amount (up to 8 decimal places).')
+        return
+      }
+      const res = await btc.send.prepare({
+        destination: toResolved,
+        amountSats,
+        feeRate: quoted.quote.rates[feeTier],
+      })
+      if (!res.ok) {
+        setFormError(describePrepareError(res))
+        return
+      }
+      setPlan(res.plan)
+    } finally {
+      setBusy(false)
+    }
+     
+  }, [btc.send, toResolved, amount, isMax, feeTier])
+
+  const handleConfirm = useCallback(async () => {
+    setFormError(null)
+    // FR-012: a quote that aged past its window can never silently price the
+    // send — the hook enforces this too; the local pre-check just gives the
+    // member the explanation without a round-trip.
+    if (!isQuoteFresh(quote)) {
+      setPlan(null)
+      setFormError('The network fee quote expired — review the refreshed fee before sending.')
+      return
+    }
+    setBusy(true)
+    try {
+      const res = await btc.send.confirmAndSend(plan)
+      if (!res.ok) {
+        if (res.error === 'stale_fee_quote') setPlan(null)
+        setFormError(describePrepareError(res))
+        return
+      }
+      showNotification(
+        `Broadcast ${satsToBtc(plan.amountSats)} BTC to ${short(plan.destination)} — pending until the Bitcoin network confirms it.`,
+        'info',
+      )
+      setToRaw(''); setToResolved(''); setAmount(''); setIsMax(false); setPlan(null); setQuote(null)
+      onSent?.(res)
+    } finally {
+      setBusy(false)
+    }
+     
+  }, [btc.send, plan, quote, showNotification, onSent])
+
+  const canPreview = Boolean(toResolved) && (isMax || parseBtcAmount(amount) != null) && !busy
+
+  if (!plan) {
+    return (
+      <>
+        <div className="pt-field">
+          <label className="pt-label" htmlFor="pt-btc-to">To</label>
+          <div className="pt-input-with-action">
+            <div className="pt-address-input-wrap">
+              <AddressInput
+                id="pt-btc-to"
+                value={toRaw}
+                onChange={(e) => { setToRaw(e.target.value); setToResolved('') }}
+                onResolvedChange={(addr) => setToResolved(addr || '')}
+                bitcoinNetworkId={networkId}
+                placeholder={network?.isTestnet ? 'tb1…, 2…, m… or n…' : 'bc1…, 1… or 3…'}
+                disabled={busy}
+              />
+            </div>
+            <button
+              type="button"
+              className="pt-scan-btn"
+              onClick={() => setScanOpen(true)}
+              disabled={busy}
+              title="Scan QR code"
+              aria-label="Scan QR code"
+            >
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M3 3h8v8H3V3zm2 2v4h4V5H5zm8-2h8v8h-8V3zm2 2v4h4V5h-4zM3 13h8v8H3v-8zm2 2v4h4v-4H5zm10-2h2v2h-2v-2zm4 0h2v2h-2v-2zm-4 4h2v2h-2v-2zm2 2h2v2h-2v-2zm2-2h2v2h-2v-2zm0 4h2v2h-2v-2z" />
+              </svg>
+            </button>
+          </div>
+          <QRScanner isOpen={scanOpen} onClose={() => setScanOpen(false)} onScanSuccess={applyScan} />
+        </div>
+
+        <div className="pt-field">
+          <label className="pt-label" htmlFor="pt-btc-amount">Amount</label>
+          <div className="pt-amount-row">
+            <input
+              id="pt-btc-amount"
+              className="pt-amount-input"
+              inputMode="decimal"
+              type="text"
+              value={isMax ? 'MAX' : amount}
+              onChange={(e) => { setIsMax(false); setAmount(e.target.value.replace(/[^0-9.]/g, '')) }}
+              placeholder="0.00000000"
+              disabled={busy}
+              aria-describedby="pt-btc-amount-hint"
+            />
+            <button
+              type="button"
+              className="pt-max"
+              onClick={() => { setIsMax(true); setAmount('') }}
+              disabled={busy || balances.spendableSats === 0}
+            >
+              MAX
+            </button>
+            <span className="pt-amount-sym">BTC</span>
+          </div>
+          <span className="pt-hint" id="pt-btc-amount-hint">
+            Spendable: <SensitiveValue>{spendableBtc}</SensitiveValue> BTC
+            {isMax && ' · MAX sends everything spendable, minus the network fee'}
+          </span>
+          {protectedSats > 0 && (
+            <span className="pt-hint">
+              {satsToBtc(protectedSats)} BTC is protected ({stampsDegraded
+                ? 'Stamps recognition is degraded — unverified coins are protected until it recovers'
+                : 'Bitcoin Stamps travel with these coins'}) and is never spent by ordinary sends.
+            </span>
+          )}
+        </div>
+
+        <div className="pt-field">
+          <span className="pt-label" id="pt-btc-fee-label">Network fee</span>
+          <div className="pt-amount-row" role="radiogroup" aria-labelledby="pt-btc-fee-label">
+            {['slow', 'normal', 'fast'].map((tier) => (
+              <label key={tier} className="pt-hint" style={{ marginRight: 12 }}>
+                <input
+                  type="radio"
+                  name="pt-btc-fee-tier"
+                  value={tier}
+                  checked={feeTier === tier}
+                  onChange={() => setFeeTier(tier)}
+                  disabled={busy}
+                />{' '}
+                {tier === 'slow' ? 'Slow' : tier === 'normal' ? 'Normal' : 'Fast'}
+              </label>
+            ))}
+          </div>
+          <span className="pt-hint">
+            You pay the Bitcoin network fee — Bitcoin sends are never gasless. The exact fee is
+            shown before you confirm.
+          </span>
+        </div>
+
+        {formError && (
+          <div className="pt-notice pt-notice-error" role="alert">{formError}</div>
+        )}
+
+        <div className="pt-actions">
+          <button
+            type="button"
+            className="pt-btn pt-btn-primary"
+            onClick={handlePreview}
+            disabled={!canPreview}
+          >
+            {busy ? 'Preparing…' : 'Preview'}
+          </button>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <div className="pt-preview" aria-live="polite">
+        <div className="pt-preview-amount">{satsToBtc(plan.amountSats)} BTC</div>
+        <div className="pt-preview-row"><span className="k">To</span><span className="v">{short(plan.destination)}</span></div>
+        <div className="pt-preview-row"><span className="k">Type</span><span className="v">{plan.destinationType.toUpperCase()}</span></div>
+        <div className="pt-preview-row"><span className="k">Network</span><span className="v">{network?.name || 'Bitcoin'}</span></div>
+        <div className="pt-preview-row">
+          <span className="k">Network fee</span>
+          <span className="v">{satsToBtc(plan.feeSats)} BTC{usd(plan.feeSats)} — you pay this fee</span>
+        </div>
+        <div className="pt-preview-row">
+          <span className="k">Total debit</span>
+          <span className="v">{satsToBtc(plan.amountSats + plan.feeSats)} BTC{usd(plan.amountSats + plan.feeSats)}</span>
+        </div>
+      </div>
+
+      {formError && (
+        <div className="pt-notice pt-notice-error" role="alert">{formError}</div>
+      )}
+
+      <div className="pt-actions">
+        <button type="button" className="pt-btn pt-btn-secondary" onClick={() => { setPlan(null); setFormError(null) }} disabled={busy}>
+          Back
+        </button>
+        <button type="button" className="pt-btn pt-btn-primary" onClick={handleConfirm} disabled={busy}>
+          {busy ? 'Broadcasting…' : 'Send Bitcoin'}
+        </button>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/components/wallet/NetworkSettings.css
+++ b/frontend/src/components/wallet/NetworkSettings.css
@@ -174,3 +174,15 @@
 .network-doc-row a:hover {
   text-decoration: underline;
 }
+
+/* Non-EVM display-only cards (spec 061): no switch affordance, neutral badge. */
+.network-display-only-badge {
+  color: var(--color-text-secondary);
+  border-color: var(--color-border, var(--color-text-secondary));
+}
+
+.network-display-only-note {
+  margin: 10px 0 0;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}

--- a/frontend/src/components/wallet/NetworkSettings.jsx
+++ b/frontend/src/components/wallet/NetworkSettings.jsx
@@ -1,7 +1,95 @@
 import { useChainId, useSwitchChain } from 'wagmi'
 import { getSelectableNetworks } from '../../config/networks'
 import { getNetworkFeatures } from '../../config/networkCapabilities'
+import { BITCOIN_NETWORKS } from '../../config/bitcoinNetworks'
 import './NetworkSettings.css'
+
+/**
+ * Bitcoin capability tags (spec 061, FR-020) — resolved from the non-EVM
+ * registry's `capabilities`, the single source of truth for what Bitcoin
+ * supports. `collect: 'stamps-only'` is truthy: the Stamps section without
+ * OpenSea integration.
+ */
+const BITCOIN_FEATURE_TAGS = [
+  { key: 'portfolio', label: 'Portfolio', description: 'Native BTC balance in the portfolio.' },
+  { key: 'send', label: 'Send', description: 'Send BTC to any standard Bitcoin address.' },
+  { key: 'receive', label: 'Receive', description: 'Receive BTC via rotating addresses.' },
+  { key: 'collect', label: 'Stamps collectibles', description: 'Bitcoin Stamps shown in Collect (no OpenSea integration).' },
+  { key: 'wagers', label: 'P2P Wagers', description: 'Create and settle peer-to-peer wagers.' },
+  { key: 'pools', label: 'Wager Pools', description: 'Group wager pools.' },
+  { key: 'membership', label: 'Memberships', description: 'On-chain membership tiers and access roles.' },
+  { key: 'gasless', label: 'Gasless', description: 'Fee-sponsored transactions. Bitcoin sends always pay the network fee.' },
+  { key: 'swap', label: 'Token Swap', description: 'In-app token swaps.' },
+  { key: 'earn', label: 'Earn', description: 'In-app lending and yield.' },
+  { key: 'predict', label: 'Predict', description: 'Polymarket prediction-market trading.' },
+]
+
+/**
+ * Display-only Bitcoin network card (spec 061, T033). Bitcoin is a non-EVM
+ * network: there is NO wallet chain switch for it (network-registry rule 2),
+ * so the card carries no switch affordance — surfaces activate per feature
+ * (portfolio, send, receive) instead. Capability tags state truthfully what
+ * is and is not supported (FR-020).
+ */
+function BitcoinNetworkCard({ net }) {
+  return (
+    <li className="network-card network-card-display-only">
+      <div className="network-card-header">
+        <div className="network-card-title">
+          <span className="network-name">{net.name}</span>
+          <span className={`network-kind ${net.isTestnet ? 'testnet' : 'mainnet'}`}>
+            {net.isTestnet ? 'Testnet' : 'Mainnet'}
+          </span>
+        </div>
+        <span className="network-active-badge network-display-only-badge">No wallet switch</span>
+      </div>
+
+      <ul className="network-feature-tags">
+        {BITCOIN_FEATURE_TAGS.map((feature) => {
+          const supported = Boolean(net.capabilities?.[feature.key])
+          return (
+            <li
+              key={feature.key}
+              className={`network-tag ${supported ? 'available' : 'unavailable'}`}
+              title={`${feature.description} ${supported ? '(Supported)' : '(Not supported on Bitcoin)'}`}
+            >
+              <span className="network-tag-icon" aria-hidden="true">
+                {supported ? '✓' : '—'}
+              </span>
+              <span className="network-tag-label">{feature.label}</span>
+            </li>
+          )
+        })}
+      </ul>
+
+      <dl className="network-docs">
+        <div className="network-doc-row">
+          <dt>Native currency</dt>
+          <dd>BTC (Bitcoin)</dd>
+        </div>
+        {net.explorer?.baseUrl && (
+          <div className="network-doc-row">
+            <dt>Explorer</dt>
+            <dd>
+              <a href={net.explorer.baseUrl} target="_blank" rel="noopener noreferrer">
+                {net.explorer.name || 'Block explorer'}
+              </a>
+            </dd>
+          </div>
+        )}
+        <div className="network-doc-row">
+          <dt>Wallet</dt>
+          <dd>Requires a FairWins passkey on a PRF-capable device.</dd>
+        </div>
+      </dl>
+
+      <p className="network-display-only-note">
+        Bitcoin has no wallet network switch — it activates per feature
+        (portfolio, send, receive). Members always pay the Bitcoin network fee.
+      </p>
+    </li>
+  )
+}
 
 /**
  * NetworkSettings
@@ -145,6 +233,13 @@ function NetworkSettings() {
               </li>
             )
           })}
+          {/* Non-EVM networks (spec 061): display-only rows — the EVM list
+              always includes testnets, and the Bitcoin pair mirrors that. */}
+          {Object.values(BITCOIN_NETWORKS)
+            .sort((a, b) => Number(a.isTestnet) - Number(b.isTestnet))
+            .map((net) => (
+              <BitcoinNetworkCard key={net.id} net={net} />
+            ))}
         </ul>
       </div>
     </div>

--- a/frontend/src/components/wallet/TransferForm.jsx
+++ b/frontend/src/components/wallet/TransferForm.jsx
@@ -15,6 +15,9 @@ import usePortfolio from '../../hooks/usePortfolio'
 import { useAddressScreening } from '../../hooks/useAddressScreening'
 import { useNotification } from '../../hooks/useUI'
 import { extractAddressFromScan } from '../../lib/addressBook/scanAddress'
+import { useBitcoinWallet } from '../../hooks/useBitcoinWallet'
+import { getBitcoinNetwork } from '../../config/bitcoinNetworks'
+import BitcoinSendPanel from './BitcoinSendPanel'
 
 const short = (a) => (a ? `${a.slice(0, 6)}…${a.slice(-4)}` : '')
 const toNum = (v) => (v == null || v === '' ? null : Number(v))
@@ -43,6 +46,10 @@ export default function TransferForm({ onSent }) {
   const { screenOne } = useAddressScreening()
   const { showNotification } = useNotification()
   const { switchChainAsync, isPending: switching } = useSwitchChain()
+  // Bitcoin (spec 061): a parallel, non-EVM send pipeline. The asset row only
+  // appears when the wallet is actually usable (ready, unlocked) — the
+  // receive/portfolio surfaces own the unlock journey, honest-state style.
+  const btc = useBitcoinWallet()
 
   const [selectedKey, setSelectedKey] = useState(null)
   const [toRaw, setToRaw] = useState('')
@@ -100,6 +107,23 @@ export default function TransferForm({ onSent }) {
       })
     }
 
+    // Native Bitcoin — personal wallet only (custody vaults are EVM Safes and
+    // can never hold BTC). Balance is the SPENDABLE amount: what a send can
+    // actually move (protected/pending value is disclosed in the panel).
+    if (!isVault && btc.status === 'ready') {
+      put({
+        key: 'bitcoin:native',
+        chainId: btc.networkId,
+        kind: 'btc-native',
+        address: null,
+        symbol: 'BTC',
+        name: 'Bitcoin',
+        decimals: 8,
+        networkName: getBitcoinNetwork(btc.networkId)?.name || 'Bitcoin',
+        balance: (btc.balances.spendableSats ?? 0) / 1e8,
+      })
+    }
+
     const source = isVault ? vaultAssets.holdings : portfolio.holdings
     for (const h of source || []) {
       if (h.asset.kind !== 'native' && h.asset.kind !== 'erc20') continue // no NFTs in a value transfer
@@ -124,7 +148,7 @@ export default function TransferForm({ onSent }) {
       if (ac !== bc) return ac - bc
       return (b.balance ?? 0) - (a.balance ?? 0)
     })
-  }, [isVault, vaultAssets.holdings, portfolio.holdings, tokens, connectedChainId, balanceOf, isConnectedStableAddr])
+  }, [isVault, vaultAssets.holdings, portfolio.holdings, tokens, connectedChainId, balanceOf, isConnectedStableAddr, btc.status, btc.networkId, btc.balances.spendableSats])
 
   // Default to the connected chain's stablecoin, then its native coin, then whatever's first.
   const defaultKey = useMemo(() => {
@@ -140,8 +164,15 @@ export default function TransferForm({ onSent }) {
   const activeKey = selectedKey && assetOptions.some((o) => o.key === selectedKey) ? selectedKey : defaultKey
   const selectedAsset = assetOptions.find((o) => o.key === activeKey) || null
 
+  const isBitcoinAsset = selectedAsset?.kind === 'btc-native'
   const onConnectedChain = selectedAsset && Number(selectedAsset.chainId) === connectedChainId
-  const gasless = selectedAsset ? quoteGaslessForAsset(selectedAsset) : false
+  // Bitcoin is never gasless (FR-015) — both the badge and the dropdown's
+  // per-option marker must say so, whatever the EVM quote would claim.
+  const gaslessForOption = useCallback(
+    (opt) => (opt?.kind === 'btc-native' ? false : quoteGaslessForAsset(opt)),
+    [quoteGaslessForAsset],
+  )
+  const gasless = selectedAsset ? gaslessForOption(selectedAsset) : false
   const bal = selectedAsset?.balance ?? null
   const symbol = selectedAsset?.symbol || ''
 
@@ -275,7 +306,7 @@ export default function TransferForm({ onSent }) {
           options={assetOptions}
           value={activeKey}
           onChange={handleSelectAsset}
-          isGasless={quoteGaslessForAsset}
+          isGasless={gaslessForOption}
           disabled={busy}
         />
         {gasless ? (
@@ -285,7 +316,13 @@ export default function TransferForm({ onSent }) {
         )}
       </div>
 
-      {!previewing ? (
+      {isBitcoinAsset ? (
+        <BitcoinSendPanel
+          btc={btc}
+          usdPerBtc={portfolio.priceMap?.get('BTC')?.usd ?? null}
+          onSent={onSent}
+        />
+      ) : !previewing ? (
         <>
           {/* From — connected wallet or a Protect vault */}
           <div className="pt-field">

--- a/frontend/src/config/__tests__/bitcoinNetworks.test.js
+++ b/frontend/src/config/__tests__/bitcoinNetworks.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import {
+  BITCOIN_NETWORKS,
+  BITCOIN_TESTNET_MAINNET_PAIR,
+  isBitcoinNetworkId,
+  getBitcoinNetwork,
+  getActiveBitcoinNetworkId,
+} from '../bitcoinNetworks'
+import { NETWORKS } from '../networks'
+
+describe('bitcoinNetworks registry (spec 061, contracts/network-registry.md)', () => {
+  it('exposes exactly the two contract networks with string ids', () => {
+    expect(Object.keys(BITCOIN_NETWORKS).sort()).toEqual(['bitcoin', 'bitcoin-testnet'])
+    for (const net of Object.values(BITCOIN_NETWORKS)) {
+      expect(typeof net.id).toBe('string')
+      expect(net.kind).toBe('bitcoin')
+    }
+  })
+
+  it('mainnet/testnet entries carry the contract constants', () => {
+    const main = BITCOIN_NETWORKS.bitcoin
+    expect(main).toMatchObject({
+      isTestnet: false,
+      gatewaySegment: 'mainnet',
+      addressHrp: 'bc',
+      coinType: 0,
+    })
+    const test = BITCOIN_NETWORKS['bitcoin-testnet']
+    expect(test).toMatchObject({
+      isTestnet: true,
+      gatewaySegment: 'testnet',
+      addressHrp: 'tb',
+      coinType: 1,
+    })
+  })
+
+  it('capabilities are honest: only portfolio/send/receive (+ stamps-only collect)', () => {
+    for (const net of Object.values(BITCOIN_NETWORKS)) {
+      const c = net.capabilities
+      expect(c.portfolio).toBe(true)
+      expect(c.send).toBe(true)
+      expect(c.receive).toBe(true)
+      expect(c.collect).toBe('stamps-only')
+      for (const key of ['wagers', 'pools', 'membership', 'gasless', 'swap', 'earn', 'predict']) {
+        expect(c[key]).toBe(false)
+      }
+    }
+  })
+
+  it('explorer builds tx and address URLs', () => {
+    const { explorer } = BITCOIN_NETWORKS.bitcoin
+    expect(explorer.tx('abc')).toBe('https://mempool.space/tx/abc')
+    expect(explorer.address('bc1qxyz')).toBe('https://mempool.space/address/bc1qxyz')
+    expect(BITCOIN_NETWORKS['bitcoin-testnet'].explorer.tx('abc')).toContain('/testnet4/')
+  })
+
+  it('isBitcoinNetworkId guards the boundary (no numeric leakage)', () => {
+    expect(isBitcoinNetworkId('bitcoin')).toBe(true)
+    expect(isBitcoinNetworkId('bitcoin-testnet')).toBe(true)
+    expect(isBitcoinNetworkId(137)).toBe(false)
+    expect(isBitcoinNetworkId('137')).toBe(false)
+    expect(isBitcoinNetworkId(0)).toBe(false)
+    expect(isBitcoinNetworkId(null)).toBe(false)
+    expect(isBitcoinNetworkId(undefined)).toBe(false)
+    expect(isBitcoinNetworkId('ethereum')).toBe(false)
+    // prototype pollution safety
+    expect(isBitcoinNetworkId('toString')).toBe(false)
+  })
+
+  it('getBitcoinNetwork soft-fails to null on unknown ids', () => {
+    expect(getBitcoinNetwork('bitcoin')?.name).toBe('Bitcoin')
+    expect(getBitcoinNetwork('dogecoin')).toBeNull()
+    expect(getBitcoinNetwork(1)).toBeNull()
+  })
+
+  it('testnet/mainnet pairing follows the app toggle (FR-021)', () => {
+    expect(BITCOIN_TESTNET_MAINNET_PAIR).toEqual(['bitcoin-testnet', 'bitcoin'])
+    expect(getActiveBitcoinNetworkId(true)).toBe('bitcoin-testnet')
+    expect(getActiveBitcoinNetworkId(false)).toBe('bitcoin')
+  })
+
+  it('never collides with the EVM NETWORKS registry', () => {
+    // Bitcoin ids are strings and must not shadow numeric chainId keys.
+    for (const id of Object.keys(BITCOIN_NETWORKS)) {
+      expect(Object.prototype.hasOwnProperty.call(NETWORKS, id)).toBe(false)
+    }
+  })
+
+  it('registry entries are frozen (config is immutable at runtime)', () => {
+    expect(Object.isFrozen(BITCOIN_NETWORKS)).toBe(true)
+    expect(Object.isFrozen(BITCOIN_NETWORKS.bitcoin)).toBe(true)
+    expect(Object.isFrozen(BITCOIN_NETWORKS.bitcoin.capabilities)).toBe(true)
+  })
+})

--- a/frontend/src/config/assetTaxonomy.js
+++ b/frontend/src/config/assetTaxonomy.js
@@ -25,6 +25,7 @@
  */
 import { NETWORKS } from './networks'
 import { getContractAddressForChain } from './contracts'
+import { getBitcoinNetwork } from './bitcoinNetworks'
 
 // The five app-aligned regulatory categories (FR-004) plus the honest
 // `unclassified` fallback (FR-012). Order is display order.
@@ -103,11 +104,13 @@ const BASELINE_SET = new Set(SEC_COMMODITY_BASELINE)
  * is the canonical mainnet whose NATIVE coin the symbol is — a native
  * instance on that chain renders its logo without a network badge (FR-026);
  * every other instance (wrapped, bridged, testnet) carries the hosting
- * network's badge.
+ * network's badge. `homeNetwork` is the non-EVM equivalent (spec 061): a
+ * string id from bitcoinNetworks.js for underlyings whose home chain is not
+ * an EVM network.
  */
 export const UNDERLYING_META = {
   ETH: { name: 'Ethereum', homeChainId: 1 },
-  BTC: { name: 'Bitcoin', homeChainId: null },
+  BTC: { name: 'Bitcoin', homeChainId: null, homeNetwork: 'bitcoin' },
   MATIC: { name: 'Polygon', homeChainId: 137 },
   POL: { name: 'Polygon', homeChainId: 137 },
   ETC: { name: 'Ethereum Classic', homeChainId: 61 },
@@ -461,4 +464,33 @@ export function getPortfolioRegistry(chainId) {
   }
 
   return Array.from(byId.values())
+}
+
+/**
+ * Native-Bitcoin portfolio asset for a non-EVM bitcoin network (spec 061,
+ * FR-008). Not part of getPortfolioRegistry — that registry is keyed by EVM
+ * chainId and scanned via RPC; the bitcoin balance source in usePortfolio
+ * feeds this descriptor instead. It aggregates with WBTC under the single
+ * `BTC` underlying via the existing baseline roll-up, and prices through the
+ * already-configured BTC/USD feeds (priceFeeds.js, key `BTC`).
+ *
+ * Returns null for non-bitcoin ids (soft-fail, mirrors getPortfolioRegistry's
+ * empty-registry behavior for unknown chains).
+ */
+export function getBitcoinPortfolioAsset(networkId) {
+  const net = getBitcoinNetwork(networkId)
+  if (!net) return null
+  return {
+    id: 'btc-native',
+    // String network id in the chainId slot — consumers on the bitcoin path
+    // are guarded by isBitcoinNetworkId and never pass this to EVM code.
+    chainId: net.id,
+    kind: 'native',
+    symbol: 'BTC',
+    name: net.isTestnet ? 'Bitcoin (Testnet)' : 'Bitcoin',
+    decimals: 8,
+    categoryId: 'digital-commodities',
+    source: 'sec-baseline',
+    baselineSymbol: 'BTC',
+  }
 }

--- a/frontend/src/config/bitcoinNetworks.js
+++ b/frontend/src/config/bitcoinNetworks.js
@@ -1,0 +1,90 @@
+/**
+ * Bitcoin network registry (spec 061) — the platform's first NON-EVM network
+ * config, implementing specs/061-bitcoin-transactions/contracts/network-registry.md.
+ *
+ * This registry is PARALLEL to the numeric-chainId `NETWORKS` map in
+ * networks.js and is never merged into it: Bitcoin has no EVM chainId, no
+ * wagmi switchChain affordance, no contracts, and no subgraph. Ids here are
+ * strings ('bitcoin', 'bitcoin-testnet') and MUST never flow into
+ * `getContractAddressForChain`, wagmi provider construction, or any consumer
+ * typed on numeric chainIds — guard every shared boundary with
+ * `isBitcoinNetworkId`.
+ *
+ * Capability honesty (FR-020): `capabilities` below is the single source of
+ * truth for what Bitcoin supports. Everything false hides/disables its
+ * surface exactly like an EVM capability that is off. `collect: 'stamps-only'`
+ * means the collectibles surface shows the Bitcoin Stamps section but no
+ * OpenSea integration.
+ */
+
+const explorer = (baseUrl) => ({
+  name: 'mempool.space',
+  baseUrl,
+  tx: (txid) => `${baseUrl}/tx/${txid}`,
+  address: (addr) => `${baseUrl}/address/${addr}`,
+})
+
+const CAPABILITIES = Object.freeze({
+  portfolio: true,
+  send: true,
+  receive: true,
+  wagers: false,
+  pools: false,
+  membership: false,
+  gasless: false,
+  swap: false,
+  earn: false,
+  predict: false,
+  collect: 'stamps-only',
+})
+
+export const BITCOIN_NETWORKS = Object.freeze({
+  bitcoin: Object.freeze({
+    id: 'bitcoin',
+    kind: 'bitcoin',
+    name: 'Bitcoin',
+    isTestnet: false,
+    // Path segment for the relay-gateway proxy: /v1/bitcoin/:network/*
+    gatewaySegment: 'mainnet',
+    // bech32/bech32m human-readable part — drives address labeling and
+    // wrong-network rejection (tb1… is never a valid mainnet destination).
+    addressHrp: 'bc',
+    // BIP44 coin type (hardened) — see contracts/key-derivation-btc.md.
+    coinType: 0,
+    explorer: explorer('https://mempool.space'),
+    capabilities: CAPABILITIES,
+  }),
+  'bitcoin-testnet': Object.freeze({
+    id: 'bitcoin-testnet',
+    kind: 'bitcoin',
+    name: 'Bitcoin Testnet4',
+    isTestnet: true,
+    gatewaySegment: 'testnet',
+    addressHrp: 'tb',
+    coinType: 1,
+    explorer: explorer('https://mempool.space/testnet4'),
+    capabilities: CAPABILITIES,
+  }),
+})
+
+/** [testnetId, mainnetId] — mirrors TESTNET_MAINNET_PAIR semantics (FR-021). */
+export const BITCOIN_TESTNET_MAINNET_PAIR = Object.freeze(['bitcoin-testnet', 'bitcoin'])
+
+/** True only for the string ids of this registry — the boundary type guard. */
+export function isBitcoinNetworkId(id) {
+  return typeof id === 'string' && Object.prototype.hasOwnProperty.call(BITCOIN_NETWORKS, id)
+}
+
+/** Lookup or null — callers soft-fail (hide surfaces) on unknown ids. */
+export function getBitcoinNetwork(id) {
+  return isBitcoinNetworkId(id) ? BITCOIN_NETWORKS[id] : null
+}
+
+/**
+ * The Bitcoin network for the app's current testnet/mainnet mode.
+ * `testnetMode` follows the existing global toggle (80002 ↔ 137 on EVM).
+ */
+export function getActiveBitcoinNetworkId(testnetMode) {
+  const [testnetId, mainnetId] = BITCOIN_TESTNET_MAINNET_PAIR
+  return testnetMode ? testnetId : mainnetId
+}

--- a/frontend/src/config/networkCapabilities.js
+++ b/frontend/src/config/networkCapabilities.js
@@ -10,6 +10,7 @@
 
 import { getContractAddressForChain } from './contracts'
 import { getNetwork } from './networks'
+import { isBitcoinNetworkId } from './bitcoinNetworks'
 
 const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/
 
@@ -84,11 +85,17 @@ export const NETWORK_FEATURES = [
  * @returns {{ key: string, label: string, description: string, deployed: boolean }[]}
  */
 export function getNetworkFeatures(chainId) {
+  // Boundary type guard (spec 061, network-registry rule 1): non-EVM string
+  // ids must never flow into getContractAddressForChain / getNetwork, whose
+  // fallback would dishonestly report the DEFAULT network's capabilities.
+  // Bitcoin surfaces read BITCOIN_NETWORKS.capabilities instead; here every
+  // EVM protocol feature is truthfully undeployed.
+  const isBitcoin = isBitcoinNetworkId(chainId)
   return NETWORK_FEATURES.map(({ key, label, description, deployed }) => ({
     key,
     label,
     description,
-    deployed: deployed(chainId),
+    deployed: isBitcoin ? false : deployed(chainId),
   }))
 }
 

--- a/frontend/src/hooks/__tests__/useBitcoinWallet.test.js
+++ b/frontend/src/hooks/__tests__/useBitcoinWallet.test.js
@@ -1,0 +1,363 @@
+/**
+ * Spec 061 T013/T025 — useBitcoinWallet orchestration hook:
+ * availability matrix (contracts/key-derivation-btc.md), unlock → discovery →
+ * balances, the send pipeline (locks + pending tracking), degraded states,
+ * and relock on account switch. No real WebAuthn: resolveMasterSeed, the
+ * gateway client, and persistence are injected.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+
+let walletState
+vi.mock('../useWalletManagement', () => ({
+  useWallet: () => walletState,
+}))
+
+import { useBitcoinWallet, __resetBitcoinWalletForTests } from '../useBitcoinWallet'
+import { rememberCredential } from '../../lib/passkey/credentials'
+import { addressAt } from '../../lib/bitcoin/derivation'
+import { ledgerStore } from '../../lib/bitcoin/wallet'
+
+const ACCOUNT = '0x00000000000000000000000000000000000A11CE'
+const OTHER_ACCOUNT = '0x0000000000000000000000000000000000000B0b'
+const SEED = new Uint8Array(32).fill(7)
+const NET = 'bitcoin-testnet' // chainId 80002 (Amoy) is a testnet → testnet4
+
+// Deterministic fixture addresses from the real derivation lib.
+const SEGWIT_0 = addressAt(SEED, { network: NET, type: 'segwit', index: 0 })
+const TAPROOT_DEST = addressAt(SEED, { network: NET, type: 'taproot', index: 9 })
+
+const FUNDING_TXID = 'ab'.repeat(32)
+const BROADCAST_TXID = 'cd'.repeat(32)
+
+function memoryStorage() {
+  const map = new Map()
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, String(v)),
+  }
+}
+
+function makeGateway({
+  utxosByAddress = {},
+  stamps = { ok: true, degraded: false, stamps: [] },
+  failLookup = false,
+} = {}) {
+  const state = { confirmed: false }
+  return {
+    state,
+    lookupAddresses: vi.fn(async (networkId, addresses) => {
+      if (failLookup) return { ok: false, error: 'upstream_unavailable', stale: true }
+      return {
+        ok: true,
+        tipHeight: 100,
+        results: addresses.map((address) => ({
+          address,
+          confirmedSats: (utxosByAddress[address] ?? []).reduce((s, u) => s + u.valueSats, 0),
+          pendingSats: 0,
+          utxos: utxosByAddress[address] ?? [],
+        })),
+      }
+    }),
+    getStamps: vi.fn(async () => stamps),
+    getFees: vi.fn(async () => ({
+      ok: true,
+      rates: { fast: 20, normal: 10, slow: 2 },
+      tipHeight: 100,
+    })),
+    broadcast: vi.fn(async () => ({ ok: true, txid: BROADCAST_TXID })),
+    getTxStatus: vi.fn(async (networkId, txid) => ({
+      ok: true,
+      found: true,
+      txid,
+      confirmed: state.confirmed,
+      confirmations: state.confirmed ? 1 : 0,
+    })),
+  }
+}
+
+function fundedGateway(overrides = {}) {
+  return makeGateway({
+    utxosByAddress: {
+      [SEGWIT_0]: [{ txid: FUNDING_TXID, vout: 0, valueSats: 100_000, confirmations: 3 }],
+    },
+    ...overrides,
+  })
+}
+
+function passkeySession({ address = ACCOUNT, prfCapable = true } = {}) {
+  walletState = { address, isConnected: true, loginMethod: 'passkey', chainId: 80002 }
+  rememberCredential({ credentialId: 'cred-1', address, publicKey: { x: '0x1', y: '0x2' }, prfCapable })
+}
+
+function makeDeps(gateway) {
+  return {
+    gateway,
+    store: ledgerStore(memoryStorage()),
+    resolveSeed: vi.fn(async () => SEED.slice()),
+    pollIntervalMs: 5,
+    pollMaxMs: 2_000,
+  }
+}
+
+async function unlockHook(deps) {
+  const rendered = renderHook(() => useBitcoinWallet(deps))
+  await act(async () => {
+    const res = await rendered.result.current.unlock()
+    expect(res.ok).toBe(true)
+  })
+  return rendered
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  __resetBitcoinWalletForTests()
+})
+
+describe('availability matrix (FR-020 / key-derivation contract)', () => {
+  it('is unavailable with an honest reason when disconnected', () => {
+    walletState = { address: null, isConnected: false, loginMethod: null, chainId: 80002 }
+    const { result } = renderHook(() => useBitcoinWallet(makeDeps(makeGateway())))
+    expect(result.current.status).toBe('unavailable')
+    expect(result.current.reason).toMatch(/connect/i)
+  })
+
+  it('is unavailable for a non-passkey (injected/WalletConnect) login', () => {
+    walletState = { address: ACCOUNT, isConnected: true, loginMethod: 'injected', chainId: 80002 }
+    const { result } = renderHook(() => useBitcoinWallet(makeDeps(makeGateway())))
+    expect(result.current.status).toBe('unavailable')
+    expect(result.current.reason).toMatch(/passkey/i)
+  })
+
+  it('is unavailable on a non-PRF authenticator, with the PRF reason', () => {
+    passkeySession({ prfCapable: false })
+    const { result } = renderHook(() => useBitcoinWallet(makeDeps(makeGateway())))
+    expect(result.current.status).toBe('unavailable')
+    expect(result.current.reason).toMatch(/PRF/i)
+  })
+
+  it('is unavailable when the gateway is unconfigured (capability off)', () => {
+    passkeySession()
+    const gateway = { ...makeGateway(), baseUrl: '' }
+    const { result } = renderHook(() => useBitcoinWallet(makeDeps(gateway)))
+    expect(result.current.status).toBe('unavailable')
+    expect(result.current.reason).toMatch(/not configured/i)
+  })
+
+  it('is locked (not unavailable) for a PRF-capable passkey before unlock', () => {
+    passkeySession()
+    const { result } = renderHook(() => useBitcoinWallet(makeDeps(makeGateway())))
+    expect(result.current.status).toBe('locked')
+    expect(result.current.networkId).toBe(NET)
+  })
+})
+
+describe('unlock → discovery → balances', () => {
+  it('resolves the seed once, discovers funded addresses, and populates balances', async () => {
+    passkeySession()
+    const gateway = fundedGateway()
+    const deps = makeDeps(gateway)
+    const { result } = await unlockHook(deps)
+
+    expect(deps.resolveSeed).toHaveBeenCalledTimes(1)
+    expect(deps.resolveSeed).toHaveBeenCalledWith({ account: ACCOUNT, credentialId: 'cred-1' })
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+    await waitFor(() => expect(result.current.balances.confirmedSats).toBe(100_000))
+    expect(result.current.balances.spendableSats).toBe(100_000)
+    expect(result.current.balances.protectedSats).toBe(0)
+    expect(result.current.stampsDegraded).toBe(false)
+
+    // Discovery rebuilt the issued-address ledger from chain state (FR-003).
+    const issued = deps.store.get(ACCOUNT, NET).issued
+    expect(issued.map((a) => a.address)).toContain(SEGWIT_0)
+  })
+
+  it('marks state stale (never zero-with-confidence) when the gateway is unreachable', async () => {
+    passkeySession()
+    const deps = makeDeps(makeGateway({ failLookup: true }))
+    const { result } = await unlockHook(deps)
+    await waitFor(() => expect(result.current.stale).toBe(true))
+    expect(result.current.status).toBe('ready')
+  })
+
+  it('fails safe when stamps recognition is degraded: all coins protected, none spendable', async () => {
+    passkeySession()
+    const deps = makeDeps(fundedGateway({ stamps: { ok: true, degraded: true, stamps: [] } }))
+    const { result } = await unlockHook(deps)
+    await waitFor(() => expect(result.current.stampsDegraded).toBe(true))
+    expect(result.current.balances.protectedSats).toBe(100_000)
+    expect(result.current.balances.spendableSats).toBe(0)
+  })
+
+  it('issues fresh, never-repeating receive addresses and formats BIP-21', async () => {
+    passkeySession()
+    const deps = makeDeps(fundedGateway())
+    const { result } = await unlockHook(deps)
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+
+    let a
+    let b
+    act(() => {
+      a = result.current.receive.nextReceiveAddress('segwit')
+    })
+    act(() => {
+      b = result.current.receive.nextReceiveAddress('segwit')
+    })
+    expect(a.address).not.toBe(b.address)
+    expect(b.index).toBeGreaterThan(a.index)
+    expect(result.current.receive.current.address).toBe(b.address)
+    expect(result.current.receive.uri).toBe(`bitcoin:${b.address}`)
+  })
+})
+
+describe('send pipeline (FR-011…FR-014)', () => {
+  async function readySend() {
+    passkeySession()
+    const gateway = fundedGateway()
+    const deps = makeDeps(gateway)
+    const rendered = await unlockHook(deps)
+    await waitFor(() => expect(rendered.result.current.balances.spendableSats).toBe(100_000))
+    await act(async () => {
+      const q = await rendered.result.current.send.getFeeQuote()
+      expect(q.ok).toBe(true)
+    })
+    return { ...rendered, gateway, deps }
+  }
+
+  it('prepares, signs, broadcasts, locks the coins, and tracks the pending tx to confirmation', async () => {
+    const { result, gateway } = await readySend()
+
+    const prep = result.current.send.prepare({
+      destination: TAPROOT_DEST,
+      amountSats: 20_000,
+      feeRate: result.current.send.feeQuote.rates.normal,
+    })
+    expect(prep.ok).toBe(true)
+    expect(prep.plan.destinationType).toBe('p2tr')
+    expect(prep.plan.feeSats).toBeGreaterThan(0)
+    expect(prep.plan.changeSats).toBeGreaterThan(0)
+
+    let res
+    await act(async () => {
+      res = await result.current.send.confirmAndSend(prep.plan)
+    })
+    expect(res.ok).toBe(true)
+    expect(res.txid).toBe(BROADCAST_TXID)
+    // The fee committed never exceeds the previewed estimate (FR-012).
+    expect(res.feeSats).toBeLessThanOrEqual(prep.plan.feeSats)
+    expect(gateway.broadcast).toHaveBeenCalledTimes(1)
+
+    // Coins committed to the in-flight send are locked (FR-014)…
+    expect(result.current.balances.spendableSats).toBe(0)
+    // …and the activity entry is honestly pending, never final early (FR-009).
+    expect(result.current.activity[0]).toMatchObject({
+      txid: BROADCAST_TXID,
+      direction: 'out',
+      amountSats: 20_000,
+      status: 'pending',
+    })
+
+    // Network confirms → polling flips the entry and releases the locks.
+    gateway.state.confirmed = true
+    await waitFor(() => expect(result.current.activity[0].status).toBe('confirmed'))
+    await waitFor(() => expect(result.current.balances.spendableSats).toBe(100_000))
+  })
+
+  it('explains a shortfall instead of failing later', async () => {
+    const { result } = await readySend()
+    const prep = result.current.send.prepare({
+      destination: TAPROOT_DEST,
+      amountSats: 200_000, // > spendable
+      feeRate: 10,
+    })
+    expect(prep.ok).toBe(false)
+    expect(prep.error).toBe('insufficient_funds')
+    expect(prep.shortfallSats).toBeGreaterThan(0)
+  })
+
+  it('rejects an invalid destination with the specific classifyAddress reason', async () => {
+    const { result } = await readySend()
+    const prep = result.current.send.prepare({
+      destination: '0x00000000000000000000000000000000000A11CE',
+      amountSats: 10_000,
+      feeRate: 10,
+    })
+    expect(prep.ok).toBe(false)
+    expect(prep.error).toBe('invalid_destination')
+    expect(prep.reason).toBe('evm_address')
+  })
+
+  it('MAX sends everything spendable net of the fee, with no change output', async () => {
+    const { result } = await readySend()
+    const prep = result.current.send.prepare({
+      destination: TAPROOT_DEST,
+      amountSats: 'max',
+      feeRate: 10,
+    })
+    expect(prep.ok).toBe(true)
+    expect(prep.plan.isMax).toBe(true)
+    expect(prep.plan.changeSats).toBe(0)
+    expect(prep.plan.amountSats + prep.plan.feeSats).toBe(100_000)
+  })
+
+  it('refuses to send against a stale fee quote (forces a re-quote)', async () => {
+    passkeySession()
+    const clock = { t: 1_000_000_000 }
+    const deps = { ...makeDeps(fundedGateway()), now: () => clock.t }
+    const { result } = await unlockHook(deps)
+    await waitFor(() => expect(result.current.balances.spendableSats).toBe(100_000))
+    await act(async () => {
+      const q = await result.current.send.getFeeQuote()
+      expect(q.ok).toBe(true)
+    })
+    const prep = result.current.send.prepare({
+      destination: TAPROOT_DEST,
+      amountSats: 20_000,
+      feeRate: 10,
+    })
+    expect(prep.ok).toBe(true)
+
+    // Age the pinned quote past the 60s freshness window (FR-012).
+    clock.t += 120_000
+    let res
+    await act(async () => {
+      res = await result.current.send.confirmAndSend(prep.plan)
+    })
+    expect(res).toEqual({ ok: false, error: 'stale_fee_quote' })
+  })
+})
+
+describe('relock semantics', () => {
+  it('locks (and zeroes the session) when the account switches', async () => {
+    passkeySession()
+    const deps = makeDeps(fundedGateway())
+    const { result, rerender } = await unlockHook(deps)
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+
+    walletState = { ...walletState, address: OTHER_ACCOUNT }
+    rerender()
+
+    await waitFor(() => expect(result.current.status).not.toBe('ready'))
+    expect(result.current.balances).toEqual({
+      confirmedSats: 0,
+      pendingSats: 0,
+      protectedSats: 0,
+      spendableSats: 0,
+    })
+    expect(result.current.activity).toEqual([])
+    // A new unlock would need a fresh ceremony — the seed is gone.
+    expect(result.current.status).toBe('unavailable') // no credential for OTHER_ACCOUNT
+  })
+
+  it('locks on disconnect', async () => {
+    passkeySession()
+    const deps = makeDeps(fundedGateway())
+    const { result, rerender } = await unlockHook(deps)
+    await waitFor(() => expect(result.current.status).toBe('ready'))
+
+    walletState = { address: null, isConnected: false, loginMethod: null, chainId: 80002 }
+    rerender()
+    await waitFor(() => expect(result.current.status).toBe('unavailable'))
+    expect(result.current.coins).toEqual([])
+  })
+})

--- a/frontend/src/hooks/useBitcoinStamps.js
+++ b/frontend/src/hooks/useBitcoinStamps.js
@@ -1,0 +1,105 @@
+/**
+ * useBitcoinStamps (spec 061, T031 — FR-017/FR-019/FR-021) — the member's
+ * Bitcoin Stamps for the collectibles surface.
+ *
+ * Data source: the bitcoin gateway's stamps endpoint, queried with the
+ * ISSUED-ADDRESS CACHE (ledgerStore) — never key material, no PRF ceremony.
+ * The active bitcoin network follows the app's testnet/mainnet mode via the
+ * BITCOIN_TESTNET_MAINNET_PAIR (FR-021), keyed off the active EVM chain's
+ * testnet flag.
+ *
+ * Honest-state statuses (never a spinner forever — the gateway client always
+ * settles with a typed result):
+ *  - 'hidden'   — no account, no issued bitcoin addresses, or the bitcoin
+ *                 module is off/unconfigured (soft-fail, spec-054 pattern);
+ *  - 'loading'  — first fetch in flight;
+ *  - 'empty'    — recognition healthy, zero stamps (section stays hidden);
+ *  - 'ready'    — stamps to show (possibly alongside degraded=true);
+ *  - 'degraded' — recognition unavailable/uncertain: no stamp list can be
+ *                 trusted, protected-value handling has already failed safe.
+ */
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { useChainId } from 'wagmi'
+import { WalletContext } from '../contexts/WalletContext.js'
+import { getCurrentChainId, getNetwork } from '../config/networks'
+import { getActiveBitcoinNetworkId } from '../config/bitcoinNetworks'
+import { createBitcoinGatewayClient, bitcoinGatewayUrl } from '../lib/bitcoin/gatewayClient'
+import { ledgerStore } from '../lib/bitcoin/wallet'
+
+export function useBitcoinStamps({ gateway, store } = {}) {
+  // Tolerant context read (useCollectibles convention): this hook must
+  // soft-fail wherever no wallet context exists, never take the page down.
+  const wallet = useContext(WalletContext) || {}
+  const { address: account, isConnected } = wallet
+  const chainId = useChainId() || getCurrentChainId()
+  const testnetMode = Boolean(getNetwork(chainId)?.isTestnet)
+  const networkId = getActiveBitcoinNetworkId(testnetMode)
+
+  const addresses = useMemo(() => {
+    if (!account) return []
+    try {
+      const s = store ?? ledgerStore()
+      return s.get(account, networkId).issued.map((a) => a.address)
+    } catch {
+      return [] // no storage ⇒ no bitcoin ledger ⇒ nothing to show
+    }
+  }, [account, networkId, store])
+
+  const enabled = Boolean(isConnected && account && addresses.length > 0 && (gateway || bitcoinGatewayUrl()))
+
+  const [state, setState] = useState({ phase: 'idle', stamps: [], degraded: false })
+  const reqIdRef = useRef(0)
+
+  const load = useCallback(async () => {
+    if (!enabled) return
+    const reqId = ++reqIdRef.current
+    setState((prev) => (prev.phase === 'idle' ? { ...prev, phase: 'loading' } : prev))
+    const client = gateway ?? createBitcoinGatewayClient({ baseUrl: bitcoinGatewayUrl() })
+    let res
+    try {
+      res = await client.getStamps(networkId, addresses)
+    } catch {
+      res = { ok: false, error: 'network_error' }
+    }
+    if (reqId !== reqIdRef.current) return
+    if (!res.ok) {
+      // Capability-off ⇒ hide; anything else ⇒ honest degraded state.
+      setState({ phase: res.disabled ? 'disabled' : 'degraded', stamps: [], degraded: true })
+      return
+    }
+    setState({
+      // Fail-safe (FR-019): a degraded merge means the list cannot be trusted
+      // as complete — surface degraded, not a confident partial gallery.
+      phase: res.degraded ? 'degraded' : 'ready',
+      stamps: res.stamps ?? [],
+      degraded: Boolean(res.degraded),
+    })
+  }, [enabled, gateway, networkId, addresses])
+
+  // Full reset before refetch on account/network change (FR-021: testnet
+  // stamps never survive into a mainnet render).
+  useEffect(() => {
+    reqIdRef.current++
+    setState({ phase: 'idle', stamps: [], degraded: false })
+    load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [account, networkId, enabled])
+
+  return useMemo(() => {
+    let status
+    if (!enabled || state.phase === 'disabled') status = 'hidden'
+    else if (state.phase === 'idle' || state.phase === 'loading') status = 'loading'
+    else if (state.phase === 'degraded') status = 'degraded'
+    else if (state.stamps.length === 0) status = 'empty'
+    else status = 'ready'
+    return {
+      status,
+      networkId,
+      stamps: state.stamps,
+      degraded: state.degraded,
+      refresh: load,
+    }
+  }, [enabled, state, networkId, load])
+}
+
+export default useBitcoinStamps

--- a/frontend/src/hooks/useBitcoinWallet.js
+++ b/frontend/src/hooks/useBitcoinWallet.js
@@ -62,7 +62,7 @@ const EMPTY_VIEW = Object.freeze({
   stale: false,
   stampsDegraded: false,
   activity: [],
-  current: null, // { address, type, index } shown on the receive surface
+  shownAddress: null, // { address, type, index } shown on the receive surface
   preferredType: 'segwit',
   gatewayOff: null,
   feeQuote: null, // { rates, tipHeight, fetchedAt }
@@ -409,7 +409,7 @@ export function useBitcoinWallet(deps = {}) {
     const t = type ?? getSnapshot().preferredType
     const entry = wallet.nextReceiveAddress(t)
     internals.sessionCurrent.set(`${internals.networkId}:${t}`, entry)
-    setView({ current: entry })
+    setView({ shownAddress: entry })
     return entry
   }, [])
 
@@ -424,7 +424,7 @@ export function useBitcoinWallet(deps = {}) {
     const key = `${internals.networkId}:${type}`
     const entry = internals.sessionCurrent.get(key) ?? wallet.nextReceiveAddress(type)
     internals.sessionCurrent.set(key, entry)
-    setView({ current: entry })
+    setView({ shownAddress: entry })
     return entry
   }, [])
 
@@ -550,8 +550,10 @@ export function useBitcoinWallet(deps = {}) {
       coins: snapshot.coins,
       activity: snapshot.activity,
       receive: {
-        current: snapshot.current,
-        uri: snapshot.current ? formatBip21(snapshot.current.address) : null,
+        // Public API name is `current`; the snapshot field avoids the name
+        // so ref-inference (react-hooks/preserve-manual-memoization) stays happy.
+        current: snapshot.shownAddress,
+        uri: snapshot.shownAddress ? formatBip21(snapshot.shownAddress.address) : null,
         preferredType: snapshot.preferredType,
         setPreferredType,
         nextReceiveAddress,

--- a/frontend/src/hooks/useBitcoinWallet.js
+++ b/frontend/src/hooks/useBitcoinWallet.js
@@ -1,0 +1,585 @@
+/**
+ * useBitcoinWallet (spec 061, tasks T013 + T025) — the orchestration hook for
+ * the member's Bitcoin wallet: availability, unlock (one PRF ceremony),
+ * receive rotation, balances, and the send pipeline.
+ *
+ * Architecture: all wallet state lives in ONE module-level session store
+ * shared by every hook instance (receive modal, transfer form, portfolio
+ * surfaces…), so a single unlock serves the whole app and no instance ever
+ * re-runs the PRF ceremony or diverges on locks/activity. Components read the
+ * store through useSyncExternalStore; key material (master seed, account
+ * nodes) lives in non-reactive module internals and is NEVER placed in React
+ * state, persisted, logged, or transmitted (contracts/key-derivation-btc.md
+ * invariant 3).
+ *
+ * Availability matrix (drives FR-020 honest disclosure):
+ *  - non-passkey login (injected / WalletConnect)  → 'unavailable'
+ *  - passkey on a non-PRF authenticator            → 'unavailable'
+ *  - passkey whose credential has no key material  → 'unavailable'
+ *  - gateway module unconfigured / killswitched    → 'unavailable'
+ *  - passkey + PRF, seed not yet resolved          → 'locked'
+ *  - after unlock()                                → 'ready'
+ *
+ * Testnet/mainnet (FR-021): the active Bitcoin network mirrors the app's EVM
+ * testnet mode (NETWORKS[chainId].isTestnet) via BITCOIN_TESTNET_MAINNET_PAIR;
+ * flipping the mode re-derives for the paired network and resets all view
+ * state — balances/addresses/activity are strictly scoped per side.
+ */
+
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from 'react'
+import { useWallet } from './useWalletManagement'
+import { getNetwork } from '../config/networks'
+import { getActiveBitcoinNetworkId } from '../config/bitcoinNetworks'
+import { capability } from '../lib/passkey/prfKeys'
+import { knownCredentials } from '../lib/passkey/credentials'
+import { readSession } from '../connectors/passkey'
+import { resolveMasterSeed } from '../lib/passkey/encryption'
+import { deriveAccount, receivePubkey, receivePrivkey } from '../lib/bitcoin/derivation'
+import { encodeAddress, formatBip21 } from '../lib/bitcoin/addresses'
+import { createBitcoinWallet, ledgerStore, classifyUtxos, nextIndex } from '../lib/bitcoin/wallet'
+import { balanceComponents } from '../lib/bitcoin/coinSelection'
+import { prepareSend, executeSend, isQuoteFresh } from '../lib/bitcoin/send'
+import { createBitcoinGatewayClient } from '../lib/bitcoin/gatewayClient'
+
+const DEFAULT_POLL_INTERVAL_MS = 15_000
+const DEFAULT_POLL_MAX_MS = 30 * 60_000
+
+const GATEWAY_OFF_REASON =
+  'The Bitcoin service is temporarily disabled — balances and sends will return when it is back.'
+
+const ZERO_BALANCES = Object.freeze({
+  confirmedSats: 0,
+  pendingSats: 0,
+  protectedSats: 0,
+  spendableSats: 0,
+})
+
+const EMPTY_VIEW = Object.freeze({
+  unlocked: false,
+  discovering: false,
+  coins: [],
+  balances: ZERO_BALANCES,
+  stale: false,
+  stampsDegraded: false,
+  activity: [],
+  current: null, // { address, type, index } shown on the receive surface
+  preferredType: 'segwit',
+  gatewayOff: null,
+  feeQuote: null, // { rates, tipHeight, fetchedAt }
+})
+
+// ---- module-level session store (shared across hook instances) -------------
+
+let view = { ...EMPTY_VIEW }
+const listeners = new Set()
+
+function emit() {
+  for (const listener of [...listeners]) listener()
+}
+
+function setView(patch) {
+  view = { ...view, ...patch }
+  emit()
+}
+
+function getSnapshot() {
+  return view
+}
+
+function subscribe(listener) {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+/**
+ * Non-reactive internals: key material and per-session bookkeeping. Never
+ * mirrored into React state. `epoch` guards async work across lock/relock.
+ */
+const internals = {
+  epoch: 0,
+  account: null, // owning FairWins account (EVM address string)
+  networkId: null,
+  seed: null, // Uint8Array(32) — memory-only, zeroed on lock
+  accounts: null, // { segwit: HDKey, taproot: HDKey } — memory-only
+  wallet: null, // createBitcoinWallet controller
+  gateway: null,
+  store: null,
+  now: Date.now,
+  pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
+  pollMaxMs: DEFAULT_POLL_MAX_MS,
+  locks: new Set(), // "txid:vout" outpoints committed to in-flight sends
+  txLocks: new Map(), // txid → outpoints[] (to release on confirmation)
+  timers: new Map(), // txid → timeout handle (pending-tx polling)
+  // Addresses already shown this session per `${networkId}:${type}` — lets the
+  // receive type toggle re-show the address it already displayed instead of
+  // burning a fresh index on every flip.
+  sessionCurrent: new Map(),
+}
+
+/** Zero the seed, wipe key material, stop polling, reset all view state. */
+function lockSession() {
+  internals.epoch += 1
+  try {
+    internals.seed?.fill(0)
+  } catch {
+    /* zeroize is best-effort */
+  }
+  internals.seed = null
+  try {
+    internals.accounts?.segwit?.wipePrivateData?.()
+    internals.accounts?.taproot?.wipePrivateData?.()
+  } catch {
+    /* wipe is best-effort */
+  }
+  internals.accounts = null
+  internals.wallet = null
+  internals.account = null
+  internals.networkId = null
+  for (const timer of internals.timers.values()) clearTimeout(timer)
+  internals.timers.clear()
+  internals.locks = new Set()
+  internals.txLocks.clear()
+  internals.sessionCurrent.clear()
+  setView({ ...EMPTY_VIEW })
+}
+
+/** Test-only: reset the shared session between test cases. */
+export function __resetBitcoinWalletForTests() {
+  lockSession()
+  internals.gateway = null
+  internals.store = null
+  internals.now = Date.now
+  internals.pollIntervalMs = DEFAULT_POLL_INTERVAL_MS
+  internals.pollMaxMs = DEFAULT_POLL_MAX_MS
+}
+
+function scriptTypeOf(type) {
+  return type === 'taproot' ? 'p2tr' : 'p2wpkh'
+}
+
+/**
+ * Re-lookup + re-classify the wallet's coins. With `discover: true` runs the
+ * gap-limit scan (unlock/recovery path); otherwise re-queries the issued
+ * ledger only. Stale results keep the last-known coins (stale-not-zero,
+ * FR-010); disabled verdicts surface the honest gateway-off reason.
+ */
+async function refreshSession({ discover = false } = {}) {
+  const epoch = internals.epoch
+  const { wallet, gateway, networkId } = internals
+  if (!wallet || !gateway) return
+
+  let utxos
+  if (discover) {
+    const res = await wallet.discover()
+    if (epoch !== internals.epoch) return
+    if (res.stale) {
+      setView({ stale: true, discovering: false })
+      return
+    }
+    utxos = res.utxos
+  } else {
+    const issued = wallet.issuedAddresses()
+    const typeByAddress = new Map(issued.map((a) => [a.address, a.type]))
+    const res = await gateway.lookupAddresses(networkId, issued.map((a) => a.address))
+    if (epoch !== internals.epoch) return
+    if (!res.ok) {
+      setView({
+        stale: true,
+        discovering: false,
+        ...(res.disabled ? { gatewayOff: GATEWAY_OFF_REASON } : {}),
+      })
+      return
+    }
+    utxos = res.results.flatMap((r) =>
+      (r.utxos ?? []).map((u) => ({
+        ...u,
+        address: r.address,
+        scriptType: scriptTypeOf(typeByAddress.get(r.address)),
+      }))
+    )
+  }
+
+  const addresses = wallet.issuedAddresses().map((a) => a.address)
+  const stamps = await gateway.getStamps(networkId, addresses)
+  if (epoch !== internals.epoch) return
+
+  // Fail-safe: a failed/disabled stamps result classifies every confirmed coin
+  // 'unverified' (treated as protected by selection) — FR-019.
+  const coins = classifyUtxos(utxos, stamps, internals.locks)
+  setView({
+    coins,
+    balances: balanceComponents(coins),
+    stale: false,
+    discovering: false,
+    stampsDegraded: !stamps?.ok || Boolean(stamps?.degraded),
+    ...(stamps?.disabled ? { gatewayOff: GATEWAY_OFF_REASON } : {}),
+  })
+}
+
+/** Derive accounts + build the wallet controller for `networkId`, then discover. */
+async function initializeSession({ account, networkId }) {
+  internals.epoch += 1
+  internals.account = account
+  internals.networkId = networkId
+  internals.accounts = {
+    segwit: deriveAccount(internals.seed, { network: networkId, type: 'segwit' }),
+    taproot: deriveAccount(internals.seed, { network: networkId, type: 'taproot' }),
+  }
+  internals.wallet = createBitcoinWallet({
+    account,
+    networkId,
+    // Same output as derivation.addressAt, but from the in-memory account
+    // nodes so discovery loops don't repeat the HKDF + full BIP32 walk.
+    deriveAddress: (type, index) =>
+      encodeAddress(receivePubkey(internals.accounts[type], index).pubkey, {
+        type,
+        network: networkId,
+      }),
+    gateway: internals.gateway,
+    store: internals.store,
+  })
+  internals.sessionCurrent.clear()
+  for (const timer of internals.timers.values()) clearTimeout(timer)
+  internals.timers.clear()
+  setView({
+    ...EMPTY_VIEW,
+    unlocked: true,
+    discovering: true,
+    preferredType: internals.wallet.preferredType(),
+  })
+  await refreshSession({ discover: true })
+}
+
+/** Poll a broadcast tx until confirmed (or ~30min), then release its locks. */
+function schedulePoll(txid, startedAt = internals.now()) {
+  const epoch = internals.epoch
+  const timer = setTimeout(async () => {
+    internals.timers.delete(txid)
+    if (epoch !== internals.epoch || !internals.gateway || !internals.wallet) return
+    let status = null
+    try {
+      status = await internals.gateway.getTxStatus(internals.networkId, txid)
+    } catch {
+      status = null
+    }
+    if (epoch !== internals.epoch) return
+    if (status?.ok && status.confirmed) {
+      const outpoints = internals.txLocks.get(txid) ?? []
+      for (const op of outpoints) internals.locks.delete(op)
+      internals.txLocks.delete(txid)
+      setView({
+        activity: getSnapshot().activity.map((e) =>
+          e.txid === txid ? { ...e, status: 'confirmed' } : e
+        ),
+      })
+      refreshSession().catch(() => {})
+      return
+    }
+    if (internals.now() - startedAt >= internals.pollMaxMs) return // stays honestly 'pending'
+    schedulePoll(txid, startedAt)
+  }, internals.pollIntervalMs)
+  internals.timers.set(txid, timer)
+}
+
+// ---- the hook --------------------------------------------------------------
+
+/**
+ * @param {object} [deps] injectable collaborators for tests:
+ *   { gateway, store, resolveSeed, now, pollIntervalMs, pollMaxMs }
+ */
+export function useBitcoinWallet(deps = {}) {
+  const { address, isConnected, loginMethod, chainId } = useWallet() || {}
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot)
+
+  // FR-021: the active Bitcoin network mirrors the app's EVM testnet mode.
+  const networkId = useMemo(
+    () => getActiveBitcoinNetworkId(Boolean(getNetwork(chainId)?.isTestnet)),
+    [chainId]
+  )
+
+  const gateway = useMemo(() => deps.gateway ?? createBitcoinGatewayClient(), [deps.gateway])
+  const store = useMemo(() => deps.store ?? ledgerStore(), [deps.store])
+
+  const credentialInfo = useMemo(() => {
+    if (loginMethod !== 'passkey' || !address) return null
+    const known =
+      knownCredentials().find((c) => c.address?.toLowerCase() === address.toLowerCase()) || null
+    // Pin ceremonies to the credential this session signed in with (spec 045),
+    // falling back to the account's known credential on this browser.
+    const credentialId = readSession()?.credentialId ?? known?.credentialId ?? null
+    return { credentialId, prfCapable: known?.prfCapable ?? false }
+  }, [loginMethod, address])
+
+  const sessionMatches =
+    snapshot.unlocked &&
+    internals.account != null &&
+    address != null &&
+    internals.account.toLowerCase() === address.toLowerCase() &&
+    internals.networkId === networkId
+
+  const availability = useMemo(() => {
+    if (!isConnected || !address) {
+      return { status: 'unavailable', reason: 'Connect your FairWins account to use Bitcoin.' }
+    }
+    if (loginMethod !== 'passkey') {
+      return {
+        status: 'unavailable',
+        reason:
+          'Bitcoin requires a FairWins passkey account — external EVM wallets cannot derive the Bitcoin wallet.',
+      }
+    }
+    const cap = capability({
+      account: address,
+      credentialId: credentialInfo?.credentialId,
+      prfCapable: credentialInfo?.prfCapable ?? false,
+    })
+    if (cap.state === 'unavailable') {
+      return { status: 'unavailable', reason: cap.reason }
+    }
+    const configured = gateway?.baseUrl === undefined || gateway.baseUrl !== ''
+    if (!configured) {
+      return {
+        status: 'unavailable',
+        reason: 'The Bitcoin service is not configured on this deployment.',
+      }
+    }
+    if (snapshot.gatewayOff) {
+      return { status: 'unavailable', reason: snapshot.gatewayOff }
+    }
+    return sessionMatches ? { status: 'ready' } : { status: 'locked' }
+  }, [
+    isConnected,
+    address,
+    loginMethod,
+    credentialInfo,
+    gateway,
+    snapshot.gatewayOff,
+    sessionMatches,
+  ])
+
+  // Lock on account change/disconnect; re-derive on testnet/mainnet flips.
+  useEffect(() => {
+    if (
+      internals.account &&
+      (!isConnected || !address || internals.account.toLowerCase() !== address.toLowerCase())
+    ) {
+      lockSession()
+      return
+    }
+    if (internals.seed && internals.account && internals.networkId !== networkId) {
+      initializeSession({ account: internals.account, networkId }).catch(() => {})
+    }
+  }, [address, isConnected, networkId])
+
+  const unlock = useCallback(async () => {
+    if (!isConnected || !address || loginMethod !== 'passkey') {
+      return { ok: false, error: 'unavailable' }
+    }
+    if (internals.seed && internals.account?.toLowerCase() === address.toLowerCase()) {
+      if (internals.networkId !== networkId) {
+        await initializeSession({ account: address, networkId })
+      }
+      return { ok: true }
+    }
+    try {
+      const resolveSeed = deps.resolveSeed ?? resolveMasterSeed
+      // ONE PRF ceremony; the seed lives only in module internals.
+      const seed = await resolveSeed({ account: address, credentialId: credentialInfo?.credentialId })
+      internals.seed = seed
+      internals.gateway = gateway
+      internals.store = store
+      internals.now = deps.now ?? Date.now
+      internals.pollIntervalMs = deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
+      internals.pollMaxMs = deps.pollMaxMs ?? DEFAULT_POLL_MAX_MS
+      await initializeSession({ account: address, networkId })
+      return { ok: true }
+    } catch (err) {
+      lockSession()
+      return { ok: false, error: 'unlock_failed', message: err?.message }
+    }
+  }, [isConnected, address, loginMethod, networkId, credentialInfo, gateway, store, deps.resolveSeed, deps.now, deps.pollIntervalMs, deps.pollMaxMs])
+
+  const refresh = useCallback(() => refreshSession(), [])
+
+  // ---- receive -------------------------------------------------------------
+
+  const nextReceiveAddress = useCallback((type) => {
+    const wallet = internals.wallet
+    if (!wallet) return null
+    const t = type ?? getSnapshot().preferredType
+    const entry = wallet.nextReceiveAddress(t)
+    internals.sessionCurrent.set(`${internals.networkId}:${t}`, entry)
+    setView({ current: entry })
+    return entry
+  }, [])
+
+  /**
+   * Show an address of `type`: re-shows the address already displayed this
+   * session for that type, or issues a fresh one. Toggling segwit ↔ taproot
+   * therefore never burns extra rotation indexes.
+   */
+  const selectReceiveType = useCallback((type) => {
+    const wallet = internals.wallet
+    if (!wallet) return null
+    const key = `${internals.networkId}:${type}`
+    const entry = internals.sessionCurrent.get(key) ?? wallet.nextReceiveAddress(type)
+    internals.sessionCurrent.set(key, entry)
+    setView({ current: entry })
+    return entry
+  }, [])
+
+  const setPreferredType = useCallback(
+    (type) => {
+      if (internals.wallet) {
+        internals.wallet.setPreferredType(type)
+      } else if (address) {
+        const state = store.get(address, networkId)
+        store.set(address, networkId, { ...state, preferredType: type })
+      }
+      setView({ preferredType: type })
+    },
+    [address, networkId, store]
+  )
+
+  // ---- send ----------------------------------------------------------------
+
+  const getFeeQuote = useCallback(async () => {
+    const gw = internals.gateway ?? gateway
+    const res = await gw.getFees(networkId)
+    if (!res.ok) {
+      if (res.disabled) setView({ gatewayOff: GATEWAY_OFF_REASON })
+      return { ok: false, error: res.error }
+    }
+    const quote = { rates: res.rates, tipHeight: res.tipHeight, fetchedAt: internals.now() }
+    setView({ feeQuote: quote })
+    return { ok: true, quote }
+  }, [gateway, networkId])
+
+  const prepare = useCallback(({ destination, amountSats, feeRate }) => {
+    const wallet = internals.wallet
+    if (!wallet || !internals.accounts) return { ok: false, error: 'locked' }
+    const snap = getSnapshot()
+    const type = snap.preferredType
+    // The change address is PEEKED here (derived, never appended to the
+    // ledger) so plans that are abandoned before confirmation don't advance
+    // the rotation cursor; the real address is issued at execute time in
+    // confirmAndSend.
+    const changeIndex = nextIndex(wallet.issuedAddresses(), type)
+    const changeAddress = encodeAddress(
+      receivePubkey(internals.accounts[type], changeIndex).pubkey,
+      { type, network: internals.networkId }
+    )
+    return prepareSend({
+      coins: snap.coins,
+      destination,
+      amountSats,
+      feeRate,
+      quote: snap.feeQuote,
+      changeAddress,
+      changeType: scriptTypeOf(type),
+      networkId: internals.networkId,
+      nowMs: internals.now(),
+    })
+  }, [])
+
+  const confirmAndSend = useCallback(async (plan) => {
+    const wallet = internals.wallet
+    if (!wallet || !internals.accounts) return { ok: false, error: 'locked' }
+    // A quote that went stale between preview and confirm forces a re-quote —
+    // the member never pays a fee they did not just see (FR-012).
+    if (!isQuoteFresh(getSnapshot().feeQuote, internals.now())) {
+      return { ok: false, error: 'stale_fee_quote' }
+    }
+    let planToSend = plan
+    if (plan.changeSats > 0) {
+      // Issue the change address for real, at execute time only. An
+      // issued-for-change address enters the ledger like any other issued
+      // address, so it is monitored and rediscovered on recovery (FR-005).
+      const change = wallet.nextReceiveAddress(getSnapshot().preferredType)
+      planToSend = { ...plan, changeAddress: change.address }
+    }
+    const ledger = new Map(wallet.issuedAddresses().map((a) => [a.address, a]))
+    const accounts = internals.accounts
+    const netId = internals.networkId
+    const keyFor = (addr) => {
+      const entry = ledger.get(addr)
+      if (!entry || entry.network !== netId) return null
+      // Memory-only: the child key exists only for the duration of signing.
+      const { privkey, pubkey } = receivePrivkey(accounts[entry.type], entry.index)
+      return { privateKey: privkey, publicKey: pubkey, scriptType: scriptTypeOf(entry.type) }
+    }
+    const res = await executeSend({ plan: planToSend, keyFor, gateway: internals.gateway })
+    if (!res.ok) return res
+
+    // Lock the spent coins against concurrent sends (FR-014) and record the
+    // honest pending activity entry (never shown as final early, FR-009).
+    for (const op of res.lockedOutpoints) internals.locks.add(op)
+    internals.txLocks.set(res.txid, res.lockedOutpoints)
+    const coins = getSnapshot().coins.map((c) => {
+      const key = `${c.txid}:${c.vout}`
+      return internals.locks.has(key) && !c.lockedByTx ? { ...c, lockedByTx: res.txid } : c
+    })
+    setView({
+      coins,
+      balances: balanceComponents(coins),
+      activity: [
+        {
+          txid: res.txid,
+          direction: 'out',
+          amountSats: plan.amountSats,
+          feeSats: res.feeSats,
+          counterparty: plan.destination,
+          status: 'pending',
+        },
+        ...getSnapshot().activity,
+      ],
+    })
+    schedulePoll(res.txid)
+    return res
+  }, [])
+
+  return useMemo(
+    () => ({
+      status: availability.status,
+      reason: availability.reason ?? null,
+      networkId,
+      balances: snapshot.balances,
+      stale: snapshot.stale,
+      discovering: snapshot.discovering,
+      stampsDegraded: snapshot.stampsDegraded,
+      coins: snapshot.coins,
+      activity: snapshot.activity,
+      receive: {
+        current: snapshot.current,
+        uri: snapshot.current ? formatBip21(snapshot.current.address) : null,
+        preferredType: snapshot.preferredType,
+        setPreferredType,
+        nextReceiveAddress,
+        select: selectReceiveType,
+      },
+      send: {
+        feeQuote: snapshot.feeQuote,
+        getFeeQuote,
+        prepare,
+        confirmAndSend,
+      },
+      unlock,
+      refresh,
+    }),
+    [
+      availability,
+      networkId,
+      snapshot,
+      setPreferredType,
+      nextReceiveAddress,
+      selectReceiveType,
+      getFeeQuote,
+      prepare,
+      confirmAndSend,
+      unlock,
+      refresh,
+    ]
+  )
+}
+
+export default useBitcoinWallet

--- a/frontend/src/hooks/usePortfolio.js
+++ b/frontend/src/hooks/usePortfolio.js
@@ -29,10 +29,13 @@ import {
   getPortfolioRegistry,
   getPortfolioChainIds,
   getTaxonomyCategory,
+  getBitcoinPortfolioAsset,
   TAXONOMY_CATEGORIES,
 } from '../config/assetTaxonomy'
 import { fetchPortfolioPrices, underlyingSymbolOf } from '../lib/portfolio/prices'
 import { aggregateHoldings } from '../lib/portfolio/aggregate'
+import { loadBitcoinHoldings, toBitcoinHolding } from '../lib/bitcoin/portfolioSource'
+import { createBitcoinGatewayClient, bitcoinGatewayUrl } from '../lib/bitcoin/gatewayClient'
 
 const POLL_MS = 60_000
 
@@ -84,7 +87,22 @@ export function usePortfolio() {
     [chainIds],
   )
 
-  const [reads, setReads] = useState({ balances: null, failedAssets: [], error: null })
+  // Non-EVM bitcoin scope (spec 061, FR-008/021): mainnet always, testnet only
+  // with the same testnet preference that gates EVM testnets. String ids —
+  // these NEVER enter the EVM balance-read loop or the provider map.
+  const bitcoinNetworkIds = useMemo(
+    () => (showTestnetAssets ? ['bitcoin', 'bitcoin-testnet'] : ['bitcoin']),
+    [showTestnetAssets],
+  )
+  // Bitcoin asset descriptors join the PRICING registry only (so underlying
+  // `BTC` resolves through the existing Chainlink feed path) — never the scan
+  // registry: their chainId is a string network id, not an EVM chain.
+  const bitcoinAssets = useMemo(
+    () => bitcoinNetworkIds.map((id) => getBitcoinPortfolioAsset(id)).filter(Boolean),
+    [bitcoinNetworkIds],
+  )
+
+  const [reads, setReads] = useState({ balances: null, failedAssets: [], error: null, bitcoinEntries: [] })
   const [priceMap, setPriceMap] = useState(() => new Map())
   const [isLoading, setIsLoading] = useState(false)
   const [lastUpdated, setLastUpdated] = useState(null)
@@ -97,17 +115,26 @@ export function usePortfolio() {
     // A retry after a failed load must leave the error state immediately so
     // the panel shows loading (and its Retry button goes away) instead of
     // inviting overlapping retries against a stale error.
-    setReads((prev) => (prev.error ? { balances: null, failedAssets: [], error: null } : prev))
+    setReads((prev) => (prev.error ? { balances: null, failedAssets: [], error: null, bitcoinEntries: [] } : prev))
     try {
       // Prices resolve concurrently with balances; a total pricing failure
       // leaves assets honestly unpriced without failing the portfolio.
-      const [settled, priced] = await Promise.all([
+      // The bitcoin source runs alongside (spec 061): a wallet with no issued
+      // bitcoin addresses contributes nothing and makes no gateway calls, and
+      // a total bitcoin failure degrades to failedAssets ['BTC'] — stale, not
+      // zero (FR-010) — without touching the EVM path (SC-008).
+      const [settled, priced, bitcoinRes] = await Promise.all([
         Promise.allSettled(
           registry.map((asset) =>
             readAssetBalance(asset, { provider: providers.get(asset.chainId), address }),
           ),
         ),
-        fetchPortfolioPrices(providers, registry).catch(() => new Map()),
+        fetchPortfolioPrices(providers, [...registry, ...bitcoinAssets]).catch(() => new Map()),
+        loadBitcoinHoldings({
+          account: address,
+          networkIds: bitcoinNetworkIds,
+          gateway: createBitcoinGatewayClient({ baseUrl: bitcoinGatewayUrl() }),
+        }).catch(() => ({ holdings: [], failed: ['BTC'] })),
       ])
       if (reqId !== reqIdRef.current) return
 
@@ -123,27 +150,34 @@ export function usePortfolio() {
       })
 
       if (failedAssets.length === registry.length) {
-        // Nothing readable on any network — an explicit error state, never a
-        // $0 portfolio.
-        setReads({ balances: null, failedAssets, error: 'Unable to read balances from the supported networks.' })
+        // Nothing readable on any EVM network — an explicit error state,
+        // never a $0 portfolio (unchanged pre-bitcoin semantics).
+        setReads({ balances: null, failedAssets, error: 'Unable to read balances from the supported networks.', bitcoinEntries: [] })
       } else {
-        setReads({ balances, failedAssets, error: null })
+        setReads({
+          balances,
+          // Bitcoin failures ride the same honest-degradation channel the EVM
+          // reads use: named in failedAssets, never rendered as zero.
+          failedAssets: [...failedAssets, ...bitcoinRes.failed],
+          error: null,
+          bitcoinEntries: bitcoinRes.holdings,
+        })
         setPriceMap(priced)
         setLastUpdated(Date.now())
       }
     } catch (err) {
       if (reqId !== reqIdRef.current) return
-      setReads({ balances: null, failedAssets: [], error: err?.message || 'Failed to load portfolio' })
+      setReads({ balances: null, failedAssets: [], error: err?.message || 'Failed to load portfolio', bitcoinEntries: [] })
     } finally {
       if (reqId === reqIdRef.current) setIsLoading(false)
     }
-  }, [isConnected, address, providers, registry])
+  }, [isConnected, address, providers, registry, bitcoinAssets, bitcoinNetworkIds])
 
   // Reset synchronously on account or scan-scope change so a stale snapshot
   // (e.g. testnet rows after the preference flips off) can never render.
   useEffect(() => {
     reqIdRef.current++
-    setReads({ balances: null, failedAssets: [], error: null })
+    setReads({ balances: null, failedAssets: [], error: null, bitcoinEntries: [] })
     setPriceMap(new Map())
     setLastUpdated(null)
     load()
@@ -172,6 +206,13 @@ export function usePortfolio() {
         const raw = reads.balances.get(`${asset.chainId}:${asset.id}`)
         if (raw == null) continue
         holdings.push(toHolding(asset, raw, priceMap))
+      }
+      // Native bitcoin holdings (spec 061) append AFTER the EVM scan so
+      // aggregateHoldings rolls native BTC + WBTC into one Bitcoin row. Each
+      // carries `holding.bitcoin` (pending/protected/spendable sats) for the
+      // instance-level pending/protected disclosures (FR-009/FR-018).
+      for (const entry of reads.bitcoinEntries || []) {
+        holdings.push(toBitcoinHolding(entry, priceMap))
       }
     }
 

--- a/frontend/src/lib/addressBook/scanAddress.js
+++ b/frontend/src/lib/addressBook/scanAddress.js
@@ -1,3 +1,5 @@
+import { parseBip21, classifyAddress } from '../bitcoin/addresses'
+
 /**
  * Extract an EVM address from scanned QR content (Spec 021 iteration 2).
  *
@@ -9,6 +11,25 @@ export function extractAddressFromScan(decodedText) {
   if (typeof decodedText !== 'string') return null
   const match = decodedText.match(/0x[a-fA-F0-9]{40}/)
   return match ? match[0] : null
+}
+
+/**
+ * Extract a Bitcoin destination from scanned QR content (spec 061, FR-016).
+ *
+ * Handles BIP-21 `bitcoin:` URIs (address + optional amount) and bare
+ * addresses of any standard type, validated for `networkId` via
+ * classifyAddress — a testnet address never resolves on mainnet or vice
+ * versa. Returns { address, type, amountSats? } or null.
+ */
+export function extractBitcoinFromScan(decodedText, networkId) {
+  if (typeof decodedText !== 'string') return null
+  const text = decodedText.trim()
+  if (/^bitcoin:/i.test(text)) {
+    const parsed = parseBip21(text, networkId)
+    return parsed?.error ? null : parsed
+  }
+  const classified = classifyAddress(text, networkId)
+  return classified.valid ? { address: text, type: classified.type } : null
 }
 
 export default extractAddressFromScan

--- a/frontend/src/lib/bitcoin/__tests__/addresses.test.js
+++ b/frontend/src/lib/bitcoin/__tests__/addresses.test.js
@@ -1,0 +1,198 @@
+/**
+ * Spec 061 T007 — address codec accept/reject matrix (FR-011/FR-016).
+ *
+ * Accepts every standard destination type on the right network; every
+ * rejection carries a SPECIFIC reason slug (wrong_network is never collapsed
+ * into "invalid", EVM 0x input gets its own verdict). BIP-350 vectors pin the
+ * bech32m behavior; BIP-21 round-trips pin the exact sats↔BTC-decimal math.
+ */
+import { describe, it, expect } from 'vitest'
+import { encodeAddress, classifyAddress, parseBip21, formatBip21 } from '../addresses'
+
+// Known-good fixtures (BIP84/86 published vectors + FairWins pinned vectors).
+const MAIN_P2WPKH = 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu'
+const MAIN_P2TR = 'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr'
+const MAIN_P2PKH = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2'
+const MAIN_P2SH = '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy'
+const MAIN_P2WSH = 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3' // BIP-173 valid vector
+const TEST_P2WPKH = 'tb1qmdwadm7qp82845m76s0d0ejuf9g7w97q8spp4t'
+const TEST_P2TR = 'tb1pk7ztpjdrm9dqac9mdwjg5rr4264cpe76l8900x5l968u20pd46ks4jrnct'
+const TEST_P2PKH = 'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn'
+const TEST_P2SH = '2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br'
+
+describe('encodeAddress', () => {
+  // A fixed compressed pubkey (BIP84 vector 0/0 key would also do — any valid point works).
+  const pubkey = Uint8Array.from([
+    0x03, 0x30, 0xd5, 0x4f, 0xd0, 0xdd, 0x42, 0x0a, 0x6e, 0x5f, 0x8d, 0x36, 0x24, 0xf5, 0xf3, 0x48, 0x2c,
+    0xae, 0x35, 0x0f, 0x79, 0xd5, 0xf0, 0x75, 0x3b, 0xf5, 0xbe, 0xef, 0x9c, 0x2d, 0x91, 0xaf, 0x3c,
+  ])
+
+  it('emits the right prefix per (type, network) and round-trips through classifyAddress', () => {
+    const cases = [
+      ['segwit', 'bitcoin', /^bc1q/, 'p2wpkh'],
+      ['taproot', 'bitcoin', /^bc1p/, 'p2tr'],
+      ['segwit', 'bitcoin-testnet', /^tb1q/, 'p2wpkh'],
+      ['taproot', 'bitcoin-testnet', /^tb1p/, 'p2tr'],
+    ]
+    for (const [type, network, prefix, classified] of cases) {
+      const address = encodeAddress(pubkey, { type, network })
+      expect(address).toMatch(prefix)
+      expect(classifyAddress(address, network)).toEqual({ valid: true, type: classified, network })
+    }
+  })
+
+  it('rejects malformed inputs (wrong key size, unknown type/network)', () => {
+    expect(() => encodeAddress(pubkey.slice(0, 20), { type: 'segwit', network: 'bitcoin' })).toThrow(/33-byte/)
+    expect(() => encodeAddress(pubkey, { type: 'p2pkh', network: 'bitcoin' })).toThrow(/unknown type/)
+    expect(() => encodeAddress(pubkey, { type: 'segwit', network: 'dogecoin' })).toThrow(/unknown network/)
+    expect(() => encodeAddress('not-bytes', { type: 'segwit', network: 'bitcoin' })).toThrow(/Uint8Array/)
+  })
+})
+
+describe('classifyAddress — accept matrix', () => {
+  const accepts = [
+    [MAIN_P2PKH, 'bitcoin', 'p2pkh'],
+    [MAIN_P2SH, 'bitcoin', 'p2sh'],
+    [MAIN_P2WPKH, 'bitcoin', 'p2wpkh'],
+    [MAIN_P2WSH, 'bitcoin', 'p2wsh'], // 32-byte v0 program
+    [MAIN_P2TR, 'bitcoin', 'p2tr'], // bech32m v1
+    [TEST_P2PKH, 'bitcoin-testnet', 'p2pkh'], // m… legacy testnet
+    [TEST_P2SH, 'bitcoin-testnet', 'p2sh'], // 2… testnet
+    [TEST_P2WPKH, 'bitcoin-testnet', 'p2wpkh'],
+    [TEST_P2TR, 'bitcoin-testnet', 'p2tr'],
+  ]
+  for (const [address, network, type] of accepts) {
+    it(`accepts ${type} ${address.slice(0, 12)}… on ${network}`, () => {
+      expect(classifyAddress(address, network)).toEqual({ valid: true, type, network })
+    })
+  }
+
+  it('accepts all-uppercase bech32 (QR alphanumeric mode)', () => {
+    expect(classifyAddress(MAIN_P2WPKH.toUpperCase(), 'bitcoin')).toEqual({
+      valid: true,
+      type: 'p2wpkh',
+      network: 'bitcoin',
+    })
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(classifyAddress(`  ${MAIN_P2TR}\n`, 'bitcoin').valid).toBe(true)
+  })
+})
+
+describe('classifyAddress — reject matrix', () => {
+  const reason = (str, network) => {
+    const verdict = classifyAddress(str, network)
+    expect(verdict.valid).toBe(false)
+    expect(verdict.message).toBeTruthy()
+    return verdict.reason
+  }
+
+  it('wrong network is a DISTINCT verdict, both directions and both encodings', () => {
+    expect(reason(TEST_P2WPKH, 'bitcoin')).toBe('wrong_network') // tb1q on mainnet
+    expect(reason(TEST_P2TR, 'bitcoin')).toBe('wrong_network') // tb1p on mainnet
+    expect(reason(MAIN_P2WPKH, 'bitcoin-testnet')).toBe('wrong_network') // bc1q on testnet
+    expect(reason(MAIN_P2PKH, 'bitcoin-testnet')).toBe('wrong_network') // 1… on testnet
+    expect(reason(TEST_P2PKH, 'bitcoin')).toBe('wrong_network') // m… on mainnet
+    expect(reason(TEST_P2SH, 'bitcoin')).toBe('wrong_network') // 2… on mainnet
+  })
+
+  it('EVM 0x addresses get their own reason', () => {
+    expect(reason('0x52908400098527886E0F7030069857D2E4169EE7', 'bitcoin')).toBe('evm_address')
+    expect(reason('0x52908400098527886E0F7030069857D2E4169EE7', 'bitcoin-testnet')).toBe('evm_address')
+  })
+
+  it('single-character mutations fail the checksum, bech32 and base58 alike', () => {
+    expect(reason(MAIN_P2WPKH.slice(0, -1) + 'v', 'bitcoin')).toBe('bad_checksum')
+    expect(reason(MAIN_P2TR.slice(0, -1) + 'q', 'bitcoin')).toBe('bad_checksum')
+    expect(reason('1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN3', 'bitcoin')).toBe('bad_checksum') // last char 2→3
+  })
+
+  it('BIP-350: bech32m checksum on v1 is enforced (v1 with bech32 checksum rejected)', () => {
+    // BIP-350 invalid vector: v1 program with bech32 (not bech32m) checksum.
+    expect(reason('bc1p38j9r5y49hruaue7wxjce0updqjuyyx0kh56v8s25huc6995vvpql3jow4', 'bitcoin')).toBe('bad_checksum')
+  })
+
+  it('witness versions above 1 are rejected (BIP-173/350 forward versions)', () => {
+    // v2 program (valid bech32 string, unknown witness template).
+    expect(reason('bc1zw508d6qejxtdg4y5r3zarvaryvaxxpcs', 'bitcoin')).toBe('unsupported_witness')
+    // v16 OP_1-style short program from the BIP-173 vector set.
+    expect(reason('BC1SW50QGDZ25J', 'bitcoin')).toBe('unsupported_witness')
+  })
+
+  it('mixed-case bech32 is rejected with its own reason', () => {
+    expect(reason(MAIN_P2WPKH.slice(0, -1) + MAIN_P2WPKH.slice(-1).toUpperCase(), 'bitcoin')).toBe('mixed_case')
+    expect(reason('tb1qMdwadm7qp82845m76s0d0ejuf9g7w97q8spp4t', 'bitcoin-testnet')).toBe('mixed_case')
+  })
+
+  it('empty and garbage inputs', () => {
+    expect(reason('', 'bitcoin')).toBe('empty')
+    expect(reason('   ', 'bitcoin')).toBe('empty')
+    expect(classifyAddress(undefined, 'bitcoin').reason).toBe('empty')
+    expect(reason('notanaddress', 'bitcoin')).toBe('unrecognized')
+    expect(reason('bitcoin is great', 'bitcoin')).toBe('unrecognized')
+  })
+
+  it('never throws on member input, only on a bad networkId (programmer error)', () => {
+    expect(() => classifyAddress(MAIN_P2WPKH, 'litecoin')).toThrow(/unknown network/)
+  })
+})
+
+describe('BIP-21 URIs', () => {
+  it('formats address-only, then round-trips through parse', () => {
+    const uri = formatBip21(MAIN_P2WPKH)
+    expect(uri).toBe(`bitcoin:${MAIN_P2WPKH}`)
+    expect(parseBip21(uri, 'bitcoin')).toEqual({ address: MAIN_P2WPKH, type: 'p2wpkh' })
+  })
+
+  it('amount is BTC decimal per BIP-21, exact to the satoshi', () => {
+    expect(formatBip21(MAIN_P2WPKH, { amountSats: 100_000_000 })).toBe(`bitcoin:${MAIN_P2WPKH}?amount=1`)
+    expect(formatBip21(MAIN_P2WPKH, { amountSats: 1 })).toBe(`bitcoin:${MAIN_P2WPKH}?amount=0.00000001`)
+    expect(formatBip21(MAIN_P2WPKH, { amountSats: 100_000_001 })).toBe(`bitcoin:${MAIN_P2WPKH}?amount=1.00000001`)
+    expect(formatBip21(MAIN_P2WPKH, { amountSats: 12_345 })).toBe(`bitcoin:${MAIN_P2WPKH}?amount=0.00012345`)
+    // A value where naive float math drifts (0.1 + satoshi-scale fractions).
+    expect(formatBip21(MAIN_P2WPKH, { amountSats: 10_000_003 })).toBe(`bitcoin:${MAIN_P2WPKH}?amount=0.10000003`)
+  })
+
+  it('round-trips amounts sats → BTC string → sats without rounding loss', () => {
+    for (const sats of [1, 546, 12_345, 10_000_003, 100_000_000, 2_100_000_000_000_000]) {
+      const parsed = parseBip21(formatBip21(MAIN_P2WPKH, { amountSats: sats }), 'bitcoin')
+      expect(parsed.amountSats).toBe(sats)
+    }
+  })
+
+  it('parses amount + label together', () => {
+    const parsed = parseBip21(`bitcoin:${MAIN_P2TR}?amount=0.001&label=Rent%20share`, 'bitcoin')
+    expect(parsed).toEqual({ address: MAIN_P2TR, type: 'p2tr', amountSats: 100_000, label: 'Rent share' })
+  })
+
+  it('scheme is case-insensitive; non-bitcoin schemes are rejected', () => {
+    expect(parseBip21(`BITCOIN:${MAIN_P2WPKH}`, 'bitcoin')).toEqual({ address: MAIN_P2WPKH, type: 'p2wpkh' })
+    expect(parseBip21(`Bitcoin:${MAIN_P2WPKH}?amount=1`, 'bitcoin').amountSats).toBe(100_000_000)
+    expect(parseBip21(`ethereum:${MAIN_P2WPKH}`, 'bitcoin').error).toBe('unsupported_scheme')
+    expect(parseBip21(MAIN_P2WPKH, 'bitcoin').error).toBe('unsupported_scheme') // bare address is not a URI
+  })
+
+  it('rejects sub-satoshi and malformed amounts', () => {
+    expect(parseBip21(`bitcoin:${MAIN_P2WPKH}?amount=0.000000001`, 'bitcoin').error).toBe('invalid_amount') // 9 dp
+    expect(parseBip21(`bitcoin:${MAIN_P2WPKH}?amount=1e-8`, 'bitcoin').error).toBe('invalid_amount')
+    expect(parseBip21(`bitcoin:${MAIN_P2WPKH}?amount=-1`, 'bitcoin').error).toBe('invalid_amount')
+    expect(parseBip21(`bitcoin:${MAIN_P2WPKH}?amount=abc`, 'bitcoin').error).toBe('invalid_amount')
+  })
+
+  it('propagates address verdicts: wrong network stays distinct, invalid is invalid', () => {
+    expect(parseBip21(`bitcoin:${TEST_P2WPKH}`, 'bitcoin').error).toBe('wrong_network')
+    expect(parseBip21(`bitcoin:${MAIN_P2WPKH}`, 'bitcoin-testnet').error).toBe('wrong_network')
+    expect(parseBip21('bitcoin:nonsense', 'bitcoin').error).toBe('invalid_address')
+  })
+
+  it('rejects unknown req-* parameters (BIP-21 MUST)', () => {
+    expect(parseBip21(`bitcoin:${MAIN_P2WPKH}?req-payjoin=1`, 'bitcoin').error).toBe('unsupported_required_param')
+  })
+
+  it('formatBip21 guards its inputs', () => {
+    expect(() => formatBip21('')).toThrow(/address is required/)
+    expect(() => formatBip21(MAIN_P2WPKH, { amountSats: 1.5 })).toThrow(/non-negative integer/)
+    expect(() => formatBip21(MAIN_P2WPKH, { amountSats: -1 })).toThrow(/non-negative integer/)
+  })
+})

--- a/frontend/src/lib/bitcoin/__tests__/coinSelection.test.js
+++ b/frontend/src/lib/bitcoin/__tests__/coinSelection.test.js
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest'
+import {
+  selectCoins,
+  maxSendable,
+  balanceComponents,
+  estimateVsize,
+  isSelectable,
+  dustThreshold,
+  DUST_SATS,
+} from '../coinSelection'
+
+let seq = 0
+const coin = (valueSats, overrides = {}) => ({
+  txid: `tx${++seq}`,
+  vout: 0,
+  valueSats,
+  address: 'bc1qtest',
+  confirmations: 3,
+  classification: 'spendable',
+  scriptType: 'p2wpkh',
+  stampId: null,
+  lockedByTx: null,
+  ...overrides,
+})
+
+describe('coinSelection (spec 061 — FR-013/FR-014/FR-018/FR-019)', () => {
+  describe('selectability (fail-safe)', () => {
+    it('only positively-spendable, unlocked coins are selectable', () => {
+      expect(isSelectable(coin(1000))).toBe(true)
+      expect(isSelectable(coin(1000, { classification: 'protected' }))).toBe(false)
+      expect(isSelectable(coin(1000, { classification: 'unverified' }))).toBe(false)
+      expect(isSelectable(coin(1000, { classification: 'pending' }))).toBe(false)
+      expect(isSelectable(coin(1000, { lockedByTx: 'txabc' }))).toBe(false)
+      // unknown/missing classification fails safe
+      expect(isSelectable(coin(1000, { classification: undefined }))).toBe(false)
+      expect(isSelectable(coin(1000, { classification: 'garbage' }))).toBe(false)
+    })
+
+    it('never selects protected/unverified/pending/locked coins at any amount', () => {
+      const utxos = [
+        coin(100_000, { classification: 'protected', stampId: 'A1' }),
+        coin(100_000, { classification: 'unverified' }),
+        coin(100_000, { classification: 'pending' }),
+        coin(100_000, { lockedByTx: 'inflight' }),
+        coin(50_000),
+      ]
+      const res = selectCoins({ utxos, targetSats: 40_000, feeRate: 2, recipientType: 'p2wpkh' })
+      expect(res.ok).toBe(true)
+      expect(res.inputs).toHaveLength(1)
+      expect(res.inputs[0].valueSats).toBe(50_000)
+
+      // Asking beyond the spendable subset fails even though total is ample.
+      const over = selectCoins({ utxos, targetSats: 200_000, feeRate: 2, recipientType: 'p2wpkh' })
+      expect(over.ok).toBe(false)
+      expect(over.error).toBe('insufficient_funds')
+      expect(over.spendableSats).toBe(50_000)
+      expect(over.shortfallSats).toBeGreaterThan(0)
+    })
+  })
+
+  describe('fee and change math', () => {
+    it('produces change when the remainder clears dust', () => {
+      const utxos = [coin(100_000)]
+      const res = selectCoins({ utxos, targetSats: 50_000, feeRate: 10, recipientType: 'p2wpkh' })
+      expect(res.ok).toBe(true)
+      expect(res.feeSats).toBe(10 * estimateVsize(res.inputs, 'p2wpkh', true, 'p2wpkh'))
+      expect(res.changeSats).toBe(100_000 - 50_000 - res.feeSats)
+      expect(res.changeSats).toBeGreaterThanOrEqual(dustThreshold('p2wpkh'))
+      // conservation: inputs = target + fee + change
+      expect(50_000 + res.feeSats + res.changeSats).toBe(100_000)
+    })
+
+    it('folds sub-dust change into the fee — never a dust output', () => {
+      const feeRate = 2
+      const utxos = [coin(60_000)]
+      const feeNoChange = feeRate * estimateVsize(utxos, 'p2wpkh', false)
+      // Leave a remainder strictly between 0 and dust.
+      const target = 60_000 - feeNoChange - 100
+      const res = selectCoins({ utxos, targetSats: target, feeRate, recipientType: 'p2wpkh' })
+      expect(res.ok).toBe(true)
+      expect(res.changeSats).toBe(0)
+      expect(res.feeSats).toBe(feeNoChange + 100) // remainder honestly reported as fee
+      expect(target + res.feeSats).toBe(60_000) // conservation, nothing stranded
+    })
+
+    it('accumulates multiple coins largest-first until covered', () => {
+      const utxos = [coin(10_000), coin(30_000), coin(20_000)]
+      const res = selectCoins({ utxos, targetSats: 45_000, feeRate: 1, recipientType: 'p2tr' })
+      expect(res.ok).toBe(true)
+      expect(res.inputs.map((c) => c.valueSats)).toEqual([30_000, 20_000])
+    })
+
+    it('rejects sub-dust recipient amounts per output type', () => {
+      const utxos = [coin(100_000)]
+      const res = selectCoins({ utxos, targetSats: 200, feeRate: 1, recipientType: 'p2wpkh' })
+      expect(res).toMatchObject({ ok: false, error: 'amount_below_dust', dustSats: DUST_SATS.p2wpkh })
+      const legacy = selectCoins({ utxos, targetSats: 500, feeRate: 1, recipientType: 'p2pkh' })
+      expect(legacy).toMatchObject({ ok: false, error: 'amount_below_dust', dustSats: 546 })
+    })
+
+    it('vsize estimates are deterministic and type-sensitive', () => {
+      const segwitIn = [coin(1, { scriptType: 'p2wpkh' })]
+      const taprootIn = [coin(1, { scriptType: 'p2tr' })]
+      expect(estimateVsize(segwitIn, 'p2wpkh', false)).toBe(11 + 68 + 31)
+      expect(estimateVsize(taprootIn, 'p2tr', true, 'p2wpkh')).toBe(11 + 58 + 43 + 31)
+      expect(estimateVsize(segwitIn, 'p2pkh', false)).toBe(11 + 68 + 34)
+      expect(estimateVsize(segwitIn, 'p2wsh', false)).toBe(11 + 68 + 43)
+      expect(estimateVsize(segwitIn, 'p2sh', false)).toBe(11 + 68 + 32)
+    })
+
+    it('throws on invalid fee rates and unknown types (never silent)', () => {
+      const utxos = [coin(10_000)]
+      expect(() => selectCoins({ utxos, targetSats: 1000, feeRate: 0, recipientType: 'p2wpkh' })).toThrow()
+      expect(() => selectCoins({ utxos, targetSats: 1000, feeRate: 1.5, recipientType: 'p2wpkh' })).toThrow()
+      expect(() =>
+        selectCoins({ utxos: [coin(10_000, { scriptType: 'p2pkh' })], targetSats: 1000, feeRate: 1, recipientType: 'p2wpkh' })
+      ).toThrow(/input script type/)
+      expect(() => selectCoins({ utxos, targetSats: 1000, feeRate: 1, recipientType: 'op_return' })).toThrow()
+    })
+  })
+
+  describe('MAX (FR-013)', () => {
+    it('MAX consumes every spendable coin, leaves zero remainder', () => {
+      const utxos = [
+        coin(40_000),
+        coin(25_000),
+        coin(9_000, { classification: 'protected', stampId: 'S1' }),
+        coin(7_000, { classification: 'pending' }),
+      ]
+      const res = maxSendable({ utxos, feeRate: 5, recipientType: 'p2tr' })
+      expect(res.ok).toBe(true)
+      expect(res.inputs).toHaveLength(2)
+      expect(res.amountSats + res.feeSats).toBe(65_000) // exact, nothing stranded
+      expect(res.feeSats).toBe(5 * estimateVsize(res.inputs, 'p2tr', false))
+      // and the resulting amount round-trips through selectCoins with no change
+      const check = selectCoins({ utxos, targetSats: res.amountSats, feeRate: 5, recipientType: 'p2tr' })
+      expect(check.ok).toBe(true)
+      expect(check.changeSats).toBe(0)
+    })
+
+    it('MAX with nothing spendable / only-dust reports honestly', () => {
+      expect(maxSendable({ utxos: [], feeRate: 2, recipientType: 'p2wpkh' })).toMatchObject({
+        ok: false,
+        error: 'insufficient_funds',
+      })
+      const dusty = maxSendable({ utxos: [coin(400)], feeRate: 2, recipientType: 'p2wpkh' })
+      expect(dusty.ok).toBe(false)
+    })
+  })
+
+  describe('balance components (data-model.md)', () => {
+    it('splits confirmed/pending/protected/spendable and explains total ≠ spendable', () => {
+      const utxos = [
+        coin(50_000),
+        coin(20_000, { lockedByTx: 'inflight' }),
+        coin(10_000, { classification: 'protected', stampId: 'S1' }),
+        coin(5_000, { classification: 'unverified' }),
+        coin(3_000, { classification: 'pending' }),
+      ]
+      const b = balanceComponents(utxos)
+      expect(b.confirmedSats).toBe(85_000)
+      expect(b.pendingSats).toBe(3_000)
+      expect(b.protectedSats).toBe(15_000) // stamps + fail-safe unverified
+      expect(b.spendableSats).toBe(50_000) // excludes locked too
+    })
+  })
+})

--- a/frontend/src/lib/bitcoin/__tests__/derivation.test.js
+++ b/frontend/src/lib/bitcoin/__tests__/derivation.test.js
@@ -1,0 +1,230 @@
+/**
+ * Spec 061 T005 — Bitcoin key derivation contract freeze.
+ *
+ * Three layers of vectors:
+ *  1. Published BIP84/BIP86 reference vectors (mnemonic "abandon ×11 about",
+ *     empty passphrase) validate the underlying @scure/bip32 + address
+ *     encoding stack against the wider ecosystem.
+ *  2. Pinned FairWins vectors (fixed 32-byte test seeds → first 3 addresses
+ *     per network × type) FREEZE the full HKDF→BIP32 derivation contract —
+ *     if any of these ever change, deployed wallets lose their funds' paths.
+ *     Generated once from contracts/key-derivation-btc.md and hardcoded.
+ *  3. Invariants: domain separation vs the spec-041 KEK info string,
+ *     determinism, and wrong-length rejection (no-silent-wrong-keys).
+ */
+import { describe, it, expect } from 'vitest'
+import { hkdf } from '@noble/hashes/hkdf'
+import { sha256 } from '@noble/hashes/sha256'
+import { bytesToHex } from '@noble/hashes/utils'
+import { HDKey } from '@scure/bip32'
+import {
+  BTC_HKDF_INFO,
+  deriveBtcSeed,
+  deriveAccount,
+  receivePubkey,
+  receivePrivkey,
+  addressAt,
+} from '../derivation'
+import { encodeAddress } from '../addresses'
+
+const hex = (s) => Uint8Array.from(s.match(/../g).map((b) => parseInt(b, 16)))
+
+// BIP39 seed for "abandon abandon abandon abandon abandon abandon abandon
+// abandon abandon abandon abandon about" with EMPTY passphrase — the seed the
+// published BIP84/BIP86 test vectors derive from (verified by reproducing the
+// published first addresses below).
+const BIP_REFERENCE_SEED = hex(
+  '5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc1' +
+    '9a5ac40b389cd370d086206dec8aa6c43daea6690f20ad3d8d48b2d2ce9e38e4'
+)
+
+// FairWins pinned test seeds (contracts/key-derivation-btc.md invariant 1).
+const SEED_A = new Uint8Array(32).fill(0x07)
+const SEED_B = Uint8Array.from({ length: 32 }, (_, i) => i + 1)
+
+describe('BIP84/BIP86 published reference vectors (underlying stack)', () => {
+  const receive = (purpose, i) =>
+    HDKey.fromMasterSeed(BIP_REFERENCE_SEED).derive(`m/${purpose}'/0'/0'`).deriveChild(0).deriveChild(i).publicKey
+
+  it('BIP84: m/84h/0h/0h/0/0 and 0/1 give the published bc1q addresses', () => {
+    expect(encodeAddress(receive(84, 0), { type: 'segwit', network: 'bitcoin' })).toBe(
+      'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu'
+    )
+    expect(encodeAddress(receive(84, 1), { type: 'segwit', network: 'bitcoin' })).toBe(
+      'bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g'
+    )
+  })
+
+  it('BIP86: m/86h/0h/0h/0/0 and 0/1 give the published bc1p addresses (BIP-341 tweak applied)', () => {
+    expect(encodeAddress(receive(86, 0), { type: 'taproot', network: 'bitcoin' })).toBe(
+      'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr'
+    )
+    expect(encodeAddress(receive(86, 1), { type: 'taproot', network: 'bitcoin' })).toBe(
+      'bc1p4qhjn9zdvkux4e44uhx8tc55attvtyu358kutcqkudyccelu0was9fqzwh'
+    )
+  })
+})
+
+describe('pinned FairWins vectors — the frozen derivation contract', () => {
+  // btcSeed = HKDF-SHA256(masterSeed, salt=32 zero bytes, info="fairwins-btc-seed-v1", L=64)
+  it('deriveBtcSeed pins the HKDF output for both test seeds', () => {
+    expect(bytesToHex(deriveBtcSeed(SEED_A))).toBe(
+      '027de0485c46bb62e5b3b3fd77878dc755256a85c9b334d5a0d7dad89a3eb739' +
+        'd6811fce8c4029acda0e3574b288832c0c6f52d5c5cb8f1d6603a9cb6a209cde'
+    )
+    expect(bytesToHex(deriveBtcSeed(SEED_B))).toBe(
+      'ae9468938d3ab6deffddcf93e454913c399bb2f8f8d96d9ea5a846790be738cd' +
+        '8efc44bb7464bb0c3c09ac745969c6f20a5a9943de227985ca2df0d55a0e882f'
+    )
+  })
+
+  const PINNED = {
+    seedA: {
+      seed: SEED_A,
+      'bitcoin/segwit': [
+        'bc1q87l6dzq2tzcsrwyllwgdzy8a63xtmda9306k07',
+        'bc1q6sv75chekyztl9nxrjak2u4snjus000neg5dyf',
+        'bc1qz53c3xvq6yk4x0kkhgggw3p05tz6fzz7ngcwae',
+      ],
+      'bitcoin/taproot': [
+        'bc1p4tw9390sr8yc4k7sqgvl6eg27a06a006rhucxpfeefka3r8l5n7sxa5zvj',
+        'bc1pv3m4cy953spd9ywx5g5j3luwyg0jmu98dk2xv4nvt2cjage2jljsccw2vd',
+        'bc1p5avgskp6n258yyaf2lz8ay7j6yf3d6ufggnzdcp0f5kse8f2l08shrq6c3',
+      ],
+      'bitcoin-testnet/segwit': [
+        'tb1qahs87cz3mcdw30yrl3e4uwe50phqe6y9w8pmhe',
+        'tb1qzns90hltlt97fgu8dtrp928tslxm6guhsnspwz',
+        'tb1qxgjzpz6up5lh5vlapu3qwaf292qhr79x065yl0',
+      ],
+      'bitcoin-testnet/taproot': [
+        'tb1p7h7d7wm9q39w2dd0ejehr5eppkj2kg0p83dhqdzyvgvvpcw2zphq6wa9km',
+        'tb1p6kd5q9q4sgl6qk8wlw6qudlzseu589ultjaegfdzzhtyrxumeevq2ugsqx',
+        'tb1pfalv8wj62ezdz7pwe4fuqzupu5et82hu672elgf92gnxxaczrquqqws9hr',
+      ],
+    },
+    seedB: {
+      seed: SEED_B,
+      'bitcoin/segwit': [
+        'bc1qfzp7p2gp3pphyhg0aaxzd8m3d2y2x8e9k8f39z',
+        'bc1qkganaxrke4f3xask8rg9yqvwtgmjp8a4l7eqyy',
+        'bc1qexdq30fe5cx0sm3luxkgc7zmynawx5uy8xa9jp',
+      ],
+      'bitcoin/taproot': [
+        'bc1padh6sdu0tc23qr5qy3vgw20klgy0zkrnvejh47cu8d5554shlnqq959v8d',
+        'bc1pjxs0jh4dymuvvszckkxe0a0njlg9h2nvvaternst2mkqmdjcftdsgm0mgf',
+        'bc1pqevyvdv3ky53uut49zrkl3mjd6j2v55pvdxc06nh3e325fzga69sk3phxu',
+      ],
+      'bitcoin-testnet/segwit': [
+        'tb1qmdwadm7qp82845m76s0d0ejuf9g7w97q8spp4t',
+        'tb1q8kglrgrx0rncrwg0ug60zs0u2kq2jd7m2cq9vj',
+        'tb1qsmpsazzxwvfysmpe42xrx34m5w6jkdnklfeem3',
+      ],
+      'bitcoin-testnet/taproot': [
+        'tb1pk7ztpjdrm9dqac9mdwjg5rr4264cpe76l8900x5l968u20pd46ks4jrnct',
+        'tb1pjz4x38nl2gvetspqxhrz4vm0scqfwvctxppxd3r57hzh4ljtgewqypfrh7',
+        'tb1pavl4yf6zcvn96ks2eel4avxtvle6uzrl85luwkkwml8y8up5jjtsm24y2c',
+      ],
+    },
+  }
+
+  for (const [name, vectors] of Object.entries(PINNED)) {
+    for (const combo of ['bitcoin/segwit', 'bitcoin/taproot', 'bitcoin-testnet/segwit', 'bitcoin-testnet/taproot']) {
+      const [network, type] = combo.split('/')
+      it(`${name} → ${combo}: first 3 receive addresses match the pinned vectors`, () => {
+        const derived = [0, 1, 2].map((index) => addressAt(vectors.seed, { network, type, index }))
+        expect(derived).toEqual(vectors[combo])
+      })
+    }
+  }
+
+  it('address prefixes match (network, type): bc1q/bc1p vs tb1q/tb1p', () => {
+    expect(addressAt(SEED_A, { network: 'bitcoin', type: 'segwit', index: 0 })).toMatch(/^bc1q/)
+    expect(addressAt(SEED_A, { network: 'bitcoin', type: 'taproot', index: 0 })).toMatch(/^bc1p/)
+    expect(addressAt(SEED_A, { network: 'bitcoin-testnet', type: 'segwit', index: 0 })).toMatch(/^tb1q/)
+    expect(addressAt(SEED_A, { network: 'bitcoin-testnet', type: 'taproot', index: 0 })).toMatch(/^tb1p/)
+  })
+})
+
+describe('domain separation (contract invariant 2)', () => {
+  it('exports the normative info string', () => {
+    expect(BTC_HKDF_INFO).toBe('fairwins-btc-seed-v1')
+  })
+
+  it('btcSeed differs from the raw masterSeed (never used directly)', () => {
+    const btcSeed = deriveBtcSeed(SEED_A)
+    expect(btcSeed).toHaveLength(64)
+    expect(bytesToHex(btcSeed.slice(0, 32))).not.toBe(bytesToHex(SEED_A))
+  })
+
+  it('btcSeed differs from an HKDF under the spec-041 KEK info string (tree isolation)', () => {
+    const kekPath = hkdf(sha256, SEED_A, new Uint8Array(32), new TextEncoder().encode('fairwins-kek-v1'), 64)
+    expect(bytesToHex(deriveBtcSeed(SEED_A))).not.toBe(bytesToHex(kekPath))
+  })
+
+  it('different master seeds yield unrelated trees', () => {
+    expect(bytesToHex(deriveBtcSeed(SEED_A))).not.toBe(bytesToHex(deriveBtcSeed(SEED_B)))
+  })
+})
+
+describe('determinism & input guards (contract invariants 1 and 5)', () => {
+  it('two independent derivations are byte-identical', () => {
+    expect(bytesToHex(deriveBtcSeed(SEED_A))).toBe(bytesToHex(deriveBtcSeed(new Uint8Array(32).fill(0x07))))
+    const a1 = addressAt(SEED_B, { network: 'bitcoin', type: 'taproot', index: 2 })
+    const a2 = addressAt(Uint8Array.from(SEED_B), { network: 'bitcoin', type: 'taproot', index: 2 })
+    expect(a1).toBe(a2)
+  })
+
+  it('wrong-length or non-Uint8Array master seed throws — never silently derives a different wallet', () => {
+    expect(() => deriveBtcSeed(new Uint8Array(31))).toThrow(/32-byte/)
+    expect(() => deriveBtcSeed(new Uint8Array(33))).toThrow(/32-byte/)
+    expect(() => deriveBtcSeed(new Uint8Array(0))).toThrow(/32-byte/)
+    expect(() => deriveBtcSeed('07'.repeat(32))).toThrow(/32-byte/)
+    expect(() => deriveBtcSeed(undefined)).toThrow(/32-byte/)
+  })
+
+  it('unknown network or type throws', () => {
+    expect(() => deriveAccount(SEED_A, { network: 'bitcoin-regtest', type: 'segwit' })).toThrow(/unknown network/)
+    expect(() => deriveAccount(SEED_A, { network: 'bitcoin', type: 'legacy' })).toThrow(/unknown address type/)
+    expect(() => addressAt(SEED_A, { network: 'polygon', type: 'segwit', index: 0 })).toThrow(/unknown network/)
+  })
+
+  it('index must be a non-negative integer < 2^31', () => {
+    const account = deriveAccount(SEED_A, { network: 'bitcoin', type: 'segwit' })
+    expect(() => receivePubkey(account, -1)).toThrow(/non-negative integer/)
+    expect(() => receivePubkey(account, 1.5)).toThrow(/non-negative integer/)
+    expect(() => receivePubkey(account, '0')).toThrow(/non-negative integer/)
+    expect(() => receivePubkey(account, 0x80000000)).toThrow(/non-negative integer/)
+    expect(() => receivePrivkey(account, -1)).toThrow(/non-negative integer/)
+    expect(() => addressAt(SEED_A, { network: 'bitcoin', type: 'segwit', index: NaN })).toThrow(/non-negative integer/)
+  })
+})
+
+describe('receive keys (external chain 0/i only)', () => {
+  it('receivePubkey returns a 33-byte compressed key with its index', () => {
+    const account = deriveAccount(SEED_A, { network: 'bitcoin', type: 'segwit' })
+    const { pubkey, index } = receivePubkey(account, 5)
+    expect(index).toBe(5)
+    expect(pubkey).toBeInstanceOf(Uint8Array)
+    expect(pubkey).toHaveLength(33)
+    expect([2, 3]).toContain(pubkey[0])
+  })
+
+  it('receivePrivkey pairs with receivePubkey at the same index (memory-only signing key)', () => {
+    const account = deriveAccount(SEED_B, { network: 'bitcoin-testnet', type: 'taproot' })
+    const { privkey, pubkey, index } = receivePrivkey(account, 3)
+    expect(index).toBe(3)
+    expect(privkey).toBeInstanceOf(Uint8Array)
+    expect(privkey).toHaveLength(32)
+    expect(bytesToHex(pubkey)).toBe(bytesToHex(receivePubkey(account, 3).pubkey))
+    // Different indexes hold different keys (no key reuse across rotation).
+    expect(bytesToHex(privkey)).not.toBe(bytesToHex(receivePrivkey(account, 4).privkey))
+  })
+
+  it('receive chain is the EXTERNAL chain: matches manual account/0/i derivation, not account/1/i', () => {
+    const account = deriveAccount(SEED_A, { network: 'bitcoin', type: 'segwit' })
+    const external = account.deriveChild(0).deriveChild(7).publicKey
+    const change = account.deriveChild(1).deriveChild(7).publicKey
+    expect(bytesToHex(receivePubkey(account, 7).pubkey)).toBe(bytesToHex(external))
+    expect(bytesToHex(receivePubkey(account, 7).pubkey)).not.toBe(bytesToHex(change))
+  })
+})

--- a/frontend/src/lib/bitcoin/__tests__/gatewayClient.test.js
+++ b/frontend/src/lib/bitcoin/__tests__/gatewayClient.test.js
@@ -1,0 +1,234 @@
+/**
+ * Spec 061 T010 — bitcoin gateway client: chunk/merge semantics, the typed
+ * error taxonomy (never-throw for expected failures, stale-not-zero flags),
+ * fail-safe stamps degradation, and the capability-off signal when the
+ * gateway is unconfigured or the module is disabled/killswitched.
+ * fetch is fully mocked (injected fetchImpl) — no network.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { createBitcoinGatewayClient, bitcoinGatewayUrl } from '../gatewayClient'
+
+const BASE = 'https://relayer.fairwins.example'
+
+const jsonRes = (status, body) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+})
+
+const addr = (i) => `bc1qaddr${i}`
+
+function makeClient(fetchImpl, opts = {}) {
+  return createBitcoinGatewayClient({ baseUrl: BASE, fetchImpl, ...opts })
+}
+
+describe('base URL resolution', () => {
+  it('reads VITE_RELAYER_URL (same source as the other gateway clients), trimming the trailing slash', () => {
+    vi.stubEnv('VITE_RELAYER_URL', `${BASE}/`)
+    expect(bitcoinGatewayUrl()).toBe(BASE)
+    vi.stubEnv('VITE_RELAYER_URL', '')
+    expect(bitcoinGatewayUrl()).toBe('')
+    vi.unstubAllEnvs()
+  })
+
+  it('unconfigured gateway ⇒ capability-off result on every method, fetch never called', async () => {
+    const fetchImpl = vi.fn()
+    const client = createBitcoinGatewayClient({ baseUrl: '', fetchImpl })
+    const off = { ok: false, error: 'unconfigured', disabled: true }
+    expect(await client.lookupAddresses('bitcoin', [addr(1)])).toEqual(off)
+    expect(await client.getFees('bitcoin')).toEqual(off)
+    expect(await client.broadcast('bitcoin', 'aabb')).toEqual(off)
+    expect(await client.getTxStatus('bitcoin', 'tx1')).toEqual(off)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})
+
+describe('network segment mapping', () => {
+  it("maps 'bitcoin' → mainnet and 'bitcoin-testnet' → testnet in the path", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, { rates: { fast: 9, normal: 5, slow: 2 }, tipHeight: 1 }))
+    const client = makeClient(fetchImpl)
+    await client.getFees('bitcoin')
+    await client.getFees('bitcoin-testnet')
+    expect(fetchImpl.mock.calls[0][0]).toBe(`${BASE}/v1/bitcoin/mainnet/fees`)
+    expect(fetchImpl.mock.calls[1][0]).toBe(`${BASE}/v1/bitcoin/testnet/fees`)
+  })
+
+  it('rejects unknown networks loudly (programmer error, not a member state)', async () => {
+    const client = makeClient(vi.fn())
+    await expect(client.getFees('dogecoin')).rejects.toThrow(/unknown network/)
+  })
+})
+
+describe('lookupAddresses — chunking and merge', () => {
+  it('auto-chunks >50 addresses into ≤50 batches and merges results + max tipHeight', async () => {
+    const addresses = Array.from({ length: 60 }, (_, i) => addr(i))
+    const fetchImpl = vi.fn(async (url, { body }) => {
+      const batch = JSON.parse(body).addresses
+      return jsonRes(200, {
+        tipHeight: batch.length === 50 ? 903_210 : 903_211,
+        results: batch.map((a) => ({ address: a, confirmedSats: 1, pendingSats: 0, utxos: [] })),
+      })
+    })
+    const res = await makeClient(fetchImpl).lookupAddresses('bitcoin', addresses)
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(JSON.parse(fetchImpl.mock.calls[0][1].body).addresses).toHaveLength(50)
+    expect(JSON.parse(fetchImpl.mock.calls[1][1].body).addresses).toHaveLength(10)
+    expect(fetchImpl.mock.calls[0][1].method).toBe('POST')
+
+    expect(res.ok).toBe(true)
+    expect(res.tipHeight).toBe(903_211) // max across chunks
+    expect(res.results).toHaveLength(60)
+    expect(res.results.map((r) => r.address)).toEqual(addresses) // order preserved
+  })
+
+  it('a failed chunk fails the WHOLE lookup with its stale semantics (no silent partial balance)', async () => {
+    const addresses = Array.from({ length: 51 }, (_, i) => addr(i))
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(200, { tipHeight: 1, results: [] }))
+      .mockResolvedValueOnce(jsonRes(502, { error: 'upstream_unavailable', message: 'esplora down' }))
+    const res = await makeClient(fetchImpl).lookupAddresses('bitcoin', addresses)
+    expect(res).toEqual({ ok: false, error: 'upstream_unavailable', stale: true })
+  })
+
+  it('empty address list short-circuits without a request', async () => {
+    const fetchImpl = vi.fn()
+    expect(await makeClient(fetchImpl).lookupAddresses('bitcoin', [])).toEqual({ ok: true, tipHeight: null, results: [] })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})
+
+describe('error taxonomy (expected classes never throw)', () => {
+  it('503 bitcoin_disabled ⇒ capability-off signal', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(503, { error: 'bitcoin_disabled', message: 'off' }))
+    expect(await makeClient(fetchImpl).getFees('bitcoin')).toEqual({ ok: false, error: 'bitcoin_disabled', disabled: true })
+  })
+
+  it('503 bitcoin_killed (ops killswitch) ⇒ capability-off signal with the honest slug', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(503, { error: 'bitcoin_killed', message: 'ops kill' }))
+    expect(await makeClient(fetchImpl).getFees('bitcoin')).toEqual({ ok: false, error: 'bitcoin_killed', disabled: true })
+  })
+
+  it('429 quota ⇒ stale (portfolio renders last-known, never zero)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(429, { error: 'quota_exceeded' }))
+    expect(await makeClient(fetchImpl).lookupAddresses('bitcoin', [addr(1)])).toEqual({ ok: false, error: 'quota', stale: true })
+  })
+
+  it('502 upstream ⇒ upstream_unavailable, stale', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(502, { error: 'upstream_unavailable' }))
+    expect(await makeClient(fetchImpl).getFees('bitcoin')).toEqual({ ok: false, error: 'upstream_unavailable', stale: true })
+  })
+
+  it('transport failure ⇒ network_error, stale', async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+    expect(await makeClient(fetchImpl).getFees('bitcoin')).toEqual({ ok: false, error: 'network_error', stale: true })
+  })
+
+  it('400 invalid_address surfaces the gateway slug + message, not stale', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(400, { error: 'invalid_address', message: 'bad hrp' }))
+    const res = await makeClient(fetchImpl).lookupAddresses('bitcoin', [addr(1)])
+    expect(res).toEqual({ ok: false, error: 'invalid_address', status: 400, message: 'bad hrp' })
+  })
+})
+
+describe('broadcast', () => {
+  it('returns the txid on success and posts { rawTx } to /tx', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, { txid: 'deadbeef' }))
+    const res = await makeClient(fetchImpl).broadcast('bitcoin-testnet', 'aabbcc')
+    expect(res).toEqual({ ok: true, txid: 'deadbeef' })
+    expect(fetchImpl.mock.calls[0][0]).toBe(`${BASE}/v1/bitcoin/testnet/tx`)
+    expect(JSON.parse(fetchImpl.mock.calls[0][1].body)).toEqual({ rawTx: 'aabbcc' })
+  })
+
+  it('upstream rejection surfaces the reason verbatim-safe', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(400, { error: 'broadcast_rejected', message: 'min relay fee not met' }))
+    const res = await makeClient(fetchImpl).broadcast('bitcoin', 'aabbcc')
+    expect(res.ok).toBe(false)
+    expect(res.error).toBe('broadcast_rejected')
+    expect(res.message).toBe('min relay fee not met')
+  })
+
+  it('rejects non-hex payloads before any network call (programmer error)', async () => {
+    const fetchImpl = vi.fn()
+    await expect(makeClient(fetchImpl).broadcast('bitcoin', 'not hex!')).rejects.toThrow(/hex/)
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})
+
+describe('getTxStatus', () => {
+  it('maps a confirmed tx', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(200, { txid: 't1', confirmed: true, blockHeight: 10, confirmations: 3 }))
+    expect(await makeClient(fetchImpl).getTxStatus('bitcoin', 't1')).toEqual({
+      ok: true,
+      found: true,
+      txid: 't1',
+      confirmed: true,
+      blockHeight: 10,
+      confirmations: 3,
+    })
+  })
+
+  it('404 tx_not_found is NOT an error — the tx stays pending for retry/backoff', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(404, { error: 'tx_not_found' }))
+    expect(await makeClient(fetchImpl).getTxStatus('bitcoin', 't2')).toEqual({
+      ok: true,
+      found: false,
+      txid: 't2',
+      confirmed: false,
+      confirmations: 0,
+    })
+  })
+
+  it('disabled module still propagates as capability-off', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(503, { error: 'bitcoin_disabled' }))
+    expect(await makeClient(fetchImpl).getTxStatus('bitcoin', 't3')).toEqual({ ok: false, error: 'bitcoin_disabled', disabled: true })
+  })
+})
+
+describe('getStamps — chunking + fail-safe degradation', () => {
+  it('chunks ≤50 per GET and merges stamps', async () => {
+    const addresses = Array.from({ length: 51 }, (_, i) => addr(i))
+    const fetchImpl = vi.fn(async (url) => {
+      const count = new URL(url).searchParams.get('addresses').split(',').length
+      return jsonRes(200, { degraded: false, stamps: [{ stampId: `S${count}` }] })
+    })
+    const res = await makeClient(fetchImpl).getStamps('bitcoin', addresses)
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(fetchImpl.mock.calls[0][0]).toContain('/v1/bitcoin/mainnet/stamps?addresses=')
+    expect(new URL(fetchImpl.mock.calls[0][0]).searchParams.get('addresses').split(',')).toHaveLength(50)
+    expect(new URL(fetchImpl.mock.calls[1][0]).searchParams.get('addresses').split(',')).toHaveLength(1)
+    expect(res).toEqual({ ok: true, degraded: false, stamps: [{ stampId: 'S50' }, { stampId: 'S1' }] })
+  })
+
+  it('ANY degraded chunk degrades the merged result (fail-safe, FR-019)', async () => {
+    const addresses = Array.from({ length: 51 }, (_, i) => addr(i))
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(200, { degraded: false, stamps: [{ stampId: 'A' }] }))
+      .mockResolvedValueOnce(jsonRes(200, { degraded: true, stamps: [] }))
+    const res = await makeClient(fetchImpl).getStamps('bitcoin', addresses)
+    expect(res).toEqual({ ok: true, degraded: true, stamps: [{ stampId: 'A' }] })
+  })
+
+  it('a hard-failed chunk also degrades (partial knowledge must protect), keeping successful chunks', async () => {
+    const addresses = Array.from({ length: 51 }, (_, i) => addr(i))
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(200, { degraded: false, stamps: [{ stampId: 'A' }] }))
+      .mockResolvedValueOnce(jsonRes(502, { error: 'upstream_unavailable' }))
+    const res = await makeClient(fetchImpl).getStamps('bitcoin', addresses)
+    expect(res).toEqual({ ok: true, degraded: true, stamps: [{ stampId: 'A' }] })
+  })
+
+  it('disabled module fails the whole call as capability-off (not merely degraded)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonRes(503, { error: 'bitcoin_disabled' }))
+    expect(await makeClient(fetchImpl).getStamps('bitcoin', [addr(1)])).toEqual({ ok: false, error: 'bitcoin_disabled', disabled: true })
+  })
+
+  it('empty address list short-circuits, never degraded', async () => {
+    const fetchImpl = vi.fn()
+    expect(await makeClient(fetchImpl).getStamps('bitcoin', [])).toEqual({ ok: true, degraded: false, stamps: [] })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/bitcoin/__tests__/portfolioSource.test.js
+++ b/frontend/src/lib/bitcoin/__tests__/portfolioSource.test.js
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest'
+import { loadBitcoinHoldings, toBitcoinHolding } from '../portfolioSource'
+import { ledgerStore } from '../wallet'
+
+function memoryStorage() {
+  const map = new Map()
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, String(v)),
+  }
+}
+
+const ACCOUNT = '0xabc'
+
+function seededStore(addresses = [{ address: 'tb1qaddr0', type: 'segwit', index: 0 }]) {
+  const store = ledgerStore(memoryStorage())
+  store.set(ACCOUNT, 'bitcoin-testnet', { issued: addresses, preferredType: 'segwit' })
+  return store
+}
+
+const okLookup = (utxosByAddress = {}) => ({
+  ok: true,
+  results: Object.entries(utxosByAddress).map(([address, utxos]) => ({
+    address,
+    confirmedSats: utxos.reduce((s, u) => s + (u.confirmations > 0 ? u.valueSats : 0), 0),
+    pendingSats: 0,
+    utxos,
+  })),
+})
+
+const healthyStamps = (stamps = []) => ({ ok: true, degraded: false, stamps })
+
+describe('loadBitcoinHoldings (spec 061 — FR-008/009/010/018/019)', () => {
+  it('returns no holding for accounts that never used bitcoin (no zero claim)', async () => {
+    const res = await loadBitcoinHoldings({
+      account: ACCOUNT,
+      networkIds: ['bitcoin-testnet'],
+      gateway: { lookupAddresses: () => { throw new Error('must not be called') }, getStamps: () => {} },
+      store: ledgerStore(memoryStorage()),
+    })
+    expect(res.holdings).toHaveLength(0)
+    expect(res.failed).toHaveLength(0)
+  })
+
+  it('sums confirmed/pending/protected across issued addresses', async () => {
+    const store = seededStore([
+      { address: 'tb1qaddr0', type: 'segwit', index: 0 },
+      { address: 'tb1paddr1', type: 'taproot', index: 0 },
+    ])
+    const gateway = {
+      lookupAddresses: async () =>
+        okLookup({
+          tb1qaddr0: [
+            { txid: 'a', vout: 0, valueSats: 60_000, confirmations: 4 },
+            { txid: 'b', vout: 0, valueSats: 10_000, confirmations: 0 },
+          ],
+          tb1paddr1: [{ txid: 'c', vout: 1, valueSats: 30_000, confirmations: 2 }],
+        }),
+      getStamps: async () =>
+        healthyStamps([{ stampId: 'S1', outpoint: { txid: 'c', vout: 1 } }]),
+    }
+    const res = await loadBitcoinHoldings({
+      account: ACCOUNT,
+      networkIds: ['bitcoin-testnet'],
+      gateway,
+      store,
+    })
+    expect(res.failed).toHaveLength(0)
+    expect(res.holdings).toHaveLength(1)
+    const h = res.holdings[0]
+    expect(h.confirmedSats).toBe(90_000)
+    expect(h.pendingSats).toBe(10_000)
+    expect(h.protectedSats).toBe(30_000) // the stamp-bearing taproot coin
+    expect(h.spendableSats).toBe(60_000)
+    expect(h.stampsDegraded).toBe(false)
+    expect(h.asset).toMatchObject({ id: 'btc-native', chainId: 'bitcoin-testnet', symbol: 'BTC' })
+  })
+
+  it('gateway failure reports BTC as failed — never zero (FR-010)', async () => {
+    const res = await loadBitcoinHoldings({
+      account: ACCOUNT,
+      networkIds: ['bitcoin-testnet'],
+      gateway: {
+        lookupAddresses: async () => ({ ok: false, error: 'upstream_unavailable', stale: true }),
+        getStamps: async () => healthyStamps(),
+      },
+      store: seededStore(),
+    })
+    expect(res.holdings).toHaveLength(0)
+    expect(res.failed).toEqual(['BTC'])
+  })
+
+  it('degraded stamps recognition protects all confirmed value (fail-safe)', async () => {
+    const gateway = {
+      lookupAddresses: async () =>
+        okLookup({ tb1qaddr0: [{ txid: 'a', vout: 0, valueSats: 50_000, confirmations: 3 }] }),
+      getStamps: async () => ({ ok: true, degraded: true, stamps: [] }),
+    }
+    const res = await loadBitcoinHoldings({
+      account: ACCOUNT,
+      networkIds: ['bitcoin-testnet'],
+      gateway,
+      store: seededStore(),
+    })
+    const h = res.holdings[0]
+    expect(h.stampsDegraded).toBe(true)
+    expect(h.confirmedSats).toBe(50_000)
+    expect(h.protectedSats).toBe(50_000)
+    expect(h.spendableSats).toBe(0)
+  })
+
+  it('networks are independent: only in-scope ids load (FR-021)', async () => {
+    const calls = []
+    const gateway = {
+      lookupAddresses: async (networkId) => {
+        calls.push(networkId)
+        return okLookup({})
+      },
+      getStamps: async () => healthyStamps(),
+    }
+    await loadBitcoinHoldings({
+      account: ACCOUNT,
+      networkIds: ['bitcoin-testnet'],
+      gateway,
+      store: seededStore(),
+    })
+    expect(calls).toEqual(['bitcoin-testnet'])
+  })
+})
+
+describe('toBitcoinHolding', () => {
+  const entry = (over = {}) => ({
+    asset: { id: 'btc-native', chainId: 'bitcoin', symbol: 'BTC', name: 'Bitcoin', decimals: 8, kind: 'native', categoryId: 'digital-commodities', baselineSymbol: 'BTC' },
+    confirmedSats: 150_000_000,
+    pendingSats: 0,
+    protectedSats: 0,
+    spendableSats: 150_000_000,
+    stampsDegraded: false,
+    ...over,
+  })
+
+  it('converts sats to BTC and prices via the BTC feed entry', () => {
+    const priceMap = new Map([['BTC', { usd: 100_000, source: 'chainlink', chainId: 137 }]])
+    const h = toBitcoinHolding(entry(), priceMap)
+    expect(h.balance).toBe(1.5)
+    expect(h.balanceRaw).toBe(150_000_000n)
+    expect(h.usd).toBe(150_000)
+    expect(h.bitcoin.spendableSats).toBe(150_000_000)
+  })
+
+  it('zero is worth exactly $0; nonzero without a price is honestly unpriced', () => {
+    const zero = toBitcoinHolding(entry({ confirmedSats: 0, spendableSats: 0 }), new Map())
+    expect(zero.usd).toBe(0)
+    const unpriced = toBitcoinHolding(entry(), new Map())
+    expect(unpriced.usd).toBeNull()
+  })
+})

--- a/frontend/src/lib/bitcoin/__tests__/psbt.test.js
+++ b/frontend/src/lib/bitcoin/__tests__/psbt.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest'
+import * as btc from '@scure/btc-signer'
+import { HDKey } from '@scure/bip32'
+import { buildAndSignTx, FeeOverrunError } from '../psbt'
+import { estimateVsize } from '../coinSelection'
+
+// Fixture keys from a fixed seed — test-only material.
+const root = HDKey.fromMasterSeed(new Uint8Array(64).fill(7))
+const segwitKey = root.derive("m/84'/1'/0'/0/0")
+const taprootKey = root.derive("m/86'/1'/0'/0/0")
+const net = btc.TEST_NETWORK
+
+const segwitInput = (valueSats, txbyte = '11') => ({
+  txid: txbyte.repeat(32),
+  vout: 0,
+  valueSats,
+  scriptType: 'p2wpkh',
+  publicKey: segwitKey.publicKey,
+  privateKey: segwitKey.privateKey,
+})
+const taprootInput = (valueSats, txbyte = '22') => ({
+  txid: txbyte.repeat(32),
+  vout: 1,
+  valueSats,
+  scriptType: 'p2tr',
+  publicKey: taprootKey.publicKey,
+  privateKey: taprootKey.privateKey,
+})
+
+// A destination of each standard type (testnet forms) — FR-011.
+const DESTINATIONS = {
+  p2pkh: 'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn',
+  p2sh: '2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc',
+  p2wpkh: 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
+  p2tr: btc.p2tr(taprootKey.publicKey.slice(1), undefined, net).address,
+}
+
+describe('psbt build + sign (spec 061, FR-011/FR-012/FR-014)', () => {
+  it.each(Object.entries(DESTINATIONS))(
+    'signs a segwit-input send to a %s destination',
+    (type, address) => {
+      const res = buildAndSignTx({
+        inputs: [segwitInput(100_000)],
+        recipient: { address, valueSats: 60_000 },
+        change: { address: btc.p2wpkh(segwitKey.publicKey, net).address, valueSats: 38_000 },
+        networkId: 'bitcoin-testnet',
+        maxFeeSats: 5_000,
+      })
+      expect(res.feeSats).toBe(2_000)
+      expect(res.txid).toMatch(/^[0-9a-f]{64}$/)
+      const decoded = btc.Transaction.fromRaw(hexToBytes(res.rawTxHex), {
+        allowUnknownInputs: true,
+        allowUnknownOutputs: true,
+      })
+      expect(decoded.inputsLength).toBe(1)
+      expect(decoded.outputsLength).toBe(2)
+      // recipient script really is the requested type
+      const outScript = decoded.getOutput(0).script
+      expect(btc.Address(net).encode(btc.OutScript.decode(outScript))).toBe(address)
+    }
+  )
+
+  it('signs mixed segwit + taproot inputs with RBF sequences', () => {
+    const res = buildAndSignTx({
+      inputs: [segwitInput(50_000), taprootInput(40_000)],
+      recipient: { address: DESTINATIONS.p2wpkh, valueSats: 60_000 },
+      change: { address: DESTINATIONS.p2tr, valueSats: 20_000 },
+      networkId: 'bitcoin-testnet',
+      maxFeeSats: 15_000,
+    })
+    expect(res.feeSats).toBe(10_000)
+    const decoded = btc.Transaction.fromRaw(hexToBytes(res.rawTxHex), { allowUnknownInputs: true })
+    expect(decoded.inputsLength).toBe(2)
+    expect(decoded.getInput(0).sequence).toBe(0xfffffffd)
+    expect(decoded.getInput(1).sequence).toBe(0xfffffffd)
+    expect(decoded.getInput(0).finalScriptWitness).toBeTruthy()
+    expect(decoded.getInput(1).finalScriptWitness).toBeTruthy()
+  })
+
+  it('actual vsize never exceeds the coinSelection estimate (quote honesty)', () => {
+    const inputs = [segwitInput(50_000), taprootInput(40_000)]
+    const est = estimateVsize(
+      inputs.map((i) => ({ scriptType: i.scriptType })),
+      'p2wpkh',
+      true,
+      'p2tr'
+    )
+    const res = buildAndSignTx({
+      inputs,
+      recipient: { address: DESTINATIONS.p2wpkh, valueSats: 60_000 },
+      change: { address: DESTINATIONS.p2tr, valueSats: 20_000 },
+      networkId: 'bitcoin-testnet',
+      maxFeeSats: 15_000,
+    })
+    expect(res.vsize).toBeLessThanOrEqual(est)
+  })
+
+  it('refuses to sign when the fee exceeds the confirmed quote (FR-012)', () => {
+    expect(() =>
+      buildAndSignTx({
+        inputs: [segwitInput(100_000)],
+        recipient: { address: DESTINATIONS.p2wpkh, valueSats: 60_000 },
+        change: null, // 40k sats would go to fee
+        networkId: 'bitcoin-testnet',
+        maxFeeSats: 5_000,
+      })
+    ).toThrow(FeeOverrunError)
+  })
+
+  it('rejects outputs exceeding inputs, empty inputs, bad networks and wrong-network destinations', () => {
+    expect(() =>
+      buildAndSignTx({
+        inputs: [segwitInput(10_000)],
+        recipient: { address: DESTINATIONS.p2wpkh, valueSats: 20_000 },
+        networkId: 'bitcoin-testnet',
+        maxFeeSats: 1_000,
+      })
+    ).toThrow(/outputs exceed inputs/)
+    expect(() =>
+      buildAndSignTx({ inputs: [], recipient: { address: DESTINATIONS.p2wpkh, valueSats: 1 }, networkId: 'bitcoin-testnet', maxFeeSats: 1 })
+    ).toThrow(/no inputs/)
+    expect(() =>
+      buildAndSignTx({
+        inputs: [segwitInput(10_000)],
+        recipient: { address: DESTINATIONS.p2wpkh, valueSats: 5_000 },
+        networkId: 'litecoin',
+        maxFeeSats: 6_000,
+      })
+    ).toThrow(/unknown bitcoin network/)
+    // mainnet destination on testnet build
+    expect(() =>
+      buildAndSignTx({
+        inputs: [segwitInput(10_000)],
+        recipient: { address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4', valueSats: 5_000 },
+        networkId: 'bitcoin-testnet',
+        maxFeeSats: 6_000,
+      })
+    ).toThrow()
+  })
+
+  it('taproot txid is deterministic (witness may differ — BIP-340 aux randomness)', () => {
+    const build = () =>
+      buildAndSignTx({
+        inputs: [taprootInput(40_000)],
+        recipient: { address: DESTINATIONS.p2wpkh, valueSats: 39_000 },
+        networkId: 'bitcoin-testnet',
+        maxFeeSats: 1_000,
+      })
+    const a = build()
+    const b = build()
+    // txid commits to everything except witness data; schnorr aux-rand makes
+    // the signature bytes differ run-to-run, which is expected and harmless.
+    expect(a.txid).toBe(b.txid)
+    expect(a.feeSats).toBe(b.feeSats)
+    expect(a.vsize).toBe(b.vsize)
+  })
+})
+
+function hexToBytes(hex) {
+  return Uint8Array.from(hex.match(/.{2}/g).map((b) => parseInt(b, 16)))
+}

--- a/frontend/src/lib/bitcoin/__tests__/send.test.js
+++ b/frontend/src/lib/bitcoin/__tests__/send.test.js
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest'
+import { HDKey } from '@scure/bip32'
+import { prepareSend, executeSend, isQuoteFresh, FEE_QUOTE_TTL_MS } from '../send'
+import { encodeAddress } from '../addresses'
+
+const root = HDKey.fromMasterSeed(new Uint8Array(64).fill(9))
+const key0 = root.derive("m/84'/1'/0'/0/0")
+const key1 = root.derive("m/84'/1'/0'/0/1")
+const addr0 = encodeAddress(key0.publicKey, { type: 'segwit', network: 'bitcoin-testnet' })
+const addr1 = encodeAddress(key1.publicKey, { type: 'segwit', network: 'bitcoin-testnet' })
+
+const DEST = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx'
+
+let seq = 0
+const coin = (valueSats, over = {}) => ({
+  txid: `${(++seq).toString(16).padStart(2, '0')}`.repeat(32),
+  vout: 0,
+  valueSats,
+  address: addr0,
+  confirmations: 3,
+  classification: 'spendable',
+  scriptType: 'p2wpkh',
+  lockedByTx: null,
+  ...over,
+})
+
+const freshQuote = (now) => ({ rates: { fast: 10, normal: 5, slow: 1 }, fetchedAt: now })
+
+const keyFor = (address) => {
+  if (address === addr0) return { publicKey: key0.publicKey, privateKey: key0.privateKey, scriptType: 'p2wpkh' }
+  if (address === addr1) return { publicKey: key1.publicKey, privateKey: key1.privateKey, scriptType: 'p2wpkh' }
+  return null
+}
+
+describe('prepareSend (FR-011/012/013)', () => {
+  const now = 1_000_000
+
+  it('builds a confirmable plan with the fee as its own component', () => {
+    const res = prepareSend({
+      coins: [coin(100_000)],
+      destination: DEST,
+      amountSats: 50_000,
+      feeRate: 5,
+      quote: freshQuote(now),
+      changeAddress: addr1,
+      networkId: 'bitcoin-testnet',
+      nowMs: now,
+    })
+    expect(res.ok).toBe(true)
+    expect(res.plan.destinationType).toBe('p2wpkh')
+    expect(res.plan.feeSats).toBeGreaterThan(0)
+    expect(res.plan.amountSats + res.plan.feeSats + res.plan.changeSats).toBe(100_000)
+    expect(res.plan.changeAddress).toBe(addr1)
+  })
+
+  it('rejects invalid and wrong-network destinations before any signing', () => {
+    const bad = prepareSend({
+      coins: [coin(100_000)],
+      destination: '0x1234567890123456789012345678901234567890',
+      amountSats: 1_000,
+      feeRate: 5,
+      quote: freshQuote(now),
+      networkId: 'bitcoin-testnet',
+      nowMs: now,
+    })
+    expect(bad).toMatchObject({ ok: false, error: 'invalid_destination' })
+    const wrongNet = prepareSend({
+      coins: [coin(100_000)],
+      destination: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      amountSats: 1_000,
+      feeRate: 5,
+      quote: freshQuote(now),
+      networkId: 'bitcoin-testnet',
+      nowMs: now,
+    })
+    expect(wrongNet.ok).toBe(false)
+  })
+
+  it('a stale quote can never price a send (edge: fee spike)', () => {
+    const res = prepareSend({
+      coins: [coin(100_000)],
+      destination: DEST,
+      amountSats: 1_000,
+      feeRate: 5,
+      quote: { ...freshQuote(now), fetchedAt: now - FEE_QUOTE_TTL_MS - 1 },
+      networkId: 'bitcoin-testnet',
+      nowMs: now,
+    })
+    expect(res).toMatchObject({ ok: false, error: 'stale_fee_quote' })
+    expect(isQuoteFresh(freshQuote(now), now)).toBe(true)
+    expect(isQuoteFresh(null, now)).toBe(false)
+  })
+
+  it("'max' consumes all spendable coins with no change", () => {
+    const res = prepareSend({
+      coins: [coin(60_000), coin(40_000, { address: addr1 }), coin(30_000, { classification: 'protected' })],
+      destination: DEST,
+      amountSats: 'max',
+      feeRate: 2,
+      quote: freshQuote(now),
+      networkId: 'bitcoin-testnet',
+      nowMs: now,
+    })
+    expect(res.ok).toBe(true)
+    expect(res.plan.isMax).toBe(true)
+    expect(res.plan.inputs).toHaveLength(2)
+    expect(res.plan.changeSats).toBe(0)
+    expect(res.plan.amountSats + res.plan.feeSats).toBe(100_000)
+  })
+
+  it('surfaces shortfalls with explainable numbers', () => {
+    const res = prepareSend({
+      coins: [coin(10_000)],
+      destination: DEST,
+      amountSats: 50_000,
+      feeRate: 2,
+      quote: freshQuote(now),
+      networkId: 'bitcoin-testnet',
+      nowMs: now,
+    })
+    expect(res).toMatchObject({ ok: false, error: 'insufficient_funds' })
+    expect(res.shortfallSats).toBeGreaterThan(0)
+  })
+})
+
+describe('executeSend (FR-012/014)', () => {
+  const now = 1_000_000
+  const plan = (coins, amountSats = 50_000) => {
+    const res = prepareSend({
+      coins,
+      destination: DEST,
+      amountSats,
+      feeRate: 5,
+      quote: freshQuote(now),
+      changeAddress: addr1,
+      networkId: 'bitcoin-testnet',
+      nowMs: now,
+    })
+    expect(res.ok).toBe(true)
+    return res.plan
+  }
+
+  it('signs, broadcasts, and reports outpoints to lock', async () => {
+    const broadcasts = []
+    const gateway = {
+      broadcast: async (networkId, rawTxHex) => {
+        broadcasts.push({ networkId, rawTxHex })
+        return { ok: true, txid: 'deadbeef' }
+      },
+    }
+    const coins = [coin(100_000)]
+    const res = await executeSend({ plan: plan(coins), keyFor, gateway })
+    expect(res.ok).toBe(true)
+    expect(res.txid).toBe('deadbeef')
+    expect(res.lockedOutpoints).toEqual([`${coins[0].txid}:0`])
+    expect(broadcasts[0].networkId).toBe('bitcoin-testnet')
+    expect(broadcasts[0].rawTxHex).toMatch(/^02000000/)
+  })
+
+  it('broadcast rejection surfaces the upstream reason, nothing locked', async () => {
+    const gateway = {
+      broadcast: async () => ({ ok: false, error: 'broadcast_rejected', message: 'min relay fee not met' }),
+    }
+    const res = await executeSend({ plan: plan([coin(100_000)]), keyFor, gateway })
+    expect(res).toMatchObject({ ok: false, error: 'broadcast_rejected', message: 'min relay fee not met' })
+  })
+
+  it('missing key material fails as signing_failed (never a partial broadcast)', async () => {
+    const gateway = { broadcast: async () => ({ ok: true, txid: 'x' }) }
+    const res = await executeSend({
+      plan: plan([coin(100_000, { address: 'tb1qunknownaddr' })]),
+      keyFor,
+      gateway,
+    })
+    expect(res.ok).toBe(false)
+    expect(res.error).toBe('signing_failed')
+  })
+})

--- a/frontend/src/lib/bitcoin/__tests__/wallet.test.js
+++ b/frontend/src/lib/bitcoin/__tests__/wallet.test.js
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createBitcoinWallet, classifyUtxos, ledgerStore, nextIndex, GAP_LIMIT } from '../wallet'
+
+// In-memory storage matching the localStorage surface ledgerStore needs.
+function memoryStorage() {
+  const map = new Map()
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, String(v)),
+  }
+}
+
+const deriveAddress = (type, index) => `${type === 'taproot' ? 'tb1p' : 'tb1q'}addr${index}`
+
+// Gateway stub: `used` maps address → { confirmedSats, utxos }.
+function gatewayStub(used = {}, { fail = false } = {}) {
+  const calls = []
+  return {
+    calls,
+    async lookupAddresses(networkId, addresses) {
+      calls.push(addresses)
+      if (fail) return { ok: false, error: 'upstream_unavailable', stale: true }
+      return {
+        ok: true,
+        results: addresses.map((address) => ({
+          address,
+          confirmedSats: used[address]?.confirmedSats ?? 0,
+          pendingSats: used[address]?.pendingSats ?? 0,
+          utxos: used[address]?.utxos ?? [],
+        })),
+      }
+    },
+  }
+}
+
+const ACCOUNT = '0xAbC0000000000000000000000000000000000001'
+
+function makeWallet({ used, fail, store } = {}) {
+  return createBitcoinWallet({
+    account: ACCOUNT,
+    networkId: 'bitcoin-testnet',
+    deriveAddress,
+    gateway: gatewayStub(used, { fail }),
+    store: store ?? ledgerStore(memoryStorage()),
+    now: () => '2026-07-20T00:00:00.000Z',
+  })
+}
+
+describe('bitcoin wallet ledger + rotation (spec 061, FR-003/004/005)', () => {
+  let store
+  beforeEach(() => {
+    store = ledgerStore(memoryStorage())
+  })
+
+  it('issues fresh addresses, never repeating (rotation)', () => {
+    const wallet = makeWallet({ store })
+    const a = wallet.nextReceiveAddress('segwit')
+    const b = wallet.nextReceiveAddress('segwit')
+    const c = wallet.nextReceiveAddress('segwit')
+    expect(a.index).toBe(0)
+    expect(b.index).toBe(1)
+    expect(c.index).toBe(2)
+    expect(new Set([a.address, b.address, c.address]).size).toBe(3)
+  })
+
+  it('rotation cursors are independent per type; preference persists', () => {
+    const wallet = makeWallet({ store })
+    expect(wallet.preferredType()).toBe('segwit')
+    wallet.nextReceiveAddress('segwit')
+    const t = wallet.nextReceiveAddress('taproot')
+    expect(t.index).toBe(0)
+    expect(t.address.startsWith('tb1p')).toBe(true)
+    wallet.setPreferredType('taproot')
+    expect(wallet.preferredType()).toBe('taproot')
+    expect(() => wallet.setPreferredType('p2pk')).toThrow()
+    // preference + ledger survive a new controller over the same store
+    const again = makeWallet({ store })
+    expect(again.preferredType()).toBe('taproot')
+    expect(again.nextReceiveAddress('segwit').index).toBe(1)
+  })
+
+  it('ledgers are scoped per account and network (no cross-leak, FR-021)', () => {
+    const walletA = makeWallet({ store })
+    walletA.nextReceiveAddress('segwit')
+    const other = createBitcoinWallet({
+      account: '0xother',
+      networkId: 'bitcoin-testnet',
+      deriveAddress,
+      gateway: gatewayStub(),
+      store,
+    })
+    expect(other.issuedAddresses()).toHaveLength(0)
+    const mainnet = createBitcoinWallet({
+      account: ACCOUNT,
+      networkId: 'bitcoin',
+      deriveAddress,
+      gateway: gatewayStub(),
+      store,
+    })
+    expect(mainnet.issuedAddresses()).toHaveLength(0)
+  })
+
+  it('nextIndex never decreases even with a sparse ledger', () => {
+    const issued = [
+      { type: 'segwit', index: 0 },
+      { type: 'segwit', index: 7 }, // discovered ahead of cursor
+      { type: 'taproot', index: 2 },
+    ]
+    expect(nextIndex(issued, 'segwit')).toBe(8)
+    expect(nextIndex(issued, 'taproot')).toBe(3)
+    expect(nextIndex([], 'segwit')).toBe(0)
+  })
+})
+
+describe('gap-limit discovery (research R5, FR-003)', () => {
+  it('recovers used addresses from an empty ledger (new device)', async () => {
+    const used = {
+      tb1qaddr0: { confirmedSats: 1000, utxos: [{ txid: 'a', vout: 0, valueSats: 1000, confirmations: 2 }] },
+      tb1qaddr3: { confirmedSats: 500, utxos: [{ txid: 'b', vout: 1, valueSats: 500, confirmations: 9 }] },
+    }
+    const wallet = makeWallet({ used })
+    const res = await wallet.discover(['segwit'])
+    expect(res.ok).toBe(true)
+    const indexes = res.addresses.filter((a) => a.type === 'segwit').map((a) => a.index).sort()
+    expect(indexes).toEqual([0, 3])
+    expect(res.utxos).toHaveLength(2)
+    expect(res.utxos[0].scriptType).toBe('p2wpkh')
+    // cursor resumes AFTER the highest used index
+    expect(wallet.nextReceiveAddress('segwit').index).toBe(4)
+  })
+
+  it('finds funds paid ahead of the cursor within the gap window', async () => {
+    const used = { [`tb1qaddr${GAP_LIMIT - 1}`]: { confirmedSats: 42, utxos: [] } }
+    const wallet = makeWallet({ used })
+    const res = await wallet.discover(['segwit'])
+    expect(res.addresses.some((a) => a.index === GAP_LIMIT - 1)).toBe(true)
+  })
+
+  it('stops after GAP_LIMIT consecutive unused addresses', async () => {
+    const wallet = createBitcoinWallet({
+      account: ACCOUNT,
+      networkId: 'bitcoin-testnet',
+      deriveAddress,
+      gateway: gatewayStub({}),
+      store: ledgerStore(memoryStorage()),
+    })
+    const res = await wallet.discover(['segwit'])
+    expect(res.ok).toBe(true)
+    expect(res.addresses).toHaveLength(0)
+  })
+
+  it('merges discovery with cached issued entries; cursor never rolls back', async () => {
+    const wallet = makeWallet({ used: {} })
+    wallet.nextReceiveAddress('segwit') // index 0 issued locally, unused on chain
+    wallet.nextReceiveAddress('segwit') // index 1
+    const res = await wallet.discover(['segwit'])
+    // unused-but-issued entries survive (they may be on printed invoices)
+    expect(res.addresses.map((a) => a.index).sort()).toEqual([0, 1])
+    expect(wallet.nextReceiveAddress('segwit').index).toBe(2)
+  })
+
+  it('gateway failure yields stale (cached ledger), never an empty reset', async () => {
+    const store = ledgerStore(memoryStorage())
+    const w1 = makeWallet({ store })
+    w1.nextReceiveAddress('segwit')
+    const w2 = makeWallet({ store, fail: true })
+    const res = await w2.discover(['segwit'])
+    expect(res.stale).toBe(true)
+    expect(res.addresses).toHaveLength(1)
+    expect(w2.nextReceiveAddress('segwit').index).toBe(1)
+  })
+})
+
+describe('classifyUtxos (FR-018/FR-019 fail-safe)', () => {
+  const utxo = (over = {}) => ({
+    txid: 't1',
+    vout: 0,
+    valueSats: 1000,
+    address: 'tb1qaddr0',
+    confirmations: 3,
+    scriptType: 'p2wpkh',
+    ...over,
+  })
+
+  it('classifies spendable / protected / pending with healthy recognition', () => {
+    const stamps = {
+      ok: true,
+      degraded: false,
+      stamps: [{ stampId: 'S1', outpoint: { txid: 't2', vout: 1 } }],
+    }
+    const coins = classifyUtxos(
+      [utxo(), utxo({ txid: 't2', vout: 1 }), utxo({ txid: 't3', confirmations: 0 })],
+      stamps
+    )
+    expect(coins[0].classification).toBe('spendable')
+    expect(coins[1]).toMatchObject({ classification: 'protected', stampId: 'S1' })
+    expect(coins[2].classification).toBe('pending')
+  })
+
+  it('degraded or failed recognition marks every confirmed coin unverified', () => {
+    for (const stamps of [
+      { ok: true, degraded: true, stamps: [] },
+      { ok: false },
+      null,
+      undefined,
+    ]) {
+      const coins = classifyUtxos([utxo(), utxo({ txid: 't9', confirmations: 0 })], stamps)
+      expect(coins[0].classification).toBe('unverified')
+      expect(coins[1].classification).toBe('pending') // pending stays pending
+    }
+  })
+
+  it('locks in-flight outpoints (FR-014)', () => {
+    const stamps = { ok: true, degraded: false, stamps: [] }
+    const coins = classifyUtxos([utxo()], stamps, new Set(['t1:0']))
+    expect(coins[0].lockedByTx).toBe('t1:0')
+    expect(coins[0].classification).toBe('spendable') // locked ≠ reclassified; selection excludes it
+  })
+})

--- a/frontend/src/lib/bitcoin/addresses.js
+++ b/frontend/src/lib/bitcoin/addresses.js
@@ -1,0 +1,221 @@
+/**
+ * Bitcoin address codecs & validation (spec 061, T006).
+ *
+ * Contract (research R7 / FR-011 / FR-016):
+ *  - encode our OWN receive addresses: P2WPKH (bech32, BIP84) and P2TR
+ *    (bech32m, BIP-341 key-path tweak via @scure/btc-signer p2tr) — nothing else;
+ *  - classify ANY destination string: accept every standard output type
+ *    (P2PKH, P2SH, P2WPKH, P2WSH, P2TR) on the CORRECT network, reject
+ *    everything else with a specific machine slug + human message
+ *    ('wrong_network' is always distinct — tb1… on mainnet is not "invalid",
+ *    it is honestly the wrong network; EVM 0x input gets its own reason);
+ *  - BIP-21 'bitcoin:' URI parse/format (amount in BTC decimal, converted
+ *    to/from integer satoshis with exact string math — never floats on the
+ *    fractional part).
+ *
+ * Invariants (tested in __tests__/addresses.test.js):
+ *  - all decoding rides @scure/btc-signer's audited Address/bech32m/base58check
+ *    codecs — no hand-rolled checksum code;
+ *  - witness versions > 1 (and v0/v1 with non-standard program sizes) are
+ *    rejected, never silently truncated (BIP-350 semantics);
+ *  - mixed-case bech32 is rejected; all-uppercase (QR alphanumeric mode) is
+ *    accepted;
+ *  - classifyAddress never throws on member input — every failure is a
+ *    { valid: false, reason, message } verdict.
+ */
+
+import { Address, p2wpkh, p2tr, NETWORK, TEST_NETWORK } from '@scure/btc-signer'
+
+/** networkId → @scure/btc-signer network params ('bitcoin-testnet' = testnet4; same encoding as testnet3). */
+const BTC_SIGNER_NETWORK = { bitcoin: NETWORK, 'bitcoin-testnet': TEST_NETWORK }
+
+/** btc-signer decoded type → spec-061 classification type. */
+const TYPE_LABEL = { pkh: 'p2pkh', sh: 'p2sh', wpkh: 'p2wpkh', wsh: 'p2wsh', tr: 'p2tr' }
+
+const NETWORK_LABEL = { bitcoin: 'Bitcoin mainnet', 'bitcoin-testnet': 'Bitcoin testnet' }
+
+function signerNetwork(networkId) {
+  const net = BTC_SIGNER_NETWORK[networkId]
+  if (!net) {
+    throw new Error(`bitcoin addresses: unknown network '${String(networkId)}' (expected 'bitcoin' or 'bitcoin-testnet')`)
+  }
+  return net
+}
+
+function otherNetworkId(networkId) {
+  return networkId === 'bitcoin' ? 'bitcoin-testnet' : 'bitcoin'
+}
+
+/**
+ * Encode one of OUR receive addresses from a public key.
+ *
+ * @param {Uint8Array} pubkey 33-byte compressed secp256k1 pubkey (a 32-byte
+ *   x-only key is also accepted for taproot)
+ * @param {{type: 'segwit'|'taproot', network: 'bitcoin'|'bitcoin-testnet'}} opts
+ * @returns {string} bc1q…/tb1q… (segwit) or bc1p…/tb1p… (taproot, BIP-341 tweaked)
+ */
+export function encodeAddress(pubkey, { type, network } = {}) {
+  const net = signerNetwork(network)
+  if (!(pubkey instanceof Uint8Array)) {
+    throw new Error('encodeAddress: pubkey must be a Uint8Array')
+  }
+  if (type === 'segwit') {
+    if (pubkey.length !== 33) throw new Error('encodeAddress: segwit requires a 33-byte compressed pubkey')
+    return p2wpkh(pubkey, net).address
+  }
+  if (type === 'taproot') {
+    // p2tr takes the 32-byte x-only internal key and applies the BIP-341 tweak.
+    const internal = pubkey.length === 33 ? pubkey.slice(1) : pubkey
+    if (internal.length !== 32) throw new Error('encodeAddress: taproot requires a 32/33-byte pubkey')
+    return p2tr(internal, undefined, net).address
+  }
+  throw new Error(`encodeAddress: unknown type '${String(type)}' (expected 'segwit' or 'taproot')`)
+}
+
+function invalid(reason, message) {
+  return { valid: false, reason, message }
+}
+
+/**
+ * Classify a destination address for `networkId`.
+ *
+ * @param {string} str candidate address (member input — never throws on it)
+ * @param {'bitcoin'|'bitcoin-testnet'} networkId active network
+ * @returns {{valid: true, type: 'p2pkh'|'p2sh'|'p2wpkh'|'p2wsh'|'p2tr', network: string}
+ *         | {valid: false, reason: string, message: string}}
+ *   reasons: 'empty' | 'evm_address' | 'mixed_case' | 'wrong_network'
+ *          | 'bad_checksum' | 'unsupported_witness' | 'unrecognized'
+ */
+export function classifyAddress(str, networkId) {
+  const net = signerNetwork(networkId) // programmer error to pass a bad networkId — throws
+  if (typeof str !== 'string' || str.trim() === '') {
+    return invalid('empty', 'Enter a Bitcoin address.')
+  }
+  const s = str.trim()
+
+  if (/^0x[0-9a-fA-F]*$/.test(s)) {
+    return invalid('evm_address', 'This is an Ethereum-style (0x…) address — Bitcoin addresses look like bc1…, 1… or 3….')
+  }
+
+  // Bech32 case rule (BIP-173/350): all-lower or all-upper only. Check before
+  // decoding so the member gets the precise reason rather than a generic error.
+  if (/^(bc|tb|bcrt)1/i.test(s) && s !== s.toLowerCase() && s !== s.toUpperCase()) {
+    return invalid('mixed_case', 'Bitcoin bech32 addresses must be all-lowercase or all-uppercase, not mixed case.')
+  }
+
+  let decodeError
+  try {
+    const decoded = Address(net).decode(s)
+    const type = TYPE_LABEL[decoded.type]
+    if (!type) return invalid('unrecognized', 'Unsupported Bitcoin address type.')
+    return { valid: true, type, network: networkId }
+  } catch (e) {
+    decodeError = e
+  }
+
+  // Valid on the OTHER Bitcoin network ⇒ honest wrong-network verdict, never
+  // a generic "invalid address" (FR-011/FR-021).
+  const otherId = otherNetworkId(networkId)
+  try {
+    const other = Address(BTC_SIGNER_NETWORK[otherId]).decode(s)
+    if (TYPE_LABEL[other.type]) {
+      return invalid(
+        'wrong_network',
+        `This is a ${NETWORK_LABEL[otherId]} address — you are sending on ${NETWORK_LABEL[networkId]}.`
+      )
+    }
+  } catch {
+    /* not valid on the other network either — fall through to specifics */
+  }
+
+  const message = String(decodeError?.message || '')
+  if (/witness/i.test(message)) {
+    return invalid('unsupported_witness', 'Unsupported witness version or program — only known Bitcoin address formats can receive funds safely.')
+  }
+  if (/^(bc|tb|bcrt)1/i.test(s) || /checksum/i.test(message)) {
+    return invalid('bad_checksum', 'Address checksum failed — check for typos.')
+  }
+  return invalid('unrecognized', 'Not a recognized Bitcoin address.')
+}
+
+const SATS_PER_BTC = 100_000_000n
+
+/** Exact BTC-decimal string for integer satoshis (trailing zeros trimmed, per BIP-21 style). */
+function satsToBtcString(amountSats) {
+  const sats = BigInt(amountSats)
+  const whole = sats / SATS_PER_BTC
+  const frac = (sats % SATS_PER_BTC).toString().padStart(8, '0').replace(/0+$/, '')
+  return frac === '' ? whole.toString() : `${whole.toString()}.${frac}`
+}
+
+/** Exact satoshis for a BTC-decimal string, or null when malformed (>8 dp, signs, exponents…). */
+function btcStringToSats(amount) {
+  const m = /^(\d+)(?:\.(\d{1,8}))?$/.exec(amount)
+  if (!m) return null
+  const sats = BigInt(m[1]) * SATS_PER_BTC + BigInt((m[2] || '').padEnd(8, '0'))
+  if (sats > BigInt(Number.MAX_SAFE_INTEGER)) return null
+  return Number(sats)
+}
+
+/**
+ * Parse a BIP-21 payment URI (case-insensitive `bitcoin:` scheme).
+ *
+ * @param {string} uri e.g. 'bitcoin:bc1q…?amount=0.001&label=Rent'
+ * @param {'bitcoin'|'bitcoin-testnet'} networkId active network
+ * @returns {{address: string, type: string, amountSats?: number, label?: string}
+ *         | {error: 'unsupported_scheme'|'invalid_address'|'wrong_network'|'invalid_amount'|'unsupported_required_param', message: string}}
+ */
+export function parseBip21(uri, networkId) {
+  if (typeof uri !== 'string') return { error: 'unsupported_scheme', message: 'Not a bitcoin: URI.' }
+  const m = /^([a-zA-Z][a-zA-Z0-9+.-]*):(.*)$/.exec(uri.trim())
+  if (!m || m[1].toLowerCase() !== 'bitcoin') {
+    return { error: 'unsupported_scheme', message: 'Only bitcoin: payment links are supported here.' }
+  }
+  const [addressPart, queryPart = ''] = m[2].split('?', 2)
+
+  const verdict = classifyAddress(addressPart, networkId)
+  if (!verdict.valid) {
+    if (verdict.reason === 'wrong_network') return { error: 'wrong_network', message: verdict.message }
+    return { error: 'invalid_address', message: verdict.message }
+  }
+
+  const params = new URLSearchParams(queryPart)
+  for (const key of params.keys()) {
+    // BIP-21: an unrecognized req-* parameter MUST invalidate the whole URI.
+    if (key.toLowerCase().startsWith('req-')) {
+      return { error: 'unsupported_required_param', message: `This payment link requires '${key}', which is not supported.` }
+    }
+  }
+
+  const result = { address: addressPart, type: verdict.type }
+  if (params.has('amount')) {
+    const amountSats = btcStringToSats(params.get('amount'))
+    if (amountSats === null) return { error: 'invalid_amount', message: 'The payment link carries an invalid BTC amount.' }
+    result.amountSats = amountSats
+  }
+  if (params.has('label')) result.label = params.get('label')
+  return result
+}
+
+/**
+ * Format a BIP-21 payment URI (amount in BTC decimal per the BIP).
+ *
+ * @param {string} address already-validated Bitcoin address
+ * @param {{amountSats?: number, label?: string}} [opts]
+ * @returns {string} 'bitcoin:<address>[?amount=…][&label=…]'
+ */
+export function formatBip21(address, { amountSats, label } = {}) {
+  if (typeof address !== 'string' || address === '') {
+    throw new Error('formatBip21: address is required')
+  }
+  const params = new URLSearchParams()
+  if (amountSats !== undefined) {
+    if (!Number.isInteger(amountSats) || amountSats < 0) {
+      throw new Error('formatBip21: amountSats must be a non-negative integer')
+    }
+    params.set('amount', satsToBtcString(amountSats))
+  }
+  if (label !== undefined && label !== '') params.set('label', label)
+  const query = params.toString()
+  return query === '' ? `bitcoin:${address}` : `bitcoin:${address}?${query}`
+}

--- a/frontend/src/lib/bitcoin/coinSelection.js
+++ b/frontend/src/lib/bitcoin/coinSelection.js
@@ -1,0 +1,186 @@
+/**
+ * Stamps-aware Bitcoin coin selection (spec 061, tasks T021) — implements
+ * research.md R6/R7 and the FR-013/FR-018/FR-019 rules:
+ *
+ *  - Only coins classified 'spendable' are ever selected. 'protected'
+ *    (stamps-bearing), 'unverified' (stamps recognition degraded — fail-safe),
+ *    'pending' (unconfirmed), and locally locked coins (in-flight sends) are
+ *    excluded from selection AND from the spendable balance.
+ *  - Fee = feeRate (sat/vB) × estimated vsize, deterministic per input/output
+ *    type; estimates round up (member-visible quotes are upper bounds).
+ *  - Change below the dust threshold is folded into the fee — the flow never
+ *    creates uneconomical outputs (FR-013).
+ *  - MAX = everything spendable minus the no-change fee.
+ *
+ * Pure module: no IO, no React, integer satoshi math only.
+ */
+
+// Deterministic vsize contributions (vbytes, conservative round-ups).
+// Inputs we own are P2WPKH or P2TR key-path only (contracts/key-derivation-btc.md).
+const INPUT_VBYTES = Object.freeze({
+  p2wpkh: 68, // 41 base + ~107 WU witness (sig+pubkey)
+  p2tr: 58, //   41 base + ~66 WU witness (64B schnorr sig + count)
+})
+
+// Any standard destination type is payable (FR-011).
+const OUTPUT_VBYTES = Object.freeze({
+  p2pkh: 34,
+  p2sh: 32,
+  p2wpkh: 31,
+  p2wsh: 43,
+  p2tr: 43,
+})
+
+// Fixed transaction overhead: version + locktime + varint counts, plus the
+// segwit marker/flag (all our inputs are witness inputs). Rounded up.
+const TX_OVERHEAD_VBYTES = 11
+
+// Dust thresholds per research.md R7: sub-dust change is folded into the fee;
+// sub-dust recipient amounts are rejected outright.
+export const DUST_SATS = Object.freeze({
+  p2pkh: 546,
+  p2sh: 546,
+  p2wpkh: 330,
+  p2wsh: 330,
+  p2tr: 330,
+})
+
+export function dustThreshold(outputType) {
+  const dust = DUST_SATS[outputType]
+  if (!dust) throw new Error(`coinSelection: unknown output type "${outputType}"`)
+  return dust
+}
+
+function inputVbytes(coin) {
+  const v = INPUT_VBYTES[coin.scriptType]
+  if (!v) throw new Error(`coinSelection: unspendable input script type "${coin.scriptType}"`)
+  return v
+}
+
+function outputVbytes(outputType) {
+  const v = OUTPUT_VBYTES[outputType]
+  if (!v) throw new Error(`coinSelection: unknown output type "${outputType}"`)
+  return v
+}
+
+/** Estimated vsize for a tx spending `coins` to one recipient (+ optional change). */
+export function estimateVsize(coins, recipientType, withChange, changeType = 'p2wpkh') {
+  const inputs = coins.reduce((sum, c) => sum + inputVbytes(c), 0)
+  const outputs = outputVbytes(recipientType) + (withChange ? outputVbytes(changeType) : 0)
+  return TX_OVERHEAD_VBYTES + inputs + outputs
+}
+
+function assertFeeRate(feeRate) {
+  if (!Number.isInteger(feeRate) || feeRate < 1) {
+    throw new Error('coinSelection: feeRate must be an integer ≥ 1 sat/vB')
+  }
+}
+
+/**
+ * A coin may fund an ordinary send only when it is positively classified
+ * spendable and not locked by an in-flight transaction (FR-014/FR-018/FR-019).
+ * Everything else — protected, unverified, pending, unknown — fails safe.
+ */
+export function isSelectable(coin) {
+  return coin.classification === 'spendable' && !coin.lockedByTx
+}
+
+/** Balance components per data-model.md (all integer sats). */
+export function balanceComponents(utxos) {
+  const sum = (coins) => coins.reduce((s, c) => s + c.valueSats, 0)
+  const confirmed = utxos.filter((c) => c.classification !== 'pending')
+  const spendable = utxos.filter(isSelectable)
+  return {
+    confirmedSats: sum(confirmed),
+    pendingSats: sum(utxos.filter((c) => c.classification === 'pending')),
+    protectedSats: sum(
+      confirmed.filter((c) => c.classification === 'protected' || c.classification === 'unverified')
+    ),
+    spendableSats: sum(spendable),
+  }
+}
+
+/**
+ * Accumulative largest-first selection with change (research R7).
+ *
+ * Returns:
+ *  { ok: true, inputs, feeSats, changeSats, vsize }  — changeSats 0 when the
+ *    remainder was sub-dust and folded into feeSats (reported honestly).
+ *  { ok: false, error: 'amount_below_dust' | 'insufficient_funds',
+ *    shortfallSats?, spendableSats? }
+ */
+export function selectCoins({ utxos, targetSats, feeRate, recipientType, changeType = 'p2wpkh' }) {
+  assertFeeRate(feeRate)
+  if (!Number.isInteger(targetSats) || targetSats <= 0) {
+    throw new Error('coinSelection: targetSats must be a positive integer')
+  }
+  if (targetSats < dustThreshold(recipientType)) {
+    return { ok: false, error: 'amount_below_dust', dustSats: dustThreshold(recipientType) }
+  }
+
+  const candidates = utxos.filter(isSelectable).sort((a, b) => b.valueSats - a.valueSats)
+  const spendableSats = candidates.reduce((s, c) => s + c.valueSats, 0)
+
+  const selected = []
+  let inputSats = 0
+  for (const coin of candidates) {
+    selected.push(coin)
+    inputSats += coin.valueSats
+
+    // Try with a change output first; fall back to no-change (remainder → fee).
+    const feeWithChange = feeRate * estimateVsize(selected, recipientType, true, changeType)
+    const changeSats = inputSats - targetSats - feeWithChange
+    if (changeSats >= dustThreshold(changeType)) {
+      return {
+        ok: true,
+        inputs: selected.slice(),
+        feeSats: feeWithChange,
+        changeSats,
+        vsize: estimateVsize(selected, recipientType, true, changeType),
+      }
+    }
+
+    const feeNoChange = feeRate * estimateVsize(selected, recipientType, false)
+    const remainder = inputSats - targetSats - feeNoChange
+    if (remainder >= 0) {
+      // Sub-dust remainder is folded into the fee — never a dust output.
+      return {
+        ok: true,
+        inputs: selected.slice(),
+        feeSats: feeNoChange + remainder,
+        changeSats: 0,
+        vsize: estimateVsize(selected, recipientType, false),
+      }
+    }
+  }
+
+  const feeAllNoChange =
+    candidates.length > 0 ? feeRate * estimateVsize(candidates, recipientType, false) : 0
+  return {
+    ok: false,
+    error: 'insufficient_funds',
+    spendableSats,
+    shortfallSats: targetSats + feeAllNoChange - spendableSats,
+  }
+}
+
+/**
+ * MAX (FR-013): largest sendable amount = all spendable coins, no change,
+ * fee at the given rate. Returns { ok, amountSats, feeSats, inputs, vsize }
+ * or { ok: false, error: 'insufficient_funds' | 'amount_below_dust' } when
+ * nothing (or only dust) would remain.
+ */
+export function maxSendable({ utxos, feeRate, recipientType }) {
+  assertFeeRate(feeRate)
+  const inputs = utxos.filter(isSelectable)
+  if (inputs.length === 0) {
+    return { ok: false, error: 'insufficient_funds', spendableSats: 0, shortfallSats: null }
+  }
+  const vsize = estimateVsize(inputs, recipientType, false)
+  const feeSats = feeRate * vsize
+  const amountSats = inputs.reduce((s, c) => s + c.valueSats, 0) - feeSats
+  if (amountSats < dustThreshold(recipientType)) {
+    return { ok: false, error: amountSats > 0 ? 'amount_below_dust' : 'insufficient_funds', spendableSats: amountSats > 0 ? amountSats : 0 }
+  }
+  return { ok: true, amountSats, feeSats, inputs, vsize }
+}

--- a/frontend/src/lib/bitcoin/derivation.js
+++ b/frontend/src/lib/bitcoin/derivation.js
@@ -1,0 +1,150 @@
+/**
+ * Bitcoin key derivation (spec 061, T004) — implements
+ * specs/061-bitcoin-transactions/contracts/key-derivation-btc.md exactly:
+ *
+ *   btcSeed     = HKDF-SHA256(ikm = masterSeed(32B, spec 041),
+ *                             salt = 32 zero bytes,
+ *                             info = "fairwins-btc-seed-v1", length = 64)
+ *   root        = HDKey.fromMasterSeed(btcSeed)            // @scure/bip32
+ *   segwitAcct  = root.derive("m/84'/{coin}'/0'")          // BIP84 → bc1q…
+ *   taprootAcct = root.derive("m/86'/{coin}'/0'")          // BIP86 → bc1p…
+ *   coin        = 0' for 'bitcoin' (mainnet), 1' for 'bitcoin-testnet' (testnet4)
+ *   receive(i)  = acct/0/i                                 // external chain ONLY (v1)
+ *
+ * These constants are WALLET-BREAKING if changed — funds live at the derived
+ * addresses; any change requires a versioned migration path.
+ *
+ * Invariants (tested in __tests__/derivation.test.js):
+ *  - Determinism: same masterSeed ⇒ byte-identical addresses, everywhere, forever
+ *    (pinned FairWins vectors + published BIP84/BIP86 reference vectors);
+ *  - Domain separation: info "fairwins-btc-seed-v1" is exclusive to this tree —
+ *    it can never collide with the spec-041 KEK path ("fairwins-kek-v1") or any
+ *    other masterSeed consumer;
+ *  - Memory-only: btcSeed, the root, account nodes, and child private keys are
+ *    NEVER persisted, logged, serialized, or transmitted. Everything returned
+ *    here lives only as long as the unlocked wallet session;
+ *  - External chain only: receive keys are …/0/i; the change chain (…/1/i) is
+ *    reserved and unused in v1;
+ *  - No wrong keys: callers must hold a real spec-041 masterSeed — wrong-length
+ *    input throws instead of silently deriving a different wallet.
+ */
+
+import { hkdf } from '@noble/hashes/hkdf'
+import { sha256 } from '@noble/hashes/sha256'
+import { HDKey } from '@scure/bip32'
+import { encodeAddress } from './addresses'
+
+/**
+ * Domain-separation constant for the Bitcoin subtree of the spec-041 master
+ * seed. Normative (contracts/key-derivation-btc.md); no other consumer of the
+ * master seed may ever use this info string.
+ */
+export const BTC_HKDF_INFO = 'fairwins-btc-seed-v1'
+
+const HKDF_INFO_BYTES = new TextEncoder().encode(BTC_HKDF_INFO)
+const HKDF_SALT = new Uint8Array(32) // 32 zero bytes, per contract
+const BTC_SEED_LENGTH = 64
+
+/** BIP purpose per address type (BIP84 native segwit, BIP86 taproot). */
+const PURPOSE = { segwit: 84, taproot: 86 }
+
+/** BIP44 coin type per FairWins network id (hardened at derivation time). */
+const COIN_TYPE = { bitcoin: 0, 'bitcoin-testnet': 1 }
+
+function assertMasterSeed(masterSeed) {
+  if (!(masterSeed instanceof Uint8Array) || masterSeed.length !== 32) {
+    throw new Error('deriveBtcSeed: masterSeed must be a 32-byte Uint8Array (spec-041 master seed)')
+  }
+}
+
+function assertIndex(index) {
+  // Non-hardened external-chain index: 0 ≤ i < 2^31.
+  if (!Number.isInteger(index) || index < 0 || index >= 0x80000000) {
+    throw new Error(`bitcoin derivation: index must be a non-negative integer < 2^31, got ${String(index)}`)
+  }
+}
+
+function assertNetworkAndType(network, type) {
+  if (!(network in COIN_TYPE)) {
+    throw new Error(`bitcoin derivation: unknown network '${String(network)}' (expected 'bitcoin' or 'bitcoin-testnet')`)
+  }
+  if (!(type in PURPOSE)) {
+    throw new Error(`bitcoin derivation: unknown address type '${String(type)}' (expected 'segwit' or 'taproot')`)
+  }
+}
+
+/**
+ * The 64-byte BIP32 seed for the Bitcoin tree — HKDF-SHA256 over the spec-041
+ * master seed with the domain-separating info string. Memory-only: never
+ * persist, log, or transmit the result.
+ *
+ * @param {Uint8Array} masterSeed 32-byte spec-041 master seed
+ * @returns {Uint8Array} 64-byte btcSeed
+ */
+export function deriveBtcSeed(masterSeed) {
+  assertMasterSeed(masterSeed)
+  return hkdf(sha256, masterSeed, HKDF_SALT, HKDF_INFO_BYTES, BTC_SEED_LENGTH)
+}
+
+/**
+ * Derive an account node: m/84'/{coin}'/0' (segwit) or m/86'/{coin}'/0'
+ * (taproot). The returned HDKey holds the account xprv — memory-only; its
+ * xpub may be used for address derivation but MUST NOT be persisted or sent
+ * to any service (xpub confinement, contract invariant 4).
+ *
+ * @param {Uint8Array} masterSeed 32-byte spec-041 master seed
+ * @param {{network: 'bitcoin'|'bitcoin-testnet', type: 'segwit'|'taproot'}} opts
+ * @returns {HDKey} account node
+ */
+export function deriveAccount(masterSeed, { network, type } = {}) {
+  assertNetworkAndType(network, type)
+  const root = HDKey.fromMasterSeed(deriveBtcSeed(masterSeed))
+  return root.derive(`m/${PURPOSE[type]}'/${COIN_TYPE[network]}'/0'`)
+}
+
+/**
+ * Public key for external-chain receive index i (account/0/i). Safe to hold
+ * for address derivation; bare addresses (never keys) go to the gateway.
+ *
+ * @param {HDKey} account node from deriveAccount
+ * @param {number} index non-negative integer
+ * @returns {{pubkey: Uint8Array, index: number}} 33-byte compressed pubkey
+ */
+export function receivePubkey(account, index) {
+  assertIndex(index)
+  const node = account.deriveChild(0).deriveChild(index)
+  return { pubkey: node.publicKey, index }
+}
+
+/**
+ * Private key for external-chain receive index i (account/0/i) — for PSBT
+ * signing ONLY. MEMORY-ONLY invariant: the returned key must never be
+ * persisted, logged, serialized, or transmitted; callers hold it strictly for
+ * the duration of a signing operation and drop the reference (zeroize where
+ * the runtime allows) immediately after.
+ *
+ * @param {HDKey} account node from deriveAccount
+ * @param {number} index non-negative integer
+ * @returns {{privkey: Uint8Array, pubkey: Uint8Array, index: number}}
+ */
+export function receivePrivkey(account, index) {
+  assertIndex(index)
+  const node = account.deriveChild(0).deriveChild(index)
+  return { privkey: node.privateKey, pubkey: node.publicKey, index }
+}
+
+/**
+ * Convenience: the receive address at (network, type, index) straight from the
+ * master seed. Derives transiently — nothing is retained.
+ *
+ * @param {Uint8Array} masterSeed 32-byte spec-041 master seed
+ * @param {{network: 'bitcoin'|'bitcoin-testnet', type: 'segwit'|'taproot', index: number}} opts
+ * @returns {string} bech32 (bc1q…/tb1q…) or bech32m (bc1p…/tb1p…) address
+ */
+export function addressAt(masterSeed, { network, type, index } = {}) {
+  assertNetworkAndType(network, type)
+  assertIndex(index)
+  const account = deriveAccount(masterSeed, { network, type })
+  const { pubkey } = receivePubkey(account, index)
+  return encodeAddress(pubkey, { type, network })
+}

--- a/frontend/src/lib/bitcoin/gatewayClient.js
+++ b/frontend/src/lib/bitcoin/gatewayClient.js
@@ -1,0 +1,221 @@
+/**
+ * Bitcoin gateway client (spec 061, T010) — the SPA side of the relay-gateway's
+ * /v1/bitcoin/* proxy (specs/061-bitcoin-transactions/contracts/bitcoin-gateway-api.md).
+ *
+ * The gateway holds no wallet state and receives BARE ADDRESSES ONLY (never
+ * xpubs/descriptors — key-derivation contract invariant 4), ≤50 per request;
+ * this client auto-chunks larger sets and merges the pages.
+ *
+ * Error contract (tested in __tests__/gatewayClient.test.js):
+ *  - expected failure classes NEVER throw — every method resolves to a typed
+ *    result: { ok: true, … } or { ok: false, error: <slug>, … };
+ *  - `stale: true` marks failures where the portfolio must keep rendering the
+ *    last-known values, never zero (FR-010 stale-not-zero);
+ *  - `disabled: true` marks capability-off verdicts (module unset/disabled/
+ *    killswitched) — Bitcoin surfaces soft-fail exactly like the spec-054
+ *    "undeployed registry" pattern;
+ *  - stamps degrade FAIL-SAFE: a failed or degraded chunk makes the WHOLE
+ *    result degraded (unverified coins are then treated as protected, FR-019).
+ *
+ * Base URL: the relay-gateway is one host for all proxy modules — resolved
+ * from VITE_RELAYER_URL exactly like the collectibles/predict clients
+ * (lib/collectibles/gatewayClient.js). The constructor stays injectable
+ * (baseUrl + fetchImpl) for tests and non-default wiring.
+ */
+
+const MAX_ADDRESSES_PER_CALL = 50
+const FETCH_TIMEOUT_MS = 10_000
+
+/** networkId (or gateway segment) → the contract's :network path value. */
+const GATEWAY_SEGMENT = {
+  bitcoin: 'mainnet',
+  'bitcoin-testnet': 'testnet',
+  mainnet: 'mainnet',
+  testnet: 'testnet',
+}
+
+function gatewaySegment(network) {
+  const segment = GATEWAY_SEGMENT[network]
+  if (!segment) {
+    throw new Error(`bitcoin gateway: unknown network '${String(network)}' (expected 'bitcoin' or 'bitcoin-testnet')`)
+  }
+  return segment
+}
+
+function chunk(list, size) {
+  const out = []
+  for (let i = 0; i < list.length; i += size) out.push(list.slice(i, i + size))
+  return out
+}
+
+/** The configured gateway base URL, or '' when unset. Read at call time so tests can stub the env. */
+export function bitcoinGatewayUrl() {
+  return (import.meta.env.VITE_RELAYER_URL || '').trim().replace(/\/$/, '')
+}
+
+/**
+ * Build a client for the five /v1/bitcoin/* endpoints.
+ *
+ * @param {{baseUrl?: string, fetchImpl?: typeof fetch, timeoutMs?: number}} [opts]
+ *   baseUrl defaults to bitcoinGatewayUrl(); '' ⇒ every method reports the
+ *   honest capability-off result ({ ok: false, error: 'unconfigured', disabled: true }).
+ */
+export function createBitcoinGatewayClient({ baseUrl, fetchImpl, timeoutMs = FETCH_TIMEOUT_MS } = {}) {
+  const base = (baseUrl ?? bitcoinGatewayUrl()).trim().replace(/\/$/, '')
+  const doFetch = fetchImpl ?? ((...args) => fetch(...args))
+
+  async function request(path, { method = 'GET', body } = {}) {
+    if (!base) return { ok: false, error: 'unconfigured', disabled: true }
+
+    let res
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      res = await doFetch(`${base}${path}`, {
+        method,
+        signal: controller.signal,
+        ...(body !== undefined
+          ? { headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
+          : {}),
+      })
+    } catch (e) {
+      return { ok: false, error: e?.name === 'AbortError' ? 'timeout' : 'network_error', stale: true }
+    } finally {
+      clearTimeout(timer)
+    }
+
+    let payload = null
+    try {
+      payload = await res.json()
+    } catch {
+      /* non-JSON body — handled per status below */
+    }
+
+    if (res.ok) {
+      if (payload === null) return { ok: false, error: 'bad_response', stale: true }
+      return { ok: true, data: payload }
+    }
+
+    const slug = payload?.error
+    // Capability-off verdicts: module disabled or ops-killswitched (503).
+    if (slug === 'bitcoin_disabled' || slug === 'bitcoin_killed' || res.status === 503) {
+      return { ok: false, error: slug || 'bitcoin_disabled', disabled: true }
+    }
+    if (res.status === 429) return { ok: false, error: 'quota', stale: true }
+    if (slug === 'upstream_unavailable' || res.status === 502) {
+      return { ok: false, error: 'upstream_unavailable', stale: true }
+    }
+    return {
+      ok: false,
+      error: slug || `http_${res.status}`,
+      status: res.status,
+      ...(payload?.message ? { message: payload.message } : {}),
+      ...(res.status >= 500 ? { stale: true } : {}),
+    }
+  }
+
+  return {
+    baseUrl: base,
+
+    /**
+     * Batch balance + UTXO lookup (POST /addresses). Auto-chunks >50 addresses
+     * and merges pages; any failed chunk fails the whole call (with its
+     * stale/disabled semantics) — a partial balance would silently under-report.
+     * @returns {Promise<{ok: true, tipHeight: number|null, results: object[]} | {ok: false, error: string}>}
+     */
+    async lookupAddresses(network, addresses) {
+      const segment = gatewaySegment(network)
+      if (!Array.isArray(addresses)) throw new Error('lookupAddresses: addresses must be an array')
+      if (addresses.length === 0) return { ok: true, tipHeight: null, results: [] }
+
+      let tipHeight = null
+      const results = []
+      for (const batch of chunk(addresses, MAX_ADDRESSES_PER_CALL)) {
+        const r = await request(`/v1/bitcoin/${segment}/addresses`, { method: 'POST', body: { addresses: batch } })
+        if (!r.ok) return r
+        results.push(...(r.data.results ?? []))
+        if (typeof r.data.tipHeight === 'number') {
+          tipHeight = tipHeight === null ? r.data.tipHeight : Math.max(tipHeight, r.data.tipHeight)
+        }
+      }
+      return { ok: true, tipHeight, results }
+    },
+
+    /**
+     * Recommended fee rates (GET /fees), sat/vB integers clamped by the gateway.
+     * @returns {Promise<{ok: true, rates: {fast: number, normal: number, slow: number}, tipHeight: number} | {ok: false, error: string}>}
+     */
+    async getFees(network) {
+      const r = await request(`/v1/bitcoin/${gatewaySegment(network)}/fees`)
+      if (!r.ok) return r
+      return { ok: true, rates: r.data.rates, tipHeight: r.data.tipHeight }
+    },
+
+    /**
+     * Broadcast a raw signed transaction (POST /tx). Upstream rejections come
+     * back as { ok: false, error: 'broadcast_rejected', message } — surfaced to
+     * the member; the coins stay locally locked-or-released by the caller.
+     * @returns {Promise<{ok: true, txid: string} | {ok: false, error: string, message?: string}>}
+     */
+    async broadcast(network, rawTxHex) {
+      if (typeof rawTxHex !== 'string' || !/^([0-9a-fA-F]{2})+$/.test(rawTxHex)) {
+        throw new Error('broadcast: rawTxHex must be a hex string')
+      }
+      const r = await request(`/v1/bitcoin/${gatewaySegment(network)}/tx`, { method: 'POST', body: { rawTx: rawTxHex } })
+      if (!r.ok) return r
+      return { ok: true, txid: r.data.txid }
+    },
+
+    /**
+     * Confirmation status (GET /tx/:txid). An upstream 404 is NOT an error —
+     * the tx is simply not yet known: { ok: true, found: false } and the caller
+     * keeps polling with backoff (contract: "client keeps it pending").
+     * @returns {Promise<{ok: true, found: boolean, txid: string, confirmed: boolean, blockHeight?: number, confirmations: number} | {ok: false, error: string}>}
+     */
+    async getTxStatus(network, txid) {
+      const r = await request(`/v1/bitcoin/${gatewaySegment(network)}/tx/${encodeURIComponent(txid)}`)
+      if (!r.ok) {
+        if (r.error === 'tx_not_found' || r.status === 404) {
+          return { ok: true, found: false, txid, confirmed: false, confirmations: 0 }
+        }
+        return r
+      }
+      return {
+        ok: true,
+        found: true,
+        txid: r.data.txid ?? txid,
+        confirmed: Boolean(r.data.confirmed),
+        blockHeight: r.data.blockHeight,
+        confirmations: r.data.confirmations ?? 0,
+      }
+    },
+
+    /**
+     * Stamps holdings (GET /stamps). Chunks ≤50 and merges; FAIL-SAFE — the
+     * merged result is degraded when ANY chunk reports degraded OR errors
+     * (partial stamp knowledge must protect, not spend). Only capability-off
+     * verdicts (disabled/killed/unconfigured) fail the whole call.
+     * @returns {Promise<{ok: true, degraded: boolean, stamps: object[]} | {ok: false, error: string, disabled: true}>}
+     */
+    async getStamps(network, addresses) {
+      const segment = gatewaySegment(network)
+      if (!Array.isArray(addresses)) throw new Error('getStamps: addresses must be an array')
+      if (addresses.length === 0) return { ok: true, degraded: false, stamps: [] }
+
+      let degraded = false
+      const stamps = []
+      for (const batch of chunk(addresses, MAX_ADDRESSES_PER_CALL)) {
+        const query = batch.map(encodeURIComponent).join(',')
+        const r = await request(`/v1/bitcoin/${segment}/stamps?addresses=${query}`)
+        if (!r.ok) {
+          if (r.disabled) return r
+          degraded = true // fail-safe: unverified ⇒ protected (FR-019)
+          continue
+        }
+        if (r.data.degraded) degraded = true
+        stamps.push(...(r.data.stamps ?? []))
+      }
+      return { ok: true, degraded, stamps }
+    },
+  }
+}

--- a/frontend/src/lib/bitcoin/portfolioSource.js
+++ b/frontend/src/lib/bitcoin/portfolioSource.js
@@ -1,0 +1,110 @@
+/**
+ * Bitcoin balance source for usePortfolio (spec 061, task T019 — FR-008/009/010).
+ *
+ * Reads the member's ISSUED-ADDRESS CACHE (ledgerStore) — never key material —
+ * so the portfolio can show Bitcoin without a PRF ceremony. A wallet that has
+ * never issued/discovered an address contributes nothing (no row, matching
+ * the registry-driven discovery disclosure); discovery happens in
+ * useBitcoinWallet on unlock, after which the ledger is populated and the
+ * portfolio picks it up.
+ *
+ * Honest-state rules:
+ *  - lookup failure ⇒ the BTC instance is reported FAILED (skipped +
+ *    surfaced via the portfolio's existing failedAssets channel), never a
+ *    zero balance (FR-010);
+ *  - stamps recognition degraded ⇒ value still displays, but coins are
+ *    classified 'unverified' so protectedSats (and NOT spendableSats)
+ *    carries them — total ≠ spendable stays explained (FR-018/FR-019);
+ *  - pending (mempool) value is separated from confirmed (FR-009).
+ */
+
+import { getBitcoinPortfolioAsset } from '../../config/assetTaxonomy'
+import { ledgerStore, classifyUtxos } from './wallet'
+import { balanceComponents } from './coinSelection'
+
+/**
+ * @param {object} p
+ * @param {string} p.account            connected account id (EVM address)
+ * @param {string[]} p.networkIds       bitcoin network ids in scope
+ * @param {object} p.gateway            bitcoin gateway client
+ * @param {object} [p.store]            ledgerStore-compatible (injectable)
+ * @returns {Promise<{holdings: Array, failed: string[]}>}
+ *   holdings: [{ asset, confirmedSats, pendingSats, protectedSats,
+ *                spendableSats, stampsDegraded }]
+ */
+export async function loadBitcoinHoldings({ account, networkIds, gateway, store = ledgerStore() }) {
+  const holdings = []
+  const failed = []
+
+  for (const networkId of networkIds) {
+    const asset = getBitcoinPortfolioAsset(networkId)
+    if (!asset || !account) continue
+
+    const issued = store.get(account, networkId).issued
+    if (issued.length === 0) continue // never used ⇒ no row (not a zero claim)
+
+    const addresses = issued.map((a) => a.address)
+    const scriptTypeOf = new Map(
+      issued.map((a) => [a.address, a.type === 'taproot' ? 'p2tr' : 'p2wpkh'])
+    )
+
+    const [lookup, stamps] = await Promise.all([
+      gateway.lookupAddresses(networkId, addresses),
+      gateway.getStamps(networkId, addresses),
+    ])
+    if (!lookup?.ok) {
+      failed.push(asset.symbol)
+      continue
+    }
+
+    const utxos = lookup.results.flatMap((r) =>
+      (r.utxos ?? []).map((u) => ({
+        ...u,
+        address: r.address,
+        scriptType: scriptTypeOf.get(r.address) ?? 'p2wpkh',
+      }))
+    )
+    const coins = classifyUtxos(utxos, stamps)
+    const components = balanceComponents(coins)
+    // Mempool-only inbound value isn't a UTXO with confirmations yet in every
+    // upstream shape — fold the per-address signed pending too.
+    const pendingFromLookup = lookup.results.reduce((s, r) => s + (r.pendingSats ?? 0), 0)
+
+    holdings.push({
+      asset,
+      confirmedSats: components.confirmedSats,
+      pendingSats: components.pendingSats || pendingFromLookup,
+      protectedSats: components.protectedSats,
+      spendableSats: components.spendableSats,
+      stampsDegraded: !stamps?.ok || Boolean(stamps?.degraded),
+    })
+  }
+
+  return { holdings, failed }
+}
+
+/** Sats → holding shape consumed by aggregateHoldings (BTC has 8 decimals). */
+export function toBitcoinHolding(entry, priceMap) {
+  const { asset } = entry
+  const balance = entry.confirmedSats / 1e8
+  let usd = null
+  if (entry.confirmedSats === 0) {
+    usd = 0
+  } else {
+    const price = priceMap.get('BTC')
+    if (price) usd = balance * price.usd
+  }
+  return {
+    asset,
+    balance,
+    balanceRaw: BigInt(entry.confirmedSats),
+    usd,
+    network: asset.name,
+    bitcoin: {
+      pendingSats: entry.pendingSats,
+      protectedSats: entry.protectedSats,
+      spendableSats: entry.spendableSats,
+      stampsDegraded: entry.stampsDegraded,
+    },
+  }
+}

--- a/frontend/src/lib/bitcoin/psbt.js
+++ b/frontend/src/lib/bitcoin/psbt.js
@@ -1,0 +1,102 @@
+/**
+ * Bitcoin transaction build + sign (spec 061, task T023) — research.md R7.
+ *
+ * Contract:
+ *  - Inputs are always our own P2WPKH or P2TR key-path coins
+ *    (contracts/key-derivation-btc.md); outputs may be any standard type —
+ *    the destination address string drives the output script.
+ *  - RBF signaled on every input (sequence 0xfffffffd).
+ *  - FR-012 fee honesty: the ACTUAL fee (inputs − outputs) is checked against
+ *    the quote the member confirmed (`maxFeeSats`); an overrun refuses to
+ *    sign — the caller must re-quote and re-confirm. Never sign first and
+ *    apologize later.
+ *  - Key material is used in-call and never stored/logged (memory-only
+ *    invariant from the derivation contract).
+ *
+ * Pure module: no IO, no React. BigInt sats at the @scure boundary, integer
+ * sats in our own API.
+ */
+
+import * as btc from '@scure/btc-signer'
+
+const RBF_SEQUENCE = 0xfffffffd
+
+function scureNetwork(networkId) {
+  if (networkId === 'bitcoin') return btc.NETWORK
+  if (networkId === 'bitcoin-testnet') return btc.TEST_NETWORK
+  throw new Error(`psbt: unknown bitcoin network "${networkId}"`)
+}
+
+/** Script + spend info for one of our own coins. */
+function ownSpend(input, network) {
+  if (input.scriptType === 'p2wpkh') {
+    return { payment: btc.p2wpkh(input.publicKey, network), tapInternalKey: undefined }
+  }
+  if (input.scriptType === 'p2tr') {
+    // x-only internal key; BIP-341 tweak applied by p2tr()/signIdx.
+    const xonly = input.publicKey.length === 33 ? input.publicKey.slice(1) : input.publicKey
+    return { payment: btc.p2tr(xonly, undefined, network), tapInternalKey: xonly }
+  }
+  throw new Error(`psbt: unsupported input script type "${input.scriptType}"`)
+}
+
+export class FeeOverrunError extends Error {
+  constructor(feeSats, maxFeeSats) {
+    super(
+      `psbt: actual fee ${feeSats} sats exceeds the confirmed quote ${maxFeeSats} sats — re-quote and re-confirm (FR-012)`
+    )
+    this.name = 'FeeOverrunError'
+    this.feeSats = feeSats
+    this.maxFeeSats = maxFeeSats
+  }
+}
+
+/**
+ * Build and sign a transaction.
+ *
+ * @param {object} p
+ * @param {Array} p.inputs   [{ txid, vout, valueSats, scriptType: 'p2wpkh'|'p2tr',
+ *                              publicKey: Uint8Array, privateKey: Uint8Array }]
+ * @param {object} p.recipient { address, valueSats }
+ * @param {object|null} p.change { address, valueSats } — omit/null for no-change
+ * @param {string} p.networkId 'bitcoin' | 'bitcoin-testnet'
+ * @param {number} p.maxFeeSats the member-confirmed fee ceiling (FR-012)
+ * @returns {{ rawTxHex: string, txid: string, feeSats: number, vsize: number }}
+ * @throws {FeeOverrunError} when the actual fee exceeds maxFeeSats
+ */
+export function buildAndSignTx({ inputs, recipient, change = null, networkId, maxFeeSats }) {
+  if (!Array.isArray(inputs) || inputs.length === 0) throw new Error('psbt: no inputs')
+  if (!Number.isInteger(maxFeeSats) || maxFeeSats < 0) throw new Error('psbt: maxFeeSats required')
+  const network = scureNetwork(networkId)
+
+  // Fee is fully determined before signing — refuse overruns up front.
+  const inSats = inputs.reduce((s, i) => s + i.valueSats, 0)
+  const outSats = recipient.valueSats + (change ? change.valueSats : 0)
+  const feeSats = inSats - outSats
+  if (feeSats < 0) throw new Error('psbt: outputs exceed inputs')
+  if (feeSats > maxFeeSats) throw new FeeOverrunError(feeSats, maxFeeSats)
+
+  const tx = new btc.Transaction()
+  for (const input of inputs) {
+    const { payment, tapInternalKey } = ownSpend(input, network)
+    tx.addInput({
+      txid: input.txid,
+      index: input.vout,
+      witnessUtxo: { script: payment.script, amount: BigInt(input.valueSats) },
+      sequence: RBF_SEQUENCE,
+      ...(tapInternalKey ? { tapInternalKey } : {}),
+    })
+  }
+
+  // addOutputAddress validates the destination against the network and
+  // supports every standard script type (P2PKH/P2SH/bech32/bech32m).
+  tx.addOutputAddress(recipient.address, BigInt(recipient.valueSats), network)
+  if (change) tx.addOutputAddress(change.address, BigInt(change.valueSats), network)
+
+  inputs.forEach((input, idx) => {
+    tx.signIdx(input.privateKey, idx)
+  })
+  tx.finalize()
+
+  return { rawTxHex: tx.hex, txid: tx.id, feeSats: Number(tx.fee), vsize: tx.vsize }
+}

--- a/frontend/src/lib/bitcoin/send.js
+++ b/frontend/src/lib/bitcoin/send.js
@@ -1,0 +1,158 @@
+/**
+ * Bitcoin send pipeline (spec 061, task T025 — research R7, FR-011…FR-015).
+ *
+ * Two pure stages, wired by useBitcoinWallet:
+ *
+ *   prepareSend()  — validate destination, classify coins, select inputs,
+ *                    price the fee. Produces the PLAN the member confirms:
+ *                    the fee shown at confirm time IS the ceiling passed to
+ *                    signing (FR-012 — the member can never pay more).
+ *   executeSend()  — derive input keys (memory-only), build + sign, broadcast
+ *                    through the gateway, and report the outpoints to lock
+ *                    (FR-014 — no double-commitment across concurrent sends).
+ *
+ * Fee-quote freshness (60s window) is enforced here so a stale quote can
+ * never silently price a send (edge case: fee spike between quote and
+ * confirm).
+ */
+
+import { classifyAddress } from './addresses'
+import { selectCoins, maxSendable } from './coinSelection'
+import { buildAndSignTx } from './psbt'
+
+export const FEE_QUOTE_TTL_MS = 60_000
+
+export function isQuoteFresh(quote, nowMs = Date.now()) {
+  return Boolean(quote) && nowMs - quote.fetchedAt <= FEE_QUOTE_TTL_MS
+}
+
+/**
+ * Build the send plan the member confirms.
+ *
+ * @returns {{ ok:true, plan }} where plan =
+ *   { destination, destinationType, amountSats, feeSats, vsize, feeRate,
+ *     inputs, changeSats, changeAddress, networkId }
+ * or { ok:false, error, ... } with a member-explainable reason:
+ *   invalid_destination (with reason slug from classifyAddress),
+ *   stale_fee_quote, amount_below_dust, insufficient_funds.
+ */
+export function prepareSend({
+  coins,
+  destination,
+  amountSats, // integer sats, or the string 'max'
+  feeRate, // integer sat/vB (member-selected tier from the quote)
+  quote, // { rates, fetchedAt } — freshness enforced here
+  changeAddress, // next unissued address of the preferred type
+  changeType = 'p2wpkh',
+  networkId,
+  nowMs = Date.now(),
+}) {
+  const dest = classifyAddress(destination, networkId)
+  if (!dest.valid) {
+    return { ok: false, error: 'invalid_destination', reason: dest.reason, message: dest.message }
+  }
+  if (!isQuoteFresh(quote, nowMs)) {
+    return { ok: false, error: 'stale_fee_quote' }
+  }
+
+  if (amountSats === 'max') {
+    const max = maxSendable({ utxos: coins, feeRate, recipientType: dest.type })
+    if (!max.ok) return { ok: false, ...max }
+    return {
+      ok: true,
+      plan: {
+        destination,
+        destinationType: dest.type,
+        amountSats: max.amountSats,
+        feeSats: max.feeSats,
+        vsize: max.vsize,
+        feeRate,
+        inputs: max.inputs,
+        changeSats: 0,
+        changeAddress: null,
+        networkId,
+        isMax: true,
+      },
+    }
+  }
+
+  const sel = selectCoins({
+    utxos: coins,
+    targetSats: amountSats,
+    feeRate,
+    recipientType: dest.type,
+    changeType,
+  })
+  if (!sel.ok) return { ok: false, ...sel }
+  return {
+    ok: true,
+    plan: {
+      destination,
+      destinationType: dest.type,
+      amountSats,
+      feeSats: sel.feeSats,
+      vsize: sel.vsize,
+      feeRate,
+      inputs: sel.inputs,
+      changeSats: sel.changeSats,
+      changeAddress: sel.changeSats > 0 ? changeAddress : null,
+      networkId,
+      isMax: false,
+    },
+  }
+}
+
+/**
+ * Sign and broadcast a confirmed plan.
+ *
+ * @param {object} p
+ * @param {object} p.plan       from prepareSend (member-confirmed)
+ * @param {(address:string) => {publicKey:Uint8Array, privateKey:Uint8Array, scriptType:string}} p.keyFor
+ *   resolves the signing key for one of OUR addresses via the ledger
+ *   (memory-only material; never retained here)
+ * @param {object} p.gateway    bitcoin gateway client
+ * @returns {Promise<{ok:true, txid, feeSats, lockedOutpoints:string[]}
+ *   | {ok:false, error, message?}>}
+ */
+export async function executeSend({ plan, keyFor, gateway }) {
+  if (plan.changeSats > 0 && !plan.changeAddress) {
+    return { ok: false, error: 'missing_change_address' }
+  }
+
+  let signed
+  try {
+    const inputs = plan.inputs.map((coin) => {
+      const key = keyFor(coin.address)
+      if (!key) throw new Error(`no key for input address ${coin.address}`)
+      return {
+        txid: coin.txid,
+        vout: coin.vout,
+        valueSats: coin.valueSats,
+        scriptType: key.scriptType,
+        publicKey: key.publicKey,
+        privateKey: key.privateKey,
+      }
+    })
+    signed = buildAndSignTx({
+      inputs,
+      recipient: { address: plan.destination, valueSats: plan.amountSats },
+      change: plan.changeSats > 0 ? { address: plan.changeAddress, valueSats: plan.changeSats } : null,
+      networkId: plan.networkId,
+      // The confirmed plan fee is the hard ceiling (FR-012).
+      maxFeeSats: plan.feeSats,
+    })
+  } catch (err) {
+    return { ok: false, error: 'signing_failed', message: err?.message }
+  }
+
+  const res = await gateway.broadcast(plan.networkId, signed.rawTxHex)
+  if (!res.ok) {
+    return { ok: false, error: res.error || 'broadcast_failed', message: res.message }
+  }
+  return {
+    ok: true,
+    txid: res.txid ?? signed.txid,
+    feeSats: signed.feeSats,
+    lockedOutpoints: plan.inputs.map((c) => `${c.txid}:${c.vout}`),
+  }
+}

--- a/frontend/src/lib/bitcoin/wallet.js
+++ b/frontend/src/lib/bitcoin/wallet.js
@@ -1,0 +1,225 @@
+/**
+ * Bitcoin wallet state: issued-address ledger, rotation, discovery, and UTXO
+ * classification (spec 061, tasks T011/T017/T029 — research.md R5/R6).
+ *
+ * Invariants (contracts/key-derivation-btc.md + data-model.md):
+ *  - The rotation cursor per (account, network, type) NEVER decreases; a fresh
+ *    receive address is the lowest index never yet displayed.
+ *  - The persisted ledger is a cache, never the source of truth: discovery
+ *    (gap-limit-20 scan) rebuilds issued addresses and the cursor from chain
+ *    state on unlock, so recovery on a new device finds all funds (FR-003).
+ *  - Classification fails safe: a coin is 'spendable' only when confirmed AND
+ *    positively known stamp-free; degraded stamps recognition ⇒ 'unverified'
+ *    (treated exactly like 'protected' by coin selection) (FR-018/FR-019).
+ *
+ * Pure logic with injected collaborators (derive fn, gateway client, storage)
+ * — no React, no direct network IO; the useBitcoinWallet hook wires the real
+ * dependencies.
+ */
+
+export const GAP_LIMIT = 20
+const LEDGER_KEY = 'fairwins.bitcoin.ledger.v1'
+
+/** Persistent issued-address ledger, keyed per (account, network). */
+export function ledgerStore(storage = globalThis.localStorage) {
+  const read = () => {
+    try {
+      return JSON.parse(storage.getItem(LEDGER_KEY) || '{}')
+    } catch {
+      return {}
+    }
+  }
+  const keyOf = (account, networkId) => `${String(account).toLowerCase()}:${networkId}`
+  return {
+    get(account, networkId) {
+      return read()[keyOf(account, networkId)] ?? { issued: [], preferredType: 'segwit' }
+    },
+    set(account, networkId, value) {
+      const all = read()
+      all[keyOf(account, networkId)] = value
+      storage.setItem(LEDGER_KEY, JSON.stringify(all))
+    },
+  }
+}
+
+/** Rotation cursor per type: max issued index + 1, never negative. */
+export function nextIndex(issued, type) {
+  const indexes = issued.filter((a) => a.type === type).map((a) => a.index)
+  return indexes.length === 0 ? 0 : Math.max(...indexes) + 1
+}
+
+/**
+ * Create the wallet controller.
+ *
+ * @param {object} p
+ * @param {string} p.account   owning FairWins account id (EVM address string)
+ * @param {string} p.networkId 'bitcoin' | 'bitcoin-testnet'
+ * @param {(type: 'segwit'|'taproot', index: number) => string} p.deriveAddress
+ * @param {object} p.gateway   bitcoin gateway client (lookupAddresses, getStamps)
+ * @param {object} [p.store]   ledgerStore-compatible persistence (injectable)
+ * @param {() => string} [p.now] ISO timestamp source (injectable for tests)
+ */
+export function createBitcoinWallet({
+  account,
+  networkId,
+  deriveAddress,
+  gateway,
+  store = ledgerStore(),
+  now = () => new Date().toISOString(),
+}) {
+  if (!account) throw new Error('bitcoin wallet: account is required')
+
+  const load = () => store.get(account, networkId)
+  const save = (state) => store.set(account, networkId, state)
+
+  /**
+   * Issue a fresh, never-before-displayed receive address of `type`
+   * (FR-004). Appends to the ledger and advances the cursor.
+   */
+  function nextReceiveAddress(type = load().preferredType) {
+    const state = load()
+    const index = nextIndex(state.issued, type)
+    const address = deriveAddress(type, index)
+    state.issued = [
+      ...state.issued,
+      { address, type, index, network: networkId, firstShownAt: now() },
+    ]
+    save(state)
+    return { address, type, index }
+  }
+
+  /** Every address we monitor (issued or discovered) — FR-005. */
+  function issuedAddresses() {
+    return load().issued.slice()
+  }
+
+  function preferredType() {
+    return load().preferredType
+  }
+
+  function setPreferredType(type) {
+    if (type !== 'segwit' && type !== 'taproot') {
+      throw new Error(`bitcoin wallet: unknown address type "${type}"`)
+    }
+    const state = load()
+    state.preferredType = type
+    save(state)
+  }
+
+  /**
+   * Gap-limit discovery (research R5): walk each type's external chain until
+   * GAP_LIMIT consecutive addresses with no history, merging results into the
+   * ledger. The cursor only moves FORWARD: used-on-chain indexes count as
+   * issued even if the local cache never saw them (sender-paid-ahead edge
+   * case), and cached issued entries survive even when unused on chain.
+   *
+   * Returns { ok, addresses, utxos, stale } — `stale: true` (with the cached
+   * ledger) when the gateway is unreachable, so callers render stale-not-zero
+   * (FR-010).
+   */
+  async function discover(types = ['segwit', 'taproot']) {
+    const state = load()
+    const allUtxos = []
+    let anyStale = false
+
+    for (const type of types) {
+      const known = new Map(
+        state.issued.filter((a) => a.type === type).map((a) => [a.index, a])
+      )
+      let index = 0
+      let gap = 0
+      while (gap < GAP_LIMIT) {
+        // Scan one gap-window batch at a time.
+        const batch = []
+        for (let i = 0; i < GAP_LIMIT; i += 1) batch.push(index + i)
+        const addresses = batch.map((i) => ({
+          index: i,
+          address: known.get(i)?.address ?? deriveAddress(type, i),
+        }))
+        const res = await gateway.lookupAddresses(
+          networkId,
+          addresses.map((a) => a.address)
+        )
+        if (!res.ok) {
+          anyStale = true
+          break
+        }
+        for (const { index: i, address } of addresses) {
+          const entry = res.results.find((r) => r.address === address)
+          const used =
+            entry &&
+            (entry.confirmedSats > 0 ||
+              entry.pendingSats !== 0 ||
+              (entry.utxos?.length ?? 0) > 0 ||
+              entry.hasHistory === true)
+          if (used) {
+            gap = 0
+            if (!known.has(i)) {
+              const discovered = {
+                address,
+                type,
+                index: i,
+                network: networkId,
+                firstShownAt: now(),
+              }
+              known.set(i, discovered)
+              state.issued = [...state.issued, discovered]
+            }
+            for (const u of entry.utxos ?? []) {
+              allUtxos.push({ ...u, address, scriptType: type === 'taproot' ? 'p2tr' : 'p2wpkh' })
+            }
+          } else {
+            gap += 1
+            if (gap >= GAP_LIMIT) break
+          }
+        }
+        index += GAP_LIMIT
+      }
+    }
+
+    save(state)
+    return { ok: !anyStale, stale: anyStale, addresses: state.issued.slice(), utxos: allUtxos }
+  }
+
+  return {
+    nextReceiveAddress,
+    issuedAddresses,
+    preferredType,
+    setPreferredType,
+    discover,
+  }
+}
+
+/**
+ * Merge stamps recognition onto raw UTXOs → classified coins (FR-018/FR-019).
+ *
+ * @param {Array} utxos    [{ txid, vout, valueSats, address, confirmations, scriptType }]
+ * @param {object} stamps  gateway stamps result: { ok, degraded, stamps: [{ outpoint, stampId, … }] }
+ * @param {Set<string>} [lockedOutpoints] "txid:vout" locked by in-flight sends
+ */
+export function classifyUtxos(utxos, stamps, lockedOutpoints = new Set()) {
+  const stampByOutpoint = new Map()
+  if (stamps?.ok && !stamps.degraded) {
+    for (const s of stamps.stamps ?? []) {
+      stampByOutpoint.set(`${s.outpoint.txid}:${s.outpoint.vout}`, s.stampId)
+    }
+  }
+  const recognitionHealthy = Boolean(stamps?.ok) && !stamps?.degraded
+
+  return utxos.map((u) => {
+    const key = `${u.txid}:${u.vout}`
+    const lockedByTx = lockedOutpoints.has(key) ? key : null
+    let classification
+    if ((u.confirmations ?? 0) < 1) {
+      classification = 'pending'
+    } else if (!recognitionHealthy) {
+      // Fail safe: nothing is positively stamp-free while recognition is down.
+      classification = 'unverified'
+    } else if (stampByOutpoint.has(key)) {
+      classification = 'protected'
+    } else {
+      classification = 'spendable'
+    }
+    return { ...u, classification, stampId: stampByOutpoint.get(key) ?? null, lockedByTx }
+  })
+}

--- a/frontend/src/lib/portfolio/aggregate.js
+++ b/frontend/src/lib/portfolio/aggregate.js
@@ -12,10 +12,15 @@ import { getUnderlyingMeta } from '../../config/assetTaxonomy'
 import { underlyingSymbolOf } from './prices'
 
 // A native instance on its underlying's canonical mainnet is "at home" —
-// it renders without a network badge (FR-026).
+// it renders without a network badge (FR-026). Non-EVM homes (spec 061:
+// native BTC on 'bitcoin') match via the string `homeNetwork` id.
 export function isHomeInstance(asset) {
   const meta = getUnderlyingMeta(underlyingSymbolOf(asset))
-  return asset.kind === 'native' && meta.homeChainId === asset.chainId
+  return (
+    asset.kind === 'native' &&
+    (meta.homeChainId === asset.chainId ||
+      (meta.homeNetwork != null && meta.homeNetwork === asset.chainId))
+  )
 }
 
 // Member-facing form label for an instance ("Native" / "Wrapped (WETH)").

--- a/frontend/src/test/AddressQRModal.bitcoin.test.jsx
+++ b/frontend/src/test/AddressQRModal.bitcoin.test.jsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import AddressQRModal from '../components/ui/AddressQRModal'
+
+// Controllable useBitcoinWallet mock — the modal is a pure consumer.
+const mockBtc = vi.fn()
+vi.mock('../hooks/useBitcoinWallet', () => ({
+  useBitcoinWallet: () => mockBtc(),
+}))
+
+// Deterministic QR stub exposing its payload for assertions.
+vi.mock('../components/ui/AddressQRCode', () => ({
+  default: ({ value, ariaLabel }) => (
+    <div data-testid="qr-stub" data-value={value} aria-label={ariaLabel} />
+  ),
+}))
+
+const receiveBase = {
+  preferredType: 'segwit',
+  setPreferredType: vi.fn(),
+  nextReceiveAddress: vi.fn(),
+  select: vi.fn(),
+}
+
+function btcState({ receive: receiveOver, ...rest } = {}) {
+  return {
+    status: 'ready',
+    reason: null,
+    networkId: 'bitcoin',
+    receive: {
+      ...receiveBase,
+      current: { address: 'bc1qexampleaddr0', type: 'segwit', index: 0 },
+      uri: 'bitcoin:bc1qexampleaddr0',
+      ...receiveOver,
+    },
+    unlock: vi.fn(async () => ({ ok: true })),
+    ...rest,
+  }
+}
+
+const openModal = () =>
+  render(<AddressQRModal isOpen onClose={vi.fn()} address="0xEvmAddr" mode="bitcoin" />)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('AddressQRModal bitcoin mode (spec 061 US1 — FR-004/006/007)', () => {
+  it('shows the rotating address as BIP-21 QR with explicit Bitcoin labeling', () => {
+    mockBtc.mockReturnValue(btcState())
+    openModal()
+    expect(screen.getByText('Your Bitcoin address')).toBeInTheDocument()
+    expect(screen.getByText(/Bitcoin — Mainnet/)).toBeInTheDocument()
+    expect(screen.getByTestId('qr-stub').dataset.value).toBe('bitcoin:bc1qexampleaddr0')
+    expect(screen.getByText('bc1qexampleaddr0')).toBeInTheDocument()
+    // never the EVM address in bitcoin mode (FR-007)
+    expect(screen.queryByText(/0xEvmAddr/)).not.toBeInTheDocument()
+  })
+
+  it('testnet is labeled distinctly (FR-021)', () => {
+    mockBtc.mockReturnValue(btcState({ networkId: 'bitcoin-testnet' }))
+    openModal()
+    expect(screen.getByText(/Bitcoin — Testnet4/)).toBeInTheDocument()
+  })
+
+  it('"New address" issues the next rotation index', () => {
+    const state = btcState()
+    mockBtc.mockReturnValue(state)
+    openModal()
+    fireEvent.click(screen.getByRole('button', { name: 'New address' }))
+    expect(state.receive.nextReceiveAddress).toHaveBeenCalledWith('segwit')
+  })
+
+  it('type toggle persists the preference and re-selects (FR-006)', () => {
+    const state = btcState()
+    mockBtc.mockReturnValue(state)
+    openModal()
+    fireEvent.click(screen.getByRole('radio', { name: /Taproot/ }))
+    expect(state.receive.setPreferredType).toHaveBeenCalledWith('taproot')
+    expect(state.receive.select).toHaveBeenCalledWith('taproot')
+    expect(screen.getByRole('radio', { name: /Native SegWit/ })).toBeChecked()
+  })
+
+  it('ready with no address yet auto-selects the preferred type (rotation entry)', () => {
+    const state = btcState({ receive: { current: null, uri: null } })
+    mockBtc.mockReturnValue(state)
+    openModal()
+    expect(state.receive.select).toHaveBeenCalledWith('segwit')
+    expect(screen.getByText(/Preparing a fresh Bitcoin address/)).toBeInTheDocument()
+  })
+
+  it('locked state offers exactly one action — the passkey unlock', () => {
+    const state = btcState({ status: 'locked', receive: { current: null, uri: null } })
+    mockBtc.mockReturnValue(state)
+    openModal()
+    const unlockBtn = screen.getByRole('button', { name: 'Unlock with your passkey' })
+    fireEvent.click(unlockBtn)
+    expect(state.unlock).toHaveBeenCalled()
+    expect(screen.queryByRole('button', { name: 'New address' })).not.toBeInTheDocument()
+  })
+
+  it('unavailable state shows the honest reason with no dead buttons (FR-020)', () => {
+    mockBtc.mockReturnValue(
+      btcState({
+        status: 'unavailable',
+        reason: 'Bitcoin requires a FairWins passkey account.',
+        receive: { current: null, uri: null },
+      })
+    )
+    openModal()
+    expect(screen.getByText('Bitcoin requires a FairWins passkey account.')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Unlock/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'New address' })).not.toBeInTheDocument()
+    expect(screen.queryByTestId('qr-stub')).not.toBeInTheDocument()
+  })
+
+  it('EVM mode never mounts the bitcoin hook (SC-008 regression guard)', () => {
+    mockBtc.mockReturnValue(btcState())
+    render(<AddressQRModal isOpen onClose={vi.fn()} address="0xEvmAddr" />)
+    expect(mockBtc).not.toHaveBeenCalled()
+    expect(screen.getByText('Your wallet address')).toBeInTheDocument()
+    expect(screen.getByText('0xEvmAddr')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/NetworkSettings.test.jsx
+++ b/frontend/src/test/NetworkSettings.test.jsx
@@ -113,4 +113,63 @@ describe('NetworkSettings — relocated network selector', () => {
     const link = within(card).getByRole('link', { name: /Open Uniswap/ })
     expect(link).toHaveAttribute('href', expect.stringContaining('app.uniswap.org'))
   })
+
+  // Spec 061 — Bitcoin renders as a DISPLAY-ONLY row (network-registry rule 2):
+  // no wallet chain switch exists for a non-EVM network.
+  describe('Bitcoin display-only rows (spec 061, FR-020)', () => {
+    it('lists Bitcoin mainnet and its testnet pair without any switch affordance', () => {
+      render(<NetworkSettings />)
+      const mainnetCard = screen.getByText('Bitcoin').closest('.network-card')
+      const testnetCard = screen.getByText('Bitcoin Testnet4').closest('.network-card')
+      expect(mainnetCard).toBeInTheDocument()
+      expect(within(mainnetCard).getByText('Mainnet')).toBeInTheDocument()
+      expect(within(testnetCard).getByText('Testnet')).toBeInTheDocument()
+      for (const card of [mainnetCard, testnetCard]) {
+        expect(within(card).queryByRole('button', { name: /switch/i })).toBeNull()
+        expect(within(card).getByText('No wallet switch')).toBeInTheDocument()
+      }
+    })
+
+    it('states supported capabilities truthfully: portfolio, send, receive, Stamps collectibles', () => {
+      render(<NetworkSettings />)
+      const card = screen.getByText('Bitcoin').closest('.network-card')
+      for (const label of ['Portfolio', 'Send', 'Receive', 'Stamps collectibles']) {
+        expect(within(card).getByText(label).closest('.network-tag')).toHaveClass('available')
+      }
+    })
+
+    it('states unsupported capabilities truthfully: wagers, pools, membership, gasless, swap, earn, predict', () => {
+      render(<NetworkSettings />)
+      const card = screen.getByText('Bitcoin').closest('.network-card')
+      for (const label of ['P2P Wagers', 'Wager Pools', 'Memberships', 'Gasless', 'Token Swap', 'Earn', 'Predict']) {
+        expect(within(card).getByText(label).closest('.network-tag')).toHaveClass('unavailable')
+      }
+    })
+
+    it('discloses the wallet requirement and that members pay the Bitcoin network fee', () => {
+      render(<NetworkSettings />)
+      const card = screen.getByText('Bitcoin').closest('.network-card')
+      expect(within(card).getByText(/Requires a FairWins passkey on a PRF-capable device/)).toBeInTheDocument()
+      expect(within(card).getByText(/always pay the Bitcoin network fee/)).toBeInTheDocument()
+    })
+
+    it('documents the mempool.space explorer on the Bitcoin card', () => {
+      render(<NetworkSettings />)
+      const card = screen.getByText('Bitcoin').closest('.network-card')
+      const link = within(card).getByRole('link', { name: 'mempool.space' })
+      expect(link).toHaveAttribute('href', 'https://mempool.space')
+      expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+    })
+
+    it('never routes a Bitcoin row through wagmi switchChain', () => {
+      render(<NetworkSettings />)
+      // Clicking around the Bitcoin card can produce no switchChain call —
+      // there is no button — and the EVM switch buttons never carry a
+      // bitcoin id.
+      expect(switchChain).not.toHaveBeenCalled()
+      for (const btn of screen.getAllByRole('button', { name: /^Switch to / })) {
+        expect(btn.getAttribute('aria-label')).not.toMatch(/Bitcoin/)
+      }
+    })
+  })
 })

--- a/frontend/src/test/TransferForm.bitcoin.test.jsx
+++ b/frontend/src/test/TransferForm.bitcoin.test.jsx
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// Same environment mocks as TransferForm.test.jsx — the EVM stack is inert
+// here; these tests exercise ONLY the parallel Bitcoin path (spec 061 US3).
+vi.mock('../components/ui/AddressInput', () => ({
+  default: ({ id, value, onChange, onResolvedChange, placeholder, disabled, bitcoinNetworkId }) => (
+    <input
+      id={id}
+      aria-label="To"
+      data-bitcoin-network={bitcoinNetworkId || ''}
+      value={value}
+      placeholder={placeholder}
+      disabled={disabled}
+      onChange={(e) => { onChange(e); onResolvedChange(e.target.value) }}
+    />
+  ),
+}))
+vi.mock('../components/ui/BlockiesAvatar', () => ({ default: () => <span data-testid="blockie" /> }))
+
+const showNotification = vi.fn()
+const screenOne = vi.fn().mockResolvedValue('clear')
+const switchChainAsync = vi.fn().mockResolvedValue({})
+
+vi.mock('wagmi', () => ({
+  useSwitchChain: () => ({ switchChainAsync, isPending: false }),
+  useChainId: () => 137,
+  useAccount: () => ({ address: '0xAaAa000000000000000000000000000000000001', chainId: 137 }),
+}))
+vi.mock('../hooks/useWalletManagement', () => ({
+  useWallet: () => ({ address: '0xAaAa000000000000000000000000000000000001', chainId: 137 }),
+}))
+vi.mock('../hooks/useActiveAccount', () => ({
+  useActiveAccount: () => ({
+    identity: { mode: 'personal' },
+    isVault: false,
+    operateAsPersonal: vi.fn(),
+    operateAsVault: vi.fn(),
+  }),
+}))
+vi.mock('../hooks/useCustodyVaults', () => ({ useCustodyVaults: () => ({ vaults: [] }) }))
+vi.mock('../hooks/useAccountAssets', () => ({ useAccountAssets: () => ({ holdings: [], refresh: vi.fn() }) }))
+vi.mock('../hooks/usePortfolio', () => ({
+  default: () => ({
+    holdings: [],
+    status: 'ready',
+    priceMap: new Map([['BTC', { usd: 100000, source: 'chainlink', chainId: 137 }]]),
+  }),
+}))
+vi.mock('../hooks/useAddressScreening', () => ({
+  useAddressScreening: () => ({ screenOne, getStatus: () => 'clear', screen: vi.fn(), search: vi.fn() }),
+}))
+vi.mock('../hooks/useUI', () => ({ useNotification: () => ({ showNotification }) }))
+vi.mock('../hooks/useTransfer', async () => {
+  const actual = await vi.importActual('../hooks/useTransfer')
+  return {
+    ...actual,
+    useTransfer: () => ({
+      send: vi.fn(),
+      status: 'idle',
+      error: null,
+      quoteGaslessForAsset: () => true, // EVM assets gasless — BTC must still say fee
+      balanceOf: () => '5',
+      refreshBalances: vi.fn(),
+      tokens: {
+        stable: 'USDC', stableName: 'USD Coin', stableDecimals: 6, stableAddress: '0xtoken',
+        native: 'MATIC', nativeName: 'MATIC', nativeDecimals: 18,
+        chainId: 137, networkName: 'Polygon',
+      },
+      isPasskey: true,
+    }),
+  }
+})
+
+// The Bitcoin wallet hook — fully controlled per test.
+const getFeeQuote = vi.fn()
+const prepare = vi.fn()
+const confirmAndSend = vi.fn()
+let btcState
+vi.mock('../hooks/useBitcoinWallet', () => ({
+  useBitcoinWallet: () => btcState,
+}))
+
+import TransferForm from '../components/wallet/TransferForm'
+
+const PLAN = {
+  destination: 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
+  destinationType: 'p2wpkh',
+  amountSats: 50_000_000, // 0.5 BTC
+  feeSats: 1_000,
+  vsize: 110,
+  feeRate: 5,
+  inputs: [],
+  changeSats: 0,
+  changeAddress: null,
+  networkId: 'bitcoin',
+  isMax: false,
+}
+
+const freshQuote = () => ({ rates: { fast: 10, normal: 5, slow: 1 }, tipHeight: 1, fetchedAt: Date.now() })
+
+async function selectBitcoinAsset(user) {
+  await user.click(screen.getByLabelText('Asset to send'))
+  const btcOption = await screen.findByRole('option', { name: /Bitcoin/ })
+  await user.click(btcOption)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  getFeeQuote.mockResolvedValue({ ok: true, quote: freshQuote() })
+  prepare.mockReturnValue({ ok: true, plan: PLAN })
+  confirmAndSend.mockResolvedValue({ ok: true, txid: 'deadbeef', feeSats: 1_000 })
+  btcState = {
+    status: 'ready',
+    reason: null,
+    networkId: 'bitcoin',
+    balances: { confirmedSats: 60_000_000, pendingSats: 0, protectedSats: 3_000_000, spendableSats: 57_000_000 },
+    stampsDegraded: false,
+    coins: [],
+    activity: [],
+    receive: { current: null, uri: null, preferredType: 'segwit', setPreferredType: vi.fn(), nextReceiveAddress: vi.fn(), select: vi.fn() },
+    send: { feeQuote: null, getFeeQuote, prepare, confirmAndSend },
+    unlock: vi.fn(),
+    refresh: vi.fn(),
+  }
+})
+
+describe('TransferForm Bitcoin path (spec 061 US3 — FR-011/012/013/015)', () => {
+  it('offers Bitcoin with an honest fee badge (never gasless) and spendable balance', async () => {
+    const user = userEvent.setup()
+    render(<TransferForm />)
+    await selectBitcoinAsset(user)
+    expect(screen.getByLabelText('Asset to send')).toHaveTextContent('BTC')
+    expect(screen.getByText(/network fee applies/i)).toBeInTheDocument()
+    // No AFFIRMATIVE gasless claim anywhere ("never gasless" disclosure is fine)
+    expect(screen.queryByText(/⚡ Gasless/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/no network fee/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/never gasless/i)).toBeInTheDocument()
+    expect(screen.getByText(/Spendable:/)).toBeInTheDocument()
+    // protected value is explained (total ≠ spendable, FR-018)
+    expect(screen.getByText(/0\.03 BTC is protected/)).toBeInTheDocument()
+    // the destination input runs in bitcoin validation mode
+    expect(screen.getByLabelText('To').dataset.bitcoinNetwork).toBe('bitcoin')
+  })
+
+  it('hides Bitcoin entirely when the wallet is not ready (honest capability)', async () => {
+    btcState = { ...btcState, status: 'locked' }
+    const user = userEvent.setup()
+    render(<TransferForm />)
+    await user.click(screen.getByLabelText('Asset to send'))
+    expect(screen.queryByRole('option', { name: /Bitcoin/ })).not.toBeInTheDocument()
+  })
+
+  it('preview quotes fees fresh, shows fee + total debit lines, and sends on confirm', async () => {
+    const user = userEvent.setup()
+    render(<TransferForm />)
+    await selectBitcoinAsset(user)
+
+    await user.type(screen.getByLabelText('To'), PLAN.destination)
+    await user.type(screen.getByLabelText('Amount'), '0.5')
+    await user.click(screen.getByRole('button', { name: 'Preview' }))
+
+    await waitFor(() => expect(getFeeQuote).toHaveBeenCalledTimes(1))
+    expect(prepare).toHaveBeenCalledWith({
+      destination: PLAN.destination,
+      amountSats: 50_000_000,
+      feeRate: 5, // normal tier from the quote
+    })
+    // Confirm screen: amount, recognized type, fee as its own line (BTC + USD), total debit
+    expect(screen.getByText('0.5 BTC')).toBeInTheDocument()
+    expect(screen.getByText('P2WPKH')).toBeInTheDocument()
+    expect(screen.getByText(/0\.00001 BTC \(~\$1\.00\) — you pay this fee/)).toBeInTheDocument()
+    expect(screen.getByText(/Total debit/)).toBeInTheDocument()
+    expect(screen.getByText(/0\.50001 BTC/)).toBeInTheDocument()
+    expect(screen.queryByText(/⚡ Gasless/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/no network fee/i)).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Send Bitcoin' }))
+    await waitFor(() => expect(confirmAndSend).toHaveBeenCalledWith(PLAN))
+    await waitFor(() => expect(showNotification).toHaveBeenCalledWith(
+      expect.stringMatching(/pending until the Bitcoin network confirms/),
+      'info',
+    ))
+  })
+
+  it('surfaces destination rejection reasons from prepare (FR-011)', async () => {
+    prepare.mockReturnValue({
+      ok: false,
+      error: 'invalid_destination',
+      reason: 'wrong_network',
+      message: 'This is a Bitcoin Testnet4 address — you are sending on Bitcoin.',
+    })
+    const user = userEvent.setup()
+    render(<TransferForm />)
+    await selectBitcoinAsset(user)
+    await user.type(screen.getByLabelText('To'), 'tb1qsomewhere')
+    await user.type(screen.getByLabelText('Amount'), '0.1')
+    await user.click(screen.getByRole('button', { name: 'Preview' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Testnet4 address/)
+  })
+
+  it('explains shortfalls with the missing amount (FR-013)', async () => {
+    prepare.mockReturnValue({ ok: false, error: 'insufficient_funds', shortfallSats: 2_500_000, spendableSats: 57_000_000 })
+    const user = userEvent.setup()
+    render(<TransferForm />)
+    await selectBitcoinAsset(user)
+    await user.type(screen.getByLabelText('To'), PLAN.destination)
+    await user.type(screen.getByLabelText('Amount'), '0.6')
+    await user.click(screen.getByRole('button', { name: 'Preview' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent(/0\.025 BTC short, network fee included/)
+  })
+
+  it('MAX prepares an everything-minus-fee send (FR-013)', async () => {
+    prepare.mockReturnValue({ ok: true, plan: { ...PLAN, isMax: true, amountSats: 56_999_000 } })
+    const user = userEvent.setup()
+    render(<TransferForm />)
+    await selectBitcoinAsset(user)
+    await user.type(screen.getByLabelText('To'), PLAN.destination)
+    await user.click(screen.getByRole('button', { name: 'MAX' }))
+    await user.click(screen.getByRole('button', { name: 'Preview' }))
+    await waitFor(() => expect(prepare).toHaveBeenCalledWith(expect.objectContaining({ amountSats: 'max' })))
+  })
+
+  it('a stale quote at confirm forces re-preview, never a silent send (FR-012)', async () => {
+    getFeeQuote.mockResolvedValue({ ok: true, quote: { ...freshQuote(), fetchedAt: Date.now() - 120_000 } })
+    const user = userEvent.setup()
+    render(<TransferForm />)
+    await selectBitcoinAsset(user)
+    await user.type(screen.getByLabelText('To'), PLAN.destination)
+    await user.type(screen.getByLabelText('Amount'), '0.5')
+    await user.click(screen.getByRole('button', { name: 'Preview' }))
+    await screen.findByRole('button', { name: 'Send Bitcoin' })
+    await user.click(screen.getByRole('button', { name: 'Send Bitcoin' }))
+    expect(confirmAndSend).not.toHaveBeenCalled()
+    expect(await screen.findByRole('alert')).toHaveTextContent(/fee quote expired/)
+    // back on the edit step
+    expect(screen.getByRole('button', { name: 'Preview' })).toBeInTheDocument()
+  })
+
+  it('degraded stamps recognition is disclosed on the send surface (FR-019)', async () => {
+    btcState = { ...btcState, stampsDegraded: true }
+    const user = userEvent.setup()
+    render(<TransferForm />)
+    await selectBitcoinAsset(user)
+    expect(screen.getByText(/Stamps recognition is degraded/)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/bitcoinNetworkGuards.test.js
+++ b/frontend/src/test/bitcoinNetworkGuards.test.js
@@ -1,0 +1,135 @@
+/**
+ * Bitcoin network guard rails (spec 061, T034 — network-registry rule 1,
+ * FR-020/FR-022).
+ *
+ * Pins that the non-EVM string ids ('bitcoin', 'bitcoin-testnet') never leak
+ * into EVM-typed surfaces: contract resolution, the portfolio scan registry,
+ * wallet-switchable network lists, and the configs that drive wager/pool/
+ * membership asset pickers. Assertions target cheap, stable CONFIG functions
+ * rather than deep component mounts.
+ */
+import { describe, it, expect } from 'vitest'
+import { getContractAddressForChain } from '../config/contracts'
+import {
+  NETWORKS,
+  getNetwork,
+  getSelectableNetworks,
+  listSupportedChainIds,
+  isSupportedChainId,
+  getSubgraphUrl,
+} from '../config/networks'
+import { getNetworkFeatures } from '../config/networkCapabilities'
+import {
+  getPortfolioRegistry,
+  getPortfolioChainIds,
+  getBitcoinPortfolioAsset,
+} from '../config/assetTaxonomy'
+import {
+  BITCOIN_NETWORKS,
+  BITCOIN_TESTNET_MAINNET_PAIR,
+  isBitcoinNetworkId,
+} from '../config/bitcoinNetworks'
+
+const BITCOIN_IDS = Object.keys(BITCOIN_NETWORKS) // ['bitcoin', 'bitcoin-testnet']
+const CONTRACT_NAMES = [
+  'wagerRegistry',
+  'membershipManager',
+  'wagerPoolFactory',
+  'callsignRegistry',
+  'feeRouter',
+  'sanctionsGuard',
+  'membershipVoucher',
+]
+
+describe('bitcoin network guard rails (spec 061)', () => {
+  it('getContractAddressForChain resolves nothing (safely, no throw) for bitcoin ids', () => {
+    for (const id of BITCOIN_IDS) {
+      for (const name of CONTRACT_NAMES) {
+        expect(() => getContractAddressForChain(name, id)).not.toThrow()
+        expect(getContractAddressForChain(name, id)).toBeUndefined()
+      }
+    }
+  })
+
+  it('getPortfolioRegistry returns [] for bitcoin ids — the EVM scan never sees them', () => {
+    for (const id of BITCOIN_IDS) {
+      expect(getPortfolioRegistry(id)).toEqual([])
+    }
+  })
+
+  it('bitcoin ids never appear in the wallet-switchable or supported chain lists', () => {
+    const selectable = getSelectableNetworks().map((net) => net.chainId)
+    const supported = listSupportedChainIds()
+    const scanned = getPortfolioChainIds({ includeTestnets: true })
+    for (const list of [selectable, supported, scanned]) {
+      expect(list.length).toBeGreaterThan(0)
+      for (const chainId of list) {
+        expect(typeof chainId).toBe('number')
+        expect(Number.isFinite(chainId)).toBe(true)
+        expect(isBitcoinNetworkId(chainId)).toBe(false)
+      }
+    }
+    for (const id of BITCOIN_IDS) {
+      expect(isSupportedChainId(id)).toBe(false)
+      expect(Object.prototype.hasOwnProperty.call(NETWORKS, id)).toBe(false)
+    }
+  })
+
+  it('getNetwork never yields a bitcoin config — the fallback stays an EVM network', () => {
+    for (const id of BITCOIN_IDS) {
+      const net = getNetwork(id)
+      // Existing safe-fallback behavior: an unknown id resolves to the default
+      // EVM network (numeric chainId), never a non-EVM entry.
+      expect(typeof net.chainId).toBe('number')
+      expect(net.kind).not.toBe('bitcoin')
+    }
+  })
+
+  it('subgraph routing never resolves an endpoint for bitcoin ids', () => {
+    for (const id of BITCOIN_IDS) {
+      expect(getSubgraphUrl(id)).toBeNull()
+    }
+  })
+
+  it('the capability-tag resolver reports every contract feature undeployed for bitcoin ids', () => {
+    for (const id of BITCOIN_IDS) {
+      const features = getNetworkFeatures(id)
+      expect(features.length).toBeGreaterThan(0)
+      expect(features.every((f) => f.deployed === false)).toBe(true)
+    }
+  })
+
+  it('wager/pool/membership asset pickers can never offer BTC: no supported chain stakes in BTC', () => {
+    // Stakes and membership payments are driven per-chain by nativeCurrency /
+    // stablecoin config (useChainTokens); pin that no EVM chain names BTC.
+    for (const chainId of listSupportedChainIds()) {
+      const net = NETWORKS[chainId]
+      expect(net.nativeCurrency?.symbol).not.toBe('BTC')
+      expect(net.stablecoin?.symbol).not.toBe('BTC')
+      // And the native-bitcoin portfolio asset never materializes for an EVM id.
+      expect(getBitcoinPortfolioAsset(chainId)).toBeNull()
+    }
+  })
+
+  it('isBitcoinNetworkId is a strict boundary guard: string registry ids only', () => {
+    expect(isBitcoinNetworkId('bitcoin')).toBe(true)
+    expect(isBitcoinNetworkId('bitcoin-testnet')).toBe(true)
+    for (const value of [137, 1, 0, '137', 'polygon', '', null, undefined, {}, 'BITCOIN']) {
+      expect(isBitcoinNetworkId(value)).toBe(false)
+    }
+    expect(BITCOIN_TESTNET_MAINNET_PAIR).toEqual(['bitcoin-testnet', 'bitcoin'])
+  })
+
+  it('bitcoin capabilities self-disclose honestly: value transfer only (FR-020)', () => {
+    for (const id of BITCOIN_IDS) {
+      const caps = BITCOIN_NETWORKS[id].capabilities
+      expect(caps.portfolio).toBe(true)
+      expect(caps.send).toBe(true)
+      expect(caps.receive).toBe(true)
+      expect(caps.collect).toBe('stamps-only')
+      for (const off of ['wagers', 'pools', 'membership', 'gasless', 'swap', 'earn', 'predict']) {
+        expect(caps[off]).toBe(false)
+      }
+    }
+  })
+})

--- a/frontend/src/test/collectibles/BitcoinStampsSection.test.jsx
+++ b/frontend/src/test/collectibles/BitcoinStampsSection.test.jsx
@@ -1,0 +1,105 @@
+/**
+ * BitcoinStampsSection (spec 061, T031 — FR-017/FR-018/FR-019): stamp cards
+ * with image fallback + Protected badge, the protected-value explainer, the
+ * stamps-only rule (no OpenSea integration), honest degraded/hidden states,
+ * axe pass.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import BitcoinStampsSection from '../../components/collectibles/BitcoinStampsSection'
+import { useBitcoinStamps } from '../../hooks/useBitcoinStamps'
+
+vi.mock('../../hooks/useBitcoinStamps', () => ({
+  useBitcoinStamps: vi.fn(),
+}))
+
+const STAMPS = [
+  {
+    stampId: 'STAMP-001',
+    imageUrl: 'https://img.example/stamp1.png',
+    mimeType: 'image/png',
+    outpoint: { txid: 'aa'.repeat(32), vout: 0 },
+    address: 'bc1qexample0',
+  },
+  {
+    stampId: 'STAMP-002',
+    imageUrl: null,
+    mimeType: null,
+    outpoint: { txid: 'bb'.repeat(32), vout: 1 },
+    address: 'bc1qexample1',
+  },
+]
+
+const hookState = (overrides = {}) => ({
+  status: 'ready',
+  networkId: 'bitcoin',
+  stamps: STAMPS,
+  degraded: false,
+  refresh: vi.fn(),
+  ...overrides,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useBitcoinStamps.mockReturnValue(hookState())
+})
+
+describe('BitcoinStampsSection', () => {
+  it('renders each Stamp as a labeled card with a Protected badge (FR-017)', () => {
+    render(<BitcoinStampsSection />)
+    expect(screen.getByRole('heading', { name: 'Bitcoin Stamps' })).toBeInTheDocument()
+    expect(screen.getByText('STAMP-001')).toBeInTheDocument()
+    expect(screen.getByText('STAMP-002')).toBeInTheDocument()
+    expect(screen.getAllByText('Bitcoin Stamp')).toHaveLength(2)
+    expect(screen.getAllByText('Protected')).toHaveLength(2)
+  })
+
+  it('explains that protected value cannot be spent by ordinary sends (FR-018)', () => {
+    render(<BitcoinStampsSection />)
+    expect(screen.getByText(/ordinary BTC sends can\s+never spend/)).toBeInTheDocument()
+    expect(screen.getByText(/excluded from your spendable\s+balance/)).toBeInTheDocument()
+  })
+
+  it('falls back to a placeholder when the image is missing or errors', () => {
+    const { container } = render(<BitcoinStampsSection />)
+    // STAMP-002 has no imageUrl — placeholder from the start.
+    expect(container.querySelectorAll('img')).toHaveLength(1)
+    fireEvent.error(container.querySelector('img'))
+    expect(container.querySelectorAll('img')).toHaveLength(0)
+    expect(screen.getByText('STAMP-001')).toBeInTheDocument()
+  })
+
+  it("is stamps-only: no OpenSea links or marketplace actions anywhere (capability 'stamps-only')", () => {
+    render(<BitcoinStampsSection />)
+    expect(screen.queryByRole('link')).toBeNull()
+    for (const label of [/opensea/i, /buy/i, /sell/i, /^list/i, /transfer/i, /make offer/i]) {
+      expect(screen.queryByRole('button', { name: label })).toBeNull()
+      expect(screen.queryByText(label)).toBeNull()
+    }
+  })
+
+  it('renders an honest degraded state with retry when recognition is unavailable (FR-019)', () => {
+    const state = hookState({ status: 'degraded', stamps: [], degraded: true })
+    useBitcoinStamps.mockReturnValue(state)
+    render(<BitcoinStampsSection />)
+    expect(screen.getByRole('status')).toHaveTextContent(/temporarily degraded/i)
+    expect(screen.getByRole('status')).toHaveTextContent(/treated as protected/i)
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+    expect(state.refresh).toHaveBeenCalled()
+  })
+
+  it('renders nothing when hidden, empty, or still loading — never an endless spinner', () => {
+    for (const status of ['hidden', 'empty', 'loading']) {
+      useBitcoinStamps.mockReturnValue(hookState({ status, stamps: [] }))
+      const { container, unmount } = render(<BitcoinStampsSection />)
+      expect(container).toBeEmptyDOMElement()
+      unmount()
+    }
+  })
+
+  it('has no axe violations in the ready state', async () => {
+    const { container } = render(<BitcoinStampsSection />)
+    expect(await axe(container)).toHaveNoViolations()
+  })
+})

--- a/frontend/src/test/collectibles/useBitcoinStamps.test.jsx
+++ b/frontend/src/test/collectibles/useBitcoinStamps.test.jsx
@@ -1,0 +1,120 @@
+/**
+ * useBitcoinStamps (spec 061, T031) — data-source behavior: ledger-driven
+ * address set, gateway stamps fetch, hidden soft-fail (no addresses / module
+ * off), fail-safe degraded handling, testnet/mainnet scoping (FR-021).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, waitFor, act } from '@testing-library/react'
+import { useChainId } from 'wagmi'
+import { WalletContext } from '../../contexts'
+import { useBitcoinStamps } from '../../hooks/useBitcoinStamps'
+
+const ACCOUNT = '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'
+
+const makeStore = (byKey = {}) => ({
+  get: (account, networkId) =>
+    byKey[`${account.toLowerCase()}:${networkId}`] ?? { issued: [], preferredType: 'segwit' },
+})
+
+const issuedEntry = (address, networkId) => ({
+  address,
+  type: 'segwit',
+  index: 0,
+  network: networkId,
+  firstShownAt: '2026-07-20T00:00:00Z',
+})
+
+let latest
+function Probe({ gateway, store }) {
+  latest = useBitcoinStamps({ gateway, store })
+  return null
+}
+
+async function renderHook({ gateway, store, wallet } = {}) {
+  await act(async () => {
+    render(
+      <WalletContext.Provider value={wallet ?? { address: ACCOUNT, isConnected: true }}>
+        <Probe gateway={gateway} store={store} />
+      </WalletContext.Provider>,
+    )
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  useChainId.mockReturnValue(137)
+  latest = undefined
+})
+
+describe('useBitcoinStamps', () => {
+  it('fetches stamps for the ledger addresses on the active bitcoin network', async () => {
+    const getStamps = vi.fn().mockResolvedValue({
+      ok: true,
+      degraded: false,
+      stamps: [{ stampId: 'S1', outpoint: { txid: 'aa'.repeat(32), vout: 0 } }],
+    })
+    const store = makeStore({
+      [`${ACCOUNT.toLowerCase()}:bitcoin`]: {
+        issued: [issuedEntry('bc1qone', 'bitcoin'), issuedEntry('bc1qtwo', 'bitcoin')],
+        preferredType: 'segwit',
+      },
+    })
+    await renderHook({ gateway: { getStamps }, store })
+    await waitFor(() => expect(latest.status).toBe('ready'))
+
+    expect(getStamps).toHaveBeenCalledWith('bitcoin', ['bc1qone', 'bc1qtwo'])
+    expect(latest.stamps).toHaveLength(1)
+    expect(latest.networkId).toBe('bitcoin')
+  })
+
+  it('scopes to bitcoin-testnet when the app is in testnet mode (FR-021)', async () => {
+    useChainId.mockReturnValue(80002) // Polygon Amoy → testnet mode
+    const getStamps = vi.fn().mockResolvedValue({ ok: true, degraded: false, stamps: [] })
+    const store = makeStore({
+      [`${ACCOUNT.toLowerCase()}:bitcoin-testnet`]: {
+        issued: [issuedEntry('tb1qone', 'bitcoin-testnet')],
+        preferredType: 'segwit',
+      },
+    })
+    await renderHook({ gateway: { getStamps }, store })
+    await waitFor(() => expect(latest.status).toBe('empty'))
+    expect(getStamps).toHaveBeenCalledWith('bitcoin-testnet', ['tb1qone'])
+  })
+
+  it('stays hidden with NO gateway calls when the member has no bitcoin ledger', async () => {
+    const getStamps = vi.fn()
+    await renderHook({ gateway: { getStamps }, store: makeStore() })
+    expect(latest.status).toBe('hidden')
+    expect(getStamps).not.toHaveBeenCalled()
+  })
+
+  it('soft-fails to hidden on capability-off verdicts (module disabled)', async () => {
+    const getStamps = vi.fn().mockResolvedValue({ ok: false, error: 'bitcoin_disabled', disabled: true })
+    const store = makeStore({
+      [`${ACCOUNT.toLowerCase()}:bitcoin`]: {
+        issued: [issuedEntry('bc1qone', 'bitcoin')],
+        preferredType: 'segwit',
+      },
+    })
+    await renderHook({ gateway: { getStamps }, store })
+    await waitFor(() => expect(getStamps).toHaveBeenCalled())
+    await waitFor(() => expect(latest.status).toBe('hidden'))
+  })
+
+  it('reports degraded — never a confident partial list — when recognition degrades (FR-019)', async () => {
+    const getStamps = vi.fn().mockResolvedValue({
+      ok: true,
+      degraded: true,
+      stamps: [{ stampId: 'S1', outpoint: { txid: 'aa'.repeat(32), vout: 0 } }],
+    })
+    const store = makeStore({
+      [`${ACCOUNT.toLowerCase()}:bitcoin`]: {
+        issued: [issuedEntry('bc1qone', 'bitcoin')],
+        preferredType: 'segwit',
+      },
+    })
+    await renderHook({ gateway: { getStamps }, store })
+    await waitFor(() => expect(latest.status).toBe('degraded'))
+    expect(latest.degraded).toBe(true)
+  })
+})

--- a/frontend/src/test/portfolio/usePortfolio.bitcoin.test.jsx
+++ b/frontend/src/test/portfolio/usePortfolio.bitcoin.test.jsx
@@ -1,0 +1,286 @@
+/**
+ * usePortfolio — bitcoin balance source branch (spec 061, T019/T020).
+ *
+ * Mirrors usePortfolio.test.jsx: wallet at the context level, per-chain read
+ * providers + ethers Contract + price ladder stubbed with fixture maps. The
+ * bitcoin gateway client is stubbed at the module boundary; the real
+ * portfolioSource/ledgerStore/classification code runs against a seeded
+ * localStorage ledger.
+ *
+ * Covers: native+WBTC roll-up into ONE Bitcoin aggregate, BTC feed pricing,
+ * gateway failure ⇒ failedAssets ['BTC'] and NO zero row (FR-010),
+ * unused wallet ⇒ no bitcoin row and no gateway calls (SC-008),
+ * EVM-only regression, pending/protected passthrough (FR-009/FR-018).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, waitFor, act } from '@testing-library/react'
+import { WalletContext } from '../../contexts'
+import usePortfolio from '../../hooks/usePortfolio'
+import { getPortfolioRegistry } from '../../config/assetTaxonomy'
+
+const fixtures = vi.hoisted(() => ({
+  nativeBalances: new Map(), // chainId -> bigint | fn
+  tokenBalances: new Map(), // `${chainId}:${addressLower}` -> bigint | fn
+  prefs: { showTestnetAssets: false, showZeroBalances: false },
+  prices: new Map(), // underlying -> {usd, source, chainId}
+  gatewayUrl: 'https://gw.test',
+  lookupResult: { ok: true, tipHeight: 100, results: [] },
+  stampsResult: { ok: true, degraded: false, stamps: [] },
+  gatewayCalls: [], // ['lookupAddresses'|'getStamps', networkId, addresses]
+}));
+
+function resolveFixture(value) {
+  if (typeof value === 'function') return value()
+  return Promise.resolve(value ?? 0n)
+}
+
+vi.mock('../../utils/rpcProvider', () => ({
+  makeReadProvider: (url, chainId) => ({
+    chainId,
+    getBalance: () => resolveFixture(fixtures.nativeBalances.get(chainId)),
+  }),
+}))
+
+vi.mock('ethers', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    Contract: class {
+      constructor(address, abi, provider) {
+        this.key = `${provider.chainId}:${String(address).toLowerCase()}`
+      }
+
+      balanceOf() {
+        return resolveFixture(fixtures.tokenBalances.get(this.key))
+      }
+    },
+  }
+})
+
+vi.mock('../../lib/portfolio/prices', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    fetchPortfolioPrices: () => Promise.resolve(new Map(fixtures.prices)),
+  }
+})
+
+vi.mock('../../hooks/useUserPreferences', () => ({
+  useUserPreferences: () => ({
+    preferences: { ...fixtures.prefs },
+    setShowTestnetAssets: vi.fn(),
+    setShowZeroBalances: vi.fn(),
+  }),
+}))
+
+vi.mock('../../lib/bitcoin/gatewayClient', () => ({
+  bitcoinGatewayUrl: () => fixtures.gatewayUrl,
+  createBitcoinGatewayClient: () => ({
+    lookupAddresses: async (networkId, addresses) => {
+      fixtures.gatewayCalls.push(['lookupAddresses', networkId, addresses])
+      const res = fixtures.lookupResult
+      return typeof res === 'function' ? res() : res
+    },
+    getStamps: async (networkId, addresses) => {
+      fixtures.gatewayCalls.push(['getStamps', networkId, addresses])
+      const res = fixtures.stampsResult
+      return typeof res === 'function' ? res() : res
+    },
+  }),
+}))
+
+const ADDRESS = '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed'
+const BTC_ADDR = 'bc1qexampleaddressxxxxxxxxxxxxxxxxxxxxx0'
+const LEDGER_KEY = 'fairwins.bitcoin.ledger.v1'
+
+function seedLedger(addresses = [BTC_ADDR], networkId = 'bitcoin') {
+  const issued = addresses.map((address, index) => ({
+    address,
+    type: 'segwit',
+    index,
+    network: networkId,
+    firstShownAt: '2026-07-20T00:00:00Z',
+  }))
+  localStorage.setItem(
+    LEDGER_KEY,
+    JSON.stringify({ [`${ADDRESS.toLowerCase()}:${networkId}`]: { issued, preferredType: 'segwit' } }),
+  )
+}
+
+const utxo = (valueSats, { txid = 'aa'.repeat(32), vout = 0, confirmations = 6 } = {}) => ({
+  txid,
+  vout,
+  valueSats,
+  confirmations,
+})
+
+const addr = (chainId, symbol) =>
+  `${chainId}:${getPortfolioRegistry(chainId).find((e) => e.symbol === symbol).address.toLowerCase()}`
+
+let latest
+function Probe() {
+  latest = usePortfolio()
+  return null
+}
+
+async function renderPortfolio() {
+  await act(async () => {
+    render(
+      <WalletContext.Provider value={{ address: ADDRESS, isConnected: true, chainId: 137 }}>
+        <Probe />
+      </WalletContext.Provider>,
+    )
+  })
+  await waitFor(() => expect(latest.status).toBe('ready'))
+}
+
+const aggFor = (underlying) => latest.aggregates.find((a) => a.underlying === underlying)
+
+beforeEach(() => {
+  localStorage.clear()
+  fixtures.nativeBalances.clear()
+  fixtures.tokenBalances.clear()
+  fixtures.prices.clear()
+  fixtures.prefs.showTestnetAssets = false
+  fixtures.prefs.showZeroBalances = false
+  fixtures.gatewayUrl = 'https://gw.test'
+  fixtures.lookupResult = { ok: true, tipHeight: 100, results: [] }
+  fixtures.stampsResult = { ok: true, degraded: false, stamps: [] }
+  fixtures.gatewayCalls = []
+  latest = undefined
+})
+
+describe('usePortfolio — bitcoin branch (spec 061)', () => {
+  it('rolls native BTC and WBTC into ONE Bitcoin aggregate priced by the BTC feed (FR-008)', async () => {
+    seedLedger()
+    fixtures.lookupResult = {
+      ok: true,
+      tipHeight: 100,
+      results: [{ address: BTC_ADDR, utxos: [utxo(50_000_000)] }], // 0.5 BTC
+    }
+    fixtures.tokenBalances.set(addr(137, 'WBTC'), 25_000_000n) // 0.25 WBTC (8 decimals)
+    fixtures.prices.set('BTC', { usd: 60_000, source: 'chainlink', chainId: 137 })
+    await renderPortfolio()
+
+    const btc = aggFor('BTC')
+    expect(btc).toBeTruthy()
+    expect(latest.aggregates.filter((a) => a.underlying === 'BTC')).toHaveLength(1)
+    // Native bitcoin + the WBTC registry instances (zero-balance ones stay
+    // listed for the sheet, existing behavior).
+    expect(btc.instances.filter((h) => h.balance > 0)).toHaveLength(2)
+    expect(btc.balance).toBeCloseTo(0.75)
+    expect(btc.usd).toBeCloseTo(45_000)
+    // Native bitcoin instance first (home instance), labeled with its network.
+    expect(btc.instances[0].asset.kind).toBe('native')
+    expect(btc.instances[0].asset.chainId).toBe('bitcoin')
+    expect(btc.instances[0].network).toBe('Bitcoin')
+    expect(btc.instances[0].usd).toBeCloseTo(30_000)
+  })
+
+  it('shows a native-only Bitcoin aggregate when no WBTC is held', async () => {
+    seedLedger()
+    fixtures.lookupResult = {
+      ok: true,
+      tipHeight: 100,
+      results: [{ address: BTC_ADDR, utxos: [utxo(10_000_000)] }], // 0.1 BTC
+    }
+    fixtures.prices.set('BTC', { usd: 60_000, source: 'chainlink', chainId: 1 })
+    await renderPortfolio()
+
+    const btc = aggFor('BTC')
+    const nonzero = btc.instances.filter((h) => h.balance > 0)
+    expect(nonzero).toHaveLength(1)
+    expect(nonzero[0].asset.chainId).toBe('bitcoin')
+    expect(btc.balance).toBeCloseTo(0.1)
+    expect(btc.usd).toBeCloseTo(6_000)
+  })
+
+  it('reports BTC in failedAssets — and renders NO zero row — when the gateway fails (FR-010)', async () => {
+    seedLedger()
+    fixtures.lookupResult = { ok: false, error: 'upstream_unavailable', stale: true }
+    fixtures.nativeBalances.set(137, 2n * 10n ** 18n)
+    fixtures.prices.set('BTC', { usd: 60_000, source: 'chainlink', chainId: 137 })
+    fixtures.prefs.showZeroBalances = true // a zero BTC row would be visible if one existed
+    await renderPortfolio()
+
+    expect(latest.failedAssets).toContain('BTC')
+    // No fabricated zero-balance native instance: the only BTC aggregate
+    // instances (if any) come from EVM WBTC entries.
+    const btc = aggFor('BTC')
+    if (btc) {
+      expect(btc.instances.every((h) => h.asset.chainId !== 'bitcoin')).toBe(true)
+    }
+    // EVM portfolio unaffected.
+    expect(aggFor('MATIC').balance).toBeCloseTo(2)
+  })
+
+  it('makes NO gateway calls and adds no bitcoin row for a wallet with no issued addresses (SC-008)', async () => {
+    fixtures.nativeBalances.set(137, 10n ** 18n)
+    fixtures.prices.set('MATIC', { usd: 0.5, source: 'chainlink', chainId: 137 })
+    await renderPortfolio()
+
+    expect(fixtures.gatewayCalls).toHaveLength(0)
+    expect(latest.holdings.every((h) => h.asset.chainId !== 'bitcoin')).toBe(true)
+    expect(latest.failedAssets).toEqual([])
+    expect(aggFor('BTC')).toBeUndefined()
+    expect(aggFor('MATIC').usd).toBeCloseTo(0.5)
+    expect(latest.totalUsd).toBeCloseTo(0.5)
+  })
+
+  it('EVM-only regression: existing behavior unchanged when bitcoin is unused', async () => {
+    fixtures.nativeBalances.set(137, 2n * 10n ** 18n)
+    fixtures.tokenBalances.set(addr(137, 'USDC'), 100_000_000n)
+    fixtures.prices.set('MATIC', { usd: 0.5, source: 'chainlink', chainId: 137 })
+    await renderPortfolio()
+
+    expect(aggFor('MATIC').usd).toBeCloseTo(1)
+    expect(aggFor('USDC').usd).toBeCloseTo(100)
+    expect(latest.totalUsd).toBeCloseTo(101)
+    expect(latest.aggregates.every((a) => a.balance > 0)).toBe(true)
+    expect(latest.failedAssets).toEqual([])
+    expect(latest.error).toBeNull()
+  })
+
+  it('passes pending/protected sats through on holding.bitcoin (FR-009/FR-018)', async () => {
+    seedLedger()
+    const stampTxid = 'bb'.repeat(32)
+    fixtures.lookupResult = {
+      ok: true,
+      tipHeight: 100,
+      results: [
+        {
+          address: BTC_ADDR,
+          pendingSats: 0,
+          utxos: [
+            utxo(50_000_000, { txid: 'aa'.repeat(32) }), // spendable
+            utxo(30_000, { txid: stampTxid }), // stamp-bearing → protected
+            utxo(100_000, { txid: 'cc'.repeat(32), confirmations: 0 }), // pending
+          ],
+        },
+      ],
+    }
+    fixtures.stampsResult = {
+      ok: true,
+      degraded: false,
+      stamps: [{ stampId: 'A1', outpoint: { txid: stampTxid, vout: 0 }, address: BTC_ADDR }],
+    }
+    fixtures.prices.set('BTC', { usd: 60_000, source: 'chainlink', chainId: 137 })
+    await renderPortfolio()
+
+    const native = aggFor('BTC').instances.find((h) => h.asset.chainId === 'bitcoin')
+    expect(native.bitcoin).toEqual({
+      pendingSats: 100_000,
+      protectedSats: 30_000,
+      spendableSats: 50_000_000,
+      stampsDegraded: false,
+    })
+    // Confirmed balance excludes the pending coin.
+    expect(native.balance).toBeCloseTo(0.5003)
+  })
+
+  it('scans bitcoin-testnet only when the testnet preference is on (FR-021)', async () => {
+    seedLedger([BTC_ADDR], 'bitcoin')
+    await renderPortfolio()
+    expect(fixtures.gatewayCalls.every(([, networkId]) => networkId === 'bitcoin')).toBe(true)
+  })
+})

--- a/services/relay-gateway/.env.example
+++ b/services/relay-gateway/.env.example
@@ -104,6 +104,26 @@ KILL_SWITCH=false
 #POLYMARKET_BUILDER_TAKER_FEE_BPS=50       # 0.50% on taker orders (default; FALLBACK since spec 060 — the FeeRouter is the live source)
 #POLYMARKET_BUILDER_MAKER_FEE_BPS=0        # makers kept whole (default; fallback since spec 060)
 
+# --- Bitcoin proxy (spec 061) ------------------------------------------------------------------
+# DISABLED by default => /v1/bitcoin/* fails closed (503 bitcoin_disabled) and the SPA soft-fails
+# the Bitcoin capability; nothing else is affected. When enabled, malformed URLs or a nonsensical
+# fee clamp fail the boot loudly. The gateway holds NO Bitcoin keys — pure data reads plus a
+# raw-tx broadcast relay of client-signed transactions.
+#BTC_ENABLED=false
+#BTC_ESPLORA_URL=https://mempool.space/api                    # Esplora-compatible mainnet upstream
+#BTC_ESPLORA_TESTNET_URL=https://mempool.space/testnet4/api   # Esplora-compatible testnet4 upstream
+# Stamps indexer (stampchain.io-compatible). UNSET => stamps route answers degraded:true and the
+# client fail-safes by treating unverified coins as protected (never spends a possible Stamp).
+#BTC_STAMPS_URL=https://stampchain.io
+#BTC_MAX_FEE_RATE=500                      # sat/vB clamp on fee responses (>= 1 when enabled)
+#BTC_TIMEOUT_MS=5000
+#BTC_RETRIES=1                             # read retries on 5xx/transport (broadcast never retries)
+#BTC_QUOTA_PER_IP=60                       # reads/min per caller IP (polymarket parity)
+#BTC_QUOTA_GLOBAL=300                      # reads/min backstop across all callers
+#BTC_WRITE_QUOTA_PER_IP=20                 # broadcasts/min per caller IP (stricter than reads)
+#BTC_WRITE_QUOTA_GLOBAL=100                # broadcasts/min backstop
+#BTC_KILLSWITCH=false                      # ops kill: all /v1/bitcoin/* routes 503 bitcoin_killed
+
 # FeeRouter (spec 060): on-chain source of truth for the Polymarket builder bps. Defaults to the
 # deployment record's feeRouter for FEE_ROUTER_CHAIN_ID; an override contradicting the record
 # fails boot. Unset + not in the record => env-fallback mode (the two bps values above).

--- a/services/relay-gateway/src/bitcoin/cache.js
+++ b/services/relay-gateway/src/bitcoin/cache.js
@@ -1,0 +1,37 @@
+/**
+ * Per-endpoint-class TTLs for the /v1/bitcoin/* proxy (spec 061), plus the degraded-stamps
+ * re-fetch helper. The cache STORE itself is the shared generic TTL cache (single-flight +
+ * serve-stale + bounded entries) from src/opensea/cache.js — the same util the Polymarket
+ * proxy reuses; keys are prefixed per endpoint class and the TTL is chosen per call.
+ *
+ * Contract TTLs (bitcoin-gateway-api.md): fees 30s; balances/UTXOs 15s; tx status 15s;
+ * stamps 300s — but a DEGRADED stamps result is honored for at most 30s so recovery is fast
+ * (a healthy indexer un-degrades within half a minute instead of five).
+ */
+export { createTtlCache } from '../opensea/cache.js'
+
+export const FEES_TTL_MS = 30_000
+export const ADDRESSES_TTL_MS = 15_000
+export const TX_STATUS_TTL_MS = 15_000
+export const STAMPS_TTL_MS = 300_000
+export const STAMPS_DEGRADED_TTL_MS = 30_000
+
+/**
+ * fetchThrough with a value-dependent TTL: a healthy stamps result lives the full 300s, a
+ * degraded one at most 30s. First pass reads at the long TTL (cheap cache hit for healthy
+ * results); when the cached value turns out degraded AND older than the short TTL, a second
+ * pass at the short TTL forces the loader. Stamps loaders never throw (they return
+ * `{degraded: true}` instead), so the cache's serve-stale path is not in play here.
+ *
+ * @param {{fetchThrough: Function}} cache
+ * @param {string} key
+ * @param {() => number} now unix milliseconds
+ * @param {() => Promise<{degraded: boolean, stamps: Array}>} loader
+ */
+export async function fetchStampsThrough(cache, key, now, loader) {
+  let result = await cache.fetchThrough(key, STAMPS_TTL_MS, loader)
+  if (result.value?.degraded && now() - result.fetchedAt >= STAMPS_DEGRADED_TTL_MS) {
+    result = await cache.fetchThrough(key, STAMPS_DEGRADED_TTL_MS, loader)
+  }
+  return result
+}

--- a/services/relay-gateway/src/bitcoin/client.js
+++ b/services/relay-gateway/src/bitcoin/client.js
@@ -1,0 +1,175 @@
+/**
+ * Bitcoin upstream clients for the /v1/bitcoin/* proxy (spec 061).
+ *
+ * Two fetchers, mirroring src/polymarket/client.js (bounded timeout, injectable fetchImpl,
+ * retries on 5xx/transport for reads, NO retry for the broadcast write):
+ *
+ * - createEsploraClient: an Esplora-compatible REST upstream (mempool.space, blockstream.info,
+ *   self-hosted electrs — all speak the same dialect; research R4). One instance per network
+ *   (mainnet/testnet4), base URLs from config. Fee recommendations prefer the mempool.space
+ *   `/fees/recommended` shape and fall back to Esplora's `/fee-estimates` when the first 404s.
+ * - createStampsClient: a stampchain.io-compatible Bitcoin Stamps indexer (research R6). The
+ *   exact upstream path is isolated in ONE function so an indexer swap is a one-line change.
+ *
+ * The gateway holds no Bitcoin keys of any kind — these are pure data reads plus a raw-tx
+ * broadcast relay of a transaction the member signed client-side.
+ */
+
+/** Upstream unreachable / persistent 5xx / upstream 429 — routes answer 502 upstream_unavailable. */
+export class BitcoinUnavailableError extends Error {
+  constructor(message, cause) {
+    super(message)
+    this.name = 'BitcoinUnavailableError'
+    this.cause = cause
+  }
+}
+
+/** Definitive upstream 4xx (unknown tx, rejected broadcast) — not retried, not maskable by cache. */
+export class BitcoinRequestError extends Error {
+  constructor(status, message) {
+    super(message)
+    this.name = 'BitcoinRequestError'
+    this.status = status
+  }
+}
+
+/**
+ * Shared HTTP core: text-first (Esplora answers plain text for tip height and broadcast,
+ * JSON everywhere else), bounded timeout, retries only when `retryable`.
+ */
+function createRequester({ baseUrl, timeoutMs, retries, fetchImpl, label }) {
+  const base = baseUrl.replace(/\/+$/, '')
+
+  async function text(path, { method = 'GET', body, contentType, retryable = method === 'GET' } = {}) {
+    const attempts = retryable ? retries + 1 : 1
+    let lastErr
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), timeoutMs)
+      try {
+        const res = await fetchImpl(`${base}${path}`, {
+          method,
+          headers: { accept: 'application/json', ...(contentType ? { 'content-type': contentType } : {}) },
+          ...(body != null ? { body } : {}),
+          signal: controller.signal,
+        })
+        // Upstream 429 is the public API shedding OUR load — backing off (serve-stale at the
+        // route layer) is correct; retrying inline would worsen the throttle.
+        if (res.status >= 500 || res.status === 429) {
+          lastErr = new BitcoinUnavailableError(`${label} returned ${res.status}`)
+          continue
+        }
+        if (!res.ok) {
+          const detail = await res.text().catch(() => '')
+          throw new BitcoinRequestError(res.status, `${label} rejected request (${res.status}): ${detail.slice(0, 200)}`)
+        }
+        return await res.text()
+      } catch (e) {
+        if (e instanceof BitcoinRequestError) throw e
+        lastErr = e
+      } finally {
+        clearTimeout(timer)
+      }
+    }
+    throw lastErr instanceof BitcoinUnavailableError
+      ? lastErr
+      : new BitcoinUnavailableError(`${label} unreachable after ${attempts} attempt(s)`, lastErr)
+  }
+
+  async function json(path, opts) {
+    const raw = await text(path, opts)
+    try {
+      return JSON.parse(raw)
+    } catch {
+      throw new BitcoinUnavailableError(`${label} returned non-JSON for ${path}`)
+    }
+  }
+
+  return { text, json }
+}
+
+/**
+ * Esplora-compatible client for one network.
+ * @param {{baseUrl: string, timeoutMs?: number, retries?: number, fetchImpl?: typeof fetch}} opts
+ */
+export function createEsploraClient({ baseUrl, timeoutMs = 5000, retries = 1, fetchImpl = fetch }) {
+  const http = createRequester({ baseUrl, timeoutMs, retries, fetchImpl, label: 'esplora' })
+
+  return {
+    /** GET /address/:addr — chain_stats/mempool_stats funded/spent sums (balances). */
+    async getAddress(address) {
+      return http.json(`/address/${encodeURIComponent(address)}`)
+    },
+
+    /** GET /address/:addr/utxo — unspent outputs with per-UTXO confirmation status. */
+    async getAddressUtxos(address) {
+      return http.json(`/address/${encodeURIComponent(address)}/utxo`)
+    },
+
+    /**
+     * Recommended fee rates. Prefers the mempool.space shape (GET /fees/recommended ->
+     * {fastestFee, halfHourFee, hourFee, ...}); a 404 (blockstream.info / plain electrs)
+     * falls back to Esplora's GET /fee-estimates ({"<target>": satPerVb, ...}).
+     * normalizeFeeRates() detects whichever shape comes back.
+     */
+    async getFees() {
+      try {
+        return await http.json('/fees/recommended')
+      } catch (e) {
+        if (e instanceof BitcoinRequestError && e.status === 404) {
+          return http.json('/fee-estimates')
+        }
+        throw e
+      }
+    },
+
+    /**
+     * POST /tx — broadcast a raw signed transaction (hex string as a text/plain body).
+     * Success returns the txid (plain text). NOT retried: re-posting after an ambiguous
+     * failure gives no benefit (same-tx rebroadcast is a no-op upstream, but we keep the
+     * platform's writes-never-retry idiom). A definitive rejection surfaces the upstream
+     * reason via BitcoinRequestError for the broadcast_rejected mapping.
+     */
+    async broadcastTx(rawTxHex) {
+      const txid = await http.text('/tx', { method: 'POST', body: rawTxHex, contentType: 'text/plain', retryable: false })
+      return txid.trim()
+    },
+
+    /** GET /tx/:txid/status — {confirmed, block_height, ...}; upstream 404 while unknown. */
+    async getTxStatus(txid) {
+      return http.json(`/tx/${encodeURIComponent(txid)}/status`)
+    },
+
+    /** GET /blocks/tip/height — current chain tip (plain-text integer). */
+    async getTipHeight() {
+      const raw = await http.text('/blocks/tip/height')
+      const height = Number.parseInt(raw, 10)
+      if (!Number.isInteger(height) || height < 0) {
+        throw new BitcoinUnavailableError(`esplora returned a non-numeric tip height: ${String(raw).slice(0, 40)}`)
+      }
+      return height
+    },
+  }
+}
+
+/**
+ * Stamps indexer client (stampchain.io-compatible). Optional infrastructure: when unconfigured
+ * or failing, the stamps route answers `degraded: true` and the CLIENT fail-safes by treating
+ * unverified coins as protected (research R6 / FR-019) — never the other way around.
+ * @param {{baseUrl: string, timeoutMs?: number, retries?: number, fetchImpl?: typeof fetch}} opts
+ */
+export function createStampsClient({ baseUrl, timeoutMs = 5000, retries = 1, fetchImpl = fetch }) {
+  const http = createRequester({ baseUrl, timeoutMs, retries, fetchImpl, label: 'stamps indexer' })
+
+  return {
+    /**
+     * Stamps balance for one address. The EXACT stampchain.io API v2 path is isolated here —
+     * swapping to another compatible indexer means changing only this line (plus BTC_STAMPS_URL).
+     * The response shape is treated as untrusted: normalizeStampsBalance() parses defensively
+     * and an unrecognizable body degrades the whole result (fail-safe), never throws to clients.
+     */
+    async getStampsBalance(address) {
+      return http.json(`/api/v2/stamps/balance/${encodeURIComponent(address)}`)
+    },
+  }
+}

--- a/services/relay-gateway/src/bitcoin/normalize.js
+++ b/services/relay-gateway/src/bitcoin/normalize.js
@@ -1,0 +1,180 @@
+/**
+ * Bitcoin upstream -> gateway DTO normalization for the /v1/bitcoin/* proxy (spec 061).
+ *
+ * The gateway never passes upstream response shapes through to clients: every field the SPA
+ * consumes is mapped here, so Esplora/indexer schema drift breaks THIS module's tests, not the
+ * frontend. All amounts are integer satoshis (never floats, never BTC decimals).
+ *
+ * Contract: specs/061-bitcoin-transactions/contracts/bitcoin-gateway-api.md.
+ */
+
+// bech32 data charset (BIP-173): excludes 1, b, i, o. Lowercase only — the client normalizes
+// user input to lowercase before calling; mixed/upper-case is rejected here as a sanity check.
+const BECH32_DATA_RE = /^[qpzry9x8gf2tvdw0s3jn54khce6mua7l]+$/
+const BASE58_RE = /^[1-9A-HJ-NP-Za-km-z]+$/
+const TXID_RE = /^[0-9a-fA-F]{64}$/
+const RAWTX_HEX_RE = /^(?:[0-9a-fA-F]{2})+$/
+
+export const MAX_ADDRESSES_PER_REQUEST = 50
+// Contract cap: raw tx <= 100 kB of transaction bytes = 200k hex characters.
+export const MAX_RAWTX_HEX_CHARS = 200_000
+
+/**
+ * Syntactic address validation per network: prefix + charset + length sanity ONLY.
+ * Full bech32/bech32m checksum validation lives CLIENT-side (@scure/btc-signer codecs,
+ * research R7/FR-011) — the gateway just refuses obviously-wrong input (EVM 0x addresses,
+ * wrong-network prefixes, junk) before spending quota or upstream calls.
+ *
+ * mainnet:  bech32/bech32m `bc1…`; base58 `1…` (P2PKH) / `3…` (P2SH)
+ * testnet:  bech32/bech32m `tb1…` (testnet4); base58 `m…`/`n…` (P2PKH) / `2…` (P2SH)
+ */
+export function isValidBitcoinAddress(address, network) {
+  if (typeof address !== 'string') return false
+  const bech32Hrp = network === 'mainnet' ? 'bc1' : 'tb1'
+  if (address.startsWith(bech32Hrp)) {
+    const data = address.slice(bech32Hrp.length)
+    // P2WPKH is 42 chars total, P2TR 62; BIP-173 caps the whole string at 90.
+    return address.length >= 14 && address.length <= 90 && BECH32_DATA_RE.test(data)
+  }
+  const base58Lead = network === 'mainnet' ? /^[13]/ : /^[mn2]/
+  if (base58Lead.test(address)) {
+    return address.length >= 26 && address.length <= 35 && BASE58_RE.test(address)
+  }
+  return false
+}
+
+export const isTxid = (v) => typeof v === 'string' && TXID_RE.test(v)
+
+/** Validated raw-tx hex within the contract's 100 kB cap. */
+export const isRawTxHex = (v) =>
+  typeof v === 'string' && v.length >= 2 && v.length <= MAX_RAWTX_HEX_CHARS && RAWTX_HEX_RE.test(v)
+
+const intOr = (v, fallback = 0) => (Number.isInteger(v) ? v : Number.isInteger(Number(v)) ? Number(v) : fallback)
+
+/** Confirmations from the tip: the tip block itself counts as 1 (standard convention). */
+const confirmationsFrom = (tipHeight, blockHeight) =>
+  blockHeight == null ? 0 : Math.max(0, tipHeight - blockHeight + 1)
+
+/**
+ * Esplora GET /address/:addr + /address/:addr/utxo -> one batch-result entry.
+ * confirmedSats = confirmed funded - confirmed spent; pendingSats is the SIGNED mempool net
+ * (an unconfirmed spend of a confirmed coin makes it negative). Malformed UTXO records are
+ * dropped rather than 500ing the whole batch.
+ */
+export function normalizeAddressResult(address, info, utxosRaw, tipHeight) {
+  const chain = info?.chain_stats ?? {}
+  const mempool = info?.mempool_stats ?? {}
+  const confirmedSats = intOr(chain.funded_txo_sum) - intOr(chain.spent_txo_sum)
+  const pendingSats = intOr(mempool.funded_txo_sum) - intOr(mempool.spent_txo_sum)
+  const utxos = (Array.isArray(utxosRaw) ? utxosRaw : [])
+    .map((u) => {
+      if (!u || !isTxid(u.txid) || !Number.isInteger(u.vout)) return null
+      const confirmed = Boolean(u.status?.confirmed)
+      const blockHeight = confirmed && Number.isInteger(u.status?.block_height) ? u.status.block_height : null
+      return {
+        txid: u.txid,
+        vout: u.vout,
+        valueSats: intOr(u.value),
+        confirmations: confirmationsFrom(tipHeight, blockHeight),
+        blockHeight,
+      }
+    })
+    .filter(Boolean)
+  return { address, confirmedSats, pendingSats, utxos }
+}
+
+/**
+ * Fee recommendations -> {fast, normal, slow} integer sat/vB, clamped to [1, maxFeeRate].
+ * Accepts BOTH upstream dialects (client.getFees() may return either):
+ * - mempool.space GET /fees/recommended: {fastestFee, halfHourFee, hourFee, ...}
+ * - Esplora GET /fee-estimates: {"1": satPerVb, "3": ..., "6": ..., "144": ...} by conf target
+ * Returns null when neither shape yields a usable fast rate (route answers upstream_unavailable
+ * — the client must never see an invented fee).
+ */
+export function normalizeFeeRates(body, maxFeeRate) {
+  let fast
+  let normal
+  let slow
+  if (body && Number.isFinite(Number(body.fastestFee))) {
+    fast = Number(body.fastestFee)
+    normal = Number(body.halfHourFee)
+    slow = Number(body.hourFee)
+  } else if (body && typeof body === 'object') {
+    const estimate = (targets) => {
+      for (const t of targets) {
+        const v = Number(body[String(t)])
+        if (Number.isFinite(v) && v > 0) return v
+      }
+      return NaN
+    }
+    fast = estimate([1, 2]) // next block
+    normal = estimate([3, 4, 5, 6]) // ~half hour
+    slow = estimate([6, 10, 12, 24, 144]) // ~an hour or better
+  }
+  if (!Number.isFinite(fast) || fast <= 0) return null
+  const clamp = (v, fallback) => {
+    const n = Number.isFinite(v) && v > 0 ? Math.ceil(v) : fallback
+    return Math.min(Math.max(n, 1), maxFeeRate)
+  }
+  const fastClamped = clamp(fast, 1)
+  const normalClamped = clamp(normal, fastClamped)
+  return { fast: fastClamped, normal: normalClamped, slow: clamp(slow, normalClamped) }
+}
+
+/** Esplora GET /tx/:txid/status -> confirmation DTO (confirmations derived from the tip). */
+export function normalizeTxStatus(txid, status, tipHeight) {
+  const confirmed = Boolean(status?.confirmed)
+  const blockHeight = confirmed && Number.isInteger(status?.block_height) ? status.block_height : null
+  return { txid, confirmed, blockHeight, confirmations: confirmationsFrom(tipHeight, blockHeight) }
+}
+
+/** "txid:vout" (or explicit fields) -> {txid, vout}, or null. */
+function parseOutpoint(raw) {
+  const packed = raw.utxo ?? raw.outpoint
+  if (typeof packed === 'string' && packed.includes(':')) {
+    const [txid, voutStr] = packed.split(':')
+    const vout = Number.parseInt(voutStr, 10)
+    if (isTxid(txid) && Number.isInteger(vout) && vout >= 0) return { txid, vout }
+    return null
+  }
+  const txid = raw.tx_hash ?? raw.txid
+  if (!isTxid(txid)) return null
+  const vout = Number.isInteger(raw.vout) ? raw.vout : 0
+  return { txid, vout }
+}
+
+/**
+ * Stamps-indexer balance body for ONE address -> {stamps, dropped} | null.
+ *
+ * DEFENSIVE by design (research R6): the indexer shape is not under our control, and coin
+ * PROTECTION rides on this data — so anything unrecognizable degrades rather than silently
+ * un-protecting coins. Returns null when the body has no recognizable stamps list (caller
+ * marks the whole result degraded); `dropped` counts entries that were present but could not
+ * be mapped to an identity + outpoint (caller also degrades, keeping the parsed subset).
+ */
+export function normalizeStampsBalance(body, address) {
+  const list = Array.isArray(body?.data) ? body.data : Array.isArray(body?.stamps) ? body.stamps : Array.isArray(body) ? body : null
+  if (!list) return null
+  let dropped = 0
+  const stamps = []
+  for (const raw of list) {
+    if (!raw || typeof raw !== 'object') {
+      dropped += 1
+      continue
+    }
+    const stampId = raw.cpid ?? raw.stamp_id ?? raw.stampId ?? (raw.stamp != null ? String(raw.stamp) : null)
+    const outpoint = parseOutpoint(raw)
+    if (typeof stampId !== 'string' || stampId === '' || !outpoint) {
+      dropped += 1
+      continue
+    }
+    stamps.push({
+      stampId,
+      address,
+      outpoint,
+      imageUrl: typeof (raw.stamp_url ?? raw.imageUrl) === 'string' ? (raw.stamp_url ?? raw.imageUrl) : null,
+      mimeType: typeof (raw.stamp_mimetype ?? raw.mimeType) === 'string' ? (raw.stamp_mimetype ?? raw.mimeType) : null,
+    })
+  }
+  return { stamps, dropped }
+}

--- a/services/relay-gateway/src/bitcoin/routes.js
+++ b/services/relay-gateway/src/bitcoin/routes.js
@@ -1,0 +1,261 @@
+/**
+ * Bitcoin proxy routes — /v1/bitcoin/* (spec 061).
+ *
+ * Contract: specs/061-bitcoin-transactions/contracts/bitcoin-gateway-api.md — implemented
+ * faithfully, including its FLAT error body `{ error: <slug>, message }` (unlike the nested
+ * `{error:{code,reason}}` of the intent/opensea/polymarket contracts).
+ *
+ * Pipeline per request: killswitch (503 bitcoin_killed) -> enabled check (503 bitcoin_disabled)
+ * -> param validation -> quota (429) -> TTL cache -> upstream (failure => 502
+ * upstream_unavailable). Quotas are keyed per caller IP (nothing to sign on these routes);
+ * broadcast uses the separate, tighter write quota. Nothing here touches intents, funds, or
+ * signing keys — the member's client holds the only Bitcoin keys, and a total outage of this
+ * group leaves every value path intact.
+ */
+import crypto from 'node:crypto'
+import express from 'express'
+import { GatewayError } from '../errors.js'
+import { BitcoinRequestError } from './client.js'
+import {
+  MAX_ADDRESSES_PER_REQUEST,
+  isValidBitcoinAddress,
+  isTxid,
+  isRawTxHex,
+  normalizeAddressResult,
+  normalizeFeeRates,
+  normalizeTxStatus,
+  normalizeStampsBalance,
+} from './normalize.js'
+import { FEES_TTL_MS, ADDRESSES_TTL_MS, TX_STATUS_TTL_MS, fetchStampsThrough } from './cache.js'
+
+/** Stable cache key for an address SET: order-insensitive (contract: sorted address set hash). */
+const addressSetHash = (addresses) =>
+  crypto.createHash('sha256').update([...addresses].sort().join(',')).digest('hex').slice(0, 32)
+
+/**
+ * @param {object} config full gateway config (only .bitcoin is read)
+ * @param {{
+ *   esploraClients: {mainnet: object, testnet: object},
+ *   stampsClient: object|null,
+ *   cache: {fetchThrough: Function},
+ *   quotas: {hit: Function},
+ *   writeQuotas: {hit: Function},
+ *   killSwitch: {isActive: () => boolean},
+ *   now?: () => number,               // unix milliseconds (cache-age checks)
+ * }} deps
+ */
+export function createBitcoinRouter(config, { esploraClients, stampsClient, cache, quotas, writeQuotas, killSwitch, now = () => Date.now() }) {
+  const btc = config.bitcoin
+  const router = express.Router()
+
+  /** Killswitch (module env + global runtime switch) then the master enable — contract order. */
+  function requireLive() {
+    if (btc.killSwitch || killSwitch.isActive()) {
+      throw new GatewayError(503, 'bitcoin_killed', 'bitcoin services are temporarily disabled; try again later')
+    }
+    if (!btc.enabled) {
+      throw new GatewayError(503, 'bitcoin_disabled', 'bitcoin services are not enabled on this gateway')
+    }
+  }
+
+  /** :network ∈ {mainnet, testnet} -> the network's Esplora client, else 404 (soft-fail). */
+  function requireNetwork(networkParam) {
+    const client = esploraClients[networkParam]
+    if (networkParam !== 'mainnet' && networkParam !== 'testnet') {
+      throw new GatewayError(404, 'unknown_network', 'network must be mainnet or testnet')
+    }
+    if (!client) throw new GatewayError(404, 'unknown_network', 'network is not configured on this gateway')
+    return client
+  }
+
+  const quotaKey = (req) => req.ip ?? 'unknown'
+
+  /** Read pre-flight: per-IP + global read quota. */
+  function guard(req) {
+    const q = quotas.hit(quotaKey(req))
+    if (!q.allowed) {
+      throw new GatewayError(429, 'quota_exceeded', `${q.scope} bitcoin read quota exceeded`, { retryAfterSec: q.retryAfterSec })
+    }
+  }
+
+  /** Broadcast pre-flight: the tighter per-IP write quota (contract: stricter than reads). */
+  function guardWrite(req) {
+    const q = (writeQuotas ?? quotas).hit(quotaKey(req))
+    if (!q.allowed) {
+      throw new GatewayError(429, 'quota_exceeded', `${q.scope} bitcoin broadcast quota exceeded`, { retryAfterSec: q.retryAfterSec })
+    }
+  }
+
+  /** Parse + validate a batch address list per network, or 400 invalid_address. */
+  function requireAddresses(list, network) {
+    if (!Array.isArray(list) || list.length === 0 || list.length > MAX_ADDRESSES_PER_REQUEST) {
+      throw new GatewayError(400, 'invalid_address', `addresses must be a list of 1-${MAX_ADDRESSES_PER_REQUEST} bitcoin addresses`)
+    }
+    for (const address of list) {
+      if (!isValidBitcoinAddress(address, network)) {
+        throw new GatewayError(400, 'invalid_address', `"${String(address).slice(0, 90)}" is not a valid ${network} bitcoin address`)
+      }
+    }
+    return list
+  }
+
+  function handleError(res, err) {
+    if (err instanceof GatewayError) {
+      if (err.retryAfterSec != null) res.set('Retry-After', String(err.retryAfterSec))
+      // Flat body per the bitcoin contract (not GatewayError.toBody()'s nested shape).
+      return res.status(err.status).json({ error: err.code, message: err.reason })
+    }
+    if (err instanceof BitcoinRequestError && err.status === 404) {
+      // Only the tx-status route can surface an upstream 404 here (address/utxo reads answer
+      // empty sets, never 404): unknown-to-upstream => the client keeps polling (contract).
+      return res.status(404).json({ error: 'tx_not_found', message: 'the network does not know this transaction yet' })
+    }
+    // BitcoinUnavailableError, unexpected upstream 4xx, shape surprises: degraded, cache had
+    // nothing to serve. The client renders stale/degraded, never zero (contract).
+    return res.status(502).json({ error: 'upstream_unavailable', message: 'bitcoin network data is temporarily unavailable; try again later' })
+  }
+
+  // ---- POST /v1/bitcoin/:network/addresses (batch balances + UTXOs) ---------------------------
+  router.post('/v1/bitcoin/:network/addresses', async (req, res) => {
+    try {
+      requireLive()
+      const client = requireNetwork(req.params.network)
+      const addresses = requireAddresses(req.body?.addresses, req.params.network)
+      guard(req)
+
+      const key = `addrs:${req.params.network}:${addressSetHash(addresses)}`
+      const result = await cache.fetchThrough(key, ADDRESSES_TTL_MS, async () => {
+        const tipHeight = await client.getTipHeight()
+        const results = await Promise.all(
+          addresses.map(async (address) => {
+            const [info, utxos] = await Promise.all([client.getAddress(address), client.getAddressUtxos(address)])
+            return normalizeAddressResult(address, info, utxos, tipHeight)
+          })
+        )
+        return { tipHeight, results }
+      })
+      res.json(result.value)
+    } catch (err) {
+      handleError(res, err)
+    }
+  })
+
+  // ---- GET /v1/bitcoin/:network/fees ----------------------------------------------------------
+  router.get('/v1/bitcoin/:network/fees', async (req, res) => {
+    try {
+      requireLive()
+      const client = requireNetwork(req.params.network)
+      guard(req)
+
+      const result = await cache.fetchThrough(`fees:${req.params.network}`, FEES_TTL_MS, async () => {
+        const [feesBody, tipHeight] = await Promise.all([client.getFees(), client.getTipHeight()])
+        const rates = normalizeFeeRates(feesBody, btc.maxFeeRate)
+        // Unusable fee data must never become an invented rate — degrade honestly instead.
+        if (!rates) throw new GatewayError(502, 'upstream_unavailable', 'fee estimates are temporarily unavailable; try again later')
+        return { rates, tipHeight }
+      })
+      res.json(result.value)
+    } catch (err) {
+      handleError(res, err)
+    }
+  })
+
+  // ---- POST /v1/bitcoin/:network/tx (broadcast; never cached) ---------------------------------
+  router.post('/v1/bitcoin/:network/tx', async (req, res) => {
+    try {
+      requireLive()
+      const client = requireNetwork(req.params.network)
+      const rawTx = req.body?.rawTx
+      if (!isRawTxHex(rawTx)) {
+        throw new GatewayError(400, 'invalid_rawtx', 'rawTx must be an even-length hex string of at most 100 kB')
+      }
+      guardWrite(req)
+
+      let txid
+      try {
+        txid = await client.broadcastTx(rawTx)
+      } catch (e) {
+        if (e instanceof BitcoinRequestError) {
+          // Surface the node's own rejection reason (verbatim-safe: it describes the member's
+          // OWN transaction — e.g. min-relay-fee, missing inputs) so they can act on it.
+          const message = typeof e.message === 'string' ? e.message.replace(/^esplora rejected request \(\d+\): /, '').slice(0, 200) : ''
+          throw new GatewayError(400, 'broadcast_rejected', message || 'the network rejected this transaction')
+        }
+        throw e
+      }
+      res.json({ txid })
+    } catch (err) {
+      handleError(res, err)
+    }
+  })
+
+  // ---- GET /v1/bitcoin/:network/tx/:txid (confirmation status) --------------------------------
+  router.get('/v1/bitcoin/:network/tx/:txid', async (req, res) => {
+    try {
+      requireLive()
+      const client = requireNetwork(req.params.network)
+      const { txid } = req.params
+      if (!isTxid(txid)) throw new GatewayError(400, 'invalid_txid', 'txid must be a 64-character hex string')
+      guard(req)
+
+      // An upstream 404 (tx unknown) throws BitcoinRequestError from the loader; with nothing
+      // cached, fetchThrough propagates it and handleError maps it to 404 tx_not_found.
+      const result = await cache.fetchThrough(`tx:${req.params.network}:${txid.toLowerCase()}`, TX_STATUS_TTL_MS, async () => {
+        const [status, tipHeight] = await Promise.all([client.getTxStatus(txid), client.getTipHeight()])
+        return normalizeTxStatus(txid, status, tipHeight)
+      })
+      res.json(result.value)
+    } catch (err) {
+      handleError(res, err)
+    }
+  })
+
+  // ---- GET /v1/bitcoin/:network/stamps?addresses=a,b,c ----------------------------------------
+  // Fail-SAFE, not fail-open (research R6/FR-019): any indexer trouble — unconfigured, down,
+  // timeout, unrecognizable shape, partially unparseable entries — answers degraded:true so the
+  // client protects unverified coins. The loader therefore never throws; 502 cannot happen here.
+  router.get('/v1/bitcoin/:network/stamps', async (req, res) => {
+    try {
+      requireLive()
+      requireNetwork(req.params.network)
+      const raw = typeof req.query.addresses === 'string' ? req.query.addresses : ''
+      const addresses = raw.split(',').map((s) => s.trim()).filter(Boolean)
+      requireAddresses(addresses, req.params.network)
+      guard(req)
+
+      if (!stampsClient) {
+        // No indexer configured (BTC_STAMPS_URL unset) — a static condition; no cache needed.
+        res.json({ degraded: true, stamps: [] })
+        return
+      }
+
+      const key = `stamps:${req.params.network}:${addressSetHash(addresses)}`
+      const result = await fetchStampsThrough(cache, key, now, async () => {
+        let degraded = false
+        const stamps = []
+        await Promise.all(
+          addresses.map(async (address) => {
+            try {
+              const body = await stampsClient.getStampsBalance(address)
+              const normalized = normalizeStampsBalance(body, address)
+              if (!normalized) {
+                degraded = true // unrecognizable body — treat the whole result as unverified
+                return
+              }
+              if (normalized.dropped > 0) degraded = true // partial parse still degrades (fail-safe)
+              stamps.push(...normalized.stamps)
+            } catch {
+              degraded = true // indexer down/timeout for this address
+            }
+          })
+        )
+        return { degraded, stamps }
+      })
+      res.json(result.value)
+    } catch (err) {
+      handleError(res, err)
+    }
+  })
+
+  return router
+}

--- a/services/relay-gateway/src/config/index.js
+++ b/services/relay-gateway/src/config/index.js
@@ -62,6 +62,22 @@
  *                              unset/unreachable; the on-chain rate is the source of truth.
  *   POLYMARKET_BUILDER_MAKER_FEE_BPS  builder fee on maker orders (default 0; hard cap 50 — fails boot if over).
  *                              Fallback since spec 060, same as the taker fee.
+ *   BTC_ENABLED                'true' enables the /v1/bitcoin/* proxy (spec 061). Default false =>
+ *                              routes answer 503 bitcoin_disabled and the SPA soft-fails the capability
+ *   BTC_ESPLORA_URL            Esplora-compatible mainnet upstream (default https://mempool.space/api;
+ *                              swappable to blockstream.info or self-hosted electrs)
+ *   BTC_ESPLORA_TESTNET_URL    Esplora-compatible testnet4 upstream (default https://mempool.space/testnet4/api)
+ *   BTC_STAMPS_URL             stampchain.io-compatible Stamps indexer base. Unset => the stamps route
+ *                              answers degraded:true and the client fail-safes (protects unverified coins)
+ *   BTC_MAX_FEE_RATE           sat/vB clamp on fee responses (default 500; must be >= 1 when enabled)
+ *   BTC_TIMEOUT_MS             upstream request timeout (default 5000)
+ *   BTC_RETRIES                upstream retries on 5xx/transport for reads (default 1; broadcast never retries)
+ *   BTC_QUOTA_PER_IP           reads/min per caller IP (default 60 — polymarket parity)
+ *   BTC_QUOTA_GLOBAL           reads/min across all callers (default 300 — polymarket parity)
+ *   BTC_QUOTA_WINDOW_MS        quota window (default 60000)
+ *   BTC_WRITE_QUOTA_PER_IP     broadcasts/min per caller IP (default 20 — stricter than reads)
+ *   BTC_WRITE_QUOTA_GLOBAL     broadcasts/min across all callers (default 100)
+ *   BTC_KILLSWITCH             'true' => all /v1/bitcoin/* routes answer 503 bitcoin_killed (ops kill)
  *   FEE_ROUTER_ADDRESS         FeeRouter proxy (spec 060) serving the LIVE polymarket.taker/.maker bps.
  *                              Defaults to the deployment record's feeRouter for FEE_ROUTER_CHAIN_ID;
  *                              a set value that CONTRADICTS the record fails boot loudly. Unset and not
@@ -376,6 +392,52 @@ export function loadConfig(env = process.env, opts = {}) {
         return bps
       })(),
     },
+    // Bitcoin proxy (spec 061): optional like the OpenSea/Polymarket proxies — disabled means the
+    // /v1/bitcoin/* routes 503 fail-closed (bitcoin_disabled) and the SPA soft-fails the capability;
+    // boot is unaffected. Fail-loud validation applies only when the module is ENABLED: a malformed
+    // upstream URL or a nonsensical fee clamp must stop the boot rather than serve garbage
+    // (same philosophy as the polymarket fee-cap boot check).
+    bitcoin: (() => {
+      const enabled = opt(env, 'BTC_ENABLED', 'false').toLowerCase() === 'true'
+      const esploraUrl = opt(env, 'BTC_ESPLORA_URL', 'https://mempool.space/api')
+      const esploraTestnetUrl = opt(env, 'BTC_ESPLORA_TESTNET_URL', 'https://mempool.space/testnet4/api')
+      const stampsUrl = opt(env, 'BTC_STAMPS_URL', null)
+      const maxFeeRate = int(env, 'BTC_MAX_FEE_RATE', 500)
+      if (enabled) {
+        const urls = [
+          ['BTC_ESPLORA_URL', esploraUrl],
+          ['BTC_ESPLORA_TESTNET_URL', esploraTestnetUrl],
+          ...(stampsUrl ? [['BTC_STAMPS_URL', stampsUrl]] : []),
+        ]
+        for (const [name, url] of urls) {
+          let ok = false
+          try {
+            ok = ['http:', 'https:'].includes(new URL(url).protocol)
+          } catch {
+            ok = false
+          }
+          if (!ok) throw new Error(`[relay-gateway] ${name}=${url} is not a valid http(s) URL`)
+        }
+        // Clamp sanity (contract: min >= 1, max >= min; the lower bound is the fixed 1 sat/vB floor).
+        if (maxFeeRate < 1) throw new Error(`[relay-gateway] BTC_MAX_FEE_RATE=${maxFeeRate} must be >= 1 sat/vB`)
+      }
+      return {
+        enabled,
+        esploraUrl,
+        esploraTestnetUrl,
+        stampsUrl,
+        maxFeeRate,
+        timeoutMs: int(env, 'BTC_TIMEOUT_MS', 5000),
+        retries: int(env, 'BTC_RETRIES', 1),
+        quotaPerIp: int(env, 'BTC_QUOTA_PER_IP', 60),
+        quotaGlobal: int(env, 'BTC_QUOTA_GLOBAL', 300),
+        quotaWindowMs: int(env, 'BTC_QUOTA_WINDOW_MS', 60_000),
+        // Broadcast: a separate, tighter per-IP quota (contract: stricter than reads).
+        writeQuotaPerIp: int(env, 'BTC_WRITE_QUOTA_PER_IP', 20),
+        writeQuotaGlobal: int(env, 'BTC_WRITE_QUOTA_GLOBAL', 100),
+        killSwitch: opt(env, 'BTC_KILLSWITCH', 'false').toLowerCase() === 'true',
+      }
+    })(),
     // FeeRouter (spec 060): the on-chain source of truth for the Polymarket builder bps. The env
     // takerFeeBps/makerFeeBps above become the FALLBACK when the router is unset or unreachable.
     // The address defaults to the deployment record's feeRouter (same pinning philosophy as

--- a/services/relay-gateway/src/server.js
+++ b/services/relay-gateway/src/server.js
@@ -33,6 +33,8 @@ import { createTtlCache } from './opensea/cache.js'
 import { createOpenSeaRouter } from './opensea/routes.js'
 import { createPolymarketClient } from './polymarket/client.js'
 import { createPolymarketRouter } from './polymarket/routes.js'
+import { createEsploraClient, createStampsClient } from './bitcoin/client.js'
+import { createBitcoinRouter } from './bitcoin/routes.js'
 import { createAuditLogger } from './audit/log.js'
 import { GatewayError, EngineUnavailableError } from './errors.js'
 import { getHash, packPaymasterAndData, stubPaymasterAndData } from './paymaster/build.js'
@@ -162,7 +164,13 @@ export function createApp(config, deps = {}) {
   })
   // Capture the raw body so the engine-webhook route can verify the HMAC over the exact bytes
   // the engine signed (re-serializing could reorder keys and break the signature).
-  app.use(express.json({ limit: '32kb', verify: (req, _res, buf) => { req.rawBody = buf } })) // intents are small fixed-shape JSON; nothing large is legitimate
+  const jsonSmall = express.json({ limit: '32kb', verify: (req, _res, buf) => { req.rawBody = buf } }) // intents are small fixed-shape JSON; nothing large is legitimate
+  // Exception: the Bitcoin broadcast route (spec 061) carries a raw signed transaction as hex —
+  // the contract caps it at 100 kB of tx bytes (200k hex chars), so it gets a larger parse limit;
+  // the route itself enforces the exact cap and hex validity.
+  const jsonBtcTx = express.json({ limit: '256kb' })
+  const BTC_TX_PATH_RE = /^\/v1\/bitcoin\/[^/]+\/tx$/
+  app.use((req, res, next) => (req.method === 'POST' && BTC_TX_PATH_RE.test(req.path) ? jsonBtcTx : jsonSmall)(req, res, next))
 
   // ---- Origin-lock middleware (FR-029, SC-016): client-facing routes require X-Origin-Auth.
   // The Cloudflare Transform Rule injects the header zone-wide; a direct *.run.app hit lacks it.
@@ -612,6 +620,47 @@ export function createApp(config, deps = {}) {
       writeQuotas: pmWriteQuotas,
       killSwitch,
       feeRates,
+    })
+  )
+
+  // ---- GET/POST /v1/bitcoin/* (spec 061 Bitcoin proxy; origin-locked via middleware) ----------
+  // Esplora-compatible reads (balances/UTXOs/fees/tx status) + raw-tx broadcast + Stamps
+  // recognition. Quotas are keyed per caller IP (no signature to recover on these routes); the
+  // broadcast write gets its own tighter quota. The routes 503 fail-closed (bitcoin_disabled)
+  // until BTC_ENABLED=true — mounting is unconditional so the answer is always honest.
+  const btcReadQuotas = createQuotas({
+    signerPerWindow: config.bitcoin.quotaPerIp,
+    globalPerWindow: config.bitcoin.quotaGlobal,
+    windowMs: config.bitcoin.quotaWindowMs,
+    now: nowMs,
+  })
+  const btcWriteQuotas = createQuotas({
+    signerPerWindow: config.bitcoin.writeQuotaPerIp,
+    globalPerWindow: config.bitcoin.writeQuotaGlobal,
+    windowMs: config.bitcoin.quotaWindowMs,
+    now: nowMs,
+  })
+  const btcFetch = deps.bitcoinFetch ? { fetchImpl: deps.bitcoinFetch } : {}
+  const btcClientOpts = { timeoutMs: config.bitcoin.timeoutMs, retries: config.bitcoin.retries, ...btcFetch }
+  const esploraClients = deps.esploraClients ?? {
+    mainnet: createEsploraClient({ baseUrl: config.bitcoin.esploraUrl, ...btcClientOpts }),
+    testnet: createEsploraClient({ baseUrl: config.bitcoin.esploraTestnetUrl, ...btcClientOpts }),
+  }
+  const stampsClient =
+    deps.stampsClient !== undefined
+      ? deps.stampsClient
+      : config.bitcoin.stampsUrl
+        ? createStampsClient({ baseUrl: config.bitcoin.stampsUrl, ...btcClientOpts })
+        : null
+  app.use(
+    createBitcoinRouter(config, {
+      esploraClients,
+      stampsClient,
+      cache: deps.bitcoinCache ?? createTtlCache({ now: nowMs }),
+      quotas: btcReadQuotas,
+      writeQuotas: btcWriteQuotas,
+      killSwitch,
+      now: nowMs,
     })
   )
 

--- a/services/relay-gateway/test/bitcoin.test.js
+++ b/services/relay-gateway/test/bitcoin.test.js
@@ -1,0 +1,510 @@
+/**
+ * /v1/bitcoin/* Bitcoin proxy tests (spec 061 — contracts/bitcoin-gateway-api.md).
+ * The Esplora + Stamps upstreams are mocked via the injectable bitcoinFetch; everything else uses
+ * the same build-the-app-with-injected-deps pattern as polymarket.test.js / opensea.test.js.
+ */
+import { describe, it, expect } from 'vitest'
+import request from 'supertest'
+import { createApp } from '../src/server.js'
+import { createKillSwitch } from '../src/policy/killswitch.js'
+import {
+  isValidBitcoinAddress,
+  isTxid,
+  isRawTxHex,
+  normalizeAddressResult,
+  normalizeFeeRates,
+  normalizeTxStatus,
+  normalizeStampsBalance,
+} from '../src/bitcoin/normalize.js'
+import { testConfig, mockProviders, mockEngine, ORIGIN_SECRET, TEST_NOW } from './helpers.js'
+
+// ---- fixtures -----------------------------------------------------------------------------------
+
+const ADDR_MAIN_BECH32 = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'
+const ADDR_MAIN_TAPROOT = 'bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297'
+const ADDR_MAIN_P2PKH = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2'
+const ADDR_MAIN_P2SH = '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy'
+const ADDR_TEST_BECH32 = 'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx'
+const ADDR_TEST_P2PKH = 'mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn'
+const ADDR_TEST_P2SH = '2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc'
+
+const TIP = 903211
+const TXID = '4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b'
+const TXID_PENDING = 'e3bf3d07d4b0375638d5f1db5255fe07ba2c4cb067cd81b84ee974b6585fb468'
+const STAMP_TX = '0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098'
+
+// Esplora GET /address/:addr — confirmed 150000-25000 = 125000; pending net 800-5000 = -4200.
+const ADDRESS_BODY = {
+  chain_stats: { funded_txo_sum: 150_000, spent_txo_sum: 25_000 },
+  mempool_stats: { funded_txo_sum: 800, spent_txo_sum: 5_000 },
+}
+const UTXOS_BODY = [
+  { txid: TXID, vout: 0, value: 125_000, status: { confirmed: true, block_height: 903_208 } },
+  { txid: TXID_PENDING, vout: 1, value: 800, status: { confirmed: false } },
+  { junk: true }, // malformed record -> dropped, never 500s
+]
+const FEES_BODY = { fastestFee: 12, halfHourFee: 6, hourFee: 2 } // mempool.space dialect
+const FEE_ESTIMATES_BODY = { 1: 11.5, 3: 5.1, 6: 2.2, 144: 1.0 } // blockstream/electrs dialect
+const TX_STATUS_BODY = { confirmed: true, block_height: 903_210 }
+// stampchain.io-compatible /api/v2/stamps/balance/:address body.
+const STAMPS_BODY = {
+  last_block: TIP,
+  data: [
+    {
+      cpid: 'A1234567890123456789',
+      stamp: 812345,
+      tx_hash: STAMP_TX,
+      vout: 1,
+      stamp_url: 'https://stampchain.io/stamps/abc.png',
+      stamp_mimetype: 'image/png',
+    },
+  ],
+}
+
+// ---- test scaffolding ---------------------------------------------------------------------------
+
+const textRes = (text, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  text: async () => text,
+  json: async () => JSON.parse(text),
+})
+const jsonRes = (body, status = 200) => textRes(JSON.stringify(body), status)
+
+function mockBitcoinFetch(overrides = {}) {
+  const calls = []
+  const impl = async (url, opts) => {
+    const method = opts?.method ?? 'GET'
+    calls.push({ url, method, body: opts?.body ?? null, headers: opts?.headers ?? {} })
+    if (impl.failWith) return jsonRes({ error: 'down' }, impl.failWith)
+    for (const [needle, resp] of Object.entries(overrides)) {
+      if (url.includes(needle)) return typeof resp === 'function' ? resp(url, opts) : jsonRes(resp)
+    }
+    if (url.includes('stamps.test.invalid')) {
+      return impl.stampsFail ? jsonRes({ error: 'indexer down' }, 500) : jsonRes(STAMPS_BODY)
+    }
+    if (url.endsWith('/blocks/tip/height')) return textRes(String(TIP))
+    if (/\/address\/[^/]+\/utxo$/.test(url)) return jsonRes(UTXOS_BODY)
+    if (url.includes('/address/')) return jsonRes(ADDRESS_BODY)
+    if (url.endsWith('/fees/recommended')) return jsonRes(FEES_BODY)
+    if (/\/tx\/[0-9a-fA-F]{64}\/status$/.test(url)) return jsonRes(TX_STATUS_BODY)
+    if (url.endsWith('/tx') && method === 'POST') return textRes(TXID)
+    return textRes('not found', 404)
+  }
+  impl.calls = calls
+  impl.failWith = null
+  impl.stampsFail = false
+  return impl
+}
+
+const BTC_ENV = { BTC_ENABLED: 'true', BTC_STAMPS_URL: 'https://stamps.test.invalid' }
+
+function build({ env = {}, bitcoinFetch = mockBitcoinFetch(), killSwitch = createKillSwitch(false) } = {}) {
+  const config = testConfig({ ...BTC_ENV, ...env })
+  const clock = { t: TEST_NOW }
+  const { app } = createApp(config, {
+    providers: mockProviders(config),
+    engineClient: mockEngine(),
+    now: () => clock.t,
+    killSwitch,
+    bitcoinFetch,
+  })
+  return { app, config, clock, bitcoinFetch, killSwitch }
+}
+
+const get = (app, path) => request(app).get(path).set('X-Origin-Auth', ORIGIN_SECRET)
+const post = (app, path, body) => request(app).post(path).set('X-Origin-Auth', ORIGIN_SECRET).send(body)
+
+const ADDRESSES_PATH = '/v1/bitcoin/mainnet/addresses'
+const FEES_PATH = '/v1/bitcoin/mainnet/fees'
+const TX_PATH = '/v1/bitcoin/mainnet/tx'
+const TX_STATUS_PATH = `/v1/bitcoin/mainnet/tx/${TXID}`
+const STAMPS_PATH = `/v1/bitcoin/mainnet/stamps?addresses=${ADDR_MAIN_BECH32}`
+
+// ---- unit: address validation -------------------------------------------------------------------
+
+describe('bitcoin address validation', () => {
+  it('accepts each mainnet address family', () => {
+    for (const a of [ADDR_MAIN_BECH32, ADDR_MAIN_TAPROOT, ADDR_MAIN_P2PKH, ADDR_MAIN_P2SH]) {
+      expect(isValidBitcoinAddress(a, 'mainnet')).toBe(true)
+    }
+  })
+
+  it('accepts each testnet address family', () => {
+    for (const a of [ADDR_TEST_BECH32, ADDR_TEST_P2PKH, ADDR_TEST_P2SH]) {
+      expect(isValidBitcoinAddress(a, 'testnet')).toBe(true)
+    }
+  })
+
+  it('rejects wrong-network prefixes both ways', () => {
+    expect(isValidBitcoinAddress(ADDR_TEST_BECH32, 'mainnet')).toBe(false)
+    expect(isValidBitcoinAddress(ADDR_MAIN_BECH32, 'testnet')).toBe(false)
+    expect(isValidBitcoinAddress(ADDR_MAIN_P2PKH, 'testnet')).toBe(false)
+  })
+
+  it('rejects EVM addresses, bad charsets, and junk', () => {
+    expect(isValidBitcoinAddress('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', 'mainnet')).toBe(false)
+    expect(isValidBitcoinAddress('bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8fbio', 'mainnet')).toBe(false) // b/i/o outside bech32 charset
+    expect(isValidBitcoinAddress('bc1', 'mainnet')).toBe(false)
+    expect(isValidBitcoinAddress('', 'mainnet')).toBe(false)
+    expect(isValidBitcoinAddress(42, 'mainnet')).toBe(false)
+  })
+
+  it('validates txids and raw-tx hex bounds', () => {
+    expect(isTxid(TXID)).toBe(true)
+    expect(isTxid('0x' + TXID)).toBe(false)
+    expect(isRawTxHex('02000000abcd')).toBe(true)
+    expect(isRawTxHex('02000000abc')).toBe(false) // odd length
+    expect(isRawTxHex('zz00')).toBe(false)
+    expect(isRawTxHex('11'.repeat(100_001))).toBe(false) // > 100 kB
+  })
+})
+
+// ---- unit: normalize ----------------------------------------------------------------------------
+
+describe('bitcoin normalize', () => {
+  it('maps balances + UTXOs with confirmations from the tip, dropping malformed records', () => {
+    const r = normalizeAddressResult(ADDR_MAIN_BECH32, ADDRESS_BODY, UTXOS_BODY, TIP)
+    expect(r.address).toBe(ADDR_MAIN_BECH32)
+    expect(r.confirmedSats).toBe(125_000)
+    expect(r.pendingSats).toBe(-4_200) // signed mempool net
+    expect(r.utxos).toHaveLength(2) // junk record dropped
+    expect(r.utxos[0]).toEqual({ txid: TXID, vout: 0, valueSats: 125_000, confirmations: 4, blockHeight: 903_208 })
+    expect(r.utxos[1]).toMatchObject({ confirmations: 0, blockHeight: null })
+  })
+
+  it('normalizes mempool.space fee recommendations with clamping', () => {
+    expect(normalizeFeeRates(FEES_BODY, 500)).toEqual({ fast: 12, normal: 6, slow: 2 })
+    expect(normalizeFeeRates(FEES_BODY, 5)).toEqual({ fast: 5, normal: 5, slow: 2 }) // max clamp
+    expect(normalizeFeeRates({ fastestFee: 0.4, halfHourFee: 0.2, hourFee: 0.1 }, 500)).toEqual({ fast: 1, normal: 1, slow: 1 }) // floor 1
+  })
+
+  it('normalizes the blockstream /fee-estimates dialect and refuses junk', () => {
+    expect(normalizeFeeRates(FEE_ESTIMATES_BODY, 500)).toEqual({ fast: 12, normal: 6, slow: 3 })
+    expect(normalizeFeeRates({ nonsense: true }, 500)).toBeNull()
+    expect(normalizeFeeRates(null, 500)).toBeNull()
+  })
+
+  it('maps tx status with tip-derived confirmations', () => {
+    expect(normalizeTxStatus(TXID, TX_STATUS_BODY, TIP)).toEqual({ txid: TXID, confirmed: true, blockHeight: 903_210, confirmations: 2 })
+    expect(normalizeTxStatus(TXID, { confirmed: false }, TIP)).toEqual({ txid: TXID, confirmed: false, blockHeight: null, confirmations: 0 })
+  })
+
+  it('maps stamps entries and counts unparseable ones as dropped', () => {
+    const r = normalizeStampsBalance(STAMPS_BODY, ADDR_MAIN_BECH32)
+    expect(r.dropped).toBe(0)
+    expect(r.stamps[0]).toEqual({
+      stampId: 'A1234567890123456789',
+      address: ADDR_MAIN_BECH32,
+      outpoint: { txid: STAMP_TX, vout: 1 },
+      imageUrl: 'https://stampchain.io/stamps/abc.png',
+      mimeType: 'image/png',
+    })
+    const partial = normalizeStampsBalance({ data: [STAMPS_BODY.data[0], { cpid: 'A2', tx_hash: 'nope' }] }, ADDR_MAIN_BECH32)
+    expect(partial.stamps).toHaveLength(1)
+    expect(partial.dropped).toBe(1)
+  })
+
+  it('treats an unrecognizable stamps body as degraded (null), never guesses', () => {
+    expect(normalizeStampsBalance({ weird: true }, ADDR_MAIN_BECH32)).toBeNull()
+    expect(normalizeStampsBalance('html error page', ADDR_MAIN_BECH32)).toBeNull()
+  })
+})
+
+// ---- config: fail-loud boot validation ----------------------------------------------------------
+
+describe('bitcoin config boot validation', () => {
+  it('fails boot loudly on a malformed Esplora URL when enabled', () => {
+    expect(() => testConfig({ BTC_ENABLED: 'true', BTC_ESPLORA_URL: 'not a url' })).toThrow(/BTC_ESPLORA_URL/)
+    expect(() => testConfig({ BTC_ENABLED: 'true', BTC_ESPLORA_TESTNET_URL: 'ftp://nope' })).toThrow(/BTC_ESPLORA_TESTNET_URL/)
+    expect(() => testConfig({ ...BTC_ENV, BTC_STAMPS_URL: '::::' })).toThrow(/BTC_STAMPS_URL/)
+  })
+
+  it('fails boot loudly on a nonsensical fee clamp when enabled', () => {
+    expect(() => testConfig({ BTC_ENABLED: 'true', BTC_MAX_FEE_RATE: '0' })).toThrow(/BTC_MAX_FEE_RATE/)
+    expect(() => testConfig({ BTC_ENABLED: 'true', BTC_MAX_FEE_RATE: '-5' })).toThrow(/BTC_MAX_FEE_RATE/)
+  })
+
+  it('tolerates malformed values while the module is disabled (soft-optional)', () => {
+    expect(() => testConfig({ BTC_ESPLORA_URL: 'not a url' })).not.toThrow()
+  })
+})
+
+// ---- cross-cutting: origin lock / disabled / killswitch / network -------------------------------
+
+describe('bitcoin proxy cross-cutting', () => {
+  it('requires the origin-auth header', async () => {
+    const { app } = build()
+    await request(app).get(FEES_PATH).expect(403)
+  })
+
+  it('503s bitcoin_disabled on every route when BTC_ENABLED is unset', async () => {
+    const { app } = build({ env: { BTC_ENABLED: '' } })
+    for (const req of [get(app, FEES_PATH), get(app, TX_STATUS_PATH), get(app, STAMPS_PATH)]) {
+      const res = await req.expect(503)
+      expect(res.body.error).toBe('bitcoin_disabled')
+    }
+    const res = await post(app, ADDRESSES_PATH, { addresses: [ADDR_MAIN_BECH32] }).expect(503)
+    expect(res.body.error).toBe('bitcoin_disabled')
+  })
+
+  it('503s bitcoin_killed on the module killswitch', async () => {
+    const { app } = build({ env: { BTC_KILLSWITCH: 'true' } })
+    const res = await get(app, FEES_PATH).expect(503)
+    expect(res.body.error).toBe('bitcoin_killed')
+  })
+
+  it('503s bitcoin_killed on the global killswitch', async () => {
+    const { app } = build({ killSwitch: createKillSwitch(true) })
+    const res = await post(app, TX_PATH, { rawTx: '0200ab' }).expect(503)
+    expect(res.body.error).toBe('bitcoin_killed')
+  })
+
+  it('404s an unknown network', async () => {
+    const { app } = build()
+    const res = await get(app, '/v1/bitcoin/regtest/fees').expect(404)
+    expect(res.body.error).toBe('unknown_network')
+  })
+})
+
+// ---- POST /addresses ----------------------------------------------------------------------------
+
+describe('bitcoin batch addresses', () => {
+  it('returns tipHeight + per-address balances and UTXOs (contract DTO)', async () => {
+    const { app } = build()
+    const res = await post(app, ADDRESSES_PATH, { addresses: [ADDR_MAIN_BECH32, ADDR_MAIN_P2PKH] }).expect(200)
+    expect(res.body.tipHeight).toBe(TIP)
+    expect(res.body.results).toHaveLength(2)
+    expect(res.body.results[0]).toMatchObject({ address: ADDR_MAIN_BECH32, confirmedSats: 125_000, pendingSats: -4_200 })
+    expect(res.body.results[0].utxos[0]).toEqual({ txid: TXID, vout: 0, valueSats: 125_000, confirmations: 4, blockHeight: 903_208 })
+  })
+
+  it('routes testnet addresses to the testnet upstream', async () => {
+    const { app, bitcoinFetch } = build()
+    await post(app, '/v1/bitcoin/testnet/addresses', { addresses: [ADDR_TEST_BECH32] }).expect(200)
+    expect(bitcoinFetch.calls.every((c) => c.url.startsWith('https://mempool.space/testnet4/api'))).toBe(true)
+  })
+
+  it('400s invalid_address on a wrong-network or malformed address', async () => {
+    const { app } = build()
+    for (const addresses of [[ADDR_TEST_BECH32], ['0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'], [], 'not-a-list']) {
+      const res = await post(app, ADDRESSES_PATH, { addresses }).expect(400)
+      expect(res.body.error).toBe('invalid_address')
+    }
+  })
+
+  it('400s a batch over 50 addresses', async () => {
+    const { app } = build()
+    const res = await post(app, ADDRESSES_PATH, { addresses: Array(51).fill(ADDR_MAIN_BECH32) }).expect(400)
+    expect(res.body.error).toBe('invalid_address')
+  })
+
+  it('serves a repeat batch from cache within the TTL (no second upstream hit)', async () => {
+    const { app, bitcoinFetch } = build()
+    await post(app, ADDRESSES_PATH, { addresses: [ADDR_MAIN_BECH32] }).expect(200)
+    const upstreamCalls = bitcoinFetch.calls.length
+    // Same SET in a different order -> same cache key (sorted-set hash).
+    await post(app, ADDRESSES_PATH, { addresses: [ADDR_MAIN_BECH32] }).expect(200)
+    expect(bitcoinFetch.calls.length).toBe(upstreamCalls)
+  })
+})
+
+// ---- GET /fees ----------------------------------------------------------------------------------
+
+describe('bitcoin fees', () => {
+  it('returns clamped integer rates + tipHeight (contract DTO)', async () => {
+    const { app } = build()
+    const res = await get(app, FEES_PATH).expect(200)
+    expect(res.body).toEqual({ rates: { fast: 12, normal: 6, slow: 2 }, tipHeight: TIP })
+  })
+
+  it('clamps rates to BTC_MAX_FEE_RATE', async () => {
+    const { app } = build({ env: { BTC_MAX_FEE_RATE: '10' } })
+    const res = await get(app, FEES_PATH).expect(200)
+    expect(res.body.rates).toEqual({ fast: 10, normal: 6, slow: 2 })
+  })
+
+  it('falls back to /fee-estimates when /fees/recommended 404s (blockstream dialect)', async () => {
+    const fetchImpl = mockBitcoinFetch({
+      '/fees/recommended': () => textRes('not found', 404),
+      '/fee-estimates': FEE_ESTIMATES_BODY,
+    })
+    const { app } = build({ bitcoinFetch: fetchImpl })
+    const res = await get(app, FEES_PATH).expect(200)
+    expect(res.body.rates).toEqual({ fast: 12, normal: 6, slow: 3 })
+    expect(fetchImpl.calls.some((c) => c.url.endsWith('/fee-estimates'))).toBe(true)
+  })
+
+  it('serves a repeat read from cache within the TTL', async () => {
+    const { app, bitcoinFetch } = build()
+    await get(app, FEES_PATH).expect(200)
+    const upstreamCalls = bitcoinFetch.calls.length
+    await get(app, FEES_PATH).expect(200)
+    expect(bitcoinFetch.calls.length).toBe(upstreamCalls)
+  })
+
+  it('502s upstream_unavailable when the upstream is down (after retries)', async () => {
+    const fetchImpl = mockBitcoinFetch()
+    fetchImpl.failWith = 500
+    const { app } = build({ bitcoinFetch: fetchImpl })
+    const res = await get(app, FEES_PATH).expect(502)
+    expect(res.body.error).toBe('upstream_unavailable')
+    expect(fetchImpl.calls.length).toBeGreaterThan(1) // retried before giving up
+  })
+})
+
+// ---- POST /tx (broadcast) -----------------------------------------------------------------------
+
+describe('bitcoin broadcast', () => {
+  it('broadcasts raw hex as text/plain and returns the txid', async () => {
+    const { app, bitcoinFetch } = build()
+    const res = await post(app, TX_PATH, { rawTx: '0200ab'.repeat(10) }).expect(200)
+    expect(res.body).toEqual({ txid: TXID })
+    const call = bitcoinFetch.calls.find((c) => c.method === 'POST')
+    expect(call.url).toBe('https://mempool.space/api/tx')
+    expect(call.headers['content-type']).toBe('text/plain')
+    expect(call.body).toBe('0200ab'.repeat(10))
+  })
+
+  it('400s invalid_rawtx on malformed hex', async () => {
+    const { app } = build()
+    for (const rawTx of ['0xzz', 'abc', '', null, '11'.repeat(100_001)]) {
+      const res = await post(app, TX_PATH, { rawTx }).expect(400)
+      expect(res.body.error).toBe('invalid_rawtx')
+    }
+  })
+
+  it('400s broadcast_rejected with the upstream reason verbatim-safe', async () => {
+    const fetchImpl = mockBitcoinFetch({
+      '/tx': (url, opts) => (opts?.method === 'POST' ? textRes('sendrawtransaction RPC error: min relay fee not met', 400) : jsonRes(TX_STATUS_BODY)),
+    })
+    const { app } = build({ bitcoinFetch: fetchImpl })
+    const res = await post(app, TX_PATH, { rawTx: '0200ab' }).expect(400)
+    expect(res.body.error).toBe('broadcast_rejected')
+    expect(res.body.message).toMatch(/min relay fee/)
+  })
+
+  it('502s when the upstream is down and never retries the broadcast', async () => {
+    const fetchImpl = mockBitcoinFetch()
+    fetchImpl.failWith = 500
+    const { app } = build({ bitcoinFetch: fetchImpl })
+    const res = await post(app, TX_PATH, { rawTx: '0200ab' }).expect(502)
+    expect(res.body.error).toBe('upstream_unavailable')
+    expect(fetchImpl.calls.filter((c) => c.method === 'POST')).toHaveLength(1) // writes never retry
+  })
+
+  it('enforces the tighter write quota with Retry-After', async () => {
+    const { app } = build({ env: { BTC_WRITE_QUOTA_PER_IP: '1' } })
+    await post(app, TX_PATH, { rawTx: '0200ab' }).expect(200)
+    const res = await post(app, TX_PATH, { rawTx: '0200ac' }).expect(429)
+    expect(res.body.error).toBe('quota_exceeded')
+    expect(res.headers['retry-after']).toBeDefined()
+  })
+})
+
+// ---- GET /tx/:txid ------------------------------------------------------------------------------
+
+describe('bitcoin tx status', () => {
+  it('returns confirmation status with tip-derived confirmations (contract DTO)', async () => {
+    const { app } = build()
+    const res = await get(app, TX_STATUS_PATH).expect(200)
+    expect(res.body).toEqual({ txid: TXID, confirmed: true, blockHeight: 903_210, confirmations: 2 })
+  })
+
+  it('400s invalid_txid on a malformed txid', async () => {
+    const { app } = build()
+    const res = await get(app, '/v1/bitcoin/mainnet/tx/nope').expect(400)
+    expect(res.body.error).toBe('invalid_txid')
+  })
+
+  it('404s tx_not_found while the upstream does not know the tx', async () => {
+    const fetchImpl = mockBitcoinFetch({ '/status': () => textRes('Transaction not found', 404) })
+    const { app } = build({ bitcoinFetch: fetchImpl })
+    const res = await get(app, TX_STATUS_PATH).expect(404)
+    expect(res.body.error).toBe('tx_not_found')
+  })
+})
+
+// ---- GET /stamps --------------------------------------------------------------------------------
+
+describe('bitcoin stamps', () => {
+  it('returns normalized stamps holdings (contract DTO, degraded:false)', async () => {
+    const { app } = build()
+    const res = await get(app, STAMPS_PATH).expect(200)
+    expect(res.body.degraded).toBe(false)
+    expect(res.body.stamps).toEqual([
+      {
+        stampId: 'A1234567890123456789',
+        address: ADDR_MAIN_BECH32,
+        outpoint: { txid: STAMP_TX, vout: 1 },
+        imageUrl: 'https://stampchain.io/stamps/abc.png',
+        mimeType: 'image/png',
+      },
+    ])
+  })
+
+  it('is degraded:true when no indexer is configured (client fail-safes)', async () => {
+    const { app } = build({ env: { BTC_STAMPS_URL: '' } })
+    const res = await get(app, STAMPS_PATH).expect(200)
+    expect(res.body).toEqual({ degraded: true, stamps: [] })
+  })
+
+  it('is degraded:true (never 502) when the indexer is down', async () => {
+    const fetchImpl = mockBitcoinFetch()
+    fetchImpl.stampsFail = true
+    const { app } = build({ bitcoinFetch: fetchImpl })
+    const res = await get(app, STAMPS_PATH).expect(200)
+    expect(res.body).toEqual({ degraded: true, stamps: [] })
+  })
+
+  it('is degraded:true on an unrecognizable indexer response shape', async () => {
+    const fetchImpl = mockBitcoinFetch({ 'stamps.test.invalid': { totally: 'unexpected' } })
+    const { app } = build({ bitcoinFetch: fetchImpl })
+    const res = await get(app, STAMPS_PATH).expect(200)
+    expect(res.body).toEqual({ degraded: true, stamps: [] })
+  })
+
+  it('400s invalid_address on a bad addresses query', async () => {
+    const { app } = build()
+    const res = await get(app, `/v1/bitcoin/mainnet/stamps?addresses=${ADDR_TEST_BECH32}`).expect(400)
+    expect(res.body.error).toBe('invalid_address')
+    await get(app, '/v1/bitcoin/mainnet/stamps').expect(400)
+  })
+
+  it('re-fetches a degraded result after 30s but caches a healthy one for 300s', async () => {
+    const fetchImpl = mockBitcoinFetch()
+    fetchImpl.stampsFail = true
+    const { app, clock } = build({ bitcoinFetch: fetchImpl })
+    let res = await get(app, STAMPS_PATH).expect(200)
+    expect(res.body.degraded).toBe(true)
+
+    // Indexer recovers; within the 30s degraded TTL the cached degraded value is still served.
+    fetchImpl.stampsFail = false
+    res = await get(app, STAMPS_PATH).expect(200)
+    expect(res.body.degraded).toBe(true)
+
+    // Past the 30s degraded TTL the loader re-runs and the healthy result replaces it...
+    clock.t += 31
+    res = await get(app, STAMPS_PATH).expect(200)
+    expect(res.body.degraded).toBe(false)
+
+    // ...and that healthy result is then honored for the long TTL (no re-fetch at +60s).
+    const upstreamCalls = fetchImpl.calls.length
+    clock.t += 60
+    res = await get(app, STAMPS_PATH).expect(200)
+    expect(res.body.degraded).toBe(false)
+    expect(fetchImpl.calls.length).toBe(upstreamCalls)
+  })
+})
+
+// ---- quotas -------------------------------------------------------------------------------------
+
+describe('bitcoin read quotas', () => {
+  it('429s past the per-IP read quota with Retry-After', async () => {
+    const { app } = build({ env: { BTC_QUOTA_PER_IP: '1' } })
+    await get(app, FEES_PATH).expect(200)
+    const res = await get(app, FEES_PATH).expect(429)
+    expect(res.body.error).toBe('quota_exceeded')
+    expect(res.headers['retry-after']).toBeDefined()
+  })
+})

--- a/specs/061-bitcoin-transactions/checklists/requirements.md
+++ b/specs/061-bitcoin-transactions/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: Bitcoin Transactions
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Address-type terms (taproot/bech32m, native segwit/bech32, P2PKH, P2SH) are
+  Bitcoin domain vocabulary — destination formats members interact with — not
+  implementation choices, so they remain in the spec deliberately.
+- Ambiguities were resolved with documented defaults in the Assumptions section
+  (custody model, default address type, Stamps scope, fee policy, Lightning out
+  of scope) rather than [NEEDS CLARIFICATION] markers, since each has a clear
+  platform-consistent default.

--- a/specs/061-bitcoin-transactions/contracts/bitcoin-gateway-api.md
+++ b/specs/061-bitcoin-transactions/contracts/bitcoin-gateway-api.md
@@ -1,0 +1,97 @@
+# Contract: Bitcoin Gateway API (spec 061)
+
+Normative REST contract for `services/relay-gateway/src/bitcoin/` mounted at
+`/v1/bitcoin/*`. Follows the platform proxy-module governance (killswitch →
+validation → quotas → TTL cache → normalized DTOs; module disabled ⇒ 503 with
+`{ error: 'bitcoin_disabled' }` and the frontend soft-fails the capability).
+
+`:network` path param ∈ `{ mainnet, testnet }` → upstream base URL from config
+(`BTC_ESPLORA_URL`, `BTC_ESPLORA_TESTNET_URL`; defaults `https://mempool.space/api`,
+`https://mempool.space/testnet4/api`). Stamps indexer: `BTC_STAMPS_URL`
+(stampchain.io-compatible), optional — unset ⇒ stamps endpoint returns
+`degraded: true` (client fail-safe applies). All responses
+`application/json`. Errors: `{ error: <slug>, message }` with 4xx/5xx; quota
+breach 429; upstream failure 502 `{ error: 'upstream_unavailable' }` (client
+must render stale/degraded, never zero).
+
+## POST /v1/bitcoin/:network/addresses
+
+Batch balance + UTXO lookup. Request: `{ "addresses": [string, ≤50] }`
+(validated: syntactically valid for `:network`, else 400 `invalid_address`).
+
+Response 200:
+
+```json
+{
+  "tipHeight": 903211,
+  "results": [{
+    "address": "bc1q…",
+    "confirmedSats": 125000,
+    "pendingSats": -4200,
+    "utxos": [{
+      "txid": "…", "vout": 0, "valueSats": 125000,
+      "confirmations": 3, "blockHeight": 903208
+    }]
+  }]
+}
+```
+
+Cache TTL 15s keyed by (network, sorted address set hash). Quotas: per-IP and
+global, config caps (mirrors polymarket quota knobs).
+
+## GET /v1/bitcoin/:network/fees
+
+Response 200: `{ "rates": { "fast": 12, "normal": 6, "slow": 2 }, "tipHeight": 903211 }`
+— integer sat/vB, from the upstream recommended-fees endpoint, clamped to
+`[1, BTC_MAX_FEE_RATE (config, default 500)]`. Cache TTL 30s. Boot fails
+loudly if config clamps are malformed (min ≥ 1, max ≥ min).
+
+## POST /v1/bitcoin/:network/tx
+
+Broadcast. Request: `{ "rawTx": "<hex>" }` (validated hex, ≤ 100 kB). Proxies
+upstream broadcast; success 200 `{ "txid": "…" }`; upstream rejection 400
+`{ error: "broadcast_rejected", message: <upstream reason> }` (surfaced to the
+member verbatim-safe). Never cached. Rate-limited per-IP (stricter than reads).
+
+## GET /v1/bitcoin/:network/tx/:txid
+
+Response 200: `{ "txid": "…", "confirmed": true, "blockHeight": 903210, "confirmations": 2 }`
+(`confirmations` derived from tip). 404 `{ error: "tx_not_found" }` while
+unknown to upstream (client keeps it pending with retry/backoff). TTL 15s.
+
+## GET /v1/bitcoin/:network/stamps?addresses=a,b,c
+
+Stamps holdings for ≤50 addresses. Response 200:
+
+```json
+{
+  "degraded": false,
+  "stamps": [{
+    "stampId": "A1234…",
+    "address": "bc1q…",
+    "outpoint": { "txid": "…", "vout": 1 },
+    "imageUrl": "https://…", "mimeType": "image/png"
+  }]
+}
+```
+
+`degraded: true` (with `stamps: []` or partial) whenever the indexer call
+fails, times out, or is unconfigured — the client MUST then treat unverified
+coins as protected (fail-safe, FR-019). Cache TTL 300s; a degraded result is
+cached ≤30s so recovery is fast.
+
+## Config (env, documented in `.env.example`)
+
+| Var | Default | Meaning |
+|---|---|---|
+| `BTC_ENABLED` | `false` | master switch; false ⇒ routes 503 |
+| `BTC_ESPLORA_URL` / `BTC_ESPLORA_TESTNET_URL` | mempool.space URLs | Esplora-compatible upstreams |
+| `BTC_STAMPS_URL` | unset | Stamps indexer base; unset ⇒ degraded |
+| `BTC_MAX_FEE_RATE` | `500` | sat/vB clamp on fee responses |
+| `BTC_QUOTA_PER_IP` / `BTC_QUOTA_GLOBAL` | polymarket-parity defaults | request quotas |
+| `BTC_KILLSWITCH` | `false` | ops kill: all routes 503 `bitcoin_killed` |
+
+## Non-goals (v1)
+
+No xpub/descriptor endpoints (client sends bare addresses only), no websocket
+push, no fee-bump/CPFP helpers, no server-side wallet state of any kind.

--- a/specs/061-bitcoin-transactions/contracts/bitcoin-gateway-api.md
+++ b/specs/061-bitcoin-transactions/contracts/bitcoin-gateway-api.md
@@ -78,7 +78,21 @@ Stamps holdings for ≤50 addresses. Response 200:
 `degraded: true` (with `stamps: []` or partial) whenever the indexer call
 fails, times out, or is unconfigured — the client MUST then treat unverified
 coins as protected (fail-safe, FR-019). Cache TTL 300s; a degraded result is
-cached ≤30s so recovery is fast.
+cached ≤30s so recovery is fast (an unconfigured indexer is a static config
+condition and is not cached at all).
+
+## Conventions (normative clarifications)
+
+- **Confirmations** = `tip − blockHeight + 1` (the tip block itself is one
+  confirmation) — used consistently by both the addresses and tx-status
+  endpoints.
+- **Additional error slugs** beyond the per-endpoint ones above:
+  `invalid_rawtx` (malformed broadcast hex), `invalid_txid`,
+  `unknown_network` (404 on a bad `:network`), `quota_exceeded` (429, with
+  `Retry-After`). All errors use the flat `{ error, message }` shape.
+- `BTC_TIMEOUT_MS` (default 5000) and `BTC_RETRIES` (default 1) tune upstream
+  fetches, at parity with the other proxy modules; broadcast POSTs are never
+  retried (a timed-out broadcast may still have propagated).
 
 ## Config (env, documented in `.env.example`)
 

--- a/specs/061-bitcoin-transactions/contracts/key-derivation-btc.md
+++ b/specs/061-bitcoin-transactions/contracts/key-derivation-btc.md
@@ -1,0 +1,65 @@
+# Contract: Bitcoin Key Derivation (spec 061)
+
+Normative. Any change to these constants is a **wallet-breaking change** and
+requires a versioned migration path — funds live at the derived addresses.
+Implements the extension of the spec-041 derivation stack
+(`frontend/src/lib/passkey/prfKeys.js` — "derived keys = existing derivation
+stack fed from masterSeed").
+
+## Inputs
+
+- `masterSeed`: the 32-byte spec-041 per-account master seed (PRF-recoverable,
+  memory-only). Never any other secret.
+
+## Derivation
+
+```
+btcSeed   = HKDF-SHA256(ikm = masterSeed,
+                        salt = 32 zero bytes,
+                        info = "fairwins-btc-seed-v1",
+                        length = 64)
+root      = BIP32.fromMasterSeed(btcSeed)          // @scure/bip32
+segwitAcct  = root.derive("m/84'/{coin}'/0'")      // BIP84  → P2WPKH bc1q…
+taprootAcct = root.derive("m/86'/{coin}'/0'")      // BIP86  → P2TR   bc1p…
+coin      = 0'  for network 'bitcoin' (mainnet)
+            1'  for network 'bitcoin-testnet' (testnet4)
+receive(i)  = acct.derive("0/" + i)                // external chain only
+```
+
+- Change chain (`…/1/i`) is RESERVED but unused in v1: change returns to the
+  next unissued **external** receive address of the active type (keeps
+  discovery/monitoring to one chain per account in v1). If a later version
+  adopts the change chain, it must ship with widened discovery.
+- Taproot output keys are BIP-341 tweaked (`@scure/btc-signer` `p2tr(internalKey)`
+  key-path only, no script tree).
+
+## Invariants (tested)
+
+1. **Determinism**: same `masterSeed` ⇒ byte-identical addresses on every
+   device, forever. Pinned test vectors: a fixed 32-byte test seed and its
+   first 3 addresses per (type × network) are committed in the test suite; the
+   BIP32/84/86 reference vectors validate the underlying libs.
+2. **Domain separation**: no other consumer of `masterSeed` may use the info
+   string `"fairwins-btc-seed-v1"`; the Bitcoin tree cannot collide with the
+   spec-041 KEK path (different info) or future consumers.
+3. **Memory-only**: `btcSeed`, `root`, account xprvs, and child private keys
+   are never persisted, logged, serialized, or transmitted. Zeroize references
+   on wallet lock where the runtime allows.
+4. **xpub confinement**: account xpubs may be held in memory for address
+   derivation but MUST NOT be persisted or sent to any service (the gateway
+   receives bare addresses only, ≤50 per call).
+5. **No wrong keys**: if the master seed is `unavailable`/`uninitialized`
+   (non-PRF authenticator, external EVM wallet, no blob), the Bitcoin wallet
+   status is `unavailable` with the honest reason — never a fallback
+   derivation from any other material.
+6. **Never-decreasing cursor**: the receive rotation index per (network, type)
+   only increases; recovery sets it to `max(discovered used index, cached) + 1`.
+
+## Availability matrix (drives FR-020 capability disclosure)
+
+| Account situation | Bitcoin wallet |
+|---|---|
+| Passkey + PRF authenticator, seed blob present | `ready` after one PRF ceremony |
+| Passkey + PRF, fresh account (no blob) | `ready` after `initMasterSeed` ceremony |
+| Passkey, non-PRF authenticator | `unavailable` — honest reason, tx features elsewhere unaffected |
+| Injected / WalletConnect EVM wallet | `unavailable` — Bitcoin requires a FairWins passkey account |

--- a/specs/061-bitcoin-transactions/contracts/network-registry.md
+++ b/specs/061-bitcoin-transactions/contracts/network-registry.md
@@ -1,0 +1,59 @@
+# Contract: Non-EVM Network Registry (spec 061)
+
+Normative shape of `frontend/src/config/bitcoinNetworks.js` — the platform's
+first non-EVM network registry. It is **parallel to** and never merged into
+the numeric `NETWORKS` map in `networks.js`; no numeric chainId is ever
+assigned to a Bitcoin network.
+
+## Registry shape
+
+```js
+export const BITCOIN_NETWORKS = {
+  bitcoin: {
+    id: 'bitcoin',                 // string id; NEVER a number
+    kind: 'bitcoin',
+    name: 'Bitcoin',
+    isTestnet: false,
+    gatewaySegment: 'mainnet',     // /v1/bitcoin/:network path value
+    addressHrp: 'bc',              // bech32/bech32m human-readable part
+    coinType: 0,                   // BIP44 coin type (hardened)
+    explorer: { name: 'mempool.space', baseUrl: 'https://mempool.space',
+                tx: (txid) => `…/tx/${txid}`, address: (a) => `…/address/${a}` },
+    capabilities: {
+      portfolio: true, send: true, receive: true,
+      wagers: false, pools: false, membership: false, gasless: false,
+      swap: false, earn: false, predict: false, collect: 'stamps-only',
+    },
+  },
+  'bitcoin-testnet': { /* id 'bitcoin-testnet', testnet4, hrp 'tb', coinType 1,
+                          gatewaySegment 'testnet', paired with 'bitcoin' */ },
+}
+export const BITCOIN_TESTNET_MAINNET_PAIR = ['bitcoin-testnet', 'bitcoin']
+export function isBitcoinNetworkId(id) { /* string ids above only */ }
+export function getBitcoinNetwork(id) { /* lookup or null — soft-fail */ }
+```
+
+## Integration rules (enforced in review + tests)
+
+1. **No numeric leakage**: Bitcoin ids MUST never be passed to
+   `getContractAddressForChain`, wagmi (`switchChain`, provider construction),
+   subgraph routing, or any API typed on EVM chainId. Type guards
+   (`isBitcoinNetworkId`) sit at every boundary that now accepts both.
+2. **Display-only network rows**: network-listing surfaces render Bitcoin
+   entries without a "switch wallet" affordance — there is no wallet chain
+   switch for Bitcoin; surfaces activate per-feature (receive/send/portfolio)
+   based on `capabilities` + wallet availability.
+3. **Capability honesty (FR-020)**: `capabilities` above is the single source
+   for what Bitcoin supports; every false capability hides/disables its
+   surface exactly as EVM `networkCapabilities.js` entries do. `collect:
+   'stamps-only'` means the collectibles surface shows the Stamps section but
+   no OpenSea integration.
+4. **Testnet separation (FR-021)**: the active Bitcoin network follows the
+   app's existing testnet/mainnet mode via `BITCOIN_TESTNET_MAINNET_PAIR`;
+   balances, addresses, QR codes, and activity are strictly scoped to the
+   active side, and testnet addresses (`tb1…`) are invalid destinations on
+   mainnet (and vice versa).
+5. **Selection semantics**: Bitcoin availability = passkey master-seed
+   capability (see key-derivation contract) AND gateway `BTC_ENABLED`. Either
+   missing ⇒ surfaces soft-fail (hide or honest unavailable-state), mirroring
+   the spec-054 "undeployed registry" soft-fail pattern.

--- a/specs/061-bitcoin-transactions/data-model.md
+++ b/specs/061-bitcoin-transactions/data-model.md
@@ -1,0 +1,102 @@
+# Data Model: Bitcoin Transactions (spec 061)
+
+All entities are client-side (frontend state/persistence) or transient gateway
+DTOs — there is no server-side storage and no on-chain contract state.
+
+## BitcoinWallet (client, derived + memory-only keys)
+
+| Field | Type | Notes |
+|---|---|---|
+| `network` | `'bitcoin' \| 'bitcoin-testnet'` | strict separation (FR-021) |
+| `accounts` | `{ segwit: AccountNode, taproot: AccountNode }` | BIP84 / BIP86 account nodes, derived on unlock, memory-only |
+| `preferredType` | `'segwit' \| 'taproot'` | persisted preference; default `'segwit'` (FR-006) |
+| `status` | `'unavailable' \| 'locked' \| 'ready'` | `unavailable` = no PRF/passkey capability; drives honest gating (FR-020) |
+
+Validation: wallet exists only when spec-041 master-seed capability is
+`available`; derivation follows `contracts/key-derivation-btc.md` exactly.
+
+## IssuedAddress (client-persisted ledger + deterministic rescan)
+
+| Field | Type | Notes |
+|---|---|---|
+| `address` | string | bech32 (`bc1q…`) or bech32m (`bc1p…`) |
+| `type` | `'segwit' \| 'taproot'` | which account chain it came from |
+| `index` | number | external-chain derivation index `…/0/index` |
+| `network` | string | as above |
+| `firstShownAt` | ISO timestamp | display metadata only |
+
+Rules: an address is appended when first displayed; the rotation cursor per
+`(network, type)` is `max(issued index) + 1` and **never decreases** (FR-004).
+Recovery rebuilds this ledger via gap-limit-20 discovery (research R5) — the
+persisted copy is a cache, never the source of truth (FR-003).
+
+## Utxo / Coin (gateway DTO → client selection input)
+
+| Field | Type | Notes |
+|---|---|---|
+| `txid`, `vout` | string, number | outpoint identity |
+| `valueSats` | number | integer satoshis |
+| `address` | string | owning issued address |
+| `confirmations` | number | 0 = mempool |
+| `classification` | `'spendable' \| 'pending' \| 'protected' \| 'unverified'` | client-computed (research R6) |
+| `stampId` | string \| null | set when a Stamp travels with this coin |
+| `lockedByTx` | string \| null | in-flight local send lock (FR-014) |
+
+State transitions: `pending → (1 conf) → unverified → (stamps check ok) →
+spendable` or `→ protected`; `spendable → lockedByTx → gone (confirmed spend)`
+or `→ spendable (broadcast failed/abandoned)`. `unverified` is treated exactly
+like `protected` for selection (fail-safe, FR-019).
+
+## Balance (client aggregate, portfolio input)
+
+| Field | Type | Notes |
+|---|---|---|
+| `confirmedSats` | number | sum of `spendable + protected` confirmed coins |
+| `pendingSats` | number | signed net of mempool inbound/outbound |
+| `protectedSats` | number | stamps-bearing + unverified value (FR-018) |
+| `spendableSats` | number | `confirmed − protected − locked` |
+| `stale` | boolean | upstream unreachable ⇒ render stale, never zero (FR-010) |
+
+## Stamp (gateway DTO)
+
+| Field | Type | Notes |
+|---|---|---|
+| `stampId` | string | indexer identifier |
+| `imageUrl` / `mimeType` | string | preview for collectibles surface |
+| `outpoint` | `{ txid, vout }` | the coin it travels with |
+| `address` | string | current holding address |
+
+## FeeQuote (gateway DTO + client pin)
+
+| Field | Type | Notes |
+|---|---|---|
+| `rates` | `{ fast, normal, slow }` | sat/vB integers |
+| `tipHeight` | number | freshness anchor |
+| `fetchedAt` | timestamp | quote validity window: 60s |
+| `pinned` | `{ rate, estFeeSats, estVsize }` | what the member confirmed; actual fee MUST be ≤ `estFeeSats` or re-confirm (FR-012) |
+
+## BitcoinTransaction (client activity entry)
+
+| Field | Type | Notes |
+|---|---|---|
+| `txid` | string | after broadcast |
+| `direction` | `'in' \| 'out'` | |
+| `amountSats`, `feeSats` | number | fee for outbound only |
+| `counterparty` | string | destination (out) / receiving address (in) |
+| `status` | `'pending' \| 'confirmed' \| 'failed'` | pending until ≥1 conf; never shown final early (FR-009) |
+
+## BitcoinNetworkEntry (config, `bitcoinNetworks.js`)
+
+See `contracts/network-registry.md` — id, label, isTestnet, addressPrefix
+(`bc1`/`tb1`), explorer URL patterns, gateway path segment, capabilities
+(`portfolio/send/receive` true, all else false), toggle pairing.
+
+## Relationships
+
+```
+BitcoinWallet 1—n IssuedAddress 1—n Utxo
+Utxo 0..1—1 Stamp            (protected coins)
+Utxo n—1 BitcoinTransaction  (spends/creates)
+Balance = fold(Utxo*)        (pure function, no stored state)
+FeeQuote —pins→ outbound BitcoinTransaction
+```

--- a/specs/061-bitcoin-transactions/plan.md
+++ b/specs/061-bitcoin-transactions/plan.md
@@ -1,0 +1,178 @@
+# Implementation Plan: Bitcoin Transactions
+
+**Branch**: `claude/fairwins-bitcoin-transactions-xy9ca5` | **Date**: 2026-07-20 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/061-bitcoin-transactions/spec.md`
+
+## Summary
+
+Give every passkey member a non-custodial Bitcoin wallet inside their existing
+FairWins account: the BIP32 root is derived client-side from the spec-041
+PRF-recoverable master seed (no new seed phrase), addresses rotate (BIP84
+native-segwit default, BIP86 taproot opt-in), balances/UTXOs/fees/broadcast and
+Stamps recognition flow through a new relay-gateway `bitcoin` proxy module
+(mempool.space-style upstream, same shape as `src/polymarket/`), transactions
+are built and signed client-side as PSBTs with stamps-aware coin selection, and
+BTC shows up in the portfolio under the existing `BTC` baseline with the
+already-configured Chainlink BTC/USD feeds. Bitcoin is the first non-EVM
+network: it lives in a separate string-keyed registry (never a fake numeric
+chainId) and self-discloses portfolio/send/receive as its only capabilities.
+
+## Technical Context
+
+**Language/Version**: JavaScript (ES2022) — React 18 + Vite frontend; Node 20
+Express-style relay-gateway. No Solidity changes (no contracts on Bitcoin).
+
+**Primary Dependencies**:
+- Frontend: `@scure/btc-signer` + `@scure/bip32` (new — audited, zero-native-dep
+  successors to the `@noble` family already in `frontend/package.json`; PSBT
+  construction/signing for P2WPKH + P2TR, bech32/bech32m address codecs),
+  existing `@noble/hashes` (HKDF), existing passkey PRF stack
+  (`frontend/src/lib/passkey/prfKeys.js`).
+- Gateway: no new runtime deps — the `bitcoin` module follows
+  `services/relay-gateway/src/polymarket/` (fetch upstream + TTL cache +
+  quotas). Upstreams: a mempool.space-compatible Esplora REST API
+  (config-swappable base URL, e.g. self-hosted mempool/electrs later) and a
+  Bitcoin Stamps indexer API (stampchain.io-compatible, config base URL).
+
+**Storage**: No new server storage (gateway stays stateless: cache + quotas
+in-memory as today). Client: rotation cursor, chosen address type, and issued-
+address metadata persist via the existing client persistence used by wallet
+preferences; the BIP32 account **xpubs never leave the client** and key
+material is memory-only (derived on demand from the master seed).
+
+**Testing**: Vitest for all frontend logic (derivation vectors, address
+codecs/validation, coin selection incl. stamps protection, fee math, rotation/
+recovery scan); node test runner for the gateway module (same harness as
+`polymarket` tests) with mocked upstreams; BIP32/84/86 published test vectors
+pinned in unit tests. No Hardhat/contract tests (no contract changes).
+
+**Target Platform**: Existing frontend browser targets (WebAuthn PRF-capable
+browsers for wallet availability) + the existing relay-gateway Node deployment.
+
+**Project Type**: Web application (frontend + gateway service); config-driven.
+
+**Performance Goals**: Receive surface shows an address in <2s after unlock
+(SC-001 budget is 15s incl. the PRF ceremony); portfolio BTC line resolves
+within the existing portfolio scan budget (balance endpoint batched: one
+gateway call per 50 addresses); fee quotes cached ≤60s.
+
+**Constraints**: Non-custodial — no key material, xpub, or descriptor is ever
+sent to any service; gateway sees only bare addresses/txids and signed raw
+transactions. Fail-safe Stamps handling (unknown ⇒ protected). Honest
+degradation when upstreams are down (stale-marked portfolio, blocked sends
+with reasons, never silent zeros). No gasless/sponsorship on the BTC path.
+
+**Scale/Scope**: Frontend: 1 new lib area (`frontend/src/lib/bitcoin/`), 1 new
+hook, additions to 4 existing surfaces (receive modal, send form, portfolio,
+network capabilities) — ~15 new/changed frontend files. Gateway: 1 new module
+(~5 files) + config/env + tests. Per-account address cardinality: bounded by
+BIP44 gap-limit-20 discovery; balance queries batch across issued addresses.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Security-first contracts** — PASS (no `contracts/` changes; nothing
+  deployed on-chain). The highest-risk surface here is client key handling and
+  transaction construction, which this plan treats with contract-grade rigor:
+  explicit derivation contract ([contracts/key-derivation-btc.md](./contracts/key-derivation-btc.md)),
+  published-vector tests, fail-safe coin selection, and a security review pass
+  (`.github/agents/`) over the key/signing code even though it is not Solidity.
+- **II. Test-first** — PASS. Every pure module (derivation, codecs, selection,
+  fees, rotation scan) lands with Vitest suites incl. BIP test vectors;
+  gateway module lands with mocked-upstream route tests; failure/edge paths
+  (degraded stamps indexer, stale fee quote, insufficient funds, checksum
+  failures) are explicit acceptance scenarios in the spec.
+- **III. Honest state** — PASS by design. Pending vs confirmed value split
+  (FR-009), stale-marking on upstream failure (FR-010), fee re-confirmation on
+  quote drift (FR-012), fail-safe stamps protection (FR-019), capability
+  self-disclosure incl. the PRF/passkey availability gate (FR-020). No mocks in
+  shipped paths; test upstreams live only in test fixtures.
+- **IV. Fail loudly in CI** — PASS. New tests join the existing gating suites;
+  no `continue-on-error`. Gateway boot fails loudly on malformed bitcoin config
+  (mirroring the polymarket fee-cap boot check).
+- **V. Accessible, consistent frontend** — PASS. New UI reuses the existing
+  receive-modal/send-form/portfolio components and their a11y patterns; axe/
+  Lighthouse stay gating. No hand-copied contract addresses (none exist here);
+  all endpoints/config flow from `networks`-style config and env.
+- **Additional constraints** — new core technology (`@scure/btc-signer`,
+  `@scure/bip32`) justified below in Complexity Tracking; floppy-keystore
+  remains the admin-key workflow and is untouched; no secrets in the repo
+  (Stamps/Esplora upstreams are public APIs; any future API key is gateway
+  env, documented in `.env.example`).
+
+**Post-design re-check (after Phase 1)**: PASS — design artifacts introduce no
+new violations; the only tracked complexity items remain the two new client
+crypto libraries and the parallel non-EVM network registry, both justified.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/061-bitcoin-transactions/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   ├── key-derivation-btc.md    # master seed → BIP32/84/86 derivation contract
+│   ├── bitcoin-gateway-api.md   # /v1/bitcoin/* REST contract
+│   └── network-registry.md      # non-EVM network registry + capability contract
+└── tasks.md             # Phase 2 output (/speckit-tasks — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+frontend/src/
+├── lib/bitcoin/
+│   ├── derivation.js        # masterSeed → HKDF → BIP32 root → BIP84/BIP86 accounts
+│   ├── addresses.js         # address encode/decode/validate (bech32, bech32m, base58check), BIP-21
+│   ├── wallet.js            # rotation state, issued-address ledger, gap-limit recovery scan
+│   ├── coinSelection.js     # stamps-aware UTXO selection, dust rules, fee math, MAX
+│   ├── psbt.js              # PSBT build + sign (P2WPKH/P2TR inputs, all output types)
+│   └── gatewayClient.js     # thin client for /v1/bitcoin/* (balances, utxos, fees, broadcast, stamps)
+├── hooks/
+│   └── useBitcoinWallet.js  # unlock/derive, balances, send pipeline, pending tracking
+├── config/
+│   ├── bitcoinNetworks.js   # NEW string-keyed non-EVM registry ('bitcoin', 'bitcoin-testnet')
+│   ├── networks.js          # + capability surfacing hooks for non-EVM entries (display only)
+│   └── assetTaxonomy.js     # + native BTC instance under the existing BTC baseline
+├── hooks/usePortfolio.js    # + bitcoin balance source branch (non-EVM, non-ethers)
+├── components/
+│   ├── ui/AddressQRModal.jsx        # + Bitcoin receive mode (rotation, type toggle, BIP-21 QR)
+│   ├── ui/AddressInput.jsx          # + Bitcoin destination validation path
+│   ├── ui/QRScanner.jsx / lib/addressBook/scanAddress.js  # + bitcoin: URI parsing
+│   └── wallet/TransferForm.jsx      # + BTC asset path (fee line, no gasless, pending states)
+└── (collectibles surface)           # + Bitcoin Stamps section (spec 055 pattern)
+
+services/relay-gateway/src/
+├── bitcoin/
+│   ├── client.js            # Esplora + Stamps upstream fetchers (timeout/retry)
+│   ├── normalize.js         # upstream → DTOs (balances, utxos, fees, tx status, stamps)
+│   ├── routes.js            # /v1/bitcoin/* (killswitch → validation → quota → cache → fetch)
+│   └── cache.js             # TTL caches per endpoint class
+├── config/index.js          # + bitcoin env block (upstream URLs, TTLs, quotas, killswitch)
+└── server.js                # + createBitcoinRouter wiring
+
+frontend/src/lib/bitcoin/__tests__/   # Vitest suites (vectors, selection, codecs, rotation)
+services/relay-gateway/test/bitcoin.test.js  # mocked-upstream route tests
+docs/developer-guide/bitcoin.md      # developer guide (mirrors predict-polymarket.md)
+docs/runbooks/bitcoin-operations.md  # upstream swap, killswitch, quota ops
+```
+
+**Structure Decision**: Web-application split matching the repo: pure Bitcoin
+logic isolated under `frontend/src/lib/bitcoin/` (unit-testable, no React), one
+orchestration hook, minimal diffs inside existing surfaces; gateway follows the
+established module-per-integration pattern (`polymarket`/`opensea` →
+`bitcoin`). No new packages/workspaces.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| New core client libs `@scure/btc-signer` + `@scure/bip32` | Bitcoin tx construction (PSBT, taproot sighash, bech32m) and BIP32 derivation are consensus-critical; hand-rolling them is the real risk | `bitcoinjs-lib` needs `tiny-secp256k1` (WASM/native) and is far heavier; hand-written derivation/signing would be an audit liability; scure libs are audited, tree-shakeable, and share the `@noble` primitives already shipped |
+| Parallel string-keyed `bitcoinNetworks.js` registry beside numeric `NETWORKS` | Bitcoin has no EVM chainId; every `NETWORKS` consumer assumes wagmi-switchable numeric ids | Overloading a fake numeric id (e.g. 0 or 8332) into `NETWORKS` would ripple through every chainId consumer (wagmi switchChain, contracts.js, subgraph routing) and create dishonest "switch wallet to Bitcoin" affordances |
+| New gateway upstream class (Esplora + Stamps indexer) | Balances/UTXOs/fees/broadcast/stamps don't exist on any current upstream; client-direct calls would leak member address sets to third parties without quotas/killswitch | Direct-from-browser upstream calls bypass the platform's quota/killswitch/cache layer and CORS-pin the product to one public provider |

--- a/specs/061-bitcoin-transactions/quickstart.md
+++ b/specs/061-bitcoin-transactions/quickstart.md
@@ -1,0 +1,84 @@
+# Quickstart: Validating Bitcoin Transactions (spec 061)
+
+Runnable validation guide. References:
+[data-model.md](./data-model.md), [contracts/](./contracts/),
+[research.md](./research.md).
+
+## Prerequisites
+
+- Node 20, repo installed (`npm install` at root and `frontend/`,
+  `services/relay-gateway/`).
+- A WebAuthn PRF-capable environment for end-to-end flows (Chrome + platform
+  authenticator, or the Vitest PRF mocks for headless runs).
+- Testnet4 coins from a public faucet (e.g. mempool.space testnet4 faucet)
+  for live-network scenarios.
+
+## 1. Unit suites (no network)
+
+```bash
+npm run test:frontend -- bitcoin        # lib/bitcoin/* suites
+cd services/relay-gateway && npm test   # includes bitcoin route tests (mocked upstreams)
+```
+
+Expected: derivation vectors (fixed test seed → pinned bc1q/bc1p/tb1
+addresses; BIP32/84/86 reference vectors), address codec accept/reject matrix
+(incl. wrong-network, bad checksum, `0x…`), BIP-21 parsing, coin-selection
+properties (stamps/unverified never selected; MAX net of fees; sub-dust change
+folded into fee; in-flight coins locked), fee-quote staleness rules, gap-limit
+recovery scan — all green.
+
+## 2. Gateway smoke (live upstream, testnet)
+
+```bash
+cd services/relay-gateway
+BTC_ENABLED=true npm start   # other BTC_* vars per contracts/bitcoin-gateway-api.md
+curl -s localhost:PORT/v1/bitcoin/testnet/fees          # → { rates: {fast,normal,slow}, tipHeight }
+curl -s -X POST localhost:PORT/v1/bitcoin/testnet/addresses \
+  -H 'content-type: application/json' -d '{"addresses":["tb1q…"]}'
+```
+
+Expected: fee rates within clamps; address lookup returns confirmed/pending
+sats + UTXOs matching mempool.space's testnet4 explorer for the same address.
+With `BTC_ENABLED=false` both routes return 503 `bitcoin_disabled`. With
+`BTC_STAMPS_URL` unset, `/stamps` returns `degraded: true`.
+
+## 3. End-to-end member flows (frontend + gateway, testnet mode)
+
+```bash
+npm run frontend   # with the gateway from step 2 configured
+```
+
+Walk the spec's acceptance scenarios in-app (testnet mode):
+
+1. **Receive + rotation (Story 1)**: sign in with a passkey → Receive →
+   Bitcoin → address shown (<15s incl. PRF ceremony), labeled testnet, QR
+   scannable by an external wallet. Request again → different address. Fund
+   the *first* address from a faucet → balance appears.
+2. **Portfolio (Story 2)**: portfolio shows the Bitcoin row summing all funded
+   addresses; unconfirmed deposits shown pending, flipping to confirmed at 1
+   conf; stop the gateway → row renders stale, not zero.
+3. **Send (Story 3)**: send to one destination of each type (`m/n…` legacy,
+   `2…`/`3…` script-hash, `tb1q…`, `tb1p…`); confirm screen shows fee line
+   (BTC + USD) and total debit; invalid/mainnet/EVM destinations rejected with
+   specific reasons; MAX leaves zero unspendable remainder; tx pending until
+   confirmed on the explorer; fee paid ≤ quoted.
+4. **Stamps (Story 4)**: with a Stamps-holding test address (or the mocked
+   indexer fixture), collectibles shows the Stamp; MAX send leaves the
+   stamps-bearing coin untouched; kill the stamps upstream → degraded banner
+   and unverified coins excluded from spendable.
+5. **Honesty (Story 5)**: Network tab lists Bitcoin with truthful
+   capabilities; wager/pool/membership flows never offer BTC; send confirm
+   never says gasless. Sign in with a non-PRF authenticator or injected EVM
+   wallet → Bitcoin surfaces show the honest unavailable state.
+6. **Recovery (SC-006)**: clear site data (or a second browser profile), sign
+   in with the same passkey → all funded addresses and balances reappear with
+   no Bitcoin-specific step; next receive address does not reuse any funded one.
+
+## 4. Regression gate (SC-008)
+
+```bash
+npm run test:frontend && npm test
+```
+
+Expected: full existing suites pass unchanged — a member who never opens a
+Bitcoin surface sees no behavioral difference.

--- a/specs/061-bitcoin-transactions/research.md
+++ b/specs/061-bitcoin-transactions/research.md
@@ -1,0 +1,261 @@
+# Research: Bitcoin Transactions (spec 061)
+
+Phase 0 output. Each entry: Decision / Rationale / Alternatives considered.
+All Technical Context unknowns from plan.md are resolved here.
+
+## R1. Bitcoin key material: derive from the spec-041 master seed
+
+**Decision**: The Bitcoin wallet root is derived client-side from the existing
+per-account master seed (`frontend/src/lib/passkey/prfKeys.js`):
+
+```
+masterSeed (32B, spec 041, PRF-recoverable)
+  → HKDF-SHA256(salt = 32 zero bytes, info = "fairwins-btc-seed-v1", L = 64)
+  → BIP32 root (via @scure/bip32 HDKey.fromMasterSeed)
+  → account nodes m/84'/{coin}'/0' (native segwit) and m/86'/{coin}'/0' (taproot)
+      coin = 0' mainnet, 1' testnet
+```
+
+Full normative detail in [contracts/key-derivation-btc.md](./contracts/key-derivation-btc.md).
+
+**Rationale**: FR-001/FR-003 demand a deterministic, recoverable wallet with no
+new backup artifact. The master seed already has exactly those properties: it is
+recoverable on any device via a PRF ceremony, syncs to added controllers
+(`wrapForController`), and is the documented root for "derived keys = existing
+derivation stack fed from masterSeed". A domain-separated HKDF step guarantees
+the Bitcoin tree can never collide with any other consumer of the seed, and the
+64-byte output matches BIP32's recommended seed entropy.
+
+**Consequences (documented honestly in UI/capabilities)**:
+- The Bitcoin wallet is available exactly where the master seed is: passkey
+  accounts on PRF-capable authenticators. Injected/WalletConnect EVM wallets
+  and non-PRF authenticators get the honest capability-off state (same
+  degradation model as spec-041 encrypted features). This is FR-020 territory,
+  not a hidden limitation.
+- Keys are memory-only; xpubs/descriptors never leave the client (gateway sees
+  bare addresses only).
+
+**Alternatives considered**:
+- *New BIP39 mnemonic per member*: violates FR-001 (new backup artifact) and
+  reintroduces the seed-phrase UX passkeys were adopted to remove.
+- *Server-side or MPC custody*: violates FR-002 and the platform's
+  non-custodial model; large new trust surface.
+- *Derive from the passkey P-256 key directly*: WebAuthn signatures are
+  non-deterministic and the P-256 private key is unextractable; PRF is the only
+  deterministic exportable secret — and spec 041 already standardized routing
+  it through the master seed.
+
+## R2. Client Bitcoin library: @scure/btc-signer + @scure/bip32
+
+**Decision**: Use `@scure/btc-signer` (PSBT construction/signing, P2WPKH +
+P2TR spends, address codecs incl. bech32m) and `@scure/bip32` (HD derivation),
+pinned exact versions.
+
+**Rationale**: Audited (Cure53 lineage shared with `@noble`), zero native/WASM
+dependencies (pure JS over `@noble/curves` secp256k1 — the frontend already
+ships `@noble/curves`/`@noble/hashes`), small and tree-shakeable, supports
+taproot key-path spends and BIP-341 sighash. Keeps the whole signing path
+auditable JS in our bundle.
+
+**Alternatives considered**:
+- *bitcoinjs-lib + ecpair + tiny-secp256k1*: the floppy-keystore CLI uses it,
+  but it drags a WASM secp256k1 into the browser bundle, is heavier, and its
+  taproot support still leans on external ECC injection. Fine for a Node CLI,
+  wrong fit for the Vite bundle.
+- *bdk-wasm / rust WASM kits*: strongest engines but a new toolchain + large
+  WASM payloads; unjustified for v1 scope (constitution: simplicity).
+
+## R3. Non-EVM network representation: parallel string-keyed registry
+
+**Decision**: New `frontend/src/config/bitcoinNetworks.js` exporting
+`BITCOIN_NETWORKS` keyed by string ids `'bitcoin'` (mainnet) and
+`'bitcoin-testnet'` (testnet4), each with name, address prefixes (`bc1`/`tb1`),
+explorer (mempool.space URL patterns), capability set
+(`{ portfolio, send, receive }` true; everything else false), and the
+testnet/mainnet pairing. Numeric `NETWORKS` in `networks.js` is untouched;
+network-listing surfaces (Network tab / capabilities panel) additionally render
+non-EVM entries as display-only rows (no wagmi switchChain affordance — there
+is no "switching your wallet to Bitcoin"). Contract resolution
+(`getContractAddressForChain`) never sees these ids. Normative shape in
+[contracts/network-registry.md](./contracts/network-registry.md).
+
+**Rationale**: Every `NETWORKS` consumer assumes a numeric, wagmi-switchable
+EVM chainId (provider construction, contracts.js, subgraph routing, chain
+toggles). A fake numeric id would silently flow into those consumers; a
+parallel registry makes non-EVM support explicit and type-checkable at each
+integration point, and matches the honest-capability pattern (spec 048) for
+networks that only do value transfer.
+
+**Alternatives considered**: fake numeric chainId in `NETWORKS` (rejected —
+ripple + dishonest switch affordances); CAIP-2 style rekeying of the whole
+registry (rejected — repo-wide churn far beyond v1 scope).
+
+## R4. Gateway module: Esplora-compatible upstream behind /v1/bitcoin/*
+
+**Decision**: New `services/relay-gateway/src/bitcoin/` following the
+`polymarket` module shape (`client.js` / `normalize.js` / `routes.js` /
+`cache.js`), mounted as `/v1/bitcoin/*`:
+
+- `POST /v1/bitcoin/:network/addresses` — batch balance + UTXO lookup for ≤50
+  addresses per call (POST because address sets exceed URL limits).
+- `GET  /v1/bitcoin/:network/fees` — recommended fee rates (fastest/normal/slow,
+  sat/vB) + current tip height.
+- `POST /v1/bitcoin/:network/tx` — broadcast raw signed tx (hex body).
+- `GET  /v1/bitcoin/:network/tx/:txid` — confirmation status.
+- `GET  /v1/bitcoin/:network/stamps?addresses=…` — Stamps holdings for
+  addresses, with a `degraded` flag when the indexer is unreachable.
+
+Upstreams are config-URL Esplora-compatible APIs (default
+`https://mempool.space/api` and `/testnet4/api`; swappable to self-hosted
+mempool/electrs) plus a stampchain.io-compatible Stamps indexer base URL.
+Killswitch → param validation → per-IP+global quotas → TTL cache (fees 30s,
+balances/UTXOs 15s, tx status 15s, stamps 5min) → normalize to DTOs. Boot
+fails loudly on malformed bitcoin config; the module is optional — unset env
+disables the routes and the frontend capability soft-fails (Bitcoin surfaces
+hide/degrade honestly). Full contract in
+[contracts/bitcoin-gateway-api.md](./contracts/bitcoin-gateway-api.md).
+
+**Rationale**: Identical governance to existing external-data proxies (quotas,
+killswitch, caching, no client-held keys), keeps member address-set queries off
+third-party CORS endpoints, and lets ops swap to self-hosted infrastructure by
+env change alone (runbook). Esplora is the de-facto REST standard (mempool.space,
+blockstream.info, self-hosted electrs all speak it).
+
+**Alternatives considered**: browser-direct mempool.space calls (rejected — no
+quota/killswitch, leaks address sets, CORS fragility); running a full node +
+custom indexer for v1 (rejected — heavy ops for no v1 functional gain; the
+config-swappable upstream keeps that door open); WebSocket push for deposits
+(deferred — polling within the existing portfolio refresh cadence satisfies
+the spec; noted as future work).
+
+## R5. Address rotation & recovery: BIP44 gap-limit discovery
+
+**Decision**: Rotation is index-based on the external chain (`…/0/i`) of the
+active account (BIP84 or BIP86 per member preference). A fresh receive shows
+the lowest index never yet displayed; issued-address metadata (index, type,
+first-shown) persists client-side via the existing wallet-preference
+persistence (and rides spec-032 sync where available). Recovery never trusts
+that cache: on unlock, the wallet runs standard gap-limit-20 discovery per
+account chain against the gateway batch endpoint until 20 consecutive unused
+addresses are seen, rebuilding the issued set and the rotation cursor
+(`next = highest used index + 1`, never below the cached cursor). All
+discovered-or-issued addresses are monitored forever (FR-005).
+
+**Rationale**: FR-003/FR-004/FR-005 and SC-002/SC-006 exactly describe BIP44
+discovery semantics; using the standard means external tooling (and any future
+wallet-export feature) agrees with our view of funds. Cursor-never-decreases
+prevents address reuse even when the local cache is stale.
+
+**Alternatives considered**: server-side registry of issued addresses
+(rejected — server learns the full wallet graph; client cache + deterministic
+rescan achieves FR-003 without it); no look-ahead window (rejected — breaks
+"sender pays an address far ahead" edge case and standard recovery).
+
+## R6. Stamps recognition & protection: indexer + fail-safe coin policy
+
+**Decision**: Stamps data comes from the gateway `stamps` endpoint (indexer-
+backed). Coin selection classifies every UTXO as `spendable` only when (a) the
+stamps lookup succeeded for its address set and (b) the UTXO is not referenced
+by any Stamp *and* (c) it is not an obviously data-carrying output
+(bare-multisig heuristic belt-and-braces). Anything else — stamp-bearing,
+unverified because the indexer is degraded, or unconfirmed inbound — is
+excluded from spendable balance and from selection. The UI shows
+`total`, `pending`, and `protected` components so total ≠ spendable is always
+explained (FR-018); degraded recognition surfaces a banner (FR-019). Stamps
+render in the collectibles surface using the spec-055 section pattern with the
+indexer's image/asset metadata.
+
+**Rationale**: Stamps live in specific UTXOs (classic Stamps encode data in
+bare multisig outputs; SRC-20 in the tx envelope) — spending the UTXO destroys
+or transfers the asset. Only fail-safe classification satisfies the spec's
+"prefer over-protection" edge case. Heuristics alone can't identify all Stamps
+(hence indexer), and the indexer alone can be down (hence fail-safe default).
+
+**Alternatives considered**: heuristics-only (misses indexer-known stamps on
+clean-looking UTXOs); blocking all sends when the indexer is down (rejected —
+worse availability than fail-safe exclusion, which keeps verified-clean coins
+spendable... note: on *first* fetch failure nothing is verified, so sends block
+with an honest reason — same outcome as spec scenario 4).
+
+## R7. Transaction construction: PSBT, fee policy, dust, RBF
+
+**Decision**:
+- Inputs: P2WPKH and P2TR (our own UTXOs only). Outputs: any standard type —
+  P2PKH, P2SH, P2WPKH/P2WSH (bech32 v0), P2TR (bech32m v1) — via
+  `@scure/btc-signer` address codecs.
+- Fee = selected rate (sat/vB from `/fees`, member picks normal by default) ×
+  estimated vsize; quote pinned at confirm time with a freshness window (60s);
+  a stale or upward-revised quote forces re-confirmation (FR-012). Fee shown in
+  BTC + USD (existing BTC/USD price source).
+- Coin selection: accumulative largest-first over spendable coins with change;
+  MAX = sum(spendable) − fee(all-inputs tx, no change). Change below the dust
+  threshold (546 sats legacy-equivalent; 330 sats for P2TR/P2WPKH outputs) is
+  folded into the fee rather than creating dust (FR-013).
+- RBF signaling on (sequence 0xfffffffd); v1 ships no fee-bump UI but
+  broadcast-replaceability keeps the door open (documented).
+- Concurrency: coins referenced by an in-flight (broadcast, unconfirmed) send
+  are locked locally and excluded from selection (FR-014).
+- Validation rejects wrong-network prefixes (`tb1`/`bcrt1` on mainnet and vice
+  versa), bech32/bech32m checksum failures, EVM `0x` input, and unknown witness
+  versions, each with a specific message (FR-011). BIP-21 `bitcoin:` URIs parse
+  address + `amount` (FR-016).
+
+**Rationale**: Matches the spec's fee-honesty and dust requirements with the
+simplest selection algorithm that satisfies them; vsize estimation for
+P2WPKH/P2TR inputs is deterministic enough for honest quotes (witness sizes are
+fixed-bound), and folding sub-dust change into fees is standard practice.
+
+**Alternatives considered**: branch-and-bound selection (better privacy/fees,
+more complexity — deferred; selection is isolated in `coinSelection.js` so the
+algorithm can be upgraded without surface changes); CPFP/RBF bump UI (deferred).
+
+## R8. Portfolio & pricing integration
+
+**Decision**: `assetTaxonomy.js` gains a native-Bitcoin instance under the
+existing `BTC` baseline (`UNDERLYING_META.BTC` gets `homeNetwork: 'bitcoin'`),
+kind `'btc-native'`, scoped to the new string network ids. `usePortfolio.js`
+adds a bitcoin balance source alongside the EVM scan: when the member's
+Bitcoin wallet is available (capability on + wallet unlocked or cached issued
+addresses present), it calls the gateway batch endpoint and yields confirmed /
+pending / protected components. Aggregation reuses the existing native+wrapped
+roll-up so native BTC and WBTC form one "Bitcoin" row (spec scenario 2).
+Pricing reuses the already-configured Chainlink BTC/USD feeds
+(`priceFeeds.js`: chains 1 & 137) keyed by underlying `BTC` — zero new price
+infrastructure. Unreachable balance source ⇒ the position renders stale/
+unavailable, never zero (FR-010).
+
+**Rationale**: The taxonomy/price layers were explicitly built with BTC as a
+baseline underlying; this is the designed seam. Balance-source branching in
+`usePortfolio` keeps EVM code paths untouched (FR-022/SC-008).
+
+**Alternatives considered**: separate Bitcoin portfolio panel (rejected —
+violates the one-portfolio aggregation UX and duplicates pricing).
+
+## R9. Bitcoin test network: testnet4
+
+**Decision**: `'bitcoin-testnet'` = **testnet4** (mempool.space
+`/testnet4/api`), paired with `'bitcoin'` mainnet under the existing
+testnet/mainnet toggle semantics (FR-021). Address prefixes `tb1…` (same as
+testnet3 — codecs unchanged), coin type 1'.
+
+**Rationale**: testnet3 is deprecated/reset-prone and faucet-hostile since
+2024; testnet4 is the maintained successor with public Esplora endpoints.
+Signet was considered but testnet4 has broader faucet/explorer support and
+matches the "one public test network" scope in the spec assumptions.
+
+**Alternatives considered**: signet (viable fallback — one env URL swap away);
+regtest (dev-only; not a shared testnet for QA flows).
+
+## R10. Where Bitcoin appears (and does not)
+
+**Decision**: Surfaces gaining Bitcoin: receive (AddressQRModal Bitcoin mode),
+send (TransferForm asset entry + AddressInput/QRScanner validation), portfolio
+(+ collectibles for Stamps), network capability listing, activity (send/receive
+entries with pending states). Surfaces explicitly untouched: wager/pool/
+membership creation, swap, earn, predict, gasless/relayer, callsigns, address
+book EVM validation (address book may store BTC addresses only if it already
+supports free-form entries — otherwise deferred and documented). The BTC send
+path never touches `useTransfer`'s EVM routing table; it is a parallel
+`useBitcoinWallet.send` pipeline so the never-stranded EVM logic stays intact.
+
+**Rationale**: FR-020/FR-022 — additive integration, zero regression surface.

--- a/specs/061-bitcoin-transactions/security-review.md
+++ b/specs/061-bitcoin-transactions/security-review.md
@@ -1,0 +1,57 @@
+# Security Review: Bitcoin Transactions (spec 061, task T040)
+
+**Date**: 2026-07-20 · **Scope**: `frontend/src/lib/bitcoin/*`,
+`frontend/src/config/bitcoinNetworks.js`, `frontend/src/hooks/useBitcoinWallet.js`,
+`services/relay-gateway/src/bitcoin/*` + config/server wiring · **Method**:
+line-by-line review of the key-handling/signing/selection paths against the
+constitution (principle I applied at contract-grade rigor to this non-Solidity
+value path), the spec-061 contracts, and the invariant test suites; behaviors
+cross-checked against the 141 frontend + 44 gateway tests added by this spec.
+
+## Findings
+
+| # | Severity | Location | Finding | Status |
+|---|----------|----------|---------|--------|
+| 1 | medium (fixed in-flight) | `frontend/src/config/networkCapabilities.js` | `getNetworkFeatures` resolved unknown ids through `getNetwork`'s default-network fallback, so bitcoin string ids reported Polygon's swap/ClearPath capabilities as available — a network-registry rule-1 leak (dishonest capability, no fund risk). Guarded with `isBitcoinNetworkId`; pinned by `bitcoinNetworkGuards.test.js`. | fixed |
+| 2 | medium (fixed in-flight) | `frontend/src/components/wallet/TransferForm.jsx` | The asset dropdown received the raw EVM `quoteGaslessForAsset`, which could render a gasless marker on the Bitcoin row for passkey users (FR-015 violation — dishonest fee claim, no fund risk). Wrapped so `btc-native` options are always fee-paying; pinned by `TransferForm.bitcoin.test.jsx`. | fixed |
+| 3 | low | `frontend/src/lib/bitcoin/wallet.js` (`ledgerStore`) | The issued-address ledger lives in client storage unauthenticated: local tampering could inject an attacker address that the UI then displays as a past receive address. Requires an already-compromised browser profile (at which point the DOM itself is attacker-controlled), and the rotation cursor never decreases, so funds at real addresses are unaffected; discovery rebuilds honest state from chain data. Accepted for v1; hardening option: MAC ledger entries under a PRF-derived key. | accepted |
+| 4 | low | `services/relay-gateway/src/bitcoin/routes.js` | Server-side address validation is prefix/charset/length sanity only (documented); a syntactically-plausible-but-invalid address reaches the upstream as a lookup for a nonexistent address. No SSRF surface (the address is path/query data against a fixed config base URL, URL-encoded); cost bounded by quotas + ≤50 batch cap. Accepted — full checksum validation is client-side by design. | accepted |
+| 5 | info | `frontend/src/lib/bitcoin/psbt.js` | BIP-340 aux randomness makes taproot witnesses non-deterministic across retries of the same plan; txid is unaffected. No security impact; noted so retry logic never assumes byte-identical raw transactions. | noted |
+| 6 | info | `frontend/src/hooks/useBitcoinWallet.js` | JS cannot guarantee zeroization; seed/account refs are nulled on lock/account-change but copies may persist until GC. Inherent to the platform (same posture as the spec-041 PRF stack). | noted |
+
+No critical or high findings. Findings 1–2 were caught by this spec's own
+guard-rail/honesty test tasks during implementation and are fixed and pinned in
+the committed test suites.
+
+## Invariants verified (positive observations)
+
+- **Key confinement**: `deriveBtcSeed`/`deriveAccount`/`receivePrivkey` never
+  persist, log, or transmit key material; the gateway client sends bare
+  addresses (≤50/batch) and signed raw hex only — no xpub/descriptor ever
+  leaves the client (contract inv. 3–4; grep + call-graph verified).
+- **Domain separation**: HKDF info `fairwins-btc-seed-v1` is exclusive; the
+  derivation test suite proves the BTC tree differs from the spec-041 KEK path
+  and pins BIP84/86 reference vectors plus FairWins fixture vectors.
+- **No wrong keys**: non-PRF/uninitialized credentials surface `unavailable`;
+  wrong-length seeds throw (never a silently different wallet).
+- **Fail-safe stamps**: coin selection only ever spends `spendable`-classified,
+  unlocked coins; degraded recognition ⇒ `unverified` ⇒ excluded, tested at
+  every selection path incl. MAX (FR-018/019).
+- **Fee ceiling**: the member-confirmed fee is enforced twice — plan-level and
+  `buildAndSignTx`'s `FeeOverrunError` refusal before any signature; quotes
+  expire in 60s with forced re-confirmation (FR-012).
+- **Dust + conservation**: selection tests assert exact sats conservation
+  (inputs = amount + fee + change), sub-dust change folded into the fee, and
+  no dust outputs ever produced.
+- **Double-spend locks**: in-flight outpoints are excluded from selection and
+  released only on confirm/abandon (FR-014).
+- **Wrong-network rejection**: bech32 HRP + base58 version checks reject
+  cross-network destinations with an explicit reason at both prepare and
+  psbt (network-typed `addOutputAddress`) layers.
+- **Gateway governance**: killswitch → enabled → validation → quota → cache
+  ordering verified by route tests; broadcasts never retried (a timed-out
+  broadcast may have propagated); boot fails loudly on malformed `BTC_*`
+  config; upstream failures map to 502 and the client renders stale-not-zero.
+- **Non-EVM containment**: `isBitcoinNetworkId` guards pinned by tests at
+  `getContractAddressForChain`, portfolio scan, selectable networks, and
+  capability resolution — no bitcoin id reaches EVM-typed code.

--- a/specs/061-bitcoin-transactions/spec.md
+++ b/specs/061-bitcoin-transactions/spec.md
@@ -1,0 +1,418 @@
+# Feature Specification: Bitcoin Transactions
+
+**Feature Branch**: `061-bitcoin-transactions`
+
+**Created**: 2026-07-20
+
+**Status**: Draft
+
+**Input**: User description: "Enable native Bitcoin (BTC) transactions on the FairWins platform, surfaced where BTC is functionally useful: the portfolio (show native BTC holdings alongside existing assets, priced in USD) and the send/receive flows (send BTC to any valid Bitcoin address; receive BTC via displayed addresses/QR). The implementation must support: (1) address rotation — fresh receive addresses per request so members don't reuse addresses, with all past addresses still monitored for balance; (2) Bitcoin Stamps — recognize Stamps assets held in the member's UTXOs, display them in the portfolio/collectibles surface, and protect stamps-bearing UTXOs from being accidentally spent as fees/inputs in ordinary sends; (3) multiple address/transaction types, including taproot (P2TR, bech32m bc1p) as well as native segwit (P2WPKH, bech32 bc1q), for both receiving and sending (recognize and pay to legacy P2PKH, P2SH, bech32, and bech32m destinations). Bitcoin is a non-EVM chain: the feature must fit FairWins' existing account model (passkey-first) and its honest-disclosure UX rules. This is the first non-EVM network in the product."
+
+## Overview
+
+FairWins members hold and move value today only on EVM networks. Bitcoin is the
+largest crypto asset by market value and the one members most often hold
+elsewhere; today the portfolio can only show it as wrapped BTC (an ERC-20 proxy).
+This feature gives every member a real Bitcoin wallet inside their existing
+FairWins account — no new seed phrase, no separate app — surfaced exactly where
+Bitcoin is functionally useful:
+
+- **Portfolio**: native BTC balance appears alongside existing assets, priced in
+  USD, aggregated with wrapped BTC under the single "Bitcoin" asset.
+- **Receive**: fresh, never-reused Bitcoin addresses on demand (address
+  rotation), shown as text + QR, with all previously issued addresses still
+  watched and counted toward the balance.
+- **Send**: pay any valid Bitcoin address (legacy, script-hash, native segwit,
+  taproot) with the network fee honestly disclosed and confirmed before signing.
+- **Stamps**: Bitcoin Stamps assets held by the member are recognized, shown in
+  the collectibles surface, and structurally protected from being accidentally
+  destroyed by an ordinary send.
+
+Bitcoin is the platform's first non-EVM network. It supports **only** portfolio,
+send, and receive — no wagers, no pools, no gasless sponsorship, no membership
+actions — and the product must say so plainly wherever a member could otherwise
+expect those features.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Receive Bitcoin with rotating addresses (Priority: P1)
+
+A member wants to move BTC into FairWins. From the receive surface they pick
+Bitcoin, and the app shows a fresh Bitcoin address (text + QR + share). The next
+time they ask to receive, they get a *new* address — addresses are never handed
+out twice — yet funds sent to any previously issued address still arrive and
+count toward their balance. The member can choose the address format (modern
+default, taproot optional) if they care, and ignore the choice if they don't.
+
+**Why this priority**: Receiving is the on-ramp; nothing else in this feature is
+useful until a member can get BTC into their wallet. Address rotation is the
+privacy property the feature is named for, and it must exist from the first
+address issued (rotation cannot be retrofitted onto a reused-address history).
+
+**Independent Test**: With a funded external Bitcoin wallet, request a receive
+address in FairWins, send a small amount to it, confirm the balance appears;
+request a second address, confirm it differs from the first; send to the first
+(older) address again and confirm the balance still updates.
+
+**Acceptance Scenarios**:
+
+1. **Given** a signed-in member on the receive surface, **When** they select
+   Bitcoin, **Then** they see a valid Bitcoin address as copyable text, a
+   scannable QR code, and a share action, clearly labeled as a Bitcoin address.
+2. **Given** a member who has been shown a receive address, **When** they
+   request a new receive address (or complete a receive and return), **Then**
+   the address shown is one never previously displayed for this account.
+3. **Given** a member with several previously issued addresses, **When** BTC is
+   sent to any of them (including the oldest), **Then** the member's portfolio
+   balance reflects the deposit.
+4. **Given** the receive surface, **When** the member opens the address-type
+   option, **Then** they can choose between the modern default format and
+   taproot, the choice persists for future receives, and each format produces a
+   valid address of that type.
+5. **Given** a receive QR code, **When** it is scanned by a common external
+   Bitcoin wallet, **Then** the wallet recognizes the address (and amount, when
+   the member specified one) without manual correction.
+
+---
+
+### User Story 2 - See Bitcoin in the portfolio (Priority: P1)
+
+A member who holds BTC (received via Story 1) opens their portfolio and sees a
+"Bitcoin" row: total BTC across all their issued addresses, its USD value, and
+— if they also hold wrapped BTC on an EVM chain — one aggregated Bitcoin
+position with the native and wrapped instances visible in the detail view, just
+like ETH/WETH today.
+
+**Why this priority**: The portfolio is where members verify a receive worked
+and see what they own; without it Story 1 is unverifiable inside the product.
+
+**Independent Test**: Fund a member's Bitcoin addresses (multiple addresses,
+plus WBTC on an EVM chain), open the portfolio, and verify one Bitcoin
+aggregate row whose BTC quantity is the sum across addresses and whose USD
+value matches quantity × current BTC/USD price.
+
+**Acceptance Scenarios**:
+
+1. **Given** a member with BTC spread across three issued addresses, **When**
+   they open the portfolio, **Then** the Bitcoin position shows the summed
+   balance and its USD value.
+2. **Given** a member holding both native BTC and wrapped BTC, **When** they
+   view the portfolio, **Then** a single aggregated Bitcoin row appears, and its
+   detail view distinguishes the native Bitcoin holding from the wrapped
+   instance(s) by network.
+3. **Given** a member with zero BTC, **When** they view the portfolio, **Then**
+   no misleading Bitcoin balance appears (the row is absent or explicitly
+   zero, consistent with how other zero assets are treated).
+4. **Given** the Bitcoin balance source is temporarily unreachable, **When** the
+   portfolio loads, **Then** the Bitcoin position is marked as unavailable/stale
+   rather than silently shown as zero.
+5. **Given** a deposit that is broadcast but not yet confirmed, **When** the
+   member views their balance, **Then** pending value is distinguished from
+   confirmed value (no false finality).
+
+---
+
+### User Story 3 - Send Bitcoin to any valid address (Priority: P2)
+
+A member wants to pay someone in BTC. From the send surface they select
+Bitcoin, paste or scan the destination (any standard format — legacy `1…`,
+script-hash `3…`, native segwit `bc1q…`, taproot `bc1p…`), enter an amount (or
+MAX), review a confirmation that shows the amount, the destination, and the
+estimated network fee as its own line, then approve. The app reports the
+transaction as pending until the Bitcoin network confirms it.
+
+**Why this priority**: Sending completes the money loop but is only useful once
+receiving and balances (Stories 1–2) work; it also carries the most risk, so it
+builds on a proven foundation.
+
+**Independent Test**: With a funded FairWins Bitcoin wallet, send BTC to one
+external address of each supported format; verify each transaction confirms on
+the Bitcoin network, the fee shown at confirm time was honest (within the
+disclosed estimate), and the portfolio balance decreases by amount + fee.
+
+**Acceptance Scenarios**:
+
+1. **Given** a funded member on the send surface, **When** they enter a valid
+   destination of each standard type (legacy, script-hash, native segwit,
+   taproot), **Then** the address is accepted and its type is recognized.
+2. **Given** an invalid or wrong-network destination (typo, checksum failure,
+   testnet address on mainnet, EVM `0x…` address), **When** entered, **Then**
+   the send is blocked before confirmation with a clear reason.
+3. **Given** a valid destination and amount, **When** the member reaches the
+   confirmation step, **Then** the estimated network fee is displayed as its own
+   line (in BTC and USD) before any signing occurs, and the total debit
+   (amount + fee) is explicit.
+4. **Given** a confirmed send, **When** the member views activity/balance,
+   **Then** the transaction is shown as pending until network confirmation and
+   the spendable balance reflects the outgoing amount immediately.
+5. **Given** an amount that exceeds spendable balance once fees are included,
+   **When** the member tries to proceed, **Then** the app explains the shortfall
+   instead of failing later; **and** MAX computes the largest sendable amount
+   net of the estimated fee.
+6. **Given** fee conditions on the Bitcoin network change between quote and
+   confirm, **When** the member approves, **Then** the fee actually paid never
+   exceeds the disclosed estimate without a fresh confirmation.
+
+---
+
+### User Story 4 - Bitcoin Stamps recognized and protected (Priority: P3)
+
+A member who holds Bitcoin Stamps (collectible assets embedded in Bitcoin
+transactions) sees them in the FairWins collectibles surface alongside their
+other collectibles. When they send ordinary BTC, the app never selects a
+stamps-bearing coin as spending input — so a member cannot accidentally destroy
+or give away a Stamp by paying for coffee. The BTC value locked alongside
+Stamps is shown as part of their holdings but excluded from "spendable"
+balance.
+
+**Why this priority**: Stamps protection is a safety property for a subset of
+members, valuable but dependent on send (Story 3) existing; recognition/display
+is additive to the portfolio (Story 2).
+
+**Independent Test**: Fund a member address that holds a known Stamp; verify
+the Stamp appears in collectibles; attempt sends up to MAX and verify the
+stamps-bearing coin is never consumed and spendable balance excludes it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a member whose addresses hold one or more Bitcoin Stamps, **When**
+   they open the collectibles surface, **Then** each Stamp is listed with its
+   image/identifier, labeled as a Bitcoin Stamp.
+2. **Given** a member with Stamps, **When** they send ordinary BTC (any amount
+   up to MAX), **Then** the transaction never spends a stamps-bearing coin.
+3. **Given** a member whose only funds are locked alongside Stamps, **When**
+   they attempt a send, **Then** the app explains that this value is protected
+   and not spendable through the ordinary send flow.
+4. **Given** the Stamps recognition source is unavailable, **When** the member
+   sends BTC, **Then** the app fails safe: coins that cannot be confirmed
+   stamp-free are treated as protected (no accidental spend), and the member is
+   told recognition is temporarily degraded.
+
+---
+
+### User Story 5 - Honest capability disclosure for Bitcoin (Priority: P3)
+
+A member exploring networks sees Bitcoin listed with an accurate capability
+statement: portfolio, send, and receive are supported; wagers, pools,
+memberships, gasless sponsorship, and all contract-based features are not.
+Nothing in the product implies a member can wager in BTC or that BTC sends can
+be fee-sponsored.
+
+**Why this priority**: Trust surface. Cheap to build, but it prevents the
+worst outcome — a member misled about what Bitcoin can do on the platform.
+
+**Independent Test**: Review every surface where networks/features are listed
+or selected; verify Bitcoin appears only where supported, is absent (or
+explicitly marked unsupported) everywhere else, and its network page states its
+capabilities truthfully.
+
+**Acceptance Scenarios**:
+
+1. **Given** the network information surface, **When** a member views Bitcoin,
+   **Then** supported capabilities (portfolio, send, receive) and unsupported
+   ones (wagers, pools, membership, gasless) are each explicitly stated.
+2. **Given** wager/pool/membership creation flows, **When** a member selects
+   assets or networks, **Then** Bitcoin is not offered.
+3. **Given** the send confirmation for Bitcoin, **When** displayed, **Then** it
+   never describes the transaction as gasless or fee-sponsored; the member
+   always pays the Bitcoin network fee and is told so.
+
+---
+
+### Edge Cases
+
+- Member restores their account (passkey recovery / new device): all previously
+  issued addresses and their funds MUST be recoverable deterministically from
+  the account itself — losing a device must not lose Bitcoin or break rotation
+  continuity.
+- A sender pays the same issued address twice, or pays an address far ahead of
+  the rotation sequence: funds are still detected and counted.
+- Deposit detected while the member is watching the receive screen: surface it
+  (at least on refresh) rather than requiring a portfolio visit.
+- Unconfirmed inbound funds: not spendable until confirmed; shown as pending.
+- Dust-level deposits and dust change: the send flow avoids creating
+  uneconomical outputs and never strands value silently.
+- Bitcoin network fee spikes: quotes refresh; a stale quote is never silently
+  honored (Story 3, scenario 6).
+- Member pastes a BIP-21 style `bitcoin:` payment link instead of a bare
+  address: destination and amount populate correctly.
+- Testnet/mainnet separation: Bitcoin testnet activity is never mixed with
+  mainnet balances, mirroring the platform's existing testnet/mainnet pairing
+  rules.
+- Stamps false positives/negatives: recognition prefers false positives
+  (over-protection) to false negatives (accidental destruction).
+- The member's balance spans many addresses: sends may combine coins from
+  multiple issued addresses in one transaction; this is expected and must not
+  confuse the activity view.
+- Concurrent sends: a second send started before the first confirms must not
+  double-spend the same coins.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Wallet & account model**
+
+- **FR-001**: Each member account MUST have exactly one Bitcoin wallet, derived
+  deterministically from the member's existing FairWins account credentials —
+  no new seed phrase, password, or backup artifact is introduced for v1.
+- **FR-002**: Bitcoin private keys MUST exist only on the member's device;
+  FairWins services MUST never receive, store, or be able to reconstruct them
+  (non-custodial, matching the platform's existing account model).
+- **FR-003**: After account recovery on a new device, the member's Bitcoin
+  wallet — all issued addresses, balances, and rotation position — MUST be
+  restored without any Bitcoin-specific backup step.
+
+**Receiving & address rotation**
+
+- **FR-004**: The receive surface MUST offer Bitcoin and display, for each
+  request, a fresh address never previously shown for that account, as
+  copyable text, QR code, and shareable payment link (with optional amount).
+- **FR-005**: All previously issued addresses MUST remain monitored
+  indefinitely; funds arriving at any of them MUST appear in the member's
+  balance and activity.
+- **FR-006**: Members MUST be able to choose the receive address type between
+  native segwit (default) and taproot; the choice persists per account and
+  each type yields standard-compliant addresses external wallets accept.
+- **FR-007**: Receive addresses MUST be clearly labeled as Bitcoin (mainnet vs
+  testnet where applicable) and MUST be visually/textually distinct from the
+  member's EVM address so the two cannot be confused.
+
+**Portfolio**
+
+- **FR-008**: The portfolio MUST show the member's total confirmed BTC across
+  all issued addresses, with USD value from the platform's existing Bitcoin
+  price source, aggregated with wrapped BTC under the single Bitcoin asset
+  (native + wrapped roll-up, consistent with existing native/wrapped behavior).
+- **FR-009**: Pending (unconfirmed) inbound and outbound value MUST be
+  distinguished from confirmed balance; the portfolio MUST never present
+  unconfirmed value as final.
+- **FR-010**: When Bitcoin balance data cannot be fetched, the portfolio MUST
+  mark the position stale/unavailable rather than showing zero or cached data
+  as current.
+
+**Sending**
+
+- **FR-011**: Members MUST be able to send BTC to any syntactically valid
+  mainnet destination of the standard types: legacy (P2PKH), script-hash
+  (P2SH), native segwit v0 (bech32), and taproot/segwit v1 (bech32m).
+  Invalid, checksum-failing, wrong-network, or non-Bitcoin destinations MUST be
+  rejected before confirmation with a specific reason.
+- **FR-012**: The send confirmation MUST disclose, before any signing: amount,
+  destination (with recognized type), estimated network fee as its own line in
+  BTC and USD, and total debit. The fee actually committed MUST NOT exceed the
+  disclosed estimate without re-confirmation.
+- **FR-013**: The send flow MUST support MAX (largest spendable amount net of
+  fees), MUST block sends that cannot cover amount + fee with a clear
+  shortfall explanation, and MUST avoid creating uneconomical (dust) change.
+- **FR-014**: Sends MUST be signed on the member's device and broadcast to the
+  Bitcoin network; the app MUST show the transaction as pending until
+  confirmed and MUST prevent the same coins from being committed to two
+  concurrent sends.
+- **FR-015**: Bitcoin sends are never gasless or fee-sponsored in v1; every
+  fee-related surface MUST state that the member pays the Bitcoin network fee.
+- **FR-016**: The app MUST accept `bitcoin:` payment links (scan or paste) and
+  populate destination and amount from them.
+
+**Bitcoin Stamps**
+
+- **FR-017**: The platform MUST recognize Bitcoin Stamps held in the member's
+  wallet and display them in the collectibles surface, labeled as Bitcoin
+  Stamps, with available imagery/identifiers.
+- **FR-018**: Ordinary sends MUST never select stamps-bearing coins as inputs.
+  Value locked alongside Stamps MUST be excluded from spendable balance and
+  MUST be visibly accounted for (the member can see why total ≠ spendable).
+- **FR-019**: When Stamps recognition is unavailable or uncertain, coin
+  selection MUST fail safe: any coin not positively known stamp-free is
+  treated as protected, and the member is informed recognition is degraded.
+
+**Capability honesty & scope**
+
+- **FR-020**: Bitcoin MUST self-disclose its capabilities wherever networks are
+  described: portfolio, send, receive supported; wagers, pools, membership,
+  gasless, and all contract-based features unsupported. Bitcoin MUST NOT be
+  offered in any flow it does not support.
+- **FR-021**: Bitcoin testnet and mainnet MUST be strictly separated, following
+  the platform's existing testnet/mainnet pairing rules; testnet balances and
+  addresses never appear in mainnet contexts or vice versa.
+- **FR-022**: Existing EVM functionality MUST be unaffected: a member who never
+  touches Bitcoin sees no behavioral change beyond the new network appearing
+  in supported surfaces.
+
+### Key Entities
+
+- **Bitcoin Wallet**: The per-member Bitcoin key context, derived from the
+  member's existing account; owns the rotation state and all issued addresses.
+- **Issued Address**: A receive address handed to the member at a point in
+  time; attributes: type (native segwit / taproot), derivation position,
+  network (mainnet/testnet), first-shown timestamp; permanently monitored.
+- **Coin (UTXO)**: A discrete piece of spendable Bitcoin value held at an
+  issued address; attributes: amount, confirmation status, protected flag
+  (stamps-bearing or unverified).
+- **Bitcoin Transaction**: An inbound or outbound transfer; attributes:
+  direction, amount, fee (outbound), destination/source, confirmation state;
+  appears in the activity surface.
+- **Stamp**: A Bitcoin Stamps collectible bound to a specific coin; attributes:
+  identifier, image/preview, the coin it travels with; displayed in
+  collectibles, protected in coin selection.
+- **Fee Quote**: A point-in-time estimate of the network fee for a proposed
+  send; attributes: rate basis, estimated total, freshness; what the member
+  confirms against.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A member can go from opening the receive surface to holding a
+  scannable Bitcoin address in under 15 seconds, and 100% of consecutive
+  receive requests produce distinct addresses.
+- **SC-002**: Deposits to any previously issued address (tested across at least
+  10 rotated addresses per account) appear in the member's balance with zero
+  missed deposits.
+- **SC-003**: 100% of test sends to each of the four standard destination
+  types confirm on the Bitcoin network, and in every case the fee paid is ≤
+  the estimate the member confirmed.
+- **SC-004**: Zero stamps-bearing coins are spent by ordinary sends across the
+  full send test matrix (including MAX sends and degraded-recognition mode).
+- **SC-005**: Portfolio BTC balances match an independent Bitcoin block
+  explorer for the same addresses in 100% of checks, with pending vs confirmed
+  value correctly distinguished.
+- **SC-006**: After account recovery on a fresh device, 100% of previously
+  issued addresses and funds are restored with no Bitcoin-specific user action.
+- **SC-007**: Every surface listing Bitcoin capabilities passes an honesty
+  review: no surface offers or implies wagers, pools, membership, or gasless
+  on Bitcoin.
+- **SC-008**: Members not using Bitcoin experience no regression: existing
+  portfolio/send/receive test suites pass unchanged.
+
+## Assumptions
+
+- **Custody model**: v1 follows the platform's non-custodial, passkey-first
+  account model; the Bitcoin wallet is derived deterministically from existing
+  account credentials rather than a new seed phrase. Members who want
+  self-managed external keys continue to use external wallets.
+- **Default address type**: native segwit (bech32) is the default receive type
+  for broadest external-wallet compatibility; taproot (bech32m) is the opt-in
+  alternative. Both are fully supported for sending.
+- **Stamps scope**: v1 recognizes, displays, and protects Stamps. Transferring
+  a Stamp to another address, and creating/minting Stamps, are out of scope.
+- **Fees**: no FairWins platform fee on Bitcoin sends in v1 — members pay only
+  the Bitcoin network fee (consistent with EVM native-asset sends). If a
+  platform fee is added later it goes through the platform's single
+  fee-configuration source of truth.
+- **Wagering scope**: BTC is not a wager/pool/membership asset. No smart
+  contracts exist on Bitcoin and none of the platform's contract features
+  extend to it in v1.
+- **Balance data**: balance/coin/Stamps data comes from public Bitcoin network
+  data sources proxied through platform infrastructure with quotas and honest
+  degradation, consistent with how other external data (e.g. prediction
+  markets, collectibles) is proxied today.
+- **Price data**: BTC/USD pricing reuses the platform's existing Bitcoin price
+  feeds (already configured for wrapped BTC).
+- **Networks**: Bitcoin mainnet plus one Bitcoin test network (for the
+  platform's existing testnet workflow); no other Bitcoin-family chains
+  (Litecoin, forks) are in scope.
+- **Lightning**: out of scope for v1; on-chain transactions only.
+- **Address monitoring cardinality**: rotation is bounded in practice by use;
+  monitoring follows standard discovery conventions (a bounded look-ahead
+  window of unused addresses) so restored wallets find all funds.

--- a/specs/061-bitcoin-transactions/tasks.md
+++ b/specs/061-bitcoin-transactions/tasks.md
@@ -20,9 +20,9 @@ implementable and testable.
 
 **Purpose**: Dependencies and config skeletons every story builds on
 
-- [ ] T001 Add pinned `@scure/btc-signer` + `@scure/bip32` to `frontend/package.json` (exact versions, lockfile updated; no other dep churn)
-- [ ] T002 [P] Add the `BTC_*` env block (per `contracts/bitcoin-gateway-api.md`) to `services/relay-gateway/src/config/index.js` with fail-loud validation (clamps sane, URLs well-formed when `BTC_ENABLED=true`) and document every var in `services/relay-gateway/.env.example`
-- [ ] T003 [P] Create `frontend/src/config/bitcoinNetworks.js` implementing `contracts/network-registry.md` exactly (`BITCOIN_NETWORKS`, `BITCOIN_TESTNET_MAINNET_PAIR`, `isBitcoinNetworkId`, `getBitcoinNetwork`), with unit tests in `frontend/src/config/__tests__/bitcoinNetworks.test.js`
+- [x] T001 Add pinned `@scure/btc-signer` + `@scure/bip32` to `frontend/package.json` (exact versions, lockfile updated; no other dep churn)
+- [x] T002 [P] Add the `BTC_*` env block (per `contracts/bitcoin-gateway-api.md`) to `services/relay-gateway/src/config/index.js` with fail-loud validation (clamps sane, URLs well-formed when `BTC_ENABLED=true`) and document every var in `services/relay-gateway/.env.example`
+- [x] T003 [P] Create `frontend/src/config/bitcoinNetworks.js` implementing `contracts/network-registry.md` exactly (`BITCOIN_NETWORKS`, `BITCOIN_TESTNET_MAINNET_PAIR`, `isBitcoinNetworkId`, `getBitcoinNetwork`), with unit tests in `frontend/src/config/__tests__/bitcoinNetworks.test.js`
 
 ---
 
@@ -32,13 +32,13 @@ implementable and testable.
 
 **⚠️ CRITICAL**: Complete before any user-story phase
 
-- [ ] T004 Implement `frontend/src/lib/bitcoin/derivation.js` per `contracts/key-derivation-btc.md`: `deriveBtcRoot(masterSeed)` (HKDF-SHA256, info `fairwins-btc-seed-v1`, 64B), account nodes m/84'/{coin}'/0' and m/86'/{coin}'/0', `receiveKey(acct, i)`, memory-only invariants (no persistence/logging of secrets)
-- [ ] T005 Vitest suite `frontend/src/lib/bitcoin/__tests__/derivation.test.js`: BIP32/84/86 published reference vectors, pinned FairWins test-seed vectors (first 3 addresses per type × network), domain-separation check (KEK path ≠ btc path), determinism across two derivations
-- [ ] T006 [P] Implement `frontend/src/lib/bitcoin/addresses.js`: encode P2WPKH (bech32) + P2TR (bech32m, BIP-341 tweaked) from pubkeys; `classifyAddress(str, networkId)` accepting P2PKH/P2SH/bech32 v0/bech32m v1 with specific rejection reasons (checksum, wrong network hrp, EVM `0x`, unknown witness version); BIP-21 `bitcoin:` URI parse/format with amount
-- [ ] T007 [P] Vitest suite `frontend/src/lib/bitcoin/__tests__/addresses.test.js`: accept/reject matrix incl. mainnet↔testnet cross-rejection, checksum mutations, BIP-21 round-trips, BIP-350 bech32m vectors
-- [ ] T008 Implement gateway module `services/relay-gateway/src/bitcoin/{client.js,normalize.js,cache.js,routes.js}` per `contracts/bitcoin-gateway-api.md`: Esplora + Stamps upstream fetchers (timeout/retry), DTO normalization, per-endpoint TTL caches, `createBitcoinRouter(config)` with killswitch → validation → quotas → cache → fetch; wire into `services/relay-gateway/src/server.js` behind `BTC_ENABLED`
-- [ ] T009 Gateway tests `services/relay-gateway/test/bitcoin.test.js` (mocked upstreams): route contracts (shapes above), 503 when disabled/killswitched, 400 invalid address/hex, 429 quota, 502 upstream-down, degraded stamps flag, cache TTL behavior, boot fail-loud on malformed config
-- [ ] T010 [P] Implement `frontend/src/lib/bitcoin/gatewayClient.js`: thin fetch client for the five `/v1/bitcoin/*` endpoints (batching ≤50 addresses, error taxonomy → typed results incl. `stale`/`degraded`), base URL from existing gateway config source; tests in `frontend/src/lib/bitcoin/__tests__/gatewayClient.test.js`
+- [x] T004 Implement `frontend/src/lib/bitcoin/derivation.js` per `contracts/key-derivation-btc.md`: `deriveBtcRoot(masterSeed)` (HKDF-SHA256, info `fairwins-btc-seed-v1`, 64B), account nodes m/84'/{coin}'/0' and m/86'/{coin}'/0', `receiveKey(acct, i)`, memory-only invariants (no persistence/logging of secrets)
+- [x] T005 Vitest suite `frontend/src/lib/bitcoin/__tests__/derivation.test.js`: BIP32/84/86 published reference vectors, pinned FairWins test-seed vectors (first 3 addresses per type × network), domain-separation check (KEK path ≠ btc path), determinism across two derivations
+- [x] T006 [P] Implement `frontend/src/lib/bitcoin/addresses.js`: encode P2WPKH (bech32) + P2TR (bech32m, BIP-341 tweaked) from pubkeys; `classifyAddress(str, networkId)` accepting P2PKH/P2SH/bech32 v0/bech32m v1 with specific rejection reasons (checksum, wrong network hrp, EVM `0x`, unknown witness version); BIP-21 `bitcoin:` URI parse/format with amount
+- [x] T007 [P] Vitest suite `frontend/src/lib/bitcoin/__tests__/addresses.test.js`: accept/reject matrix incl. mainnet↔testnet cross-rejection, checksum mutations, BIP-21 round-trips, BIP-350 bech32m vectors
+- [x] T008 Implement gateway module `services/relay-gateway/src/bitcoin/{client.js,normalize.js,cache.js,routes.js}` per `contracts/bitcoin-gateway-api.md`: Esplora + Stamps upstream fetchers (timeout/retry), DTO normalization, per-endpoint TTL caches, `createBitcoinRouter(config)` with killswitch → validation → quotas → cache → fetch; wire into `services/relay-gateway/src/server.js` behind `BTC_ENABLED`
+- [x] T009 Gateway tests `services/relay-gateway/test/bitcoin.test.js` (mocked upstreams): route contracts (shapes above), 503 when disabled/killswitched, 400 invalid address/hex, 429 quota, 502 upstream-down, degraded stamps flag, cache TTL behavior, boot fail-loud on malformed config
+- [x] T010 [P] Implement `frontend/src/lib/bitcoin/gatewayClient.js`: thin fetch client for the five `/v1/bitcoin/*` endpoints (batching ≤50 addresses, error taxonomy → typed results incl. `stale`/`degraded`), base URL from existing gateway config source; tests in `frontend/src/lib/bitcoin/__tests__/gatewayClient.test.js`
 
 **Checkpoint**: keys derive deterministically, addresses encode/validate, gateway serves testnet data
 
@@ -50,11 +50,11 @@ implementable and testable.
 
 **Independent Test**: quickstart.md §3.1 + §3.6 (receive, rotate, fund old address, recover on clean profile)
 
-- [ ] T011 [US1] Implement `frontend/src/lib/bitcoin/wallet.js`: issued-address ledger + rotation cursor per (network, type) with never-decreasing invariant; gap-limit-20 discovery scan over `gatewayClient` rebuilding ledger/cursor on unlock (research R5); client persistence via the existing wallet-preference storage
-- [ ] T012 [US1] Vitest suite `frontend/src/lib/bitcoin/__tests__/wallet.test.js`: rotation never repeats, cursor never decreases (stale cache vs discovery), discovery finds funds at index gaps ≤20, ahead-of-cursor deposits detected, testnet/mainnet ledgers isolated
-- [ ] T013 [US1] Implement `frontend/src/hooks/useBitcoinWallet.js` (unlock/receive portion): wallet status (`unavailable/locked/ready`) from spec-041 capability + `initMasterSeed`/`unwrapMasterSeed` ceremony, `nextReceiveAddress()`, preferred-type get/set, discovery-on-unlock
-- [ ] T014 [US1] Extend `frontend/src/components/ui/AddressQRModal.jsx` with a Bitcoin mode: fresh address display (text/QR/share as BIP-21), "new address" affordance, segwit/taproot type toggle (persisted), explicit Bitcoin + testnet/mainnet labeling distinct from the EVM address view, honest unavailable state for non-PRF/injected accounts
-- [ ] T015 [US1] Component tests `frontend/src/components/ui/__tests__/AddressQRModal.bitcoin.test.jsx`: rotation on reopen, type toggle changes prefix (bc1q/bc1p), BIP-21 payload in QR, unavailable-state rendering, a11y roles/labels
+- [x] T011 [US1] Implement `frontend/src/lib/bitcoin/wallet.js`: issued-address ledger + rotation cursor per (network, type) with never-decreasing invariant; gap-limit-20 discovery scan over `gatewayClient` rebuilding ledger/cursor on unlock (research R5); client persistence via the existing wallet-preference storage
+- [x] T012 [US1] Vitest suite `frontend/src/lib/bitcoin/__tests__/wallet.test.js`: rotation never repeats, cursor never decreases (stale cache vs discovery), discovery finds funds at index gaps ≤20, ahead-of-cursor deposits detected, testnet/mainnet ledgers isolated
+- [x] T013 [US1] Implement `frontend/src/hooks/useBitcoinWallet.js` (unlock/receive portion): wallet status (`unavailable/locked/ready`) from spec-041 capability + `initMasterSeed`/`unwrapMasterSeed` ceremony, `nextReceiveAddress()`, preferred-type get/set, discovery-on-unlock
+- [x] T014 [US1] Extend `frontend/src/components/ui/AddressQRModal.jsx` with a Bitcoin mode: fresh address display (text/QR/share as BIP-21), "new address" affordance, segwit/taproot type toggle (persisted), explicit Bitcoin + testnet/mainnet labeling distinct from the EVM address view, honest unavailable state for non-PRF/injected accounts
+- [x] T015 [US1] Component tests `frontend/src/components/ui/__tests__/AddressQRModal.bitcoin.test.jsx`: rotation on reopen, type toggle changes prefix (bc1q/bc1p), BIP-21 payload in QR, unavailable-state rendering, a11y roles/labels
 
 **Checkpoint**: MVP — members can receive BTC with rotation and recover addresses on a new device
 
@@ -66,11 +66,11 @@ implementable and testable.
 
 **Independent Test**: quickstart.md §3.2 (multi-address sum, pending flip, gateway-down staleness)
 
-- [ ] T016 [P] [US2] Add the native-Bitcoin instance to `frontend/src/config/assetTaxonomy.js` under the `BTC` baseline (kind `btc-native`, network ids from `bitcoinNetworks.js`, `UNDERLYING_META.BTC.homeNetwork = 'bitcoin'`) without disturbing EVM registry shapes; update taxonomy tests
-- [ ] T017 [US2] Implement balance folding in `frontend/src/lib/bitcoin/wallet.js` (or `balances.js` if cleaner): UTXO set → `{confirmedSats, pendingSats, protectedSats, spendableSats, stale}` per data-model.md rules
-- [ ] T018 [US2] Vitest suite `frontend/src/lib/bitcoin/__tests__/balances.test.js`: pending vs confirmed math (inbound/outbound mempool), protected exclusion, stale flag on gateway failure, empty wallet
-- [ ] T019 [US2] Add the bitcoin balance source branch to `frontend/src/hooks/usePortfolio.js`: non-EVM source keyed by `isBitcoinNetworkId`, feeding aggregation so native BTC + WBTC roll up under one Bitcoin row; BTC/USD from the existing `BTC` price feed path; stale renders stale, never zero; zero-BTC accounts render exactly as before (SC-008)
-- [ ] T020 [US2] Tests for the portfolio integration in `frontend/src/hooks/__tests__/usePortfolio.bitcoin.test.js`: aggregation with/without WBTC, price application, stale path, wallet-unavailable path (no bitcoin row, no errors), EVM-only regression snapshot
+- [x] T016 [P] [US2] Add the native-Bitcoin instance to `frontend/src/config/assetTaxonomy.js` under the `BTC` baseline (kind `btc-native`, network ids from `bitcoinNetworks.js`, `UNDERLYING_META.BTC.homeNetwork = 'bitcoin'`) without disturbing EVM registry shapes; update taxonomy tests
+- [x] T017 [US2] Implement balance folding in `frontend/src/lib/bitcoin/wallet.js` (or `balances.js` if cleaner): UTXO set → `{confirmedSats, pendingSats, protectedSats, spendableSats, stale}` per data-model.md rules
+- [x] T018 [US2] Vitest suite `frontend/src/lib/bitcoin/__tests__/balances.test.js`: pending vs confirmed math (inbound/outbound mempool), protected exclusion, stale flag on gateway failure, empty wallet
+- [x] T019 [US2] Add the bitcoin balance source branch to `frontend/src/hooks/usePortfolio.js`: non-EVM source keyed by `isBitcoinNetworkId`, feeding aggregation so native BTC + WBTC roll up under one Bitcoin row; BTC/USD from the existing `BTC` price feed path; stale renders stale, never zero; zero-BTC accounts render exactly as before (SC-008)
+- [x] T020 [US2] Tests for the portfolio integration in `frontend/src/hooks/__tests__/usePortfolio.bitcoin.test.js`: aggregation with/without WBTC, price application, stale path, wallet-unavailable path (no bitcoin row, no errors), EVM-only regression snapshot
 
 **Checkpoint**: receive + verify loop closed inside the product
 
@@ -82,14 +82,14 @@ implementable and testable.
 
 **Independent Test**: quickstart.md §3.3 (four destination types on testnet4, fee ≤ quote, rejection matrix)
 
-- [ ] T021 [P] [US3] Implement `frontend/src/lib/bitcoin/coinSelection.js`: spendable-only accumulative selection with change, deterministic vsize estimation (P2WPKH/P2TR inputs, all output types), fee = rate × vsize, MAX net of fees, sub-dust change folded into fee (546/330 thresholds), in-flight coin locks
-- [ ] T022 [P] [US3] Vitest suite `frontend/src/lib/bitcoin/__tests__/coinSelection.test.js`: property-style checks — never selects protected/unverified/locked/unconfirmed coins, MAX leaves zero remainder, no dust outputs ever produced, shortfall reported with amounts, vsize estimates within known bounds for fixture txs
-- [ ] T023 [US3] Implement `frontend/src/lib/bitcoin/psbt.js`: PSBT build + sign via `@scure/btc-signer` (P2WPKH + P2TR key-path inputs, RBF sequence 0xfffffffd, any standard output type), returning raw hex + actual fee; refuse to sign if actual fee > pinned quote (FR-012)
-- [ ] T024 [US3] Vitest suite `frontend/src/lib/bitcoin/__tests__/psbt.test.js`: fixture-seed signed-tx vectors decode correctly (input/output scripts, witness types, sequence), fee-overrun refusal, mixed-input (segwit+taproot) transaction
-- [ ] T025 [US3] Extend `frontend/src/hooks/useBitcoinWallet.js` with the send pipeline: fee-quote fetch/pin with 60s freshness + re-confirm on drift, selection → psbt → broadcast via gateway, pending tracking (`tx/:txid` polling with backoff), coin locking across concurrent sends, activity entries
-- [ ] T026 [US3] Add Bitcoin destination support to `frontend/src/components/ui/AddressInput.jsx` (validation path via `classifyAddress` with per-reason messages, recognized-type display) and `bitcoin:` URI handling to `frontend/src/components/ui/QRScanner.jsx` + `frontend/src/lib/addressBook/scanAddress.js`; tests in the components' existing test files
-- [ ] T027 [US3] Extend `frontend/src/components/wallet/TransferForm.jsx` with the BTC asset path: separate `useBitcoinWallet.send` pipeline (never `useTransfer` EVM routing), preview step showing amount, destination + type, fee line in BTC + USD, total debit, explicit "you pay the Bitcoin network fee" (never gasless wording), MAX, shortfall explanation, pending state after submit
-- [ ] T028 [US3] Component tests `frontend/src/components/wallet/__tests__/TransferForm.bitcoin.test.jsx`: full preview disclosure assertions, rejection matrix surfaces reasons, quote-drift forces re-confirm, EVM asset flows untouched (regression)
+- [x] T021 [P] [US3] Implement `frontend/src/lib/bitcoin/coinSelection.js`: spendable-only accumulative selection with change, deterministic vsize estimation (P2WPKH/P2TR inputs, all output types), fee = rate × vsize, MAX net of fees, sub-dust change folded into fee (546/330 thresholds), in-flight coin locks
+- [x] T022 [P] [US3] Vitest suite `frontend/src/lib/bitcoin/__tests__/coinSelection.test.js`: property-style checks — never selects protected/unverified/locked/unconfirmed coins, MAX leaves zero remainder, no dust outputs ever produced, shortfall reported with amounts, vsize estimates within known bounds for fixture txs
+- [x] T023 [US3] Implement `frontend/src/lib/bitcoin/psbt.js`: PSBT build + sign via `@scure/btc-signer` (P2WPKH + P2TR key-path inputs, RBF sequence 0xfffffffd, any standard output type), returning raw hex + actual fee; refuse to sign if actual fee > pinned quote (FR-012)
+- [x] T024 [US3] Vitest suite `frontend/src/lib/bitcoin/__tests__/psbt.test.js`: fixture-seed signed-tx vectors decode correctly (input/output scripts, witness types, sequence), fee-overrun refusal, mixed-input (segwit+taproot) transaction
+- [x] T025 [US3] Extend `frontend/src/hooks/useBitcoinWallet.js` with the send pipeline: fee-quote fetch/pin with 60s freshness + re-confirm on drift, selection → psbt → broadcast via gateway, pending tracking (`tx/:txid` polling with backoff), coin locking across concurrent sends, activity entries
+- [x] T026 [US3] Add Bitcoin destination support to `frontend/src/components/ui/AddressInput.jsx` (validation path via `classifyAddress` with per-reason messages, recognized-type display) and `bitcoin:` URI handling to `frontend/src/components/ui/QRScanner.jsx` + `frontend/src/lib/addressBook/scanAddress.js`; tests in the components' existing test files
+- [x] T027 [US3] Extend `frontend/src/components/wallet/TransferForm.jsx` with the BTC asset path: separate `useBitcoinWallet.send` pipeline (never `useTransfer` EVM routing), preview step showing amount, destination + type, fee line in BTC + USD, total debit, explicit "you pay the Bitcoin network fee" (never gasless wording), MAX, shortfall explanation, pending state after submit
+- [x] T028 [US3] Component tests `frontend/src/components/wallet/__tests__/TransferForm.bitcoin.test.jsx`: full preview disclosure assertions, rejection matrix surfaces reasons, quote-drift forces re-confirm, EVM asset flows untouched (regression)
 
 **Checkpoint**: full money loop — receive, hold, verify, send
 
@@ -101,10 +101,10 @@ implementable and testable.
 
 **Independent Test**: quickstart.md §3.4 (stamp shown, MAX never consumes it, degraded banner)
 
-- [ ] T029 [US4] Implement stamps classification in `frontend/src/lib/bitcoin/wallet.js`/`coinSelection.js`: merge gateway stamps DTOs onto the UTXO set (`stampId`, `protected`), `degraded ⇒ unverified ⇒ protected` fail-safe, bare-multisig heuristic belt-and-braces, protectedSats accounting
-- [ ] T030 [US4] Vitest suite `frontend/src/lib/bitcoin/__tests__/stamps.test.js`: stamp coins excluded at every selection path incl. MAX, degraded flag protects all unverified coins with honest reason, recovery of spendability after indexer returns, only-stamps wallet blocks sends with explanation
-- [ ] T031 [US4] Add the Bitcoin Stamps section to the collectibles surface (spec-055 section pattern, `collect: 'stamps-only'` capability): stamp cards with image/id, "protected" badge and total-vs-spendable explainer link in the portfolio detail; component tests alongside the existing collectibles tests
-- [ ] T032 [US4] Add the degraded-recognition banner + protected-balance explainer to the send flow in `frontend/src/components/wallet/TransferForm.jsx` (test additions in the US3 test file)
+- [x] T029 [US4] Implement stamps classification in `frontend/src/lib/bitcoin/wallet.js`/`coinSelection.js`: merge gateway stamps DTOs onto the UTXO set (`stampId`, `protected`), `degraded ⇒ unverified ⇒ protected` fail-safe, bare-multisig heuristic belt-and-braces, protectedSats accounting
+- [x] T030 [US4] Vitest suite `frontend/src/lib/bitcoin/__tests__/stamps.test.js`: stamp coins excluded at every selection path incl. MAX, degraded flag protects all unverified coins with honest reason, recovery of spendability after indexer returns, only-stamps wallet blocks sends with explanation
+- [x] T031 [US4] Add the Bitcoin Stamps section to the collectibles surface (spec-055 section pattern, `collect: 'stamps-only'` capability): stamp cards with image/id, "protected" badge and total-vs-spendable explainer link in the portfolio detail; component tests alongside the existing collectibles tests
+- [x] T032 [US4] Add the degraded-recognition banner + protected-balance explainer to the send flow in `frontend/src/components/wallet/TransferForm.jsx` (test additions in the US3 test file)
 
 **Checkpoint**: stamps safe by construction
 
@@ -116,9 +116,9 @@ implementable and testable.
 
 **Independent Test**: quickstart.md §3.5 (network tab truthfulness, no BTC in wager/pool/membership flows, no gasless wording, unavailable states)
 
-- [ ] T033 [P] [US5] Render Bitcoin (and testnet pair) as display-only rows in the Network tab / capabilities surface from `BITCOIN_NETWORKS.capabilities` (no switch-wallet affordance), including the wallet-availability reason (PRF/passkey matrix from `contracts/key-derivation-btc.md`); tests with the existing capabilities-panel suites
-- [ ] T034 [P] [US5] Guard-rail audit + type guards: assert `isBitcoinNetworkId` boundaries so Bitcoin ids never reach `getContractAddressForChain`, wagmi switch/provider paths, subgraph routing, or wager/pool/membership asset pickers; add regression tests pinning BTC absence from those flows
-- [ ] T035 [US5] Testnet/mainnet mode integration: bind the active Bitcoin network to the app's existing testnet/mainnet toggle via `BITCOIN_TESTNET_MAINNET_PAIR`, with strict scoping of balances/addresses/activity per side; tests cover no cross-leak (FR-021)
+- [x] T033 [P] [US5] Render Bitcoin (and testnet pair) as display-only rows in the Network tab / capabilities surface from `BITCOIN_NETWORKS.capabilities` (no switch-wallet affordance), including the wallet-availability reason (PRF/passkey matrix from `contracts/key-derivation-btc.md`); tests with the existing capabilities-panel suites
+- [x] T034 [P] [US5] Guard-rail audit + type guards: assert `isBitcoinNetworkId` boundaries so Bitcoin ids never reach `getContractAddressForChain`, wagmi switch/provider paths, subgraph routing, or wager/pool/membership asset pickers; add regression tests pinning BTC absence from those flows
+- [x] T035 [US5] Testnet/mainnet mode integration: bind the active Bitcoin network to the app's existing testnet/mainnet toggle via `BITCOIN_TESTNET_MAINNET_PAIR`, with strict scoping of balances/addresses/activity per side; tests cover no cross-leak (FR-021)
 
 **Checkpoint**: all five stories complete
 
@@ -126,11 +126,11 @@ implementable and testable.
 
 ## Phase 8: Polish & Cross-Cutting
 
-- [ ] T036 [P] Write `docs/developer-guide/bitcoin.md` (architecture, derivation contract pointer, gateway module, surfaces, availability matrix) mirroring `docs/developer-guide/predict-polymarket.md` depth
-- [ ] T037 [P] Write `docs/runbooks/bitcoin-operations.md`: upstream swap (self-hosted mempool/electrs), killswitch, quotas, stamps-indexer degradation playbook, testnet4 notes
-- [ ] T038 [P] Add the spec-061 guardrail summary block to `CLAUDE.md` (pattern: existing per-spec bullets — derivation constants are wallet-breaking, no numeric chainId for Bitcoin, fail-safe stamps rule, no gasless on BTC)
+- [x] T036 [P] Write `docs/developer-guide/bitcoin.md` (architecture, derivation contract pointer, gateway module, surfaces, availability matrix) mirroring `docs/developer-guide/predict-polymarket.md` depth
+- [x] T037 [P] Write `docs/runbooks/bitcoin-operations.md`: upstream swap (self-hosted mempool/electrs), killswitch, quotas, stamps-indexer degradation playbook, testnet4 notes
+- [x] T038 [P] Add the spec-061 guardrail summary block to `CLAUDE.md` (pattern: existing per-spec bullets — derivation constants are wallet-breaking, no numeric chainId for Bitcoin, fail-safe stamps rule, no gasless on BTC)
 - [ ] T039 Accessibility pass on new/changed UI (axe on receive modal Bitcoin mode, TransferForm BTC path, stamps section, network rows) — fix findings; CI a11y gates stay green
-- [ ] T040 Security review pass per `.github/agents/` over `frontend/src/lib/bitcoin/` (key handling, signing, selection) + gateway module; record findings/resolutions in `specs/061-bitcoin-transactions/security-review.md`
+- [x] T040 Security review pass per `.github/agents/` over `frontend/src/lib/bitcoin/` (key handling, signing, selection) + gateway module; record findings/resolutions in `specs/061-bitcoin-transactions/security-review.md`
 - [ ] T041 Full regression gate: `npm run test:frontend`, root `npm test`, relay-gateway suite — all green (SC-008); run quickstart.md §3 end-to-end on testnet4 and record results in the PR description
 
 ---
@@ -155,3 +155,20 @@ feature is deployable with receive-only Bitcoin (send surfaces stay hidden via
 capabilities until US3 lands); each subsequent phase flips one capability on.
 `BTC_ENABLED=false` keeps the entire feature dark in production until ops
 enables the gateway module.
+
+---
+
+## Status notes (2026-07-20)
+
+- T030's stamps-classification coverage lives in `wallet.test.js` (classifyUtxos
+  fail-safe matrix) and `coinSelection.test.js`/`TransferForm.bitcoin.test.jsx`
+  (never-spend + degraded disclosure) rather than a separate `stamps.test.js`.
+- T020's test lives at `src/test/portfolio/usePortfolio.bitcoin.test.jsx`
+  (matching the existing usePortfolio test location).
+- T039 (a11y audit): new components ship with roles/labels/focus management and
+  an axe test on the stamps section; the full axe/Lighthouse pass runs in CI —
+  left unchecked until that gate reports.
+- T041 (regression + live testnet4 e2e): the full local frontend + gateway
+  suites are green; the LIVE testnet4 walk-through of quickstart.md §3 (faucet
+  funds, real broadcasts) still needs a human-driven session and is the
+  remaining open item.

--- a/specs/061-bitcoin-transactions/tasks.md
+++ b/specs/061-bitcoin-transactions/tasks.md
@@ -1,0 +1,157 @@
+# Tasks: Bitcoin Transactions
+
+**Input**: Design documents from `/specs/061-bitcoin-transactions/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: INCLUDED — constitution principle II (test-first) is non-negotiable; every
+behavior task pairs with its Vitest/node-test suite in the same story phase.
+
+**Organization**: Grouped by user story (US1 receive/rotation, US2 portfolio,
+US3 send, US4 stamps, US5 capability honesty) so each is independently
+implementable and testable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1–US5 per spec.md
+
+## Phase 1: Setup
+
+**Purpose**: Dependencies and config skeletons every story builds on
+
+- [ ] T001 Add pinned `@scure/btc-signer` + `@scure/bip32` to `frontend/package.json` (exact versions, lockfile updated; no other dep churn)
+- [ ] T002 [P] Add the `BTC_*` env block (per `contracts/bitcoin-gateway-api.md`) to `services/relay-gateway/src/config/index.js` with fail-loud validation (clamps sane, URLs well-formed when `BTC_ENABLED=true`) and document every var in `services/relay-gateway/.env.example`
+- [ ] T003 [P] Create `frontend/src/config/bitcoinNetworks.js` implementing `contracts/network-registry.md` exactly (`BITCOIN_NETWORKS`, `BITCOIN_TESTNET_MAINNET_PAIR`, `isBitcoinNetworkId`, `getBitcoinNetwork`), with unit tests in `frontend/src/config/__tests__/bitcoinNetworks.test.js`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Key derivation, address codecs, and the gateway data plane — no story works without them
+
+**⚠️ CRITICAL**: Complete before any user-story phase
+
+- [ ] T004 Implement `frontend/src/lib/bitcoin/derivation.js` per `contracts/key-derivation-btc.md`: `deriveBtcRoot(masterSeed)` (HKDF-SHA256, info `fairwins-btc-seed-v1`, 64B), account nodes m/84'/{coin}'/0' and m/86'/{coin}'/0', `receiveKey(acct, i)`, memory-only invariants (no persistence/logging of secrets)
+- [ ] T005 Vitest suite `frontend/src/lib/bitcoin/__tests__/derivation.test.js`: BIP32/84/86 published reference vectors, pinned FairWins test-seed vectors (first 3 addresses per type × network), domain-separation check (KEK path ≠ btc path), determinism across two derivations
+- [ ] T006 [P] Implement `frontend/src/lib/bitcoin/addresses.js`: encode P2WPKH (bech32) + P2TR (bech32m, BIP-341 tweaked) from pubkeys; `classifyAddress(str, networkId)` accepting P2PKH/P2SH/bech32 v0/bech32m v1 with specific rejection reasons (checksum, wrong network hrp, EVM `0x`, unknown witness version); BIP-21 `bitcoin:` URI parse/format with amount
+- [ ] T007 [P] Vitest suite `frontend/src/lib/bitcoin/__tests__/addresses.test.js`: accept/reject matrix incl. mainnet↔testnet cross-rejection, checksum mutations, BIP-21 round-trips, BIP-350 bech32m vectors
+- [ ] T008 Implement gateway module `services/relay-gateway/src/bitcoin/{client.js,normalize.js,cache.js,routes.js}` per `contracts/bitcoin-gateway-api.md`: Esplora + Stamps upstream fetchers (timeout/retry), DTO normalization, per-endpoint TTL caches, `createBitcoinRouter(config)` with killswitch → validation → quotas → cache → fetch; wire into `services/relay-gateway/src/server.js` behind `BTC_ENABLED`
+- [ ] T009 Gateway tests `services/relay-gateway/test/bitcoin.test.js` (mocked upstreams): route contracts (shapes above), 503 when disabled/killswitched, 400 invalid address/hex, 429 quota, 502 upstream-down, degraded stamps flag, cache TTL behavior, boot fail-loud on malformed config
+- [ ] T010 [P] Implement `frontend/src/lib/bitcoin/gatewayClient.js`: thin fetch client for the five `/v1/bitcoin/*` endpoints (batching ≤50 addresses, error taxonomy → typed results incl. `stale`/`degraded`), base URL from existing gateway config source; tests in `frontend/src/lib/bitcoin/__tests__/gatewayClient.test.js`
+
+**Checkpoint**: keys derive deterministically, addresses encode/validate, gateway serves testnet data
+
+---
+
+## Phase 3: User Story 1 — Receive with rotating addresses (P1) 🎯 MVP
+
+**Goal**: Fresh never-reused receive addresses (segwit default / taproot opt-in), QR + BIP-21, all issued addresses recoverable and monitored
+
+**Independent Test**: quickstart.md §3.1 + §3.6 (receive, rotate, fund old address, recover on clean profile)
+
+- [ ] T011 [US1] Implement `frontend/src/lib/bitcoin/wallet.js`: issued-address ledger + rotation cursor per (network, type) with never-decreasing invariant; gap-limit-20 discovery scan over `gatewayClient` rebuilding ledger/cursor on unlock (research R5); client persistence via the existing wallet-preference storage
+- [ ] T012 [US1] Vitest suite `frontend/src/lib/bitcoin/__tests__/wallet.test.js`: rotation never repeats, cursor never decreases (stale cache vs discovery), discovery finds funds at index gaps ≤20, ahead-of-cursor deposits detected, testnet/mainnet ledgers isolated
+- [ ] T013 [US1] Implement `frontend/src/hooks/useBitcoinWallet.js` (unlock/receive portion): wallet status (`unavailable/locked/ready`) from spec-041 capability + `initMasterSeed`/`unwrapMasterSeed` ceremony, `nextReceiveAddress()`, preferred-type get/set, discovery-on-unlock
+- [ ] T014 [US1] Extend `frontend/src/components/ui/AddressQRModal.jsx` with a Bitcoin mode: fresh address display (text/QR/share as BIP-21), "new address" affordance, segwit/taproot type toggle (persisted), explicit Bitcoin + testnet/mainnet labeling distinct from the EVM address view, honest unavailable state for non-PRF/injected accounts
+- [ ] T015 [US1] Component tests `frontend/src/components/ui/__tests__/AddressQRModal.bitcoin.test.jsx`: rotation on reopen, type toggle changes prefix (bc1q/bc1p), BIP-21 payload in QR, unavailable-state rendering, a11y roles/labels
+
+**Checkpoint**: MVP — members can receive BTC with rotation and recover addresses on a new device
+
+---
+
+## Phase 4: User Story 2 — Bitcoin in the portfolio (P1)
+
+**Goal**: One aggregated Bitcoin row (native + WBTC), USD-priced, pending/confirmed split, stale-not-zero degradation
+
+**Independent Test**: quickstart.md §3.2 (multi-address sum, pending flip, gateway-down staleness)
+
+- [ ] T016 [P] [US2] Add the native-Bitcoin instance to `frontend/src/config/assetTaxonomy.js` under the `BTC` baseline (kind `btc-native`, network ids from `bitcoinNetworks.js`, `UNDERLYING_META.BTC.homeNetwork = 'bitcoin'`) without disturbing EVM registry shapes; update taxonomy tests
+- [ ] T017 [US2] Implement balance folding in `frontend/src/lib/bitcoin/wallet.js` (or `balances.js` if cleaner): UTXO set → `{confirmedSats, pendingSats, protectedSats, spendableSats, stale}` per data-model.md rules
+- [ ] T018 [US2] Vitest suite `frontend/src/lib/bitcoin/__tests__/balances.test.js`: pending vs confirmed math (inbound/outbound mempool), protected exclusion, stale flag on gateway failure, empty wallet
+- [ ] T019 [US2] Add the bitcoin balance source branch to `frontend/src/hooks/usePortfolio.js`: non-EVM source keyed by `isBitcoinNetworkId`, feeding aggregation so native BTC + WBTC roll up under one Bitcoin row; BTC/USD from the existing `BTC` price feed path; stale renders stale, never zero; zero-BTC accounts render exactly as before (SC-008)
+- [ ] T020 [US2] Tests for the portfolio integration in `frontend/src/hooks/__tests__/usePortfolio.bitcoin.test.js`: aggregation with/without WBTC, price application, stale path, wallet-unavailable path (no bitcoin row, no errors), EVM-only regression snapshot
+
+**Checkpoint**: receive + verify loop closed inside the product
+
+---
+
+## Phase 5: User Story 3 — Send to any valid address (P2)
+
+**Goal**: Pay legacy/P2SH/bech32/bech32m destinations with honest fee quotes, MAX, dust handling, pending tracking, concurrency locks
+
+**Independent Test**: quickstart.md §3.3 (four destination types on testnet4, fee ≤ quote, rejection matrix)
+
+- [ ] T021 [P] [US3] Implement `frontend/src/lib/bitcoin/coinSelection.js`: spendable-only accumulative selection with change, deterministic vsize estimation (P2WPKH/P2TR inputs, all output types), fee = rate × vsize, MAX net of fees, sub-dust change folded into fee (546/330 thresholds), in-flight coin locks
+- [ ] T022 [P] [US3] Vitest suite `frontend/src/lib/bitcoin/__tests__/coinSelection.test.js`: property-style checks — never selects protected/unverified/locked/unconfirmed coins, MAX leaves zero remainder, no dust outputs ever produced, shortfall reported with amounts, vsize estimates within known bounds for fixture txs
+- [ ] T023 [US3] Implement `frontend/src/lib/bitcoin/psbt.js`: PSBT build + sign via `@scure/btc-signer` (P2WPKH + P2TR key-path inputs, RBF sequence 0xfffffffd, any standard output type), returning raw hex + actual fee; refuse to sign if actual fee > pinned quote (FR-012)
+- [ ] T024 [US3] Vitest suite `frontend/src/lib/bitcoin/__tests__/psbt.test.js`: fixture-seed signed-tx vectors decode correctly (input/output scripts, witness types, sequence), fee-overrun refusal, mixed-input (segwit+taproot) transaction
+- [ ] T025 [US3] Extend `frontend/src/hooks/useBitcoinWallet.js` with the send pipeline: fee-quote fetch/pin with 60s freshness + re-confirm on drift, selection → psbt → broadcast via gateway, pending tracking (`tx/:txid` polling with backoff), coin locking across concurrent sends, activity entries
+- [ ] T026 [US3] Add Bitcoin destination support to `frontend/src/components/ui/AddressInput.jsx` (validation path via `classifyAddress` with per-reason messages, recognized-type display) and `bitcoin:` URI handling to `frontend/src/components/ui/QRScanner.jsx` + `frontend/src/lib/addressBook/scanAddress.js`; tests in the components' existing test files
+- [ ] T027 [US3] Extend `frontend/src/components/wallet/TransferForm.jsx` with the BTC asset path: separate `useBitcoinWallet.send` pipeline (never `useTransfer` EVM routing), preview step showing amount, destination + type, fee line in BTC + USD, total debit, explicit "you pay the Bitcoin network fee" (never gasless wording), MAX, shortfall explanation, pending state after submit
+- [ ] T028 [US3] Component tests `frontend/src/components/wallet/__tests__/TransferForm.bitcoin.test.jsx`: full preview disclosure assertions, rejection matrix surfaces reasons, quote-drift forces re-confirm, EVM asset flows untouched (regression)
+
+**Checkpoint**: full money loop — receive, hold, verify, send
+
+---
+
+## Phase 6: User Story 4 — Stamps recognized and protected (P3)
+
+**Goal**: Stamps visible in collectibles; stamps-bearing and unverified coins never spent; degraded recognition fails safe
+
+**Independent Test**: quickstart.md §3.4 (stamp shown, MAX never consumes it, degraded banner)
+
+- [ ] T029 [US4] Implement stamps classification in `frontend/src/lib/bitcoin/wallet.js`/`coinSelection.js`: merge gateway stamps DTOs onto the UTXO set (`stampId`, `protected`), `degraded ⇒ unverified ⇒ protected` fail-safe, bare-multisig heuristic belt-and-braces, protectedSats accounting
+- [ ] T030 [US4] Vitest suite `frontend/src/lib/bitcoin/__tests__/stamps.test.js`: stamp coins excluded at every selection path incl. MAX, degraded flag protects all unverified coins with honest reason, recovery of spendability after indexer returns, only-stamps wallet blocks sends with explanation
+- [ ] T031 [US4] Add the Bitcoin Stamps section to the collectibles surface (spec-055 section pattern, `collect: 'stamps-only'` capability): stamp cards with image/id, "protected" badge and total-vs-spendable explainer link in the portfolio detail; component tests alongside the existing collectibles tests
+- [ ] T032 [US4] Add the degraded-recognition banner + protected-balance explainer to the send flow in `frontend/src/components/wallet/TransferForm.jsx` (test additions in the US3 test file)
+
+**Checkpoint**: stamps safe by construction
+
+---
+
+## Phase 7: User Story 5 — Honest capability disclosure (P3)
+
+**Goal**: Bitcoin appears exactly where supported, absent or honestly-off everywhere else
+
+**Independent Test**: quickstart.md §3.5 (network tab truthfulness, no BTC in wager/pool/membership flows, no gasless wording, unavailable states)
+
+- [ ] T033 [P] [US5] Render Bitcoin (and testnet pair) as display-only rows in the Network tab / capabilities surface from `BITCOIN_NETWORKS.capabilities` (no switch-wallet affordance), including the wallet-availability reason (PRF/passkey matrix from `contracts/key-derivation-btc.md`); tests with the existing capabilities-panel suites
+- [ ] T034 [P] [US5] Guard-rail audit + type guards: assert `isBitcoinNetworkId` boundaries so Bitcoin ids never reach `getContractAddressForChain`, wagmi switch/provider paths, subgraph routing, or wager/pool/membership asset pickers; add regression tests pinning BTC absence from those flows
+- [ ] T035 [US5] Testnet/mainnet mode integration: bind the active Bitcoin network to the app's existing testnet/mainnet toggle via `BITCOIN_TESTNET_MAINNET_PAIR`, with strict scoping of balances/addresses/activity per side; tests cover no cross-leak (FR-021)
+
+**Checkpoint**: all five stories complete
+
+---
+
+## Phase 8: Polish & Cross-Cutting
+
+- [ ] T036 [P] Write `docs/developer-guide/bitcoin.md` (architecture, derivation contract pointer, gateway module, surfaces, availability matrix) mirroring `docs/developer-guide/predict-polymarket.md` depth
+- [ ] T037 [P] Write `docs/runbooks/bitcoin-operations.md`: upstream swap (self-hosted mempool/electrs), killswitch, quotas, stamps-indexer degradation playbook, testnet4 notes
+- [ ] T038 [P] Add the spec-061 guardrail summary block to `CLAUDE.md` (pattern: existing per-spec bullets — derivation constants are wallet-breaking, no numeric chainId for Bitcoin, fail-safe stamps rule, no gasless on BTC)
+- [ ] T039 Accessibility pass on new/changed UI (axe on receive modal Bitcoin mode, TransferForm BTC path, stamps section, network rows) — fix findings; CI a11y gates stay green
+- [ ] T040 Security review pass per `.github/agents/` over `frontend/src/lib/bitcoin/` (key handling, signing, selection) + gateway module; record findings/resolutions in `specs/061-bitcoin-transactions/security-review.md`
+- [ ] T041 Full regression gate: `npm run test:frontend`, root `npm test`, relay-gateway suite — all green (SC-008); run quickstart.md §3 end-to-end on testnet4 and record results in the PR description
+
+---
+
+## Dependencies & Execution Order
+
+- **Phase 1 → Phase 2 → story phases**: T004/T005 (derivation) block everything key-touching; T008/T009 (gateway) block wallet discovery, portfolio, send, stamps; T003 (registry) blocks all surface work.
+- **Story order**: US1 → US2 → US3 → US4; US5 is independent of US3/US4 after Phase 2 and can run in parallel with them. MVP = Phases 1–3.
+- **Within stories**: lib → tests → hook → UI → component tests (test tasks may be written first — constitution II encourages it).
+
+### Parallel opportunities
+
+- Phase 1: T002 ∥ T003 (after T001 starts independently)
+- Phase 2: {T004+T005} ∥ {T006+T007} ∥ {T008+T009}; T010 after T008
+- US2: T016 ∥ T017; US3: T021/T022 ∥ T023/T024; US5: T033 ∥ T034
+- Phase 8: T036 ∥ T037 ∥ T038
+
+## Implementation Strategy
+
+Ship incrementally behind honest capability gates: after Phase 3 (MVP) the
+feature is deployable with receive-only Bitcoin (send surfaces stay hidden via
+capabilities until US3 lands); each subsequent phase flips one capability on.
+`BTC_ENABLED=false` keeps the entire feature dark in production until ops
+enables the gateway module.


### PR DESCRIPTION
## Summary

Enables native Bitcoin on FairWins — the platform's **first non-EVM network** — surfaced where BTC is functionally useful: the portfolio and the send/receive flows. Full Spec Kit feature (`specs/061-bitcoin-transactions/`: spec, plan, research, data model, normative contracts, quickstart, tasks, security review).

**Wallet & keys (non-custodial, no new seed phrase)**
- BIP32 root derived client-side from the spec-041 passkey master seed via domain-separated HKDF (`fairwins-btc-seed-v1`); BIP84 native segwit (`bc1q…`, default) + BIP86 taproot (`bc1p…`, opt-in). Constants are contract-frozen (wallet-breaking if changed).
- Keys/xpubs never leave the client; recovery on a new device needs no Bitcoin-specific backup (gap-limit-20 discovery rebuilds the wallet).

**Address rotation (receive)**
- Fresh, never-reissued address per receive request; per-type rotation cursors never decrease; all issued addresses monitored indefinitely; BIP-21 QR/share. Receive surface: AddressQRModal `mode="bitcoin"` (entry point in Account → Wallet preferences) with segwit/taproot toggle and honest unavailable/locked states.

**Send (all standard destination types)**
- Pays P2PKH, P2SH, bech32 v0, and bech32m/taproot destinations; PSBT built+signed client-side (`@scure/btc-signer`), RBF-signaled; fee quotes expire after 60s and the member-confirmed fee is a **hard signing ceiling** (`FeeOverrunError`); sub-dust change folds into the fee; in-flight coins locked against concurrent sends. UI: BTC asset in the Transfer form routes to a parallel `BitcoinSendPanel` (fee tier selection, fee + total debit in BTC and USD before signing, MAX, shortfall explanations, stale-quote re-confirmation). Never gasless — stated explicitly, and the dropdown's gasless marker is guarded off for BTC.

**Bitcoin Stamps**
- Stamps recognized via an indexer-backed gateway endpoint and shown in collectibles; **fail-safe coin selection**: only positively-verified stamp-free coins are spendable — degraded recognition protects everything (over-protection beats accidental destruction), with protected value visibly accounted for on both portfolio and send surfaces.

**Gateway module** (`services/relay-gateway/src/bitcoin/`)
- Esplora-compatible upstream proxy (`/v1/bitcoin/:network/*`: batch balances/UTXOs, fees, broadcast, tx status, stamps) with killswitch → validation → quotas → TTL caches, config-swappable upstreams (mempool.space default, self-hosted electrs ready), fail-loud boot validation. `BTC_ENABLED=false` keeps the feature fully dark.

**Non-EVM network model**
- String-keyed `bitcoinNetworks.js` registry (`'bitcoin'`, `'bitcoin-testnet'` = testnet4) parallel to the numeric `NETWORKS` map — no fake chainId, `isBitcoinNetworkId` guards every boundary (incl. a fixed capability-resolver fallback leak); capabilities self-disclose honestly (portfolio/send/receive only; display-only Network tab rows, no wallet-switch affordance).

**Portfolio**
- Native BTC joins the existing `BTC` baseline: aggregates with WBTC into one Bitcoin row, priced by the already-configured Chainlink BTC/USD feeds; pending/confirmed/protected value split; balance-source failure renders stale via `failedAssets`, never zero.

**Docs**: `docs/developer-guide/bitcoin.md`, `docs/runbooks/bitcoin-operations.md`, CLAUDE.md guardrail block. **Security review** (T040): `specs/061-bitcoin-transactions/security-review.md` — no critical/high findings; two medium honesty issues found and fixed in-flight (capability fallback leak, dropdown gasless marker), both pinned by tests.

## Test plan

- [x] Derivation: BIP84/BIP86 published reference vectors + pinned FairWins vectors, domain-separation and determinism checks
- [x] Address codecs: accept/reject matrix (checksum mutations, wrong-network, EVM `0x`, mixed case, BIP-350 vectors), BIP-21 round-trips
- [x] Coin selection: stamps/unverified/locked/pending never selected; MAX leaves zero remainder; no dust outputs; conservation checks
- [x] PSBT: signs to all four destination types, mixed segwit+taproot inputs, fee-overrun refusal, vsize estimate ≥ actual
- [x] Wallet: rotation never repeats, cursor never rolls back, gap-limit recovery incl. paid-ahead addresses, per-account/network ledger isolation
- [x] Send pipeline: stale-quote rejection, shortfall explanations, broadcast rejection surfacing, outpoint locking
- [x] Gateway: 44 route tests (DTO shapes, killswitch/disabled 503s, quota 429s, upstream-down 502s, stamps degradation, cache TTLs, fail-loud boot) — 188 total gateway tests green
- [x] UI surface tests: receive modal bitcoin mode (8), hook (16), TransferForm bitcoin path (8) + EVM regression (5), portfolio wiring (7), stamps section (12), network capability rows (6), non-EVM guard rails (9)
- [x] Full-suite regression (SC-008): full frontend suite green locally before the UI-integration pushes; final verdict via CI on this PR
- [ ] Live testnet4 walk-through of `specs/061-bitcoin-transactions/quickstart.md` §3 (faucet funds, real broadcasts) — needs a human-driven session; the one open item

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Suzktv5y6E3uKSPZYf5wz3