### PR TITLE
Make passkey open-challenge codes recoverable and encryption transparent

### DIFF
--- a/frontend/src/components/fairwins/TakeChallengePanel.jsx
+++ b/frontend/src/components/fairwins/TakeChallengePanel.jsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useContext } from 'react'
 import { useOpenChallengeAccept } from '../../hooks/useOpenChallengeAccept'
+import { useOpenChallengeCodeVault } from '../../hooks/useOpenChallengeCodeVault'
 import { usePolymarketMarket } from '../../hooks/usePolymarketMarket'
 import { useChainTokens } from '../../hooks/useChainTokens'
 import { ResolutionType } from '../../constants/wagerDefaults'
@@ -20,6 +21,11 @@ import './TakeChallengePanel.css'
  */
 export default function TakeChallengePanel({ code, match, onClose, onBuyMembership, onBack }) {
   const { accept, busy } = useOpenChallengeAccept()
+  // Recovery-code vault: once a taker binds themselves to a challenge, save their code
+  // (encrypted, account-scoped) so re-reading the private terms later is transparent — no
+  // re-typing the four words. canUse is false without a connected account; the save is
+  // best-effort and never blocks the (already-confirmed on-chain) acceptance.
+  const { saveCode, canUse: canBackup } = useOpenChallengeCodeVault()
   // Access the notification system directly (optional) so this panel still renders in tests without a
   // UIProvider, while routing the take-success event into the app's notification toasts (spec 037).
   const ui = useContext(UIContext)
@@ -35,6 +41,7 @@ export default function TakeChallengePanel({ code, match, onClose, onBuyMembersh
   const [progress, setProgress] = useState(null)
   const [txHash, setTxHash] = useState(null)
   const [error, setError] = useState(null)
+  const [codeSaved, setCodeSaved] = useState(false)
   const found = match
 
   // Oracle-settled open challenges (spec 041): the on-chain fields are authoritative for
@@ -55,12 +62,26 @@ export default function TakeChallengePanel({ code, match, onClose, onBuyMembersh
       setTxHash(hash)
       setPhase('accepted')
       ui?.showNotification?.('You’ve taken the challenge — your stake is escrowed.', 'success', 6000)
+      // Save the code to the recovery vault so the taker can re-read the terms later without
+      // re-entering it (transparent decryption). Best-effort: a declined ceremony or missing
+      // wallet must not undo the on-chain acceptance, so failure only leaves codeSaved false.
+      if (canBackup) {
+        try {
+          const desc = typeof found.terms === 'string' ? found.terms : found.terms?.description
+          await saveCode({
+            code,
+            wagerId: found.wagerId != null ? String(found.wagerId) : null,
+            description: desc || '',
+          })
+          setCodeSaved(true)
+        } catch { /* keep the take successful; manual re-entry stays available */ }
+      }
     } catch (err) {
       setError(err.message)
     } finally {
       setProgress(null)
     }
-  }, [accept, code, found, ui])
+  }, [accept, code, found, ui, canBackup, saveCode])
 
   if (!found) return null
 
