### PR TITLE
Let passkey accounts register an encryption key self-service

### DIFF
--- a/frontend/src/hooks/useEncryption.js
+++ b/frontend/src/hooks/useEncryption.js
@@ -357,27 +357,43 @@ export function useEncryption() {
       throw new Error('Connect your account to register an encryption key.')
     }
     const readProvider = signer?.provider || provider
-    const { publicKey } = await ensureInitialized()
-    if (!publicKey) throw new Error('Failed to derive encryption keys.')
-
-    // Idempotent: never re-submit (and never charge a fee / ceremony) for an already-registered key.
-    if (readProvider && (await hasRegisteredKey(account, readProvider))) {
-      return { publicKey, alreadyRegistered: true }
-    }
+    // Whether the account already has a published on-chain key. This is the safety gate for the
+    // passkey bootstrap below: if a key IS published, its seed is authoritative and we must NEVER
+    // mint a fresh one; if it is NOT, a device that lacks local key material is free to bootstrap
+    // its own seed and register it, instead of dead-ending with "add it from another device".
+    const alreadyRegistered = Boolean(readProvider) && (await hasRegisteredKey(account, readProvider))
 
     if (isPasskey) {
       if (typeof sendCalls !== 'function') {
         throw new Error('This account cannot register a key on the current transaction rail.')
       }
+      const credentialId = readSession()?.credentialId
+      // allowInit only when nothing is published on-chain — a single-device passkey with a stale/
+      // foreign wrapped-seed blob (listCredentials > 0 but none for THIS credential) can now mint
+      // key material for itself and register, which is exactly the flow that was stranded before.
+      const keys = await ensurePasskeyEncryptionKeys({ account, credentialId, allowInit: !alreadyRegistered })
+      // Publish to hook state so backup, recovery codes, and encrypted wagers use these keys
+      // immediately — no second ceremony, and the (now-written) wrapped seed unblocks those surfaces.
+      applyKeyPairs({
+        x25519: { publicKey: keys.publicKey, privateKey: keys.privateKey },
+        xwing: { publicKey: keys.xwingPublicKey, secretKey: keys.xwingSecretKey },
+      })
+      setCachedVersion(CURRENT_ENCRYPTION_VERSION)
+      if (alreadyRegistered) return { publicKey: keys.publicKey, alreadyRegistered: true }
       const termsHash = getCurrentDocument('terms')?.hash || null
       // Awaited (not fire-and-forget): a relayer/paymaster outage or an undeployed KeyRegistry
       // now surfaces to the caller instead of being swallowed as a console warning.
-      await sendCalls(buildRegisterKeyCalls(publicKey, chainId, termsHash))
-    } else {
-      await registerEncryptionKey(signer, publicKey)
+      await sendCalls(buildRegisterKeyCalls(keys.publicKey, chainId, termsHash))
+      return { publicKey: keys.publicKey, alreadyRegistered: false }
     }
+
+    // EOA: derive from the wallet signature and register with the signer.
+    const { publicKey } = await ensureInitialized()
+    if (!publicKey) throw new Error('Failed to derive encryption keys.')
+    if (alreadyRegistered) return { publicKey, alreadyRegistered: true }
+    await registerEncryptionKey(signer, publicKey)
     return { publicKey, alreadyRegistered: false }
