### PR TITLE
Passkey account UX: light-theme fix + informed-consent sheets for add-passkey & link-wallet

### DIFF
--- a/frontend/src/components/account/ActionSheet.css
+++ b/frontend/src/components/account/ActionSheet.css
@@ -1,0 +1,185 @@
+/* Shared informative bottom sheet for account-security actions (specs 041/045).
+   Mirrors the connect surface (ConnectModal.css): centered card on desktop,
+   bottom sheet on mobile, with the mobile bottom-nav clearance fixed in #938
+   (backdrop z-index 1500 + safe-area padding) so actions never hide behind the
+   fixed icon nav.
+
+   Colors use the FairWins theme tokens from src/theme.css so text stays
+   high-contrast in BOTH light and dark themes. Fallbacks are the light-mode
+   values (light is the default theme) — never dark literals. */
+
+/* --- Sheet shell --- */
+.action-sheet__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1500;
+  padding: 16px;
+}
+
+.action-sheet {
+  width: 100%;
+  max-width: 460px;
+  max-height: 85vh;
+  overflow-y: auto;
+  background: var(--surface-color, #ffffff);
+  color: var(--text-primary, #1f2933);
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 16px;
+  box-shadow: var(--shadow-lg, 0 10px 15px rgba(0, 0, 0, 0.1));
+  outline: none;
+}
+
+.action-sheet__handle {
+  display: none;
+}
+
+.action-sheet__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid var(--border-color, #e3e7eb);
+}
+
+.action-sheet__header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--text-primary, #1f2933);
+}
+
+.action-sheet__close {
+  background: none;
+  border: none;
+  color: var(--text-secondary, #5a6772);
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 8px;
+}
+
+.action-sheet__close:hover:not(:disabled),
+.action-sheet__close:focus-visible {
+  color: var(--text-primary, #1f2933);
+  background: var(--bg-primary, #f7f9fa);
+}
+
+.action-sheet__close:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.action-sheet__body {
+  padding: 16px 20px 20px;
+}
+
+/* --- Shared content helpers --- */
+.action-sheet__text {
+  color: var(--text-secondary, #5a6772);
+  font-size: 0.92rem;
+  line-height: 1.5;
+  margin: 0 0 12px;
+}
+
+.action-sheet__list {
+  margin: 0 0 14px;
+  padding-left: 1.2rem;
+  color: var(--text-secondary, #5a6772);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.action-sheet__list li {
+  margin-bottom: 4px;
+}
+
+.action-sheet__warn {
+  border: 1px solid var(--warning-color, #f59e0b);
+  border-radius: 10px;
+  padding: 10px 12px;
+  color: var(--text-primary, #1f2933);
+  background: color-mix(in srgb, var(--warning-color, #f59e0b) 14%, transparent);
+  font-size: 0.88rem;
+  line-height: 1.5;
+  margin: 0 0 12px;
+}
+
+.action-sheet__addr {
+  display: block;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.85rem;
+  color: var(--text-primary, #1f2933);
+  background: var(--bg-primary, #f7f9fa);
+  border: 1px solid var(--border-color, #e3e7eb);
+  border-radius: 8px;
+  padding: 8px 10px;
+  margin: 0 0 12px;
+  overflow-wrap: anywhere;
+  word-break: break-all;
+}
+
+.action-sheet__progress {
+  color: var(--brand-primary, #36b37e);
+  font-size: 0.88rem;
+  margin: 0 0 12px;
+}
+
+.action-sheet__notice {
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 0.86rem;
+  line-height: 1.45;
+  margin: 0 0 12px;
+}
+
+.action-sheet__notice--error {
+  border: 1px solid var(--danger-color, #dc2626);
+  color: var(--danger-color, #dc2626);
+  background: color-mix(in srgb, var(--danger-color, #dc2626) 10%, transparent);
+}
+
+.action-sheet__notice--info {
+  border: 1px solid var(--accent-color, #4c9aff);
+  color: var(--text-primary, #1f2933);
+  background: color-mix(in srgb, var(--accent-color, #4c9aff) 10%, transparent);
+}
+
+.action-sheet__actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.action-sheet__actions .btn {
+  flex: 1;
+}
+
+/* Bottom sheet on mobile, like the connect surface. */
+@media (max-width: 640px) {
+  .action-sheet__backdrop {
+    align-items: flex-end;
+    padding: 0;
+  }
+
+  .action-sheet {
+    max-width: 100%;
+    max-height: calc(85vh - 64px);
+    border-radius: 20px 20px 0 0;
+    /* Reserve room so the last actions clear the fixed icon nav (z-index 1200)
+       and stay visible/tappable (#938). */
+    padding-bottom: calc(64px + env(safe-area-inset-bottom, 0px));
+  }
+
+  .action-sheet__handle {
+    display: block;
+    width: 36px;
+    height: 4px;
+    border-radius: 999px;
+    background: var(--border-color, #e3e7eb);
+    margin: 8px auto 0;
+  }
+}

--- a/frontend/src/components/account/ActionSheet.jsx
+++ b/frontend/src/components/account/ActionSheet.jsx
@@ -1,0 +1,106 @@
+/**
+ * Shared informative bottom sheet for account-security actions (specs 041/045).
+ *
+ * High-stakes, infrequent account actions (recover an account, add a passkey,
+ * link a controller wallet) each open one of these so the member is fully
+ * informed before they act. Centered card on desktop, sheet rising from the
+ * bottom on mobile, with the mobile bottom-nav clearance from #938 (backdrop
+ * z-index 1500 + safe-area padding) so the actions never hide behind the fixed
+ * icon nav. Traps focus, locks background scroll, and closes on Escape +
+ * backdrop — unless `closeDisabled` (e.g. a ceremony/transaction is in flight,
+ * which must never be dismissed out from under). Renders nothing when closed.
+ */
+
+import { useEffect, useRef } from 'react'
+import PropTypes from 'prop-types'
+import './ActionSheet.css'
+
+export default function ActionSheet({ open, onClose, title, children, closeDisabled = false }) {
+  const dialogRef = useRef(null)
+  const onCloseRef = useRef(onClose)
+  const closeDisabledRef = useRef(closeDisabled)
+  useEffect(() => {
+    onCloseRef.current = onClose
+  })
+  useEffect(() => {
+    closeDisabledRef.current = closeDisabled
+  })
+
+  useEffect(() => {
+    if (!open) return undefined
+    const onKey = (e) => {
+      if (e.key === 'Escape') {
+        if (!closeDisabledRef.current) onCloseRef.current?.()
+        return
+      }
+      if (e.key !== 'Tab') return
+      const dialog = dialogRef.current
+      if (!dialog) return
+      const focusables = dialog.querySelectorAll(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )
+      if (!focusables.length) return
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      const outside = !dialog.contains(document.activeElement)
+      if (e.shiftKey && (document.activeElement === first || outside)) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && (document.activeElement === last || outside)) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    dialogRef.current?.focus()
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.body.style.overflow = prevOverflow
+    }
+  }, [open])
+
+  if (!open) return null
+
+  const handleBackdrop = () => {
+    if (!closeDisabled) onClose?.()
+  }
+
+  return (
+    <div className="action-sheet__backdrop" role="presentation" onClick={handleBackdrop}>
+      <div
+        className="action-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        ref={dialogRef}
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="action-sheet__handle" aria-hidden="true" />
+        <div className="action-sheet__header">
+          <h3>{title}</h3>
+          <button
+            type="button"
+            className="action-sheet__close"
+            onClick={onClose}
+            disabled={closeDisabled}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+        <div className="action-sheet__body">{children}</div>
+      </div>
+    </div>
+  )
+}
+
+ActionSheet.propTypes = {
+  open: PropTypes.bool,
+  onClose: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  children: PropTypes.node,
+  closeDisabled: PropTypes.bool,
+}

--- a/frontend/src/components/account/ControllersPanel.jsx
+++ b/frontend/src/components/account/ControllersPanel.jsx
@@ -26,6 +26,7 @@ import AddressInput from '../ui/AddressInput'
 import AddressBookButton from '../ui/AddressBookButton'
 import QRScanner from '../ui/QRScanner'
 import { extractAddressFromScan } from '../../lib/addressBook/scanAddress'
+import ActionSheet from './ActionSheet'
 
 const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/
 
@@ -40,6 +41,8 @@ function ControllersPanel({ deps = {} }) {
   const [linkAddress, setLinkAddress] = useState('')
   const [linkAddressResolved, setLinkAddressResolved] = useState('')
   const [scanOpen, setScanOpen] = useState(false)
+  // Informed-consent bottom sheet before a full-controller action: null | 'add' | 'link'.
+  const [sheet, setSheet] = useState(null)
 
   const applyLinkAddress = useCallback((addr) => {
     setLinkAddress(addr)
@@ -52,6 +55,8 @@ function ControllersPanel({ deps = {} }) {
     setScanOpen(false)
   }, [applyLinkAddress])
 
+  // Returns true only when the action fully succeeded, so a confirmation sheet
+  // can close on success and stay open (for a retry) on error/cancel.
   const run = useCallback(
     async (fn) => {
       setBusy(true)
@@ -59,9 +64,11 @@ function ControllersPanel({ deps = {} }) {
       try {
         await fn()
         await account.refresh()
+        return true
       } catch (e) {
         if (e?.name === 'CeremonyCancelled') setNotice(null) // clean abort
         else setNotice({ kind: 'error', text: e.message })
+        return false
       } finally {
         setBusy(false)
       }
@@ -139,6 +146,18 @@ function ControllersPanel({ deps = {} }) {
     [run, account.controllerCount, sendCalls, address, deps]
   )
 
+  // Confirm handlers for the informed-consent sheets: run the action, and close
+  // the sheet only if it fully succeeded (errors stay in the sheet for a retry).
+  const confirmAddPasskey = useCallback(async () => {
+    if (await addPasskey()) setSheet(null)
+  }, [addPasskey])
+
+  const confirmLinkWallet = useCallback(async () => {
+    if (await linkWallet()) setSheet(null)
+  }, [linkWallet])
+
+  const linkTarget = (linkAddressResolved || linkAddress).trim()
+
   if (!account.isPasskeySession) return null
 
   return (
@@ -194,7 +213,15 @@ function ControllersPanel({ deps = {} }) {
       </ul>
 
       <div className="controllers-panel__actions">
-        <button type="button" className="btn" disabled={busy || !account.deployed} onClick={addPasskey}>
+        <button
+          type="button"
+          className="btn"
+          disabled={busy || !account.deployed}
+          onClick={() => {
+            setNotice(null)
+            setSheet('add')
+          }}
+        >
           Add a passkey
         </button>
         <div className="controllers-panel__link">
@@ -239,20 +266,94 @@ function ControllersPanel({ deps = {} }) {
           <button
             type="button"
             className="btn"
-            disabled={busy || !account.deployed || !ADDRESS_RE.test((linkAddressResolved || linkAddress).trim())}
-            onClick={linkWallet}
+            disabled={busy || !account.deployed || !ADDRESS_RE.test(linkTarget)}
+            onClick={() => {
+              setNotice(null)
+              setSheet('link')
+            }}
           >
             Link wallet
           </button>
         </div>
       </div>
 
-      {notice && (
+      {/* Panel-level notice only when no sheet is up (the sheet shows its own). */}
+      {!sheet && notice && (
         <p role={notice.kind === 'error' ? 'alert' : 'status'} className={`controllers-panel__${notice.kind}`}>
           {notice.text}
         </p>
       )}
       {account.error && <p role="alert">{account.error}</p>}
+
+      {/* Add-a-passkey: full-controller consequences before the ceremony. */}
+      <ActionSheet
+        open={sheet === 'add'}
+        onClose={() => setSheet(null)}
+        title="Add a passkey"
+        closeDisabled={busy}
+      >
+        <p className="action-sheet__text">
+          A passkey is a second key for this account, stored on this device and unlocked with Face ID,
+          Touch ID, or your device PIN.
+        </p>
+        <p className="action-sheet__warn">
+          It becomes a <strong>full controller</strong> — like your current passkey, it can approve
+          actions, move funds, and add or remove controllers. Keeping a second key is the recommended way
+          to make sure losing one device never locks you out.
+        </p>
+        <ol className="action-sheet__list">
+          <li>Your device prompts you to create the passkey.</li>
+          <li>One on-chain transaction authorizes it on the account.</li>
+        </ol>
+        {busy && <p className="action-sheet__progress">Working… confirm the prompts on your device.</p>}
+        {notice && (
+          <p role="alert" className={`action-sheet__notice action-sheet__notice--${notice.kind}`}>
+            {notice.text}
+          </p>
+        )}
+        <div className="action-sheet__actions">
+          <button type="button" className="btn" onClick={() => setSheet(null)} disabled={busy}>
+            Cancel
+          </button>
+          <button type="button" className="btn btn-primary" onClick={confirmAddPasskey} disabled={busy}>
+            {busy ? 'Adding…' : 'Create passkey'}
+          </button>
+        </div>
+      </ActionSheet>
+
+      {/* Link-wallet: linking grants FULL control — say so plainly before the act (FR-011). */}
+      <ActionSheet
+        open={sheet === 'link'}
+        onClose={() => setSheet(null)}
+        title="Link this wallet?"
+        closeDisabled={busy}
+      >
+        <p className="action-sheet__text">You&apos;re about to link this wallet as a controller:</p>
+        <code className="action-sheet__addr">{linkTarget}</code>
+        <p className="action-sheet__warn">
+          A linked wallet becomes a <strong>full controller</strong> of your account. It can move your
+          funds, add or remove controllers, and recover the account if you lose your passkeys. Only link a
+          wallet you exclusively control.
+        </p>
+        <ol className="action-sheet__list">
+          <li>We screen the address first (linking is blocked if screening flags it or can&apos;t run).</li>
+          <li>One on-chain transaction links it to your account.</li>
+        </ol>
+        {busy && <p className="action-sheet__progress">Screening and linking… confirm any prompts.</p>}
+        {notice && (
+          <p role="alert" className={`action-sheet__notice action-sheet__notice--${notice.kind}`}>
+            {notice.text}
+          </p>
+        )}
+        <div className="action-sheet__actions">
+          <button type="button" className="btn" onClick={() => setSheet(null)} disabled={busy}>
+            Cancel
+          </button>
+          <button type="button" className="btn btn-primary" onClick={confirmLinkWallet} disabled={busy}>
+            {busy ? 'Linking…' : 'Link wallet'}
+          </button>
+        </div>
+      </ActionSheet>
     </section>
   )
 }

--- a/frontend/src/components/account/RecoverAccountPanel.css
+++ b/frontend/src/components/account/RecoverAccountPanel.css
@@ -1,82 +1,15 @@
-/* Guided passkey-recovery wizard (spec 045, US6). The sheet mirrors the
-   connect surface (ConnectModal.css): centered card on desktop, bottom sheet on
-   mobile, and the same mobile bottom-nav clearance fixed in #938 (backdrop
-   z-index 1500 + safe-area padding) so the actions never hide behind the fixed
-   icon nav.
+/* Guided passkey-recovery wizard (spec 045, US6). The sheet shell lives in the
+   shared ActionSheet (ActionSheet.css); this file styles only the recovery
+   entry card and the per-step content that fills the sheet.
 
    Colors use the FairWins theme tokens from src/theme.css (--text-primary,
-   --text-secondary, --surface-color, --border-color, --warning-color,
-   --danger-color, --brand-primary) so text stays high-contrast in BOTH light
-   and dark themes. Fallbacks are the light-mode values (light is the default
-   theme) — never dark literals, which is what made light-theme text and chips
-   unreadable before. */
+   --text-secondary, --border-color, --warning-color, --danger-color,
+   --brand-primary) so text stays high-contrast in BOTH light and dark themes.
+   Fallbacks are the light-mode values (light is the default theme) — never dark
+   literals, which is what made light-theme text and chips unreadable before. */
 
 .recover-account-panel__start {
   margin-top: 8px;
-}
-
-/* --- Sheet shell --- */
-.recover-sheet__backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.55);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1500;
-  padding: 16px;
-}
-
-.recover-sheet {
-  width: 100%;
-  max-width: 460px;
-  max-height: 85vh;
-  overflow-y: auto;
-  background: var(--surface-color, #ffffff);
-  color: var(--text-primary, #1f2933);
-  border: 1px solid var(--border-color, #e3e7eb);
-  border-radius: 16px;
-  box-shadow: var(--shadow-lg, 0 10px 15px rgba(0, 0, 0, 0.1));
-  outline: none;
-}
-
-.recover-sheet__handle {
-  display: none;
-}
-
-.recover-sheet__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 16px 20px 12px;
-  border-bottom: 1px solid var(--border-color, #e3e7eb);
-}
-
-.recover-sheet__header h3 {
-  margin: 0;
-  font-size: 1.1rem;
-  color: var(--text-primary, #1f2933);
-}
-
-.recover-sheet__close {
-  background: none;
-  border: none;
-  color: var(--text-secondary, #5a6772);
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-  padding: 4px 8px;
-  border-radius: 8px;
-}
-
-.recover-sheet__close:hover,
-.recover-sheet__close:focus-visible {
-  color: var(--text-primary, #1f2933);
-  background: var(--bg-primary, #f7f9fa);
-}
-
-.recover-sheet__body {
-  padding: 16px 20px 20px;
 }
 
 /* --- Step content --- */
@@ -226,30 +159,4 @@
 
 .recover-step__actions .btn {
   flex: 1;
-}
-
-/* Bottom sheet on mobile, like the connect surface. */
-@media (max-width: 640px) {
-  .recover-sheet__backdrop {
-    align-items: flex-end;
-    padding: 0;
-  }
-
-  .recover-sheet {
-    max-width: 100%;
-    max-height: calc(85vh - 64px);
-    border-radius: 20px 20px 0 0;
-    /* Reserve room so the last actions clear the fixed icon nav (z-index 1200)
-       and stay visible/tappable (#938). */
-    padding-bottom: calc(64px + env(safe-area-inset-bottom, 0px));
-  }
-
-  .recover-sheet__handle {
-    display: block;
-    width: 36px;
-    height: 4px;
-    border-radius: 999px;
-    background: var(--border-color, #e3e7eb);
-    margin: 8px auto 0;
-  }
 }

--- a/frontend/src/components/account/RecoverAccountPanel.css
+++ b/frontend/src/components/account/RecoverAccountPanel.css
@@ -2,7 +2,14 @@
    connect surface (ConnectModal.css): centered card on desktop, bottom sheet on
    mobile, and the same mobile bottom-nav clearance fixed in #938 (backdrop
    z-index 1500 + safe-area padding) so the actions never hide behind the fixed
-   icon nav. Uses shared theme variables to render in both themes. */
+   icon nav.
+
+   Colors use the FairWins theme tokens from src/theme.css (--text-primary,
+   --text-secondary, --surface-color, --border-color, --warning-color,
+   --danger-color, --brand-primary) so text stays high-contrast in BOTH light
+   and dark themes. Fallbacks are the light-mode values (light is the default
+   theme) — never dark literals, which is what made light-theme text and chips
+   unreadable before. */
 
 .recover-account-panel__start {
   margin-top: 8px;
@@ -25,10 +32,11 @@
   max-width: 460px;
   max-height: 85vh;
   overflow-y: auto;
-  background: var(--color-surface, var(--surface-color, #1a1a1a));
-  border: 1px solid var(--color-border, #333);
+  background: var(--surface-color, #ffffff);
+  color: var(--text-primary, #1f2933);
+  border: 1px solid var(--border-color, #e3e7eb);
   border-radius: 16px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-lg, 0 10px 15px rgba(0, 0, 0, 0.1));
   outline: none;
 }
 
@@ -41,19 +49,19 @@
   align-items: center;
   justify-content: space-between;
   padding: 16px 20px 12px;
-  border-bottom: 1px solid var(--color-border, #333);
+  border-bottom: 1px solid var(--border-color, #e3e7eb);
 }
 
 .recover-sheet__header h3 {
   margin: 0;
   font-size: 1.1rem;
-  color: var(--color-text, #fff);
+  color: var(--text-primary, #1f2933);
 }
 
 .recover-sheet__close {
   background: none;
   border: none;
-  color: var(--color-text-secondary, #aaa);
+  color: var(--text-secondary, #5a6772);
   font-size: 1.5rem;
   line-height: 1;
   cursor: pointer;
@@ -63,8 +71,8 @@
 
 .recover-sheet__close:hover,
 .recover-sheet__close:focus-visible {
-  color: var(--color-text, #fff);
-  background: var(--color-surface-secondary, #262626);
+  color: var(--text-primary, #1f2933);
+  background: var(--bg-primary, #f7f9fa);
 }
 
 .recover-sheet__body {
@@ -73,7 +81,7 @@
 
 /* --- Step content --- */
 .recover-step p {
-  color: var(--color-text-secondary, #ccc);
+  color: var(--text-secondary, #5a6772);
   font-size: 0.92rem;
   line-height: 1.5;
   margin: 0 0 12px;
@@ -82,7 +90,7 @@
 .recover-step__list {
   margin: 0 0 14px;
   padding-left: 1.2rem;
-  color: var(--color-text-secondary, #ccc);
+  color: var(--text-secondary, #5a6772);
   font-size: 0.9rem;
   line-height: 1.5;
 }
@@ -100,16 +108,16 @@
 
 .recover-step__chip {
   font-size: 0.78rem;
-  color: var(--color-text-secondary, #aaa);
-  background: var(--color-surface-secondary, #262626);
-  border: 1px solid var(--color-border, #333);
+  color: var(--text-secondary, #5a6772);
+  background: var(--bg-primary, #f7f9fa);
+  border: 1px solid var(--border-color, #e3e7eb);
   border-radius: 999px;
   padding: 4px 10px;
 }
 
 .recover-step__meta-line {
   font-size: 0.8rem !important;
-  color: var(--color-text-secondary, #999) !important;
+  color: var(--text-muted, #8a959e) !important;
 }
 
 .recover-step__meta-line code {
@@ -117,7 +125,7 @@
 }
 
 .recover-step__ok {
-  color: var(--color-success, #36B37E) !important;
+  color: var(--brand-primary, #36b37e) !important;
   font-weight: 600;
 }
 
@@ -126,16 +134,16 @@
 }
 
 .recover-step__warn {
-  border: 1px solid var(--color-warning, #E2A93B);
+  border: 1px solid var(--warning-color, #f59e0b);
   border-radius: 10px;
   padding: 10px 12px;
-  color: var(--color-text, #eee) !important;
-  background: color-mix(in srgb, var(--color-warning, #E2A93B) 12%, transparent);
+  color: var(--text-primary, #1f2933) !important;
+  background: color-mix(in srgb, var(--warning-color, #f59e0b) 14%, transparent);
   font-size: 0.86rem !important;
 }
 
 .recover-step__progress {
-  color: var(--color-primary, #36B37E) !important;
+  color: var(--brand-primary, #36b37e) !important;
   font-size: 0.88rem !important;
 }
 
@@ -145,7 +153,7 @@
 
 .recover-step__hint a,
 .recover-account-panel a {
-  color: var(--color-primary, #36B37E);
+  color: var(--brand-primary, #36b37e);
 }
 
 .recover-step__notice {
@@ -156,9 +164,9 @@
 }
 
 .recover-step__notice--error {
-  border: 1px solid var(--color-danger, #ef4444);
-  color: var(--color-danger, #ef4444) !important;
-  background: color-mix(in srgb, var(--color-danger, #ef4444) 8%, transparent);
+  border: 1px solid var(--danger-color, #dc2626);
+  color: var(--danger-color, #dc2626) !important;
+  background: color-mix(in srgb, var(--danger-color, #dc2626) 10%, transparent);
 }
 
 /* --- Address entry (matches the controllers panel link row) --- */
@@ -183,15 +191,15 @@
   min-width: 42px;
   height: 42px;
   border-radius: 8px;
-  border: 1px solid var(--color-border);
-  background: var(--color-surface-secondary);
-  color: var(--color-text);
+  border: 1px solid var(--border-color, #e3e7eb);
+  background: var(--bg-primary, #f7f9fa);
+  color: var(--text-primary, #1f2933);
   cursor: pointer;
 }
 
 .recover-step__scan-btn:hover:not(:disabled) {
-  border-color: var(--color-primary, #36B37E);
-  color: var(--color-primary, #36B37E);
+  border-color: var(--brand-primary, #36b37e);
+  color: var(--brand-primary, #36b37e);
 }
 
 .recover-step__scan-btn:disabled {
@@ -206,7 +214,7 @@
   gap: 8px;
   margin-bottom: 12px;
   font-size: 0.82rem;
-  color: var(--color-text-secondary, #aaa);
+  color: var(--text-secondary, #5a6772);
 }
 
 /* --- Actions --- */
@@ -241,7 +249,7 @@
     width: 36px;
     height: 4px;
     border-radius: 999px;
-    background: var(--color-border, #444);
+    background: var(--border-color, #e3e7eb);
     margin: 8px auto 0;
   }
 }

--- a/frontend/src/components/account/RecoverAccountPanel.jsx
+++ b/frontend/src/components/account/RecoverAccountPanel.jsx
@@ -16,7 +16,7 @@
  * actionable guidance instead of an error boundary.
  */
 
-import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
+import { useState, useCallback, useMemo, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { ethers } from 'ethers'
 import { useWallet } from '../../hooks/useWalletManagement'
@@ -32,6 +32,7 @@ import AddressInput from '../ui/AddressInput'
 import AddressBookButton from '../ui/AddressBookButton'
 import QRScanner from '../ui/QRScanner'
 import { extractAddressFromScan } from '../../lib/addressBook/scanAddress'
+import ActionSheet from './ActionSheet'
 import './RecoverAccountPanel.css'
 
 // Human-readable fragments for the vendored Coinbase Smart Wallet MultiOwnable
@@ -47,90 +48,6 @@ const shortAddr = (a) => (a ? `${a.substring(0, 6)}…${a.substring(a.length - 4
 
 // User-facing guide for how passkey account recovery via a linked wallet works.
 const RECOVERY_DOCS_URL = 'https://docs.FairWins.app/user-guide/account-recovery/'
-
-/**
- * The bottom-sheet host. Kept local (no global modal singleton) and styled to
- * match the connect surface — including the mobile bottom-nav clearance fixed
- * in #938 (backdrop z-index 1500 + safe-area padding so the actions never hide
- * behind the icon nav). Renders nothing when closed; closes on backdrop click
- * and Escape and traps focus (aria-modal).
- */
-function RecoverSheet({ open, onClose, title, step, children }) {
-  const dialogRef = useRef(null)
-  const onCloseRef = useRef(onClose)
-  useEffect(() => {
-    onCloseRef.current = onClose
-  })
-
-  useEffect(() => {
-    if (!open) return undefined
-    const onKey = (e) => {
-      if (e.key === 'Escape') {
-        onCloseRef.current?.()
-        return
-      }
-      if (e.key !== 'Tab') return
-      const dialog = dialogRef.current
-      if (!dialog) return
-      const focusables = dialog.querySelectorAll(
-        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-      )
-      if (!focusables.length) return
-      const first = focusables[0]
-      const last = focusables[focusables.length - 1]
-      const outside = !dialog.contains(document.activeElement)
-      if (e.shiftKey && (document.activeElement === first || outside)) {
-        e.preventDefault()
-        last.focus()
-      } else if (!e.shiftKey && (document.activeElement === last || outside)) {
-        e.preventDefault()
-        first.focus()
-      }
-    }
-    document.addEventListener('keydown', onKey)
-    const prevOverflow = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
-    dialogRef.current?.focus()
-    return () => {
-      document.removeEventListener('keydown', onKey)
-      document.body.style.overflow = prevOverflow
-    }
-  }, [open])
-
-  if (!open) return null
-
-  return (
-    <div className="recover-sheet__backdrop" role="presentation" onClick={onClose}>
-      <div
-        className="recover-sheet"
-        role="dialog"
-        aria-modal="true"
-        aria-label={title}
-        ref={dialogRef}
-        tabIndex={-1}
-        data-step={step}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="recover-sheet__handle" aria-hidden="true" />
-        <div className="recover-sheet__header">
-          <h3>{title}</h3>
-          <button type="button" className="recover-sheet__close" onClick={onClose} aria-label="Close">
-            ×
-          </button>
-        </div>
-        <div className="recover-sheet__body">{children}</div>
-      </div>
-    </div>
-  )
-}
-
-RecoverSheet.propTypes = {
-  open: PropTypes.bool,
-  onClose: PropTypes.func.isRequired,
-  title: PropTypes.string.isRequired,
-  step: PropTypes.string,
-  children: PropTypes.node,
-}
 
 const STEP_TITLES = {
   intro: 'Recover your account',
@@ -324,7 +241,7 @@ function RecoverAccountPanel({ deps = {} }) {
         Recover an account
       </button>
 
-      <RecoverSheet open={open} onClose={closeWizard} title={STEP_TITLES[step]} step={step}>
+      <ActionSheet open={open} onClose={closeWizard} title={STEP_TITLES[step]} closeDisabled={busy}>
         {/* Step 1 — what this does + prerequisites, checked while it's fresh. */}
         {step === 'intro' && (
           <div className="recover-step">
@@ -505,7 +422,7 @@ function RecoverAccountPanel({ deps = {} }) {
             </div>
           </div>
         )}
-      </RecoverSheet>
+      </ActionSheet>
     </section>
   )
 }

--- a/frontend/src/components/account/__tests__/ControllersPanel.test.jsx
+++ b/frontend/src/components/account/__tests__/ControllersPanel.test.jsx
@@ -5,7 +5,7 @@
  * fail-closed), remove with last-controller refusal, counterfactual gating.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 
 let walletState
 vi.mock('../../../hooks/useWalletManagement', () => ({ useWallet: () => walletState }))
@@ -23,6 +23,15 @@ import ControllersPanel from '../ControllersPanel'
 
 const ACCOUNT = '0x00000000000000000000000000000000000A11CE'
 const WALLET = '0x' + 'c'.repeat(40)
+
+// Open the link-wallet consent sheet and click its confirm button. The panel
+// button and the sheet's confirm button share the label "Link wallet", so the
+// confirm is scoped to the dialog.
+function confirmLink() {
+  fireEvent.click(screen.getByRole('button', { name: /link wallet/i })) // panel → opens sheet
+  const dialog = screen.getByRole('dialog')
+  fireEvent.click(within(dialog).getByRole('button', { name: /link wallet/i })) // confirm
+}
 
 function passkeyRow(i, extra = {}) {
   return {
@@ -69,11 +78,18 @@ describe('ControllersPanel', () => {
     expect(screen.getByRole('button', { name: /remove/i })).toBeDisabled()
   })
 
-  it('links a CLEAR wallet through one sendCalls self-call (FR-019)', async () => {
+  it('shows an informed-consent sheet before linking, then links a CLEAR wallet through one sendCalls self-call (FR-019)', async () => {
     const screenController = vi.fn(async () => ({ clear: true, available: true }))
     render(<ControllersPanel deps={{ screenController }} />)
     fireEvent.change(screen.getByLabelText(/wallet address to link/i), { target: { value: WALLET } })
+    // Opening the sheet alone must NOT act — the member has to confirm first.
     fireEvent.click(screen.getByRole('button', { name: /link wallet/i }))
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveTextContent(/full controller/i)
+    expect(dialog).toHaveTextContent(WALLET)
+    expect(screenController).not.toHaveBeenCalled()
+    // Confirm inside the sheet performs the action.
+    fireEvent.click(within(dialog).getByRole('button', { name: /link wallet/i }))
     await waitFor(() => expect(walletState.sendCalls).toHaveBeenCalledTimes(1))
     expect(screenController).toHaveBeenCalledWith(WALLET, walletState.provider)
     expect(walletState.sendCalls.mock.calls[0][0][0].target).toBe(ACCOUNT) // self-call
@@ -83,7 +99,7 @@ describe('ControllersPanel', () => {
     const screenController = vi.fn(async () => ({ clear: false, available: true }))
     render(<ControllersPanel deps={{ screenController }} />)
     fireEvent.change(screen.getByLabelText(/wallet address to link/i), { target: { value: WALLET } })
-    fireEvent.click(screen.getByRole('button', { name: /link wallet/i }))
+    confirmLink()
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/flagged/i))
     expect(walletState.sendCalls).not.toHaveBeenCalled()
   })
@@ -96,7 +112,7 @@ describe('ControllersPanel', () => {
     }
     render(<ControllersPanel deps={{ screenController }} />)
     fireEvent.change(screen.getByLabelText(/wallet address to link/i), { target: { value: WALLET } })
-    fireEvent.click(screen.getByRole('button', { name: /link wallet/i }))
+    confirmLink()
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/already a controller/i))
     expect(screenController).not.toHaveBeenCalled()
     expect(walletState.sendCalls).not.toHaveBeenCalled()
@@ -106,12 +122,12 @@ describe('ControllersPanel', () => {
     const screenController = vi.fn(async () => ({ clear: false, available: false }))
     render(<ControllersPanel deps={{ screenController }} />)
     fireEvent.change(screen.getByLabelText(/wallet address to link/i), { target: { value: WALLET } })
-    fireEvent.click(screen.getByRole('button', { name: /link wallet/i }))
+    confirmLink()
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/fail-closed/i))
     expect(walletState.sendCalls).not.toHaveBeenCalled()
   })
 
-  it('adds a passkey: ceremony → ownerAdd self-call → refresh (FR-019)', async () => {
+  it('shows an informed-consent sheet before adding a passkey, then runs the ceremony → ownerAdd self-call → refresh (FR-019)', async () => {
     const createCredential = vi.fn(async () => ({
       credentialId: 'cred-new',
       publicKey: { x: '0x' + '3'.repeat(64), y: '0x' + '4'.repeat(64) },
@@ -119,6 +135,10 @@ describe('ControllersPanel', () => {
     }))
     render(<ControllersPanel deps={{ createCredential }} />)
     fireEvent.click(screen.getByRole('button', { name: /add a passkey/i }))
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveTextContent(/full controller/i)
+    expect(createCredential).not.toHaveBeenCalled() // opening the sheet doesn't act
+    fireEvent.click(within(dialog).getByRole('button', { name: /create passkey/i }))
     await waitFor(() => expect(walletState.sendCalls).toHaveBeenCalledTimes(1))
     expect(createCredential).toHaveBeenCalled()
     expect(accountState.refresh).toHaveBeenCalled()


### PR DESCRIPTION
Follow-ups to the passkey-recovery wizard (#940), on the same feature branch.

## 1. Light-theme contrast fix

In light theme the recovery bottom sheet had unreadable text: body copy and numbered steps were near-invisible light gray, the wallet/network chips were dark pills, and the "can't create passkeys" warning was faint.

**Cause:** the CSS used `--color-*` custom properties that this app never defines (its real tokens live in `src/theme.css` as `--text-primary`, `--text-secondary`, `--surface-color`, `--warning-color`, …). Every `var(--color-x, <fallback>)` fell through to the fallback, and I'd used **dark** fallbacks — invisible on the white light-theme sheet. Dark theme only looked right by coincidence.

**Fix:** swapped every color to the app's real theme tokens with light-mode fallbacks, so both themes stay high-contrast.

## 2. Informed-consent sheets for full-controller actions

Adding a passkey and linking a wallet each make the new key a **full controller** (it can move funds and manage other controllers), but both fired immediately from a single tap with only inline copy. Each now opens an informative bottom sheet first, matching the guided recovery flow — the member is fully informed before they act.

- **Add a passkey** sheet: explains the passkey becomes a full controller and that it takes a device prompt + one on-chain transaction.
- **Link wallet** sheet: shows the target address and states plainly that a linked wallet becomes a full controller that can move funds and recover the account — confirm required before screening + the on-chain link.
- Opening a sheet never acts; the action runs only on **confirm**, closes the sheet on success, and keeps it open with the error inside on failure/cancel (retry-friendly). Sheets can't be dismissed while a ceremony/transaction is in flight.

## 3. Shared `ActionSheet` primitive

Extracted the recovery wizard's bottom-sheet shell (focus trap, scroll lock, Escape/backdrop close, and the #938 mobile bottom-nav clearance) into one shared `ActionSheet` component used by both the recovery wizard and the two new consent sheets. `RecoverAccountPanel` was migrated onto it, so there's a single sheet primitive with the corrected theme tokens.

## Files

- `frontend/src/components/account/ActionSheet.jsx` / `ActionSheet.css` — new shared sheet + content helpers
- `frontend/src/components/account/RecoverAccountPanel.jsx` / `.css` — migrated to `ActionSheet`; light-theme color fix
- `frontend/src/components/account/ControllersPanel.jsx` — consent sheets before add-passkey / link-wallet
- `frontend/src/components/account/__tests__/ControllersPanel.test.jsx` — click through the consent step

## Testing

- `npx vitest run src/components/account` — 31 passed (10 recovery + 9 controllers + others).
- `npm run build` — clean.
- Verified every referenced token is defined in `src/theme.css` for both `.theme-light` and `.theme-dark`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)