@@ -69,7 +90,12 @@ export default function TakeChallengePanel({ code, match, onClose, onBuyMembersh
       <div className="fm-success">
         <div className="fm-success-icon" aria-hidden="true">&#10003;</div>
         <h3>You&apos;ve taken the challenge</h3>
-        <p className="fm-success-desc">You&apos;re now the bound opponent. Keep your code to re-read the private terms in future.</p>
+        <p className="fm-success-desc">
+          You&apos;re now the bound opponent.{' '}
+          {codeSaved
+            ? 'Your code is saved to this account — re-read the private terms anytime from My Wagers, no code needed.'
+            : 'Keep your code to re-read the private terms in future.'}
+        </p>
         <div className="fm-success-actions">
           <button type="button" className="fm-btn-primary fm-success-done" onClick={onClose}>Done</button>
         </div>

--- a/frontend/src/components/fairwins/__tests__/TakeChallengePanel.test.jsx
+++ b/frontend/src/components/fairwins/__tests__/TakeChallengePanel.test.jsx
@@ -6,6 +6,13 @@ vi.mock('../../../hooks/useOpenChallengeAccept', () => ({
   useOpenChallengeAccept: () => ({ accept, busy: false, lookup: vi.fn(), discover: vi.fn(), error: null }),
 }))
 
+// Recovery-code vault: control saveCode/canUse so we can assert the taker's code is auto-saved.
+const saveCode = vi.fn().mockResolvedValue(undefined)
+let vaultCanUse = true
+vi.mock('../../../hooks/useOpenChallengeCodeVault', () => ({
+  useOpenChallengeCodeVault: () => ({ saveCode, canUse: vaultCanUse }),
+}))
+
 import TakeChallengePanel from '../TakeChallengePanel'
 import { UIContext } from '../../../contexts/UIContext'
 import { WalletContext } from '../../../contexts/WalletContext'
@@ -20,7 +27,12 @@ function renderPanel(ui, wallet = connectedWallet) {
 }
 
 describe('TakeChallengePanel (spec 037, US1)', () => {
-  beforeEach(() => { accept.mockReset(); connectedWallet.openConnectModal.mockReset() })
+  beforeEach(() => {
+    accept.mockReset()
+    connectedWallet.openConnectModal.mockReset()
+    saveCode.mockReset().mockResolvedValue(undefined)
+    vaultCanUse = true
+  })
 
   it('shows terms + funding steps and accepts (onProgress passed through)', async () => {
     accept.mockResolvedValue({ txHash: '0xdef' })
@@ -86,6 +98,28 @@ describe('TakeChallengePanel (spec 037, US1)', () => {
     renderPanel(<TakeChallengePanel code="river tiger kite zoo" match={matchOpen} onClose={() => {}} />)
     fireEvent.click(screen.getByRole('button', { name: /lock in/i }))
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/no longer open/i))
+  })
+
+  it('auto-saves the code to the recovery vault on accept so re-reads are transparent', async () => {
+    accept.mockResolvedValue({ txHash: '0xdef' })
+    renderPanel(<TakeChallengePanel code="river tiger kite zoo" match={matchOpen} onClose={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: /lock in/i }))
+    await waitFor(() => expect(saveCode).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'river tiger kite zoo', wagerId: '4', description: 'Will it snow?' })
+    ))
+    // Success copy reflects the transparent save (no "keep your code" burden).
+    expect(await screen.findByText(/re-read the private terms anytime from My Wagers, no code needed/i)).toBeInTheDocument()
+  })
+
+  it('still completes the take when the vault is unavailable (save is best-effort)', async () => {
+    accept.mockResolvedValue({ txHash: '0xdef' })
+    vaultCanUse = false
+    renderPanel(<TakeChallengePanel code="river tiger kite zoo" match={matchOpen} onClose={() => {}} />)
+    fireEvent.click(screen.getByRole('button', { name: /lock in/i }))
+    expect(await screen.findByText(/taken the challenge/i)).toBeInTheDocument()
+    expect(saveCode).not.toHaveBeenCalled()
+    // Falls back to the "keep your code" guidance rather than falsely claiming it was saved.
+    expect(screen.getByText(/keep your code to re-read the private terms/i)).toBeInTheDocument()
   })
 
   it('routes a success toast into the notification system (spec 037)', async () => {

--- a/frontend/src/hooks/useEncryption.js
+++ b/frontend/src/hooks/useEncryption.js
@@ -39,6 +39,7 @@ import {
   lookupPublicKey,
   hasRegisteredKey,
   ensureKeyRegistered,
+  registerEncryptionKey,
   buildRegisterKeyCalls,
   clearKeyCache
 } from '../utils/keyRegistryService.js'
@@ -341,6 +342,44 @@ export function useEncryption() {
   }, [signature, cachedVersion, keyPairs, isPasskey, applyKeyPairs, initializeKeys])
 
   /**
+   * Register this account's X25519 encryption key on-chain, AWAITING the write and surfacing
+   * real errors (unlike initializeKeys' passkey auto-register, which is deliberately non-blocking
+   * so wager creation isn't delayed and therefore can only warn on failure). This is what the
+   * explicit "Register Encryption Key" control needs: a passkey user must be able to see whether
+   * registration actually landed — and why it didn't — rather than a fire-and-forget that leaves
+   * the status stuck on "Not registered".
+   *
+   * @returns {Promise<{ publicKey: Uint8Array, alreadyRegistered: boolean }>}
+   * @throws when key derivation or the on-chain registration fails (caller surfaces the message)
+   */
+  const registerKeyNow = useCallback(async () => {
+    if (!account || (!signer && !isPasskey)) {
+      throw new Error('Connect your account to register an encryption key.')
+    }
+    const readProvider = signer?.provider || provider
+    const { publicKey } = await ensureInitialized()
+    if (!publicKey) throw new Error('Failed to derive encryption keys.')
+
+    // Idempotent: never re-submit (and never charge a fee / ceremony) for an already-registered key.
+    if (readProvider && (await hasRegisteredKey(account, readProvider))) {
+      return { publicKey, alreadyRegistered: true }
+    }
+
+    if (isPasskey) {
+      if (typeof sendCalls !== 'function') {
+        throw new Error('This account cannot register a key on the current transaction rail.')
+      }
+      const termsHash = getCurrentDocument('terms')?.hash || null
+      // Awaited (not fire-and-forget): a relayer/paymaster outage or an undeployed KeyRegistry
+      // now surfaces to the caller instead of being swallowed as a console warning.
+      await sendCalls(buildRegisterKeyCalls(publicKey, chainId, termsHash))
+    } else {
+      await registerEncryptionKey(signer, publicKey)
+    }
+    return { publicKey, alreadyRegistered: false }
+  }, [account, signer, isPasskey, provider, sendCalls, chainId, ensureInitialized])
+
+  /**
    * Create encrypted market metadata
    * Returns envelope ready for IPFS upload
    * Uses X-Wing (post-quantum) by default for new markets
@@ -627,6 +666,7 @@ export function useEncryption() {
     // Key management
     initializeKeys,
     ensureInitialized,
+    registerKeyNow,
     clearKeys,
 
     // Encryption operations

--- a/frontend/src/lib/backup/syncedObjects.js
+++ b/frontend/src/lib/backup/syncedObjects.js
@@ -13,6 +13,7 @@ import {
   listClientRecordsAllChains,
   mergeClientRecordsAllChains,
 } from '../../data/ledger/ledgerClientStore'
+import { readVaultEnvelope, writeVaultEnvelope, hasVault } from '../openChallenge/codeVault'
 
 const PREF_KEYS = {
   recentSearches: 'recent_searches',
@@ -99,6 +100,30 @@ export const syncedObjects = [
       const fresh = (incoming || []).filter((r) => r?.entryId && !have.has(r.entryId))
       return { value: [...(current || []), ...fresh], conflicts: [] }
     },
+  },
+  {
+    // Spec 024/037 follow-up — the open-challenge recovery-code vault. Passkeys sync across
+    // devices but the vault is device-local localStorage, so a new device / reinstall lost every
+    // saved four-word code (the exact "passkey users can't recover their codes" gap). Riding this
+    // channel restores them, because the vault's at-rest envelope is encrypted under the account's
+    // key material and the SAME account re-derives that key on any device (passkey master seed or
+    // wallet signature). The value put in the bundle is the OPAQUE ciphertext envelope — the codes
+    // never enter the backup channel in cleartext, and this stays consistent whether or not the
+    // member has ever run a manual backup (auto-backup carries it too).
+    key: 'openChallengeCodes',
+    label: 'Recovery codes',
+    networkScoped: false, // the envelope is opaque ciphertext; code entries are not identity-keyed by chain
+    load: (account) => readVaultEnvelope(account),
+    // Ciphertext envelopes from the same account share a key but use per-write nonces over
+    // different entry sets, so they can't be unioned without the (async, ceremony-gated) vault
+    // key that this synchronous path deliberately never holds. Both modes therefore RESTORE the
+    // backed-up envelope only when this device has no local vault, and NEVER clobber existing
+    // local codes — recovery is purely additive from the member's perspective.
+    apply: (account, value, _mode) => {
+      if (value && !hasVault(account)) writeVaultEnvelope(account, value)
+      return { conflicts: [] }
+    },
+    merge: (current, incoming) => ({ value: current || incoming || null, conflicts: [] }),
   },
 ]
 

--- a/frontend/src/lib/openChallenge/codeVault.js
+++ b/frontend/src/lib/openChallenge/codeVault.js
@@ -72,6 +72,29 @@ export function hasVault(address) {
 }
 
 /**
+ * Read the wallet's raw at-rest vault envelope (opaque ciphertext) without decrypting it.
+ * Used by the spec-032 cross-device backup layer (syncedObjects): the envelope is already
+ * encrypted under this account's key material, and the SAME account (passkey master seed or
+ * wallet signature) re-derives that key on any device — so restoring the blob elsewhere makes
+ * the codes recoverable without ever exposing them to the backup channel in cleartext. Returns
+ * null when nothing is saved on this device.
+ */
+export function readVaultEnvelope(address) {
+  if (!address) return null
+  return readEnvelope(address)
+}
+
+/**
+ * Write a raw vault envelope for the wallet (the inverse of {@link readVaultEnvelope}), used by
+ * the spec-032 restore path. The envelope must be one produced by this module for this account —
+ * it stays encrypted at rest and is only openable with the account's key material.
+ */
+export function writeVaultEnvelope(address, envelope) {
+  if (!address || !envelope) return
+  writeEnvelope(address, envelope)
+}
+
+/**
  * Read and decrypt the saved code entries for a wallet. Returns [] when nothing is stored.
  * Throws a friendly error when an envelope exists but the key can't open it (wrong wallet / corrupt).
  */

--- a/frontend/src/pages/WalletPage.jsx
+++ b/frontend/src/pages/WalletPage.jsx
@@ -8,7 +8,7 @@ import { usePwaUpdate } from '../hooks/usePwaUpdate'
 import { useChainTokens } from '../hooks/useChainTokens'
 import { useModal } from '../hooks/useUI'
 import { ROLES, ROLE_INFO } from '../contexts/RoleContext'
-import { hasRegisteredKey, ensureKeyRegistered } from '../utils/keyRegistryService'
+import { hasRegisteredKey } from '../utils/keyRegistryService'
 import TradePanel from '../components/fairwins/TradePanel'
 import EarnPanel from '../components/earn/EarnPanel'
 import PayTransferPanel from '../components/wallet/PayTransferPanel'
@@ -86,7 +86,7 @@ function WalletPage() {
   const isPasskey = loginMethod === 'passkey'
   const { showModal, hideModal } = useModal()
   const { roles, hasRole } = useWalletRoles()
-  const { isInitialized, isInitializing, ensureInitialized } = useEncryption()
+  const { isInitialized, isInitializing, registerKeyNow } = useEncryption()
   const { preferences, setPolymarketCategories } = useUserPreferences()
   const { capabilities } = useChainTokens()
   const polymarketSidebetsEnabled = Boolean(capabilities?.polymarketSidebets)
@@ -150,9 +150,11 @@ function WalletPage() {
   }, [address, provider])
 
   const handleRegisterKey = useCallback(async () => {
-    // Passkey sessions have no ethers signer — keys derive from the WebAuthn PRF master seed and the
-    // on-chain registration is submitted through the smart account (sendCalls), all inside
-    // ensureInitialized(). Classic wallets keep the signer path (sign the derivation message → register tx).
+    // registerKeyNow derives the account's encryption keys and AWAITS the on-chain registration,
+    // login-method agnostic: a passkey submits through the smart account (sendCalls / one WebAuthn
+    // ceremony), a classic wallet signs the register tx. Awaiting it — rather than the old
+    // fire-and-forget + poll — is what lets a passkey user actually see success or a real failure
+    // reason instead of a status stuck on "Not registered".
     if (!address || (!signer && !isPasskey)) {
       setKeyError('Not connected. Please sign in again.')
       return
@@ -160,35 +162,21 @@ function WalletPage() {
     setKeyRegisterLoading(true)
     setKeyError(null)
     try {
-      const result = await ensureInitialized()
-      if (!result?.publicKey) {
-        throw new Error('Failed to derive encryption keys')
+      await registerKeyNow()
+      // Confirm against the registry so the flip to "Registered" reflects on-chain truth. A passkey
+      // UserOp can take a moment to include, so poll briefly before reporting.
+      let registered = await hasRegisteredKey(address, provider)
+      for (let i = 0; !registered && isPasskey && i < 5; i++) {
+        await new Promise((r) => setTimeout(r, 2000))
+        registered = await hasRegisteredKey(address, provider)
       }
-      if (isPasskey) {
-        // ensureInitialized() already kicked off the on-chain registration (non-blocking, via sendCalls).
-        // Reflect it honestly: poll the registry briefly so the UI flips to "Registered" once it lands,
-        // and otherwise tell the user it's finishing rather than claiming failure.
-        let registered = await hasRegisteredKey(address, provider)
-        for (let i = 0; !registered && i < 5; i++) {
-          await new Promise((r) => setTimeout(r, 2000))
-          registered = await hasRegisteredKey(address, provider)
-        }
-        setKeyRegistered(registered)
-        if (!registered) {
-          setKeyError('Encryption key setup submitted — it can take a moment to finish. Use “Check Status” shortly.')
-        }
-        return
-      }
-      // ensureKeyRegistered checks on-chain first, only registers if needed
-      const wasNewlyRegistered = await ensureKeyRegistered(signer, address, result.publicKey)
-      setKeyRegistered(true)
-      if (!wasNewlyRegistered) {
-        // Key was already registered — not an error, just inform user
-        console.log('[WalletPage] Key was already registered on-chain')
+      setKeyRegistered(registered)
+      if (!registered && isPasskey) {
+        setKeyError('Encryption key setup submitted — it can take a moment to confirm. Use “Check Status” shortly.')
       }
     } catch (err) {
-      if (err.message.includes('rejected') || err.message.includes('denied')) {
-        setKeyError('Transaction was rejected.')
+      if (err.message.includes('rejected') || err.message.includes('denied') || err.name === 'CeremonyCancelled') {
+        setKeyError('Registration was cancelled.')
       } else if (err.message.includes('KeyAlreadyExists') || err.message.includes('0xe0accd63')) {
         // Key already exists on-chain — treat as success
         setKeyRegistered(true)
@@ -198,7 +186,7 @@ function WalletPage() {
     } finally {
       setKeyRegisterLoading(false)
     }
-  }, [ensureInitialized, signer, address, isPasskey, provider])
+  }, [registerKeyNow, signer, address, isPasskey, provider])
 
   // Auto-check key status when Security tab is shown
   useEffect(() => {

--- a/frontend/src/test/backup/syncedObjects.test.js
+++ b/frontend/src/test/backup/syncedObjects.test.js
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { syncedObjects } from '../../lib/backup/syncedObjects'
+import {
+  deriveVaultKeyFromSeed,
+  addEntry,
+  readEntries,
+  hasVault,
+} from '../../lib/openChallenge/codeVault'
 
 // Spec 032 — the synced-object registry: address book is network-scoped and merges additively by
 // (address, chainId) so the same address on two networks stays two distinct entries (FR-015a/FR-008);
@@ -29,5 +35,54 @@ describe('syncedObjects', () => {
     expect(prefs.networkScoped).toBe(false)
     const { value } = prefs.merge({ defaultSlippage: 0.5 }, { defaultSlippage: 2.0 })
     expect(value).toEqual({ defaultSlippage: 2.0 })
+  })
+})
+
+// Spec 024/037 follow-up — the open-challenge recovery-code vault rides the spec-032 backup channel
+// so passkey users recover their codes on a new device. The bundled value is the OPAQUE at-rest
+// ciphertext envelope; restore re-writes it and the SAME account key material re-opens it.
+describe('syncedObjects — open-challenge recovery codes', () => {
+  const codes = syncedObjects.find((o) => o.key === 'openChallengeCodes')
+  const seedKey = deriveVaultKeyFromSeed(new Uint8Array(32).fill(9)) // deterministic passkey seed key
+
+  beforeEach(() => localStorage.clear())
+
+  it('is registered, network-agnostic, and loads the opaque encrypted envelope (never cleartext)', () => {
+    expect(codes).toBeTruthy()
+    expect(codes.networkScoped).toBe(false)
+    addEntry(ADDR, seedKey, { code: 'river tiger kite zoo', wagerId: '7' })
+    const loaded = codes.load(ADDR)
+    expect(loaded).toMatchObject({ nonce: expect.any(String), ciphertext: expect.any(String) })
+    expect(JSON.stringify(loaded)).not.toContain('river tiger kite zoo')
+  })
+
+  it('restores a passkey vault onto a fresh device and re-opens it with the same seed key', () => {
+    // "Device A": save a code, then capture the bundle value the backup would carry.
+    addEntry(ADDR, seedKey, { code: 'river tiger kite zoo', wagerId: '7', description: 'Rain?' })
+    const bundled = codes.load(ADDR)
+
+    // "Device B": nothing saved locally (the vault is otherwise device-local localStorage).
+    localStorage.clear()
+    expect(hasVault(ADDR)).toBe(false)
+
+    codes.apply(ADDR, bundled, 'merge')
+
+    // The restored envelope re-opens with the same passkey master seed → codes recovered.
+    expect(readEntries(ADDR, seedKey)).toEqual([
+      expect.objectContaining({ code: 'river tiger kite zoo', wagerId: '7', description: 'Rain?' }),
+    ])
+  })
+
+  it('never clobbers existing local codes on restore (additive recovery only)', () => {
+    addEntry(ADDR, seedKey, { code: 'local aaa bbb ccc', wagerId: '1' })
+    const foreign = { format: 'fairwins-oc-code-vault', version: 1, alg: 'chacha20poly1305', nonce: 'x', ciphertext: 'y' }
+    codes.apply(ADDR, foreign, 'merge')
+    // Local vault is untouched — still decrypts to the original, unshredded by the (unmergeable) incoming blob.
+    expect(readEntries(ADDR, seedKey).map((e) => e.code)).toEqual(['local aaa bbb ccc'])
+  })
+
+  it('no-ops when there is nothing to restore', () => {
+    expect(() => codes.apply(ADDR, null, 'merge')).not.toThrow()
+    expect(hasVault(ADDR)).toBe(false)
   })
 })

--- a/frontend/src/test/useEncryption.passkey.test.jsx
+++ b/frontend/src/test/useEncryption.passkey.test.jsx
@@ -56,10 +56,12 @@ vi.mock('../utils/legalDocs.js', () => ({
 
 const buildRegisterKeyCalls = vi.fn(() => [{ target: '0xkeyRegistry', data: '0xdead', value: 0n }])
 const hasRegisteredKey = vi.fn(async () => false)
+const registerEncryptionKey = vi.fn(async () => ({ hash: '0x1', status: 'success' }))
 vi.mock('../utils/keyRegistryService.js', () => ({
   lookupPublicKey: vi.fn(async () => null),
   hasRegisteredKey: (...a) => hasRegisteredKey(...a),
   ensureKeyRegistered: vi.fn(async () => false),
+  registerEncryptionKey: (...a) => registerEncryptionKey(...a),
   buildRegisterKeyCalls: (...a) => buildRegisterKeyCalls(...a),
   clearKeyCache: vi.fn(),
 }))
@@ -75,6 +77,42 @@ describe('useEncryption — passkey encrypt/decrypt surface', () => {
     ensurePasskeyEncryptionKeys.mockClear()
     buildRegisterKeyCalls.mockClear()
     hasRegisteredKey.mockClear()
+    hasRegisteredKey.mockResolvedValue(false)
+  })
+
+  it('registerKeyNow awaits the on-chain register through sendCalls and surfaces failures', async () => {
+    const { result } = renderHook(() => useEncryption())
+    // Initialize first and let the non-blocking auto-register settle, so the assertions below
+    // observe registerKeyNow's OWN sendCalls rather than racing initializeKeys' auto-register.
+    await act(async () => { await result.current.ensureInitialized() })
+    await vi.waitFor(() => expect(sendCalls).toHaveBeenCalled())
+    sendCalls.mockClear()
+    buildRegisterKeyCalls.mockClear()
+
+    let out
+    await act(async () => {
+      out = await result.current.registerKeyNow()
+    })
+    expect(buildRegisterKeyCalls).toHaveBeenCalledWith(PASSKEY_KEYS.publicKey, 137, null)
+    expect(sendCalls).toHaveBeenCalledWith([{ target: '0xkeyRegistry', data: '0xdead', value: 0n }])
+    expect(out).toMatchObject({ alreadyRegistered: false })
+
+    // A relayer/paymaster outage now propagates to the caller (was swallowed by the fire-and-forget path).
+    sendCalls.mockRejectedValueOnce(new Error('paymaster unavailable'))
+    await act(async () => {
+      await expect(result.current.registerKeyNow()).rejects.toThrow(/paymaster unavailable/i)
+    })
+  })
+
+  it('registerKeyNow is idempotent — an already-registered key skips the ceremony', async () => {
+    hasRegisteredKey.mockResolvedValue(true)
+    const { result } = renderHook(() => useEncryption())
+    let out
+    await act(async () => {
+      out = await result.current.registerKeyNow()
+    })
+    expect(out).toMatchObject({ alreadyRegistered: true })
+    expect(sendCalls).not.toHaveBeenCalled()
   })
 
   it('derives encryption keys from the PRF seed — no signer, no signMessage', async () => {


### PR DESCRIPTION
## Problem

Passkey users could not recover the four-word codes that encrypt/decrypt their open challenges, and were being asked to remember/re-type those codes even for their own wagers. Two structural gaps caused this:

- The open-challenge **recovery-code vault was device-local `localStorage` only** and was **not** part of the spec-032 encrypted backup bundle. Passkeys sync across devices, but the codes did not — so a new device / reinstall / cleared storage lost every saved code (the "passkey users can't recover their codes" symptom).
- The **take/accept flow never saved the taker's code**, so a taker had to re-enter the four words forever to re-read their own wager (only the *create* flow auto-saved).
- **Passkey encryption-key registration** relied on a fire-and-forget `sendCalls` plus polling, so a real failure (relayer/paymaster outage, undeployed KeyRegistry, wrong chainId) was swallowed and left the status stuck on "Not registered" with no error.

The four-word code is a bearer token (anyone with it can take the challenge) shared out-of-band, so it can't be replaced by the passkey's own keys. The fix instead makes it **transparent for participants**: saved and recovered automatically, never re-typed.

## Changes

- **Cross-device recovery** — `codeVault.js` exposes `readVaultEnvelope`/`writeVaultEnvelope`; `syncedObjects.js` registers the vault as a spec-032 synced object. Its already-encrypted at-rest envelope now rides the existing IPFS backup/restore channel and re-opens on any device with the same account key material (passkey master seed or wallet signature) — codes never enter the backup channel in cleartext. Restore is additive and never clobbers local codes (ciphertext envelopes can't be merged synchronously, so restore only fills an empty local vault).
- **Transparent take flow** — `TakeChallengePanel` auto-saves the taker's code to the vault on a successful accept. Combined with the existing My Wagers auto-unlock, a participant never re-types the code for their own wagers. Best-effort: a declined ceremony or missing wallet never undoes the on-chain acceptance; the success copy adjusts honestly.
- **Passkey key registration** — new `useEncryption.registerKeyNow()` awaits the on-chain register (`sendCalls` for passkey, `registerEncryptionKey` for EOA) and surfaces real errors; `WalletPage.handleRegisterKey` uses it in place of the fire-and-forget path.

## Testing

- `src/test/backup/syncedObjects.test.js` — vault is registered/opaque, restores a passkey vault onto a fresh device and re-opens it with the same seed key, never clobbers local codes, no-ops when empty.
- `src/components/fairwins/__tests__/TakeChallengePanel.test.jsx` — code auto-saved on accept with wagerId + description; take still completes when the vault is unavailable.
- `src/test/useEncryption.passkey.test.jsx` — `registerKeyNow` awaits `sendCalls`, surfaces failures, and is idempotent for an already-registered key.
- All affected suites pass (`backup/`, `claimCode/`, `TakeChallengePanel`, `useEncryption` passkey + EOA, `WalletPage`); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWbcD1wJAoj92UJ9TDGRcD

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWbcD1wJAoj92UJ9TDGRcD)_