-  }, [account, signer, isPasskey, provider, sendCalls, chainId, ensureInitialized])
+  }, [account, signer, isPasskey, provider, sendCalls, chainId, applyKeyPairs, ensureInitialized])
 
   /**
    * Create encrypted market metadata

--- a/frontend/src/lib/passkey/__tests__/encryption.test.js
+++ b/frontend/src/lib/passkey/__tests__/encryption.test.js
@@ -89,6 +89,31 @@ describe('ensurePasskeyEncryptionKeys', () => {
     await expect(
       resolveMasterSeed({ account: ACCOUNT, credentialId: CRED_B, deps: { store, getAssertion: makeAssertion(9) } })
     ).rejects.toMatchObject({ name: 'EncryptionUnavailable' })
+    // The message must NOT point at a non-existent "Account → Controllers" component.
+    await resolveMasterSeed({ account: ACCOUNT, credentialId: CRED_B, deps: { store, getAssertion: makeAssertion(9) } })
+      .catch((e) => {
+        expect(e.message).not.toMatch(/Account → Controllers/)
+        expect(e.message).toMatch(/Backup & Security/)
+      })
+  })
+
+  it('allowInit bootstraps a fresh seed for a stranded credential (single-device register self-heal)', async () => {
+    const store = blobStore(storage)
+    // The account carries a stale/foreign blob for CRED_A, but this device signs as CRED_B and has
+    // no on-chain key — the caller opts into a safe bootstrap instead of dead-ending.
+    await ensurePasskeyEncryptionKeys({
+      account: ACCOUNT, credentialId: CRED_A, deps: { store, getAssertion: makeAssertion(1) },
+    })
+    const keys = await ensurePasskeyEncryptionKeys({
+      account: ACCOUNT, credentialId: CRED_B, allowInit: true, deps: { store, getAssertion: makeAssertion(9) },
+    })
+    expect(keys.publicKey).toHaveLength(32)
+    // The bootstrap wrote a wrapped seed for CRED_B, so a later ceremony unwraps deterministically.
+    expect(store.get(ACCOUNT, CRED_B)).toBeTruthy()
+    const again = await ensurePasskeyEncryptionKeys({
+      account: ACCOUNT, credentialId: CRED_B, deps: { store, getAssertion: makeAssertion(9) },
+    })
+    expect(Array.from(again.publicKey)).toEqual(Array.from(keys.publicKey))
   })
 
   it('requires a bound credential id', async () => {

--- a/frontend/src/lib/passkey/encryption.js
+++ b/frontend/src/lib/passkey/encryption.js
@@ -20,7 +20,7 @@
  * fully valid and only gates encrypted features off.
  */
 
-import { blobStore, initMasterSeed, unwrapMasterSeed, EncryptionUnavailable } from './prfKeys'
+import { blobStore, initMasterSeed, initMasterSeedForCredential, unwrapMasterSeed, EncryptionUnavailable } from './prfKeys'
 import { deriveKeyPairFromSeed, deriveXWingKeyPairFromSeed } from '../../utils/crypto/envelopeEncryption'
 
 /**
@@ -28,16 +28,20 @@ import { deriveKeyPairFromSeed, deriveXWingKeyPairFromSeed } from '../../utils/c
  *
  *  - blob for this credential exists ⇒ unwrap it (returning device / synced credential);
  *  - account has NO blobs at all ⇒ first-time init (this credential becomes the first controller);
- *  - account initialized but not for THIS credential ⇒ EncryptionUnavailable (add it from a
- *    signed-in device via Account → Controllers), never derive wrong keys.
+ *  - account has blobs but NOT for THIS credential ⇒
+ *      · allowInit=false (default) ⇒ EncryptionUnavailable, never derive wrong keys;
+ *      · allowInit=true ⇒ bootstrap a fresh seed for this credential. The CALLER must gate this on
+ *        "nothing depends on a prior seed" (no encryption key published on-chain), so a single-device
+ *        passkey can register self-service instead of being stranded pointing at another device.
  *
  * @param {object} opts
  * @param {string} opts.account - passkey smart-account address
  * @param {string} opts.credentialId - the session credential (pins the ceremony)
+ * @param {boolean} [opts.allowInit] - permit safe bootstrap when this credential has no blob (see above)
  * @param {object} [opts.deps] - injectable getAssertion / store / subtle for tests
  * @returns {Promise<Uint8Array>} 32-byte master seed (memory-only)
  */
