### PR TITLE
Fix passkey explainer bottom sheet hidden behind mobile bottom nav

### DIFF
--- a/frontend/src/components/wallet/ConnectModal.css
+++ b/frontend/src/components/wallet/ConnectModal.css
@@ -227,11 +227,20 @@
 @media (max-width: 640px) {
   .connect-modal__backdrop {
     align-items: flex-end;
+    /* Sit above the fixed bottom icon nav (z-index 1200) and nav drawer
+       (1401); otherwise the nav covers the bottom of the sheet and hides the
+       Continue/Back actions (e.g. the passkey explainer step), leaving users
+       unable to proceed. */
+    z-index: 1500;
   }
 
   .connect-modal {
     max-width: 100%;
+    max-height: calc(85vh - 64px);
     border-radius: 20px 20px 0 0;
+    /* Reserve room at the bottom so the last actions clear the icon nav and
+       stay visible/tappable. */
+    padding-bottom: calc(0.75rem + 64px + env(safe-area-inset-bottom, 0px));
   }
 }
 


### PR DESCRIPTION
## Summary
- On mobile, `ConnectModal`'s backdrop (which renders as a bottom sheet, hosting the passkey explainer's Continue/Back buttons) used `z-index: 1100`.
- The fixed mobile bottom icon nav (`SectionIconNav`, `z-index: 1200`) and the nav drawer (`1400`/`1401`) both sit above that, so the nav bar visually covered the bottom of the sheet — hiding the Continue button and blocking users from proceeding with passkey setup.
- Raised `.connect-modal__backdrop` to `z-index: 1500` in the mobile media query and added bottom padding to `.connect-modal` so its content clears the icon nav, matching the identical fix already applied to the wallet dropdown sheet (`WalletButton.css`, which has a comment describing the same problem).

## Test plan
- [x] `npx vitest run src/components/wallet/__tests__/ConnectModal.test.jsx` — 14 tests pass
- [x] `npx vitest run src/test/GroupPoolModal.test.jsx` — 8 tests pass (uses similar modal patterns)
- [ ] Manual check on a mobile viewport that the passkey explainer sheet's Continue/Back buttons are fully visible and clickable above the bottom nav


---
_Generated by [Claude Code](https://claude.ai/code/session_01DKiDdLfhfpaTnAvihdTPPx)_