-export async function resolveMasterSeed({ account, credentialId, deps = {} }) {
+export async function resolveMasterSeed({ account, credentialId, allowInit = false, deps = {} }) {
   if (!account) throw new Error('resolveMasterSeed: account is required')
   if (!credentialId) {
     throw new EncryptionUnavailable('no passkey credential is bound to this session — sign in again')
@@ -49,8 +53,13 @@ export async function resolveMasterSeed({ account, credentialId, deps = {} }) {
   if (store.listCredentials(account).length === 0) {
     return initMasterSeed({ account, credentialId, deps })
   }
+  // Blobs exist for the account but not for this credential.
+  if (allowInit) {
+    return initMasterSeedForCredential({ account, credentialId, deps })
+  }
   throw new EncryptionUnavailable(
-    'this passkey has no key material on this account yet — add it from a signed-in device (Account → Controllers)'
+    'this passkey has no encryption key material on this account yet — register your encryption key under Backup & Security, ' +
+    'or open FairWins on the device where you first enabled encryption (or restore your encrypted backup) to use it here'
   )
 }
 
@@ -60,13 +69,13 @@ export async function resolveMasterSeed({ account, credentialId, deps = {} }) {
  * into usePurchaseFlow's `sign` step (`{ publicKey }` is required; the rest lets
  * callers encrypt/decrypt locally).
  *
- * @param {object} opts - { account, credentialId, deps }
+ * @param {object} opts - { account, credentialId, allowInit, deps }
  * @returns {Promise<{publicKey: Uint8Array, privateKey: Uint8Array,
  *   xwingPublicKey: Uint8Array, xwingSecretKey: Uint8Array}>}
  * @throws {EncryptionUnavailable} on a non-PRF authenticator or missing key material
  */
-export async function ensurePasskeyEncryptionKeys({ account, credentialId, deps = {} }) {
-  const seed = await resolveMasterSeed({ account, credentialId, deps })
+export async function ensurePasskeyEncryptionKeys({ account, credentialId, allowInit = false, deps = {} }) {
+  const seed = await resolveMasterSeed({ account, credentialId, allowInit, deps })
   const x25519 = deriveKeyPairFromSeed(seed)
   const xwing = deriveXWingKeyPairFromSeed(seed)
   return {

--- a/frontend/src/lib/passkey/prfKeys.js
+++ b/frontend/src/lib/passkey/prfKeys.js
@@ -131,6 +131,23 @@ export async function initMasterSeed({ account, credentialId, deps = {} }) {
   return seed
 }
 
+/**
+ * Bootstrap key material for a SPECIFIC credential even when the account already carries blobs for
+ * other credentials. `initMasterSeed` deliberately refuses a non-empty account (it must never mint a
+ * second seed out from under an existing controller); this is the guarded escape hatch for a
+ * credential that is otherwise dead-ended with no usable seed on this device. The CALLER is
+ * responsible for the safety gate — mint fresh material only when nothing depends on a prior seed
+ * (i.e. no encryption key is published on-chain yet), so a single-device passkey can register
+ * instead of being stranded. Mints a fresh random seed, wraps it for this credential, returns it.
+ */
+export async function initMasterSeedForCredential({ account, credentialId, deps = {} }) {
+  const store = deps.store ?? blobStore()
+  const seed = crypto.getRandomValues(new Uint8Array(32))
+  const kek = await kekForCredential({ credentialId, deps })
+  store.set(account, credentialId, await wrapSeed(kek, seed, deps.subtle))
+  return seed
+}
+
 /** Recover the master seed with one PRF ceremony (returning device or synced credential). */
 export async function unwrapMasterSeed({ account, credentialId, deps = {} }) {
   const store = deps.store ?? blobStore()
@@ -185,6 +202,6 @@ export function capability({ account, credentialId, prfCapable, deps = {} }) {
   if (store.get(account, credentialId)) return { state: 'available' }
   return {
     state: 'unavailable',
-    reason: 'This passkey has no key material yet — add it from a signed-in device (Account → Controllers).',
+    reason: 'This passkey has no key material yet — register your encryption key under Backup & Security, or open FairWins on the device where you first enabled encryption.',
   }
 }

--- a/frontend/src/test/useEncryption.passkey.test.jsx
+++ b/frontend/src/test/useEncryption.passkey.test.jsx
@@ -80,19 +80,16 @@ describe('useEncryption — passkey encrypt/decrypt surface', () => {
     hasRegisteredKey.mockResolvedValue(false)
   })
 
-  it('registerKeyNow awaits the on-chain register through sendCalls and surfaces failures', async () => {
+  it('registerKeyNow bootstraps (allowInit) + awaits the on-chain register, and surfaces failures', async () => {
     const { result } = renderHook(() => useEncryption())
-    // Initialize first and let the non-blocking auto-register settle, so the assertions below
-    // observe registerKeyNow's OWN sendCalls rather than racing initializeKeys' auto-register.
-    await act(async () => { await result.current.ensureInitialized() })
-    await vi.waitFor(() => expect(sendCalls).toHaveBeenCalled())
-    sendCalls.mockClear()
-    buildRegisterKeyCalls.mockClear()
-
     let out
     await act(async () => {
       out = await result.current.registerKeyNow()
     })
+    // No on-chain key yet ⇒ allowInit true, so a stranded single-device passkey can mint its own seed.
+    expect(ensurePasskeyEncryptionKeys).toHaveBeenCalledWith(
+      expect.objectContaining({ account: ACCOUNT, credentialId: 'cred-1', allowInit: true })
+    )
     expect(buildRegisterKeyCalls).toHaveBeenCalledWith(PASSKEY_KEYS.publicKey, 137, null)
     expect(sendCalls).toHaveBeenCalledWith([{ target: '0xkeyRegistry', data: '0xdead', value: 0n }])
     expect(out).toMatchObject({ alreadyRegistered: false })
@@ -104,13 +101,17 @@ describe('useEncryption — passkey encrypt/decrypt surface', () => {
     })
   })
 
-  it('registerKeyNow is idempotent — an already-registered key skips the ceremony', async () => {
+  it('registerKeyNow never bootstraps a fresh seed when a key is already published on-chain', async () => {
     hasRegisteredKey.mockResolvedValue(true)
     const { result } = renderHook(() => useEncryption())
     let out
     await act(async () => {
       out = await result.current.registerKeyNow()
     })
+    // allowInit MUST be false so we never mint a second seed that would orphan the published key.
+    expect(ensurePasskeyEncryptionKeys).toHaveBeenCalledWith(
+      expect.objectContaining({ allowInit: false })
+    )
     expect(out).toMatchObject({ alreadyRegistered: true })
     expect(sendCalls).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## Problem

Registering an encryption key from a **single passkey device** dead-ended with:

> Key registration failed: Encrypted features are unavailable: this passkey has no key material on this account yet — add it from a signed-in device **(Account → Controllers)**

Two things were wrong:

1. **The instruction points at a component that doesn't exist.** There is no "Account → Controllers" — the controllers panel lives under **Backup & Security → Devices & controllers**, and on a lone device there is no *other* signed-in device to "add it from" anyway.
2. **The account could never bootstrap.** `resolveMasterSeed` refuses to initialize when the account has wrapped-seed blobs but none for the current session's credential (`listCredentials > 0`, no blob for this credential). That guard exists to avoid minting a second seed under an account that already has one — but when **nothing is published on-chain** (screenshot: *On-chain Registration: Not registered*), there is no seed to protect, so refusing just strands the user. The same dead-end also broke **Back up my data** and **Recovery codes**, since they resolve the same seed.

## Fix

- **Safe self-service bootstrap.** `resolveMasterSeed` / `ensurePasskeyEncryptionKeys` take an `allowInit` flag; `prfKeys.initMasterSeedForCredential` mints key material for the *current* credential even when stale/foreign blobs exist. `useEncryption.registerKeyNow()` passes `allowInit` **only when no key is published on-chain** — so a stranded single-device passkey can mint its own seed and register, while an account that already has a published key never forks its authoritative seed (guarded by `hasRegisteredKey`).
- **Unblocks the rest.** `registerKeyNow` publishes the derived keys to hook state and writes the wrapped seed, so once the key is registered, encrypted backup, recovery codes, and encrypted wagers all work with no extra ceremony.
- **Honest guidance.** The seed-missing error and the capability-degradation reason no longer reference the non-existent "Account → Controllers"; they point at **Backup & Security** / the device where encryption was first enabled.

## Safety

Bootstrapping a fresh seed is gated strictly on **no on-chain key** for the account. If a key is already published, `allowInit` is `false` and the original refusal stands (with corrected wording) — a device that lacks the seed still cannot mint a divergent one that would orphan the published key or its encrypted data.

## Testing

- `src/lib/passkey/__tests__/encryption.test.js` — `allowInit` bootstraps a fresh seed for a stranded credential and round-trips on the next ceremony; the refusal message no longer mentions "Account → Controllers" and names Backup & Security.
- `src/test/useEncryption.passkey.test.jsx` — `registerKeyNow` threads `allowInit: true` when unregistered (mints + registers, awaits `sendCalls`, surfaces failures) and `allowInit: false` when a key is already published (no re-mint, no `sendCalls`).
- Affected suites pass: passkey `encryption`/`prfKeys`, `useEncryption` (passkey + EOA), `WalletPage`; lint clean.

Follow-up to the merged #939 (this branch was restarted from `main`; this is a new PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWbcD1wJAoj92UJ9TDGRcD

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWbcD1wJAoj92UJ9TDGRcD)_